### PR TITLE
Fix link to Extend in Vec::set_len

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -861,7 +861,7 @@ impl<T> Vec<T> {
     ///
     /// [`truncate`]: #method.truncate
     /// [`resize`]: #method.resize
-    /// [`extend`]: #method.extend-1
+    /// [`extend`]: ../../std/iter/trait.Extend.html#tymethod.extend
     /// [`clear`]: #method.clear
     ///
     /// # Safety


### PR DESCRIPTION
Fixes #66354

Unrelated to this PR, I think we should stop using `../../std/MODULE` and replace it with `../MODULE` that way if you're looking at docs in `core` or `alloc` clicking at a link won't forward you to `std`.
