### PR TITLE
Format libcore with rustfmt

### DIFF
--- a/src/libcore/ascii.rs
+++ b/src/libcore/ascii.rs
@@ -12,8 +12,8 @@
 #![stable(feature = "core_ascii", since = "1.26.0")]
 
 use crate::fmt;
-use crate::ops::Range;
 use crate::iter::FusedIterator;
+use crate::ops::Range;
 use crate::str::from_utf8_unchecked;
 
 /// An iterator over the escaped version of a byte.
@@ -100,7 +100,7 @@ pub fn escape_default(c: u8) -> EscapeDefault {
         b'\\' => ([b'\\', b'\\', 0, 0], 2),
         b'\'' => ([b'\\', b'\'', 0, 0], 2),
         b'"' => ([b'\\', b'"', 0, 0], 2),
-        b'\x20' ..= b'\x7e' => ([c, 0, 0, 0], 1),
+        b'\x20'..=b'\x7e' => ([c, 0, 0, 0], 1),
         _ => ([b'\\', b'x', hexify(c >> 4), hexify(c & 0xf)], 4),
     };
 
@@ -108,7 +108,7 @@ pub fn escape_default(c: u8) -> EscapeDefault {
 
     fn hexify(b: u8) -> u8 {
         match b {
-            0 ..= 9 => b'0' + b,
+            0..=9 => b'0' + b,
             _ => b'a' + b - 10,
         }
     }
@@ -117,9 +117,15 @@ pub fn escape_default(c: u8) -> EscapeDefault {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Iterator for EscapeDefault {
     type Item = u8;
-    fn next(&mut self) -> Option<u8> { self.range.next().map(|i| self.data[i]) }
-    fn size_hint(&self) -> (usize, Option<usize>) { self.range.size_hint() }
-    fn last(mut self) -> Option<u8> { self.next_back() }
+    fn next(&mut self) -> Option<u8> {
+        self.range.next().map(|i| self.data[i])
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
+    fn last(mut self) -> Option<u8> {
+        self.next_back()
+    }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl DoubleEndedIterator for EscapeDefault {

--- a/src/libcore/char/convert.rs
+++ b/src/libcore/char/convert.rs
@@ -158,7 +158,6 @@ impl From<u8> for char {
     }
 }
 
-
 /// An error which can be returned when parsing a char.
 #[stable(feature = "char_from_str", since = "1.20.0")]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -167,16 +166,16 @@ pub struct ParseCharError {
 }
 
 impl ParseCharError {
-    #[unstable(feature = "char_error_internals",
-               reason = "this method should not be available publicly",
-               issue = "0")]
+    #[unstable(
+        feature = "char_error_internals",
+        reason = "this method should not be available publicly",
+        issue = "0"
+    )]
     #[doc(hidden)]
     pub fn __description(&self) -> &str {
         match self.kind {
-            CharErrorKind::EmptyString => {
-                "cannot parse char from empty string"
-            },
-            CharErrorKind::TooManyChars => "too many characters in string"
+            CharErrorKind::EmptyString => "cannot parse char from empty string",
+            CharErrorKind::TooManyChars => "too many characters in string",
         }
     }
 }
@@ -194,7 +193,6 @@ impl fmt::Display for ParseCharError {
     }
 }
 
-
 #[stable(feature = "char_from_str", since = "1.20.0")]
 impl FromStr for char {
     type Err = ParseCharError;
@@ -203,17 +201,12 @@ impl FromStr for char {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut chars = s.chars();
         match (chars.next(), chars.next()) {
-            (None, _) => {
-                Err(ParseCharError { kind: CharErrorKind::EmptyString })
-            },
+            (None, _) => Err(ParseCharError { kind: CharErrorKind::EmptyString }),
             (Some(c), None) => Ok(c),
-            _ => {
-                Err(ParseCharError { kind: CharErrorKind::TooManyChars })
-            }
+            _ => Err(ParseCharError { kind: CharErrorKind::TooManyChars }),
         }
     }
 }
-
 
 #[stable(feature = "try_from", since = "1.34.0")]
 impl TryFrom<u32> for char {
@@ -304,11 +297,7 @@ pub fn from_digit(num: u32, radix: u32) -> Option<char> {
     }
     if num < radix {
         let num = num as u8;
-        if num < 10 {
-            Some((b'0' + num) as char)
-        } else {
-            Some((b'a' + num - 10) as char)
-        }
+        if num < 10 { Some((b'0' + num) as char) } else { Some((b'a' + num - 10) as char) }
     } else {
         None
     }

--- a/src/libcore/char/decode.rs
+++ b/src/libcore/char/decode.rs
@@ -8,7 +8,8 @@ use super::from_u32_unchecked;
 #[stable(feature = "decode_utf16", since = "1.9.0")]
 #[derive(Clone, Debug)]
 pub struct DecodeUtf16<I>
-    where I: Iterator<Item = u16>
+where
+    I: Iterator<Item = u16>,
 {
     iter: I,
     buf: Option<u16>,
@@ -70,10 +71,7 @@ pub struct DecodeUtf16Error {
 #[stable(feature = "decode_utf16", since = "1.9.0")]
 #[inline]
 pub fn decode_utf16<I: IntoIterator<Item = u16>>(iter: I) -> DecodeUtf16<I::IntoIter> {
-    DecodeUtf16 {
-        iter: iter.into_iter(),
-        buf: None,
-    }
+    DecodeUtf16 { iter: iter.into_iter(), buf: None }
 }
 
 #[stable(feature = "decode_utf16", since = "1.9.0")]
@@ -83,7 +81,7 @@ impl<I: Iterator<Item = u16>> Iterator for DecodeUtf16<I> {
     fn next(&mut self) -> Option<Result<char, DecodeUtf16Error>> {
         let u = match self.buf.take() {
             Some(buf) => buf,
-            None => self.iter.next()?
+            None => self.iter.next()?,
         };
 
         if u < 0xD800 || 0xDFFF < u {

--- a/src/libcore/char/methods.rs
+++ b/src/libcore/char/methods.rs
@@ -130,11 +130,7 @@ impl char {
             }
         };
 
-        if val < radix {
-            Some(val)
-        } else {
-            None
-        }
+        if val < radix { Some(val) } else { None }
     }
 
     /// Returns an iterator that yields the hexadecimal Unicode escape of a
@@ -950,11 +946,7 @@ impl char {
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn to_ascii_uppercase(&self) -> char {
-        if self.is_ascii() {
-            (*self as u8).to_ascii_uppercase() as char
-        } else {
-            *self
-        }
+        if self.is_ascii() { (*self as u8).to_ascii_uppercase() as char } else { *self }
     }
 
     /// Makes a copy of the value in its ASCII lower case equivalent.
@@ -982,11 +974,7 @@ impl char {
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn to_ascii_lowercase(&self) -> char {
-        if self.is_ascii() {
-            (*self as u8).to_ascii_lowercase() as char
-        } else {
-            *self
-        }
+        if self.is_ascii() { (*self as u8).to_ascii_lowercase() as char } else { *self }
     }
 
     /// Checks that two values are an ASCII case-insensitive match.

--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -107,7 +107,7 @@
 /// [impls]: #implementors
 #[stable(feature = "rust1", since = "1.0.0")]
 #[lang = "clone"]
-pub trait Clone : Sized {
+pub trait Clone: Sized {
     /// Returns a copy of the value.
     ///
     /// # Examples
@@ -137,7 +137,9 @@ pub trait Clone : Sized {
 #[rustc_builtin_macro]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[allow_internal_unstable(core_intrinsics, derive_clone_copy)]
-pub macro Clone($item:item) { /* compiler built-in */ }
+pub macro Clone($item:item) {
+    /* compiler built-in */
+}
 
 // FIXME(aburka): these structs are used solely by #[derive] to
 // assert that every component of a type implements Clone or Copy.
@@ -145,16 +147,24 @@ pub macro Clone($item:item) { /* compiler built-in */ }
 // These structs should never appear in user code.
 #[doc(hidden)]
 #[allow(missing_debug_implementations)]
-#[unstable(feature = "derive_clone_copy",
-           reason = "deriving hack, should not be public",
-           issue = "0")]
-pub struct AssertParamIsClone<T: Clone + ?Sized> { _field: crate::marker::PhantomData<T> }
+#[unstable(
+    feature = "derive_clone_copy",
+    reason = "deriving hack, should not be public",
+    issue = "0"
+)]
+pub struct AssertParamIsClone<T: Clone + ?Sized> {
+    _field: crate::marker::PhantomData<T>,
+}
 #[doc(hidden)]
 #[allow(missing_debug_implementations)]
-#[unstable(feature = "derive_clone_copy",
-           reason = "deriving hack, should not be public",
-           issue = "0")]
-pub struct AssertParamIsCopy<T: Copy + ?Sized> { _field: crate::marker::PhantomData<T> }
+#[unstable(
+    feature = "derive_clone_copy",
+    reason = "deriving hack, should not be public",
+    issue = "0"
+)]
+pub struct AssertParamIsCopy<T: Copy + ?Sized> {
+    _field: crate::marker::PhantomData<T>,
+}
 
 /// Implementations of `Clone` for primitive types.
 ///
@@ -217,5 +227,4 @@ mod impls {
             *self
         }
     }
-
 }

--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -95,7 +95,9 @@
 /// ```
 #[stable(feature = "convert_id", since = "1.33.0")]
 #[inline]
-pub const fn identity<T>(x: T) -> T { x }
+pub const fn identity<T>(x: T) -> T {
+    x
+}
 
 /// Used to do a cheap reference-to-reference conversion.
 ///
@@ -364,12 +366,10 @@ pub trait Into<T>: Sized {
 /// [`from`]: trait.From.html#tymethod.from
 /// [book]: ../../book/ch09-00-error-handling.html
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented(
-    on(
-        all(_Self="&str", T="std::string::String"),
-        note="to coerce a `{T}` into a `{Self}`, use `&*` as a prefix",
-    )
-)]
+#[rustc_on_unimplemented(on(
+    all(_Self = "&str", T = "std::string::String"),
+    note = "to coerce a `{T}` into a `{Self}`, use `&*` as a prefix",
+))]
 pub trait From<T>: Sized {
     /// Performs the conversion.
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -490,7 +490,9 @@ pub trait TryFrom<T>: Sized {
 
 // As lifts over &
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized, U: ?Sized> AsRef<U> for &T where T: AsRef<U>
+impl<T: ?Sized, U: ?Sized> AsRef<U> for &T
+where
+    T: AsRef<U>,
 {
     fn as_ref(&self) -> &U {
         <T as AsRef<U>>::as_ref(*self)
@@ -499,7 +501,9 @@ impl<T: ?Sized, U: ?Sized> AsRef<U> for &T where T: AsRef<U>
 
 // As lifts over &mut
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized, U: ?Sized> AsRef<U> for &mut T where T: AsRef<U>
+impl<T: ?Sized, U: ?Sized> AsRef<U> for &mut T
+where
+    T: AsRef<U>,
 {
     fn as_ref(&self) -> &U {
         <T as AsRef<U>>::as_ref(*self)
@@ -516,7 +520,9 @@ impl<T: ?Sized, U: ?Sized> AsRef<U> for &mut T where T: AsRef<U>
 
 // AsMut lifts over &mut
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized, U: ?Sized> AsMut<U> for &mut T where T: AsMut<U>
+impl<T: ?Sized, U: ?Sized> AsMut<U> for &mut T
+where
+    T: AsMut<U>,
 {
     fn as_mut(&mut self) -> &mut U {
         (*self).as_mut()
@@ -533,7 +539,9 @@ impl<T: ?Sized, U: ?Sized> AsMut<U> for &mut T where T: AsMut<U>
 
 // From implies Into
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T, U> Into<U> for T where U: From<T>
+impl<T, U> Into<U> for T
+where
+    U: From<T>,
 {
     fn into(self) -> U {
         U::from(self)
@@ -543,7 +551,9 @@ impl<T, U> Into<U> for T where U: From<T>
 // From (and thus Into) is reflexive
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> From<T> for T {
-    fn from(t: T) -> T { t }
+    fn from(t: T) -> T {
+        t
+    }
 }
 
 /// **Stability note:** This impl does not yet exist, but we are
@@ -552,15 +562,19 @@ impl<T> From<T> for T {
 ///
 /// [#64715]: https://github.com/rust-lang/rust/issues/64715
 #[stable(feature = "convert_infallible", since = "1.34.0")]
-#[rustc_reservation_impl="permitting this impl would forbid us from adding \
-`impl<T> From<!> for T` later; see rust-lang/rust#64715 for details"]
+#[rustc_reservation_impl = "permitting this impl would forbid us from adding \
+                            `impl<T> From<!> for T` later; see rust-lang/rust#64715 for details"]
 impl<T> From<!> for T {
-    fn from(t: !) -> T { t }
+    fn from(t: !) -> T {
+        t
+    }
 }
 
 // TryFrom implies TryInto
 #[stable(feature = "try_from", since = "1.34.0")]
-impl<T, U> TryInto<U> for T where U: TryFrom<T>
+impl<T, U> TryInto<U> for T
+where
+    U: TryFrom<T>,
 {
     type Error = U::Error;
 
@@ -572,7 +586,10 @@ impl<T, U> TryInto<U> for T where U: TryFrom<T>
 // Infallible conversions are semantically equivalent to fallible conversions
 // with an uninhabited error type.
 #[stable(feature = "try_from", since = "1.34.0")]
-impl<T, U> TryFrom<U> for T where U: Into<T> {
+impl<T, U> TryFrom<U> for T
+where
+    U: Into<T>,
+{
     type Error = Infallible;
 
     fn try_from(value: U) -> Result<Self, Self::Error> {

--- a/src/libcore/default.rs
+++ b/src/libcore/default.rs
@@ -119,7 +119,9 @@ pub trait Default: Sized {
 #[rustc_builtin_macro]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[allow_internal_unstable(core_intrinsics)]
-pub macro Default($item:item) { /* compiler built-in */ }
+pub macro Default($item:item) {
+    /* compiler built-in */
+}
 
 macro_rules! default_impl {
     ($t:ty, $v:expr, $doc:tt) => {

--- a/src/libcore/ffi.rs
+++ b/src/libcore/ffi.rs
@@ -1,5 +1,4 @@
 #![stable(feature = "", since = "1.30.0")]
-
 #![allow(non_camel_case_types)]
 
 //! Utilities related to FFI bindings.
@@ -36,12 +35,20 @@ use crate::ops::{Deref, DerefMut};
 #[repr(u8)]
 #[stable(feature = "core_c_void", since = "1.30.0")]
 pub enum c_void {
-    #[unstable(feature = "c_void_variant", reason = "temporary implementation detail",
-               issue = "0")]
-    #[doc(hidden)] __variant1,
-    #[unstable(feature = "c_void_variant", reason = "temporary implementation detail",
-               issue = "0")]
-    #[doc(hidden)] __variant2,
+    #[unstable(
+        feature = "c_void_variant",
+        reason = "temporary implementation detail",
+        issue = "0"
+    )]
+    #[doc(hidden)]
+    __variant1,
+    #[unstable(
+        feature = "c_void_variant",
+        reason = "temporary implementation detail",
+        issue = "0"
+    )]
+    #[doc(hidden)]
+    __variant2,
 }
 
 #[stable(feature = "std_debug", since = "1.16.0")]
@@ -53,17 +60,20 @@ impl fmt::Debug for c_void {
 
 /// Basic implementation of a `va_list`.
 // The name is WIP, using `VaListImpl` for now.
-#[cfg(any(all(not(target_arch = "aarch64"), not(target_arch = "powerpc"),
-              not(target_arch = "x86_64")),
-          all(target_arch = "aarch64", target_os = "ios"),
-          target_arch = "wasm32",
-          target_arch = "asmjs",
-          windows))]
+#[cfg(any(
+    all(not(target_arch = "aarch64"), not(target_arch = "powerpc"), not(target_arch = "x86_64")),
+    all(target_arch = "aarch64", target_os = "ios"),
+    target_arch = "wasm32",
+    target_arch = "asmjs",
+    windows
+))]
 #[repr(transparent)]
-#[unstable(feature = "c_variadic",
-           reason = "the `c_variadic` feature has not been properly tested on \
-                     all supported platforms",
-           issue = "44930")]
+#[unstable(
+    feature = "c_variadic",
+    reason = "the `c_variadic` feature has not been properly tested on \
+              all supported platforms",
+    issue = "44930"
+)]
 #[lang = "va_list"]
 pub struct VaListImpl<'f> {
     ptr: *mut c_void,
@@ -73,16 +83,19 @@ pub struct VaListImpl<'f> {
     _marker: PhantomData<&'f mut &'f c_void>,
 }
 
-#[cfg(any(all(not(target_arch = "aarch64"), not(target_arch = "powerpc"),
-              not(target_arch = "x86_64")),
-          all(target_arch = "aarch64", target_os = "ios"),
-          target_arch = "wasm32",
-          target_arch = "asmjs",
-          windows))]
-#[unstable(feature = "c_variadic",
-           reason = "the `c_variadic` feature has not been properly tested on \
-                     all supported platforms",
-           issue = "44930")]
+#[cfg(any(
+    all(not(target_arch = "aarch64"), not(target_arch = "powerpc"), not(target_arch = "x86_64")),
+    all(target_arch = "aarch64", target_os = "ios"),
+    target_arch = "wasm32",
+    target_arch = "asmjs",
+    windows
+))]
+#[unstable(
+    feature = "c_variadic",
+    reason = "the `c_variadic` feature has not been properly tested on \
+              all supported platforms",
+    issue = "44930"
+)]
 impl<'f> fmt::Debug for VaListImpl<'f> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "va_list* {:p}", self.ptr)
@@ -97,10 +110,12 @@ impl<'f> fmt::Debug for VaListImpl<'f> {
 #[cfg(all(target_arch = "aarch64", not(target_os = "ios"), not(windows)))]
 #[repr(C)]
 #[derive(Debug)]
-#[unstable(feature = "c_variadic",
-           reason = "the `c_variadic` feature has not been properly tested on \
-                     all supported platforms",
-           issue = "44930")]
+#[unstable(
+    feature = "c_variadic",
+    reason = "the `c_variadic` feature has not been properly tested on \
+              all supported platforms",
+    issue = "44930"
+)]
 #[lang = "va_list"]
 pub struct VaListImpl<'f> {
     stack: *mut c_void,
@@ -115,10 +130,12 @@ pub struct VaListImpl<'f> {
 #[cfg(all(target_arch = "powerpc", not(windows)))]
 #[repr(C)]
 #[derive(Debug)]
-#[unstable(feature = "c_variadic",
-           reason = "the `c_variadic` feature has not been properly tested on \
-                     all supported platforms",
-           issue = "44930")]
+#[unstable(
+    feature = "c_variadic",
+    reason = "the `c_variadic` feature has not been properly tested on \
+              all supported platforms",
+    issue = "44930"
+)]
 #[lang = "va_list"]
 pub struct VaListImpl<'f> {
     gpr: u8,
@@ -133,10 +150,12 @@ pub struct VaListImpl<'f> {
 #[cfg(all(target_arch = "x86_64", not(windows)))]
 #[repr(C)]
 #[derive(Debug)]
-#[unstable(feature = "c_variadic",
-           reason = "the `c_variadic` feature has not been properly tested on \
-                     all supported platforms",
-           issue = "44930")]
+#[unstable(
+    feature = "c_variadic",
+    reason = "the `c_variadic` feature has not been properly tested on \
+              all supported platforms",
+    issue = "44930"
+)]
 #[lang = "va_list"]
 pub struct VaListImpl<'f> {
     gp_offset: i32,
@@ -149,76 +168,86 @@ pub struct VaListImpl<'f> {
 /// A wrapper for a `va_list`
 #[repr(transparent)]
 #[derive(Debug)]
-#[unstable(feature = "c_variadic",
-           reason = "the `c_variadic` feature has not been properly tested on \
-                     all supported platforms",
-           issue = "44930")]
+#[unstable(
+    feature = "c_variadic",
+    reason = "the `c_variadic` feature has not been properly tested on \
+              all supported platforms",
+    issue = "44930"
+)]
 pub struct VaList<'a, 'f: 'a> {
-    #[cfg(any(all(not(target_arch = "aarch64"), not(target_arch = "powerpc"),
-                  not(target_arch = "x86_64")),
-              all(target_arch = "aarch64", target_os = "ios"),
-              target_arch = "wasm32",
-              target_arch = "asmjs",
-              windows))]
+    #[cfg(any(
+        all(
+            not(target_arch = "aarch64"),
+            not(target_arch = "powerpc"),
+            not(target_arch = "x86_64")
+        ),
+        all(target_arch = "aarch64", target_os = "ios"),
+        target_arch = "wasm32",
+        target_arch = "asmjs",
+        windows
+    ))]
     inner: VaListImpl<'f>,
 
-    #[cfg(all(any(target_arch = "aarch64", target_arch = "powerpc",
-                  target_arch = "x86_64"),
-              any(not(target_arch = "aarch64"), not(target_os = "ios")),
-              not(target_arch = "wasm32"),
-              not(target_arch = "asmjs"),
-              not(windows)))]
+    #[cfg(all(
+        any(target_arch = "aarch64", target_arch = "powerpc", target_arch = "x86_64"),
+        any(not(target_arch = "aarch64"), not(target_os = "ios")),
+        not(target_arch = "wasm32"),
+        not(target_arch = "asmjs"),
+        not(windows)
+    ))]
     inner: &'a mut VaListImpl<'f>,
 
     _marker: PhantomData<&'a mut VaListImpl<'f>>,
 }
 
-#[cfg(any(all(not(target_arch = "aarch64"), not(target_arch = "powerpc"),
-              not(target_arch = "x86_64")),
-          all(target_arch = "aarch64", target_os = "ios"),
-          target_arch = "wasm32",
-          target_arch = "asmjs",
-          windows))]
-#[unstable(feature = "c_variadic",
-           reason = "the `c_variadic` feature has not been properly tested on \
-                     all supported platforms",
-           issue = "44930")]
+#[cfg(any(
+    all(not(target_arch = "aarch64"), not(target_arch = "powerpc"), not(target_arch = "x86_64")),
+    all(target_arch = "aarch64", target_os = "ios"),
+    target_arch = "wasm32",
+    target_arch = "asmjs",
+    windows
+))]
+#[unstable(
+    feature = "c_variadic",
+    reason = "the `c_variadic` feature has not been properly tested on \
+              all supported platforms",
+    issue = "44930"
+)]
 impl<'f> VaListImpl<'f> {
     /// Convert a `VaListImpl` into a `VaList` that is binary-compatible with C's `va_list`.
     #[inline]
     pub fn as_va_list<'a>(&'a mut self) -> VaList<'a, 'f> {
-        VaList {
-            inner: VaListImpl { ..*self },
-            _marker: PhantomData,
-        }
+        VaList { inner: VaListImpl { ..*self }, _marker: PhantomData }
     }
 }
 
-#[cfg(all(any(target_arch = "aarch64", target_arch = "powerpc",
-              target_arch = "x86_64"),
-          any(not(target_arch = "aarch64"), not(target_os = "ios")),
-          not(target_arch = "wasm32"),
-          not(target_arch = "asmjs"),
-          not(windows)))]
-#[unstable(feature = "c_variadic",
-           reason = "the `c_variadic` feature has not been properly tested on \
-                     all supported platforms",
-           issue = "44930")]
+#[cfg(all(
+    any(target_arch = "aarch64", target_arch = "powerpc", target_arch = "x86_64"),
+    any(not(target_arch = "aarch64"), not(target_os = "ios")),
+    not(target_arch = "wasm32"),
+    not(target_arch = "asmjs"),
+    not(windows)
+))]
+#[unstable(
+    feature = "c_variadic",
+    reason = "the `c_variadic` feature has not been properly tested on \
+              all supported platforms",
+    issue = "44930"
+)]
 impl<'f> VaListImpl<'f> {
     /// Convert a `VaListImpl` into a `VaList` that is binary-compatible with C's `va_list`.
     #[inline]
     pub fn as_va_list<'a>(&'a mut self) -> VaList<'a, 'f> {
-        VaList {
-            inner: self,
-            _marker: PhantomData,
-        }
+        VaList { inner: self, _marker: PhantomData }
     }
 }
 
