### PR TITLE
Use LLVMDisposePassManager instead of raw delete in rustllvm

### DIFF
--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -537,7 +537,7 @@ LLVMRustWriteOutputFile(LLVMTargetMachineRef Target, LLVMPassManagerRef PMR,
   // Apparently `addPassesToEmitFile` adds a pointer to our on-the-stack output
   // stream (OS), so the only real safe place to delete this is here? Don't we
   // wish this was written in Rust?
-  delete PM;
+  LLVMDisposePassManager(PMR);
   return LLVMRustResult::Success;
 }
 


### PR DESCRIPTION
LLVM has a dedicated API call which wraps the destructor invocation for the PassManager.
Rust invokes it [otherwhere](https://github.com/rust-lang/rust/blob/d63b24ffcc48f44ef09e0369e6516d6f2dec3520/src/librustc_codegen_llvm/back/write.rs#L446-L447), but not in the `LLVMRustWriteOutputFile`.

Since `LLVMDisposePassManager` might be extended to perform additional cleanup actions in the future, this change replaces raw destructor invocation with that API call.