### PR TITLE
Rollup of 14 pull requests

### DIFF
--- a/src/doc/rustdoc/src/documentation-tests.md
+++ b/src/doc/rustdoc/src/documentation-tests.md
@@ -1,7 +1,7 @@
 # Documentation tests
 
 `rustdoc` supports executing your documentation examples as tests. This makes sure
-that your tests are up to date and working.
+that examples within your documentation are up to date and working.
 
 The basic idea is this:
 

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -152,6 +152,33 @@ impl<T> Box<T> {
         Box(ptr.cast().into())
     }
 
+    /// Constructs a new `Box` with uninitialized contents, with the memory
+    /// being filled with `0` bytes.
+    ///
+    /// See [`MaybeUninit::zeroed`][zeroed] for examples of correct and incorrect usage
+    /// of this method.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(new_uninit)]
+    ///
+    /// let zero = Box::<u32>::new_zeroed();
+    /// let zero = unsafe { zero.assume_init() };
+    ///
+    /// assert_eq!(*zero, 0)
+    /// ```
+    ///
+    /// [zeroed]: ../../std/mem/union.MaybeUninit.html#method.zeroed
+    #[unstable(feature = "new_uninit", issue = "63291")]
+    pub fn new_zeroed() -> Box<mem::MaybeUninit<T>> {
+        unsafe {
+            let mut uninit = Self::new_uninit();
+            ptr::write_bytes::<T>(uninit.as_mut_ptr(), 0, 1);
+            uninit
+        }
+    }
+
     /// Constructs a new `Pin<Box<T>>`. If `T` does not implement `Unpin`, then
     /// `x` will be pinned in memory and unable to be moved.
     #[stable(feature = "pin", since = "1.33.0")]

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -361,6 +361,35 @@ impl<T> Rc<T> {
         }
     }
 
+    /// Constructs a new `Rc` with uninitialized contents, with the memory
+    /// being filled with `0` bytes.
+    ///
+    /// See [`MaybeUninit::zeroed`][zeroed] for examples of correct and
+    /// incorrect usage of this method.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(new_uninit)]
+    ///
+    /// use std::rc::Rc;
+    ///
+    /// let zero = Rc::<u32>::new_zeroed();
+    /// let zero = unsafe { zero.assume_init() };
+    ///
+    /// assert_eq!(*zero, 0)
+    /// ```
+    ///
+    /// [zeroed]: ../../std/mem/union.MaybeUninit.html#method.zeroed
+    #[unstable(feature = "new_uninit", issue = "63291")]
+    pub fn new_zeroed() -> Rc<mem::MaybeUninit<T>> {
+        unsafe {
+            let mut uninit = Self::new_uninit();
+            ptr::write_bytes::<T>(Rc::get_mut_unchecked(&mut uninit).as_mut_ptr(), 0, 1);
+            uninit
+        }
+    }
+
     /// Constructs a new `Pin<Rc<T>>`. If `T` does not implement `Unpin`, then
     /// `value` will be pinned in memory and unable to be moved.
     #[stable(feature = "pin", since = "1.33.0")]

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -341,6 +341,35 @@ impl<T> Arc<T> {
         }
     }
 
+    /// Constructs a new `Arc` with uninitialized contents, with the memory
+    /// being filled with `0` bytes.
+    ///
+    /// See [`MaybeUninit::zeroed`][zeroed] for examples of correct and incorrect usage
+    /// of this method.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(new_uninit)]
+    ///
+    /// use std::sync::Arc;
+    ///
+    /// let zero = Arc::<u32>::new_zeroed();
+    /// let zero = unsafe { zero.assume_init() };
+    ///
+    /// assert_eq!(*zero, 0)
+    /// ```
+    ///
+    /// [zeroed]: ../../std/mem/union.MaybeUninit.html#method.zeroed
+    #[unstable(feature = "new_uninit", issue = "63291")]
+    pub fn new_zeroed() -> Arc<mem::MaybeUninit<T>> {
+        unsafe {
+            let mut uninit = Self::new_uninit();
+            ptr::write_bytes::<T>(Arc::get_mut_unchecked(&mut uninit).as_mut_ptr(), 0, 1);
+            uninit
+        }
+    }
+
     /// Constructs a new `Pin<Arc<T>>`. If `T` does not implement `Unpin`, then
     /// `data` will be pinned in memory and unable to be moved.
     #[stable(feature = "pin", since = "1.33.0")]

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -464,9 +464,9 @@ impl<T: PartialOrd> PartialOrd for Reverse<T> {
     #[inline]
     fn le(&self, other: &Self) -> bool { other.0 <= self.0 }
     #[inline]
-    fn ge(&self, other: &Self) -> bool { other.0 >= self.0 }
-    #[inline]
     fn gt(&self, other: &Self) -> bool { other.0 > self.0 }
+    #[inline]
+    fn ge(&self, other: &Self) -> bool { other.0 >= self.0 }
 }
 
 #[stable(feature = "reverse_cmp_key", since = "1.19.0")]
@@ -1176,9 +1176,9 @@ mod impls {
         #[inline]
         fn le(&self, other: & &B) -> bool { PartialOrd::le(*self, *other) }
         #[inline]
-        fn ge(&self, other: & &B) -> bool { PartialOrd::ge(*self, *other) }
-        #[inline]
         fn gt(&self, other: & &B) -> bool { PartialOrd::gt(*self, *other) }
+        #[inline]
+        fn ge(&self, other: & &B) -> bool { PartialOrd::ge(*self, *other) }
     }
     #[stable(feature = "rust1", since = "1.0.0")]
     impl<A: ?Sized> Ord for &A where A: Ord {
@@ -1208,9 +1208,9 @@ mod impls {
         #[inline]
         fn le(&self, other: &&mut B) -> bool { PartialOrd::le(*self, *other) }
         #[inline]
-        fn ge(&self, other: &&mut B) -> bool { PartialOrd::ge(*self, *other) }
-        #[inline]
         fn gt(&self, other: &&mut B) -> bool { PartialOrd::gt(*self, *other) }
+        #[inline]
+        fn ge(&self, other: &&mut B) -> bool { PartialOrd::ge(*self, *other) }
     }
     #[stable(feature = "rust1", since = "1.0.0")]
     impl<A: ?Sized> Ord for &mut A where A: Ord {

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -463,7 +463,6 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         &self,
         err: &mut DiagnosticBuilder<'_>,
         terr: &TypeError<'tcx>,
-        sp: Span,
     ) {
         use hir::def_id::CrateNum;
         use hir::map::DisambiguatedDefPathData;
@@ -577,14 +576,10 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 };
                 if same_path().unwrap_or(false) {
                     let crate_name = self.tcx.crate_name(did1.krate);
-                    err.span_note(
-                        sp,
-                        &format!(
-                            "Perhaps two different versions \
-                             of crate `{}` are being used?",
-                            crate_name
-                        ),
-                    );
+                    err.note(&format!(
+                        "perhaps two different versions of crate `{}` are being used?",
+                        crate_name
+                    ));
                 }
             }
         };
@@ -1263,7 +1258,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             .unwrap_or_else(|| {
                 self.tcx.hir().body_owner_def_id(hir::BodyId { hir_id: cause.body_id })
             });
-        self.check_and_note_conflicting_crates(diag, terr, span);
+        self.check_and_note_conflicting_crates(diag, terr);
         self.tcx.note_and_explain_type_err(diag, terr, span, body_owner_def_id);
 
         // It reads better to have the error origin as the final

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -12,7 +12,7 @@ use rustc_target::spec::{LinkerFlavor, MergeFunctions, PanicStrategy, RelroLevel
 use rustc_target::spec::{Target, TargetTriple};
 
 use syntax;
-use syntax::ast::{self, IntTy, UintTy};
+use syntax::ast;
 use syntax::source_map::{FileName, FilePathMapping};
 use syntax::edition::{Edition, EDITION_NAME_LIST, DEFAULT_EDITION};
 use syntax::symbol::{sym, Symbol};
@@ -36,8 +36,7 @@ use std::path::{Path, PathBuf};
 
 pub struct Config {
     pub target: Target,
-    pub isize_ty: IntTy,
-    pub usize_ty: UintTy,
+    pub ptr_width: u32,
 }
 
 #[derive(Clone, Hash, Debug)]
@@ -1570,10 +1569,10 @@ pub fn build_target_config(opts: &Options, sp: &Handler) -> Config {
         FatalError.raise();
     });
 
