### PR TITLE
Trigger a panic on allocation error on nightly Rust

### DIFF
--- a/src/libstd/alloc.rs
+++ b/src/libstd/alloc.rs
@@ -202,15 +202,15 @@ pub fn take_alloc_error_hook() -> fn(Layout) {
 /// This lives in `libstd` so that we can call `dumb_print`.
 ///
 /// This hook prints out a message like the default error hook,
-/// but then panics to generate a backtrace. If we are completely
-/// out of memory, panicking and/or backtrace generation may fail:
+/// and then attempts to print a backtrace (without panicking).
+/// If we are completely out of memory, backtrace generation may fail:
 /// this is fine, since the backtrace is best-effort only. We
 /// are guaranteed to print the actual error message, though.
 #[doc(hidden)]
 #[unstable(feature = "alloc_internals", issue = "0")]
 pub fn rustc_alloc_error_hook(layout: Layout) {
     dumb_print(format_args!("memory allocation of {} bytes failed. backtrace:", layout.size()));
-    panic!();
+    dumb_print(format_args!("{:?}", crate::backtrace::Backtrace::capture()));
 }
 
 fn default_alloc_error_hook(layout: Layout) {

--- a/src/libstd/alloc.rs
+++ b/src/libstd/alloc.rs
@@ -198,6 +198,21 @@ pub fn take_alloc_error_hook() -> fn(Layout) {
     }
 }
 
+/// A custom error hook, used by librustc_driver.
+/// This lives in `libstd` so that we can call `dumb_print`.
+///
+/// This hook prints out a message like the default error hook,
+/// but then panics to generate a backtrace. If we are completely
+/// out of memory, panicking and/or backtrace generation may fail:
+/// this is fine, since the backtrace is best-effort only. We
+/// are guaranteed to print the actual error message, though.
+#[doc(hidden)]
+#[unstable(feature = "alloc_internals", issue = "0")]
+pub fn rustc_alloc_error_hook(layout: Layout) {
+    dumb_print(format_args!("memory allocation of {} bytes failed. backtrace:", layout.size()));
+    panic!();
+}
+
 fn default_alloc_error_hook(layout: Layout) {
     dumb_print(format_args!("memory allocation of {} bytes failed", layout.size()));
 }


### PR DESCRIPTION
In issue #66342, we're seeing extremely large allocations by rustc
(4GB for the `hex` crate, which is only a few hundred lines). This is
exhausing the memory on CI, causing jobs to fail intermittently.

This PR installs a custom allocation error hook for nightly compilers,
which attempts to trigger a panic after printing the initial error
message. Hopefully, this will allow us to retrieve a backtrace when one
of these large spurious allocations occurs.

The hook is installed in `librustc_driver`, so that other compiler
frontends (e.g. clippy) will get this logic as well.

I'm unsure if this needs to be behind any kind of additional feature
gate, beyond being ngithly only. This only affects compiler frontends,
not generic users of `libstd`. While this will nake OOM errors on
nightly much more verbose, I don't think this is necessarily a bad
thing. I would expect that out of memory errors when running the
compiler are usually infrequent, so most users will probably never
notice this change. If any users are experiencing #66342 (or something
like it) on their own crates, the extra output might even be useful to
them.

I don't know of any reasonable way of writing a test for this. I
manually verified the implementation by inserting:
`let _a: Vec<usize> = Vec::with_capacity(9999999999)` into
`librustc_driver` after the hook installation, and verified that
a backtrace was printed.

If we're very unlucky, it may turn out the large allocation on CI
happens to occur after several large successful allocations, leaving
extremely little memory left when we try to panic. If this is the case,
then we may fail to panic or print the backtrace, since panicking
currently allocates memory. However, we will still print an error
message, so the output will be no less useful (though a little more
spammy) then before.