### PR TITLE
Allow `Unreachable` terminators through `min_const_fn` checks

### DIFF
--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -337,6 +337,9 @@ fn check_terminator(
             check_operand(tcx, discr, span, def_id, body)
         }
 
+        // FIXME(ecstaticmorse): We probably want to allow `Unreachable` unconditionally.
+        TerminatorKind::Unreachable if tcx.features().const_if_match => Ok(()),
+
         | TerminatorKind::Abort | TerminatorKind::Unreachable => {
             Err((span, "const fn with unreachable code is not stable".into()))
         }

--- a/src/test/ui/consts/control-flow/exhaustive-c-like-enum-match.rs
+++ b/src/test/ui/consts/control-flow/exhaustive-c-like-enum-match.rs
@@ -1,0 +1,27 @@
+// Test for <https://github.com/rust-lang/rust/issues/66756>
+
+// check-pass
+
+#![feature(const_if_match)]
+
+enum E {
+    A,
+    B,
+    C
+}
+
+const fn f(e: E) {
+    match e {
+        E::A => {}
+        E::B => {}
+        E::C => {}
+    }
+}
+
+const fn g(e: E) {
+    match e {
+        _ => {}
+    }
+}
+
+fn main() {}

--- a/src/test/ui/consts/control-flow/exhaustive-c-like-enum-match.rs
+++ b/src/test/ui/consts/control-flow/exhaustive-c-like-enum-match.rs
@@ -18,10 +18,4 @@ const fn f(e: E) {
     }
 }
 
-const fn g(e: E) {
-    match e {
-        _ => {}
-    }
-}
-
 fn main() {}


### PR DESCRIPTION
Resolves #66756.

This allows `Unreachable` terminators through the `min_const_fn` checks if `#![feature(const_if_match)]` is enabled. We could probably just allow them with no feature flag, but it seems okay to be conservative here.

r? @oli-obk 