-    let (isize_ty, usize_ty) = match &target.target_pointer_width[..] {
-        "16" => (ast::IntTy::I16, ast::UintTy::U16),
-        "32" => (ast::IntTy::I32, ast::UintTy::U32),
-        "64" => (ast::IntTy::I64, ast::UintTy::U64),
+    let ptr_width = match &target.target_pointer_width[..] {
+        "16" => 16,
+        "32" => 32,
+        "64" => 64,
         w => sp.fatal(&format!(
             "target specification was invalid: \
              unrecognized target-pointer-width {}",
@@ -1583,8 +1582,7 @@ pub fn build_target_config(opts: &Options, sp: &Handler) -> Config {
 
     Config {
         target,
-        isize_ty,
-        usize_ty,
+        ptr_width,
     }
 }
 

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -7,7 +7,6 @@ use std::fmt::Debug;
 use std::time::{Duration, Instant};
 
 use syntax::symbol::{Symbol, sym};
-use rustc_macros::HashStable;
 use crate::session::Session;
 
 #[cfg(test)]
@@ -16,10 +15,7 @@ mod tests;
 // The name of the associated type for `Fn` return types.
 pub const FN_OUTPUT_NAME: Symbol = sym::Output;
 
-// Useful type to use with `Result<>` indicate that an error has already
-// been reported to the user, so no need to continue checking.
-#[derive(Clone, Copy, Debug, RustcEncodable, RustcDecodable, HashStable)]
-pub struct ErrorReported;
+pub use errors::ErrorReported;
 
 thread_local!(static TIME_DEPTH: Cell<usize> = Cell::new(0));
 

--- a/src/librustc_codegen_llvm/builder.rs
+++ b/src/librustc_codegen_llvm/builder.rs
@@ -325,8 +325,8 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         use rustc::ty::{Int, Uint};
 
         let new_kind = match ty.kind {
-            Int(Isize) => Int(self.tcx.sess.target.isize_ty),
-            Uint(Usize) => Uint(self.tcx.sess.target.usize_ty),
+            Int(t @ Isize) => Int(t.normalize(self.tcx.sess.target.ptr_width)),
+            Uint(t @ Usize) => Uint(t.normalize(self.tcx.sess.target.ptr_width)),
             ref t @ Uint(_) | ref t @ Int(_) => t.clone(),
             _ => panic!("tried to get overflow intrinsic for op applied to non-int type")
         };

--- a/src/librustc_codegen_llvm/intrinsic.rs
+++ b/src/librustc_codegen_llvm/intrinsic.rs
@@ -1926,7 +1926,7 @@ unsupported {} from `{}` with element `{}` of size `{}` to `{}`"#,
 fn int_type_width_signed(ty: Ty<'_>, cx: &CodegenCx<'_, '_>) -> Option<(u64, bool)> {
     match ty.kind {
         ty::Int(t) => Some((match t {
-            ast::IntTy::Isize => cx.tcx.sess.target.isize_ty.bit_width().unwrap() as u64,
+            ast::IntTy::Isize => cx.tcx.sess.target.ptr_width as u64,
             ast::IntTy::I8 => 8,
             ast::IntTy::I16 => 16,
             ast::IntTy::I32 => 32,
@@ -1934,7 +1934,7 @@ fn int_type_width_signed(ty: Ty<'_>, cx: &CodegenCx<'_, '_>) -> Option<(u64, boo
             ast::IntTy::I128 => 128,
         }, true)),
         ty::Uint(t) => Some((match t {
-            ast::UintTy::Usize => cx.tcx.sess.target.usize_ty.bit_width().unwrap() as u64,
+            ast::UintTy::Usize => cx.tcx.sess.target.ptr_width as u64,
             ast::UintTy::U8 => 8,
             ast::UintTy::U16 => 16,
             ast::UintTy::U32 => 32,

--- a/src/librustc_error_codes/error_codes/E0062.md
+++ b/src/librustc_error_codes/error_codes/E0062.md
@@ -1,6 +1,6 @@
-This error indicates that during an attempt to build a struct or struct-like
-enum variant, one of the fields was specified more than once. Erroneous code
-example:
+A struct's or struct-like enum variant's field was specified more than once.
+
+Erroneous code example:
 
 ```compile_fail,E0062
 struct Foo {
@@ -15,7 +15,9 @@ fn main() {
 }
 ```
 
-Each field should be specified exactly one time. Example:
+This error indicates that during an attempt to build a struct or struct-like
+enum variant, one of the fields was specified more than once. Each field should
+be specified exactly one time. Example:
 
 ```
 struct Foo {

--- a/src/librustc_error_codes/error_codes/E0063.md
+++ b/src/librustc_error_codes/error_codes/E0063.md
@@ -1,5 +1,6 @@
-This error indicates that during an attempt to build a struct or struct-like
-enum variant, one of the fields was not provided. Erroneous code example:
+A struct's or struct-like enum variant's field was not provided.
+
+Erroneous code example:
 
 ```compile_fail,E0063
 struct Foo {

--- a/src/librustc_error_codes/error_codes/E0067.md
+++ b/src/librustc_error_codes/error_codes/E0067.md
@@ -1,33 +1,15 @@
-The left-hand side of a compound assignment expression must be a place
-expression. A place expression represents a memory location and includes
-item paths (ie, namespaced variables), dereferences, indexing expressions,
-and field references.
+An invalid left-hand side expression was used on an assignment operation.
 
-Let's start with some erroneous code examples:
+Erroneous code example:
 
 ```compile_fail,E0067
-use std::collections::LinkedList;
-
-// Bad: assignment to non-place expression
-LinkedList::new() += 1;
-
-// ...
-
-fn some_func(i: &mut i32) {
-    i += 12; // Error : '+=' operation cannot be applied on a reference !
-}
+12 += 1; // error!
 ```
 
-And now some working examples:
+You need to have a place expression to be able to assign it something. For
+example:
 
 ```
-let mut i : i32 = 0;
-
-i += 12; // Good !
-
-// ...
-
-fn some_func(i: &mut i32) {
-    *i += 12; // Good !
-}
+let mut x: i8 = 12;
+x += 1; // ok!
 ```

--- a/src/librustc_error_codes/error_codes/E0069.md
+++ b/src/librustc_error_codes/error_codes/E0069.md
@@ -1,5 +1,7 @@
 The compiler found a function whose body contains a `return;` statement but
-whose return type is not `()`. An example of this is:
+whose return type is not `()`.
+
+Erroneous code example:
 
 ```compile_fail,E0069
 // error

--- a/src/librustc_error_codes/error_codes/E0070.md
+++ b/src/librustc_error_codes/error_codes/E0070.md
@@ -1,3 +1,26 @@
+An assignment operator was used on a non-place expression.
+
+Erroneous code examples:
+
+```compile_fail,E0070
+struct SomeStruct {
+    x: i32,
+    y: i32,
+}
+
+const SOME_CONST: i32 = 12;
+
+fn some_other_func() {}
+
+fn some_function() {
+    SOME_CONST = 14; // error: a constant value cannot be changed!
+    1 = 3; // error: 1 isn't a valid place!
+    some_other_func() = 4; // error: we cannot assign value to a function!
+    SomeStruct::x = 12; // error: SomeStruct a structure name but it is used
+                        //        like a variable!
+}
+```
+
 The left-hand side of an assignment operator must be a place expression. A
 place expression represents a memory location and can be a variable (with
 optional namespacing), a dereference, an indexing expression or a field
@@ -7,35 +30,14 @@ More details can be found in the [Expressions] section of the Reference.
 
 [Expressions]: https://doc.rust-lang.org/reference/expressions.html#places-rvalues-and-temporaries
 
-Now, we can go further. Here are some erroneous code examples:
-
-```compile_fail,E0070
-struct SomeStruct {
-    x: i32,
-    y: i32
-}
-
-const SOME_CONST : i32 = 12;
-
-fn some_other_func() {}
-
-fn some_function() {
-    SOME_CONST = 14; // error : a constant value cannot be changed!
-    1 = 3; // error : 1 isn't a valid place!
-    some_other_func() = 4; // error : we cannot assign value to a function!
-    SomeStruct.x = 12; // error : SomeStruct a structure name but it is used
-                       // like a variable!
-}
-```
-
 And now let's give working examples:
 
 ```
 struct SomeStruct {
     x: i32,
-    y: i32
+    y: i32,
 }
-let mut s = SomeStruct {x: 0, y: 0};
+let mut s = SomeStruct { x: 0, y: 0 };
 
 s.x = 3; // that's good !
 

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -993,3 +993,10 @@ macro_rules! pluralize {
         if $x != 1 { "s" } else { "" }
     };
 }
+
+// Useful type to use with `Result<>` indicate that an error has already
+// been reported to the user, so no need to continue checking.
+#[derive(Clone, Copy, Debug, RustcEncodable, RustcDecodable, Hash, PartialEq, Eq)]
+pub struct ErrorReported;
+
+rustc_data_structures::impl_stable_hash_via_hash!(ErrorReported);

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -252,12 +252,7 @@ fn lint_int_literal<'a, 'tcx>(
     t: ast::IntTy,
     v: u128,
 ) {
-    let int_type = if let ast::IntTy::Isize = t {
-        cx.sess().target.isize_ty
-    } else {
-        t
-    };
-
+    let int_type = t.normalize(cx.sess().target.ptr_width);
     let (_, max) = int_ty_range(int_type);
     let max = max as u128;
     let negative = type_limits.negated_expr_id == e.hir_id;
@@ -303,11 +298,7 @@ fn lint_uint_literal<'a, 'tcx>(
     lit: &hir::Lit,
     t: ast::UintTy,
 ) {
-    let uint_type = if let ast::UintTy::Usize = t {
-        cx.sess().target.usize_ty
-    } else {
-        t
-    };
+    let uint_type = t.normalize(cx.sess().target.ptr_width);
     let (min, max) = uint_ty_range(uint_type);
     let lit_val: u128 = match lit.node {
         // _v is u8, within range by definition

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -698,7 +698,9 @@ impl<'a> CrateLoader<'a> {
         let has_global_allocator = match &*global_allocator_spans(krate) {
             [span1, span2, ..] => {
                 self.sess.struct_span_err(*span2, "cannot define multiple global allocators")
-                         .span_note(*span1, "the previous global allocator is defined here").emit();
+                    .span_label(*span2, "cannot define a new global allocator")
+                    .span_label(*span1, "previous global allocator is defined here")
+                    .emit();
                 true
             }
             spans => !spans.is_empty()

--- a/src/librustc_mir/borrow_check/conflict_errors.rs
+++ b/src/librustc_mir/borrow_check/conflict_errors.rs
@@ -1256,23 +1256,17 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             Applicability::MachineApplicable,
         );
 
-        match category {
-            ConstraintCategory::Return => {
-                err.span_note(constraint_span, "closure is returned here");
-            }
-            ConstraintCategory::OpaqueType => {
-                err.span_note(constraint_span, "generator is returned here");
-            }
+        let msg = match category {
+            ConstraintCategory::Return => "closure is returned here".to_string(),
+            ConstraintCategory::OpaqueType => "generator is returned here".to_string(),
             ConstraintCategory::CallArgument => {
                 fr_name.highlight_region_name(&mut err);
-                err.span_note(
-                    constraint_span,
-                    &format!("function requires argument type to outlive `{}`", fr_name),
-                );
+                format!("function requires argument type to outlive `{}`", fr_name)
             }
             _ => bug!("report_escaping_closure_capture called with unexpected constraint \
                        category: `{:?}`", category),
-        }
+        };
+        err.span_note(constraint_span, &msg);
         err
     }
 

--- a/src/librustc_mir/borrow_check/move_errors.rs
+++ b/src/librustc_mir/borrow_check/move_errors.rs
@@ -555,7 +555,6 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
         err: &mut DiagnosticBuilder<'a>,
         binds_to: &[Local],
     ) {
-        let mut noncopy_var_spans = Vec::new();
         for (j, local) in binds_to.into_iter().enumerate() {
             let bind_to = &self.body.local_decls[*local];
             let binding_span = bind_to.source_info.span;
@@ -573,16 +572,12 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                     bind_to.ty,
                     Some(binding_span)
                 );
-            } else {
-                noncopy_var_spans.push(binding_span);
             }
         }
 
         if binds_to.len() > 1 {
-            err.span_note(
-                noncopy_var_spans,
-                "move occurs because these variables have types that \
-                    don't implement the `Copy` trait",
+            err.note("move occurs because these variables have types that \
+                      don't implement the `Copy` trait",
             );
         }
     }

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -703,7 +703,9 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         if let LocalValue::Live(Operand::Indirect(MemPlace { ptr, .. })) = local {
             trace!("deallocating local");
             let ptr = ptr.to_ptr()?;
-            self.memory.dump_alloc(ptr.alloc_id);
+            if log_enabled!(::log::Level::Trace) {
+                self.memory.dump_alloc(ptr.alloc_id);
+            }
             self.memory.deallocate_local(ptr)?;
         };
         Ok(())

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -752,12 +752,14 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
     }
 
     pub fn leak_report(&self) -> usize {
-        eprintln!("### LEAK REPORT ###");
         let leaks: Vec<_> = self.alloc_map.filter_map_collect(|&id, &(kind, _)| {
             if kind.may_leak() { None } else { Some(id) }
         });
         let n = leaks.len();
-        self.dump_allocs(leaks);
+        if n > 0 {
+            eprintln!("### LEAK REPORT ###");
+            self.dump_allocs(leaks);
+        }
         n
     }
 

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -635,7 +635,9 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
         Ok(())
     }
 
-    /// For debugging, print an allocation and all allocations it points to, recursively.
+    /// Print an allocation and all allocations it points to, recursively.
+    /// This prints directly to stderr, ignoring RUSTC_LOG! It is up to the caller to
+    /// control for this.
     pub fn dump_alloc(&self, id: AllocId) {
         self.dump_allocs(vec![id]);
     }
@@ -674,7 +676,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
             }
         }
 
-        trace!(
+        eprintln!(
             "{}({} bytes, alignment {}){}",
             msg,
             alloc.size.bytes(),
@@ -695,15 +697,14 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
                 write!(msg, "└{0:─^1$}┘ ", target, relocation_width as usize).unwrap();
                 pos = i + self.pointer_size();
             }
-            trace!("{}", msg);
+            eprintln!("{}", msg);
         }
     }
 
-    /// For debugging, print a list of allocations and all allocations they point to, recursively.
+    /// Print a list of allocations and all allocations they point to, recursively.
+    /// This prints directly to stderr, ignoring RUSTC_LOG! It is up to the caller to
+    /// control for this.
     pub fn dump_allocs(&self, mut allocs: Vec<AllocId>) {
-        if !log_enabled!(::log::Level::Trace) {
-            return;
-        }
         allocs.sort();
         allocs.dedup();
         let mut allocs_to_print = VecDeque::from(allocs);
@@ -735,13 +736,13 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
                             );
                         }
                         Some(GlobalAlloc::Function(func)) => {
-                            trace!("{} {}", msg, func);
+                            eprintln!("{} {}", msg, func);
                         }
                         Some(GlobalAlloc::Static(did)) => {
-                            trace!("{} {:?}", msg, did);
+                            eprintln!("{} {:?}", msg, did);
                         }
                         None => {
-                            trace!("{} (deallocated)", msg);
+                            eprintln!("{} (deallocated)", msg);
                         }
                     }
                 },
@@ -751,7 +752,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
     }
 
     pub fn leak_report(&self) -> usize {
-        trace!("### LEAK REPORT ###");
+        eprintln!("### LEAK REPORT ###");
         let leaks: Vec<_> = self.alloc_map.filter_map_collect(|&id, &(kind, _)| {
             if kind.may_leak() { None } else { Some(id) }
         });

--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -337,6 +337,9 @@ fn check_terminator(
             check_operand(tcx, discr, span, def_id, body)
         }
 
+        // FIXME(ecstaticmorse): We probably want to allow `Unreachable` unconditionally.
+        TerminatorKind::Unreachable if tcx.features().const_if_match => Ok(()),
+
         | TerminatorKind::Abort | TerminatorKind::Unreachable => {
             Err((span, "const fn with unreachable code is not stable".into()))
         }

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -490,9 +490,12 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses a macro invocation inside a `trait`, `impl` or `extern` block.
-    fn parse_assoc_macro_invoc(&mut self, item_kind: &str, vis: Option<&Visibility>,
-                               at_end: &mut bool) -> PResult<'a, Option<Mac>>
-    {
+    fn parse_assoc_macro_invoc(
+        &mut self,
+        item_kind: &str,
+        vis: Option<&Visibility>,
+        at_end: &mut bool,
+    ) -> PResult<'a, Option<Mac>> {
         if self.token.is_path_start() &&
                 !(self.is_async_fn() && self.token.span.rust_2015()) {
             let prev_span = self.prev_span;
@@ -531,9 +534,11 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn missing_assoc_item_kind_err(&self, item_type: &str, prev_span: Span)
-                                   -> DiagnosticBuilder<'a>
-    {
+    fn missing_assoc_item_kind_err(
+        &self,
+        item_type: &str,
+        prev_span: Span,
+    ) -> DiagnosticBuilder<'a> {
         let expected_kinds = if item_type == "extern" {
             "missing `fn`, `type`, or `static`"
         } else {

--- a/src/librustc_passes/loops.rs
+++ b/src/librustc_passes/loops.rs
@@ -144,8 +144,8 @@ impl<'a, 'hir> Visitor<'hir> for CheckLoopVisitor<'a, 'hir> {
                                             "`continue` pointing to a labeled block")
                                 .span_label(e.span,
                                             "labeled blocks cannot be `continue`'d")
-                                .span_note(block.span,
-                                            "labeled block the continue points to")
+                                .span_label(block.span,
+                                            "labeled block the `continue` points to")
                                 .emit();
                         }
                     }

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -1160,8 +1160,10 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
                     .emit();
             } else {
                 let msg = format!("`{}` is private, and cannot be re-exported", ident);
-                let note_msg =
-                    format!("consider marking `{}` as `pub` in the imported module", ident);
+                let note_msg = format!(
+                    "consider marking `{}` as `pub` in the imported module",
+                    ident,
+                );
                 struct_span_err!(self.r.session, directive.span, E0364, "{}", &msg)
                     .span_note(directive.span, &note_msg)
                     .emit();

--- a/src/librustc_target/spec/aarch64_pc_windows_msvc.rs
+++ b/src/librustc_target/spec/aarch64_pc_windows_msvc.rs
@@ -4,6 +4,7 @@ pub fn target() -> TargetResult {
     let mut base = super::windows_msvc_base::opts();
     base.max_atomic_width = Some(64);
     base.has_elf_tls = true;
+    base.features = "+neon,+fp-armv8".to_string();
 
     // FIXME: this shouldn't be panic=abort, it should be panic=unwind
     base.panic_strategy = PanicStrategy::Abort;

--- a/src/librustc_target/spec/hermit_kernel_base.rs
+++ b/src/librustc_target/spec/hermit_kernel_base.rs
@@ -1,0 +1,26 @@
+use crate::spec::{LldFlavor, LinkArgs, LinkerFlavor, PanicStrategy, TargetOptions};
+use std::default::Default;
+
+pub fn opts() -> TargetOptions {
+    let mut pre_link_args = LinkArgs::new();
+    pre_link_args.insert(LinkerFlavor::Lld(LldFlavor::Ld), vec![
+        "--build-id".to_string(),
+        "--hash-style=gnu".to_string(),
+        "--Bstatic".to_string(),
+    ]);
+
+    TargetOptions {
+        linker: Some("rust-lld".to_owned()),
+        executables: true,
+        has_elf_tls: true,
+        linker_is_gnu: true,
+        pre_link_args,
+        no_default_libraries: true,
+        panic_strategy: PanicStrategy::Abort,
+        position_independent_executables: true,
+        relocation_model: "static".to_string(),
+        target_family: None,
+        tls_model: "initial-exec".to_string(),
+        .. Default::default()
+    }
+}

--- a/src/librustc_target/spec/hermit_kernel_base.rs
+++ b/src/librustc_target/spec/hermit_kernel_base.rs
@@ -10,6 +10,7 @@ pub fn opts() -> TargetOptions {
     ]);
 
     TargetOptions {
+        disable_redzone: true,
         linker: Some("rust-lld".to_owned()),
         executables: true,
         has_elf_tls: true,

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -487,6 +487,7 @@ supported_targets! {
     ("riscv32imac-unknown-none-elf", riscv32imac_unknown_none_elf),
     ("riscv64imac-unknown-none-elf", riscv64imac_unknown_none_elf),
     ("riscv64gc-unknown-none-elf", riscv64gc_unknown_none_elf),
+    ("riscv64gc-unknown-linux-gnu", riscv64gc_unknown_linux_gnu),
 
     ("aarch64-unknown-none", aarch64_unknown_none),
     ("aarch64-unknown-none-softfloat", aarch64_unknown_none_softfloat),

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -54,6 +54,7 @@ mod dragonfly_base;
 mod freebsd_base;
 mod haiku_base;
 mod hermit_base;
+mod hermit_kernel_base;
 mod linux_base;
 mod linux_kernel_base;
 mod linux_musl_base;
@@ -481,6 +482,7 @@ supported_targets! {
 
     ("aarch64-unknown-hermit", aarch64_unknown_hermit),
     ("x86_64-unknown-hermit", x86_64_unknown_hermit),
+    ("x86_64-unknown-hermit-kernel", x86_64_unknown_hermit_kernel),
 
     ("riscv32i-unknown-none-elf", riscv32i_unknown_none_elf),
     ("riscv32imc-unknown-none-elf", riscv32imc_unknown_none_elf),

--- a/src/librustc_target/spec/riscv64gc_unknown_linux_gnu.rs
+++ b/src/librustc_target/spec/riscv64gc_unknown_linux_gnu.rs
@@ -1,0 +1,25 @@
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+
+pub fn target() -> TargetResult {
+    Ok(Target {
+        llvm_target: "riscv64-unknown-linux-gnu".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "64".to_string(),
+        target_c_int_width: "32".to_string(),
+        target_env: "gnu".to_string(),
+        data_layout: "e-m:e-p:64:64-i64:64-i128:128-n64-S128".to_string(),
+        arch: "riscv64".to_string(),
+        target_os: "linux".to_string(),
+        target_vendor: "unknown".to_string(),
+        linker_flavor: LinkerFlavor::Gcc,
+        options: TargetOptions {
+            abi_blacklist: super::riscv_base::abi_blacklist(),
+            code_model: Some("medium".to_string()),
+            cpu: "generic-rv64".to_string(),
+            features: "+m,+a,+f,+d,+c".to_string(),
+            llvm_abiname: "lp64d".to_string(),
+            max_atomic_width: Some(64),
+            ..super::linux_base::opts()
+        },
+    })
+}

--- a/src/librustc_target/spec/x86_64_unknown_hermit_kernel.rs
+++ b/src/librustc_target/spec/x86_64_unknown_hermit_kernel.rs
@@ -1,0 +1,23 @@
+use crate::spec::{LldFlavor, LinkerFlavor, Target, TargetResult};
+
+pub fn target() -> TargetResult {
+    let mut base = super::hermit_kernel_base::opts();
+    base.cpu = "x86-64".to_string();
+    base.max_atomic_width = Some(64);
+    base.features = "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2,+soft-float".to_string();
+    base.stack_probes = true;
+
+    Ok(Target {
+        llvm_target: "x86_64-unknown-hermit".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "64".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "e-m:e-i64:64-f80:128-n8:16:32:64-S128".to_string(),
+        arch: "x86_64".to_string(),
+        target_os: "hermit".to_string(),
+        target_env: String::new(),
+        target_vendor: "unknown".to_string(),
+        linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
+        options: base,
+    })
+}

--- a/src/librustc_target/spec/x86_64_unknown_hermit_kernel.rs
+++ b/src/librustc_target/spec/x86_64_unknown_hermit_kernel.rs
@@ -4,7 +4,9 @@ pub fn target() -> TargetResult {
     let mut base = super::hermit_kernel_base::opts();
     base.cpu = "x86-64".to_string();
     base.max_atomic_width = Some(64);
-    base.features = "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2,+soft-float".to_string();
+    base.features =
+        "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2,+soft-float"
+        .to_string();
     base.stack_probes = true;
 
     Ok(Target {

--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -344,7 +344,7 @@ pub fn look_for_tests<'tcx>(
             lint::builtin::MISSING_DOC_CODE_EXAMPLES,
             hir_id,
             sp,
-            "Missing code example in this documentation");
+            "missing code example in this documentation");
         diag.emit();
     } else if check_missing_code == false &&
               tests.found_tests > 0 &&
@@ -353,7 +353,7 @@ pub fn look_for_tests<'tcx>(
             lint::builtin::PRIVATE_DOC_TESTS,
             hir_id,
             span_of_attrs(&item.attrs).unwrap_or(item.source.span()),
-            "Documentation test in private item");
+            "documentation test in private item");
         diag.emit();
     }
 }
@@ -367,7 +367,7 @@ crate fn span_of_attrs(attrs: &clean::Attributes) -> Option<Span> {
     if start == DUMMY_SP {
         return None;
     }
-    let end = attrs.doc_strings.last().expect("No doc strings provided").span();
+    let end = attrs.doc_strings.last().expect("no doc strings provided").span();
     Some(start.to(end))
 }
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1693,6 +1693,18 @@ impl IntTy {
             IntTy::I128 => 128,
         })
     }
+
+    pub fn normalize(&self, target_width: u32) -> Self {
+        match self {
+            IntTy::Isize => match target_width {
+                16 => IntTy::I16,
+                32 => IntTy::I32,
+                64 => IntTy::I64,
+                _ => unreachable!(),
+            },
+            _ => *self,
+        }
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, HashStable_Generic,
@@ -1742,6 +1754,18 @@ impl UintTy {
             UintTy::U64 => 64,
             UintTy::U128 => 128,
         })
+    }
+
+    pub fn normalize(&self, target_width: u32) -> Self {
+        match self {
+            UintTy::Usize => match target_width {
+                16 => UintTy::U16,
+                32 => UintTy::U32,
+                64 => UintTy::U64,
+                _ => unreachable!(),
+            },
+            _ => *self,
+        }
     }
 }
 

