### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -452,7 +452,6 @@ impl<'a> LoweringContext<'a> {
                     | ItemKind::Union(_, ref generics)
                     | ItemKind::Enum(_, ref generics)
                     | ItemKind::TyAlias(_, ref generics)
-                    | ItemKind::OpaqueTy(_, ref generics)
                     | ItemKind::Trait(_, _, ref generics, ..) => {
                         let def_id = self.lctx.resolver.definitions().local_def_id(item.id);
                         let count = generics

--- a/src/librustc/hir/lowering/item.rs
+++ b/src/librustc/hir/lowering/item.rs
@@ -335,20 +335,22 @@ impl LoweringContext<'_> {
             ItemKind::Mod(ref m) => hir::ItemKind::Mod(self.lower_mod(m)),
             ItemKind::ForeignMod(ref nm) => hir::ItemKind::ForeignMod(self.lower_foreign_mod(nm)),
             ItemKind::GlobalAsm(ref ga) => hir::ItemKind::GlobalAsm(self.lower_global_asm(ga)),
-            ItemKind::TyAlias(ref t, ref generics) => hir::ItemKind::TyAlias(
-                self.lower_ty(t, ImplTraitContext::disallowed()),
-                self.lower_generics(generics, ImplTraitContext::disallowed()),
-            ),
-            ItemKind::OpaqueTy(ref b, ref generics) => hir::ItemKind::OpaqueTy(
-                hir::OpaqueTy {
-                    generics: self.lower_generics(generics,
-                        ImplTraitContext::OpaqueTy(None)),
-                    bounds: self.lower_param_bounds(b,
-                        ImplTraitContext::OpaqueTy(None)),
-                    impl_trait_fn: None,
-                    origin: hir::OpaqueTyOrigin::TypeAlias,
+            ItemKind::TyAlias(ref ty, ref generics) => match ty.kind.opaque_top_hack() {
+                None => {
+                    let ty = self.lower_ty(ty, ImplTraitContext::disallowed());
+                    let generics = self.lower_generics(generics, ImplTraitContext::disallowed());
+                    hir::ItemKind::TyAlias(ty, generics)
                 },
-            ),
+                Some(bounds) => {
+                    let ty = hir::OpaqueTy {
+                        generics: self.lower_generics(generics, ImplTraitContext::OpaqueTy(None)),
+                        bounds: self.lower_param_bounds(bounds, ImplTraitContext::OpaqueTy(None)),
+                        impl_trait_fn: None,
+                        origin: hir::OpaqueTyOrigin::TypeAlias,
+                    };
+                    hir::ItemKind::OpaqueTy(ty)
+                }
+            }
             ItemKind::Enum(ref enum_definition, ref generics) => {
                 hir::ItemKind::Enum(
                     hir::EnumDef {
@@ -914,16 +916,20 @@ impl LoweringContext<'_> {
 
                 (generics, hir::ImplItemKind::Method(sig, body_id))
             }
-            ImplItemKind::TyAlias(ref ty) => (
-                self.lower_generics(&i.generics, ImplTraitContext::disallowed()),
-                hir::ImplItemKind::TyAlias(self.lower_ty(ty, ImplTraitContext::disallowed())),
-            ),
-            ImplItemKind::OpaqueTy(ref bounds) => (
-                self.lower_generics(&i.generics, ImplTraitContext::disallowed()),
-                hir::ImplItemKind::OpaqueTy(
-                    self.lower_param_bounds(bounds, ImplTraitContext::disallowed()),
-                ),
-            ),
+            ImplItemKind::TyAlias(ref ty) => {
+                let generics = self.lower_generics(&i.generics, ImplTraitContext::disallowed());
+                let kind = match ty.kind.opaque_top_hack() {
+                    None => {
+                        let ty = self.lower_ty(ty, ImplTraitContext::disallowed());
+                        hir::ImplItemKind::TyAlias(ty)
+                    }
+                    Some(bs) => {
+                        let bounds = self.lower_param_bounds(bs, ImplTraitContext::disallowed());
+                        hir::ImplItemKind::OpaqueTy(bounds)
+                    }
+                };
+                (generics, kind)
+            },
             ImplItemKind::Macro(..) => bug!("`TyMac` should have been expanded by now"),
         };
 
@@ -948,11 +954,13 @@ impl LoweringContext<'_> {
             span: i.span,
             vis: self.lower_visibility(&i.vis, Some(i.id)),
             defaultness: self.lower_defaultness(i.defaultness, true /* [1] */),
-            kind: match i.kind {
+            kind: match &i.kind {
                 ImplItemKind::Const(..) => hir::AssocItemKind::Const,
-                ImplItemKind::TyAlias(..) => hir::AssocItemKind::Type,
-                ImplItemKind::OpaqueTy(..) => hir::AssocItemKind::OpaqueTy,
-                ImplItemKind::Method(ref sig, _) => hir::AssocItemKind::Method {
+                ImplItemKind::TyAlias(ty) => match ty.kind.opaque_top_hack() {
+                    None => hir::AssocItemKind::Type,
+                    Some(_) => hir::AssocItemKind::OpaqueTy,
+                },
+                ImplItemKind::Method(sig, _) => hir::AssocItemKind::Method {
                     has_self: sig.decl.has_self(),
                 },
                 ImplItemKind::Macro(..) => unimplemented!(),

--- a/src/librustc/hir/map/def_collector.rs
+++ b/src/librustc/hir/map/def_collector.rs
@@ -107,7 +107,7 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
             }
             ItemKind::Mod(..) | ItemKind::Trait(..) | ItemKind::TraitAlias(..) |
             ItemKind::Enum(..) | ItemKind::Struct(..) | ItemKind::Union(..) |
-            ItemKind::OpaqueTy(..) | ItemKind::ExternCrate(..) | ItemKind::ForeignMod(..) |
+            ItemKind::ExternCrate(..) | ItemKind::ForeignMod(..) |
             ItemKind::TyAlias(..) => DefPathData::TypeNs(i.ident.name),
             ItemKind::Fn(sig, generics, body) if sig.header.asyncness.node.is_async() => {
                 return self.visit_async_fn(
@@ -239,8 +239,7 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
             }
             ImplItemKind::Method(..) |
             ImplItemKind::Const(..) => DefPathData::ValueNs(ii.ident.name),
-            ImplItemKind::TyAlias(..) |
-            ImplItemKind::OpaqueTy(..) => DefPathData::TypeNs(ii.ident.name),
+            ImplItemKind::TyAlias(..) => DefPathData::TypeNs(ii.ident.name),
             ImplItemKind::Macro(..) => return self.visit_macro_invoc(ii.id),
         };
 

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -2176,15 +2176,15 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 err.note(&format!("required by cast to type `{}`",
                                   self.ty_to_string(target)));
             }
-            ObligationCauseCode::RepeatVec(suggest_const_in_array_repeat_expression) => {
+            ObligationCauseCode::RepeatVec(suggest_const_in_array_repeat_expressions) => {
                 err.note("the `Copy` trait is required because the \
                           repeated element will be copied");
-                if suggest_const_in_array_repeat_expression {
+                if suggest_const_in_array_repeat_expressions {
                     err.note("this array initializer can be evaluated at compile-time, for more \
                               information, see issue \
                               https://github.com/rust-lang/rust/issues/49147");
                     if tcx.sess.opts.unstable_features.is_nightly_build() {
-                        err.help("add `#![feature(const_in_array_repeat_expression)]` to the \
+                        err.help("add `#![feature(const_in_array_repeat_expressions)]` to the \
                                   crate attributes to enable");
                     }
                 }

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -206,7 +206,7 @@ pub enum ObligationCauseCode<'tcx> {
     SizedReturnType,
     /// Yield type must be Sized
     SizedYieldType,
-    /// [T,..n] --> T must be Copy. If `true`, suggest `const_in_array_repeat_expression` feature
+    /// [T,..n] --> T must be Copy. If `true`, suggest `const_in_array_repeat_expressions` feature
     /// flag.
     RepeatVec(bool),
 

--- a/src/librustc_error_codes/error_codes.rs
+++ b/src/librustc_error_codes/error_codes.rs
@@ -1,6 +1,11 @@
 // Error messages for EXXXX errors.  Each message should start and end with a
 // new line, and be wrapped to 80 characters.  In vim you can `:set tw=80` and
 // use `gq` to wrap paragraphs. Use `:set tw=0` to disable.
+//
+// /!\ IMPORTANT /!\
+//
+// Error messages' format must follow the RFC 1567 available here:
+// https://github.com/rust-lang/rfcs/pull/1567
 
 crate::register_diagnostics! {
 

--- a/src/librustc_error_codes/error_codes/E0023.md
+++ b/src/librustc_error_codes/error_codes/E0023.md
@@ -1,6 +1,6 @@
-A pattern used to match against an enum variant must provide a sub-pattern for
-each field of the enum variant. This error indicates that a pattern attempted to
-extract an incorrect number of fields from a variant.
+A pattern attempted to extract an incorrect number of fields from a variant.
+
+Erroneous code example:
 
 ```
 enum Fruit {
@@ -8,6 +8,9 @@ enum Fruit {
     Pear(u32),
 }
 ```
+
+A pattern used to match against an enum variant must provide a sub-pattern for
+each field of the enum variant.
 
 Here the `Apple` variant has two fields, and should be matched against like so:
 

--- a/src/librustc_error_codes/error_codes/E0025.md
+++ b/src/librustc_error_codes/error_codes/E0025.md
@@ -1,5 +1,6 @@
-Each field of a struct can only be bound once in a pattern. Erroneous code
-example:
+Each field of a struct can only be bound once in a pattern.
+
+Erroneous code example:
 
 ```compile_fail,E0025
 struct Foo {

--- a/src/librustc_error_codes/error_codes/E0026.md
+++ b/src/librustc_error_codes/error_codes/E0026.md
@@ -1,51 +1,34 @@
-This error indicates that a struct pattern attempted to extract a non-existent
-field from a struct. Struct fields are identified by the name used before the
-colon `:` so struct patterns should resemble the declaration of the struct type
-being matched.
+A struct pattern attempted to extract a non-existent field from a struct.
 
-```
-// Correct matching.
-struct Thing {
-    x: u32,
-    y: u32
-}
-
-let thing = Thing { x: 1, y: 2 };
-
-match thing {
-    Thing { x: xfield, y: yfield } => {}
-}
-```
-
-If you are using shorthand field patterns but want to refer to the struct field
-by a different name, you should rename it explicitly.
-
-Change this:
+Erroneous code example:
 
 ```compile_fail,E0026
 struct Thing {
     x: u32,
-    y: u32
+    y: u32,
 }
 
 let thing = Thing { x: 0, y: 0 };
 
 match thing {
-    Thing { x, z } => {}
+    Thing { x, z } => {} // error: `Thing::z` field doesn't exist
 }
 ```
 
-To this:
+If you are using shorthand field patterns but want to refer to the struct field
+by a different name, you should rename it explicitly. Struct fields are
+identified by the name used before the colon `:` so struct patterns should
+resemble the declaration of the struct type being matched.
 
 ```
 struct Thing {
     x: u32,
-    y: u32
+    y: u32,
 }
 
 let thing = Thing { x: 0, y: 0 };
 
 match thing {
-    Thing { x, y: z } => {}
+    Thing { x, y: z } => {} // we renamed `y` to `z`
 }
 ```

--- a/src/librustc_error_codes/error_codes/E0027.md
+++ b/src/librustc_error_codes/error_codes/E0027.md
@@ -1,8 +1,7 @@
-This error indicates that a pattern for a struct fails to specify a sub-pattern
-for every one of the struct's fields. Ensure that each field from the struct's
-definition is mentioned in the pattern, or use `..` to ignore unwanted fields.
+A pattern for a struct fails to specify a sub-pattern for every one of the
+struct's fields.
 
-For example:
+Erroneous code example:
 
 ```compile_fail,E0027
 struct Dog {
@@ -18,7 +17,8 @@ match d {
 }
 ```
 
-This is correct (explicit):
+To fix this error, ensure that each field from the struct's definition is
+mentioned in the pattern, or use `..` to ignore unwanted fields. Example:
 
 ```
 struct Dog {

--- a/src/librustc_error_codes/error_codes/E0029.md
+++ b/src/librustc_error_codes/error_codes/E0029.md
@@ -1,8 +1,6 @@
-In a match expression, only numbers and characters can be matched against a
-range. This is because the compiler checks that the range is non-empty at
-compile-time, and is unable to evaluate arbitrary comparison functions. If you
-want to capture values of an orderable type between two end-points, you can use
-a guard.
+Something other than numbers and characters has been used for a range.
+
+Erroneous code example:
 
 ```compile_fail,E0029
 let string = "salutations !";
@@ -20,3 +18,9 @@ match string {
     _ => {}
 }
 ```
+
+In a match expression, only numbers and characters can be matched against a
+range. This is because the compiler checks that the range is non-empty at
+compile-time, and is unable to evaluate arbitrary comparison functions. If you
+want to capture values of an orderable type between two end-points, you can use
+a guard.

--- a/src/librustc_error_codes/error_codes/E0033.md
+++ b/src/librustc_error_codes/error_codes/E0033.md
@@ -1,8 +1,6 @@
-This error indicates that a pointer to a trait type cannot be implicitly
-dereferenced by a pattern. Every trait defines a type, but because the
-size of trait implementers isn't fixed, this type has no compile-time size.
-Therefore, all accesses to trait types must be through pointers. If you
-encounter this error you should try to avoid dereferencing the pointer.
+A trait type has been dereferenced.
+
+Erroneous code example:
 
 ```compile_fail,E0033
 # trait SomeTrait { fn method_one(&self){} fn method_two(&self){} }
@@ -16,6 +14,12 @@ let &invalid = trait_obj;
 trait_obj.method_one();
 trait_obj.method_two();
 ```
+
+A pointer to a trait type cannot be implicitly dereferenced by a pattern. Every
+trait defines a type, but because the size of trait implementers isn't fixed,
+this type has no compile-time size. Therefore, all accesses to trait types must
+be through pointers. If you encounter this error you should try to avoid
+dereferencing the pointer.
 
 You can read more about trait objects in the [Trait Objects] section of the
 Reference.

--- a/src/librustc_error_codes/error_codes/E0034.md
+++ b/src/librustc_error_codes/error_codes/E0034.md
@@ -1,5 +1,7 @@
 The compiler doesn't know what method to call because more than one method
-has the same prototype. Erroneous code example:
+has the same prototype.
+
+Erroneous code example:
 
 ```compile_fail,E0034
 struct Test;

--- a/src/librustc_error_codes/error_codes/E0040.md
+++ b/src/librustc_error_codes/error_codes/E0040.md
@@ -1,8 +1,6 @@
-It is not allowed to manually call destructors in Rust. It is also not
-necessary to do this since `drop` is called automatically whenever a value goes
-out of scope.
+It is not allowed to manually call destructors in Rust.
 
-Here's an example of this error:
+Erroneous code example:
 
 ```compile_fail,E0040
 struct Foo {
@@ -18,5 +16,24 @@ impl Drop for Foo {
 fn main() {
     let mut x = Foo { x: -7 };
     x.drop(); // error: explicit use of destructor method
+}
+```
+
+It is unnecessary to do this since `drop` is called automatically whenever a
+value goes out of scope. However, if you really need to drop a value by hand,
+you can use the `std::mem::drop` function:
+
+```
+struct Foo {
+    x: i32,
+}
+impl Drop for Foo {
+    fn drop(&mut self) {
+        println!("kaboom");
+    }
+}
+fn main() {
+    let mut x = Foo { x: -7 };
+    drop(x); // ok!
 }
 ```

--- a/src/librustc_error_codes/error_codes/E0044.md
+++ b/src/librustc_error_codes/error_codes/E0044.md
@@ -1,4 +1,5 @@
 You cannot use type or const parameters on foreign items.
+
 Example of erroneous code:
 
 ```compile_fail,E0044

--- a/src/librustc_error_codes/error_codes/E0045.md
+++ b/src/librustc_error_codes/error_codes/E0045.md
@@ -1,18 +1,18 @@
-Rust only supports variadic parameters for interoperability with C code in its
-FFI. As such, variadic parameters can only be used with functions which are
-using the C ABI. Examples of erroneous code:
+Variadic parameters have been used on a non-C ABI function.
 
-```compile_fail
+Erroneous code example:
+
+```compile_fail,E0045
 #![feature(unboxed_closures)]
 
-extern "rust-call" { fn foo(x: u8, ...); }
-
-// or
-
-fn foo(x: u8, ...) {}
+extern "rust-call" {
+    fn foo(x: u8, ...); // error!
+}
 ```
 
-To fix such code, put them in an extern "C" block:
+Rust only supports variadic parameters for interoperability with C code in its
+FFI. As such, variadic parameters can only be used with functions which are
+using the C ABI. To fix such code, put them in an extern "C" block:
 
 ```
 extern "C" {

--- a/src/librustc_error_codes/error_codes/E0046.md
+++ b/src/librustc_error_codes/error_codes/E0046.md
@@ -1,4 +1,6 @@
-Items are missing in a trait implementation. Erroneous code example:
+Items are missing in a trait implementation.
+
+Erroneous code example:
 
 ```compile_fail,E0046
 trait Foo {

--- a/src/librustc_error_codes/error_codes/E0049.md
+++ b/src/librustc_error_codes/error_codes/E0049.md
@@ -1,8 +1,7 @@
-This error indicates that an attempted implementation of a trait method
-has the wrong number of type or const parameters.
+An attempted implementation of a trait method has the wrong number of type or
+const parameters.
 
-For example, the trait below has a method `foo` with a type parameter `T`,
-but the implementation of `foo` for the type `Bar` is missing this parameter:
+Erroneous code example:
 
 ```compile_fail,E0049
 trait Foo {
@@ -15,5 +14,23 @@ struct Bar;
 // type parameter
 impl Foo for Bar {
     fn foo(x: bool) -> Self { Bar }
+}
+```
+
+For example, the `Foo` trait has a method `foo` with a type parameter `T`,
+but the implementation of `foo` for the type `Bar` is missing this parameter.
+To fix this error, they must have the same type parameters:
+
+```
+trait Foo {
+    fn foo<T: Default>(x: T) -> Self;
+}
+
+struct Bar;
+
+impl Foo for Bar {
+    fn foo<T: Default>(x: T) -> Self { // ok!
+        Bar
+    }
 }
 ```

--- a/src/librustc_error_codes/error_codes/E0050.md
+++ b/src/librustc_error_codes/error_codes/E0050.md
@@ -1,9 +1,7 @@
-This error indicates that an attempted implementation of a trait method
-has the wrong number of function parameters.
+An attempted implementation of a trait method has the wrong number of function
+parameters.
 
-For example, the trait below has a method `foo` with two function parameters
-(`&self` and `u8`), but the implementation of `foo` for the type `Bar` omits
-the `u8` parameter:
+Erroneous code example:
 
 ```compile_fail,E0050
 trait Foo {
@@ -16,5 +14,23 @@ struct Bar;
 // has 2
 impl Foo for Bar {
     fn foo(&self) -> bool { true }
+}
+```
+
+For example, the `Foo` trait has a method `foo` with two function parameters
+(`&self` and `u8`), but the implementation of `foo` for the type `Bar` omits
+the `u8` parameter. To fix this error, they must have the same parameters:
+
+```
+trait Foo {
+    fn foo(&self, x: u8) -> bool;
+}
+
+struct Bar;
+
+impl Foo for Bar {
+    fn foo(&self, x: u8) -> bool { // ok!
+        true
+    }
 }
 ```

--- a/src/librustc_error_codes/error_codes/E0053.md
+++ b/src/librustc_error_codes/error_codes/E0053.md
@@ -1,7 +1,7 @@
 The parameters of any trait method must match between a trait implementation
 and the trait definition.
 
-Here are a couple examples of this error:
+Erroneous code example:
 
 ```compile_fail,E0053
 trait Foo {

--- a/src/librustc_error_codes/error_codes/E0054.md
+++ b/src/librustc_error_codes/error_codes/E0054.md
@@ -1,5 +1,6 @@
-It is not allowed to cast to a bool. If you are trying to cast a numeric type
-to a bool, you can compare it with zero instead:
+It is not allowed to cast to a bool.
+
+Erroneous code example:
 
 ```compile_fail,E0054
 let x = 5;
@@ -7,6 +8,9 @@ let x = 5;
 // Not allowed, won't compile
 let x_is_nonzero = x as bool;
 ```
+
+If you are trying to cast a numeric type to a bool, you can compare it with
+zero instead:
 
 ```
 let x = 5;

--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -1987,7 +1987,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                     let span = body.source_info(location).span;
                     let ty = operand.ty(body, tcx);
                     if !self.infcx.type_is_copy_modulo_regions(self.param_env, ty, span) {
-                        // To determine if `const_in_array_repeat_expression` feature gate should
+                        // To determine if `const_in_array_repeat_expressions` feature gate should
                         // be mentioned, need to check if the rvalue is promotable.
                         let should_suggest =
                             should_suggest_const_in_array_repeat_expressions_attribute(

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -1185,7 +1185,7 @@ pub fn promote_candidates<'tcx>(
     promotions
 }
 
-/// This function returns `true` if the `const_in_array_repeat_expression` feature attribute should
+/// This function returns `true` if the `const_in_array_repeat_expressions` feature attribute should
 /// be suggested. This function is probably quite expensive, it shouldn't be run in the happy path.
 /// Feature attribute should be suggested if `operand` can be promoted and the feature is not
 /// enabled.

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -7,7 +7,7 @@ use syntax::ast::{self, Abi, DUMMY_NODE_ID, Ident, Attribute, AttrKind, AttrStyl
 use syntax::ast::{ItemKind, ImplItem, ImplItemKind, TraitItem, TraitItemKind, UseTree, UseTreeKind};
 use syntax::ast::{PathSegment, IsAuto, Constness, IsAsync, Unsafety, Defaultness};
 use syntax::ast::{Visibility, VisibilityKind, Mutability, FnHeader, ForeignItem, ForeignItemKind};
-use syntax::ast::{Ty, TyKind, Generics, GenericBounds, TraitRef, EnumDef, VariantData, StructField};
+use syntax::ast::{Ty, TyKind, Generics, TraitRef, EnumDef, VariantData, StructField};
 use syntax::ast::{Mac, MacDelimiter, Block, BindingMode, FnDecl, FnSig, SelfKind, Param};
 use syntax::ptr::P;
 use syntax::ThinVec;
@@ -20,15 +20,6 @@ use syntax_pos::symbol::{kw, sym};
 use log::debug;
 use std::mem;
 use errors::{PResult, Applicability, DiagnosticBuilder, DiagnosticId, StashKey};
-
-/// Whether the type alias or associated type is a concrete type or an opaque type.
-#[derive(Debug)]
-pub(super) enum AliasKind {
-    /// Just a new name for the same type.
-    Weak(P<Ty>),
-    /// Only trait impls of the type will be usable, not the actual type itself.
-    OpaqueTy(GenericBounds),
-}
 
 pub(super) type ItemInfo = (Ident, ItemKind, Option<Vec<Attribute>>);
 
@@ -266,15 +257,11 @@ impl<'a> Parser<'a> {
             return self.mk_item_with_info(attrs, lo, vis, info);
         }
 
-        if let Some(type_) = self.eat_type() {
-            let (ident, alias, generics) = type_?;
+        if self.eat_keyword(kw::Type) {
             // TYPE ITEM
-            let item_ = match alias {
-                AliasKind::Weak(ty) => ItemKind::TyAlias(ty, generics),
-                AliasKind::OpaqueTy(bounds) => ItemKind::OpaqueTy(bounds, generics),
-            };
-            let span = lo.to(self.prev_span);
-            return Ok(Some(self.mk_item(span, ident, item_, vis, attrs)));
+            let (ident, ty, generics) = self.parse_type_alias()?;
+            let kind = ItemKind::TyAlias(ty, generics);
+            return self.mk_item_with_info(attrs, lo, vis, (ident, kind, None));
         }
 
         if self.eat_keyword(kw::Enum) {
@@ -708,13 +695,9 @@ impl<'a> Parser<'a> {
         let lo = self.token.span;
         let vis = self.parse_visibility(false)?;
         let defaultness = self.parse_defaultness();
-        let (name, kind, generics) = if let Some(type_) = self.eat_type() {
-            let (name, alias, generics) = type_?;
-            let kind = match alias {
-                AliasKind::Weak(typ) => ast::ImplItemKind::TyAlias(typ),
-                AliasKind::OpaqueTy(bounds) => ast::ImplItemKind::OpaqueTy(bounds),
-            };
-            (name, kind, generics)
+        let (name, kind, generics) = if self.eat_keyword(kw::Type) {
+            let (name, ty, generics) = self.parse_type_alias()?;
+            (name, ast::ImplItemKind::TyAlias(ty), generics)
         } else if self.is_const_item() {
             self.parse_impl_const()?
         } else if let Some(mac) = self.parse_assoc_macro_invoc("impl", Some(&vis), at_end)? {
@@ -1318,34 +1301,16 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Parses `type Foo = Bar;` or returns `None`
-    /// without modifying the parser state.
-    fn eat_type(&mut self) -> Option<PResult<'a, (Ident, AliasKind, Generics)>> {
-        // This parses the grammar:
-        //     Ident ["<"...">"] ["where" ...] ("=" | ":") Ty ";"
-        if self.eat_keyword(kw::Type) {
-            Some(self.parse_type_alias())
-        } else {
-            None
-        }
-    }
-
-    /// Parses a type alias or opaque type.
-    fn parse_type_alias(&mut self) -> PResult<'a, (Ident, AliasKind, Generics)> {
+    /// Parses the grammar:
+    ///     Ident ["<"...">"] ["where" ...] ("=" | ":") Ty ";"
+    fn parse_type_alias(&mut self) -> PResult<'a, (Ident, P<Ty>, Generics)> {
         let ident = self.parse_ident()?;
         let mut tps = self.parse_generics()?;
         tps.where_clause = self.parse_where_clause()?;
         self.expect(&token::Eq)?;
-        let alias = if self.check_keyword(kw::Impl) {
-            self.bump();
-            let bounds = self.parse_generic_bounds(Some(self.prev_span))?;
-            AliasKind::OpaqueTy(bounds)
-        } else {
-            let ty = self.parse_ty()?;
-            AliasKind::Weak(ty)
-        };
+        let ty = self.parse_ty()?;
         self.expect_semi()?;
-        Ok((ident, alias, tps))
+        Ok((ident, ty, tps))
     }
 
     /// Parses an enum declaration.

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -20,7 +20,7 @@ use syntax::source_map::Spanned;
 use syntax::symbol::{kw, sym};
 use syntax::visit::{self, Visitor};
 use syntax::{span_err, struct_span_err, walk_list};
-use syntax_pos::{Span, MultiSpan};
+use syntax_pos::Span;
 use errors::{Applicability, FatalError};
 
 struct AstValidator<'a> {
@@ -582,14 +582,6 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 if vdata.fields().is_empty() {
                     self.err_handler().span_err(item.span,
                                                 "unions cannot have zero fields");
-                }
-            }
-            ItemKind::OpaqueTy(ref bounds, _) => {
-                if !bounds.iter()
-                          .any(|b| if let GenericBound::Trait(..) = *b { true } else { false }) {
-                    let msp = MultiSpan::from_spans(bounds.iter()
-                        .map(|bound| bound.span()).collect());
-                    self.err_handler().span_err(msp, "at least one trait must be specified");
                 }
             }
             _ => {}

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -699,13 +699,12 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
             }
 
             // These items live in the type namespace.
-            ItemKind::TyAlias(..) => {
-                let res = Res::Def(DefKind::TyAlias, self.r.definitions.local_def_id(item.id));
-                self.r.define(parent, ident, TypeNS, (res, vis, sp, expansion));
-            }
-
-            ItemKind::OpaqueTy(_, _) => {
-                let res = Res::Def(DefKind::OpaqueTy, self.r.definitions.local_def_id(item.id));
+            ItemKind::TyAlias(ref ty, _) => {
+                let def_kind = match ty.kind.opaque_top_hack() {
+                    None => DefKind::TyAlias,
+                    Some(_) => DefKind::OpaqueTy,
+                };
+                let res = Res::Def(def_kind, self.r.definitions.local_def_id(item.id));
                 self.r.define(parent, ident, TypeNS, (res, vis, sp, expansion));
             }
 

--- a/src/librustc_resolve/late.rs
+++ b/src/librustc_resolve/late.rs
@@ -730,7 +730,6 @@ impl<'a, 'b> LateResolutionVisitor<'a, '_> {
 
         match item.kind {
             ItemKind::TyAlias(_, ref generics) |
-            ItemKind::OpaqueTy(_, ref generics) |
             ItemKind::Fn(_, ref generics, _) => {
                 self.with_generic_param_rib(generics, ItemRibKind(HasGenericParams::Yes),
                                             |this| visit::walk_item(this, item));
@@ -1084,18 +1083,6 @@ impl<'a, 'b> LateResolutionVisitor<'a, '_> {
                                                     |n, s| TypeNotMemberOfTrait(n, s));
 
                                                 this.visit_ty(ty);
-                                            }
-                                            ImplItemKind::OpaqueTy(ref bounds) => {
-                                                // If this is a trait impl, ensure the type
-                                                // exists in trait
-                                                this.check_trait_item(impl_item.ident,
-                                                                      TypeNS,
-                                                                      impl_item.span,
-                                                    |n, s| TypeNotMemberOfTrait(n, s));
-
-                                                for bound in bounds {
-                                                    this.visit_param_bound(bound);
-                                                }
                                             }
                                             ImplItemKind::Macro(_) =>
                                                 panic!("unexpanded macro in resolve!"),

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -1133,12 +1133,6 @@ impl<'l, 'tcx> DumpVisitor<'l, 'tcx> {
                 // trait.
                 self.visit_ty(ty)
             }
-            ast::ImplItemKind::OpaqueTy(ref bounds) => {
-                // FIXME: uses of the assoc type should ideally point to this
-                // 'def' and the name here should be a ref to the def in the
-                // trait.
-                self.process_bounds(&bounds);
-            }
             ast::ImplItemKind::Macro(_) => {}
         }
     }
@@ -1382,38 +1376,6 @@ impl<'l, 'tcx> Visitor<'l> for DumpVisitor<'l, 'tcx> {
                 }
 
                 self.visit_ty(&ty);
-                self.process_generic_params(ty_params, &qualname, item.id);
-            }
-            OpaqueTy(ref bounds, ref ty_params) => {
-                let qualname = format!("::{}",
-                    self.tcx.def_path_str(self.tcx.hir().local_def_id_from_node_id(item.id)));
-
-                let value = String::new();
-                if !self.span.filter_generated(item.ident.span) {
-                    let span = self.span_from_span(item.ident.span);
-                    let id = id_from_node_id(item.id, &self.save_ctxt);
-                    let hir_id = self.tcx.hir().node_to_hir_id(item.id);
-
-                    self.dumper.dump_def(
-                        &access_from!(self.save_ctxt, item, hir_id),
-                        Def {
-                            kind: DefKind::Type,
-                            id,
-                            span,
-                            name: item.ident.to_string(),
-                            qualname: qualname.clone(),
-                            value,
-                            parent: None,
-                            children: vec![],
-                            decl_id: None,
-                            docs: self.save_ctxt.docs_for_attrs(&item.attrs),
-                            sig: sig::item_signature(item, &self.save_ctxt),
-                            attributes: lower_attributes(item.attrs.clone(), &self.save_ctxt),
-                        },
-                    );
-                }
-
-                self.process_bounds(bounds);
                 self.process_generic_params(ty_params, &qualname, item.id);
             }
             Mac(_) => (),

--- a/src/librustc_save_analysis/sig.rs
+++ b/src/librustc_save_analysis/sig.rs
@@ -447,16 +447,6 @@ impl Sig for ast::Item {
 
                 Ok(merge_sigs(sig.text.clone(), vec![sig, ty]))
             }
-            ast::ItemKind::OpaqueTy(ref bounds, ref generics) => {
-                let text = "type ".to_owned();
-                let mut sig = name_and_generics(text, offset, generics, self.id, self.ident, scx)?;
-
-                sig.text.push_str(" = impl ");
-                sig.text.push_str(&pprust::bounds_to_string(bounds));
-                sig.text.push(';');
-
-                Ok(sig)
-            }
             ast::ItemKind::Enum(_, ref generics) => {
                 let text = "enum ".to_owned();
                 let mut sig = name_and_generics(text, offset, generics, self.id, self.ident, scx)?;

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1815,6 +1815,15 @@ impl TyKind {
             false
         }
     }
+
+    /// HACK(type_alias_impl_trait, Centril): A temporary crutch used
+    /// in lowering to avoid making larger changes there and beyond.
+    pub fn opaque_top_hack(&self) -> Option<&GenericBounds> {
+        match self {
+            Self::ImplTrait(_, bounds) => Some(bounds),
+            _ => None,
+        }
+    }
 }
 
 /// Syntax used to declare a trait object.

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1579,7 +1579,6 @@ pub enum ImplItemKind {
     Const(P<Ty>, P<Expr>),
     Method(FnSig, P<Block>),
     TyAlias(P<Ty>),
-    OpaqueTy(GenericBounds),
     Macro(Mac),
 }
 
@@ -2483,10 +2482,6 @@ pub enum ItemKind {
     ///
     /// E.g., `type Foo = Bar<u8>;`.
     TyAlias(P<Ty>, Generics),
-    /// An opaque `impl Trait` type alias.
-    ///
-    /// E.g., `type Foo = impl Bar + Boo;`.
-    OpaqueTy(GenericBounds, Generics),
     /// An enum definition (`enum`).
     ///
     /// E.g., `enum Foo<A, B> { C<A>, D<B> }`.
@@ -2540,7 +2535,6 @@ impl ItemKind {
             ItemKind::ForeignMod(..) => "foreign module",
             ItemKind::GlobalAsm(..) => "global asm",
             ItemKind::TyAlias(..) => "type alias",
-            ItemKind::OpaqueTy(..) => "opaque type",
             ItemKind::Enum(..) => "enum",
             ItemKind::Struct(..) => "struct",
             ItemKind::Union(..) => "union",

--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -318,6 +318,27 @@ impl<'a> PostExpansionVisitor<'a> {
             );
         }
     }
+
+    /// Feature gate `impl Trait` inside `type Alias = $type_expr;`.
+    fn check_impl_trait(&self, ty: &ast::Ty) {
+        struct ImplTraitVisitor<'a> {
+            vis: &'a PostExpansionVisitor<'a>,
+        }
+        impl Visitor<'_> for ImplTraitVisitor<'_> {
+            fn visit_ty(&mut self, ty: &ast::Ty) {
+                if let ast::TyKind::ImplTrait(..) = ty.kind {
+                    gate_feature_post!(
+                        &self.vis,
+                        type_alias_impl_trait,
+                        ty.span,
+                        "`impl Trait` in type aliases is unstable"
+                    );
+                }
+                visit::walk_ty(self, ty);
+            }
+        }
+        ImplTraitVisitor { vis: self }.visit_ty(ty);
+    }
 }
 
 impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
@@ -452,14 +473,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 gate_feature_post!(&self, decl_macro, i.span, msg);
             }
 
-            ast::ItemKind::OpaqueTy(..) => {
-                gate_feature_post!(
-                    &self,
-                    type_alias_impl_trait,
-                    i.span,
-                    "`impl Trait` in type aliases is unstable"
-                );
-            }
+            ast::ItemKind::TyAlias(ref ty, ..) => self.check_impl_trait(&ty),
 
             _ => {}
         }
@@ -633,9 +647,8 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 }
             }
             ast::TraitItemKind::Type(_, ref default) => {
-                // We use three if statements instead of something like match guards so that all
-                // of these errors can be emitted if all cases apply.
-                if default.is_some() {
+                if let Some(ty) = default {
+                    self.check_impl_trait(ty);
                     gate_feature_post!(&self, associated_type_defaults, ti.span,
                                        "associated type defaults are unstable");
                 }
@@ -660,15 +673,8 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                                        "C-variadic functions are unstable");
                 }
             }
-            ast::ImplItemKind::OpaqueTy(..) => {
-                gate_feature_post!(
-                    &self,
-                    type_alias_impl_trait,
-                    ii.span,
-                    "`impl Trait` in type aliases is unstable"
-                );
-            }
-            ast::ImplItemKind::TyAlias(_) => {
+            ast::ImplItemKind::TyAlias(ref ty) => {
+                self.check_impl_trait(ty);
                 self.check_gat(&ii.generics, ii.span);
             }
             _ => {}

--- a/src/libsyntax/mut_visit.rs
+++ b/src/libsyntax/mut_visit.rs
@@ -887,10 +887,6 @@ pub fn noop_visit_item_kind<T: MutVisitor>(kind: &mut ItemKind, vis: &mut T) {
             vis.visit_ty(ty);
             vis.visit_generics(generics);
         }
-        ItemKind::OpaqueTy(bounds, generics) => {
-            visit_bounds(bounds, vis);
-            vis.visit_generics(generics);
-        }
         ItemKind::Enum(EnumDef { variants }, generics) => {
             variants.flat_map_in_place(|variant| vis.flat_map_variant(variant));
             vis.visit_generics(generics);
@@ -970,7 +966,6 @@ pub fn noop_flat_map_impl_item<T: MutVisitor>(mut item: ImplItem, visitor: &mut 
             visitor.visit_block(body);
         }
         ImplItemKind::TyAlias(ty) => visitor.visit_ty(ty),
-        ImplItemKind::OpaqueTy(bounds) => visit_bounds(bounds, visitor),
         ImplItemKind::Macro(mac) => visitor.visit_mac(mac),
     }
     visitor.visit_span(span);

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1255,19 +1255,6 @@ impl<'a> State<'a> {
                 self.s.word(";");
                 self.end(); // end the outer ibox
             }
-            ast::ItemKind::OpaqueTy(ref bounds, ref generics) => {
-                self.head(visibility_qualified(&item.vis, "type"));
-                self.print_ident(item.ident);
-                self.word_space("= impl");
-                self.print_generic_params(&generics.params);
-                self.end(); // end the inner ibox
-
-                self.print_where_clause(&generics.where_clause);
-                self.s.space();
-                self.print_type_bounds(":", bounds);
-                self.s.word(";");
-                self.end(); // end the outer ibox
-            }
             ast::ItemKind::Enum(ref enum_definition, ref params) => {
                 self.print_enum_def(
                     enum_definition,
@@ -1619,13 +1606,6 @@ impl<'a> State<'a> {
             }
             ast::ImplItemKind::TyAlias(ref ty) => {
                 self.print_associated_type(ii.ident, None, Some(ty));
-            }
-            ast::ImplItemKind::OpaqueTy(ref bounds) => {
-                self.word_space("type");
-                self.print_ident(ii.ident);
-                self.word_space("= impl");
-                self.print_type_bounds(":", bounds);
-                self.s.word(";");
             }
             ast::ImplItemKind::Macro(ref mac) => {
                 self.print_mac(mac);

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -263,10 +263,6 @@ pub fn walk_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a Item) {
             visitor.visit_ty(typ);
             visitor.visit_generics(generics)
         }
-        ItemKind::OpaqueTy(ref bounds, ref generics) => {
-            walk_list!(visitor, visit_param_bound, bounds);
-            visitor.visit_generics(generics)
-        }
         ItemKind::Enum(ref enum_definition, ref generics) => {
             visitor.visit_generics(generics);
             visitor.visit_enum_def(enum_definition, generics, item.id, item.span)
@@ -627,9 +623,6 @@ pub fn walk_impl_item<'a, V: Visitor<'a>>(visitor: &mut V, impl_item: &'a ImplIt
         }
         ImplItemKind::TyAlias(ref ty) => {
             visitor.visit_ty(ty);
-        }
-        ImplItemKind::OpaqueTy(ref bounds) => {
-            walk_list!(visitor, visit_param_bound, bounds);
         }
         ImplItemKind::Macro(ref mac) => {
             visitor.visit_mac(mac);

--- a/src/libsyntax_ext/test_harness.rs
+++ b/src/libsyntax_ext/test_harness.rs
@@ -67,7 +67,8 @@ pub fn inject(
                 PanicStrategy::Unwind
             }
             (PanicStrategy::Abort, false) => {
-                span_diagnostic.err("building tests with panic=abort is not yet supported");
+                span_diagnostic.err("building tests with panic=abort is not supported \
+                                     without `-Zpanic_abort_tests`");
                 PanicStrategy::Unwind
             }
             (PanicStrategy::Unwind, _) => PanicStrategy::Unwind,

--- a/src/libtest/cli.rs
+++ b/src/libtest/cli.rs
@@ -13,6 +13,7 @@ pub struct TestOpts {
     pub list: bool,
     pub filter: Option<String>,
     pub filter_exact: bool,
+    pub force_run_in_process: bool,
     pub exclude_should_panic: bool,
     pub run_ignored: RunIgnored,
     pub run_tests: bool,
@@ -46,6 +47,7 @@ fn optgroups() -> getopts::Options {
     let mut opts = getopts::Options::new();
     opts.optflag("", "include-ignored", "Run ignored and not ignored tests")
         .optflag("", "ignored", "Run only ignored tests")
+        .optflag("", "force-run-in-process", "Forces tests to run in-process when panic=abort")
         .optflag("", "exclude-should-panic", "Excludes tests marked as should_panic")
         .optflag("", "test", "Run tests and not benchmarks")
         .optflag("", "bench", "Run benchmarks instead of tests")
@@ -233,6 +235,7 @@ fn parse_opts_impl(matches: getopts::Matches) -> OptRes {
     let allow_unstable = get_allow_unstable(&matches)?;
 
     // Unstable flags
+    let force_run_in_process = unstable_optflag!(matches, allow_unstable, "force-run-in-process");
     let exclude_should_panic = unstable_optflag!(matches, allow_unstable, "exclude-should-panic");
     let include_ignored = unstable_optflag!(matches, allow_unstable, "include-ignored");
     let time_options = get_time_options(&matches, allow_unstable)?;
@@ -259,6 +262,7 @@ fn parse_opts_impl(matches: getopts::Matches) -> OptRes {
         list,
         filter,
         filter_exact: exact,
+        force_run_in_process,
         exclude_should_panic,
         run_ignored,
         run_tests,

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -254,7 +254,7 @@ where
     let mut pending = 0;
 
     let (tx, rx) = channel::<CompletedTest>();
-    let run_strategy = if opts.options.panic_abort {
+    let run_strategy = if opts.options.panic_abort && !opts.force_run_in_process {
         RunStrategy::SpawnPrimary
     } else {
         RunStrategy::InProcess

--- a/src/test/ui/feature-gates/feature-gate-const_in_array_repeat_expressions.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_in_array_repeat_expressions.stderr
@@ -8,7 +8,7 @@ LL |     let arr: [Option<String>; 2] = [None::<String>; 2];
              <std::option::Option<T> as std::marker::Copy>
    = note: the `Copy` trait is required because the repeated element will be copied
    = note: this array initializer can be evaluated at compile-time, for more information, see issue https://github.com/rust-lang/rust/issues/49147
-   = help: add `#![feature(const_in_array_repeat_expression)]` to the crate attributes to enable
+   = help: add `#![feature(const_in_array_repeat_expressions)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `std::option::Option<std::string::String>: std::marker::Copy` is not satisfied
   --> $DIR/feature-gate-const_in_array_repeat_expressions.rs:14:36

--- a/src/test/ui/feature-gates/feature-gate-type_alias_impl_trait.rs
+++ b/src/test/ui/feature-gates/feature-gate-type_alias_impl_trait.rs
@@ -1,15 +1,45 @@
-type Foo = impl std::fmt::Debug; //~ ERROR `impl Trait` in type aliases is unstable
+use std::fmt::Debug;
+
+type Foo = impl Debug; //~ ERROR `impl Trait` in type aliases is unstable
 
 trait Bar {
-    type Baa: std::fmt::Debug;
+    type Baa: Debug;
     fn define() -> Self::Baa;
 }
 
 impl Bar for () {
-    type Baa = impl std::fmt::Debug; //~ ERROR `impl Trait` in type aliases is unstable
+    type Baa = impl Debug; //~ ERROR `impl Trait` in type aliases is unstable
     fn define() -> Self::Baa { 0 }
 }
 
 fn define() -> Foo { 0 }
+
+trait TraitWithDefault {
+    type Assoc = impl Debug;
+    //~^ ERROR associated type defaults are unstable
+    //~| ERROR `impl Trait` not allowed outside of function
+    //~| ERROR `impl Trait` in type aliases is unstable
+}
+
+type NestedFree = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
+//~^ ERROR `impl Trait` in type aliases is unstable
+//~| ERROR `impl Trait` in type aliases is unstable
+//~| ERROR `impl Trait` in type aliases is unstable
+//~| ERROR `impl Trait` in type aliases is unstable
+//~| ERROR `impl Trait` not allowed outside of function
+//~| ERROR `impl Trait` not allowed outside of function
+//~| ERROR `impl Trait` not allowed outside of function
+
+impl Bar for u8 {
+    type Baa = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
+    //~^ ERROR `impl Trait` in type aliases is unstable
+    //~| ERROR `impl Trait` in type aliases is unstable
+    //~| ERROR `impl Trait` in type aliases is unstable
+    //~| ERROR `impl Trait` in type aliases is unstable
+    //~| ERROR `impl Trait` not allowed outside of function
+    //~| ERROR `impl Trait` not allowed outside of function
+    //~| ERROR `impl Trait` not allowed outside of function
+    fn define() -> Self::Baa { (vec![true], 0u8, 0i32..1) }
+}
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-type_alias_impl_trait.stderr
+++ b/src/test/ui/feature-gates/feature-gate-type_alias_impl_trait.stderr
@@ -1,21 +1,154 @@
 error[E0658]: `impl Trait` in type aliases is unstable
-  --> $DIR/feature-gate-type_alias_impl_trait.rs:1:1
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:3:12
    |
-LL | type Foo = impl std::fmt::Debug;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | type Foo = impl Debug;
+   |            ^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/63063
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in type aliases is unstable
-  --> $DIR/feature-gate-type_alias_impl_trait.rs:9:5
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:11:16
    |
-LL |     type Baa = impl std::fmt::Debug;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     type Baa = impl Debug;
+   |                ^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/63063
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
-error: aborting due to 2 previous errors
+error[E0658]: `impl Trait` in type aliases is unstable
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:18:18
+   |
+LL |     type Assoc = impl Debug;
+   |                  ^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0658]: associated type defaults are unstable
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:18:5
+   |
+LL |     type Assoc = impl Debug;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29661
+   = help: add `#![feature(associated_type_defaults)]` to the crate attributes to enable
+
+error[E0658]: `impl Trait` in type aliases is unstable
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:24:24
+   |
+LL | type NestedFree = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
+   |                        ^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+
+error[E0658]: `impl Trait` in type aliases is unstable
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:24:37
+   |
+LL | type NestedFree = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
+   |                                     ^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+
+error[E0658]: `impl Trait` in type aliases is unstable
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:24:49
+   |
+LL | type NestedFree = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
+   |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+
+error[E0658]: `impl Trait` in type aliases is unstable
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:24:70
+   |
+LL | type NestedFree = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
+   |                                                                      ^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+
+error[E0658]: `impl Trait` in type aliases is unstable
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:34:21
+   |
+LL |     type Baa = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
+   |                     ^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+
+error[E0658]: `impl Trait` in type aliases is unstable
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:34:34
+   |
+LL |     type Baa = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
+   |                                  ^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+
+error[E0658]: `impl Trait` in type aliases is unstable
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:34:46
+   |
+LL |     type Baa = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+
+error[E0658]: `impl Trait` in type aliases is unstable
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:34:67
+   |
+LL |     type Baa = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
+   |                                                                   ^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+
+error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:18:18
+   |
+LL |     type Assoc = impl Debug;
+   |                  ^^^^^^^^^^
+
+error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:24:24
+   |
+LL | type NestedFree = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
+   |                        ^^^^^^^^^^
+
+error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:24:37
+   |
+LL | type NestedFree = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
+   |                                     ^^^^^^^^^^
+
+error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:24:49
+   |
+LL | type NestedFree = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
+   |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:34:21
+   |
+LL |     type Baa = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
+   |                     ^^^^^^^^^^
+
+error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:34:34
+   |
+LL |     type Baa = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
+   |                                  ^^^^^^^^^^
+
+error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:34:46
+   |
+LL |     type Baa = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 19 previous errors
+
+Some errors have detailed explanations: E0562, E0658.
+For more information about an error, try `rustc --explain E0562`.

--- a/src/test/ui/impl-trait/where-allowed.rs
+++ b/src/test/ui/impl-trait/where-allowed.rs
@@ -163,6 +163,7 @@ type InTypeAlias<R> = impl Debug;
 
 type InReturnInTypeAlias<R> = fn() -> impl Debug;
 //~^ ERROR `impl Trait` not allowed outside of function and inherent method return types
+//~| ERROR `impl Trait` in type aliases is unstable
 
 // Disallowed in impl headers
 impl PartialEq<impl Debug> for () {

--- a/src/test/ui/impl-trait/where-allowed.stderr
+++ b/src/test/ui/impl-trait/where-allowed.stderr
@@ -17,19 +17,28 @@ LL | fn in_impl_Fn_parameter_in_return() -> &'static impl Fn(impl Debug) { panic
    |                                                 outer `impl Trait`
 
 error[E0658]: `impl Trait` in type aliases is unstable
-  --> $DIR/where-allowed.rs:124:5
+  --> $DIR/where-allowed.rs:124:16
    |
 LL |     type Out = impl Debug;
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/63063
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in type aliases is unstable
-  --> $DIR/where-allowed.rs:160:1
+  --> $DIR/where-allowed.rs:160:23
    |
 LL | type InTypeAlias<R> = impl Debug;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                       ^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+
+error[E0658]: `impl Trait` in type aliases is unstable
+  --> $DIR/where-allowed.rs:164:39
+   |
+LL | type InReturnInTypeAlias<R> = fn() -> impl Debug;
+   |                                       ^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/63063
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
@@ -179,61 +188,61 @@ LL | type InReturnInTypeAlias<R> = fn() -> impl Debug;
    |                                       ^^^^^^^^^^
 
 error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
-  --> $DIR/where-allowed.rs:168:16
+  --> $DIR/where-allowed.rs:169:16
    |
 LL | impl PartialEq<impl Debug> for () {
    |                ^^^^^^^^^^
 
 error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
-  --> $DIR/where-allowed.rs:173:24
+  --> $DIR/where-allowed.rs:174:24
    |
 LL | impl PartialEq<()> for impl Debug {
    |                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
-  --> $DIR/where-allowed.rs:178:6
+  --> $DIR/where-allowed.rs:179:6
    |
 LL | impl impl Debug {
    |      ^^^^^^^^^^
 
 error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
-  --> $DIR/where-allowed.rs:184:24
+  --> $DIR/where-allowed.rs:185:24
    |
 LL | impl InInherentImplAdt<impl Debug> {
    |                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
-  --> $DIR/where-allowed.rs:190:11
+  --> $DIR/where-allowed.rs:191:11
    |
 LL |     where impl Debug: Debug
    |           ^^^^^^^^^^
 
 error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
-  --> $DIR/where-allowed.rs:197:15
+  --> $DIR/where-allowed.rs:198:15
    |
 LL |     where Vec<impl Debug>: Debug
    |               ^^^^^^^^^^
 
 error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
-  --> $DIR/where-allowed.rs:204:24
+  --> $DIR/where-allowed.rs:205:24
    |
 LL |     where T: PartialEq<impl Debug>
    |                        ^^^^^^^^^^
 
 error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
-  --> $DIR/where-allowed.rs:211:17
+  --> $DIR/where-allowed.rs:212:17
    |
 LL |     where T: Fn(impl Debug)
    |                 ^^^^^^^^^^
 
 error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
-  --> $DIR/where-allowed.rs:218:22
+  --> $DIR/where-allowed.rs:219:22
    |
 LL |     where T: Fn() -> impl Debug
    |                      ^^^^^^^^^^
 
 error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
-  --> $DIR/where-allowed.rs:224:29
+  --> $DIR/where-allowed.rs:225:29
    |
 LL |     let _in_local_variable: impl Fn() = || {};
    |                             ^^^^^^^^^
@@ -241,7 +250,7 @@ LL |     let _in_local_variable: impl Fn() = || {};
    = help: add `#![feature(impl_trait_in_bindings)]` to the crate attributes to enable
 
 error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
-  --> $DIR/where-allowed.rs:226:46
+  --> $DIR/where-allowed.rs:227:46
    |
 LL |     let _in_return_in_local_variable = || -> impl Fn() { || {} };
    |                                              ^^^^^^^^^
@@ -270,7 +279,7 @@ error: could not find defining uses
 LL |     type Out = impl Debug;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 43 previous errors
+error: aborting due to 44 previous errors
 
 Some errors have detailed explanations: E0282, E0562, E0658, E0666.
 For more information about an error, try `rustc --explain E0282`.

--- a/src/test/ui/parser/issue-62524.rs
+++ b/src/test/ui/parser/issue-62524.rs
@@ -1,0 +1,4 @@
+// ignore-tidy-trailing-newlines
+// error-pattern: aborting due to 3 previous errors
+y![
+Ϥ,

--- a/src/test/ui/parser/issue-62524.stderr
+++ b/src/test/ui/parser/issue-62524.stderr
@@ -1,0 +1,34 @@
+error: this file contains an un-closed delimiter
+  --> $DIR/issue-62524.rs:4:3
+   |
+LL | y![
+   |   - un-closed delimiter
+LL | Ϥ,
+   |   ^
+
+error: macros that expand to items must be delimited with braces or followed by a semicolon
+  --> $DIR/issue-62524.rs:3:3
+   |
+LL |   y![
+   |  ___^
+LL | | Ϥ,
+   | |__^
+   |
+help: change the delimiters to curly braces
+   |
+LL | y!{
+LL | Ϥ}
+   |
+help: add a semicolon
+   |
+LL | Ϥ,;
+   |   ^
+
+error: cannot find macro `y` in this scope
+  --> $DIR/issue-62524.rs:3:1
+   |
+LL | y![
+   | ^
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/test-panic-abort-disabled.rs
+++ b/src/test/ui/test-panic-abort-disabled.rs
@@ -1,4 +1,4 @@
-// error-pattern:building tests with panic=abort is not yet supported
+// error-pattern:building tests with panic=abort is not supported
 // no-prefer-dynamic
 // compile-flags: --test -Cpanic=abort
 // run-flags: --test-threads=1

--- a/src/test/ui/test-panic-abort-disabled.stderr
+++ b/src/test/ui/test-panic-abort-disabled.stderr
@@ -1,4 +1,4 @@
-error: building tests with panic=abort is not yet supported
+error: building tests with panic=abort is not supported without `-Zpanic_abort_tests`
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/generic_nondefining_use.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_nondefining_use.stderr
@@ -1,8 +1,8 @@
 error: at least one trait must be specified
-  --> $DIR/generic_nondefining_use.rs:5:20
+  --> $DIR/generic_nondefining_use.rs:5:15
    |
 LL | type Cmp<T> = impl 'static;
-   |                    ^^^^^^^
+   |               ^^^^^^^^^^^^
 
 error: defining opaque type use does not fully define opaque type
   --> $DIR/generic_nondefining_use.rs:11:1

--- a/src/test/ui/type-alias-impl-trait/generic_not_used.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_not_used.stderr
@@ -1,8 +1,8 @@
 error: at least one trait must be specified
-  --> $DIR/generic_not_used.rs:5:38
+  --> $DIR/generic_not_used.rs:5:33
    |
 LL | type WrongGeneric<T: 'static> = impl 'static;
-   |                                      ^^^^^^^
+   |                                 ^^^^^^^^^^^^
 
 error: type parameter `V` is part of concrete type but not used in parameter list for the `impl Trait` type alias
   --> $DIR/generic_not_used.rs:8:73

--- a/src/test/ui/type-alias-impl-trait/generic_type_does_not_live_long_enough.nll.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_type_does_not_live_long_enough.nll.stderr
@@ -1,8 +1,8 @@
 error: at least one trait must be specified
-  --> $DIR/generic_type_does_not_live_long_enough.rs:9:29
+  --> $DIR/generic_type_does_not_live_long_enough.rs:9:24
    |
 LL | type WrongGeneric<T> = impl 'static;
-   |                             ^^^^^^^
+   |                        ^^^^^^^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/generic_type_does_not_live_long_enough.rs:6:18

--- a/src/test/ui/type-alias-impl-trait/generic_type_does_not_live_long_enough.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_type_does_not_live_long_enough.stderr
@@ -1,8 +1,8 @@
 error: at least one trait must be specified
-  --> $DIR/generic_type_does_not_live_long_enough.rs:9:29
+  --> $DIR/generic_type_does_not_live_long_enough.rs:9:24
    |
 LL | type WrongGeneric<T> = impl 'static;
-   |                             ^^^^^^^
+   |                        ^^^^^^^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/generic_type_does_not_live_long_enough.rs:6:18

--- a/src/test/ui/type-alias-impl-trait/generic_underconstrained.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_underconstrained.stderr
@@ -1,8 +1,8 @@
 error: at least one trait must be specified
-  --> $DIR/generic_underconstrained.rs:6:40
+  --> $DIR/generic_underconstrained.rs:6:35
    |
 LL | type Underconstrained<T: Trait> = impl 'static;
-   |                                        ^^^^^^^
+   |                                   ^^^^^^^^^^^^
 
 error[E0277]: the trait bound `T: Trait` is not satisfied
   --> $DIR/generic_underconstrained.rs:6:1

--- a/src/test/ui/type-alias-impl-trait/generic_underconstrained2.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_underconstrained2.stderr
@@ -1,14 +1,14 @@
 error: at least one trait must be specified
-  --> $DIR/generic_underconstrained2.rs:5:50
+  --> $DIR/generic_underconstrained2.rs:5:45
    |
 LL | type Underconstrained<T: std::fmt::Debug> = impl 'static;
-   |                                                  ^^^^^^^
+   |                                             ^^^^^^^^^^^^
 
 error: at least one trait must be specified
-  --> $DIR/generic_underconstrained2.rs:14:51
+  --> $DIR/generic_underconstrained2.rs:14:46
    |
 LL | type Underconstrained2<T: std::fmt::Debug> = impl 'static;
-   |                                                   ^^^^^^^
+   |                                              ^^^^^^^^^^^^
 
 error[E0277]: `U` doesn't implement `std::fmt::Debug`
   --> $DIR/generic_underconstrained2.rs:5:1

--- a/src/test/ui/type-alias-impl-trait/issue-60371.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-60371.stderr
@@ -1,8 +1,8 @@
 error[E0658]: `impl Trait` in type aliases is unstable
-  --> $DIR/issue-60371.rs:8:5
+  --> $DIR/issue-60371.rs:8:17
    |
 LL |     type Item = impl Bug;
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/63063
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable

--- a/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-with-no-traits.stderr
+++ b/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-with-no-traits.stderr
@@ -1,8 +1,8 @@
 error: at least one trait must be specified
-  --> $DIR/type-alias-impl-trait-with-no-traits.rs:3:17
+  --> $DIR/type-alias-impl-trait-with-no-traits.rs:3:12
    |
 LL | type Foo = impl 'static;
-   |                 ^^^^^^^
+   |            ^^^^^^^^^^^^
 
 error: at least one trait must be specified
   --> $DIR/type-alias-impl-trait-with-no-traits.rs:10:13

--- a/src/test/ui/type-alias-impl-trait/unused_generic_param.stderr
+++ b/src/test/ui/type-alias-impl-trait/unused_generic_param.stderr
@@ -1,14 +1,14 @@
 error: at least one trait must be specified
-  --> $DIR/unused_generic_param.rs:6:33
+  --> $DIR/unused_generic_param.rs:6:28
    |
 LL | type PartiallyDefined<T> = impl 'static;
-   |                                 ^^^^^^^
+   |                            ^^^^^^^^^^^^
 
 error: at least one trait must be specified
-  --> $DIR/unused_generic_param.rs:13:34
+  --> $DIR/unused_generic_param.rs:13:29
    |
 LL | type PartiallyDefined2<T> = impl 'static;
-   |                                  ^^^^^^^
+   |                             ^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #66197 (Push `ast::{ItemKind, ImplItemKind}::OpaqueTy` hack down into lowering)
 - #66415 (Add --force-run-in-process unstable option to libtest)
 - #66429 (Add a regression test for #62524)
 - #66435 (Correct `const_in_array_repeat_expressions` feature name)
 - #66443 (Port erased cleanup)

Failed merges:


r? @ghost