### PR TITLE
fix typo in `const_in_array_repeat_expressions` suggestion

### DIFF
--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -2184,7 +2184,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                               information, see issue \
                               https://github.com/rust-lang/rust/issues/49147");
                     if tcx.sess.opts.unstable_features.is_nightly_build() {
-                        err.help("add `#![feature(const_in_array_repeat_expression)]` to the \
+                        err.help("add `#![feature(const_in_array_repeat_expressions)]` to the \
                                   crate attributes to enable");
                     }
                 }

--- a/src/test/ui/feature-gates/feature-gate-const_in_array_repeat_expressions.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_in_array_repeat_expressions.stderr
@@ -8,7 +8,7 @@ LL |     let arr: [Option<String>; 2] = [None::<String>; 2];
              <std::option::Option<T> as std::marker::Copy>
    = note: the `Copy` trait is required because the repeated element will be copied
    = note: this array initializer can be evaluated at compile-time, for more information, see issue https://github.com/rust-lang/rust/issues/49147
-   = help: add `#![feature(const_in_array_repeat_expression)]` to the crate attributes to enable
+   = help: add `#![feature(const_in_array_repeat_expressions)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `std::option::Option<std::string::String>: std::marker::Copy` is not satisfied
   --> $DIR/feature-gate-const_in_array_repeat_expressions.rs:14:36


### PR DESCRIPTION
update suggestion and ui test `const_in_array_repeat_expression` to
`const_in_array_repeat_expressions` (adding 's' at the end)

Closes: https://github.com/rust-lang/rust/issues/66433