### PR TITLE
Add new `rustc_panic_abort_runtime` attribute for `libpanic_abort`

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -94,6 +94,14 @@ fn main() {
         // other crate intentionally as this is the only crate for now that we
         // ship with panic=abort.
         //
+        // This hack is being replaced with a new "rustc_panic_abort_runtime"
+        // attribute, which moves the special-casing out of `bootstrap` and
+        // into the compiler itself. Until this change makes its way into
+        // the bootstrap compiler, we still need this hack when building
+        // stage0. Once the boostrap compiler is updated, we can remove
+        // this check entirely.
+        // cfg(bootstrap): (Added to make this show up when searching for "cfg(bootstrap)")
+        //
         // This... is a bit of a hack how we detect this. Ideally this
         // information should be encoded in the crate I guess? Would likely
         // require an RFC amendment to RFC 1513, however.
@@ -101,7 +109,7 @@ fn main() {
         // `compiler_builtins` are unconditionally compiled with panic=abort to
         // workaround undefined references to `rust_eh_unwind_resume` generated
         // otherwise, see issue https://github.com/rust-lang/rust/issues/43095.
-        if crate_name == Some("panic_abort") ||
+        if (crate_name == Some("panic_abort") && stage == "0") ||
            crate_name == Some("compiler_builtins") && stage != "0" {
             cmd.arg("-C").arg("panic=abort");
         }

--- a/src/libpanic_abort/lib.rs
+++ b/src/libpanic_abort/lib.rs
@@ -8,6 +8,7 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/")]
 #![panic_runtime]
+#![cfg_attr(not(bootstrap), rustc_panic_abort_runtime)]
 
 #![allow(unused_features)]
 

--- a/src/librustc_codegen_llvm/lib.rs
+++ b/src/librustc_codegen_llvm/lib.rs
@@ -202,6 +202,10 @@ impl CodegenBackend for LlvmCodegenBackend {
         llvm_util::init(sess); // Make sure llvm is inited
     }
 
+    fn after_expansion(&self, sess: &Session) {
+        llvm_util::late_init(sess);
+    }
+
     fn print(&self, req: PrintRequest, sess: &Session) {
         match req {
             PrintRequest::RelocationModels => {

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -1871,4 +1871,5 @@ extern "C" {
                              bytecode: *const c_char,
                              bytecode_len: usize) -> bool;
     pub fn LLVMRustLinkerFree(linker: &'a mut Linker<'a>);
+    pub fn LLVMRustEnableEmscriptenCXXExceptions();
 }

--- a/src/librustc_codegen_llvm/llvm_util.rs
+++ b/src/librustc_codegen_llvm/llvm_util.rs
@@ -45,6 +45,13 @@ fn require_inited() {
     }
 }
 
+pub(crate) fn late_init(sess: &Session) {
+    if sess.target.target.target_os == "emscripten" &&
+        sess.panic_strategy() == PanicStrategy::Unwind {
+        unsafe { llvm::LLVMRustEnableEmscriptenCXXExceptions(); }
+    }
+}
+
 unsafe fn configure_llvm(sess: &Session) {
     let n_args = sess.opts.cg.llvm_args.len();
     let mut llvm_c_strs = Vec::with_capacity(n_args + 1);
@@ -93,11 +100,6 @@ unsafe fn configure_llvm(sess: &Session) {
                     add("-mergefunc-use-aliases", false);
                 }
             }
-        }
-
-        if sess.target.target.target_os == "emscripten" &&
-            sess.panic_strategy() == PanicStrategy::Unwind {
-            add("-enable-emscripten-cxx-exceptions", false);
         }
 
         // HACK(eddyb) LLVM inserts `llvm.assume` calls to preserve align attributes

--- a/src/librustc_codegen_utils/codegen_backend.rs
+++ b/src/librustc_codegen_utils/codegen_backend.rs
@@ -21,6 +21,7 @@ pub use rustc_data_structures::sync::MetadataRef;
 
 pub trait CodegenBackend {
     fn init(&self, _sess: &Session) {}
+    fn after_expansion(&self, _sess: &Session) {}
     fn print(&self, _req: PrintRequest, _sess: &Session) {}
     fn target_features(&self, _sess: &Session) -> Vec<Symbol> { vec![] }
     fn print_passes(&self) {}

--- a/src/librustc_feature/builtin_attrs.rs
+++ b/src/librustc_feature/builtin_attrs.rs
@@ -379,6 +379,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     rustc_attr!(rustc_allocator, Whitelisted, template!(Word), IMPL_DETAIL),
     rustc_attr!(rustc_allocator_nounwind, Whitelisted, template!(Word), IMPL_DETAIL),
     gated!(alloc_error_handler, Normal, template!(Word), experimental!(alloc_error_handler)),
+    rustc_attr!(rustc_panic_abort_runtime, Whitelisted, template!(Word), IMPL_DETAIL),
     gated!(
         default_lib_allocator, Whitelisted, template!(Word), allocator_internals,
         experimental!(default_lib_allocator),

--- a/src/librustc_interface/queries.rs
+++ b/src/librustc_interface/queries.rs
@@ -186,6 +186,7 @@ impl<'tcx> Queries<'tcx> {
             let crate_name = self.crate_name()?.peek().clone();
             let (krate, lint_store) = self.register_plugins()?.take();
             passes::configure_and_expand(
+                self.codegen_backend().clone(),
                 self.session().clone(),
                 lint_store.clone(),
                 self.codegen_backend().metadata_loader(),

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -125,6 +125,11 @@ pub struct Session {
     /// false positives about a job server in our environment.
     pub jobserver: Client,
 
+    /// Whether or not to force the panic strategy for this
+    /// crate to be PanicStrategy::Abort. Only used
+    /// for 'libpanic_abort'
+    pub force_panic_abort: Once<bool>,
+
     /// Cap lint level specified by a driver specifically.
     pub driver_lint_caps: FxHashMap<lint::LintId, lint::Level>,
 
@@ -543,6 +548,10 @@ impl Session {
     /// Returns the panic strategy for this compile session. If the user explicitly selected one
     /// using '-C panic', use that, otherwise use the panic strategy defined by the target.
     pub fn panic_strategy(&self) -> PanicStrategy {
+        if *self.force_panic_abort.get() {
+            return PanicStrategy::Abort
+        }
+
         self.opts
             .cg
             .panic
@@ -1164,6 +1173,7 @@ fn build_session_(
         print_fuel_crate,
         print_fuel,
         jobserver: jobserver::client(),
+        force_panic_abort: Once::new(),
         driver_lint_caps,
         trait_methods_not_found: Lock::new(Default::default()),
         confused_type_with_std_module: Lock::new(Default::default()),

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -630,6 +630,7 @@ symbols! {
         rustc_object_lifetime_default,
         rustc_on_unimplemented,
         rustc_outlives,
+        rustc_panic_abort_runtime,
         rustc_paren_sugar,
         rustc_partition_codegened,
         rustc_partition_reused,

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -1545,7 +1545,7 @@ LLVMRustEnableEmscriptenCXXExceptions() {
     // of our other LLVM arguments when we initialize LLVM.
     // Unfortunately, whether or not we pass this flag depends
     // on the crate panic strategy. Determining the crate
-    // panic strategy requires us to have paresed crate arributes
+    // panic strategy requires us to have parsed crate attributes
     // (so that we can have special handling for `libpanic_abort`).
     // Parsing crate attributes actually requires us to have initialized
     // LLVM, so that we can handle cfg-gating involving LLVM target


### PR DESCRIPTION
Supersedes #66311

This replaces the hack in `bootstrap`, allowing the special handling for
`libpanic_abort` to be encoded into the crate source itself, rather than
existing as special knowledge in the build system. This will allow Miri
(and any other users of Xargo) to correctly build `libpanic_abort`
without relying on `bootstrap` or custom wrapepr hacks.

The trickeist part of this PR is how we handle LLVM. The `emscripten`
target family requires the "-enable-emscripten-cxx-exceptions" flag
to be passed to LLVM when the panic strategy is set to "unwind".

Unfortunately, the location of this emscripten-specific check ends up
creating a circular dependency between LLVM and attribute resoltion.
When we check the panic strategy, we need to have already parsed crate
attributes, so that we determine if `rustc_panic_abort_runtime` was set.
However, attribute parsing requires LLVM to be initialized, so that we
can proerly handle cfg-gating of target-specific features. However, the
whole point of checking the panic strategy is to determinne which flags
to use during LLVM initialization!

To break this circular dependency, we explicitly set the
"-enable-emscripten-cxx-exceptions" in LLVM's argument-parsing framework
(using public but poorly-documented APIs). While this approach is
unfortunate, it only affects emscripten, and only modifies a
command-line flag which is never used until much later (when we create a
`PassManager`).