### PR TITLE
Format libstd/os with rustfmt

### DIFF
--- a/src/libstd/os/android/fs.rs
+++ b/src/libstd/os/android/fs.rs
@@ -18,9 +18,11 @@ pub trait MetadataExt {
     /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
     /// cross-Unix abstractions contained within the raw stat.
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    #[rustc_deprecated(since = "1.8.0",
-                       reason = "deprecated in favor of the accessor \
-                                 methods of this trait")]
+    #[rustc_deprecated(
+        since = "1.8.0",
+        reason = "deprecated in favor of the accessor \
+                  methods of this trait"
+    )]
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat;
 
@@ -62,10 +64,7 @@ pub trait MetadataExt {
 impl MetadataExt for Metadata {
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat {
-        unsafe {
-            &*(self.as_inner().as_inner() as *const libc::stat
-                                          as *const raw::stat)
-        }
+        unsafe { &*(self.as_inner().as_inner() as *const libc::stat as *const raw::stat) }
     }
     fn st_dev(&self) -> u64 {
         self.as_inner().as_inner().st_dev as u64

--- a/src/libstd/os/android/mod.rs
+++ b/src/libstd/os/android/mod.rs
@@ -2,5 +2,5 @@
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
-pub mod raw;
 pub mod fs;
+pub mod raw;

--- a/src/libstd/os/android/raw.rs
+++ b/src/libstd/os/android/raw.rs
@@ -1,11 +1,13 @@
 //! Android-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
-#![rustc_deprecated(since = "1.8.0",
-                    reason = "these type aliases are no longer supported by \
-                              the standard library, the `libc` crate on \
-                              crates.io should be used instead for the correct \
-                              definitions")]
+#![rustc_deprecated(
+    since = "1.8.0",
+    reason = "these type aliases are no longer supported by \
+              the standard library, the `libc` crate on \
+              crates.io should be used instead for the correct \
+              definitions"
+)]
 #![allow(deprecated)]
 
 use crate::os::raw::c_long;
@@ -15,12 +17,12 @@ pub type pthread_t = c_long;
 
 #[doc(inline)]
 #[stable(feature = "raw_ext", since = "1.1.0")]
-pub use self::arch::{dev_t, mode_t, blkcnt_t, blksize_t, ino_t, nlink_t, off_t, stat, time_t};
+pub use self::arch::{blkcnt_t, blksize_t, dev_t, ino_t, mode_t, nlink_t, off_t, stat, time_t};
 
 #[cfg(any(target_arch = "arm", target_arch = "x86"))]
 mod arch {
-    use crate::os::raw::{c_uint, c_uchar, c_ulonglong, c_longlong, c_ulong};
-    use crate::os::unix::raw::{uid_t, gid_t};
+    use crate::os::raw::{c_longlong, c_uchar, c_uint, c_ulong, c_ulonglong};
+    use crate::os::unix::raw::{gid_t, uid_t};
 
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type dev_t = u64;
@@ -83,14 +85,12 @@ mod arch {
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ino: c_ulonglong,
     }
-
 }
-
 
 #[cfg(target_arch = "aarch64")]
 mod arch {
     use crate::os::raw::{c_uchar, c_ulong};
-    use crate::os::unix::raw::{uid_t, gid_t};
+    use crate::os::unix::raw::{gid_t, uid_t};
 
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type dev_t = u64;
@@ -157,8 +157,8 @@ mod arch {
 
 #[cfg(target_arch = "x86_64")]
 mod arch {
-    use crate::os::raw::{c_uint, c_long, c_ulong};
-    use crate::os::unix::raw::{uid_t, gid_t};
+    use crate::os::raw::{c_long, c_uint, c_ulong};
+    use crate::os::unix::raw::{gid_t, uid_t};
 
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type dev_t = u64;

--- a/src/libstd/os/dragonfly/fs.rs
+++ b/src/libstd/os/dragonfly/fs.rs
@@ -18,9 +18,11 @@ pub trait MetadataExt {
     /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
     /// cross-Unix abstractions contained within the raw stat.
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    #[rustc_deprecated(since = "1.8.0",
-                       reason = "deprecated in favor of the accessor \
-                                 methods of this trait")]
+    #[rustc_deprecated(
+        since = "1.8.0",
+        reason = "deprecated in favor of the accessor \
+                  methods of this trait"
+    )]
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat;
 
@@ -68,10 +70,7 @@ pub trait MetadataExt {
 impl MetadataExt for Metadata {
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat {
-        unsafe {
-            &*(self.as_inner().as_inner() as *const libc::stat
-                                          as *const raw::stat)
-        }
+        unsafe { &*(self.as_inner().as_inner() as *const libc::stat as *const raw::stat) }
     }
     fn st_dev(&self) -> u64 {
         self.as_inner().as_inner().st_dev as u64

--- a/src/libstd/os/dragonfly/mod.rs
+++ b/src/libstd/os/dragonfly/mod.rs
@@ -2,5 +2,5 @@
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
-pub mod raw;
 pub mod fs;
+pub mod raw;

--- a/src/libstd/os/dragonfly/raw.rs
+++ b/src/libstd/os/dragonfly/raw.rs
@@ -1,24 +1,35 @@
 //! Dragonfly-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
-#![rustc_deprecated(since = "1.8.0",
-                    reason = "these type aliases are no longer supported by \
-                              the standard library, the `libc` crate on \
-                              crates.io should be used instead for the correct \
-                              definitions")]
+#![rustc_deprecated(
+    since = "1.8.0",
+    reason = "these type aliases are no longer supported by \
+              the standard library, the `libc` crate on \
+              crates.io should be used instead for the correct \
+              definitions"
+)]
 #![allow(deprecated)]
 
 use crate::os::raw::c_long;
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type fflags_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blkcnt_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blksize_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type dev_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type fflags_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type ino_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type mode_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type nlink_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type off_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type time_t = i64;
 
 #[stable(feature = "pthread_t", since = "1.8.0")]
 pub type pthread_t = usize;

--- a/src/libstd/os/emscripten/fs.rs
+++ b/src/libstd/os/emscripten/fs.rs
@@ -18,9 +18,11 @@ pub trait MetadataExt {
     /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
     /// cross-Unix abstractions contained within the raw stat.
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    #[rustc_deprecated(since = "1.8.0",
-                       reason = "deprecated in favor of the accessor \
-                                 methods of this trait")]
+    #[rustc_deprecated(
+        since = "1.8.0",
+        reason = "deprecated in favor of the accessor \
+                  methods of this trait"
+    )]
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat;
 
