### PR TITLE
BTreeMap/BTreeSet drain & retain

### DIFF
--- a/src/liballoc/benches/btree/map.rs
+++ b/src/liballoc/benches/btree/map.rs
@@ -146,6 +146,36 @@ pub fn iter_100000(b: &mut Bencher) {
     bench_iter(b, 100000);
 }
 
+fn bench_iter_mut(b: &mut Bencher, size: i32) {
+    let mut map = BTreeMap::<i32, i32>::new();
+    let mut rng = thread_rng();
+
+    for _ in 0..size {
+        map.insert(rng.gen(), rng.gen());
+    }
+
+    b.iter(|| {
+        for kv in map.iter_mut() {
+            black_box(kv);
+        }
+    });
+}
+
+#[bench]
+pub fn iter_mut_20(b: &mut Bencher) {
+    bench_iter_mut(b, 20);
+}
+
+#[bench]
+pub fn iter_mut_1000(b: &mut Bencher) {
+    bench_iter_mut(b, 1000);
+}
+
+#[bench]
+pub fn iter_mut_100000(b: &mut Bencher) {
+    bench_iter_mut(b, 100000);
+}
+
 fn bench_first_and_last(b: &mut Bencher, size: i32) {
     let map: BTreeMap<_, _> = (0..size).map(|i| (i, i)).collect();
     b.iter(|| {

--- a/src/liballoc/benches/btree/set.rs
+++ b/src/liballoc/benches/btree/set.rs
@@ -14,19 +14,13 @@ fn random(n: usize) -> BTreeSet<usize> {
 }
 
 fn neg(n: usize) -> BTreeSet<i32> {
-    let mut set = BTreeSet::new();
-    for i in -(n as i32)..=-1 {
-        set.insert(i);
-    }
+    let set: BTreeSet<i32> = (-(n as i32)..=-1).collect();
     assert_eq!(set.len(), n);
     set
 }
 
 fn pos(n: usize) -> BTreeSet<i32> {
-    let mut set = BTreeSet::new();
-    for i in 1..=(n as i32) {
-        set.insert(i);
-    }
+    let set: BTreeSet<i32> = (1..=(n as i32)).collect();
     assert_eq!(set.len(), n);
     set
 }
@@ -54,6 +48,54 @@ macro_rules! set_bench {
             b.iter(|| sets[0].$set_func(&sets[1]).$result_func())
         }
     };
+}
+
+const BUILD_SET_SIZE: usize = 100;
+
+#[bench]
+pub fn build_and_clear(b: &mut Bencher) {
+    b.iter(|| pos(BUILD_SET_SIZE).clear())
+}
+
+#[bench]
+pub fn build_and_drain(b: &mut Bencher) {
+    b.iter(|| pos(BUILD_SET_SIZE).drain().count())
+}
+
+#[bench]
+pub fn build_and_drop(b: &mut Bencher) {
+    b.iter(|| pos(BUILD_SET_SIZE))
+}
+
+#[bench]
+pub fn build_and_into_iter(b: &mut Bencher) {
+    b.iter(|| pos(BUILD_SET_SIZE).into_iter().count())
+}
+
+#[bench]
+pub fn build_and_pop_all(b: &mut Bencher) {
+    b.iter(|| {
+        let mut s = pos(BUILD_SET_SIZE);
+        while s.pop_first().is_some() {
+        }
+        s
+    });
+}
+
+#[bench]
+pub fn build_and_remove_all(b: &mut Bencher) {
+    b.iter(|| {
+        let mut s = pos(BUILD_SET_SIZE);
+        while let Some(elt) = s.iter().copied().next() {
+            s.remove(&elt);
+        }
+        s
+    });
+}
+
+#[bench]
+pub fn build_and_retain_nothing(b: &mut Bencher) {
+    b.iter(|| pos(BUILD_SET_SIZE).retain(|_| false))
 }
 
 set_bench! {intersection_100_neg_vs_100_pos, intersection, count, [neg(100), pos(100)]}

--- a/src/liballoc/benches/lib.rs
+++ b/src/liballoc/benches/lib.rs
@@ -1,3 +1,4 @@
+#![feature(btree_drain_retain)]
 #![feature(map_first_last)]
 #![feature(repr_simd)]
 #![feature(test)]

--- a/src/liballoc/collections/btree/set.rs
+++ b/src/liballoc/collections/btree/set.rs
@@ -515,6 +515,31 @@ impl<T: Ord> BTreeSet<T> {
         Union(MergeIterInner::new(self.iter(), other.iter()))
     }
 
+    /// Clears the set, returning all values as an iterator.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// #![feature(btree_drain_retain)]
+    /// use std::collections::BTreeSet;
+    ///
+    /// let mut a = BTreeSet::new();
+    /// a.insert(1);
+    /// a.insert(2);
+    ///
+    /// for k in a.drain().take(1) {
+    ///     assert!(k == 1 || k == 2);
+    /// }
+    ///
+    /// assert!(a.is_empty());
+    /// ```
+    #[unstable(feature = "btree_drain_retain", issue = "42849")]
+    pub fn drain(&mut self) -> IntoIter<T> {
+        IntoIter { iter: self.map.drain() }
+    }
+
     /// Clears the set, removing all values.
     ///
     /// # Examples
@@ -882,6 +907,27 @@ impl<T: Ord> BTreeSet<T> {
               Q: Ord
     {
         Recover::take(&mut self.map, value)
+    }
+
+    /// Retains only the value specified by the predicate.
+    ///
+    /// In other words, remove all value `v` such that `f(&v)` returns `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(btree_drain_retain)]
+    /// use std::collections::BTreeSet;
+    ///
+    /// let mut set: BTreeSet<i32> = (0..8).collect();
+    /// set.retain(|&v| v % 2 == 0);
+    /// assert_eq!(set.len(), 4);
+    /// ```
+    #[unstable(feature = "btree_drain_retain", issue = "42849")]
+    pub fn retain<F>(&mut self, mut f: F)
+        where F: FnMut(&T) -> bool,
+    {
+        self.map.retain(|k, _| f(k));
     }
 
     /// Moves all elements from `other` into `Self`, leaving `other` empty.

--- a/src/liballoc/tests/btree/set.rs
+++ b/src/liballoc/tests/btree/set.rs
@@ -306,6 +306,43 @@ fn test_is_subset() {
 }
 
 #[test]
+fn test_drain() {
+    let mut x: BTreeSet<_> = [1].iter().copied().collect();
+    let mut y: BTreeSet<_> = [1].iter().copied().collect();
+
+    let v: Vec<_> = x.drain().collect();
+    y.drain();
+    assert_eq!(v, [1]);
+    assert!(x.is_empty());
+    assert!(y.is_empty());
+    x.drain();
+    y.drain();
+    assert!(x.is_empty());
+    assert!(y.is_empty());
+}
+
+#[test]
+fn test_retain() {
+    let mut x: BTreeSet<_> = [1].iter().copied().collect();
+    let mut y: BTreeSet<_> = [1].iter().copied().collect();
+
+    x.retain(|_| false);
+    y.retain(|_| true);
+    assert!(x.is_empty());
+    assert_eq!(y.iter().copied().collect::<Vec<_>>(), vec![1]);
+}
+
+#[test]
+fn test_clear() {
+    let mut x: BTreeSet<_> = [1].iter().copied().collect();
+
+    x.clear();
+    assert!(x.is_empty());
+    x.clear();
+    assert!(x.is_empty());
+}
+
+#[test]
 fn test_zip() {
     let mut x = BTreeSet::new();
     x.insert(5);

--- a/src/liballoc/tests/lib.rs
+++ b/src/liballoc/tests/lib.rs
@@ -1,5 +1,6 @@
 #![feature(allocator_api)]
 #![feature(box_syntax)]
+#![feature(btree_drain_retain)]
 #![feature(drain_filter)]
 #![feature(exact_size_is_empty)]
 #![feature(map_first_last)]


### PR DESCRIPTION
Attempt at providing and testing drain and retain members on BTreeMap and BTreeSet as requested in https://github.com/rust-lang/rfcs/issues/1338.

`drain` is relatively easy and therefore reliable.

I'm not quite sure that `retain` is trustworthy, given how noob I am, how much unsafe code there is all around, and that I don't quite understand why #58431 happened, the code comments there, or how it can be tested, although in theory this code respects the order introduced there.

According to this new benchmark, `retain` is worth the trouble even if you end up retaining nothing:
```
test btree::set::build_and_clear                         ... bench:       3,949 ns/iter (+/- 68)
test btree::set::build_and_drain                         ... bench:       3,945 ns/iter (+/- 68)
test btree::set::build_and_drop                          ... bench:       3,980 ns/iter (+/- 34)
test btree::set::build_and_into_iter                     ... bench:       4,045 ns/iter (+/- 75)
test btree::set::build_and_pop_all                       ... bench:       5,090 ns/iter (+/- 64)
test btree::set::build_and_remove_all                    ... bench:       6,835 ns/iter (+/- 50)
test btree::set::build_and_retain_nothing                ... bench:       4,741 ns/iter (+/- 140)
```
Most of the time in these is spent building the set (I don't know how to separate that off) but _retain_nothing is faster than _pop_all (which is also unstable), and way faster than _remove_all (a stable way to naively implement retain). That's because it's optimized to remove from leaf nodes as long as they remain sufficiently full. It's probably easy to extend that to leaf nodes that are the root node and are therefore allowed to underflow, and it's probably possible when stealing, but I tried to minimize changes in existing code.