### PR TITLE
parser: don't use `unreachable!()` in `fn unexpected`.

### DIFF
--- a/src/librustc_parse/parser/mod.rs
+++ b/src/librustc_parse/parser/mod.rs
@@ -443,7 +443,9 @@ impl<'a> Parser<'a> {
     crate fn unexpected<T>(&mut self) -> PResult<'a, T> {
         match self.expect_one_of(&[], &[]) {
             Err(e) => Err(e),
-            Ok(_) => unreachable!(),
+            // We can get `Ok(true)` from `recover_closing_delimiter`
+            // which is called in `expected_one_of_not_found`.
+            Ok(_) => FatalError.raise(),
         }
     }
 

--- a/src/test/ui/parser/issue-66357-unexpected-unreachable.rs
+++ b/src/test/ui/parser/issue-66357-unexpected-unreachable.rs
@@ -1,0 +1,14 @@
+// The problem in #66357 was that the call trace:
+//
+// - parse_fn_block_decl
+// - expect_or
+// - unexpected
+// - expect_one_of
+// - expected_one_of_not_found
+// - recover_closing_delimiter
+//
+// ended up bubbling up `Ok(true)` to `unexpected` which then used `unreachable!()`.
+
+fn f() { |[](* }
+//~^ ERROR expected one of `,` or `:`, found `(`
+//~| ERROR expected one of `)`, `-`, `_`, `box`, `mut`, `ref`, `|`, identifier, or path, found `*`

--- a/src/test/ui/parser/issue-66357-unexpected-unreachable.stderr
+++ b/src/test/ui/parser/issue-66357-unexpected-unreachable.stderr
@@ -1,0 +1,16 @@
+error: expected one of `,` or `:`, found `(`
+  --> $DIR/issue-66357-unexpected-unreachable.rs:12:13
+   |
+LL | fn f() { |[](* }
+   |             ^ expected one of `,` or `:`
+
+error: expected one of `)`, `-`, `_`, `box`, `mut`, `ref`, `|`, identifier, or path, found `*`
+  --> $DIR/issue-66357-unexpected-unreachable.rs:12:14
+   |
+LL | fn f() { |[](* }
+   |             -^ help: `)` may belong here
+   |             |
+   |             unclosed delimiter
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #66357 

r? @estebank 