@@ -62,10 +64,7 @@ pub trait MetadataExt {
 impl MetadataExt for Metadata {
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat {
-        unsafe {
-            &*(self.as_inner().as_inner() as *const libc::stat64
-                                          as *const raw::stat)
-        }
+        unsafe { &*(self.as_inner().as_inner() as *const libc::stat64 as *const raw::stat) }
     }
     fn st_dev(&self) -> u64 {
         self.as_inner().as_inner().st_dev as u64

--- a/src/libstd/os/emscripten/mod.rs
+++ b/src/libstd/os/emscripten/mod.rs
@@ -2,5 +2,5 @@
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
-pub mod raw;
 pub mod fs;
+pub mod raw;

--- a/src/libstd/os/emscripten/raw.rs
+++ b/src/libstd/os/emscripten/raw.rs
@@ -3,28 +3,38 @@
 //! except using the musl-specific stat64 structure in liblibc.
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
-#![rustc_deprecated(since = "1.8.0",
-                    reason = "these type aliases are no longer supported by \
-                              the standard library, the `libc` crate on \
-                              crates.io should be used instead for the correct \
-                              definitions")]
+#![rustc_deprecated(
+    since = "1.8.0",
+    reason = "these type aliases are no longer supported by \
+              the standard library, the `libc` crate on \
+              crates.io should be used instead for the correct \
+              definitions"
+)]
 #![allow(deprecated)]
 
 use crate::os::raw::{c_long, c_short, c_uint, c_ulong};
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type dev_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type mode_t = u32;
 
 #[stable(feature = "pthread_t", since = "1.8.0")]
 pub type pthread_t = c_ulong;
 
 #[doc(inline)]
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = c_long;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blkcnt_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blksize_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type ino_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type nlink_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type off_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type time_t = c_long;
 
 #[repr(C)]
 #[derive(Clone)]

--- a/src/libstd/os/fortanix_sgx/mod.rs
+++ b/src/libstd/os/fortanix_sgx/mod.rs
@@ -21,19 +21,20 @@ pub mod usercalls {
 
     /// Lowest-level interfaces to usercalls and usercall ABI type definitions.
     pub mod raw {
+        pub use crate::sys::abi::usercalls::raw::{
+            accept_stream, alloc, async_queues, bind_stream, close, connect_stream, exit, flush,
+            free, insecure_time, launch_thread, read, read_alloc, send, wait, write,
+        };
         pub use crate::sys::abi::usercalls::raw::{do_usercall, Usercalls as UsercallNrs};
-        pub use crate::sys::abi::usercalls::raw::{accept_stream, alloc, async_queues, bind_stream,
-                                           close, connect_stream, exit, flush, free, insecure_time,
-                                           launch_thread, read, read_alloc, send, wait, write};
 
         // fortanix-sgx-abi re-exports
-        pub use crate::sys::abi::usercalls::raw::{ByteBuffer, FifoDescriptor, Return, Usercall};
         pub use crate::sys::abi::usercalls::raw::Error;
-        pub use crate::sys::abi::usercalls::raw::{EV_RETURNQ_NOT_EMPTY, EV_UNPARK,
-                                           EV_USERCALLQ_NOT_FULL, FD_STDERR, FD_STDIN, FD_STDOUT,
-                                           RESULT_SUCCESS, USERCALL_USER_DEFINED, WAIT_INDEFINITE,
-                                           WAIT_NO};
+        pub use crate::sys::abi::usercalls::raw::{ByteBuffer, FifoDescriptor, Return, Usercall};
         pub use crate::sys::abi::usercalls::raw::{Fd, Result, Tcs};
+        pub use crate::sys::abi::usercalls::raw::{
+            EV_RETURNQ_NOT_EMPTY, EV_UNPARK, EV_USERCALLQ_NOT_FULL, FD_STDERR, FD_STDIN, FD_STDOUT,
+            RESULT_SUCCESS, USERCALL_USER_DEFINED, WAIT_INDEFINITE, WAIT_NO,
+        };
     }
 }
 
@@ -42,7 +43,7 @@ pub mod mem {
     pub use crate::sys::abi::mem::*;
 }
 
-pub use crate::sys::ext::{io, arch, ffi};
+pub use crate::sys::ext::{arch, ffi, io};
 
 /// Functions for querying thread-related information.
 pub mod thread {

--- a/src/libstd/os/freebsd/fs.rs
+++ b/src/libstd/os/freebsd/fs.rs
@@ -18,9 +18,11 @@ pub trait MetadataExt {
     /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
     /// cross-Unix abstractions contained within the raw stat.
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    #[rustc_deprecated(since = "1.8.0",
-                       reason = "deprecated in favor of the accessor \
-                                 methods of this trait")]
+    #[rustc_deprecated(
+        since = "1.8.0",
+        reason = "deprecated in favor of the accessor \
+                  methods of this trait"
+    )]
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat;
 
@@ -72,10 +74,7 @@ pub trait MetadataExt {
 impl MetadataExt for Metadata {
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat {
-        unsafe {
-            &*(self.as_inner().as_inner() as *const libc::stat
-                                          as *const raw::stat)
-        }
+        unsafe { &*(self.as_inner().as_inner() as *const libc::stat as *const raw::stat) }
     }
     fn st_dev(&self) -> u64 {
         self.as_inner().as_inner().st_dev as u64

--- a/src/libstd/os/freebsd/mod.rs
+++ b/src/libstd/os/freebsd/mod.rs
@@ -2,5 +2,5 @@
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
-pub mod raw;
 pub mod fs;
+pub mod raw;

--- a/src/libstd/os/freebsd/raw.rs
+++ b/src/libstd/os/freebsd/raw.rs
@@ -1,24 +1,35 @@
 //! FreeBSD-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
-#![rustc_deprecated(since = "1.8.0",
-                    reason = "these type aliases are no longer supported by \
-                              the standard library, the `libc` crate on \
-                              crates.io should be used instead for the correct \
-                              definitions")]
+#![rustc_deprecated(
+    since = "1.8.0",
+    reason = "these type aliases are no longer supported by \
+              the standard library, the `libc` crate on \
+              crates.io should be used instead for the correct \
+              definitions"
+)]
 #![allow(deprecated)]
 
 use crate::os::raw::c_long;
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type fflags_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blkcnt_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blksize_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type dev_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type fflags_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type ino_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type mode_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type nlink_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type off_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type time_t = i64;
 
 #[stable(feature = "pthread_t", since = "1.8.0")]
 pub type pthread_t = usize;

