### PR TITLE
Fix spelling typos

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -113,7 +113,7 @@ impl Step for Std {
     }
 }
 
-/// Copies third pary objects needed by various targets.
+/// Copies third party objects needed by various targets.
 fn copy_third_party_objects(builder: &Builder<'_>, compiler: &Compiler, target: Interned<String>)
     -> Vec<PathBuf>
 {

--- a/src/liballoc/collections/btree/node.rs
+++ b/src/liballoc/collections/btree/node.rs
@@ -596,7 +596,7 @@ impl<'a, K: 'a, V: 'a, Type> NodeRef<marker::Immut<'a>, K, V, Type> {
             // (We might be one-past-the-end, but that is allowed by LLVM.)
             // Getting the pointer is tricky though.  `NodeHeader` does not have a `keys`
             // field because we want its size to not depend on the alignment of `K`
-            // (needed becuase `as_header` should be safe).  We cannot call `as_leaf`
+            // (needed because `as_header` should be safe).  We cannot call `as_leaf`
             // because we might be the shared root.
             // For this reason, `NodeHeader` has this `K2` parameter (that's usually `()`
             // and hence just adds a size-0-align-1 field, not affecting layout).

--- a/src/liballoc/tests/vec.rs
+++ b/src/liballoc/tests/vec.rs
@@ -985,7 +985,7 @@ fn drain_filter_consumed_panic() {
         };
         let drain = data.drain_filter(filter);
 
-        // NOTE: The DrainFilter is explictly consumed
+        // NOTE: The DrainFilter is explicitly consumed
         drain.for_each(drop);
     });
 

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2837,7 +2837,7 @@ pub struct DrainFilter<'a, T, F>
     old_len: usize,
     /// The filter test predicate.
     pred: F,
-    /// A flag that indicates a panic has occured in the filter test prodicate.
+    /// A flag that indicates a panic has occurred in the filter test prodicate.
     /// This is used as a hint in the drop implmentation to prevent consumption
     /// of the remainder of the `DrainFilter`. Any unprocessed items will be
     /// backshifted in the `vec`, but no further items will be dropped or

--- a/src/libcore/hint.rs
+++ b/src/libcore/hint.rs
@@ -113,7 +113,7 @@ pub fn spin_loop() {
 pub fn black_box<T>(dummy: T) -> T {
     // We need to "use" the argument in some way LLVM can't introspect, and on
     // targets that support it we can typically leverage inline assembly to do
-    // this. LLVM's intepretation of inline assembly is that it's, well, a black
+    // this. LLVM's interpretation of inline assembly is that it's, well, a black
     // box. This isn't the greatest implementation since it probably deoptimizes
     // more than we want, but it's so far good enough.
     unsafe {

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1279,7 +1279,7 @@ extern "rust-intrinsic" {
     /// undefined behavior when `x + y > T::max_value()` or `x + y < T::min_value()`.
     pub fn unchecked_add<T>(x: T, y: T) -> T;
 
-    /// Returns the result of an unchecked substraction, resulting in
+    /// Returns the result of an unchecked subtraction, resulting in
     /// undefined behavior when `x - y > T::max_value()` or `x - y < T::min_value()`.
     pub fn unchecked_sub<T>(x: T, y: T) -> T;
 

--- a/src/libpanic_unwind/dwarf/eh.rs
+++ b/src/libpanic_unwind/dwarf/eh.rs
@@ -130,7 +130,7 @@ pub unsafe fn find_eh_action(lsda: *const u8, context: &EHContext<'_>, foreign_e
 fn interpret_cs_action(cs_action: u64, lpad: usize, foreign_exception: bool) -> EHAction {
     if cs_action == 0 {
         // If cs_action is 0 then this is a cleanup (Drop::drop). We run these
-        // for both Rust panics and foriegn exceptions.
+        // for both Rust panics and foreign exceptions.
         EHAction::Cleanup(lpad)
     } else if foreign_exception {
         // catch_unwind should not catch foreign exceptions, only Rust panics.

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -185,7 +185,7 @@ pub fn struct_error<'tcx>(tcx: TyCtxtAt<'tcx>, msg: &str) -> DiagnosticBuilder<'
 }
 
 /// Packages the kind of error we got from the const code interpreter
-/// up with a Rust-level backtrace of where the error occured.
+/// up with a Rust-level backtrace of where the error occurred.
 /// Thsese should always be constructed by calling `.into()` on
 /// a `InterpError`. In `librustc_mir::interpret`, we have `throw_err_*`
 /// macros for this.

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -450,7 +450,7 @@ impl<T: Decodable> rustc_serialize::UseSpecializedDecodable for ClearCrossCrate<
 /// Grouped information about the source code origin of a MIR entity.
 /// Intended to be inspected by diagnostics and debuginfo.
 /// Most passes can work with it as a whole, within a single function.
-// The unoffical Cranelift backend, at least as of #65828, needs `SourceInfo` to implement `Eq` and
+// The unofficial Cranelift backend, at least as of #65828, needs `SourceInfo` to implement `Eq` and
 // `Hash`. Please ping @bjorn3 if removing them.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, RustcEncodable, RustcDecodable, Hash, HashStable)]
 pub struct SourceInfo {

--- a/src/librustc/traits/auto_trait.rs
+++ b/src/librustc/traits/auto_trait.rs
@@ -461,7 +461,7 @@ impl AutoTraitFinder<'tcx> {
                                     // The old predicate has a region variable where the new
                                     // predicate has some other kind of region. An region
                                     // variable isn't something we can actually display to a user,
-                                    // so we choose ther new predicate (which doesn't have a region
+                                    // so we choose their new predicate (which doesn't have a region
                                     // varaible).
                                     //
                                     // In both cases, we want to remove the old predicate,
@@ -703,7 +703,7 @@ impl AutoTraitFinder<'tcx> {
                     // that we could add to our ParamEnv that would 'fix' this kind
                     // of error, as it's not caused by an unimplemented type.
                     //
-                    // 2. We succesfully project the predicate (Ok(Some(_))), generating
+                    // 2. We successfully project the predicate (Ok(Some(_))), generating
                     //  some subobligations. We then process these subobligations
                     //  like any other generated sub-obligations.
                     //
@@ -770,7 +770,7 @@ impl AutoTraitFinder<'tcx> {
                         Ok(None) => {
                             // It's ok not to make progress when hvave no inference variables -
                             // in that case, we were only performing unifcation to check if an
-                            // error occured (which would indicate that it's impossible for our
+                            // error occurred (which would indicate that it's impossible for our
                             // type to implement the auto trait).
                             // However, we should always make progress (either by generating
                             // subobligations or getting an error) when we started off with

--- a/src/librustc/ty/diagnostics.rs
+++ b/src/librustc/ty/diagnostics.rs
@@ -15,7 +15,7 @@ impl<'tcx> TyS<'tcx> {
         }
     }
 
-    /// Whether the type is succinctly representable as a type instead of just refered to with a
+    /// Whether the type is succinctly representable as a type instead of just referred to with a
     /// description in error messages. This is used in the main error message.
     pub fn is_simple_ty(&self) -> bool {
         match self.kind {
@@ -28,7 +28,7 @@ impl<'tcx> TyS<'tcx> {
         }
     }
 
-    /// Whether the type is succinctly representable as a type instead of just refered to with a
+    /// Whether the type is succinctly representable as a type instead of just referred to with a
     /// description in error messages. This is used in the primary span label. Beyond what
     /// `is_simple_ty` includes, it also accepts ADTs with no type arguments and references to
     /// ADTs with no type arguments.

--- a/src/librustc/ty/print/pretty.rs
+++ b/src/librustc/ty/print/pretty.rs
@@ -54,7 +54,7 @@ thread_local! {
 }
 
 /// Avoids running any queries during any prints that occur
-/// during the closure. This may alter the apperance of some
+/// during the closure. This may alter the appearance of some
 /// types (e.g. forcing verbose printing for opaque types).
 /// This method is used during some queries (e.g. `predicates_of`
 /// for opaque types), to ensure that any debug printing that

--- a/src/librustc_data_structures/stable_hasher.rs
+++ b/src/librustc_data_structures/stable_hasher.rs
@@ -149,7 +149,7 @@ impl Hasher for StableHasher {
 ///
 ///   That second condition is usually not required for hash functions
 ///   (e.g. `Hash`). In practice this means that `hash_stable` must feed any
-///   information into the hasher that a `PartialEq` comparision takes into
+///   information into the hasher that a `PartialEq` comparison takes into
 ///   account. See [#49300](https://github.com/rust-lang/rust/issues/49300)
 ///   for an example where violating this invariant has caused trouble in the
 ///   past.

--- a/src/librustc_error_codes/error_codes/E0307.md
+++ b/src/librustc_error_codes/error_codes/E0307.md
@@ -1,5 +1,5 @@
 This error indicates that the `self` parameter in a method has an invalid
-"reciever type".
+"receiver type".
 
 Methods take a special first parameter, of which there are three variants:
 `self`, `&self`, and `&mut self`. These are syntactic sugar for

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -937,7 +937,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             self.check_access_for_conflict(location, place_span, sd, rw, flow_state);
 
         if let (Activation(_, borrow_idx), true) = (kind.1, conflict_error) {
-            // Suppress this warning when there's an error being emited for the
+            // Suppress this warning when there's an error being emitted for the
             // same borrow: fixing the error is likely to fix the warning.
             self.reservation_warnings.remove(&borrow_idx);
         }

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -488,7 +488,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// Given that we are performing `test` against `test_place`, this job
     /// sorts out what the status of `candidate` will be after the test. See
     /// `test_candidates` for the usage of this function. The returned index is
-    /// the index that this candiate should be placed in the
+    /// the index that this candidate should be placed in the
     /// `target_candidates` vec. The candidate may be modified to update its
     /// `match_pairs`.
     ///

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -55,7 +55,7 @@ fn op_to_const<'tcx>(
     ecx: &CompileTimeEvalContext<'_, 'tcx>,
     op: OpTy<'tcx>,
 ) -> &'tcx ty::Const<'tcx> {
-    // We do not have value optmizations for everything.
+    // We do not have value optimizations for everything.
     // Only scalars and slices, since they are very common.
     // Note that further down we turn scalars of undefined bits back to `ByRef`. These can result
     // from scalar unions that are initialized with one of their zero sized variants. We could

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -95,7 +95,7 @@ pub trait Machine<'mir, 'tcx>: Sized {
     type PointerTag: ::std::fmt::Debug + Copy + Eq + Hash + 'static;
 
     /// Machines can define extra (non-instance) things that represent values of function pointers.
-    /// For example, Miri uses this to return a fucntion pointer from `dlsym`
+    /// For example, Miri uses this to return a function pointer from `dlsym`
     /// that can later be called to execute the right thing.
     type ExtraFnVal: ::std::fmt::Debug + Copy;
 

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -185,7 +185,7 @@ impl<'tcx> Visitor<'tcx> for Collector<'_, 'tcx> {
 
         // Ignore drops, if the temp gets promoted,
         // then it's constant and thus drop is noop.
-        // Non-uses are also irrelevent.
+        // Non-uses are also irrelevant.
         if context.is_drop() || !context.is_use() {
             debug!(
                 "visit_local: context.is_drop={:?} context.is_use={:?}",

--- a/src/librustc_parse/parser/diagnostics.rs
+++ b/src/librustc_parse/parser/diagnostics.rs
@@ -1515,11 +1515,11 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Replace duplicated recovered parameters with `_` pattern to avoid unecessary errors.
+    /// Replace duplicated recovered parameters with `_` pattern to avoid unnecessary errors.
     ///
     /// This is necessary because at this point we don't know whether we parsed a function with
     /// anonymous parameters or a function with names but no types. In order to minimize
-    /// unecessary errors, we assume the parameters are in the shape of `fn foo(a, b, c)` where
+    /// unnecessary errors, we assume the parameters are in the shape of `fn foo(a, b, c)` where
     /// the parameters are *names* (so we don't emit errors about not being able to find `b` in
     /// the local scope), but if we find the same name multiple times, like in `fn foo(i8, i8)`,
     /// we deduplicate them to not complain about duplicated parameter names.

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -2028,7 +2028,7 @@ impl<'a> Parser<'a> {
 
         let mut params: Vec<_> = params.into_iter().filter_map(|x| x).collect();
 
-        // Replace duplicated recovered params with `_` pattern to avoid unecessary errors.
+        // Replace duplicated recovered params with `_` pattern to avoid unnecessary errors.
         self.deduplicate_recovered_params_names(&mut params);
 
         if c_variadic && params.len() <= 1 {

--- a/src/librustc_target/spec/i686_unknown_uefi.rs
+++ b/src/librustc_target/spec/i686_unknown_uefi.rs
@@ -32,7 +32,7 @@ pub fn target() -> TargetResult {
     // Backgound and Problem:
     //   If we use i686-unknown-windows, the LLVM IA32 MSVC generates compiler intrinsic
     //   _alldiv, _aulldiv, _allrem, _aullrem, _allmul, which will cause undefined symbol.
-    //   A real issue is __aulldiv() is refered by __udivdi3() - udivmod_inner!(), from
+    //   A real issue is __aulldiv() is referred by __udivdi3() - udivmod_inner!(), from
     //   https://github.com/rust-lang-nursery/compiler-builtins.
     //   As result, rust-lld generates link error finally.
     // Root-cause:

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -434,7 +434,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             segment.ident.name,
                         ) {
                             // If this expression had a clone call when suggesting borrowing
-                            // we want to suggest removing it because it'd now be unecessary.
+                            // we want to suggest removing it because it'd now be unnecessary.
                             sugg_sp = arg.span;
                         }
                     }

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -550,7 +550,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
             // Here we want to prevent struct constructors from returning unsized types.
             // There were two cases this happened: fn pointer coercion in stable
-            // and usual function call in presense of unsized_locals.
+            // and usual function call in presence of unsized_locals.
             // Also, as we just want to check sizedness, instead of introducing
             // placeholder lifetimes with probing, we just replace higher lifetimes
             // with fresh vars.

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -916,7 +916,7 @@ fn receiver_is_valid<'fcx, 'tcx>(
             debug!("receiver_is_valid: type `{:?}` does not deref to `{:?}`",
                 receiver_ty, self_ty);
             // If he receiver already has errors reported due to it, consider it valid to avoid
-            // unecessary errors (#58712).
+            // unnecessary errors (#58712).
             return receiver_ty.references_error();
         }
 

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -206,7 +206,7 @@ pub trait Error: Debug + Display {
         TypeId::of::<Self>()
     }
 
-    /// Returns a stack backtrace, if available, of where this error ocurred.
+    /// Returns a stack backtrace, if available, of where this error occurred.
     ///
     /// This function allows inspecting the location, in code, of where an error
     /// happened. The returned `Backtrace` contains information about the stack

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -128,7 +128,7 @@ cfg_has_statx! {{
                 // It is a trick to call `statx` with NULL pointers to check if the syscall
                 // is available. According to the manual, it is expected to fail with EFAULT.
                 // We do this mainly for performance, since it is nearly hundreds times
-                // faster than a normal successfull call.
+                // faster than a normal successful call.
                 let err = cvt(statx(0, ptr::null(), 0, libc::STATX_ALL, ptr::null_mut()))
                     .err()
                     .and_then(|e| e.raw_os_error());
@@ -1223,7 +1223,7 @@ pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
             // The code below ensures that `FreeOnDrop` is never a null pointer
             unsafe {
                 // `copyfile_state_free` returns -1 if the `to` or `from` files
-                // cannot be closed. However, this is not considerd this an
+                // cannot be closed. However, this is not considered this an
                 // error.
                 copyfile_state_free(self.0);
             }

--- a/src/libstd/sys/wasm/fast_thread_local.rs
+++ b/src/libstd/sys/wasm/fast_thread_local.rs
@@ -3,7 +3,7 @@
 pub unsafe fn register_dtor(_t: *mut u8, _dtor: unsafe extern fn(*mut u8)) {
     // FIXME: right now there is no concept of "thread exit", but this is likely
     // going to show up at some point in the form of an exported symbol that the
-    // wasm runtime is oging to be expected to call. For now we basically just
+    // wasm runtime is going to be expected to call. For now we basically just
     // ignore the arguments, but if such a function starts to exist it will
     // likely look like the OSX implementation in `unix/fast_thread_local.rs`
 }

--- a/src/libsyntax_expand/mbe/macro_rules.rs
+++ b/src/libsyntax_expand/mbe/macro_rules.rs
@@ -190,7 +190,7 @@ fn generic_extension<'cx>(
 
         // Take a snapshot of the state of pre-expansion gating at this point.
         // This is used so that if a matcher is not `Success(..)`ful,
-        // then the spans which became gated when parsing the unsucessful matcher
+        // then the spans which became gated when parsing the unsuccessful matcher
         // are not recorded. On the first `Success(..)`ful matcher, the spans are merged.
         let mut gated_spans_snaphot = mem::take(&mut *cx.parse_sess.gated_spans.spans.borrow_mut());
 

--- a/src/test/rustdoc/issue-66159.rs
+++ b/src/test/rustdoc/issue-66159.rs
@@ -4,7 +4,7 @@
 
 // The issue was an ICE which meant that we never actually generated the docs
 // so if we have generated the docs, we're okay.
-// Since we don't generate the docs for the auxilliary files, we can't actually
+// Since we don't generate the docs for the auxiliary files, we can't actually
 // verify that the struct is linked correctly.
 
 // @has issue_66159/index.html

--- a/src/test/ui/layout/homogeneous-aggr-zero-sized-c-struct.rs
+++ b/src/test/ui/layout/homogeneous-aggr-zero-sized-c-struct.rs
@@ -2,7 +2,7 @@
 
 // Show that `homogeneous_aggregate` code ignores zero-length C
 // arrays.  This matches the recent C standard, though not the
-// behavior of all older compilers, which somtimes consider `T[0]` to
+// behavior of all older compilers, which sometimes consider `T[0]` to
 // be a "flexible array member" (see discussion on #56877 for
 // details).
 

--- a/src/test/ui/traits/trait-object-with-self-in-projection-output-repeated-supertrait.rs
+++ b/src/test/ui/traits/trait-object-with-self-in-projection-output-repeated-supertrait.rs
@@ -4,7 +4,7 @@
 #![crate_name = "trait_test"]
 
 // Regression test related to #56288. Check that a supertrait projection (of
-// `Output`) that references `Self` is ok if there is another occurence of
+// `Output`) that references `Self` is ok if there is another occurrence of
 // the same supertrait that specifies the projection explicitly, even if
 // the projection's associated type is not explicitly specified in the object type.
 //


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos.