### PR TITLE
Make a test compatible across python versions.

### DIFF
--- a/src/test/run-make-fulldeps/sysroot-crates-are-unstable/Makefile
+++ b/src/test/run-make-fulldeps/sysroot-crates-are-unstable/Makefile
@@ -1,2 +1,2 @@
 all:
-	python test.py
+	python2.7 test.py

--- a/src/test/run-make-fulldeps/sysroot-crates-are-unstable/Makefile
+++ b/src/test/run-make-fulldeps/sysroot-crates-are-unstable/Makefile
@@ -1,2 +1,2 @@
 all:
-	python2.7 test.py
+	python test.py

--- a/src/test/run-make-fulldeps/sysroot-crates-are-unstable/test.py
+++ b/src/test/run-make-fulldeps/sysroot-crates-are-unstable/test.py
@@ -33,7 +33,7 @@ def check_lib(lib):
     print('verifying if {} is an unstable crate'.format(lib['name']))
     stdout, stderr = exec_command([os.environ['RUSTC'], '-', '--crate-type', 'rlib',
                                    '--extern', '{}={}'.format(lib['name'], lib['path'])],
-                                  to_input='extern crate {};'.format(lib['name']))
+                                  to_input=('extern crate {};'.format(lib['name'])).encode('utf-8'))
     if not 'use of unstable library feature' in '{}{}'.format(stdout, stderr):
         print('crate {} "{}" is not unstable'.format(lib['name'], lib['path']))
         print('{}{}'.format(stdout, stderr))


### PR DESCRIPTION
Progress on #65063

This PR allows this test to work on both python2 and python3, ~~and it also allows `./x.py test` to fully complete on my system without python2 installed at all.~~