--- a/src/libstd/os/fuchsia/mod.rs
+++ b/src/libstd/os/fuchsia/mod.rs
@@ -2,5 +2,5 @@
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
-pub mod raw;
 pub mod fs;
+pub mod raw;

--- a/src/libstd/os/fuchsia/raw.rs
+++ b/src/libstd/os/fuchsia/raw.rs
@@ -1,38 +1,50 @@
 //! Fuchsia-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
-#![rustc_deprecated(since = "1.8.0",
-                    reason = "these type aliases are no longer supported by \
-                              the standard library, the `libc` crate on \
-                              crates.io should be used instead for the correct \
-                              definitions")]
+#![rustc_deprecated(
+    since = "1.8.0",
+    reason = "these type aliases are no longer supported by \
+              the standard library, the `libc` crate on \
+              crates.io should be used instead for the correct \
+              definitions"
+)]
 #![allow(deprecated)]
 
 use crate::os::raw::c_ulong;
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type dev_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type mode_t = u32;
 
 #[stable(feature = "pthread_t", since = "1.8.0")]
 pub type pthread_t = c_ulong;
 
 #[doc(inline)]
 #[stable(feature = "raw_ext", since = "1.1.0")]
-pub use self::arch::{off_t, ino_t, nlink_t, blksize_t, blkcnt_t, stat, time_t};
+pub use self::arch::{blkcnt_t, blksize_t, ino_t, nlink_t, off_t, stat, time_t};
 
-#[cfg(any(target_arch = "x86",
-          target_arch = "le32",
-          target_arch = "powerpc",
-          target_arch = "arm"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "le32",
+    target_arch = "powerpc",
+    target_arch = "arm"
+))]
 mod arch {
     use crate::os::raw::{c_long, c_short, c_uint};
 
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type blkcnt_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type blksize_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type ino_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type nlink_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type off_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type time_t = i64;
 
     #[repr(C)]
     #[derive(Clone)]
@@ -84,20 +96,29 @@ mod arch {
     use crate::os::raw::{c_long, c_ulong};
 
     #[cfg(target_env = "musl")]
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type blkcnt_t = i64;
     #[cfg(not(target_env = "musl"))]
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type blkcnt_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type blksize_t = u64;
     #[cfg(target_env = "musl")]
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type ino_t = u64;
     #[cfg(not(target_env = "musl"))]
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type ino_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type nlink_t = u64;
     #[cfg(target_env = "musl")]
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type off_t = u64;
     #[cfg(not(target_env = "musl"))]
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type off_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type time_t = i64;
 
     #[repr(C)]
     #[derive(Clone)]
@@ -146,19 +167,25 @@ mod arch {
 
 #[cfg(target_arch = "mips64")]
 mod arch {
-    pub use libc::{off_t, ino_t, nlink_t, blksize_t, blkcnt_t, stat, time_t};
+    pub use libc::{blkcnt_t, blksize_t, ino_t, nlink_t, off_t, stat, time_t};
 }
 
 #[cfg(target_arch = "aarch64")]
 mod arch {
-    use crate::os::raw::{c_long, c_int};
+    use crate::os::raw::{c_int, c_long};
 
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type blkcnt_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type blksize_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type ino_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type nlink_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type off_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type time_t = i64;
 
     #[repr(C)]
     #[derive(Clone)]
@@ -207,14 +234,20 @@ mod arch {
 
 #[cfg(target_arch = "x86_64")]
 mod arch {
-    use crate::os::raw::{c_long, c_int};
+    use crate::os::raw::{c_int, c_long};
 
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type blkcnt_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type blksize_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type ino_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type nlink_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type off_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type time_t = i64;
 
     #[repr(C)]
     #[derive(Clone)]

--- a/src/libstd/os/haiku/fs.rs
+++ b/src/libstd/os/haiku/fs.rs
@@ -18,9 +18,11 @@ pub trait MetadataExt {
     /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
     /// cross-Unix abstractions contained within the raw stat.
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    #[rustc_deprecated(since = "1.8.0",
-                       reason = "deprecated in favor of the accessor \
-                                 methods of this trait")]
+    #[rustc_deprecated(
+        since = "1.8.0",
+        reason = "deprecated in favor of the accessor \
+                  methods of this trait"
+    )]
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat;
 
@@ -66,10 +68,7 @@ pub trait MetadataExt {
 impl MetadataExt for Metadata {
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat {
-        unsafe {
-            &*(self.as_inner().as_inner() as *const libc::stat
-                                          as *const raw::stat)
-        }
+        unsafe { &*(self.as_inner().as_inner() as *const libc::stat as *const raw::stat) }
     }
     fn st_dev(&self) -> u64 {
         self.as_inner().as_inner().st_dev as u64

--- a/src/libstd/os/haiku/mod.rs
+++ b/src/libstd/os/haiku/mod.rs
@@ -2,5 +2,5 @@
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
-pub mod raw;
 pub mod fs;
+pub mod raw;

--- a/src/libstd/os/haiku/raw.rs
+++ b/src/libstd/os/haiku/raw.rs
@@ -1,23 +1,31 @@
 //! Haiku-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
-
 #![allow(deprecated)]
 
-use crate::os::raw::{c_long};
-use crate::os::unix::raw::{uid_t, gid_t};
+use crate::os::raw::c_long;
+use crate::os::unix::raw::{gid_t, uid_t};
 
 // Use the direct definition of usize, instead of uintptr_t like in libc
-#[stable(feature = "pthread_t", since = "1.8.0")] pub type pthread_t = usize;
+#[stable(feature = "pthread_t", since = "1.8.0")]
+pub type pthread_t = usize;
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = i32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = i64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = i32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blkcnt_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blksize_t = i32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type dev_t = i32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type ino_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type mode_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type nlink_t = i32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type off_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type time_t = i32;
 
 #[repr(C)]
 #[derive(Clone)]

--- a/src/libstd/os/ios/fs.rs
+++ b/src/libstd/os/ios/fs.rs
@@ -18,9 +18,11 @@ pub trait MetadataExt {
     /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
     /// cross-Unix abstractions contained within the raw stat.
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    #[rustc_deprecated(since = "1.8.0",
-                       reason = "deprecated in favor of the accessor \
-                                 methods of this trait")]
+    #[rustc_deprecated(
+        since = "1.8.0",
+        reason = "deprecated in favor of the accessor \
+                  methods of this trait"
+    )]
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat;
 
@@ -72,10 +74,7 @@ pub trait MetadataExt {
 impl MetadataExt for Metadata {
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat {
-        unsafe {
-            &*(self.as_inner().as_inner() as *const libc::stat
-                                          as *const raw::stat)
-        }
+        unsafe { &*(self.as_inner().as_inner() as *const libc::stat as *const raw::stat) }
     }
     fn st_dev(&self) -> u64 {
         self.as_inner().as_inner().st_dev as u64

--- a/src/libstd/os/ios/mod.rs
+++ b/src/libstd/os/ios/mod.rs
@@ -2,5 +2,5 @@
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
-pub mod raw;
 pub mod fs;
+pub mod raw;

--- a/src/libstd/os/ios/raw.rs
+++ b/src/libstd/os/ios/raw.rs
@@ -1,23 +1,33 @@
 //! iOS-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
-#![rustc_deprecated(since = "1.8.0",
-                    reason = "these type aliases are no longer supported by \
-                              the standard library, the `libc` crate on \
-                              crates.io should be used instead for the correct \
-                              definitions")]
+#![rustc_deprecated(
+    since = "1.8.0",
+    reason = "these type aliases are no longer supported by \
+              the standard library, the `libc` crate on \
+              crates.io should be used instead for the correct \
+              definitions"
+)]
 #![allow(deprecated)]
 
 use crate::os::raw::c_long;
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blkcnt_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blksize_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type dev_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type ino_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type mode_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type nlink_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type off_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type time_t = i64;
 
 #[stable(feature = "pthread_t", since = "1.8.0")]
 pub type pthread_t = usize;

--- a/src/libstd/os/linux/fs.rs
+++ b/src/libstd/os/linux/fs.rs
@@ -34,10 +34,7 @@ pub trait MetadataExt {
     /// }
     /// ```
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    #[rustc_deprecated(
-        since = "1.8.0",
-        reason = "other methods of this trait are now prefered"
-    )]
+    #[rustc_deprecated(since = "1.8.0", reason = "other methods of this trait are now prefered")]
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat;
 
@@ -328,10 +325,7 @@ pub trait MetadataExt {
 impl MetadataExt for Metadata {
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat {
-        unsafe {
-            &*(self.as_inner().as_inner() as *const libc::stat64
-                                          as *const raw::stat)
-        }
+        unsafe { &*(self.as_inner().as_inner() as *const libc::stat64 as *const raw::stat) }
     }
     fn st_dev(&self) -> u64 {
         self.as_inner().as_inner().st_dev as u64

--- a/src/libstd/os/linux/mod.rs
+++ b/src/libstd/os/linux/mod.rs
@@ -2,5 +2,5 @@
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
-pub mod raw;
 pub mod fs;
+pub mod raw;

--- a/src/libstd/os/linux/raw.rs
+++ b/src/libstd/os/linux/raw.rs
@@ -1,41 +1,53 @@
 //! Linux-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
-#![rustc_deprecated(since = "1.8.0",
-                    reason = "these type aliases are no longer supported by \
-                              the standard library, the `libc` crate on \
-                              crates.io should be used instead for the correct \
-                              definitions")]
+#![rustc_deprecated(
+    since = "1.8.0",
+    reason = "these type aliases are no longer supported by \
+              the standard library, the `libc` crate on \
+              crates.io should be used instead for the correct \
+              definitions"
+)]
 #![allow(deprecated)]
 #![allow(missing_debug_implementations)]
 
 use crate::os::raw::c_ulong;
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type dev_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type mode_t = u32;
 
 #[stable(feature = "pthread_t", since = "1.8.0")]
 pub type pthread_t = c_ulong;
 
 #[doc(inline)]
 #[stable(feature = "raw_ext", since = "1.1.0")]
