### PR TITLE
rustdoc: Mark `--extern-private` as unstable

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -144,7 +144,7 @@ fn opts() -> Vec<RustcOptGroup> {
         stable("extern", |o| {
             o.optmulti("", "extern", "pass an --extern to rustc", "NAME[=PATH]")
         }),
-        stable("extern-private", |o| {
+        unstable("extern-private", |o| {
             o.optmulti("", "extern-private",
                        "pass an --extern to rustc (compatibility only)", "NAME=PATH")
         }),

--- a/src/test/rustdoc/issue-66159.rs
+++ b/src/test/rustdoc/issue-66159.rs
@@ -1,4 +1,5 @@
 // aux-build:issue-66159-1.rs
+// compile-flags:-Z unstable-options
 // extern-private:issue_66159_1
 
 // The issue was an ICE which meant that we never actually generated the docs


### PR DESCRIPTION
It's not even stable in rustc so it shouldn't be stable in rustdoc.

r? @kinnison