### PR TITLE
rustc_metadata: simplify the interactions between Lazy and Table.

### DIFF
--- a/src/librustc_metadata/rmeta/decoder.rs
+++ b/src/librustc_metadata/rmeta/decoder.rs
@@ -1,9 +1,9 @@
 // Decoding metadata from a single crate's metadata
 
 use crate::rmeta::*;
-use crate::rmeta::table::{FixedSizeEncoding, PerDefTable};
+use crate::rmeta::table::{FixedSizeEncoding, Table};
 
-use rustc_index::vec::IndexVec;
+use rustc_index::vec::{Idx, IndexVec};
 use rustc_data_structures::sync::{Lrc, Lock, Once, AtomicCell};
 use rustc::hir::map::{DefKey, DefPath, DefPathData, DefPathHash};
 use rustc::hir::map::definitions::DefPathTable;
@@ -341,10 +341,10 @@ impl<'a, 'tcx, T: Encodable> SpecializedDecoder<Lazy<[T]>> for DecodeContext<'a,
     }
 }
 
-impl<'a, 'tcx, T> SpecializedDecoder<Lazy<PerDefTable<T>>> for DecodeContext<'a, 'tcx>
+impl<'a, 'tcx, I: Idx, T> SpecializedDecoder<Lazy<Table<I, T>>> for DecodeContext<'a, 'tcx>
     where Option<T>: FixedSizeEncoding,
 {
-    fn specialized_decode(&mut self) -> Result<Lazy<PerDefTable<T>>, Self::Error> {
+    fn specialized_decode(&mut self) -> Result<Lazy<Table<I, T>>, Self::Error> {
         let len = self.read_usize()?;
         self.read_lazy_with_meta(len)
     }

--- a/src/librustc_metadata/rmeta/decoder.rs
+++ b/src/librustc_metadata/rmeta/decoder.rs
@@ -32,7 +32,7 @@ use std::mem;
 use std::num::NonZeroUsize;
 use std::u32;
 
-use rustc_serialize::{Decodable, Decoder, Encodable, SpecializedDecoder, opaque};
+use rustc_serialize::{Decodable, Decoder, SpecializedDecoder, opaque};
 use syntax::attr;
 use syntax::ast::{self, Ident};
 use syntax::source_map::{self, respan, Spanned};
@@ -217,7 +217,7 @@ impl<'a, 'tcx> Metadata<'a, 'tcx> for (&'a CrateMetadata, TyCtxt<'tcx>) {
     }
 }
 
-impl<'a, 'tcx, T: Encodable + Decodable> Lazy<T> {
+impl<'a, 'tcx, T: Decodable> Lazy<T> {
     fn decode<M: Metadata<'a, 'tcx>>(self, metadata: M) -> T {
         let mut dcx = metadata.decoder(self.position.get());
         dcx.lazy_state = LazyState::NodeStart(self.position);
@@ -225,7 +225,7 @@ impl<'a, 'tcx, T: Encodable + Decodable> Lazy<T> {
     }
 }
 
-impl<'a: 'x, 'tcx: 'x, 'x, T: Encodable + Decodable> Lazy<[T]> {
+impl<'a: 'x, 'tcx: 'x, 'x, T: Decodable> Lazy<[T]> {
     fn decode<M: Metadata<'a, 'tcx>>(
         self,
         metadata: M,
@@ -324,13 +324,13 @@ impl<'a, 'tcx> TyDecoder<'tcx> for DecodeContext<'a, 'tcx> {
     }
 }
 
-impl<'a, 'tcx, T: Encodable> SpecializedDecoder<Lazy<T>> for DecodeContext<'a, 'tcx> {
+impl<'a, 'tcx, T> SpecializedDecoder<Lazy<T>> for DecodeContext<'a, 'tcx> {
     fn specialized_decode(&mut self) -> Result<Lazy<T>, Self::Error> {
         self.read_lazy_with_meta(())
     }
 }
 
-impl<'a, 'tcx, T: Encodable> SpecializedDecoder<Lazy<[T]>> for DecodeContext<'a, 'tcx> {
+impl<'a, 'tcx, T> SpecializedDecoder<Lazy<[T]>> for DecodeContext<'a, 'tcx> {
     fn specialized_decode(&mut self) -> Result<Lazy<[T]>, Self::Error> {
         let len = self.read_usize()?;
         if len == 0 {

--- a/src/librustc_metadata/rmeta/encoder.rs
+++ b/src/librustc_metadata/rmeta/encoder.rs
@@ -1,5 +1,5 @@
 use crate::rmeta::*;
-use crate::rmeta::table::{FixedSizeEncoding, Table};
+use crate::rmeta::table::{FixedSizeEncoding, TableBuilder};
 
 use rustc::middle::cstore::{LinkagePreference, NativeLibrary,
                             EncodedMetadata, ForeignModule};
@@ -47,7 +47,7 @@ struct EncodeContext<'tcx> {
     opaque: opaque::Encoder,
     tcx: TyCtxt<'tcx>,
 
-    per_def: PerDefTables<'tcx>,
+    per_def: PerDefTableBuilders<'tcx>,
 
     lazy_state: LazyState,
     type_shorthands: FxHashMap<Ty<'tcx>, usize>,
@@ -61,27 +61,27 @@ struct EncodeContext<'tcx> {
 }
 
 #[derive(Default)]
-struct PerDefTables<'tcx> {
-    kind: Table<DefIndex, Lazy<EntryKind<'tcx>>>,
-    visibility: Table<DefIndex, Lazy<ty::Visibility>>,
-    span: Table<DefIndex, Lazy<Span>>,
-    attributes: Table<DefIndex, Lazy<[ast::Attribute]>>,
-    children: Table<DefIndex, Lazy<[DefIndex]>>,
-    stability: Table<DefIndex, Lazy<attr::Stability>>,
-    deprecation: Table<DefIndex, Lazy<attr::Deprecation>>,
+struct PerDefTableBuilders<'tcx> {
+    kind: TableBuilder<DefIndex, Lazy<EntryKind<'tcx>>>,
+    visibility: TableBuilder<DefIndex, Lazy<ty::Visibility>>,
+    span: TableBuilder<DefIndex, Lazy<Span>>,
+    attributes: TableBuilder<DefIndex, Lazy<[ast::Attribute]>>,
+    children: TableBuilder<DefIndex, Lazy<[DefIndex]>>,
+    stability: TableBuilder<DefIndex, Lazy<attr::Stability>>,
+    deprecation: TableBuilder<DefIndex, Lazy<attr::Deprecation>>,
 
-    ty: Table<DefIndex, Lazy<Ty<'tcx>>>,
-    fn_sig: Table<DefIndex, Lazy<ty::PolyFnSig<'tcx>>>,
-    impl_trait_ref: Table<DefIndex, Lazy<ty::TraitRef<'tcx>>>,
-    inherent_impls: Table<DefIndex, Lazy<[DefIndex]>>,
-    variances: Table<DefIndex, Lazy<[ty::Variance]>>,
-    generics: Table<DefIndex, Lazy<ty::Generics>>,
-    explicit_predicates: Table<DefIndex, Lazy<ty::GenericPredicates<'tcx>>>,
-    inferred_outlives: Table<DefIndex, Lazy<&'tcx [(ty::Predicate<'tcx>, Span)]>>,
-    super_predicates: Table<DefIndex, Lazy<ty::GenericPredicates<'tcx>>>,
+    ty: TableBuilder<DefIndex, Lazy<Ty<'tcx>>>,
+    fn_sig: TableBuilder<DefIndex, Lazy<ty::PolyFnSig<'tcx>>>,
+    impl_trait_ref: TableBuilder<DefIndex, Lazy<ty::TraitRef<'tcx>>>,
+    inherent_impls: TableBuilder<DefIndex, Lazy<[DefIndex]>>,
+    variances: TableBuilder<DefIndex, Lazy<[ty::Variance]>>,
+    generics: TableBuilder<DefIndex, Lazy<ty::Generics>>,
+    explicit_predicates: TableBuilder<DefIndex, Lazy<ty::GenericPredicates<'tcx>>>,
+    inferred_outlives: TableBuilder<DefIndex, Lazy<&'tcx [(ty::Predicate<'tcx>, Span)]>>,
+    super_predicates: TableBuilder<DefIndex, Lazy<ty::GenericPredicates<'tcx>>>,
 
-    mir: Table<DefIndex, Lazy<mir::Body<'tcx>>>,
-    promoted_mir: Table<DefIndex, Lazy<IndexVec<mir::Promoted, mir::Body<'tcx>>>>,
+    mir: TableBuilder<DefIndex, Lazy<mir::Body<'tcx>>>,
+    promoted_mir: TableBuilder<DefIndex, Lazy<IndexVec<mir::Promoted, mir::Body<'tcx>>>>,
 }
 
 macro_rules! encoder_methods {

--- a/src/librustc_metadata/rmeta/encoder.rs
+++ b/src/librustc_metadata/rmeta/encoder.rs
@@ -122,13 +122,13 @@ impl<'tcx> Encoder for EncodeContext<'tcx> {
     }
 }
 
-impl<'tcx, T: Encodable> SpecializedEncoder<Lazy<T>> for EncodeContext<'tcx> {
+impl<'tcx, T> SpecializedEncoder<Lazy<T>> for EncodeContext<'tcx> {
     fn specialized_encode(&mut self, lazy: &Lazy<T>) -> Result<(), Self::Error> {
         self.emit_lazy_distance(*lazy)
     }
 }
 
-impl<'tcx, T: Encodable> SpecializedEncoder<Lazy<[T]>> for EncodeContext<'tcx> {
+impl<'tcx, T> SpecializedEncoder<Lazy<[T]>> for EncodeContext<'tcx> {
     fn specialized_encode(&mut self, lazy: &Lazy<[T]>) -> Result<(), Self::Error> {
         self.emit_usize(lazy.meta)?;
         if lazy.meta == 0 {

--- a/src/librustc_metadata/rmeta/mod.rs
+++ b/src/librustc_metadata/rmeta/mod.rs
@@ -1,5 +1,5 @@
 use decoder::Metadata;
-use table::PerDefTable;
+use table::Table;
 
 use rustc::hir;
 use rustc::hir::def::{self, CtorKind};
@@ -166,8 +166,7 @@ enum LazyState {
 // manually, instead of relying on the default, to get the correct variance.
 // Only needed when `T` itself contains a parameter (e.g. `'tcx`).
 macro_rules! Lazy {
-    (Table<$T:ty>) => {Lazy<Table<$T>, usize>};
-    (PerDefTable<$T:ty>) => {Lazy<PerDefTable<$T>, usize>};
+    (Table<$I:ty, $T:ty>) => {Lazy<Table<$I, $T>, usize>};
     ([$T:ty]) => {Lazy<[$T], usize>};
     ($T:ty) => {Lazy<$T, ()>};
 }
@@ -234,29 +233,29 @@ crate struct TraitImpls {
 
 #[derive(RustcEncodable, RustcDecodable)]
 crate struct LazyPerDefTables<'tcx> {
-    kind: Lazy!(PerDefTable<Lazy!(EntryKind<'tcx>)>),
-    visibility: Lazy!(PerDefTable<Lazy<ty::Visibility>>),
-    span: Lazy!(PerDefTable<Lazy<Span>>),
-    attributes: Lazy!(PerDefTable<Lazy<[ast::Attribute]>>),
-    children: Lazy!(PerDefTable<Lazy<[DefIndex]>>),
-    stability: Lazy!(PerDefTable<Lazy<attr::Stability>>),
-    deprecation: Lazy!(PerDefTable<Lazy<attr::Deprecation>>),
-    ty: Lazy!(PerDefTable<Lazy!(Ty<'tcx>)>),
-    fn_sig: Lazy!(PerDefTable<Lazy!(ty::PolyFnSig<'tcx>)>),
-    impl_trait_ref: Lazy!(PerDefTable<Lazy!(ty::TraitRef<'tcx>)>),
-    inherent_impls: Lazy!(PerDefTable<Lazy<[DefIndex]>>),
-    variances: Lazy!(PerDefTable<Lazy<[ty::Variance]>>),
-    generics: Lazy!(PerDefTable<Lazy<ty::Generics>>),
-    explicit_predicates: Lazy!(PerDefTable<Lazy!(ty::GenericPredicates<'tcx>)>),
+    kind: Lazy!(Table<DefIndex, Lazy!(EntryKind<'tcx>)>),
+    visibility: Lazy!(Table<DefIndex, Lazy<ty::Visibility>>),
+    span: Lazy!(Table<DefIndex, Lazy<Span>>),
+    attributes: Lazy!(Table<DefIndex, Lazy<[ast::Attribute]>>),
+    children: Lazy!(Table<DefIndex, Lazy<[DefIndex]>>),
+    stability: Lazy!(Table<DefIndex, Lazy<attr::Stability>>),
+    deprecation: Lazy!(Table<DefIndex, Lazy<attr::Deprecation>>),
+    ty: Lazy!(Table<DefIndex, Lazy!(Ty<'tcx>)>),
+    fn_sig: Lazy!(Table<DefIndex, Lazy!(ty::PolyFnSig<'tcx>)>),
+    impl_trait_ref: Lazy!(Table<DefIndex, Lazy!(ty::TraitRef<'tcx>)>),
+    inherent_impls: Lazy!(Table<DefIndex, Lazy<[DefIndex]>>),
+    variances: Lazy!(Table<DefIndex, Lazy<[ty::Variance]>>),
+    generics: Lazy!(Table<DefIndex, Lazy<ty::Generics>>),
+    explicit_predicates: Lazy!(Table<DefIndex, Lazy!(ty::GenericPredicates<'tcx>)>),
     // FIXME(eddyb) this would ideally be `Lazy<[...]>` but `ty::Predicate`
     // doesn't handle shorthands in its own (de)serialization impls,
     // as it's an `enum` for which we want to derive (de)serialization,
     // so the `ty::codec` APIs handle the whole `&'tcx [...]` at once.
     // Also, as an optimization, a missing entry indicates an empty `&[]`.
-    inferred_outlives: Lazy!(PerDefTable<Lazy!(&'tcx [(ty::Predicate<'tcx>, Span)])>),
-    super_predicates: Lazy!(PerDefTable<Lazy!(ty::GenericPredicates<'tcx>)>),
-    mir: Lazy!(PerDefTable<Lazy!(mir::Body<'tcx>)>),
-    promoted_mir: Lazy!(PerDefTable<Lazy!(IndexVec<mir::Promoted, mir::Body<'tcx>>)>),
+    inferred_outlives: Lazy!(Table<DefIndex, Lazy!(&'tcx [(ty::Predicate<'tcx>, Span)])>),
+    super_predicates: Lazy!(Table<DefIndex, Lazy!(ty::GenericPredicates<'tcx>)>),
+    mir: Lazy!(Table<DefIndex, Lazy!(mir::Body<'tcx>)>),
+    promoted_mir: Lazy!(Table<DefIndex, Lazy!(IndexVec<mir::Promoted, mir::Body<'tcx>>)>),
 }
 
 #[derive(Copy, Clone, RustcEncodable, RustcDecodable)]

--- a/src/librustc_metadata/rmeta/mod.rs
+++ b/src/librustc_metadata/rmeta/mod.rs
@@ -15,7 +15,6 @@ use rustc_target::spec::{PanicStrategy, TargetTriple};
 use rustc_index::vec::IndexVec;
 use rustc_data_structures::svh::Svh;
 use rustc_data_structures::sync::MetadataRef;
-use rustc_serialize::Encodable;
 use syntax::{ast, attr};
 use syntax::edition::Edition;
 use syntax::symbol::Symbol;
@@ -59,7 +58,7 @@ trait LazyMeta {
     fn min_size(meta: Self::Meta) -> usize;
 }
 
-impl<T: Encodable> LazyMeta for T {
+impl<T> LazyMeta for T {
     type Meta = ();
 
     fn min_size(_: ()) -> usize {
@@ -68,7 +67,7 @@ impl<T: Encodable> LazyMeta for T {
     }
 }
 
-impl<T: Encodable> LazyMeta for [T] {
+impl<T> LazyMeta for [T] {
     type Meta = usize;
 
     fn min_size(len: usize) -> usize {
@@ -124,13 +123,13 @@ impl<T: ?Sized + LazyMeta> Lazy<T> {
     }
 }
 
-impl<T: Encodable> Lazy<T> {
+impl<T> Lazy<T> {
     fn from_position(position: NonZeroUsize) -> Lazy<T> {
         Lazy::from_position_and_meta(position, ())
     }
 }
 
-impl<T: Encodable> Lazy<[T]> {
+impl<T> Lazy<[T]> {
     fn empty() -> Lazy<[T]> {
         Lazy::from_position_and_meta(NonZeroUsize::new(1).unwrap(), 0)
     }


### PR DESCRIPTION
These are small post-#59953 cleanups (including undoing some contrivances from that PR).

r? @michaelwoerister 