### PR TITLE
Clarify transmute_copy documentation example

### DIFF
--- a/src/libcore/mem/mod.rs
+++ b/src/libcore/mem/mod.rs
@@ -744,11 +744,11 @@ pub fn drop<T>(_x: T) { }
 ///     bar: u8,
 /// }
 ///
-/// let foo_slice = [10u8];
+/// let foo_array = [10u8];
 ///
 /// unsafe {
-///     // Copy the data from 'foo_slice' and treat it as a 'Foo'
-///     let mut foo_struct: Foo = mem::transmute_copy(&foo_slice);
+///     // Copy the data from 'foo_array' and treat it as a 'Foo'
+///     let mut foo_struct: Foo = mem::transmute_copy(&foo_array);
 ///     assert_eq!(foo_struct.bar, 10);
 ///
 ///     // Modify the copied data
@@ -756,8 +756,8 @@ pub fn drop<T>(_x: T) { }
 ///     assert_eq!(foo_struct.bar, 20);
 /// }
 ///
-/// // The contents of 'foo_slice' should not have changed
-/// assert_eq!(foo_slice, [10]);
+/// // The contents of 'foo_array' should not have changed
+/// assert_eq!(foo_array, [10]);
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
Currently the documentation for `transmute_copy` implies that the function accepts a slice due to the variable name chosen in the example. This is misleading as `foo_slice` is actually an array and `transmute_copy` cannot take an unsized type anyway.

This PR just clarifies things by renaming the variable used in the example.