-#[unstable(feature = "c_variadic",
-           reason = "the `c_variadic` feature has not been properly tested on \
-                     all supported platforms",
-           issue = "44930")]
+#[unstable(
+    feature = "c_variadic",
+    reason = "the `c_variadic` feature has not been properly tested on \
+              all supported platforms",
+    issue = "44930"
+)]
 impl<'a, 'f: 'a> Deref for VaList<'a, 'f> {
     type Target = VaListImpl<'f>;
 
@@ -228,10 +257,12 @@ impl<'a, 'f: 'a> Deref for VaList<'a, 'f> {
     }
 }
 
-#[unstable(feature = "c_variadic",
-           reason = "the `c_variadic` feature has not been properly tested on \
-                     all supported platforms",
-           issue = "44930")]
+#[unstable(
+    feature = "c_variadic",
+    reason = "the `c_variadic` feature has not been properly tested on \
+              all supported platforms",
+    issue = "44930"
+)]
 impl<'a, 'f: 'a> DerefMut for VaList<'a, 'f> {
     #[inline]
     fn deref_mut(&mut self) -> &mut VaListImpl<'f> {
@@ -252,10 +283,12 @@ mod sealed_trait {
     /// Trait which whitelists the allowed types to be used with [VaList::arg]
     ///
     /// [VaList::va_arg]: struct.VaList.html#method.arg
-    #[unstable(feature = "c_variadic",
-               reason = "the `c_variadic` feature has not been properly tested on \
-                         all supported platforms",
-               issue = "44930")]
+    #[unstable(
+        feature = "c_variadic",
+        reason = "the `c_variadic` feature has not been properly tested on \
+                  all supported platforms",
+        issue = "44930"
+    )]
     pub trait VaArgSafe {}
 }
 
@@ -271,25 +304,31 @@ macro_rules! impl_va_arg_safe {
     }
 }
 
-impl_va_arg_safe!{i8, i16, i32, i64, usize}
-impl_va_arg_safe!{u8, u16, u32, u64, isize}
-impl_va_arg_safe!{f64}
+impl_va_arg_safe! {i8, i16, i32, i64, usize}
+impl_va_arg_safe! {u8, u16, u32, u64, isize}
+impl_va_arg_safe! {f64}
 
-#[unstable(feature = "c_variadic",
-           reason = "the `c_variadic` feature has not been properly tested on \
-                     all supported platforms",
-           issue = "44930")]
+#[unstable(
+    feature = "c_variadic",
+    reason = "the `c_variadic` feature has not been properly tested on \
+              all supported platforms",
+    issue = "44930"
+)]
 impl<T> sealed_trait::VaArgSafe for *mut T {}
-#[unstable(feature = "c_variadic",
-           reason = "the `c_variadic` feature has not been properly tested on \
-                     all supported platforms",
-           issue = "44930")]
+#[unstable(
+    feature = "c_variadic",
+    reason = "the `c_variadic` feature has not been properly tested on \
+              all supported platforms",
+    issue = "44930"
+)]
 impl<T> sealed_trait::VaArgSafe for *const T {}
 
-#[unstable(feature = "c_variadic",
-           reason = "the `c_variadic` feature has not been properly tested on \
-                     all supported platforms",
-           issue = "44930")]
+#[unstable(
+    feature = "c_variadic",
+    reason = "the `c_variadic` feature has not been properly tested on \
+              all supported platforms",
+    issue = "44930"
+)]
 impl<'f> VaListImpl<'f> {
     /// Advance to the next arg.
     #[inline]
@@ -299,7 +338,9 @@ impl<'f> VaListImpl<'f> {
 
     /// Copies the `va_list` at the current location.
     pub unsafe fn with_copy<F, R>(&self, f: F) -> R
-            where F: for<'copy> FnOnce(VaList<'copy, 'f>) -> R {
+    where
+        F: for<'copy> FnOnce(VaList<'copy, 'f>) -> R,
+    {
         let mut ap = self.clone();
         let ret = f(ap.as_va_list());
         va_end(&mut ap);
@@ -307,10 +348,12 @@ impl<'f> VaListImpl<'f> {
     }
 }
 
-#[unstable(feature = "c_variadic",
-           reason = "the `c_variadic` feature has not been properly tested on \
-                     all supported platforms",
-           issue = "44930")]
+#[unstable(
+    feature = "c_variadic",
+    reason = "the `c_variadic` feature has not been properly tested on \
+              all supported platforms",
+    issue = "44930"
+)]
 impl<'f> Clone for VaListImpl<'f> {
     #[inline]
     fn clone(&self) -> Self {
@@ -323,10 +366,12 @@ impl<'f> Clone for VaListImpl<'f> {
     }
 }
 
-#[unstable(feature = "c_variadic",
-           reason = "the `c_variadic` feature has not been properly tested on \
-                     all supported platforms",
-           issue = "44930")]
+#[unstable(
+    feature = "c_variadic",
+    reason = "the `c_variadic` feature has not been properly tested on \
+              all supported platforms",
+    issue = "44930"
+)]
 impl<'f> Drop for VaListImpl<'f> {
     fn drop(&mut self) {
         // FIXME: this should call `va_end`, but there's no clean way to

--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -1,4 +1,4 @@
-use crate::fmt::{Formatter, Result, LowerExp, UpperExp, Display, Debug};
+use crate::fmt::{Debug, Display, Formatter, LowerExp, Result, UpperExp};
 use crate::mem::MaybeUninit;
 use crate::num::flt2dec;
 
@@ -7,9 +7,14 @@ use crate::num::flt2dec;
 // Don't inline this so callers don't use the stack space this function
 // requires unless they have to.
 #[inline(never)]
-fn float_to_decimal_common_exact<T>(fmt: &mut Formatter<'_>, num: &T,
-                                    sign: flt2dec::Sign, precision: usize) -> Result
-    where T: flt2dec::DecodableFloat
+fn float_to_decimal_common_exact<T>(
+    fmt: &mut Formatter<'_>,
+    num: &T,
+    sign: flt2dec::Sign,
+    precision: usize,
+) -> Result
+where
+    T: flt2dec::DecodableFloat,
 {
     unsafe {
         let mut buf = MaybeUninit::<[u8; 1024]>::uninit(); // enough for f32 and f64
@@ -19,9 +24,15 @@ fn float_to_decimal_common_exact<T>(fmt: &mut Formatter<'_>, num: &T,
         // we decided whether that is valid or not.
         // We can do this only because we are libstd and coupled to the compiler.
         // (FWIW, using `freeze` would not be enough; `flt2dec::Part` is an enum!)
-        let formatted = flt2dec::to_exact_fixed_str(flt2dec::strategy::grisu::format_exact,
-                                                    *num, sign, precision,
-                                                    false, buf.get_mut(), parts.get_mut());
+        let formatted = flt2dec::to_exact_fixed_str(
+            flt2dec::strategy::grisu::format_exact,
+            *num,
+            sign,
+            precision,
+            false,
+            buf.get_mut(),
+            parts.get_mut(),
+        );
         fmt.pad_formatted_parts(&formatted)
     }
 }
@@ -29,33 +40,49 @@ fn float_to_decimal_common_exact<T>(fmt: &mut Formatter<'_>, num: &T,
 // Don't inline this so callers that call both this and the above won't wind
 // up using the combined stack space of both functions in some cases.
 #[inline(never)]
-fn float_to_decimal_common_shortest<T>(fmt: &mut Formatter<'_>, num: &T,
-                                       sign: flt2dec::Sign, precision: usize) -> Result
-    where T: flt2dec::DecodableFloat
+fn float_to_decimal_common_shortest<T>(
+    fmt: &mut Formatter<'_>,
+    num: &T,
+    sign: flt2dec::Sign,
+    precision: usize,
+) -> Result
+where
+    T: flt2dec::DecodableFloat,
 {
     unsafe {
         // enough for f32 and f64
         let mut buf = MaybeUninit::<[u8; flt2dec::MAX_SIG_DIGITS]>::uninit();
         let mut parts = MaybeUninit::<[flt2dec::Part<'_>; 4]>::uninit();
         // FIXME(#53491)
-        let formatted = flt2dec::to_shortest_str(flt2dec::strategy::grisu::format_shortest, *num,
-                                                 sign, precision, false, buf.get_mut(),
-                                                 parts.get_mut());
+        let formatted = flt2dec::to_shortest_str(
+            flt2dec::strategy::grisu::format_shortest,
+            *num,
+            sign,
+            precision,
+            false,
+            buf.get_mut(),
+            parts.get_mut(),
+        );
         fmt.pad_formatted_parts(&formatted)
     }
 }
 
 // Common code of floating point Debug and Display.
-fn float_to_decimal_common<T>(fmt: &mut Formatter<'_>, num: &T,
-                              negative_zero: bool, min_precision: usize) -> Result
-    where T: flt2dec::DecodableFloat
+fn float_to_decimal_common<T>(
+    fmt: &mut Formatter<'_>,
+    num: &T,
+    negative_zero: bool,
+    min_precision: usize,
+) -> Result
+where
+    T: flt2dec::DecodableFloat,
 {
     let force_sign = fmt.sign_plus();
     let sign = match (force_sign, negative_zero) {
         (false, false) => flt2dec::Sign::Minus,
-        (false, true)  => flt2dec::Sign::MinusRaw,
-        (true,  false) => flt2dec::Sign::MinusPlus,
-        (true,  true)  => flt2dec::Sign::MinusPlusRaw,
+        (false, true) => flt2dec::Sign::MinusRaw,
+        (true, false) => flt2dec::Sign::MinusPlus,
+        (true, true) => flt2dec::Sign::MinusPlusRaw,
     };
 
     if let Some(precision) = fmt.precision {
@@ -68,18 +95,29 @@ fn float_to_decimal_common<T>(fmt: &mut Formatter<'_>, num: &T,
 // Don't inline this so callers don't use the stack space this function
 // requires unless they have to.
 #[inline(never)]
-fn float_to_exponential_common_exact<T>(fmt: &mut Formatter<'_>, num: &T,
-                                        sign: flt2dec::Sign, precision: usize,
-                                        upper: bool) -> Result
-    where T: flt2dec::DecodableFloat
+fn float_to_exponential_common_exact<T>(
+    fmt: &mut Formatter<'_>,
+    num: &T,
+    sign: flt2dec::Sign,
+    precision: usize,
+    upper: bool,
+) -> Result
+where
+    T: flt2dec::DecodableFloat,
 {
     unsafe {
         let mut buf = MaybeUninit::<[u8; 1024]>::uninit(); // enough for f32 and f64
         let mut parts = MaybeUninit::<[flt2dec::Part<'_>; 6]>::uninit();
         // FIXME(#53491)
-        let formatted = flt2dec::to_exact_exp_str(flt2dec::strategy::grisu::format_exact,
-                                                  *num, sign, precision,
-                                                  upper, buf.get_mut(), parts.get_mut());
+        let formatted = flt2dec::to_exact_exp_str(
+            flt2dec::strategy::grisu::format_exact,
+            *num,
+            sign,
+            precision,
+            upper,
+            buf.get_mut(),
+            parts.get_mut(),
+        );
         fmt.pad_formatted_parts(&formatted)
     }
 }
@@ -87,31 +125,42 @@ fn float_to_exponential_common_exact<T>(fmt: &mut Formatter<'_>, num: &T,
 // Don't inline this so callers that call both this and the above won't wind
 // up using the combined stack space of both functions in some cases.
 #[inline(never)]
-fn float_to_exponential_common_shortest<T>(fmt: &mut Formatter<'_>,
-                                           num: &T, sign: flt2dec::Sign,
-                                           upper: bool) -> Result
-    where T: flt2dec::DecodableFloat
+fn float_to_exponential_common_shortest<T>(
+    fmt: &mut Formatter<'_>,
+    num: &T,
+    sign: flt2dec::Sign,
+    upper: bool,
+) -> Result
+where
+    T: flt2dec::DecodableFloat,
 {
     unsafe {
         // enough for f32 and f64
         let mut buf = MaybeUninit::<[u8; flt2dec::MAX_SIG_DIGITS]>::uninit();
         let mut parts = MaybeUninit::<[flt2dec::Part<'_>; 6]>::uninit();
         // FIXME(#53491)
-        let formatted = flt2dec::to_shortest_exp_str(flt2dec::strategy::grisu::format_shortest,
-                                                     *num, sign, (0, 0), upper,
-                                                     buf.get_mut(), parts.get_mut());
+        let formatted = flt2dec::to_shortest_exp_str(
+            flt2dec::strategy::grisu::format_shortest,
+            *num,
+            sign,
+            (0, 0),
+            upper,
+            buf.get_mut(),
+            parts.get_mut(),
+        );
         fmt.pad_formatted_parts(&formatted)
     }
 }
 
 // Common code of floating point LowerExp and UpperExp.
 fn float_to_exponential_common<T>(fmt: &mut Formatter<'_>, num: &T, upper: bool) -> Result
-    where T: flt2dec::DecodableFloat
+where
+    T: flt2dec::DecodableFloat,
 {
     let force_sign = fmt.sign_plus();
     let sign = match force_sign {
         false => flt2dec::Sign::Minus,
-        true  => flt2dec::Sign::MinusPlus,
+        true => flt2dec::Sign::MinusPlus,
     };
 
     if let Some(precision) = fmt.precision {
@@ -123,7 +172,7 @@ fn float_to_exponential_common<T>(fmt: &mut Formatter<'_>, num: &T, upper: bool)
 }
 
 macro_rules! floating {
-    ($ty:ident) => (
+    ($ty:ident) => {
         #[stable(feature = "rust1", since = "1.0.0")]
         impl Debug for $ty {
             fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
@@ -151,7 +200,7 @@ macro_rules! floating {
                 float_to_exponential_common(fmt, self, true)
             }
         }
-    )
+    };
 }
 
 floating! { f32 }

--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -192,7 +192,8 @@ pub trait Hash {
     /// [`Hasher`]: trait.Hasher.html
     #[stable(feature = "hash_slice", since = "1.3.0")]
     fn hash_slice<H: Hasher>(data: &[Self], state: &mut H)
-        where Self: Sized
+    where
+        Self: Sized,
     {
         for piece in data {
             piece.hash(state);
@@ -206,7 +207,9 @@ pub(crate) mod macros {
     #[rustc_builtin_macro]
     #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
     #[allow_internal_unstable(core_intrinsics)]
-    pub macro Hash($item:item) { /* compiler built-in */ }
+    pub macro Hash($item:item) {
+        /* compiler built-in */
+    }
 }
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[doc(inline)]
@@ -666,7 +669,6 @@ mod impls {
         }
     }
 
-
     #[stable(feature = "rust1", since = "1.0.0")]
     impl<T: ?Sized + Hash> Hash for &T {
         fn hash<H: Hasher>(&self, state: &mut H) {
@@ -689,9 +691,7 @@ mod impls {
                 state.write_usize(*self as *const () as usize);
             } else {
                 // Fat pointer
-                let (a, b) = unsafe {
-                    *(self as *const Self as *const (usize, usize))
-                };
+                let (a, b) = unsafe { *(self as *const Self as *const (usize, usize)) };
                 state.write_usize(a);
                 state.write_usize(b);
             }
@@ -706,9 +706,7 @@ mod impls {
                 state.write_usize(*self as *const () as usize);
             } else {
                 // Fat pointer
-                let (a, b) = unsafe {
-                    *(self as *const Self as *const (usize, usize))
-                };
+                let (a, b) = unsafe { *(self as *const Self as *const (usize, usize)) };
                 state.write_usize(a);
                 state.write_usize(b);
             }

--- a/src/libcore/hash/sip.rs
+++ b/src/libcore/hash/sip.rs
@@ -4,10 +4,10 @@
 
 #![allow(deprecated)] // the types in this module are deprecated
 
-use crate::marker::PhantomData;
-use crate::ptr;
 use crate::cmp;
+use crate::marker::PhantomData;
 use crate::mem;
+use crate::ptr;
 
 /// An implementation of SipHash 1-3.
 ///
@@ -16,8 +16,10 @@ use crate::mem;
 ///
 /// See: <https://131002.net/siphash>
 #[unstable(feature = "hashmap_internals", issue = "0")]
-#[rustc_deprecated(since = "1.13.0",
-                   reason = "use `std::collections::hash_map::DefaultHasher` instead")]
+#[rustc_deprecated(
+    since = "1.13.0",
+    reason = "use `std::collections::hash_map::DefaultHasher` instead"
+)]
 #[derive(Debug, Clone, Default)]
 #[doc(hidden)]
 pub struct SipHasher13 {
@@ -28,8 +30,10 @@ pub struct SipHasher13 {
 ///
 /// See: <https://131002.net/siphash/>
 #[unstable(feature = "hashmap_internals", issue = "0")]
-#[rustc_deprecated(since = "1.13.0",
-                   reason = "use `std::collections::hash_map::DefaultHasher` instead")]
+#[rustc_deprecated(
+    since = "1.13.0",
+    reason = "use `std::collections::hash_map::DefaultHasher` instead"
+)]
 #[derive(Debug, Clone, Default)]
 struct SipHasher24 {
     hasher: Hasher<Sip24Rounds>,
@@ -48,8 +52,10 @@ struct SipHasher24 {
 /// it is not intended for cryptographic purposes. As such, all
 /// cryptographic uses of this implementation are _strongly discouraged_.
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.13.0",
-                   reason = "use `std::collections::hash_map::DefaultHasher` instead")]
+#[rustc_deprecated(
+    since = "1.13.0",
+    reason = "use `std::collections::hash_map::DefaultHasher` instead"
+)]
 #[derive(Debug, Clone, Default)]
 pub struct SipHasher(SipHasher24);
 
@@ -58,9 +64,9 @@ struct Hasher<S: Sip> {
     k0: u64,
     k1: u64,
     length: usize, // how many bytes we've processed
-    state: State, // hash State
-    tail: u64, // unprocessed bytes le
-    ntail: usize, // how many bytes in tail are valid
+    state: State,  // hash State
+    tail: u64,     // unprocessed bytes le
+    ntail: usize,  // how many bytes in tail are valid
     _marker: PhantomData<S>,
 }
 
@@ -78,18 +84,23 @@ struct State {
 }
 
 macro_rules! compress {
-    ($state:expr) => ({
-        compress!($state.v0, $state.v1, $state.v2, $state.v3)
-    });
-    ($v0:expr, $v1:expr, $v2:expr, $v3:expr) =>
-    ({
-        $v0 = $v0.wrapping_add($v1); $v1 = $v1.rotate_left(13); $v1 ^= $v0;
+    ($state:expr) => {{ compress!($state.v0, $state.v1, $state.v2, $state.v3) }};
+    ($v0:expr, $v1:expr, $v2:expr, $v3:expr) => {{
+        $v0 = $v0.wrapping_add($v1);
+        $v1 = $v1.rotate_left(13);
+        $v1 ^= $v0;
         $v0 = $v0.rotate_left(32);
-        $v2 = $v2.wrapping_add($v3); $v3 = $v3.rotate_left(16); $v3 ^= $v2;
-        $v0 = $v0.wrapping_add($v3); $v3 = $v3.rotate_left(21); $v3 ^= $v0;
-        $v2 = $v2.wrapping_add($v1); $v1 = $v1.rotate_left(17); $v1 ^= $v2;
+        $v2 = $v2.wrapping_add($v3);
+        $v3 = $v3.rotate_left(16);
+        $v3 ^= $v2;
+        $v0 = $v0.wrapping_add($v3);
+        $v3 = $v3.rotate_left(21);
+        $v3 ^= $v0;
+        $v2 = $v2.wrapping_add($v1);
+        $v1 = $v1.rotate_left(17);
+        $v1 ^= $v2;
         $v2 = $v2.rotate_left(32);
-    });
+    }};
 }
 
 /// Loads an integer of the desired type from a byte stream, in LE order. Uses
@@ -98,15 +109,16 @@ macro_rules! compress {
 ///
 /// Unsafe because: unchecked indexing at i..i+size_of(int_ty)
 macro_rules! load_int_le {
-    ($buf:expr, $i:expr, $int_ty:ident) =>
-    ({
-       debug_assert!($i + mem::size_of::<$int_ty>() <= $buf.len());
-       let mut data = 0 as $int_ty;
-       ptr::copy_nonoverlapping($buf.get_unchecked($i),
-                                &mut data as *mut _ as *mut u8,
-                                mem::size_of::<$int_ty>());
-       data.to_le()
-    });
+    ($buf:expr, $i:expr, $int_ty:ident) => {{
+        debug_assert!($i + mem::size_of::<$int_ty>() <= $buf.len());
+        let mut data = 0 as $int_ty;
+        ptr::copy_nonoverlapping(
+            $buf.get_unchecked($i),
+            &mut data as *mut _ as *mut u8,
+            mem::size_of::<$int_ty>(),
+        );
+        data.to_le()
+    }};
 }
 
 /// Loads an u64 using up to 7 bytes of a byte slice.
@@ -137,8 +149,10 @@ impl SipHasher {
     /// Creates a new `SipHasher` with the two initial keys set to 0.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_deprecated(since = "1.13.0",
-                       reason = "use `std::collections::hash_map::DefaultHasher` instead")]
+    #[rustc_deprecated(
+        since = "1.13.0",
+        reason = "use `std::collections::hash_map::DefaultHasher` instead"
+    )]
     pub fn new() -> SipHasher {
         SipHasher::new_with_keys(0, 0)
     }
@@ -146,12 +160,12 @@ impl SipHasher {
     /// Creates a `SipHasher` that is keyed off the provided keys.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_deprecated(since = "1.13.0",
-                       reason = "use `std::collections::hash_map::DefaultHasher` instead")]
+    #[rustc_deprecated(
+        since = "1.13.0",
+        reason = "use `std::collections::hash_map::DefaultHasher` instead"
+    )]
     pub fn new_with_keys(key0: u64, key1: u64) -> SipHasher {
-        SipHasher(SipHasher24 {
-            hasher: Hasher::new_with_keys(key0, key1)
-        })
+        SipHasher(SipHasher24 { hasher: Hasher::new_with_keys(key0, key1) })
     }
 }
 
@@ -159,8 +173,10 @@ impl SipHasher13 {
     /// Creates a new `SipHasher13` with the two initial keys set to 0.
     #[inline]
     #[unstable(feature = "hashmap_internals", issue = "0")]
-    #[rustc_deprecated(since = "1.13.0",
-                       reason = "use `std::collections::hash_map::DefaultHasher` instead")]
+    #[rustc_deprecated(
+        since = "1.13.0",
+        reason = "use `std::collections::hash_map::DefaultHasher` instead"
+    )]
     pub fn new() -> SipHasher13 {
         SipHasher13::new_with_keys(0, 0)
     }
@@ -168,12 +184,12 @@ impl SipHasher13 {
     /// Creates a `SipHasher13` that is keyed off the provided keys.
     #[inline]
     #[unstable(feature = "hashmap_internals", issue = "0")]
-    #[rustc_deprecated(since = "1.13.0",
-                       reason = "use `std::collections::hash_map::DefaultHasher` instead")]
+    #[rustc_deprecated(
+        since = "1.13.0",
+        reason = "use `std::collections::hash_map::DefaultHasher` instead"
+    )]
     pub fn new_with_keys(key0: u64, key1: u64) -> SipHasher13 {
-        SipHasher13 {
-            hasher: Hasher::new_with_keys(key0, key1)
-        }
+        SipHasher13 { hasher: Hasher::new_with_keys(key0, key1) }
     }
 }
 
