### PR TITLE
tell clang where to look for the system includes

### DIFF
--- a/src/ci/docker/dist-x86_64-linux/build-clang.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-clang.sh
@@ -18,21 +18,6 @@ patch -Np1 < ../llvm-project-centos.patch
 mkdir clang-build
 cd clang-build
 
-# For whatever reason the default set of include paths for clang is different
-# than that of gcc. As a result we need to manually include our sysroot's
-# include path, /rustroot/include, to clang's default include path.
-#
-# Alsow there's this weird oddity with gcc where there's an 'include-fixed'
-# directory that it generates. It turns out [1] that Centos 5's headers are so
-# old that they're incompatible with modern C semantics. While gcc automatically
-# fixes that clang doesn't account for this. Tell clang to manually include the
-# fixed headers so we can successfully compile code later on.
-#
-# [1]: https://sourceware.org/ml/crossgcc/2008-11/msg00028.html
-INC="/rustroot/include"
-INC="$INC:/rustroot/lib/gcc/x86_64-unknown-linux-gnu/5.5.0/include-fixed"
-INC="$INC:/usr/include"
-
 hide_output \
     cmake ../llvm \
       -DCMAKE_C_COMPILER=/rustroot/bin/gcc \
@@ -41,7 +26,7 @@ hide_output \
       -DCMAKE_INSTALL_PREFIX=/rustroot \
       -DLLVM_TARGETS_TO_BUILD=X86 \
       -DLLVM_ENABLE_PROJECTS="clang;lld" \
-      -DC_INCLUDE_DIRS="$INC"
+      -DGCC_INSTALL_PREFIX=/rustroot
 
 hide_output make -j10
 hide_output make install


### PR DESCRIPTION
to avoid problem if gcc version is changed it is better to tell clang what gcc that was used to build it so it can find the system includes by it self.

more info can be found in http://btorpey.github.io/blog/2015/01/02/building-clang/

r? @alexcrichton