-pub use self::arch::{off_t, ino_t, nlink_t, blksize_t, blkcnt_t, stat, time_t};
+pub use self::arch::{blkcnt_t, blksize_t, ino_t, nlink_t, off_t, stat, time_t};
 
-#[cfg(any(target_arch = "x86",
-          target_arch = "le32",
-          target_arch = "powerpc",
-          target_arch = "arm",
-          target_arch = "asmjs",
-          target_arch = "wasm32"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "le32",
+    target_arch = "powerpc",
+    target_arch = "arm",
+    target_arch = "asmjs",
+    target_arch = "wasm32"
+))]
 mod arch {
     use crate::os::raw::{c_long, c_short, c_uint};
 
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type blkcnt_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type blksize_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type ino_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type nlink_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type off_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type time_t = i64;
 
     #[repr(C)]
     #[derive(Clone)]
@@ -87,20 +99,29 @@ mod arch {
     use crate::os::raw::{c_long, c_ulong};
 
     #[cfg(target_env = "musl")]
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type blkcnt_t = i64;
     #[cfg(not(target_env = "musl"))]
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type blkcnt_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type blksize_t = u64;
     #[cfg(target_env = "musl")]
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type ino_t = u64;
     #[cfg(not(target_env = "musl"))]
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type ino_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type nlink_t = u64;
     #[cfg(target_env = "musl")]
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type off_t = u64;
     #[cfg(not(target_env = "musl"))]
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type off_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type time_t = i64;
 
     #[repr(C)]
     #[derive(Clone)]
@@ -149,14 +170,20 @@ mod arch {
 
 #[cfg(target_arch = "hexagon")]
 mod arch {
-    use crate::os::raw::{c_long, c_int, c_longlong, culonglong};
+    use crate::os::raw::{c_int, c_long, c_longlong, culonglong};
 
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = c_longlong;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = c_long;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = c_ulonglong;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = c_uint;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = c_longlong;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = c_long;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type blkcnt_t = c_longlong;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type blksize_t = c_long;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type ino_t = c_ulonglong;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type nlink_t = c_uint;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type off_t = c_longlong;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type time_t = c_long;
 
     #[repr(C)]
     #[derive(Clone)]
@@ -199,27 +226,31 @@ mod arch {
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime_nsec: ::c_long,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub __pad3: [::c_int;2],
+        pub __pad3: [::c_int; 2],
     }
 }
 
-#[cfg(any(target_arch = "mips64",
-          target_arch = "s390x",
-          target_arch = "sparc64"))]
+#[cfg(any(target_arch = "mips64", target_arch = "s390x", target_arch = "sparc64"))]
 mod arch {
-    pub use libc::{off_t, ino_t, nlink_t, blksize_t, blkcnt_t, stat, time_t};
+    pub use libc::{blkcnt_t, blksize_t, ino_t, nlink_t, off_t, stat, time_t};
 }
 
 #[cfg(target_arch = "aarch64")]
 mod arch {
-    use crate::os::raw::{c_long, c_int};
+    use crate::os::raw::{c_int, c_long};
 
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type blkcnt_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type blksize_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type ino_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type nlink_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type off_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type time_t = i64;
 
     #[repr(C)]
     #[derive(Clone)]
@@ -268,14 +299,20 @@ mod arch {
 
 #[cfg(any(target_arch = "x86_64", target_arch = "powerpc64"))]
 mod arch {
-    use crate::os::raw::{c_long, c_int};
+    use crate::os::raw::{c_int, c_long};
 
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type blkcnt_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type blksize_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type ino_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type nlink_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type off_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub type time_t = i64;
 
     #[repr(C)]
     #[derive(Clone)]

--- a/src/libstd/os/macos/fs.rs
+++ b/src/libstd/os/macos/fs.rs
@@ -18,9 +18,11 @@ pub trait MetadataExt {
     /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
     /// cross-Unix abstractions contained within the raw stat.
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    #[rustc_deprecated(since = "1.8.0",
-                       reason = "deprecated in favor of the accessor \
-                                 methods of this trait")]
+    #[rustc_deprecated(
+        since = "1.8.0",
+        reason = "deprecated in favor of the accessor \
+                  methods of this trait"
+    )]
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat;
 
