### PR TITLE
remove dependency from libhermit

### DIFF
--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -54,7 +54,5 @@ fn main() {
         }
         println!("cargo:rustc-link-lib=c");
         println!("cargo:rustc-link-lib=compiler_rt");
-    } else if target.contains("hermit") {
-        println!("cargo:rustc-link-lib=hermit");
     }
 }


### PR DESCRIPTION
The build process of the unikernel HermitCore is redesigned and doesn't longer depend on libhermit.