### PR TITLE
Add --force-run-in-process unstable option to libtest

### DIFF
--- a/src/libsyntax_ext/test_harness.rs
+++ b/src/libsyntax_ext/test_harness.rs
@@ -67,7 +67,8 @@ pub fn inject(
                 PanicStrategy::Unwind
             }
             (PanicStrategy::Abort, false) => {
-                span_diagnostic.err("building tests with panic=abort is not yet supported");
+                span_diagnostic.err("building tests with panic=abort is not supported \
+                                     without `-Zpanic_abort_tests`");
                 PanicStrategy::Unwind
             }
             (PanicStrategy::Unwind, _) => PanicStrategy::Unwind,

--- a/src/libtest/cli.rs
+++ b/src/libtest/cli.rs
@@ -13,6 +13,7 @@ pub struct TestOpts {
     pub list: bool,
     pub filter: Option<String>,
     pub filter_exact: bool,
+    pub force_run_in_process: bool,
     pub exclude_should_panic: bool,
     pub run_ignored: RunIgnored,
     pub run_tests: bool,
@@ -46,6 +47,7 @@ fn optgroups() -> getopts::Options {
     let mut opts = getopts::Options::new();
     opts.optflag("", "include-ignored", "Run ignored and not ignored tests")
         .optflag("", "ignored", "Run only ignored tests")
+        .optflag("", "force-run-in-process", "Forces tests to run in-process when panic=abort")
         .optflag("", "exclude-should-panic", "Excludes tests marked as should_panic")
         .optflag("", "test", "Run tests and not benchmarks")
         .optflag("", "bench", "Run benchmarks instead of tests")
@@ -233,6 +235,7 @@ fn parse_opts_impl(matches: getopts::Matches) -> OptRes {
     let allow_unstable = get_allow_unstable(&matches)?;
 
     // Unstable flags
+    let force_run_in_process = unstable_optflag!(matches, allow_unstable, "force-run-in-process");
     let exclude_should_panic = unstable_optflag!(matches, allow_unstable, "exclude-should-panic");
     let include_ignored = unstable_optflag!(matches, allow_unstable, "include-ignored");
     let time_options = get_time_options(&matches, allow_unstable)?;
@@ -259,6 +262,7 @@ fn parse_opts_impl(matches: getopts::Matches) -> OptRes {
         list,
         filter,
         filter_exact: exact,
+        force_run_in_process,
         exclude_should_panic,
         run_ignored,
         run_tests,

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -254,7 +254,7 @@ where
     let mut pending = 0;
 
     let (tx, rx) = channel::<CompletedTest>();
-    let run_strategy = if opts.options.panic_abort {
+    let run_strategy = if opts.options.panic_abort && !opts.force_run_in_process {
         RunStrategy::SpawnPrimary
     } else {
         RunStrategy::InProcess

--- a/src/libtest/tests.rs
+++ b/src/libtest/tests.rs
@@ -24,6 +24,7 @@ impl TestOpts {
             list: false,
             filter: None,
             filter_exact: false,
+            force_run_in_process: false,
             exclude_should_panic: false,
             run_ignored: RunIgnored::No,
             run_tests: false,

--- a/src/test/ui/test-panic-abort-disabled.rs
+++ b/src/test/ui/test-panic-abort-disabled.rs
@@ -1,4 +1,4 @@
-// error-pattern:building tests with panic=abort is not yet supported
+// error-pattern:building tests with panic=abort is not supported
 // no-prefer-dynamic
 // compile-flags: --test -Cpanic=abort
 // run-flags: --test-threads=1

--- a/src/test/ui/test-panic-abort-disabled.stderr
+++ b/src/test/ui/test-panic-abort-disabled.stderr
@@ -1,4 +1,4 @@
-error: building tests with panic=abort is not yet supported
+error: building tests with panic=abort is not supported without `-Zpanic_abort_tests`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
When running tests with `-Zpanic_abort_tests`, it's sometimes desirable to fall back to the old behavior of only running tests in-process. This comes in handy if the system process launcher is unavailable, or the test code somehow expects all tests to be run in the same process.

For example, in Fuchsia we have unit tests that actually test the process launcher itself, in which case we can't use the process launcher to run the tests :).

r? @alexcrichton 
cc @cramertj,@petrhosek 