--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -688,10 +688,9 @@ pub fn get_features(span_handler: &Handler, krate_attrs: &[ast::Attribute],
                     crate_edition: Edition, allow_features: &Option<Vec<String>>) -> Features {
     fn feature_removed(span_handler: &Handler, span: Span, reason: Option<&str>) {
         let mut err = struct_span_err!(span_handler, span, E0557, "feature has been removed");
+        err.span_label(span, "feature has been removed");
         if let Some(reason) = reason {
-            err.span_note(span, reason);
-        } else {
-            err.span_label(span, "feature has been removed");
+            err.note(reason);
         }
         err.emit();
     }

--- a/src/libsyntax_expand/mbe/macro_check.rs
+++ b/src/libsyntax_expand/mbe/macro_check.rs
@@ -269,7 +269,8 @@ fn check_binders(
                 // for nested macro definitions.
                 sess.span_diagnostic
                     .struct_span_err(span, "duplicate matcher binding")
-                    .span_note(prev_info.span, "previous declaration was here")
+                    .span_label(span, "duplicate binding")
+                    .span_label(prev_info.span, "previous binding")
                     .emit();
                 *valid = false;
             } else {

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -172,7 +172,8 @@ fn parse_args<'a>(
             let e = p.parse_expr()?;
             if let Some(prev) = names.get(&name) {
                 ecx.struct_span_err(e.span, &format!("duplicate argument named `{}`", name))
-                    .span_note(args[*prev].span, "previously here")
+                    .span_label(args[*prev].span, "previously here")
+                    .span_label(e.span, "duplicate argument")
                     .emit();
                 continue;
             }

--- a/src/libsyntax_ext/proc_macro_harness.rs
+++ b/src/libsyntax_ext/proc_macro_harness.rs
@@ -270,7 +270,7 @@ impl<'a> Visitor<'a> for CollectProcMacros<'a> {
                     };
 
                     self.handler.struct_span_err(attr.span, &msg)
-                        .span_note(prev_attr.span, "previous attribute here")
+                        .span_label(prev_attr.span, "previous attribute here")
                         .emit();
 
                     return;

--- a/src/test/rustdoc-ui/doc-without-codeblock.rs
+++ b/src/test/rustdoc-ui/doc-without-codeblock.rs
@@ -1,13 +1,13 @@
-#![deny(missing_doc_code_examples)] //~ ERROR Missing code example in this documentation
+#![deny(missing_doc_code_examples)] //~ ERROR missing code example in this documentation
 
 /// Some docs.
-//~^ ERROR Missing code example in this documentation
+//~^ ERROR missing code example in this documentation
 pub struct Foo;
 
 /// And then, the princess died.
-//~^ ERROR Missing code example in this documentation
+//~^ ERROR missing code example in this documentation
 pub mod foo {
     /// Or maybe not because she saved herself!
-    //~^ ERROR Missing code example in this documentation
+    //~^ ERROR missing code example in this documentation
     pub fn bar() {}
 }

--- a/src/test/rustdoc-ui/doc-without-codeblock.stderr
+++ b/src/test/rustdoc-ui/doc-without-codeblock.stderr
@@ -1,4 +1,4 @@
-error: Missing code example in this documentation
+error: missing code example in this documentation
   --> $DIR/doc-without-codeblock.rs:1:1
    |
 LL | / #![deny(missing_doc_code_examples)]
@@ -16,19 +16,19 @@ note: lint level defined here
 LL | #![deny(missing_doc_code_examples)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Missing code example in this documentation
+error: missing code example in this documentation
   --> $DIR/doc-without-codeblock.rs:3:1
    |
 LL | /// Some docs.
    | ^^^^^^^^^^^^^^
 
-error: Missing code example in this documentation
+error: missing code example in this documentation
   --> $DIR/doc-without-codeblock.rs:7:1
    |
 LL | /// And then, the princess died.
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Missing code example in this documentation
+error: missing code example in this documentation
   --> $DIR/doc-without-codeblock.rs:10:5
    |
 LL |     /// Or maybe not because she saved herself!

--- a/src/test/rustdoc-ui/lint-group.rs
+++ b/src/test/rustdoc-ui/lint-group.rs
@@ -14,11 +14,11 @@
 pub fn link_error() {} //~^^^^^ ERROR cannot be resolved, ignoring it
 
 /// wait, this doesn't have a doctest?
-pub fn no_doctest() {} //~^ ERROR Missing code example in this documentation
+pub fn no_doctest() {} //~^ ERROR missing code example in this documentation
 
 /// wait, this *does* have a doctest?
 ///
 /// ```
 /// println!("sup");
 /// ```
-fn private_doctest() {} //~^^^^^ ERROR Documentation test in private item
+fn private_doctest() {} //~^^^^^ ERROR documentation test in private item

--- a/src/test/rustdoc-ui/lint-group.stderr
+++ b/src/test/rustdoc-ui/lint-group.stderr
@@ -1,4 +1,4 @@
-error: Documentation test in private item
+error: documentation test in private item
   --> $DIR/lint-group.rs:19:1
    |
 LL | / /// wait, this *does* have a doctest?
@@ -29,7 +29,7 @@ LL | #![deny(rustdoc)]
    = note: `#[deny(intra_doc_link_resolution_failure)]` implied by `#[deny(rustdoc)]`
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
 
-error: Missing code example in this documentation
+error: missing code example in this documentation
   --> $DIR/lint-group.rs:16:1
    |
 LL | /// wait, this doesn't have a doctest?

--- a/src/test/rustdoc-ui/lint-missing-doc-code-example.stderr
+++ b/src/test/rustdoc-ui/lint-missing-doc-code-example.stderr
@@ -1,4 +1,4 @@
-error: Missing code example in this documentation
+error: missing code example in this documentation
   --> $DIR/lint-missing-doc-code-example.rs:19:1
    |
 LL | / mod module1 {
@@ -11,7 +11,7 @@ note: lint level defined here
 LL | #![deny(missing_doc_code_examples)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Missing code example in this documentation
+error: missing code example in this documentation
   --> $DIR/lint-missing-doc-code-example.rs:37:3
    |
 LL |   /// doc

--- a/src/test/rustdoc-ui/private-item-doc-test.rs
+++ b/src/test/rustdoc-ui/private-item-doc-test.rs
@@ -6,6 +6,6 @@ mod foo {
     /// ```
     /// assert!(false);
     /// ```
-    //~^^^^^ ERROR Documentation test in private item
+    //~^^^^^ ERROR documentation test in private item
     fn bar() {}
 }

--- a/src/test/rustdoc-ui/private-item-doc-test.stderr
+++ b/src/test/rustdoc-ui/private-item-doc-test.stderr
@@ -1,4 +1,4 @@
-error: Documentation test in private item
+error: documentation test in private item
   --> $DIR/private-item-doc-test.rs:4:5
    |
 LL | /     /// private doc test

--- a/src/test/ui/allocator/two-allocators.stderr
+++ b/src/test/ui/allocator/two-allocators.stderr
@@ -1,14 +1,11 @@
 error: cannot define multiple global allocators
   --> $DIR/two-allocators.rs:6:1
    |
-LL | static B: System = System;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: the previous global allocator is defined here
-  --> $DIR/two-allocators.rs:4:1
-   |
 LL | static A: System = System;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | -------------------------- previous global allocator is defined here
+LL | #[global_allocator]
+LL | static B: System = System;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot define a new global allocator
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-move-error-with-note.stderr
+++ b/src/test/ui/borrowck/borrowck-move-error-with-note.stderr
@@ -10,15 +10,7 @@ LL |                   num2) => (),
 LL |         Foo::Foo2(num) => (),
    |                   --- ...and here
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/borrowck-move-error-with-note.rs:12:19
-   |
-LL |         Foo::Foo1(num1,
-   |                   ^^^^
-LL |                   num2) => (),
-   |                   ^^^^
-LL |         Foo::Foo2(num) => (),
-   |                   ^^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0509]: cannot move out of type `S`, which implements the `Drop` trait
   --> $DIR/borrowck-move-error-with-note.rs:28:11
