### PR TITLE
Stop explicitly depending on python 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ or reading the [rustc dev guide][rustcguidebuild].
 1. Make sure you have installed the dependencies:
 
    * `g++` 5.1 or later or `clang++` 3.5 or later
-   * `python` 2.7 (but not 3.x)
+   * `python` 3 or 2.7
    * GNU `make` 3.81 or later
    * `cmake` 3.4.3 or later
    * `curl`
@@ -113,7 +113,7 @@ build.
                make \
                diffutils \
                tar \
-               mingw-w64-x86_64-python2 \
+               mingw-w64-x86_64-python \
                mingw-w64-x86_64-cmake \
                mingw-w64-x86_64-gcc
    ```

--- a/config.toml.example
+++ b/config.toml.example
@@ -168,11 +168,9 @@
 
 # Python interpreter to use for various tasks throughout the build, notably
 # rustdoc tests, the lldb python interpreter, and some dist bits and pieces.
-# Note that Python 2 is currently required.
 #
-# Defaults to python2.7, then python2. If neither executable can be found, then
-# it defaults to the Python interpreter used to execute x.py.
-#python = "python2.7"
+# Defaults to the Python interpreter used to execute x.py.
+#python = "python"
 
 # Force Cargo to check that Cargo.lock describes the precise dependency
 # set that all the Cargo.toml files create, instead of updating it.

--- a/configure
+++ b/configure
@@ -11,6 +11,7 @@ try() {
     fi
 }
 
+try python3 "$@"
 try python2.7 "$@"
 try python27 "$@"
 try python2 "$@"

--- a/src/bootstrap/job.rs
+++ b/src/bootstrap/job.rs
@@ -103,7 +103,12 @@ pub unsafe fn setup(build: &mut Build) {
     };
 
     let parent = OpenProcess(PROCESS_DUP_HANDLE, FALSE, pid.parse().unwrap());
-    assert!(!parent.is_null(), "{}", io::Error::last_os_error());
+    assert!(
+        !parent.is_null(),
+        "PID `{}` doesn't seem to exist: {}",
+        pid,
+        io::Error::last_os_error()
+    );
     let mut parent_handle = ptr::null_mut();
     let r = DuplicateHandle(
         GetCurrentProcess(),

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -132,8 +132,6 @@ pub fn check(build: &mut Build) {
         .python
         .take()
         .map(|p| cmd_finder.must_have(p))
-        .or_else(|| cmd_finder.maybe_have("python2.7"))
-        .or_else(|| cmd_finder.maybe_have("python2"))
         .or_else(|| env::var_os("BOOTSTRAP_PYTHON").map(PathBuf::from)) // set by bootstrap.py
         .or_else(|| Some(cmd_finder.must_have("python")));
 

--- a/src/ci/docker/arm-android/Dockerfile
+++ b/src/ci/docker/arm-android/Dockerfile
@@ -31,7 +31,7 @@ ENV TARGETS=arm-linux-androideabi
 
 ENV RUST_CONFIGURE_ARGS --arm-linux-androideabi-ndk=/android/ndk/arm-14
 
-ENV SCRIPT python2.7 ../x.py test --target $TARGETS
+ENV SCRIPT python3 ../x.py test --target $TARGETS
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh

--- a/src/ci/docker/armhf-gnu/Dockerfile
+++ b/src/ci/docker/armhf-gnu/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
       libc6-dev \
       libc6-dev-armhf-cross \
       make \
-      python2.7 \
+      python3 \
       qemu-system-arm \
       xz-utils
 
@@ -78,6 +78,6 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV RUST_CONFIGURE_ARGS --qemu-armhf-rootfs=/tmp/rootfs
-ENV SCRIPT python2.7 ../x.py test --target arm-unknown-linux-gnueabihf
+ENV SCRIPT python3 ../x.py test --target arm-unknown-linux-gnueabihf
 
 ENV NO_CHANGE_USER=1

--- a/src/ci/docker/disabled/aarch64-gnu/Dockerfile
+++ b/src/ci/docker/disabled/aarch64-gnu/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
       libc6-dev \
       libc6-dev-arm64-cross \
       make \
-      python2.7 \
+      python3 \
       qemu-system-aarch64 \
       xz-utils
 
@@ -75,5 +75,5 @@ RUN sh /scripts/sccache.sh
 
 ENV RUST_CONFIGURE_ARGS \
       --qemu-aarch64-rootfs=/tmp/rootfs
-ENV SCRIPT python2.7 ../x.py test --target aarch64-unknown-linux-gnu
+ENV SCRIPT python3 ../x.py test --target aarch64-unknown-linux-gnu
 ENV NO_CHANGE_USER=1

--- a/src/ci/docker/disabled/asmjs/Dockerfile
+++ b/src/ci/docker/disabled/asmjs/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python \
+  python3 \
   git \
   cmake \
   sudo \
@@ -33,7 +33,7 @@ ENV EMCC_CFLAGS=-O1
 # Emscripten installation is user-specific
 ENV NO_CHANGE_USER=1
 
-ENV SCRIPT python2.7 ../x.py test --target $TARGETS
+ENV SCRIPT python3 ../x.py test --target $TARGETS
 
 # This is almost identical to the wasm32-unknown-emscripten target, so
 # running with assertions again is not useful

--- a/src/ci/docker/disabled/dist-aarch64-android/Dockerfile
+++ b/src/ci/docker/disabled/dist-aarch64-android/Dockerfile
@@ -19,7 +19,7 @@ ENV RUST_CONFIGURE_ARGS \
       --enable-extended \
       --enable-cargo-openssl-static
 
-ENV SCRIPT python2.7 ../x.py dist --target $HOSTS --host $HOSTS
+ENV SCRIPT python3 ../x.py dist --target $HOSTS --host $HOSTS
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh

--- a/src/ci/docker/disabled/dist-armv7-android/Dockerfile
+++ b/src/ci/docker/disabled/dist-armv7-android/Dockerfile
@@ -33,11 +33,11 @@ ENV RUST_CONFIGURE_ARGS \
 # build to finish we use --warn-unresolved-symbols. Note that the missing
 # symbols does not affect std, only the compiler (llvm) and cargo (openssl).
 ENV SCRIPT \
-  python2.7 ../x.py build src/llvm --host $HOSTS --target $HOSTS && \
+  python3 ../x.py build src/llvm --host $HOSTS --target $HOSTS && \
   (export RUSTFLAGS="\"-C link-arg=-Wl,--warn-unresolved-symbols\""; \
     rm /android/ndk/arm && \
     ln -s /android/ndk/arm-14 /android/ndk/arm && \
-    python2.7 ../x.py dist --host $HOSTS --target $HOSTS)
+    python3 ../x.py dist --host $HOSTS --target $HOSTS)
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh

--- a/src/ci/docker/disabled/dist-i686-android/Dockerfile
+++ b/src/ci/docker/disabled/dist-i686-android/Dockerfile
@@ -33,11 +33,11 @@ ENV RUST_CONFIGURE_ARGS \
 # build to finish we use --warn-unresolved-symbols. Note that the missing
 # symbols does not affect std, only the compiler (llvm) and cargo (openssl).
 ENV SCRIPT \
-  python2.7 ../x.py build src/llvm --host $HOSTS --target $HOSTS && \
+  python3 ../x.py build src/llvm --host $HOSTS --target $HOSTS && \
   (export RUSTFLAGS="\"-C link-arg=-Wl,--warn-unresolved-symbols\""; \
     rm /android/ndk/x86 && \
     ln -s /android/ndk/x86-14 /android/ndk/x86 && \
-    python2.7 ../x.py dist --host $HOSTS --target $HOSTS)
+    python3 ../x.py dist --host $HOSTS --target $HOSTS)
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh

--- a/src/ci/docker/disabled/dist-powerpcspe-linux/Dockerfile
+++ b/src/ci/docker/disabled/dist-powerpcspe-linux/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python2.7 \
+  python3 \
   git \
   cmake \
   sudo \
@@ -23,4 +23,4 @@ RUN sh /scripts/sccache.sh
 ENV HOSTS=powerpc-unknown-linux-gnuspe
 
 ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/disabled/dist-sparc64-linux/Dockerfile
+++ b/src/ci/docker/disabled/dist-sparc64-linux/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python2.7 \
+  python3 \
   git \
   cmake \
   sudo \
@@ -23,4 +23,4 @@ RUN sh /scripts/sccache.sh
 ENV HOSTS=sparc64-unknown-linux-gnu
 
 ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/disabled/dist-x86_64-android/Dockerfile
+++ b/src/ci/docker/disabled/dist-x86_64-android/Dockerfile
@@ -19,7 +19,7 @@ ENV RUST_CONFIGURE_ARGS \
       --enable-extended \
       --enable-cargo-openssl-static
 
-ENV SCRIPT python2.7 ../x.py dist --target $HOSTS --host $HOSTS
+ENV SCRIPT python3 ../x.py dist --target $HOSTS --host $HOSTS
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh

--- a/src/ci/docker/disabled/dist-x86_64-dragonfly/Dockerfile
+++ b/src/ci/docker/disabled/dist-x86_64-dragonfly/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python2.7 \
+  python3 \
   git \
   cmake \
   sudo \
@@ -33,4 +33,4 @@ ENV \
 ENV HOSTS=x86_64-unknown-dragonfly
 
 ENV RUST_CONFIGURE_ARGS --enable-extended
-ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/disabled/dist-x86_64-haiku/Dockerfile
+++ b/src/ci/docker/disabled/dist-x86_64-haiku/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   make \
   nasm \
   pkg-config \
-  python2.7 \
+  python3 \
   sudo \
   texinfo \
   wget \
@@ -46,4 +46,4 @@ ENV RUST_CONFIGURE_ARGS --disable-jemalloc \
   --set=$TARGET.cc=x86_64-unknown-haiku-gcc \
   --set=$TARGET.cxx=x86_64-unknown-haiku-g++ \
   --set=$TARGET.llvm-config=/bin/llvm-config-haiku
-ENV SCRIPT python2.7 ../x.py dist --host=$HOST --target=$HOST
+ENV SCRIPT python3 ../x.py dist --host=$HOST --target=$HOST

--- a/src/ci/docker/disabled/dist-x86_64-redox/Dockerfile
+++ b/src/ci/docker/disabled/dist-x86_64-redox/Dockerfile
@@ -19,4 +19,4 @@ ENV \
     CXX_x86_64_unknown_redox=x86_64-unknown-redox-g++
 
 ENV RUST_CONFIGURE_ARGS --enable-extended
-ENV SCRIPT python2.7 ../x.py dist --target x86_64-unknown-redox
+ENV SCRIPT python3 ../x.py dist --target x86_64-unknown-redox

--- a/src/ci/docker/dist-aarch64-linux/Dockerfile
+++ b/src/ci/docker/dist-aarch64-linux/Dockerfile
@@ -36,4 +36,4 @@ ENV RUST_CONFIGURE_ARGS \
       --enable-extended \
       --enable-profiler \
       --disable-docs
-ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-android/Dockerfile
+++ b/src/ci/docker/dist-android/Dockerfile
@@ -32,7 +32,7 @@ ENV RUST_CONFIGURE_ARGS \
       --x86_64-linux-android-ndk=/android/ndk/x86_64-21 \
       --disable-docs
 
-ENV SCRIPT python2.7 ../x.py dist --target $TARGETS
+ENV SCRIPT python3 ../x.py dist --target $TARGETS
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh

--- a/src/ci/docker/dist-arm-linux/Dockerfile
+++ b/src/ci/docker/dist-arm-linux/Dockerfile
@@ -28,4 +28,4 @@ ENV CC_arm_unknown_linux_gnueabi=arm-unknown-linux-gnueabi-gcc \
 ENV HOSTS=arm-unknown-linux-gnueabi
 
 ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-armhf-linux/Dockerfile
+++ b/src/ci/docker/dist-armhf-linux/Dockerfile
@@ -28,4 +28,4 @@ ENV CC_arm_unknown_linux_gnueabihf=arm-unknown-linux-gnueabihf-gcc \
 ENV HOSTS=arm-unknown-linux-gnueabihf
 
 ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-armv7-linux/Dockerfile
+++ b/src/ci/docker/dist-armv7-linux/Dockerfile
@@ -28,4 +28,4 @@ ENV CC_armv7_unknown_linux_gnueabihf=armv7-unknown-linux-gnueabihf-gcc \
 ENV HOSTS=armv7-unknown-linux-gnueabihf
 
 ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-i586-gnu-i586-i686-musl/Dockerfile
+++ b/src/ci/docker/dist-i586-gnu-i586-i686-musl/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python2.7 \
+  python3 \
   git \
   cmake \
   xz-utils \
@@ -46,5 +46,5 @@ ENV CFLAGS_i586_unknown_linux_musl=-Wa,-mrelax-relocations=no
 ENV TARGETS=i586-unknown-linux-gnu,i686-unknown-linux-musl
 
 ENV SCRIPT \
-      python2.7 ../x.py test --target $TARGETS && \
-      python2.7 ../x.py dist --target $TARGETS,i586-unknown-linux-musl
+      python3 ../x.py test --target $TARGETS && \
+      python3 ../x.py dist --target $TARGETS,i586-unknown-linux-musl

--- a/src/ci/docker/dist-i686-freebsd/Dockerfile
+++ b/src/ci/docker/dist-i686-freebsd/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python2.7 \
+  python3 \
   git \
   cmake \
   sudo \
@@ -30,4 +30,4 @@ ENV \
 ENV HOSTS=i686-unknown-freebsd
 
 ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-mips-linux/Dockerfile
+++ b/src/ci/docker/dist-mips-linux/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python2.7 \
+  python3 \
   git \
   cmake \
   sudo \
@@ -23,4 +23,4 @@ RUN sh /scripts/sccache.sh
 ENV HOSTS=mips-unknown-linux-gnu
 
 ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-mips64-linux/Dockerfile
+++ b/src/ci/docker/dist-mips64-linux/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python2.7 \
+  python3 \
   git \
   cmake \
   sudo \
@@ -22,4 +22,4 @@ RUN sh /scripts/sccache.sh
 ENV HOSTS=mips64-unknown-linux-gnuabi64
 
 ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-mips64el-linux/Dockerfile
+++ b/src/ci/docker/dist-mips64el-linux/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python2.7 \
+  python3 \
   git \
   cmake \
   sudo \
@@ -23,4 +23,4 @@ RUN sh /scripts/sccache.sh
 ENV HOSTS=mips64el-unknown-linux-gnuabi64
 
 ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-mipsel-linux/Dockerfile
+++ b/src/ci/docker/dist-mipsel-linux/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python2.7 \
+  python3 \
   git \
   cmake \
   sudo \
@@ -22,4 +22,4 @@ RUN sh /scripts/sccache.sh
 ENV HOSTS=mipsel-unknown-linux-gnu
 
 ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-powerpc-linux/Dockerfile
+++ b/src/ci/docker/dist-powerpc-linux/Dockerfile
@@ -35,4 +35,4 @@ ENV \
 ENV HOSTS=powerpc-unknown-linux-gnu
 
 ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-powerpc64-linux/Dockerfile
+++ b/src/ci/docker/dist-powerpc64-linux/Dockerfile
@@ -36,4 +36,4 @@ ENV \
 ENV HOSTS=powerpc64-unknown-linux-gnu
 
 ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-powerpc64le-linux/Dockerfile
+++ b/src/ci/docker/dist-powerpc64le-linux/Dockerfile
@@ -33,4 +33,4 @@ ENV \
 ENV HOSTS=powerpc64le-unknown-linux-gnu
 
 ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-s390x-linux/Dockerfile
+++ b/src/ci/docker/dist-s390x-linux/Dockerfile
@@ -35,4 +35,4 @@ ENV \
 ENV HOSTS=s390x-unknown-linux-gnu
 
 ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-various-1/Dockerfile
+++ b/src/ci/docker/dist-various-1/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python2.7 \
   python3 \
   git \
   cmake \
@@ -209,8 +208,8 @@ ENV RUST_CONFIGURE_ARGS \
       --disable-docs
 
 ENV SCRIPT \
-      python2.7 ../x.py test --target $RUN_MAKE_TARGETS src/test/run-make && \
-      python2.7 ../x.py dist --target $TARGETS
+      python3 ../x.py test --target $RUN_MAKE_TARGETS src/test/run-make && \
+      python3 ../x.py dist --target $TARGETS
 
 # sccache
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/docker/dist-various-2/Dockerfile
+++ b/src/ci/docker/dist-various-2/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get build-dep -y clang llvm && apt-get install -y --no
   libmpfr-dev \
   ninja-build \
   nodejs \
-  python2.7-dev \
+  python3-dev \
   software-properties-common \
   unzip \
   # Needed for apt-key to work:
@@ -110,4 +110,4 @@ ENV RUST_CONFIGURE_ARGS --enable-extended --enable-lld --disable-docs \
   --set target.wasm32-wasi.wasi-root=/wasm32-wasi \
   --musl-root-armv7=/musl-armv7
 
-ENV SCRIPT python2.7 ../x.py dist --target $TARGETS
+ENV SCRIPT python3 ../x.py dist --target $TARGETS

--- a/src/ci/docker/dist-x86_64-freebsd/Dockerfile
+++ b/src/ci/docker/dist-x86_64-freebsd/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python2.7 \
+  python3 \
   git \
   cmake \
   sudo \
@@ -30,4 +30,4 @@ ENV \
 ENV HOSTS=x86_64-unknown-freebsd
 
 ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-x86_64-musl/Dockerfile
+++ b/src/ci/docker/dist-x86_64-musl/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   wget \
   curl \
   ca-certificates \
-  python2.7 \
+  python3 \
   git \
   cmake \
   xz-utils \
@@ -47,4 +47,4 @@ ENV CFLAGS_x86_64_unknown_linux_musl="-Wa,-mrelax-relocations=no -Wa,--compress-
     -Wl,--compress-debug-sections=none"
 
 # To run native tests replace `dist` below with `test`
-ENV SCRIPT python2.7 ../x.py dist --build $HOSTS
+ENV SCRIPT python3 ../x.py dist --build $HOSTS

--- a/src/ci/docker/dist-x86_64-netbsd/Dockerfile
+++ b/src/ci/docker/dist-x86_64-netbsd/Dockerfile
@@ -19,4 +19,4 @@ ENV \
 ENV HOSTS=x86_64-unknown-netbsd
 
 ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/i686-gnu-nopt/Dockerfile
+++ b/src/ci/docker/i686-gnu-nopt/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python2.7 \
+  python3 \
   git \
   cmake \
   sudo \
@@ -18,7 +18,7 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV RUST_CONFIGURE_ARGS --build=i686-unknown-linux-gnu --disable-optimize-tests
-ENV SCRIPT python2.7 ../x.py test
+ENV SCRIPT python3 ../x.py test
 
 # FIXME(#59637) takes too long on CI right now
 ENV NO_LLVM_ASSERTIONS=1 NO_DEBUG_ASSERTIONS=1

--- a/src/ci/docker/i686-gnu/Dockerfile
+++ b/src/ci/docker/i686-gnu/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python2.7 \
+  python3 \
   git \
   cmake \
   sudo \
@@ -20,7 +20,7 @@ RUN sh /scripts/sccache.sh
 ENV RUST_CONFIGURE_ARGS --build=i686-unknown-linux-gnu
 # Exclude some tests that are unlikely to be platform specific, to speed up
 # this slow job.
-ENV SCRIPT python2.7 ../x.py test \
+ENV SCRIPT python3 ../x.py test \
   --exclude src/bootstrap \
   --exclude src/test/rustdoc-js \
   --exclude src/tools/error_index_generator \

--- a/src/ci/docker/mingw-check/Dockerfile
+++ b/src/ci/docker/mingw-check/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python2.7 \
+  python3 \
   git \
   cmake \
   sudo \
@@ -22,9 +22,9 @@ RUN sh /scripts/sccache.sh
 COPY mingw-check/validate-toolstate.sh /scripts/
 
 ENV RUN_CHECK_WITH_PARALLEL_QUERIES 1
-ENV SCRIPT python2.7 ../x.py test src/tools/expand-yaml-anchors && \
-           python2.7 ../x.py check --target=i686-pc-windows-gnu --host=i686-pc-windows-gnu && \
-           python2.7 ../x.py build --stage 0 src/tools/build-manifest && \
-           python2.7 ../x.py test --stage 0 src/tools/compiletest && \
-           python2.7 ../x.py test src/tools/tidy && \
+ENV SCRIPT python3 ../x.py test src/tools/expand-yaml-anchors && \
+           python3 ../x.py check --target=i686-pc-windows-gnu --host=i686-pc-windows-gnu && \
+           python3 ../x.py build --stage 0 src/tools/build-manifest && \
+           python3 ../x.py test --stage 0 src/tools/compiletest && \
+           python3 ../x.py test src/tools/tidy && \
            /scripts/validate-toolstate.sh

--- a/src/ci/docker/mingw-check/validate-toolstate.sh
+++ b/src/ci/docker/mingw-check/validate-toolstate.sh
@@ -7,12 +7,12 @@ IFS=$'\n\t'
 rm -rf rust-toolstate
 git clone --depth=1 https://github.com/rust-lang-nursery/rust-toolstate.git
 cd rust-toolstate
-python2.7 "../../src/tools/publish_toolstate.py" "$(git rev-parse HEAD)" \
+python3 "../../src/tools/publish_toolstate.py" "$(git rev-parse HEAD)" \
     "$(git log --format=%s -n1 HEAD)" "" ""
 # Only check maintainers if this build is supposed to publish toolstate.
 # Builds that are not supposed to publish don't have the access token.
 if [ -n "${TOOLSTATE_PUBLISH+is_set}" ]; then
-  TOOLSTATE_VALIDATE_MAINTAINERS_REPO=rust-lang/rust python2.7 \
+  TOOLSTATE_VALIDATE_MAINTAINERS_REPO=rust-lang/rust python3 \
       "../../src/tools/publish_toolstate.py"
 fi
 cd ..

--- a/src/ci/docker/scripts/android-base-apt-get.sh
+++ b/src/ci/docker/scripts/android-base-apt-get.sh
@@ -11,7 +11,7 @@ apt-get install -y --no-install-recommends \
   libssl-dev \
   make \
   pkg-config \
-  python2.7 \
+  python3 \
   sudo \
   unzip \
   xz-utils

--- a/src/ci/docker/scripts/android-ndk.sh
+++ b/src/ci/docker/scripts/android-ndk.sh
@@ -13,7 +13,7 @@ download_ndk() {
 
 make_standalone_toolchain() {
     # See https://developer.android.com/ndk/guides/standalone_toolchain.htm
-    python2.7 /android/ndk/ndk/build/tools/make_standalone_toolchain.py \
+    python3 /android/ndk/ndk/build/tools/make_standalone_toolchain.py \
         --install-dir /android/ndk/$1-$2 \
         --arch $1 \
         --api $2

--- a/src/ci/docker/scripts/cross-apt-packages.sh
+++ b/src/ci/docker/scripts/cross-apt-packages.sh
@@ -19,7 +19,7 @@ apt-get update && apt-get install -y --no-install-recommends \
   make \
   patch \
   pkg-config \
-  python2.7 \
+  python3 \
   sudo \
   texinfo \
   unzip \

--- a/src/ci/docker/test-various/Dockerfile
+++ b/src/ci/docker/test-various/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python \
+  python3 \
   git \
   cmake \
   sudo \
@@ -40,7 +40,7 @@ ENV RUST_CONFIGURE_ARGS \
 ENV NO_DEBUG_ASSERTIONS=1
 
 ENV WASM_TARGETS=wasm32-unknown-unknown
-ENV WASM_SCRIPT python2.7 /checkout/x.py test --target $WASM_TARGETS \
+ENV WASM_SCRIPT python3 /checkout/x.py test --target $WASM_TARGETS \
   src/test/run-make \
   src/test/ui \
   src/test/compile-fail \
@@ -49,13 +49,13 @@ ENV WASM_SCRIPT python2.7 /checkout/x.py test --target $WASM_TARGETS \
   src/libcore
 
 ENV NVPTX_TARGETS=nvptx64-nvidia-cuda
-ENV NVPTX_SCRIPT python2.7 /checkout/x.py test --target $NVPTX_TARGETS \
+ENV NVPTX_SCRIPT python3 /checkout/x.py test --target $NVPTX_TARGETS \
   src/test/run-make \
   src/test/assembly
 
 ENV MUSL_TARGETS=x86_64-unknown-linux-musl \
     CC_x86_64_unknown_linux_musl=x86_64-linux-musl-gcc \
     CXX_x86_64_unknown_linux_musl=x86_64-linux-musl-g++
-ENV MUSL_SCRIPT python2.7 /checkout/x.py test --target $MUSL_TARGETS
+ENV MUSL_SCRIPT python3 /checkout/x.py test --target $MUSL_TARGETS
 
 ENV SCRIPT $WASM_SCRIPT && $NVPTX_SCRIPT && $MUSL_SCRIPT

--- a/src/ci/docker/wasm32/Dockerfile
+++ b/src/ci/docker/wasm32/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python \
+  python3 \
   git \
   cmake \
   sudo \
@@ -19,6 +19,9 @@ RUN bash /scripts/emscripten.sh
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
+
+# emcc seems to need python to specifically be "python" and not "python3"
+RUN ln `which python3` /usr/bin/python
 
 ENV PATH=$PATH:/emsdk-portable
 ENV PATH=$PATH:/emsdk-portable/upstream/emscripten/
@@ -35,7 +38,7 @@ ENV NO_CHANGE_USER=1
 
 # FIXME: Re-enable these tests once https://github.com/rust-lang/cargo/pull/7476
 # is picked up by CI
-ENV SCRIPT python2.7 ../x.py test --target $TARGETS \
+ENV SCRIPT python3 ../x.py test --target $TARGETS \
     --exclude src/libcore \
     --exclude src/liballoc \
     --exclude src/libproc_macro \

--- a/src/ci/docker/x86_64-gnu-aux/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-aux/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python2.7 \
+  python3 \
   git \
   cmake \
   libssl-dev \

--- a/src/ci/docker/x86_64-gnu-debug/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-debug/Dockerfile
@@ -6,8 +6,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python2.7 \
-  python2.7-dev \
+  python3 \
+  python3-dev \
   libxml2-dev \
   libncurses-dev \
   libedit-dev \
@@ -40,5 +40,5 @@ ENV RUST_CONFIGURE_ARGS \
       --set target.x86_64-unknown-linux-gnu.cxx=clang++
 
 ENV SCRIPT \
-  python2.7 ../x.py build && \
-  python2.7 ../x.py test src/test/run-make-fulldeps --test-args clang
+  python3 ../x.py build && \
+  python3 ../x.py test src/test/run-make-fulldeps --test-args clang

--- a/src/ci/docker/x86_64-gnu-distcheck/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-distcheck/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python2.7 \
+  python3 \
   git \
   cmake \
   sudo \
@@ -19,7 +19,7 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu --set rust.ignore-git=false
-ENV SCRIPT python2.7 ../x.py test distcheck
+ENV SCRIPT python3 ../x.py test distcheck
 ENV DIST_SRC 1
 
 # The purpose of this builder is to test that we can `./x.py test` successfully

--- a/src/ci/docker/x86_64-gnu-full-bootstrap/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-full-bootstrap/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python2.7 \
+  python3 \
   git \
   cmake \
   sudo \
@@ -21,7 +21,7 @@ RUN sh /scripts/sccache.sh
 ENV RUST_CONFIGURE_ARGS \
       --build=x86_64-unknown-linux-gnu \
       --enable-full-bootstrap
-ENV SCRIPT python2.7 ../x.py build
+ENV SCRIPT python3 ../x.py build
 
 # In general this just slows down the build and we're just a smoke test that
 # a full bootstrap works in general, so there's not much need to take this

--- a/src/ci/docker/x86_64-gnu-nopt/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-nopt/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python2.7 \
+  python3 \
   git \
   cmake \
   sudo \
@@ -21,4 +21,4 @@ RUN sh /scripts/sccache.sh
 ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu \
   --disable-optimize-tests \
   --set rust.test-compare-mode
-ENV SCRIPT python2.7 ../x.py test
+ENV SCRIPT python3 ../x.py test

--- a/src/ci/docker/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-tools/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python2.7 \
+  python3 \
   git \
   cmake \
   libssl-dev \

--- a/src/ci/docker/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/x86_64-gnu-tools/checktools.sh
@@ -7,7 +7,7 @@ X_PY="$1"
 # Try to test all the tools and store the build/test success in the TOOLSTATE_FILE
 
 set +e
-python2.7 "$X_PY" test --no-fail-fast \
+python3 "$X_PY" test --no-fail-fast \
     src/doc/book \
     src/doc/nomicon \
     src/doc/reference \
@@ -22,4 +22,4 @@ python2.7 "$X_PY" test --no-fail-fast \
 
 set -e
 
-python2.7 "$X_PY" test check-tools
+python3 "$X_PY" test check-tools

--- a/src/ci/docker/x86_64-gnu/Dockerfile
+++ b/src/ci/docker/x86_64-gnu/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   curl \
   ca-certificates \
-  python2.7 \
+  python3 \
   git \
   cmake \
   sudo \
@@ -23,4 +23,4 @@ ENV RUST_CONFIGURE_ARGS \
  --enable-sanitizers \
  --enable-profiler \
  --enable-compiler-docs
-ENV SCRIPT python2.7 ../x.py test
+ENV SCRIPT python3 ../x.py test

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -23,6 +23,14 @@ fi
 ci_dir=`cd $(dirname $0) && pwd`
 source "$ci_dir/shared.sh"
 
+if command -v python > /dev/null; then
+    PYTHON="python"
+elif command -v python3 > /dev/null; then
+    PYTHON="python3"
+else
+    PYTHON="python2"
+fi
+
 if ! isCI || isCiBranch auto || isCiBranch beta; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set build.print-step-timings --enable-verbose-tests"
 fi
@@ -107,7 +115,7 @@ SCCACHE_IDLE_TIMEOUT=10800 sccache --start-server || true
 
 if [ "$RUN_CHECK_WITH_PARALLEL_QUERIES" != "" ]; then
   $SRC/configure --enable-parallel-compiler
-  CARGO_INCREMENTAL=0 python2.7 ../x.py check
+  CARGO_INCREMENTAL=0 $PYTHON ../x.py check
   rm -f config.toml
   rm -rf build
 fi

--- a/src/ci/scripts/install-mingw.sh
+++ b/src/ci/scripts/install-mingw.sh
@@ -50,8 +50,9 @@ if isWindows; then
     esac
 
     if [[ "${CUSTOM_MINGW-0}" -ne 1 ]]; then
-        pacman -S --noconfirm --needed mingw-w64-$arch-toolchain \
-            mingw-w64-$arch-cmake mingw-w64-$arch-gcc mingw-w64-$arch-python2
+        pacman -S --noconfirm --needed mingw-w64-$arch-toolchain mingw-w64-$arch-cmake \
+            mingw-w64-$arch-gcc \
+            mingw-w64-$arch-python # the python package is actually for python3
         ciCommandAddPath "$(ciCheckoutPath)/msys2/mingw${bits}/bin"
     else
         mingw_dir="mingw${bits}"

--- a/src/ci/scripts/install-msys2-packages.sh
+++ b/src/ci/scripts/install-msys2-packages.sh
@@ -13,7 +13,7 @@ if isWindows; then
     # one way or another. The msys interpreters seem to have weird path conversions
     # baked in which break LLVM's build system one way or another, so let's use the
     # native version which keeps everything as native as possible.
-    python_home="C:/hostedtoolcache/windows/Python/2.7.17/x64"
-    cp "${python_home}/python.exe" "${python_home}/python2.7.exe"
-    ciCommandAddPath "C:\\hostedtoolcache\\windows\\Python\\2.7.17\\x64"
+    python_home="C:/hostedtoolcache/windows/Python/3.7.6/x64"
+    cp "${python_home}/python.exe" "${python_home}/python3.exe"
+    ciCommandAddPath "C:\\hostedtoolcache\\windows\\Python\\3.7.6\\x64"
 fi

--- a/src/etc/dec2flt_table.py
+++ b/src/etc/dec2flt_table.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 
 """
 Generate powers of ten using William Clinger's ``AlgorithmM`` for use in

--- a/src/etc/test-float-parse/runtests.py
+++ b/src/etc/test-float-parse/runtests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 
 """
 Testing dec2flt

--- a/src/test/run-make-fulldeps/sysroot-crates-are-unstable/Makefile
+++ b/src/test/run-make-fulldeps/sysroot-crates-are-unstable/Makefile
@@ -1,2 +1,2 @@
 all:
-	python2.7 test.py
+	'$(PYTHON)' test.py

--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -57,6 +57,13 @@ REPOS = {
     'rustc-dev-guide': 'https://github.com/rust-lang/rustc-dev-guide',
 }
 
+def load_json_from_response(resp):
+    content = resp.read()
+    if isinstance(content, bytes):
+        content = content.decode('utf-8')
+    else:
+        print("Refusing to decode " + str(type(content)) + " to str")
+    return json.loads(content)
 
 def validate_maintainers(repo, github_token):
     '''Ensure all maintainers are assignable on a GitHub repo'''
@@ -71,7 +78,7 @@ def validate_maintainers(repo, github_token):
             # Properly load nested teams.
             'Accept': 'application/vnd.github.hellcat-preview+json',
         }))
-        assignable.extend(user['login'] for user in json.load(response))
+        assignable.extend(user['login'] for user in load_json_from_response(response))
         # Load the next page if available
         url = None
         link_header = response.headers.get('Link')
@@ -176,7 +183,7 @@ def update_latest(
 ):
     '''Updates `_data/latest.json` to match build result of the given commit.
     '''
-    with open('_data/latest.json', 'rb+') as f:
+    with open('_data/latest.json', 'r+') as f:
         latest = json.load(f, object_pairs_hook=collections.OrderedDict)
 
         current_status = {


### PR DESCRIPTION
This PR revises our previous policy of officially only supporting and testing with python 2 in the CI environment to instead test with python 3. It also changes the defaults to python 3 in our various scripts (usually, by way of `python` rather than `python3` to preserve compatibility with systems that do not have a python 3 available). 

The effect of this is that we expect all new patches to support python 3 (and will test as such). We explicitly also expect that patches support python 2.7 as well -- and test as such, though only on one builder. This is intended as a temporary, though likely long-lived, measure to preserve compatibility while looking towards the future which is likely to be a python 3 only world. We do not at this point set a timeline for when we'll drop support for python 2.7; it's plausible that this is months or years into the future, depending on how quickly the ecosystem drops support and how painful it is for us to maintain that support over time.

Closes #65063 (as far as I can tell; please file explicit and separate issues or PRs if not).