### PR TITLE
rustc_metadata: Privatize more things

### DIFF
--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -207,7 +207,7 @@ impl<'a> CrateLoader<'a> {
         let root = if let Some(root) = root {
             root
         } else {
-            crate_paths = CratePaths { name: crate_root.name, source: source.clone() };
+            crate_paths = CratePaths::new(crate_root.name, source.clone());
             &crate_paths
         };
 

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -1,8 +1,8 @@
 //! Validates all used crates and extern libraries and loads their metadata
 
-use crate::cstore::{self, CStore, MetadataBlob};
+use crate::cstore::{self, CStore};
 use crate::locator::{self, CratePaths};
-use crate::rmeta::{CrateRoot, CrateDep};
+use crate::rmeta::{CrateRoot, CrateDep, MetadataBlob};
 use rustc_data_structures::sync::{Lock, Once, AtomicCell};
 
 use rustc::hir::def_id::CrateNum;

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -350,26 +350,19 @@ impl<'a> CrateLoader<'a> {
             (LoadResult::Previous(cnum), None)
         } else {
             info!("falling back to a load");
-            let mut locator = CrateLocator {
-                sess: self.sess,
-                span,
-                crate_name: name,
+            let mut locator = CrateLocator::new(
+                self.sess,
+                self.metadata_loader,
+                name,
                 hash,
                 host_hash,
                 extra_filename,
-                filesearch: self.sess.target_filesearch(path_kind),
-                target: &self.sess.target.target,
-                triple: self.sess.opts.target_triple.clone(),
+                false, // is_host
+                path_kind,
+                span,
                 root,
-                rejected_via_hash: vec![],
-                rejected_via_triple: vec![],
-                rejected_via_kind: vec![],
-                rejected_via_version: vec![],
-                rejected_via_filename: vec![],
-                should_match_name: true,
-                is_proc_macro: Some(false),
-                metadata_loader: self.metadata_loader,
-            };
+                Some(false), // is_proc_macro
+            );
 
             self.load(&mut locator).map(|r| (r, None)).or_else(|| {
                 dep_kind = DepKind::UnexportedMacrosOnly;

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -141,7 +141,7 @@ impl<'a> CrateLoader<'a> {
             let prev_kind = source.dylib.as_ref().or(source.rlib.as_ref())
                                   .or(source.rmeta.as_ref())
                                   .expect("No sources for crate").1;
-            if ret.is_none() && (prev_kind == kind || prev_kind == PathKind::All) {
+            if kind.matches(prev_kind) {
                 ret = Some(cnum);
             }
         });

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -1,91 +1,17 @@
 // The crate store - a central repo for information collected about external
 // crates and libraries
 
-use crate::rmeta::{CrateRoot, ImportedSourceFile, Lazy, MetadataBlob};
-use rustc::dep_graph::DepNodeIndex;
-use rustc::hir::def_id::{CrateNum, DefIndex};
-use rustc::hir::map::definitions::DefPathTable;
-use rustc::middle::cstore::{CrateSource, DepKind, ExternCrate};
-use rustc::mir::interpret::AllocDecodingState;
-use rustc::session::Session;
+use crate::rmeta::CrateMetadata;
+
+use rustc_data_structures::sync::Lrc;
 use rustc_index::vec::IndexVec;
-use rustc::util::common::record_time;
-use rustc::util::nodemap::FxHashMap;
-use rustc_data_structures::sync::{Lrc, Lock, Once, AtomicCell};
-use rustc_data_structures::svh::Svh;
+use rustc::hir::def_id::CrateNum;
 use syntax::ast;
 use syntax::edition::Edition;
-use syntax_expand::base::SyntaxExtension;
 use syntax::expand::allocator::AllocatorKind;
-use proc_macro::bridge::client::ProcMacro;
+use syntax_expand::base::SyntaxExtension;
 
 pub use crate::rmeta::{provide, provide_extern};
-
-// A map from external crate numbers (as decoded from some crate file) to
-// local crate numbers (as generated during this session). Each external
-// crate may refer to types in other external crates, and each has their
-// own crate numbers.
-crate type CrateNumMap = IndexVec<CrateNum, CrateNum>;
-
-crate struct CrateMetadata {
-    /// The primary crate data - binary metadata blob.
-    crate blob: MetadataBlob,
-
-    // --- Some data pre-decoded from the metadata blob, usually for performance ---
-
-    /// Properties of the whole crate.
-    /// NOTE(eddyb) we pass `'static` to a `'tcx` parameter because this
-    /// lifetime is only used behind `Lazy`, and therefore acts like an
-    /// universal (`for<'tcx>`), that is paired up with whichever `TyCtxt`
-    /// is being used to decode those values.
-    crate root: CrateRoot<'static>,
-    /// For each definition in this crate, we encode a key. When the
-    /// crate is loaded, we read all the keys and put them in this
-    /// hashmap, which gives the reverse mapping. This allows us to
-    /// quickly retrace a `DefPath`, which is needed for incremental
-    /// compilation support.
-    crate def_path_table: DefPathTable,
-    /// Trait impl data.
-    /// FIXME: Used only from queries and can use query cache,
-    /// so pre-decoding can probably be avoided.
-    crate trait_impls: FxHashMap<(u32, DefIndex), Lazy<[DefIndex]>>,
-    /// Proc macro descriptions for this crate, if it's a proc macro crate.
-    crate raw_proc_macros: Option<&'static [ProcMacro]>,
-    /// Source maps for code from the crate.
-    crate source_map_import_info: Once<Vec<ImportedSourceFile>>,
-    /// Used for decoding interpret::AllocIds in a cached & thread-safe manner.
-    crate alloc_decoding_state: AllocDecodingState,
-    /// The `DepNodeIndex` of the `DepNode` representing this upstream crate.
-    /// It is initialized on the first access in `get_crate_dep_node_index()`.
-    /// Do not access the value directly, as it might not have been initialized yet.
-    /// The field must always be initialized to `DepNodeIndex::INVALID`.
-    crate dep_node_index: AtomicCell<DepNodeIndex>,
-
-    // --- Other significant crate properties ---
-
-    /// ID of this crate, from the current compilation session's point of view.
-    crate cnum: CrateNum,
-    /// Maps crate IDs as they are were seen from this crate's compilation sessions into
-    /// IDs as they are seen from the current compilation session.
-    crate cnum_map: CrateNumMap,
-    /// Same ID set as `cnum_map` plus maybe some injected crates like panic runtime.
-    crate dependencies: Lock<Vec<CrateNum>>,
-    /// How to link (or not link) this crate to the currently compiled crate.
-    crate dep_kind: Lock<DepKind>,
-    /// Filesystem location of this crate.
-    crate source: CrateSource,
-    /// Whether or not this crate should be consider a private dependency
-    /// for purposes of the 'exported_private_dependencies' lint
-    crate private_dep: bool,
-    /// The hash for the host proc macro. Used to support `-Z dual-proc-macro`.
-    crate host_hash: Option<Svh>,
-
-    // --- Data used only for improving diagnostics ---
-
-    /// Information about the `extern crate` item or path that caused this crate to be loaded.
-    /// If this is `None`, then the crate was injected (e.g., by the allocator).
-    crate extern_crate: Lock<Option<ExternCrate>>,
-}
 
 #[derive(Clone)]
 pub struct CStore {
@@ -97,48 +23,6 @@ pub struct CStore {
 pub enum LoadedMacro {
     MacroDef(ast::Item, Edition),
     ProcMacro(SyntaxExtension),
-}
-
-impl CrateMetadata {
-    crate fn new(
-        sess: &Session,
-        blob: MetadataBlob,
-        root: CrateRoot<'static>,
-        raw_proc_macros: Option<&'static [ProcMacro]>,
-        cnum: CrateNum,
-        cnum_map: CrateNumMap,
-        dep_kind: DepKind,
-        source: CrateSource,
-        private_dep: bool,
-        host_hash: Option<Svh>,
-    ) -> CrateMetadata {
-        let def_path_table = record_time(&sess.perf_stats.decode_def_path_tables_time, || {
-            root.def_path_table.decode((&blob, sess))
-        });
-        let trait_impls = root.impls.decode((&blob, sess))
-            .map(|trait_impls| (trait_impls.trait_id, trait_impls.impls)).collect();
-        let alloc_decoding_state =
-            AllocDecodingState::new(root.interpret_alloc_index.decode(&blob).collect());
-        let dependencies = Lock::new(cnum_map.iter().cloned().collect());
-        CrateMetadata {
-            blob,
-            root,
-            def_path_table,
-            trait_impls,
-            raw_proc_macros,
-            source_map_import_info: Once::new(),
-            alloc_decoding_state,
-            dep_node_index: AtomicCell::new(DepNodeIndex::INVALID),
-            cnum,
-            cnum_map,
-            dependencies,
-            dep_kind: Lock::new(dep_kind),
-            source,
-            private_dep,
-            host_hash,
-            extern_crate: Lock::new(None),
-        }
-    }
 }
 
 impl Default for CStore {

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -90,8 +90,8 @@ crate struct CrateMetadata {
 #[derive(Clone)]
 pub struct CStore {
     metas: IndexVec<CrateNum, Option<Lrc<CrateMetadata>>>,
-    pub(crate) injected_panic_runtime: Option<CrateNum>,
-    pub(crate) allocator_kind: Option<AllocatorKind>,
+    crate injected_panic_runtime: Option<CrateNum>,
+    crate allocator_kind: Option<AllocatorKind>,
 }
 
 pub enum LoadedMacro {

--- a/src/librustc_metadata/locator.rs
+++ b/src/librustc_metadata/locator.rs
@@ -254,7 +254,7 @@ crate struct CrateMismatch {
 }
 
 #[derive(Clone)]
-crate struct Context<'a> {
+crate struct CrateLocator<'a> {
     pub sess: &'a Session,
     pub span: Span,
     pub crate_name: Symbol,
@@ -298,7 +298,7 @@ impl fmt::Display for CrateFlavor {
     }
 }
 
-impl<'a> Context<'a> {
+impl<'a> CrateLocator<'a> {
     crate fn reset(&mut self) {
         self.rejected_via_hash.clear();
         self.rejected_via_triple.clear();
@@ -926,7 +926,7 @@ pub fn find_plugin_registrar(
     let host_triple = TargetTriple::from_triple(config::host_triple());
     let is_cross = target_triple != host_triple;
     let mut target_only = false;
-    let mut locate_ctxt = Context {
+    let mut locator = CrateLocator {
         sess,
         span,
         crate_name: name,
@@ -947,7 +947,7 @@ pub fn find_plugin_registrar(
         metadata_loader,
     };
 
-    let library = locate_ctxt.maybe_load_library_crate().or_else(|| {
+    let library = locator.maybe_load_library_crate().or_else(|| {
         if !is_cross {
             return None
         }
@@ -955,15 +955,15 @@ pub fn find_plugin_registrar(
         // try to load a plugin registrar function,
         target_only = true;
 
-        locate_ctxt.target = &sess.target.target;
-        locate_ctxt.triple = target_triple;
-        locate_ctxt.filesearch = sess.target_filesearch(PathKind::Crate);
+        locator.target = &sess.target.target;
+        locator.triple = target_triple;
+        locator.filesearch = sess.target_filesearch(PathKind::Crate);
 
-        locate_ctxt.maybe_load_library_crate()
+        locator.maybe_load_library_crate()
     });
     let library = match library {
         Some(l) => l,
-        None => locate_ctxt.report_errs(),
+        None => locator.report_errs(),
     };
 
     if target_only {

--- a/src/librustc_metadata/locator.rs
+++ b/src/librustc_metadata/locator.rs
@@ -281,8 +281,14 @@ crate struct CrateLocator<'a> {
 }
 
 crate struct CratePaths {
-    pub name: Symbol,
-    pub source: CrateSource,
+    name: Symbol,
+    source: CrateSource,
+}
+
+impl CratePaths {
+    crate fn new(name: Symbol, source: CrateSource) -> CratePaths {
+        CratePaths { name, source }
+    }
 }
 
 #[derive(Copy, Clone, PartialEq)]

--- a/src/librustc_metadata/locator.rs
+++ b/src/librustc_metadata/locator.rs
@@ -768,10 +768,11 @@ impl<'a> CrateLocator<'a> {
         }
 
         let root = metadata.get_root();
-        if let Some(is_proc_macro) = self.is_proc_macro {
-            if root.proc_macro_data.is_some() != is_proc_macro {
+        if let Some(expected_is_proc_macro) = self.is_proc_macro {
+            let is_proc_macro = root.is_proc_macro_crate();
+            if is_proc_macro != expected_is_proc_macro {
                 info!("Rejecting via proc macro: expected {} got {}",
-                      is_proc_macro, root.proc_macro_data.is_some());
+                      expected_is_proc_macro, is_proc_macro);
                 return None;
             }
         }

--- a/src/librustc_metadata/locator.rs
+++ b/src/librustc_metadata/locator.rs
@@ -212,9 +212,8 @@
 //! no means all of the necessary details. Take a look at the rest of
 //! metadata::locator or metadata::creader for all the juicy details!
 
-use crate::cstore::MetadataBlob;
 use crate::creader::Library;
-use crate::rmeta::{METADATA_HEADER, rustc_version};
+use crate::rmeta::{METADATA_HEADER, rustc_version, MetadataBlob};
 
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::svh::Svh;
@@ -907,7 +906,7 @@ fn get_metadata_section_imp(target: &Target,
             rustc_erase_owner!(OwningRef::new(StableDerefMmap(mmap)).map_owner_box())
         }
     };
-    let blob = MetadataBlob(raw_bytes);
+    let blob = MetadataBlob::new(raw_bytes);
     if blob.is_compatible() {
         Ok(blob)
     } else {

--- a/src/librustc_metadata/rmeta/decoder.rs
+++ b/src/librustc_metadata/rmeta/decoder.rs
@@ -607,10 +607,6 @@ impl<'a, 'tcx> CrateMetadata {
         }
     }
 
-    fn is_proc_macro_crate(&self) -> bool {
-        self.root.is_proc_macro_crate()
-    }
-
     fn is_proc_macro(&self, id: DefIndex) -> bool {
         self.root.proc_macro_data.and_then(|data| data.decode(self).find(|x| *x == id)).is_some()
     }
@@ -895,7 +891,7 @@ impl<'a, 'tcx> CrateMetadata {
 
     /// Iterates over the language items in the given crate.
     fn get_lang_items(&self, tcx: TyCtxt<'tcx>) -> &'tcx [(DefId, usize)] {
-        if self.is_proc_macro_crate() {
+        if self.root.is_proc_macro_crate() {
             // Proc macro crates do not export any lang-items to the target.
             &[]
         } else {
@@ -911,7 +907,7 @@ impl<'a, 'tcx> CrateMetadata {
         &self,
         tcx: TyCtxt<'tcx>,
     ) -> &'tcx FxHashMap<Symbol, DefId> {
-        tcx.arena.alloc(if self.is_proc_macro_crate() {
+        tcx.arena.alloc(if self.root.is_proc_macro_crate() {
             // Proc macro crates do not export any diagnostic-items to the target.
             Default::default()
         } else {
@@ -1219,7 +1215,7 @@ impl<'a, 'tcx> CrateMetadata {
         tcx: TyCtxt<'tcx>,
         filter: Option<DefId>,
     ) -> &'tcx [DefId] {
-        if self.is_proc_macro_crate() {
+        if self.root.is_proc_macro_crate() {
             // proc-macro crates export no trait impls.
             return &[]
         }
@@ -1263,7 +1259,7 @@ impl<'a, 'tcx> CrateMetadata {
 
 
     fn get_native_libraries(&self, sess: &Session) -> Vec<NativeLibrary> {
-        if self.is_proc_macro_crate() {
+        if self.root.is_proc_macro_crate() {
             // Proc macro crates do not have any *target* native libraries.
             vec![]
         } else {
@@ -1272,7 +1268,7 @@ impl<'a, 'tcx> CrateMetadata {
     }
 
     fn get_foreign_modules(&self, tcx: TyCtxt<'tcx>) -> &'tcx [ForeignModule] {
-        if self.is_proc_macro_crate() {
+        if self.root.is_proc_macro_crate() {
             // Proc macro crates do not have any *target* foreign modules.
             &[]
         } else {
@@ -1295,7 +1291,7 @@ impl<'a, 'tcx> CrateMetadata {
     }
 
     fn get_missing_lang_items(&self, tcx: TyCtxt<'tcx>) -> &'tcx [lang_items::LangItem] {
-        if self.is_proc_macro_crate() {
+        if self.root.is_proc_macro_crate() {
             // Proc macro crates do not depend on any target weak lang-items.
             &[]
         } else {
@@ -1319,7 +1315,7 @@ impl<'a, 'tcx> CrateMetadata {
         &self,
         tcx: TyCtxt<'tcx>,
     ) -> Vec<(ExportedSymbol<'tcx>, SymbolExportLevel)> {
-        if self.is_proc_macro_crate() {
+        if self.root.is_proc_macro_crate() {
             // If this crate is a custom derive crate, then we're not even going to
             // link those in so we skip those crates.
             vec![]

--- a/src/librustc_metadata/rmeta/decoder.rs
+++ b/src/librustc_metadata/rmeta/decoder.rs
@@ -1,27 +1,30 @@
 // Decoding metadata from a single crate's metadata
 
-use crate::cstore::CrateMetadata;
 use crate::rmeta::*;
 use crate::rmeta::table::{FixedSizeEncoding, PerDefTable};
 
 use rustc_index::vec::IndexVec;
-use rustc_data_structures::sync::Lrc;
+use rustc_data_structures::sync::{Lrc, Lock, Once, AtomicCell};
 use rustc::hir::map::{DefKey, DefPath, DefPathData, DefPathHash};
+use rustc::hir::map::definitions::DefPathTable;
 use rustc::hir;
+use rustc::middle::cstore::{CrateSource, ExternCrate};
 use rustc::middle::cstore::{LinkagePreference, NativeLibrary, ForeignModule};
 use rustc::middle::exported_symbols::{ExportedSymbol, SymbolExportLevel};
 use rustc::hir::def::{self, Res, DefKind, CtorOf, CtorKind};
 use rustc::hir::def_id::{CrateNum, DefId, DefIndex, LocalDefId, CRATE_DEF_INDEX, LOCAL_CRATE};
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::fx::FxHashMap;
-use rustc::dep_graph::{DepNodeIndex, DepKind};
+use rustc_data_structures::svh::Svh;
+use rustc::dep_graph::{self, DepNodeIndex};
 use rustc::middle::lang_items;
 use rustc::mir::{self, interpret};
-use rustc::mir::interpret::AllocDecodingSession;
+use rustc::mir::interpret::{AllocDecodingSession, AllocDecodingState};
 use rustc::session::Session;
 use rustc::ty::{self, Ty, TyCtxt};
 use rustc::ty::codec::TyDecoder;
 use rustc::mir::{Body, Promoted};
+use rustc::util::common::record_time;
 use rustc::util::captures::Captures;
 
 use std::io;
@@ -46,9 +49,75 @@ mod cstore_impl;
 
 crate struct MetadataBlob(MetadataRef);
 
+// A map from external crate numbers (as decoded from some crate file) to
+// local crate numbers (as generated during this session). Each external
+// crate may refer to types in other external crates, and each has their
+// own crate numbers.
+crate type CrateNumMap = IndexVec<CrateNum, CrateNum>;
+
+crate struct CrateMetadata {
+    /// The primary crate data - binary metadata blob.
+    blob: MetadataBlob,
+
+    // --- Some data pre-decoded from the metadata blob, usually for performance ---
+
+    /// Properties of the whole crate.
+    /// NOTE(eddyb) we pass `'static` to a `'tcx` parameter because this
+    /// lifetime is only used behind `Lazy`, and therefore acts like an
+    /// universal (`for<'tcx>`), that is paired up with whichever `TyCtxt`
+    /// is being used to decode those values.
+    crate root: CrateRoot<'static>,
+    /// For each definition in this crate, we encode a key. When the
+    /// crate is loaded, we read all the keys and put them in this
+    /// hashmap, which gives the reverse mapping. This allows us to
+    /// quickly retrace a `DefPath`, which is needed for incremental
+    /// compilation support.
+    def_path_table: DefPathTable,
+    /// Trait impl data.
+    /// FIXME: Used only from queries and can use query cache,
+    /// so pre-decoding can probably be avoided.
+    trait_impls: FxHashMap<(u32, DefIndex), Lazy<[DefIndex]>>,
+    /// Proc macro descriptions for this crate, if it's a proc macro crate.
+    raw_proc_macros: Option<&'static [ProcMacro]>,
+    /// Source maps for code from the crate.
+    source_map_import_info: Once<Vec<ImportedSourceFile>>,
+    /// Used for decoding interpret::AllocIds in a cached & thread-safe manner.
+    alloc_decoding_state: AllocDecodingState,
+    /// The `DepNodeIndex` of the `DepNode` representing this upstream crate.
+    /// It is initialized on the first access in `get_crate_dep_node_index()`.
+    /// Do not access the value directly, as it might not have been initialized yet.
+    /// The field must always be initialized to `DepNodeIndex::INVALID`.
+    dep_node_index: AtomicCell<DepNodeIndex>,
+
+    // --- Other significant crate properties ---
+
+    /// ID of this crate, from the current compilation session's point of view.
+    cnum: CrateNum,
+    /// Maps crate IDs as they are were seen from this crate's compilation sessions into
+    /// IDs as they are seen from the current compilation session.
+    cnum_map: CrateNumMap,
+    /// Same ID set as `cnum_map` plus maybe some injected crates like panic runtime.
+    crate dependencies: Lock<Vec<CrateNum>>,
+    /// How to link (or not link) this crate to the currently compiled crate.
+    crate dep_kind: Lock<DepKind>,
+    /// Filesystem location of this crate.
+    crate source: CrateSource,
+    /// Whether or not this crate should be consider a private dependency
+    /// for purposes of the 'exported_private_dependencies' lint
+    private_dep: bool,
+    /// The hash for the host proc macro. Used to support `-Z dual-proc-macro`.
+    host_hash: Option<Svh>,
+
+    // --- Data used only for improving diagnostics ---
+
+    /// Information about the `extern crate` item or path that caused this crate to be loaded.
+    /// If this is `None`, then the crate was injected (e.g., by the allocator).
+    crate extern_crate: Lock<Option<ExternCrate>>,
+}
+
 /// Holds information about a syntax_pos::SourceFile imported from another crate.
 /// See `imported_source_files()` for more information.
-crate struct ImportedSourceFile {
+struct ImportedSourceFile {
     /// This SourceFile's byte-offset within the source_map of its original crate
     original_start_pos: syntax_pos::BytePos,
     /// The end of this SourceFile within the source_map of its original crate
@@ -485,6 +554,46 @@ impl<'tcx> EntryKind<'tcx> {
 }
 
 impl<'a, 'tcx> CrateMetadata {
+    crate fn new(
+        sess: &Session,
+        blob: MetadataBlob,
+        root: CrateRoot<'static>,
+        raw_proc_macros: Option<&'static [ProcMacro]>,
+        cnum: CrateNum,
+        cnum_map: CrateNumMap,
+        dep_kind: DepKind,
+        source: CrateSource,
+        private_dep: bool,
+        host_hash: Option<Svh>,
+    ) -> CrateMetadata {
+        let def_path_table = record_time(&sess.perf_stats.decode_def_path_tables_time, || {
+            root.def_path_table.decode((&blob, sess))
+        });
+        let trait_impls = root.impls.decode((&blob, sess))
+            .map(|trait_impls| (trait_impls.trait_id, trait_impls.impls)).collect();
+        let alloc_decoding_state =
+            AllocDecodingState::new(root.interpret_alloc_index.decode(&blob).collect());
+        let dependencies = Lock::new(cnum_map.iter().cloned().collect());
+        CrateMetadata {
+            blob,
+            root,
+            def_path_table,
+            trait_impls,
+            raw_proc_macros,
+            source_map_import_info: Once::new(),
+            alloc_decoding_state,
+            dep_node_index: AtomicCell::new(DepNodeIndex::INVALID),
+            cnum,
+            cnum_map,
+            dependencies,
+            dep_kind: Lock::new(dep_kind),
+            source,
+            private_dep,
+            host_hash,
+            extern_crate: Lock::new(None),
+        }
+    }
+
     fn is_proc_macro_crate(&self) -> bool {
         self.root.proc_macro_decls_static.is_some()
     }
@@ -1391,7 +1500,7 @@ impl<'a, 'tcx> CrateMetadata {
             // would always write the same value.
 
             let def_path_hash = self.def_path_hash(CRATE_DEF_INDEX);
-            let dep_node = def_path_hash.to_dep_node(DepKind::CrateMetadata);
+            let dep_node = def_path_hash.to_dep_node(dep_graph::DepKind::CrateMetadata);
 
             dep_node_index = tcx.dep_graph.dep_node_index_of(&dep_node);
             assert!(dep_node_index != DepNodeIndex::INVALID);

--- a/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
+++ b/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
@@ -410,7 +410,7 @@ impl cstore::CStore {
         let _prof_timer = sess.prof.generic_activity("metadata_load_macro");
 
         let data = self.get_crate_data(id.krate);
-        if data.is_proc_macro_crate() {
+        if data.root.is_proc_macro_crate() {
             return LoadedMacro::ProcMacro(data.load_proc_macro(id.index, sess));
         }
 

--- a/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
+++ b/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
@@ -52,7 +52,7 @@ macro_rules! provide {
                 assert!(!$def_id.is_local());
 
                 let $cdata = $tcx.crate_data_as_any($def_id.krate);
-                let $cdata = $cdata.downcast_ref::<cstore::CrateMetadata>()
+                let $cdata = $cdata.downcast_ref::<rmeta::CrateMetadata>()
                     .expect("CrateStore created data is not a CrateMetadata");
 
                 if $tcx.dep_graph.is_fully_enabled() {

--- a/src/librustc_metadata/rmeta/mod.rs
+++ b/src/librustc_metadata/rmeta/mod.rs
@@ -51,7 +51,7 @@ crate const METADATA_HEADER: &[u8; 8] =
 
 /// Additional metadata for a `Lazy<T>` where `T` may not be `Sized`,
 /// e.g. for `Lazy<[T]>`, this is the length (count of `T` values).
-crate trait LazyMeta {
+trait LazyMeta {
     type Meta: Copy + 'static;
 
     /// Returns the minimum encoded size.
@@ -105,7 +105,7 @@ impl<T: Encodable> LazyMeta for [T] {
 #[must_use]
 // FIXME(#59875) the `Meta` parameter only exists to dodge
 // invariance wrt `T` (coming from the `meta: T::Meta` field).
-crate struct Lazy<T, Meta = <T as LazyMeta>::Meta>
+struct Lazy<T, Meta = <T as LazyMeta>::Meta>
     where T: ?Sized + LazyMeta<Meta = Meta>,
           Meta: 'static + Copy,
 {
@@ -188,7 +188,7 @@ crate struct CrateRoot<'tcx> {
     proc_macro_decls_static: Option<DefIndex>,
     proc_macro_stability: Option<attr::Stability>,
 
-    pub crate_deps: Lazy<[CrateDep]>,
+    crate_deps: Lazy<[CrateDep]>,
     dylib_dependency_formats: Lazy<[Option<LinkagePreference>]>,
     lib_features: Lazy<[(Symbol, Option<Symbol>)]>,
     lang_items: Lazy<[(DefIndex, usize)]>,
@@ -204,9 +204,8 @@ crate struct CrateRoot<'tcx> {
 
     per_def: LazyPerDefTables<'tcx>,
 
-    /// The DefIndex's of any proc macros delcared by
-    /// this crate
-    pub proc_macro_data: Option<Lazy<[DefIndex]>>,
+    /// The DefIndex's of any proc macros delcared by this crate.
+    proc_macro_data: Option<Lazy<[DefIndex]>>,
 
     compiler_builtins: bool,
     pub needs_allocator: bool,

--- a/src/librustc_metadata/rmeta/mod.rs
+++ b/src/librustc_metadata/rmeta/mod.rs
@@ -14,6 +14,7 @@ use rustc::ty::{self, Ty, ReprOptions};
 use rustc_target::spec::{PanicStrategy, TargetTriple};
 use rustc_index::vec::IndexVec;
 use rustc_data_structures::svh::Svh;
+use rustc_data_structures::sync::MetadataRef;
 use rustc_serialize::Encodable;
 use syntax::{ast, attr};
 use syntax::edition::Edition;
@@ -24,6 +25,7 @@ use std::marker::PhantomData;
 use std::num::NonZeroUsize;
 
 pub use decoder::{provide, provide_extern};
+crate use decoder::{ImportedSourceFile, MetadataBlob};
 
 mod decoder;
 mod encoder;

--- a/src/librustc_metadata/rmeta/mod.rs
+++ b/src/librustc_metadata/rmeta/mod.rs
@@ -25,7 +25,7 @@ use std::marker::PhantomData;
 use std::num::NonZeroUsize;
 
 pub use decoder::{provide, provide_extern};
-crate use decoder::{ImportedSourceFile, MetadataBlob};
+crate use decoder::{CrateMetadata, CrateNumMap, MetadataBlob};
 
 mod decoder;
 mod encoder;
@@ -197,10 +197,10 @@ crate struct CrateRoot<'tcx> {
     native_libraries: Lazy<[NativeLibrary]>,
     foreign_modules: Lazy<[ForeignModule]>,
     source_map: Lazy<[syntax_pos::SourceFile]>,
-    pub def_path_table: Lazy<hir::map::definitions::DefPathTable>,
-    pub impls: Lazy<[TraitImpls]>,
+    def_path_table: Lazy<hir::map::definitions::DefPathTable>,
+    impls: Lazy<[TraitImpls]>,
     exported_symbols: Lazy!([(ExportedSymbol<'tcx>, SymbolExportLevel)]),
-    pub interpret_alloc_index: Lazy<[u32]>,
+    interpret_alloc_index: Lazy<[u32]>,
 
     per_def: LazyPerDefTables<'tcx>,
 
@@ -229,8 +229,8 @@ crate struct CrateDep {
 
 #[derive(RustcEncodable, RustcDecodable)]
 crate struct TraitImpls {
-    pub trait_id: (u32, DefIndex),
-    pub impls: Lazy<[DefIndex]>,
+    trait_id: (u32, DefIndex),
+    impls: Lazy<[DefIndex]>,
 }
 
 #[derive(RustcEncodable, RustcDecodable)]


### PR DESCRIPTION
Continuation of https://github.com/rust-lang/rust/pull/66056.

The most notable change here is that `CrateMetadata` is moved from `cstore.rs` to `decoder.rs`.
Most of uses of `CrateMetadata` fields are in the decoder and uses of `root: CrateRoot` and other fields are so intertwined with each other that it would be hard to move a part of them into `cstore.rs` to privatize `CrateMetadata` fields, so we are going the other way round.

`cstore.rs` can probably be dismantled now, but I'll leave this to some other day.
Similarly, remaining `CrateMetadata` fields can be privatized by introducing some getter/setter methods, but not today.

r? @eddyb 