### PR TITLE
Move `test::Bencher` to a new (unstable) `std::bench` module

### DIFF
--- a/src/liballoc/alloc/tests.rs
+++ b/src/liballoc/alloc/tests.rs
@@ -23,7 +23,7 @@ fn allocate_zeroed() {
 
 #[bench]
 #[cfg(not(miri))] // Miri does not support benchmarks
-fn alloc_owned_small(b: &mut Bencher) {
+fn alloc_owned_small(b: &mut Bencher<'_>) {
     b.iter(|| {
         let _: Box<_> = box 10;
     })

--- a/src/liballoc/collections/vec_deque/tests.rs
+++ b/src/liballoc/collections/vec_deque/tests.rs
@@ -4,7 +4,7 @@ use ::test;
 
 #[bench]
 #[cfg(not(miri))] // Miri does not support benchmarks
-fn bench_push_back_100(b: &mut test::Bencher) {
+fn bench_push_back_100(b: &mut test::Bencher<'_>) {
     let mut deq = VecDeque::with_capacity(101);
     b.iter(|| {
         for i in 0..100 {
@@ -17,7 +17,7 @@ fn bench_push_back_100(b: &mut test::Bencher) {
 
 #[bench]
 #[cfg(not(miri))] // Miri does not support benchmarks
-fn bench_push_front_100(b: &mut test::Bencher) {
+fn bench_push_front_100(b: &mut test::Bencher<'_>) {
     let mut deq = VecDeque::with_capacity(101);
     b.iter(|| {
         for i in 0..100 {
@@ -30,7 +30,7 @@ fn bench_push_front_100(b: &mut test::Bencher) {
 
 #[bench]
 #[cfg(not(miri))] // Miri does not support benchmarks
-fn bench_pop_back_100(b: &mut test::Bencher) {
+fn bench_pop_back_100(b: &mut test::Bencher<'_>) {
     let mut deq = VecDeque::<i32>::with_capacity(101);
 
     b.iter(|| {
@@ -44,7 +44,7 @@ fn bench_pop_back_100(b: &mut test::Bencher) {
 
 #[bench]
 #[cfg(not(miri))] // Miri does not support benchmarks
-fn bench_pop_front_100(b: &mut test::Bencher) {
+fn bench_pop_front_100(b: &mut test::Bencher<'_>) {
     let mut deq = VecDeque::<i32>::with_capacity(101);
 
     b.iter(|| {

--- a/src/libarena/tests.rs
+++ b/src/libarena/tests.rs
@@ -69,13 +69,13 @@ pub fn test_copy() {
 }
 
 #[bench]
-pub fn bench_copy(b: &mut Bencher) {
+pub fn bench_copy(b: &mut Bencher<'_>) {
     let arena = TypedArena::default();
     b.iter(|| arena.alloc(Point { x: 1, y: 2, z: 3 }))
 }
 
 #[bench]
-pub fn bench_copy_nonarena(b: &mut Bencher) {
+pub fn bench_copy_nonarena(b: &mut Bencher<'_>) {
     b.iter(|| {
         let _: Box<_> = Box::new(Point { x: 1, y: 2, z: 3 });
     })
@@ -118,7 +118,7 @@ pub fn test_typed_arena_clear() {
 }
 
 #[bench]
-pub fn bench_typed_arena_clear(b: &mut Bencher) {
+pub fn bench_typed_arena_clear(b: &mut Bencher<'_>) {
     let mut arena = TypedArena::default();
     b.iter(|| {
         arena.alloc(Point { x: 1, y: 2, z: 3 });
@@ -192,7 +192,7 @@ fn test_typed_arena_drop_small_count() {
 }
 
 #[bench]
-pub fn bench_noncopy(b: &mut Bencher) {
+pub fn bench_noncopy(b: &mut Bencher<'_>) {
     let arena = TypedArena::default();
     b.iter(|| {
         arena.alloc(Noncopy {
@@ -203,7 +203,7 @@ pub fn bench_noncopy(b: &mut Bencher) {
 }
 
 #[bench]
-pub fn bench_noncopy_nonarena(b: &mut Bencher) {
+pub fn bench_noncopy_nonarena(b: &mut Bencher<'_>) {
     b.iter(|| {
         let _: Box<_> = Box::new(Noncopy {
             string: "hello world".to_string(),

--- a/src/librustc/benches/dispatch.rs
+++ b/src/librustc/benches/dispatch.rs
@@ -17,7 +17,7 @@ impl Trait for Struct {
 }
 
 #[bench]
-fn trait_vtable_method_call(b: &mut Bencher) {
+fn trait_vtable_method_call(b: &mut Bencher<'_>) {
     let s = Struct { field: 10 };
     let t = &s as &Trait;
     b.iter(|| {
@@ -26,7 +26,7 @@ fn trait_vtable_method_call(b: &mut Bencher) {
 }
 
 #[bench]
-fn trait_static_method_call(b: &mut Bencher) {
+fn trait_static_method_call(b: &mut Bencher<'_>) {
     let s = Struct { field: 10 };
     b.iter(|| {
         s.method()

--- a/src/librustc/benches/pattern.rs
+++ b/src/librustc/benches/pattern.rs
@@ -3,7 +3,7 @@ use test::Bencher;
 // Overhead of various match forms
 
 #[bench]
-fn option_some(b: &mut Bencher) {
+fn option_some(b: &mut Bencher<'_>) {
     let x = Some(10);
     b.iter(|| {
         match x {
@@ -14,7 +14,7 @@ fn option_some(b: &mut Bencher) {
 }
 
 #[bench]
-fn vec_pattern(b: &mut Bencher) {
+fn vec_pattern(b: &mut Bencher<'_>) {
     let x = [1,2,3,4,5,6];
     b.iter(|| {
         match x {

--- a/src/librustc_data_structures/tiny_list/tests.rs
+++ b/src/librustc_data_structures/tiny_list/tests.rs
@@ -96,7 +96,7 @@ fn test_remove_single() {
 }
 
 #[bench]
-fn bench_insert_empty(b: &mut Bencher) {
+fn bench_insert_empty(b: &mut Bencher<'_>) {
     b.iter(|| {
         let mut list = black_box(TinyList::new());
         list.insert(1);
@@ -105,7 +105,7 @@ fn bench_insert_empty(b: &mut Bencher) {
 }
 
 #[bench]
-fn bench_insert_one(b: &mut Bencher) {
+fn bench_insert_one(b: &mut Bencher<'_>) {
     b.iter(|| {
         let mut list = black_box(TinyList::new_single(0));
         list.insert(1);
@@ -114,42 +114,42 @@ fn bench_insert_one(b: &mut Bencher) {
 }
 
 #[bench]
-fn bench_contains_empty(b: &mut Bencher) {
+fn bench_contains_empty(b: &mut Bencher<'_>) {
     b.iter(|| {
         black_box(TinyList::new()).contains(&1)
     });
 }
 
 #[bench]
-fn bench_contains_unknown(b: &mut Bencher) {
+fn bench_contains_unknown(b: &mut Bencher<'_>) {
     b.iter(|| {
         black_box(TinyList::new_single(0)).contains(&1)
     });
 }
 
 #[bench]
-fn bench_contains_one(b: &mut Bencher) {
+fn bench_contains_one(b: &mut Bencher<'_>) {
     b.iter(|| {
         black_box(TinyList::new_single(1)).contains(&1)
     });
 }
 
 #[bench]
-fn bench_remove_empty(b: &mut Bencher) {
+fn bench_remove_empty(b: &mut Bencher<'_>) {
     b.iter(|| {
         black_box(TinyList::new()).remove(&1)
     });
 }
 
 #[bench]
-fn bench_remove_unknown(b: &mut Bencher) {
+fn bench_remove_unknown(b: &mut Bencher<'_>) {
     b.iter(|| {
         black_box(TinyList::new_single(0)).remove(&1)
     });
 }
 
 #[bench]
-fn bench_remove_one(b: &mut Bencher) {
+fn bench_remove_one(b: &mut Bencher<'_>) {
     b.iter(|| {
         black_box(TinyList::new_single(1)).remove(&1)
     });

--- a/src/librustc_index/bit_set/tests.rs
+++ b/src/librustc_index/bit_set/tests.rs
@@ -286,7 +286,7 @@ fn sparse_matrix_iter() {
 
 /// Merge dense hybrid set into empty sparse hybrid set.
 #[bench]
-fn union_hybrid_sparse_empty_to_dense(b: &mut Bencher) {
+fn union_hybrid_sparse_empty_to_dense(b: &mut Bencher<'_>) {
     let mut pre_dense: HybridBitSet<usize> = HybridBitSet::new_empty(256);
     for i in 0..10 {
         assert!(pre_dense.insert(i));
@@ -301,7 +301,7 @@ fn union_hybrid_sparse_empty_to_dense(b: &mut Bencher) {
 
 /// Merge dense hybrid set into full hybrid set with same indices.
 #[bench]
-fn union_hybrid_sparse_full_to_dense(b: &mut Bencher) {
+fn union_hybrid_sparse_full_to_dense(b: &mut Bencher<'_>) {
     let mut pre_dense: HybridBitSet<usize> = HybridBitSet::new_empty(256);
     for i in 0..10 {
         assert!(pre_dense.insert(i));
@@ -319,7 +319,7 @@ fn union_hybrid_sparse_full_to_dense(b: &mut Bencher) {
 
 /// Merge dense hybrid set into full hybrid set with indices over the whole domain.
 #[bench]
-fn union_hybrid_sparse_domain_to_dense(b: &mut Bencher) {
+fn union_hybrid_sparse_domain_to_dense(b: &mut Bencher<'_>) {
     let mut pre_dense: HybridBitSet<usize> = HybridBitSet::new_empty(SPARSE_MAX*64);
     for i in 0..10 {
         assert!(pre_dense.insert(i));
@@ -337,7 +337,7 @@ fn union_hybrid_sparse_domain_to_dense(b: &mut Bencher) {
 
 /// Merge dense hybrid set into empty hybrid set where the domain is very small.
 #[bench]
-fn union_hybrid_sparse_empty_small_domain(b: &mut Bencher) {
+fn union_hybrid_sparse_empty_small_domain(b: &mut Bencher<'_>) {
     let mut pre_dense: HybridBitSet<usize> = HybridBitSet::new_empty(SPARSE_MAX);
     for i in 0..SPARSE_MAX {
         assert!(pre_dense.insert(i));
@@ -352,7 +352,7 @@ fn union_hybrid_sparse_empty_small_domain(b: &mut Bencher) {
 
 /// Merge dense hybrid set into full hybrid set where the domain is very small.
 #[bench]
-fn union_hybrid_sparse_full_small_domain(b: &mut Bencher) {
+fn union_hybrid_sparse_full_small_domain(b: &mut Bencher<'_>) {
     let mut pre_dense: HybridBitSet<usize> = HybridBitSet::new_empty(SPARSE_MAX);
     for i in 0..SPARSE_MAX {
         assert!(pre_dense.insert(i));

--- a/src/libserialize/hex/tests.rs
+++ b/src/libserialize/hex/tests.rs
@@ -53,7 +53,7 @@ pub fn test_from_hex_all_bytes() {
 }
 
 #[bench]
-pub fn bench_to_hex(b: &mut Bencher) {
+pub fn bench_to_hex(b: &mut Bencher<'_>) {
     let s = "イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム \
              ウヰノオクヤマ ケフコエテ アサキユメミシ ヱヒモセスン";
     b.iter(|| {
@@ -63,7 +63,7 @@ pub fn bench_to_hex(b: &mut Bencher) {
 }
 
 #[bench]
-pub fn bench_from_hex(b: &mut Bencher) {
+pub fn bench_from_hex(b: &mut Bencher<'_>) {
     let s = "イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム \
              ウヰノオクヤマ ケフコエテ アサキユメミシ ヱヒモセスン";
     let sb = s.as_bytes().to_hex();

--- a/src/libserialize/json/tests.rs
+++ b/src/libserialize/json/tests.rs
@@ -70,7 +70,7 @@ fn test_stack() {
 }
 
 #[bench]
-fn bench_streaming_small(b: &mut Bencher) {
+fn bench_streaming_small(b: &mut Bencher<'_>) {
     b.iter( || {
         let mut parser = Parser::new(
             r#"{
@@ -91,7 +91,7 @@ fn bench_streaming_small(b: &mut Bencher) {
     });
 }
 #[bench]
-fn bench_small(b: &mut Bencher) {
+fn bench_small(b: &mut Bencher<'_>) {
     b.iter( || {
         let _ = from_str(r#"{
             "a": 1.0,
@@ -115,7 +115,7 @@ fn big_json() -> string::String {
 }
 
 #[bench]
-fn bench_streaming_large(b: &mut Bencher) {
+fn bench_streaming_large(b: &mut Bencher<'_>) {
     let src = big_json();
     b.iter( || {
         let mut parser = Parser::new(src.chars());
@@ -128,7 +128,7 @@ fn bench_streaming_large(b: &mut Bencher) {
     });
 }
 #[bench]
-fn bench_large(b: &mut Bencher) {
+fn bench_large(b: &mut Bencher<'_>) {
     let src = big_json();
     b.iter( || { let _ = from_str(&src); });
 }

--- a/src/libstd/bench.rs
+++ b/src/libstd/bench.rs
@@ -1,0 +1,55 @@
+//! Benchmarking
+
+#![unstable(feature = "test", issue = "50297")]
+
+use crate::hint::black_box;
+use crate::time::{Instant, Duration};
+
+
+/// Manager of the benchmarking runs.
+///
+/// This is fed into functions marked with `#[bench]` to allow for
+/// set-up & tear-down before running a piece of code repeatedly via a
+/// call to `iter`.
+#[allow(missing_debug_implementations)]
+pub struct Bencher<'a> {
+    callback: Callback<'a>,
+    /// FIXME
+    pub bytes: u64,
+}
+
+impl<'a> Bencher<'a> {
+    /// Callback for benchmark functions to run in their body.
+    pub fn iter<T>(&mut self, mut f: impl FnMut() -> T) {
+        (self.callback)(self.bytes, &mut |n_iterations| {
+            let start = Instant::now();
+            for _ in 0..n_iterations {
+                black_box(f());
+            }
+            ns_from_dur(start.elapsed())
+        })
+    }
+}
+
+fn ns_from_dur(dur: Duration) -> u64 {
+    dur.as_secs() * 1_000_000_000 + (dur.subsec_nanos() as u64)
+}
+
+// Permanently-unstable implementation details, only public for use by the `test` crate:
+
+/// n_iterations -> nanoseconds
+#[doc(hidden)]
+#[unstable(feature = "test_internals", issue = "0")]
+pub type TimeIterations<'i> = &'i mut dyn FnMut(u64) -> u64;
+
+#[doc(hidden)]
+#[unstable(feature = "test_internals", issue = "0")]
+pub type Callback<'a> = &'a mut dyn FnMut(/* bytes: */ u64, TimeIterations<'_>);
+
+#[doc(hidden)]
+#[unstable(feature = "test_internals", issue = "0")]
+impl<'a> Bencher<'a> {
+    pub fn new(callback: Callback<'a>) -> Self {
+        Self { callback, bytes: 0 }
+    }
+}

--- a/src/libstd/collections/hash/bench.rs
+++ b/src/libstd/collections/hash/bench.rs
@@ -3,7 +3,7 @@
 use test::Bencher;
 
 #[bench]
-fn new_drop(b: &mut Bencher) {
+fn new_drop(b: &mut Bencher<'_>) {
     use super::map::HashMap;
 
     b.iter(|| {
@@ -13,7 +13,7 @@ fn new_drop(b: &mut Bencher) {
 }
 
 #[bench]
-fn new_insert_drop(b: &mut Bencher) {
+fn new_insert_drop(b: &mut Bencher<'_>) {
     use super::map::HashMap;
 
     b.iter(|| {
@@ -24,7 +24,7 @@ fn new_insert_drop(b: &mut Bencher) {
 }
 
 #[bench]
-fn grow_by_insertion(b: &mut Bencher) {
+fn grow_by_insertion(b: &mut Bencher<'_>) {
     use super::map::HashMap;
 
     let mut m = HashMap::new();
@@ -42,7 +42,7 @@ fn grow_by_insertion(b: &mut Bencher) {
 }
 
 #[bench]
-fn find_existing(b: &mut Bencher) {
+fn find_existing(b: &mut Bencher<'_>) {
     use super::map::HashMap;
 
     let mut m = HashMap::new();
@@ -59,7 +59,7 @@ fn find_existing(b: &mut Bencher) {
 }
 
 #[bench]
-fn find_nonexisting(b: &mut Bencher) {
+fn find_nonexisting(b: &mut Bencher<'_>) {
     use super::map::HashMap;
 
     let mut m = HashMap::new();
@@ -76,7 +76,7 @@ fn find_nonexisting(b: &mut Bencher) {
 }
 
 #[bench]
-fn hashmap_as_queue(b: &mut Bencher) {
+fn hashmap_as_queue(b: &mut Bencher<'_>) {
     use super::map::HashMap;
 
     let mut m = HashMap::new();
@@ -95,7 +95,7 @@ fn hashmap_as_queue(b: &mut Bencher) {
 }
 
 #[bench]
-fn get_remove_insert(b: &mut Bencher) {
+fn get_remove_insert(b: &mut Bencher<'_>) {
     use super::map::HashMap;
 
     let mut m = HashMap::new();

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -1418,14 +1418,14 @@ mod tests {
     }
 
     #[bench]
-    fn bench_buffered_reader(b: &mut test::Bencher) {
+    fn bench_buffered_reader(b: &mut test::Bencher<'_>) {
         b.iter(|| {
             BufReader::new(io::empty())
         });
     }
 
     #[bench]
-    fn bench_buffered_writer(b: &mut test::Bencher) {
+    fn bench_buffered_writer(b: &mut test::Bencher<'_>) {
         b.iter(|| {
             BufWriter::new(io::sink())
         });

--- a/src/libstd/io/impls.rs
+++ b/src/libstd/io/impls.rs
@@ -340,7 +340,7 @@ mod tests {
     use crate::io::prelude::*;
 
     #[bench]
-    fn bench_read_slice(b: &mut test::Bencher) {
+    fn bench_read_slice(b: &mut test::Bencher<'_>) {
         let buf = [5; 1024];
         let mut dst = [0; 128];
 
@@ -354,7 +354,7 @@ mod tests {
     }
 
     #[bench]
-    fn bench_write_slice(b: &mut test::Bencher) {
+    fn bench_write_slice(b: &mut test::Bencher<'_>) {
         let mut buf = [0; 1024];
         let src = [5; 128];
 
@@ -368,7 +368,7 @@ mod tests {
     }
 
     #[bench]
-    fn bench_read_vec(b: &mut test::Bencher) {
+    fn bench_read_vec(b: &mut test::Bencher<'_>) {
         let buf = vec![5; 1024];
         let mut dst = [0; 128];
 
@@ -382,7 +382,7 @@ mod tests {
     }
 
     #[bench]
-    fn bench_write_vec(b: &mut test::Bencher) {
+    fn bench_write_vec(b: &mut test::Bencher<'_>) {
         let mut buf = Vec::with_capacity(1024);
         let src = [5; 128];
 

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -2612,7 +2612,7 @@ mod tests {
 
     #[bench]
     #[cfg_attr(target_os = "emscripten", ignore)]
-    fn bench_read_to_end(b: &mut test::Bencher) {
+    fn bench_read_to_end(b: &mut test::Bencher<'_>) {
         b.iter(|| {
             let mut lr = repeat(1).take(10000000);
             let mut vec = Vec::with_capacity(1024);

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -454,6 +454,7 @@ pub mod f64;
 pub mod thread;
 pub mod ascii;
 pub mod backtrace;
+pub mod bench;
 pub mod collections;
 pub mod env;
 pub mod error;

--- a/src/libstd/num.rs
+++ b/src/libstd/num.rs
@@ -286,7 +286,7 @@ mod bench {
     use test::Bencher;
 
     #[bench]
-    fn bench_pow_function(b: &mut Bencher) {
+    fn bench_pow_function(b: &mut Bencher<'_>) {
         let v = (0..1024).collect::<Vec<u32>>();
         b.iter(|| {v.iter().fold(0u32, |old, new| old.pow(*new as u32));});
     }

--- a/src/libsyntax_ext/test.rs
+++ b/src/libsyntax_ext/test.rs
@@ -371,7 +371,7 @@ fn has_bench_signature(cx: &ExtCtxt<'_>, i: &ast::Item) -> bool {
 
     if !has_sig {
         cx.parse_sess.span_diagnostic.span_err(i.span, "functions used as benches must have \
-            signature `fn(&mut Bencher) -> impl Termination`");
+            signature `fn(&mut Bencher<'_>) -> impl Termination`");
     }
 
     has_sig

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -29,6 +29,7 @@
 #![feature(staged_api)]
 #![feature(termination_trait_lib)]
 #![feature(test)]
+#![feature(test_internals)]
 
 // Public reexports
 pub use self::ColorConfig::*;

--- a/src/libtest/options.rs
+++ b/src/libtest/options.rs
@@ -7,13 +7,6 @@ pub enum Concurrent {
     No,
 }
 
-/// Number of times to run a benchmarked function
-#[derive(Clone, PartialEq, Eq)]
-pub enum BenchMode {
-    Auto,
-    Single,
-}
-
 /// Whether test is expected to panic or not
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum ShouldPanic {

--- a/src/libtest/stats/tests.rs
+++ b/src/libtest/stats/tests.rs
@@ -578,13 +578,13 @@ fn test_sum_f64_between_ints_that_sum_to_0() {
 }
 
 #[bench]
-pub fn sum_three_items(b: &mut Bencher) {
+pub fn sum_three_items(b: &mut Bencher<'_>) {
     b.iter(|| {
         [1e20f64, 1.5f64, -1e20f64].sum();
     })
 }
 #[bench]
-pub fn sum_many_f64(b: &mut Bencher) {
+pub fn sum_many_f64(b: &mut Bencher<'_>) {
     let nums = [-1e30f64, 1e60, 1e30, 1.0, -1e60];
     let v = (0..500).map(|i| nums[i % 5]).collect::<Vec<_>>();
 
@@ -594,4 +594,4 @@ pub fn sum_many_f64(b: &mut Bencher) {
 }
 
 #[bench]
-pub fn no_iter(_: &mut Bencher) {}
+pub fn no_iter(_: &mut Bencher<'_>) {}

--- a/src/libtest/tests.rs
+++ b/src/libtest/tests.rs
@@ -598,13 +598,13 @@ pub fn test_metricmap_compare() {
 
 #[test]
 pub fn test_bench_once_no_iter() {
-    fn f(_: &mut Bencher) {}
+    fn f(_: &mut Bencher<'_>) {}
     bench::run_once(f);
 }
 
 #[test]
 pub fn test_bench_once_iter() {
-    fn f(b: &mut Bencher) {
+    fn f(b: &mut Bencher<'_>) {
         b.iter(|| {})
     }
     bench::run_once(f);
@@ -612,7 +612,7 @@ pub fn test_bench_once_iter() {
 
 #[test]
 pub fn test_bench_no_iter() {
-    fn f(_: &mut Bencher) {}
+    fn f(_: &mut Bencher<'_>) {}
 
     let (tx, rx) = channel();
 
@@ -630,7 +630,7 @@ pub fn test_bench_no_iter() {
 
 #[test]
 pub fn test_bench_iter() {
-    fn f(b: &mut Bencher) {
+    fn f(b: &mut Bencher<'_>) {
         b.iter(|| {})
     }
 

--- a/src/libtest/types.rs
+++ b/src/libtest/types.rs
@@ -76,7 +76,7 @@ impl fmt::Display for TestName {
 
 /// Represents a benchmark function.
 pub trait TDynBenchFn: Send {
-    fn run(&self, harness: &mut Bencher);
+    fn run(&self, harness: &mut Bencher<'_>);
 }
 
 // A function that runs a test. If the function returns successfully,
@@ -85,7 +85,7 @@ pub trait TDynBenchFn: Send {
 // to support isolation of tests into threads.
 pub enum TestFn {
     StaticTestFn(fn()),
-    StaticBenchFn(fn(&mut Bencher)),
+    StaticBenchFn(fn(&mut Bencher<'_>)),
     DynTestFn(Box<dyn FnOnce() + Send>),
     DynBenchFn(Box<dyn TDynBenchFn + 'static>),
 }

--- a/src/test/ui/issues/issue-12997-1.stderr
+++ b/src/test/ui/issues/issue-12997-1.stderr
@@ -1,10 +1,10 @@
-error: functions used as benches must have signature `fn(&mut Bencher) -> impl Termination`
+error: functions used as benches must have signature `fn(&mut Bencher<'_>) -> impl Termination`
   --> $DIR/issue-12997-1.rs:8:1
    |
 LL | fn foo() { }
    | ^^^^^^^^^^^^
 
-error: functions used as benches must have signature `fn(&mut Bencher) -> impl Termination`
+error: functions used as benches must have signature `fn(&mut Bencher<'_>) -> impl Termination`
   --> $DIR/issue-12997-1.rs:11:1
    |
 LL | fn bar(x: isize, y: isize) { }

--- a/src/test/ui/issues/issue-12997-2.stderr
+++ b/src/test/ui/issues/issue-12997-2.stderr
@@ -5,7 +5,7 @@ LL | fn bar(x: isize) { }
    | ^^^^^^^^^^^^^^^^^^^^ expected isize, found mutable reference
    |
    = note: expected type `isize`
-              found type `&mut test::Bencher`
+              found type `&mut test::Bencher<'_>`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This is a first step toward stabilizing it and the `#[bench]` attribute: #66287

To avoid also moving much of the `test` crate `Bencher` is now only responsible for runnning user code and measuring the time it takes, not anymore for doing statistical analysis. This separation is based on `&mut dyn FnMut` callbacks.

This introduces dynamic dispatch, which in general could affect performance characteristics of a program. However I expect benchmarking results not to be affected here since the {`Instant::new`; user code; `Instant::elapsed`} sequence is kept monomorphized and not crossing a dynamic dispatch boundary.

This also adds a lifetime parameter to the `Bencher` struct, which is is technically a breaking change to an unstable type. I expect the impact to be low on existing users: only those with `#[deny(warnings)]` or `#[deny(elided_lifetimes_in_paths)]` would need to change their code. (See second commit.) This lint is `allow` by default.