@@ -31,13 +23,7 @@ LL |             f: _s,
 LL |             g: _t
    |                -- ...and here
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/borrowck-move-error-with-note.rs:31:16
-   |
-LL |             f: _s,
-   |                ^^
-LL |             g: _t
-   |                ^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0507]: cannot move out of `a.a` which is behind a shared reference
   --> $DIR/borrowck-move-error-with-note.rs:46:11

--- a/src/test/ui/borrowck/borrowck-move-out-of-vec-tail.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-of-vec-tail.stderr
@@ -9,13 +9,7 @@ LL |                 &[Foo { string: a },
 LL |                   Foo { string: b }] => {
    |                                 - ...and here
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/borrowck-move-out-of-vec-tail.rs:21:33
-   |
-LL |                 &[Foo { string: a },
-   |                                 ^
-LL |                   Foo { string: b }] => {
-   |                                 ^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 help: consider removing the `&`
    |
 LL |                 [Foo { string: a },

--- a/src/test/ui/borrowck/borrowck-vec-pattern-nesting.rs
+++ b/src/test/ui/borrowck/borrowck-vec-pattern-nesting.rs
@@ -75,12 +75,12 @@ fn e() {
     match vec {
         //~^ ERROR cannot move out
         //~| NOTE cannot move out
+        //~| NOTE move occurs because these variables have types
         &mut [_a, _b, _c] => {}
         //~^ NOTE data moved here
         //~| NOTE and here
         //~| NOTE and here
         //~| HELP consider removing the `&mut`
-        //~| NOTE move occurs because these variables have types
         _ => {}
     }
     let a = vec[0]; //~ ERROR cannot move out

--- a/src/test/ui/borrowck/borrowck-vec-pattern-nesting.stderr
+++ b/src/test/ui/borrowck/borrowck-vec-pattern-nesting.stderr
@@ -97,11 +97,7 @@ LL |         &mut [_a, _b, _c] => {}
    |         |     data moved here
    |         help: consider removing the `&mut`: `[_a, _b, _c]`
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/borrowck-vec-pattern-nesting.rs:78:15
-   |
-LL |         &mut [_a, _b, _c] => {}
-   |               ^^  ^^  ^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0508]: cannot move out of type `[std::boxed::Box<isize>]`, a non-copy slice
   --> $DIR/borrowck-vec-pattern-nesting.rs:86:13

--- a/src/test/ui/consts/control-flow/exhaustive-c-like-enum-match.rs
+++ b/src/test/ui/consts/control-flow/exhaustive-c-like-enum-match.rs
@@ -1,0 +1,27 @@
+// Test for <https://github.com/rust-lang/rust/issues/66756>
+
+// check-pass
+
+#![feature(const_if_match)]
+
+enum E {
+    A,
+    B,
+    C
+}
+
+const fn f(e: E) {
+    match e {
+        E::A => {}
+        E::B => {}
+        E::C => {}
+    }
+}
+
+const fn g(e: E) {
+    match e {
+        _ => {}
+    }
+}
+
+fn main() {}

--- a/src/test/ui/consts/control-flow/exhaustive-c-like-enum-match.rs
+++ b/src/test/ui/consts/control-flow/exhaustive-c-like-enum-match.rs
@@ -18,10 +18,4 @@ const fn f(e: E) {
     }
 }
 
-const fn g(e: E) {
-    match e {
-        _ => {}
-    }
-}
-
 fn main() {}

--- a/src/test/ui/consts/control-flow/single-arm-match-wild.rs
+++ b/src/test/ui/consts/control-flow/single-arm-match-wild.rs
@@ -1,0 +1,19 @@
+// check-pass
+
+#![feature(const_if_match)]
+
+enum E {
+    A,
+    B,
+    C
+}
+
+const fn f(e: E) -> usize {
+    match e {
+        _ => 0
+    }
+}
+
+fn main() {
+    assert_eq!(f(E::A), 0);
+}

--- a/src/test/ui/consts/control-flow/single-arm-match-wild.rs
+++ b/src/test/ui/consts/control-flow/single-arm-match-wild.rs
@@ -15,5 +15,7 @@ const fn f(e: E) -> usize {
 }
 
 fn main() {
+    const X: usize = f(E::C);
+    assert_eq!(X, 0);
     assert_eq!(f(E::A), 0);
 }

--- a/src/test/ui/if/ifmt-bad-arg.stderr
+++ b/src/test/ui/if/ifmt-bad-arg.stderr
@@ -138,13 +138,9 @@ error: duplicate argument named `foo`
   --> $DIR/ifmt-bad-arg.rs:40:33
    |
 LL |     format!("{foo}", foo=1, foo=2);
-   |                                 ^
-   |
-note: previously here
-  --> $DIR/ifmt-bad-arg.rs:40:26
-   |
-LL |     format!("{foo}", foo=1, foo=2);
-   |                          ^
+   |                          -      ^ duplicate argument
+   |                          |
+   |                          previously here
 
 error: positional arguments cannot follow named arguments
   --> $DIR/ifmt-bad-arg.rs:41:35

--- a/src/test/ui/issues/issue-12567.stderr
+++ b/src/test/ui/issues/issue-12567.stderr
@@ -10,14 +10,7 @@ LL |             => println!("one empty"),
 LL |         (&[hd1, ..], &[hd2, ..])
    |                        --- ...and here
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/issue-12567.rs:8:17
-   |
-LL |         (&[], &[hd, ..]) | (&[hd, ..], &[])
-   |                 ^^
-LL |             => println!("one empty"),
-LL |         (&[hd1, ..], &[hd2, ..])
-   |                        ^^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0508]: cannot move out of type `[T]`, a non-copy slice
   --> $DIR/issue-12567.rs:4:11
@@ -31,14 +24,7 @@ LL |             => println!("one empty"),
 LL |         (&[hd1, ..], &[hd2, ..])
    |            --- ...and here
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/issue-12567.rs:8:17
-   |
-LL |         (&[], &[hd, ..]) | (&[hd, ..], &[])
-   |                 ^^
-LL |             => println!("one empty"),
-LL |         (&[hd1, ..], &[hd2, ..])
-   |            ^^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-40402-ref-hints/issue-40402-2.stderr
+++ b/src/test/ui/issues/issue-40402-ref-hints/issue-40402-2.stderr
@@ -7,11 +7,7 @@ LL |     let (a, b) = x[0];
    |          |  ...and here
    |          data moved here
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/issue-40402-2.rs:5:10
-   |
-LL |     let (a, b) = x[0];
-   |          ^  ^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/label/label_break_value_continue.stderr
+++ b/src/test/ui/label/label_break_value_continue.stderr
@@ -7,16 +7,11 @@ LL |         continue;
 error[E0696]: `continue` pointing to a labeled block
   --> $DIR/label_break_value_continue.rs:14:9
    |
-LL |         continue 'b;
-   |         ^^^^^^^^^^^ labeled blocks cannot be `continue`'d
-   |
-note: labeled block the continue points to
-  --> $DIR/label_break_value_continue.rs:13:5
-   |
 LL | /     'b: {
 LL | |         continue 'b;
+   | |         ^^^^^^^^^^^ labeled blocks cannot be `continue`'d
 LL | |     }
