### PR TITLE
tidy: Remove unused import

### DIFF
--- a/src/tools/tidy/src/error_codes_check.rs
+++ b/src/tools/tidy/src/error_codes_check.rs
@@ -4,7 +4,6 @@
 use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::fs::read_to_string;
-use std::io::Read;
 use std::path::Path;
 
 // A few of those error codes can't be tested but all the others can and *should* be tested!


### PR DESCRIPTION
It produces annoying warnings on `x.py` runs.