### PR TITLE
Add `ExactSizeIterator` impl for `iter::Chain`

### DIFF
--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -1,3 +1,7 @@
+// ignore-tidy-filelength
+// This file almost exclusively consists of the definition of `Iterator`. We
+// can't split that into multiple files.
+
 use crate::cmp::{self, Ordering};
 use crate::ops::{Add, Try};
 
@@ -387,6 +391,26 @@ pub trait Iterator {
     ///
     /// [`once`] is commonly used to adapt a single value into a chain of
     /// other kinds of iteration.
+    ///
+    ///
+    /// # Overflowing behavior for long iterators
+    ///
+    /// This method allows to easily build an iterator that yields more than
+    /// [`usize::MAX`] items. In that case, some methods that return `usize`
+    /// are not guarded against overflow. For example, this includes the
+    /// following methods:
+    ///
+    /// - [`Iterator::count`]
+    /// - [`Iterator::enumerate`]
+    /// - [`Iterator::position`] and [`Iterator::rposition`]
+    /// - [`ExactSizeIterator::len`]
+    ///
+    /// An overflow in those methods leads to a wrong result or a panic. If
+    /// debug assertions are enabled, a panic is guaranteed.
+    ///
+    ///
+    /// [`usize::MAX`]: ../../std/usize/constant.MAX.html
+    ///
     ///
     /// # Examples
     ///

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -257,6 +257,50 @@ fn test_iterator_chain_size_hint() {
 }
 
 #[test]
+fn test_iterator_chain_len() {
+    let xs = [0, 1, 2];
+    let ys = [30, 40, 50, 60];
+
+    // First iterator is exhausted first
+    let mut iter = xs.iter().chain(&ys);
+    assert_eq!(iter.len(), 7);
+    assert_eq!(iter.next(), Some(&0));
+    assert_eq!(iter.len(), 6);
+    assert_eq!(iter.next(), Some(&1));
+    assert_eq!(iter.len(), 5);
+    assert_eq!(iter.next_back(), Some(&60));
+    assert_eq!(iter.len(), 4);
+    assert_eq!(iter.next(), Some(&2));
+    assert_eq!(iter.len(), 3);
+    assert_eq!(iter.next(), Some(&30));
+    assert_eq!(iter.len(), 2);
+    assert_eq!(iter.next(), Some(&40));
+    assert_eq!(iter.len(), 1);
+    assert_eq!(iter.next(), Some(&50));
+    assert_eq!(iter.len(), 0);
+    assert_eq!(iter.next(), None);
+
+    // Second iterator is exhausted first
+    let mut iter = xs.iter().chain(&ys);
+    assert_eq!(iter.len(), 7);
+    assert_eq!(iter.next_back(), Some(&60));
+    assert_eq!(iter.len(), 6);
+    assert_eq!(iter.next(), Some(&0));
+    assert_eq!(iter.len(), 5);
+    assert_eq!(iter.next_back(), Some(&50));
+    assert_eq!(iter.len(), 4);
+    assert_eq!(iter.next_back(), Some(&40));
+    assert_eq!(iter.len(), 3);
+    assert_eq!(iter.next_back(), Some(&30));
+    assert_eq!(iter.len(), 2);
+    assert_eq!(iter.next(), Some(&1));
+    assert_eq!(iter.len(), 1);
+    assert_eq!(iter.next(), Some(&2));
+    assert_eq!(iter.len(), 0);
+    assert_eq!(iter.next(), None);
+}
+
+#[test]
 fn test_zip_nth() {
     let xs = [0, 1, 2, 4, 5];
     let ys = [10, 11, 12];


### PR DESCRIPTION
In the issue about this impl (#34433), people concluded that it was impossible to add due to `usize` overflowing: if we create an iterator with `Chain` that contains more than `usize::MAX` items, then `ExactSizeIterator::len` would not be able to return the correct value. This is true, but I don't think that's a reason not to add the impl:

- There are plenty of ways to create iterators with more than `usize::MAX` elements without using `Chain`. `Range<u128>`, `iter::repeat`, `flat_map`, just to name a few.
- There are already multiple examples of functions involving `usize` that state they would panic on overflow: `Iterator::count`, `Iterator::enumerate`, `Iterator::position`. 

So the "long iterator `usize` overflow" problem is already a thing and more importantly: it is already well documented how affected methods behave. So I don't think it's a problem to add this impl if it is properly documented (which hopefully this PR does). After that issue was closed, two people mentioned how useful that impl would be and that a panic in the overflow case would be certainly fine. I agree with that.


r? @SimonSapin
CC @oli-obk @RalfJung @bluss (some people involved in the original issue)