### PR TITLE
introduce a target to build the kernel of the unikernel HermitCore

### DIFF
--- a/src/librustc_target/spec/hermit_kernel_base.rs
+++ b/src/librustc_target/spec/hermit_kernel_base.rs
@@ -1,0 +1,26 @@
+use crate::spec::{LldFlavor, LinkArgs, LinkerFlavor, PanicStrategy, TargetOptions};
+use std::default::Default;
+
+pub fn opts() -> TargetOptions {
+    let mut pre_link_args = LinkArgs::new();
+    pre_link_args.insert(LinkerFlavor::Lld(LldFlavor::Ld), vec![
+        "--build-id".to_string(),
+        "--hash-style=gnu".to_string(),
+        "--Bstatic".to_string(),
+    ]);
+
+    TargetOptions {
+        linker: Some("rust-lld".to_owned()),
+        executables: true,
+        has_elf_tls: true,
+        linker_is_gnu: true,
+        pre_link_args,
+        no_default_libraries: true,
+        panic_strategy: PanicStrategy::Abort,
+        position_independent_executables: true,
+        relocation_model: "static".to_string(),
+        target_family: None,
+        tls_model: "initial-exec".to_string(),
+        .. Default::default()
+    }
+}

--- a/src/librustc_target/spec/hermit_kernel_base.rs
+++ b/src/librustc_target/spec/hermit_kernel_base.rs
@@ -10,6 +10,7 @@ pub fn opts() -> TargetOptions {
     ]);
 
     TargetOptions {
+        disable_redzone: true,
         linker: Some("rust-lld".to_owned()),
         executables: true,
         has_elf_tls: true,

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -54,6 +54,7 @@ mod dragonfly_base;
 mod freebsd_base;
 mod haiku_base;
 mod hermit_base;
+mod hermit_kernel_base;
 mod linux_base;
 mod linux_kernel_base;
 mod linux_musl_base;
@@ -481,6 +482,7 @@ supported_targets! {
 
     ("aarch64-unknown-hermit", aarch64_unknown_hermit),
     ("x86_64-unknown-hermit", x86_64_unknown_hermit),
+    ("x86_64-unknown-hermit-kernel", x86_64_unknown_hermit_kernel),
 
     ("riscv32i-unknown-none-elf", riscv32i_unknown_none_elf),
     ("riscv32imc-unknown-none-elf", riscv32imc_unknown_none_elf),

--- a/src/librustc_target/spec/x86_64_unknown_hermit_kernel.rs
+++ b/src/librustc_target/spec/x86_64_unknown_hermit_kernel.rs
@@ -1,0 +1,23 @@
+use crate::spec::{LldFlavor, LinkerFlavor, Target, TargetResult};
+
+pub fn target() -> TargetResult {
+    let mut base = super::hermit_kernel_base::opts();
+    base.cpu = "x86-64".to_string();
+    base.max_atomic_width = Some(64);
+    base.features = "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2,+soft-float".to_string();
+    base.stack_probes = true;
+
+    Ok(Target {
+        llvm_target: "x86_64-unknown-hermit".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "64".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "e-m:e-i64:64-f80:128-n8:16:32:64-S128".to_string(),
+        arch: "x86_64".to_string(),
+        target_os: "hermit".to_string(),
+        target_env: String::new(),
+        target_vendor: "unknown".to_string(),
+        linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
+        options: base,
+    })
+}

--- a/src/librustc_target/spec/x86_64_unknown_hermit_kernel.rs
+++ b/src/librustc_target/spec/x86_64_unknown_hermit_kernel.rs
@@ -4,7 +4,9 @@ pub fn target() -> TargetResult {
     let mut base = super::hermit_kernel_base::opts();
     base.cpu = "x86-64".to_string();
     base.max_atomic_width = Some(64);
-    base.features = "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2,+soft-float".to_string();
+    base.features =
+        "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2,+soft-float"
+        .to_string();
     base.stack_probes = true;
 
     Ok(Target {


### PR DESCRIPTION
We are developing the unikernel HermitCore, where the kernel is written in Rust and is already supported by the Rust Standard Library. To compile the kernel with the new build flag "-Z build-std", we introduce a new target, which avoids the usage of SSE & AVX within the kernel.