### PR TITLE
Stabilize Result::map_or_else

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -529,7 +529,6 @@ impl<T, E> Result<T, E> {
     /// Basic usage:
     ///
     /// ```
-    /// #![feature(result_map_or_else)]
     /// let k = 21;
     ///
     /// let x : Result<_, &str> = Ok("foo");
@@ -539,7 +538,7 @@ impl<T, E> Result<T, E> {
     /// assert_eq!(x.map_or_else(|e| k * 2, |v| v.len()), 42);
     /// ```
     #[inline]
-    #[unstable(feature = "result_map_or_else", issue = "53268")]
+    #[stable(feature = "result_map_or_else", since = "1.41.0")]
     pub fn map_or_else<U, D: FnOnce(E) -> U, F: FnOnce(T) -> U>(self, default: D, f: F) -> U {
         match self {
             Ok(t) => f(t),

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -540,8 +540,11 @@ impl<T, E> Result<T, E> {
     /// ```
     #[inline]
     #[unstable(feature = "result_map_or_else", issue = "53268")]
-    pub fn map_or_else<U, M: FnOnce(T) -> U, F: FnOnce(E) -> U>(self, fallback: F, map: M) -> U {
-        self.map(map).unwrap_or_else(fallback)
+    pub fn map_or_else<U, D: FnOnce(E) -> U, F: FnOnce(T) -> U>(self, default: D, f: F) -> U {
+        match self {
+            Ok(t) => f(t),
+            Err(e) => default(e),
+        }
     }
 
     /// Maps a `Result<T, E>` to `Result<T, F>` by applying a function to a


### PR DESCRIPTION
Stabilized this API:
```rust
impl<T, E> Result<T, E> {
    pub fn map_or_else<U, D: FnOnce(E) -> U, F: FnOnce(T) -> U>(self, default: D, f: F) -> U {
        match self {
            Ok(t) => f(t),
            Err(e) => default(e),
        }
    }
}
```

Closes #53268
r? @SimonSapin 