### PR TITLE
remove the 'dereferenceable' attribute from Box

### DIFF
--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -2526,8 +2526,14 @@ where
 
             if let Some(pointee) = layout.pointee_info_at(cx, offset) {
                 if let Some(kind) = pointee.safe {
-                    attrs.pointee_size = pointee.size;
                     attrs.pointee_align = Some(pointee.align);
+
+                    // `Box` (`UniqueBorrowed`) are not necessarily dereferencable
+                    // for the entire duration of the function, so set their size to 0.
+                    attrs.pointee_size =  match kind {
+                        PointerKind::UniqueOwned => Size::ZERO,
+                        _ => pointee.size
+                    };
 
                     // `Box` pointer parameters never alias because ownership is transferred
                     // `&mut` pointer parameters never alias other parameters,

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -2529,8 +2529,9 @@ where
                     attrs.pointee_align = Some(pointee.align);
 
                     // `Box` (`UniqueBorrowed`) are not necessarily dereferencable
-                    // for the entire duration of the function, so set their size to 0.
-                    attrs.pointee_size =  match kind {
+                    // for the entire duration of the function as they can be deallocated
+                    // any time. Set their valid size to 0.
+                    attrs.pointee_size = match kind {
                         PointerKind::UniqueOwned => Size::ZERO,
                         _ => pointee.size
                     };

--- a/src/librustc_target/abi/call/mod.rs
+++ b/src/librustc_target/abi/call/mod.rs
@@ -69,7 +69,8 @@ mod attr_impl {
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct ArgAttributes {
     pub regular: ArgAttribute,
-    /// The dereferenceable size of the pointee.
+    /// The minimum size of the pointee, guaranteed to be valid for the duration of the whole call
+    /// (corresponding to LLVM's dereferenceable and dereferenceable_or_null attributes).
     pub pointee_size: Size,
     pub pointee_align: Option<Align>
 }

--- a/src/librustc_target/abi/call/mod.rs
+++ b/src/librustc_target/abi/call/mod.rs
@@ -69,6 +69,7 @@ mod attr_impl {
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct ArgAttributes {
     pub regular: ArgAttribute,
+    /// The dereferenceable size of the pointee.
     pub pointee_size: Size,
     pub pointee_align: Option<Align>
 }

--- a/src/test/codegen/function-arguments.rs
+++ b/src/test/codegen/function-arguments.rs
@@ -65,7 +65,9 @@ pub fn indirect_struct(_: S) {
 pub fn borrowed_struct(_: &S) {
 }
 
-// CHECK: noalias align 4 dereferenceable(4) i32* @_box(i32* noalias align 4 dereferenceable(4) %x)
+// `Box` can get deallocated during execution of the function, so it should
+// not get `dereferenceable`.
+// CHECK: noalias nonnull align 4 i32* @_box(i32* noalias nonnull align 4 %x)
 #[no_mangle]
 pub fn _box(x: Box<i32>) -> Box<i32> {
   x


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/66600

r? @eddyb @rkruppe 