### PR TITLE
Move process_configure_mod to rustc_parse

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -24,7 +24,7 @@ use syntax::edition::Edition;
 use syntax::feature_gate;
 use errors::json::JsonEmitter;
 use syntax::source_map;
-use syntax::sess::{ParseSess, ProcessCfgMod};
+use syntax::sess::ParseSess;
 use syntax_pos::{MultiSpan, Span};
 
 use rustc_target::spec::{PanicStrategy, RelroLevel, Target, TargetTriple};
@@ -925,7 +925,6 @@ pub fn build_session(
     sopts: config::Options,
     local_crate_source_file: Option<PathBuf>,
     registry: errors::registry::Registry,
-    process_cfg_mod: ProcessCfgMod,
 ) -> Session {
     let file_path_mapping = sopts.file_path_mapping();
 
@@ -936,7 +935,6 @@ pub fn build_session(
         Lrc::new(source_map::SourceMap::new(file_path_mapping)),
         DiagnosticOutput::Default,
         Default::default(),
-        process_cfg_mod,
     )
 }
 
@@ -1015,7 +1013,6 @@ pub fn build_session_with_source_map(
     source_map: Lrc<source_map::SourceMap>,
     diagnostics_output: DiagnosticOutput,
     lint_caps: FxHashMap<lint::LintId, lint::Level>,
-    process_cfg_mod: ProcessCfgMod,
 ) -> Session {
     // FIXME: This is not general enough to make the warning lint completely override
     // normal diagnostic warnings, since the warning lint can also be denied and changed
@@ -1061,7 +1058,6 @@ pub fn build_session_with_source_map(
         diagnostic_handler,
         source_map,
         lint_caps,
-        process_cfg_mod,
     )
 }
 
