### PR TITLE
Test setting a lower import limit for ThinLTO.

### DIFF
--- a/src/librustc_codegen_llvm/llvm_util.rs
+++ b/src/librustc_codegen_llvm/llvm_util.rs
@@ -76,7 +76,7 @@ unsafe fn configure_llvm(sess: &Session) {
             }
         }
 
-        add("-import-instr-limit=50");
+        add("-import-instr-limit=75");
 
         if sess.target.target.target_os == "emscripten" &&
             sess.panic_strategy() == PanicStrategy::Unwind {

--- a/src/librustc_codegen_llvm/llvm_util.rs
+++ b/src/librustc_codegen_llvm/llvm_util.rs
@@ -76,7 +76,7 @@ unsafe fn configure_llvm(sess: &Session) {
             }
         }
 
-        add("-import-instr-limit=25");
+        add("-import-instr-limit=50");
 
         if sess.target.target.target_os == "emscripten" &&
             sess.panic_strategy() == PanicStrategy::Unwind {

--- a/src/librustc_codegen_llvm/llvm_util.rs
+++ b/src/librustc_codegen_llvm/llvm_util.rs
@@ -76,6 +76,8 @@ unsafe fn configure_llvm(sess: &Session) {
             }
         }
 
+        add("-import-instr-limit=25");
+
         if sess.target.target.target_os == "emscripten" &&
             sess.panic_strategy() == PanicStrategy::Unwind {
             add("-enable-emscripten-cxx-exceptions");


### PR DESCRIPTION
The Firefox build system [sets a lower ThinLTO import limit](https://searchfox.org/mozilla-central/search?q=-import-instr-limit&path=) since recently but because they discovered that that can significantly lower build times without really affecting runtime performance too much. Let's see how this would affect our benchmarks.

r? @ghost