### PR TITLE
rustdoc: fixes #64305: disable search field instead of hidding it

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -86,10 +86,11 @@ pub fn render<T: Print, S: Print>(
     </div>\
     <script src=\"{static_root_path}theme{suffix}.js\"></script>\
     <nav class=\"sub\">\
-        <form class=\"search-form js-only\">\
+        <form class=\"search-form\">\
             <div class=\"search-container\">\
                 <div>{filter_crates}\
                     <input class=\"search-input\" name=\"search\" \
+                           disabled \
                            autocomplete=\"off\" \
                            spellcheck=\"false\" \
                            placeholder=\"Click or press ‘S’ to search, ‘?’ for more options…\" \

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -142,10 +142,6 @@ function getSearchElement() {
     var TY_PRIMITIVE = itemTypes.indexOf("primitive");
     var TY_KEYWORD = itemTypes.indexOf("keyword");
 
-    onEachLazy(document.getElementsByClassName("js-only"), function(e) {
-        removeClass(e, "js-only");
-    });
-
     function getQueryStringParams() {
         var params = {};
         window.location.search.substring(1).split("&").
@@ -2626,6 +2622,10 @@ function getSearchElement() {
             option.innerText = crates_text[i];
             elem.appendChild(option);
         }
+
+        if (search_input) {
+            search_input.removeAttribute('disabled');
+        };
     }
 
     window.addSearchOptions = addSearchOptions;

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -197,7 +197,7 @@ nav.sub {
 
 /* Everything else */
 
-.js-only, .hidden {
+.hidden {
 	display: none !important;
 }
 

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -177,6 +177,10 @@ a.test-arrow {
 	border-color: #008dfd;
 }
 
+.search-focus:disabled {
+	background-color: #c5c4c4;
+}
+
 #crate-search + .search-input:focus {
 	box-shadow: 0 0 8px 4px #078dd8;
 }

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -177,6 +177,10 @@ a.test-arrow {
 	border-color: #66afe9;
 }
 
+.search-focus:disabled {
+	background-color: #e6e6e6;
+}
+
 #crate-search + .search-input:focus {
 	box-shadow: 0 0 8px #078dd8;
 }


### PR DESCRIPTION
The result seems to be ok but I wasn't entirely sure how to get there. I tried to stay generic a bit but maybe it's not required at all.

@GuillaumeGomez 

Signed-off-by: Maxime “pep” Buquet <pep@bouah.net>