### PR TITLE
Miri: print leak report even without tracing

### DIFF
--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -703,7 +703,9 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         if let LocalValue::Live(Operand::Indirect(MemPlace { ptr, .. })) = local {
             trace!("deallocating local");
             let ptr = ptr.to_ptr()?;
-            self.memory.dump_alloc(ptr.alloc_id);
+            if log_enabled!(::log::Level::Trace) {
+                self.memory.dump_alloc(ptr.alloc_id);
+            }
             self.memory.deallocate_local(ptr)?;
         };
         Ok(())

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -752,12 +752,14 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
     }
 
     pub fn leak_report(&self) -> usize {
-        eprintln!("### LEAK REPORT ###");
         let leaks: Vec<_> = self.alloc_map.filter_map_collect(|&id, &(kind, _)| {
             if kind.may_leak() { None } else { Some(id) }
         });
         let n = leaks.len();
-        self.dump_allocs(leaks);
+        if n > 0 {
+            eprintln!("### LEAK REPORT ###");
+            self.dump_allocs(leaks);
+        }
         n
     }
 

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -635,7 +635,9 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
         Ok(())
     }
 
-    /// For debugging, print an allocation and all allocations it points to, recursively.
+    /// Print an allocation and all allocations it points to, recursively.
+    /// This prints directly to stderr, ignoring RUSTC_LOG! It is up to the caller to
+    /// control for this.
     pub fn dump_alloc(&self, id: AllocId) {
         self.dump_allocs(vec![id]);
     }
@@ -674,7 +676,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
             }
         }
 
-        trace!(
+        eprintln!(
             "{}({} bytes, alignment {}){}",
             msg,
             alloc.size.bytes(),
@@ -695,15 +697,14 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
                 write!(msg, "└{0:─^1$}┘ ", target, relocation_width as usize).unwrap();
                 pos = i + self.pointer_size();
             }
-            trace!("{}", msg);
+            eprintln!("{}", msg);
         }
     }
 
-    /// For debugging, print a list of allocations and all allocations they point to, recursively.
+    /// Print a list of allocations and all allocations they point to, recursively.
+    /// This prints directly to stderr, ignoring RUSTC_LOG! It is up to the caller to
+    /// control for this.
     pub fn dump_allocs(&self, mut allocs: Vec<AllocId>) {
-        if !log_enabled!(::log::Level::Trace) {
-            return;
-        }
         allocs.sort();
         allocs.dedup();
         let mut allocs_to_print = VecDeque::from(allocs);
@@ -735,13 +736,13 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
                             );
                         }
                         Some(GlobalAlloc::Function(func)) => {
-                            trace!("{} {}", msg, func);
+                            eprintln!("{} {}", msg, func);
                         }
                         Some(GlobalAlloc::Static(did)) => {
-                            trace!("{} {:?}", msg, did);
+                            eprintln!("{} {:?}", msg, did);
                         }
                         None => {
-                            trace!("{} (deallocated)", msg);
+                            eprintln!("{} (deallocated)", msg);
                         }
                     }
                 },
@@ -751,7 +752,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
     }
 
     pub fn leak_report(&self) -> usize {
-        trace!("### LEAK REPORT ###");
+        eprintln!("### LEAK REPORT ###");
         let leaks: Vec<_> = self.alloc_map.filter_map_collect(|&id, &(kind, _)| {
             if kind.may_leak() { None } else { Some(id) }
         });


### PR DESCRIPTION
Currently, the rustup-installed Miri has no way to actually print a leak report (as `trace!` is compiled out). Make it print that per default instead when there is a leak.

r? @oli-obk 