### PR TITLE
Ast address-of

### DIFF
--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -1024,7 +1024,7 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
             visitor.visit_expr(left_expression);
             visitor.visit_expr(right_expression)
         }
-        ExprKind::AddrOf(_, ref subexpression) | ExprKind::Unary(_, ref subexpression) => {
+        ExprKind::AddrOf(_, _, ref subexpression) | ExprKind::Unary(_, ref subexpression) => {
             visitor.visit_expr(subexpression)
         }
         ExprKind::Cast(ref subexpression, ref typ) | ExprKind::Type(ref subexpression, ref typ) => {

--- a/src/librustc/hir/lowering/expr.rs
+++ b/src/librustc/hir/lowering/expr.rs
@@ -65,9 +65,9 @@ impl LoweringContext<'_> {
                 let expr = P(self.lower_expr(expr));
                 hir::ExprKind::Type(expr, self.lower_ty(ty, ImplTraitContext::disallowed()))
             }
-            ExprKind::AddrOf(m, ref ohs) => {
+            ExprKind::AddrOf(k, m, ref ohs) => {
                 let ohs = P(self.lower_expr(ohs));
-                hir::ExprKind::AddrOf(m, ohs)
+                hir::ExprKind::AddrOf(k, m, ohs)
             }
             ExprKind::Let(ref pat, ref scrutinee) => self.lower_expr_let(e.span, pat, scrutinee),
             ExprKind::If(ref cond, ref then, ref else_opt) => {
@@ -1339,7 +1339,11 @@ impl LoweringContext<'_> {
     }
 
     fn expr_mut_addr_of(&mut self, span: Span, e: P<hir::Expr>) -> hir::Expr {
-        self.expr(span, hir::ExprKind::AddrOf(hir::Mutability::Mutable, e), ThinVec::new())
+        self.expr(
+            span,
+            hir::ExprKind::AddrOf(hir::BorrowKind::Ref, hir::Mutability::Mutable, e),
+            ThinVec::new(),
+        )
     }
 
     fn expr_unit(&mut self, sp: Span) -> hir::Expr {

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -276,7 +276,7 @@ impl<'a, 'tcx> ExprUseVisitor<'a, 'tcx> {
                 self.consume_exprs(exprs);
             }
 
-            hir::ExprKind::AddrOf(m, ref base) => {   // &base
+            hir::ExprKind::AddrOf(_, m, ref base) => {   // &base
                 // make sure that the thing we are pointing out stays valid
                 // for the lifetime `scope_r` of the resulting ptr:
                 let bk = ty::BorrowKind::from_mutbl(m);

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -1241,7 +1241,7 @@ fn resolve_local<'tcx>(
         blk_id: Option<Scope>,
     ) {
         match expr.kind {
-            hir::ExprKind::AddrOf(_, ref subexpr) => {
+            hir::ExprKind::AddrOf(_, _, ref subexpr) => {
                 record_rvalue_scope_if_borrow_expr(visitor, &subexpr, blk_id);
                 record_rvalue_scope(visitor, &subexpr, blk_id);
             }
@@ -1301,7 +1301,7 @@ fn resolve_local<'tcx>(
             visitor.scope_tree.record_rvalue_scope(expr.hir_id.local_id, blk_scope);
 
             match expr.kind {
-                hir::ExprKind::AddrOf(_, ref subexpr) |
+                hir::ExprKind::AddrOf(_, _, ref subexpr) |
                 hir::ExprKind::Unary(hir::UnDeref, ref subexpr) |
                 hir::ExprKind::Field(ref subexpr, _) |
                 hir::ExprKind::Index(ref subexpr, _) => {

--- a/src/librustc_error_codes/error_codes.rs
+++ b/src/librustc_error_codes/error_codes.rs
@@ -409,6 +409,7 @@ E0741: include_str!("./error_codes/E0741.md"),
 E0742: include_str!("./error_codes/E0742.md"),
 E0743: include_str!("./error_codes/E0743.md"),
 E0744: include_str!("./error_codes/E0744.md"),
+E0745: include_str!("./error_codes/E0745.md"),
 ;
 //  E0006, // merged with E0005
 //  E0008, // cannot bind by-move into a pattern guard

--- a/src/librustc_error_codes/error_codes/E0745.md
+++ b/src/librustc_error_codes/error_codes/E0745.md
@@ -1,0 +1,20 @@
+Cannot take address of temporary value.
+
+Erroneous code example:
+
+```compile_fail,E0745
+# #![feature(raw_ref_op)]
+fn temp_address() {
+    let ptr = &raw const 2;   // ERROR
+}
+```
+
+To avoid the error, first bind the temporary to a named local variable.
+
+```ignore
+# #![feature(raw_ref_op)]
+fn temp_address() {
+    let val = 2;
+    let ptr = &raw const val;
+}
+```

--- a/src/librustc_parse/parser/diagnostics.rs
+++ b/src/librustc_parse/parser/diagnostics.rs
@@ -726,7 +726,7 @@ impl<'a> Parser<'a> {
                 let sum_with_parens = pprust::to_string(|s| {
                     s.s.word("&");
                     s.print_opt_lifetime(lifetime);
-                    s.print_mutability(mut_ty.mutbl);
+                    s.print_mutability(mut_ty.mutbl, false);
                     s.popen();
                     s.print_type(&mut_ty.ty);
                     s.print_type_bounds(" +", &bounds);

--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -592,7 +592,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Parse `& mut? <expr>` or `& raw [ const | mut ] <expr>`
+    /// Parse `& mut? <expr>` or `& raw [ const | mut ] <expr>`.
     fn parse_address_of(&mut self, lo: Span) -> PResult<'a, (Span, ExprKind)> {
         self.expect_and()?;
         let (k, m) = if self.check_keyword(kw::Raw)

--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -442,11 +442,7 @@ impl<'a> Parser<'a> {
                 (lo.to(span), self.mk_unary(UnOp::Deref, e))
             }
             token::BinOp(token::And) | token::AndAnd => {
-                self.expect_and()?;
-                let m = self.parse_mutability();
-                let e = self.parse_prefix_expr(None);
-                let (span, e) = self.interpolated_or_expr_span(e)?;
-                (lo.to(span), ExprKind::AddrOf(m, e))
+                self.parse_address_of(lo)?
             }
             token::Ident(..) if self.token.is_keyword(kw::Box) => {
                 self.bump();
@@ -594,6 +590,25 @@ impl<'a> Parser<'a> {
                 }
             }
         }
+    }
+
+    /// Parse `& mut? <expr>` or `& raw [ const | mut ] <expr>`
+    fn parse_address_of(&mut self, lo: Span) -> PResult<'a, (Span, ExprKind)> {
+        self.expect_and()?;
+        let (k, m) = if self.check_keyword(kw::Raw)
+            && self.look_ahead(1, Token::is_mutability)
+        {
+            let found_raw = self.eat_keyword(kw::Raw);
+            assert!(found_raw);
+            let mutability = self.parse_const_or_mut().unwrap();
+            self.sess.gated_spans.gate(sym::raw_ref_op, lo.to(self.prev_span));
+            (ast::BorrowKind::Raw, mutability)
+        } else {
+            (ast::BorrowKind::Ref, self.parse_mutability())
+        };
+        let e = self.parse_prefix_expr(None);
+        let (span, e) = self.interpolated_or_expr_span(e)?;
+        Ok((lo.to(span), ExprKind::AddrOf(k, m, e)))
     }
 
     /// Parses `a.b` or `a(13)` or `a[4]` or just `a`.

--- a/src/librustc_passes/liveness.rs
+++ b/src/librustc_passes/liveness.rs
@@ -1174,7 +1174,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
             }
 
             hir::ExprKind::Box(ref e) |
-            hir::ExprKind::AddrOf(_, ref e) |
+            hir::ExprKind::AddrOf(_, _, ref e) |
             hir::ExprKind::Cast(ref e, _) |
             hir::ExprKind::Type(ref e, _) |
             hir::ExprKind::DropTemps(ref e) |

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -484,7 +484,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                 }
             },
-            (hir::ExprKind::AddrOf(_, ref expr), _, &ty::Ref(_, checked, _)) if {
+            (
+                hir::ExprKind::AddrOf(hir::BorrowKind::Ref, _, ref expr),
+                _,
+                &ty::Ref(_, checked, _)
+            ) if {
                 self.infcx.can_sub(self.param_env, checked, &expected).is_ok() && !is_macro
             } => {
                 // We have `&T`, check if what was expected was `T`. If so,

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -238,8 +238,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ExprKind::Unary(unop, ref oprnd) => {
                 self.check_expr_unary(unop, oprnd, expected, needs, expr)
             }
-            ExprKind::AddrOf(mutbl, ref oprnd) => {
-                self.check_expr_addr_of(mutbl, oprnd, expected, expr)
+            ExprKind::AddrOf(kind, mutbl, ref oprnd) => {
+                self.check_expr_addr_of(kind, mutbl, oprnd, expected, expr)
             }
             ExprKind::Path(ref qpath) => {
                 self.check_expr_path(qpath, expr)
@@ -424,6 +424,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
     fn check_expr_addr_of(
         &self,
+        kind: hir::BorrowKind,
         mutbl: hir::Mutability,
         oprnd: &'tcx hir::Expr,
         expected: Expectation<'tcx>,
@@ -432,7 +433,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let hint = expected.only_has_type(self).map_or(NoExpectation, |ty| {
             match ty.kind {
                 ty::Ref(_, ty, _) | ty::RawPtr(ty::TypeAndMut { ty, .. }) => {
-                    if oprnd.is_place_expr() {
+                    if oprnd.is_syntactic_place_expr() {
                         // Places may legitimately have unsized types.
                         // For example, dereferences of a fat pointer and
                         // the last field of a struct can be unsized.
@@ -448,24 +449,63 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let ty = self.check_expr_with_expectation_and_needs(&oprnd, hint, needs);
 
         let tm = ty::TypeAndMut { ty: ty, mutbl: mutbl };
-        if tm.ty.references_error() {
-            self.tcx.types.err
-        } else {
-            // Note: at this point, we cannot say what the best lifetime
-            // is to use for resulting pointer.  We want to use the
-            // shortest lifetime possible so as to avoid spurious borrowck
-            // errors.  Moreover, the longest lifetime will depend on the
-            // precise details of the value whose address is being taken
-            // (and how long it is valid), which we don't know yet until type
-            // inference is complete.
+        match kind {
+            _ if tm.ty.references_error() => self.tcx.types.err,
+            hir::BorrowKind::Raw => {
+                self.check_named_place_expr(oprnd);
+                self.tcx.mk_ptr(tm)
+            }
+            hir::BorrowKind::Ref => {
+                // Note: at this point, we cannot say what the best lifetime
+                // is to use for resulting pointer.  We want to use the
+                // shortest lifetime possible so as to avoid spurious borrowck
+                // errors.  Moreover, the longest lifetime will depend on the
+                // precise details of the value whose address is being taken
+                // (and how long it is valid), which we don't know yet until
+                // type inference is complete.
+                //
+                // Therefore, here we simply generate a region variable. The
+                // region inferencer will then select a suitable value.
+                // Finally, borrowck will infer the value of the region again,
+                // this time with enough precision to check that the value
+                // whose address was taken can actually be made to live as long
+                // as it needs to live.
+                let region = self.next_region_var(infer::AddrOfRegion(expr.span));
+                self.tcx.mk_ref(region, tm)
+            }
+        }
+    }
+
+    /// Does this expression refer to a place that either:
+    /// * Is based on a local or static.
+    /// * Contains a dereference
+    /// Note that the adjustments for the children of `expr` should already
+    /// have been resolved.
+    fn check_named_place_expr(&self, oprnd: &'tcx hir::Expr) {
+        let is_named = oprnd.is_place_expr(|base| {
+            // Allow raw borrows if there are any deref adjustments.
             //
-            // Therefore, here we simply generate a region variable.  The
-            // region inferencer will then select the ultimate value.
-            // Finally, borrowck is charged with guaranteeing that the
-            // value whose address was taken can actually be made to live
-            // as long as it needs to live.
-            let region = self.next_region_var(infer::AddrOfRegion(expr.span));
-            self.tcx.mk_ref(region, tm)
+            // const VAL: (i32,) = (0,);
+            // const REF: &(i32,) = &(0,);
+            //
+            // &raw const VAL.0;            // ERROR
+            // &raw const REF.0;            // OK, same as &raw const (*REF).0;
+            //
+            // This is maybe too permissive, since it allows
+            // `let u = &raw const Box::new((1,)).0`, which creates an
+            // immediately dangling raw pointer.
+            self.tables.borrow().adjustments().get(base.hir_id).map_or(false, |x| {
+                x.iter().any(|adj| if let Adjust::Deref(_) = adj.kind {
+                    true
+                } else {
+                    false
+                })
+            })
+        });
+        if !is_named {
+            struct_span_err!(self.tcx.sess, oprnd.span, E0745, "cannot take address of a temporary")
+                .span_label(oprnd.span, "temporary value")
+                .emit();
         }
     }
 
@@ -740,7 +780,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 err.help(msg);
             }
             err.emit();
-        } else if !lhs.is_place_expr() {
+        } else if !lhs.is_syntactic_place_expr() {
             struct_span_err!(self.tcx.sess, expr.span, E0070,
                                 "invalid left-hand side expression")
                 .span_label(expr.span, "left-hand of expression not valid")

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -33,7 +33,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return_ty
         };
 
-        if !lhs_expr.is_place_expr() {
+        if !lhs_expr.is_syntactic_place_expr() {
             struct_span_err!(
                 self.tcx.sess, lhs_expr.span,
                 E0067, "invalid left-hand side expression")

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -645,7 +645,7 @@ impl<'a, 'tcx> Visitor<'tcx> for RegionCtxt<'a, 'tcx> {
                 intravisit::walk_expr(self, expr);
             }
 
-            hir::ExprKind::AddrOf(m, ref base) => {
+            hir::ExprKind::AddrOf(hir::BorrowKind::Ref, m, ref base) => {
                 self.link_addr_of(expr, m, &base);
 
                 // Require that when you write a `&expr` expression, the

--- a/src/libsyntax/feature_gate/active.rs
+++ b/src/libsyntax/feature_gate/active.rs
@@ -520,13 +520,16 @@ declare_features! (
     /// Allows using the `efiapi` ABI.
     (active, abi_efiapi, "1.40.0", Some(65815), None),
 
+    /// Allows `&raw const $place_expr` and `&raw mut $place_expr` expressions.
+    (active, raw_ref_op, "1.41.0", Some(64490), None),
+
     /// Allows diverging expressions to fall back to `!` rather than `()`.
     (active, never_type_fallback, "1.41.0", Some(65992), None),
 
     /// Allows using the `#[register_attr]` attribute.
     (active, register_attr, "1.41.0", Some(66080), None),
 
-    /// Allows using the `#[register_attr]` attribute.
+    /// Allows using the `#[register_tool]` attribute.
     (active, register_tool, "1.41.0", Some(66079), None),
 
     /// Allows the use of `if` and `match` in constants.

--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -866,6 +866,7 @@ pub fn check_crate(krate: &ast::Crate,
     gate_all!(generators, "yield syntax is experimental");
     gate_all!(or_patterns, "or-patterns syntax is experimental");
     gate_all!(const_extern_fn, "`const extern fn` definitions are unstable");
+    gate_all!(raw_ref_op, "raw address of syntax is experimental");
 
     // All uses of `gate_all!` below this point were added in #65742,
     // and subsequently disabled (with the non-early gating readded).

--- a/src/libsyntax/mut_visit.rs
+++ b/src/libsyntax/mut_visit.rs
@@ -1128,7 +1128,7 @@ pub fn noop_visit_expr<T: MutVisitor>(Expr { kind, id, span, attrs }: &mut Expr,
             vis.visit_expr(expr);
             vis.visit_ty(ty);
         }
-        ExprKind::AddrOf(_m, ohs) => vis.visit_expr(ohs),
+        ExprKind::AddrOf(_, _, ohs) => vis.visit_expr(ohs),
         ExprKind::Let(pat, scrutinee) => {
             vis.visit_pat(pat);
             vis.visit_expr(scrutinee);

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -708,7 +708,7 @@ pub fn walk_expr<'a, V: Visitor<'a>>(visitor: &mut V, expression: &'a Expr) {
             visitor.visit_expr(left_expression);
             visitor.visit_expr(right_expression)
         }
-        ExprKind::AddrOf(_, ref subexpression) | ExprKind::Unary(_, ref subexpression) => {
+        ExprKind::AddrOf(_, _, ref subexpression) | ExprKind::Unary(_, ref subexpression) => {
             visitor.visit_expr(subexpression)
         }
         ExprKind::Cast(ref subexpression, ref typ) | ExprKind::Type(ref subexpression, ref typ) => {

--- a/src/libsyntax_expand/build.rs
+++ b/src/libsyntax_expand/build.rs
@@ -270,7 +270,7 @@ impl<'a> ExtCtxt<'a> {
     }
 
     pub fn expr_addr_of(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr> {
-        self.expr(sp, ast::ExprKind::AddrOf(ast::Mutability::Immutable, e))
+        self.expr(sp, ast::ExprKind::AddrOf(ast::BorrowKind::Ref, ast::Mutability::Immutable, e))
     }
 
     pub fn expr_call(

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -98,6 +98,7 @@ symbols! {
         Auto:               "auto",
         Catch:              "catch",
         Default:            "default",
+        Raw:                "raw",
         Union:              "union",
     }
 
@@ -546,6 +547,7 @@ symbols! {
         RangeToInclusive,
         raw_dylib,
         raw_identifiers,
+        raw_ref_op,
         Ready,
         reason,
         recursion_limit,

--- a/src/test/ui-fulldeps/pprust-expr-roundtrip.rs
+++ b/src/test/ui-fulldeps/pprust-expr-roundtrip.rs
@@ -139,7 +139,10 @@ fn iter_exprs(depth: usize, f: &mut dyn FnMut(P<Expr>)) {
                             Some(make_x()), Some(e), RangeLimits::HalfOpen)));
             },
             15 => {
-                iter_exprs(depth - 1, &mut |e| g(ExprKind::AddrOf(Mutability::Immutable, e)));
+                iter_exprs(
+                    depth - 1,
+                    &mut |e| g(ExprKind::AddrOf(BorrowKind::Ref, Mutability::Immutable, e)),
+                );
             },
             16 => {
                 g(ExprKind::Ret(None));

--- a/src/test/ui/raw-ref-op/feature-raw-ref-op.rs
+++ b/src/test/ui/raw-ref-op/feature-raw-ref-op.rs
@@ -1,0 +1,21 @@
+// gate-test-raw_ref_op
+
+macro_rules! is_expr {
+    ($e:expr) => {}
+}
+
+is_expr!(&raw const a);         //~ ERROR raw address of syntax is experimental
+is_expr!(&raw mut a);           //~ ERROR raw address of syntax is experimental
+
+#[cfg(FALSE)]
+fn cfgd_out() {
+    let mut a = 0;
+    &raw const a;               //~ ERROR raw address of syntax is experimental
+    &raw mut a;                 //~ ERROR raw address of syntax is experimental
+}
+
+fn main() {
+    let mut y = 123;
+    let x = &raw const y;       //~ ERROR raw address of syntax is experimental
+    let x = &raw mut y;         //~ ERROR raw address of syntax is experimental
+}

--- a/src/test/ui/raw-ref-op/feature-raw-ref-op.stderr
+++ b/src/test/ui/raw-ref-op/feature-raw-ref-op.stderr
@@ -1,0 +1,57 @@
+error[E0658]: raw address of syntax is experimental
+  --> $DIR/feature-raw-ref-op.rs:13:5
+   |
+LL |     &raw const a;
+   |     ^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+   = help: add `#![feature(raw_ref_op)]` to the crate attributes to enable
+
+error[E0658]: raw address of syntax is experimental
+  --> $DIR/feature-raw-ref-op.rs:14:5
+   |
+LL |     &raw mut a;
+   |     ^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+   = help: add `#![feature(raw_ref_op)]` to the crate attributes to enable
+
+error[E0658]: raw address of syntax is experimental
+  --> $DIR/feature-raw-ref-op.rs:19:13
+   |
+LL |     let x = &raw const y;
+   |             ^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+   = help: add `#![feature(raw_ref_op)]` to the crate attributes to enable
+
+error[E0658]: raw address of syntax is experimental
+  --> $DIR/feature-raw-ref-op.rs:20:13
+   |
+LL |     let x = &raw mut y;
+   |             ^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+   = help: add `#![feature(raw_ref_op)]` to the crate attributes to enable
+
+error[E0658]: raw address of syntax is experimental
+  --> $DIR/feature-raw-ref-op.rs:7:10
+   |
+LL | is_expr!(&raw const a);
+   |          ^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+   = help: add `#![feature(raw_ref_op)]` to the crate attributes to enable
+
+error[E0658]: raw address of syntax is experimental
+  --> $DIR/feature-raw-ref-op.rs:8:10
+   |
+LL | is_expr!(&raw mut a);
+   |          ^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+   = help: add `#![feature(raw_ref_op)]` to the crate attributes to enable
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/raw-ref-op/raw-ref-op.rs
+++ b/src/test/ui/raw-ref-op/raw-ref-op.rs
@@ -1,0 +1,13 @@
+// FIXME(#64490): make this run-pass
+
+#![feature(raw_ref_op)]
+
+fn main() {
+    let mut x = 123;
+    let c_p = &raw const x;                     //~ ERROR not yet implemented
+    let m_p = &raw mut x;                       //~ ERROR not yet implemented
+    let i_r = &x;
+    assert!(c_p == i_r);
+    assert!(c_p == m_p);
+    unsafe { assert!(*c_p == *i_r ); }
+}

--- a/src/test/ui/raw-ref-op/raw-ref-op.stderr
+++ b/src/test/ui/raw-ref-op/raw-ref-op.stderr
@@ -1,0 +1,18 @@
+error: raw borrows are not yet implemented
+  --> $DIR/raw-ref-op.rs:7:15
+   |
+LL |     let c_p = &raw const x;
+   |               ^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+
+error: raw borrows are not yet implemented
+  --> $DIR/raw-ref-op.rs:8:15
+   |
+LL |     let m_p = &raw mut x;
+   |               ^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/raw-ref-op/raw-ref-temp-deref.rs
+++ b/src/test/ui/raw-ref-op/raw-ref-temp-deref.rs
@@ -1,0 +1,19 @@
+// Ensure that we don't allow taking the address of temporary values
+#![feature(raw_ref_op)]
+
+const PAIR: (i32, i64) = (1, 2);
+const PAIR_REF: &(i32, i64) = &(1, 2);
+
+const ARRAY: [i32; 2] = [1, 2];
+const ARRAY_REF: &[i32; 2] = &[3, 4];
+const SLICE_REF: &[i32] = &[5, 6];
+
+fn main() {
+    // These are all OK, we're not taking the address of the temporary
+    let deref_ref = &raw const *PAIR_REF;               //~ ERROR not yet implemented
+    let field_deref_ref = &raw const PAIR_REF.0;        //~ ERROR not yet implemented
+    let deref_ref = &raw const *ARRAY_REF;              //~ ERROR not yet implemented
+    let field_deref_ref = &raw const ARRAY_REF[0];      //~ ERROR not yet implemented
+    let deref_ref = &raw const *SLICE_REF;              //~ ERROR not yet implemented
+    let field_deref_ref = &raw const SLICE_REF[1];      //~ ERROR not yet implemented
+}

--- a/src/test/ui/raw-ref-op/raw-ref-temp-deref.rs
+++ b/src/test/ui/raw-ref-op/raw-ref-temp-deref.rs
@@ -1,19 +1,24 @@
-// Ensure that we don't allow taking the address of temporary values
-#![feature(raw_ref_op)]
+// FIXME(#64490) This should be check-pass
+// Check that taking the address of a place that contains a dereference is
+// allowed.
+#![feature(raw_ref_op, type_ascription)]
 
-const PAIR: (i32, i64) = (1, 2);
 const PAIR_REF: &(i32, i64) = &(1, 2);
 
-const ARRAY: [i32; 2] = [1, 2];
 const ARRAY_REF: &[i32; 2] = &[3, 4];
 const SLICE_REF: &[i32] = &[5, 6];
 
 fn main() {
     // These are all OK, we're not taking the address of the temporary
-    let deref_ref = &raw const *PAIR_REF;               //~ ERROR not yet implemented
-    let field_deref_ref = &raw const PAIR_REF.0;        //~ ERROR not yet implemented
-    let deref_ref = &raw const *ARRAY_REF;              //~ ERROR not yet implemented
-    let field_deref_ref = &raw const ARRAY_REF[0];      //~ ERROR not yet implemented
-    let deref_ref = &raw const *SLICE_REF;              //~ ERROR not yet implemented
-    let field_deref_ref = &raw const SLICE_REF[1];      //~ ERROR not yet implemented
+    let deref_ref = &raw const *PAIR_REF;                       //~ ERROR not yet implemented
+    let field_deref_ref = &raw const PAIR_REF.0;                //~ ERROR not yet implemented
+    let deref_ref = &raw const *ARRAY_REF;                      //~ ERROR not yet implemented
+    let index_deref_ref = &raw const ARRAY_REF[0];              //~ ERROR not yet implemented
+    let deref_ref = &raw const *SLICE_REF;                      //~ ERROR not yet implemented
+    let index_deref_ref = &raw const SLICE_REF[1];              //~ ERROR not yet implemented
+
+    let x = 0;
+    let ascribe_ref = &raw const (x: i32);                      //~ ERROR not yet implemented
+    let ascribe_deref = &raw const (*ARRAY_REF: [i32; 2]);      //~ ERROR not yet implemented
+    let ascribe_index_deref = &raw const (ARRAY_REF[0]: i32);   //~ ERROR not yet implemented
 }

--- a/src/test/ui/raw-ref-op/raw-ref-temp-deref.stderr
+++ b/src/test/ui/raw-ref-op/raw-ref-temp-deref.stderr
@@ -1,0 +1,74 @@
+error: raw borrows are not yet implemented
+  --> $DIR/raw-ref-temp-deref.rs:13:21
+   |
+LL |     let deref_ref = &raw const *PAIR_REF;
+   |                     ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+
+error: raw borrows are not yet implemented
+  --> $DIR/raw-ref-temp-deref.rs:14:27
+   |
+LL |     let field_deref_ref = &raw const PAIR_REF.0;
+   |                           ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+
+error: raw borrows are not yet implemented
+  --> $DIR/raw-ref-temp-deref.rs:15:21
+   |
+LL |     let deref_ref = &raw const *ARRAY_REF;
+   |                     ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+
+error: raw borrows are not yet implemented
+  --> $DIR/raw-ref-temp-deref.rs:16:27
+   |
+LL |     let index_deref_ref = &raw const ARRAY_REF[0];
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+
+error: raw borrows are not yet implemented
+  --> $DIR/raw-ref-temp-deref.rs:17:21
+   |
+LL |     let deref_ref = &raw const *SLICE_REF;
+   |                     ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+
+error: raw borrows are not yet implemented
+  --> $DIR/raw-ref-temp-deref.rs:18:27
+   |
+LL |     let index_deref_ref = &raw const SLICE_REF[1];
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+
+error: raw borrows are not yet implemented
+  --> $DIR/raw-ref-temp-deref.rs:21:23
+   |
+LL |     let ascribe_ref = &raw const (x: i32);
+   |                       ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+
+error: raw borrows are not yet implemented
+  --> $DIR/raw-ref-temp-deref.rs:22:25
+   |
+LL |     let ascribe_deref = &raw const (*ARRAY_REF: [i32; 2]);
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+
+error: raw borrows are not yet implemented
+  --> $DIR/raw-ref-temp-deref.rs:23:31
+   |
+LL |     let ascribe_index_deref = &raw const (ARRAY_REF[0]: i32);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+
+error: aborting due to 9 previous errors
+

--- a/src/test/ui/raw-ref-op/raw-ref-temp.rs
+++ b/src/test/ui/raw-ref-op/raw-ref-temp.rs
@@ -1,0 +1,29 @@
+// Ensure that we don't allow taking the address of temporary values
+#![feature(raw_ref_op, type_ascription)]
+
+const PAIR: (i32, i64) = (1, 2);
+
+const ARRAY: [i32; 2] = [1, 2];
+
+fn main() {
+    let ref_expr = &raw const 2;                        //~ ERROR cannot take address
+    let mut_ref_expr = &raw mut 3;                      //~ ERROR cannot take address
+    let ref_const = &raw const 4;                       //~ ERROR cannot take address
+    let mut_ref_const = &raw mut 5;                     //~ ERROR cannot take address
+
+    let field_ref_expr = &raw const (1, 2).0;           //~ ERROR cannot take address
+    let mut_field_ref_expr = &raw mut (1, 2).0;         //~ ERROR cannot take address
+    let field_ref = &raw const PAIR.0;                  //~ ERROR cannot take address
+    let mut_field_ref = &raw mut PAIR.0;                //~ ERROR cannot take address
+
+    let index_ref_expr = &raw const [1, 2][0];          //~ ERROR cannot take address
+    let mut_index_ref_expr = &raw mut [1, 2][0];        //~ ERROR cannot take address
+    let index_ref = &raw const ARRAY[0];                //~ ERROR cannot take address
+    let mut_index_ref = &raw mut ARRAY[1];              //~ ERROR cannot take address
+
+    let ref_ascribe = &raw const (2: i32);              //~ ERROR cannot take address
+    let mut_ref_ascribe = &raw mut (3: i32);            //~ ERROR cannot take address
+
+    let ascribe_field_ref = &raw const (PAIR.0: i32);   //~ ERROR cannot take address
+    let ascribe_index_ref = &raw mut (ARRAY[0]: i32);   //~ ERROR cannot take address
+}

--- a/src/test/ui/raw-ref-op/raw-ref-temp.stderr
+++ b/src/test/ui/raw-ref-op/raw-ref-temp.stderr
@@ -1,0 +1,99 @@
+error[E0745]: cannot take address of a temporary
+  --> $DIR/raw-ref-temp.rs:9:31
+   |
+LL |     let ref_expr = &raw const 2;
+   |                               ^ temporary value
+
+error[E0745]: cannot take address of a temporary
+  --> $DIR/raw-ref-temp.rs:10:33
+   |
+LL |     let mut_ref_expr = &raw mut 3;
+   |                                 ^ temporary value
+
+error[E0745]: cannot take address of a temporary
+  --> $DIR/raw-ref-temp.rs:11:32
+   |
+LL |     let ref_const = &raw const 4;
+   |                                ^ temporary value
+
+error[E0745]: cannot take address of a temporary
+  --> $DIR/raw-ref-temp.rs:12:34
+   |
+LL |     let mut_ref_const = &raw mut 5;
+   |                                  ^ temporary value
+
+error[E0745]: cannot take address of a temporary
+  --> $DIR/raw-ref-temp.rs:14:37
+   |
+LL |     let field_ref_expr = &raw const (1, 2).0;
+   |                                     ^^^^^^^^ temporary value
+
+error[E0745]: cannot take address of a temporary
+  --> $DIR/raw-ref-temp.rs:15:39
+   |
+LL |     let mut_field_ref_expr = &raw mut (1, 2).0;
+   |                                       ^^^^^^^^ temporary value
+
+error[E0745]: cannot take address of a temporary
+  --> $DIR/raw-ref-temp.rs:16:32
+   |
+LL |     let field_ref = &raw const PAIR.0;
+   |                                ^^^^^^ temporary value
+
+error[E0745]: cannot take address of a temporary
+  --> $DIR/raw-ref-temp.rs:17:34
+   |
+LL |     let mut_field_ref = &raw mut PAIR.0;
+   |                                  ^^^^^^ temporary value
+
+error[E0745]: cannot take address of a temporary
+  --> $DIR/raw-ref-temp.rs:19:37
+   |
+LL |     let index_ref_expr = &raw const [1, 2][0];
+   |                                     ^^^^^^^^^ temporary value
+
+error[E0745]: cannot take address of a temporary
+  --> $DIR/raw-ref-temp.rs:20:39
+   |
+LL |     let mut_index_ref_expr = &raw mut [1, 2][0];
+   |                                       ^^^^^^^^^ temporary value
+
+error[E0745]: cannot take address of a temporary
+  --> $DIR/raw-ref-temp.rs:21:32
+   |
+LL |     let index_ref = &raw const ARRAY[0];
+   |                                ^^^^^^^^ temporary value
+
+error[E0745]: cannot take address of a temporary
+  --> $DIR/raw-ref-temp.rs:22:34
+   |
+LL |     let mut_index_ref = &raw mut ARRAY[1];
+   |                                  ^^^^^^^^ temporary value
+
+error[E0745]: cannot take address of a temporary
+  --> $DIR/raw-ref-temp.rs:24:34
+   |
+LL |     let ref_ascribe = &raw const (2: i32);
+   |                                  ^^^^^^^^ temporary value
+
+error[E0745]: cannot take address of a temporary
+  --> $DIR/raw-ref-temp.rs:25:36
+   |
+LL |     let mut_ref_ascribe = &raw mut (3: i32);
+   |                                    ^^^^^^^^ temporary value
+
+error[E0745]: cannot take address of a temporary
+  --> $DIR/raw-ref-temp.rs:27:40
+   |
+LL |     let ascribe_field_ref = &raw const (PAIR.0: i32);
+   |                                        ^^^^^^^^^^^^^ temporary value
+
+error[E0745]: cannot take address of a temporary
+  --> $DIR/raw-ref-temp.rs:28:38
+   |
+LL |     let ascribe_index_ref = &raw mut (ARRAY[0]: i32);
+   |                                      ^^^^^^^^^^^^^^^ temporary value
+
+error: aborting due to 16 previous errors
+
+For more information about this error, try `rustc --explain E0745`.

--- a/src/test/ui/raw-ref-op/unusual_locations.rs
+++ b/src/test/ui/raw-ref-op/unusual_locations.rs
@@ -1,0 +1,25 @@
+// FIXME(#64490): make this check-pass
+
+#![feature(raw_ref_op)]
+
+const USES_PTR: () = { let u = (); &raw const u; };         //~ ERROR not yet implemented
+static ALSO_USES_PTR: () = { let u = (); &raw const u; };   //~ ERROR not yet implemented
+
+fn main() {
+    #[cfg(FALSE)]
+    {
+        let x: [i32; { let u = 2; let x = &raw const u; 4 }]
+            = [2; { let v = 3; let y = &raw const v; 4 }];
+        let mut one = 1;
+        let two = 2;
+        if &raw const one == &raw mut one {
+            match &raw const two {
+                _ => {}
+            }
+        }
+        let three = 3;
+        let mut four = 4;
+        println!("{:p}", &raw const three);
+        unsafe { &raw mut four; }
+    }
+}

--- a/src/test/ui/raw-ref-op/unusual_locations.stderr
+++ b/src/test/ui/raw-ref-op/unusual_locations.stderr
@@ -1,0 +1,18 @@
+error: raw borrows are not yet implemented
+  --> $DIR/unusual_locations.rs:5:36
+   |
+LL | const USES_PTR: () = { let u = (); &raw const u; };
+   |                                    ^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+
+error: raw borrows are not yet implemented
+  --> $DIR/unusual_locations.rs:6:42
+   |
+LL | static ALSO_USES_PTR: () = { let u = (); &raw const u; };
+   |                                          ^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
This is the parts of #64588 that don't affect MIR. If an address-of expression makes it to MIR lowering we error and lower to the best currently expressible approximation to limit further errors.

r? @Centril 
