### PR TITLE
rustdoc: Don't panic when failing to write .lock file

### DIFF
--- a/src/librustc_data_structures/flock.rs
+++ b/src/librustc_data_structures/flock.rs
@@ -298,15 +298,3 @@ cfg_if! {
         }
     }
 }
-
-impl Lock {
-    pub fn panicking_new(p: &Path,
-                         wait: bool,
-                         create: bool,
-                         exclusive: bool)
-                         -> Lock {
-        Lock::new(p, wait, create, exclusive).unwrap_or_else(|err| {
-            panic!("could not lock `{}`: {}", p.display(), err);
-        })
-    }
-}

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -546,7 +546,8 @@ fn write_shared(
     // Write out the shared files. Note that these are shared among all rustdoc
     // docs placed in the output directory, so this needs to be a synchronized
     // operation with respect to all other rustdocs running around.
-    let _lock = flock::Lock::panicking_new(&cx.dst.join(".lock"), true, true, true);
+    let lock_file = cx.dst.join(".lock");
+    let _lock = try_err!(flock::Lock::new(&lock_file, true, true, true), &lock_file);
 
     // Add all the static files. These may already exist, but we just
     // overwrite them anyway to make sure that they're fresh and up-to-date.


### PR DESCRIPTION
It can be treated like any other unexpected IO error.

I couldn't think of a good way to add a test for this unfortunately.

r? @GuillaumeGomez