### PR TITLE
Remove useless line for error index generation

### DIFF
--- a/src/tools/error_index_generator/build.rs
+++ b/src/tools/error_index_generator/build.rs
@@ -13,7 +13,6 @@ fn main() {
 
     println!("cargo:rerun-if-changed={}", error_codes_path);
     let file = fs::read_to_string(error_codes_path).unwrap()
-                  .replace("crate::register_diagnostics!", "register_diagnostics!")
                   .replace(": include_str!(\"./error_codes/", ": include_str!(\"./");
     let contents = format!("(|| {{\n{}\n}})()", file);
     fs::write(&out_dir.join("all_error_codes.rs"), &contents).unwrap();


### PR DESCRIPTION
As you can see here: https://github.com/rust-lang/rust/blob/master/src/librustc_error_codes/error_codes.rs#L10, this replacement is now completely useless.

r? @Dylan-DPC 