### PR TITLE
Avoid ICE when `break`ing to an unreachable label

### DIFF
--- a/src/test/ui/issues/issue-62480.rs
+++ b/src/test/ui/issues/issue-62480.rs
@@ -1,0 +1,10 @@
+#![feature(label_break_value)]
+
+fn main() {
+    // This used to ICE during liveness check because `target_id` passed to
+    // `propagate_through_expr` would be the closure and not the `loop`, which wouldn't be found in
+    // `self.break_ln`. (#62480)
+    'a: {
+        || break 'a //~ ERROR `break` to unknown label
+    }
+}

--- a/src/test/ui/issues/issue-62480.stderr
+++ b/src/test/ui/issues/issue-62480.stderr
@@ -1,0 +1,8 @@
+error: `break` to unknown label
+  --> $DIR/issue-62480.rs:8:12
+   |
+LL |         || break 'a
+   |            ^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fix #62480.