### PR TITLE
miri panic_unwind: fix hack for SEH platforms

### DIFF
--- a/src/libpanic_unwind/lib.rs
+++ b/src/libpanic_unwind/lib.rs
@@ -39,11 +39,6 @@ cfg_if::cfg_if! {
     if #[cfg(miri)] {
         #[path = "miri.rs"]
         mod imp;
-        // On MSVC we need the SEH lang items as well...
-        // This should match the conditions of the `seh.rs` import below.
-        #[cfg(all(target_env = "msvc", not(target_arch = "aarch64")))]
-        #[allow(unused)]
-        mod seh;
     } else if #[cfg(target_os = "emscripten")] {
         #[path = "emcc.rs"]
         mod imp;

--- a/src/libpanic_unwind/miri.rs
+++ b/src/libpanic_unwind/miri.rs
@@ -1,3 +1,5 @@
+#![allow(nonstandard_style)]
+
 use core::any::Any;
 use alloc::boxed::Box;
 
@@ -13,7 +15,6 @@ pub unsafe fn cleanup(ptr: *mut u8) -> Box<dyn Any + Send> {
     Box::from_raw(ptr)
 }
 
-
 // This is required by the compiler to exist (e.g., it's a lang item),
 // but is never used by Miri. Therefore, we just use a stub here
 #[lang = "eh_personality"]
@@ -21,3 +22,26 @@ pub unsafe fn cleanup(ptr: *mut u8) -> Box<dyn Any + Send> {
 fn rust_eh_personality() {
     unsafe { core::intrinsics::abort() }
 }
+
+// The rest is required on *some* targets to exist (specifically, MSVC targets that use SEH).
+// We just add it on all targets. Copied from `seh.rs`.
+#[repr(C)]
+pub struct _TypeDescriptor {
+    pub pVFTable: *const u8,
+    pub spare: *mut u8,
+    pub name: [u8; 11],
+}
+
+extern "C" {
+    #[link_name = "\x01??_7type_info@@6B@"]
+    static TYPE_INFO_VTABLE: *const u8;
+}
+
+const TYPE_NAME: [u8; 11] = *b"rust_panic\0";
+
+#[cfg_attr(not(test), lang = "eh_catch_typeinfo")]
+static mut TYPE_DESCRIPTOR: _TypeDescriptor = _TypeDescriptor {
+    pVFTable: unsafe { &TYPE_INFO_VTABLE } as *const _ as *const _,
+    spare: core::ptr::null_mut(),
+    name: TYPE_NAME,
+};

--- a/src/libpanic_unwind/miri.rs
+++ b/src/libpanic_unwind/miri.rs
@@ -32,16 +32,11 @@ pub struct _TypeDescriptor {
     pub name: [u8; 11],
 }
 
-extern "C" {
-    #[link_name = "\x01??_7type_info@@6B@"]
-    static TYPE_INFO_VTABLE: *const u8;
-}
-
 const TYPE_NAME: [u8; 11] = *b"rust_panic\0";
 
 #[cfg_attr(not(test), lang = "eh_catch_typeinfo")]
 static mut TYPE_DESCRIPTOR: _TypeDescriptor = _TypeDescriptor {
-    pVFTable: unsafe { &TYPE_INFO_VTABLE } as *const _ as *const _,
+    pVFTable: core::ptr::null(),
     spare: core::ptr::null_mut(),
     name: TYPE_NAME,
 };


### PR DESCRIPTION
The old hack didn't work as we ended up duplicating the `eh_personality` lang item...

I have no idea if rustc cares that `eh_catch_typeinfo` has a certain shape, but better safe than sorry. I cannot test this locally.

r? @oli-obk Cc @Aaron1011 