@@ -74,10 +76,7 @@ pub trait MetadataExt {
 impl MetadataExt for Metadata {
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat {
-        unsafe {
-            &*(self.as_inner().as_inner() as *const libc::stat
-                                          as *const raw::stat)
-        }
+        unsafe { &*(self.as_inner().as_inner() as *const libc::stat as *const raw::stat) }
     }
     fn st_dev(&self) -> u64 {
         self.as_inner().as_inner().st_dev as u64

--- a/src/libstd/os/macos/mod.rs
+++ b/src/libstd/os/macos/mod.rs
@@ -2,5 +2,5 @@
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
-pub mod raw;
 pub mod fs;
+pub mod raw;

--- a/src/libstd/os/macos/raw.rs
+++ b/src/libstd/os/macos/raw.rs
@@ -1,23 +1,33 @@
 //! macOS-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
-#![rustc_deprecated(since = "1.8.0",
-                    reason = "these type aliases are no longer supported by \
-                              the standard library, the `libc` crate on \
-                              crates.io should be used instead for the correct \
-                              definitions")]
+#![rustc_deprecated(
+    since = "1.8.0",
+    reason = "these type aliases are no longer supported by \
+              the standard library, the `libc` crate on \
+              crates.io should be used instead for the correct \
+              definitions"
+)]
 #![allow(deprecated)]
 
 use crate::os::raw::c_long;
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blkcnt_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blksize_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type dev_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type ino_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type mode_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type nlink_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type off_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type time_t = i64;
 
 #[stable(feature = "pthread_t", since = "1.8.0")]
 pub type pthread_t = usize;

--- a/src/libstd/os/mod.rs
+++ b/src/libstd/os/mod.rs
@@ -38,20 +38,35 @@ cfg_if::cfg_if! {
     }
 }
 
-#[cfg(target_os = "android")]    pub mod android;
-#[cfg(target_os = "dragonfly")]  pub mod dragonfly;
-#[cfg(target_os = "freebsd")]    pub mod freebsd;
-#[cfg(target_os = "haiku")]      pub mod haiku;
-#[cfg(target_os = "ios")]        pub mod ios;
-#[cfg(target_os = "macos")]      pub mod macos;
-#[cfg(target_os = "netbsd")]     pub mod netbsd;
-#[cfg(target_os = "openbsd")]    pub mod openbsd;
-#[cfg(target_os = "solaris")]    pub mod solaris;
-#[cfg(target_os = "emscripten")] pub mod emscripten;
-#[cfg(target_os = "fuchsia")]    pub mod fuchsia;
-#[cfg(target_os = "redox")]      pub mod redox;
-#[cfg(target_os = "wasi")]       pub mod wasi;
-#[cfg(target_os = "vxworks")]    pub mod vxworks;
-#[cfg(all(target_vendor = "fortanix", target_env = "sgx"))] pub mod fortanix_sgx;
+#[cfg(target_os = "android")]
+pub mod android;
+#[cfg(target_os = "dragonfly")]
+pub mod dragonfly;
+#[cfg(target_os = "emscripten")]
+pub mod emscripten;
+#[cfg(all(target_vendor = "fortanix", target_env = "sgx"))]
+pub mod fortanix_sgx;
+#[cfg(target_os = "freebsd")]
+pub mod freebsd;
+#[cfg(target_os = "fuchsia")]
+pub mod fuchsia;
+#[cfg(target_os = "haiku")]
+pub mod haiku;
+#[cfg(target_os = "ios")]
+pub mod ios;
+#[cfg(target_os = "macos")]
+pub mod macos;
+#[cfg(target_os = "netbsd")]
+pub mod netbsd;
+#[cfg(target_os = "openbsd")]
+pub mod openbsd;
+#[cfg(target_os = "redox")]
+pub mod redox;
+#[cfg(target_os = "solaris")]
+pub mod solaris;
+#[cfg(target_os = "vxworks")]
+pub mod vxworks;
+#[cfg(target_os = "wasi")]
+pub mod wasi;
 
 pub mod raw;

--- a/src/libstd/os/netbsd/fs.rs
+++ b/src/libstd/os/netbsd/fs.rs
@@ -18,9 +18,11 @@ pub trait MetadataExt {
     /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
     /// cross-Unix abstractions contained within the raw stat.
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    #[rustc_deprecated(since = "1.8.0",
-                       reason = "deprecated in favor of the accessor \
-                                 methods of this trait")]
+    #[rustc_deprecated(
+        since = "1.8.0",
+        reason = "deprecated in favor of the accessor \
+                  methods of this trait"
+    )]
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat;
 
