### PR TITLE
resolve: Give derive helpers highest priority during resolution

### DIFF
--- a/src/test/ui/proc-macro/auxiliary/derive-helper-shadowing-2.rs
+++ b/src/test/ui/proc-macro/auxiliary/derive-helper-shadowing-2.rs
@@ -1,0 +1,12 @@
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+use proc_macro::*;
+
+#[proc_macro_derive(same_name, attributes(same_name))]
+pub fn derive_a(_: TokenStream) -> TokenStream {
+    TokenStream::new()
+}

--- a/src/test/ui/proc-macro/derive-helper-shadowing-2.rs
+++ b/src/test/ui/proc-macro/derive-helper-shadowing-2.rs
@@ -1,0 +1,16 @@
+// If a derive macro introduces a helper attribute with the same name as that macro,
+// then make sure that it's usable without ambiguities.
+
+// check-pass
+// aux-build:derive-helper-shadowing-2.rs
+
+#[macro_use]
+extern crate derive_helper_shadowing_2;
+
+#[derive(same_name)]
+struct S {
+    #[same_name] // OK, no ambiguity, derive helpers have highest priority
+    field: u8,
+}
+
+fn main() {}

--- a/src/test/ui/proc-macro/derive-helper-shadowing.rs
+++ b/src/test/ui/proc-macro/derive-helper-shadowing.rs
@@ -19,11 +19,11 @@ macro_rules! gen_helper_use {
 #[empty_helper] //~ ERROR `empty_helper` is ambiguous
 #[derive(Empty)]
 struct S {
-    #[empty_helper] //~ ERROR `empty_helper` is ambiguous
+    #[empty_helper] // OK, no ambiguity, derive helpers have highest priority
     field: [u8; {
         use empty_helper; //~ ERROR `empty_helper` is ambiguous
 
-        #[empty_helper] //~ ERROR `empty_helper` is ambiguous
+        #[empty_helper] // OK, no ambiguity, derive helpers have highest priority
         struct U;
 
         mod inner {

--- a/src/test/ui/proc-macro/derive-helper-shadowing.stderr
+++ b/src/test/ui/proc-macro/derive-helper-shadowing.stderr
@@ -61,42 +61,6 @@ LL | use test_macros::empty_attr as empty_helper;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: use `crate::empty_helper` to refer to this attribute macro unambiguously
 
-error[E0659]: `empty_helper` is ambiguous (derive helper attribute vs any other name)
-  --> $DIR/derive-helper-shadowing.rs:22:7
-   |
-LL |     #[empty_helper]
-   |       ^^^^^^^^^^^^ ambiguous name
-   |
-note: `empty_helper` could refer to the derive helper attribute defined here
-  --> $DIR/derive-helper-shadowing.rs:20:10
-   |
-LL | #[derive(Empty)]
-   |          ^^^^^
-note: `empty_helper` could also refer to the attribute macro imported here
-  --> $DIR/derive-helper-shadowing.rs:10:5
-   |
-LL | use test_macros::empty_attr as empty_helper;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: use `crate::empty_helper` to refer to this attribute macro unambiguously
-
-error[E0659]: `empty_helper` is ambiguous (derive helper attribute vs any other name)
-  --> $DIR/derive-helper-shadowing.rs:26:11
-   |
-LL |         #[empty_helper]
-   |           ^^^^^^^^^^^^ ambiguous name
-   |
-note: `empty_helper` could refer to the derive helper attribute defined here
-  --> $DIR/derive-helper-shadowing.rs:20:10
-   |
-LL | #[derive(Empty)]
-   |          ^^^^^
-note: `empty_helper` could also refer to the attribute macro imported here
-  --> $DIR/derive-helper-shadowing.rs:10:5
-   |
-LL | use test_macros::empty_attr as empty_helper;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: use `crate::empty_helper` to refer to this attribute macro unambiguously
-
-error: aborting due to 7 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0659`.


### PR DESCRIPTION
So they just shadow everything else and don't create ambiguity errors.
This matches the old pre-#64694 behavior most closely.

---
The change doesn't apply to this "compatibility" case
```rust
#[trait_helper] // The helper attribute is used before it introduced.
                        // Sadly, compiles on stable, supported via hacks.
                        // I plan to make a compatibility warning for this.
#[derive(Trait)]
struct S;
``` 
, such attributes still create ambiguities, but #64694 didn't change anything for this case.

Fixes https://github.com/rust-lang/rust/issues/66508
Fixes https://github.com/rust-lang/rust/issues/66525