### PR TITLE
Make Vec::len() and Vec::is_empty() const fn

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1311,7 +1311,7 @@ impl<T> Vec<T> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.len
     }
 

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1327,7 +1327,7 @@ impl<T> Vec<T> {
     /// assert!(!v.is_empty());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 


### PR DESCRIPTION
Making these two functions const fn will improve the usability in constant context.

This also open the possibility of contify `String` functions with the same names.

Maybe this is putting the cart before the horse, since we don't have const allocation yet and should be delayed till we have one