### PR TITLE
Fix #53820

### DIFF
--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -969,19 +969,21 @@ impl<'tcx> Constructor<'tcx> {
                 }
                 VarLen(prefix, _) => {
                     let mut prefix: Vec<_> = subpatterns.by_ref().take(prefix as usize).collect();
-                    let mut suffix: Vec<_> = subpatterns.collect();
                     if slice.array_len.is_some() {
                         // Improves diagnostics a bit: if the type is a known-size array, instead
                         // of reporting `[x, _, .., _, y]`, we prefer to report `[x, .., y]`.
                         // This is incorrect if the size is not known, since `[_, ..]` captures
                         // arrays of lengths `>= 1` whereas `[..]` captures any length.
-                        while !suffix.is_empty() && suffix.first().unwrap().is_wildcard() {
-                            suffix.remove(0);
-                        }
                         while !prefix.is_empty() && prefix.last().unwrap().is_wildcard() {
                             prefix.pop();
                         }
                     }
+                    let suffix: Vec<_> = if slice.array_len.is_some() {
+                        // Same as above.
+                        subpatterns.skip_while(Pat::is_wildcard).collect()
+                    } else {
+                        subpatterns.collect()
+                    };
                     let wild = Pat::wildcard_from_ty(ty);
                     PatKind::Slice { prefix, slice: Some(wild), suffix }
                 }

--- a/src/test/ui/pattern/issue-53820-slice-pattern-large-array.rs
+++ b/src/test/ui/pattern/issue-53820-slice-pattern-large-array.rs
@@ -1,0 +1,10 @@
+// check-pass
+#![feature(slice_patterns)]
+
+fn main() {
+    const LARGE_SIZE: usize = 1024 * 1024;
+    let [..] = [0u8; LARGE_SIZE];
+    match [0u8; LARGE_SIZE] {
+        [..] => {}
+    }
+}

--- a/src/test/ui/pattern/issue-53820-slice-pattern-large-array.rs
+++ b/src/test/ui/pattern/issue-53820-slice-pattern-large-array.rs
@@ -1,4 +1,7 @@
 // check-pass
