### PR TITLE
Fallback to .init_array when no arguments are available on glibc Linux

### DIFF
--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -702,6 +702,11 @@ pub struct ArgsOs { inner: sys::args::Args }
 /// (such as `*` and `?`). On Windows this is not done, and such arguments are
 /// passed as-is.
 ///
+/// On glibc Linux, arguments are retrieved by placing a function in .init_array.
+/// glibc passes argc, argv, and envp to functions in .init_array, as a non-standard extension.
+/// This allows `std::env::args` to work even in a `cdylib` or `staticlib`, as it does on macOS
+/// and Windows.
+///
 /// # Panics
 ///
 /// The returned iterator will panic during iteration if any argument to the
@@ -731,6 +736,11 @@ pub fn args() -> Args {
 /// The first element is traditionally the path of the executable, but it can be
 /// set to arbitrary text, and it may not even exist, so this property should
 /// not be relied upon for security purposes.
+///
+/// On glibc Linux, arguments are retrieved by placing a function in .init_array.
+/// glibc passes argc, argv, and envp to functions in .init_array, as a non-standard extension.
+/// This allows `std::env::args` to work even in a `cdylib` or `staticlib`, as it does on macOS
+/// and Windows.
 ///
 /// # Examples
 ///

--- a/src/libstd/sys/unix/args.rs
+++ b/src/libstd/sys/unix/args.rs
@@ -78,6 +78,8 @@ mod imp {
         ARGV = argv;
     }
 
+    /// glibc passes argc, argv, and envp to functions in .init_array, as a non-standard extension.
+    /// This allows `std::env::args` to work even in a `cdylib`, as it does on macOS and Windows.
     #[cfg(all(target_os = "linux", target_env = "gnu"))]
     #[used]
     #[link_section = ".init_array.00099"]

--- a/src/libstd/sys/unix/args.rs
+++ b/src/libstd/sys/unix/args.rs
@@ -80,7 +80,7 @@ mod imp {
 
     #[cfg(all(target_os = "linux", target_env = "gnu"))]
     #[used]
-    #[link_section = ".init_array"]
+    #[link_section = ".init_array.00099"]
     static ARGV_INIT_ARRAY: extern "C" fn(
         crate::os::raw::c_int,
         *const *const u8,

--- a/src/libstd/sys/unix/args.rs
+++ b/src/libstd/sys/unix/args.rs
@@ -78,6 +78,26 @@ mod imp {
         ARGV = argv;
     }
 
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    #[used]
+    #[link_section = ".init_array"]
+    static ARGV_INIT_ARRAY: extern "C" fn(
+        crate::os::raw::c_int,
+        *const *const u8,
+        *const *const u8,
+    ) = {
+        extern "C" fn init_wrapper(
+            argc: crate::os::raw::c_int,
+            argv: *const *const u8,
+            _envp: *const *const u8,
+        ) {
+            unsafe {
+                init(argc as isize, argv);
+            }
+        }
+        init_wrapper
+    };
+
     pub unsafe fn cleanup() {
         let _guard = LOCK.lock();
         ARGC = 0;

--- a/src/test/run-make-fulldeps/glibc-staticlib-args/Makefile
+++ b/src/test/run-make-fulldeps/glibc-staticlib-args/Makefile
@@ -1,0 +1,12 @@
+# only-gnu
+# only-linux
+
+-include ../tools.mk
+
+# This ensures that std::env::args works in a library called from C on glibc Linux.
+
+all:
+	$(RUSTC) --crate-type=staticlib library.rs
+	$(CC) program.c $(call STATICLIB,library) $(call OUT_EXE,program) \
+		$(EXTRACFLAGS) $(EXTRACXXFLAGS)
+	$(call RUN,program)

--- a/src/test/run-make-fulldeps/glibc-staticlib-args/library.rs
+++ b/src/test/run-make-fulldeps/glibc-staticlib-args/library.rs
@@ -1,0 +1,4 @@
+#[no_mangle]
+pub extern fn args_check() {
+    assert_ne!(std::env::args_os().count(), 0);
+}

--- a/src/test/run-make-fulldeps/glibc-staticlib-args/program.c
+++ b/src/test/run-make-fulldeps/glibc-staticlib-args/program.c
@@ -1,0 +1,7 @@
+// ignore-license
+void args_check();
+
+int main() {
+    args_check();
+    return 0;
+}


### PR DESCRIPTION
Linux is one of the only platforms where `std::env::args` doesn't work in a cdylib.