### PR TITLE
Extend vec::FromIterator specialization to collect in-place for some iterator pipelines

### DIFF
--- a/src/liballoc/benches/vec.rs
+++ b/src/liballoc/benches/vec.rs
@@ -237,6 +237,20 @@ fn do_bench_push_all(b: &mut Bencher, dst_len: usize, src_len: usize) {
 }
 
 #[bench]
+fn bench_extend_recycle(b: &mut Bencher) {
+    let mut data = vec![0; 1000];
+
+    b.iter(|| {
+        let tmp = std::mem::replace(&mut data, Vec::new());
+        let mut to_extend = black_box(Vec::new());
+        to_extend.extend(tmp.into_iter());
+        std::mem::replace(&mut data, black_box(to_extend));
+    });
+
+    black_box(data);
+}
+
+#[bench]
 fn bench_push_all_0000_0000(b: &mut Bencher) {
     do_bench_push_all(b, 0, 0)
 }

--- a/src/liballoc/benches/vec.rs
+++ b/src/liballoc/benches/vec.rs
@@ -532,6 +532,26 @@ bench_in_place![
 ];
 
 #[bench]
+fn bench_in_place_recycle(b: &mut test::Bencher) {
+    let mut data = vec![0; 1000];
+
+    b.iter(|| {
+        let tmp = std::mem::replace(&mut data, Vec::new());
+        std::mem::replace(
+            &mut data,
+            black_box(
+                tmp.into_iter()
+                    .enumerate()
+                    .map(|(idx, e)| idx.wrapping_add(e))
+                    .fuse()
+                    .peekable()
+                    .collect::<Vec<usize>>(),
+            ),
+        );
+    });
+}
+
+#[bench]
 fn bench_chain_collect(b: &mut test::Bencher) {
     let data = black_box([0; LEN]);
     b.iter(|| data.iter().cloned().chain([1].iter().cloned()).collect::<Vec<_>>());

--- a/src/liballoc/benches/vec.rs
+++ b/src/liballoc/benches/vec.rs
@@ -554,10 +554,10 @@ fn bench_in_place_recycle(b: &mut test::Bencher) {
 
 #[bench]
 fn bench_in_place_zip_recycle(b: &mut test::Bencher) {
-    let mut data = vec![0u8; 256];
+    let mut data = vec![0u8; 1000];
     let mut rng = rand::thread_rng();
-    let mut subst = (0..=255u8).collect::<Vec<_>>();
-    subst.shuffle(&mut rng);
+    let mut subst = vec![0u8; 1000];
+    rng.fill_bytes(&mut subst[..]);
 
     b.iter(|| {
         let tmp = std::mem::replace(&mut data, Vec::new());
@@ -567,7 +567,7 @@ fn bench_in_place_zip_recycle(b: &mut test::Bencher) {
             .enumerate()
             .map(|(i, (d, s))| d.wrapping_add(i as u8) ^ s)
             .collect::<Vec<_>>();
-        assert_eq!(mangled.len(), 256);
+        assert_eq!(mangled.len(), 1000);
         std::mem::replace(&mut data, black_box(mangled));
     });
 }
@@ -576,8 +576,8 @@ fn bench_in_place_zip_recycle(b: &mut test::Bencher) {
 fn bench_in_place_zip_iter_mut(b: &mut test::Bencher) {
     let mut data = vec![0u8; 256];
     let mut rng = rand::thread_rng();
-    let mut subst = (0..=255u8).collect::<Vec<_>>();
-    subst.shuffle(&mut rng);
+    let mut subst = vec![0u8; 1000];
+    rng.fill_bytes(&mut subst[..]);
 
     b.iter(|| {
         data.iter_mut().enumerate().for_each(|(i, d)| {

--- a/src/liballoc/benches/vec.rs
+++ b/src/liballoc/benches/vec.rs
@@ -1,3 +1,4 @@
+use rand::prelude::*;
 use std::iter::{repeat, FromIterator};
 use test::{black_box, Bencher};
 
@@ -549,6 +550,42 @@ fn bench_in_place_recycle(b: &mut test::Bencher) {
             ),
         );
     });
+}
+
+#[bench]
+fn bench_in_place_zip_recycle(b: &mut test::Bencher) {
+    let mut data = vec![0u8; 256];
+    let mut rng = rand::thread_rng();
+    let mut subst = (0..=255u8).collect::<Vec<_>>();
+    subst.shuffle(&mut rng);
+
+    b.iter(|| {
+        let tmp = std::mem::replace(&mut data, Vec::new());
+        let mangled = tmp
+            .into_iter()
+            .zip(subst.iter().copied())
+            .enumerate()
+            .map(|(i, (d, s))| d.wrapping_add(i as u8) ^ s)
+            .collect::<Vec<_>>();
+        assert_eq!(mangled.len(), 256);
+        std::mem::replace(&mut data, black_box(mangled));
+    });
+}
+
+#[bench]
+fn bench_in_place_zip_iter_mut(b: &mut test::Bencher) {
+    let mut data = vec![0u8; 256];
+    let mut rng = rand::thread_rng();
+    let mut subst = (0..=255u8).collect::<Vec<_>>();
+    subst.shuffle(&mut rng);
+
+    b.iter(|| {
+        data.iter_mut().enumerate().for_each(|(i, d)| {
+            *d = d.wrapping_add(i as u8) ^ subst[i];
+        });
+    });
+
+    black_box(data);
 }
 
 #[derive(Clone)]

--- a/src/liballoc/benches/vec.rs
+++ b/src/liballoc/benches/vec.rs
@@ -563,7 +563,14 @@ impl Drop for Droppable {
 #[bench]
 fn bench_in_place_collect_droppable(b: &mut test::Bencher) {
     let v: Vec<Droppable> = std::iter::repeat_with(|| Droppable(0)).take(1000).collect();
-    b.iter(|| v.clone().into_iter().skip(100).collect::<Vec<_>>())
+    b.iter(|| {
+        v.clone()
+            .into_iter()
+            .skip(100)
+            .enumerate()
+            .map(|(i, e)| Droppable(i ^ e.0))
+            .collect::<Vec<_>>()
+    })
 }
 
 #[bench]

--- a/src/liballoc/benches/vec.rs
+++ b/src/liballoc/benches/vec.rs
@@ -1,5 +1,5 @@
 use std::iter::{repeat, FromIterator};
-use test::Bencher;
+use test::{black_box, Bencher};
 
 #[bench]
 fn bench_new(b: &mut Bencher) {
@@ -480,3 +480,42 @@ fn bench_clone_from_10_0100_0010(b: &mut Bencher) {
 fn bench_clone_from_10_1000_0100(b: &mut Bencher) {
     do_bench_clone_from(b, 10, 1000, 100)
 }
+
+macro_rules! bench_in_place {
+    (
+        $($fname:ident, $type:ty , $count:expr, $init: expr);*
+    ) => {
+        $(
+            #[bench]
+            fn $fname(b: &mut Bencher) {
+                b.iter(|| {
+                    let src: Vec<$type> = vec![$init; $count];
+                    black_box(src.into_iter()
+                        .enumerate()
+                        .map(|(idx, e)| { (idx as $type) ^ e }).collect::<Vec<$type>>())
+                });
+            }
+        )+
+    };
+}
+
+bench_in_place![
+    bench_in_place_xxu8_i0_0010,     u8,     10, 0;
+    bench_in_place_xxu8_i0_0100,     u8,    100, 0;
+    bench_in_place_xxu8_i0_1000,     u8,   1000, 0;
+    bench_in_place_xxu8_i1_0010,     u8,     10, 1;
+    bench_in_place_xxu8_i1_0100,     u8,    100, 1;
+    bench_in_place_xxu8_i1_1000,     u8,   1000, 1;
+    bench_in_place_xu32_i0_0010,    u32,     10, 0;
+    bench_in_place_xu32_i0_0100,    u32,    100, 0;
+    bench_in_place_xu32_i0_1000,    u32,   1000, 0;
+    bench_in_place_xu32_i1_0010,    u32,     10, 1;
+    bench_in_place_xu32_i1_0100,    u32,    100, 1;
+    bench_in_place_xu32_i1_1000,    u32,   1000, 1;
+    bench_in_place_u128_i0_0010,   u128,     10, 0;
+    bench_in_place_u128_i0_0100,   u128,    100, 0;
+    bench_in_place_u128_i0_1000,   u128,   1000, 0;
+    bench_in_place_u128_i1_0010,   u128,     10, 1;
+    bench_in_place_u128_i1_0100,   u128,    100, 1;
+    bench_in_place_u128_i1_1000,   u128,   1000, 1
+];

--- a/src/liballoc/benches/vec.rs
+++ b/src/liballoc/benches/vec.rs
@@ -489,10 +489,11 @@ macro_rules! bench_in_place {
             #[bench]
             fn $fname(b: &mut Bencher) {
                 b.iter(|| {
-                    let src: Vec<$type> = vec![$init; $count];
-                    black_box(src.into_iter()
+                    let src: Vec<$type> = black_box(vec![$init; $count]);
+                    let mut sink = src.into_iter()
                         .enumerate()
-                        .map(|(idx, e)| { (idx as $type) ^ e }).collect::<Vec<$type>>())
+                        .map(|(idx, e)| { (idx as $type) ^ e }).collect::<Vec<$type>>();
+                    black_box(sink.as_mut_ptr())
                 });
             }
         )+

--- a/src/liballoc/benches/vec.rs
+++ b/src/liballoc/benches/vec.rs
@@ -693,9 +693,7 @@ fn bench_rev_1(b: &mut test::Bencher) {
 #[bench]
 fn bench_rev_2(b: &mut test::Bencher) {
     let data = black_box([0; LEN]);
-    b.iter(|| {
-        example_plain_slow(&data);
-    });
+    b.iter(|| example_plain_slow(&data));
 }
 
 #[bench]

--- a/src/liballoc/benches/vec.rs
+++ b/src/liballoc/benches/vec.rs
@@ -7,6 +7,7 @@ fn bench_new(b: &mut Bencher) {
         let v: Vec<u32> = Vec::new();
         assert_eq!(v.len(), 0);
         assert_eq!(v.capacity(), 0);
+        v
     })
 }
 
@@ -17,6 +18,7 @@ fn do_bench_with_capacity(b: &mut Bencher, src_len: usize) {
         let v: Vec<u32> = Vec::with_capacity(src_len);
         assert_eq!(v.len(), 0);
         assert_eq!(v.capacity(), src_len);
+        v
     })
 }
 
@@ -47,6 +49,7 @@ fn do_bench_from_fn(b: &mut Bencher, src_len: usize) {
         let dst = (0..src_len).collect::<Vec<_>>();
         assert_eq!(dst.len(), src_len);
         assert!(dst.iter().enumerate().all(|(i, x)| i == *x));
+        dst
     })
 }
 
@@ -77,6 +80,7 @@ fn do_bench_from_elem(b: &mut Bencher, src_len: usize) {
         let dst: Vec<usize> = repeat(5).take(src_len).collect();
         assert_eq!(dst.len(), src_len);
         assert!(dst.iter().all(|x| *x == 5));
+        dst
     })
 }
 
@@ -109,6 +113,7 @@ fn do_bench_from_slice(b: &mut Bencher, src_len: usize) {
         let dst = src.clone()[..].to_vec();
         assert_eq!(dst.len(), src_len);
         assert!(dst.iter().enumerate().all(|(i, x)| i == *x));
+        dst
     });
 }
 
@@ -141,6 +146,7 @@ fn do_bench_from_iter(b: &mut Bencher, src_len: usize) {
         let dst: Vec<_> = FromIterator::from_iter(src.clone());
         assert_eq!(dst.len(), src_len);
         assert!(dst.iter().enumerate().all(|(i, x)| i == *x));
+        dst
     });
 }
 
@@ -175,6 +181,7 @@ fn do_bench_extend(b: &mut Bencher, dst_len: usize, src_len: usize) {
         dst.extend(src.clone());
         assert_eq!(dst.len(), dst_len + src_len);
         assert!(dst.iter().enumerate().all(|(i, x)| i == *x));
+        dst
     });
 }
 
@@ -224,6 +231,7 @@ fn do_bench_push_all(b: &mut Bencher, dst_len: usize, src_len: usize) {
         dst.extend_from_slice(&src);
         assert_eq!(dst.len(), dst_len + src_len);
         assert!(dst.iter().enumerate().all(|(i, x)| i == *x));
+        dst
     });
 }
 
@@ -273,6 +281,7 @@ fn do_bench_push_all_move(b: &mut Bencher, dst_len: usize, src_len: usize) {
         dst.extend(src.clone());
         assert_eq!(dst.len(), dst_len + src_len);
         assert!(dst.iter().enumerate().all(|(i, x)| i == *x));
+        dst
     });
 }
 
@@ -320,6 +329,7 @@ fn do_bench_clone(b: &mut Bencher, src_len: usize) {
         let dst = src.clone();
         assert_eq!(dst.len(), src_len);
         assert!(dst.iter().enumerate().all(|(i, x)| i == *x));
+        dst
     });
 }
 
@@ -354,10 +364,10 @@ fn do_bench_clone_from(b: &mut Bencher, times: usize, dst_len: usize, src_len: u
 
         for _ in 0..times {
             dst.clone_from(&src);
-
             assert_eq!(dst.len(), src_len);
             assert!(dst.iter().enumerate().all(|(i, x)| dst_len + i == *x));
         }
+        dst
     });
 }
 

--- a/src/liballoc/benches/vec.rs
+++ b/src/liballoc/benches/vec.rs
@@ -520,3 +520,107 @@ bench_in_place![
     bench_in_place_u128_i1_0100,   u128,    100, 1;
     bench_in_place_u128_i1_1000,   u128,   1000, 1
 ];
+
+#[bench]
+fn bench_chain_collect(b: &mut test::Bencher) {
+    let data = black_box([0; LEN]);
+    b.iter(|| data.iter().cloned().chain([1].iter().cloned()).collect::<Vec<_>>());
+}
+
+#[bench]
+fn bench_chain_chain_collect(b: &mut test::Bencher) {
+    let data = black_box([0; LEN]);
+    b.iter(|| {
+        data.iter()
+            .cloned()
+            .chain([1].iter().cloned())
+            .chain([2].iter().cloned())
+            .collect::<Vec<_>>()
+    });
+}
+
+#[bench]
+fn bench_nest_chain_chain_collect(b: &mut test::Bencher) {
+    let data = black_box([0; LEN]);
+    b.iter(|| {
+        data.iter().cloned().chain([1].iter().chain([2].iter()).cloned()).collect::<Vec<_>>()
+    });
+}
+
+pub fn example_plain_slow(l: &[u32]) -> Vec<u32> {
+    let mut result = Vec::with_capacity(l.len());
+    result.extend(l.iter().rev());
+    result
+}
+
+pub fn map_fast(l: &[(u32, u32)]) -> Vec<u32> {
+    let mut result = Vec::with_capacity(l.len());
+    for i in 0..l.len() {
+        unsafe {
+            *result.get_unchecked_mut(i) = l[i].0;
+            result.set_len(i);
+        }
+    }
+    result
+}
+
+const LEN: usize = 16384;
+
+#[bench]
+fn bench_range_map_collect(b: &mut test::Bencher) {
+    b.iter(|| (0..LEN).map(|_| u32::default()).collect::<Vec<_>>());
+}
+
+#[bench]
+fn bench_chain_extend_ref(b: &mut test::Bencher) {
+    let data = black_box([0; LEN]);
+    b.iter(|| {
+        let mut v = Vec::<u32>::with_capacity(data.len() + 1);
+        v.extend(data.iter().chain([1].iter()));
+        v
+    });
+}
+
+#[bench]
+fn bench_chain_extend_value(b: &mut test::Bencher) {
+    let data = black_box([0; LEN]);
+    b.iter(|| {
+        let mut v = Vec::<u32>::with_capacity(data.len() + 1);
+        v.extend(data.iter().cloned().chain(Some(1)));
+        v
+    });
+}
+
+#[bench]
+fn bench_rev_1(b: &mut test::Bencher) {
+    let data = black_box([0; LEN]);
+    b.iter(|| {
+        let mut v = Vec::<u32>::new();
+        v.extend(data.iter().rev());
+        v
+    });
+}
+
+#[bench]
+fn bench_rev_2(b: &mut test::Bencher) {
+    let data = black_box([0; LEN]);
+    b.iter(|| {
+        example_plain_slow(&data);
+    });
+}
+
+#[bench]
+fn bench_map_regular(b: &mut test::Bencher) {
+    let data = black_box([(0, 0); LEN]);
+    b.iter(|| {
+        let mut v = Vec::<u32>::new();
+        v.extend(data.iter().map(|t| t.1));
+        v
+    });
+}
+
+#[bench]
+fn bench_map_fast(b: &mut test::Bencher) {
+    let data = black_box([(0, 0); LEN]);
+    b.iter(|| map_fast(&data));
+}

