### PR TITLE
Free memory before calling linker

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -283,120 +283,124 @@ pub fn run_compiler(
             return sess.compile_status();
         }
 
-        compiler.parse()?;
+        compiler.enter(|queries| {
+            queries.parse()?;
 
-        if let Some(ppm) = &sess.opts.pretty {
-            if ppm.needs_ast_map() {
-                compiler.global_ctxt()?.peek_mut().enter(|tcx| {
-                    let expanded_crate = compiler.expansion()?.take().0;
-                    pretty::print_after_hir_lowering(
-                        tcx,
-                        compiler.input(),
-                        &expanded_crate,
+            if let Some(ppm) = &sess.opts.pretty {
+                if ppm.needs_ast_map() {
+                    queries.global_ctxt()?.peek_mut().enter(|tcx| {
+                        let expanded_crate = queries.expansion()?.take().0;
+                        pretty::print_after_hir_lowering(
+                            tcx,
+                            compiler.input(),
+                            &expanded_crate,
+                            *ppm,
+                            compiler.output_file().as_ref().map(|p| &**p),
+                        );
+                        Ok(())
+                    })?;
+                } else {
+                    let krate = queries.parse()?.take();
+                    pretty::print_after_parsing(
+                        sess,
+                        &compiler.input(),
+                        &krate,
                         *ppm,
                         compiler.output_file().as_ref().map(|p| &**p),
                     );
-                    Ok(())
-                })?;
-            } else {
-                let krate = compiler.parse()?.take();
-                pretty::print_after_parsing(
-                    sess,
-                    &compiler.input(),
-                    &krate,
-                    *ppm,
-                    compiler.output_file().as_ref().map(|p| &**p),
-                );
-            }
-            return sess.compile_status();
-        }
-
-        if callbacks.after_parsing(compiler) == Compilation::Stop {
-            return sess.compile_status();
-        }
-
-        if sess.opts.debugging_opts.parse_only ||
-           sess.opts.debugging_opts.show_span.is_some() ||
-           sess.opts.debugging_opts.ast_json_noexpand {
-            return sess.compile_status();
-        }
-
-        {
-            let (_, lint_store) = &*compiler.register_plugins()?.peek();
-
-            // Lint plugins are registered; now we can process command line flags.
-            if sess.opts.describe_lints {
-                describe_lints(&sess, &lint_store, true);
+                }
                 return sess.compile_status();
             }
-        }
 
-        compiler.expansion()?;
-        if callbacks.after_expansion(compiler) == Compilation::Stop {
-            return sess.compile_status();
-        }
+            if callbacks.after_parsing(compiler) == Compilation::Stop {
+                return sess.compile_status();
+            }
 
-        compiler.prepare_outputs()?;
+            if sess.opts.debugging_opts.parse_only ||
+               sess.opts.debugging_opts.show_span.is_some() ||
+               sess.opts.debugging_opts.ast_json_noexpand {
+                return sess.compile_status();
+            }
 
-        if sess.opts.output_types.contains_key(&OutputType::DepInfo)
-            && sess.opts.output_types.len() == 1
-        {
-            return sess.compile_status();
-        }
+            {
+                let (_, lint_store) = &*queries.register_plugins()?.peek();
 
-        compiler.global_ctxt()?;
+                // Lint plugins are registered; now we can process command line flags.
+                if sess.opts.describe_lints {
+                    describe_lints(&sess, &lint_store, true);
+                    return sess.compile_status();
+                }
+            }
 
-        if sess.opts.debugging_opts.no_analysis ||
-           sess.opts.debugging_opts.ast_json {
-            return sess.compile_status();
-        }
+            queries.expansion()?;
+            if callbacks.after_expansion(compiler) == Compilation::Stop {
+                return sess.compile_status();
+            }
 
-        if sess.opts.debugging_opts.save_analysis {
-            let expanded_crate = &compiler.expansion()?.peek().0;
-            let crate_name = compiler.crate_name()?.peek().clone();
-            compiler.global_ctxt()?.peek_mut().enter(|tcx| {
-                let result = tcx.analysis(LOCAL_CRATE);
+            queries.prepare_outputs()?;
 
-                time(sess, "save analysis", || {
-                    save::process_crate(
-                        tcx,
-                        &expanded_crate,
-                        &crate_name,
-                        &compiler.input(),
-                        None,
-                        DumpHandler::new(compiler.output_dir().as_ref().map(|p| &**p), &crate_name)
-                    )
-                });
+            if sess.opts.output_types.contains_key(&OutputType::DepInfo)
+                && sess.opts.output_types.len() == 1
+            {
+                return sess.compile_status();
+            }
 
-                result
-                // AST will be dropped *after* the `after_analysis` callback
-                // (needed by the RLS)
-            })?;
-        } else {
-            // Drop AST after creating GlobalCtxt to free memory
-            mem::drop(compiler.expansion()?.take());
-        }
+            queries.global_ctxt()?;
 
-        compiler.global_ctxt()?.peek_mut().enter(|tcx| tcx.analysis(LOCAL_CRATE))?;
+            if sess.opts.debugging_opts.no_analysis ||
+               sess.opts.debugging_opts.ast_json {
+                return sess.compile_status();
+            }
 
-        if callbacks.after_analysis(compiler) == Compilation::Stop {
-            return sess.compile_status();
-        }
+            if sess.opts.debugging_opts.save_analysis {
+                let expanded_crate = &queries.expansion()?.peek().0;
+                let crate_name = queries.crate_name()?.peek().clone();
+                queries.global_ctxt()?.peek_mut().enter(|tcx| {
+                    let result = tcx.analysis(LOCAL_CRATE);
 
-        if sess.opts.debugging_opts.save_analysis {
-            mem::drop(compiler.expansion()?.take());
-        }
+                    time(sess, "save analysis", || {
+                        save::process_crate(
+                            tcx,
+                            &expanded_crate,
+                            &crate_name,
+                            &compiler.input(),
+                            None,
+                            DumpHandler::new(compiler.output_dir().as_ref().map(|p| &**p), &crate_name)
+                        )
+                    });
 
-        compiler.ongoing_codegen()?;
+                    result
+                    // AST will be dropped *after* the `after_analysis` callback
+                    // (needed by the RLS)
+                })?;
+            } else {
+                // Drop AST after creating GlobalCtxt to free memory
+                mem::drop(queries.expansion()?.take());
+            }
 
-        // Drop GlobalCtxt after starting codegen to free memory
-        mem::drop(compiler.global_ctxt()?.take());
+            queries.global_ctxt()?.peek_mut().enter(|tcx| tcx.analysis(LOCAL_CRATE))?;
 
-        if sess.opts.debugging_opts.print_type_sizes {
-            sess.code_stats.print_type_sizes();
-        }
+            if callbacks.after_analysis(compiler) == Compilation::Stop {
+                return sess.compile_status();
+            }
 
-        compiler.link()?;
+            if sess.opts.debugging_opts.save_analysis {
+                mem::drop(queries.expansion()?.take());
+            }
+
+            queries.ongoing_codegen()?;
+
+            // Drop GlobalCtxt after starting codegen to free memory
+            mem::drop(queries.global_ctxt()?.take());
+
+            if sess.opts.debugging_opts.print_type_sizes {
+                sess.code_stats.print_type_sizes();
+            }
+
+            queries.link()?;
+
+            Ok(())
+        })?;
 
         if sess.opts.debugging_opts.perf_stats {
             sess.print_perf_stats();

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -393,9 +393,6 @@ pub fn run_compiler(
 
             queries.ongoing_codegen()?;
 
-            // Drop GlobalCtxt after starting codegen to free memory
-            mem::drop(queries.global_ctxt()?.take());
-
             if sess.opts.debugging_opts.print_type_sizes {
                 sess.code_stats.print_type_sizes();
             }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -372,7 +372,9 @@ pub fn run_compiler(
                             &crate_name,
                             &compiler.input(),
                             None,
-                            DumpHandler::new(compiler.output_dir().as_ref().map(|p| &**p), &crate_name)
+                            DumpHandler::new(
+                                compiler.output_dir().as_ref().map(|p| &**p), &crate_name
+                            )
                         )
                     });
 

--- a/src/librustc_interface/interface.rs
+++ b/src/librustc_interface/interface.rs
@@ -1,4 +1,3 @@
-use crate::queries::Queries;
 use crate::util;
 pub use crate::passes::BoxedResolver;
 
@@ -36,7 +35,6 @@ pub struct Compiler {
     pub(crate) input_path: Option<PathBuf>,
     pub(crate) output_dir: Option<PathBuf>,
     pub(crate) output_file: Option<PathBuf>,
-    pub(crate) queries: Queries,
     pub(crate) crate_name: Option<String>,
     pub(crate) register_lints: Option<Box<dyn Fn(&Session, &mut lint::LintStore) + Send + Sync>>,
     pub(crate) override_queries:
@@ -169,7 +167,6 @@ pub fn run_compiler_in_existing_thread_pool<R>(
         input_path: config.input_path,
         output_dir: config.output_dir,
         output_file: config.output_file,
-        queries: Default::default(),
         crate_name: config.crate_name,
         register_lints: config.register_lints,
         override_queries: config.override_queries,

--- a/src/librustc_interface/queries.rs
+++ b/src/librustc_interface/queries.rs
@@ -236,7 +236,9 @@ impl<'comp> Queries<'comp> {
             let (krate, boxed_resolver, _) = &*expansion_result.peek();
             let crate_name = self.crate_name()?;
             let crate_name = crate_name.peek();
-            passes::prepare_outputs(self.session(), self.compiler, &krate, &boxed_resolver, &crate_name)
+            passes::prepare_outputs(
+                self.session(), self.compiler, &krate, &boxed_resolver, &crate_name
+            )
         })
     }
 

--- a/src/librustc_interface/queries.rs
+++ b/src/librustc_interface/queries.rs
@@ -316,11 +316,6 @@ impl Linker {
 }
 
 impl Compiler {
-    // This method is different to all the other methods in `Compiler` because
-    // it lacks a `Queries` entry. It's also not currently used. It does serve
-    // as an example of how `Compiler` can be used, with additional steps added
-    // between some passes. And see `rustc_driver::run_compiler` for a more
-    // complex example.
     pub fn enter<'c, F, T>(&'c self, f: F) -> Result<T>
         where F: FnOnce(Queries<'c>) -> Result<T>
     {

--- a/src/librustc_interface/queries.rs
+++ b/src/librustc_interface/queries.rs
@@ -278,7 +278,7 @@ impl<'comp> Queries<'comp> {
         })
     }
 
-    pub fn linker(self) -> Result<Linker> {
+    pub fn linker(&self) -> Result<Linker> {
         let dep_graph = self.dep_graph()?;
         let prepare_outputs = self.prepare_outputs()?;
         let ongoing_codegen = self.ongoing_codegen()?;
@@ -288,7 +288,7 @@ impl<'comp> Queries<'comp> {
 
         Ok(Linker {
             sess,
-            dep_graph: dep_graph.take(),
+            dep_graph: dep_graph.peek().clone(),
             prepare_outputs: prepare_outputs.take(),
             ongoing_codegen: ongoing_codegen.take(),
             codegen_backend,
@@ -316,11 +316,11 @@ impl Linker {
 }
 
 impl Compiler {
-    pub fn enter<'c, F, T>(&'c self, f: F) -> Result<T>
-        where F: FnOnce(Queries<'c>) -> Result<T>
+    pub fn enter<'c, F, T>(&'c self, f: F) -> T
+        where F: for<'q> FnOnce(&'q Queries<'c>) -> T
     {
         let queries = Queries::new(&self);
-        f(queries)
+        f(&queries)
     }
 
     // This method is different to all the other methods in `Compiler` because

--- a/src/librustc_interface/queries.rs
+++ b/src/librustc_interface/queries.rs
@@ -316,8 +316,8 @@ impl Linker {
 }
 
 impl Compiler {
-    pub fn enter<'c, F, T>(&'c self, f: F) -> T
-        where F: for<'q> FnOnce(&'q Queries<'c>) -> T
+    pub fn enter<F, T>(&self, f: F) -> T
+        where F: for<'q> FnOnce(&'q Queries<'_>) -> T
     {
         let queries = Queries::new(&self);
         f(&queries)

--- a/src/librustc_interface/queries.rs
+++ b/src/librustc_interface/queries.rs
@@ -317,7 +317,7 @@ impl Linker {
 
 impl Compiler {
     pub fn enter<F, T>(&self, f: F) -> T
-        where F: for<'q> FnOnce(&'q Queries<'_>) -> T
+        where F: FnOnce(&Queries<'_>) -> T
     {
         let queries = Queries::new(&self);
         f(&queries)
@@ -344,9 +344,6 @@ impl Compiler {
             mem::drop(queries.expansion()?.take());
 
             queries.ongoing_codegen()?;
-
-            // Drop GlobalCtxt after starting codegen to free memory.
-            mem::drop(queries.global_ctxt()?.take());
 
             let linker = queries.linker()?;
             Ok(Some(linker))

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -359,10 +359,11 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
                 // intra-doc-links
                 resolver.borrow_mut().access(|resolver| {
                     for extern_name in &extern_names {
-                        resolver.resolve_str_path_error(DUMMY_SP, extern_name, TypeNS, CRATE_NODE_ID)
-                            .unwrap_or_else(
-                                |()| panic!("Unable to resolve external crate {}", extern_name)
-                            );
+                        resolver.resolve_str_path_error(
+                            DUMMY_SP, extern_name, TypeNS, CRATE_NODE_ID
+                        ).unwrap_or_else(
+                            |()| panic!("Unable to resolve external crate {}", extern_name)
+                        );
                     }
                 });
 

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -343,7 +343,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
         registry: rustc_driver::diagnostics_registry(),
     };
 
-    interface::run_compiler_in_existing_thread_pool(config, |compiler| { compiler.enter(|queries| {
+    interface::run_compiler_in_existing_thread_pool(config, |compiler| compiler.enter(|queries| {
         let sess = compiler.session();
 
         // We need to hold on to the complete resolver, so we cause everything to be
@@ -487,7 +487,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
 
             (krate, ctxt.renderinfo.into_inner(), render_options)
         })
-    }) })
+    }))
 }
 
 /// `DefId` or parameter index (`ty::ParamTy.index`) of a synthetic type parameter

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -343,153 +343,151 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
         registry: rustc_driver::diagnostics_registry(),
     };
 
-    interface::run_compiler_in_existing_thread_pool(config, |compiler| {
-        compiler.enter(|queries| {
-            let sess = compiler.session();
+    interface::run_compiler_in_existing_thread_pool(config, |compiler| { compiler.enter(|queries| {
+        let sess = compiler.session();
 
-            // We need to hold on to the complete resolver, so we cause everything to be
-            // cloned for the analysis passes to use. Suboptimal, but necessary in the
-            // current architecture.
-            let resolver = {
-                let parts = abort_on_err(queries.expansion(), sess).peek();
-                let resolver = parts.1.borrow();
+        // We need to hold on to the complete resolver, so we cause everything to be
+        // cloned for the analysis passes to use. Suboptimal, but necessary in the
+        // current architecture.
+        let resolver = {
+            let parts = abort_on_err(queries.expansion(), sess).peek();
+            let resolver = parts.1.borrow();
 
-                // Before we actually clone it, let's force all the extern'd crates to
-                // actually be loaded, just in case they're only referred to inside
-                // intra-doc-links
-                resolver.borrow_mut().access(|resolver| {
-                    for extern_name in &extern_names {
-                        resolver.resolve_str_path_error(
-                            DUMMY_SP, extern_name, TypeNS, CRATE_NODE_ID
-                        ).unwrap_or_else(
-                            |()| panic!("Unable to resolve external crate {}", extern_name)
-                        );
-                    }
-                });
+            // Before we actually clone it, let's force all the extern'd crates to
+            // actually be loaded, just in case they're only referred to inside
+            // intra-doc-links
+            resolver.borrow_mut().access(|resolver| {
+                for extern_name in &extern_names {
+                    resolver.resolve_str_path_error(
+                        DUMMY_SP, extern_name, TypeNS, CRATE_NODE_ID
+                    ).unwrap_or_else(
+                        |()| panic!("Unable to resolve external crate {}", extern_name)
+                    );
+                }
+            });
 
-                // Now we're good to clone the resolver because everything should be loaded
-                resolver.clone()
+            // Now we're good to clone the resolver because everything should be loaded
+            resolver.clone()
+        };
+
+        if sess.has_errors() {
+            sess.fatal("Compilation failed, aborting rustdoc");
+        }
+
+        let mut global_ctxt = abort_on_err(queries.global_ctxt(), sess).take();
+
+        global_ctxt.enter(|tcx| {
+            tcx.analysis(LOCAL_CRATE).ok();
+
+            // Abort if there were any errors so far
+            sess.abort_if_errors();
+
+            let access_levels = tcx.privacy_access_levels(LOCAL_CRATE);
+            // Convert from a HirId set to a DefId set since we don't always have easy access
+            // to the map from defid -> hirid
+            let access_levels = AccessLevels {
+                map: access_levels.map.iter()
+                                    .map(|(&k, &v)| (tcx.hir().local_def_id(k), v))
+                                    .collect()
             };
 
-            if sess.has_errors() {
-                sess.fatal("Compilation failed, aborting rustdoc");
+            let mut renderinfo = RenderInfo::default();
+            renderinfo.access_levels = access_levels;
+
+            let mut ctxt = DocContext {
+                tcx,
+                resolver,
+                external_traits: Default::default(),
+                active_extern_traits: Default::default(),
+                renderinfo: RefCell::new(renderinfo),
+                ty_substs: Default::default(),
+                lt_substs: Default::default(),
+                ct_substs: Default::default(),
+                impl_trait_bounds: Default::default(),
+                fake_def_ids: Default::default(),
+                all_fake_def_ids: Default::default(),
+                generated_synthetics: Default::default(),
+                auto_traits: tcx.all_traits(LOCAL_CRATE).iter().cloned().filter(|trait_def_id| {
+                    tcx.trait_is_auto(*trait_def_id)
+                }).collect(),
+            };
+            debug!("crate: {:?}", tcx.hir().krate());
+
+            let mut krate = clean::krate(&mut ctxt);
+
+            fn report_deprecated_attr(name: &str, diag: &errors::Handler) {
+                let mut msg = diag.struct_warn(&format!("the `#![doc({})]` attribute is \
+                                                         considered deprecated", name));
+                msg.warn("please see https://github.com/rust-lang/rust/issues/44136");
+
+                if name == "no_default_passes" {
+                    msg.help("you may want to use `#![doc(document_private_items)]`");
+                }
+
+                msg.emit();
             }
 
-            let mut global_ctxt = abort_on_err(queries.global_ctxt(), sess).take();
+            // Process all of the crate attributes, extracting plugin metadata along
+            // with the passes which we are supposed to run.
+            for attr in krate.module.as_ref().unwrap().attrs.lists(sym::doc) {
+                let diag = ctxt.sess().diagnostic();
 
-            global_ctxt.enter(|tcx| {
-                tcx.analysis(LOCAL_CRATE).ok();
-
-                // Abort if there were any errors so far
-                sess.abort_if_errors();
-
-                let access_levels = tcx.privacy_access_levels(LOCAL_CRATE);
-                // Convert from a HirId set to a DefId set since we don't always have easy access
-                // to the map from defid -> hirid
-                let access_levels = AccessLevels {
-                    map: access_levels.map.iter()
-                                        .map(|(&k, &v)| (tcx.hir().local_def_id(k), v))
-                                        .collect()
-                };
-
-                let mut renderinfo = RenderInfo::default();
-                renderinfo.access_levels = access_levels;
-
-                let mut ctxt = DocContext {
-                    tcx,
-                    resolver,
-                    external_traits: Default::default(),
-                    active_extern_traits: Default::default(),
-                    renderinfo: RefCell::new(renderinfo),
-                    ty_substs: Default::default(),
-                    lt_substs: Default::default(),
-                    ct_substs: Default::default(),
-                    impl_trait_bounds: Default::default(),
-                    fake_def_ids: Default::default(),
-                    all_fake_def_ids: Default::default(),
-                    generated_synthetics: Default::default(),
-                    auto_traits: tcx.all_traits(LOCAL_CRATE).iter().cloned().filter(|trait_def_id| {
-                        tcx.trait_is_auto(*trait_def_id)
-                    }).collect(),
-                };
-                debug!("crate: {:?}", tcx.hir().krate());
-
-                let mut krate = clean::krate(&mut ctxt);
-
-                fn report_deprecated_attr(name: &str, diag: &errors::Handler) {
-                    let mut msg = diag.struct_warn(&format!("the `#![doc({})]` attribute is \
-                                                             considered deprecated", name));
-                    msg.warn("please see https://github.com/rust-lang/rust/issues/44136");
-
-                    if name == "no_default_passes" {
-                        msg.help("you may want to use `#![doc(document_private_items)]`");
-                    }
-
-                    msg.emit();
-                }
-
-                // Process all of the crate attributes, extracting plugin metadata along
-                // with the passes which we are supposed to run.
-                for attr in krate.module.as_ref().unwrap().attrs.lists(sym::doc) {
-                    let diag = ctxt.sess().diagnostic();
-
-                    let name = attr.name_or_empty();
-                    if attr.is_word() {
-                        if name == sym::no_default_passes {
-                            report_deprecated_attr("no_default_passes", diag);
-                            if default_passes == passes::DefaultPassOption::Default {
-                                default_passes = passes::DefaultPassOption::None;
-                            }
-                        }
-                    } else if let Some(value) = attr.value_str() {
-                        let sink = match name {
-                            sym::passes => {
-                                report_deprecated_attr("passes = \"...\"", diag);
-                                &mut manual_passes
-                            },
-                            sym::plugins => {
-                                report_deprecated_attr("plugins = \"...\"", diag);
-                                eprintln!("WARNING: `#![doc(plugins = \"...\")]` \
-                                          no longer functions; see CVE-2018-1000622");
-                                continue
-                            },
-                            _ => continue,
-                        };
-                        for name in value.as_str().split_whitespace() {
-                            sink.push(name.to_string());
-                        }
-                    }
-
-                    if attr.is_word() && name == sym::document_private_items {
+                let name = attr.name_or_empty();
+                if attr.is_word() {
+                    if name == sym::no_default_passes {
+                        report_deprecated_attr("no_default_passes", diag);
                         if default_passes == passes::DefaultPassOption::Default {
-                            default_passes = passes::DefaultPassOption::Private;
+                            default_passes = passes::DefaultPassOption::None;
                         }
+                    }
+                } else if let Some(value) = attr.value_str() {
+                    let sink = match name {
+                        sym::passes => {
+                            report_deprecated_attr("passes = \"...\"", diag);
+                            &mut manual_passes
+                        },
+                        sym::plugins => {
+                            report_deprecated_attr("plugins = \"...\"", diag);
+                            eprintln!("WARNING: `#![doc(plugins = \"...\")]` \
+                                      no longer functions; see CVE-2018-1000622");
+                            continue
+                        },
+                        _ => continue,
+                    };
+                    for name in value.as_str().split_whitespace() {
+                        sink.push(name.to_string());
                     }
                 }
 
-                let passes = passes::defaults(default_passes).iter().chain(manual_passes.into_iter()
-                    .flat_map(|name| {
-                        if let Some(pass) = passes::find_pass(&name) {
-                            Some(pass)
-                        } else {
-                            error!("unknown pass {}, skipping", name);
-                            None
-                        }
-                    }));
-
-                info!("Executing passes");
-
-                for pass in passes {
-                    debug!("running pass {}", pass.name);
-                    krate = (pass.pass)(krate, &ctxt);
+                if attr.is_word() && name == sym::document_private_items {
+                    if default_passes == passes::DefaultPassOption::Default {
+                        default_passes = passes::DefaultPassOption::Private;
+                    }
                 }
+            }
 
-                ctxt.sess().abort_if_errors();
+            let passes = passes::defaults(default_passes).iter().chain(manual_passes.into_iter()
+                .flat_map(|name| {
+                    if let Some(pass) = passes::find_pass(&name) {
+                        Some(pass)
+                    } else {
+                        error!("unknown pass {}, skipping", name);
+                        None
+                    }
+                }));
 
-                (krate, ctxt.renderinfo.into_inner(), render_options)
-            })
+            info!("Executing passes");
+
+            for pass in passes {
+                debug!("running pass {}", pass.name);
+                krate = (pass.pass)(krate, &ctxt);
+            }
+
+            ctxt.sess().abort_if_errors();
+
+            (krate, ctxt.renderinfo.into_inner(), render_options)
         })
-    })
+    }) })
 }
 
 /// `DefId` or parameter index (`ty::ParamTy.index`) of a synthetic type parameter

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -377,8 +377,8 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
 
             let global_ctxt = abort_on_err(queries.global_ctxt(), sess).take();
 
-            Ok((resolver, global_ctxt))
-        }).unwrap();
+            (resolver, global_ctxt)
+        });
 
         global_ctxt.enter(|tcx| {
             tcx.analysis(LOCAL_CRATE).ok();

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -86,13 +86,13 @@ pub fn run(options: Options) -> i32 {
     let display_warnings = options.display_warnings;
 
     let tests = interface::run_compiler(config, |compiler| -> Result<_, ErrorReported> {
-        let (mut collector, mut global_ctxt) = compiler.enter(|queries| {
+        compiler.enter(|queries| {
             let lower_to_hir = queries.lower_to_hir()?;
 
             let mut opts = scrape_test_config(lower_to_hir.peek().0.borrow().krate());
             opts.display_warnings |= options.display_warnings;
             let enable_per_target_ignores = options.enable_per_target_ignores;
-            let collector = Collector::new(
+            let mut collector = Collector::new(
                 queries.crate_name()?.peek().to_string(),
                 options,
                 false,
@@ -102,24 +102,24 @@ pub fn run(options: Options) -> i32 {
                 enable_per_target_ignores,
             );
 
-            let global_ctxt = queries.global_ctxt()?.take();
-            Ok((collector, global_ctxt))
-        })?;
-        global_ctxt.enter(|tcx| {
-            let krate = tcx.hir().krate();
-            let mut hir_collector = HirCollector {
-                sess: compiler.session(),
-                collector: &mut collector,
-                map: tcx.hir(),
-                codes: ErrorCodes::from(compiler.session().opts
-                                                .unstable_features.is_nightly_build()),
-            };
-            hir_collector.visit_testable("".to_string(), &krate.attrs, |this| {
-                intravisit::walk_crate(this, krate);
-            });
-        });
+            let mut global_ctxt = queries.global_ctxt()?.take();
 
-        Ok(collector.tests)
+            global_ctxt.enter(|tcx| {
+                let krate = tcx.hir().krate();
+                let mut hir_collector = HirCollector {
+                    sess: compiler.session(),
+                    collector: &mut collector,
+                    map: tcx.hir(),
+                    codes: ErrorCodes::from(compiler.session().opts
+                                                    .unstable_features.is_nightly_build()),
+                };
+                hir_collector.visit_testable("".to_string(), &krate.attrs, |this| {
+                    intravisit::walk_crate(this, krate);
+                });
+            });
+
+            Ok(collector.tests)
+        })
     }).expect("compiler aborted in rustdoc!");
 
     test_args.insert(0, "rustdoctest".to_string());

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -86,22 +86,25 @@ pub fn run(options: Options) -> i32 {
     let display_warnings = options.display_warnings;
 
     let tests = interface::run_compiler(config, |compiler| -> Result<_, ErrorReported> {
-        let lower_to_hir = compiler.lower_to_hir()?;
+        let (mut collector, mut global_ctxt) = compiler.enter(|queries| {
+            let lower_to_hir = queries.lower_to_hir()?;
 
-        let mut opts = scrape_test_config(lower_to_hir.peek().0.borrow().krate());
-        opts.display_warnings |= options.display_warnings;
-        let enable_per_target_ignores = options.enable_per_target_ignores;
-        let mut collector = Collector::new(
-            compiler.crate_name()?.peek().to_string(),
-            options,
-            false,
-            opts,
-            Some(compiler.source_map().clone()),
-            None,
-            enable_per_target_ignores,
-        );
+            let mut opts = scrape_test_config(lower_to_hir.peek().0.borrow().krate());
+            opts.display_warnings |= options.display_warnings;
+            let enable_per_target_ignores = options.enable_per_target_ignores;
+            let collector = Collector::new(
+                queries.crate_name()?.peek().to_string(),
+                options,
+                false,
+                opts,
+                Some(compiler.source_map().clone()),
+                None,
+                enable_per_target_ignores,
+            );
 
-        let mut global_ctxt = compiler.global_ctxt()?.take();
+            let global_ctxt = queries.global_ctxt()?.take();
+            Ok((collector, global_ctxt))
+        })?;
         global_ctxt.enter(|tcx| {
             let krate = tcx.hir().krate();
             let mut hir_collector = HirCollector {

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -85,7 +85,7 @@ pub fn run(options: Options) -> i32 {
     let mut test_args = options.test_args.clone();
     let display_warnings = options.display_warnings;
 
-    let tests = interface::run_compiler(config, |compiler| { compiler.enter(|queries| {
+    let tests = interface::run_compiler(config, |compiler| compiler.enter(|queries| {
         let lower_to_hir = queries.lower_to_hir()?;
 
         let mut opts = scrape_test_config(lower_to_hir.peek().0.borrow().krate());
@@ -119,7 +119,7 @@ pub fn run(options: Options) -> i32 {
 
         let ret : Result<_, ErrorReported> = Ok(collector.tests);
         ret
-    }) }).expect("compiler aborted in rustdoc!");
+    })).expect("compiler aborted in rustdoc!");
 
     test_args.insert(0, "rustdoctest".to_string());
 

--- a/src/test/run-make-fulldeps/issue-19371/foo.rs
+++ b/src/test/run-make-fulldeps/issue-19371/foo.rs
@@ -66,6 +66,11 @@ fn compile(code: String, output: PathBuf, sysroot: PathBuf) {
 
     interface::run_compiler(config, |compiler| {
         // This runs all the passes prior to linking, too.
-        compiler.link().ok();
+        let linker = compiler.enter(|queries| {
+            queries.linker()
+        });
+        if let Ok(linker) = linker {
+            linker.link();
+        }
     });
 }


### PR DESCRIPTION
The queries in rustc_interfaces are isolated in the `Queries` type. The `Queries` object constructed to have the smallest possible lifetime, and to drop contents as soon as possible. The information needed by the link phase is extracted through a `Linker` object for later use.

r? @Zoxc 