### PR TITLE
Fix ICE when trying to suggest `Type<>` instead of `Type()`

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1860,15 +1860,16 @@ impl<'a> LoweringContext<'a> {
                         if let Ok(snippet) = self.sess.source_map().span_to_snippet(data.span) {
                             // Do not suggest going from `Trait()` to `Trait<>`
                             if data.inputs.len() > 0 {
-                                let split = snippet.find('(').unwrap();
-                                let trait_name = &snippet[0..split];
-                                let args = &snippet[split + 1 .. snippet.len() - 1];
-                                err.span_suggestion(
-                                    data.span,
-                                    "use angle brackets instead",
-                                    format!("{}<{}>", trait_name, args),
-                                    Applicability::MaybeIncorrect,
-                                );
+                                if let Some(split) = snippet.find('(') {
+                                    let trait_name = &snippet[0..split];
+                                    let args = &snippet[split + 1 .. snippet.len() - 1];
+                                    err.span_suggestion(
+                                        data.span,
+                                        "use angle brackets instead",
+                                        format!("{}<{}>", trait_name, args),
+                                        Applicability::MaybeIncorrect,
+                                    );
+                                }
                             }
                         };
                         err.emit();


### PR DESCRIPTION
Fixes #66286, but the output has no span:

```
error[E0214]: parenthesized type parameters may only be used with a `Fn` trait

error: aborting due to previous error

For more information about this error, try `rustc --explain E0214`.
```