### PR TITLE
Fix shrink_to panic documentation

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -629,6 +629,8 @@ impl<T> Vec<T> {
     /// The capacity will remain at least as large as both the length
     /// and the supplied value.
     ///
+    /// # Panics
+    ///
     /// Panics if the current capacity is smaller than the supplied
     /// minimum capacity.
     ///


### PR DESCRIPTION
While the potential for panicking is already documented for the
`Vec::shrink_to` method, it is not clearly labeled with the usual
`# Panics` heading.

r? @steveklabnik