### PR TITLE
Refactor integer range handling in the usefulness algorithm

### DIFF
--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -1282,11 +1282,10 @@ impl<'tcx> IntRange<'tcx> {
         (*self.range.start(), *self.range.end())
     }
 
-    fn should_treat_range_exhaustively(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> bool {
+    fn treat_exhaustively(&self, tcx: TyCtxt<'tcx>) -> bool {
         // Don't treat `usize`/`isize` exhaustively unless the `precise_pointer_size_matching`
         // feature is enabled.
-        IntRange::is_integral(ty)
-            && (!ty.is_ptr_sized_integral() || tcx.features().precise_pointer_size_matching)
+        !self.ty.is_ptr_sized_integral() || tcx.features().precise_pointer_size_matching
     }
 
     #[inline]
@@ -1414,7 +1413,7 @@ impl<'tcx> IntRange<'tcx> {
         let ty = self.ty;
         let (lo, hi) = self.boundaries();
         let (other_lo, other_hi) = other.boundaries();
-        if Self::should_treat_range_exhaustively(tcx, ty) {
+        if self.treat_exhaustively(tcx) {
             if lo <= other_hi && other_lo <= hi {
                 let span = other.span;
                 Some(IntRange { range: max(lo, other_lo)..=min(hi, other_hi), ty, span })
@@ -1881,7 +1880,7 @@ fn split_grouped_constructors<'p, 'tcx>(
 
     for ctor in ctors.into_iter() {
         match ctor {
-            IntRange(ctor_range) if IntRange::should_treat_range_exhaustively(tcx, ty) => {
+            IntRange(ctor_range) if ctor_range.treat_exhaustively(tcx) => {
                 // Fast-track if the range is trivial. In particular, don't do the overlapping
                 // ranges check.
                 if ctor_range.is_singleton() {

--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -737,7 +737,7 @@ impl<'tcx> Constructor<'tcx> {
 
     /// This returns one wildcard pattern for each argument to this constructor.
     ///
-    /// This must be consistent with `apply`, `specialize_one_pattern` and `arity`.
+    /// This must be consistent with `apply`, `specialize_one_pattern`, and `arity`.
     fn wildcard_subpatterns<'a>(
         &self,
         cx: &MatchCheckCtxt<'a, 'tcx>,
@@ -815,7 +815,7 @@ impl<'tcx> Constructor<'tcx> {
     /// For instance, a tuple pattern `(_, 42, Some([]))` has the arity of 3.
     /// A struct pattern's arity is the number of fields it contains, etc.
     ///
-    /// This must be consistent with `wildcard_subpatterns`, `specialize_one_pattern` and `apply`.
+    /// This must be consistent with `wildcard_subpatterns`, `specialize_one_pattern`, and `apply`.
     fn arity<'a>(&self, cx: &MatchCheckCtxt<'a, 'tcx>, ty: Ty<'tcx>) -> u64 {
         debug!("Constructor::arity({:#?}, {:?})", self, ty);
         match self {
@@ -837,7 +837,7 @@ impl<'tcx> Constructor<'tcx> {
     /// Apply a constructor to a list of patterns, yielding a new pattern. `pats`
     /// must have as many elements as this constructor's arity.
     ///
-    /// This must be consistent with `wildcard_subpatterns`, `specialize_one_pattern` and `arity`.
+    /// This must be consistent with `wildcard_subpatterns`, `specialize_one_pattern`, and `arity`.
     ///
     /// Examples:
     /// `self`: `Constructor::Single`
@@ -1369,7 +1369,7 @@ impl<'tcx> IntRange<'tcx> {
                 None
             }
         } else {
-            // If the range sould not be treated exhaustively, fallback to checking for inclusion.
+            // If the range should not be treated exhaustively, fallback to checking for inclusion.
             if other_lo <= lo && hi <= other_hi { Some(self.clone()) } else { None }
         }
     }

--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -313,10 +313,11 @@ impl PatternFolder<'tcx> for LiteralExpander<'tcx> {
             (
                 &ty::Ref(_, rty, _),
                 &PatKind::Constant {
-                    value: Const {
-                        val: ty::ConstKind::Value(val),
-                        ty: ty::TyS { kind: ty::Ref(_, crty, _), .. }
-                    },
+                    value:
+                        Const {
+                            val: ty::ConstKind::Value(val),
+                            ty: ty::TyS { kind: ty::Ref(_, crty, _), .. },
+                        },
                 },
             ) => Pat {
                 ty: pat.ty,
@@ -328,7 +329,7 @@ impl PatternFolder<'tcx> for LiteralExpander<'tcx> {
                         kind: box PatKind::Constant {
                             value: self.tcx.mk_const(Const {
                                 val: ty::ConstKind::Value(
-                                    self.fold_const_value_deref(*val, rty, crty)
+                                    self.fold_const_value_deref(*val, rty, crty),
                                 ),
                                 ty: rty,
                             }),
@@ -1314,9 +1315,9 @@ impl<'tcx> IntRange<'tcx> {
     ) -> Option<IntRange<'tcx>> {
         if let Some((target_size, bias)) = Self::integral_size_and_signed_bias(tcx, value.ty) {
             let ty = value.ty;
-            let val = if let ty::ConstKind::Value(ConstValue::Scalar(
-                Scalar::Raw { data, size }
-            )) = value.val {
+            let val = if let ty::ConstKind::Value(ConstValue::Scalar(Scalar::Raw { data, size })) =
+                value.val
+            {
                 // For this specific pattern we can skip a lot of effort and go
                 // straight to the result, after doing a bit of checking. (We
                 // could remove this branch and just use the next branch, which
@@ -2069,10 +2070,10 @@ fn split_grouped_constructors<'p, 'tcx>(
                                     max_fixed_len =
                                         cmp::max(max_fixed_len, n.eval_usize(tcx, param_env))
                                 }
-                                (ty::ConstKind::Value(ConstValue::Slice { start, end, .. }),
-                                 ty::Slice(_)) => {
-                                    max_fixed_len = cmp::max(max_fixed_len, (end - start) as u64)
-                                }
+                                (
+                                    ty::ConstKind::Value(ConstValue::Slice { start, end, .. }),
+                                    ty::Slice(_),
+                                ) => max_fixed_len = cmp::max(max_fixed_len, (end - start) as u64),
                                 _ => {}
                             }
                         }

--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -590,7 +590,10 @@ enum Constructor<'tcx> {
     Variant(DefId),
     /// Literal values.
     ConstantValue(&'tcx ty::Const<'tcx>, Span),
-    /// Ranges of literal values (`2..=5` and `2..5`).
+    /// Ranges of integer literal values (`2`, `2..=5` or `2..5`).
+    IntRange(IntRange<'tcx>),
+    // TODO: non-integer
+    /// Ranges of literal values (`2.0..=5.2`).
     ConstantRange(u128, u128, Ty<'tcx>, RangeEnd, Span),
     /// Array patterns of length `n`.
     FixedLenSlice(u64),
@@ -612,6 +615,7 @@ impl<'tcx> std::cmp::PartialEq for Constructor<'tcx> {
                 Constructor::ConstantRange(a_start, a_end, a_ty, a_range_end, _),
                 Constructor::ConstantRange(b_start, b_end, b_ty, b_range_end, _),
             ) => a_start == b_start && a_end == b_end && a_ty == b_ty && a_range_end == b_range_end,
+            (Constructor::IntRange(a), Constructor::IntRange(b)) => a == b,
             (Constructor::FixedLenSlice(a), Constructor::FixedLenSlice(b)) => a == b,
             (
                 Constructor::VarLenSlice(a_prefix, a_suffix),
@@ -634,6 +638,7 @@ impl<'tcx> Constructor<'tcx> {
         let ty = match self {
             ConstantValue(value, _) => value.ty,
             ConstantRange(_, _, ty, _, _) => ty,
+            IntRange(_) => return true,
             _ => return false,
         };
         IntRange::is_integral(ty)
@@ -743,7 +748,7 @@ impl<'tcx> Constructor<'tcx> {
 
                 remaining_ctors
             }
-            ConstantRange(..) | ConstantValue(..) => {
+            IntRange(..) | ConstantRange(..) | ConstantValue(..) => {
                 if let Some(self_range) = IntRange::from_ctor(tcx, param_env, self) {
                     let mut remaining_ranges = vec![self_range.clone()];
                     let other_ranges = other_ctors
@@ -767,7 +772,7 @@ impl<'tcx> Constructor<'tcx> {
                     }
 
                     // Convert the ranges back into constructors
-                    remaining_ranges.into_iter().map(|range| range.into_ctor(tcx)).collect()
+                    remaining_ranges.into_iter().map(IntRange).collect()
                 } else {
                     if other_ctors.iter().any(|c| {
                         c == self
@@ -855,7 +860,7 @@ impl<'tcx> Constructor<'tcx> {
                 }
                 _ => bug!("bad slice pattern {:?} {:?}", self, ty),
             },
-            ConstantValue(..) | ConstantRange(..) | NonExhaustive => vec![],
+            ConstantValue(..) | ConstantRange(..) | IntRange(..) | NonExhaustive => vec![],
         }
     }
 
@@ -880,7 +885,7 @@ impl<'tcx> Constructor<'tcx> {
             },
             FixedLenSlice(length) => *length,
             VarLenSlice(prefix, suffix) => prefix + suffix,
-            ConstantValue(..) | ConstantRange(..) | NonExhaustive => 0,
+            ConstantValue(..) | ConstantRange(..) | IntRange(..) | NonExhaustive => 0,
         }
     }
 
@@ -949,6 +954,10 @@ impl<'tcx> Constructor<'tcx> {
                 hi: ty::Const::from_bits(cx.tcx, hi, ty::ParamEnv::empty().and(ty)),
                 end,
             }),
+            IntRange(range) => {
+                // TODO: do it more directly
+                return range.clone().into_ctor(cx.tcx).apply(cx, ty, None.into_iter());
+            }
             NonExhaustive => PatKind::Wild,
         };
 
@@ -1145,7 +1154,14 @@ fn all_constructors<'a, 'tcx>(
     pcx: PatCtxt<'tcx>,
 ) -> Vec<Constructor<'tcx>> {
     debug!("all_constructors({:?})", pcx.ty);
-    let make_range = |start, end| ConstantRange(start, end, pcx.ty, RangeEnd::Included, pcx.span);
+    let make_range = |start, end| {
+        IntRange(
+            // `unwrap()` is ok because we know the type is an integer and the range is
+            // well-formed.
+            IntRange::from_range(cx.tcx, start, end, pcx.ty, &RangeEnd::Included, pcx.span)
+                .unwrap(),
+        )
+    };
     match pcx.ty.kind {
         ty::Bool => [true, false]
             .iter()
@@ -1356,6 +1372,7 @@ impl<'tcx> IntRange<'tcx> {
         match ctor {
             ConstantRange(lo, hi, ty, end, span) => Self::from_range(tcx, *lo, *hi, ty, end, *span),
             ConstantValue(val, span) => Self::from_const(tcx, param_env, val, *span),
+            IntRange(range) => Some(range.clone()),
             _ => None,
         }
     }
@@ -1381,6 +1398,7 @@ impl<'tcx> IntRange<'tcx> {
     }
 
     /// Converts an `IntRange` to a `ConstantValue` or inclusive `ConstantRange`.
+    /// TODO: Deprecated
     fn into_ctor(self, tcx: TyCtxt<'tcx>) -> Constructor<'tcx> {
         let bias = IntRange::signed_bias(tcx, self.ty);
         let (lo, hi) = self.range.into_inner();
@@ -1889,7 +1907,9 @@ fn split_grouped_constructors<'p, 'tcx>(
 
     for ctor in ctors.into_iter() {
         match ctor {
-            ConstantRange(..) if IntRange::should_treat_range_exhaustively(tcx, ty) => {
+            IntRange(..) | ConstantRange(..)
+                if IntRange::should_treat_range_exhaustively(tcx, ty) =>
+            {
                 // We only care about finding all the subranges within the range of the constructor
                 // range. Anything else is irrelevant, because it is guaranteed to result in
                 // `NotUseful`, which is the default case anyway, and can be ignored.
@@ -1968,7 +1988,7 @@ fn split_grouped_constructors<'p, 'tcx>(
                             }
                             (Border::AfterMax, _) => None,
                         })
-                        .map(|range| range.into_ctor(tcx)),
+                        .map(IntRange),
                 );
             }
             VarLenSlice(self_prefix, self_suffix) => {

--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -611,13 +611,6 @@ impl<'tcx> Constructor<'tcx> {
         }
     }
 
-    fn is_integral_range(&self) -> bool {
-        match self {
-            IntRange(_) => return true,
-            _ => return false,
-        };
-    }
-
     fn variant_index_for_adt<'a>(
         &self,
         cx: &MatchCheckCtxt<'a, 'tcx>,
@@ -639,12 +632,8 @@ impl<'tcx> Constructor<'tcx> {
     fn subtract_ctors(&self, other_ctors: &Vec<Constructor<'tcx>>) -> Vec<Constructor<'tcx>> {
         match self {
             // Those constructors can only match themselves.
-            Single | Variant(_) => {
-                if other_ctors.iter().any(|c| c == self) {
-                    vec![]
-                } else {
-                    vec![self.clone()]
-                }
+            Single | Variant(_) | ConstantValue(..) | ConstantRange(..) => {
+                if other_ctors.iter().any(|c| c == self) { vec![] } else { vec![self.clone()] }
             }
             &FixedLenSlice(self_len) => {
                 let overlaps = |c: &Constructor<'_>| match *c {
@@ -740,17 +729,6 @@ impl<'tcx> Constructor<'tcx> {
 
                 // Convert the ranges back into constructors
                 remaining_ranges.into_iter().map(IntRange).collect()
-            }
-            ConstantRange(..) | ConstantValue(..) => {
-                if other_ctors.iter().any(|c| {
-                    c == self
-                        // FIXME(Nadrieril): This condition looks fishy
-                        || c.is_integral_range()
-                }) {
-                    vec![]
-                } else {
-                    vec![self.clone()]
-                }
             }
             // This constructor is never covered by anything else
             NonExhaustive => vec![NonExhaustive],

--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -786,6 +786,8 @@ impl<'tcx> Constructor<'tcx> {
     }
 
     /// This returns one wildcard pattern for each argument to this constructor.
+    ///
+    /// This must be consistent with `apply`, `specialize_one_pattern` and `arity`.
     fn wildcard_subpatterns<'a>(
         &self,
         cx: &MatchCheckCtxt<'a, 'tcx>,
@@ -862,6 +864,8 @@ impl<'tcx> Constructor<'tcx> {
     ///
     /// For instance, a tuple pattern `(_, 42, Some([]))` has the arity of 3.
     /// A struct pattern's arity is the number of fields it contains, etc.
+    ///
+    /// This must be consistent with `wildcard_subpatterns`, `specialize_one_pattern` and `apply`.
     fn arity<'a>(&self, cx: &MatchCheckCtxt<'a, 'tcx>, ty: Ty<'tcx>) -> u64 {
         debug!("Constructor::arity({:#?}, {:?})", self, ty);
         match self {
@@ -882,6 +886,8 @@ impl<'tcx> Constructor<'tcx> {
 
     /// Apply a constructor to a list of patterns, yielding a new pattern. `pats`
     /// must have as many elements as this constructor's arity.
+    ///
+    /// This must be consistent with `wildcard_subpatterns`, `specialize_one_pattern` and `arity`.
     ///
     /// Examples:
     /// `self`: `Constructor::Single`

--- a/src/test/ui/pattern/usefulness/exhaustive_integer_patterns.rs
+++ b/src/test/ui/pattern/usefulness/exhaustive_integer_patterns.rs
@@ -163,4 +163,10 @@ fn main() {
         BAR => {} // Not detected as unreachable because `try_eval_bits` fails on `BAR`.
         _ => {}
     }
+
+    // Regression test, see https://github.com/rust-lang/rust/pull/66326#issuecomment-552889933
+    match &0 {
+        BAR => {} // ok
+        _ => {}
+    }
 }

--- a/src/test/ui/pattern/usefulness/exhaustive_integer_patterns.rs
+++ b/src/test/ui/pattern/usefulness/exhaustive_integer_patterns.rs
@@ -154,4 +154,13 @@ fn main() {
     match 0u128 { //~ ERROR non-exhaustive patterns
         4 ..= u128::MAX => {}
     }
+
+    const FOO: i32 = 42;
+    const BAR: &i32 = &42;
+    match &0 {
+        &42 => {}
+        &FOO => {} //~ ERROR unreachable pattern
+        BAR => {} // not detected as unreachable because `try_eval_bits` fails on BAR
+        _ => {}
+    }
 }

--- a/src/test/ui/pattern/usefulness/exhaustive_integer_patterns.rs
+++ b/src/test/ui/pattern/usefulness/exhaustive_integer_patterns.rs
@@ -160,7 +160,7 @@ fn main() {
     match &0 {
         &42 => {}
         &FOO => {} //~ ERROR unreachable pattern
-        BAR => {} // not detected as unreachable because `try_eval_bits` fails on BAR
+        BAR => {} // Not detected as unreachable because `try_eval_bits` fails on `BAR`.
         _ => {}
     }
 }

--- a/src/test/ui/pattern/usefulness/exhaustive_integer_patterns.stderr
+++ b/src/test/ui/pattern/usefulness/exhaustive_integer_patterns.stderr
@@ -118,6 +118,12 @@ LL |     match 0u128 {
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
-error: aborting due to 14 previous errors
+error: unreachable pattern
+  --> $DIR/exhaustive_integer_patterns.rs:162:9
+   |
+LL |         &FOO => {}
+   |         ^^^^
+
+error: aborting due to 15 previous errors
 
 For more information about this error, try `rustc --explain E0004`.


### PR DESCRIPTION
Integer range handling had accumulated a lot of debt. This cleans up a lot of it.

In particular this:
- removes unnecessary conversions between `Const` and `u128`, and between `Constructor` and `IntRange`
- clearly distinguishes between on the one hand ranges of integers that may or may not be matched exhaustively, and on the other hand ranges of non-integers that are never matched exhaustively and are compared using Const-based shenanigans
- cleans up some overly complicated code paths
- generally tries to be more idiomatic.

As a nice side-effect, I measured a 10% perf increase on `unicode_normalization`.

There's one thing that I feel remains to clean up: the [overlapping range check](https://github.com/rust-lang/rust/pull/64007), which is currently quite ad-hoc. But that is intricate enough that I'm leaving it out of this PR.

There's also one little thing I'm not sure I understand: can `try_eval_bits` fail for an integer constant value in that code ? What would that mean, and how do I construct a test case for this possibility ?