### PR TITLE
libpanic_unwind for Miri: make sure we have the SEH lang items when needed

### DIFF
--- a/src/libpanic_unwind/lib.rs
+++ b/src/libpanic_unwind/lib.rs
@@ -39,6 +39,10 @@ cfg_if::cfg_if! {
     if #[cfg(miri)] {
         #[path = "miri.rs"]
         mod imp;
+        // On MSVC we need the SEH lang items as well...
+        #[cfg(all(target_env = "msvc", not(target_arch = "aarch64")))]
+        #[allow(unused)]
+        mod seh;
     } else if #[cfg(target_os = "emscripten")] {
         #[path = "emcc.rs"]
         mod imp;

--- a/src/libpanic_unwind/lib.rs
+++ b/src/libpanic_unwind/lib.rs
@@ -40,6 +40,7 @@ cfg_if::cfg_if! {
         #[path = "miri.rs"]
         mod imp;
         // On MSVC we need the SEH lang items as well...
+        // This should match the conditions of the `seh.rs` import below.
         #[cfg(all(target_env = "msvc", not(target_arch = "aarch64")))]
         #[allow(unused)]
         mod seh;


### PR DESCRIPTION
r? @oli-obk  @alexcrichton This is required to fix the Miri toolstate. Turns out rustc complains when doing codegen for MSVC and these lang items do not exist. For now `cfg(miri)` needs to still be able to codegen (we [plan to change that](https://github.com/rust-lang/miri/pull/1048#issuecomment-554108470) but that's a larger project requiring improvements to xargo and maybe also cargo; that should not block fixing the toolstate). Yes, this is a hack, but it is inside `cfg(miri)` so I hope this is okay.

Cc @Aaron1011 