### PR TITLE
Change unused_labels from allow to warn

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -327,7 +327,7 @@ declare_lint! {
 
 declare_lint! {
     pub UNUSED_LABELS,
-    Allow,
+    Warn,
     "detects labels that are never used"
 }
 

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -2557,7 +2557,7 @@ where
                     'descend_newtypes: while !fat_pointer_layout.ty.is_unsafe_ptr()
                         && !fat_pointer_layout.ty.is_region_ptr()
                     {
-                        'iter_fields: for i in 0..fat_pointer_layout.fields.count() {
+                        for i in 0..fat_pointer_layout.fields.count() {
                             let field_layout = fat_pointer_layout.field(cx, i);
 
                             if !field_layout.is_zst() {

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -721,7 +721,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     'descend_newtypes: while !op.layout.ty.is_unsafe_ptr()
                                     && !op.layout.ty.is_region_ptr()
                     {
-                        'iter_fields: for i in 0..op.layout.fields.count() {
+                        for i in 0..op.layout.fields.count() {
                             let field = op.extract_field(&mut bx, i);
                             if !field.layout.is_zst() {
                                 // we found the one non-zero-sized field that is allowed

--- a/src/librustc_mir/borrow_check/nll/type_check/liveness/trace.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/liveness/trace.rs
@@ -249,7 +249,7 @@ impl LivenessResults<'me, 'typeck, 'flow, 'tcx> {
         // Reverse DFS. But for drops, we do it a bit differently.
         // The stack only ever stores *terminators of blocks*. Within
         // a block, we walk back the statements in an inner loop.
-        'next_block: while let Some(term_point) = self.stack.pop() {
+        while let Some(term_point) = self.stack.pop() {
             self.compute_drop_live_points_for_block(mpi, term_point);
         }
     }

--- a/src/libstd/keyword_docs.rs
+++ b/src/libstd/keyword_docs.rs
@@ -57,7 +57,7 @@ mod as_keyword { }
 /// 'outer: for i in 1..=5 {
 ///     println!("outer iteration (i): {}", i);
 ///
-///     'inner: for j in 1..=200 {
+///     '_inner: for j in 1..=200 {
 ///         println!("    inner iteration (j): {}", j);
 ///         if j >= 3 {
 ///             // breaks from inner loop, let's outer loop continue.
@@ -178,7 +178,7 @@ mod const_keyword { }
 ///```rust
 /// // Print Odd numbers under 30 with unit <= 5
 /// 'tens: for ten in 0..3 {
-///     'units: for unit in 0..=9 {
+///     '_units: for unit in 0..=9 {
 ///         if unit % 2 == 0 {
 ///             continue;
 ///         }

--- a/src/test/ui/for-loop-while/label_break_value.rs
+++ b/src/test/ui/for-loop-while/label_break_value.rs
@@ -77,7 +77,7 @@ fn label_break_mixed(v: u32) -> u32 {
         }
         // Labeled breaking an outer loop still works
         'd: loop {
-            'e: {
+            {
                 if v == r {
                     break 'b;
                 }

--- a/src/test/ui/for-loop-while/loop-label-shadowing.rs
+++ b/src/test/ui/for-loop-while/loop-label-shadowing.rs
@@ -5,6 +5,7 @@
 
 fn main() {
     let mut foo = Vec::new();
+    #[allow(unused_labels)]
     'foo: for i in &[1, 2, 3] {
         foo.push(*i);
     }

--- a/src/test/ui/hygiene/hygienic-labels-in-let.rs
+++ b/src/test/ui/hygiene/hygienic-labels-in-let.rs
@@ -1,5 +1,6 @@
 // run-pass
 #![allow(unreachable_code)]
+#![allow(unused_labels)]
 
 // Test that labels injected by macros do not break hygiene.  This
 // checks cases where the macros invocations are under the rhs of a

--- a/src/test/ui/hygiene/hygienic-labels-in-let.stderr
+++ b/src/test/ui/hygiene/hygienic-labels-in-let.stderr
@@ -1,5 +1,5 @@
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:15:9
+  --> $DIR/hygienic-labels-in-let.rs:16:9
    |
 LL |         'x: loop { $e }
    |         ^^ lifetime 'x already in scope
@@ -11,7 +11,7 @@ LL |             loop_x!(break 'x);
    |             ------------------ in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:63:9
+  --> $DIR/hygienic-labels-in-let.rs:64:9
    |
 LL |         'x: loop {
    |         -- first declared here
@@ -20,7 +20,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:63:9
+  --> $DIR/hygienic-labels-in-let.rs:64:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -29,7 +29,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:15:9
+  --> $DIR/hygienic-labels-in-let.rs:16:9
    |
 LL |         'x: loop { $e }
    |         ^^ lifetime 'x already in scope
@@ -41,7 +41,7 @@ LL |             loop_x!(break 'x);
    |             ------------------ in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:15:9
+  --> $DIR/hygienic-labels-in-let.rs:16:9
    |
 LL |         'x: loop { $e }
    |         ^^
@@ -53,7 +53,7 @@ LL |             loop_x!(break 'x);
    |             ------------------ in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:15:9
+  --> $DIR/hygienic-labels-in-let.rs:16:9
    |
 LL |         'x: loop { $e }
    |         ^^ lifetime 'x already in scope
@@ -65,7 +65,7 @@ LL |             loop_x!(break 'x);
    |             ------------------ in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:75:9
+  --> $DIR/hygienic-labels-in-let.rs:76:9
    |
 LL |         'x: loop {
    |         -- first declared here
@@ -74,7 +74,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:75:9
+  --> $DIR/hygienic-labels-in-let.rs:76:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -83,7 +83,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:75:9
+  --> $DIR/hygienic-labels-in-let.rs:76:9
    |
 LL |         'x: for _ in 0..1 {
    |         -- first declared here
@@ -92,7 +92,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:75:9
+  --> $DIR/hygienic-labels-in-let.rs:76:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -101,7 +101,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:26:9
+  --> $DIR/hygienic-labels-in-let.rs:27:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ lifetime 'x already in scope
@@ -113,7 +113,7 @@ LL |             while_true!(break 'x);
    |             ---------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:26:9
+  --> $DIR/hygienic-labels-in-let.rs:27:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -125,7 +125,7 @@ LL |             while_true!(break 'x);
    |             ---------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:26:9
+  --> $DIR/hygienic-labels-in-let.rs:27:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ lifetime 'x already in scope
@@ -137,7 +137,7 @@ LL |             while_true!(break 'x);
    |             ---------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:26:9
+  --> $DIR/hygienic-labels-in-let.rs:27:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -149,7 +149,7 @@ LL |             while_true!(break 'x);
    |             ---------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:26:9
+  --> $DIR/hygienic-labels-in-let.rs:27:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ lifetime 'x already in scope
@@ -161,7 +161,7 @@ LL |             while_true!(break 'x);
    |             ---------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:89:9
+  --> $DIR/hygienic-labels-in-let.rs:90:9
    |
 LL |         'x: loop {
    |         -- first declared here
@@ -170,7 +170,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:89:9
+  --> $DIR/hygienic-labels-in-let.rs:90:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -179,7 +179,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:89:9
+  --> $DIR/hygienic-labels-in-let.rs:90:9
    |
 LL |         'x: for _ in 0..1 {
    |         -- first declared here
@@ -188,7 +188,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:89:9
+  --> $DIR/hygienic-labels-in-let.rs:90:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -197,7 +197,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:89:9
+  --> $DIR/hygienic-labels-in-let.rs:90:9
    |
 LL |         'x: for _ in 0..1 {
    |         -- first declared here
@@ -206,7 +206,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:89:9
+  --> $DIR/hygienic-labels-in-let.rs:90:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         -- first declared here
@@ -215,7 +215,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:38:9
+  --> $DIR/hygienic-labels-in-let.rs:39:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
@@ -227,7 +227,7 @@ LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:38:9
+  --> $DIR/hygienic-labels-in-let.rs:39:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -239,7 +239,7 @@ LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:38:9
+  --> $DIR/hygienic-labels-in-let.rs:39:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
@@ -251,7 +251,7 @@ LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:38:9
+  --> $DIR/hygienic-labels-in-let.rs:39:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -263,7 +263,7 @@ LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:38:9
+  --> $DIR/hygienic-labels-in-let.rs:39:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
@@ -275,7 +275,7 @@ LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:38:9
+  --> $DIR/hygienic-labels-in-let.rs:39:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         -- first declared here
@@ -287,7 +287,7 @@ LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:38:9
+  --> $DIR/hygienic-labels-in-let.rs:39:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope

--- a/src/test/ui/hygiene/hygienic-labels.rs
+++ b/src/test/ui/hygiene/hygienic-labels.rs
@@ -1,5 +1,6 @@
 // run-pass
 #![allow(unreachable_code)]
+#![allow(unused_labels)]
 // Test that labels injected by macros do not break hygiene.
 
 // Issue #24278: The label/lifetime shadowing checker from #24162

--- a/src/test/ui/hygiene/hygienic-labels.stderr
+++ b/src/test/ui/hygiene/hygienic-labels.stderr
@@ -1,5 +1,5 @@
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:12:9
+  --> $DIR/hygienic-labels.rs:13:9
    |
 LL |         'x: loop { $e }
    |         ^^ lifetime 'x already in scope
@@ -11,7 +11,7 @@ LL |         loop_x!(break 'x);
    |         ------------------ in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:53:5
+  --> $DIR/hygienic-labels.rs:54:5
    |
 LL |     'x: for _ in 0..1 {
    |     -- first declared here
@@ -20,7 +20,7 @@ LL |     'x: loop {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:53:5
+  --> $DIR/hygienic-labels.rs:54:5
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -29,7 +29,7 @@ LL |     'x: loop {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:12:9
+  --> $DIR/hygienic-labels.rs:13:9
    |
 LL |         'x: loop { $e }
    |         ^^ lifetime 'x already in scope
@@ -41,7 +41,7 @@ LL |         loop_x!(break 'x);
    |         ------------------ in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:12:9
+  --> $DIR/hygienic-labels.rs:13:9
    |
 LL |         'x: loop { $e }
    |         ^^
@@ -53,7 +53,7 @@ LL |         loop_x!(break 'x);
    |         ------------------ in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:12:9
+  --> $DIR/hygienic-labels.rs:13:9
    |
 LL |         'x: loop { $e }
    |         ^^ lifetime 'x already in scope
@@ -65,7 +65,7 @@ LL |         loop_x!(break 'x);
    |         ------------------ in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:62:5
+  --> $DIR/hygienic-labels.rs:63:5
    |
 LL |     'x: for _ in 0..1 {
    |     -- first declared here
@@ -74,7 +74,7 @@ LL |     'x: while 1 + 1 == 2 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:62:5
+  --> $DIR/hygienic-labels.rs:63:5
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -83,7 +83,7 @@ LL |     'x: while 1 + 1 == 2 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:62:5
+  --> $DIR/hygienic-labels.rs:63:5
    |
 LL |     'x: loop {
    |     -- first declared here
@@ -92,7 +92,7 @@ LL |     'x: while 1 + 1 == 2 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:62:5
+  --> $DIR/hygienic-labels.rs:63:5
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -101,7 +101,7 @@ LL |     'x: while 1 + 1 == 2 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:37:9
+  --> $DIR/hygienic-labels.rs:38:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ lifetime 'x already in scope
@@ -113,7 +113,7 @@ LL |         while_x!(break 'x);
    |         ------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:37:9
+  --> $DIR/hygienic-labels.rs:38:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -125,7 +125,7 @@ LL |         while_x!(break 'x);
    |         ------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:37:9
+  --> $DIR/hygienic-labels.rs:38:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ lifetime 'x already in scope
@@ -137,7 +137,7 @@ LL |         while_x!(break 'x);
    |         ------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:37:9
+  --> $DIR/hygienic-labels.rs:38:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -149,7 +149,7 @@ LL |         while_x!(break 'x);
    |         ------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:37:9
+  --> $DIR/hygienic-labels.rs:38:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ lifetime 'x already in scope
@@ -161,7 +161,7 @@ LL |         while_x!(break 'x);
    |         ------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:72:5
+  --> $DIR/hygienic-labels.rs:73:5
    |
 LL |     'x: for _ in 0..1 {
    |     -- first declared here
@@ -170,7 +170,7 @@ LL |     'x: for _ in 0..1 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:72:5
+  --> $DIR/hygienic-labels.rs:73:5
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -179,7 +179,7 @@ LL |     'x: for _ in 0..1 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:72:5
+  --> $DIR/hygienic-labels.rs:73:5
    |
 LL |     'x: loop {
    |     -- first declared here
@@ -188,7 +188,7 @@ LL |     'x: for _ in 0..1 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:72:5
+  --> $DIR/hygienic-labels.rs:73:5
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -197,7 +197,7 @@ LL |     'x: for _ in 0..1 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:72:5
+  --> $DIR/hygienic-labels.rs:73:5
    |
 LL |     'x: while 1 + 1 == 2 {
    |     -- first declared here
@@ -206,7 +206,7 @@ LL |     'x: for _ in 0..1 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:72:5
+  --> $DIR/hygienic-labels.rs:73:5
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         -- first declared here
@@ -215,7 +215,7 @@ LL |     'x: for _ in 0..1 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:23:9
+  --> $DIR/hygienic-labels.rs:24:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
@@ -227,7 +227,7 @@ LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:23:9
+  --> $DIR/hygienic-labels.rs:24:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -239,7 +239,7 @@ LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:23:9
+  --> $DIR/hygienic-labels.rs:24:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
@@ -251,7 +251,7 @@ LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:23:9
+  --> $DIR/hygienic-labels.rs:24:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -263,7 +263,7 @@ LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:23:9
+  --> $DIR/hygienic-labels.rs:24:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
@@ -275,7 +275,7 @@ LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:23:9
+  --> $DIR/hygienic-labels.rs:24:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
@@ -287,7 +287,7 @@ LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:23:9
+  --> $DIR/hygienic-labels.rs:24:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope

--- a/src/test/ui/issues/issue-2216.rs
+++ b/src/test/ui/issues/issue-2216.rs
@@ -5,7 +5,7 @@ pub fn main() {
 
     'foo: loop {
         'bar: loop {
-            'quux: loop {
+            loop {
                 if 1 == 2 {
                     break 'foo;
                 }

--- a/src/test/ui/macros/macro-lifetime-used-with-labels.rs
+++ b/src/test/ui/macros/macro-lifetime-used-with-labels.rs
@@ -1,6 +1,6 @@
 // run-pass
 #![allow(stable_features)]
-
+#![allow(unused_labels)]
 #![allow(unreachable_code)]
 
 macro_rules! x {


### PR DESCRIPTION
Fixes #66324, making the unused_labels lint warn instead of allow by default. I'm told @rust-lang/lang will need to review this, and perhaps will want to do a crater run.