### PR TITLE
Remove duplicate function

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -84,13 +84,6 @@ const ICE_REPORT_COMPILER_FLAGS_EXCLUDE: &[&str] = &["metadata", "extra-filename
 
 const ICE_REPORT_COMPILER_FLAGS_STRIP_VALUE: &[&str] = &["incremental"];
 
-pub fn source_name(input: &Input) -> FileName {
-    match *input {
-        Input::File(ref ifile) => ifile.clone().into(),
-        Input::Str { ref name, .. } => name.clone(),
-    }
-}
-
 pub fn abort_on_err<T>(result: Result<T, ErrorReported>, sess: &Session) -> T {
     match result {
         Err(..) => {

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -24,10 +24,6 @@ pub use self::PpSourceMode::*;
 pub use self::PpMode::*;
 use crate::abort_on_err;
 
-use crate::source_name;
-
-
-
 // This slightly awkward construction is to allow for each PpMode to
 // choose whether it needs to do analyses (which can consume the
 // Session) and then pass through the session (now attached to the
@@ -391,7 +387,7 @@ impl<'a, 'tcx> pprust_hir::PpAnn for TypedAnnotation<'a, 'tcx> {
 }
 
 fn get_source(input: &Input, sess: &Session) -> (String, FileName) {
-    let src_name = source_name(input);
+    let src_name = input.source_name();
     let src = String::clone(&sess.source_map()
         .get_source_file(&src_name)
         .unwrap()


### PR DESCRIPTION
Function `source_name` declared in file

[src/librustc_driver/lib.rs](https://github.com/rust-lang/rust/blob/master/src/librustc_driver/lib.rs#L87)

is a duplicate of the function by the same name declared in file

[src/librustc/session/config.rs](https://github.com/rust-lang/rust/blob/master/src/librustc/session/config.rs#L511)