### PR TITLE
Move ErrorReported to rustc_errors

### DIFF
--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -7,7 +7,6 @@ use std::fmt::Debug;
 use std::time::{Duration, Instant};
 
 use syntax::symbol::{Symbol, sym};
-use rustc_macros::HashStable;
 use crate::session::Session;
 
 #[cfg(test)]
@@ -16,10 +15,7 @@ mod tests;
 // The name of the associated type for `Fn` return types.
 pub const FN_OUTPUT_NAME: Symbol = sym::Output;
 
-// Useful type to use with `Result<>` indicate that an error has already
-// been reported to the user, so no need to continue checking.
-#[derive(Clone, Copy, Debug, RustcEncodable, RustcDecodable, HashStable)]
-pub struct ErrorReported;
+pub use errors::ErrorReported;
 
 thread_local!(static TIME_DEPTH: Cell<usize> = Cell::new(0));
 

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -993,3 +993,10 @@ macro_rules! pluralize {
         if $x != 1 { "s" } else { "" }
     };
 }
+
+// Useful type to use with `Result<>` indicate that an error has already
+// been reported to the user, so no need to continue checking.
+#[derive(Clone, Copy, Debug, RustcEncodable, RustcDecodable, Hash, PartialEq, Eq)]
+pub struct ErrorReported;
+
+rustc_data_structures::impl_stable_hash_via_hash!(ErrorReported);


### PR DESCRIPTION
The new location is more consistent with what this type is for, though we don't remove it from the old location (via a re-export) to avoid changing the dozens of use sites (~139 at this time).