@@ -70,10 +72,7 @@ pub trait MetadataExt {
 impl MetadataExt for Metadata {
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat {
-        unsafe {
-            &*(self.as_inner().as_inner() as *const libc::stat
-                                          as *const raw::stat)
-        }
+        unsafe { &*(self.as_inner().as_inner() as *const libc::stat as *const raw::stat) }
     }
     fn st_dev(&self) -> u64 {
         self.as_inner().as_inner().st_dev as u64

--- a/src/libstd/os/netbsd/mod.rs
+++ b/src/libstd/os/netbsd/mod.rs
@@ -2,5 +2,5 @@
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
-pub mod raw;
 pub mod fs;
+pub mod raw;

--- a/src/libstd/os/netbsd/raw.rs
+++ b/src/libstd/os/netbsd/raw.rs
@@ -1,25 +1,36 @@
 //! NetBSD-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
-#![rustc_deprecated(since = "1.8.0",
-                    reason = "these type aliases are no longer supported by \
-                              the standard library, the `libc` crate on \
-                              crates.io should be used instead for the correct \
-                              definitions")]
+#![rustc_deprecated(
+    since = "1.8.0",
+    reason = "these type aliases are no longer supported by \
+              the standard library, the `libc` crate on \
+              crates.io should be used instead for the correct \
+              definitions"
+)]
 #![allow(deprecated)]
 
 use crate::os::raw::c_long;
-use crate::os::unix::raw::{uid_t, gid_t};
+use crate::os::unix::raw::{gid_t, uid_t};
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type fflags_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blkcnt_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blksize_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type dev_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type fflags_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type ino_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type mode_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type nlink_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type off_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type time_t = i64;
 
 #[stable(feature = "pthread_t", since = "1.8.0")]
 pub type pthread_t = usize;

--- a/src/libstd/os/openbsd/fs.rs
+++ b/src/libstd/os/openbsd/fs.rs
@@ -18,9 +18,11 @@ pub trait MetadataExt {
     /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
     /// cross-Unix abstractions contained within the raw stat.
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    #[rustc_deprecated(since = "1.8.0",
-                       reason = "deprecated in favor of the accessor \
-                                 methods of this trait")]
+    #[rustc_deprecated(
+        since = "1.8.0",
+        reason = "deprecated in favor of the accessor \
+                  methods of this trait"
+    )]
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat;
 
@@ -70,10 +72,7 @@ pub trait MetadataExt {
 impl MetadataExt for Metadata {
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat {
-        unsafe {
-            &*(self.as_inner().as_inner() as *const libc::stat
-                                          as *const raw::stat)
-        }
+        unsafe { &*(self.as_inner().as_inner() as *const libc::stat as *const raw::stat) }
     }
     fn st_dev(&self) -> u64 {
         self.as_inner().as_inner().st_dev as u64

--- a/src/libstd/os/openbsd/mod.rs
+++ b/src/libstd/os/openbsd/mod.rs
@@ -2,5 +2,5 @@
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
-pub mod raw;
 pub mod fs;
+pub mod raw;

--- a/src/libstd/os/openbsd/raw.rs
+++ b/src/libstd/os/openbsd/raw.rs
@@ -1,24 +1,35 @@
 //! OpenBSD-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
-#![rustc_deprecated(since = "1.8.0",
-                    reason = "these type aliases are no longer supported by \
-                              the standard library, the `libc` crate on \
-                              crates.io should be used instead for the correct \
-                              definitions")]
+#![rustc_deprecated(
+    since = "1.8.0",
+    reason = "these type aliases are no longer supported by \
+              the standard library, the `libc` crate on \
+              crates.io should be used instead for the correct \
+              definitions"
+)]
 #![allow(deprecated)]
 
 use crate::os::raw::c_long;
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type fflags_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blkcnt_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blksize_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type dev_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type fflags_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type ino_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type mode_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type nlink_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type off_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type time_t = i64;
 
 #[stable(feature = "pthread_t", since = "1.8.0")]
 pub type pthread_t = usize;

--- a/src/libstd/os/raw/mod.rs
+++ b/src/libstd/os/raw/mod.rs
@@ -9,85 +9,135 @@
 #![stable(feature = "raw_os", since = "1.1.0")]
 
 #[doc(include = "char.md")]
-#[cfg(any(all(target_os = "linux", any(target_arch = "aarch64",
-                                       target_arch = "arm",
-                                       target_arch = "hexagon",
-                                       target_arch = "powerpc",
-                                       target_arch = "powerpc64",
-                                       target_arch = "s390x")),
-          all(target_os = "android", any(target_arch = "aarch64",
-                                         target_arch = "arm")),
-          all(target_os = "l4re", target_arch = "x86_64"),
-          all(target_os = "freebsd", any(target_arch = "aarch64",
-                                         target_arch = "arm",
-                                         target_arch = "powerpc",
-                                         target_arch = "powerpc64")),
-          all(target_os = "netbsd", any(target_arch = "aarch64",
-                                        target_arch = "arm",
-                                        target_arch = "powerpc")),
-          all(target_os = "openbsd", target_arch = "aarch64"),
-          all(target_os = "vxworks", any(target_arch = "aarch64",
-                                         target_arch = "arm",
-                                         target_arch = "powerpc64",
-                                         target_arch = "powerpc")),
-          all(target_os = "fuchsia", target_arch = "aarch64")))]
-#[stable(feature = "raw_os", since = "1.1.0")] pub type c_char = u8;
+#[cfg(any(
+    all(
+        target_os = "linux",
+        any(
+            target_arch = "aarch64",
+            target_arch = "arm",
+            target_arch = "hexagon",
+            target_arch = "powerpc",
+            target_arch = "powerpc64",
+            target_arch = "s390x"
+        )
+    ),
+    all(target_os = "android", any(target_arch = "aarch64", target_arch = "arm")),
+    all(target_os = "l4re", target_arch = "x86_64"),
+    all(
+        target_os = "freebsd",
+        any(
+            target_arch = "aarch64",
+            target_arch = "arm",
+            target_arch = "powerpc",
+            target_arch = "powerpc64"
+        )
+    ),
+    all(
+        target_os = "netbsd",
+        any(target_arch = "aarch64", target_arch = "arm", target_arch = "powerpc")
+    ),
+    all(target_os = "openbsd", target_arch = "aarch64"),
+    all(
+        target_os = "vxworks",
+        any(
+            target_arch = "aarch64",
+            target_arch = "arm",
+            target_arch = "powerpc64",
+            target_arch = "powerpc"
+        )
+    ),
+    all(target_os = "fuchsia", target_arch = "aarch64")
+))]
+#[stable(feature = "raw_os", since = "1.1.0")]
+pub type c_char = u8;
 #[doc(include = "char.md")]