-   | |_____^
+   | |_____- labeled block the `continue` points to
 
 error[E0695]: unlabeled `continue` inside of a labeled block
   --> $DIR/label_break_value_continue.rs:22:13

--- a/src/test/ui/macros/macro-multiple-matcher-bindings.stderr
+++ b/src/test/ui/macros/macro-multiple-matcher-bindings.stderr
@@ -2,49 +2,33 @@ error: duplicate matcher binding
   --> $DIR/macro-multiple-matcher-bindings.rs:7:16
    |
 LL |     ($a:ident, $a:ident) => {};
-   |                ^^^^^^^^
-   |
-note: previous declaration was here
-  --> $DIR/macro-multiple-matcher-bindings.rs:7:6
-   |
-LL |     ($a:ident, $a:ident) => {};
-   |      ^^^^^^^^
+   |      --------  ^^^^^^^^ duplicate binding
+   |      |
+   |      previous binding
 
 error: duplicate matcher binding
   --> $DIR/macro-multiple-matcher-bindings.rs:8:16
    |
 LL |     ($a:ident, $a:path) => {};
-   |                ^^^^^^^
-   |
-note: previous declaration was here
-  --> $DIR/macro-multiple-matcher-bindings.rs:8:6
-   |
-LL |     ($a:ident, $a:path) => {};
-   |      ^^^^^^^^
+   |      --------  ^^^^^^^ duplicate binding
+   |      |
+   |      previous binding
 
 error: duplicate matcher binding
   --> $DIR/macro-multiple-matcher-bindings.rs:17:18
    |
 LL |     ($a:ident, $($a:ident),*) => {};
