### PR TITLE
impl TrustedLen for vec::Drain

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2701,6 +2701,9 @@ impl<T> ExactSizeIterator for Drain<'_, T> {
     }
 }
 
+#[unstable(feature = "trusted_len", issue = "37572")]
+unsafe impl<T> TrustedLen for Drain<'_, T> {}
+
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for Drain<'_, T> {}
 


### PR DESCRIPTION
The iterator methods just forward to `slice::Iter`, which is `TrustedLen`.

This can probably be applied to other `Drain` structs as well.