### PR TITLE
Use recursion_limit for const eval stack limit

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -95,9 +95,6 @@ pub struct Session {
     /// The maximum length of types during monomorphization.
     pub type_length_limit: Once<usize>,
 
-    /// The maximum number of stackframes allowed in const eval.
-    pub const_eval_stack_frame_limit: usize,
-
     /// Map from imported macro spans (which consist of
     /// the localized span for the macro body) to the
     /// macro name and definition span in the source crate.
@@ -1159,7 +1156,6 @@ fn build_session_(
         features: Once::new(),
         recursion_limit: Once::new(),
         type_length_limit: Once::new(),
-        const_eval_stack_frame_limit: 100,
         imported_macro_spans: OneThread::new(RefCell::new(FxHashMap::default())),
         incr_comp_session: OneThread::new(RefCell::new(IncrCompSession::NotInitialized)),
         cgu_reuse_tracker,

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -548,7 +548,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
         info!("ENTERING({}) {}", self.cur_frame(), self.frame().instance);
 
-        if self.stack.len() > self.tcx.sess.const_eval_stack_frame_limit {
+        if self.stack.len() > *self.tcx.sess.recursion_limit.get() {
             throw_exhaust!(StackFrameLimitReached)
         } else {
             Ok(())


### PR DESCRIPTION
cc https://github.com/rust-lang/miri/issues/643 @orium @RalfJung 

I'm really not certain how exactly to handle this change, but it looks like it's that simple.

Reuse `recursion_limit` ("The maximum recursion limit for potentially infinitely recursive operations such as auto-dereference and monomorphization") which is configurable by the user for the const evaluation stack frame limit.

The other option is to make `const_eval_stack_frame_limit` configurable in the same way as `recursion_limit` (but I'm not sure how to do that and it'd be a bigger change).

Fixes https://github.com/rust-lang/miri/issues/643.