-   |                  ^^^^^^^^
-   |
-note: previous declaration was here
-  --> $DIR/macro-multiple-matcher-bindings.rs:17:6
-   |
-LL |     ($a:ident, $($a:ident),*) => {};
-   |      ^^^^^^^^
+   |      --------    ^^^^^^^^ duplicate binding
+   |      |
+   |      previous binding
 
 error: duplicate matcher binding
   --> $DIR/macro-multiple-matcher-bindings.rs:18:25
    |
 LL |     ($($a:ident)+ # $($($a:path),+);*) => {};
-   |                         ^^^^^^^
-   |
-note: previous declaration was here
-  --> $DIR/macro-multiple-matcher-bindings.rs:18:8
-   |
-LL |     ($($a:ident)+ # $($($a:path),+);*) => {};
-   |        ^^^^^^^^
+   |        --------         ^^^^^^^ duplicate binding
+   |        |
+   |        previous binding
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/macros/macro-reexport-removed.stderr
+++ b/src/test/ui/macros/macro-reexport-removed.stderr
@@ -2,13 +2,9 @@ error[E0557]: feature has been removed
   --> $DIR/macro-reexport-removed.rs:3:12
    |
 LL | #![feature(macro_reexport)]
-   |            ^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^^^^^ feature has been removed
    |
-note: subsumed by `pub use`
-  --> $DIR/macro-reexport-removed.rs:3:12
-   |
-LL | #![feature(macro_reexport)]
-   |            ^^^^^^^^^^^^^^
+   = note: subsumed by `pub use`
 
 error: cannot find attribute `macro_reexport` in this scope
   --> $DIR/macro-reexport-removed.rs:5:3

--- a/src/test/ui/nll/move-errors.stderr
+++ b/src/test/ui/nll/move-errors.stderr
@@ -83,13 +83,7 @@ LL |         B::U(d) => (),
 LL |         B::V(s) => (),
    |              - ...and here
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/move-errors.rs:76:14
-   |
-LL |         B::U(d) => (),
-   |              ^
-LL |         B::V(s) => (),
-   |              ^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0509]: cannot move out of type `D`, which implements the `Drop` trait
   --> $DIR/move-errors.rs:83:11
@@ -138,11 +132,7 @@ LL |         F(s, mut t) => (),
    |           |
    |           data moved here
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/move-errors.rs:104:11
-   |
-LL |         F(s, mut t) => (),
-   |           ^  ^^^^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0507]: cannot move out of `x.0` which is behind a shared reference
   --> $DIR/move-errors.rs:110:11

