### PR TITLE
Add support for sanitizer recover and tracking origins of uninitialized memory

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -834,6 +834,7 @@ macro_rules! options {
             Some("one of: `address`, `leak`, `memory` or `thread`");
         pub const parse_sanitizer_list: Option<&str> =
             Some("comma separated list of sanitizers");
+        pub const parse_sanitizer_memory_track_origins: Option<&str> = None;
         pub const parse_linker_flavor: Option<&str> =
             Some(::rustc_target::spec::LinkerFlavor::one_of());
         pub const parse_optimization_fuel: Option<&str> =
@@ -1051,6 +1052,22 @@ macro_rules! options {
                 true
             } else {
                 false
+            }
+        }
+
+        fn parse_sanitizer_memory_track_origins(slot: &mut usize, v: Option<&str>) -> bool {
+            match v.map(|s| s.parse()) {
+                None => {
+                    *slot = 2;
+                    true
+                }
+                Some(Ok(i)) if i <= 2 => {
+                    *slot = i;
+                    true
+                }
+                _ => {
+                    false
+                }
             }
         }
 
@@ -1411,6 +1428,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
                                     "use a sanitizer"),
     sanitizer_recover: Vec<Sanitizer> = (vec![], parse_sanitizer_list, [TRACKED],
         "Enable recovery for selected sanitizers"),
