### PR TITLE
Remove compiler_builtins_lib feature from libstd

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -244,7 +244,6 @@
 #![feature(cfg_target_thread_local)]
 #![feature(char_error_internals)]
 #![feature(clamp)]
-#![feature(compiler_builtins_lib)]
 #![feature(concat_idents)]
 #![feature(const_cstr_unchecked)]
 #![feature(const_raw_ptr_deref)]


### PR DESCRIPTION
Test if we can close #66368 by this patch.