### PR TITLE
Add unix::process::CommandExt::arg0

### DIFF
--- a/src/libstd/sys/unix/ext/process.rs
+++ b/src/libstd/sys/unix/ext/process.rs
@@ -2,6 +2,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+use crate::ffi::OsStr;
 use crate::io;
 use crate::os::unix::io::{FromRawFd, RawFd, AsRawFd, IntoRawFd};
 use crate::process;
@@ -103,6 +104,14 @@ pub trait CommandExt {
     /// cross-platform `spawn` instead.
     #[stable(feature = "process_exec2", since = "1.9.0")]
     fn exec(&mut self) -> io::Error;
+
+    /// Set executable argument
+    ///
+    /// Set the first process argument, `argv[0]`, to something other than the
+    /// default executable path.
+    #[unstable(feature = "process_set_argv0", issue = "66510")]
+    fn arg0<S>(&mut self, arg: S) -> &mut process::Command
+        where S: AsRef<OsStr>;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -126,6 +135,13 @@ impl CommandExt for process::Command {
 
     fn exec(&mut self) -> io::Error {
         self.as_inner_mut().exec(sys::process::Stdio::Inherit)
+    }
+
+    fn arg0<S>(&mut self, arg: S) -> &mut process::Command
+        where S: AsRef<OsStr>
+    {
+        self.as_inner_mut().set_arg_0(arg.as_ref());
+        self
     }
 }
 

--- a/src/libstd/sys/unix/process/process_fuchsia.rs
+++ b/src/libstd/sys/unix/process/process_fuchsia.rs
@@ -110,7 +110,7 @@ impl Command {
             ZX_HANDLE_INVALID,
             FDIO_SPAWN_CLONE_JOB | FDIO_SPAWN_CLONE_LDSVC | FDIO_SPAWN_CLONE_NAMESPACE
             | FDIO_SPAWN_CLONE_ENVIRON,  // this is ignored when envp is non-null
-            self.get_argv()[0], self.get_argv().as_ptr(), envp,
+            self.get_program().as_ptr(), self.get_argv().as_ptr(), envp,
             actions.len() as size_t, actions.as_ptr(),
             &mut process_handle,
             ptr::null_mut(),

--- a/src/libstd/sys/unix/process/process_unix.rs
+++ b/src/libstd/sys/unix/process/process_unix.rs
@@ -248,7 +248,7 @@ impl Command {
             *sys::os::environ() = envp.as_ptr();
         }
 
-        libc::execvp(self.get_argv()[0], self.get_argv().as_ptr());
+        libc::execvp(self.get_program().as_ptr(), self.get_argv().as_ptr());
         Err(io::Error::last_os_error())
     }
 
@@ -373,7 +373,7 @@ impl Command {
                 .unwrap_or_else(|| *sys::os::environ() as *const _);
             let ret = libc::posix_spawnp(
                 &mut p.pid,
-                self.get_argv()[0],
+                self.get_program().as_ptr(),
                 file_actions.0.as_ptr(),
                 attrs.0.as_ptr(),
                 self.get_argv().as_ptr() as *const _,

--- a/src/test/ui/command-argv0.rs
+++ b/src/test/ui/command-argv0.rs
@@ -1,0 +1,33 @@
+// run-pass
+
+// ignore-windows - this is a unix-specific test
+// ignore-cloudabi no processes
+// ignore-emscripten no processes
+// ignore-sgx no processes
+#![feature(process_set_argv0)]
+
+use std::env;
+use std::os::unix::process::CommandExt;
+use std::process::Command;
+
+fn main() {
+    let args: Vec<_> = env::args().collect();
+
+    if args.len() > 1 {
+        assert_eq!(args[1], "doing-test");
+        assert_eq!(args[0], "i have a silly name");
+
+        println!("passed");
+        return;
+    }
+
+    let output =
+        Command::new(&args[0]).arg("doing-test").arg0("i have a silly name").output().unwrap();
+    assert!(
+        output.stderr.is_empty(),
+        "Non-empty stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.status.success());
+    assert_eq!(output.stdout, b"passed\n");
+}


### PR DESCRIPTION
This allows argv[0] to be overridden on the executable's command-line. This also makes the program
executed independent of argv[0].

Does Fuchsia have the same semantics? I'm assuming so.

Addresses: #66510