### PR TITLE
Use a relative bindir for rustdoc to find rustc

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1231,7 +1231,9 @@ impl<'a> Builder<'a> {
             cargo.arg("--frozen");
         }
 
-        cargo.env("RUSTC_INSTALL_BINDIR", &self.config.bindir);
+        // Try to use a sysroot-relative bindir, in case it was configured absolutely.
+        let bindir = self.config.bindir_relative().unwrap_or(&self.config.bindir);
+        cargo.env("RUSTC_INSTALL_BINDIR", bindir);
 
         self.ci_env.force_coloring_in_ci(&mut cargo);
 

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1232,8 +1232,7 @@ impl<'a> Builder<'a> {
         }
 
         // Try to use a sysroot-relative bindir, in case it was configured absolutely.
-        let bindir = self.config.bindir_relative().unwrap_or(&self.config.bindir);
-        cargo.env("RUSTC_INSTALL_BINDIR", bindir);
+        cargo.env("RUSTC_INSTALL_BINDIR", self.config.bindir_relative());
 
         self.ci_env.force_coloring_in_ci(&mut cargo);
 

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -647,6 +647,17 @@ impl Config {
         config
     }
 
+    /// Try to find the relative path of `bindir`.
+    pub fn bindir_relative(&self) -> Option<&Path> {
+        let bindir = &self.bindir;
+        if bindir.is_relative() {
+            Some(bindir)
+        } else {
+            // Try to make it relative to the prefix.
+            bindir.strip_prefix(self.prefix.as_ref()?).ok()
+        }
+    }
+
     /// Try to find the relative path of `libdir`.
     pub fn libdir_relative(&self) -> Option<&Path> {
         let libdir = self.libdir.as_ref()?;

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -647,15 +647,18 @@ impl Config {
         config
     }
 
-    /// Try to find the relative path of `bindir`.
-    pub fn bindir_relative(&self) -> Option<&Path> {
+    /// Try to find the relative path of `bindir`, otherwise return it in full.
+    pub fn bindir_relative(&self) -> &Path {
         let bindir = &self.bindir;
-        if bindir.is_relative() {
-            Some(bindir)
-        } else {
+        if bindir.is_absolute() {
             // Try to make it relative to the prefix.
-            bindir.strip_prefix(self.prefix.as_ref()?).ok()
+            if let Some(prefix) = &self.prefix {
+                if let Ok(stripped) = bindir.strip_prefix(prefix) {
+                    return stripped;
+                }
+            }
         }
+        bindir
     }
 
     /// Try to find the relative path of `libdir`.


### PR DESCRIPTION
In bootstrap, we set `RUSTC_INSTALL_BINDIR` to `config.bindir`, so
rustdoc can find rustc relative to the toolchain sysroot. However, if a
distro script like Fedora's `%configure` sets an absolute path, then
rustdoc's `sysroot.join(bin_path)` ignores that sysroot altogether.

That would be OK once the toolchain is actually installed, but it breaks
the in-tree doc tests during the build, since `/usr/bin/rustc` is still
the old version. So now we try to make `RUSTC_INSTALL_BINDIR` relative
to the sysroot prefix in the first place.

r? @Mark-Simulacrum 