### PR TITLE
Move def collector from `rustc` to `rustc_resolve`

### DIFF
--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -105,7 +105,7 @@ pub struct Definitions {
     /// we know what parent node that fragment should be attached to thanks to this table.
     invocation_parents: FxHashMap<ExpnId, DefIndex>,
     /// Indices of unnamed struct or variant fields with unresolved attributes.
-    pub(super) placeholder_field_indices: NodeMap<usize>,
+    placeholder_field_indices: NodeMap<usize>,
 }
 
 /// A unique identifier that we can use to lookup a definition
@@ -534,6 +534,15 @@ impl Definitions {
     pub fn set_invocation_parent(&mut self, invoc_id: ExpnId, parent: DefIndex) {
         let old_parent = self.invocation_parents.insert(invoc_id, parent);
         assert!(old_parent.is_none(), "parent `DefIndex` is reset for an invocation");
+    }
+
+    pub fn placeholder_field_index(&self, node_id: ast::NodeId) -> usize {
+        self.placeholder_field_indices[&node_id]
+    }
+
+    pub fn set_placeholder_field_index(&mut self, node_id: ast::NodeId, index: usize) {
+        let old_index = self.placeholder_field_indices.insert(node_id, index);
+        assert!(old_index.is_none(), "placeholder field index is reset for a node ID");
     }
 }
 

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -1,5 +1,4 @@
 use self::collector::NodeCollector;
-pub use self::def_collector::DefCollector;
 pub use self::definitions::{
     Definitions, DefKey, DefPath, DefPathData, DisambiguatedDefPathData, DefPathHash
 };
@@ -25,7 +24,6 @@ use syntax_pos::{Span, DUMMY_SP};
 
 pub mod blocks;
 mod collector;
-mod def_collector;
 pub mod definitions;
 mod hir_id_validator;
 

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -5,6 +5,7 @@
 //! unexpanded macros in the fragment are visited and registered.
 //! Imports are also considered items and placed into modules here, but not resolved yet.
 
+use crate::def_collector::collect_definitions;
 use crate::macros::{LegacyBinding, LegacyScope};
 use crate::resolve_imports::ImportDirective;
 use crate::resolve_imports::ImportDirectiveSubclass::{self, GlobImport, SingleImport};
@@ -16,7 +17,6 @@ use crate::{ResolutionError, Determinacy, PathResult, CrateLint};
 use rustc::bug;
 use rustc::hir::def::{self, *};
 use rustc::hir::def_id::{CRATE_DEF_INDEX, LOCAL_CRATE, DefId};
-use rustc::hir::map::DefCollector;
 use rustc::ty;
 use rustc::middle::cstore::CrateStore;
 use rustc_metadata::cstore::LoadedMacro;
@@ -167,8 +167,7 @@ impl<'a> Resolver<'a> {
         fragment: &AstFragment,
         parent_scope: ParentScope<'a>,
     ) -> LegacyScope<'a> {
-        let mut def_collector = DefCollector::new(&mut self.definitions, parent_scope.expansion);
-        fragment.visit_with(&mut def_collector);
+        collect_definitions(&mut self.definitions, fragment, parent_scope.expansion);
         let mut visitor = BuildReducedGraphVisitor { r: self, parent_scope };
         fragment.visit_with(&mut visitor);
         visitor.parent_scope.legacy

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -68,6 +68,7 @@ use rustc_error_codes::*;
 
 type Res = def::Res<NodeId>;
 
+mod def_collector;
 mod diagnostics;
 mod late;
 mod macros;


### PR DESCRIPTION
It's used only from `rustc_resolve`, so we can move it there, thus reducing the size of `rustc` (https://github.com/rust-lang/rust/issues/65031).

It's quite possible that we can merge the def collector pass into the "build reduced graph" pass (they are always run together and do similar things), but it's some larger work.

r? @eddyb 