+
+// This used to cause a stack overflow in the compiler.
+
 #![feature(slice_patterns)]
 
 fn main() {

--- a/src/test/ui/pattern/usefulness/match-byte-array-patterns-2.stderr
+++ b/src/test/ui/pattern/usefulness/match-byte-array-patterns-2.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `&[_, _, _, _]` not covered
+error[E0004]: non-exhaustive patterns: `&[..]` not covered
   --> $DIR/match-byte-array-patterns-2.rs:4:11
    |
 LL |     match buf {
-   |           ^^^ pattern `&[_, _, _, _]` not covered
+   |           ^^^ pattern `&[..]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 

--- a/src/test/ui/pattern/usefulness/slice-patterns-exhaustiveness.rs
+++ b/src/test/ui/pattern/usefulness/slice-patterns-exhaustiveness.rs
@@ -5,6 +5,20 @@ fn main() {
     let s1: &[bool; 1] = &[false; 1];
     let s2: &[bool; 2] = &[false; 2];
     let s3: &[bool; 3] = &[false; 3];
+    let s10: &[bool; 10] = &[false; 10];
+
+    match s2 {
+    //~^ ERROR `&[false, _]` not covered
+        [true, .., true] => {}
+    }
+    match s3 {
+    //~^ ERROR `&[false, _, _]` not covered
+        [true, .., true] => {}
+    }
+    match s10 {
+    //~^ ERROR `&[false, _, _, _, _, _, _, _, _, _]` not covered
+        [true, .., true] => {}
+    }
 
     match s1 {
         [true, ..] => {}
@@ -27,10 +41,6 @@ fn main() {
         [.., false] => {}
     }
 
-    match s3 {
-    //~^ ERROR `&[false, _, _]` not covered
-        [true, .., true] => {}
-    }
     match s {
     //~^ ERROR `&[_, ..]` not covered
         [] => {}

--- a/src/test/ui/pattern/usefulness/slice-patterns-exhaustiveness.rs
+++ b/src/test/ui/pattern/usefulness/slice-patterns-exhaustiveness.rs
@@ -12,11 +12,11 @@ fn main() {
         [true, .., true] => {}
     }
     match s3 {
-    //~^ ERROR `&[false, _, _]` not covered
+    //~^ ERROR `&[false, .., _]` not covered
         [true, .., true] => {}
     }
     match s10 {
-    //~^ ERROR `&[false, _, _, _, _, _, _, _, _, _]` not covered
+    //~^ ERROR `&[false, .., _]` not covered
         [true, .., true] => {}
     }
 
@@ -30,7 +30,7 @@ fn main() {
         [.., false] => {}
     }
     match s3 {
-    //~^ ERROR `&[false, _, true]` not covered
+    //~^ ERROR `&[false, .., true]` not covered
         [true, ..] => {}
         [.., false] => {}
     }

--- a/src/test/ui/pattern/usefulness/slice-patterns-exhaustiveness.rs
+++ b/src/test/ui/pattern/usefulness/slice-patterns-exhaustiveness.rs
@@ -12,11 +12,11 @@ fn main() {
         [true, .., true] => {}
     }
     match s3 {
-    //~^ ERROR `&[false, .., _]` not covered
+    //~^ ERROR `&[false, ..]` not covered
         [true, .., true] => {}
     }
     match s10 {
-    //~^ ERROR `&[false, .., _]` not covered
+    //~^ ERROR `&[false, ..]` not covered
         [true, .., true] => {}
     }
 

--- a/src/test/ui/pattern/usefulness/slice-patterns-exhaustiveness.stderr
+++ b/src/test/ui/pattern/usefulness/slice-patterns-exhaustiveness.stderr
@@ -6,19 +6,19 @@ LL |     match s2 {
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
-error[E0004]: non-exhaustive patterns: `&[false, _, _]` not covered
+error[E0004]: non-exhaustive patterns: `&[false, .., _]` not covered
   --> $DIR/slice-patterns-exhaustiveness.rs:14:11
    |
 LL |     match s3 {
-   |           ^^ pattern `&[false, _, _]` not covered
+   |           ^^ pattern `&[false, .., _]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
-error[E0004]: non-exhaustive patterns: `&[false, _, _, _, _, _, _, _, _, _]` not covered
+error[E0004]: non-exhaustive patterns: `&[false, .., _]` not covered
   --> $DIR/slice-patterns-exhaustiveness.rs:18:11
    |
 LL |     match s10 {
-   |           ^^^ pattern `&[false, _, _, _, _, _, _, _, _, _]` not covered
+   |           ^^^ pattern `&[false, .., _]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
@@ -30,11 +30,11 @@ LL |     match s2 {
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
-error[E0004]: non-exhaustive patterns: `&[false, _, true]` not covered
+error[E0004]: non-exhaustive patterns: `&[false, .., true]` not covered
   --> $DIR/slice-patterns-exhaustiveness.rs:32:11
    |
 LL |     match s3 {
-   |           ^^ pattern `&[false, _, true]` not covered
+   |           ^^ pattern `&[false, .., true]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 

--- a/src/test/ui/pattern/usefulness/slice-patterns-exhaustiveness.stderr
+++ b/src/test/ui/pattern/usefulness/slice-patterns-exhaustiveness.stderr
@@ -6,19 +6,19 @@ LL |     match s2 {
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
-error[E0004]: non-exhaustive patterns: `&[false, .., _]` not covered
+error[E0004]: non-exhaustive patterns: `&[false, ..]` not covered
   --> $DIR/slice-patterns-exhaustiveness.rs:14:11
    |
 LL |     match s3 {
-   |           ^^ pattern `&[false, .., _]` not covered
+   |           ^^ pattern `&[false, ..]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
-error[E0004]: non-exhaustive patterns: `&[false, .., _]` not covered
+error[E0004]: non-exhaustive patterns: `&[false, ..]` not covered
   --> $DIR/slice-patterns-exhaustiveness.rs:18:11
    |
 LL |     match s10 {
-   |           ^^^ pattern `&[false, .., _]` not covered
+   |           ^^^ pattern `&[false, ..]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 

--- a/src/test/ui/pattern/usefulness/slice-patterns-exhaustiveness.stderr
+++ b/src/test/ui/pattern/usefulness/slice-patterns-exhaustiveness.stderr
@@ -1,5 +1,29 @@
+error[E0004]: non-exhaustive patterns: `&[false, _]` not covered
+  --> $DIR/slice-patterns-exhaustiveness.rs:10:11
+   |
+LL |     match s2 {
+   |           ^^ pattern `&[false, _]` not covered
+   |
+   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+
+error[E0004]: non-exhaustive patterns: `&[false, _, _]` not covered
+  --> $DIR/slice-patterns-exhaustiveness.rs:14:11
+   |
+LL |     match s3 {
+   |           ^^ pattern `&[false, _, _]` not covered
+   |
+   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+
+error[E0004]: non-exhaustive patterns: `&[false, _, _, _, _, _, _, _, _, _]` not covered
+  --> $DIR/slice-patterns-exhaustiveness.rs:18:11
+   |
+LL |     match s10 {
+   |           ^^^ pattern `&[false, _, _, _, _, _, _, _, _, _]` not covered
+   |
+   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+
 error[E0004]: non-exhaustive patterns: `&[false, true]` not covered
-  --> $DIR/slice-patterns-exhaustiveness.rs:13:11
+  --> $DIR/slice-patterns-exhaustiveness.rs:27:11
    |
 LL |     match s2 {
    |           ^^ pattern `&[false, true]` not covered
@@ -7,7 +31,7 @@ LL |     match s2 {
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: `&[false, _, true]` not covered
-  --> $DIR/slice-patterns-exhaustiveness.rs:18:11
+  --> $DIR/slice-patterns-exhaustiveness.rs:32:11
    |
 LL |     match s3 {
    |           ^^ pattern `&[false, _, true]` not covered
@@ -15,23 +39,15 @@ LL |     match s3 {
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: `&[false, .., true]` not covered
-  --> $DIR/slice-patterns-exhaustiveness.rs:23:11
+  --> $DIR/slice-patterns-exhaustiveness.rs:37:11
    |
 LL |     match s {
    |           ^ pattern `&[false, .., true]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
-error[E0004]: non-exhaustive patterns: `&[false, _, _]` not covered
-  --> $DIR/slice-patterns-exhaustiveness.rs:30:11
-   |
-LL |     match s3 {
-   |           ^^ pattern `&[false, _, _]` not covered
-   |
-   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
-
 error[E0004]: non-exhaustive patterns: `&[_, ..]` not covered
-  --> $DIR/slice-patterns-exhaustiveness.rs:34:11
+  --> $DIR/slice-patterns-exhaustiveness.rs:44:11
    |
 LL |     match s {
    |           ^ pattern `&[_, ..]` not covered
@@ -39,7 +55,7 @@ LL |     match s {
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: `&[_, _, ..]` not covered
-  --> $DIR/slice-patterns-exhaustiveness.rs:38:11
+  --> $DIR/slice-patterns-exhaustiveness.rs:48:11
    |
 LL |     match s {
    |           ^ pattern `&[_, _, ..]` not covered
@@ -47,7 +63,7 @@ LL |     match s {
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: `&[false, ..]` not covered
-  --> $DIR/slice-patterns-exhaustiveness.rs:43:11
+  --> $DIR/slice-patterns-exhaustiveness.rs:53:11
    |
 LL |     match s {
    |           ^ pattern `&[false, ..]` not covered
@@ -55,7 +71,7 @@ LL |     match s {
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: `&[false, _, ..]` not covered
-  --> $DIR/slice-patterns-exhaustiveness.rs:48:11
+  --> $DIR/slice-patterns-exhaustiveness.rs:58:11
    |
 LL |     match s {
    |           ^ pattern `&[false, _, ..]` not covered
@@ -63,7 +79,7 @@ LL |     match s {
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: `&[_, .., false]` not covered
-  --> $DIR/slice-patterns-exhaustiveness.rs:54:11
+  --> $DIR/slice-patterns-exhaustiveness.rs:64:11
    |
 LL |     match s {
    |           ^ pattern `&[_, .., false]` not covered
@@ -71,7 +87,7 @@ LL |     match s {
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: `&[_, _, .., true]` not covered
-  --> $DIR/slice-patterns-exhaustiveness.rs:61:11
+  --> $DIR/slice-patterns-exhaustiveness.rs:71:11
    |
 LL |     match s {
    |           ^ pattern `&[_, _, .., true]` not covered
@@ -79,13 +95,13 @@ LL |     match s {
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: `&[true, _, .., _]` not covered
-  --> $DIR/slice-patterns-exhaustiveness.rs:68:11
+  --> $DIR/slice-patterns-exhaustiveness.rs:78:11
    |
 LL |     match s {
    |           ^ pattern `&[true, _, .., _]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
-error: aborting due to 11 previous errors
+error: aborting due to 13 previous errors
 
 For more information about this error, try `rustc --explain E0004`.


### PR DESCRIPTION
This fixes ICE #53820 by being more clever when matching large arrays with slice patterns.
In particular, it avoids treating large arrays like large tuples, and instead reuses the `VarLenSlice` constructor behaviour to only consider as little values as needed.
As a side-effect, such matches also get improved diagnostics, by reporting `[true, ..]` missing instead of `[true, _, _, _, _, _, _, _]`.