### PR TITLE
Add explicit XP targets

### DIFF
--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -1109,7 +1109,8 @@ fn link_args<'a, B: ArchiveBuilder<'a>>(
 
     if crate_type == config::CrateType::Executable && sess.target.target.options.is_like_windows {
         if let Some(ref s) = codegen_results.windows_subsystem {
-            cmd.subsystem(s);
+            let version = s.version.as_ref().map(|v| &**v);
+            cmd.subsystem(&s.name, version);
         }
     }
 

--- a/src/librustc_codegen_ssa/back/linker.rs
+++ b/src/librustc_codegen_ssa/back/linker.rs
@@ -743,7 +743,7 @@ impl<'a> Linker for MsvcLinker<'a> {
         // correctly.
         //
         // For more information see RFC #1665
-        if subsystem.starts_with("windows") {
+        if subsystem == "windows" {
             self.cmd.arg("/ENTRY:mainCRTStartup");
         }
     }

--- a/src/librustc_codegen_ssa/back/linker.rs
+++ b/src/librustc_codegen_ssa/back/linker.rs
@@ -743,7 +743,7 @@ impl<'a> Linker for MsvcLinker<'a> {
         // correctly.
         //
         // For more information see RFC #1665
-        if subsystem == "windows" {
+        if subsystem.starts_with("windows") {
             self.cmd.arg("/ENTRY:mainCRTStartup");
         }
     }

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -347,7 +347,21 @@ pub fn start_async_codegen<B: ExtraBackendMethods>(
                 subsystem
             ));
         }
-        subsystem.to_string()
+        let t = &sess.target.target;
+        if t.target_vendor == "xp" {
+            // For Windows XP the subsystem version needs to be set appropriately.
+            let version = match t.arch.as_str() {
+                "x86" => "5.01",
+                "x86_64" => "5.02",
+                arch => tcx.sess.fatal(&format!("invalid Windows XP arch `{}`, only \
+                                     `x86` and `x86_64` are supported",
+                                    arch))
+            };
+            format!("{},{}", subsystem, version)
+        }
+        else {
+            subsystem.to_string()
+        }
     });
 
     let linker_info = LinkerInfo::new(tcx);

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -347,21 +347,7 @@ pub fn start_async_codegen<B: ExtraBackendMethods>(
                 subsystem
             ));
         }
-        let t = &sess.target.target;
-        if t.target_vendor == "xp" {
-            // For Windows XP the subsystem version needs to be set appropriately.
-            let version = match t.arch.as_str() {
-                "x86" => "5.01",
-                "x86_64" => "5.02",
-                arch => tcx.sess.fatal(&format!("invalid Windows XP arch `{}`, only \
-                                     `x86` and `x86_64` are supported",
-                                    arch))
-            };
-            format!("{},{}", subsystem, version)
-        }
-        else {
-            subsystem.to_string()
-        }
+        subsystem.to_string()
     });
 
     let linker_info = LinkerInfo::new(tcx);

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -5,7 +5,7 @@ use super::lto::{self, SerializedModule};
 use super::symbol_export::ExportedSymbols;
 use crate::{
     CachedModuleCodegen, CodegenResults, CompiledModule, CrateInfo, ModuleCodegen, ModuleKind,
-    RLIB_BYTECODE_EXTENSION, WindowsSubsystem
+    WindowsSubsystem, RLIB_BYTECODE_EXTENSION,
 };
 
 use crate::traits::*;
