### PR TITLE
Improve error message in make_tests

### DIFF
--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -581,7 +581,7 @@ pub fn make_tests(config: &Config) -> Vec<test::TestDescAndFn> {
         &config.src_base,
         &PathBuf::new(),
         &mut tests,
-    ).unwrap();
+    ).expect(&format!("Could not read tests from {}", config.src_base.display()));
     tests
 }
 


### PR DESCRIPTION
We should use expect instead of unwrap.

This commit is based on https://github.com/laumann/compiletest-rs/pull/58. Thanks to @colin-kiegel.