### PR TITLE
Record temporary static references in generator witnesses

### DIFF
--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -682,6 +682,23 @@ impl<'tcx> TyCtxt<'tcx> {
         self.static_mutability(def_id) == Some(hir::Mutability::Mutable)
     }
 
+    /// Get the type of the pointer to the static that we use in MIR.
+    pub fn static_ptr_ty(&self, def_id: DefId) -> Ty<'tcx> {
+        // Make sure that any constants in the static's type are evaluated.
+        let static_ty = self.normalize_erasing_regions(
+            ty::ParamEnv::empty(),
+            self.type_of(def_id),
+        );
+
+        if self.is_mutable_static(def_id) {
+            self.mk_mut_ptr(static_ty)
+        } else if self.is_foreign_item(def_id) {
+            self.mk_imm_ptr(static_ty)
+        } else {
+            self.mk_imm_ref(self.lifetimes.re_erased, static_ty)
+        }
+    }
+
     /// Expands the given impl trait type, stopping if the type is recursive.
     pub fn try_expand_impl_trait_type(
         self,

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -933,14 +933,7 @@ fn convert_path_expr<'a, 'tcx>(
         // We encode uses of statics as a `*&STATIC` where the `&STATIC` part is
         // a constant reference (or constant raw pointer for `static mut`) in MIR
         Res::Def(DefKind::Static, id) => {
-            let ty = cx.tcx.type_of(id);
-            let ty = if cx.tcx.is_mutable_static(id) {
-                cx.tcx.mk_mut_ptr(ty)
-            } else if cx.tcx.is_foreign_item(id) {
-                cx.tcx.mk_imm_ptr(ty)
-            } else {
-                cx.tcx.mk_imm_ref(cx.tcx.lifetimes.re_static, ty)
-            };
+            let ty = cx.tcx.static_ptr_ty(id);
             let ptr = cx.tcx.alloc_map.lock().create_static_alloc(id);
             let temp_lifetime = cx.region_scope_tree.temporary_scope(expr.hir_id.local_id);
             ExprKind::Deref { arg: Expr {

--- a/src/librustc_typeck/check/generator_interior.rs
+++ b/src/librustc_typeck/check/generator_interior.rs
@@ -185,6 +185,8 @@ impl<'a, 'tcx> Visitor<'tcx> for InteriorVisitor<'a, 'tcx> {
     }
 
     fn visit_expr(&mut self, expr: &'tcx Expr) {
+        let scope = self.region_scope_tree.temporary_scope(expr.hir_id.local_id);
+
         match &expr.kind {
             ExprKind::Call(callee, args) => match &callee.kind {
                 ExprKind::Path(qpath) => {
@@ -210,12 +212,19 @@ impl<'a, 'tcx> Visitor<'tcx> for InteriorVisitor<'a, 'tcx> {
                 }
                 _ => intravisit::walk_expr(self, expr),
             }
+            ExprKind::Path(qpath) => {
+                let res = self.fcx.tables.borrow().qpath_res(qpath, expr.hir_id);
+                if let Res::Def(DefKind::Static, def_id) = res {
+                    // Statics are lowered to temporary references or
+                    // pointers in MIR, so record that type.
+                    let ptr_ty = self.fcx.tcx.static_ptr_ty(def_id);
+                    self.record(ptr_ty, scope, Some(expr), expr.span);
+                }
+            }
             _ => intravisit::walk_expr(self, expr),
         }
 
         self.expr_count += 1;
-
-        let scope = self.region_scope_tree.temporary_scope(expr.hir_id.local_id);
 
         // If there are adjustments, then record the final type --
         // this is the actual value that is being produced.

--- a/src/test/ui/async-await/issues/issue-66695-static-refs.rs
+++ b/src/test/ui/async-await/issues/issue-66695-static-refs.rs
@@ -1,0 +1,24 @@
+// build-pass
+// edition:2018
+
+static A: [i32; 5] = [1, 2, 3, 4, 5];
+
+async fn fun() {
+    let u = A[async { 1 }.await];
+    match A {
+        i if async { true }.await => (),
+        _ => (),
+    }
+}
+
+fn main() {
+    async {
+        let u = A[async { 1 }.await];
+    };
+    async {
+        match A {
+            i if async { true }.await => (),
+            _ => (),
+        }
+    };
+}

--- a/src/test/ui/generator/static-reference-across-yield.rs
+++ b/src/test/ui/generator/static-reference-across-yield.rs
@@ -1,0 +1,16 @@
+// build-pass
+#![feature(generators)]
+
+static A: [i32; 5] = [1, 2, 3, 4, 5];
+
+fn main() {
+    static || {
+        let u = A[{yield; 1}];
+    };
+    static || {
+        match A {
+            i if { yield; true } => (),
+            _ => (),
+        }
+    };
+}


### PR DESCRIPTION
Closes #66695

* Record the pointer to static's type in MIR.
* Normalize the static's type (so that constants can be compared correctly).
