### PR TITLE
Ignore run-make reproducible-build-2 on Mac

### DIFF
--- a/src/test/run-make-fulldeps/reproducible-build-2/Makefile
+++ b/src/test/run-make-fulldeps/reproducible-build-2/Makefile
@@ -2,6 +2,7 @@
 
 # ignore-musl
 # ignore-windows
+# ignore-macos (rust-lang/rust#66568)
 # Objects are reproducible but their path is not.
 
 all:  \


### PR DESCRIPTION
Ignore run-make reproducible-build-2 on Mac (we already ignore it on Windows).

Until we can dedicate resources to fixing this properly, I think we are best off just ignoring this test on platforms/contexts where it does not matter as much.

cc #66568 