### PR TITLE
Update the `wasi` crate for `wasm32-wasi`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,7 +1294,7 @@ checksum = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.7.0",
 ]
 
 [[package]]
@@ -4301,7 +4301,7 @@ dependencies = [
  "rustc_msan",
  "rustc_tsan",
  "unwind",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -5172,6 +5172,12 @@ name = "wasi"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",

--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -54,7 +54,7 @@ fortanix-sgx-abi = { version = "0.3.2", features = ['rustc-dep-of-std'] }
 hermit-abi = { version = "0.1", features = ['rustc-dep-of-std'] }
 
 [target.wasm32-wasi.dependencies]
-wasi = { version = "0.7.0", features = ['rustc-dep-of-std', 'alloc'] }
+wasi = { version = "0.9.0", features = ['rustc-dep-of-std'], default-features = false }
 
 [features]
 default = ["std_detect_file_io", "std_detect_dlsym_getauxval"]

--- a/src/libstd/sys/wasi/ext/io.rs
+++ b/src/libstd/sys/wasi/ext/io.rs
@@ -8,8 +8,6 @@ use crate::sys;
 use crate::net;
 use crate::sys_common::{AsInner, FromInner, IntoInner};
 
-use ::wasi::wasi_unstable as wasi;
-
 /// Raw file descriptors.
 pub type RawFd = u32;
 
@@ -127,18 +125,18 @@ impl IntoRawFd for fs::File {
 
 impl AsRawFd for io::Stdin {
     fn as_raw_fd(&self) -> RawFd {
-        wasi::STDIN_FD
+        sys::stdio::Stdin.as_raw_fd()
     }
 }
 
 impl AsRawFd for io::Stdout {
     fn as_raw_fd(&self) -> RawFd {
-        wasi::STDOUT_FD
+        sys::stdio::Stdout.as_raw_fd()
     }
 }
 
 impl AsRawFd for io::Stderr {
     fn as_raw_fd(&self) -> RawFd {
-        wasi::STDERR_FD
+        sys::stdio::Stderr.as_raw_fd()
     }
 }

--- a/src/libstd/sys/wasi/fd.rs
+++ b/src/libstd/sys/wasi/fd.rs
@@ -1,40 +1,31 @@
 #![allow(dead_code)]
 
+use super::err2io;
 use crate::io::{self, IoSlice, IoSliceMut, SeekFrom};
 use crate::mem;
 use crate::net::Shutdown;
-use super::err2io;
-use ::wasi::wasi_unstable as wasi;
 
 #[derive(Debug)]
 pub struct WasiFd {
     fd: wasi::Fd,
 }
 
-fn iovec<'a>(a: &'a mut [IoSliceMut<'_>]) -> &'a [wasi::IoVec] {
-    assert_eq!(
-        mem::size_of::<IoSliceMut<'_>>(),
-        mem::size_of::<wasi::IoVec>()
-    );
-    assert_eq!(
-        mem::align_of::<IoSliceMut<'_>>(),
-        mem::align_of::<wasi::IoVec>()
-    );
+fn iovec<'a>(a: &'a mut [IoSliceMut<'_>]) -> &'a [wasi::Iovec] {
+    assert_eq!(mem::size_of::<IoSliceMut<'_>>(), mem::size_of::<wasi::Iovec>());
+    assert_eq!(mem::align_of::<IoSliceMut<'_>>(), mem::align_of::<wasi::Iovec>());
     /// SAFETY: `IoSliceMut` and `IoVec` have exactly the same memory layout
-    unsafe { mem::transmute(a) }
+    unsafe {
+        mem::transmute(a)
+    }
 }
 
-fn ciovec<'a>(a: &'a [IoSlice<'_>]) -> &'a [wasi::CIoVec] {
-    assert_eq!(
-        mem::size_of::<IoSlice<'_>>(),
-        mem::size_of::<wasi::CIoVec>()
-    );
-    assert_eq!(
-        mem::align_of::<IoSlice<'_>>(),
-        mem::align_of::<wasi::CIoVec>()
-    );
+fn ciovec<'a>(a: &'a [IoSlice<'_>]) -> &'a [wasi::Ciovec] {
+    assert_eq!(mem::size_of::<IoSlice<'_>>(), mem::size_of::<wasi::Ciovec>());
+    assert_eq!(mem::align_of::<IoSlice<'_>>(), mem::align_of::<wasi::Ciovec>());
     /// SAFETY: `IoSlice` and `CIoVec` have exactly the same memory layout
-    unsafe { mem::transmute(a) }
+    unsafe {
+        mem::transmute(a)
+    }
 }
 
 impl WasiFd {
@@ -87,7 +78,7 @@ impl WasiFd {
 
     // FIXME: __wasi_fd_fdstat_get
 
-    pub fn set_flags(&self, flags: wasi::FdFlags) -> io::Result<()> {
+    pub fn set_flags(&self, flags: wasi::Fdflags) -> io::Result<()> {
         unsafe { wasi::fd_fdstat_set_flags(self.fd, flags).map_err(err2io) }
     }
 
@@ -107,31 +98,30 @@ impl WasiFd {
         unsafe { wasi::fd_allocate(self.fd, offset, len).map_err(err2io) }
     }
 
-    pub fn create_directory(&self, path: &[u8]) -> io::Result<()> {
+    pub fn create_directory(&self, path: &str) -> io::Result<()> {
         unsafe { wasi::path_create_directory(self.fd, path).map_err(err2io) }
     }
 
     pub fn link(
         &self,
-        old_flags: wasi::LookupFlags,
-        old_path: &[u8],
+        old_flags: wasi::Lookupflags,
+        old_path: &str,
         new_fd: &WasiFd,
-        new_path: &[u8],
+        new_path: &str,
     ) -> io::Result<()> {
         unsafe {
-            wasi::path_link(self.fd, old_flags, old_path, new_fd.fd, new_path)
-                .map_err(err2io)
+            wasi::path_link(self.fd, old_flags, old_path, new_fd.fd, new_path).map_err(err2io)
         }
     }
 
     pub fn open(
         &self,
-        dirflags: wasi::LookupFlags,
-        path: &[u8],
-        oflags: wasi::OFlags,
+        dirflags: wasi::Lookupflags,
+        path: &str,
+        oflags: wasi::Oflags,
         fs_rights_base: wasi::Rights,
         fs_rights_inheriting: wasi::Rights,
-        fs_flags: wasi::FdFlags,
+        fs_flags: wasi::Fdflags,
     ) -> io::Result<WasiFd> {
         unsafe {
             wasi::path_open(
@@ -142,25 +132,25 @@ impl WasiFd {
                 fs_rights_base,
                 fs_rights_inheriting,
                 fs_flags,
-            ).map(|fd| WasiFd::from_raw(fd)).map_err(err2io)
+            )
+            .map(|fd| WasiFd::from_raw(fd))
+            .map_err(err2io)
         }
     }
 
-    pub fn readdir(&self, buf: &mut [u8], cookie: wasi::DirCookie) -> io::Result<usize> {
-        unsafe { wasi::fd_readdir(self.fd, buf, cookie).map_err(err2io) }
+    pub fn readdir(&self, buf: &mut [u8], cookie: wasi::Dircookie) -> io::Result<usize> {
+        unsafe { wasi::fd_readdir(self.fd, buf.as_mut_ptr(), buf.len(), cookie).map_err(err2io) }
     }
 
-    pub fn readlink(&self, path: &[u8], buf: &mut [u8]) -> io::Result<usize> {
-        unsafe { wasi::path_readlink(self.fd, path, buf).map_err(err2io) }
+    pub fn readlink(&self, path: &str, buf: &mut [u8]) -> io::Result<usize> {
+        unsafe { wasi::path_readlink(self.fd, path, buf.as_mut_ptr(), buf.len()).map_err(err2io) }
     }
 
-    pub fn rename(&self, old_path: &[u8], new_fd: &WasiFd, new_path: &[u8]) -> io::Result<()> {
-        unsafe {
-            wasi::path_rename(self.fd, old_path, new_fd.fd, new_path).map_err(err2io)
-        }
+    pub fn rename(&self, old_path: &str, new_fd: &WasiFd, new_path: &str) -> io::Result<()> {
+        unsafe { wasi::path_rename(self.fd, old_path, new_fd.fd, new_path).map_err(err2io) }
     }
 
-    pub fn filestat_get(&self) -> io::Result<wasi::FileStat> {
+    pub fn filestat_get(&self) -> io::Result<wasi::Filestat> {
         unsafe { wasi::fd_filestat_get(self.fd).map_err(err2io) }
     }
 
@@ -168,11 +158,9 @@ impl WasiFd {
         &self,
         atim: wasi::Timestamp,
         mtim: wasi::Timestamp,
-        fstflags: wasi::FstFlags,
+        fstflags: wasi::Fstflags,
     ) -> io::Result<()> {
-        unsafe {
-            wasi::fd_filestat_set_times(self.fd, atim, mtim, fstflags).map_err(err2io)
-        }
+        unsafe { wasi::fd_filestat_set_times(self.fd, atim, mtim, fstflags).map_err(err2io) }
     }
 
     pub fn filestat_set_size(&self, size: u64) -> io::Result<()> {
@@ -181,61 +169,55 @@ impl WasiFd {
 
     pub fn path_filestat_get(
         &self,
-        flags: wasi::LookupFlags,
-        path: &[u8],
-    ) -> io::Result<wasi::FileStat> {
+        flags: wasi::Lookupflags,
+        path: &str,
+    ) -> io::Result<wasi::Filestat> {
         unsafe { wasi::path_filestat_get(self.fd, flags, path).map_err(err2io) }
     }
 
     pub fn path_filestat_set_times(
         &self,
-        flags: wasi::LookupFlags,
-        path: &[u8],
+        flags: wasi::Lookupflags,
+        path: &str,
         atim: wasi::Timestamp,
         mtim: wasi::Timestamp,
-        fstflags: wasi::FstFlags,
+        fstflags: wasi::Fstflags,
     ) -> io::Result<()> {
         unsafe {
-            wasi::path_filestat_set_times(
-                self.fd,
-                flags,
-                path,
-                atim,
-                mtim,
-                fstflags,
-            ).map_err(err2io)
+            wasi::path_filestat_set_times(self.fd, flags, path, atim, mtim, fstflags)
+                .map_err(err2io)
         }
     }
 
-    pub fn symlink(&self, old_path: &[u8], new_path: &[u8]) -> io::Result<()> {
+    pub fn symlink(&self, old_path: &str, new_path: &str) -> io::Result<()> {
         unsafe { wasi::path_symlink(old_path, self.fd, new_path).map_err(err2io) }
     }
 
-    pub fn unlink_file(&self, path: &[u8]) -> io::Result<()> {
+    pub fn unlink_file(&self, path: &str) -> io::Result<()> {
         unsafe { wasi::path_unlink_file(self.fd, path).map_err(err2io) }
     }
 
-    pub fn remove_directory(&self, path: &[u8]) -> io::Result<()> {
+    pub fn remove_directory(&self, path: &str) -> io::Result<()> {
         unsafe { wasi::path_remove_directory(self.fd, path).map_err(err2io) }
     }
 
     pub fn sock_recv(
         &self,
         ri_data: &mut [IoSliceMut<'_>],
-        ri_flags: wasi::RiFlags,
-    ) -> io::Result<(usize, wasi::RoFlags)> {
+        ri_flags: wasi::Riflags,
+    ) -> io::Result<(usize, wasi::Roflags)> {
         unsafe { wasi::sock_recv(self.fd, iovec(ri_data), ri_flags).map_err(err2io) }
     }
 
-    pub fn sock_send(&self, si_data: &[IoSlice<'_>], si_flags: wasi::SiFlags) -> io::Result<usize> {
+    pub fn sock_send(&self, si_data: &[IoSlice<'_>], si_flags: wasi::Siflags) -> io::Result<usize> {
         unsafe { wasi::sock_send(self.fd, ciovec(si_data), si_flags).map_err(err2io) }
     }
 
     pub fn sock_shutdown(&self, how: Shutdown) -> io::Result<()> {
         let how = match how {
-            Shutdown::Read => wasi::SHUT_RD,
-            Shutdown::Write => wasi::SHUT_WR,
-            Shutdown::Both => wasi::SHUT_WR | wasi::SHUT_RD,
+            Shutdown::Read => wasi::SDFLAGS_RD,
+            Shutdown::Write => wasi::SDFLAGS_WR,
+            Shutdown::Both => wasi::SDFLAGS_WR | wasi::SDFLAGS_RD,
         };
         unsafe { wasi::sock_shutdown(self.fd, how).map_err(err2io) }
     }

--- a/src/libstd/sys/wasi/io.rs
+++ b/src/libstd/sys/wasi/io.rs
@@ -1,12 +1,9 @@
 use crate::marker::PhantomData;
 use crate::slice;
 
-use ::wasi::wasi_unstable as wasi;
-use core::ffi::c_void;
-
 #[repr(transparent)]
 pub struct IoSlice<'a> {
-    vec: wasi::CIoVec,
+    vec: wasi::Ciovec,
     _p: PhantomData<&'a [u8]>,
 }
 
@@ -14,8 +11,8 @@ impl<'a> IoSlice<'a> {
     #[inline]
     pub fn new(buf: &'a [u8]) -> IoSlice<'a> {
         IoSlice {
-            vec: wasi::CIoVec {
-                buf: buf.as_ptr() as *const c_void,
+            vec: wasi::Ciovec {
+                buf: buf.as_ptr(),
                 buf_len: buf.len(),
             },
             _p: PhantomData,
@@ -44,7 +41,7 @@ impl<'a> IoSlice<'a> {
 
 #[repr(transparent)]
 pub struct IoSliceMut<'a> {
-    vec: wasi::IoVec,
+    vec: wasi::Iovec,
     _p: PhantomData<&'a mut [u8]>,
 }
 
@@ -52,8 +49,8 @@ impl<'a> IoSliceMut<'a> {
     #[inline]
     pub fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
         IoSliceMut {
-            vec: wasi::IoVec {
-                buf: buf.as_mut_ptr() as *mut c_void,
+            vec: wasi::Iovec {
+                buf: buf.as_mut_ptr(),
                 buf_len: buf.len()
             },
             _p: PhantomData,

--- a/src/libstd/sys/wasi/stdio.rs
+++ b/src/libstd/sys/wasi/stdio.rs
@@ -2,8 +2,6 @@ use crate::io::{self, IoSlice, IoSliceMut};
 use crate::mem::ManuallyDrop;
 use crate::sys::fd::WasiFd;
 
-use ::wasi::wasi_unstable as wasi;
-
 pub struct Stdin;
 pub struct Stdout;
 pub struct Stderr;
@@ -18,8 +16,11 @@ impl Stdin {
     }
 
     pub fn read_vectored(&self, data: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
-        ManuallyDrop::new(unsafe { WasiFd::from_raw(wasi::STDIN_FD) })
-            .read(data)
+        ManuallyDrop::new(unsafe { WasiFd::from_raw(self.as_raw_fd()) }).read(data)
+    }
+
+    pub fn as_raw_fd(&self) -> u32 {
+        0
     }
 }
 
@@ -33,12 +34,15 @@ impl Stdout {
     }
 
     pub fn write_vectored(&self, data: &[IoSlice<'_>]) -> io::Result<usize> {
-        ManuallyDrop::new(unsafe { WasiFd::from_raw(wasi::STDOUT_FD) })
-            .write(data)
+        ManuallyDrop::new(unsafe { WasiFd::from_raw(self.as_raw_fd()) }).write(data)
     }
 
     pub fn flush(&self) -> io::Result<()> {
         Ok(())
+    }
+
+    pub fn as_raw_fd(&self) -> u32 {
+        1
     }
 }
 
@@ -52,12 +56,15 @@ impl Stderr {
     }
 
     pub fn write_vectored(&self, data: &[IoSlice<'_>]) -> io::Result<usize> {
-        ManuallyDrop::new(unsafe { WasiFd::from_raw(wasi::STDERR_FD) })
-            .write(data)
+        ManuallyDrop::new(unsafe { WasiFd::from_raw(self.as_raw_fd()) }).write(data)
     }
 
     pub fn flush(&self) -> io::Result<()> {
         Ok(())
+    }
+
+    pub fn as_raw_fd(&self) -> u32 {
+        2
     }
 }
 
@@ -74,7 +81,7 @@ impl io::Write for Stderr {
 pub const STDIN_BUF_SIZE: usize = crate::sys_common::io::DEFAULT_BUF_SIZE;
 
 pub fn is_ebadf(err: &io::Error) -> bool {
-    err.raw_os_error() == Some(wasi::EBADF.get() as i32)
+    err.raw_os_error() == Some(wasi::ERRNO_BADF.into())
 }
 
 pub fn panic_output() -> Option<impl io::Write> {


### PR DESCRIPTION
This commit updates the `wasi` crate used by the standard library which
is used to implement most of the functionality of libstd on the
`wasm32-wasi` target. This update comes with a brand new crate structure
in the `wasi` crate which caused quite a few changes for the wasi target
here, but it also comes with a significant change to where the
functionality is coming from.

The WASI specification is organized into "snapshots" and a new snapshot
happened recently, so the WASI APIs themselves have changed since the
previous revision. This had only minor impact on the public facing
surface area of libstd, only changing on `u32` to a `u64` in an unstable
API. The actual source for all of these types and such, however, is now
coming from the `wasi_preview_snapshot1` module instead of the
`wasi_unstable` module like before. This means that any implementors
generating binaries will need to ensure that their embedding environment
handles the `wasi_preview_snapshot1` module.