### PR TITLE
Move Session fields to CrateStore

### DIFF
--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -227,6 +227,7 @@ pub trait CrateStore {
     // utility functions
     fn encode_metadata(&self, tcx: TyCtxt<'_>) -> EncodedMetadata;
     fn metadata_encoding_version(&self) -> &[u8];
+    fn injected_panic_runtime(&self) -> Option<CrateNum>;
 }
 
 pub type CrateStoreDyn = dyn CrateStore + sync::Sync;

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -15,6 +15,7 @@ use std::path::{Path, PathBuf};
 use syntax::ast;
 use syntax::symbol::Symbol;
 use syntax_pos::Span;
+use syntax::expand::allocator::AllocatorKind;
 use rustc_target::spec::Target;
 use rustc_data_structures::sync::{self, MetadataRef};
 use rustc_macros::HashStable;
@@ -228,6 +229,7 @@ pub trait CrateStore {
     fn encode_metadata(&self, tcx: TyCtxt<'_>) -> EncodedMetadata;
     fn metadata_encoding_version(&self) -> &[u8];
     fn injected_panic_runtime(&self) -> Option<CrateNum>;
+    fn allocator_kind(&self) -> Option<AllocatorKind>;
 }
 
 pub type CrateStoreDyn = dyn CrateStore + sync::Sync;

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -21,7 +21,6 @@ use errors::emitter::{Emitter, EmitterWriter};
 use errors::emitter::HumanReadableErrorType;
 use errors::annotate_snippet_emitter_writer::{AnnotateSnippetEmitterWriter};
 use syntax::edition::Edition;
-use syntax::expand::allocator::AllocatorKind;
 use syntax::feature_gate::{self, AttributeType};
 use syntax::json::JsonEmitter;
 use syntax::source_map;
@@ -99,11 +98,6 @@ pub struct Session {
 
     /// The maximum number of stackframes allowed in const eval.
     pub const_eval_stack_frame_limit: usize,
-
-    /// The `metadata::creader` module may inject an allocator/`panic_runtime`
-    /// dependency if it didn't already find one, and this tracks what was
-    /// injected.
-    pub allocator_kind: Once<Option<AllocatorKind>>,
 
     /// Map from imported macro spans (which consist of
     /// the localized span for the macro body) to the
@@ -1179,7 +1173,6 @@ fn build_session_(
         recursion_limit: Once::new(),
         type_length_limit: Once::new(),
         const_eval_stack_frame_limit: 100,
-        allocator_kind: Once::new(),
         imported_macro_spans: OneThread::new(RefCell::new(FxHashMap::default())),
         incr_comp_session: OneThread::new(RefCell::new(IncrCompSession::NotInitialized)),
         cgu_reuse_tracker,

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -2,7 +2,6 @@ pub use self::code_stats::{DataTypeKind, SizeKind, FieldInfo, VariantInfo};
 use self::code_stats::CodeStats;
 
 use crate::dep_graph::cgu_reuse_tracker::CguReuseTracker;
-use crate::hir::def_id::CrateNum;
 use rustc_data_structures::fingerprint::Fingerprint;
 
 use crate::lint;
@@ -105,7 +104,6 @@ pub struct Session {
     /// dependency if it didn't already find one, and this tracks what was
     /// injected.
     pub allocator_kind: Once<Option<AllocatorKind>>,
-    pub injected_panic_runtime: Once<Option<CrateNum>>,
 
     /// Map from imported macro spans (which consist of
     /// the localized span for the macro body) to the
@@ -1182,7 +1180,6 @@ fn build_session_(
         type_length_limit: Once::new(),
         const_eval_stack_frame_limit: 100,
         allocator_kind: Once::new(),
-        injected_panic_runtime: Once::new(),
         imported_macro_spans: OneThread::new(RefCell::new(FxHashMap::default())),
         incr_comp_session: OneThread::new(RefCell::new(IncrCompSession::NotInitialized)),
         cgu_reuse_tracker,

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1338,6 +1338,10 @@ impl<'tcx> TyCtxt<'tcx> {
         self.all_crate_nums(LOCAL_CRATE)
     }
 
+    pub fn injected_panic_runtime(self) -> Option<CrateNum> {
+        self.cstore.injected_panic_runtime()
+    }
+
     pub fn features(self) -> &'tcx feature_gate::Features {
         self.features_query(LOCAL_CRATE)
     }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -75,6 +75,7 @@ use syntax::source_map::MultiSpan;
 use syntax::feature_gate;
 use syntax::symbol::{Symbol, kw, sym};
 use syntax_pos::Span;
+use syntax::expand::allocator::AllocatorKind;
 
 pub struct AllArenas {
     pub interner: SyncDroplessArena,
@@ -1340,6 +1341,10 @@ impl<'tcx> TyCtxt<'tcx> {
 
     pub fn injected_panic_runtime(self) -> Option<CrateNum> {
         self.cstore.injected_panic_runtime()
+    }
+
+    pub fn allocator_kind(self) -> Option<AllocatorKind> {
+        self.cstore.allocator_kind()
     }
 
     pub fn features(self) -> &'tcx feature_gate::Features {

--- a/src/librustc_codegen_ssa/back/symbol_export.rs
+++ b/src/librustc_codegen_ssa/back/symbol_export.rs
@@ -194,7 +194,7 @@ fn exported_symbols_provider_local(
         symbols.push((exported_symbol, SymbolExportLevel::C));
     }
 
-    if tcx.sess.allocator_kind.get().is_some() {
+    if tcx.allocator_kind().is_some() {
         for method in ALLOCATOR_METHODS {
             let symbol_name = format!("__rust_{}", method.name);
             let exported_symbol = ExportedSymbol::NoDefId(SymbolName::new(&symbol_name));

--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -549,7 +549,7 @@ pub fn codegen_crate<B: ExtraBackendMethods>(
         });
     let allocator_module = if any_dynamic_crate {
         None
-    } else if let Some(kind) = *tcx.sess.allocator_kind.get() {
+    } else if let Some(kind) = tcx.allocator_kind() {
         let llmod_id = cgu_name_builder.build_cgu_name(LOCAL_CRATE,
                                                        &["crate"],
                                                        Some("allocator")).to_string();

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -722,7 +722,7 @@ impl<'a> CrateLoader<'a> {
         }
     }
 
-    fn inject_allocator_crate(&self, krate: &ast::Crate) {
+    fn inject_allocator_crate(&mut self, krate: &ast::Crate) {
         let has_global_allocator = match &*global_allocator_spans(krate) {
             [span1, span2, ..] => {
                 self.sess.struct_span_err(*span2, "cannot define multiple global allocators")
@@ -742,7 +742,7 @@ impl<'a> CrateLoader<'a> {
             needs_allocator = needs_allocator || data.root.needs_allocator;
         });
         if !needs_allocator {
-            self.sess.allocator_kind.set(None);
+            self.cstore.allocator_kind = None;
             return
         }
 
@@ -758,7 +758,7 @@ impl<'a> CrateLoader<'a> {
                 }
             });
         if all_rlib {
-            self.sess.allocator_kind.set(None);
+            self.cstore.allocator_kind = None;
             return
         }
 
@@ -795,7 +795,7 @@ impl<'a> CrateLoader<'a> {
             }
         });
         if global_allocator.is_some() {
-            self.sess.allocator_kind.set(Some(AllocatorKind::Global));
+            self.cstore.allocator_kind = Some(AllocatorKind::Global);
             return
         }
 
@@ -816,7 +816,7 @@ impl<'a> CrateLoader<'a> {
                            add `#[global_allocator]` to a static item \
                            that implements the GlobalAlloc trait.");
         }
-        self.sess.allocator_kind.set(Some(AllocatorKind::DefaultLib));
+        self.cstore.allocator_kind = Some(AllocatorKind::DefaultLib);
     }
 
     fn inject_dependency_if(&self,

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -531,7 +531,7 @@ impl<'a> CrateLoader<'a> {
         });
         if !any_non_rlib {
             info!("panic runtime injection skipped, only generating rlib");
-            self.sess.injected_panic_runtime.set(None);
+            self.cstore.injected_panic_runtime = None;
             return
         }
 
@@ -563,7 +563,7 @@ impl<'a> CrateLoader<'a> {
         // we just don't need one at all, then we're done here and there's
         // nothing else to do.
         if !needs_panic_runtime || runtime_found {
-            self.sess.injected_panic_runtime.set(None);
+            self.cstore.injected_panic_runtime = None;
             return
         }
 
@@ -600,7 +600,7 @@ impl<'a> CrateLoader<'a> {
                                    name, desired_strategy.desc()));
         }
 
-        self.sess.injected_panic_runtime.set(Some(cnum));
+        self.cstore.injected_panic_runtime = Some(cnum);
         self.inject_dependency_if(cnum, "a panic runtime",
                                   &|data| data.root.needs_panic_runtime);
     }

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -101,6 +101,7 @@ crate struct CrateMetadata {
 #[derive(Clone)]
 pub struct CStore {
     metas: IndexVec<CrateNum, Option<Lrc<CrateMetadata>>>,
+    pub(crate) injected_panic_runtime: Option<CrateNum>,
 }
 
 pub enum LoadedMacro {
@@ -116,6 +117,7 @@ impl Default for CStore {
             // corresponding `CrateNum`. This first entry will always remain
             // `None`.
             metas: IndexVec::from_elem_n(None, 1),
+            injected_panic_runtime: None,
         }
     }
 }

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -14,6 +14,7 @@ use rustc_data_structures::svh::Svh;
 use syntax::ast;
 use syntax::edition::Edition;
 use syntax_expand::base::SyntaxExtension;
+use syntax::expand::allocator::AllocatorKind;
 use syntax_pos;
 use proc_macro::bridge::client::ProcMacro;
 
@@ -102,6 +103,7 @@ crate struct CrateMetadata {
 pub struct CStore {
     metas: IndexVec<CrateNum, Option<Lrc<CrateMetadata>>>,
     pub(crate) injected_panic_runtime: Option<CrateNum>,
+    pub(crate) allocator_kind: Option<AllocatorKind>,
 }
 
 pub enum LoadedMacro {
@@ -118,6 +120,7 @@ impl Default for CStore {
             // `None`.
             metas: IndexVec::from_elem_n(None, 1),
             injected_panic_runtime: None,
+            allocator_kind: None,
         }
     }
 }

--- a/src/librustc_metadata/dependency_format.rs
+++ b/src/librustc_metadata/dependency_format.rs
@@ -184,7 +184,7 @@ fn calculate_type(tcx: TyCtxt<'_>, ty: config::CrateType) -> DependencyList {
     //
     // Things like allocators and panic runtimes may not have been activated
     // quite yet, so do so here.
-    activate_injected_dep(*sess.injected_panic_runtime.get(), &mut ret,
+    activate_injected_dep(tcx.injected_panic_runtime(), &mut ret,
                           &|cnum| tcx.is_panic_runtime(cnum));
 
     // When dylib B links to dylib A, then when using B we must also link to A.
@@ -244,7 +244,6 @@ fn add_library(
 }
 
 fn attempt_static(tcx: TyCtxt<'_>) -> Option<DependencyList> {
-    let sess = &tcx.sess;
     let crates = cstore::used_crates(tcx, RequireStatic);
     if !crates.iter().by_ref().all(|&(_, ref p)| p.is_some()) {
         return None
@@ -264,7 +263,7 @@ fn attempt_static(tcx: TyCtxt<'_>) -> Option<DependencyList> {
     // Our allocator/panic runtime may not have been linked above if it wasn't
     // explicitly linked, which is the case for any injected dependency. Handle
     // that here and activate them.
-    activate_injected_dep(*sess.injected_panic_runtime.get(), &mut ret,
+    activate_injected_dep(tcx.injected_panic_runtime(), &mut ret,
                           &|cnum| tcx.is_panic_runtime(cnum));
 
     Some(ret)

--- a/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
+++ b/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
@@ -527,4 +527,8 @@ impl CrateStore for cstore::CStore {
     {
         rmeta::METADATA_HEADER
     }
+
+    fn injected_panic_runtime(&self) -> Option<CrateNum> {
+        self.injected_panic_runtime
+    }
 }

--- a/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
+++ b/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
@@ -31,6 +31,7 @@ use syntax::attr;
 use syntax::source_map;
 use syntax::source_map::Spanned;
 use syntax::symbol::Symbol;
+use syntax::expand::allocator::AllocatorKind;
 use syntax_pos::{Span, FileName};
 
 macro_rules! provide {
@@ -530,5 +531,9 @@ impl CrateStore for cstore::CStore {
 
     fn injected_panic_runtime(&self) -> Option<CrateNum> {
         self.injected_panic_runtime
+    }
+
+    fn allocator_kind(&self) -> Option<AllocatorKind> {
+        self.allocator_kind
     }
 }


### PR DESCRIPTION
`allocator_kind` and `injected_panic_runtime` are both query-like, this moves them out of Session and into CrateStore, avoiding the `Once` they previously had by clearing separating initialization and de-initialization.