### PR TITLE
Add a callback that allows compiler consumers to override queries.

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -181,6 +181,7 @@ pub fn run_compiler(
             crate_name: None,
             lint_caps: Default::default(),
             register_lints: None,
+            override_queries: None,
         };
         callbacks.config(&mut config);
         config
@@ -259,6 +260,7 @@ pub fn run_compiler(
         crate_name: None,
         lint_caps: Default::default(),
         register_lints: None,
+        override_queries: None,
     };
 
     callbacks.config(&mut config);

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -786,6 +786,7 @@ pub fn create_global_ctxt(
     let codegen_backend = compiler.codegen_backend().clone();
     let crate_name = crate_name.to_string();
     let defs = mem::take(&mut resolver_outputs.definitions);
+    let override_queries = compiler.override_queries;
 
     let ((), result) = BoxedGlobalCtxt::new(static move || {
         let sess = &*sess;
@@ -809,6 +810,10 @@ pub fn create_global_ctxt(
         let mut extern_providers = local_providers;
         default_provide_extern(&mut extern_providers);
         codegen_backend.provide_extern(&mut extern_providers);
+
+        if let Some(callback) = override_queries {
+            callback(sess, &mut local_providers, &mut extern_providers);
+        }
 
         let gcx = TyCtxt::create_global_ctxt(
             sess,

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -335,6 +335,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
         crate_name,
         lint_caps,
         register_lints: None,
+        override_queries: None,
     };
 
     interface::run_compiler_in_existing_thread_pool(config, |compiler| {

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -79,6 +79,7 @@ pub fn run(options: Options) -> i32 {
         crate_name: options.crate_name.clone(),
         lint_caps: Default::default(),
         register_lints: None,
+        override_queries: None,
     };
 
     let mut test_args = options.test_args.clone();

--- a/src/test/run-make-fulldeps/issue-19371/foo.rs
+++ b/src/test/run-make-fulldeps/issue-19371/foo.rs
@@ -60,6 +60,7 @@ fn compile(code: String, output: PathBuf, sysroot: PathBuf) {
         crate_name: None,
         lint_caps: Default::default(),
         register_lints: None,
+        override_queries: None,
     };
 
     interface::run_compiler(config, |compiler| {


### PR DESCRIPTION
This pull request adds an additional callback that allows compiler consumers such as Prusti and MIRAI to override queries. My hope is that in this way it will be possible to get access to the internal compiler information (e.g. borrow checker) without major changes to the compiler.

This pull request is work in progress because I am still testing if I can get the information which I need.

cc @nikomatsakis 

r? @oli-obk 