--- a/src/liballoc/benches/vec.rs
+++ b/src/liballoc/benches/vec.rs
@@ -551,6 +551,21 @@ fn bench_in_place_recycle(b: &mut test::Bencher) {
     });
 }
 
+#[derive(Clone)]
+struct Droppable(usize);
+
+impl Drop for Droppable {
+    fn drop(&mut self) {
+        black_box(self);
+    }
+}
+
+#[bench]
+fn bench_in_place_collect_droppable(b: &mut test::Bencher) {
+    let v: Vec<Droppable> = std::iter::repeat_with(|| Droppable(0)).take(1000).collect();
+    b.iter(|| v.clone().into_iter().skip(100).collect::<Vec<_>>())
+}
+
 #[bench]
 fn bench_chain_collect(b: &mut test::Bencher) {
     let data = black_box([0; LEN]);

--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -146,7 +146,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use core::fmt;
-use core::iter::{FromIterator, FusedIterator, TrustedLen};
+use core::iter::{FromIterator, FusedIterator, InPlaceIterable, SourceIter, TrustedLen};
 use core::mem::{size_of, swap, ManuallyDrop};
 use core::ops::{Deref, DerefMut};
 use core::ptr;
@@ -1144,6 +1144,19 @@ impl<T> ExactSizeIterator for IntoIter<T> {
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for IntoIter<T> {}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+impl<T> SourceIter for IntoIter<T> {
+    type Source = crate::vec::IntoIter<T>;
+
+    #[inline]
+    fn as_inner(&mut self) -> &mut Self::Source {
+        &mut self.iter
+    }
+}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<I> InPlaceIterable for IntoIter<I> {}
 
 #[unstable(feature = "binary_heap_into_iter_sorted", issue = "59278")]
 #[derive(Clone, Debug)]

--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -1150,7 +1150,7 @@ unsafe impl<T> SourceIter for IntoIter<T> {
     type Source = IntoIter<T>;
 
     #[inline]
-    fn as_inner(&mut self) -> &mut Self::Source {
+    unsafe fn as_inner(&mut self) -> &mut Self::Source {
         self
     }
 }

--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -152,7 +152,7 @@ use core::ops::{Deref, DerefMut};
 use core::ptr;
 
 use crate::slice;
-use crate::vec::{self, Vec};
+use crate::vec::{self, Vec, AsIntoIter};
 
 use super::SpecExtend;
 
@@ -1147,16 +1147,22 @@ impl<T> FusedIterator for IntoIter<T> {}
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
 unsafe impl<T> SourceIter for IntoIter<T> {
-    type Source = impl Iterator<Item = T>;
+    type Source = IntoIter<T>;
 
     #[inline]
     fn as_inner(&mut self) -> &mut Self::Source {
-        &mut self.iter
+        self
     }
 }
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
 unsafe impl<I> InPlaceIterable for IntoIter<I> {}
+
+impl<I> AsIntoIter<I> for IntoIter<I> {
+    fn as_into_iter(&mut self) -> &mut vec::IntoIter<I> {
+        &mut self.iter
+    }
+}
 
 #[unstable(feature = "binary_heap_into_iter_sorted", issue = "59278")]
 #[derive(Clone, Debug)]

--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -152,7 +152,7 @@ use core::ops::{Deref, DerefMut};
 use core::ptr;
 
 use crate::slice;
-use crate::vec::{self, Vec, AsIntoIter};
+use crate::vec::{self, AsIntoIter, Vec};
 
 use super::SpecExtend;
 
@@ -1145,7 +1145,7 @@ impl<T> ExactSizeIterator for IntoIter<T> {
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for IntoIter<T> {}
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<T> SourceIter for IntoIter<T> {
     type Source = IntoIter<T>;
 
@@ -1155,7 +1155,7 @@ unsafe impl<T> SourceIter for IntoIter<T> {
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<I> InPlaceIterable for IntoIter<I> {}
 
 impl<I> AsIntoIter<I> for IntoIter<I> {

--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -1147,7 +1147,7 @@ impl<T> FusedIterator for IntoIter<T> {}
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
 unsafe impl<T> SourceIter for IntoIter<T> {
-    type Source = crate::vec::IntoIter<T>;
+    type Source = impl Iterator<Item = T>;
 
     #[inline]
     fn as_inner(&mut self) -> &mut Self::Source {

--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -1158,8 +1158,10 @@ unsafe impl<T> SourceIter for IntoIter<T> {
 #[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<I> InPlaceIterable for IntoIter<I> {}
 
-impl<I> AsIntoIter<I> for IntoIter<I> {
-    fn as_into_iter(&mut self) -> &mut vec::IntoIter<I> {
+impl<I> AsIntoIter for IntoIter<I> {
+    type Item = I;
+
+    fn as_into_iter(&mut self) -> &mut vec::IntoIter<Self::Item> {
         &mut self.iter
     }
 }

--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -1146,7 +1146,7 @@ impl<T> ExactSizeIterator for IntoIter<T> {
 impl<T> FusedIterator for IntoIter<T> {}
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
-impl<T> SourceIter for IntoIter<T> {
+unsafe impl<T> SourceIter for IntoIter<T> {
     type Source = crate::vec::IntoIter<T>;
 
     #[inline]

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -122,6 +122,7 @@
 #![feature(try_trait)]
 #![feature(associated_type_bounds)]
 #![feature(inplace_iteration)]
+#![feature(never_type)]
 
 // Allow testing this library
 

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -122,7 +122,6 @@
 #![feature(try_trait)]
 #![feature(associated_type_bounds)]
 #![feature(inplace_iteration)]
-#![feature(never_type)]
 #![feature(type_alias_impl_trait)]
 
 // Allow testing this library

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -123,6 +123,7 @@
 #![feature(associated_type_bounds)]
 #![feature(inplace_iteration)]
 #![feature(never_type)]
+#![feature(type_alias_impl_trait)]
 
 // Allow testing this library
 

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -123,6 +123,7 @@
 #![feature(associated_type_bounds)]
 #![feature(inplace_iteration)]
 #![feature(type_alias_impl_trait)]
+#![cfg_attr(bootstrap, feature(never_type))]
 
 // Allow testing this library
 

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -123,7 +123,7 @@
 #![feature(associated_type_bounds)]
 #![feature(inplace_iteration)]
 #![feature(type_alias_impl_trait)]
-#![cfg_attr(bootstrap, feature(never_type))]
+#![feature(never_type)]
 
 // Allow testing this library
 

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -121,6 +121,7 @@
 #![feature(alloc_layout_extra)]
 #![feature(try_trait)]
 #![feature(associated_type_bounds)]
+#![feature(inplace_iteration)]
 
 // Allow testing this library
 

--- a/src/liballoc/tests/binary_heap.rs
+++ b/src/liballoc/tests/binary_heap.rs
@@ -229,6 +229,18 @@ fn test_to_vec() {
 }
 
 #[test]
+fn test_in_place_iterator_specialization() {
+    let src: Vec<usize> = vec![1, 2, 3];
+    let src_ptr = src.as_ptr();
+    let heap: BinaryHeap<_> = src.into_iter().map(std::convert::identity).collect();
+    let heap_ptr = heap.iter().next().unwrap() as *const usize;
+    assert_eq!(src_ptr, heap_ptr);
+    let sink: Vec<_> = heap.into_iter().map(std::convert::identity).collect();
+    let sink_ptr = sink.as_ptr();
+    assert_eq!(heap_ptr, sink_ptr);
+}
+
+#[test]
 fn test_empty_pop() {
     let mut heap = BinaryHeap::<i32>::new();
     assert!(heap.pop().is_none());

--- a/src/liballoc/tests/lib.rs
+++ b/src/liballoc/tests/lib.rs
@@ -12,6 +12,7 @@
 #![feature(binary_heap_into_iter_sorted)]
 #![feature(binary_heap_drain_sorted)]
 #![feature(vec_remove_item)]
+#![feature(inplace_iteration)]
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};

--- a/src/liballoc/tests/slice.rs
+++ b/src/liballoc/tests/slice.rs
@@ -1386,6 +1386,15 @@ fn test_to_vec() {
 }
 
 #[test]
+fn test_in_place_iterator_specialization() {
+    let src: Box<[usize]> = box [1, 2, 3];
+    let src_ptr = src.as_ptr();
+    let sink: Box<_> = src.into_vec().into_iter().map(std::convert::identity).collect();
+    let sink_ptr = sink.as_ptr();
+    assert_eq!(src_ptr, sink_ptr);
+}
+
+#[test]
 fn test_box_slice_clone() {
     let data = vec![vec![0, 1], vec![0], vec![1]];
     let data2 = data.clone().into_boxed_slice().clone().to_vec();

--- a/src/liballoc/tests/vec.rs
+++ b/src/liballoc/tests/vec.rs
@@ -737,6 +737,28 @@ fn test_from_iter_specialization() {
 }
 
 #[test]
+fn test_from_iter_partially_drained_in_place_specialization() {
+    let src: Vec<usize> = vec![0usize; 10];
+    let srcptr = src.as_ptr();
+    let mut iter = src.into_iter();
+    iter.next();
+    iter.next();
+    let sink = iter.collect::<Vec<_>>();
+    let sinkptr = sink.as_ptr();
+    assert_eq!(srcptr, sinkptr);
+}
+
+#[test]
+fn test_extend_in_place_specialization() {
+    let src: Vec<usize> = vec![0usize; 1];
+    let srcptr = src.as_ptr();
+    let mut dst = Vec::new();
+    dst.extend(src.into_iter());
+    let dstptr = dst.as_ptr();
+    assert_eq!(srcptr, dstptr);
+}
+
+#[test]
 fn test_from_iter_specialization_with_iterator_adapters() {
     fn assert_in_place_trait<T: InPlaceIterable>(_: &T) {};
     let src: Vec<usize> = vec![0usize; 65535];

--- a/src/liballoc/tests/vec.rs
+++ b/src/liballoc/tests/vec.rs
@@ -763,7 +763,14 @@ fn test_from_iter_specialization_with_iterator_adapters() {
     fn assert_in_place_trait<T: InPlaceIterable>(_: &T) {};
     let src: Vec<usize> = vec![0usize; 65535];
     let srcptr = src.as_ptr();
-    let iter = src.into_iter().enumerate().map(|i| i.0 + i.1).peekable().skip(1);
+    let iter = src
+        .into_iter()
+        .enumerate()
+        .map(|i| i.0 + i.1)
+        .zip(std::iter::repeat(1usize))
+        .map(|(a, b)| a + b)
+        .peekable()
+        .skip(1);
     assert_in_place_trait(&iter);
     let sink = iter.collect::<Vec<_>>();
     let sinkptr = sink.as_ptr();

--- a/src/liballoc/tests/vec.rs
+++ b/src/liballoc/tests/vec.rs
@@ -772,11 +772,12 @@ fn test_from_iter_specialization_with_iterator_adapters() {
         .zip(std::iter::repeat(1usize))
         .map(|(a, b)| a + b)
         .peekable()
-        .skip(1);
+        .skip(1)
+        .map(|e| std::num::NonZeroUsize::new(e));
     assert_in_place_trait(&iter);
     let sink = iter.collect::<Vec<_>>();
     let sinkptr = sink.as_ptr();
-    assert_eq!(srcptr, sinkptr);
+    assert_eq!(srcptr, sinkptr as *const usize);
 }
 
 #[test]

--- a/src/liballoc/tests/vec.rs
+++ b/src/liballoc/tests/vec.rs
@@ -2,6 +2,8 @@ use std::borrow::Cow;
 use std::collections::TryReserveError::*;
 use std::iter::InPlaceIterable;
 use std::mem::size_of;
+use std::panic::AssertUnwindSafe;
+use std::rc::Rc;
 use std::vec::{Drain, IntoIter};
 use std::{isize, usize};
 
@@ -775,6 +777,45 @@ fn test_from_iter_specialization_with_iterator_adapters() {
     let sink = iter.collect::<Vec<_>>();
     let sinkptr = sink.as_ptr();
     assert_eq!(srcptr, sinkptr);
+}
+
+#[test]
+fn test_from_iter_specialization_head_tail_drop() {
+    let drop_count: Vec<_> = (0..=2).map(|_| Rc::new(())).collect();
+    let src: Vec<_> = drop_count.iter().cloned().collect();
+    let srcptr = src.as_ptr();
+    let iter = src.into_iter();
+    let sink: Vec<_> = iter.skip(1).take(1).collect();
+    let sinkptr = sink.as_ptr();
+    assert_eq!(srcptr, sinkptr, "specialization was applied");
+    assert_eq!(Rc::strong_count(&drop_count[0]), 1, "front was dropped");
+    assert_eq!(Rc::strong_count(&drop_count[1]), 2, "one element was collected");
+    assert_eq!(Rc::strong_count(&drop_count[2]), 1, "tail was dropped");
+    assert_eq!(sink.len(), 1);
+}
+
+#[test]
+fn test_from_iter_specialization_panic_drop() {
+    let drop_count: Vec<_> = (0..=2).map(|_| Rc::new(())).collect();
+    let src: Vec<_> = drop_count.iter().cloned().collect();
+    let iter = src.into_iter();
+
+    let _ = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        let _ = iter
+            .enumerate()
+            .filter_map(|(i, e)| {
+                if i == 1 {
+                    std::panic!("aborting iteration");
+                }
+                Some(e)
+            })
+            .collect::<Vec<_>>();
+    }));
+
+    assert!(
+        drop_count.iter().map(Rc::strong_count).all(|count| count == 1),
+        "all items were dropped once"
+    );
 }
 
 #[test]

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2281,12 +2281,7 @@ where
 {
     fn spec_extend(&mut self, iterator: slice::Iter<'a, T>) {
         let slice = iterator.as_slice();
-        self.reserve(slice.len());
-        unsafe {
-            let len = self.len();
-            self.set_len(len + slice.len());
-            self.get_unchecked_mut(len..).copy_from_slice(slice);
-        }
+        unsafe { self.append_elements(slice) };
     }
 }
 

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2025,12 +2025,14 @@ where
     I: Iterator<Item = T> + InPlaceIterable + SourceIter<Source = IntoIter<T>>,
 {
     let mut insert_pos = 0;
+    let original_ptr = iterator.as_inner().buf.as_ptr();
 
     // FIXME: how to drop values written into source when iteration panics?
     //   tail already gets cleaned by IntoIter::drop
     while let Some(item) = iterator.next() {
         let source_iter = iterator.as_inner();
         let src_buf = source_iter.buf.as_ptr();
+        debug_assert_eq!(original_ptr, src_buf);
         let src_idx = source_iter.ptr;
         unsafe {
             let dst = src_buf.offset(insert_pos as isize);

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2800,7 +2800,7 @@ impl<T> FusedIterator for IntoIter<T> {}
 unsafe impl<T> TrustedLen for IntoIter<T> {}
 
 #[doc(hidden)]
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 // T: Copy as approximation for !Drop since get_unchecked does not advance self.ptr
 // and thus we can't implement drop-handling
 unsafe impl<T> TrustedRandomAccess for IntoIter<T>
@@ -2833,10 +2833,10 @@ unsafe impl<#[may_dangle] T> Drop for IntoIter<T> {
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<T> InPlaceIterable for IntoIter<T> {}
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<T> SourceIter for IntoIter<T> {
     type Source = IntoIter<T>;
 

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2112,8 +2112,8 @@ impl<T> SpecFrom<T, IntoIter<T>> for Vec<T> {
         // has not been advanced at all.
         if iterator.buf.as_ptr() as *const _ == iterator.ptr {
             unsafe {
+                let iterator = mem::ManuallyDrop::new(iterator);
                 let vec = Vec::from_raw_parts(iterator.buf.as_ptr(), iterator.len(), iterator.cap);
-                mem::forget(iterator);
                 return vec;
             }
         }

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -53,7 +53,7 @@
 //! [`Index`]: ../../std/ops/trait.Index.html
 //! [`IndexMut`]: ../../std/ops/trait.IndexMut.html
 //! [`vec!`]: ../../std/macro.vec.html
-
+// ignore-tidy-filelength
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use core::array::LengthAtMost32;

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2066,7 +2066,6 @@ where
 struct InPlaceDrop<T> {
     inner: *mut T,
     dst: *mut T,
-    did_panic: bool,
 }
 
 impl<T> InPlaceDrop<T> {
@@ -2079,9 +2078,7 @@ impl<T> Drop for InPlaceDrop<T> {
     #[inline]
     fn drop(&mut self) {
         unsafe {
-            if self.did_panic {
-                ptr::drop_in_place(slice::from_raw_parts_mut(self.inner, self.len()) as *mut _);
-            }
+            ptr::drop_in_place(slice::from_raw_parts_mut(self.inner, self.len()) as *mut _);
         }
     }
 }
@@ -2135,7 +2132,7 @@ where
 
         let dst = if mem::needs_drop::<T>() {
             // special-case drop handling since it prevents vectorization
-            let mut sink = InPlaceDrop { inner: src_buf, dst, did_panic: true };
+            let mut sink = InPlaceDrop { inner: src_buf, dst };
             let _ = iterator.try_for_each::<_, Result<_, !>>(|item| {
                 unsafe {
                     debug_assert!(
@@ -2147,7 +2144,8 @@ where
                 }
                 Ok(())
             });
-            sink.did_panic = false;
+            // iteration succeeded, don't drop head
+            let sink = mem::ManuallyDrop::new(sink);
             sink.dst
         } else {
             // use try-fold

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2020,23 +2020,23 @@ where
     }
 }
 
-struct InPlaceIterFront<T> {
+struct InPlaceDrop<T> {
     inner: *mut T,
     dst: *mut T,
     did_panic: bool,
 }
 
-impl<T> InPlaceIterFront<T> {
+impl<T> InPlaceDrop<T> {
     unsafe fn len(&self) -> usize {
         self.dst.offset_from(self.inner) as usize
     }
 }
 
-impl<T> Drop for InPlaceIterFront<T> {
+impl<T> Drop for InPlaceDrop<T> {
     #[inline]
     fn drop(&mut self) {
         unsafe {
-            if mem::needs_drop::<T>() && self.did_panic {
+            if self.did_panic {
                 ptr::drop_in_place(slice::from_raw_parts_mut(self.inner, self.len()) as *mut _);
             }
         }
@@ -2047,31 +2047,61 @@ fn from_into_iter_source<T, I>(mut iterator: I) -> Vec<T>
 where
     I: Iterator<Item = T> + InPlaceIterable + SourceIter<Source = IntoIter<T>>,
 {
-    let original_ptr = iterator.as_inner().buf.as_ptr();
-    let mut front_buffer =
-        InPlaceIterFront { inner: original_ptr, dst: original_ptr, did_panic: true };
+    let src_buf = iterator.as_inner().buf.as_ptr();
+    let src_end = iterator.as_inner().end;
+    let dst = src_buf;
 
-    while let Some(item) = iterator.next() {
-        let source_iter = iterator.as_inner();
-        debug_assert_eq!(original_ptr, source_iter.buf.as_ptr());
-        unsafe {
-            debug_assert!(
-                front_buffer.dst as *const _ < source_iter.ptr,
-                "InPlaceIterable implementation produced more\
-                          items than it consumed from the source"
-            );
-            ptr::write(front_buffer.dst, item);
-            front_buffer.dst = front_buffer.dst.add(1);
-        }
-    }
+    let dst = if mem::needs_drop::<T>() {
+        // special-case drop handling since it prevents vectorization
+        let mut sink = InPlaceDrop { inner: src_buf, dst, did_panic: true };
+        let _ = iterator.try_for_each::<_, Result<_, !>>(|item| {
+            unsafe {
+                debug_assert!(
+                    sink.dst as *const _ <= src_end,
+                    "InPlaceIterable contract violation"
+                );
+                ptr::write(sink.dst, item);
+                sink.dst = sink.dst.add(1);
+            }
+            Ok(())
+        });
+        sink.did_panic = false;
+        sink.dst
+    } else {
+        // use try-fold since it vectorizes better, does not take ownership and lets us thread the
+        // write pointer through its innards
+        iterator
+            .try_fold::<_, _, Result<_, !>>(dst, move |mut dst, item| {
+                unsafe {
+                    // the InPlaceIterable contract cannot be verified precisely here since
+                    // try_fold has an exclusive reference to the source pointer
+                    // all we can do is check if it's still in range
+                    debug_assert!(dst as *const _ <= src_end, "InPlaceIterable contract violation");
+                    ptr::write(dst, item);
+                    dst = dst.add(1);
+                }
+                Ok(dst)
+            })
+            .unwrap()
+    };
 
     let src = iterator.as_inner();
-    front_buffer.did_panic = false;
-    let vec = unsafe { Vec::from_raw_parts(src.buf.as_ptr(), front_buffer.len(), src.cap) };
+    // check if SourceIter and InPlaceIterable contracts were upheld.
+    // but if they weren't we may not even make it to this point
+    debug_assert_eq!(src_buf, src.buf.as_ptr());
+    debug_assert!(dst as *const _ <= src.ptr, "InPlaceIterable contract violation");
+
+    let vec = unsafe {
+        let len = dst.offset_from(src_buf) as usize;
+        Vec::from_raw_parts(src.buf.as_ptr(), len, src.cap)
+    };
+    // prevent drop of the underlying storage by turning the IntoIter into
+    // the equivalent of Vec::new().into_iter()
     src.cap = 0;
     src.buf = unsafe { NonNull::new_unchecked(RawVec::NEW.ptr()) };
     src.ptr = src.buf.as_ptr();
     src.end = src.buf.as_ptr();
+
     vec
 }
 

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2121,9 +2121,9 @@ where
             return SpecFromNested::from_iter(iterator);
         }
 
-        let (src_buf, src_end) = {
+        let (src_buf, src_end, cap) = {
             let inner = unsafe { iterator.as_inner().as_into_iter() };
-            (inner.buf.as_ptr(), inner.end)
+            (inner.buf.as_ptr(), inner.end, inner.cap)
         };
         let dst = src_buf;
 
@@ -2173,23 +2173,15 @@ where
         debug_assert_eq!(src_buf, src.buf.as_ptr());
         debug_assert!(dst as *const _ <= src.ptr, "InPlaceIterable contract violation");
 
-        if mem::needs_drop::<T>() {
-            // drop tail if iterator was only partially exhausted
-            unsafe {
-                ptr::drop_in_place(src.as_mut_slice());
-            }
-        }
+        // drop any remaining values at the tail of the source
+        src.drop_in_place();
+        // but prevent drop of the allocation itself once IntoIter goes out of scope
+        src.forget_in_place();
 
         let vec = unsafe {
             let len = dst.offset_from(src_buf) as usize;
-            Vec::from_raw_parts(src.buf.as_ptr(), len, src.cap)
+            Vec::from_raw_parts(src_buf, len, cap)
         };
-        // prevent drop of the underlying storage by turning the IntoIter into
-        // the equivalent of Vec::new().into_iter()
-        src.cap = 0;
-        src.buf = unsafe { NonNull::new_unchecked(RawVec::NEW.ptr()) };
-        src.ptr = src.buf.as_ptr();
-        src.end = src.buf.as_ptr();
 
         vec
     }
@@ -2704,6 +2696,24 @@ impl<T> IntoIter<T> {
     #[stable(feature = "vec_into_iter_as_slice", since = "1.15.0")]
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         unsafe { slice::from_raw_parts_mut(self.ptr as *mut T, self.len()) }
+    }
+
+    fn drop_in_place(&mut self) {
+        if mem::needs_drop::<T>() {
+            unsafe {
+                ptr::drop_in_place(self.as_mut_slice());
+            }
+        }
+        self.ptr = self.end;
+    }
+
+    /// Relinquishes the backing allocation, equivalent to
+    /// `ptr::write(&mut self, Vec::new().into_iter())`
+    fn forget_in_place(&mut self) {
+        self.cap = 0;
+        self.buf = unsafe { NonNull::new_unchecked(RawVec::NEW.ptr()) };
+        self.ptr = self.buf.as_ptr();
+        self.end = self.buf.as_ptr();
     }
 }
 

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2020,22 +2020,37 @@ where
     }
 }
 
+struct InPlaceIterFront<T> {
+    inner: *mut T,
+    count: usize,
+    did_panic: bool,
+}
+
+impl<T> Drop for InPlaceIterFront<T> {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            if mem::needs_drop::<T>() && self.did_panic {
+                ptr::drop_in_place(slice::from_raw_parts_mut(self.inner, self.count) as *mut _);
+            }
+        }
+    }
+}
+
 fn from_into_iter_source<T, I>(mut iterator: I) -> Vec<T>
 where
     I: Iterator<Item = T> + InPlaceIterable + SourceIter<Source = IntoIter<T>>,
 {
-    let mut insert_pos = 0;
     let original_ptr = iterator.as_inner().buf.as_ptr();
+    let mut front_buffer = InPlaceIterFront { inner: original_ptr, count: 0, did_panic: true };
 
-    // FIXME: how to drop values written into source when iteration panics?
-    //   tail already gets cleaned by IntoIter::drop
     while let Some(item) = iterator.next() {
         let source_iter = iterator.as_inner();
         let src_buf = source_iter.buf.as_ptr();
         debug_assert_eq!(original_ptr, src_buf);
         let src_idx = source_iter.ptr;
         unsafe {
-            let dst = src_buf.offset(insert_pos as isize);
+            let dst = src_buf.offset(front_buffer.count as isize);
             debug_assert!(
                 dst as *const _ < src_idx,
                 "InPlaceIterable implementation produced more\
@@ -2043,12 +2058,16 @@ where
             );
             ptr::write(dst, item)
         }
-        insert_pos += 1;
+        front_buffer.count += 1;
     }
 
     let src = iterator.as_inner();
-    let vec = unsafe { Vec::from_raw_parts(src.buf.as_ptr(), insert_pos, src.cap) };
-    mem::forget(iterator);
+    front_buffer.did_panic = false;
+    let vec = unsafe { Vec::from_raw_parts(src.buf.as_ptr(), front_buffer.count, src.cap) };
+    src.cap = 0;
+    src.buf = unsafe { NonNull::new_unchecked(RawVec::NEW.ptr()) };
+    src.ptr = src.buf.as_ptr();
+    src.end = src.buf.as_ptr();
     vec
 }
 

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2674,7 +2674,7 @@ unsafe impl<#[may_dangle] T> Drop for IntoIter<T> {
 unsafe impl<T> InPlaceIterable for IntoIter<T> {}
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
-impl<T> SourceIter for IntoIter<T> {
+unsafe impl<T> SourceIter for IntoIter<T> {
     type Source = IntoIter<T>;
 
     #[inline]

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2050,7 +2050,7 @@ where
         debug_assert_eq!(original_ptr, src_buf);
         let src_idx = source_iter.ptr;
         unsafe {
-            let dst = src_buf.offset(front_buffer.count as isize);
+            let dst = src_buf.add(front_buffer.count);
             debug_assert!(
                 dst as *const _ < src_idx,
                 "InPlaceIterable implementation produced more\

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2002,7 +2002,13 @@ trait SpecFrom<T, I> {
     fn from_iter(iter: I) -> Self;
 }
 
-impl<T, I> SpecFrom<T, I> for Vec<T>
+// Another specialization trait for Vec::from_iter
+// necessary to manually prioritize overlapping specializations
+trait SpecFromNested<T, I> {
+    fn from_iter(iter: I) -> Self;
+}
+
+impl<T, I> SpecFromNested<T, I> for Vec<T>
 where
     I: Iterator<Item = T>,
 {
@@ -2028,6 +2034,28 @@ where
         // to spec_from for empty Vecs
         <Vec<T> as SpecExtend<T, I>>::spec_extend(&mut vector, iterator);
         vector
+    }
+}
+
+impl<T, I> SpecFromNested<T, I> for Vec<T>
+where
+    I: TrustedLen<Item = T>,
+{
+    fn from_iter(iterator: I) -> Self {
+        let mut vector = Vec::new();
+        // must delegate to spec_extend() since extend() itself delegates
+        // to spec_from for empty Vecs
+        vector.spec_extend(iterator);
+        vector
+    }
+}
+
+impl<T, I> SpecFrom<T, I> for Vec<T>
+where
+    I: Iterator<Item = T>,
+{
+    default fn from_iter(iterator: I) -> Self {
+        SpecFromNested::from_iter(iterator)
     }
 }
 

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2058,8 +2058,8 @@ where
     }
 }
 
-// A helper struct for in-place iteration that drops the destination slice of iteration.
-// The source slice is dropped by IntoIter
+// A helper struct for in-place iteration that drops the destination slice of iteration,
+// i.e. the head. The source slice (the tail) is dropped by IntoIter.
 struct InPlaceDrop<T> {
     inner: *mut T,
     dst: *mut T,

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2022,8 +2022,14 @@ where
 
 struct InPlaceIterFront<T> {
     inner: *mut T,
-    count: usize,
+    dst: *mut T,
     did_panic: bool,
+}
+
+impl<T> InPlaceIterFront<T> {
+    unsafe fn len(&self) -> usize {
+        self.dst.offset_from(self.inner) as usize
+    }
 }
 
 impl<T> Drop for InPlaceIterFront<T> {
@@ -2031,7 +2037,7 @@ impl<T> Drop for InPlaceIterFront<T> {
     fn drop(&mut self) {
         unsafe {
             if mem::needs_drop::<T>() && self.did_panic {
-                ptr::drop_in_place(slice::from_raw_parts_mut(self.inner, self.count) as *mut _);
+                ptr::drop_in_place(slice::from_raw_parts_mut(self.inner, self.len()) as *mut _);
             }
         }
     }
@@ -2042,28 +2048,26 @@ where
     I: Iterator<Item = T> + InPlaceIterable + SourceIter<Source = IntoIter<T>>,
 {
     let original_ptr = iterator.as_inner().buf.as_ptr();
-    let mut front_buffer = InPlaceIterFront { inner: original_ptr, count: 0, did_panic: true };
+    let mut front_buffer =
+        InPlaceIterFront { inner: original_ptr, dst: original_ptr, did_panic: true };
 
     while let Some(item) = iterator.next() {
         let source_iter = iterator.as_inner();
-        let src_buf = source_iter.buf.as_ptr();
-        debug_assert_eq!(original_ptr, src_buf);
-        let src_idx = source_iter.ptr;
+        debug_assert_eq!(original_ptr, source_iter.buf.as_ptr());
         unsafe {
-            let dst = src_buf.add(front_buffer.count);
             debug_assert!(
-                dst as *const _ < src_idx,
+                front_buffer.dst as *const _ < source_iter.ptr,
                 "InPlaceIterable implementation produced more\
                           items than it consumed from the source"
             );
-            ptr::write(dst, item)
+            ptr::write(front_buffer.dst, item);
+            front_buffer.dst = front_buffer.dst.add(1);
         }
-        front_buffer.count += 1;
     }
 
     let src = iterator.as_inner();
     front_buffer.did_panic = false;
-    let vec = unsafe { Vec::from_raw_parts(src.buf.as_ptr(), front_buffer.count, src.cap) };
+    let vec = unsafe { Vec::from_raw_parts(src.buf.as_ptr(), front_buffer.len(), src.cap) };
     src.cap = 0;
     src.buf = unsafe { NonNull::new_unchecked(RawVec::NEW.ptr()) };
     src.ptr = src.buf.as_ptr();

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -61,7 +61,7 @@ use core::cmp::{self, Ordering};
 use core::fmt;
 use core::hash::{self, Hash};
 use core::intrinsics::{arith_offset, assume};
-use core::iter::{FromIterator, FusedIterator, TrustedLen};
+use core::iter::{FromIterator, FusedIterator, InPlaceIterable, SourceIter, TrustedLen};
 use core::marker::PhantomData;
 use core::mem;
 use core::ops::Bound::{Excluded, Included, Unbounded};
@@ -1916,7 +1916,7 @@ impl<T> ops::DerefMut for Vec<T> {
 impl<T> FromIterator<T> for Vec<T> {
     #[inline]
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Vec<T> {
-        <Self as SpecExtend<T, I::IntoIter>>::from_iter(iter.into_iter())
+        <Self as SpecFrom<T, I::IntoIter>>::from_iter(iter.into_iter())
     }
 }
 
@@ -1988,13 +1988,12 @@ impl<T> Extend<T> for Vec<T> {
     }
 }
 
-// Specialization trait used for Vec::from_iter and Vec::extend
-trait SpecExtend<T, I> {
+// Specialization trait used for Vec::from_iter
+trait SpecFrom<T, I> {
     fn from_iter(iter: I) -> Self;
-    fn spec_extend(&mut self, iter: I);
 }
 
-impl<T, I> SpecExtend<T, I> for Vec<T>
+impl<T, I> SpecFrom<T, I> for Vec<T>
 where
     I: Iterator<Item = T>,
 {
@@ -2019,7 +2018,87 @@ where
         <Vec<T> as SpecExtend<T, I>>::spec_extend(&mut vector, iterator);
         vector
     }
+}
 
+fn from_into_iter_source<T, I>(mut iterator: I) -> Vec<T>
+where
+    I: Iterator<Item = T> + InPlaceIterable + SourceIter<Source = IntoIter<T>>,
+{
+    let mut insert_pos = 0;
+
+    // FIXME: how to drop values written into source when iteration panics?
+    //   tail already gets cleaned by IntoIter::drop
+    while let Some(item) = iterator.next() {
+        let source_iter = iterator.as_inner();
+        let src_buf = source_iter.buf.as_ptr();
+        let src_idx = source_iter.ptr;
+        unsafe {
+            let dst = src_buf.offset(insert_pos as isize);
+            debug_assert!(
+                dst as *const _ < src_idx,
+                "InPlaceIterable implementation produced more\
+                          items than it consumed from the source"
+            );
+            ptr::write(dst, item)
+        }
+        insert_pos += 1;
+    }
+
+    let src = iterator.as_inner();
+    let vec = unsafe { Vec::from_raw_parts(src.buf.as_ptr(), insert_pos, src.cap) };
+    mem::forget(iterator);
+    vec
+}
+
+impl<T> SpecFrom<T, IntoIter<T>> for Vec<T> {
+    fn from_iter(iterator: IntoIter<T>) -> Self {
+        // A common case is passing a vector into a function which immediately
+        // re-collects into a vector. We can short circuit this if the IntoIter
+        // has not been advanced at all.
+        if iterator.buf.as_ptr() as *const _ == iterator.ptr {
+            unsafe {
+                let vec = Vec::from_raw_parts(iterator.buf.as_ptr(), iterator.len(), iterator.cap);
+                mem::forget(iterator);
+                return vec;
+            }
+        }
+
+        from_into_iter_source(iterator)
+    }
+}
+
+// Further specialization potential once lattice specialization exists
+// and https://github.com/rust-lang/rust/issues/62645 has been solved:
+// This can be broadened to only require size and alignment equality between
+// input and output Item types.
+impl<T, I> SpecFrom<T, I> for Vec<T>
+where
+    I: Iterator<Item = T> + InPlaceIterable + SourceIter<Source = IntoIter<T>>,
+{
+    default fn from_iter(iterator: I) -> Self {
+        from_into_iter_source(iterator)
+    }
+}
+
+impl<'a, T: 'a, I> SpecFrom<&'a T, I> for Vec<T>
+where
+    I: Iterator<Item = &'a T>,
+    T: Clone,
+{
+    default fn from_iter(iterator: I) -> Self {
+        SpecFrom::from_iter(iterator.cloned())
+    }
+}
+
+// Specialization trait used for Vec::extend
+trait SpecExtend<T, I> {
+    fn spec_extend(&mut self, iter: I);
+}
+
+impl<T, I> SpecExtend<T, I> for Vec<T>
+where
+    I: Iterator<Item = T>,
+{
     default fn spec_extend(&mut self, iter: I) {
         self.extend_desugared(iter)
     }
@@ -2029,12 +2108,6 @@ impl<T, I> SpecExtend<T, I> for Vec<T>
 where
     I: TrustedLen<Item = T>,
 {
-    default fn from_iter(iterator: I) -> Self {
-        let mut vector = Vec::new();
-        vector.spec_extend(iterator);
-        vector
-    }
-
     default fn spec_extend(&mut self, iterator: I) {
         // This is the case for a TrustedLen iterator.
         let (low, high) = iterator.size_hint();
@@ -2064,41 +2137,11 @@ where
     }
 }
 
-impl<T> SpecExtend<T, IntoIter<T>> for Vec<T> {
-    fn from_iter(iterator: IntoIter<T>) -> Self {
-        // A common case is passing a vector into a function which immediately
-        // re-collects into a vector. We can short circuit this if the IntoIter
-        // has not been advanced at all.
-        if iterator.buf.as_ptr() as *const _ == iterator.ptr {
-            unsafe {
-                let vec = Vec::from_raw_parts(iterator.buf.as_ptr(), iterator.len(), iterator.cap);
-                mem::forget(iterator);
-                vec
-            }
-        } else {
-            let mut vector = Vec::new();
-            vector.spec_extend(iterator);
-            vector
-        }
-    }
-
-    fn spec_extend(&mut self, mut iterator: IntoIter<T>) {
-        unsafe {
-            self.append_elements(iterator.as_slice() as _);
-        }
-        iterator.ptr = iterator.end;
-    }
-}
-
 impl<'a, T: 'a, I> SpecExtend<&'a T, I> for Vec<T>
 where
     I: Iterator<Item = &'a T>,
     T: Clone,
 {
-    default fn from_iter(iterator: I) -> Self {
-        SpecExtend::from_iter(iterator.cloned())
-    }
-
     default fn spec_extend(&mut self, iterator: I) {
         self.spec_extend(iterator.cloned())
     }
@@ -2624,6 +2667,19 @@ unsafe impl<#[may_dangle] T> Drop for IntoIter<T> {
 
         // RawVec handles deallocation
         let _ = unsafe { RawVec::from_raw_parts(self.buf.as_ptr(), self.cap) };
+    }
+}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<T> InPlaceIterable for IntoIter<T> {}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+impl<T> SourceIter for IntoIter<T> {
+    type Source = IntoIter<T>;
+
+    #[inline]
+    fn as_inner(&mut self) -> &mut Self::Source {
+        self
     }
 }
 

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2075,7 +2075,7 @@ impl<T> Drop for InPlaceDrop<T> {
     #[inline]
     fn drop(&mut self) {
         unsafe {
-            ptr::drop_in_place(slice::from_raw_parts_mut(self.inner, self.len()) as *mut _);
+            ptr::drop_in_place(slice::from_raw_parts_mut(self.inner, self.len()));
         }
     }
 }

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2107,6 +2107,34 @@ impl<T> SpecFrom<T, IntoIter<T>> for Vec<T> {
     }
 }
 
+fn write_in_place<T>(src_end: *const T) -> impl FnMut(*mut T, T) -> Result<*mut T, !> {
+    move |mut dst, item| {
+        unsafe {
+            // the InPlaceIterable contract cannot be verified precisely here since
+            // try_fold has an exclusive reference to the source pointer
+            // all we can do is check if it's still in range
+            debug_assert!(dst as *const _ <= src_end, "InPlaceIterable contract violation");
+            ptr::write(dst, item);
+            dst = dst.add(1);
+        }
+        Ok(dst)
+    }
+}
+
+fn write_in_place_with_drop<T>(
+    src_end: *const T,
+) -> impl FnMut(InPlaceDrop<T>, T) -> Result<InPlaceDrop<T>, !> {
+    move |mut sink, item| {
+        unsafe {
+            // same caveat as above
+            debug_assert!(sink.dst as *const _ <= src_end, "InPlaceIterable contract violation");
+            ptr::write(sink.dst, item);
+            sink.dst = sink.dst.add(1);
+        }
+        Ok(sink)
+    }
+}
+
 // Further specialization potential once
 // https://github.com/rust-lang/rust/issues/62645 has been solved:
 // T can be split into IN and OUT which only need to have the same size and alignment
@@ -2125,46 +2153,23 @@ where
             let inner = unsafe { iterator.as_inner().as_into_iter() };
             (inner.buf.as_ptr(), inner.end, inner.cap)
         };
-        let dst = src_buf;
 
+        // use try-fold
+        // - it vectorizes better for some iterator adapters
+        // - unlike most internal iteration methods methods it only takes a &mut self
+        // - lets us thread the write pointer through its innards and get it back in the end
         let dst = if mem::needs_drop::<T>() {
-            // special-case drop handling since it prevents vectorization
-            let mut sink = InPlaceDrop { inner: src_buf, dst };
-            let _ = iterator.try_for_each::<_, Result<_, !>>(|item| {
-                unsafe {
-                    debug_assert!(
-                        sink.dst as *const _ <= src_end,
-                        "InPlaceIterable contract violation"
-                    );
-                    ptr::write(sink.dst, item);
-                    sink.dst = sink.dst.add(1);
-                }
-                Ok(())
-            });
+            // special-case drop handling since it forces us to lug that extra field around which
+            // can inhibit optimizations
+            let sink = InPlaceDrop { inner: src_buf, dst: src_buf };
+            let sink = iterator
+                .try_fold::<_, _, Result<_, !>>(sink, write_in_place_with_drop(src_end))
+                .unwrap();
             // iteration succeeded, don't drop head
             let sink = mem::ManuallyDrop::new(sink);
             sink.dst
         } else {
-            // use try-fold
-            // - it vectorizes better
-            // - unlike most internal iteration methods methods it only takes a &mut self
-            // - lets us thread the write pointer through its innards and get it back in the end
-            iterator
-                .try_fold::<_, _, Result<_, !>>(dst, move |mut dst, item| {
-                    unsafe {
-                        // the InPlaceIterable contract cannot be verified precisely here since
-                        // try_fold has an exclusive reference to the source pointer
-                        // all we can do is check if it's still in range
-                        debug_assert!(
-                            dst as *const _ <= src_end,
-                            "InPlaceIterable contract violation"
-                        );
-                        ptr::write(dst, item);
-                        dst = dst.add(1);
-                    }
-                    Ok(dst)
-                })
-                .unwrap()
+            iterator.try_fold::<_, _, Result<_, !>>(src_buf, write_in_place(src_end)).unwrap()
         };
 
         let src = unsafe { iterator.as_inner().as_into_iter() };

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2192,6 +2192,15 @@ where
     }
 }
 
+impl<T> SpecExtend<T, IntoIter<T>> for Vec<T> {
+    fn spec_extend(&mut self, mut iterator: IntoIter<T>) {
+        unsafe {
+            self.append_elements(iterator.as_slice() as _);
+        }
+        iterator.ptr = iterator.end;
+    }
+}
+
 impl<'a, T: 'a, I> SpecExtend<&'a T, I> for Vec<T>
 where
     I: Iterator<Item = &'a T>,

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2194,6 +2194,20 @@ where
     }
 }
 
+impl<'a, T: 'a> SpecFrom<&'a T, slice::Iter<'a, T>> for Vec<T>
+where
+    T: Copy,
+{
+    // reuses the extend specialization for T: Copy
+    fn from_iter(iterator: slice::Iter<'a, T>) -> Self {
+        let mut vec = Vec::new();
+        // must delegate to spec_extend() since extend() itself delegates
+        // to spec_from for empty Vecs
+        vec.spec_extend(iterator);
+        vec
+    }
+}
+
 // Specialization trait used for Vec::extend
 trait SpecExtend<T, I> {
     fn spec_extend(&mut self, iter: I);

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2107,8 +2107,10 @@ where
         sink.did_panic = false;
         sink.dst
     } else {
-        // use try-fold since it vectorizes better, does not take ownership and lets us thread the
-        // write pointer through its innards
+        // use try-fold
+        // - it vectorizes better
+        // - unlike most internal iteration methods methods it only takes a &mut self
+        // - lets us thread the write pointer through its innards and get it back in the end
         iterator
             .try_fold::<_, _, Result<_, !>>(dst, move |mut dst, item| {
                 unsafe {
@@ -2126,7 +2128,7 @@ where
 
     let src = iterator.as_inner();
     // check if SourceIter and InPlaceIterable contracts were upheld.
-    // but if they weren't we may not even make it to this point
+    // caveat: if they weren't we may not even make it to this point
     debug_assert_eq!(src_buf, src.buf.as_ptr());
     debug_assert!(dst as *const _ <= src.ptr, "InPlaceIterable contract violation");
 
@@ -2171,10 +2173,9 @@ impl<T> SpecFrom<T, IntoIter<T>> for Vec<T> {
     }
 }
 
-// Further specialization potential once lattice specialization exists
-// and https://github.com/rust-lang/rust/issues/62645 has been solved:
-// This can be broadened to only require size and alignment equality between
-// input and output Item types.
+// Further specialization potential once
+// https://github.com/rust-lang/rust/issues/62645 has been solved:
+// T can be split into IN and OUT which only need to have the same size and alignment
 impl<T, I> SpecFrom<T, I> for Vec<T>
 where
     I: Iterator<Item = T> + InPlaceIterable + SourceIter<Source = IntoIter<T>>,
@@ -2290,6 +2291,8 @@ where
 }
 
 impl<T> Vec<T> {
+    // leaf method to which various SpecFrom/SpecExtend implementations delegate when
+    // they have no further optimizations to apply
     fn extend_desugared<I: Iterator<Item = T>>(&mut self, mut iterator: I) {
         // This is the case for a general iterator.
         //

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2066,8 +2066,8 @@ struct InPlaceDrop<T> {
 }
 
 impl<T> InPlaceDrop<T> {
-    unsafe fn len(&self) -> usize {
-        self.dst.offset_from(self.inner) as usize
+    fn len(&self) -> usize {
+        unsafe { self.dst.offset_from(self.inner) as usize }
     }
 }
 

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -61,7 +61,9 @@ use core::cmp::{self, Ordering};
 use core::fmt;
 use core::hash::{self, Hash};
 use core::intrinsics::{arith_offset, assume};
-use core::iter::{FromIterator, FusedIterator, InPlaceIterable, SourceIter, TrustedLen};
+use core::iter::{
+    FromIterator, FusedIterator, InPlaceIterable, SourceIter, TrustedLen, TrustedRandomAccess,
+};
 use core::marker::PhantomData;
 use core::mem;
 use core::ops::Bound::{Excluded, Included, Unbounded};
@@ -2794,6 +2796,22 @@ impl<T> FusedIterator for IntoIter<T> {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<T> TrustedLen for IntoIter<T> {}
+
+#[doc(hidden)]
+#[unstable(issue = "0", feature = "std_internals")]
+// T: Copy as approximation for !Drop since get_unchecked does not advance self.ptr
+// and thus we can't implement drop-handling
+unsafe impl<T> TrustedRandomAccess for IntoIter<T>
+where
+    T: Copy,
+{
+    unsafe fn get_unchecked(&mut self, i: usize) -> Self::Item {
+        if mem::size_of::<T>() == 0 { mem::zeroed() } else { ptr::read(self.ptr.add(i)) }
+    }
+    fn may_have_side_effect() -> bool {
+        false
+    }
+}
 
 #[stable(feature = "vec_into_iter_clone", since = "1.8.0")]
 impl<T: Clone> Clone for IntoIter<T> {

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2116,7 +2116,7 @@ impl<T> SpecFrom<T, IntoIter<T>> for Vec<T> {
 // T can be split into IN and OUT which only need to have the same size and alignment
 impl<T, I> SpecFrom<T, I> for Vec<T>
 where
-    I: Iterator<Item = T> + InPlaceIterable + SourceIter<Source = IntoIter<T>>,
+    I: Iterator<Item = T> + InPlaceIterable + SourceIter<Source: AsIntoIter<T>>,
 {
     default fn from_iter(mut iterator: I) -> Self {
         // This specialization only makes sense if we're juggling real allocations.
@@ -2125,8 +2125,8 @@ where
             return SpecFromNested::from_iter(iterator);
         }
 
-        let src_buf = iterator.as_inner().buf.as_ptr();
-        let src_end = iterator.as_inner().end;
+        let src_buf = iterator.as_inner().as_into_iter().buf.as_ptr();
+        let src_end = iterator.as_inner().as_into_iter().end;
         let dst = src_buf;
 
         let dst = if mem::needs_drop::<T>() {
@@ -2168,14 +2168,14 @@ where
                 .unwrap()
         };
 
-        let src = iterator.as_inner();
+        let src = iterator.as_inner().as_into_iter();
         // check if SourceIter and InPlaceIterable contracts were upheld.
         // caveat: if they weren't we may not even make it to this point
         debug_assert_eq!(src_buf, src.buf.as_ptr());
         debug_assert!(dst as *const _ <= src.ptr, "InPlaceIterable contract violation");
 
         if mem::needs_drop::<T>() {
-            // drop tail if iterator was only partially exhaused
+            // drop tail if iterator was only partially exhausted
             unsafe {
                 ptr::drop_in_place(src.as_mut_slice());
             }
@@ -2840,6 +2840,17 @@ unsafe impl<T> SourceIter for IntoIter<T> {
 
     #[inline]
     fn as_inner(&mut self) -> &mut Self::Source {
+        self
+    }
+}
+
+// internal helper trait for in-place iteration specialization.
+pub(crate) trait AsIntoIter<T> {
+    fn as_into_iter(&mut self) -> &mut IntoIter<T>;
+}
+
+impl<T> AsIntoIter<T> for IntoIter<T> {
+    fn as_into_iter(&mut self) -> &mut IntoIter<T> {
         self
     }
 }

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1990,11 +1990,8 @@ impl<T> Extend<T> for Vec<T> {
             <Self as SpecExtend<T, I::IntoIter>>::spec_extend(self, iter.into_iter())
         } else {
             // if self has no allocation then use the more powerful from_iter specializations
-            let other = SpecFrom::from_iter(iter.into_iter());
-            // replace self, don't run drop since self was empty
-            unsafe {
-                ptr::write(self, other);
-            }
+            // and overwrite self
+            mem::replace(self, SpecFrom::from_iter(iter.into_iter()));
         }
     }
 }
@@ -2440,11 +2437,8 @@ impl<'a, T: 'a + Copy> Extend<&'a T> for Vec<T> {
             self.spec_extend(iter.into_iter())
         } else {
             // if self has no allocation then use the more powerful from_iter specializations
-            let other = SpecFrom::from_iter(iter.into_iter());
-            // replace self, don't run drop since self was empty
-            unsafe {
-                ptr::write(self, other);
-            }
+            // and overwrite self
+            mem::replace(self, SpecFrom::from_iter(iter.into_iter()));
         }
     }
 }

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1984,7 +1984,16 @@ impl<'a, T> IntoIterator for &'a mut Vec<T> {
 impl<T> Extend<T> for Vec<T> {
     #[inline]
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
-        <Self as SpecExtend<T, I::IntoIter>>::spec_extend(self, iter.into_iter())
+        if self.capacity() > 0 {
+            <Self as SpecExtend<T, I::IntoIter>>::spec_extend(self, iter.into_iter())
+        } else {
+            // if self has no allocation then use the more powerful from_iter specializations
+            let other = SpecFrom::from_iter(iter.into_iter());
+            // replace self, don't run drop since self was empty
+            unsafe {
+                ptr::write(self, other);
+            }
+        }
     }
 }
 
@@ -2015,6 +2024,8 @@ where
                 vector
             }
         };
+        // must delegate to spec_extend() since extend() itself delegates
+        // to spec_from for empty Vecs
         <Vec<T> as SpecExtend<T, I>>::spec_extend(&mut vector, iterator);
         vector
     }
@@ -2125,7 +2136,9 @@ impl<T> SpecFrom<T, IntoIter<T>> for Vec<T> {
         }
 
         let mut vec = Vec::new();
-        vec.extend(iterator);
+        // must delegate to spec_extend() since extend() itself delegates
+        // to spec_from for empty Vecs
+        vec.spec_extend(iterator);
         vec
     }
 }
@@ -2370,7 +2383,16 @@ impl<T> Vec<T> {
 #[stable(feature = "extend_ref", since = "1.2.0")]
 impl<'a, T: 'a + Copy> Extend<&'a T> for Vec<T> {
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
-        self.spec_extend(iter.into_iter())
+        if self.capacity() > 0 {
+            self.spec_extend(iter.into_iter())
+        } else {
+            // if self has no allocation then use the more powerful from_iter specializations
+            let other = SpecFrom::from_iter(iter.into_iter());
+            // replace self, don't run drop since self was empty
+            unsafe {
+                ptr::write(self, other);
+            }
+        }
     }
 }
 

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2061,6 +2061,8 @@ where
     }
 }
 
+// A helper struct for in-place iteration that drops the destination slice of iteration.
+// The source slice is dropped by IntoIter
 struct InPlaceDrop<T> {
     inner: *mut T,
     dst: *mut T,
@@ -2125,8 +2127,10 @@ where
             return SpecFromNested::from_iter(iterator);
         }
 
-        let src_buf = iterator.as_inner().as_into_iter().buf.as_ptr();
-        let src_end = iterator.as_inner().as_into_iter().end;
+        let (src_buf, src_end) = {
+            let inner = unsafe { iterator.as_inner().as_into_iter() };
+            (inner.buf.as_ptr(), inner.end)
+        };
         let dst = src_buf;
 
         let dst = if mem::needs_drop::<T>() {
@@ -2168,7 +2172,7 @@ where
                 .unwrap()
         };
 
-        let src = iterator.as_inner().as_into_iter();
+        let src = unsafe { iterator.as_inner().as_into_iter() };
         // check if SourceIter and InPlaceIterable contracts were upheld.
         // caveat: if they weren't we may not even make it to this point
         debug_assert_eq!(src_buf, src.buf.as_ptr());
@@ -2839,7 +2843,7 @@ unsafe impl<T> SourceIter for IntoIter<T> {
     type Source = IntoIter<T>;
 
     #[inline]
-    fn as_inner(&mut self) -> &mut Self::Source {
+    unsafe fn as_inner(&mut self) -> &mut Self::Source {
         self
     }
 }

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2865,8 +2865,8 @@ where
     old_len: usize,
     /// The filter test predicate.
     pred: F,
-    /// A flag that indicates a panic has occurred in the filter test prodicate.
-    /// This is used as a hint in the drop implmentation to prevent consumption
+    /// A flag that indicates a panic has occurred in the filter test predicate.
+    /// This is used as a hint in the drop implementation to prevent consumption
     /// of the remainder of the `DrainFilter`. Any unprocessed items will be
     /// backshifted in the `vec`, but no further items will be dropped or
     /// tested by the filter predicate.

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2086,6 +2086,12 @@ fn from_into_iter_source<T, I>(mut iterator: I) -> Vec<T>
 where
     I: Iterator<Item = T> + InPlaceIterable + SourceIter<Source = IntoIter<T>>,
 {
+    // This specialization only makes sense if we're juggling real allocations.
+    // Additionally some of the pointer arithmetic would panic on ZSTs.
+    if mem::size_of::<T>() == 0 {
+        return SpecFromNested::from_iter(iterator);
+    }
+
     let src_buf = iterator.as_inner().buf.as_ptr();
     let src_end = iterator.as_inner().end;
     let dst = src_buf;
@@ -2131,6 +2137,13 @@ where
     // caveat: if they weren't we may not even make it to this point
     debug_assert_eq!(src_buf, src.buf.as_ptr());
     debug_assert!(dst as *const _ <= src.ptr, "InPlaceIterable contract violation");
+
+    if mem::needs_drop::<T>() {
+        // drop tail if iterator was only partially exhaused
+        unsafe {
+            ptr::drop_in_place(src.as_mut_slice());
+        }
+    }
 
     let vec = unsafe {
         let len = dst.offset_from(src_buf) as usize;

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2082,83 +2082,6 @@ impl<T> Drop for InPlaceDrop<T> {
     }
 }
 
-fn from_into_iter_source<T, I>(mut iterator: I) -> Vec<T>
-where
-    I: Iterator<Item = T> + InPlaceIterable + SourceIter<Source = IntoIter<T>>,
-{
-    // This specialization only makes sense if we're juggling real allocations.
-    // Additionally some of the pointer arithmetic would panic on ZSTs.
-    if mem::size_of::<T>() == 0 {
-        return SpecFromNested::from_iter(iterator);
-    }
-
-    let src_buf = iterator.as_inner().buf.as_ptr();
-    let src_end = iterator.as_inner().end;
-    let dst = src_buf;
-
-    let dst = if mem::needs_drop::<T>() {
-        // special-case drop handling since it prevents vectorization
-        let mut sink = InPlaceDrop { inner: src_buf, dst, did_panic: true };
-        let _ = iterator.try_for_each::<_, Result<_, !>>(|item| {
-            unsafe {
-                debug_assert!(
-                    sink.dst as *const _ <= src_end,
-                    "InPlaceIterable contract violation"
-                );
-                ptr::write(sink.dst, item);
-                sink.dst = sink.dst.add(1);
-            }
-            Ok(())
-        });
-        sink.did_panic = false;
-        sink.dst
-    } else {
-        // use try-fold
-        // - it vectorizes better
-        // - unlike most internal iteration methods methods it only takes a &mut self
-        // - lets us thread the write pointer through its innards and get it back in the end
-        iterator
-            .try_fold::<_, _, Result<_, !>>(dst, move |mut dst, item| {
-                unsafe {
-                    // the InPlaceIterable contract cannot be verified precisely here since
-                    // try_fold has an exclusive reference to the source pointer
-                    // all we can do is check if it's still in range
-                    debug_assert!(dst as *const _ <= src_end, "InPlaceIterable contract violation");
-                    ptr::write(dst, item);
-                    dst = dst.add(1);
-                }
-                Ok(dst)
-            })
-            .unwrap()
-    };
-
-    let src = iterator.as_inner();
-    // check if SourceIter and InPlaceIterable contracts were upheld.
-    // caveat: if they weren't we may not even make it to this point
-    debug_assert_eq!(src_buf, src.buf.as_ptr());
-    debug_assert!(dst as *const _ <= src.ptr, "InPlaceIterable contract violation");
-
-    if mem::needs_drop::<T>() {
-        // drop tail if iterator was only partially exhaused
-        unsafe {
-            ptr::drop_in_place(src.as_mut_slice());
-        }
-    }
-
-    let vec = unsafe {
-        let len = dst.offset_from(src_buf) as usize;
-        Vec::from_raw_parts(src.buf.as_ptr(), len, src.cap)
-    };
-    // prevent drop of the underlying storage by turning the IntoIter into
-    // the equivalent of Vec::new().into_iter()
-    src.cap = 0;
-    src.buf = unsafe { NonNull::new_unchecked(RawVec::NEW.ptr()) };
-    src.ptr = src.buf.as_ptr();
-    src.end = src.buf.as_ptr();
-
-    vec
-}
-
 impl<T> SpecFrom<T, IntoIter<T>> for Vec<T> {
     fn from_iter(iterator: IntoIter<T>) -> Self {
         // A common case is passing a vector into a function which immediately
@@ -2193,8 +2116,81 @@ impl<T, I> SpecFrom<T, I> for Vec<T>
 where
     I: Iterator<Item = T> + InPlaceIterable + SourceIter<Source = IntoIter<T>>,
 {
-    default fn from_iter(iterator: I) -> Self {
-        from_into_iter_source(iterator)
+    default fn from_iter(mut iterator: I) -> Self {
+        // This specialization only makes sense if we're juggling real allocations.
+        // Additionally some of the pointer arithmetic would panic on ZSTs.
+        if mem::size_of::<T>() == 0 {
+            return SpecFromNested::from_iter(iterator);
+        }
+
+        let src_buf = iterator.as_inner().buf.as_ptr();
+        let src_end = iterator.as_inner().end;
+        let dst = src_buf;
+
+        let dst = if mem::needs_drop::<T>() {
+            // special-case drop handling since it prevents vectorization
+            let mut sink = InPlaceDrop { inner: src_buf, dst, did_panic: true };
+            let _ = iterator.try_for_each::<_, Result<_, !>>(|item| {
+                unsafe {
+                    debug_assert!(
+                        sink.dst as *const _ <= src_end,
+                        "InPlaceIterable contract violation"
+                    );
+                    ptr::write(sink.dst, item);
+                    sink.dst = sink.dst.add(1);
+                }
+                Ok(())
+            });
+            sink.did_panic = false;
+            sink.dst
+        } else {
+            // use try-fold
+            // - it vectorizes better
+            // - unlike most internal iteration methods methods it only takes a &mut self
+            // - lets us thread the write pointer through its innards and get it back in the end
+            iterator
+                .try_fold::<_, _, Result<_, !>>(dst, move |mut dst, item| {
+                    unsafe {
+                        // the InPlaceIterable contract cannot be verified precisely here since
+                        // try_fold has an exclusive reference to the source pointer
+                        // all we can do is check if it's still in range
+                        debug_assert!(
+                            dst as *const _ <= src_end,
+                            "InPlaceIterable contract violation"
+                        );
+                        ptr::write(dst, item);
+                        dst = dst.add(1);
+                    }
+                    Ok(dst)
+                })
+                .unwrap()
+        };
+
+        let src = iterator.as_inner();
+        // check if SourceIter and InPlaceIterable contracts were upheld.
+        // caveat: if they weren't we may not even make it to this point
+        debug_assert_eq!(src_buf, src.buf.as_ptr());
+        debug_assert!(dst as *const _ <= src.ptr, "InPlaceIterable contract violation");
+
+        if mem::needs_drop::<T>() {
+            // drop tail if iterator was only partially exhaused
+            unsafe {
+                ptr::drop_in_place(src.as_mut_slice());
+            }
+        }
+
+        let vec = unsafe {
+            let len = dst.offset_from(src_buf) as usize;
+            Vec::from_raw_parts(src.buf.as_ptr(), len, src.cap)
+        };
+        // prevent drop of the underlying storage by turning the IntoIter into
+        // the equivalent of Vec::new().into_iter()
+        src.cap = 0;
+        src.buf = unsafe { NonNull::new_unchecked(RawVec::NEW.ptr()) };
+        src.ptr = src.buf.as_ptr();
+        src.end = src.buf.as_ptr();
+
+        vec
     }
 }
 

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2135,23 +2135,28 @@ fn write_in_place_with_drop<T>(
     }
 }
 
-// Further specialization potential once
-// https://github.com/rust-lang/rust/issues/62645 has been solved:
-// T can be split into IN and OUT which only need to have the same size and alignment
 impl<T, I> SpecFrom<T, I> for Vec<T>
 where
-    I: Iterator<Item = T> + InPlaceIterable + SourceIter<Source: AsIntoIter<T>>,
+    I: Iterator<Item = T> + InPlaceIterable + SourceIter<Source: AsIntoIter>,
 {
     default fn from_iter(mut iterator: I) -> Self {
-        // This specialization only makes sense if we're juggling real allocations.
-        // Additionally some of the pointer arithmetic would panic on ZSTs.
-        if mem::size_of::<T>() == 0 {
+        // Additional requirements which cannot expressed via trait bounds. We rely on const eval
+        // instead:
+        // a) no ZSTs as there would be no allocation to reuse and pointer arithmetic would panic
+        // b) size match as required by Alloc contract
+        // c) alignments match as required by Alloc contract
+        if mem::size_of::<T>() == 0
+            || mem::size_of::<T>()
+                != mem::size_of::<<<I as SourceIter>::Source as AsIntoIter>::Item>()
+            || mem::align_of::<T>()
+                != mem::align_of::<<<I as SourceIter>::Source as AsIntoIter>::Item>()
+        {
             return SpecFromNested::from_iter(iterator);
         }
 
-        let (src_buf, src_end, cap) = {
-            let inner = unsafe { iterator.as_inner().as_into_iter() };
-            (inner.buf.as_ptr(), inner.end, inner.cap)
+        let (src_buf, dst_buf, dst_end, cap) = unsafe {
+            let inner = iterator.as_inner().as_into_iter();
+            (inner.buf.as_ptr(), inner.buf.as_ptr() as *mut T, inner.end as *const T, inner.cap)
         };
 
         // use try-fold
@@ -2161,15 +2166,15 @@ where
         let dst = if mem::needs_drop::<T>() {
             // special-case drop handling since it forces us to lug that extra field around which
             // can inhibit optimizations
-            let sink = InPlaceDrop { inner: src_buf, dst: src_buf };
+            let sink = InPlaceDrop { inner: dst_buf, dst: dst_buf };
             let sink = iterator
-                .try_fold::<_, _, Result<_, !>>(sink, write_in_place_with_drop(src_end))
+                .try_fold::<_, _, Result<_, !>>(sink, write_in_place_with_drop(dst_end))
                 .unwrap();
             // iteration succeeded, don't drop head
             let sink = mem::ManuallyDrop::new(sink);
             sink.dst
         } else {
-            iterator.try_fold::<_, _, Result<_, !>>(src_buf, write_in_place(src_end)).unwrap()
+            iterator.try_fold::<_, _, Result<_, !>>(dst_buf, write_in_place(dst_end)).unwrap()
         };
 
         let src = unsafe { iterator.as_inner().as_into_iter() };
@@ -2184,8 +2189,8 @@ where
         src.forget_in_place();
 
         let vec = unsafe {
-            let len = dst.offset_from(src_buf) as usize;
-            Vec::from_raw_parts(src_buf, len, cap)
+            let len = dst.offset_from(dst_buf) as usize;
+            Vec::from_raw_parts(dst_buf, len, cap)
         };
 
         vec
@@ -2856,12 +2861,15 @@ unsafe impl<T> SourceIter for IntoIter<T> {
 }
 
 // internal helper trait for in-place iteration specialization.
-pub(crate) trait AsIntoIter<T> {
-    fn as_into_iter(&mut self) -> &mut IntoIter<T>;
+pub(crate) trait AsIntoIter {
+    type Item;
+    fn as_into_iter(&mut self) -> &mut IntoIter<Self::Item>;
 }
 
-impl<T> AsIntoIter<T> for IntoIter<T> {
-    fn as_into_iter(&mut self) -> &mut IntoIter<T> {
+impl<T> AsIntoIter for IntoIter<T> {
+    type Item = T;
+
+    fn as_into_iter(&mut self) -> &mut IntoIter<Self::Item> {
         self
     }
 }

--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -1,3 +1,4 @@
+// ignore-tidy-filelength
 use crate::cmp;
 use crate::fmt;
 use crate::intrinsics;

--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -1107,7 +1107,8 @@ unsafe impl<S: Iterator, P, I: Iterator> SourceIter for Filter<I, P> where
 }
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<I: InPlaceIterable, P> InPlaceIterable for Filter<I, P> where P: FnMut(&I::Item) -> bool {}
+unsafe impl<I: InPlaceIterable, P> InPlaceIterable for Filter<I, P>
+    where P: FnMut(&I::Item) -> bool {}
 
 /// An iterator that uses `f` to both filter and map elements from `iter`.
 ///
@@ -1249,7 +1250,8 @@ unsafe impl<S: Iterator, B, I: Iterator, F> SourceIter for FilterMap<I, F> where
 }
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<B, I: InPlaceIterable, F> InPlaceIterable for FilterMap<I, F> where F: FnMut(I::Item) -> Option<B> {}
+unsafe impl<B, I: InPlaceIterable, F> InPlaceIterable for FilterMap<I, F>
+    where F: FnMut(I::Item) -> Option<B> {}
 
 
 /// An iterator that yields the current count and the element during iteration.
@@ -1824,7 +1826,8 @@ unsafe impl<S: Iterator, P, I: Iterator> SourceIter for SkipWhile<I, P> where
 }
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<I: InPlaceIterable, F> InPlaceIterable for SkipWhile<I, F> where F: FnMut(&I::Item) -> bool {}
+unsafe impl<I: InPlaceIterable, F> InPlaceIterable for SkipWhile<I, F>
+    where F: FnMut(&I::Item) -> bool {}
 
 /// An iterator that only accepts elements while `predicate` returns `true`.
 ///
@@ -2030,7 +2033,8 @@ unsafe impl<S: Iterator, P, I: Iterator> SourceIter for TakeWhile<I, P> where
 }
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<I: InPlaceIterable, F> InPlaceIterable for TakeWhile<I, F> where F: FnMut(&I::Item) -> bool {}
+unsafe impl<I: InPlaceIterable, F> InPlaceIterable for TakeWhile<I, F>
+    where F: FnMut(&I::Item) -> bool {}
 
 
 /// An iterator that skips over `n` elements of `iter`.

--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -83,7 +83,7 @@ pub unsafe trait SourceIter {
     /// and side-effects of the pipeline stages from affecting or relying on that storage.
     ///
     /// [`TrustedRandomAccess`]: trait.TrustedRandomAccess.html
-    /// [`next`]: trait.Iterator.html#method.next
+    /// [`next()`]: trait.Iterator.html#method.next
     fn as_inner(&mut self) -> &mut Self::Source;
 }
 

--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -16,8 +16,9 @@ mod zip;
 pub use self::chain::Chain;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::flatten::{FlatMap, Flatten};
-pub(crate) use self::zip::TrustedRandomAccess;
 pub use self::zip::Zip;
+#[unstable(issue = "0", feature = "std_internals")]
+pub use self::zip::TrustedRandomAccess;
 
 /// This trait provides transitive access to source-stages in an interator-adapter pipeline
 /// under the conditions that
@@ -318,6 +319,7 @@ where
 }
 
 #[doc(hidden)]
+#[unstable(issue = "0", feature = "std_internals")]
 unsafe impl<'a, I, T: 'a> TrustedRandomAccess for Copied<I>
 where
     I: TrustedRandomAccess<Item = &'a T>,
@@ -448,6 +450,7 @@ where
 }
 
 #[doc(hidden)]
+#[unstable(issue = "0", feature = "std_internals")]
 unsafe impl<'a, I, T: 'a> TrustedRandomAccess for Cloned<I>
 where
     I: TrustedRandomAccess<Item = &'a T>,
@@ -464,6 +467,7 @@ where
 }
 
 #[doc(hidden)]
+#[unstable(issue = "0", feature = "std_internals")]
 unsafe impl<'a, I, T: 'a> TrustedRandomAccess for Cloned<I>
 where
     I: TrustedRandomAccess<Item = &'a T>,
@@ -931,6 +935,7 @@ where
 }
 
 #[doc(hidden)]
+#[unstable(issue = "0", feature = "std_internals")]
 unsafe impl<B, I, F> TrustedRandomAccess for Map<I, F>
 where
     I: TrustedRandomAccess,
@@ -1446,6 +1451,7 @@ where
 }
 
 #[doc(hidden)]
+#[unstable(issue = "0", feature = "std_internals")]
 unsafe impl<I> TrustedRandomAccess for Enumerate<I>
 where
     I: TrustedRandomAccess,
@@ -2638,6 +2644,7 @@ where
     }
 }
 
+#[unstable(issue = "0", feature = "std_internals")]
 unsafe impl<I> TrustedRandomAccess for Fuse<I>
 where
     I: TrustedRandomAccess,

--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -19,37 +19,71 @@ pub use self::flatten::{FlatMap, Flatten};
 pub(crate) use self::zip::TrustedRandomAccess;
 pub use self::zip::Zip;
 
-/// This trait provides access to to the backing source of an interator-adapter pipeline
+/// This trait provides transitive access to source-stages in an interator-adapter pipeline
 /// under the conditions that
 /// * the iterator source `S` itself implements `SourceIter<Source = S>`
-/// * there is a delegating implementation of this trait for each adapter in the pipeline
+/// * there is a delegating implementation of this trait for each adapter in the pipeline between
+///   the source and the pipeline consumer.
 ///
-/// This is useful for specializing [`FromIterator`] implementations or to retrieve
-/// the remaining values from a source of a partially consumed iterator.
+/// When the source is an owning iterator struct (commonly called `IntoIter`) then
+/// this can be useful for specializing [`FromIterator`] implementations or recovering the
+/// remaining elements after an iterator has been partially exhausted.
+///
+/// Note that implementations do not necessarily have to provide access to the inner-most
+/// source of a pipeline. A stateful intermediate adapter might eagerly evaluate a part
+/// of the pipeline and expose its internal storage as source.
+///
+/// The trait is unsafe because implementers must uphold additional safety properties.
+/// See [`as_inner`] for details.
 ///
 /// # Examples
 ///
-/// Retrieving a partially consumed source and wrapping it into a different pipeline:
+/// Retrieving a partially consumed source:
 ///
 /// ```
 /// # #![feature(inplace_iteration)]
 /// # use std::iter::SourceIter;
 ///
 /// let mut iter = vec![9, 9, 9].into_iter().map(|i| i * i);
-/// let first = iter.next().unwrap();
+/// let _ = iter.next();
 /// let mut remainder = std::mem::replace(iter.as_inner(), Vec::new().into_iter());
-/// let second = remainder.map(|i| i + 1).next().unwrap();
-/// assert_eq!(first, 81);
-/// assert_eq!(second, 10);
+/// println!("n = {} elements remaining", remainder.len());
 /// ```
 ///
 /// [`FromIterator`]: trait.FromIterator.html
+/// [`as_inner`]: #method.as_inner
 #[unstable(issue = "0", feature = "inplace_iteration")]
-pub trait SourceIter {
-    /// The source iterator of the adapter.
+pub unsafe trait SourceIter {
+    /// A source stage in an iterator pipeline.
     type Source: Iterator;
 
-    /// Recursively extract the source of an iterator pipeline.
+    /// Extract the source of an iterator pipeline.
+    ///
+    /// Callers may assume that calls to [`next()`] or any method taking `&self`
+    /// does no replace the referenced value.
+    /// But callers may replace the referenced values as long they in turn do not
+    /// expose it through a delegating implementation of this trait.
+    /// Which means that while adapters may not modify the reference they cannot
+    /// rely on it not being modified.
+    ///
+    /// Adapters must not rely on exclusive ownership or immutability of the source.
+    /// For example a peeking adapter could either exploit [`TrustedRandomAccess`] to look ahead
+    /// or implement this trait, but it cannot do both because a caller could call `next()` or any
+    /// other mutating method on the source between iteration steps and thus invalidate the peeked
+    /// values.
+    /// The lack of exclusive ownership also requires that adapters must uphold the source's
+    /// public API even when they have crate- or module-internal access.
+    ///
+    /// Callers in turn must expect the source to be in any state that is consistent with
+    /// its public API since adapters sitting between it and the source have the same
+    /// access. In particular an adapter may have consumed more elements than strictly necessary.
+    ///
+    /// The overall goal of these requirements is to grant the consumer of a pipeline
+    /// access to the underlying storage of an iterator while restricting any statefulness
+    /// and side-effects of the pipeline stages from affecting or relying on that storage.
+    ///
+    /// [`TrustedRandomAccess`]: trait.TrustedRandomAccess.html
+    /// [`next`]: trait.Iterator.html#method.next
     fn as_inner(&mut self) -> &mut Self::Source;
 }
 
@@ -917,7 +951,7 @@ where
 }
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
-impl<S: Iterator, B, I: Iterator, F> SourceIter for Map<I, F>
+unsafe impl<S: Iterator, B, I: Iterator, F> SourceIter for Map<I, F>
 where
     F: FnMut(I::Item) -> B,
     I: SourceIter<Source = S>,
@@ -1402,7 +1436,7 @@ impl<I> FusedIterator for Enumerate<I> where I: FusedIterator {}
 unsafe impl<I> TrustedLen for Enumerate<I> where I: TrustedLen {}
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
-impl<S: Iterator, I: Iterator> SourceIter for Enumerate<I>
+unsafe impl<S: Iterator, I: Iterator> SourceIter for Enumerate<I>
 where
     I: SourceIter<Source = S>,
 {
@@ -1632,7 +1666,7 @@ impl<I: Iterator> Peekable<I> {
 unsafe impl<I> TrustedLen for Peekable<I> where I: TrustedLen {}
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
-impl<S: Iterator, I: Iterator> SourceIter for Peekable<I>
+unsafe impl<S: Iterator, I: Iterator> SourceIter for Peekable<I>
 where
     I: SourceIter<Source = S>,
 {
@@ -2119,7 +2153,7 @@ where
 impl<I> FusedIterator for Skip<I> where I: FusedIterator {}
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
-impl<S: Iterator, I: Iterator> SourceIter for Skip<I>
+unsafe impl<S: Iterator, I: Iterator> SourceIter for Skip<I>
 where
     I: SourceIter<Source = S>,
 {
@@ -2618,7 +2652,7 @@ where
 }
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
-impl<S: Iterator, I: Iterator> SourceIter for Fuse<I>
+unsafe impl<S: Iterator, I: Iterator> SourceIter for Fuse<I>
 where
     I: SourceIter<Source = S>,
 {

--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -1093,6 +1093,22 @@ where
 #[stable(feature = "fused", since = "1.26.0")]
 impl<I: FusedIterator, P> FusedIterator for Filter<I, P> where P: FnMut(&I::Item) -> bool {}
 
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, P, I: Iterator> SourceIter for Filter<I, P> where
+    P: FnMut(&I::Item) -> bool,
+    I: SourceIter<Source = S>
+{
+    type Source = S;
+
+    #[inline]
+    fn as_inner(&mut self) -> &mut S {
+        SourceIter::as_inner(&mut self.iter)
+    }
+}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<I: InPlaceIterable, P> InPlaceIterable for Filter<I, P> where P: FnMut(&I::Item) -> bool {}
+
 /// An iterator that uses `f` to both filter and map elements from `iter`.
 ///
 /// This `struct` is created by the [`filter_map`] method on [`Iterator`]. See its
@@ -1218,6 +1234,23 @@ where
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<B, I: FusedIterator, F> FusedIterator for FilterMap<I, F> where F: FnMut(I::Item) -> Option<B> {}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, B, I: Iterator, F> SourceIter for FilterMap<I, F> where
+    F: FnMut(I::Item) -> Option<B>,
+    I: SourceIter<Source = S>
+{
+    type Source = S;
+
+    #[inline]
+    fn as_inner(&mut self) -> &mut S {
+        SourceIter::as_inner(&mut self.iter)
+    }
+}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<B, I: InPlaceIterable, F> InPlaceIterable for FilterMap<I, F> where F: FnMut(I::Item) -> Option<B> {}
+
 
 /// An iterator that yields the current count and the element during iteration.
 ///
@@ -1777,6 +1810,22 @@ where
 {
 }
 
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, P, I: Iterator> SourceIter for SkipWhile<I, P> where
+    P: FnMut(&I::Item) -> bool,
+    I: SourceIter<Source = S>
+{
+    type Source = S;
+
+    #[inline]
+    fn as_inner(&mut self) -> &mut S {
+        SourceIter::as_inner(&mut self.iter)
+    }
+}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<I: InPlaceIterable, F> InPlaceIterable for SkipWhile<I, F> where F: FnMut(&I::Item) -> bool {}
+
 /// An iterator that only accepts elements while `predicate` returns `true`.
 ///
 /// This `struct` is created by the [`take_while`] method on [`Iterator`]. See its
@@ -1965,6 +2014,24 @@ where
     P: FnMut(&I::Item) -> bool,
 {
 }
+
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, P, I: Iterator> SourceIter for TakeWhile<I, P> where
+    P: FnMut(&I::Item) -> bool,
+    I: SourceIter<Source = S>
+{
+    type Source = S;
+
+    #[inline]
+    fn as_inner(&mut self) -> &mut S {
+        SourceIter::as_inner(&mut self.iter)
+    }
+}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<I: InPlaceIterable, F> InPlaceIterable for TakeWhile<I, F> where F: FnMut(&I::Item) -> bool {}
+
 
 /// An iterator that skips over `n` elements of `iter`.
 ///
@@ -2259,6 +2326,19 @@ where
     }
 }
 
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, I: Iterator> SourceIter for Take<I> where I: SourceIter<Source = S> {
+    type Source = S;
+
+    #[inline]
+    fn as_inner(&mut self) -> &mut S {
+        SourceIter::as_inner(&mut self.iter)
+    }
+}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<I: InPlaceIterable> InPlaceIterable for Take<I> {}
+
 #[stable(feature = "double_ended_take_iterator", since = "1.38.0")]
 impl<I> DoubleEndedIterator for Take<I>
 where
@@ -2390,6 +2470,24 @@ where
         self.iter.try_fold(init, scan(state, f, fold)).into_try()
     }
 }
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<St, F, B, S: Iterator, I: Iterator> SourceIter for Scan<I, St, F>
+    where I: SourceIter<Source = S>,
+          F: FnMut(&mut St, I::Item) -> Option<B>,
+{
+    type Source = S;
+
+    #[inline]
+    fn as_inner(&mut self) -> &mut S {
+        SourceIter::as_inner(&mut self.iter)
+    }
+}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<St, F, B, I: InPlaceIterable> InPlaceIterable for Scan<I, St, F>
+    where F: FnMut(&mut St, I::Item) -> Option<B>,
+{}
 
 /// An iterator that yields `None` forever after the underlying iterator
 /// yields `None` once.
@@ -2807,6 +2905,22 @@ where
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<I: FusedIterator, F> FusedIterator for Inspect<I, F> where F: FnMut(&I::Item) {}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, I: Iterator, F> SourceIter for Inspect<I, F> where
+    F: FnMut(&I::Item),
+    I: SourceIter<Source = S>
+{
+    type Source = S;
+
+    #[inline]
+    fn as_inner(&mut self) -> &mut S {
+        SourceIter::as_inner(&mut self.iter)
+    }
+}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<I: InPlaceIterable, F> InPlaceIterable for Inspect<I, F> where F: FnMut(&I::Item)  {}
 
 /// An iterator adapter that produces output as long as the underlying
 /// iterator produces `Result::Ok` values.

--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -16,9 +16,9 @@ mod zip;
 pub use self::chain::Chain;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::flatten::{FlatMap, Flatten};
-pub use self::zip::Zip;
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 pub use self::zip::TrustedRandomAccess;
+pub use self::zip::Zip;
 
 /// This trait provides transitive access to source-stage in an interator-adapter pipeline
 /// under the conditions that
@@ -53,7 +53,7 @@ pub use self::zip::TrustedRandomAccess;
 ///
 /// [`FromIterator`]: trait.FromIterator.html
 /// [`as_inner`]: #method.as_inner
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 pub unsafe trait SourceIter {
     /// A source stage in an iterator pipeline.
     type Source: Iterator;
@@ -323,7 +323,7 @@ where
 }
 
 #[doc(hidden)]
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 unsafe impl<'a, I, T: 'a> TrustedRandomAccess for Copied<I>
 where
     I: TrustedRandomAccess<Item = &'a T>,
@@ -454,7 +454,7 @@ where
 }
 
 #[doc(hidden)]
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 unsafe impl<'a, I, T: 'a> TrustedRandomAccess for Cloned<I>
 where
     I: TrustedRandomAccess<Item = &'a T>,
@@ -471,7 +471,7 @@ where
 }
 
 #[doc(hidden)]
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 unsafe impl<'a, I, T: 'a> TrustedRandomAccess for Cloned<I>
 where
     I: TrustedRandomAccess<Item = &'a T>,
@@ -939,7 +939,7 @@ where
 }
 
 #[doc(hidden)]
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 unsafe impl<B, I, F> TrustedRandomAccess for Map<I, F>
 where
     I: TrustedRandomAccess,
@@ -954,7 +954,7 @@ where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<S: Iterator, B, I: Iterator, F> SourceIter for Map<I, F>
 where
     F: FnMut(I::Item) -> B,
@@ -968,7 +968,7 @@ where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<B, I: InPlaceIterable, F> InPlaceIterable for Map<I, F> where F: FnMut(I::Item) -> B {}
 
 /// An iterator that filters the elements of `iter` with `predicate`.
@@ -1102,10 +1102,11 @@ where
 #[stable(feature = "fused", since = "1.26.0")]
 impl<I: FusedIterator, P> FusedIterator for Filter<I, P> where P: FnMut(&I::Item) -> bool {}
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<S: Iterator, P, I: Iterator> SourceIter for Filter<I, P> where
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, P, I: Iterator> SourceIter for Filter<I, P>
+where
     P: FnMut(&I::Item) -> bool,
-    I: SourceIter<Source = S>
+    I: SourceIter<Source = S>,
 {
     type Source = S;
 
@@ -1115,9 +1116,8 @@ unsafe impl<S: Iterator, P, I: Iterator> SourceIter for Filter<I, P> where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<I: InPlaceIterable, P> InPlaceIterable for Filter<I, P>
-    where P: FnMut(&I::Item) -> bool {}
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<I: InPlaceIterable, P> InPlaceIterable for Filter<I, P> where P: FnMut(&I::Item) -> bool {}
 
 /// An iterator that uses `f` to both filter and map elements from `iter`.
 ///
@@ -1245,10 +1245,11 @@ where
 #[stable(feature = "fused", since = "1.26.0")]
 impl<B, I: FusedIterator, F> FusedIterator for FilterMap<I, F> where F: FnMut(I::Item) -> Option<B> {}
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<S: Iterator, B, I: Iterator, F> SourceIter for FilterMap<I, F> where
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, B, I: Iterator, F> SourceIter for FilterMap<I, F>
+where
     F: FnMut(I::Item) -> Option<B>,
-    I: SourceIter<Source = S>
+    I: SourceIter<Source = S>,
 {
     type Source = S;
 
@@ -1258,10 +1259,11 @@ unsafe impl<S: Iterator, B, I: Iterator, F> SourceIter for FilterMap<I, F> where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<B, I: InPlaceIterable, F> InPlaceIterable for FilterMap<I, F>
-    where F: FnMut(I::Item) -> Option<B> {}
-
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<B, I: InPlaceIterable, F> InPlaceIterable for FilterMap<I, F> where
+    F: FnMut(I::Item) -> Option<B>
+{
+}
 
 /// An iterator that yields the current count and the element during iteration.
 ///
@@ -1455,7 +1457,7 @@ where
 }
 
 #[doc(hidden)]
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 unsafe impl<I> TrustedRandomAccess for Enumerate<I>
 where
     I: TrustedRandomAccess,
@@ -1475,7 +1477,7 @@ impl<I> FusedIterator for Enumerate<I> where I: FusedIterator {}
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<I> TrustedLen for Enumerate<I> where I: TrustedLen {}
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<S: Iterator, I: Iterator> SourceIter for Enumerate<I>
 where
     I: SourceIter<Source = S>,
@@ -1488,7 +1490,7 @@ where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<I: InPlaceIterable> InPlaceIterable for Enumerate<I> {}
 
 /// An iterator with a `peek()` that returns an optional reference to the next
@@ -1705,7 +1707,7 @@ impl<I: Iterator> Peekable<I> {
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<I> TrustedLen for Peekable<I> where I: TrustedLen {}
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<S: Iterator, I: Iterator> SourceIter for Peekable<I>
 where
     I: SourceIter<Source = S>,
@@ -1718,7 +1720,7 @@ where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<I: InPlaceIterable> InPlaceIterable for Peekable<I> {}
 
 /// An iterator that rejects elements while `predicate` returns `true`.
@@ -1822,10 +1824,11 @@ where
 {
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<S: Iterator, P, I: Iterator> SourceIter for SkipWhile<I, P> where
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, P, I: Iterator> SourceIter for SkipWhile<I, P>
+where
     P: FnMut(&I::Item) -> bool,
-    I: SourceIter<Source = S>
+    I: SourceIter<Source = S>,
 {
     type Source = S;
 
@@ -1835,9 +1838,11 @@ unsafe impl<S: Iterator, P, I: Iterator> SourceIter for SkipWhile<I, P> where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<I: InPlaceIterable, F> InPlaceIterable for SkipWhile<I, F>
-    where F: FnMut(&I::Item) -> bool {}
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<I: InPlaceIterable, F> InPlaceIterable for SkipWhile<I, F> where
+    F: FnMut(&I::Item) -> bool
+{
+}
 
 /// An iterator that only accepts elements while `predicate` returns `true`.
 ///
@@ -2028,11 +2033,11 @@ where
 {
 }
 
-
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<S: Iterator, P, I: Iterator> SourceIter for TakeWhile<I, P> where
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, P, I: Iterator> SourceIter for TakeWhile<I, P>
+where
     P: FnMut(&I::Item) -> bool,
-    I: SourceIter<Source = S>
+    I: SourceIter<Source = S>,
 {
     type Source = S;
 
@@ -2042,10 +2047,11 @@ unsafe impl<S: Iterator, P, I: Iterator> SourceIter for TakeWhile<I, P> where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<I: InPlaceIterable, F> InPlaceIterable for TakeWhile<I, F>
-    where F: FnMut(&I::Item) -> bool {}
-
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<I: InPlaceIterable, F> InPlaceIterable for TakeWhile<I, F> where
+    F: FnMut(&I::Item) -> bool
+{
+}
 
 /// An iterator that skips over `n` elements of `iter`.
 ///
@@ -2228,7 +2234,7 @@ where
 #[stable(feature = "fused", since = "1.26.0")]
 impl<I> FusedIterator for Skip<I> where I: FusedIterator {}
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<S: Iterator, I: Iterator> SourceIter for Skip<I>
 where
     I: SourceIter<Source = S>,
@@ -2241,7 +2247,7 @@ where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<I: InPlaceIterable> InPlaceIterable for Skip<I> {}
 
 /// An iterator that only iterates over the first `n` iterations of `iter`.
@@ -2340,8 +2346,11 @@ where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<S: Iterator, I: Iterator> SourceIter for Take<I> where I: SourceIter<Source = S> {
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, I: Iterator> SourceIter for Take<I>
+where
+    I: SourceIter<Source = S>,
+{
     type Source = S;
 
     #[inline]
@@ -2350,7 +2359,7 @@ unsafe impl<S: Iterator, I: Iterator> SourceIter for Take<I> where I: SourceIter
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<I: InPlaceIterable> InPlaceIterable for Take<I> {}
 
 #[stable(feature = "double_ended_take_iterator", since = "1.38.0")]
@@ -2485,10 +2494,11 @@ where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<St, F, B, S: Iterator, I: Iterator> SourceIter for Scan<I, St, F>
-    where I: SourceIter<Source = S>,
-          F: FnMut(&mut St, I::Item) -> Option<B>,
+where
+    I: SourceIter<Source = S>,
+    F: FnMut(&mut St, I::Item) -> Option<B>,
 {
     type Source = S;
 
@@ -2498,10 +2508,11 @@ unsafe impl<St, F, B, S: Iterator, I: Iterator> SourceIter for Scan<I, St, F>
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<St, F, B, I: InPlaceIterable> InPlaceIterable for Scan<I, St, F>
-    where F: FnMut(&mut St, I::Item) -> Option<B>,
-{}
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<St, F, B, I: InPlaceIterable> InPlaceIterable for Scan<I, St, F> where
+    F: FnMut(&mut St, I::Item) -> Option<B>
+{
+}
 
 /// An iterator that yields `None` forever after the underlying iterator
 /// yields `None` once.
@@ -2648,7 +2659,7 @@ where
     }
 }
 
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 unsafe impl<I> TrustedRandomAccess for Fuse<I>
 where
     I: TrustedRandomAccess,
@@ -2759,7 +2770,7 @@ where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<S: Iterator, I: Iterator> SourceIter for Fuse<I>
 where
     I: SourceIter<Source = S>,
@@ -2772,7 +2783,7 @@ where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<I: InPlaceIterable> InPlaceIterable for Fuse<I> {}
 
 /// An iterator that calls a function with a reference to each element before
@@ -2921,10 +2932,11 @@ where
 #[stable(feature = "fused", since = "1.26.0")]
 impl<I: FusedIterator, F> FusedIterator for Inspect<I, F> where F: FnMut(&I::Item) {}
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<S: Iterator, I: Iterator, F> SourceIter for Inspect<I, F> where
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, I: Iterator, F> SourceIter for Inspect<I, F>
+where
     F: FnMut(&I::Item),
-    I: SourceIter<Source = S>
+    I: SourceIter<Source = S>,
 {
     type Source = S;
 
@@ -2934,8 +2946,8 @@ unsafe impl<S: Iterator, I: Iterator, F> SourceIter for Inspect<I, F> where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<I: InPlaceIterable, F> InPlaceIterable for Inspect<I, F> where F: FnMut(&I::Item)  {}
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<I: InPlaceIterable, F> InPlaceIterable for Inspect<I, F> where F: FnMut(&I::Item) {}
 
 /// An iterator adapter that produces output as long as the underlying
 /// iterator produces `Result::Ok` values.

--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -67,10 +67,6 @@ pub unsafe trait SourceIter {
     /// rely on it not being modified.
     ///
     /// Adapters must not rely on exclusive ownership or immutability of the source.
-    /// For example a peeking adapter could either exploit [`TrustedRandomAccess`] to look ahead
-    /// or implement this trait, but it cannot do both because a caller could call `next()` or any
-    /// other mutating method on the source between iteration steps and thus invalidate the peeked
-    /// values.
     /// The lack of exclusive ownership also requires that adapters must uphold the source's
     /// public API even when they have crate- or module-internal access.
     ///
@@ -82,7 +78,6 @@ pub unsafe trait SourceIter {
     /// access to the underlying storage of an iterator while restricting any statefulness
     /// and side-effects of the pipeline stages from affecting or relying on that storage.
     ///
-    /// [`TrustedRandomAccess`]: trait.TrustedRandomAccess.html
     /// [`next()`]: trait.Iterator.html#method.next
     fn as_inner(&mut self) -> &mut Self::Source;
 }

--- a/src/libcore/iter/adapters/zip.rs
+++ b/src/libcore/iter/adapters/zip.rs
@@ -262,6 +262,7 @@ where
 }
 
 #[doc(hidden)]
+#[unstable(issue = "0", feature = "std_internals")]
 unsafe impl<A, B> TrustedRandomAccess for Zip<A, B>
 where
     A: TrustedRandomAccess,
@@ -322,7 +323,10 @@ unsafe impl<A: InPlaceIterable, B: Iterator> InPlaceIterable for Zip<A, B> {}
 /// .get_unchecked() must return distinct mutable references for distinct
 /// indices (if applicable), and must return a valid reference if index is in
 /// 0..self.len().
-pub(crate) unsafe trait TrustedRandomAccess: ExactSizeIterator {
+#[unstable(issue = "0", feature = "std_internals")]
+pub unsafe trait TrustedRandomAccess: ExactSizeIterator {
+    /// Returns item at offset `i` from the current position of the iterator.
+    /// It does not advance the iterator.
     unsafe fn get_unchecked(&mut self, i: usize) -> Self::Item;
     /// Returns `true` if getting an iterator element may have
     /// side effects. Remember to take inner iterators into account.

--- a/src/libcore/iter/adapters/zip.rs
+++ b/src/libcore/iter/adapters/zip.rs
@@ -2,7 +2,10 @@
 
 use crate::cmp;
 
-use super::super::{DoubleEndedIterator, ExactSizeIterator, FusedIterator, Iterator, TrustedLen};
+use super::super::{
+    DoubleEndedIterator, ExactSizeIterator, FusedIterator, InPlaceIterable, Iterator, SourceIter,
+    TrustedLen,
+};
 
 /// An iterator that iterates two other iterators simultaneously.
 ///
@@ -288,6 +291,26 @@ where
     B: TrustedLen,
 {
 }
+
+// Arbitrarily selects the left side of the zip iteration as extractable "source"
+// it would require negative trait bounds to be able to try both
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<S, A, B> SourceIter for Zip<A, B>
+where
+    A: SourceIter<Source = S>,
+    B: Iterator,
+    S: Iterator,
+{
+    type Source = S;
+
+    #[inline]
+    fn as_inner(&mut self) -> &mut S {
+        SourceIter::as_inner(&mut self.a)
+    }
+}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<A: InPlaceIterable, B: Iterator> InPlaceIterable for Zip<A, B> {}
 
 /// An iterator whose items are random-accessible efficiently
 ///

--- a/src/libcore/iter/adapters/zip.rs
+++ b/src/libcore/iter/adapters/zip.rs
@@ -305,13 +305,18 @@ where
     type Source = S;
 
     #[inline]
-    fn as_inner(&mut self) -> &mut S {
+    unsafe fn as_inner(&mut self) -> &mut S {
         SourceIter::as_inner(&mut self.a)
     }
 }
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<A: InPlaceIterable, B: Iterator> InPlaceIterable for Zip<A, B> {}
+// Limited to Item: Copy since interaction between Zip's use of TrustedRandomAccess
+// and Drop implementation of the source is unclear.
+//
+// An additional method returning the number of times the source has been logically advanced
+// (without calling next()) would be needed to properly drop the remainder of the source.
+unsafe impl<A: InPlaceIterable, B: Iterator> InPlaceIterable for Zip<A, B> where A::Item: Copy {}
 
 /// An iterator whose items are random-accessible efficiently
 ///

--- a/src/libcore/iter/adapters/zip.rs
+++ b/src/libcore/iter/adapters/zip.rs
@@ -262,7 +262,7 @@ where
 }
 
 #[doc(hidden)]
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 unsafe impl<A, B> TrustedRandomAccess for Zip<A, B>
 where
     A: TrustedRandomAccess,
@@ -295,7 +295,7 @@ where
 
 // Arbitrarily selects the left side of the zip iteration as extractable "source"
 // it would require negative trait bounds to be able to try both
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<S, A, B> SourceIter for Zip<A, B>
 where
     A: SourceIter<Source = S>,
@@ -310,7 +310,7 @@ where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 // Limited to Item: Copy since interaction between Zip's use of TrustedRandomAccess
 // and Drop implementation of the source is unclear.
 //
@@ -328,7 +328,7 @@ unsafe impl<A: InPlaceIterable, B: Iterator> InPlaceIterable for Zip<A, B> where
 /// .get_unchecked() must return distinct mutable references for distinct
 /// indices (if applicable), and must return a valid reference if index is in
 /// 0..self.len().
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 pub unsafe trait TrustedRandomAccess: ExactSizeIterator {
     /// Returns item at offset `i` from the current position of the iterator.
     /// It does not advance the iterator.

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -345,6 +345,9 @@ pub use self::traits::{DoubleEndedIterator, Extend, FromIterator, IntoIterator};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::traits::{ExactSizeIterator, Product, Sum};
 
+#[unstable(issue = "0", feature = "inplace_iteration")]
+pub use self::traits::InPlaceIterable;
+
 #[stable(feature = "iter_cloned", since = "1.1.0")]
 pub use self::adapters::Cloned;
 #[stable(feature = "iter_copied", since = "1.36.0")]
@@ -353,6 +356,8 @@ pub use self::adapters::Copied;
 pub use self::adapters::Flatten;
 #[unstable(feature = "iter_map_while", reason = "recently added", issue = "68537")]
 pub use self::adapters::MapWhile;
+#[unstable(issue = "0", feature = "inplace_iteration")]
+pub use self::adapters::SourceIter;
 #[stable(feature = "iterator_step_by", since = "1.28.0")]
 pub use self::adapters::StepBy;
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -345,7 +345,7 @@ pub use self::traits::{DoubleEndedIterator, Extend, FromIterator, IntoIterator};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::traits::{ExactSizeIterator, Product, Sum};
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 pub use self::traits::InPlaceIterable;
 
 #[stable(feature = "iter_cloned", since = "1.1.0")]
@@ -354,13 +354,14 @@ pub use self::adapters::Cloned;
 pub use self::adapters::Copied;
 #[stable(feature = "iterator_flatten", since = "1.29.0")]
 pub use self::adapters::Flatten;
+
 #[unstable(feature = "iter_map_while", reason = "recently added", issue = "68537")]
 pub use self::adapters::MapWhile;
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 pub use self::adapters::SourceIter;
 #[stable(feature = "iterator_step_by", since = "1.28.0")]
 pub use self::adapters::StepBy;
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 pub use self::adapters::TrustedRandomAccess;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::adapters::{Chain, Cycle, Enumerate, Filter, FilterMap, Map, Rev, Zip};

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -360,6 +360,8 @@ pub use self::adapters::MapWhile;
 pub use self::adapters::SourceIter;
 #[stable(feature = "iterator_step_by", since = "1.28.0")]
 pub use self::adapters::StepBy;
+#[unstable(issue = "0", feature = "std_internals")]
+pub use self::adapters::TrustedRandomAccess;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::adapters::{Chain, Cycle, Enumerate, Filter, FilterMap, Map, Rev, Zip};
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -367,7 +369,7 @@ pub use self::adapters::{FlatMap, Peekable, Scan, Skip, SkipWhile, Take, TakeWhi
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::adapters::{Fuse, Inspect};
 
-pub(crate) use self::adapters::{process_results, TrustedRandomAccess};
+pub(crate) use self::adapters::process_results;
 
 mod adapters;
 mod range;

--- a/src/libcore/iter/traits/marker.rs
+++ b/src/libcore/iter/traits/marker.rs
@@ -52,5 +52,5 @@ unsafe impl<I: TrustedLen + ?Sized> TrustedLen for &mut I {}
 /// In other words this trait indicates that an iterator pipeline can be collected in place.
 ///
 /// [`SourceIter`]: ../../std/iter/trait.SourceIter.html
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 pub unsafe trait InPlaceIterable: Iterator {}

--- a/src/libcore/iter/traits/marker.rs
+++ b/src/libcore/iter/traits/marker.rs
@@ -42,3 +42,15 @@ pub unsafe trait TrustedLen: Iterator {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<I: TrustedLen + ?Sized> TrustedLen for &mut I {}
+
+/// An iterator that when yielding an item will have taken at least one element
+/// from its underlying [`SourceIter`].
+///
+/// Calling next() guarantees that at least one value of the iterator's underlying source
+/// has been moved out and the result of the iterator chain could be inserted in its place,
+/// assuming structural constraints of the source allow such an insertion.
+/// In other words this trait indicates that an iterator pipeline can be collected in place.
+///
+/// [`SourceIter`]: ../../std/iter/trait.SourceIter.html
+#[unstable(issue = "0", feature = "inplace_iteration")]
+pub unsafe trait InPlaceIterable: Iterator {}

--- a/src/libcore/iter/traits/mod.rs
+++ b/src/libcore/iter/traits/mod.rs
@@ -11,7 +11,7 @@ pub use self::double_ended::DoubleEndedIterator;
 pub use self::exact_size::ExactSizeIterator;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::iterator::Iterator;
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 pub use self::marker::InPlaceIterable;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::marker::{FusedIterator, TrustedLen};

--- a/src/libcore/iter/traits/mod.rs
+++ b/src/libcore/iter/traits/mod.rs
@@ -11,5 +11,7 @@ pub use self::double_ended::DoubleEndedIterator;
 pub use self::exact_size::ExactSizeIterator;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::iterator::Iterator;
+#[unstable(issue = "0", feature = "inplace_iteration")]
+pub use self::marker::InPlaceIterable;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::marker::{FusedIterator, TrustedLen};

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -4210,6 +4210,7 @@ unsafe impl<T> TrustedLen for Windows<'_, T> {}
 impl<T> FusedIterator for Windows<'_, T> {}
 
 #[doc(hidden)]
+#[unstable(issue = "0", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for Windows<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a [T] {
         from_raw_parts(self.v.as_ptr().add(i), self.size)
@@ -4349,6 +4350,7 @@ unsafe impl<T> TrustedLen for Chunks<'_, T> {}
 impl<T> FusedIterator for Chunks<'_, T> {}
 
 #[doc(hidden)]
+#[unstable(issue = "0", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for Chunks<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a [T] {
         let start = i * self.chunk_size;
@@ -4491,6 +4493,7 @@ unsafe impl<T> TrustedLen for ChunksMut<'_, T> {}
 impl<T> FusedIterator for ChunksMut<'_, T> {}
 
 #[doc(hidden)]
+#[unstable(issue = "0", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for ChunksMut<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a mut [T] {
         let start = i * self.chunk_size;
@@ -4631,7 +4634,7 @@ unsafe impl<T> TrustedLen for ChunksExact<'_, T> {}
 impl<T> FusedIterator for ChunksExact<'_, T> {}
 
 #[doc(hidden)]
-#[stable(feature = "chunks_exact", since = "1.31.0")]
+#[unstable(issue = "0", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for ChunksExact<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a [T] {
         let start = i * self.chunk_size;
@@ -4765,7 +4768,7 @@ unsafe impl<T> TrustedLen for ChunksExactMut<'_, T> {}
 impl<T> FusedIterator for ChunksExactMut<'_, T> {}
 
 #[doc(hidden)]
-#[stable(feature = "chunks_exact", since = "1.31.0")]
+#[unstable(issue = "0", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for ChunksExactMut<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a mut [T] {
         let start = i * self.chunk_size;
@@ -4908,7 +4911,7 @@ unsafe impl<T> TrustedLen for RChunks<'_, T> {}
 impl<T> FusedIterator for RChunks<'_, T> {}
 
 #[doc(hidden)]
-#[stable(feature = "rchunks", since = "1.31.0")]
+#[unstable(issue = "0", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for RChunks<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a [T] {
         let end = self.v.len() - i * self.chunk_size;
@@ -5053,7 +5056,7 @@ unsafe impl<T> TrustedLen for RChunksMut<'_, T> {}
 impl<T> FusedIterator for RChunksMut<'_, T> {}
 
 #[doc(hidden)]
-#[stable(feature = "rchunks", since = "1.31.0")]
+#[unstable(issue = "0", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for RChunksMut<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a mut [T] {
         let end = self.v.len() - i * self.chunk_size;
@@ -5197,7 +5200,7 @@ unsafe impl<T> TrustedLen for RChunksExact<'_, T> {}
 impl<T> FusedIterator for RChunksExact<'_, T> {}
 
 #[doc(hidden)]
-#[stable(feature = "rchunks", since = "1.31.0")]
+#[unstable(issue = "0", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for RChunksExact<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a [T] {
         let end = self.v.len() - i * self.chunk_size;
@@ -5336,7 +5339,7 @@ unsafe impl<T> TrustedLen for RChunksExactMut<'_, T> {}
 impl<T> FusedIterator for RChunksExactMut<'_, T> {}
 
 #[doc(hidden)]
-#[stable(feature = "rchunks", since = "1.31.0")]
+#[unstable(issue = "0", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for RChunksExactMut<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a mut [T] {
         let end = self.v.len() - i * self.chunk_size;
@@ -5683,6 +5686,7 @@ impl_marker_for!(BytewiseEquality,
                  u8 i8 u16 i16 u32 i32 u64 i64 u128 i128 usize isize char bool);
 
 #[doc(hidden)]
+#[unstable(issue = "0", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for Iter<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a T {
         &*self.ptr.as_ptr().add(i)
@@ -5693,6 +5697,7 @@ unsafe impl<'a, T> TrustedRandomAccess for Iter<'a, T> {
 }
 
 #[doc(hidden)]
+#[unstable(issue = "0", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for IterMut<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a mut T {
         &mut *self.ptr.as_ptr().add(i)

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -4210,7 +4210,7 @@ unsafe impl<T> TrustedLen for Windows<'_, T> {}
 impl<T> FusedIterator for Windows<'_, T> {}
 
 #[doc(hidden)]
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for Windows<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a [T] {
         from_raw_parts(self.v.as_ptr().add(i), self.size)
@@ -4350,7 +4350,7 @@ unsafe impl<T> TrustedLen for Chunks<'_, T> {}
 impl<T> FusedIterator for Chunks<'_, T> {}
 
 #[doc(hidden)]
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for Chunks<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a [T] {
         let start = i * self.chunk_size;
@@ -4493,7 +4493,7 @@ unsafe impl<T> TrustedLen for ChunksMut<'_, T> {}
 impl<T> FusedIterator for ChunksMut<'_, T> {}
 
 #[doc(hidden)]
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for ChunksMut<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a mut [T] {
         let start = i * self.chunk_size;
@@ -4634,7 +4634,7 @@ unsafe impl<T> TrustedLen for ChunksExact<'_, T> {}
 impl<T> FusedIterator for ChunksExact<'_, T> {}
 
 #[doc(hidden)]
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for ChunksExact<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a [T] {
         let start = i * self.chunk_size;
@@ -4768,7 +4768,7 @@ unsafe impl<T> TrustedLen for ChunksExactMut<'_, T> {}
 impl<T> FusedIterator for ChunksExactMut<'_, T> {}
 
 #[doc(hidden)]
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for ChunksExactMut<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a mut [T] {
         let start = i * self.chunk_size;
@@ -4911,7 +4911,7 @@ unsafe impl<T> TrustedLen for RChunks<'_, T> {}
 impl<T> FusedIterator for RChunks<'_, T> {}
 
 #[doc(hidden)]
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for RChunks<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a [T] {
         let end = self.v.len() - i * self.chunk_size;
@@ -5056,7 +5056,7 @@ unsafe impl<T> TrustedLen for RChunksMut<'_, T> {}
 impl<T> FusedIterator for RChunksMut<'_, T> {}
 
 #[doc(hidden)]
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for RChunksMut<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a mut [T] {
         let end = self.v.len() - i * self.chunk_size;
@@ -5200,7 +5200,7 @@ unsafe impl<T> TrustedLen for RChunksExact<'_, T> {}
 impl<T> FusedIterator for RChunksExact<'_, T> {}
 
 #[doc(hidden)]
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for RChunksExact<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a [T] {
         let end = self.v.len() - i * self.chunk_size;
@@ -5339,7 +5339,7 @@ unsafe impl<T> TrustedLen for RChunksExactMut<'_, T> {}
 impl<T> FusedIterator for RChunksExactMut<'_, T> {}
 
 #[doc(hidden)]
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for RChunksExactMut<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a mut [T] {
         let end = self.v.len() - i * self.chunk_size;
@@ -5686,7 +5686,7 @@ impl_marker_for!(BytewiseEquality,
                  u8 i8 u16 i16 u32 i32 u64 i64 u128 i128 usize isize char bool);
 
 #[doc(hidden)]
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for Iter<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a T {
         &*self.ptr.as_ptr().add(i)
@@ -5697,7 +5697,7 @@ unsafe impl<'a, T> TrustedRandomAccess for Iter<'a, T> {
 }
 
 #[doc(hidden)]
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 unsafe impl<'a, T> TrustedRandomAccess for IterMut<'a, T> {
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a mut T {
         &mut *self.ptr.as_ptr().add(i)

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -863,6 +863,7 @@ impl FusedIterator for Bytes<'_> {}
 unsafe impl TrustedLen for Bytes<'_> {}
 
 #[doc(hidden)]
+#[unstable(issue = "0", feature = "std_internals")]
 unsafe impl TrustedRandomAccess for Bytes<'_> {
     unsafe fn get_unchecked(&mut self, i: usize) -> u8 {
         self.0.get_unchecked(i)

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -863,7 +863,7 @@ impl FusedIterator for Bytes<'_> {}
 unsafe impl TrustedLen for Bytes<'_> {}
 
 #[doc(hidden)]
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 unsafe impl TrustedRandomAccess for Bytes<'_> {
     unsafe fn get_unchecked(&mut self, i: usize) -> u8 {
         self.0.get_unchecked(i)


### PR DESCRIPTION
This extends the existing `vec.into_iter().collect::<Vec>()` specialization to cover more cases, including iterator pipelines that flow from `IntoIter` through `Map`, `Filter`, `Zip` and `Enumerate` and several others.

[Benchmark results](https://gist.github.com/the8472/6d999b2d08a2bedf3b93f12112f96e2f) with defaults and opt-level = 3, codegen-units=1.

The specialization should be conservative, it is only applied when we know the iterator will fit into the source allocation.

Additionally some existing specializations now applied in a few more code-paths.