### PR TITLE
Implement `DebugStruct::non_exhaustive`.

### DIFF
--- a/src/libcore/tests/fmt/builders.rs
+++ b/src/libcore/tests/fmt/builders.rs
@@ -93,6 +93,89 @@ mod debug_struct {
             format!("{:#?}", Bar)
         );
     }
+
+    #[test]
+    fn test_only_non_exhaustive() {
+        struct Foo;
+
+        impl fmt::Debug for Foo {
+            fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt.debug_struct("Foo")
+                    .finish_non_exhaustive()
+            }
+        }
+
+
+        assert_eq!("Foo { .. }", format!("{:?}", Foo));
+        assert_eq!(
+"Foo {
+    ..
+}",
+                   format!("{:#?}", Foo));
+    }
+
+    #[test]
+    fn test_multiple_and_non_exhaustive() {
+        struct Foo;
+
+        impl fmt::Debug for Foo {
+            fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt.debug_struct("Foo")
+                    .field("bar", &true)
+                    .field("baz", &format_args!("{}/{}", 10, 20))
+                    .finish_non_exhaustive()
+            }
+        }
+
+        assert_eq!("Foo { bar: true, baz: 10/20, .. }", format!("{:?}", Foo));
+        assert_eq!(
+"Foo {
+    bar: true,
+    baz: 10/20,
+    ..
+}",
+                   format!("{:#?}", Foo));
+    }
+
+    #[test]
+    fn test_nested_non_exhaustive() {
+        struct Foo;
+
+        impl fmt::Debug for Foo {
+            fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt.debug_struct("Foo")
+                    .field("bar", &true)
+                    .field("baz", &format_args!("{}/{}", 10, 20))
+                    .finish_non_exhaustive()
+            }
+        }
+
+        struct Bar;
+
+        impl fmt::Debug for Bar {
+            fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt.debug_struct("Bar")
+                    .field("foo", &Foo)
+                    .field("hello", &"world")
+                    .finish_non_exhaustive()
+            }
+        }
+
+        assert_eq!("Bar { foo: Foo { bar: true, baz: 10/20, .. }, hello: \"world\", .. }",
+                   format!("{:?}", Bar));
+        assert_eq!(
+"Bar {
+    foo: Foo {
+        bar: true,
+        baz: 10/20,
+        ..
+    },
+    hello: \"world\",
+    ..
+}",
+                   format!("{:#?}", Bar));
+    }
+
 }
 
 mod debug_tuple {

--- a/src/libcore/tests/fmt/builders.rs
+++ b/src/libcore/tests/fmt/builders.rs
@@ -100,18 +100,17 @@ mod debug_struct {
 
         impl fmt::Debug for Foo {
             fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-                fmt.debug_struct("Foo")
-                    .finish_non_exhaustive()
+                fmt.debug_struct("Foo").finish_non_exhaustive()
             }
         }
 
-
         assert_eq!("Foo { .. }", format!("{:?}", Foo));
         assert_eq!(
-"Foo {
+            "Foo {
     ..
 }",
-                   format!("{:#?}", Foo));
+            format!("{:#?}", Foo)
+        );
     }
 
     #[test]
@@ -129,12 +128,13 @@ mod debug_struct {
 
         assert_eq!("Foo { bar: true, baz: 10/20, .. }", format!("{:?}", Foo));
         assert_eq!(
-"Foo {
+            "Foo {
     bar: true,
     baz: 10/20,
     ..
 }",
-                   format!("{:#?}", Foo));
+            format!("{:#?}", Foo)
+        );
     }
 
     #[test]
@@ -161,10 +161,12 @@ mod debug_struct {
             }
         }
 
-        assert_eq!("Bar { foo: Foo { bar: true, baz: 10/20, .. }, hello: \"world\", .. }",
-                   format!("{:?}", Bar));
         assert_eq!(
-"Bar {
+            "Bar { foo: Foo { bar: true, baz: 10/20, .. }, hello: \"world\", .. }",
+            format!("{:?}", Bar)
+        );
+        assert_eq!(
+            "Bar {
     foo: Foo {
         bar: true,
         baz: 10/20,
@@ -173,9 +175,9 @@ mod debug_struct {
     hello: \"world\",
     ..
 }",
-                   format!("{:#?}", Bar));
+            format!("{:#?}", Bar)
+        );
     }
-
 }
 
 mod debug_tuple {

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -5,6 +5,7 @@
 #![feature(core_private_bignum)]
 #![feature(core_private_diy_float)]
 #![feature(debug_map_key_value)]
+#![feature(debug_non_exhaustive)]
 #![feature(dec2flt)]
 #![feature(exact_size_is_empty)]
 #![feature(fixed_size_array)]


### PR DESCRIPTION
This patch adds a function (finish_non_exhaustive) to add ellipsis before the closing brace when formatting using `DebugStruct`.

 ## Example

 ```rust
 #![feature(debug_non_exhaustive)]
 use std::fmt;

 struct Bar {
     bar: i32,
     hidden: f32,
 }

 impl fmt::Debug for Bar {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("Bar")
            .field("bar", &self.bar)
            .non_exhaustive(true) // Show that some other field(s) exist.
            .finish()
     }
 }

 assert_eq!(
     format!("{:?}", Bar { bar: 10, hidden: 1.0 }),
     "Bar { bar: 10, .. }",
 );
 ```