--- a/src/test/ui/suggestions/dont-suggest-ref/duplicate-suggestions.stderr
+++ b/src/test/ui/suggestions/dont-suggest-ref/duplicate-suggestions.stderr
@@ -8,11 +8,7 @@ LL |     let &(X(_t), X(_u)) = &(x.clone(), x.clone());
    |         |   data moved here
    |         help: consider removing the `&`: `(X(_t), X(_u))`
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/duplicate-suggestions.rs:39:13
-   |
-LL |     let &(X(_t), X(_u)) = &(x.clone(), x.clone());
-   |             ^^     ^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/duplicate-suggestions.rs:43:50
@@ -24,11 +20,7 @@ LL |     if let &(Either::One(_t), Either::Two(_u)) = &(e.clone(), e.clone()) { 
    |            |             data moved here
    |            help: consider removing the `&`: `(Either::One(_t), Either::Two(_u))`
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/duplicate-suggestions.rs:43:26
-   |
-LL |     if let &(Either::One(_t), Either::Two(_u)) = &(e.clone(), e.clone()) { }
-   |                          ^^               ^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/duplicate-suggestions.rs:47:53
@@ -40,11 +32,7 @@ LL |     while let &(Either::One(_t), Either::Two(_u)) = &(e.clone(), e.clone())
    |               |             data moved here
    |               help: consider removing the `&`: `(Either::One(_t), Either::Two(_u))`
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/duplicate-suggestions.rs:47:29
-   |
-LL |     while let &(Either::One(_t), Either::Two(_u)) = &(e.clone(), e.clone()) { }
-   |                             ^^               ^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/duplicate-suggestions.rs:51:11
@@ -60,14 +48,7 @@ LL |         &(Either::One(_t), Either::Two(_u)) => (),
 LL |         &(Either::Two(_t), Either::One(_u)) => (),
    |                       -- ...and here   -- ...and here
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/duplicate-suggestions.rs:53:23
-   |
-LL |         &(Either::One(_t), Either::Two(_u)) => (),
-   |                       ^^               ^^
-...
-LL |         &(Either::Two(_t), Either::One(_u)) => (),
-   |                       ^^               ^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 help: consider removing the `&`
    |
 LL |         (Either::One(_t), Either::Two(_u)) => (),
@@ -90,11 +71,7 @@ LL |         &(Either::One(_t), Either::Two(_u))
    |         |             data moved here
    |         help: consider removing the `&`: `(Either::One(_t), Either::Two(_u))`
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/duplicate-suggestions.rs:63:23
-   |
-LL |         &(Either::One(_t), Either::Two(_u))
-   |                       ^^               ^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/duplicate-suggestions.rs:70:11
@@ -109,11 +86,7 @@ LL |         &(Either::One(_t), Either::Two(_u)) => (),
    |         |             data moved here
    |         help: consider removing the `&`: `(Either::One(_t), Either::Two(_u))`
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/duplicate-suggestions.rs:72:23
-   |
-LL |         &(Either::One(_t), Either::Two(_u)) => (),
-   |                       ^^               ^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/duplicate-suggestions.rs:78:11
@@ -128,11 +101,7 @@ LL |         &(Either::One(_t), Either::Two(_u)) => (),
    |         |             data moved here
    |         help: consider removing the `&`: `(Either::One(_t), Either::Two(_u))`
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/duplicate-suggestions.rs:80:23
-   |
-LL |         &(Either::One(_t), Either::Two(_u)) => (),
-   |                       ^^               ^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0507]: cannot move out of a mutable reference
   --> $DIR/duplicate-suggestions.rs:91:31
@@ -144,11 +113,7 @@ LL |     let &mut (X(_t), X(_u)) = &mut (xm.clone(), xm.clone());
    |         |       data moved here
    |         help: consider removing the `&mut`: `(X(_t), X(_u))`
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/duplicate-suggestions.rs:91:17
-   |
-LL |     let &mut (X(_t), X(_u)) = &mut (xm.clone(), xm.clone());
-   |                 ^^     ^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0507]: cannot move out of a mutable reference
   --> $DIR/duplicate-suggestions.rs:95:54
@@ -160,11 +125,7 @@ LL |     if let &mut (Either::One(_t), Either::Two(_u)) = &mut (em.clone(), em.c
    |            |                 data moved here
    |            help: consider removing the `&mut`: `(Either::One(_t), Either::Two(_u))`
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/duplicate-suggestions.rs:95:30
-   |
-LL |     if let &mut (Either::One(_t), Either::Two(_u)) = &mut (em.clone(), em.clone()) { }
-   |                              ^^               ^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0507]: cannot move out of a mutable reference
   --> $DIR/duplicate-suggestions.rs:99:57
