### PR TITLE
Stabilize the `core::panic` module

### DIFF
--- a/src/libcore/panic.rs
+++ b/src/libcore/panic.rs
@@ -1,8 +1,6 @@
 //! Panic support in the standard library.
 
-#![unstable(feature = "core_panic_info",
-            reason = "newly available in libcore",
-            issue = "44489")]
+#![stable(feature = "core_panic_info", since = "1.41.0")]
 
 use crate::any::Any;
 use crate::fmt;

--- a/src/libcore/panic.rs
+++ b/src/libcore/panic.rs
@@ -39,10 +39,10 @@ pub struct PanicInfo<'a> {
 }
 
 impl<'a> PanicInfo<'a> {
-    #![unstable(feature = "panic_internals",
-                reason = "internal details of the implementation of the `panic!` \
-                          and related macros",
-                issue = "0")]
+    #[unstable(feature = "panic_internals",
+               reason = "internal details of the implementation of the `panic!` \
+                         and related macros",
+               issue = "0")]
     #[doc(hidden)]
     #[inline]
     pub fn internal_constructor(
@@ -57,6 +57,10 @@ impl<'a> PanicInfo<'a> {
         }
     }
 
+    #[unstable(feature = "panic_internals",
+               reason = "internal details of the implementation of the `panic!` \
+                         and related macros",
+               issue = "0")]
     #[doc(hidden)]
     #[inline]
     pub fn set_payload(&mut self, info: &'a (dyn Any + Send)) {

--- a/src/libcore/panic.rs
+++ b/src/libcore/panic.rs
@@ -94,7 +94,7 @@ impl<'a> PanicInfo<'a> {
     /// returns that message ready to be used for example with [`fmt::write`]
     ///
     /// [`fmt::write`]: ../fmt/fn.write.html
-    #[unstable(feature = "panic_info_message", issue = "44489")]
+    #[unstable(feature = "panic_info_message", issue = "66745")]
     pub fn message(&self) -> Option<&fmt::Arguments<'_>> {
         self.message
     }


### PR DESCRIPTION
`std::panic` is already stable.

`core::panic::PanicInfo` and `core::panic::Location` are stable and can be used through that path because of a bug in stability checking: #15702