### PR TITLE
Apply proper commit from PR #63934

### DIFF
--- a/src/test/ui/type-alias-impl-trait/issue-66580-closure-coherence.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-66580-closure-coherence.rs
@@ -1,0 +1,19 @@
+// Regression test for issue #66580
+// Ensures that we don't try to determine whether a closure
+// is foreign when it's the underlying type of an opaque type
+// check-pass
+#![feature(type_alias_impl_trait)]
+
+type Closure = impl FnOnce();
+
+fn closure() -> Closure {
+    || {}
+}
+
+struct Wrap<T> { f: T }
+
+impl Wrap<Closure> {}
+
+impl<T> Wrap<T> {}
+
+fn main() {}


### PR DESCRIPTION
While working on PR #63934, I accidentally reverted to an older version
of the PR while working on a rebase. The PR was then merged, not with
the later, approved changes, but with earlier, unapproved changes.

This PR applies the changes that were *suppoesd* to be mereged in
PR #63934. All of the proper tests appear to have been merged
in PR #63934, so this PR adds no new tests