@@ -1071,7 +1067,6 @@ fn build_session_(
     span_diagnostic: errors::Handler,
     source_map: Lrc<source_map::SourceMap>,
     driver_lint_caps: FxHashMap<lint::LintId, lint::Level>,
-    process_cfg_mod: ProcessCfgMod,
 ) -> Session {
     let self_profiler =
         if let SwitchWithOptPath::Enabled(ref d) = sopts.debugging_opts.self_profile {
@@ -1109,7 +1104,6 @@ fn build_session_(
     let parse_sess = ParseSess::with_span_handler(
         span_diagnostic,
         source_map,
-        process_cfg_mod,
     );
     let sysroot = match &sopts.maybe_sysroot {
         Some(sysroot) => sysroot.clone(),

--- a/src/librustc_interface/interface.rs
+++ b/src/librustc_interface/interface.rs
@@ -21,7 +21,6 @@ use syntax::ast::{self, MetaItemKind};
 use syntax::token;
 use syntax::source_map::{FileName, FileLoader, SourceMap};
 use syntax::sess::ParseSess;
-use syntax_expand::config::process_configure_mod;
 use syntax_pos::edition;
 
 pub type Result<T> = result::Result<T, ErrorReported>;
@@ -69,7 +68,7 @@ impl Compiler {
 pub fn parse_cfgspecs(cfgspecs: Vec<String>) -> FxHashSet<(String, Option<String>)> {
     syntax::with_default_globals(move || {
         let cfg = cfgspecs.into_iter().map(|s| {
-            let sess = ParseSess::with_silent_emitter(process_configure_mod);
+            let sess = ParseSess::with_silent_emitter();
             let filename = FileName::cfg_spec_source_code(&s);
             let mut parser = new_parser_from_source_str(&sess, filename, s.to_string());
 

--- a/src/librustc_interface/tests.rs
+++ b/src/librustc_interface/tests.rs
@@ -17,7 +17,6 @@ use rustc_target::spec::{MergeFunctions, PanicStrategy, RelroLevel};
 use syntax::symbol::sym;
 use syntax::edition::{Edition, DEFAULT_EDITION};
 use syntax;
-use syntax_expand::config::process_configure_mod;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::{ColorConfig, emitter::HumanReadableErrorType, registry};
 
@@ -32,7 +31,7 @@ fn build_session_options_and_crate_config(matches: getopts::Matches) -> (Options
 fn mk_session(matches: getopts::Matches) -> (Session, CfgSpecs) {
     let registry = registry::Registry::new(&[]);
     let (sessopts, cfg) = build_session_options_and_crate_config(matches);
-    let sess = build_session(sessopts, None, registry, process_configure_mod);
+    let sess = build_session(sessopts, None, registry);
     (sess, cfg)
 }
 

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -31,7 +31,6 @@ use syntax::util::lev_distance::find_best_match_for_name;
 use syntax::source_map::{FileLoader, RealFileLoader, SourceMap};
 use syntax::symbol::{Symbol, sym};
 use syntax::{self, ast, attr};
-use syntax_expand::config::process_configure_mod;
 use syntax_pos::edition::Edition;
 #[cfg(not(parallel_compiler))]
 use std::{thread, panic};
@@ -81,7 +80,6 @@ pub fn create_session(
         source_map.clone(),
         diagnostic_output,
         lint_caps,
-        process_configure_mod,
     );
 
     sess.prof.register_queries(|profiler| {

--- a/src/librustc_parse/config.rs
+++ b/src/librustc_parse/config.rs
@@ -1,4 +1,14 @@
-use rustc_parse::validate_attr;
+//! Process the potential `cfg` attributes on a module.
+//! Also determine if the module should be included in this configuration.
+//!
+//! This module properly belongs in syntax_expand, but for now it's tied into
+//! parsing, so we leave it here to avoid complicated out-of-line dependencies.
+//!
+//! A principled solution to this wrong location would be to implement [#64197].
+//!
+//! [#64197]: https://github.com/rust-lang/rust/issues/64197
+
+use crate::validate_attr;
 use syntax::attr::HasAttrs;
 use syntax::feature_gate::{
     feature_err,
@@ -113,7 +123,7 @@ impl<'a> StripUnconfigured<'a> {
             return vec![];
         }
 
-        let res = rustc_parse::parse_in_attr(self.sess, &attr, |p| p.parse_cfg_attr());
+        let res = crate::parse_in_attr(self.sess, &attr, |p| p.parse_cfg_attr());
         let (cfg_predicate, expanded_attrs) = match res {
             Ok(result) => result,
             Err(mut e) => {

--- a/src/librustc_parse/lib.rs
+++ b/src/librustc_parse/lib.rs
@@ -25,6 +25,8 @@ pub mod parser;
 use parser::{Parser, emit_unclosed_delims, make_unclosed_delims_error};
 pub mod lexer;
 pub mod validate_attr;
+#[macro_use]
+pub mod config;
 
 #[derive(Clone)]
 pub struct Directory<'a> {

--- a/src/librustc_parse/parser/module.rs
+++ b/src/librustc_parse/parser/module.rs
@@ -40,7 +40,6 @@ impl<'a> Parser<'a> {
 
     /// Parses a `mod <foo> { ... }` or `mod <foo>;` item.
     pub(super) fn parse_item_mod(&mut self, outer_attrs: &[Attribute]) -> PResult<'a, ItemInfo> {
-        // HACK(Centril): See documentation on `ParseSess::process_cfg_mod`.
         let (in_cfg, outer_attrs) = crate::config::process_configure_mod(
             self.sess,
             self.cfg_mods,

--- a/src/librustc_parse/parser/module.rs
+++ b/src/librustc_parse/parser/module.rs
@@ -41,7 +41,7 @@ impl<'a> Parser<'a> {
     /// Parses a `mod <foo> { ... }` or `mod <foo>;` item.
     pub(super) fn parse_item_mod(&mut self, outer_attrs: &[Attribute]) -> PResult<'a, ItemInfo> {
         // HACK(Centril): See documentation on `ParseSess::process_cfg_mod`.
-        let (in_cfg, outer_attrs) = (self.sess.process_cfg_mod)(
+        let (in_cfg, outer_attrs) = crate::config::process_configure_mod(
             self.sess,
             self.cfg_mods,
             outer_attrs,

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -16,7 +16,6 @@ use syntax::token::{self, Token};
 use syntax::sess::ParseSess;
 use syntax::source_map::SourceMap;
 use syntax::symbol::{kw, sym};
-use syntax_expand::config::process_configure_mod;
 use syntax_pos::{Span, FileName};
 
 /// Highlights `src`, returning the HTML output.
@@ -34,7 +33,7 @@ pub fn render_with_highlighting(
                class, tooltip).unwrap();
     }
 
-    let sess = ParseSess::with_silent_emitter(process_configure_mod);
+    let sess = ParseSess::with_silent_emitter();
     let fm = sess.source_map().new_source_file(
         FileName::Custom(String::from("rustdoc-highlighting")),
         src.to_owned(),

--- a/src/librustdoc/passes/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/check_code_block_syntax.rs
@@ -3,7 +3,6 @@ use rustc_parse::lexer::{StringReader as Lexer};
 use syntax::token;
 use syntax::sess::ParseSess;
 use syntax::source_map::FilePathMapping;
-use syntax_expand::config::process_configure_mod;
 use syntax_pos::{InnerSpan, FileName};
 
 use crate::clean;
@@ -28,7 +27,7 @@ struct SyntaxChecker<'a, 'tcx> {
 
 impl<'a, 'tcx> SyntaxChecker<'a, 'tcx> {
     fn check_rust_syntax(&self, item: &clean::Item, dox: &str, code_block: RustCodeBlock) {
-        let sess = ParseSess::new(FilePathMapping::empty(), process_configure_mod);
+        let sess = ParseSess::new(FilePathMapping::empty());
         let source_file = sess.source_map().new_source_file(
             FileName::Custom(String::from("doctest")),
             dox[code_block.code].to_owned(),

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -17,7 +17,6 @@ use std::path::PathBuf;
 use std::process::{self, Command, Stdio};
 use std::str;
 use syntax::symbol::sym;
-use syntax_expand::config::process_configure_mod;
 use syntax_pos::{BytePos, DUMMY_SP, Pos, Span, FileName};
 use tempfile::Builder as TempFileBuilder;
 use testing;
@@ -415,7 +414,7 @@ pub fn make_test(s: &str,
         let emitter = EmitterWriter::new(box io::sink(), None, false, false, false, None, false);
         // FIXME(misdreavus): pass `-Z treat-err-as-bug` to the doctest parser
         let handler = Handler::with_emitter(false, None, box emitter);
-        let sess = ParseSess::with_span_handler(handler, cm, process_configure_mod);
+        let sess = ParseSess::with_span_handler(handler, cm);
 
         let mut found_main = false;
         let mut found_extern_crate = cratename.is_none();

--- a/src/libsyntax_expand/expand.rs
+++ b/src/libsyntax_expand/expand.rs
@@ -4,7 +4,7 @@ use crate::hygiene::{ExpnId, SyntaxContext, ExpnData, ExpnKind};
 use crate::mbe::macro_rules::annotate_err_with_kind;
 use crate::placeholders::{placeholder, PlaceholderExpander};
 use crate::config::StripUnconfigured;
-use crate::configure;
+use rustc_parse::configure;
 
 use rustc_parse::DirectoryOwnership;
 use rustc_parse::parser::Parser;

--- a/src/libsyntax_expand/lib.rs
+++ b/src/libsyntax_expand/lib.rs
@@ -33,7 +33,7 @@ pub use mbe::macro_rules::compile_declarative_macro;
 pub mod base;
 pub mod build;
 pub mod expand;
-#[macro_use] pub mod config;
+pub use rustc_parse::config;
 pub mod proc_macro;
 
 crate mod mbe;

--- a/src/libsyntax_expand/parse/lexer/tests.rs
+++ b/src/libsyntax_expand/parse/lexer/tests.rs
@@ -1,5 +1,3 @@
-use crate::config::process_configure_mod;
-
 use rustc_data_structures::sync::Lrc;
 use rustc_parse::lexer::StringReader;
 use syntax::token::{self, Token, TokenKind};
@@ -27,7 +25,6 @@ fn mk_sess(sm: Lrc<SourceMap>) -> ParseSess {
     ParseSess::with_span_handler(
         Handler::with_emitter(true, None, Box::new(emitter)),
         sm,
-        process_configure_mod,
     )
 }
 

--- a/src/libsyntax_expand/parse/tests.rs
+++ b/src/libsyntax_expand/parse/tests.rs
@@ -1,4 +1,3 @@
-use crate::config::process_configure_mod;
 use crate::tests::{matches_codepattern, string_to_stream, with_error_checking_parse};
 
 use rustc_parse::new_parser_from_source_str;
@@ -19,7 +18,7 @@ use errors::PResult;
 use std::path::PathBuf;
 
 fn sess() -> ParseSess {
-    ParseSess::new(FilePathMapping::empty(), process_configure_mod)
+    ParseSess::new(FilePathMapping::empty())
 }
 
 /// Parses an item.

--- a/src/libsyntax_expand/tests.rs
+++ b/src/libsyntax_expand/tests.rs
@@ -1,4 +1,3 @@
-use crate::config::process_configure_mod;
 use rustc_parse::{source_file_to_stream, new_parser_from_source_str, parser::Parser};
 use syntax::ast;
 use syntax::tokenstream::TokenStream;
@@ -34,7 +33,7 @@ crate fn with_error_checking_parse<'a, T, F>(s: String, ps: &'a ParseSess, f: F)
 
 /// Maps a string to tts, using a made-up filename.
 crate fn string_to_stream(source_str: String) -> TokenStream {
-    let ps = ParseSess::new(FilePathMapping::empty(), process_configure_mod);
+    let ps = ParseSess::new(FilePathMapping::empty());
     source_file_to_stream(
         &ps,
         ps.source_map().new_source_file(PathBuf::from("bogofile").into(),
@@ -44,7 +43,7 @@ crate fn string_to_stream(source_str: String) -> TokenStream {
 
 /// Parses a string, returns a crate.
 crate fn string_to_crate(source_str : String) -> ast::Crate {
-    let ps = ParseSess::new(FilePathMapping::empty(), process_configure_mod);
+    let ps = ParseSess::new(FilePathMapping::empty());
     with_error_checking_parse(source_str, &ps, |p| {
         p.parse_crate_mod()
     })

--- a/src/test/ui-fulldeps/ast_stmt_expr_attr.rs
+++ b/src/test/ui-fulldeps/ast_stmt_expr_attr.rs
@@ -22,7 +22,6 @@ use syntax::source_map::{FilePathMapping, FileName};
 use syntax::ptr::P;
 use syntax::print::pprust;
 use syntax::token;
-use syntax_expand::config::process_configure_mod;
 use std::fmt;
 
 // Copied out of syntax::util::parser_testing
@@ -75,7 +74,7 @@ fn str_compare<T, F: Fn(&T) -> String>(e: &str, expected: &[T], actual: &[T], f:
 }
 
 fn sess() -> ParseSess {
-    ParseSess::new(FilePathMapping::empty(), process_configure_mod)
+    ParseSess::new(FilePathMapping::empty())
 }
 
 fn check_expr_attrs(es: &str, expected: &[&str]) {

--- a/src/test/ui-fulldeps/mod_dir_path_canonicalized.rs
+++ b/src/test/ui-fulldeps/mod_dir_path_canonicalized.rs
@@ -12,7 +12,6 @@ use rustc_parse::new_parser_from_file;
 use std::path::Path;
 use syntax::sess::ParseSess;
 use syntax::source_map::FilePathMapping;
-use syntax_expand::config::process_configure_mod;
 
 #[path = "mod_dir_simple/test.rs"]
 mod gravy;
@@ -24,7 +23,7 @@ pub fn main() {
 }
 
 fn parse() {
-    let parse_session = ParseSess::new(FilePathMapping::empty(), process_configure_mod);
+    let parse_session = ParseSess::new(FilePathMapping::empty());
 
     let path = Path::new(file!());
     let path = path.canonicalize().unwrap();

--- a/src/test/ui-fulldeps/pprust-expr-roundtrip.rs
+++ b/src/test/ui-fulldeps/pprust-expr-roundtrip.rs
@@ -33,7 +33,6 @@ use syntax::source_map::FilePathMapping;
 use syntax::mut_visit::{self, MutVisitor, visit_clobber};
 use syntax::print::pprust;
 use syntax::ptr::P;
-use syntax_expand::config::process_configure_mod;
 
 fn parse_expr(ps: &ParseSess, src: &str) -> Option<P<Expr>> {
     let src_as_string = src.to_string();
@@ -205,7 +204,7 @@ fn main() {
 }
 
 fn run() {
-    let ps = ParseSess::new(FilePathMapping::empty(), process_configure_mod);
+    let ps = ParseSess::new(FilePathMapping::empty());
 
     iter_exprs(2, &mut |mut e| {
         // If the pretty printer is correct, then `parse(print(e))` should be identical to `e`,


### PR DESCRIPTION
This removes the hack in favor of perhaps a less principled, but less painful, approach.

This also supports my work to decouple `Session` from librustc, as `ParseSess` currently has `Attribute` as "part" of it but after this PR will no longer do so.