@@ -342,9 +342,11 @@ pub fn start_async_codegen<B: ExtraBackendMethods>(
     let windows_subsystem = {
         let name = subsystem.map(|subsystem| {
             if subsystem != sym::windows && subsystem != sym::console {
-                tcx.sess.fatal(&format!("invalid windows subsystem `{}`, only \
-                                         `windows` and `console` are allowed",
-                                        subsystem));
+                tcx.sess.fatal(&format!(
+                    "invalid windows subsystem `{}`, only \
+                    `windows` and `console` are allowed",
+                    subsystem
+                ));
             }
             subsystem.to_string()
         });
@@ -355,15 +357,15 @@ pub fn start_async_codegen<B: ExtraBackendMethods>(
             let version = match t.arch.as_str() {
                 "x86" => Some("5.01".to_string()),
                 "x86_64" => Some("5.02".to_string()),
-                arch => tcx.sess.fatal(&format!("invalid Windows XP arch `{}`, only \
-                                     `x86` and `x86_64` are supported",
-                                    arch))
+                arch => tcx.sess.fatal(&format!(
+                    "invalid Windows XP arch `{}`, only \
+                    `x86` and `x86_64` are supported",
+                    arch
+                )),
             };
             Some(WindowsSubsystem { name, version })
         } else {
-            name.and_then(|name| Some(WindowsSubsystem {
-                name, version: None
-            }))
+            name.and_then(|name| Some(WindowsSubsystem { name, version: None }))
         }
     };
 

--- a/src/librustc_codegen_ssa/lib.rs
+++ b/src/librustc_codegen_ssa/lib.rs
@@ -141,7 +141,7 @@ pub struct CrateInfo {
 #[derive(Debug)]
 pub struct WindowsSubsystem {
     pub name: String,
-    pub version: Option<String>
+    pub version: Option<String>,
 }
 
 pub struct CodegenResults {

--- a/src/librustc_codegen_ssa/lib.rs
+++ b/src/librustc_codegen_ssa/lib.rs
@@ -138,6 +138,12 @@ pub struct CrateInfo {
     pub dependency_formats: Lrc<Dependencies>,
 }
 
+#[derive(Debug)]
+pub struct WindowsSubsystem {
+    pub name: String,
+    pub version: Option<String>
+}
+
 pub struct CodegenResults {
     pub crate_name: Symbol,
     pub modules: Vec<CompiledModule>,
@@ -145,7 +151,7 @@ pub struct CodegenResults {
     pub metadata_module: Option<CompiledModule>,
     pub crate_hash: Svh,
     pub metadata: rustc::middle::cstore::EncodedMetadata,
-    pub windows_subsystem: Option<String>,
+    pub windows_subsystem: Option<WindowsSubsystem>,
     pub linker_info: back::linker::LinkerInfo,
     pub crate_info: CrateInfo,
 }

--- a/src/librustc_target/spec/i686_xp_windows_msvc.rs
+++ b/src/librustc_target/spec/i686_xp_windows_msvc.rs
@@ -7,8 +7,7 @@ pub fn target() -> TargetResult {
 
     // Mark all dynamic libraries and executables as compatible with the larger 4GiB address
     // space available to x86 Windows binaries on x86_64.
-    base.pre_link_args
-        .get_mut(&LinkerFlavor::Msvc).unwrap().push("/LARGEADDRESSAWARE".to_string());
+    base.pre_link_args.get_mut(&LinkerFlavor::Msvc).unwrap().push("/LARGEADDRESSAWARE".to_string());
 
     // Ensure the linker will only produce an image if it can also produce a table of
     // the image's safe exception handlers.

--- a/src/librustc_target/spec/i686_xp_windows_msvc.rs
+++ b/src/librustc_target/spec/i686_xp_windows_msvc.rs
@@ -1,0 +1,31 @@
+use crate::spec::{LinkerFlavor, Target, TargetResult};
+
+pub fn target() -> TargetResult {
+    let mut base = super::windows_msvc_base::opts();
+    base.cpu = "pentium4".to_string();
+    base.max_atomic_width = Some(64);
+
+    // Mark all dynamic libraries and executables as compatible with the larger 4GiB address
+    // space available to x86 Windows binaries on x86_64.
+    base.pre_link_args
+        .get_mut(&LinkerFlavor::Msvc).unwrap().push("/LARGEADDRESSAWARE".to_string());
+
+    // Ensure the linker will only produce an image if it can also produce a table of
+    // the image's safe exception handlers.
+    // https://msdn.microsoft.com/en-us/library/9a89h429.aspx
+    base.pre_link_args.get_mut(&LinkerFlavor::Msvc).unwrap().push("/SAFESEH".to_string());
+
+    Ok(Target {
+        llvm_target: "i686-pc-windows-msvc".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "e-m:x-p:32:32-i64:64-f80:32-n8:16:32-a:0:32-S32".to_string(),
+        arch: "x86".to_string(),
+        target_os: "windows".to_string(),
+        target_env: "msvc".to_string(),
+        target_vendor: "xp".to_string(),
+        linker_flavor: LinkerFlavor::Msvc,
+        options: base,
+    })
+}

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -454,8 +454,10 @@ supported_targets! {
     ("aarch64-uwp-windows-msvc", aarch64_uwp_windows_msvc),
     ("x86_64-pc-windows-msvc", x86_64_pc_windows_msvc),
     ("x86_64-uwp-windows-msvc", x86_64_uwp_windows_msvc),
+    ("x86_64-xp-windows-msvc", x86_64_xp_windows_msvc),
     ("i686-pc-windows-msvc", i686_pc_windows_msvc),
     ("i686-uwp-windows-msvc", i686_uwp_windows_msvc),
+    ("i686-xp-windows-msvc", i686_xp_windows_msvc),
     ("i586-pc-windows-msvc", i586_pc_windows_msvc),
     ("thumbv7a-pc-windows-msvc", thumbv7a_pc_windows_msvc),
 

--- a/src/librustc_target/spec/x86_64_xp_windows_msvc.rs
+++ b/src/librustc_target/spec/x86_64_xp_windows_msvc.rs
@@ -1,0 +1,22 @@
+use crate::spec::{LinkerFlavor, Target, TargetResult};
+
+pub fn target() -> TargetResult {
+    let mut base = super::windows_msvc_base::opts();
+    base.cpu = "x86-64".to_string();
+    base.max_atomic_width = Some(64);
+    base.has_elf_tls = true;
+
+    Ok(Target {
+        llvm_target: "x86_64-pc-windows-msvc".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "64".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "e-m:w-i64:64-f80:128-n8:16:32:64-S128".to_string(),
+        arch: "x86_64".to_string(),
+        target_os: "windows".to_string(),
+        target_env: "msvc".to_string(),
+        target_vendor: "xp".to_string(),
+        linker_flavor: LinkerFlavor::Msvc,
+        options: base,
+    })
+}


### PR DESCRIPTION
Windows XP support in Rust can generously be described as anaemic (if not outright [broken](https://github.com/rust-lang/rust/issues/34538)) and yet the fully supported Windows 7+ target is partially reliant on maintaining some compatibility with XP (e.g. the runtime compatibility layer in libstd). So this PR adds two target triples for XP, allowing 32-bit and 64-bit Windows XP to be targetted separately from Windows 7+. For now the targets are literally a copy/paste of the current i686-pc-windows-msvc and x86_64-pc-windows-msvc, though this could be improved if someone is willing to tackle XP support more thoroughly.

I think this is advantageous whatever [the future of XP in Rust](https://internals.rust-lang.org/t/consider-dropping-support-for-windows-xp/8745). If support is dropped completely then this could potentially provide a more graceful transition before removing it. However if anybody is willing to maintain an XP target then having an explicit triple can only help. And even if XP support remains, as it is now, in a kind of limbo then at least crates will be able to target XP separately from Windows 7+ (although unsurprisingly most crates ignore XP support entirely).

In any case allowing the pc-windows targets to be focused on Windows7+ support would be an advantage.