@@ -176,11 +137,7 @@ LL |     while let &mut (Either::One(_t), Either::Two(_u)) = &mut (em.clone(), e
    |               |                 data moved here
    |               help: consider removing the `&mut`: `(Either::One(_t), Either::Two(_u))`
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/duplicate-suggestions.rs:99:33
-   |
-LL |     while let &mut (Either::One(_t), Either::Two(_u)) = &mut (em.clone(), em.clone()) { }
-   |                                 ^^               ^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0507]: cannot move out of a mutable reference
   --> $DIR/duplicate-suggestions.rs:103:11
@@ -196,14 +153,7 @@ LL |         &mut (Either::One(_t), Either::Two(_u)) => (),
 LL |         &mut (Either::Two(_t), Either::One(_u)) => (),
    |                           -- ...and here   -- ...and here
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/duplicate-suggestions.rs:105:27
-   |
-LL |         &mut (Either::One(_t), Either::Two(_u)) => (),
-   |                           ^^               ^^
-...
-LL |         &mut (Either::Two(_t), Either::One(_u)) => (),
-   |                           ^^               ^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 help: consider removing the `&mut`
    |
 LL |         (Either::One(_t), Either::Two(_u)) => (),
@@ -226,11 +176,7 @@ LL |         &mut (Either::One(_t), Either::Two(_u))
    |         |                 data moved here
    |         help: consider removing the `&mut`: `(Either::One(_t), Either::Two(_u))`
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/duplicate-suggestions.rs:115:27
-   |
-LL |         &mut (Either::One(_t), Either::Two(_u))
-   |                           ^^               ^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0507]: cannot move out of a mutable reference
   --> $DIR/duplicate-suggestions.rs:122:11
@@ -245,11 +191,7 @@ LL |         &mut (Either::One(_t), Either::Two(_u)) => (),
    |         |                 data moved here
    |         help: consider removing the `&mut`: `(Either::One(_t), Either::Two(_u))`
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/duplicate-suggestions.rs:124:27
-   |
-LL |         &mut (Either::One(_t), Either::Two(_u)) => (),
-   |                           ^^               ^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0507]: cannot move out of a mutable reference
   --> $DIR/duplicate-suggestions.rs:130:11
@@ -264,11 +206,7 @@ LL |         &mut (Either::One(_t), Either::Two(_u)) => (),
    |         |                 data moved here
    |         help: consider removing the `&mut`: `(Either::One(_t), Either::Two(_u))`
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/duplicate-suggestions.rs:132:27
-   |
-LL |         &mut (Either::One(_t), Either::Two(_u)) => (),
-   |                           ^^               ^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0507]: cannot move out of a mutable reference
   --> $DIR/duplicate-suggestions.rs:138:11
@@ -283,11 +221,7 @@ LL |         &mut (Either::One(_t), Either::Two(_u)) => (),
    |         |                 data moved here
    |         help: consider removing the `&mut`: `(Either::One(_t), Either::Two(_u))`
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/duplicate-suggestions.rs:140:27
-   |
-LL |         &mut (Either::One(_t), Either::Two(_u)) => (),
-   |                           ^^               ^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/duplicate-suggestions.rs:86:11
@@ -299,11 +233,7 @@ LL |     fn f5(&(X(_t), X(_u)): &(X, X)) { }
    |           |   data moved here
    |           help: consider removing the `&`: `(X(_t), X(_u))`
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/duplicate-suggestions.rs:86:15
-   |
-LL |     fn f5(&(X(_t), X(_u)): &(X, X)) { }
-   |               ^^     ^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0507]: cannot move out of a mutable reference
   --> $DIR/duplicate-suggestions.rs:146:11
@@ -315,11 +245,7 @@ LL |     fn f6(&mut (X(_t), X(_u)): &mut (X, X)) { }
    |           |       data moved here
    |           help: consider removing the `&mut`: `(X(_t), X(_u))`
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/duplicate-suggestions.rs:146:19
-   |
-LL |     fn f6(&mut (X(_t), X(_u)): &mut (X, X)) { }
-   |                   ^^     ^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error: aborting due to 17 previous errors
 

--- a/src/test/ui/suggestions/dont-suggest-ref/simple.stderr
+++ b/src/test/ui/suggestions/dont-suggest-ref/simple.stderr
@@ -337,14 +337,7 @@ LL |         &mut Either::One(_t) => (),
 LL |         &mut Either::Two(_t) => (),
    |                          -- ...and here
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/simple.rs:221:26
-   |
-LL |         &mut Either::One(_t) => (),
-   |                          ^^
-...
-LL |         &mut Either::Two(_t) => (),
-   |                          ^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 help: consider removing the `&mut`
    |
 LL |         Either::One(_t) => (),
@@ -470,13 +463,7 @@ LL |         (&mut Either::One(_t),) => (),
 LL |         (&mut Either::Two(_t),) => (),
    |                           -- ...and here
    |
-note: move occurs because these variables have types that don't implement the `Copy` trait
-  --> $DIR/simple.rs:280:27
-   |
-LL |         (&mut Either::One(_t),) => (),
-   |                           ^^
-LL |         (&mut Either::Two(_t),) => (),
-   |                           ^^
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/simple.rs:288:18

--- a/src/test/ui/type/type-mismatch-same-crate-name.rs
+++ b/src/test/ui/type/type-mismatch-same-crate-name.rs
@@ -15,11 +15,11 @@ fn main() {
         extern crate crate_a1 as a;
         a::try_foo(foo2);
         //~^ ERROR mismatched types
-        //~| Perhaps two different versions of crate `crate_a1`
+        //~| perhaps two different versions of crate `crate_a1`
         //~| expected struct `main::a::Foo`
         a::try_bar(bar2);
         //~^ ERROR mismatched types
-        //~| Perhaps two different versions of crate `crate_a1`
+        //~| perhaps two different versions of crate `crate_a1`
         //~| expected trait `main::a::Bar`
         //~| expected struct `std::boxed::Box<(dyn main::a::Bar + 'static)>`
         //~| found struct `std::boxed::Box<dyn main::a::Bar>`

--- a/src/test/ui/type/type-mismatch-same-crate-name.stderr
+++ b/src/test/ui/type/type-mismatch-same-crate-name.stderr
@@ -4,11 +4,7 @@ error[E0308]: mismatched types
 LL |         a::try_foo(foo2);
    |                    ^^^^ expected struct `main::a::Foo`, found a different struct `main::a::Foo`
    |
-note: Perhaps two different versions of crate `crate_a1` are being used?
-  --> $DIR/type-mismatch-same-crate-name.rs:16:20
-   |
-LL |         a::try_foo(foo2);
-   |                    ^^^^
+   = note: perhaps two different versions of crate `crate_a1` are being used?
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch-same-crate-name.rs:20:20
@@ -18,11 +14,7 @@ LL |         a::try_bar(bar2);
    |
    = note: expected struct `std::boxed::Box<(dyn main::a::Bar + 'static)>`
               found struct `std::boxed::Box<dyn main::a::Bar>`
-note: Perhaps two different versions of crate `crate_a1` are being used?
-  --> $DIR/type-mismatch-same-crate-name.rs:20:20
-   |
-LL |         a::try_bar(bar2);
-   |                    ^^^^
+   = note: perhaps two different versions of crate `crate_a1` are being used?
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #66128 (alloc: Add new_zeroed() versions like new_uninit().)
 - #66661 (Add riscv64gc-unknown-linux-gnu target)
 - #66663 (Miri: print leak report even without tracing)
 - #66711 (Add hardware floating point features to aarch64-pc-windows-msvc)
 - #66713 (introduce a target to build the kernel of the unikernel HermitCore)
 - #66717 (tidy: Accommodate rustfmt's preferred layout of stability attributes)
 - #66719 (Store pointer width as u32 on Config)
 - #66720 (Move ErrorReported to rustc_errors)
 - #66737 (Error codes cleanup)
 - #66754 (Various tweaks to diagnostic output)
 - #66763 (Minor edit for documentation-tests.md that increases clarity)
 - #66779 (follow the same function order in the trait)
 - #66786 (Add wildcard test for const_if_match)
 - #66788 (Allow `Unreachable` terminators through `min_const_fn` checks)

Failed merges:


r? @ghost