### PR TITLE
Link to tracking issue in HIR const-check error code description

### DIFF
--- a/src/librustc_error_codes/error_codes/E0744.md
+++ b/src/librustc_error_codes/error_codes/E0744.md
@@ -15,3 +15,10 @@ const _: i32 = {
     x
 };
 ```
+
+This will be allowed at some point in the future, but the implementation is not
+yet complete. See the tracking issue for [conditionals] or [loops] in a const
+context for the current status.
+
+[conditionals]: https://github.com/rust-lang/rust/issues/49146
+[loops]: https://github.com/rust-lang/rust/issues/52000


### PR DESCRIPTION
This is a follow up to #66170 that addresses [this comment](https://github.com/rust-lang/rust/pull/66170#discussion_r344021268).

As an aside, the only other error code whose description uses the phrase "tracking issue" is `E0202`. We may want to come up with standards around this, especially since error codes are now centralized and easier to keep track of (thanks @GuillaumeGomez).

r? @estebank (since they +1'ed the comment)