-#[cfg(not(any(all(target_os = "linux", any(target_arch = "aarch64",
-                                           target_arch = "arm",
-                                           target_arch = "hexagon",
-                                           target_arch = "powerpc",
-                                           target_arch = "powerpc64",
-                                           target_arch = "s390x")),
-              all(target_os = "android", any(target_arch = "aarch64",
-                                             target_arch = "arm")),
-              all(target_os = "l4re", target_arch = "x86_64"),
-              all(target_os = "freebsd", any(target_arch = "aarch64",
-                                             target_arch = "arm",
-                                             target_arch = "powerpc",
-                                             target_arch = "powerpc64")),
-              all(target_os = "netbsd", any(target_arch = "aarch64",
-                                            target_arch = "arm",
-                                            target_arch = "powerpc")),
-              all(target_os = "openbsd", target_arch = "aarch64"),
-              all(target_os = "vxworks", any(target_arch = "aarch64",
-                                             target_arch = "arm",
-                                             target_arch = "powerpc64",
-                                             target_arch = "powerpc")),
-              all(target_os = "fuchsia", target_arch = "aarch64"))))]
-#[stable(feature = "raw_os", since = "1.1.0")] pub type c_char = i8;
+#[cfg(not(any(
+    all(
+        target_os = "linux",
+        any(
+            target_arch = "aarch64",
+            target_arch = "arm",
+            target_arch = "hexagon",
+            target_arch = "powerpc",
+            target_arch = "powerpc64",
+            target_arch = "s390x"
+        )
+    ),
+    all(target_os = "android", any(target_arch = "aarch64", target_arch = "arm")),
+    all(target_os = "l4re", target_arch = "x86_64"),
+    all(
+        target_os = "freebsd",
+        any(
+            target_arch = "aarch64",
+            target_arch = "arm",
+            target_arch = "powerpc",
+            target_arch = "powerpc64"
+        )
+    ),
+    all(
+        target_os = "netbsd",
+        any(target_arch = "aarch64", target_arch = "arm", target_arch = "powerpc")
+    ),
+    all(target_os = "openbsd", target_arch = "aarch64"),
+    all(
+        target_os = "vxworks",
+        any(
+            target_arch = "aarch64",
+            target_arch = "arm",
+            target_arch = "powerpc64",
+            target_arch = "powerpc"
+        )
+    ),
+    all(target_os = "fuchsia", target_arch = "aarch64")
+)))]
+#[stable(feature = "raw_os", since = "1.1.0")]
+pub type c_char = i8;
 #[doc(include = "schar.md")]
-#[stable(feature = "raw_os", since = "1.1.0")] pub type c_schar = i8;
+#[stable(feature = "raw_os", since = "1.1.0")]
+pub type c_schar = i8;
 #[doc(include = "uchar.md")]
-#[stable(feature = "raw_os", since = "1.1.0")] pub type c_uchar = u8;
+#[stable(feature = "raw_os", since = "1.1.0")]
+pub type c_uchar = u8;
 #[doc(include = "short.md")]
-#[stable(feature = "raw_os", since = "1.1.0")] pub type c_short = i16;
+#[stable(feature = "raw_os", since = "1.1.0")]
+pub type c_short = i16;
 #[doc(include = "ushort.md")]
-#[stable(feature = "raw_os", since = "1.1.0")] pub type c_ushort = u16;
+#[stable(feature = "raw_os", since = "1.1.0")]
+pub type c_ushort = u16;
 #[doc(include = "int.md")]
-#[stable(feature = "raw_os", since = "1.1.0")] pub type c_int = i32;
+#[stable(feature = "raw_os", since = "1.1.0")]
+pub type c_int = i32;
 #[doc(include = "uint.md")]
-#[stable(feature = "raw_os", since = "1.1.0")] pub type c_uint = u32;
+#[stable(feature = "raw_os", since = "1.1.0")]
+pub type c_uint = u32;
 #[doc(include = "long.md")]
 #[cfg(any(target_pointer_width = "32", windows))]
-#[stable(feature = "raw_os", since = "1.1.0")] pub type c_long = i32;
+#[stable(feature = "raw_os", since = "1.1.0")]
+pub type c_long = i32;
 #[doc(include = "ulong.md")]
 #[cfg(any(target_pointer_width = "32", windows))]
-#[stable(feature = "raw_os", since = "1.1.0")] pub type c_ulong = u32;
+#[stable(feature = "raw_os", since = "1.1.0")]
+pub type c_ulong = u32;
 #[doc(include = "long.md")]
 #[cfg(all(target_pointer_width = "64", not(windows)))]
-#[stable(feature = "raw_os", since = "1.1.0")] pub type c_long = i64;
+#[stable(feature = "raw_os", since = "1.1.0")]
+pub type c_long = i64;
 #[doc(include = "ulong.md")]
 #[cfg(all(target_pointer_width = "64", not(windows)))]
-#[stable(feature = "raw_os", since = "1.1.0")] pub type c_ulong = u64;
+#[stable(feature = "raw_os", since = "1.1.0")]
+pub type c_ulong = u64;
 #[doc(include = "longlong.md")]
-#[stable(feature = "raw_os", since = "1.1.0")] pub type c_longlong = i64;
+#[stable(feature = "raw_os", since = "1.1.0")]
+pub type c_longlong = i64;
 #[doc(include = "ulonglong.md")]
-#[stable(feature = "raw_os", since = "1.1.0")] pub type c_ulonglong = u64;
+#[stable(feature = "raw_os", since = "1.1.0")]
+pub type c_ulonglong = u64;
 #[doc(include = "float.md")]
-#[stable(feature = "raw_os", since = "1.1.0")] pub type c_float = f32;
+#[stable(feature = "raw_os", since = "1.1.0")]
+pub type c_float = f32;
 #[doc(include = "double.md")]
-#[stable(feature = "raw_os", since = "1.1.0")] pub type c_double = f64;
+#[stable(feature = "raw_os", since = "1.1.0")]
+pub type c_double = f64;
 
 #[stable(feature = "raw_os", since = "1.1.0")]
 #[doc(no_inline)]

--- a/src/libstd/os/redox/fs.rs
+++ b/src/libstd/os/redox/fs.rs
@@ -34,9 +34,11 @@ pub trait MetadataExt {
     /// }
     /// ```
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    #[rustc_deprecated(since = "1.8.0",
-                       reason = "deprecated in favor of the accessor \
-                                 methods of this trait")]
+    #[rustc_deprecated(
+        since = "1.8.0",
+        reason = "deprecated in favor of the accessor \
+                  methods of this trait"
+    )]
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat;
 
