### PR TITLE
Don't warn labels beginning with `_` on unused_labels lint

### DIFF
--- a/src/librustc_resolve/late.rs
+++ b/src/librustc_resolve/late.rs
@@ -1767,7 +1767,9 @@ impl<'a, 'b> LateResolutionVisitor<'a, '_> {
 
     fn with_resolved_label(&mut self, label: Option<Label>, id: NodeId, f: impl FnOnce(&mut Self)) {
         if let Some(label) = label {
-            self.diagnostic_metadata.unused_labels.insert(id, label.ident.span);
+            if label.ident.as_str().as_bytes()[1] != b'_' {
+                self.diagnostic_metadata.unused_labels.insert(id, label.ident.span);
+            }
             self.with_label_rib(NormalRibKind, |this| {
                 let ident = label.ident.modern_and_legacy();
                 this.label_ribs.last_mut().unwrap().bindings.insert(ident, id);

--- a/src/test/ui/label/label-beginning-with-underscore.rs
+++ b/src/test/ui/label/label-beginning-with-underscore.rs
@@ -1,0 +1,10 @@
+// check-pass
+
+#![deny(unused_labels)]
+
+fn main() {
+    // `unused_label` shouldn't warn labels beginning with `_`
+    '_unused: loop {
+        break;
+    }
+}


### PR DESCRIPTION
Fixes #66382

r? @varkor 