+    sanitizer_memory_track_origins: usize = (0, parse_sanitizer_memory_track_origins, [TRACKED],
+        "Enable origins tracking in MemorySanitizer"),
     fuel: Option<(String, u64)> = (None, parse_optimization_fuel, [TRACKED],
         "set the optimization fuel quota for a crate"),
     print_fuel: Option<String> = (None, parse_opt_string, [TRACKED],

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -29,7 +29,7 @@ use std::path::{Path, PathBuf};
 use std::str;
 use std::sync::Arc;
 use std::slice;
-use libc::{c_uint, c_void, c_char, size_t};
+use libc::{c_int, c_uint, c_void, c_char, size_t};
 
 pub const RELOC_MODEL_ARGS : [(&str, llvm::RelocMode); 7] = [
     ("pic", llvm::RelocMode::PIC),
@@ -373,7 +373,7 @@ pub(crate) unsafe fn optimize(cgcx: &CodegenContext<LlvmCodegenBackend>,
                                 recover));
                     }
                     Sanitizer::Memory => {
-                        let track_origins = 0;
+                        let track_origins = config.sanitizer_memory_track_origins as c_int;
                         extra_passes.push(llvm::LLVMRustCreateMemorySanitizerPass(
                                 track_origins, recover));
                     }

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -364,9 +364,9 @@ pub(crate) unsafe fn optimize(cgcx: &CodegenContext<LlvmCodegenBackend>,
             }
 
             if let Some(sanitizer) = &config.sanitizer {
+                let recover = config.sanitizer_recover.contains(sanitizer);
                 match sanitizer {
                     Sanitizer::Address => {
-                        let recover = false;
                         extra_passes.push(llvm::LLVMRustCreateAddressSanitizerFunctionPass(
                                 recover));
                         extra_passes.push(llvm::LLVMRustCreateModuleAddressSanitizerPass(
@@ -374,7 +374,6 @@ pub(crate) unsafe fn optimize(cgcx: &CodegenContext<LlvmCodegenBackend>,
                     }
                     Sanitizer::Memory => {
                         let track_origins = 0;
-                        let recover = false;
                         extra_passes.push(llvm::LLVMRustCreateMemorySanitizerPass(
                                 track_origins, recover));
                     }

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -1670,6 +1670,11 @@ extern "C" {
 
     pub fn LLVMRustPassKind(Pass: &Pass) -> PassKind;
     pub fn LLVMRustFindAndCreatePass(Pass: *const c_char) -> Option<&'static mut Pass>;
+    pub fn LLVMRustCreateAddressSanitizerFunctionPass(Recover: bool) -> &'static mut Pass;
+    pub fn LLVMRustCreateModuleAddressSanitizerPass(Recover: bool) -> &'static mut Pass;
+    pub fn LLVMRustCreateMemorySanitizerPass(TrackOrigins: c_int,
+                                             Recover: bool) -> &'static mut Pass;
+    pub fn LLVMRustCreateThreadSanitizerPass() -> &'static mut Pass;
     pub fn LLVMRustAddPass(PM: &PassManager<'_>, Pass: &'static mut Pass);
     pub fn LLVMRustAddLastExtensionPasses(PMB: &PassManagerBuilder,
                                           Passes: *const &'static mut Pass,

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -60,6 +60,7 @@ pub struct ModuleConfig {
     pub pgo_use: Option<PathBuf>,
 
     pub sanitizer: Option<Sanitizer>,
+    pub sanitizer_recover: Vec<Sanitizer>,
 
     // Flags indicating which outputs to produce.
     pub emit_pre_lto_bc: bool,
@@ -100,6 +101,7 @@ impl ModuleConfig {
             pgo_use: None,
 
             sanitizer: None,
+            sanitizer_recover: Default::default(),
 
             emit_no_opt_bc: false,
             emit_pre_lto_bc: false,
@@ -356,6 +358,7 @@ pub fn start_async_codegen<B: ExtraBackendMethods>(
     modules_config.pgo_gen = sess.opts.cg.profile_generate.clone();
     modules_config.pgo_use = sess.opts.cg.profile_use.clone();
     modules_config.sanitizer = sess.opts.debugging_opts.sanitizer.clone();
+    modules_config.sanitizer_recover = sess.opts.debugging_opts.sanitizer_recover.clone();
     modules_config.opt_level = Some(sess.opts.optimize);
     modules_config.opt_size = Some(sess.opts.optimize);
 

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -59,6 +59,8 @@ pub struct ModuleConfig {
     pub pgo_gen: SwitchWithOptPath,
     pub pgo_use: Option<PathBuf>,
 
+    pub sanitizer: Option<Sanitizer>,
+
     // Flags indicating which outputs to produce.
     pub emit_pre_lto_bc: bool,
     pub emit_no_opt_bc: bool,
@@ -96,6 +98,8 @@ impl ModuleConfig {
 
             pgo_gen: SwitchWithOptPath::Disabled,
             pgo_use: None,
+
+            sanitizer: None,
 
             emit_no_opt_bc: false,
             emit_pre_lto_bc: false,
@@ -345,29 +349,13 @@ pub fn start_async_codegen<B: ExtraBackendMethods>(
     let mut metadata_config = ModuleConfig::new(vec![]);
     let mut allocator_config = ModuleConfig::new(vec![]);
 
-    if let Some(ref sanitizer) = sess.opts.debugging_opts.sanitizer {
-        match *sanitizer {
-            Sanitizer::Address => {
-                modules_config.passes.push("asan".to_owned());
-                modules_config.passes.push("asan-module".to_owned());
-            }
-            Sanitizer::Memory => {
-                modules_config.passes.push("msan".to_owned())
-            }
-            Sanitizer::Thread => {
-                modules_config.passes.push("tsan".to_owned())
-            }
-            _ => {}
-        }
-    }
-
     if sess.opts.debugging_opts.profile {
         modules_config.passes.push("insert-gcov-profiling".to_owned())
     }
 
     modules_config.pgo_gen = sess.opts.cg.profile_generate.clone();
     modules_config.pgo_use = sess.opts.cg.profile_use.clone();
-
+    modules_config.sanitizer = sess.opts.debugging_opts.sanitizer.clone();
     modules_config.opt_level = Some(sess.opts.optimize);
     modules_config.opt_size = Some(sess.opts.optimize);
 

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -61,6 +61,7 @@ pub struct ModuleConfig {
 
     pub sanitizer: Option<Sanitizer>,
     pub sanitizer_recover: Vec<Sanitizer>,
+    pub sanitizer_memory_track_origins: usize,
 
     // Flags indicating which outputs to produce.
     pub emit_pre_lto_bc: bool,
@@ -102,6 +103,7 @@ impl ModuleConfig {
 
             sanitizer: None,
             sanitizer_recover: Default::default(),
+            sanitizer_memory_track_origins: 0,
 
             emit_no_opt_bc: false,
             emit_pre_lto_bc: false,
@@ -359,6 +361,8 @@ pub fn start_async_codegen<B: ExtraBackendMethods>(
     modules_config.pgo_use = sess.opts.cg.profile_use.clone();
     modules_config.sanitizer = sess.opts.debugging_opts.sanitizer.clone();
     modules_config.sanitizer_recover = sess.opts.debugging_opts.sanitizer_recover.clone();
+    modules_config.sanitizer_memory_track_origins =
+        sess.opts.debugging_opts.sanitizer_memory_track_origins;
     modules_config.opt_level = Some(sess.opts.optimize);
     modules_config.opt_size = Some(sess.opts.optimize);
 

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -18,6 +18,9 @@
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 #include "llvm/Transforms/IPO/AlwaysInliner.h"
 #include "llvm/Transforms/IPO/FunctionImport.h"
+#include "llvm/Transforms/Instrumentation/AddressSanitizer.h"
+#include "llvm/Transforms/Instrumentation/MemorySanitizer.h"
+#include "llvm/Transforms/Instrumentation/ThreadSanitizer.h"
 #include "llvm/Transforms/Utils/FunctionImportUtils.h"
 #include "llvm/LTO/LTO.h"
 
@@ -74,6 +77,29 @@ extern "C" LLVMPassRef LLVMRustFindAndCreatePass(const char *PassName) {
     return wrap(PI->createPass());
   }
   return nullptr;
+}
+
+extern "C" LLVMPassRef LLVMRustCreateAddressSanitizerFunctionPass(bool Recover) {
+  const bool CompileKernel = false;
+
+  return wrap(createAddressSanitizerFunctionPass(CompileKernel, Recover));
+}
+
+extern "C" LLVMPassRef LLVMRustCreateModuleAddressSanitizerPass(bool Recover) {
+  const bool CompileKernel = false;
+
+  return wrap(createModuleAddressSanitizerLegacyPassPass(CompileKernel, Recover));
+}
+
+extern "C" LLVMPassRef LLVMRustCreateMemorySanitizerPass(int TrackOrigins, bool Recover) {
+  const bool CompileKernel = false;
+
+  return wrap(createMemorySanitizerLegacyPassPass(
+      MemorySanitizerOptions{TrackOrigins, Recover, CompileKernel}));
+}
+
+extern "C" LLVMPassRef LLVMRustCreateThreadSanitizerPass() {
+  return wrap(createThreadSanitizerLegacyPassPass());
 }
 
 extern "C" LLVMRustPassKind LLVMRustPassKind(LLVMPassRef RustPass) {

--- a/src/test/codegen/sanitizer-memory-track-orgins.rs
+++ b/src/test/codegen/sanitizer-memory-track-orgins.rs
@@ -1,0 +1,28 @@
+// Verifies that MemorySanitizer track-origins level can be controlled
+// with -Zsanitizer-memory-track-origins option.
+//
+// needs-sanitizer-support
+// only-linux
+// only-x86_64
+// revisions:MSAN-0 MSAN-1 MSAN-2
+//
+//[MSAN-0] compile-flags: -Zsanitizer=memory
+//[MSAN-1] compile-flags: -Zsanitizer=memory -Zsanitizer-memory-track-origins=1
+//[MSAN-2] compile-flags: -Zsanitizer=memory -Zsanitizer-memory-track-origins
+
+#![crate_type="lib"]
+
+// MSAN-0-NOT: @__msan_track_origins
+// MSAN-1:     @__msan_track_origins = weak_odr local_unnamed_addr constant i32 1
+// MSAN-2:     @__msan_track_origins = weak_odr local_unnamed_addr constant i32 2
+//
+// MSAN-0-LABEL: define void @copy(
+// MSAN-1-LABEL: define void @copy(
+// MSAN-2-LABEL: define void @copy(
+#[no_mangle]
+pub fn copy(dst: &mut i32, src: &i32) {
+    // MSAN-0-NOT: call i32 @__msan_chain_origin(
+    // MSAN-1-NOT: call i32 @__msan_chain_origin(
+    // MSAN-2:     call i32 @__msan_chain_origin(
+    *dst = *src;
+}

--- a/src/test/codegen/sanitizer-recover.rs
+++ b/src/test/codegen/sanitizer-recover.rs
@@ -1,0 +1,34 @@
+// Verifies that AddressSanitizer and MemorySanitizer
+// recovery mode can be enabled with -Zsanitizer-recover.
+//
+// needs-sanitizer-support
+// only-linux
+// only-x86_64
+// revisions:ASAN ASAN-RECOVER MSAN MSAN-RECOVER
+//
+//[ASAN]         compile-flags: -Zsanitizer=address
+//[ASAN-RECOVER] compile-flags: -Zsanitizer=address -Zsanitizer-recover=address
+//[MSAN]         compile-flags: -Zsanitizer=memory
+//[MSAN-RECOVER] compile-flags: -Zsanitizer=memory  -Zsanitizer-recover=memory
+
+#![crate_type="lib"]
+
+// ASAN-LABEL:         define i32 @penguin(
+// ASAN-RECOVER-LABEL: define i32 @penguin(
+// MSAN-LABEL:         define i32 @penguin(
+// MSAN-RECOVER-LABEL: define i32 @penguin(
+#[no_mangle]
+pub fn penguin(p: &mut i32) -> i32 {
+    // ASAN:             call void @__asan_report_load4(i64 %0)
+    // ASAN:             unreachable
+    //
+    // ASAN-RECOVER:     call void @__asan_report_load4_noabort(
+    // ASAN-RECOVER-NOT: unreachable
+    //
+    // MSAN:             call void @__msan_warning_noreturn()
+    // MSAN:             unreachable
+    //
+    // MSAN-RECOVER:     call void @__msan_warning()
+    // MSAN-RECOVER-NOT: unreachable
+    *p
+}


### PR DESCRIPTION
* Add support for sanitizer recovery `-Zsanitizer-recover=...` (equivalent to `-fsanitize-recover` in clang).
* Add support for tracking origins of uninitialized memory in MemorySanitizer `-Zsanitizer-memory-track-origins` (equivalent to `-fsanitize-memory-track-origins` in clang).
