### PR TITLE
Rollup of 14 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3120,7 +3120,6 @@ dependencies = [
  "graphviz",
  "jobserver",
  "log",
- "measureme",
  "num_cpus",
  "parking_lot 0.9.0",
  "polonius-engine",
@@ -3470,6 +3469,7 @@ dependencies = [
 name = "rustc_data_structures"
 version = "0.0.0"
 dependencies = [
+ "bitflags",
  "cfg-if",
  "crossbeam-utils 0.6.5",
  "ena",
@@ -3478,6 +3478,7 @@ dependencies = [
  "jobserver",
  "lazy_static 1.3.0",
  "log",
+ "measureme",
  "parking_lot 0.9.0",
  "rustc-hash",
  "rustc-rayon 0.3.0",

--- a/src/bootstrap/bin/rustdoc.rs
+++ b/src/bootstrap/bin/rustdoc.rs
@@ -25,7 +25,7 @@ fn main() {
     let mut dylib_path = bootstrap::util::dylib_path();
     dylib_path.insert(0, PathBuf::from(libdir.clone()));
 
-    //FIXME(misdreavus): once stdsimd uses cfg(rustdoc) instead of cfg(dox), remove the `--cfg dox`
+    //FIXME(misdreavus): once stdsimd uses cfg(doc) instead of cfg(dox), remove the `--cfg dox`
     //arguments here
     let mut cmd = Command::new(rustdoc);
     cmd.args(&args)

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -102,10 +102,10 @@ def verify(path, sha_path, verbose):
     return verified
 
 
-def unpack(tarball, dst, verbose=False, match=None):
+def unpack(tarball, tarball_suffix, dst, verbose=False, match=None):
     """Unpack the given tarball file"""
     print("extracting", tarball)
-    fname = os.path.basename(tarball).replace(".tar.gz", "")
+    fname = os.path.basename(tarball).replace(tarball_suffix, "")
     with contextlib.closing(tarfile.open(tarball)) as tar:
         for member in tar.getnames():
             if "/" not in member:
@@ -331,6 +331,18 @@ class RustBuild(object):
         self.use_vendored_sources = ''
         self.verbose = False
 
+        def support_xz():
+            try:
+                with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+                    temp_path = temp_file.name
+                with tarfile.open(temp_path, "w:xz") as tar:
+                    pass
+                return True
+            except tarfile.CompressionError:
+                return False
+
+        self.tarball_suffix = '.tar.xz' if support_xz() else '.tar.gz'
+
     def download_stage0(self):
         """Fetch the build system for Rust, written in Rust
 
@@ -349,12 +361,13 @@ class RustBuild(object):
                  self.program_out_of_date(self.rustc_stamp())):
             if os.path.exists(self.bin_root()):
                 shutil.rmtree(self.bin_root())
-            filename = "rust-std-{}-{}.tar.gz".format(
-                rustc_channel, self.build)
+            filename = "rust-std-{}-{}{}".format(
+                rustc_channel, self.build, self.tarball_suffix)
             pattern = "rust-std-{}".format(self.build)
             self._download_stage0_helper(filename, pattern)
 
-            filename = "rustc-{}-{}.tar.gz".format(rustc_channel, self.build)
+            filename = "rustc-{}-{}{}".format(rustc_channel, self.build,
+                                              self.tarball_suffix)
             self._download_stage0_helper(filename, "rustc")
             self.fix_executable("{}/bin/rustc".format(self.bin_root()))
             self.fix_executable("{}/bin/rustdoc".format(self.bin_root()))
@@ -365,14 +378,15 @@ class RustBuild(object):
             # libraries/binaries that are included in rust-std with
             # the system MinGW ones.
             if "pc-windows-gnu" in self.build:
-                filename = "rust-mingw-{}-{}.tar.gz".format(
-                    rustc_channel, self.build)
+                filename = "rust-mingw-{}-{}{}".format(
+                    rustc_channel, self.build, self.tarball_suffix)
                 self._download_stage0_helper(filename, "rust-mingw")
 
         if self.cargo().startswith(self.bin_root()) and \
                 (not os.path.exists(self.cargo()) or
                  self.program_out_of_date(self.cargo_stamp())):
-            filename = "cargo-{}-{}.tar.gz".format(cargo_channel, self.build)
+            filename = "cargo-{}-{}{}".format(cargo_channel, self.build,
+                                              self.tarball_suffix)
             self._download_stage0_helper(filename, "cargo")
             self.fix_executable("{}/bin/cargo".format(self.bin_root()))
             with output(self.cargo_stamp()) as cargo_stamp:
@@ -388,7 +402,7 @@ class RustBuild(object):
         tarball = os.path.join(rustc_cache, filename)
         if not os.path.exists(tarball):
             get("{}/{}".format(url, filename), tarball, verbose=self.verbose)
-        unpack(tarball, self.bin_root(), match=pattern, verbose=self.verbose)
+        unpack(tarball, self.tarball_suffix, self.bin_root(), match=pattern, verbose=self.verbose)
 
     @staticmethod
     def fix_executable(fname):

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1231,7 +1231,9 @@ impl<'a> Builder<'a> {
             cargo.arg("--frozen");
         }
 
-        cargo.env("RUSTC_INSTALL_BINDIR", &self.config.bindir);
+        // Try to use a sysroot-relative bindir, in case it was configured absolutely.
+        let bindir = self.config.bindir_relative().unwrap_or(&self.config.bindir);
+        cargo.env("RUSTC_INSTALL_BINDIR", bindir);
 
         self.ci_env.force_coloring_in_ci(&mut cargo);
 

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1232,8 +1232,7 @@ impl<'a> Builder<'a> {
         }
 
         // Try to use a sysroot-relative bindir, in case it was configured absolutely.
-        let bindir = self.config.bindir_relative().unwrap_or(&self.config.bindir);
-        cargo.env("RUSTC_INSTALL_BINDIR", bindir);
+        cargo.env("RUSTC_INSTALL_BINDIR", self.config.bindir_relative());
 
         self.ci_env.force_coloring_in_ci(&mut cargo);
 

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -647,6 +647,17 @@ impl Config {
         config
     }
 
+    /// Try to find the relative path of `bindir`.
+    pub fn bindir_relative(&self) -> Option<&Path> {
+        let bindir = &self.bindir;
+        if bindir.is_relative() {
+            Some(bindir)
+        } else {
+            // Try to make it relative to the prefix.
+            bindir.strip_prefix(self.prefix.as_ref()?).ok()
+        }
+    }
+
     /// Try to find the relative path of `libdir`.
     pub fn libdir_relative(&self) -> Option<&Path> {
         let libdir = self.libdir.as_ref()?;

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -647,15 +647,18 @@ impl Config {
         config
     }
 
-    /// Try to find the relative path of `bindir`.
-    pub fn bindir_relative(&self) -> Option<&Path> {
+    /// Try to find the relative path of `bindir`, otherwise return it in full.
+    pub fn bindir_relative(&self) -> &Path {
         let bindir = &self.bindir;
-        if bindir.is_relative() {
-            Some(bindir)
-        } else {
+        if bindir.is_absolute() {
             // Try to make it relative to the prefix.
-            bindir.strip_prefix(self.prefix.as_ref()?).ok()
+            if let Some(prefix) = &self.prefix {
+                if let Ok(stripped) = bindir.strip_prefix(prefix) {
+                    return stripped;
+                }
+            }
         }
+        bindir
     }
 
     /// Try to find the relative path of `libdir`.

--- a/src/doc/rustdoc/src/unstable-features.md
+++ b/src/doc/rustdoc/src/unstable-features.md
@@ -106,11 +106,11 @@ item, it will be accompanied by a banner explaining that the item is only availa
 platforms.
 
 For Rustdoc to document an item, it needs to see it, regardless of what platform it's currently
-running on. To aid this, Rustdoc sets the flag `#[cfg(rustdoc)]` when running on your crate.
+running on. To aid this, Rustdoc sets the flag `#[cfg(doc)]` when running on your crate.
 Combining this with the target platform of a given item allows it to appear when building your crate
 normally on that platform, as well as when building documentation anywhere.
 
-For example, `#[cfg(any(windows, rustdoc))]` will preserve the item either on Windows or during the
+For example, `#[cfg(any(windows, doc))]` will preserve the item either on Windows or during the
 documentation process. Then, adding a new attribute `#[doc(cfg(windows))]` will tell Rustdoc that
 the item is supposed to be used on Windows. For example:
 
@@ -118,12 +118,12 @@ the item is supposed to be used on Windows. For example:
 #![feature(doc_cfg)]
 
 /// Token struct that can only be used on Windows.
-#[cfg(any(windows, rustdoc))]
+#[cfg(any(windows, doc))]
 #[doc(cfg(windows))]
 pub struct WindowsToken;
 
 /// Token struct that can only be used on Unix.
-#[cfg(any(unix, rustdoc))]
+#[cfg(any(unix, doc))]
 #[doc(cfg(unix))]
 pub struct UnixToken;
 ```

--- a/src/doc/unstable-book/src/language-features/doc-cfg.md
+++ b/src/doc/unstable-book/src/language-features/doc-cfg.md
@@ -13,7 +13,7 @@ This attribute has two effects:
 2. The item's doc-tests will only run on the specific platform.
 
 In addition to allowing the use of the `#[doc(cfg)]` attribute, this feature enables the use of a
-special conditional compilation flag, `#[cfg(rustdoc)]`, set whenever building documentation on your
+special conditional compilation flag, `#[cfg(doc)]`, set whenever building documentation on your
 crate.
 
 This feature was introduced as part of PR [#43348] to allow the platform-specific parts of the
@@ -22,7 +22,7 @@ standard library be documented.
 ```rust
 #![feature(doc_cfg)]
 
-#[cfg(any(windows, rustdoc))]
+#[cfg(any(windows, doc))]
 #[doc(cfg(windows))]
 /// The application's icon in the notification area (a.k.a. system tray).
 ///

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1572,18 +1572,18 @@ impl<T: ?Sized> UnsafeCell<T> {
     /// use std::mem::MaybeUninit;
     ///
     /// let m = MaybeUninit::<UnsafeCell<i32>>::uninit();
-    /// unsafe { m.as_ptr().raw_get().write(5); }
+    /// unsafe { UnsafeCell::raw_get(m.as_ptr()).write(5); }
     /// let uc = unsafe { m.assume_init() };
     ///
     /// assert_eq!(uc.into_inner(), 5);
     /// ```
     #[inline]
     #[unstable(feature = "unsafe_cell_raw_get", issue = "66358")]
-    pub const fn raw_get(self: *const Self) -> *mut T {
+    pub const fn raw_get(this: *const Self) -> *mut T {
         // We can just cast the pointer from `UnsafeCell<T>` to `T` because of
         // #[repr(transparent)]. This exploits libstd's special status, there is
         // no guarantee for user code that this will work in future versions of the compiler!
-        self as *const T as *mut T
+        this as *const T as *mut T
     }
 }
 

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1551,15 +1551,20 @@ impl<T: ?Sized> UnsafeCell<T> {
     }
 
     /// Gets a mutable pointer to the wrapped value.
+    /// The difference to [`get`] is that this function accepts a raw pointer,
+    /// which is useful to avoid the creation of temporary references.
     ///
-    /// This can be cast to a pointer of any kind.
+    /// The result can be cast to a pointer of any kind.
     /// Ensure that the access is unique (no active references, mutable or not)
     /// when casting to `&mut T`, and ensure that there are no mutations
     /// or mutable aliases going on when casting to `&T`.
     ///
+    /// [`get`]: #method.get
+    ///
     /// # Examples
     ///
-    /// Gradual initialization of an `UnsafeCell`:
+    /// Gradual initialization of an `UnsafeCell` requires `raw_get`, as
+    /// calling `get` would require creating a reference to uninitialized data:
     ///
     /// ```
     /// #![feature(unsafe_cell_raw_get)]

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1548,6 +1548,36 @@ impl<T: ?Sized> UnsafeCell<T> {
         // #[repr(transparent)]
         self as *const UnsafeCell<T> as *const T as *mut T
     }
+
+    /// Gets a mutable pointer to the wrapped value.
+    ///
+    /// This can be cast to a pointer of any kind.
+    /// Ensure that the access is unique (no active references, mutable or not)
+    /// when casting to `&mut T`, and ensure that there are no mutations
+    /// or mutable aliases going on when casting to `&T`
+    ///
+    /// # Examples
+    ///
+    /// Gradual initialization of an `UnsafeCell`:
+    ///
+    /// ```
+    /// #![feature(unsafe_cell_raw_get)]
+    /// use std::cell::UnsafeCell;
+    /// use std::mem::MaybeUninit;
+    ///
+    /// let m = MaybeUninit::<UnsafeCell<i32>>::uninit();
+    /// unsafe { m.as_ptr().raw_get().write(5); }
+    /// let uc = unsafe { m.assume_init() };
+    ///
+    /// assert_eq!(uc.into_inner(), 5);
+    /// ```
+    #[inline]
+    #[unstable(feature = "unsafe_cell_raw_get", issue = "0")]
+    pub const fn raw_get(self: *const Self) -> *mut T {
+        // We can just cast the pointer from `UnsafeCell<T>` to `T` because of
+        // #[repr(transparent)]
+        self as *const T as *mut T
+    }
 }
 
 #[stable(feature = "unsafe_cell_default", since = "1.10.0")]

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1545,7 +1545,8 @@ impl<T: ?Sized> UnsafeCell<T> {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const fn get(&self) -> *mut T {
         // We can just cast the pointer from `UnsafeCell<T>` to `T` because of
-        // #[repr(transparent)]
+        // #[repr(transparent)]. This exploits libstd's special status, there is
+        // no guarantee for user code that this will work in future versions of the compiler!
         self as *const UnsafeCell<T> as *const T as *mut T
     }
 
@@ -1572,10 +1573,11 @@ impl<T: ?Sized> UnsafeCell<T> {
     /// assert_eq!(uc.into_inner(), 5);
     /// ```
     #[inline]
-    #[unstable(feature = "unsafe_cell_raw_get", issue = "0")]
+    #[unstable(feature = "unsafe_cell_raw_get", issue = "66358")]
     pub const fn raw_get(self: *const Self) -> *mut T {
         // We can just cast the pointer from `UnsafeCell<T>` to `T` because of
-        // #[repr(transparent)]
+        // #[repr(transparent)]. This exploits libstd's special status, there is
+        // no guarantee for user code that this will work in future versions of the compiler!
         self as *const T as *mut T
     }
 }

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1554,7 +1554,7 @@ impl<T: ?Sized> UnsafeCell<T> {
     /// This can be cast to a pointer of any kind.
     /// Ensure that the access is unique (no active references, mutable or not)
     /// when casting to `&mut T`, and ensure that there are no mutations
-    /// or mutable aliases going on when casting to `&T`
+    /// or mutable aliases going on when casting to `&T`.
     ///
     /// # Examples
     ///

--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -201,13 +201,13 @@ pub trait Iterator {
 
     /// Consumes the iterator, counting the number of iterations and returning it.
     ///
-    /// This method will evaluate the iterator until its [`next`] returns
-    /// [`None`]. Once [`None`] is encountered, `count()` returns one less than the
-    /// number of times it called [`next`]. Note that [`next`] has to be called at
-    /// least once even if the iterator does not have any elements.
+    /// This method will call [`next`] repeatedly until [`None`] is encountered,
+    /// returning the number of times it saw [`Some`]. Note that [`next`] has to be
+    /// called at least once even if the iterator does not have any elements.
     ///
     /// [`next`]: #tymethod.next
     /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`Some`]: ../../std/option/enum.Option.html#variant.Some
     ///
     /// # Overflow Behavior
     ///

--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -202,8 +202,9 @@ pub trait Iterator {
     /// Consumes the iterator, counting the number of iterations and returning it.
     ///
     /// This method will evaluate the iterator until its [`next`] returns
-    /// [`None`]. Once [`None`] is encountered, `count()` returns the number of
-    /// times it called [`next`].
+    /// [`None`]. Once [`None`] is encountered, `count()` returns one less than the 
+    /// number of times it called [`next`]. Note that [`next`] has to be called at
+    /// least once even if the iterator does not have any elements.
     ///
     /// [`next`]: #tymethod.next
     /// [`None`]: ../../std/option/enum.Option.html#variant.None

--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -202,7 +202,7 @@ pub trait Iterator {
     /// Consumes the iterator, counting the number of iterations and returning it.
     ///
     /// This method will evaluate the iterator until its [`next`] returns
-    /// [`None`]. Once [`None`] is encountered, `count()` returns one less than the 
+    /// [`None`]. Once [`None`] is encountered, `count()` returns one less than the
     /// number of times it called [`next`]. Note that [`next`] has to be called at
     /// least once even if the iterator does not have any elements.
     ///

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -514,6 +514,28 @@ impl<T, E> Result<T, E> {
         }
     }
 
+    /// Applies a function to the contained value (if any),
+    /// or returns the provided default (if not).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(result_map_or)]
+    /// let x: Result<_, &str> = Ok("foo");
+    /// assert_eq!(x.map_or(42, |v| v.len()), 3);
+    ///
+    /// let x: Result<&str, _> = Err("bar");
+    /// assert_eq!(x.map_or(42, |v| v.len()), 42);
+    /// ```
+    #[inline]
+    #[unstable(feature = "result_map_or", issue = "66293")]
+    pub fn map_or<U, F: FnOnce(T) -> U>(self, default: U, f: F) -> U {
+        match self {
+            Ok(t) => f(t),
+            Err(_) => default,
+        }
+    }
+
     /// Maps a `Result<T, E>` to `U` by applying a function to a
     /// contained [`Ok`] value, or a fallback function to a
     /// contained [`Err`] value.

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -40,4 +40,3 @@ byteorder = { version = "1.3" }
 chalk-engine = { version = "0.9.0", default-features=false }
 rustc_fs_util = { path = "../librustc_fs_util" }
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }
-measureme = "0.4"

--- a/src/librustc/error_codes.rs
+++ b/src/librustc/error_codes.rs
@@ -1912,8 +1912,8 @@ fn bar<'short, 'long>(c: Foo<'short>, l: &'long isize) {
 ```
 
 In this example, we tried to set a value with an incompatible lifetime to
-another one (`'long` is unrelated to `'short`). We can solve this issue in two different
-ways:
+another one (`'long` is unrelated to `'short`). We can solve this issue in
+two different ways:
 
 Either we make `'short` live at least as long as `'long`:
 

--- a/src/librustc/error_codes.rs
+++ b/src/librustc/error_codes.rs
@@ -1896,6 +1896,49 @@ fn foo<'a>(x: &'a i32, y: &i32) -> &'a i32 {
 ```
 "##,
 
+E0623: r##"
+A lifetime didn't match what was expected.
+
+Erroneous code example:
+
+```compile_fail,E0623
+struct Foo<'a> {
+    x: &'a isize,
+}
+
+fn bar<'short, 'long>(c: Foo<'short>, l: &'long isize) {
+    let _: Foo<'long> = c; // error!
+}
+```
+
+In this example, we tried to set a value with an incompatible lifetime to
+another one (`'long` != `'short`). We can solve this issue in two different
+ways: either we make `'short` lives longer than `'long`:
+
+```
+struct Foo<'a> {
+    x: &'a isize,
+}
+
+// we set 'short to outlive 'long
+fn bar<'short: 'long, 'long>(c: Foo<'short>, l: &'long isize) {
+    let _: Foo<'long> = c; // ok!
+}
+```
+
+Or we use only one lifetime:
+
+```
+struct Foo<'a> {
+    x: &'a isize,
+}
+
+fn bar<'short>(c: Foo<'short>, l: &'short isize) {
+    let _: Foo<'short> = c; // ok!
+}
+```
+"##,
+
 E0635: r##"
 The `#![feature]` attribute specified an unknown feature.
 
@@ -2329,7 +2372,6 @@ the future, [RFC 2091] prohibits their implementation without a follow-up RFC.
     E0488, // lifetime of variable does not enclose its declaration
     E0489, // type/lifetime parameter not in scope here
     E0490, // a value of type `..` is borrowed for too long
-    E0623, // lifetime mismatch where both parameters are anonymous regions
     E0628, // generators cannot have explicit parameters
     E0631, // type mismatch in closure arguments
     E0637, // "'_" is not a valid lifetime bound

--- a/src/librustc/error_codes.rs
+++ b/src/librustc/error_codes.rs
@@ -1912,15 +1912,17 @@ fn bar<'short, 'long>(c: Foo<'short>, l: &'long isize) {
 ```
 
 In this example, we tried to set a value with an incompatible lifetime to
-another one (`'long` != `'short`). We can solve this issue in two different
-ways: either we make `'short` lives longer than `'long`:
+another one (`'long` is unrelated to `'short`). We can solve this issue in two different
+ways:
+
+Either we make `'short` live at least as long as `'long`:
 
 ```
 struct Foo<'a> {
     x: &'a isize,
 }
 
-// we set 'short to outlive 'long
+// we set 'short to live at least as long as 'long
 fn bar<'short: 'long, 'long>(c: Foo<'short>, l: &'long isize) {
     let _: Foo<'long> = c; // ok!
 }

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -126,7 +126,6 @@ pub mod util {
     pub mod captures;
     pub mod common;
     pub mod nodemap;
-    pub mod profiling;
     pub mod bug;
 }
 

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -227,6 +227,7 @@ pub trait CrateStore {
     // utility functions
     fn encode_metadata(&self, tcx: TyCtxt<'_>) -> EncodedMetadata;
     fn metadata_encoding_version(&self) -> &[u8];
+    fn injected_panic_runtime(&self) -> Option<CrateNum>;
 }
 
 pub type CrateStoreDyn = dyn CrateStore + sync::Sync;

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -15,6 +15,7 @@ use std::path::{Path, PathBuf};
 use syntax::ast;
 use syntax::symbol::Symbol;
 use syntax_pos::Span;
+use syntax::expand::allocator::AllocatorKind;
 use rustc_target::spec::Target;
 use rustc_data_structures::sync::{self, MetadataRef};
 use rustc_macros::HashStable;
@@ -228,6 +229,7 @@ pub trait CrateStore {
     fn encode_metadata(&self, tcx: TyCtxt<'_>) -> EncodedMetadata;
     fn metadata_encoding_version(&self) -> &[u8];
     fn injected_panic_runtime(&self) -> Option<CrateNum>;
+    fn allocator_kind(&self) -> Option<AllocatorKind>;
 }
 
 pub type CrateStoreDyn = dyn CrateStore + sync::Sync;

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -29,11 +29,11 @@ use syntax::source_map;
 use syntax::sess::{ParseSess, ProcessCfgMod};
 use syntax::symbol::Symbol;
 use syntax_pos::{MultiSpan, Span};
-use crate::util::profiling::{SelfProfiler, SelfProfilerRef};
 
 use rustc_target::spec::{PanicStrategy, RelroLevel, Target, TargetTriple};
 use rustc_data_structures::flock;
 use rustc_data_structures::jobserver;
+use rustc_data_structures::profiling::{SelfProfiler, SelfProfilerRef};
 use ::jobserver::Client;
 
 use std;

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -1099,7 +1099,6 @@ fn build_session_(
             );
             match profiler {
                 Ok(profiler) => {
-                    crate::ty::query::QueryName::register_with_profiler(&profiler);
                     Some(Arc::new(profiler))
                 },
                 Err(e) => {

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -21,7 +21,6 @@ use errors::emitter::{Emitter, EmitterWriter};
 use errors::emitter::HumanReadableErrorType;
 use errors::annotate_snippet_emitter_writer::{AnnotateSnippetEmitterWriter};
 use syntax::edition::Edition;
-use syntax::expand::allocator::AllocatorKind;
 use syntax::feature_gate::{self, AttributeType};
 use syntax::json::JsonEmitter;
 use syntax::source_map;
@@ -99,11 +98,6 @@ pub struct Session {
 
     /// The maximum number of stackframes allowed in const eval.
     pub const_eval_stack_frame_limit: usize,
-
-    /// The `metadata::creader` module may inject an allocator/`panic_runtime`
-    /// dependency if it didn't already find one, and this tracks what was
-    /// injected.
-    pub allocator_kind: Once<Option<AllocatorKind>>,
 
     /// Map from imported macro spans (which consist of
     /// the localized span for the macro body) to the
@@ -1179,7 +1173,6 @@ fn build_session_(
         recursion_limit: Once::new(),
         type_length_limit: Once::new(),
         const_eval_stack_frame_limit: 100,
-        allocator_kind: Once::new(),
         imported_macro_spans: OneThread::new(RefCell::new(FxHashMap::default())),
         incr_comp_session: OneThread::new(RefCell::new(IncrCompSession::NotInitialized)),
         cgu_reuse_tracker,

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -2,7 +2,6 @@ pub use self::code_stats::{DataTypeKind, SizeKind, FieldInfo, VariantInfo};
 use self::code_stats::CodeStats;
 
 use crate::dep_graph::cgu_reuse_tracker::CguReuseTracker;
-use crate::hir::def_id::CrateNum;
 use rustc_data_structures::fingerprint::Fingerprint;
 
 use crate::lint;
@@ -105,7 +104,6 @@ pub struct Session {
     /// dependency if it didn't already find one, and this tracks what was
     /// injected.
     pub allocator_kind: Once<Option<AllocatorKind>>,
-    pub injected_panic_runtime: Once<Option<CrateNum>>,
 
     /// Map from imported macro spans (which consist of
     /// the localized span for the macro body) to the
@@ -1182,7 +1180,6 @@ fn build_session_(
         type_length_limit: Once::new(),
         const_eval_stack_frame_limit: 100,
         allocator_kind: Once::new(),
-        injected_panic_runtime: Once::new(),
         imported_macro_spans: OneThread::new(RefCell::new(FxHashMap::default())),
         incr_comp_session: OneThread::new(RefCell::new(IncrCompSession::NotInitialized)),
         cgu_reuse_tracker,

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1338,6 +1338,10 @@ impl<'tcx> TyCtxt<'tcx> {
         self.all_crate_nums(LOCAL_CRATE)
     }
 
+    pub fn injected_panic_runtime(self) -> Option<CrateNum> {
+        self.cstore.injected_panic_runtime()
+    }
+
     pub fn features(self) -> &'tcx feature_gate::Features {
         self.features_query(LOCAL_CRATE)
     }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -75,6 +75,7 @@ use syntax::source_map::MultiSpan;
 use syntax::feature_gate;
 use syntax::symbol::{Symbol, kw, sym};
 use syntax_pos::Span;
+use syntax::expand::allocator::AllocatorKind;
 
 pub struct AllArenas {
     pub interner: SyncDroplessArena,
@@ -1340,6 +1341,10 @@ impl<'tcx> TyCtxt<'tcx> {
 
     pub fn injected_panic_runtime(self) -> Option<CrateNum> {
         self.cstore.injected_panic_runtime()
+    }
+
+    pub fn allocator_kind(self) -> Option<AllocatorKind> {
+        self.cstore.allocator_kind()
     }
 
     pub fn features(self) -> &'tcx feature_gate::Features {

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -46,11 +46,11 @@ use crate::ty::CanonicalPolyFnSig;
 use crate::util::common::ErrorReported;
 use crate::util::nodemap::{DefIdMap, DefIdSet, ItemLocalMap, ItemLocalSet, NodeMap};
 use crate::util::nodemap::{FxHashMap, FxHashSet};
-use crate::util::profiling::SelfProfilerRef;
 
 use errors::DiagnosticBuilder;
 use arena::SyncDroplessArena;
 use smallvec::SmallVec;
+use rustc_data_structures::profiling::SelfProfilerRef;
 use rustc_data_structures::stable_hasher::{
     HashStable, StableHasher, StableVec, hash_stable_hashmap,
 };

--- a/src/librustc/ty/query/config.rs
+++ b/src/librustc/ty/query/config.rs
@@ -6,7 +6,7 @@ use crate::ty::query::queries;
 use crate::ty::query::{Query, QueryName};
 use crate::ty::query::QueryCache;
 use crate::ty::query::plumbing::CycleError;
-use crate::util::profiling::ProfileCategory;
+use rustc_data_structures::profiling::ProfileCategory;
 
 use std::borrow::Cow;
 use std::hash::Hash;

--- a/src/librustc/ty/query/mod.rs
+++ b/src/librustc/ty/query/mod.rs
@@ -39,7 +39,7 @@ use crate::ty::util::NeedsDrop;
 use crate::ty::subst::SubstsRef;
 use crate::util::nodemap::{DefIdSet, DefIdMap};
 use crate::util::common::ErrorReported;
-use crate::util::profiling::ProfileCategory::*;
+use rustc_data_structures::profiling::ProfileCategory::*;
 
 use rustc_data_structures::svh::Svh;
 use rustc_index::vec::IndexVec;

--- a/src/librustc/ty/query/plumbing.rs
+++ b/src/librustc/ty/query/plumbing.rs
@@ -827,7 +827,9 @@ macro_rules! define_queries_inner {
         }
 
         impl QueryName {
-            pub fn register_with_profiler(profiler: &rustc_data_structures::profiling::SelfProfiler) {
+            pub fn register_with_profiler(
+                profiler: &rustc_data_structures::profiling::SelfProfiler,
+            ) {
                 $(profiler.register_query_name(QueryName::$name);)*
             }
 

--- a/src/librustc/ty/query/plumbing.rs
+++ b/src/librustc/ty/query/plumbing.rs
@@ -672,7 +672,7 @@ macro_rules! define_queries_inner {
             rustc_data_structures::stable_hasher::StableHasher,
             ich::StableHashingContext
         };
-        use crate::util::profiling::ProfileCategory;
+        use rustc_data_structures::profiling::ProfileCategory;
 
         define_queries_struct! {
             tcx: $tcx,
@@ -816,8 +816,18 @@ macro_rules! define_queries_inner {
             $($name),*
         }
 
+        impl rustc_data_structures::profiling::QueryName for QueryName {
+            fn discriminant(self) -> std::mem::Discriminant<QueryName> {
+                std::mem::discriminant(&self)
+            }
+
+            fn as_str(self) -> &'static str {
+                QueryName::as_str(&self)
+            }
+        }
+
         impl QueryName {
-            pub fn register_with_profiler(profiler: &crate::util::profiling::SelfProfiler) {
+            pub fn register_with_profiler(profiler: &rustc_data_structures::profiling::SelfProfiler) {
                 $(profiler.register_query_name(QueryName::$name);)*
             }
 

--- a/src/librustc_codegen_ssa/back/symbol_export.rs
+++ b/src/librustc_codegen_ssa/back/symbol_export.rs
@@ -194,7 +194,7 @@ fn exported_symbols_provider_local(
         symbols.push((exported_symbol, SymbolExportLevel::C));
     }
 
-    if tcx.sess.allocator_kind.get().is_some() {
+    if tcx.allocator_kind().is_some() {
         for method in ALLOCATOR_METHODS {
             let symbol_name = format!("__rust_{}", method.name);
             let exported_symbol = ExportedSymbol::NoDefId(SymbolName::new(&symbol_name));

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -19,7 +19,7 @@ use rustc::util::nodemap::FxHashMap;
 use rustc::hir::def_id::{CrateNum, LOCAL_CRATE};
 use rustc::ty::TyCtxt;
 use rustc::util::common::{time_depth, set_time_depth, print_time_passes_entry};
-use rustc::util::profiling::SelfProfilerRef;
+use rustc_data_structures::profiling::SelfProfilerRef;
 use rustc_fs_util::link_or_copy;
 use rustc_data_structures::svh::Svh;
 use rustc_data_structures::sync::Lrc;

--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -549,7 +549,7 @@ pub fn codegen_crate<B: ExtraBackendMethods>(
         });
     let allocator_module = if any_dynamic_crate {
         None
-    } else if let Some(kind) = *tcx.sess.allocator_kind.get() {
+    } else if let Some(kind) = tcx.allocator_kind() {
         let llmod_id = cgu_name_builder.build_cgu_name(LOCAL_CRATE,
                                                        &["crate"],
                                                        Some("allocator")).to_string();

--- a/src/librustc_data_structures/Cargo.toml
+++ b/src/librustc_data_structures/Cargo.toml
@@ -25,6 +25,8 @@ rayon-core = { version = "0.3.0", package = "rustc-rayon-core" }
 rustc-hash = "1.0.1"
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }
 rustc_index = { path = "../librustc_index", package = "rustc_index" }
+bitflags = "1.2.1"
+measureme = "0.4"
 
 [dependencies.parking_lot]
 version = "0.9"

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -94,6 +94,7 @@ pub use ena::unify;
 pub mod vec_linked_list;
 pub mod work_queue;
 pub mod fingerprint;
+pub mod profiling;
 
 pub struct OnDrop<F: Fn()>(pub F);
 

--- a/src/librustc_data_structures/profiling.rs
+++ b/src/librustc_data_structures/profiling.rs
@@ -7,8 +7,6 @@ use std::sync::Arc;
 use std::thread::ThreadId;
 use std::u32;
 
-use crate::ty::query::QueryName;
-
 use measureme::{StringId, TimestampKind};
 
 /// MmapSerializatioSink is faster on macOS and Linux
@@ -20,6 +18,10 @@ type SerializationSink = measureme::FileSerializationSink;
 
 type Profiler = measureme::Profiler<SerializationSink>;
 
+pub trait QueryName: Sized + Copy {
+    fn discriminant(self) -> Discriminant<Self>;
+    fn as_str(self) -> &'static str;
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd)]
 pub enum ProfileCategory {
@@ -32,7 +34,7 @@ pub enum ProfileCategory {
     Other,
 }
 
-bitflags! {
+bitflags::bitflags! {
     struct EventFilter: u32 {
         const GENERIC_ACTIVITIES = 1 << 0;
         const QUERY_PROVIDERS    = 1 << 1;
@@ -137,7 +139,7 @@ impl SelfProfilerRef {
     /// Start profiling a query provider. Profiling continues until the
     /// TimingGuard returned from this call is dropped.
     #[inline(always)]
-    pub fn query_provider(&self, query_name: QueryName) -> TimingGuard<'_> {
+    pub fn query_provider(&self, query_name: impl QueryName) -> TimingGuard<'_> {
         self.exec(EventFilter::QUERY_PROVIDERS, |profiler| {
             let event_id = SelfProfiler::get_query_name_string_id(query_name);
             TimingGuard::start(profiler, profiler.query_event_kind, event_id)
@@ -146,7 +148,7 @@ impl SelfProfilerRef {
 
     /// Record a query in-memory cache hit.
     #[inline(always)]
-    pub fn query_cache_hit(&self, query_name: QueryName) {
+    pub fn query_cache_hit(&self, query_name: impl QueryName) {
         self.non_guard_query_event(
             |profiler| profiler.query_cache_hit_event_kind,
             query_name,
@@ -159,7 +161,7 @@ impl SelfProfilerRef {
     /// Profiling continues until the TimingGuard returned from this call is
     /// dropped.
     #[inline(always)]
-    pub fn query_blocked(&self, query_name: QueryName) -> TimingGuard<'_> {
+    pub fn query_blocked(&self, query_name: impl QueryName) -> TimingGuard<'_> {
         self.exec(EventFilter::QUERY_BLOCKED, |profiler| {
             let event_id = SelfProfiler::get_query_name_string_id(query_name);
             TimingGuard::start(profiler, profiler.query_blocked_event_kind, event_id)
@@ -170,7 +172,7 @@ impl SelfProfilerRef {
     /// incremental compilation on-disk cache. Profiling continues until the
     /// TimingGuard returned from this call is dropped.
     #[inline(always)]
-    pub fn incr_cache_loading(&self, query_name: QueryName) -> TimingGuard<'_> {
+    pub fn incr_cache_loading(&self, query_name: impl QueryName) -> TimingGuard<'_> {
         self.exec(EventFilter::INCR_CACHE_LOADS, |profiler| {
             let event_id = SelfProfiler::get_query_name_string_id(query_name);
             TimingGuard::start(
@@ -185,7 +187,7 @@ impl SelfProfilerRef {
     fn non_guard_query_event(
         &self,
         event_kind: fn(&SelfProfiler) -> StringId,
-        query_name: QueryName,
+        query_name: impl QueryName,
         event_filter: EventFilter,
         timestamp_kind: TimestampKind
     ) {
@@ -274,15 +276,15 @@ impl SelfProfiler {
         })
     }
 
-    fn get_query_name_string_id(query_name: QueryName) -> StringId {
+    fn get_query_name_string_id(query_name: impl QueryName) -> StringId {
         let discriminant = unsafe {
-            mem::transmute::<Discriminant<QueryName>, u64>(mem::discriminant(&query_name))
+            mem::transmute::<Discriminant<_>, u64>(query_name.discriminant())
         };
 
         StringId::reserved(discriminant as u32)
     }
 
-    pub fn register_query_name(&self, query_name: QueryName) {
+    pub fn register_query_name(&self, query_name: impl QueryName) {
         let id = SelfProfiler::get_query_name_string_id(query_name);
         self.profiler.alloc_string_with_reserved_id(id, query_name.as_str());
     }

--- a/src/librustc_data_structures/profiling.rs
+++ b/src/librustc_data_structures/profiling.rs
@@ -205,6 +205,12 @@ impl SelfProfilerRef {
             TimingGuard::none()
         }));
     }
+
+    pub fn register_queries(&self, f: impl FnOnce(&SelfProfiler)) {
+        if let Some(profiler) = &self.profiler {
+            f(&profiler)
+        }
+    }
 }
 
 pub struct SelfProfiler {

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -181,6 +181,7 @@ pub fn run_compiler(
             crate_name: None,
             lint_caps: Default::default(),
             register_lints: None,
+            override_queries: None,
         };
         callbacks.config(&mut config);
         config
@@ -259,6 +260,7 @@ pub fn run_compiler(
         crate_name: None,
         lint_caps: Default::default(),
         register_lints: None,
+        override_queries: None,
     };
 
     callbacks.config(&mut config);

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -786,6 +786,7 @@ pub fn create_global_ctxt(
     let codegen_backend = compiler.codegen_backend().clone();
     let crate_name = crate_name.to_string();
     let defs = mem::take(&mut resolver_outputs.definitions);
+    let override_queries = compiler.override_queries;
 
     let ((), result) = BoxedGlobalCtxt::new(static move || {
         let sess = &*sess;
@@ -809,6 +810,10 @@ pub fn create_global_ctxt(
         let mut extern_providers = local_providers;
         default_provide_extern(&mut extern_providers);
         codegen_backend.provide_extern(&mut extern_providers);
+
+        if let Some(callback) = override_queries {
+            callback(sess, &mut local_providers, &mut extern_providers);
+        }
 
         let gcx = TyCtxt::create_global_ctxt(
             sess,

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -108,6 +108,10 @@ pub fn create_session(
         process_configure_mod,
     );
 
+    sess.prof.register_queries(|profiler| {
+        rustc::ty::query::QueryName::register_with_profiler(&profiler);
+    });
+
     let codegen_backend = get_codegen_backend(&sess);
 
     let mut cfg = config::build_configuration(&sess, config::to_crate_config(cfg));

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -722,7 +722,7 @@ impl<'a> CrateLoader<'a> {
         }
     }
 
-    fn inject_allocator_crate(&self, krate: &ast::Crate) {
+    fn inject_allocator_crate(&mut self, krate: &ast::Crate) {
         let has_global_allocator = match &*global_allocator_spans(krate) {
             [span1, span2, ..] => {
                 self.sess.struct_span_err(*span2, "cannot define multiple global allocators")
@@ -742,7 +742,7 @@ impl<'a> CrateLoader<'a> {
             needs_allocator = needs_allocator || data.root.needs_allocator;
         });
         if !needs_allocator {
-            self.sess.allocator_kind.set(None);
+            self.cstore.allocator_kind = None;
             return
         }
 
@@ -758,7 +758,7 @@ impl<'a> CrateLoader<'a> {
                 }
             });
         if all_rlib {
-            self.sess.allocator_kind.set(None);
+            self.cstore.allocator_kind = None;
             return
         }
 
@@ -795,7 +795,7 @@ impl<'a> CrateLoader<'a> {
             }
         });
         if global_allocator.is_some() {
-            self.sess.allocator_kind.set(Some(AllocatorKind::Global));
+            self.cstore.allocator_kind = Some(AllocatorKind::Global);
             return
         }
 
@@ -816,7 +816,7 @@ impl<'a> CrateLoader<'a> {
                            add `#[global_allocator]` to a static item \
                            that implements the GlobalAlloc trait.");
         }
-        self.sess.allocator_kind.set(Some(AllocatorKind::DefaultLib));
+        self.cstore.allocator_kind = Some(AllocatorKind::DefaultLib);
     }
 
     fn inject_dependency_if(&self,

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -531,7 +531,7 @@ impl<'a> CrateLoader<'a> {
         });
         if !any_non_rlib {
             info!("panic runtime injection skipped, only generating rlib");
-            self.sess.injected_panic_runtime.set(None);
+            self.cstore.injected_panic_runtime = None;
             return
         }
 
@@ -563,7 +563,7 @@ impl<'a> CrateLoader<'a> {
         // we just don't need one at all, then we're done here and there's
         // nothing else to do.
         if !needs_panic_runtime || runtime_found {
-            self.sess.injected_panic_runtime.set(None);
+            self.cstore.injected_panic_runtime = None;
             return
         }
 
@@ -600,7 +600,7 @@ impl<'a> CrateLoader<'a> {
                                    name, desired_strategy.desc()));
         }
 
-        self.sess.injected_panic_runtime.set(Some(cnum));
+        self.cstore.injected_panic_runtime = Some(cnum);
         self.inject_dependency_if(cnum, "a panic runtime",
                                   &|data| data.root.needs_panic_runtime);
     }

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -101,6 +101,7 @@ crate struct CrateMetadata {
 #[derive(Clone)]
 pub struct CStore {
     metas: IndexVec<CrateNum, Option<Lrc<CrateMetadata>>>,
+    pub(crate) injected_panic_runtime: Option<CrateNum>,
 }
 
 pub enum LoadedMacro {
@@ -116,6 +117,7 @@ impl Default for CStore {
             // corresponding `CrateNum`. This first entry will always remain
             // `None`.
             metas: IndexVec::from_elem_n(None, 1),
+            injected_panic_runtime: None,
         }
     }
 }

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -14,6 +14,7 @@ use rustc_data_structures::svh::Svh;
 use syntax::ast;
 use syntax::edition::Edition;
 use syntax_expand::base::SyntaxExtension;
+use syntax::expand::allocator::AllocatorKind;
 use syntax_pos;
 use proc_macro::bridge::client::ProcMacro;
 
@@ -102,6 +103,7 @@ crate struct CrateMetadata {
 pub struct CStore {
     metas: IndexVec<CrateNum, Option<Lrc<CrateMetadata>>>,
     pub(crate) injected_panic_runtime: Option<CrateNum>,
+    pub(crate) allocator_kind: Option<AllocatorKind>,
 }
 
 pub enum LoadedMacro {
@@ -118,6 +120,7 @@ impl Default for CStore {
             // `None`.
             metas: IndexVec::from_elem_n(None, 1),
             injected_panic_runtime: None,
+            allocator_kind: None,
         }
     }
 }

--- a/src/librustc_metadata/dependency_format.rs
+++ b/src/librustc_metadata/dependency_format.rs
@@ -184,7 +184,7 @@ fn calculate_type(tcx: TyCtxt<'_>, ty: config::CrateType) -> DependencyList {
     //
     // Things like allocators and panic runtimes may not have been activated
     // quite yet, so do so here.
-    activate_injected_dep(*sess.injected_panic_runtime.get(), &mut ret,
+    activate_injected_dep(tcx.injected_panic_runtime(), &mut ret,
                           &|cnum| tcx.is_panic_runtime(cnum));
 
     // When dylib B links to dylib A, then when using B we must also link to A.
@@ -244,7 +244,6 @@ fn add_library(
 }
 
 fn attempt_static(tcx: TyCtxt<'_>) -> Option<DependencyList> {
-    let sess = &tcx.sess;
     let crates = cstore::used_crates(tcx, RequireStatic);
     if !crates.iter().by_ref().all(|&(_, ref p)| p.is_some()) {
         return None
@@ -264,7 +263,7 @@ fn attempt_static(tcx: TyCtxt<'_>) -> Option<DependencyList> {
     // Our allocator/panic runtime may not have been linked above if it wasn't
     // explicitly linked, which is the case for any injected dependency. Handle
     // that here and activate them.
-    activate_injected_dep(*sess.injected_panic_runtime.get(), &mut ret,
+    activate_injected_dep(tcx.injected_panic_runtime(), &mut ret,
                           &|cnum| tcx.is_panic_runtime(cnum));
 
     Some(ret)

--- a/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
+++ b/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
@@ -527,4 +527,8 @@ impl CrateStore for cstore::CStore {
     {
         rmeta::METADATA_HEADER
     }
+
+    fn injected_panic_runtime(&self) -> Option<CrateNum> {
+        self.injected_panic_runtime
+    }
 }

--- a/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
+++ b/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
@@ -31,6 +31,7 @@ use syntax::attr;
 use syntax::source_map;
 use syntax::source_map::Spanned;
 use syntax::symbol::Symbol;
+use syntax::expand::allocator::AllocatorKind;
 use syntax_pos::{Span, FileName};
 
 macro_rules! provide {
@@ -530,5 +531,9 @@ impl CrateStore for cstore::CStore {
 
     fn injected_panic_runtime(&self) -> Option<CrateNum> {
         self.injected_panic_runtime
+    }
+
+    fn allocator_kind(&self) -> Option<AllocatorKind> {
+        self.allocator_kind
     }
 }

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -335,6 +335,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
         crate_name,
         lint_caps,
         register_lints: None,
+        override_queries: None,
     };
 
     interface::run_compiler_in_existing_thread_pool(config, |compiler| {

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -247,7 +247,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
     } = options;
 
     // Add the rustdoc cfg into the doc build.
-    cfgs.push("rustdoc".to_string());
+    cfgs.push("doc".to_string());
 
     let cpath = Some(input.clone());
     let input = Input::File(input);

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -79,6 +79,7 @@ pub fn run(options: Options) -> i32 {
         crate_name: options.crate_name.clone(),
         lint_caps: Default::default(),
         register_lints: None,
+        override_queries: None,
     };
 
     let mut test_args = options.test_args.clone();

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -63,7 +63,7 @@ pub fn run(options: Options) -> i32 {
     };
 
     let mut cfgs = options.cfgs.clone();
-    cfgs.push("rustdoc".to_owned());
+    cfgs.push("doc".to_owned());
     cfgs.push("doctest".to_owned());
     let config = interface::Config {
         opts: sessopts,

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -369,7 +369,7 @@ impl<R: Seek> Seek for BufReader<R> {
 ///
 /// It is critical to call [`flush`] before `BufWriter<W>` is dropped. Though
 /// dropping will attempt to flush the the contents of the buffer, any errors
-/// that happen in the process of dropping will be ignored. Calling ['flush']
+/// that happen in the process of dropping will be ignored. Calling [`flush`]
 /// ensures that the buffer is empty and thus dropping will not even attempt
 /// file operations.
 ///

--- a/src/libstd/os/mod.rs
+++ b/src/libstd/os/mod.rs
@@ -4,7 +4,7 @@
 #![allow(missing_docs, nonstandard_style, missing_debug_implementations)]
 
 cfg_if::cfg_if! {
-    if #[cfg(rustdoc)] {
+    if #[cfg(doc)] {
 
         // When documenting libstd we want to show unix/windows/linux modules as
         // these are the "main modules" that are used across platforms. This

--- a/src/libstd/sys/mod.rs
+++ b/src/libstd/sys/mod.rs
@@ -56,7 +56,7 @@ cfg_if::cfg_if! {
 // then later used in the `std::os` module when documenting, for example,
 // Windows when we're compiling for Linux.
 
-#[cfg(rustdoc)]
+#[cfg(doc)]
 cfg_if::cfg_if! {
     if #[cfg(unix)] {
         // On unix we'll document what's already available
@@ -80,7 +80,7 @@ cfg_if::cfg_if! {
     }
 }
 
-#[cfg(rustdoc)]
+#[cfg(doc)]
 cfg_if::cfg_if! {
     if #[cfg(windows)] {
         // On windows we'll just be documenting what's already available

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -2,21 +2,21 @@
 
 use crate::io::ErrorKind;
 
-#[cfg(any(rustdoc, target_os = "linux"))] pub use crate::os::linux as platform;
+#[cfg(any(doc, target_os = "linux"))] pub use crate::os::linux as platform;
 
-#[cfg(all(not(rustdoc), target_os = "android"))]   pub use crate::os::android as platform;
-#[cfg(all(not(rustdoc), target_os = "dragonfly"))] pub use crate::os::dragonfly as platform;
-#[cfg(all(not(rustdoc), target_os = "freebsd"))]   pub use crate::os::freebsd as platform;
-#[cfg(all(not(rustdoc), target_os = "haiku"))]     pub use crate::os::haiku as platform;
-#[cfg(all(not(rustdoc), target_os = "ios"))]       pub use crate::os::ios as platform;
-#[cfg(all(not(rustdoc), target_os = "macos"))]     pub use crate::os::macos as platform;
-#[cfg(all(not(rustdoc), target_os = "netbsd"))]    pub use crate::os::netbsd as platform;
-#[cfg(all(not(rustdoc), target_os = "openbsd"))]   pub use crate::os::openbsd as platform;
-#[cfg(all(not(rustdoc), target_os = "solaris"))]   pub use crate::os::solaris as platform;
-#[cfg(all(not(rustdoc), target_os = "emscripten"))] pub use crate::os::emscripten as platform;
-#[cfg(all(not(rustdoc), target_os = "fuchsia"))]   pub use crate::os::fuchsia as platform;
-#[cfg(all(not(rustdoc), target_os = "l4re"))]      pub use crate::os::linux as platform;
-#[cfg(all(not(rustdoc), target_os = "redox"))]      pub use crate::os::redox as platform;
+#[cfg(all(not(doc), target_os = "android"))]   pub use crate::os::android as platform;
+#[cfg(all(not(doc), target_os = "dragonfly"))] pub use crate::os::dragonfly as platform;
+#[cfg(all(not(doc), target_os = "freebsd"))]   pub use crate::os::freebsd as platform;
+#[cfg(all(not(doc), target_os = "haiku"))]     pub use crate::os::haiku as platform;
+#[cfg(all(not(doc), target_os = "ios"))]       pub use crate::os::ios as platform;
+#[cfg(all(not(doc), target_os = "macos"))]     pub use crate::os::macos as platform;
+#[cfg(all(not(doc), target_os = "netbsd"))]    pub use crate::os::netbsd as platform;
+#[cfg(all(not(doc), target_os = "openbsd"))]   pub use crate::os::openbsd as platform;
+#[cfg(all(not(doc), target_os = "solaris"))]   pub use crate::os::solaris as platform;
+#[cfg(all(not(doc), target_os = "emscripten"))] pub use crate::os::emscripten as platform;
+#[cfg(all(not(doc), target_os = "fuchsia"))]   pub use crate::os::fuchsia as platform;
+#[cfg(all(not(doc), target_os = "l4re"))]      pub use crate::os::linux as platform;
+#[cfg(all(not(doc), target_os = "redox"))]      pub use crate::os::redox as platform;
 
 pub use self::rand::hashmap_random_keys;
 pub use libc::strlen;

--- a/src/libstd/sys_common/mod.rs
+++ b/src/libstd/sys_common/mod.rs
@@ -45,7 +45,7 @@ pub mod backtrace;
 pub mod condvar;
 pub mod io;
 pub mod mutex;
-#[cfg(any(rustdoc, // see `mod os`, docs are generated for multiple platforms
+#[cfg(any(doc, // see `mod os`, docs are generated for multiple platforms
           unix,
           target_os = "redox",
           target_os = "cloudabi",

--- a/src/libsyntax/feature_gate/builtin_attrs.rs
+++ b/src/libsyntax/feature_gate/builtin_attrs.rs
@@ -30,7 +30,7 @@ const GATED_CFGS: &[(Symbol, Symbol, GateFn)] = &[
     (sym::target_thread_local, sym::cfg_target_thread_local, cfg_fn!(cfg_target_thread_local)),
     (sym::target_has_atomic, sym::cfg_target_has_atomic, cfg_fn!(cfg_target_has_atomic)),
     (sym::target_has_atomic_load_store, sym::cfg_target_has_atomic, cfg_fn!(cfg_target_has_atomic)),
-    (sym::rustdoc, sym::doc_cfg, cfg_fn!(doc_cfg)),
+    (sym::doc, sym::doc_cfg, cfg_fn!(doc_cfg)),
 ];
 
 #[derive(Debug)]

--- a/src/test/run-make-fulldeps/issue-19371/foo.rs
+++ b/src/test/run-make-fulldeps/issue-19371/foo.rs
@@ -60,6 +60,7 @@ fn compile(code: String, output: PathBuf, sysroot: PathBuf) {
         crate_name: None,
         lint_caps: Default::default(),
         register_lints: None,
+        override_queries: None,
     };
 
     interface::run_compiler(config, |compiler| {

--- a/src/test/rustdoc-ui/doc-test-rustdoc-feature.rs
+++ b/src/test/rustdoc-ui/doc-test-rustdoc-feature.rs
@@ -4,11 +4,11 @@
 
 #![feature(doc_cfg)]
 
-// Make sure `cfg(rustdoc)` is set when finding doctests but not inside the doctests.
+// Make sure `cfg(doc)` is set when finding doctests but not inside the doctests.
 
 /// ```
 /// #![feature(doc_cfg)]
-/// assert!(!cfg!(rustdoc));
+/// assert!(!cfg!(doc));
 /// ```
-#[cfg(rustdoc)]
+#[cfg(doc)]
 pub struct Foo;

--- a/src/test/ui/associated-type-bounds/implied-region-constraints.stderr
+++ b/src/test/ui/associated-type-bounds/implied-region-constraints.stderr
@@ -18,3 +18,4 @@ LL |             let _failure_proves_not_implied_outlives_region_b: &'b T = &x;
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/associated-types/associated-types-project-from-hrtb-in-fn-body.stderr
+++ b/src/test/ui/associated-types/associated-types-project-from-hrtb-in-fn-body.stderr
@@ -11,3 +11,4 @@ LL |     let z: I::A = if cond { x } else { y };
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/associated-types/associated-types-subtyping-1.stderr
+++ b/src/test/ui/associated-types/associated-types-subtyping-1.stderr
@@ -18,3 +18,4 @@ LL |     let _c: <T as Trait<'a>>::Type = b;
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/associated-types/cache/project-fn-ret-contravariant.krisskross.stderr
+++ b/src/test/ui/associated-types/cache/project-fn-ret-contravariant.krisskross.stderr
@@ -22,3 +22,4 @@ LL |    (a, b)
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/associated-types/cache/project-fn-ret-invariant.krisskross.stderr
+++ b/src/test/ui/associated-types/cache/project-fn-ret-invariant.krisskross.stderr
@@ -21,3 +21,4 @@ LL |    let b = bar(foo, x);
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/associated-types/cache/project-fn-ret-invariant.oneuse.stderr
+++ b/src/test/ui/associated-types/cache/project-fn-ret-invariant.oneuse.stderr
@@ -11,3 +11,4 @@ LL |    let b = bar(f, y);
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/async-await/issues/issue-63388-1.stderr
+++ b/src/test/ui/async-await/issues/issue-63388-1.stderr
@@ -11,3 +11,4 @@ LL |         foo
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/async-await/multiple-lifetimes/ret-impl-trait-one.stderr
+++ b/src/test/ui/async-await/multiple-lifetimes/ret-impl-trait-one.stderr
@@ -9,3 +9,4 @@ LL | async fn async_ret_impl_trait1<'a, 'b>(a: &'a u8, b: &'b u8) -> impl Trait<
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/borrowck/borrowck-reborrow-from-shorter-lived-andmut.stderr
+++ b/src/test/ui/borrowck/borrowck-reborrow-from-shorter-lived-andmut.stderr
@@ -10,3 +10,4 @@ LL |     S { pointer: &mut *p.pointer }
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/consts/issue-52432.rs
+++ b/src/test/ui/consts/issue-52432.rs
@@ -1,0 +1,10 @@
+#![feature(const_raw_ptr_to_usize_cast)]
+
+fn main() {
+    [(); &(static |x| {}) as *const _ as usize];
+    //~^ ERROR: closures cannot be static
+    //~| ERROR: type annotations needed
+    [(); &(static || {}) as *const _ as usize];
+    //~^ ERROR: closures cannot be static
+    //~| ERROR: evaluation of constant value failed
+}

--- a/src/test/ui/consts/issue-52432.stderr
+++ b/src/test/ui/consts/issue-52432.stderr
@@ -1,0 +1,28 @@
+error[E0697]: closures cannot be static
+  --> $DIR/issue-52432.rs:4:12
+   |
+LL |     [(); &(static |x| {}) as *const _ as usize];
+   |            ^^^^^^^^^^
+
+error[E0697]: closures cannot be static
+  --> $DIR/issue-52432.rs:7:12
+   |
+LL |     [(); &(static || {}) as *const _ as usize];
+   |            ^^^^^^^^^
+
+error[E0282]: type annotations needed
+  --> $DIR/issue-52432.rs:4:20
+   |
+LL |     [(); &(static |x| {}) as *const _ as usize];
+   |                    ^ consider giving this closure parameter a type
+
+error[E0080]: evaluation of constant value failed
+  --> $DIR/issue-52432.rs:7:10
+   |
+LL |     [(); &(static || {}) as *const _ as usize];
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ "pointer-to-integer cast" needs an rfc before being allowed inside constants
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0080, E0282, E0697.
+For more information about an error, try `rustc --explain E0080`.

--- a/src/test/ui/continue-after-missing-main.stderr
+++ b/src/test/ui/continue-after-missing-main.stderr
@@ -21,4 +21,5 @@ LL |     let _: AdaptedMatrixProvider<'original_data, MP> = tableau.provider().c
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0601`.
+Some errors have detailed explanations: E0601, E0623.
+For more information about an error, try `rustc --explain E0601`.

--- a/src/test/ui/feature-gates/feature-gate-doc_cfg-cfg-rustdoc.rs
+++ b/src/test/ui/feature-gates/feature-gate-doc_cfg-cfg-rustdoc.rs
@@ -1,4 +1,4 @@
-#[cfg(rustdoc)] //~ ERROR: `cfg(rustdoc)` is experimental and subject to change
+#[cfg(doc)] //~ ERROR: `cfg(doc)` is experimental and subject to change
 pub struct SomeStruct;
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-doc_cfg-cfg-rustdoc.stderr
+++ b/src/test/ui/feature-gates/feature-gate-doc_cfg-cfg-rustdoc.stderr
@@ -1,8 +1,8 @@
-error[E0658]: `cfg(rustdoc)` is experimental and subject to change
+error[E0658]: `cfg(doc)` is experimental and subject to change
   --> $DIR/feature-gate-doc_cfg-cfg-rustdoc.rs:1:7
    |
-LL | #[cfg(rustdoc)]
-   |       ^^^^^^^
+LL | #[cfg(doc)]
+   |       ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/43781
    = help: add `#![feature(doc_cfg)]` to the crate attributes to enable

--- a/src/test/ui/impl-trait/must_outlive_least_region_or_bound.stderr
+++ b/src/test/ui/impl-trait/must_outlive_least_region_or_bound.stderr
@@ -77,4 +77,5 @@ LL | fn ty_param_wont_outlive_static<T:Debug>(x: T) -> impl Debug + 'static {
 
 error: aborting due to 5 previous errors
 
-For more information about this error, try `rustc --explain E0310`.
+Some errors have detailed explanations: E0310, E0623.
+For more information about an error, try `rustc --explain E0310`.

--- a/src/test/ui/in-band-lifetimes/mismatched.stderr
+++ b/src/test/ui/in-band-lifetimes/mismatched.stderr
@@ -16,4 +16,5 @@ LL | fn foo2(x: &'a u32, y: &'b u32) -> &'a u32 { y }
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0621`.
+Some errors have detailed explanations: E0621, E0623.
+For more information about an error, try `rustc --explain E0621`.

--- a/src/test/ui/in-band-lifetimes/mismatched_trait_impl.stderr
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait_impl.stderr
@@ -22,3 +22,4 @@ LL |         x
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/issues/issue-17728.stderr
+++ b/src/test/ui/issues/issue-17728.stderr
@@ -29,4 +29,5 @@ LL | |     }
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0308`.
+Some errors have detailed explanations: E0308, E0623.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/issues/issue-40231-1.rs
+++ b/src/test/ui/issues/issue-40231-1.rs
@@ -1,0 +1,54 @@
+// check-pass
+
+#![allow(dead_code)]
+
+trait Structure<E>: Sized where E: Encoding {
+    type RefTarget: ?Sized;
+    type FfiPtr;
+    unsafe fn borrow_from_ffi_ptr<'a>(ptr: Self::FfiPtr) -> Option<&'a Self::RefTarget>;
+}
+
+enum Slice {}
+
+impl<E> Structure<E> for Slice where E: Encoding {
+    type RefTarget = [E::Unit];
+    type FfiPtr = (*const E::FfiUnit, usize);
+    unsafe fn borrow_from_ffi_ptr<'a>(_ptr: Self::FfiPtr) -> Option<&'a Self::RefTarget> {
+        panic!()
+    }
+}
+
+trait Encoding {
+    type Unit: Unit;
+    type FfiUnit;
+}
+
+trait Unit {}
+
+enum Utf16 {}
+
+impl Encoding for Utf16 {
+    type Unit = Utf16Unit;
+    type FfiUnit = u16;
+}
+
+struct Utf16Unit(pub u16);
+
+impl Unit for Utf16Unit {}
+
+type SUtf16Str = SeStr<Slice, Utf16>;
+
+struct SeStr<S, E> where S: Structure<E>, E: Encoding {
+    _data: S::RefTarget,
+}
+
+impl<S, E> SeStr<S, E> where S: Structure<E>, E: Encoding {
+    pub unsafe fn from_ptr<'a>(_ptr: S::FfiPtr) -> Option<&'a Self> {
+        panic!()
+    }
+}
+
+fn main() {
+    const TEXT_U16: &'static [u16] = &[];
+    let _ = unsafe { SUtf16Str::from_ptr((TEXT_U16.as_ptr(), TEXT_U16.len())).unwrap() };
+}

--- a/src/test/ui/issues/issue-40231-2.rs
+++ b/src/test/ui/issues/issue-40231-2.rs
@@ -1,0 +1,54 @@
+// check-pass
+
+#![allow(dead_code)]
+
+trait Structure<E>: Sized where E: Encoding {
+    type RefTarget: ?Sized;
+    type FfiPtr;
+    unsafe fn borrow_from_ffi_ptr<'a>(ptr: Self::FfiPtr) -> Option<&'a Self::RefTarget>;
+}
+
+enum Slice {}
+
+impl<E> Structure<E> for Slice where E: Encoding {
+    type RefTarget = [E::Unit];
+    type FfiPtr = (*const E::FfiUnit, usize);
+    unsafe fn borrow_from_ffi_ptr<'a>(_ptr: Self::FfiPtr) -> Option<&'a Self::RefTarget> {
+        panic!()
+    }
+}
+
+trait Encoding {
+    type Unit: Unit;
+    type FfiUnit;
+}
+
+trait Unit {}
+
+enum Utf16 {}
+
+impl Encoding for Utf16 {
+    type Unit = Utf16Unit;
+    type FfiUnit = u16;
+}
+
+struct Utf16Unit(pub u16);
+
+impl Unit for Utf16Unit {}
+
+struct SUtf16Str {
+    _data: <Slice as Structure<Utf16>>::RefTarget,
+}
+
+impl SUtf16Str {
+    pub unsafe fn from_ptr<'a>(ptr: <Slice as Structure<Utf16>>::FfiPtr)
+    -> Option<&'a Self> {
+        std::mem::transmute::<Option<&[<Utf16 as Encoding>::Unit]>, _>(
+            <Slice as Structure<Utf16>>::borrow_from_ffi_ptr(ptr))
+    }
+}
+
+fn main() {
+    const TEXT_U16: &'static [u16] = &[];
+    let _ = unsafe { SUtf16Str::from_ptr((TEXT_U16.as_ptr(), TEXT_U16.len())).unwrap() };
+}

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl.stderr
@@ -11,3 +11,4 @@ LL |         if x > y { x } else { y }
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.stderr
@@ -11,3 +11,4 @@ LL |     x
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-self-is-anon.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-self-is-anon.stderr
@@ -11,3 +11,4 @@ LL |         if true { x } else { self }
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex2b-push-no-existing-names.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex2b-push-no-existing-names.stderr
@@ -8,3 +8,4 @@ LL |     x.push(y);
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex2c-push-inference-variable.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex2c-push-inference-variable.stderr
@@ -9,3 +9,4 @@ LL |     x.push(z);
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex2d-push-inference-variable-2.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex2d-push-inference-variable-2.stderr
@@ -8,3 +8,4 @@ LL |     let a: &mut Vec<Ref<i32>> = x;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex2e-push-inference-variable-3.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex2e-push-inference-variable-3.stderr
@@ -8,3 +8,4 @@ LL |     let a: &mut Vec<Ref<i32>> = x;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-2.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-2.stderr
@@ -8,3 +8,4 @@ LL |     *v = x;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-3.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-3.stderr
@@ -16,3 +16,4 @@ LL |     z.push((x,y));
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-2.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-2.stderr
@@ -8,3 +8,4 @@ LL |     x.b = y.b;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-3.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-3.stderr
@@ -8,3 +8,4 @@ LL |     x.a = x.b;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-earlybound-regions.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-earlybound-regions.stderr
@@ -9,3 +9,4 @@ LL |     x.push(y);
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-latebound-regions.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-latebound-regions.stderr
@@ -8,3 +8,4 @@ LL |     x.push(y);
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs.stderr
@@ -8,3 +8,4 @@ LL |     x.push(y);
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-latebound-regions.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-latebound-regions.stderr
@@ -8,3 +8,4 @@ LL |     x.push(y);
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-2.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-2.stderr
@@ -10,3 +10,4 @@ LL |     y = x.b;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-3.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-3.stderr
@@ -8,3 +8,4 @@ LL |     y.b = x;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-4.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-4.stderr
@@ -8,3 +8,4 @@ LL |     y.b = x;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct.stderr
@@ -8,3 +8,4 @@ LL |     x.b = y;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.stderr
@@ -10,3 +10,4 @@ LL |     x
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-self-is-anon.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-self-is-anon.stderr
@@ -10,3 +10,4 @@ LL |         if true { x } else { self }
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-fn-items.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-fn-items.stderr
@@ -8,3 +8,4 @@ LL |   y.push(z);
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-impl-items.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-impl-items.stderr
@@ -8,3 +8,4 @@ LL |         x.push(y);
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-trait-objects.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-trait-objects.stderr
@@ -8,3 +8,4 @@ LL |   y.push(z);
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions.stderr
@@ -8,3 +8,4 @@ LL |     x.push(y);
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/object-lifetime/object-lifetime-default-mybox.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-mybox.stderr
@@ -27,4 +27,5 @@ LL | fn load2<'a>(ss: &MyBox<dyn SomeTrait + 'a>) -> MyBox<dyn SomeTrait + 'a> {
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0308`.
+Some errors have detailed explanations: E0308, E0623.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/regions/region-lifetime-bounds-on-fns-where-clause.stderr
+++ b/src/test/ui/regions/region-lifetime-bounds-on-fns-where-clause.stderr
@@ -27,4 +27,5 @@ LL |     let _: fn(&mut &isize, &mut &isize) = a;
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0308`.
+Some errors have detailed explanations: E0308, E0623.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.stderr
+++ b/src/test/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.stderr
@@ -38,4 +38,5 @@ LL |     let _: fn(&mut &isize, &mut &isize, &mut &isize) = a;
 
 error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0308`.
+Some errors have detailed explanations: E0308, E0623.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/regions/regions-bounded-method-type-parameters-cross-crate.stderr
+++ b/src/test/ui/regions/regions-bounded-method-type-parameters-cross-crate.stderr
@@ -9,3 +9,4 @@ LL |     a.bigger_region(b)
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/regions/regions-bounded-method-type-parameters-trait-bound.stderr
+++ b/src/test/ui/regions/regions-bounded-method-type-parameters-trait-bound.stderr
@@ -9,3 +9,4 @@ LL |     f.method(b);
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/regions/regions-creating-enums3.stderr
+++ b/src/test/ui/regions/regions-creating-enums3.stderr
@@ -10,3 +10,4 @@ LL |     Ast::Add(x, y)
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/regions/regions-free-region-ordering-callee.stderr
+++ b/src/test/ui/regions/regions-free-region-ordering-callee.stderr
@@ -22,3 +22,4 @@ LL |     let z: &'b usize = &*x;
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/regions/regions-free-region-ordering-caller.migrate.stderr
+++ b/src/test/ui/regions/regions-free-region-ordering-caller.migrate.stderr
@@ -29,3 +29,4 @@ LL |     let z: Option<&'a &'b usize> = None;
 
 error: aborting due to 3 previous errors
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/regions/regions-infer-contravariance-due-to-decl.stderr
+++ b/src/test/ui/regions/regions-infer-contravariance-due-to-decl.stderr
@@ -12,3 +12,4 @@ LL |     let _: Contravariant<'long> = c;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/regions/regions-infer-covariance-due-to-decl.stderr
+++ b/src/test/ui/regions/regions-infer-covariance-due-to-decl.stderr
@@ -11,3 +11,4 @@ LL |     let _: Covariant<'short> = c;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/regions/regions-lifetime-bounds-on-fns.stderr
+++ b/src/test/ui/regions/regions-lifetime-bounds-on-fns.stderr
@@ -27,4 +27,5 @@ LL |     let _: fn(&mut &isize, &mut &isize) = a;
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0308`.
+Some errors have detailed explanations: E0308, E0623.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/regions/regions-reborrow-from-shorter-mut-ref-mut-ref.stderr
+++ b/src/test/ui/regions/regions-reborrow-from-shorter-mut-ref-mut-ref.stderr
@@ -10,3 +10,4 @@ LL |     &mut ***p
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/regions/regions-reborrow-from-shorter-mut-ref.stderr
+++ b/src/test/ui/regions/regions-reborrow-from-shorter-mut-ref.stderr
@@ -10,3 +10,4 @@ LL |     &mut **p
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/regions/regions-variance-contravariant-use-covariant-in-second-position.stderr
+++ b/src/test/ui/regions/regions-variance-contravariant-use-covariant-in-second-position.stderr
@@ -9,3 +9,4 @@ LL |     let _: S<'long, 'long> = c;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/regions/regions-variance-contravariant-use-covariant.stderr
+++ b/src/test/ui/regions/regions-variance-contravariant-use-covariant.stderr
@@ -12,3 +12,4 @@ LL |     let _: Contravariant<'long> = c;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/regions/regions-variance-covariant-use-contravariant.stderr
+++ b/src/test/ui/regions/regions-variance-covariant-use-contravariant.stderr
@@ -11,3 +11,4 @@ LL |     let _: Covariant<'short> = c;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/regions/regions-variance-invariant-use-contravariant.stderr
+++ b/src/test/ui/regions/regions-variance-invariant-use-contravariant.stderr
@@ -11,3 +11,4 @@ LL |     let _: Invariant<'short> = c;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.stderr
@@ -24,3 +24,4 @@ LL |     async fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }
 
 error: aborting due to 3 previous errors
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch.stderr
@@ -24,3 +24,4 @@ LL |     fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }
 
 error: aborting due to 3 previous errors
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/self/elision/lt-ref-self-async.stderr
+++ b/src/test/ui/self/elision/lt-ref-self-async.stderr
@@ -60,3 +60,4 @@ LL |         f
 
 error: aborting due to 6 previous errors
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/self/elision/lt-ref-self.stderr
+++ b/src/test/ui/self/elision/lt-ref-self.stderr
@@ -60,3 +60,4 @@ LL |         f
 
 error: aborting due to 6 previous errors
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/self/elision/ref-mut-self-async.stderr
+++ b/src/test/ui/self/elision/ref-mut-self-async.stderr
@@ -60,3 +60,4 @@ LL |         f
 
 error: aborting due to 6 previous errors
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/self/elision/ref-mut-self.stderr
+++ b/src/test/ui/self/elision/ref-mut-self.stderr
@@ -60,3 +60,4 @@ LL |         f
 
 error: aborting due to 6 previous errors
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/self/elision/ref-mut-struct-async.stderr
+++ b/src/test/ui/self/elision/ref-mut-struct-async.stderr
@@ -50,3 +50,4 @@ LL |         f
 
 error: aborting due to 5 previous errors
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/self/elision/ref-mut-struct.stderr
+++ b/src/test/ui/self/elision/ref-mut-struct.stderr
@@ -50,3 +50,4 @@ LL |         f
 
 error: aborting due to 5 previous errors
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/self/elision/ref-self-async.stderr
+++ b/src/test/ui/self/elision/ref-self-async.stderr
@@ -70,3 +70,4 @@ LL |         f
 
 error: aborting due to 7 previous errors
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/self/elision/ref-self.stderr
+++ b/src/test/ui/self/elision/ref-self.stderr
@@ -70,3 +70,4 @@ LL |         f
 
 error: aborting due to 7 previous errors
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/self/elision/ref-struct-async.stderr
+++ b/src/test/ui/self/elision/ref-struct-async.stderr
@@ -50,3 +50,4 @@ LL |         f
 
 error: aborting due to 5 previous errors
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/self/elision/ref-struct.stderr
+++ b/src/test/ui/self/elision/ref-struct.stderr
@@ -50,3 +50,4 @@ LL |         f
 
 error: aborting due to 5 previous errors
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/type-alias-impl-trait/issue-63279.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-63279.rs
@@ -1,0 +1,9 @@
+#![feature(type_alias_impl_trait)]
+
+type Closure = impl FnOnce(); //~ ERROR: type mismatch resolving
+
+fn c() -> Closure {
+    || -> Closure { || () }
+}
+
+fn main() {}

--- a/src/test/ui/type-alias-impl-trait/issue-63279.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-63279.stderr
@@ -1,0 +1,13 @@
+error[E0271]: type mismatch resolving `<[closure@$DIR/issue-63279.rs:6:5: 6:28] as std::ops::FnOnce<()>>::Output == ()`
+  --> $DIR/issue-63279.rs:3:1
+   |
+LL | type Closure = impl FnOnce();
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected opaque type, found ()
+   |
+   = note: expected type `Closure`
+              found type `()`
+   = note: the return type of a function must have a statically known size
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0271`.

--- a/src/test/ui/unboxed-closures/issue-30904.rs
+++ b/src/test/ui/unboxed-closures/issue-30904.rs
@@ -1,0 +1,36 @@
+#![feature(fn_traits, unboxed_closures)]
+
+fn test<F: for<'x> FnOnce<(&'x str,)>>(_: F) {}
+
+struct Compose<F,G>(F,G);
+impl<T,F,G> FnOnce<(T,)> for Compose<F,G>
+where F: FnOnce<(T,)>, G: FnOnce<(F::Output,)> {
+    type Output = G::Output;
+    extern "rust-call" fn call_once(self, (x,): (T,)) -> G::Output {
+        (self.1)((self.0)(x))
+    }
+}
+
+struct Str<'a>(&'a str);
+fn mk_str<'a>(s: &'a str) -> Str<'a> { Str(s) }
+
+fn main() {
+    let _: for<'a> fn(&'a str) -> Str<'a> = mk_str;
+    // expected concrete lifetime, found bound lifetime parameter 'a
+    let _: for<'a> fn(&'a str) -> Str<'a> = Str;
+    //~^ ERROR: mismatched types
+
+    test(|_: &str| {});
+    test(mk_str);
+    // expected concrete lifetime, found bound lifetime parameter 'x
+    test(Str); //~ ERROR: type mismatch in function arguments
+
+    test(Compose(|_: &str| {}, |_| {}));
+    test(Compose(mk_str, |_| {}));
+    // internal compiler error: cannot relate bound region:
+    //   ReLateBound(DebruijnIndex { depth: 2 },
+    //     BrNamed(DefId { krate: 0, node: DefIndex(6) => test::'x }, 'x(65)))
+    //<= ReSkolemized(0,
+    //     BrNamed(DefId { krate: 0, node: DefIndex(6) => test::'x }, 'x(65)))
+    test(Compose(Str, |_| {}));
+}

--- a/src/test/ui/unboxed-closures/issue-30904.stderr
+++ b/src/test/ui/unboxed-closures/issue-30904.stderr
@@ -1,0 +1,24 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-30904.rs:20:45
+   |
+LL |     let _: for<'a> fn(&'a str) -> Str<'a> = Str;
+   |                                             ^^^ expected concrete lifetime, found bound lifetime parameter 'a
+   |
+   = note: expected type `for<'a> fn(&'a str) -> Str<'a>`
+              found type `fn(&str) -> Str<'_> {Str::<'_>}`
+
+error[E0631]: type mismatch in function arguments
+  --> $DIR/issue-30904.rs:26:10
+   |
+LL | fn test<F: for<'x> FnOnce<(&'x str,)>>(_: F) {}
+   |    ----    -------------------------- required by this bound in `test`
+...
+LL | struct Str<'a>(&'a str);
+   | ------------------------ found signature of `fn(&str) -> _`
+...
+LL |     test(Str);
+   |          ^^^ expected signature of `for<'x> fn(&'x str) -> _`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/underscore-lifetime/underscore-lifetime-elison-mismatch.stderr
+++ b/src/test/ui/underscore-lifetime/underscore-lifetime-elison-mismatch.stderr
@@ -8,3 +8,4 @@ LL | fn foo(x: &mut Vec<&'_ u8>, y: &'_ u8) { x.push(y); }
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/variance/variance-cell-is-invariant.stderr
+++ b/src/test/ui/variance/variance-cell-is-invariant.stderr
@@ -12,3 +12,4 @@ LL |     let _: Foo<'long> = c;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0623`.


### PR DESCRIPTION
Successful merges:

 - #65932 (download .tar.xz if python3 is used)
 - #66094 (Fix documentation for `Iterator::count()`.)
 - #66166 (rename cfg(rustdoc) into cfg(doc))
 - #66186 (Add long error explanation for E0623)
 - #66227 (docs: Fix link to BufWriter::flush)
 - #66248 (add raw ptr variant of UnsafeCell::get)
 - #66292 (add Result::map_or)
 - #66297 (Add a callback that allows compiler consumers to override queries.)
 - #66317 (Use a relative bindir for rustdoc to find rustc)
 - #66330 (Improve non-exhaustiveness handling in usefulness checking)
 - #66331 (Add some tests for fixed ICEs)
 - #66334 (Move Session fields to CrateStore)
 - #66335 (Move self-profile infrastructure to data structures)
 - #66337 (Remove dead code for encoding/decoding lint IDs)

Failed merges:


r? @ghost