### PR TITLE
Intra doc enum variant field

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -84,17 +84,16 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
         let ty_res = ty_res.map_id(|_| panic!("unexpected node_id"));
         match ty_res {
             Res::Def(DefKind::Enum, did) => {
-                let item = cx.tcx.inherent_impls(did)
-                                 .iter()
-                                 .flat_map(|imp| cx.tcx.associated_items(*imp))
-                                 .find(|item| item.ident.name == variant_name);
-                if item.is_some() {
+                if cx.tcx.inherent_impls(did)
+                         .iter()
+                         .flat_map(|imp| cx.tcx.associated_items(*imp))
+                         .any(|item| item.ident.name == variant_name) {
                     return Err(());
                 }
                 match cx.tcx.type_of(did).kind {
                     ty::Adt(def, _) if def.is_enum() => {
                         if def.all_fields()
-                              .find(|item| item.ident.name == variant_field_name).is_some() {
+                              .any(|item| item.ident.name == variant_field_name) {
                             Ok((ty_res,
                                 Some(format!("variant.{}.field.{}",
                                              variant_name, variant_field_name))))

--- a/src/test/rustdoc/intra-doc-link-enum-struct-field.rs
+++ b/src/test/rustdoc/intra-doc-link-enum-struct-field.rs
@@ -1,0 +1,14 @@
+#![crate_name = "foo"]
+
+pub enum Foo {
+    X {
+        y: u8,
+    }
+}
+
+/// Hello
+///
+/// I want [Foo::X::y].
+pub fn foo() {}
+
+// @has foo/fn.foo.html '//a/@href' '../foo/enum.Foo.html#variant.X.field.y'


### PR DESCRIPTION
Part of #43466.

Add intra-doc link support for this:

```rust
enum Foo {
    X {
        y: u8, // can be found with Foo::X::y
    }
}
```

r? @kinnison 