@@ -327,10 +329,7 @@ pub trait MetadataExt {
 impl MetadataExt for Metadata {
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat {
-        unsafe {
-            &*(self.as_inner().as_inner() as *const libc::stat
-                                          as *const raw::stat)
-        }
+        unsafe { &*(self.as_inner().as_inner() as *const libc::stat as *const raw::stat) }
     }
     fn st_dev(&self) -> u64 {
         self.as_inner().as_inner().st_dev as u64

--- a/src/libstd/os/redox/mod.rs
+++ b/src/libstd/os/redox/mod.rs
@@ -2,5 +2,5 @@
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
-pub mod raw;
 pub mod fs;
+pub mod raw;

--- a/src/libstd/os/redox/raw.rs
+++ b/src/libstd/os/redox/raw.rs
@@ -1,30 +1,42 @@
 //! Redox-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
-#![rustc_deprecated(since = "1.8.0",
-                    reason = "these type aliases are no longer supported by \
-                              the standard library, the `libc` crate on \
-                              crates.io should be used instead for the correct \
-                              definitions")]
+#![rustc_deprecated(
+    since = "1.8.0",
+    reason = "these type aliases are no longer supported by \
+              the standard library, the `libc` crate on \
+              crates.io should be used instead for the correct \
+              definitions"
+)]
 #![allow(deprecated)]
 #![allow(missing_debug_implementations)]
 
 use crate::os::raw::{c_char, c_int, c_long, c_ulong, c_void};
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = c_long;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type gid_t = c_int;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = c_int;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type uid_t = c_int;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type dev_t = c_long;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type gid_t = c_int;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type mode_t = c_int;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type uid_t = c_int;
 
 #[stable(feature = "pthread_t", since = "1.8.0")]
 pub type pthread_t = *mut c_void;
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = c_ulong;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = c_ulong;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = c_ulong;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = c_ulong;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = c_long;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = c_long;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blkcnt_t = c_ulong;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blksize_t = c_ulong;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type ino_t = c_ulong;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type nlink_t = c_ulong;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type off_t = c_long;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type time_t = c_long;
 
 #[repr(C)]
 #[derive(Clone)]

--- a/src/libstd/os/solaris/fs.rs
+++ b/src/libstd/os/solaris/fs.rs
@@ -18,9 +18,11 @@ pub trait MetadataExt {
     /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
     /// cross-Unix abstractions contained within the raw stat.
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    #[rustc_deprecated(since = "1.8.0",
-                       reason = "deprecated in favor of the accessor \
-                                 methods of this trait")]
+    #[rustc_deprecated(
+        since = "1.8.0",
+        reason = "deprecated in favor of the accessor \
+                  methods of this trait"
+    )]
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat;
 
@@ -62,10 +64,7 @@ pub trait MetadataExt {
 impl MetadataExt for Metadata {
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat {
-        unsafe {
-            &*(self.as_inner().as_inner() as *const libc::stat
-                                          as *const raw::stat)
-        }
+        unsafe { &*(self.as_inner().as_inner() as *const libc::stat as *const raw::stat) }
     }
     fn st_dev(&self) -> u64 {
         self.as_inner().as_inner().st_dev as u64

--- a/src/libstd/os/solaris/mod.rs
+++ b/src/libstd/os/solaris/mod.rs
@@ -2,5 +2,5 @@
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
-pub mod raw;
 pub mod fs;
+pub mod raw;

--- a/src/libstd/os/solaris/raw.rs
+++ b/src/libstd/os/solaris/raw.rs
@@ -1,25 +1,36 @@
 //! Solaris-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
-#![rustc_deprecated(since = "1.8.0",
-                    reason = "these type aliases are no longer supported by \
-                              the standard library, the `libc` crate on \
-                              crates.io should be used instead for the correct \
-                              definitions")]
+#![rustc_deprecated(
+    since = "1.8.0",
+    reason = "these type aliases are no longer supported by \
+              the standard library, the `libc` crate on \
+              crates.io should be used instead for the correct \
+              definitions"
+)]
 #![allow(deprecated)]
 
 use crate::os::raw::c_long;
-use crate::os::unix::raw::{uid_t, gid_t};
+use crate::os::unix::raw::{gid_t, uid_t};
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type fflags_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blkcnt_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blksize_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type dev_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type fflags_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type ino_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type mode_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type nlink_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type off_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type time_t = i64;
 
 #[stable(feature = "pthread_t", since = "1.8.0")]
 pub type pthread_t = u32;
@@ -61,5 +72,5 @@ pub struct stat {
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_blocks: blkcnt_t,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub __unused: [u8; 16]
+    pub __unused: [u8; 16],
 }

--- a/src/libstd/os/vxworks/mod.rs
+++ b/src/libstd/os/vxworks/mod.rs
@@ -2,5 +2,5 @@
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
-pub mod raw;
 pub mod fs;
+pub mod raw;

--- a/src/libstd/os/vxworks/raw.rs
+++ b/src/libstd/os/vxworks/raw.rs
@@ -1,7 +1,7 @@
 //! VxWorks-specific raw type definitions
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
-use crate::os::raw::{c_ulong};
+use crate::os::raw::c_ulong;
 
 #[stable(feature = "pthread_t", since = "1.8.0")]
 pub type pthread_t = c_ulong;


### PR DESCRIPTION
(Same strategy as #66691.)

This commit applies rustfmt with rust-lang/rust's default settings to files in src/libstd/os *that are not involved in any currently open PR* to minimize merge conflicts. The list of files involved in open PRs was determined by querying GitHub's GraphQL API [with this script](https://gist.github.com/dtolnay/aa9c34993dc051a4f344d1b10e4487e8).

With the list of files from the script in outstanding_files, the relevant commands were:

    $ find src/libstd/os -name '*.rs' \
        | xargs rustfmt --edition=2018 --unstable-features --skip-children
    $ rg libstd/os outstanding_files | xargs git checkout --

Repeating this process several months apart should get us coverage of most of the rest of the files.

To confirm no funny business:

    $ git checkout $THIS_COMMIT^
    $ git show --pretty= --name-only $THIS_COMMIT \
        | xargs rustfmt --edition=2018 --unstable-features --skip-children
    $ git diff $THIS_COMMIT  # there should be no difference