### PR TITLE
Remove cannot mutate statics in initializer of another static error

### DIFF
--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -326,17 +326,7 @@ impl Visitor<'tcx> for Validator<'_, 'mir, 'tcx> {
                 let is_thread_local = self.tcx.has_attr(*def_id, sym::thread_local);
                 if is_thread_local {
                     self.check_op(ops::ThreadLocalAccess);
-                } else if self.const_kind() == ConstKind::Static && context.is_mutating_use() {
-                    // this is not strictly necessary as miri will also bail out
-                    // For interior mutability we can't really catch this statically as that
-                    // goes through raw pointers and intermediate temporaries, so miri has
-                    // to catch this anyway
-
-                    self.tcx.sess.span_err(
-                        self.span,
-                        "cannot mutate statics in the initializer of another static",
-                    );
-                } else {
+                } else if self.const_kind() != ConstKind::Static || !context.is_mutating_use() {
                     self.check_op(ops::StaticAccess);
                 }
             }

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -782,19 +782,6 @@ impl<'a, 'tcx> Visitor<'tcx> for Checker<'a, 'tcx> {
 
                 // Only allow statics (not consts) to refer to other statics.
                 if self.mode == Mode::Static || self.mode == Mode::StaticMut {
-                    if self.mode == Mode::Static
-                        && context.is_mutating_use()
-                        && !self.suppress_errors
-                    {
-                        // this is not strictly necessary as miri will also bail out
-                        // For interior mutability we can't really catch this statically as that
-                        // goes through raw pointers and intermediate temporaries, so miri has
-                        // to catch this anyway
-                        self.tcx.sess.span_err(
-                            self.span,
-                            "cannot mutate statics in the initializer of another static",
-                        );
-                    }
                     return;
                 }
                 unleash_miri!(self);

--- a/src/test/ui/consts/const-eval/assign-to-static-within-other-static.rs
+++ b/src/test/ui/consts/const-eval/assign-to-static-within-other-static.rs
@@ -7,7 +7,8 @@ use std::cell::UnsafeCell;
 
 static mut FOO: u32 = 42;
 static BOO: () = unsafe {
-    FOO = 5; //~ ERROR cannot mutate statics in the initializer of another static
+    FOO = 5;
+    //~^ could not evaluate static initializer [E0080]
 };
 
 fn main() {}

--- a/src/test/ui/consts/const-eval/assign-to-static-within-other-static.stderr
+++ b/src/test/ui/consts/const-eval/assign-to-static-within-other-static.stderr
@@ -1,8 +1,9 @@
-error: cannot mutate statics in the initializer of another static
+error[E0080]: could not evaluate static initializer
   --> $DIR/assign-to-static-within-other-static.rs:10:5
    |
 LL |     FOO = 5;
-   |     ^^^^^^^
+   |     ^^^^^^^ tried to modify a static's initial value from another static's initializer
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/error-codes/E0017.rs
+++ b/src/test/ui/error-codes/E0017.rs
@@ -4,6 +4,5 @@ const C: i32 = 2;
 const CR: &'static mut i32 = &mut C; //~ ERROR E0017
 static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0017
                                               //~| ERROR cannot borrow
-                                              //~| ERROR cannot mutate statics
 static CONST_REF: &'static mut i32 = &mut C; //~ ERROR E0017
 fn main() {}

--- a/src/test/ui/error-codes/E0017.stderr
+++ b/src/test/ui/error-codes/E0017.stderr
@@ -10,12 +10,6 @@ error[E0017]: references in statics may only refer to immutable values
 LL | static STATIC_REF: &'static mut i32 = &mut X;
    |                                       ^^^^^^ statics require immutable values
 
-error: cannot mutate statics in the initializer of another static
-  --> $DIR/E0017.rs:5:39
-   |
-LL | static STATIC_REF: &'static mut i32 = &mut X;
-   |                                       ^^^^^^
-
 error[E0596]: cannot borrow immutable static item `X` as mutable
   --> $DIR/E0017.rs:5:39
    |
@@ -23,12 +17,12 @@ LL | static STATIC_REF: &'static mut i32 = &mut X;
    |                                       ^^^^^^ cannot borrow as mutable
 
 error[E0017]: references in statics may only refer to immutable values
-  --> $DIR/E0017.rs:8:38
+  --> $DIR/E0017.rs:7:38
    |
 LL | static CONST_REF: &'static mut i32 = &mut C;
    |                                      ^^^^^^ statics require immutable values
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0017, E0596.
 For more information about an error, try `rustc --explain E0017`.

--- a/src/test/ui/error-codes/E0388.rs
+++ b/src/test/ui/error-codes/E0388.rs
@@ -4,7 +4,6 @@ const C: i32 = 2;
 const CR: &'static mut i32 = &mut C; //~ ERROR E0017
 static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0017
                                               //~| ERROR cannot borrow
-                                              //~| ERROR cannot mutate statics
 static CONST_REF: &'static mut i32 = &mut C; //~ ERROR E0017
 
 fn main() {}

--- a/src/test/ui/error-codes/E0388.stderr
+++ b/src/test/ui/error-codes/E0388.stderr
@@ -10,12 +10,6 @@ error[E0017]: references in statics may only refer to immutable values
 LL | static STATIC_REF: &'static mut i32 = &mut X;
    |                                       ^^^^^^ statics require immutable values
 
-error: cannot mutate statics in the initializer of another static
-  --> $DIR/E0388.rs:5:39
-   |
-LL | static STATIC_REF: &'static mut i32 = &mut X;
-   |                                       ^^^^^^
-
 error[E0596]: cannot borrow immutable static item `X` as mutable
   --> $DIR/E0388.rs:5:39
    |
@@ -23,12 +17,12 @@ LL | static STATIC_REF: &'static mut i32 = &mut X;
    |                                       ^^^^^^ cannot borrow as mutable
 
 error[E0017]: references in statics may only refer to immutable values
-  --> $DIR/E0388.rs:8:38
+  --> $DIR/E0388.rs:7:38
    |
 LL | static CONST_REF: &'static mut i32 = &mut C;
    |                                      ^^^^^^ statics require immutable values
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0017, E0596.
 For more information about an error, try `rustc --explain E0017`.


### PR DESCRIPTION
r? @oli-obk

This is just a refactoring. As the removed code itself said, it only a heuristic catching a few cases early instead of leaving it all to const eval. It's easy to work around the static check and then run into the miri-engine check.