### PR TITLE
Store pointer width as u32 on Config

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -12,7 +12,7 @@ use rustc_target::spec::{LinkerFlavor, MergeFunctions, PanicStrategy, RelroLevel
 use rustc_target::spec::{Target, TargetTriple};
 
 use syntax;
-use syntax::ast::{self, IntTy, UintTy};
+use syntax::ast;
 use syntax::source_map::{FileName, FilePathMapping};
 use syntax::edition::{Edition, EDITION_NAME_LIST, DEFAULT_EDITION};
 use syntax::symbol::{sym, Symbol};
@@ -36,8 +36,7 @@ use std::path::{Path, PathBuf};
 
 pub struct Config {
     pub target: Target,
-    pub isize_ty: IntTy,
-    pub usize_ty: UintTy,
+    pub ptr_width: u32,
 }
 
 #[derive(Clone, Hash, Debug)]
@@ -1570,10 +1569,10 @@ pub fn build_target_config(opts: &Options, sp: &Handler) -> Config {
         FatalError.raise();
     });
 
-    let (isize_ty, usize_ty) = match &target.target_pointer_width[..] {
-        "16" => (ast::IntTy::I16, ast::UintTy::U16),
-        "32" => (ast::IntTy::I32, ast::UintTy::U32),
-        "64" => (ast::IntTy::I64, ast::UintTy::U64),
+    let ptr_width = match &target.target_pointer_width[..] {
+        "16" => 16,
+        "32" => 32,
+        "64" => 64,
         w => sp.fatal(&format!(
             "target specification was invalid: \
              unrecognized target-pointer-width {}",
@@ -1583,8 +1582,7 @@ pub fn build_target_config(opts: &Options, sp: &Handler) -> Config {
 
     Config {
         target,
-        isize_ty,
-        usize_ty,
+        ptr_width,
     }
 }
 

--- a/src/librustc_codegen_llvm/builder.rs
+++ b/src/librustc_codegen_llvm/builder.rs
@@ -325,8 +325,8 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         use rustc::ty::{Int, Uint};
 
         let new_kind = match ty.kind {
-            Int(Isize) => Int(self.tcx.sess.target.isize_ty),
-            Uint(Usize) => Uint(self.tcx.sess.target.usize_ty),
+            Int(t @ Isize) => Int(t.normalize(self.tcx.sess.target.ptr_width)),
+            Uint(t @ Usize) => Uint(t.normalize(self.tcx.sess.target.ptr_width)),
             ref t @ Uint(_) | ref t @ Int(_) => t.clone(),
             _ => panic!("tried to get overflow intrinsic for op applied to non-int type")
         };

--- a/src/librustc_codegen_llvm/intrinsic.rs
+++ b/src/librustc_codegen_llvm/intrinsic.rs
@@ -1926,7 +1926,7 @@ unsupported {} from `{}` with element `{}` of size `{}` to `{}`"#,
 fn int_type_width_signed(ty: Ty<'_>, cx: &CodegenCx<'_, '_>) -> Option<(u64, bool)> {
     match ty.kind {
         ty::Int(t) => Some((match t {
-            ast::IntTy::Isize => cx.tcx.sess.target.isize_ty.bit_width().unwrap() as u64,
+            ast::IntTy::Isize => cx.tcx.sess.target.ptr_width as u64,
             ast::IntTy::I8 => 8,
             ast::IntTy::I16 => 16,
             ast::IntTy::I32 => 32,
@@ -1934,7 +1934,7 @@ fn int_type_width_signed(ty: Ty<'_>, cx: &CodegenCx<'_, '_>) -> Option<(u64, boo
             ast::IntTy::I128 => 128,
         }, true)),
         ty::Uint(t) => Some((match t {
-            ast::UintTy::Usize => cx.tcx.sess.target.usize_ty.bit_width().unwrap() as u64,
+            ast::UintTy::Usize => cx.tcx.sess.target.ptr_width as u64,
             ast::UintTy::U8 => 8,
             ast::UintTy::U16 => 16,
             ast::UintTy::U32 => 32,

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -252,12 +252,7 @@ fn lint_int_literal<'a, 'tcx>(
     t: ast::IntTy,
     v: u128,
 ) {
-    let int_type = if let ast::IntTy::Isize = t {
-        cx.sess().target.isize_ty
-    } else {
-        t
-    };
-
+    let int_type = t.normalize(cx.sess().target.ptr_width);
     let (_, max) = int_ty_range(int_type);
     let max = max as u128;
     let negative = type_limits.negated_expr_id == e.hir_id;
@@ -303,11 +298,7 @@ fn lint_uint_literal<'a, 'tcx>(
     lit: &hir::Lit,
     t: ast::UintTy,
 ) {
-    let uint_type = if let ast::UintTy::Usize = t {
-        cx.sess().target.usize_ty
-    } else {
-        t
-    };
+    let uint_type = t.normalize(cx.sess().target.ptr_width);
     let (min, max) = uint_ty_range(uint_type);
     let lit_val: u128 = match lit.node {
         // _v is u8, within range by definition

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1693,6 +1693,18 @@ impl IntTy {
             IntTy::I128 => 128,
         })
     }
+
+    pub fn normalize(&self, target_width: u32) -> Self {
+        match self {
+            IntTy::Isize => match target_width {
+                16 => IntTy::I16,
+                32 => IntTy::I32,
+                64 => IntTy::I64,
+                _ => unreachable!(),
+            },
+            _ => *self,
+        }
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, HashStable_Generic,
@@ -1742,6 +1754,18 @@ impl UintTy {
             UintTy::U64 => 64,
             UintTy::U128 => 128,
         })
+    }
+
+    pub fn normalize(&self, target_width: u32) -> Self {
+        match self {
+            UintTy::Usize => match target_width {
+                16 => UintTy::U16,
+                32 => UintTy::U32,
+                64 => UintTy::U64,
+                _ => unreachable!(),
+            },
+            _ => *self,
+        }
     }
 }
 


### PR DESCRIPTION
This removes the dependency on IntTy, UintTy from Session.

It's not obviously a win, but it seems a bit odd to store the AST IntTy/UintTy in Session, rather we store the pointer width as an integer and add normalization methods to IntTy and UintTy.