### PR TITLE
Add an option to omit LLVM bitcode from rlibs.

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1222,6 +1222,8 @@ options! {CodegenOptions, CodegenSetter, basic_codegen_options,
         "compile the program with profiling instrumentation"),
     profile_use: Option<PathBuf> = (None, parse_opt_pathbuf, [TRACKED],
         "use the given `.profdata` file for profile-guided optimization"),
+    no_rlib_bitcode: bool = (false, parse_bool, [TRACKED],
+        "don't put LLVM bitcode in rlib files"),
 }
 
 options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -383,9 +383,11 @@ pub fn start_async_codegen<B: ExtraBackendMethods>(
 
     // Emit compressed bitcode files for the crate if we're emitting an rlib.
     // Whenever an rlib is created, the bitcode is inserted into the archive in
-    // order to allow LTO against it.
+    // order to allow LTO against it (unless --no-rlib-bitcode is specified).
     if need_crate_bitcode_for_rlib(sess) {
-        modules_config.emit_bc_compressed = true;
+        if !sess.opts.cg.no_rlib_bitcode {
+            modules_config.emit_bc_compressed = true;
+        }
         allocator_config.emit_bc_compressed = true;
     }
 


### PR DESCRIPTION
Because it's only needed when doing LTO, so including it all the time
wastes time and disk space.

r? @michaelwoerister 