### PR TITLE
Adjust cannot move out of static error in prep for removing Statics from Place

### DIFF
--- a/src/librustc_mir/borrow_check/move_errors.rs
+++ b/src/librustc_mir/borrow_check/move_errors.rs
@@ -242,7 +242,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
             (
                 match kind {
                     IllegalMoveOriginKind::Static => {
-                        self.report_cannot_move_from_static(original_path, span)
+                        self.cannot_move_out_of(span, "an immutable place")
                     }
                     IllegalMoveOriginKind::BorrowedContent { target_place } => {
                         self.report_cannot_move_from_borrowed_content(
@@ -265,29 +265,6 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
 
         self.add_move_hints(error, &mut err, err_span);
         err.buffer(&mut self.errors_buffer);
-    }
-
-    fn report_cannot_move_from_static(
-        &mut self,
-        place: &Place<'tcx>,
-        span: Span
-    ) -> DiagnosticBuilder<'a> {
-        let description = if place.projection.is_empty() {
-            format!("static item `{}`", self.describe_place(place.as_ref()).unwrap())
-        } else {
-            let base_static = PlaceRef {
-                base: &place.base,
-                projection: &place.projection[..1],
-            };
-
-            format!(
-                "`{:?}` as `{:?}` is a static item",
-                self.describe_place(place.as_ref()).unwrap(),
-                self.describe_place(base_static).unwrap(),
-            )
-        };
-
-        self.cannot_move_out_of(span, &description)
     }
 
     fn report_cannot_move_from_borrowed_content(

--- a/src/test/ui/borrowck/borrowck-move-out-of-static-item.rs
+++ b/src/test/ui/borrowck/borrowck-move-out-of-static-item.rs
@@ -12,5 +12,5 @@ fn test(f: Foo) {
 }
 
 fn main() {
-    test(BAR); //~ ERROR cannot move out of static item `BAR` [E0507]
+    test(BAR); //~ ERROR cannot move out of an immutable place [E0507]
 }

--- a/src/test/ui/borrowck/borrowck-move-out-of-static-item.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-of-static-item.stderr
@@ -1,4 +1,4 @@
-error[E0507]: cannot move out of static item `BAR`
+error[E0507]: cannot move out of an immutable place
   --> $DIR/borrowck-move-out-of-static-item.rs:15:10
    |
 LL |     test(BAR);

--- a/src/test/ui/borrowck/issue-47215-ice-from-drop-elab.rs
+++ b/src/test/ui/borrowck/issue-47215-ice-from-drop-elab.rs
@@ -2,8 +2,8 @@
 // thread-local statics as a temporary rvalue, as a way to enforce
 // that they are only valid for a given lifetime.
 //
-// The problem with this is that you cannot move out of static items,
-// but you *can* move temporary rvalues. I.e., the categorization
+// The problem with this is that you cannot move out of an immutable
+// place but you *can* move temporary rvalues. I.e., the categorization
 // above only solves half of the problem presented by thread-local
 // statics.
 
@@ -14,7 +14,7 @@ static mut X: ::std::sync::atomic::AtomicUsize = ::std::sync::atomic::AtomicUsiz
 
 fn main() {
     unsafe {
-        let mut x = X; //~ ERROR cannot move out of static item `X` [E0507]
+        let mut x = X; //~ ERROR cannot move out of an immutable place [E0507]
         let _y = x.get_mut();
     }
 }

--- a/src/test/ui/borrowck/issue-47215-ice-from-drop-elab.stderr
+++ b/src/test/ui/borrowck/issue-47215-ice-from-drop-elab.stderr
@@ -1,4 +1,4 @@
-error[E0507]: cannot move out of static item `X`
+error[E0507]: cannot move out of an immutable place
   --> $DIR/issue-47215-ice-from-drop-elab.rs:17:21
    |
 LL |         let mut x = X;

--- a/src/test/ui/borrowck/issue-64453.rs
+++ b/src/test/ui/borrowck/issue-64453.rs
@@ -13,7 +13,7 @@ fn set_editor(_: Value) {}
 
 fn main() {
     let settings_data = from_string(settings_dir);
-    //~^ ERROR cannot move out of static item `settings_dir` [E0507]
+    //~^ ERROR cannot move out of an immutable place [E0507]
     let args: i32 = 0;
 
     match args {

--- a/src/test/ui/borrowck/issue-64453.stderr
+++ b/src/test/ui/borrowck/issue-64453.stderr
@@ -1,4 +1,4 @@
-error[E0507]: cannot move out of static item `settings_dir`
+error[E0507]: cannot move out of an immutable place
   --> $DIR/issue-64453.rs:15:37
    |
 LL |     let settings_data = from_string(settings_dir);

--- a/src/test/ui/borrowck/move-error-snippets.stderr
+++ b/src/test/ui/borrowck/move-error-snippets.stderr
@@ -1,4 +1,4 @@
-error[E0507]: cannot move out of static item `D`
+error[E0507]: cannot move out of an immutable place
   --> $DIR/move-error-snippets.rs:16:18
    |
 LL | | #[macro_use]

--- a/src/test/ui/check-static-values-constraints.rs
+++ b/src/test/ui/check-static-values-constraints.rs
@@ -115,6 +115,6 @@ static STATIC19: Box<isize> =
 pub fn main() {
     let y = { static x: Box<isize> = box 3; x };
     //~^ ERROR allocations are not allowed in statics
-    //~| ERROR cannot move out of static item
+    //~| ERROR cannot move out of an immutable place
     //~| ERROR contains unimplemented expression
 }

--- a/src/test/ui/check-static-values-constraints.stderr
+++ b/src/test/ui/check-static-values-constraints.stderr
@@ -85,7 +85,7 @@ error[E0019]: static contains unimplemented expression type
 LL |     box 3;
    |         ^
 
-error[E0507]: cannot move out of static item `x`
+error[E0507]: cannot move out of an immutable place
   --> $DIR/check-static-values-constraints.rs:116:45
    |
 LL |     let y = { static x: Box<isize> = box 3; x };

--- a/src/test/ui/issues/issue-17718-static-move.rs
+++ b/src/test/ui/issues/issue-17718-static-move.rs
@@ -3,5 +3,5 @@ const INIT: Foo = Foo;
 static FOO: Foo = INIT;
 
 fn main() {
-    let _a = FOO; //~ ERROR: cannot move out of static item
+    let _a = FOO; //~ ERROR: cannot move out of an immutable place
 }

--- a/src/test/ui/issues/issue-17718-static-move.stderr
+++ b/src/test/ui/issues/issue-17718-static-move.stderr
@@ -1,4 +1,4 @@
-error[E0507]: cannot move out of static item `FOO`
+error[E0507]: cannot move out of an immutable place
   --> $DIR/issue-17718-static-move.rs:6:14
    |
 LL |     let _a = FOO;

--- a/src/test/ui/static/static-items-cant-move.rs
+++ b/src/test/ui/static/static-items-cant-move.rs
@@ -15,5 +15,5 @@ fn test(f: Foo) {
 }
 
 fn main() {
-    test(BAR); //~ ERROR cannot move out of static item
+    test(BAR); //~ ERROR cannot move out of an immutable place
 }

--- a/src/test/ui/static/static-items-cant-move.stderr
+++ b/src/test/ui/static/static-items-cant-move.stderr
@@ -1,4 +1,4 @@
-error[E0507]: cannot move out of static item `BAR`
+error[E0507]: cannot move out of an immutable place
   --> $DIR/static-items-cant-move.rs:18:10
    |
 LL |     test(BAR);


### PR DESCRIPTION
This is in preparation to remove Statics from Place. We are going to loose some information on Mir so we need to make these static errors a bit more generic.

r? @oli-obk 