### PR TITLE
Disable gdb pretty printer global section on wasm targets

### DIFF
--- a/src/librustc_target/spec/wasm32_base.rs
+++ b/src/librustc_target/spec/wasm32_base.rs
@@ -140,6 +140,9 @@ pub fn options() -> TargetOptions {
         has_elf_tls: true,
         tls_model: "local-exec".to_string(),
 
+        // gdb scripts don't work on wasm blobs
+        emit_debug_gdb_scripts: false,
+
         .. Default::default()
     }
 }

--- a/src/test/codegen/gdb_debug_script_load.rs
+++ b/src/test/codegen/gdb_debug_script_load.rs
@@ -1,6 +1,8 @@
 // ignore-tidy-linelength
 // ignore-windows
 // ignore-macos
+// ignore-wasm
+// ignore-emscripten
 
 // compile-flags: -g -C no-prepopulate-passes
 


### PR DESCRIPTION
The wasm targets don't support gdb anyway so there's no need for this
section there.