### PR TITLE
Removes references to hidden elementes in rustdoc

### DIFF
--- a/src/test/rustdoc/auxiliary/issue-13698.rs
+++ b/src/test/rustdoc/auxiliary/issue-13698.rs
@@ -1,8 +1,13 @@
 // compile-flags: -Cmetadata=aux
 
-pub trait Foo {
+pub trait FooAux {
     #[doc(hidden)]
     fn foo(&self) {}
+
+    #[doc(hidden)]
+    fn foo2(&self);
 }
 
-impl Foo for i32 {}
+impl FooAux for i32 {
+  fn foo2(&self) {}
+}

--- a/src/test/rustdoc/issue-13698.rs
+++ b/src/test/rustdoc/issue-13698.rs
@@ -5,12 +5,20 @@ extern crate issue_13698;
 
 pub struct Foo;
 // @!has issue_13698/struct.Foo.html '//*[@id="method.foo"]' 'fn foo'
-impl issue_13698::Foo for Foo {}
+// @!has - '//*[@id="method.foo2"]' 'fn foo2'
+impl issue_13698::FooAux for Foo {
+  fn foo2(&self) {}
+}
 
 pub trait Bar {
     #[doc(hidden)]
     fn bar(&self) {}
+    #[doc(hidden)]
+    fn qux(&self);
 }
 
 // @!has issue_13698/struct.Foo.html '//*[@id="method.bar"]' 'fn bar'
-impl Bar for Foo {}
+// @!has - '//*[@id="method.qux"]' 'fn qux'
+impl Bar for Foo {
+  fn qux(&self) {}
+}


### PR DESCRIPTION
This is my first PR dealing with `rustc`/`rustdoc` internals, usual warnings apply :sweat_smile:

This is a partial attempt to fix #13698. The approach is pretty blunt: we keep a reference to the _defining_ item in a trait implementation, and we then strip all items with a "parent" marked as `#[doc(hidden)]`. It is not finished but I wanted to gather feedback early.

### TODOs / Questions / Doubts / Alternatives
* [ ] TODO: handle all trait items, not only `Method`.
* Digging a bit, I see that the `Clean` implementation that I have modified is called during the `collect_trait_impls` pass. I'm not sure whether it would be better to try to tackle hidden elements at that point, instead of waiting to `strip-hidden`.
* Is `parent` a good name for defining item? Maybe `definition` would be better?
* Where should we place the `parent` field? Right now, I'm stuffing it into each `ItemEnum` variant, but maybe we could just add it to the `Item` struct.