@@ -184,12 +200,7 @@ impl<S: Sip> Hasher<S> {
             k0: key0,
             k1: key1,
             length: 0,
-            state: State {
-                v0: 0,
-                v1: 0,
-                v2: 0,
-                v3: 0,
-            },
+            state: State { v0: 0, v1: 0, v2: 0, v3: 0 },
             tail: 0,
             ntail: 0,
             _marker: PhantomData,
@@ -294,7 +305,7 @@ impl<S: Sip> super::Hasher for Hasher<S> {
             self.tail |= unsafe { u8to64_le(msg, 0, cmp::min(length, needed)) } << 8 * self.ntail;
             if length < needed {
                 self.ntail += length;
-                return
+                return;
             } else {
                 self.state.v3 ^= self.tail;
                 S::c_rounds(&mut self.state);

--- a/src/libcore/iter/adapters/flatten.rs
+++ b/src/libcore/iter/adapters/flatten.rs
@@ -1,7 +1,7 @@
 use crate::fmt;
 use crate::ops::Try;
 
-use super::super::{Iterator, DoubleEndedIterator, FusedIterator};
+use super::super::{DoubleEndedIterator, FusedIterator, Iterator};
 use super::Map;
 
 /// An iterator that maps each element to an iterator, and yields the elements
@@ -15,7 +15,7 @@ use super::Map;
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct FlatMap<I, U: IntoIterator, F> {
-    inner: FlattenCompat<Map<I, F>, <U as IntoIterator>::IntoIter>
+    inner: FlattenCompat<Map<I, F>, <U as IntoIterator>::IntoIter>,
 }
 impl<I: Iterator, U: IntoIterator, F: FnMut(I::Item) -> U> FlatMap<I, U, F> {
     pub(in super::super) fn new(iter: I, f: F) -> FlatMap<I, U, F> {
@@ -28,7 +28,9 @@ impl<I: Clone, U, F: Clone> Clone for FlatMap<I, U, F>
 where
     U: Clone + IntoIterator<IntoIter: Clone>,
 {
-    fn clone(&self) -> Self { FlatMap { inner: self.inner.clone() } }
+    fn clone(&self) -> Self {
+        FlatMap { inner: self.inner.clone() }
+    }
 }
 
 #[stable(feature = "core_impl_debug", since = "1.9.0")]
@@ -43,26 +45,35 @@ where
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<I: Iterator, U: IntoIterator, F> Iterator for FlatMap<I, U, F>
-    where F: FnMut(I::Item) -> U,
+where
+    F: FnMut(I::Item) -> U,
 {
     type Item = U::Item;
 
     #[inline]
-    fn next(&mut self) -> Option<U::Item> { self.inner.next() }
+    fn next(&mut self) -> Option<U::Item> {
+        self.inner.next()
+    }
 
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { self.inner.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
 
     #[inline]
-    fn try_fold<Acc, Fold, R>(&mut self, init: Acc, fold: Fold) -> R where
-        Self: Sized, Fold: FnMut(Acc, Self::Item) -> R, R: Try<Ok=Acc>
+    fn try_fold<Acc, Fold, R>(&mut self, init: Acc, fold: Fold) -> R
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, Self::Item) -> R,
+        R: Try<Ok = Acc>,
     {
         self.inner.try_fold(init, fold)
     }
 
     #[inline]
     fn fold<Acc, Fold>(self, init: Acc, fold: Fold) -> Acc
-        where Fold: FnMut(Acc, Self::Item) -> Acc,
+    where
+        Fold: FnMut(Acc, Self::Item) -> Acc,
     {
         self.inner.fold(init, fold)
     }
@@ -75,18 +86,24 @@ where
     U: IntoIterator<IntoIter: DoubleEndedIterator>,
 {
     #[inline]
-    fn next_back(&mut self) -> Option<U::Item> { self.inner.next_back() }
+    fn next_back(&mut self) -> Option<U::Item> {
+        self.inner.next_back()
+    }
 
     #[inline]
-    fn try_rfold<Acc, Fold, R>(&mut self, init: Acc, fold: Fold) -> R where
-        Self: Sized, Fold: FnMut(Acc, Self::Item) -> R, R: Try<Ok=Acc>
+    fn try_rfold<Acc, Fold, R>(&mut self, init: Acc, fold: Fold) -> R
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, Self::Item) -> R,
+        R: Try<Ok = Acc>,
     {
         self.inner.try_rfold(init, fold)
     }
 
     #[inline]
     fn rfold<Acc, Fold>(self, init: Acc, fold: Fold) -> Acc
-        where Fold: FnMut(Acc, Self::Item) -> Acc,
+    where
+        Fold: FnMut(Acc, Self::Item) -> Acc,
     {
         self.inner.rfold(init, fold)
     }
@@ -94,7 +111,12 @@ where
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<I, U, F> FusedIterator for FlatMap<I, U, F>
-    where I: FusedIterator, U: IntoIterator, F: FnMut(I::Item) -> U {}
+where
+    I: FusedIterator,
+    U: IntoIterator,
+    F: FnMut(I::Item) -> U,
+{
+}
 
 /// An iterator that flattens one level of nesting in an iterator of things
 /// that can be turned into iterators.
@@ -133,7 +155,9 @@ where
     I: Clone + Iterator<Item: IntoIterator<IntoIter = U, Item = U::Item>>,
     U: Clone + Iterator,
 {
-    fn clone(&self) -> Self { Flatten { inner: self.inner.clone() } }
+    fn clone(&self) -> Self {
+        Flatten { inner: self.inner.clone() }
+    }
 }
 
 #[stable(feature = "iterator_flatten", since = "1.29.0")]
@@ -145,21 +169,29 @@ where
     type Item = U::Item;
 
     #[inline]
-    fn next(&mut self) -> Option<U::Item> { self.inner.next() }
+    fn next(&mut self) -> Option<U::Item> {
+        self.inner.next()
+    }
 
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { self.inner.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
 
     #[inline]
-    fn try_fold<Acc, Fold, R>(&mut self, init: Acc, fold: Fold) -> R where
-        Self: Sized, Fold: FnMut(Acc, Self::Item) -> R, R: Try<Ok=Acc>
+    fn try_fold<Acc, Fold, R>(&mut self, init: Acc, fold: Fold) -> R
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, Self::Item) -> R,
+        R: Try<Ok = Acc>,
     {
         self.inner.try_fold(init, fold)
     }
 
     #[inline]
     fn fold<Acc, Fold>(self, init: Acc, fold: Fold) -> Acc
-        where Fold: FnMut(Acc, Self::Item) -> Acc,
+    where
+        Fold: FnMut(Acc, Self::Item) -> Acc,
     {
         self.inner.fold(init, fold)
     }
@@ -172,18 +204,24 @@ where
     U: DoubleEndedIterator,
 {
     #[inline]
-    fn next_back(&mut self) -> Option<U::Item> { self.inner.next_back() }
+    fn next_back(&mut self) -> Option<U::Item> {
+        self.inner.next_back()
+    }
 
     #[inline]
-    fn try_rfold<Acc, Fold, R>(&mut self, init: Acc, fold: Fold) -> R where
-        Self: Sized, Fold: FnMut(Acc, Self::Item) -> R, R: Try<Ok=Acc>
+    fn try_rfold<Acc, Fold, R>(&mut self, init: Acc, fold: Fold) -> R
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, Self::Item) -> R,
+        R: Try<Ok = Acc>,
     {
         self.inner.try_rfold(init, fold)
     }
 
     #[inline]
     fn rfold<Acc, Fold>(self, init: Acc, fold: Fold) -> Acc
-        where Fold: FnMut(Acc, Self::Item) -> Acc,
+    where
+        Fold: FnMut(Acc, Self::Item) -> Acc,
     {
         self.inner.rfold(init, fold)
     }
@@ -194,7 +232,8 @@ impl<I, U> FusedIterator for Flatten<I>
 where
     I: FusedIterator<Item: IntoIterator<IntoIter = U, Item = U::Item>>,
     U: Iterator,
-{}
+{
+}
 
 /// Real logic of both `Flatten` and `FlatMap` which simply delegate to
 /// this type.
@@ -222,7 +261,9 @@ where
     fn next(&mut self) -> Option<U::Item> {
         loop {
             if let Some(ref mut inner) = self.frontiter {
-                if let elt@Some(_) = inner.next() { return elt }
+                if let elt @ Some(_) = inner.next() {
+                    return elt;
+                }
             }
             match self.iter.next() {
                 None => return self.backiter.as_mut()?.next(),
@@ -238,13 +279,16 @@ where
         let lo = flo.saturating_add(blo);
         match (self.iter.size_hint(), fhi, bhi) {
             ((0, Some(0)), Some(a), Some(b)) => (lo, a.checked_add(b)),
-            _ => (lo, None)
+            _ => (lo, None),
         }
     }
 
     #[inline]
-    fn try_fold<Acc, Fold, R>(&mut self, mut init: Acc, mut fold: Fold) -> R where
-        Self: Sized, Fold: FnMut(Acc, Self::Item) -> R, R: Try<Ok=Acc>
+    fn try_fold<Acc, Fold, R>(&mut self, mut init: Acc, mut fold: Fold) -> R
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, Self::Item) -> R,
+        R: Try<Ok = Acc>,
     {
         #[inline]
         fn flatten<'a, T: IntoIterator, Acc, R: Try<Ok = Acc>>(
@@ -277,7 +321,8 @@ where
 
     #[inline]
     fn fold<Acc, Fold>(self, init: Acc, ref mut fold: Fold) -> Acc
-        where Fold: FnMut(Acc, Self::Item) -> Acc,
+    where
+        Fold: FnMut(Acc, Self::Item) -> Acc,
     {
         #[inline]
         fn flatten<U: Iterator, Acc>(
@@ -286,7 +331,8 @@ where
             move |acc, iter| iter.fold(acc, &mut *fold)
         }
 
-        self.frontiter.into_iter()
+        self.frontiter
+            .into_iter()
             .chain(self.iter.map(IntoIterator::into_iter))
             .chain(self.backiter)
             .fold(init, flatten(fold))
@@ -302,7 +348,9 @@ where
     fn next_back(&mut self) -> Option<U::Item> {
         loop {
             if let Some(ref mut inner) = self.backiter {
-                if let elt@Some(_) = inner.next_back() { return elt }
+                if let elt @ Some(_) = inner.next_back() {
+                    return elt;
+                }
             }
             match self.iter.next_back() {
                 None => return self.frontiter.as_mut()?.next_back(),
@@ -312,14 +360,18 @@ where
     }
 
     #[inline]
-    fn try_rfold<Acc, Fold, R>(&mut self, mut init: Acc, mut fold: Fold) -> R where
-        Self: Sized, Fold: FnMut(Acc, Self::Item) -> R, R: Try<Ok=Acc>
+    fn try_rfold<Acc, Fold, R>(&mut self, mut init: Acc, mut fold: Fold) -> R
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, Self::Item) -> R,
+        R: Try<Ok = Acc>,
     {
         #[inline]
         fn flatten<'a, T: IntoIterator, Acc, R: Try<Ok = Acc>>(
             backiter: &'a mut Option<T::IntoIter>,
             fold: &'a mut impl FnMut(Acc, T::Item) -> R,
-        ) -> impl FnMut(Acc, T) -> R + 'a where
+        ) -> impl FnMut(Acc, T) -> R + 'a
+        where
             T::IntoIter: DoubleEndedIterator,
         {
             move |acc, x| {
@@ -348,7 +400,8 @@ where
 
     #[inline]
     fn rfold<Acc, Fold>(self, init: Acc, ref mut fold: Fold) -> Acc
-        where Fold: FnMut(Acc, Self::Item) -> Acc,
+    where
+        Fold: FnMut(Acc, Self::Item) -> Acc,
     {
         #[inline]
         fn flatten<U: DoubleEndedIterator, Acc>(
@@ -357,7 +410,8 @@ where
             move |acc, iter| iter.rfold(acc, &mut *fold)
         }
 
-        self.frontiter.into_iter()
+        self.frontiter
+            .into_iter()
             .chain(self.iter.map(IntoIterator::into_iter))
             .chain(self.backiter)
             .rfold(init, flatten(fold))

--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -12,7 +12,7 @@ use super::{FusedIterator, TrustedLen};
 #[derive(Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Repeat<A> {
-    element: A
+    element: A,
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -20,15 +20,21 @@ impl<A: Clone> Iterator for Repeat<A> {
     type Item = A;
 
     #[inline]
-    fn next(&mut self) -> Option<A> { Some(self.element.clone()) }
+    fn next(&mut self) -> Option<A> {
+        Some(self.element.clone())
+    }
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { (usize::MAX, None) }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (usize::MAX, None)
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A: Clone> DoubleEndedIterator for Repeat<A> {
     #[inline]
-    fn next_back(&mut self) -> Option<A> { Some(self.element.clone()) }
+    fn next_back(&mut self) -> Option<A> {
+        Some(self.element.clone())
+    }
 }
 
 #[stable(feature = "fused", since = "1.26.0")]
@@ -91,7 +97,7 @@ unsafe impl<A: Clone> TrustedLen for Repeat<A> {}
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn repeat<T: Clone>(elt: T) -> Repeat<T> {
-    Repeat{element: elt}
+    Repeat { element: elt }
 }
 
 /// An iterator that repeats elements of type `A` endlessly by
@@ -104,7 +110,7 @@ pub fn repeat<T: Clone>(elt: T) -> Repeat<T> {
 #[derive(Copy, Clone, Debug)]
 #[stable(feature = "iterator_repeat_with", since = "1.28.0")]
 pub struct RepeatWith<F> {
-    repeater: F
+    repeater: F,
 }
 
 #[stable(feature = "iterator_repeat_with", since = "1.28.0")]
@@ -112,10 +118,14 @@ impl<A, F: FnMut() -> A> Iterator for RepeatWith<F> {
     type Item = A;
 
     #[inline]
-    fn next(&mut self) -> Option<A> { Some((self.repeater)()) }
+    fn next(&mut self) -> Option<A> {
+        Some((self.repeater)())
+    }
 
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { (usize::MAX, None) }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (usize::MAX, None)
+    }
 }
 
 #[stable(feature = "iterator_repeat_with", since = "1.28.0")]
@@ -213,7 +223,7 @@ impl<T> Iterator for Empty<T> {
         None
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>){
+    fn size_hint(&self) -> (usize, Option<usize>) {
         (0, Some(0))
     }
 }
@@ -283,7 +293,7 @@ pub const fn empty<T>() -> Empty<T> {
 #[derive(Clone, Debug)]
 #[stable(feature = "iter_once", since = "1.2.0")]
 pub struct Once<T> {
-    inner: crate::option::IntoIter<T>
+    inner: crate::option::IntoIter<T>,
 }
 
 #[stable(feature = "iter_once", since = "1.2.0")]
@@ -530,7 +540,8 @@ pub fn once_with<A, F: FnOnce() -> A>(gen: F) -> OnceWith<F> {
 #[inline]
 #[stable(feature = "iter_from_fn", since = "1.34.0")]
 pub fn from_fn<T, F>(f: F) -> FromFn<F>
-    where F: FnMut() -> Option<T>
+where
+    F: FnMut() -> Option<T>,
 {
     FromFn(f)
 }
@@ -547,7 +558,8 @@ pub struct FromFn<F>(F);
 
 #[stable(feature = "iter_from_fn", since = "1.34.0")]
 impl<T, F> Iterator for FromFn<F>
-    where F: FnMut() -> Option<T>
+where
+    F: FnMut() -> Option<T>,
 {
     type Item = T;
 
@@ -577,15 +589,13 @@ impl<F> fmt::Debug for FromFn<F> {
 /// ```
 #[stable(feature = "iter_successors", since = "1.34.0")]
 pub fn successors<T, F>(first: Option<T>, succ: F) -> Successors<T, F>
-    where F: FnMut(&T) -> Option<T>
+where
+    F: FnMut(&T) -> Option<T>,
 {
     // If this function returned `impl Iterator<Item=T>`
     // it could be based on `unfold` and not need a dedicated type.
     // However having a named `Successors<T, F>` type allows it to be `Clone` when `T` and `F` are.
-    Successors {
-        next: first,
-        succ,
-    }
+    Successors { next: first, succ }
 }
 
 /// An new iterator where each successive item is computed based on the preceding one.
@@ -603,7 +613,8 @@ pub struct Successors<T, F> {
 
 #[stable(feature = "iter_successors", since = "1.34.0")]
 impl<T, F> Iterator for Successors<T, F>
-    where F: FnMut(&T) -> Option<T>
+where
+    F: FnMut(&T) -> Option<T>,
 {
     type Item = T;
 
@@ -616,24 +627,16 @@ impl<T, F> Iterator for Successors<T, F>
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.next.is_some() {
-            (1, None)
-        } else {
-            (0, Some(0))
-        }
+        if self.next.is_some() { (1, None) } else { (0, Some(0)) }
     }
 }
 
 #[stable(feature = "iter_successors", since = "1.34.0")]
-impl<T, F> FusedIterator for Successors<T, F>
-    where F: FnMut(&T) -> Option<T>
-{}
+impl<T, F> FusedIterator for Successors<T, F> where F: FnMut(&T) -> Option<T> {}
 
 #[stable(feature = "iter_successors", since = "1.34.0")]
 impl<T: fmt::Debug, F> fmt::Debug for Successors<T, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Successors")
-            .field("next", &self.next)
-            .finish()
+        f.debug_struct("Successors").field("next", &self.next).finish()
     }
 }

--- a/src/libcore/iter/traits/accum.rs
+++ b/src/libcore/iter/traits/accum.rs
@@ -1,6 +1,6 @@
-use crate::ops::{Mul, Add};
-use crate::num::Wrapping;
 use crate::iter;
+use crate::num::Wrapping;
+use crate::ops::{Add, Mul};
 
 /// Trait to represent types that can be created by summing up an iterator.
 ///
@@ -17,7 +17,7 @@ pub trait Sum<A = Self>: Sized {
     /// Method which takes an iterator and generates `Self` from the elements by
     /// "summing up" the items.
     #[stable(feature = "iter_arith_traits", since = "1.12.0")]
-    fn sum<I: Iterator<Item=A>>(iter: I) -> Self;
+    fn sum<I: Iterator<Item = A>>(iter: I) -> Self;
 }
 
 /// Trait to represent types that can be created by multiplying elements of an
@@ -36,7 +36,7 @@ pub trait Product<A = Self>: Sized {
     /// Method which takes an iterator and generates `Self` from the elements by
     /// multiplying the items.
     #[stable(feature = "iter_arith_traits", since = "1.12.0")]
-    fn product<I: Iterator<Item=A>>(iter: I) -> Self;
+    fn product<I: Iterator<Item = A>>(iter: I) -> Self;
 }
 
 // N.B., explicitly use Add and Mul here to inherit overflow checks
@@ -115,9 +115,10 @@ macro_rules! float_sum_product {
 integer_sum_product! { i8 i16 i32 i64 i128 isize u8 u16 u32 u64 u128 usize }
 float_sum_product! { f32 f64 }
 
-#[stable(feature = "iter_arith_traits_result", since="1.16.0")]
+#[stable(feature = "iter_arith_traits_result", since = "1.16.0")]
 impl<T, U, E> Sum<Result<U, E>> for Result<T, E>
-    where T: Sum<U>,
+where
+    T: Sum<U>,
 {
     /// Takes each element in the `Iterator`: if it is an `Err`, no further
     /// elements are taken, and the `Err` is returned. Should no `Err` occur,
@@ -137,21 +138,24 @@ impl<T, U, E> Sum<Result<U, E>> for Result<T, E>
     /// assert_eq!(res, Ok(3));
     /// ```
     fn sum<I>(iter: I) -> Result<T, E>
-        where I: Iterator<Item = Result<U, E>>,
+    where
+        I: Iterator<Item = Result<U, E>>,
     {
         iter::process_results(iter, |i| i.sum())
     }
 }
 
-#[stable(feature = "iter_arith_traits_result", since="1.16.0")]
+#[stable(feature = "iter_arith_traits_result", since = "1.16.0")]
 impl<T, U, E> Product<Result<U, E>> for Result<T, E>
-    where T: Product<U>,
+where
+    T: Product<U>,
 {
     /// Takes each element in the `Iterator`: if it is an `Err`, no further
     /// elements are taken, and the `Err` is returned. Should no `Err` occur,
     /// the product of all elements is returned.
     fn product<I>(iter: I) -> Result<T, E>
-        where I: Iterator<Item = Result<U, E>>,
+    where
+        I: Iterator<Item = Result<U, E>>,
     {
         iter::process_results(iter, |i| i.product())
     }

--- a/src/libcore/iter/traits/double_ended.rs
+++ b/src/libcore/iter/traits/double_ended.rs
@@ -1,5 +1,5 @@
-use crate::ops::Try;
 use crate::iter::LoopState;
+use crate::ops::Try;
 
 /// An iterator able to yield elements from both ends.
 ///
@@ -113,7 +113,9 @@ pub trait DoubleEndedIterator: Iterator {
     #[stable(feature = "iter_nth_back", since = "1.37.0")]
     fn nth_back(&mut self, mut n: usize) -> Option<Self::Item> {
         for x in self.rev() {
-            if n == 0 { return Some(x) }
+            if n == 0 {
+                return Some(x);
+            }
             n -= 1;
         }
         None
@@ -157,7 +159,7 @@ pub trait DoubleEndedIterator: Iterator {
     where
         Self: Sized,
         F: FnMut(B, Self::Item) -> R,
-        R: Try<Ok=B>
+        R: Try<Ok = B>,
     {
         let mut accum = init;
         while let Some(x) = self.next_back() {
@@ -279,7 +281,7 @@ pub trait DoubleEndedIterator: Iterator {
     fn rfind<P>(&mut self, predicate: P) -> Option<Self::Item>
     where
         Self: Sized,
-        P: FnMut(&Self::Item) -> bool
+        P: FnMut(&Self::Item) -> bool,
     {
         #[inline]
         fn check<T>(

--- a/src/libcore/macros/mod.rs
+++ b/src/libcore/macros/mod.rs
@@ -337,13 +337,17 @@ macro_rules! matches {
 #[rustc_deprecated(since = "1.39.0", reason = "use the `?` operator instead")]
 #[doc(alias = "?")]
 macro_rules! r#try {
-    ($expr:expr) => (match $expr {
-        $crate::result::Result::Ok(val) => val,
-        $crate::result::Result::Err(err) => {
-            return $crate::result::Result::Err($crate::convert::From::from(err))
+    ($expr:expr) => {
+        match $expr {
+            $crate::result::Result::Ok(val) => val,
+            $crate::result::Result::Err(err) => {
+                return $crate::result::Result::Err($crate::convert::From::from(err));
+            }
         }
-    });
-    ($expr:expr,) => ($crate::r#try!($expr));
+    };
+    ($expr:expr,) => {
+        $crate::r#try!($expr)
+    };
 }
 
 /// Writes formatted data into a buffer.
@@ -734,8 +738,8 @@ pub(crate) mod builtin {
     #[rustc_builtin_macro]
     #[macro_export]
     macro_rules! compile_error {
-        ($msg:expr) => ({ /* compiler built-in */ });
-        ($msg:expr,) => ({ /* compiler built-in */ })
+        ($msg:expr) => {{ /* compiler built-in */ }};
+        ($msg:expr,) => {{ /* compiler built-in */ }};
     }
 
     /// Constructs parameters for the other string-formatting macros.
@@ -788,20 +792,23 @@ pub(crate) mod builtin {
     #[rustc_builtin_macro]
     #[macro_export]
     macro_rules! format_args {
-        ($fmt:expr) => ({ /* compiler built-in */ });
-        ($fmt:expr, $($args:tt)*) => ({ /* compiler built-in */ })
+        ($fmt:expr) => {{ /* compiler built-in */ }};
+        ($fmt:expr, $($args:tt)*) => {{ /* compiler built-in */ }};
     }
 
     /// Same as `format_args`, but adds a newline in the end.
-    #[unstable(feature = "format_args_nl", issue = "0",
-               reason = "`format_args_nl` is only for internal \
-                         language use and is subject to change")]
+    #[unstable(
+        feature = "format_args_nl",
+        issue = "0",
+        reason = "`format_args_nl` is only for internal \
+                  language use and is subject to change"
+    )]
     #[allow_internal_unstable(fmt_internals)]
     #[rustc_builtin_macro]
     #[macro_export]
     macro_rules! format_args_nl {
-        ($fmt:expr) => ({ /* compiler built-in */ });
-        ($fmt:expr, $($args:tt)*) => ({ /* compiler built-in */ })
+        ($fmt:expr) => {{ /* compiler built-in */ }};
+        ($fmt:expr, $($args:tt)*) => {{ /* compiler built-in */ }};
     }
 
     /// Inspects an environment variable at compile time.
@@ -839,8 +846,8 @@ pub(crate) mod builtin {
     #[rustc_builtin_macro]
     #[macro_export]
     macro_rules! env {
-        ($name:expr) => ({ /* compiler built-in */ });
-        ($name:expr,) => ({ /* compiler built-in */ })
+        ($name:expr) => {{ /* compiler built-in */ }};
+        ($name:expr,) => {{ /* compiler built-in */ }};
     }
 
     /// Optionally inspects an environment variable at compile time.
@@ -866,8 +873,8 @@ pub(crate) mod builtin {
     #[rustc_builtin_macro]
     #[macro_export]
     macro_rules! option_env {
-        ($name:expr) => ({ /* compiler built-in */ });
-        ($name:expr,) => ({ /* compiler built-in */ })
+        ($name:expr) => {{ /* compiler built-in */ }};
+        ($name:expr,) => {{ /* compiler built-in */ }};
     }
 
     /// Concatenates identifiers into one identifier.
@@ -894,13 +901,16 @@ pub(crate) mod builtin {
     /// // fn concat_idents!(new, fun, name) { } // not usable in this way!
     /// # }
     /// ```
-    #[unstable(feature = "concat_idents", issue = "29599",
-               reason = "`concat_idents` is not stable enough for use and is subject to change")]
+    #[unstable(
+        feature = "concat_idents",
+        issue = "29599",
+        reason = "`concat_idents` is not stable enough for use and is subject to change"
+    )]
     #[rustc_builtin_macro]
     #[macro_export]
     macro_rules! concat_idents {
-        ($($e:ident),+) => ({ /* compiler built-in */ });
-        ($($e:ident,)+) => ({ /* compiler built-in */ })
+        ($($e:ident),+) => {{ /* compiler built-in */ }};
+        ($($e:ident,)+) => {{ /* compiler built-in */ }};
     }
 
     /// Concatenates literals into a static string slice.
@@ -922,8 +932,8 @@ pub(crate) mod builtin {
     #[rustc_builtin_macro]
     #[macro_export]
     macro_rules! concat {
-        ($($e:expr),*) => ({ /* compiler built-in */ });
-        ($($e:expr,)*) => ({ /* compiler built-in */ })
+        ($($e:expr),*) => {{ /* compiler built-in */ }};
+        ($($e:expr,)*) => {{ /* compiler built-in */ }};
     }
 
     /// Expands to the line number on which it was invoked.
@@ -950,7 +960,11 @@ pub(crate) mod builtin {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
     #[macro_export]
-    macro_rules! line { () => { /* compiler built-in */ } }
+    macro_rules! line {
+        () => {
+            /* compiler built-in */
+        };
+    }
 
     /// Expands to the column number at which it was invoked.
     ///
@@ -976,7 +990,11 @@ pub(crate) mod builtin {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
     #[macro_export]
-    macro_rules! column { () => { /* compiler built-in */ } }
+    macro_rules! column {
+        () => {
+            /* compiler built-in */
+        };
+    }
 
     /// Expands to the file name in which it was invoked.
     ///
@@ -1001,7 +1019,11 @@ pub(crate) mod builtin {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
     #[macro_export]
-    macro_rules! file { () => { /* compiler built-in */ } }
+    macro_rules! file {
+        () => {
+            /* compiler built-in */
+        };
+    }
 
     /// Stringifies its arguments.
     ///
@@ -1021,7 +1043,11 @@ pub(crate) mod builtin {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
     #[macro_export]
-    macro_rules! stringify { ($($t:tt)*) => { /* compiler built-in */ } }
+    macro_rules! stringify {
+        ($($t:tt)*) => {
+            /* compiler built-in */
+        };
+    }
 
     /// Includes a utf8-encoded file as a string.
     ///
@@ -1057,8 +1083,8 @@ pub(crate) mod builtin {
     #[rustc_builtin_macro]
     #[macro_export]
     macro_rules! include_str {
-        ($file:expr) => ({ /* compiler built-in */ });
-        ($file:expr,) => ({ /* compiler built-in */ })
+        ($file:expr) => {{ /* compiler built-in */ }};
+        ($file:expr,) => {{ /* compiler built-in */ }};
     }
 
     /// Includes a file as a reference to a byte array.
@@ -1095,8 +1121,8 @@ pub(crate) mod builtin {
     #[rustc_builtin_macro]
     #[macro_export]
     macro_rules! include_bytes {
-        ($file:expr) => ({ /* compiler built-in */ });
-        ($file:expr,) => ({ /* compiler built-in */ })
+        ($file:expr) => {{ /* compiler built-in */ }};
+        ($file:expr,) => {{ /* compiler built-in */ }};
     }
 
     /// Expands to a string that represents the current module path.
@@ -1119,7 +1145,11 @@ pub(crate) mod builtin {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
     #[macro_export]
-    macro_rules! module_path { () => { /* compiler built-in */ } }
+    macro_rules! module_path {
+        () => {
+            /* compiler built-in */
+        };
+    }
 
     /// Evaluates boolean combinations of configuration flags at compile-time.
     ///
@@ -1144,7 +1174,11 @@ pub(crate) mod builtin {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
     #[macro_export]
-    macro_rules! cfg { ($($cfg:tt)*) => { /* compiler built-in */ } }
+    macro_rules! cfg {
+        ($($cfg:tt)*) => {
+            /* compiler built-in */
+        };
+    }
 
     /// Parses a file as an expression or an item according to the context.
     ///
@@ -1189,8 +1223,8 @@ pub(crate) mod builtin {
     #[rustc_builtin_macro]
     #[macro_export]
     macro_rules! include {
-        ($file:expr) => ({ /* compiler built-in */ });
-        ($file:expr,) => ({ /* compiler built-in */ })
+        ($file:expr) => {{ /* compiler built-in */ }};
+        ($file:expr,) => {{ /* compiler built-in */ }};
     }
 
     /// Asserts that a boolean expression is `true` at runtime.
@@ -1242,9 +1276,9 @@ pub(crate) mod builtin {
     #[rustc_builtin_macro]
     #[macro_export]
     macro_rules! assert {
-        ($cond:expr) => ({ /* compiler built-in */ });
-        ($cond:expr,) => ({ /* compiler built-in */ });
-        ($cond:expr, $($arg:tt)+) => ({ /* compiler built-in */ })
+        ($cond:expr) => {{ /* compiler built-in */ }};
+        ($cond:expr,) => {{ /* compiler built-in */ }};
+        ($cond:expr, $($arg:tt)+) => {{ /* compiler built-in */ }};
     }
 
     /// Inline assembly.
@@ -1252,75 +1286,118 @@ pub(crate) mod builtin {
     /// Read the [unstable book] for the usage.
     ///
     /// [unstable book]: ../unstable-book/library-features/asm.html
-    #[unstable(feature = "asm", issue = "29722",
-               reason = "inline assembly is not stable enough for use and is subject to change")]
+    #[unstable(
+        feature = "asm",
+        issue = "29722",
+        reason = "inline assembly is not stable enough for use and is subject to change"
+    )]
     #[rustc_builtin_macro]
     #[macro_export]
-    macro_rules! asm { ("assembly template"
+    macro_rules! asm {
+        ("assembly template"
                         : $("output"(operand),)*
                         : $("input"(operand),)*
                         : $("clobbers",)*
-                        : $("options",)*) => { /* compiler built-in */ } }
+                        : $("options",)*) => {
+            /* compiler built-in */
+        };
+    }
 
     /// Module-level inline assembly.
-    #[unstable(feature = "global_asm", issue = "35119",
-               reason = "`global_asm!` is not stable enough for use and is subject to change")]
+    #[unstable(
+        feature = "global_asm",
+        issue = "35119",
+        reason = "`global_asm!` is not stable enough for use and is subject to change"
+    )]
     #[rustc_builtin_macro]
     #[macro_export]
-    macro_rules! global_asm { ("assembly") => { /* compiler built-in */ } }
+    macro_rules! global_asm {
+        ("assembly") => {
+            /* compiler built-in */
+        };
+    }
 
     /// Prints passed tokens into the standard output.
-    #[unstable(feature = "log_syntax", issue = "29598",
-               reason = "`log_syntax!` is not stable enough for use and is subject to change")]
+    #[unstable(
+        feature = "log_syntax",
+        issue = "29598",
+        reason = "`log_syntax!` is not stable enough for use and is subject to change"
+    )]
     #[rustc_builtin_macro]
     #[macro_export]
-    macro_rules! log_syntax { ($($arg:tt)*) => { /* compiler built-in */ } }
+    macro_rules! log_syntax {
+        ($($arg:tt)*) => {
+            /* compiler built-in */
+        };
+    }
 
     /// Enables or disables tracing functionality used for debugging other macros.
-    #[unstable(feature = "trace_macros", issue = "29598",
-               reason = "`trace_macros` is not stable enough for use and is subject to change")]
+    #[unstable(
+        feature = "trace_macros",
+        issue = "29598",
+        reason = "`trace_macros` is not stable enough for use and is subject to change"
+    )]
     #[rustc_builtin_macro]
     #[macro_export]
     macro_rules! trace_macros {
-        (true) => ({ /* compiler built-in */ });
-        (false) => ({ /* compiler built-in */ })
+        (true) => {{ /* compiler built-in */ }};
+        (false) => {{ /* compiler built-in */ }};
     }
 
     /// Attribute macro applied to a function to turn it into a unit test.
     #[stable(feature = "rust1", since = "1.0.0")]
     #[allow_internal_unstable(test, rustc_attrs)]
     #[rustc_builtin_macro]
-    pub macro test($item:item) { /* compiler built-in */ }
+    pub macro test($item:item) {
+        /* compiler built-in */
+    }
 
     /// Attribute macro applied to a function to turn it into a benchmark test.
-    #[unstable(soft, feature = "test", issue = "50297",
-               reason = "`bench` is a part of custom test frameworks which are unstable")]
+    #[unstable(
+        feature = "test",
+        issue = "50297",
+        soft,
+        reason = "`bench` is a part of custom test frameworks which are unstable"
+    )]
     #[allow_internal_unstable(test, rustc_attrs)]
     #[rustc_builtin_macro]
-    pub macro bench($item:item) { /* compiler built-in */ }
+    pub macro bench($item:item) {
+        /* compiler built-in */
+    }
 
     /// An implementation detail of the `#[test]` and `#[bench]` macros.
-    #[unstable(feature = "custom_test_frameworks", issue = "50297",
-               reason = "custom test frameworks are an unstable feature")]
+    #[unstable(
+        feature = "custom_test_frameworks",
+        issue = "50297",
+        reason = "custom test frameworks are an unstable feature"
+    )]
     #[allow_internal_unstable(test, rustc_attrs)]
     #[rustc_builtin_macro]
-    pub macro test_case($item:item) { /* compiler built-in */ }
+    pub macro test_case($item:item) {
+        /* compiler built-in */
+    }
 
     /// Attribute macro applied to a static to register it as a global allocator.
     #[stable(feature = "global_allocator", since = "1.28.0")]
     #[allow_internal_unstable(rustc_attrs)]
     #[rustc_builtin_macro]
-    pub macro global_allocator($item:item) { /* compiler built-in */ }
+    pub macro global_allocator($item:item) {
+        /* compiler built-in */
+    }
 
     /// Unstable implementation detail of the `rustc` compiler, do not use.
     #[rustc_builtin_macro]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[allow_internal_unstable(core_intrinsics, libstd_sys_internals)]
-    pub macro RustcDecodable($item:item) { /* compiler built-in */ }
+    pub macro RustcDecodable($item:item) {
+        /* compiler built-in */
+    }
 
     /// Unstable implementation detail of the `rustc` compiler, do not use.
     #[rustc_builtin_macro]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[allow_internal_unstable(core_intrinsics)]
-    pub macro RustcEncodable($item:item) { /* compiler built-in */ }
+    pub macro RustcEncodable($item:item) {
+        /* compiler built-in */
+    }
 }

--- a/src/libcore/mem/manually_drop.rs
+++ b/src/libcore/mem/manually_drop.rs
@@ -1,5 +1,5 @@
-use crate::ptr;
 use crate::ops::{Deref, DerefMut};
+use crate::ptr;
 
 /// A wrapper to inhibit compiler from automatically calling `T`’s destructor.
 ///

--- a/src/libcore/num/dec2flt/algorithm.rs
+++ b/src/libcore/num/dec2flt/algorithm.rs
@@ -1,11 +1,11 @@
 //! The various algorithms from the paper.
 
 use crate::cmp::min;
-use crate::cmp::Ordering::{Less, Equal, Greater};
-use crate::num::diy_float::Fp;
-use crate::num::dec2flt::table;
-use crate::num::dec2flt::rawfp::{self, Unpacked, RawFloat, fp_to_float, next_float, prev_float};
+use crate::cmp::Ordering::{Equal, Greater, Less};
 use crate::num::dec2flt::num::{self, Big};
+use crate::num::dec2flt::rawfp::{self, fp_to_float, next_float, prev_float, RawFloat, Unpacked};
+use crate::num::dec2flt::table;
+use crate::num::diy_float::Fp;
 
 /// Number of significand bits in Fp
 const P: u32 = 64;
@@ -23,9 +23,9 @@ fn power_of_ten(e: i16) -> Fp {
 
 // In most architectures, floating point operations have an explicit bit size, therefore the
 // precision of the computation is determined on a per-operation basis.
-#[cfg(any(not(target_arch="x86"), target_feature="sse2"))]
+#[cfg(any(not(target_arch = "x86"), target_feature = "sse2"))]
 mod fpu_precision {
-    pub fn set_precision<T>() { }
+    pub fn set_precision<T>() {}
 }
 
 // On x86, the x87 FPU is used for float operations if the SSE/SSE2 extensions are not available.
@@ -33,7 +33,7 @@ mod fpu_precision {
 // round to 80 bits causing double rounding to happen when values are eventually represented as
 // 32/64 bit float values. To overcome this, the FPU control word can be set so that the
 // computations are performed in the desired precision.
-#[cfg(all(target_arch="x86", not(target_feature="sse2")))]
+#[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]
 mod fpu_precision {
     use crate::mem::size_of;
 

--- a/src/libcore/num/dec2flt/mod.rs
+++ b/src/libcore/num/dec2flt/mod.rs
@@ -78,23 +78,25 @@
 //! turned into {positive,negative} {zero,infinity}.
 
 #![doc(hidden)]
-#![unstable(feature = "dec2flt",
-            reason = "internal routines only exposed for testing",
-            issue = "0")]
+#![unstable(
+    feature = "dec2flt",
+    reason = "internal routines only exposed for testing",
+    issue = "0"
+)]
 
 use crate::fmt;
 use crate::str::FromStr;
 
-use self::parse::{parse_decimal, Decimal, Sign, ParseResult};
 use self::num::digits_to_big;
+use self::parse::{parse_decimal, Decimal, ParseResult, Sign};
 use self::rawfp::RawFloat;
 
 mod algorithm;
-mod table;
 mod num;
+mod table;
 // These two have their own tests.
-pub mod rawfp;
 pub mod parse;
+pub mod rawfp;
 
 macro_rules! from_str_float_impl {
     ($t:ty) => {
@@ -155,7 +157,7 @@ macro_rules! from_str_float_impl {
                 dec2flt(src)
             }
         }
-    }
+    };
 }
 from_str_float_impl!(f32);
 from_str_float_impl!(f64);
@@ -171,7 +173,7 @@ from_str_float_impl!(f64);
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct ParseFloatError {
-    kind: FloatErrorKind
+    kind: FloatErrorKind,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -181,10 +183,12 @@ enum FloatErrorKind {
 }
 
 impl ParseFloatError {
-    #[unstable(feature = "int_error_internals",
-               reason = "available through Error trait and this method should \
-                         not be exposed publicly",
-               issue = "0")]
+    #[unstable(
+        feature = "int_error_internals",
+        reason = "available through Error trait and this method should \
+                  not be exposed publicly",
+        issue = "0"
+    )]
     #[doc(hidden)]
     pub fn __description(&self) -> &str {
         match self.kind {
@@ -222,7 +226,7 @@ fn extract_sign(s: &str) -> (Sign, &str) {
 /// Converts a decimal string into a floating point number.
 fn dec2flt<T: RawFloat>(s: &str) -> Result<T, ParseFloatError> {
     if s.is_empty() {
-        return Err(pfe_empty())
+        return Err(pfe_empty());
     }
     let (sign, s) = extract_sign(s);
     let flt = match parse_decimal(s) {
@@ -232,8 +236,10 @@ fn dec2flt<T: RawFloat>(s: &str) -> Result<T, ParseFloatError> {
         ParseResult::Invalid => match s {
             "inf" => T::INFINITY,
             "NaN" => T::NAN,
-            _ => { return Err(pfe_invalid()); }
-        }
+            _ => {
+                return Err(pfe_invalid());
+            }
+        },
     };
 
     match sign {

--- a/src/libcore/num/dec2flt/num.rs
+++ b/src/libcore/num/dec2flt/num.rs
@@ -2,7 +2,7 @@
 
 // FIXME This module's name is a bit unfortunate, since other modules also import `core::num`.
 
-use crate::cmp::Ordering::{self, Less, Equal, Greater};
+use crate::cmp::Ordering::{self, Equal, Greater, Less};
 
 pub use crate::num::bignum::Big32x40 as Big;
 
@@ -36,7 +36,10 @@ pub fn compare_with_half_ulp(f: &Big, ones_place: usize) -> Ordering {
 /// 1. using `FromStr` on `&[u8]` requires `from_utf8_unchecked`, which is bad, and
 /// 2. piecing together the results of `integral.parse()` and `fractional.parse()` is
 ///    more complicated than this entire function.
-pub fn from_str_unchecked<'a, T>(bytes: T) -> u64 where T : IntoIterator<Item=&'a u8> {
+pub fn from_str_unchecked<'a, T>(bytes: T) -> u64
+where
+    T: IntoIterator<Item = &'a u8>,
+{
     let mut result = 0;
     for &c in bytes {
         result = result * 10 + (c - b'0') as u64;
@@ -61,13 +64,8 @@ pub fn digits_to_big(integral: &[u8], fractional: &[u8]) -> Big {
 pub fn to_u64(x: &Big) -> u64 {
     assert!(x.bit_length() < 64);
     let d = x.digits();
-    if d.len() < 2 {
-        d[0] as u64
-    } else {
-        (d[1] as u64) << 32 | d[0] as u64
-    }
+    if d.len() < 2 { d[0] as u64 } else { (d[1] as u64) << 32 | d[0] as u64 }
 }
-
 
 /// Extracts a range of bits.
 

--- a/src/libcore/num/dec2flt/parse.rs
+++ b/src/libcore/num/dec2flt/parse.rs
@@ -10,8 +10,8 @@
 //! modules rely on to not panic (or overflow) in turn.
 //! To make matters worse, all that happens in a single pass over the input.
 //! So, be careful when modifying anything, and double-check with the other modules.
+use self::ParseResult::{Invalid, ShortcutToInf, ShortcutToZero, Valid};
 use super::num;
-use self::ParseResult::{Valid, ShortcutToInf, ShortcutToZero, Invalid};
 
 #[derive(Debug)]
 pub enum Sign {

--- a/src/libcore/num/diy_float.rs
+++ b/src/libcore/num/diy_float.rs
@@ -3,9 +3,11 @@
 // This module is only for dec2flt and flt2dec, and only public because of coretests.
 // It is not intended to ever be stabilized.
 #![doc(hidden)]
-#![unstable(feature = "core_private_diy_float",
-            reason = "internal routines only exposed for testing",
-            issue = "0")]
+#![unstable(
+    feature = "core_private_diy_float",
+    reason = "internal routines only exposed for testing",
+    issue = "0"
+)]
 
 /// A custom 64-bit floating point type, representing `f * 2^e`.
 #[derive(Copy, Clone, Debug)]
@@ -74,9 +76,6 @@ impl Fp {
         assert!(edelta >= 0);
         let edelta = edelta as usize;
         assert_eq!(self.f << edelta >> edelta, self.f);
-        Fp {
-            f: self.f << edelta,
-            e,
-        }
+        Fp { f: self.f << edelta, e }
     }
 }

--- a/src/libcore/num/flt2dec/decoder.rs
+++ b/src/libcore/num/flt2dec/decoder.rs
@@ -1,8 +1,8 @@
 //! Decodes a floating-point value into individual parts and error ranges.
 
-use crate::{f32, f64};
-use crate::num::FpCategory;
 use crate::num::dec2flt::rawfp::RawFloat;
+use crate::num::FpCategory;
+use crate::{f32, f64};
 
 /// Decoded unsigned finite value, such that:
 ///
@@ -47,11 +47,15 @@ pub trait DecodableFloat: RawFloat + Copy {
 }
 
 impl DecodableFloat for f32 {
-    fn min_pos_norm_value() -> Self { f32::MIN_POSITIVE }
+    fn min_pos_norm_value() -> Self {
+        f32::MIN_POSITIVE
+    }
 }
 
 impl DecodableFloat for f64 {
-    fn min_pos_norm_value() -> Self { f64::MIN_POSITIVE }
+    fn min_pos_norm_value() -> Self {
+        f64::MIN_POSITIVE
+    }
 }
 
 /// Returns a sign (true when negative) and `FullDecoded` value
@@ -67,20 +71,29 @@ pub fn decode<T: DecodableFloat>(v: T) -> (/*negative?*/ bool, FullDecoded) {
             // neighbors: (mant - 2, exp) -- (mant, exp) -- (mant + 2, exp)
             // Float::integer_decode always preserves the exponent,
             // so the mantissa is scaled for subnormals.
-            FullDecoded::Finite(Decoded { mant, minus: 1, plus: 1,
-                                          exp, inclusive: even })
+            FullDecoded::Finite(Decoded { mant, minus: 1, plus: 1, exp, inclusive: even })
         }
         FpCategory::Normal => {
             let minnorm = <T as DecodableFloat>::min_pos_norm_value().integer_decode();
             if mant == minnorm.0 {
                 // neighbors: (maxmant, exp - 1) -- (minnormmant, exp) -- (minnormmant + 1, exp)
                 // where maxmant = minnormmant * 2 - 1
-                FullDecoded::Finite(Decoded { mant: mant << 2, minus: 1, plus: 2,
-                                              exp: exp - 2, inclusive: even })
+                FullDecoded::Finite(Decoded {
+                    mant: mant << 2,
+                    minus: 1,
+                    plus: 2,
+                    exp: exp - 2,
+                    inclusive: even,
+                })
             } else {
                 // neighbors: (mant - 1, exp) -- (mant, exp) -- (mant + 1, exp)
-                FullDecoded::Finite(Decoded { mant: mant << 1, minus: 1, plus: 1,
-                                              exp: exp - 1, inclusive: even })
+                FullDecoded::Finite(Decoded {
+                    mant: mant << 1,
+                    minus: 1,
+                    plus: 1,
+                    exp: exp - 1,
+                    inclusive: even,
+                })
             }
         }
     };

--- a/src/libcore/num/flt2dec/strategy/dragon.rs
+++ b/src/libcore/num/flt2dec/strategy/dragon.rs
@@ -6,38 +6,54 @@
 
 use crate::cmp::Ordering;
 
-use crate::num::flt2dec::{Decoded, MAX_SIG_DIGITS, round_up};
-use crate::num::flt2dec::estimator::estimate_scaling_factor;
-use crate::num::bignum::Digit32 as Digit;
 use crate::num::bignum::Big32x40 as Big;
+use crate::num::bignum::Digit32 as Digit;
+use crate::num::flt2dec::estimator::estimate_scaling_factor;
+use crate::num::flt2dec::{round_up, Decoded, MAX_SIG_DIGITS};
 
-static POW10: [Digit; 10] = [1, 10, 100, 1000, 10000, 100000,
-                             1000000, 10000000, 100000000, 1000000000];
-static TWOPOW10: [Digit; 10] = [2, 20, 200, 2000, 20000, 200000,
-                                2000000, 20000000, 200000000, 2000000000];
+static POW10: [Digit; 10] =
+    [1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000];
+static TWOPOW10: [Digit; 10] =
+    [2, 20, 200, 2000, 20000, 200000, 2000000, 20000000, 200000000, 2000000000];
 
 // precalculated arrays of `Digit`s for 10^(2^n)
 static POW10TO16: [Digit; 2] = [0x6fc10000, 0x2386f2];
 static POW10TO32: [Digit; 4] = [0, 0x85acef81, 0x2d6d415b, 0x4ee];
 static POW10TO64: [Digit; 7] = [0, 0, 0xbf6a1f01, 0x6e38ed64, 0xdaa797ed, 0xe93ff9f4, 0x184f03];
-static POW10TO128: [Digit; 14] =
-    [0, 0, 0, 0, 0x2e953e01, 0x3df9909, 0xf1538fd, 0x2374e42f, 0xd3cff5ec, 0xc404dc08,
-     0xbccdb0da, 0xa6337f19, 0xe91f2603, 0x24e];
-static POW10TO256: [Digit; 27] =
-    [0, 0, 0, 0, 0, 0, 0, 0, 0x982e7c01, 0xbed3875b, 0xd8d99f72, 0x12152f87, 0x6bde50c6,
-     0xcf4a6e70, 0xd595d80f, 0x26b2716e, 0xadc666b0, 0x1d153624, 0x3c42d35a, 0x63ff540e,
-     0xcc5573c0, 0x65f9ef17, 0x55bc28f2, 0x80dcc7f7, 0xf46eeddc, 0x5fdcefce, 0x553f7];
+static POW10TO128: [Digit; 14] = [
+    0, 0, 0, 0, 0x2e953e01, 0x3df9909, 0xf1538fd, 0x2374e42f, 0xd3cff5ec, 0xc404dc08, 0xbccdb0da,
+    0xa6337f19, 0xe91f2603, 0x24e,
+];
+static POW10TO256: [Digit; 27] = [
+    0, 0, 0, 0, 0, 0, 0, 0, 0x982e7c01, 0xbed3875b, 0xd8d99f72, 0x12152f87, 0x6bde50c6, 0xcf4a6e70,
+    0xd595d80f, 0x26b2716e, 0xadc666b0, 0x1d153624, 0x3c42d35a, 0x63ff540e, 0xcc5573c0, 0x65f9ef17,
+    0x55bc28f2, 0x80dcc7f7, 0xf46eeddc, 0x5fdcefce, 0x553f7,
+];
 
 #[doc(hidden)]
 pub fn mul_pow10(x: &mut Big, n: usize) -> &mut Big {
     debug_assert!(n < 512);
-    if n &   7 != 0 { x.mul_small(POW10[n & 7]); }
-    if n &   8 != 0 { x.mul_small(POW10[8]); }
-    if n &  16 != 0 { x.mul_digits(&POW10TO16); }
-    if n &  32 != 0 { x.mul_digits(&POW10TO32); }
-    if n &  64 != 0 { x.mul_digits(&POW10TO64); }
-    if n & 128 != 0 { x.mul_digits(&POW10TO128); }
-    if n & 256 != 0 { x.mul_digits(&POW10TO256); }
+    if n & 7 != 0 {
+        x.mul_small(POW10[n & 7]);
+    }
+    if n & 8 != 0 {
+        x.mul_small(POW10[8]);
+    }
+    if n & 16 != 0 {
+        x.mul_digits(&POW10TO16);
+    }
+    if n & 32 != 0 {
+        x.mul_digits(&POW10TO32);
+    }
+    if n & 64 != 0 {
+        x.mul_digits(&POW10TO64);
+    }
+    if n & 128 != 0 {
+        x.mul_digits(&POW10TO128);
+    }
+    if n & 256 != 0 {
+        x.mul_digits(&POW10TO256);
+    }
     x
 }
 
@@ -52,13 +68,30 @@ fn div_2pow10(x: &mut Big, mut n: usize) -> &mut Big {
 }
 
 // only usable when `x < 16 * scale`; `scaleN` should be `scale.mul_small(N)`
-fn div_rem_upto_16<'a>(x: &'a mut Big, scale: &Big,
-                       scale2: &Big, scale4: &Big, scale8: &Big) -> (u8, &'a mut Big) {
+fn div_rem_upto_16<'a>(
+    x: &'a mut Big,
+    scale: &Big,
+    scale2: &Big,
+    scale4: &Big,
+    scale8: &Big,
+) -> (u8, &'a mut Big) {
     let mut d = 0;
-    if *x >= *scale8 { x.sub(scale8); d += 8; }
-    if *x >= *scale4 { x.sub(scale4); d += 4; }
-    if *x >= *scale2 { x.sub(scale2); d += 2; }
-    if *x >= *scale  { x.sub(scale);  d += 1; }
+    if *x >= *scale8 {
+        x.sub(scale8);
+        d += 8;
+    }
+    if *x >= *scale4 {
+        x.sub(scale4);
+        d += 4;
+    }
+    if *x >= *scale2 {
+        x.sub(scale2);
+        d += 2;
+    }
+    if *x >= *scale {
+        x.sub(scale);
+        d += 1;
+    }
     debug_assert!(*x < *scale);
     (d, x)
 }
@@ -85,7 +118,7 @@ pub fn format_shortest(d: &Decoded, buf: &mut [u8]) -> (/*#digits*/ usize, /*exp
     assert!(buf.len() >= MAX_SIG_DIGITS);
 
     // `a.cmp(&b) < rounding` is `if d.inclusive {a <= b} else {a < b}`
-    let rounding = if d.inclusive {Ordering::Greater} else {Ordering::Equal};
+    let rounding = if d.inclusive { Ordering::Greater } else { Ordering::Equal };
 
     // estimate `k_0` from original inputs satisfying `10^(k_0-1) < high <= 10^(k_0+1)`.
     // the tight bound `k` satisfying `10^(k-1) < high <= 10^k` is calculated later.
@@ -132,9 +165,12 @@ pub fn format_shortest(d: &Decoded, buf: &mut [u8]) -> (/*#digits*/ usize, /*exp
     }
 
     // cache `(2, 4, 8) * scale` for digit generation.
-    let mut scale2 = scale.clone(); scale2.mul_pow2(1);
-    let mut scale4 = scale.clone(); scale4.mul_pow2(2);
-    let mut scale8 = scale.clone(); scale8.mul_pow2(3);
+    let mut scale2 = scale.clone();
+    scale2.mul_pow2(1);
+    let mut scale4 = scale.clone();
+    scale4.mul_pow2(2);
+    let mut scale8 = scale.clone();
+    scale8.mul_pow2(3);
 
     let mut down;
     let mut up;
@@ -186,7 +222,9 @@ pub fn format_shortest(d: &Decoded, buf: &mut [u8]) -> (/*#digits*/ usize, /*exp
         // - keep generating otherwise.
         down = mant.cmp(&minus) < rounding;
         up = scale.cmp(mant.clone().add(&plus)) < rounding;
-        if down || up { break; } // we have the shortest representation, proceed to the rounding
+        if down || up {
+            break;
+        } // we have the shortest representation, proceed to the rounding
 
         // restore the invariants.
         // this makes the algorithm always terminating: `minus` and `plus` always increases,
@@ -269,22 +307,40 @@ pub fn format_exact(d: &Decoded, buf: &mut [u8], limit: i16) -> (/*#digits*/ usi
     if len > 0 {
         // cache `(2, 4, 8) * scale` for digit generation.
         // (this can be expensive, so do not calculate them when the buffer is empty.)
-        let mut scale2 = scale.clone(); scale2.mul_pow2(1);
-        let mut scale4 = scale.clone(); scale4.mul_pow2(2);
-        let mut scale8 = scale.clone(); scale8.mul_pow2(3);
+        let mut scale2 = scale.clone();
+        scale2.mul_pow2(1);
+        let mut scale4 = scale.clone();
+        scale4.mul_pow2(2);
+        let mut scale8 = scale.clone();
+        scale8.mul_pow2(3);
 
         for i in 0..len {
-            if mant.is_zero() { // following digits are all zeroes, we stop here
+            if mant.is_zero() {
+                // following digits are all zeroes, we stop here
                 // do *not* try to perform rounding! rather, fill remaining digits.
-                for c in &mut buf[i..len] { *c = b'0'; }
+                for c in &mut buf[i..len] {
+                    *c = b'0';
+                }
                 return (len, k);
             }
 
             let mut d = 0;
-            if mant >= scale8 { mant.sub(&scale8); d += 8; }
-            if mant >= scale4 { mant.sub(&scale4); d += 4; }
-            if mant >= scale2 { mant.sub(&scale2); d += 2; }
-            if mant >= scale  { mant.sub(&scale);  d += 1; }
+            if mant >= scale8 {
+                mant.sub(&scale8);
+                d += 8;
+            }
+            if mant >= scale4 {
+                mant.sub(&scale4);
+                d += 4;
+            }
+            if mant >= scale2 {
+                mant.sub(&scale2);
+                d += 2;
+            }
+            if mant >= scale {
+                mant.sub(&scale);
+                d += 1;
+            }
             debug_assert!(mant < scale);
             debug_assert!(d < 10);
             buf[i] = b'0' + d;
@@ -296,8 +352,9 @@ pub fn format_exact(d: &Decoded, buf: &mut [u8], limit: i16) -> (/*#digits*/ usi
     // if the following digits are exactly 5000..., check the prior digit and try to
     // round to even (i.e., avoid rounding up when the prior digit is even).
     let order = mant.cmp(scale.mul_small(5));
-    if order == Ordering::Greater || (order == Ordering::Equal &&
-                                      (len == 0 || buf[len-1] & 1 == 1)) {
+    if order == Ordering::Greater
+        || (order == Ordering::Equal && (len == 0 || buf[len - 1] & 1 == 1))
+    {
         // if rounding up changes the length, the exponent should also change.
         // but we've been requested a fixed number of digits, so do not alter the buffer...
         if let Some(c) = round_up(buf, len) {

--- a/src/libcore/num/wrapping.rs
+++ b/src/libcore/num/wrapping.rs
@@ -4,7 +4,7 @@ use crate::ops::*;
 
 #[allow(unused_macros)]
 macro_rules! sh_impl_signed {
-    ($t:ident, $f:ident) => (
+    ($t:ident, $f:ident) => {
         #[stable(feature = "rust1", since = "1.0.0")]
         impl Shl<$f> for Wrapping<$t> {
             type Output = Wrapping<$t>;
@@ -19,7 +19,7 @@ macro_rules! sh_impl_signed {
             }
         }
         forward_ref_binop! { impl Shl, shl for Wrapping<$t>, $f,
-                #[stable(feature = "wrapping_ref_ops", since = "1.39.0")] }
+        #[stable(feature = "wrapping_ref_ops", since = "1.39.0")] }
 
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl ShlAssign<$f> for Wrapping<$t> {
@@ -44,7 +44,7 @@ macro_rules! sh_impl_signed {
             }
         }
         forward_ref_binop! { impl Shr, shr for Wrapping<$t>, $f,
-                #[stable(feature = "wrapping_ref_ops", since = "1.39.0")] }
+        #[stable(feature = "wrapping_ref_ops", since = "1.39.0")] }
 
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl ShrAssign<$f> for Wrapping<$t> {
@@ -54,11 +54,11 @@ macro_rules! sh_impl_signed {
             }
         }
         forward_ref_op_assign! { impl ShrAssign, shr_assign for Wrapping<$t>, $f }
-    )
+    };
 }
 
 macro_rules! sh_impl_unsigned {
-    ($t:ident, $f:ident) => (
+    ($t:ident, $f:ident) => {
         #[stable(feature = "rust1", since = "1.0.0")]
         impl Shl<$f> for Wrapping<$t> {
             type Output = Wrapping<$t>;
@@ -69,7 +69,7 @@ macro_rules! sh_impl_unsigned {
             }
         }
         forward_ref_binop! { impl Shl, shl for Wrapping<$t>, $f,
-                #[stable(feature = "wrapping_ref_ops", since = "1.39.0")] }
+        #[stable(feature = "wrapping_ref_ops", since = "1.39.0")] }
 
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl ShlAssign<$f> for Wrapping<$t> {
@@ -90,7 +90,7 @@ macro_rules! sh_impl_unsigned {
             }
         }
         forward_ref_binop! { impl Shr, shr for Wrapping<$t>, $f,
-                #[stable(feature = "wrapping_ref_ops", since = "1.39.0")] }
+        #[stable(feature = "wrapping_ref_ops", since = "1.39.0")] }
 
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl ShrAssign<$f> for Wrapping<$t> {
@@ -100,7 +100,7 @@ macro_rules! sh_impl_unsigned {
             }
         }
         forward_ref_op_assign! { impl ShrAssign, shr_assign for Wrapping<$t>, $f }
-    )
+    };
 }
 
 // FIXME (#23545): uncomment the remaining impls

--- a/src/libcore/ops/arith.rs
+++ b/src/libcore/ops/arith.rs
@@ -66,19 +66,13 @@
 #[lang = "add"]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_on_unimplemented(
-    on(
-        all(_Self="{integer}", Rhs="{float}"),
-        message="cannot add a float to an integer",
-    ),
-    on(
-        all(_Self="{float}", Rhs="{integer}"),
-        message="cannot add an integer to a float",
-    ),
-    message="cannot add `{Rhs}` to `{Self}`",
-    label="no implementation for `{Self} + {Rhs}`",
+    on(all(_Self = "{integer}", Rhs = "{float}"), message = "cannot add a float to an integer",),
+    on(all(_Self = "{float}", Rhs = "{integer}"), message = "cannot add an integer to a float",),
+    message = "cannot add `{Rhs}` to `{Self}`",
+    label = "no implementation for `{Self} + {Rhs}`"
 )]
 #[doc(alias = "+")]
-pub trait Add<Rhs=Self> {
+pub trait Add<Rhs = Self> {
     /// The resulting type after applying the `+` operator.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output;
@@ -173,10 +167,12 @@ add_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// ```
 #[lang = "sub"]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented(message="cannot subtract `{Rhs}` from `{Self}`",
-                         label="no implementation for `{Self} - {Rhs}`")]
+#[rustc_on_unimplemented(
+    message = "cannot subtract `{Rhs}` from `{Self}`",
+    label = "no implementation for `{Self} - {Rhs}`"
+)]
 #[doc(alias = "-")]
-pub trait Sub<Rhs=Self> {
+pub trait Sub<Rhs = Self> {
     /// The resulting type after applying the `-` operator.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output;
@@ -293,10 +289,12 @@ sub_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// ```
 #[lang = "mul"]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented(message="cannot multiply `{Rhs}` to `{Self}`",
-                         label="no implementation for `{Self} * {Rhs}`")]
+#[rustc_on_unimplemented(
+    message = "cannot multiply `{Rhs}` to `{Self}`",
+    label = "no implementation for `{Self} * {Rhs}`"
+)]
 #[doc(alias = "*")]
-pub trait Mul<Rhs=Self> {
+pub trait Mul<Rhs = Self> {
     /// The resulting type after applying the `*` operator.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output;
@@ -417,10 +415,12 @@ mul_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// ```
 #[lang = "div"]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented(message="cannot divide `{Self}` by `{Rhs}`",
-                         label="no implementation for `{Self} / {Rhs}`")]
+#[rustc_on_unimplemented(
+    message = "cannot divide `{Self}` by `{Rhs}`",
+    label = "no implementation for `{Self} / {Rhs}`"
+)]
 #[doc(alias = "/")]
-pub trait Div<Rhs=Self> {
+pub trait Div<Rhs = Self> {
     /// The resulting type after applying the `/` operator.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output;
@@ -502,10 +502,12 @@ div_impl_float! { f32 f64 }
 /// ```
 #[lang = "rem"]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented(message="cannot mod `{Self}` by `{Rhs}`",
-                         label="no implementation for `{Self} % {Rhs}`")]
+#[rustc_on_unimplemented(
+    message = "cannot mod `{Self}` by `{Rhs}`",
+    label = "no implementation for `{Self} % {Rhs}`"
+)]
 #[doc(alias = "%")]
-pub trait Rem<Rhs=Self> {
+pub trait Rem<Rhs = Self> {
     /// The resulting type after applying the `%` operator.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output;
@@ -533,7 +535,6 @@ macro_rules! rem_impl_integer {
 }
 
 rem_impl_integer! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
-
 
 macro_rules! rem_impl_float {
     ($($t:ty)*) => ($(
@@ -616,8 +617,6 @@ pub trait Neg {
     fn neg(self) -> Self::Output;
 }
 
-
-
 macro_rules! neg_impl_core {
     ($id:ident => $body:expr, $($t:ty)*) => ($(
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -679,11 +678,13 @@ neg_impl_numeric! { isize i8 i16 i32 i64 i128 f32 f64 }
 /// ```
 #[lang = "add_assign"]
 #[stable(feature = "op_assign_traits", since = "1.8.0")]
-#[rustc_on_unimplemented(message="cannot add-assign `{Rhs}` to `{Self}`",
-                         label="no implementation for `{Self} += {Rhs}`")]
+#[rustc_on_unimplemented(
+    message = "cannot add-assign `{Rhs}` to `{Self}`",
+    label = "no implementation for `{Self} += {Rhs}`"
+)]
 #[doc(alias = "+")]
 #[doc(alias = "+=")]
-pub trait AddAssign<Rhs=Self> {
+pub trait AddAssign<Rhs = Self> {
     /// Performs the `+=` operation.
     #[stable(feature = "op_assign_traits", since = "1.8.0")]
     fn add_assign(&mut self, rhs: Rhs);
@@ -735,11 +736,13 @@ add_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// ```
 #[lang = "sub_assign"]
 #[stable(feature = "op_assign_traits", since = "1.8.0")]
-#[rustc_on_unimplemented(message="cannot subtract-assign `{Rhs}` from `{Self}`",
-                         label="no implementation for `{Self} -= {Rhs}`")]
+#[rustc_on_unimplemented(
+    message = "cannot subtract-assign `{Rhs}` from `{Self}`",
+    label = "no implementation for `{Self} -= {Rhs}`"
+)]
 #[doc(alias = "-")]
 #[doc(alias = "-=")]
-pub trait SubAssign<Rhs=Self> {
+pub trait SubAssign<Rhs = Self> {
     /// Performs the `-=` operation.
     #[stable(feature = "op_assign_traits", since = "1.8.0")]
     fn sub_assign(&mut self, rhs: Rhs);
@@ -782,11 +785,13 @@ sub_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// ```
 #[lang = "mul_assign"]
 #[stable(feature = "op_assign_traits", since = "1.8.0")]
-#[rustc_on_unimplemented(message="cannot multiply-assign `{Rhs}` to `{Self}`",
-                         label="no implementation for `{Self} *= {Rhs}`")]
+#[rustc_on_unimplemented(
+    message = "cannot multiply-assign `{Rhs}` to `{Self}`",
+    label = "no implementation for `{Self} *= {Rhs}`"
+)]
 #[doc(alias = "*")]
 #[doc(alias = "*=")]
-pub trait MulAssign<Rhs=Self> {
+pub trait MulAssign<Rhs = Self> {
     /// Performs the `*=` operation.
     #[stable(feature = "op_assign_traits", since = "1.8.0")]
     fn mul_assign(&mut self, rhs: Rhs);
@@ -829,11 +834,13 @@ mul_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// ```
 #[lang = "div_assign"]
 #[stable(feature = "op_assign_traits", since = "1.8.0")]
-#[rustc_on_unimplemented(message="cannot divide-assign `{Self}` by `{Rhs}`",
-                         label="no implementation for `{Self} /= {Rhs}`")]
+#[rustc_on_unimplemented(
+    message = "cannot divide-assign `{Self}` by `{Rhs}`",
+    label = "no implementation for `{Self} /= {Rhs}`"
+)]
 #[doc(alias = "/")]
 #[doc(alias = "/=")]
-pub trait DivAssign<Rhs=Self> {
+pub trait DivAssign<Rhs = Self> {
     /// Performs the `/=` operation.
     #[stable(feature = "op_assign_traits", since = "1.8.0")]
     fn div_assign(&mut self, rhs: Rhs);
@@ -879,11 +886,13 @@ div_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// ```
 #[lang = "rem_assign"]
 #[stable(feature = "op_assign_traits", since = "1.8.0")]
-#[rustc_on_unimplemented(message="cannot mod-assign `{Self}` by `{Rhs}``",
-                         label="no implementation for `{Self} %= {Rhs}`")]
+#[rustc_on_unimplemented(
+    message = "cannot mod-assign `{Self}` by `{Rhs}``",
+    label = "no implementation for `{Self} %= {Rhs}`"
+)]
 #[doc(alias = "%")]
 #[doc(alias = "%=")]
-pub trait RemAssign<Rhs=Self> {
+pub trait RemAssign<Rhs = Self> {
     /// Performs the `%=` operation.
     #[stable(feature = "op_assign_traits", since = "1.8.0")]
     fn rem_assign(&mut self, rhs: Rhs);

--- a/src/libcore/ops/bit.rs
+++ b/src/libcore/ops/bit.rs
@@ -112,9 +112,11 @@ not_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 #[lang = "bitand"]
 #[doc(alias = "&")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented(message="no implementation for `{Self} & {Rhs}`",
-                         label="no implementation for `{Self} & {Rhs}`")]
-pub trait BitAnd<Rhs=Self> {
+#[rustc_on_unimplemented(
+    message = "no implementation for `{Self} & {Rhs}`",
+    label = "no implementation for `{Self} & {Rhs}`"
+)]
+pub trait BitAnd<Rhs = Self> {
     /// The resulting type after applying the `&` operator.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output;
@@ -196,9 +198,11 @@ bitand_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 #[lang = "bitor"]
 #[doc(alias = "|")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented(message="no implementation for `{Self} | {Rhs}`",
-                         label="no implementation for `{Self} | {Rhs}`")]
-pub trait BitOr<Rhs=Self> {
+#[rustc_on_unimplemented(
+    message = "no implementation for `{Self} | {Rhs}`",
+    label = "no implementation for `{Self} | {Rhs}`"
+)]
+pub trait BitOr<Rhs = Self> {
     /// The resulting type after applying the `|` operator.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output;
@@ -283,9 +287,11 @@ bitor_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 #[lang = "bitxor"]
 #[doc(alias = "^")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented(message="no implementation for `{Self} ^ {Rhs}`",
-                         label="no implementation for `{Self} ^ {Rhs}`")]
-pub trait BitXor<Rhs=Self> {
+#[rustc_on_unimplemented(
+    message = "no implementation for `{Self} ^ {Rhs}`",
+    label = "no implementation for `{Self} ^ {Rhs}`"
+)]
+pub trait BitXor<Rhs = Self> {
     /// The resulting type after applying the `^` operator.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output;
@@ -371,9 +377,11 @@ bitxor_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 #[lang = "shl"]
 #[doc(alias = "<<")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented(message="no implementation for `{Self} << {Rhs}`",
-                         label="no implementation for `{Self} << {Rhs}`")]
-pub trait Shl<Rhs=Self> {
+#[rustc_on_unimplemented(
+    message = "no implementation for `{Self} << {Rhs}`",
+    label = "no implementation for `{Self} << {Rhs}`"
+)]
+pub trait Shl<Rhs = Self> {
     /// The resulting type after applying the `<<` operator.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output;
@@ -385,7 +393,7 @@ pub trait Shl<Rhs=Self> {
 }
 
 macro_rules! shl_impl {
-    ($t:ty, $f:ty) => (
+    ($t:ty, $f:ty) => {
         #[stable(feature = "rust1", since = "1.0.0")]
         impl Shl<$f> for $t {
             type Output = $t;
@@ -398,7 +406,7 @@ macro_rules! shl_impl {
         }
 
         forward_ref_binop! { impl Shl, shl for $t, $f }
-    )
+    };
 }
 
 macro_rules! shl_impl_all {
@@ -480,9 +488,11 @@ shl_impl_all! { u8 u16 u32 u64 u128 usize i8 i16 i32 i64 isize i128 }
 #[lang = "shr"]
 #[doc(alias = ">>")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_on_unimplemented(message="no implementation for `{Self} >> {Rhs}`",
-                         label="no implementation for `{Self} >> {Rhs}`")]
-pub trait Shr<Rhs=Self> {
+#[rustc_on_unimplemented(
+    message = "no implementation for `{Self} >> {Rhs}`",
+    label = "no implementation for `{Self} >> {Rhs}`"
+)]
+pub trait Shr<Rhs = Self> {
     /// The resulting type after applying the `>>` operator.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output;
@@ -494,7 +504,7 @@ pub trait Shr<Rhs=Self> {
 }
 
 macro_rules! shr_impl {
-    ($t:ty, $f:ty) => (
+    ($t:ty, $f:ty) => {
         #[stable(feature = "rust1", since = "1.0.0")]
         impl Shr<$f> for $t {
             type Output = $t;
@@ -507,7 +517,7 @@ macro_rules! shr_impl {
         }
 
         forward_ref_binop! { impl Shr, shr for $t, $f }
-    )
+    };
 }
 
 macro_rules! shr_impl_all {
@@ -596,9 +606,11 @@ shr_impl_all! { u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize }
 #[lang = "bitand_assign"]
 #[doc(alias = "&=")]
 #[stable(feature = "op_assign_traits", since = "1.8.0")]
-#[rustc_on_unimplemented(message="no implementation for `{Self} &= {Rhs}`",
-                         label="no implementation for `{Self} &= {Rhs}`")]
-pub trait BitAndAssign<Rhs=Self> {
+#[rustc_on_unimplemented(
+    message = "no implementation for `{Self} &= {Rhs}`",
+    label = "no implementation for `{Self} &= {Rhs}`"
+)]
+pub trait BitAndAssign<Rhs = Self> {
     /// Performs the `&=` operation.
     #[stable(feature = "op_assign_traits", since = "1.8.0")]
     fn bitand_assign(&mut self, rhs: Rhs);
@@ -645,9 +657,11 @@ bitand_assign_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 #[lang = "bitor_assign"]
 #[doc(alias = "|=")]
 #[stable(feature = "op_assign_traits", since = "1.8.0")]
-#[rustc_on_unimplemented(message="no implementation for `{Self} |= {Rhs}`",
-                         label="no implementation for `{Self} |= {Rhs}`")]
-pub trait BitOrAssign<Rhs=Self> {
+#[rustc_on_unimplemented(
+    message = "no implementation for `{Self} |= {Rhs}`",
+    label = "no implementation for `{Self} |= {Rhs}`"
+)]
+pub trait BitOrAssign<Rhs = Self> {
     /// Performs the `|=` operation.
     #[stable(feature = "op_assign_traits", since = "1.8.0")]
     fn bitor_assign(&mut self, rhs: Rhs);
@@ -694,9 +708,11 @@ bitor_assign_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 #[lang = "bitxor_assign"]
 #[doc(alias = "^=")]
 #[stable(feature = "op_assign_traits", since = "1.8.0")]
-#[rustc_on_unimplemented(message="no implementation for `{Self} ^= {Rhs}`",
-                         label="no implementation for `{Self} ^= {Rhs}`")]
-pub trait BitXorAssign<Rhs=Self> {
+#[rustc_on_unimplemented(
+    message = "no implementation for `{Self} ^= {Rhs}`",
+    label = "no implementation for `{Self} ^= {Rhs}`"
+)]
+pub trait BitXorAssign<Rhs = Self> {
     /// Performs the `^=` operation.
     #[stable(feature = "op_assign_traits", since = "1.8.0")]
     fn bitxor_assign(&mut self, rhs: Rhs);
@@ -741,16 +757,18 @@ bitxor_assign_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 #[lang = "shl_assign"]
 #[doc(alias = "<<=")]
 #[stable(feature = "op_assign_traits", since = "1.8.0")]
-#[rustc_on_unimplemented(message="no implementation for `{Self} <<= {Rhs}`",
-                         label="no implementation for `{Self} <<= {Rhs}`")]
-pub trait ShlAssign<Rhs=Self> {
+#[rustc_on_unimplemented(
+    message = "no implementation for `{Self} <<= {Rhs}`",
+    label = "no implementation for `{Self} <<= {Rhs}`"
+)]
+pub trait ShlAssign<Rhs = Self> {
     /// Performs the `<<=` operation.
     #[stable(feature = "op_assign_traits", since = "1.8.0")]
     fn shl_assign(&mut self, rhs: Rhs);
 }
 
 macro_rules! shl_assign_impl {
-    ($t:ty, $f:ty) => (
+    ($t:ty, $f:ty) => {
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl ShlAssign<$f> for $t {
             #[inline]
@@ -761,7 +779,7 @@ macro_rules! shl_assign_impl {
         }
 
         forward_ref_op_assign! { impl ShlAssign, shl_assign for $t, $f }
-    )
+    };
 }
 
 macro_rules! shl_assign_impl_all {
@@ -809,16 +827,18 @@ shl_assign_impl_all! { u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize }
 #[lang = "shr_assign"]
 #[doc(alias = ">>=")]
 #[stable(feature = "op_assign_traits", since = "1.8.0")]
-#[rustc_on_unimplemented(message="no implementation for `{Self} >>= {Rhs}`",
-                         label="no implementation for `{Self} >>= {Rhs}`")]
-pub trait ShrAssign<Rhs=Self> {
+#[rustc_on_unimplemented(
+    message = "no implementation for `{Self} >>= {Rhs}`",
+    label = "no implementation for `{Self} >>= {Rhs}`"
+)]
+pub trait ShrAssign<Rhs = Self> {
     /// Performs the `>>=` operation.
     #[stable(feature = "op_assign_traits", since = "1.8.0")]
     fn shr_assign(&mut self, rhs: Rhs);
 }
 
 macro_rules! shr_assign_impl {
-    ($t:ty, $f:ty) => (
+    ($t:ty, $f:ty) => {
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl ShrAssign<$f> for $t {
             #[inline]
@@ -829,7 +849,7 @@ macro_rules! shr_assign_impl {
         }
 
         forward_ref_op_assign! { impl ShrAssign, shr_assign for $t, $f }
-    )
+    };
 }
 
 macro_rules! shr_assign_impl_all {

--- a/src/libcore/ops/deref.rs
+++ b/src/libcore/ops/deref.rs
@@ -76,14 +76,18 @@ pub trait Deref {
 impl<T: ?Sized> Deref for &T {
     type Target = T;
 
-    fn deref(&self) -> &T { *self }
+    fn deref(&self) -> &T {
+        *self
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> Deref for &mut T {
     type Target = T;
 
-    fn deref(&self) -> &T { *self }
+    fn deref(&self) -> &T {
+        *self
+    }
 }
 
 /// Used for mutable dereferencing operations, like in `*v = 1;`.
@@ -165,7 +169,9 @@ pub trait DerefMut: Deref {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> DerefMut for &mut T {
-    fn deref_mut(&mut self) -> &mut T { *self }
+    fn deref_mut(&mut self) -> &mut T {
+        *self
+    }
 }
 
 /// Indicates that a struct can be used as a method receiver, without the

--- a/src/libcore/ops/function.rs
+++ b/src/libcore/ops/function.rs
@@ -57,13 +57,16 @@
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_paren_sugar]
 #[rustc_on_unimplemented(
-    on(Args="()", note="wrap the `{Self}` in a closure with no arguments: `|| {{ /* code */ }}"),
-    message="expected a `{Fn}<{Args}>` closure, found `{Self}`",
-    label="expected an `Fn<{Args}>` closure, found `{Self}`",
+    on(
+        Args = "()",
+        note = "wrap the `{Self}` in a closure with no arguments: `|| {{ /* code */ }}"
+    ),
+    message = "expected a `{Fn}<{Args}>` closure, found `{Self}`",
+    label = "expected an `Fn<{Args}>` closure, found `{Self}`"
 )]
 #[fundamental] // so that regex can rely that `&str: !FnMut`
 #[must_use = "closures are lazy and do nothing unless called"]
-pub trait Fn<Args> : FnMut<Args> {
+pub trait Fn<Args>: FnMut<Args> {
     /// Performs the call operation.
     #[unstable(feature = "fn_traits", issue = "29625")]
     extern "rust-call" fn call(&self, args: Args) -> Self::Output;
@@ -136,13 +139,16 @@ pub trait Fn<Args> : FnMut<Args> {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_paren_sugar]
 #[rustc_on_unimplemented(
-    on(Args="()", note="wrap the `{Self}` in a closure with no arguments: `|| {{ /* code */ }}"),
-    message="expected a `{FnMut}<{Args}>` closure, found `{Self}`",
-    label="expected an `FnMut<{Args}>` closure, found `{Self}`",
+    on(
+        Args = "()",
+        note = "wrap the `{Self}` in a closure with no arguments: `|| {{ /* code */ }}"
+    ),
+    message = "expected a `{FnMut}<{Args}>` closure, found `{Self}`",
+    label = "expected an `FnMut<{Args}>` closure, found `{Self}`"
 )]
 #[fundamental] // so that regex can rely that `&str: !FnMut`
 #[must_use = "closures are lazy and do nothing unless called"]
-pub trait FnMut<Args> : FnOnce<Args> {
+pub trait FnMut<Args>: FnOnce<Args> {
     /// Performs the call operation.
     #[unstable(feature = "fn_traits", issue = "29625")]
     extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output;
@@ -207,9 +213,12 @@ pub trait FnMut<Args> : FnOnce<Args> {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_paren_sugar]
 #[rustc_on_unimplemented(
-    on(Args="()", note="wrap the `{Self}` in a closure with no arguments: `|| {{ /* code */ }}"),
-    message="expected a `{FnOnce}<{Args}>` closure, found `{Self}`",
-    label="expected an `FnOnce<{Args}>` closure, found `{Self}`",
+    on(
+        Args = "()",
+        note = "wrap the `{Self}` in a closure with no arguments: `|| {{ /* code */ }}"
+    ),
+    message = "expected a `{FnOnce}<{Args}>` closure, found `{Self}`",
+    label = "expected an `FnOnce<{Args}>` closure, found `{Self}`"
 )]
 #[fundamental] // so that regex can rely that `&str: !FnMut`
 #[must_use = "closures are lazy and do nothing unless called"]
@@ -225,8 +234,9 @@ pub trait FnOnce<Args> {
 
 mod impls {
     #[stable(feature = "rust1", since = "1.0.0")]
-    impl<A,F:?Sized> Fn<A> for &F
-        where F : Fn<A>
+    impl<A, F: ?Sized> Fn<A> for &F
+    where
+        F: Fn<A>,
     {
         extern "rust-call" fn call(&self, args: A) -> F::Output {
             (**self).call(args)
@@ -234,8 +244,9 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    impl<A,F:?Sized> FnMut<A> for &F
-        where F : Fn<A>
+    impl<A, F: ?Sized> FnMut<A> for &F
+    where
+        F: Fn<A>,
     {
         extern "rust-call" fn call_mut(&mut self, args: A) -> F::Output {
             (**self).call(args)
@@ -243,8 +254,9 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    impl<A,F:?Sized> FnOnce<A> for &F
-        where F : Fn<A>
+    impl<A, F: ?Sized> FnOnce<A> for &F
+    where
+        F: Fn<A>,
     {
         type Output = F::Output;
 
@@ -254,8 +266,9 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    impl<A,F:?Sized> FnMut<A> for &mut F
-        where F : FnMut<A>
+    impl<A, F: ?Sized> FnMut<A> for &mut F
+    where
+        F: FnMut<A>,
     {
         extern "rust-call" fn call_mut(&mut self, args: A) -> F::Output {
             (*self).call_mut(args)
@@ -263,8 +276,9 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    impl<A,F:?Sized> FnOnce<A> for &mut F
-        where F : FnMut<A>
+    impl<A, F: ?Sized> FnOnce<A> for &mut F
+    where
+        F: FnMut<A>,
     {
         type Output = F::Output;
         extern "rust-call" fn call_once(self, args: A) -> F::Output {

--- a/src/libcore/ops/index.rs
+++ b/src/libcore/ops/index.rs
@@ -51,8 +51,8 @@
 /// ```
 #[lang = "index"]
 #[rustc_on_unimplemented(
-    message="the type `{Self}` cannot be indexed by `{Idx}`",
-    label="`{Self}` cannot be indexed by `{Idx}`",
+    message = "the type `{Self}` cannot be indexed by `{Idx}`",
+    label = "`{Self}` cannot be indexed by `{Idx}`"
 )]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(alias = "]")]
@@ -142,22 +142,22 @@ pub trait Index<Idx: ?Sized> {
 #[lang = "index_mut"]
 #[rustc_on_unimplemented(
     on(
-        _Self="&str",
-        note="you can use `.chars().nth()` or `.bytes().nth()`
+        _Self = "&str",
+        note = "you can use `.chars().nth()` or `.bytes().nth()`
 see chapter in The Book <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>"
     ),
     on(
-        _Self="str",
-        note="you can use `.chars().nth()` or `.bytes().nth()`
+        _Self = "str",
+        note = "you can use `.chars().nth()` or `.bytes().nth()`
 see chapter in The Book <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>"
     ),
     on(
-        _Self="std::string::String",
-        note="you can use `.chars().nth()` or `.bytes().nth()`
+        _Self = "std::string::String",
+        note = "you can use `.chars().nth()` or `.bytes().nth()`
 see chapter in The Book <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>"
     ),
-    message="the type `{Self}` cannot be mutably indexed by `{Idx}`",
-    label="`{Self}` cannot be mutably indexed by `{Idx}`",
+    message = "the type `{Self}` cannot be mutably indexed by `{Idx}`",
+    label = "`{Self}` cannot be mutably indexed by `{Idx}`"
 )]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(alias = "[")]

--- a/src/libcore/ops/mod.rs
+++ b/src/libcore/ops/mod.rs
@@ -156,12 +156,12 @@ mod r#try;
 mod unsize;
 
 #[stable(feature = "rust1", since = "1.0.0")]
-pub use self::arith::{Add, Sub, Mul, Div, Rem, Neg};
+pub use self::arith::{Add, Div, Mul, Neg, Rem, Sub};
 #[stable(feature = "op_assign_traits", since = "1.8.0")]
-pub use self::arith::{AddAssign, SubAssign, MulAssign, DivAssign, RemAssign};
+pub use self::arith::{AddAssign, DivAssign, MulAssign, RemAssign, SubAssign};
 
 #[stable(feature = "rust1", since = "1.0.0")]
-pub use self::bit::{Not, BitAnd, BitOr, BitXor, Shl, Shr};
+pub use self::bit::{BitAnd, BitOr, BitXor, Not, Shl, Shr};
 #[stable(feature = "op_assign_traits", since = "1.8.0")]
 pub use self::bit::{BitAndAssign, BitOrAssign, BitXorAssign, ShlAssign, ShrAssign};
 
@@ -184,7 +184,7 @@ pub use self::index::{Index, IndexMut};
 pub use self::range::{Range, RangeFrom, RangeFull, RangeTo};
 
 #[stable(feature = "inclusive_range", since = "1.26.0")]
-pub use self::range::{RangeInclusive, RangeToInclusive, RangeBounds, Bound};
+pub use self::range::{Bound, RangeBounds, RangeInclusive, RangeToInclusive};
 
 #[unstable(feature = "try_trait", issue = "42327")]
 pub use self::r#try::Try;

--- a/src/libcore/ops/range.rs
+++ b/src/libcore/ops/range.rs
@@ -399,11 +399,7 @@ impl<Idx> RangeInclusive<Idx> {
     #[inline]
     #[rustc_promotable]
     pub const fn new(start: Idx, end: Idx) -> Self {
-        Self {
-            start,
-            end,
-            is_empty: None,
-        }
+        Self { start, end, is_empty: None }
     }
 
     /// Returns the lower bound of the range (inclusive).

--- a/src/libcore/ops/unsize.rs
+++ b/src/libcore/ops/unsize.rs
@@ -39,35 +39,34 @@ pub trait CoerceUnsized<T: ?Sized> {
 
 // &mut T -> &mut U
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<'a, T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<&'a mut U> for &'a mut T {}
+impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<&'a mut U> for &'a mut T {}
 // &mut T -> &U
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<'a, 'b: 'a, T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<&'a U> for &'b mut T {}
+impl<'a, 'b: 'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<&'a U> for &'b mut T {}
 // &mut T -> *mut U
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<'a, T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<*mut U> for &'a mut T {}
+impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*mut U> for &'a mut T {}
 // &mut T -> *const U
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<'a, T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for &'a mut T {}
+impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for &'a mut T {}
 
 // &T -> &U
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<'a, 'b: 'a, T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<&'a U> for &'b T {}
+impl<'a, 'b: 'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<&'a U> for &'b T {}
 // &T -> *const U
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<'a, T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for &'a T {}
+impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for &'a T {}
 
 // *mut T -> *mut U
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<*mut U> for *mut T {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*mut U> for *mut T {}
 // *mut T -> *const U
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *mut T {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *mut T {}
 
 // *const T -> *const U
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *const T {}
-
+impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *const T {}
 
 /// This is used for object safety, to check that a method's receiver type can be dispatched on.
 ///
@@ -90,13 +89,13 @@ pub trait DispatchFromDyn<T> {
 
 // &T -> &U
 #[unstable(feature = "dispatch_from_dyn", issue = "0")]
-impl<'a, T: ?Sized+Unsize<U>, U: ?Sized> DispatchFromDyn<&'a U> for &'a T {}
+impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<&'a U> for &'a T {}
 // &mut T -> &mut U
 #[unstable(feature = "dispatch_from_dyn", issue = "0")]
-impl<'a, T: ?Sized+Unsize<U>, U: ?Sized> DispatchFromDyn<&'a mut U> for &'a mut T {}
+impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<&'a mut U> for &'a mut T {}
 // *const T -> *const U
 #[unstable(feature = "dispatch_from_dyn", issue = "0")]
-impl<T: ?Sized+Unsize<U>, U: ?Sized> DispatchFromDyn<*const U> for *const T {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<*const U> for *const T {}
 // *mut T -> *mut U
 #[unstable(feature = "dispatch_from_dyn", issue = "0")]
-impl<T: ?Sized+Unsize<U>, U: ?Sized> DispatchFromDyn<*mut U> for *mut T {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<*mut U> for *mut T {}

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -138,8 +138,11 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::iter::{FromIterator, FusedIterator, TrustedLen};
-use crate::{convert, fmt, hint, mem, ops::{self, Deref, DerefMut}};
 use crate::pin::Pin;
+use crate::{
+    convert, fmt, hint, mem,
+    ops::{self, Deref, DerefMut},
+};
 
 // Note that this is not a lang item per se, but it has a hidden dependency on
 // `Iterator`, which is one. The compiler assumes that the `next` method of
@@ -230,7 +233,10 @@ impl<T> Option<T> {
     #[must_use]
     #[inline]
     #[unstable(feature = "option_result_contains", issue = "62358")]
-    pub fn contains<U>(&self, x: &U) -> bool where U: PartialEq<T> {
+    pub fn contains<U>(&self, x: &U) -> bool
+    where
+        U: PartialEq<T>,
+    {
         match self {
             Some(y) => x == y,
             None => false,
@@ -291,16 +297,13 @@ impl<T> Option<T> {
         }
     }
 
-
     /// Converts from [`Pin`]`<&Option<T>>` to `Option<`[`Pin`]`<&T>>`.
     ///
     /// [`Pin`]: ../pin/struct.Pin.html
     #[inline]
     #[stable(feature = "pin", since = "1.33.0")]
     pub fn as_pin_ref(self: Pin<&Self>) -> Option<Pin<&T>> {
-        unsafe {
-            Pin::get_ref(self).as_ref().map(|x| Pin::new_unchecked(x))
-        }
+        unsafe { Pin::get_ref(self).as_ref().map(|x| Pin::new_unchecked(x)) }
     }
 
     /// Converts from [`Pin`]`<&mut Option<T>>` to `Option<`[`Pin`]`<&mut T>>`.
@@ -309,9 +312,7 @@ impl<T> Option<T> {
     #[inline]
     #[stable(feature = "pin", since = "1.33.0")]
     pub fn as_pin_mut(self: Pin<&mut Self>) -> Option<Pin<&mut T>> {
-        unsafe {
-            Pin::get_unchecked_mut(self).as_mut().map(|x| Pin::new_unchecked(x))
-        }
+        unsafe { Pin::get_unchecked_mut(self).as_mut().map(|x| Pin::new_unchecked(x)) }
     }
 
     /////////////////////////////////////////////////////////////////////////
@@ -690,7 +691,7 @@ impl<T> Option<T> {
     pub fn filter<P: FnOnce(&T) -> bool>(self, predicate: P) -> Self {
         if let Some(x) = self {
             if predicate(&x) {
-                return Some(x)
+                return Some(x);
             }
         }
         None
@@ -1228,7 +1229,9 @@ impl<T> Default for Option<T> {
     /// assert!(opt.is_none());
     /// ```
     #[inline]
-    fn default() -> Option<T> { None }
+    fn default() -> Option<T> {
+        None
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1302,7 +1305,7 @@ impl<'a, T> From<&'a mut Option<T>> for Option<&'a mut T> {
 
 #[derive(Clone, Debug)]
 struct Item<A> {
-    opt: Option<A>
+    opt: Option<A>,
 }
 
 impl<A> Iterator for Item<A> {
@@ -1344,22 +1347,30 @@ unsafe impl<A> TrustedLen for Item<A> {}
 /// [`Option::iter`]: enum.Option.html#method.iter
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug)]
-pub struct Iter<'a, A: 'a> { inner: Item<&'a A> }
+pub struct Iter<'a, A: 'a> {
+    inner: Item<&'a A>,
+}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, A> Iterator for Iter<'a, A> {
     type Item = &'a A;
 
     #[inline]
-    fn next(&mut self) -> Option<&'a A> { self.inner.next() }
+    fn next(&mut self) -> Option<&'a A> {
+        self.inner.next()
+    }
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { self.inner.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, A> DoubleEndedIterator for Iter<'a, A> {
     #[inline]
-    fn next_back(&mut self) -> Option<&'a A> { self.inner.next_back() }
+    fn next_back(&mut self) -> Option<&'a A> {
+        self.inner.next_back()
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1390,22 +1401,30 @@ impl<A> Clone for Iter<'_, A> {
 /// [`Option::iter_mut`]: enum.Option.html#method.iter_mut
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug)]
-pub struct IterMut<'a, A: 'a> { inner: Item<&'a mut A> }
+pub struct IterMut<'a, A: 'a> {
+    inner: Item<&'a mut A>,
+}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, A> Iterator for IterMut<'a, A> {
     type Item = &'a mut A;
 
     #[inline]
-    fn next(&mut self) -> Option<&'a mut A> { self.inner.next() }
+    fn next(&mut self) -> Option<&'a mut A> {
+        self.inner.next()
+    }
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { self.inner.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, A> DoubleEndedIterator for IterMut<'a, A> {
     #[inline]
-    fn next_back(&mut self) -> Option<&'a mut A> { self.inner.next_back() }
+    fn next_back(&mut self) -> Option<&'a mut A> {
+        self.inner.next_back()
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1427,22 +1446,30 @@ unsafe impl<A> TrustedLen for IterMut<'_, A> {}
 /// [`Option::into_iter`]: enum.Option.html#method.into_iter
 #[derive(Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct IntoIter<A> { inner: Item<A> }
+pub struct IntoIter<A> {
+    inner: Item<A>,
+}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A> Iterator for IntoIter<A> {
     type Item = A;
 
     #[inline]
-    fn next(&mut self) -> Option<A> { self.inner.next() }
+    fn next(&mut self) -> Option<A> {
+        self.inner.next()
+    }
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { self.inner.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A> DoubleEndedIterator for IntoIter<A> {
     #[inline]
-    fn next_back(&mut self) -> Option<A> { self.inner.next_back() }
+    fn next_back(&mut self) -> Option<A> {
+        self.inner.next_back()
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1523,14 +1550,11 @@ impl<A, V: FromIterator<A>> FromIterator<Option<A>> for Option<V> {
     ///
     /// [`Iterator`]: ../iter/trait.Iterator.html
     #[inline]
-    fn from_iter<I: IntoIterator<Item=Option<A>>>(iter: I) -> Option<V> {
+    fn from_iter<I: IntoIterator<Item = Option<A>>>(iter: I) -> Option<V> {
         // FIXME(#11084): This could be replaced with Iterator::scan when this
         // performance bug is closed.
 
-        iter.into_iter()
-            .map(|x| x.ok_or(()))
-            .collect::<Result<_, _>>()
-            .ok()
+        iter.into_iter().map(|x| x.ok_or(())).collect::<Result<_, _>>().ok()
     }
 }
 

--- a/src/libcore/pin.rs
+++ b/src/libcore/pin.rs
@@ -374,10 +374,10 @@
 
 #![stable(feature = "pin", since = "1.33.0")]
 
+use crate::cmp::{self, PartialEq, PartialOrd};
 use crate::fmt;
 use crate::marker::{Sized, Unpin};
-use crate::cmp::{self, PartialEq, PartialOrd};
-use crate::ops::{Deref, DerefMut, Receiver, CoerceUnsized, DispatchFromDyn};
+use crate::ops::{CoerceUnsized, Deref, DerefMut, DispatchFromDyn, Receiver};
 
 /// A pinned pointer.
 ///
@@ -646,7 +646,8 @@ impl<'a, T: ?Sized> Pin<&'a T> {
     ///
     /// [`pin` module]: ../../std/pin/index.html#projections-and-structural-pinning
     #[stable(feature = "pin", since = "1.33.0")]
-    pub unsafe fn map_unchecked<U, F>(self, func: F) -> Pin<&'a U> where
+    pub unsafe fn map_unchecked<U, F>(self, func: F) -> Pin<&'a U>
+    where
         F: FnOnce(&T) -> &U,
     {
         let pointer = &*self.pointer;
@@ -698,7 +699,8 @@ impl<'a, T: ?Sized> Pin<&'a mut T> {
     #[stable(feature = "pin", since = "1.33.0")]
     #[inline(always)]
     pub fn get_mut(self) -> &'a mut T
-        where T: Unpin,
+    where
+        T: Unpin,
     {
         self.pointer
     }
@@ -735,7 +737,8 @@ impl<'a, T: ?Sized> Pin<&'a mut T> {
     ///
     /// [`pin` module]: ../../std/pin/index.html#projections-and-structural-pinning
     #[stable(feature = "pin", since = "1.33.0")]
-    pub unsafe fn map_unchecked_mut<U, F>(self, func: F) -> Pin<&'a mut U> where
+    pub unsafe fn map_unchecked_mut<U, F>(self, func: F) -> Pin<&'a mut U>
+    where
         F: FnOnce(&mut T) -> &mut U,
     {
         let pointer = Pin::get_unchecked_mut(self);
@@ -789,13 +792,7 @@ impl<P: fmt::Pointer> fmt::Pointer for Pin<P> {
 // for other reasons, though, so we just need to take care not to allow such
 // impls to land in std.
 #[stable(feature = "pin", since = "1.33.0")]
-impl<P, U> CoerceUnsized<Pin<U>> for Pin<P>
-where
-    P: CoerceUnsized<U>,
-{}
+impl<P, U> CoerceUnsized<Pin<U>> for Pin<P> where P: CoerceUnsized<U> {}
 
 #[stable(feature = "pin", since = "1.33.0")]
-impl<P, U> DispatchFromDyn<Pin<U>> for Pin<P>
-where
-    P: DispatchFromDyn<U>,
-{}
+impl<P, U> DispatchFromDyn<Pin<U>> for Pin<P> where P: DispatchFromDyn<U> {}

--- a/src/libcore/prelude/v1.rs
+++ b/src/libcore/prelude/v1.rs
@@ -25,25 +25,25 @@ pub use crate::mem::drop;
 pub use crate::clone::Clone;
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use crate::cmp::{PartialEq, PartialOrd, Eq, Ord};
+pub use crate::cmp::{Eq, Ord, PartialEq, PartialOrd};
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use crate::convert::{AsRef, AsMut, Into, From};
+pub use crate::convert::{AsMut, AsRef, From, Into};
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
 pub use crate::default::Default;
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use crate::iter::{Iterator, Extend, IntoIterator};
-#[stable(feature = "core_prelude", since = "1.4.0")]
-#[doc(no_inline)]
 pub use crate::iter::{DoubleEndedIterator, ExactSizeIterator};
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use crate::option::Option::{self, Some, None};
+pub use crate::iter::{Extend, IntoIterator, Iterator};
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use crate::result::Result::{self, Ok, Err};
+pub use crate::option::Option::{self, None, Some};
+#[stable(feature = "core_prelude", since = "1.4.0")]
+#[doc(no_inline)]
+pub use crate::result::Result::{self, Err, Ok};
 
 // Re-exported built-in macros
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
@@ -56,37 +56,14 @@ pub use crate::hash::macros::Hash;
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[doc(no_inline)]
 pub use crate::{
-    asm,
-    assert,
-    cfg,
-    column,
-    compile_error,
-    concat,
-    concat_idents,
-    env,
-    file,
-    format_args,
-    format_args_nl,
-    global_asm,
-    include,
-    include_bytes,
-    include_str,
-    line,
-    log_syntax,
-    module_path,
-    option_env,
-    stringify,
-    trace_macros,
+    asm, assert, cfg, column, compile_error, concat, concat_idents, env, file, format_args,
+    format_args_nl, global_asm, include, include_bytes, include_str, line, log_syntax, module_path,
+    option_env, stringify, trace_macros,
 };
 
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[allow(deprecated)]
 #[doc(no_inline)]
 pub use crate::macros::builtin::{
-    RustcDecodable,
-    RustcEncodable,
-    bench,
-    global_allocator,
-    test,
-    test_case,
+    bench, global_allocator, test, test_case, RustcDecodable, RustcEncodable,
 };

--- a/src/libcore/ptr/non_null.rs
+++ b/src/libcore/ptr/non_null.rs
@@ -1,11 +1,11 @@
+use crate::cmp::Ordering;
 use crate::convert::From;
-use crate::ops::{CoerceUnsized, DispatchFromDyn};
 use crate::fmt;
 use crate::hash;
 use crate::marker::Unsize;
 use crate::mem;
+use crate::ops::{CoerceUnsized, DispatchFromDyn};
 use crate::ptr::Unique;
-use crate::cmp::Ordering;
 
 // ignore-tidy-undocumented-unsafe
 
@@ -48,12 +48,12 @@ pub struct NonNull<T: ?Sized> {
 /// `NonNull` pointers are not `Send` because the data they reference may be aliased.
 // N.B., this impl is unnecessary, but should provide better error messages.
 #[stable(feature = "nonnull", since = "1.25.0")]
-impl<T: ?Sized> !Send for NonNull<T> { }
+impl<T: ?Sized> !Send for NonNull<T> {}
 
 /// `NonNull` pointers are not `Sync` because the data they reference may be aliased.
 // N.B., this impl is unnecessary, but should provide better error messages.
 #[stable(feature = "nonnull", since = "1.25.0")]
-impl<T: ?Sized> !Sync for NonNull<T> { }
+impl<T: ?Sized> !Sync for NonNull<T> {}
 
 impl<T: Sized> NonNull<T> {
     /// Creates a new `NonNull` that is dangling, but well-aligned.
@@ -91,11 +91,7 @@ impl<T: ?Sized> NonNull<T> {
     #[stable(feature = "nonnull", since = "1.25.0")]
     #[inline]
     pub fn new(ptr: *mut T) -> Option<Self> {
-        if !ptr.is_null() {
-            Some(unsafe { Self::new_unchecked(ptr) })
-        } else {
-            None
-        }
+        if !ptr.is_null() { Some(unsafe { Self::new_unchecked(ptr) }) } else { None }
     }
 
     /// Acquires the underlying `*mut` pointer.
@@ -131,9 +127,7 @@ impl<T: ?Sized> NonNull<T> {
     #[stable(feature = "nonnull_cast", since = "1.27.0")]
     #[inline]
     pub const fn cast<U>(self) -> NonNull<U> {
-        unsafe {
-            NonNull::new_unchecked(self.as_ptr() as *mut U)
-        }
+        unsafe { NonNull::new_unchecked(self.as_ptr() as *mut U) }
     }
 }
 
@@ -146,13 +140,13 @@ impl<T: ?Sized> Clone for NonNull<T> {
 }
 
 #[stable(feature = "nonnull", since = "1.25.0")]
-impl<T: ?Sized> Copy for NonNull<T> { }
+impl<T: ?Sized> Copy for NonNull<T> {}
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: ?Sized, U: ?Sized> CoerceUnsized<NonNull<U>> for NonNull<T> where T: Unsize<U> { }
+impl<T: ?Sized, U: ?Sized> CoerceUnsized<NonNull<U>> for NonNull<T> where T: Unsize<U> {}
 
 #[unstable(feature = "dispatch_from_dyn", issue = "0")]
-impl<T: ?Sized, U: ?Sized> DispatchFromDyn<NonNull<U>> for NonNull<T> where T: Unsize<U> { }
+impl<T: ?Sized, U: ?Sized> DispatchFromDyn<NonNull<U>> for NonNull<T> where T: Unsize<U> {}
 
 #[stable(feature = "nonnull", since = "1.25.0")]
 impl<T: ?Sized> fmt::Debug for NonNull<T> {

--- a/src/libcore/ptr/unique.rs
+++ b/src/libcore/ptr/unique.rs
@@ -1,8 +1,8 @@
 use crate::convert::From;
-use crate::ops::{CoerceUnsized, DispatchFromDyn};
 use crate::fmt;
 use crate::marker::{PhantomData, Unsize};
 use crate::mem;
+use crate::ops::{CoerceUnsized, DispatchFromDyn};
 use crate::ptr::NonNull;
 
 // ignore-tidy-undocumented-unsafe
@@ -27,9 +27,12 @@ use crate::ptr::NonNull;
 ///
 /// Unlike `*mut T`, `Unique<T>` is covariant over `T`. This should always be correct
 /// for any type which upholds Unique's aliasing requirements.
-#[unstable(feature = "ptr_internals", issue = "0",
-           reason = "use `NonNull` instead and consider `PhantomData<T>` \
-                     (if you also use `#[may_dangle]`), `Send`, and/or `Sync`")]
+#[unstable(
+    feature = "ptr_internals",
+    issue = "0",
+    reason = "use `NonNull` instead and consider `PhantomData<T>` \
+              (if you also use `#[may_dangle]`), `Send`, and/or `Sync`"
+)]
 #[doc(hidden)]
 #[repr(transparent)]
 #[rustc_layout_scalar_valid_range_start(1)]
@@ -48,14 +51,14 @@ pub struct Unique<T: ?Sized> {
 /// unenforced by the type system; the abstraction using the
 /// `Unique` must enforce it.
 #[unstable(feature = "ptr_internals", issue = "0")]
-unsafe impl<T: Send + ?Sized> Send for Unique<T> { }
+unsafe impl<T: Send + ?Sized> Send for Unique<T> {}
 
 /// `Unique` pointers are `Sync` if `T` is `Sync` because the data they
 /// reference is unaliased. Note that this aliasing invariant is
 /// unenforced by the type system; the abstraction using the
 /// `Unique` must enforce it.
 #[unstable(feature = "ptr_internals", issue = "0")]
-unsafe impl<T: Sync + ?Sized> Sync for Unique<T> { }
+unsafe impl<T: Sync + ?Sized> Sync for Unique<T> {}
 
 #[unstable(feature = "ptr_internals", issue = "0")]
 impl<T: Sized> Unique<T> {
@@ -71,9 +74,7 @@ impl<T: Sized> Unique<T> {
     // FIXME: rename to dangling() to match NonNull?
     #[inline]
     pub const fn empty() -> Self {
-        unsafe {
-            Unique::new_unchecked(mem::align_of::<T>() as *mut T)
-        }
+        unsafe { Unique::new_unchecked(mem::align_of::<T>() as *mut T) }
     }
 }
 
@@ -128,9 +129,7 @@ impl<T: ?Sized> Unique<T> {
     /// Casts to a pointer of another type.
     #[inline]
     pub const fn cast<U>(self) -> Unique<U> {
-        unsafe {
-            Unique::new_unchecked(self.as_ptr() as *mut U)
-        }
+        unsafe { Unique::new_unchecked(self.as_ptr() as *mut U) }
     }
 }
 
@@ -143,13 +142,13 @@ impl<T: ?Sized> Clone for Unique<T> {
 }
 
 #[unstable(feature = "ptr_internals", issue = "0")]
-impl<T: ?Sized> Copy for Unique<T> { }
+impl<T: ?Sized> Copy for Unique<T> {}
 
 #[unstable(feature = "ptr_internals", issue = "0")]
-impl<T: ?Sized, U: ?Sized> CoerceUnsized<Unique<U>> for Unique<T> where T: Unsize<U> { }
+impl<T: ?Sized, U: ?Sized> CoerceUnsized<Unique<U>> for Unique<T> where T: Unsize<U> {}
 
 #[unstable(feature = "ptr_internals", issue = "0")]
-impl<T: ?Sized, U: ?Sized> DispatchFromDyn<Unique<U>> for Unique<T> where T: Unsize<U> { }
+impl<T: ?Sized, U: ?Sized> DispatchFromDyn<Unique<U>> for Unique<T> where T: Unsize<U> {}
 
 #[unstable(feature = "ptr_internals", issue = "0")]
 impl<T: ?Sized> fmt::Debug for Unique<T> {

--- a/src/libcore/slice/sort.rs
+++ b/src/libcore/slice/sort.rs
@@ -20,13 +20,16 @@ struct CopyOnDrop<T> {
 
 impl<T> Drop for CopyOnDrop<T> {
     fn drop(&mut self) {
-        unsafe { ptr::copy_nonoverlapping(self.src, self.dest, 1); }
+        unsafe {
+            ptr::copy_nonoverlapping(self.src, self.dest, 1);
+        }
     }
 }
 
 /// Shifts the first element to the right until it encounters a greater or equal element.
 fn shift_head<T, F>(v: &mut [T], is_less: &mut F)
-    where F: FnMut(&T, &T) -> bool
+where
+    F: FnMut(&T, &T) -> bool,
 {
     let len = v.len();
     unsafe {
@@ -36,10 +39,7 @@ fn shift_head<T, F>(v: &mut [T], is_less: &mut F)
             // operation panics, `hole` will get dropped and automatically write the element back
             // into the slice.
             let mut tmp = mem::ManuallyDrop::new(ptr::read(v.get_unchecked(0)));
-            let mut hole = CopyOnDrop {
-                src: &mut *tmp,
-                dest: v.get_unchecked_mut(1),
-            };
+            let mut hole = CopyOnDrop { src: &mut *tmp, dest: v.get_unchecked_mut(1) };
             ptr::copy_nonoverlapping(v.get_unchecked(1), v.get_unchecked_mut(0), 1);
 
             for i in 2..len {
@@ -58,7 +58,8 @@ fn shift_head<T, F>(v: &mut [T], is_less: &mut F)
 
 /// Shifts the last element to the left until it encounters a smaller or equal element.
 fn shift_tail<T, F>(v: &mut [T], is_less: &mut F)
-    where F: FnMut(&T, &T) -> bool
+where
+    F: FnMut(&T, &T) -> bool,
 {
     let len = v.len();
     unsafe {
@@ -68,13 +69,10 @@ fn shift_tail<T, F>(v: &mut [T], is_less: &mut F)
             // operation panics, `hole` will get dropped and automatically write the element back
             // into the slice.
             let mut tmp = mem::ManuallyDrop::new(ptr::read(v.get_unchecked(len - 1)));
-            let mut hole = CopyOnDrop {
-                src: &mut *tmp,
-                dest: v.get_unchecked_mut(len - 2),
-            };
+            let mut hole = CopyOnDrop { src: &mut *tmp, dest: v.get_unchecked_mut(len - 2) };
             ptr::copy_nonoverlapping(v.get_unchecked(len - 2), v.get_unchecked_mut(len - 1), 1);
 
-            for i in (0..len-2).rev() {
+            for i in (0..len - 2).rev() {
                 if !is_less(&*tmp, v.get_unchecked(i)) {
                     break;
                 }
@@ -93,7 +91,8 @@ fn shift_tail<T, F>(v: &mut [T], is_less: &mut F)
 /// Returns `true` if the slice is sorted at the end. This function is `O(n)` worst-case.
 #[cold]
 fn partial_insertion_sort<T, F>(v: &mut [T], is_less: &mut F) -> bool
-    where F: FnMut(&T, &T) -> bool
+where
+    F: FnMut(&T, &T) -> bool,
 {
     // Maximum number of adjacent out-of-order pairs that will get shifted.
     const MAX_STEPS: usize = 5;
@@ -136,17 +135,19 @@ fn partial_insertion_sort<T, F>(v: &mut [T], is_less: &mut F) -> bool
 
 /// Sorts a slice using insertion sort, which is `O(n^2)` worst-case.
 fn insertion_sort<T, F>(v: &mut [T], is_less: &mut F)
-    where F: FnMut(&T, &T) -> bool
+where
+    F: FnMut(&T, &T) -> bool,
 {
     for i in 1..v.len() {
-        shift_tail(&mut v[..i+1], is_less);
+        shift_tail(&mut v[..i + 1], is_less);
     }
 }
 
 /// Sorts `v` using heapsort, which guarantees `O(n log n)` worst-case.
 #[cold]
 pub fn heapsort<T, F>(v: &mut [T], is_less: &mut F)
-    where F: FnMut(&T, &T) -> bool
+where
+    F: FnMut(&T, &T) -> bool,
 {
     // This binary heap respects the invariant `parent >= child`.
     let mut sift_down = |v: &mut [T], mut node| {
@@ -156,11 +157,8 @@ pub fn heapsort<T, F>(v: &mut [T], is_less: &mut F)
             let right = 2 * node + 2;
 
             // Choose the greater child.
-            let greater = if right < v.len() && is_less(&v[left], &v[right]) {
-                right
-            } else {
-                left
-            };
+            let greater =
+                if right < v.len() && is_less(&v[left], &v[right]) { right } else { left };
 
             // Stop if the invariant holds at `node`.
             if greater >= v.len() || !is_less(&v[node], &v[greater]) {
@@ -174,12 +172,12 @@ pub fn heapsort<T, F>(v: &mut [T], is_less: &mut F)
     };
 
     // Build the heap in linear time.
-    for i in (0 .. v.len() / 2).rev() {
+    for i in (0..v.len() / 2).rev() {
         sift_down(v, i);
     }
 
     // Pop maximal elements from the heap.
-    for i in (1 .. v.len()).rev() {
+    for i in (1..v.len()).rev() {
         v.swap(0, i);
         sift_down(&mut v[..i], 0);
     }
@@ -195,7 +193,8 @@ pub fn heapsort<T, F>(v: &mut [T], is_less: &mut F)
 ///
 /// [pdf]: http://drops.dagstuhl.de/opus/volltexte/2016/6389/pdf/LIPIcs-ESA-2016-38.pdf
 fn partition_in_blocks<T, F>(v: &mut [T], pivot: &T, is_less: &mut F) -> usize
-    where F: FnMut(&T, &T) -> bool
+where
+    F: FnMut(&T, &T) -> bool,
 {
     // Number of elements in a typical block.
     const BLOCK: usize = 128;
@@ -298,8 +297,16 @@ fn partition_in_blocks<T, F>(v: &mut [T], pivot: &T, is_less: &mut F) -> usize
         let count = cmp::min(width(start_l, end_l), width(start_r, end_r));
 
         if count > 0 {
-            macro_rules! left { () => { l.offset(*start_l as isize) } }
-            macro_rules! right { () => { r.offset(-(*start_r as isize) - 1) } }
+            macro_rules! left {
+                () => {
+                    l.offset(*start_l as isize)
+                };
+            }
+            macro_rules! right {
+                () => {
+                    r.offset(-(*start_r as isize) - 1)
+                };
+            }
 
             // Instead of swapping one pair at the time, it is more efficient to perform a cyclic
             // permutation. This is not strictly equivalent to swapping, but produces a similar
@@ -379,7 +386,8 @@ fn partition_in_blocks<T, F>(v: &mut [T], pivot: &T, is_less: &mut F) -> usize
 /// 1. Number of elements smaller than `v[pivot]`.
 /// 2. True if `v` was already partitioned.
 fn partition<T, F>(v: &mut [T], pivot: usize, is_less: &mut F) -> (usize, bool)
-    where F: FnMut(&T, &T) -> bool
+where
+    F: FnMut(&T, &T) -> bool,
 {
     let (mid, was_partitioned) = {
         // Place the pivot at the beginning of slice.
@@ -390,10 +398,7 @@ fn partition<T, F>(v: &mut [T], pivot: usize, is_less: &mut F) -> (usize, bool)
         // Read the pivot into a stack-allocated variable for efficiency. If a following comparison
         // operation panics, the pivot will be automatically written back into the slice.
         let mut tmp = mem::ManuallyDrop::new(unsafe { ptr::read(pivot) });
-        let _pivot_guard = CopyOnDrop {
-            src: &mut *tmp,
-            dest: pivot,
-        };
+        let _pivot_guard = CopyOnDrop { src: &mut *tmp, dest: pivot };
         let pivot = &*tmp;
 
         // Find the first pair of out-of-order elements.
@@ -429,7 +434,8 @@ fn partition<T, F>(v: &mut [T], pivot: usize, is_less: &mut F) -> (usize, bool)
 /// Returns the number of elements equal to the pivot. It is assumed that `v` does not contain
 /// elements smaller than the pivot.
 fn partition_equal<T, F>(v: &mut [T], pivot: usize, is_less: &mut F) -> usize
-    where F: FnMut(&T, &T) -> bool
+where
+    F: FnMut(&T, &T) -> bool,
 {
     // Place the pivot at the beginning of slice.
     v.swap(0, pivot);
@@ -439,10 +445,7 @@ fn partition_equal<T, F>(v: &mut [T], pivot: usize, is_less: &mut F) -> usize
     // Read the pivot into a stack-allocated variable for efficiency. If a following comparison
     // operation panics, the pivot will be automatically written back into the slice.
     let mut tmp = mem::ManuallyDrop::new(unsafe { ptr::read(pivot) });
-    let _pivot_guard = CopyOnDrop {
-        src: &mut *tmp,
-        dest: pivot,
-    };
+    let _pivot_guard = CopyOnDrop { src: &mut *tmp, dest: pivot };
     let pivot = &*tmp;
 
     // Now partition the slice.
@@ -528,7 +531,8 @@ fn break_patterns<T>(v: &mut [T]) {
 ///
 /// Elements in `v` might be reordered in the process.
 fn choose_pivot<T, F>(v: &mut [T], is_less: &mut F) -> (usize, bool)
-    where F: FnMut(&T, &T) -> bool
+where
+    F: FnMut(&T, &T) -> bool,
 {
     // Minimum length to choose the median-of-medians method.
     // Shorter slices use the simple median-of-three method.
@@ -596,7 +600,8 @@ fn choose_pivot<T, F>(v: &mut [T], is_less: &mut F) -> (usize, bool)
 /// `limit` is the number of allowed imbalanced partitions before switching to `heapsort`. If zero,
 /// this function will immediately switch to heapsort.
 fn recurse<'a, T, F>(mut v: &'a mut [T], is_less: &mut F, mut pred: Option<&'a T>, mut limit: usize)
-    where F: FnMut(&T, &T) -> bool
+where
+    F: FnMut(&T, &T) -> bool,
 {
     // Slices of up to this length get sorted using insertion sort.
     const MAX_INSERTION: usize = 20;
@@ -650,7 +655,7 @@ fn recurse<'a, T, F>(mut v: &'a mut [T], is_less: &mut F, mut pred: Option<&'a T
                 let mid = partition_equal(v, pivot, is_less);
 
                 // Continue sorting elements greater than the pivot.
-                v = &mut {v}[mid..];
+                v = &mut { v }[mid..];
                 continue;
             }
         }
@@ -661,7 +666,7 @@ fn recurse<'a, T, F>(mut v: &'a mut [T], is_less: &mut F, mut pred: Option<&'a T
         was_partitioned = was_p;
 
         // Split the slice into `left`, `pivot`, and `right`.
-        let (left, right) = {v}.split_at_mut(mid);
+        let (left, right) = { v }.split_at_mut(mid);
         let (pivot, right) = right.split_at_mut(1);
         let pivot = &pivot[0];
 
@@ -681,7 +686,8 @@ fn recurse<'a, T, F>(mut v: &'a mut [T], is_less: &mut F, mut pred: Option<&'a T
 
 /// Sorts `v` using pattern-defeating quicksort, which is `O(n log n)` worst-case.
 pub fn quicksort<T, F>(v: &mut [T], mut is_less: F)
-    where F: FnMut(&T, &T) -> bool
+where
+    F: FnMut(&T, &T) -> bool,
 {
     // Sorting has no meaningful behavior on zero-sized types.
     if mem::size_of::<T>() == 0 {
@@ -694,8 +700,13 @@ pub fn quicksort<T, F>(v: &mut [T], mut is_less: F)
     recurse(v, &mut is_less, None, limit);
 }
 
-fn partition_at_index_loop<'a, T, F>( mut v: &'a mut [T], mut index: usize, is_less: &mut F
-                                    , mut pred: Option<&'a T>) where F: FnMut(&T, &T) -> bool
+fn partition_at_index_loop<'a, T, F>(
+    mut v: &'a mut [T],
+    mut index: usize,
+    is_less: &mut F,
+    mut pred: Option<&'a T>,
+) where
+    F: FnMut(&T, &T) -> bool,
 {
     loop {
         // For slices of up to this length it's probably faster to simply sort them.
@@ -731,7 +742,7 @@ fn partition_at_index_loop<'a, T, F>( mut v: &'a mut [T], mut index: usize, is_l
         let (mid, _) = partition(v, pivot, is_less);
 
         // Split the slice into `left`, `pivot`, and `right`.
-        let (left, right) = {v}.split_at_mut(mid);
+        let (left, right) = { v }.split_at_mut(mid);
         let (pivot, right) = right.split_at_mut(1);
         let pivot = &pivot[0];
 
@@ -749,11 +760,16 @@ fn partition_at_index_loop<'a, T, F>( mut v: &'a mut [T], mut index: usize, is_l
     }
 }
 
-pub fn partition_at_index<T, F>(v: &mut [T], index: usize, mut is_less: F)
-                                -> (&mut [T], &mut T, &mut [T]) where F: FnMut(&T, &T) -> bool
+pub fn partition_at_index<T, F>(
+    v: &mut [T],
+    index: usize,
+    mut is_less: F,
+) -> (&mut [T], &mut T, &mut [T])
+where
+    F: FnMut(&T, &T) -> bool,
 {
-    use cmp::Ordering::Less;
     use cmp::Ordering::Greater;
+    use cmp::Ordering::Less;
 
     if index >= v.len() {
         panic!("partition_at_index index {} greater than length of slice {}", index, v.len());
@@ -764,14 +780,20 @@ pub fn partition_at_index<T, F>(v: &mut [T], index: usize, mut is_less: F)
     } else if index == v.len() - 1 {
         // Find max element and place it in the last position of the array. We're free to use
         // `unwrap()` here because we know v must not be empty.
-        let (max_index, _) = v.iter().enumerate().max_by(
-            |&(_, x), &(_, y)| if is_less(x, y) { Less } else { Greater }).unwrap();
+        let (max_index, _) = v
+            .iter()
+            .enumerate()
+            .max_by(|&(_, x), &(_, y)| if is_less(x, y) { Less } else { Greater })
+            .unwrap();
         v.swap(max_index, index);
     } else if index == 0 {
         // Find min element and place it in the first position of the array. We're free to use
         // `unwrap()` here because we know v must not be empty.
-        let (min_index, _) = v.iter().enumerate().min_by(
-            |&(_, x), &(_, y)| if is_less(x, y) { Less } else { Greater }).unwrap();
+        let (min_index, _) = v
+            .iter()
+            .enumerate()
+            .min_by(|&(_, x), &(_, y)| if is_less(x, y) { Less } else { Greater })
+            .unwrap();
         v.swap(min_index, index);
     } else {
         partition_at_index_loop(v, index, &mut is_less, None);

--- a/src/libcore/task/mod.rs
+++ b/src/libcore/task/mod.rs
@@ -8,4 +8,4 @@ pub use self::poll::Poll;
 
 mod wake;
 #[stable(feature = "futures_api", since = "1.36.0")]
-pub use self::wake::{Context, Waker, RawWaker, RawWakerVTable};
+pub use self::wake::{Context, RawWaker, RawWakerVTable, Waker};

--- a/src/libcore/task/poll.rs
+++ b/src/libcore/task/poll.rs
@@ -11,10 +11,7 @@ use crate::result::Result;
 pub enum Poll<T> {
     /// Represents that a value is immediately ready.
     #[stable(feature = "futures_api", since = "1.36.0")]
-    Ready(
-        #[stable(feature = "futures_api", since = "1.36.0")]
-        T
-    ),
+    Ready(#[stable(feature = "futures_api", since = "1.36.0")] T),
 
     /// Represents that a value is not ready yet.
     ///
@@ -29,7 +26,8 @@ impl<T> Poll<T> {
     /// Changes the ready value of this `Poll` with the closure provided.
     #[stable(feature = "futures_api", since = "1.36.0")]
     pub fn map<U, F>(self, f: F) -> Poll<U>
-        where F: FnOnce(T) -> U
+    where
+        F: FnOnce(T) -> U,
     {
         match self {
             Poll::Ready(t) => Poll::Ready(f(t)),
@@ -59,7 +57,8 @@ impl<T, E> Poll<Result<T, E>> {
     /// Changes the success value of this `Poll` with the closure provided.
     #[stable(feature = "futures_api", since = "1.36.0")]
     pub fn map_ok<U, F>(self, f: F) -> Poll<Result<U, E>>
-        where F: FnOnce(T) -> U
+    where
+        F: FnOnce(T) -> U,
     {
         match self {
             Poll::Ready(Ok(t)) => Poll::Ready(Ok(f(t))),
@@ -71,7 +70,8 @@ impl<T, E> Poll<Result<T, E>> {
     /// Changes the error value of this `Poll` with the closure provided.
     #[stable(feature = "futures_api", since = "1.36.0")]
     pub fn map_err<U, F>(self, f: F) -> Poll<Result<T, U>>
-        where F: FnOnce(E) -> U
+    where
+        F: FnOnce(E) -> U,
     {
         match self {
             Poll::Ready(Ok(t)) => Poll::Ready(Ok(t)),
@@ -85,7 +85,8 @@ impl<T, E> Poll<Option<Result<T, E>>> {
     /// Changes the success value of this `Poll` with the closure provided.
     #[unstable(feature = "poll_map", issue = "63514")]
     pub fn map_ok<U, F>(self, f: F) -> Poll<Option<Result<U, E>>>
-        where F: FnOnce(T) -> U
+    where
+        F: FnOnce(T) -> U,
     {
         match self {
             Poll::Ready(Some(Ok(t))) => Poll::Ready(Some(Ok(f(t)))),
@@ -98,7 +99,8 @@ impl<T, E> Poll<Option<Result<T, E>>> {
     /// Changes the error value of this `Poll` with the closure provided.
     #[unstable(feature = "poll_map", issue = "63514")]
     pub fn map_err<U, F>(self, f: F) -> Poll<Option<Result<T, U>>>
-        where F: FnOnce(E) -> U
+    where
+        F: FnOnce(E) -> U,
     {
         match self {
             Poll::Ready(Some(Ok(t))) => Poll::Ready(Some(Ok(t))),

--- a/src/libcore/task/wake.rs
+++ b/src/libcore/task/wake.rs
@@ -40,10 +40,7 @@ impl RawWaker {
     #[rustc_promotable]
     #[stable(feature = "futures_api", since = "1.36.0")]
     pub const fn new(data: *const (), vtable: &'static RawWakerVTable) -> RawWaker {
-        RawWaker {
-            data,
-            vtable,
-        }
+        RawWaker { data, vtable }
     }
 }
 
@@ -160,12 +157,7 @@ impl RawWakerVTable {
         wake_by_ref: unsafe fn(*const ()),
         drop: unsafe fn(*const ()),
     ) -> Self {
-        Self {
-            clone,
-            wake,
-            wake_by_ref,
-            drop,
-        }
+        Self { clone, wake, wake_by_ref, drop }
     }
 }
 
@@ -188,10 +180,7 @@ impl<'a> Context<'a> {
     #[stable(feature = "futures_api", since = "1.36.0")]
     #[inline]
     pub fn from_waker(waker: &'a Waker) -> Self {
-        Context {
-            waker,
-            _marker: PhantomData,
-        }
+        Context { waker, _marker: PhantomData }
     }
 
     /// Returns a reference to the `Waker` for the current task.
@@ -205,9 +194,7 @@ impl<'a> Context<'a> {
 #[stable(feature = "futures_api", since = "1.36.0")]
 impl fmt::Debug for Context<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Context")
-            .field("waker", &self.waker)
-            .finish()
+        f.debug_struct("Context").field("waker", &self.waker).finish()
     }
 }
 
@@ -291,9 +278,7 @@ impl Waker {
     #[inline]
     #[stable(feature = "futures_api", since = "1.36.0")]
     pub unsafe fn from_raw(waker: RawWaker) -> Waker {
-        Waker {
-            waker,
-        }
+        Waker { waker }
     }
 }
 

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -12,9 +12,9 @@
 //! assert_eq!(Duration::new(5, 0), Duration::from_secs(5));
 //! ```
 
-use crate::{fmt, u64};
 use crate::iter::Sum;
-use crate::ops::{Add, Sub, Mul, Div, AddAssign, SubAssign, MulAssign, DivAssign};
+use crate::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
+use crate::{fmt, u64};
 
 const NANOS_PER_SEC: u32 = 1_000_000_000;
 const NANOS_PER_MILLI: u32 = 1_000_000;
@@ -131,8 +131,8 @@ impl Duration {
     #[stable(feature = "duration", since = "1.3.0")]
     #[inline]
     pub fn new(secs: u64, nanos: u32) -> Duration {
-        let secs = secs.checked_add((nanos / NANOS_PER_SEC) as u64)
-            .expect("overflow in Duration::new");
+        let secs =
+            secs.checked_add((nanos / NANOS_PER_SEC) as u64).expect("overflow in Duration::new");
         let nanos = nanos % NANOS_PER_SEC;
         Duration { secs, nanos }
     }
@@ -252,7 +252,9 @@ impl Duration {
     /// [`subsec_nanos`]: #method.subsec_nanos
     #[stable(feature = "duration", since = "1.3.0")]
     #[inline]
-    pub const fn as_secs(&self) -> u64 { self.secs }
+    pub const fn as_secs(&self) -> u64 {
+        self.secs
+    }
 
     /// Returns the fractional part of this `Duration`, in whole milliseconds.
     ///
@@ -271,7 +273,9 @@ impl Duration {
     /// ```
     #[stable(feature = "duration_extras", since = "1.27.0")]
     #[inline]
-    pub const fn subsec_millis(&self) -> u32 { self.nanos / NANOS_PER_MILLI }
+    pub const fn subsec_millis(&self) -> u32 {
+        self.nanos / NANOS_PER_MILLI
+    }
 
     /// Returns the fractional part of this `Duration`, in whole microseconds.
     ///
@@ -290,7 +294,9 @@ impl Duration {
     /// ```
     #[stable(feature = "duration_extras", since = "1.27.0")]
     #[inline]
-    pub const fn subsec_micros(&self) -> u32 { self.nanos / NANOS_PER_MICRO }
+    pub const fn subsec_micros(&self) -> u32 {
+        self.nanos / NANOS_PER_MICRO
+    }
 
     /// Returns the fractional part of this `Duration`, in nanoseconds.
     ///
@@ -309,7 +315,9 @@ impl Duration {
     /// ```
     #[stable(feature = "duration", since = "1.3.0")]
     #[inline]
-    pub const fn subsec_nanos(&self) -> u32 { self.nanos }
+    pub const fn subsec_nanos(&self) -> u32 {
+        self.nanos
+    }
 
     /// Returns the total number of whole milliseconds contained by this `Duration`.
     ///
@@ -388,10 +396,7 @@ impl Duration {
                 }
             }
             debug_assert!(nanos < NANOS_PER_SEC);
-            Some(Duration {
-                secs,
-                nanos,
-            })
+            Some(Duration { secs, nanos })
         } else {
             None
         }
@@ -455,14 +460,11 @@ impl Duration {
         let total_nanos = self.nanos as u64 * rhs as u64;
         let extra_secs = total_nanos / (NANOS_PER_SEC as u64);
         let nanos = (total_nanos % (NANOS_PER_SEC as u64)) as u32;
-        if let Some(secs) = self.secs
-            .checked_mul(rhs as u64)
-            .and_then(|s| s.checked_add(extra_secs)) {
+        if let Some(secs) =
+            self.secs.checked_mul(rhs as u64).and_then(|s| s.checked_add(extra_secs))
+        {
             debug_assert!(nanos < NANOS_PER_SEC);
-            Some(Duration {
-                secs,
-                nanos,
-            })
+            Some(Duration { secs, nanos })
         } else {
             None
         }
@@ -549,9 +551,8 @@ impl Duration {
     #[stable(feature = "duration_float", since = "1.38.0")]
     #[inline]
     pub fn from_secs_f64(secs: f64) -> Duration {
-        const MAX_NANOS_F64: f64 =
-            ((u64::MAX as u128 + 1)*(NANOS_PER_SEC as u128)) as f64;
-        let nanos =  secs * (NANOS_PER_SEC as f64);
+        const MAX_NANOS_F64: f64 = ((u64::MAX as u128 + 1) * (NANOS_PER_SEC as u128)) as f64;
+        let nanos = secs * (NANOS_PER_SEC as f64);
         if !nanos.is_finite() {
             panic!("got non-finite value when converting float to duration");
         }
@@ -561,7 +562,7 @@ impl Duration {
         if nanos < 0.0 {
             panic!("underflow when converting float to duration");
         }
-        let nanos =  nanos as u128;
+        let nanos = nanos as u128;
         Duration {
             secs: (nanos / (NANOS_PER_SEC as u128)) as u64,
             nanos: (nanos % (NANOS_PER_SEC as u128)) as u32,
@@ -584,9 +585,8 @@ impl Duration {
     #[stable(feature = "duration_float", since = "1.38.0")]
     #[inline]
     pub fn from_secs_f32(secs: f32) -> Duration {
-        const MAX_NANOS_F32: f32 =
-            ((u64::MAX as u128 + 1)*(NANOS_PER_SEC as u128)) as f32;
-        let nanos =  secs * (NANOS_PER_SEC as f32);
+        const MAX_NANOS_F32: f32 = ((u64::MAX as u128 + 1) * (NANOS_PER_SEC as u128)) as f32;
+        let nanos = secs * (NANOS_PER_SEC as f32);
         if !nanos.is_finite() {
             panic!("got non-finite value when converting float to duration");
         }
@@ -596,7 +596,7 @@ impl Duration {
         if nanos < 0.0 {
             panic!("underflow when converting float to duration");
         }
-        let nanos =  nanos as u128;
+        let nanos = nanos as u128;
         Duration {
             secs: (nanos / (NANOS_PER_SEC as u128)) as u64,
             nanos: (nanos % (NANOS_PER_SEC as u128)) as u32,
@@ -799,9 +799,8 @@ macro_rules! sum_durations {
         let mut total_nanos: u64 = 0;
 
         for entry in $iter {
-            total_secs = total_secs
-                .checked_add(entry.secs)
-                .expect("overflow in iter::sum over durations");
+            total_secs =
+                total_secs.checked_add(entry.secs).expect("overflow in iter::sum over durations");
             total_nanos = match total_nanos.checked_add(entry.nanos as u64) {
                 Some(n) => n,
                 None => {
@@ -816,23 +815,20 @@ macro_rules! sum_durations {
             .checked_add(total_nanos / NANOS_PER_SEC as u64)
             .expect("overflow in iter::sum over durations");
         total_nanos = total_nanos % NANOS_PER_SEC as u64;
-        Duration {
-            secs: total_secs,
-            nanos: total_nanos as u32,
-        }
+        Duration { secs: total_secs, nanos: total_nanos as u32 }
     }};
 }
 
 #[stable(feature = "duration_sum", since = "1.16.0")]
 impl Sum for Duration {
-    fn sum<I: Iterator<Item=Duration>>(iter: I) -> Duration {
+    fn sum<I: Iterator<Item = Duration>>(iter: I) -> Duration {
         sum_durations!(iter)
     }
 }
 
 #[stable(feature = "duration_sum", since = "1.16.0")]
 impl<'a> Sum<&'a Duration> for Duration {
-    fn sum<I: Iterator<Item=&'a Duration>>(iter: I) -> Duration {
+    fn sum<I: Iterator<Item = &'a Duration>>(iter: I) -> Duration {
         sum_durations!(iter)
     }
 }
@@ -922,9 +918,7 @@ impl fmt::Debug for Duration {
             } else {
                 // SAFETY: We are only writing ASCII digits into the buffer and it was
                 // initialized with '0's, so it contains valid UTF8.
-                let s = unsafe {
-                    crate::str::from_utf8_unchecked(&buf[..end])
-                };
+                let s = unsafe { crate::str::from_utf8_unchecked(&buf[..end]) };
 
                 // If the user request a precision > 9, we pad '0's at the end.
                 let w = f.precision().unwrap_or(pos);

--- a/src/libcore/tuple.rs
+++ b/src/libcore/tuple.rs
@@ -1,7 +1,7 @@
 // See src/libstd/primitive_docs.rs for documentation.
 
-use crate::cmp::*;
 use crate::cmp::Ordering::*;
+use crate::cmp::*;
 
 // macro for implementing n-ary tuple functions and operations
 macro_rules! tuple_impls {

--- a/src/libcore/unicode/bool_trie.rs
+++ b/src/libcore/unicode/bool_trie.rs
@@ -19,16 +19,16 @@
 /// non-BMP range of most Unicode sets.
 pub struct BoolTrie {
     // 0..0x800 (corresponding to 1 and 2 byte utf-8 sequences)
-    pub r1: [u64; 32],   // leaves
+    pub r1: [u64; 32], // leaves
 
     // 0x800..0x10000 (corresponding to 3 byte utf-8 sequences)
     pub r2: [u8; 992],      // first level
-    pub r3: &'static [u64],  // leaves
+    pub r3: &'static [u64], // leaves
 
     // 0x10000..0x110000 (corresponding to 4 byte utf-8 sequences)
-    pub r4: [u8; 256],       // first level
-    pub r5: &'static [u8],   // second level
-    pub r6: &'static [u64],  // leaves
+    pub r4: [u8; 256],      // first level
+    pub r5: &'static [u8],  // second level
+    pub r6: &'static [u64], // leaves
 }
 impl BoolTrie {
     pub fn lookup(&self, c: char) -> bool {
@@ -48,7 +48,7 @@ impl BoolTrie {
 
 pub struct SmallBoolTrie {
     pub(crate) r1: &'static [u8],  // first level
-    pub(crate) r2: &'static [u64],  // leaves
+    pub(crate) r2: &'static [u64], // leaves
 }
 
 impl SmallBoolTrie {

--- a/src/libcore/unit.rs
+++ b/src/libcore/unit.rs
@@ -15,7 +15,7 @@ use crate::iter::FromIterator;
 /// ```
 #[stable(feature = "unit_from_iter", since = "1.23.0")]
 impl FromIterator<()> for () {
-    fn from_iter<I: IntoIterator<Item=()>>(iter: I) -> Self {
+    fn from_iter<I: IntoIterator<Item = ()>>(iter: I) -> Self {
         iter.into_iter().for_each(|()| {})
     }
 }

--- a/src/test/ui/macros/unknown-builtin.stderr
+++ b/src/test/ui/macros/unknown-builtin.stderr
@@ -7,8 +7,8 @@ LL | macro_rules! unknown { () => () }
 error: cannot find a built-in macro with name `line`
   --> <::core::macros::builtin::line macros>:1:1
    |
-LL | () => { }
-   | ^^^^^^^^^
+LL | () => { } ;
+   | ^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
I am interested in whether we can begin cautious incremental progress on #66688 and assess along the way whether we can keep the disruption sufficiently small.

This PR applies rustfmt with default settings to files in src/libcore *that are not involved in any currently open PR* to minimize merge conflicts. The list of files involved in open PRs was determined by querying GitHub's GraphQL API  [with this script](https://gist.github.com/dtolnay/aa9c34993dc051a4f344d1b10e4487e8).

With the list of files from the script in `outstanding_files`, the relevant commands were:

```console
$ find src/libcore -name '*.rs' | xargs rustfmt --edition=2018
$ rg libcore outstanding_files | xargs git checkout --
```

Repeating this process several months apart should get us coverage of most of the rest of libcore.