### PR TITLE
introduce benchmarks of HashSet operations

### DIFF
--- a/src/liballoc/benches/btree/set.rs
+++ b/src/liballoc/benches/btree/set.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use rand::{thread_rng, Rng};
-use test::{black_box, Bencher};
+use test::Bencher;
 
 fn random(n: usize) -> BTreeSet<usize> {
     let mut rng = thread_rng();
@@ -31,7 +31,6 @@ fn pos(n: usize) -> BTreeSet<i32> {
     set
 }
 
-
 fn stagger(n1: usize, factor: usize) -> [BTreeSet<u32>; 2] {
     let n2 = n1 * factor;
     let mut sets = [BTreeSet::new(), BTreeSet::new()];
@@ -52,10 +51,7 @@ macro_rules! set_bench {
             let sets = $sets;
 
             // measure
-            b.iter(|| {
-                let x = sets[0].$set_func(&sets[1]).$result_func();
-                black_box(x);
-            })
+            b.iter(|| sets[0].$set_func(&sets[1]).$result_func())
         }
     };
 }

--- a/src/libstd/benches/hash/map.rs
+++ b/src/libstd/benches/hash/map.rs
@@ -1,11 +1,10 @@
 #![cfg(test)]
 
 use test::Bencher;
+use std::collections::HashMap;
 
 #[bench]
 fn new_drop(b: &mut Bencher) {
-    use super::map::HashMap;
-
     b.iter(|| {
         let m: HashMap<i32, i32> = HashMap::new();
         assert_eq!(m.len(), 0);
@@ -14,8 +13,6 @@ fn new_drop(b: &mut Bencher) {
 
 #[bench]
 fn new_insert_drop(b: &mut Bencher) {
-    use super::map::HashMap;
-
     b.iter(|| {
         let mut m = HashMap::new();
         m.insert(0, 0);
@@ -25,8 +22,6 @@ fn new_insert_drop(b: &mut Bencher) {
 
 #[bench]
 fn grow_by_insertion(b: &mut Bencher) {
-    use super::map::HashMap;
-
     let mut m = HashMap::new();
 
     for i in 1..1001 {
@@ -43,8 +38,6 @@ fn grow_by_insertion(b: &mut Bencher) {
 
 #[bench]
 fn find_existing(b: &mut Bencher) {
-    use super::map::HashMap;
-
     let mut m = HashMap::new();
 
     for i in 1..1001 {
@@ -60,8 +53,6 @@ fn find_existing(b: &mut Bencher) {
 
 #[bench]
 fn find_nonexisting(b: &mut Bencher) {
-    use super::map::HashMap;
-
     let mut m = HashMap::new();
 
     for i in 1..1001 {
@@ -77,8 +68,6 @@ fn find_nonexisting(b: &mut Bencher) {
 
 #[bench]
 fn hashmap_as_queue(b: &mut Bencher) {
-    use super::map::HashMap;
-
     let mut m = HashMap::new();
 
     for i in 1..1001 {
@@ -96,8 +85,6 @@ fn hashmap_as_queue(b: &mut Bencher) {
 
 #[bench]
 fn get_remove_insert(b: &mut Bencher) {
-    use super::map::HashMap;
-
     let mut m = HashMap::new();
 
     for i in 1..1001 {

--- a/src/libstd/benches/hash/mod.rs
+++ b/src/libstd/benches/hash/mod.rs
@@ -1,0 +1,2 @@
+mod map;
+mod set_ops;

--- a/src/libstd/benches/hash/set_ops.rs
+++ b/src/libstd/benches/hash/set_ops.rs
@@ -1,0 +1,42 @@
+use std::collections::HashSet;
+use test::Bencher;
+
+#[bench]
+fn set_difference(b: &mut Bencher) {
+    let small: HashSet<_> = (0..10).collect();
+    let large: HashSet<_> = (0..100).collect();
+
+    b.iter(|| small.difference(&large).count());
+}
+
+#[bench]
+fn set_is_subset(b: &mut Bencher) {
+    let small: HashSet<_> = (0..10).collect();
+    let large: HashSet<_> = (0..100).collect();
+
+    b.iter(|| small.is_subset(&large));
+}
+
+#[bench]
+fn set_intersection(b: &mut Bencher) {
+    let small: HashSet<_> = (0..10).collect();
+    let large: HashSet<_> = (0..100).collect();
+
+    b.iter(|| small.intersection(&large).count());
+}
+
+#[bench]
+fn set_symmetric_difference(b: &mut Bencher) {
+    let small: HashSet<_> = (0..10).collect();
+    let large: HashSet<_> = (0..100).collect();
+
+    b.iter(|| small.symmetric_difference(&large).count());
+}
+
+#[bench]
+fn set_union(b: &mut Bencher) {
+    let small: HashSet<_> = (0..10).collect();
+    let large: HashSet<_> = (0..100).collect();
+
+    b.iter(|| small.union(&large).count());
+}

--- a/src/libstd/benches/lib.rs
+++ b/src/libstd/benches/lib.rs
@@ -1,0 +1,5 @@
+#![feature(test)]
+
+extern crate test;
+
+mod hash;

--- a/src/libstd/collections/hash/mod.rs
+++ b/src/libstd/collections/hash/mod.rs
@@ -1,5 +1,4 @@
 //! Unordered containers, implemented as hash-tables
 
-mod bench;
 pub mod map;
 pub mod set;


### PR DESCRIPTION
To avoid goofs such as corrected by #66280, I added benchmarks of binary HashSet operations.

Due to the fact x.py keeps recompiling the whole shebang (or at least a big part of it) whenever you touch the test code, and because piling up all tests in one file does not strike me as future proof, I tried moving the hash benches to the separate place they are for liballoc/collections/btree. But it turns out that, in a cleaned checkout, x.py still recompiles the whole shebang whenever you touch the test code (PS or when you add or delete any irrelevant file). So I'm not going to add more tests, and I doubt others will, and these tests have proven their point already, so this PR is kind of pointless