### PR TITLE
Format libstd/sys with rustfmt

### DIFF
--- a/src/libstd/sys/cloudabi/os.rs
+++ b/src/libstd/sys/cloudabi/os.rs
@@ -18,9 +18,7 @@ pub fn errno() -> i32 {
 pub fn error_string(errno: i32) -> String {
     // cloudlibc's strerror() is guaranteed to be thread-safe. There is
     // thus no need to use strerror_r().
-    str::from_utf8(unsafe { CStr::from_ptr(libc::strerror(errno)) }.to_bytes())
-        .unwrap()
-        .to_owned()
+    str::from_utf8(unsafe { CStr::from_ptr(libc::strerror(errno)) }.to_bytes()).unwrap().to_owned()
 }
 
 pub fn exit(code: i32) -> ! {

--- a/src/libstd/sys/cloudabi/shims/fs.rs
+++ b/src/libstd/sys/cloudabi/shims/fs.rs
@@ -1,7 +1,7 @@
 use crate::ffi::OsString;
 use crate::fmt;
 use crate::hash::{Hash, Hasher};
-use crate::io::{self, SeekFrom, IoSlice, IoSliceMut};
+use crate::io::{self, IoSlice, IoSliceMut, SeekFrom};
 use crate::path::{Path, PathBuf};
 use crate::sys::time::SystemTime;
 use crate::sys::{unsupported, Void};

--- a/src/libstd/sys/cloudabi/shims/mod.rs
+++ b/src/libstd/sys/cloudabi/shims/mod.rs
@@ -4,19 +4,16 @@ pub mod args;
 pub mod env;
 pub mod fs;
 pub mod net;
+pub mod os;
 #[path = "../../unix/path.rs"]
 pub mod path;
 pub mod pipe;
 pub mod process;
-pub mod os;
 
 // This enum is used as the storage for a bunch of types which can't actually exist.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub enum Void {}
 
 pub fn unsupported<T>() -> io::Result<T> {
-    Err(io::Error::new(
-        io::ErrorKind::Other,
-        "This function is not available on CloudABI.",
-    ))
+    Err(io::Error::new(io::ErrorKind::Other, "This function is not available on CloudABI."))
 }

--- a/src/libstd/sys/cloudabi/shims/net.rs
+++ b/src/libstd/sys/cloudabi/shims/net.rs
@@ -1,9 +1,9 @@
+use crate::convert::TryFrom;
 use crate::fmt;
 use crate::io::{self, IoSlice, IoSliceMut};
 use crate::net::{Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr};
-use crate::time::Duration;
 use crate::sys::{unsupported, Void};
-use crate::convert::TryFrom;
+use crate::time::Duration;
 
 #[allow(unused_extern_crates)]
 pub extern crate libc as netc;

--- a/src/libstd/sys/cloudabi/shims/process.rs
+++ b/src/libstd/sys/cloudabi/shims/process.rs
@@ -32,9 +32,7 @@ pub enum Stdio {
 
 impl Command {
     pub fn new(_program: &OsStr) -> Command {
-        Command {
-            env: Default::default(),
-        }
+        Command { env: Default::default() }
     }
 
     pub fn arg(&mut self, _arg: &OsStr) {}

--- a/src/libstd/sys/cloudabi/thread.rs
+++ b/src/libstd/sys/cloudabi/thread.rs
@@ -58,8 +58,8 @@ impl Thread {
     }
 
     pub fn sleep(dur: Duration) {
-        let timeout = checked_dur2intervals(&dur)
-            .expect("overflow converting duration to nanoseconds");
+        let timeout =
+            checked_dur2intervals(&dur).expect("overflow converting duration to nanoseconds");
         unsafe {
             let subscription = abi::subscription {
                 type_: abi::eventtype::CLOCK,
@@ -85,11 +85,7 @@ impl Thread {
         unsafe {
             let ret = libc::pthread_join(self.id, ptr::null_mut());
             mem::forget(self);
-            assert!(
-                ret == 0,
-                "failed to join thread: {}",
-                io::Error::from_raw_os_error(ret)
-            );
+            assert!(ret == 0, "failed to join thread: {}", io::Error::from_raw_os_error(ret));
         }
     }
 }

--- a/src/libstd/sys/cloudabi/time.rs
+++ b/src/libstd/sys/cloudabi/time.rs
@@ -10,9 +10,7 @@ pub struct Instant {
 }
 
 pub fn checked_dur2intervals(dur: &Duration) -> Option<abi::timestamp> {
-    dur.as_secs()
-        .checked_mul(NSEC_PER_SEC)?
-        .checked_add(dur.subsec_nanos() as abi::timestamp)
+    dur.as_secs().checked_mul(NSEC_PER_SEC)?.checked_add(dur.subsec_nanos() as abi::timestamp)
 }
 
 impl Instant {
@@ -39,15 +37,11 @@ impl Instant {
     }
 
     pub fn checked_add_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant {
-            t: self.t.checked_add(checked_dur2intervals(other)?)?,
-        })
+        Some(Instant { t: self.t.checked_add(checked_dur2intervals(other)?)? })
     }
 
     pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant {
-            t: self.t.checked_sub(checked_dur2intervals(other)?)?,
-        })
+        Some(Instant { t: self.t.checked_sub(checked_dur2intervals(other)?)? })
     }
 }
 
@@ -69,29 +63,19 @@ impl SystemTime {
     pub fn sub_time(&self, other: &SystemTime) -> Result<Duration, Duration> {
         if self.t >= other.t {
             let diff = self.t - other.t;
-            Ok(Duration::new(
-                diff / NSEC_PER_SEC,
-                (diff % NSEC_PER_SEC) as u32,
-            ))
+            Ok(Duration::new(diff / NSEC_PER_SEC, (diff % NSEC_PER_SEC) as u32))
         } else {
             let diff = other.t - self.t;
-            Err(Duration::new(
-                diff / NSEC_PER_SEC,
-                (diff % NSEC_PER_SEC) as u32,
-            ))
+            Err(Duration::new(diff / NSEC_PER_SEC, (diff % NSEC_PER_SEC) as u32))
         }
     }
 
     pub fn checked_add_duration(&self, other: &Duration) -> Option<SystemTime> {
-        Some(SystemTime {
-            t: self.t.checked_add(checked_dur2intervals(other)?)?,
-        })
+        Some(SystemTime { t: self.t.checked_add(checked_dur2intervals(other)?)? })
     }
 
     pub fn checked_sub_duration(&self, other: &Duration) -> Option<SystemTime> {
-        Some(SystemTime {
-            t: self.t.checked_sub(checked_dur2intervals(other)?)?,
-        })
+        Some(SystemTime { t: self.t.checked_sub(checked_dur2intervals(other)?)? })
     }
 }
 

--- a/src/libstd/sys/hermit/alloc.rs
+++ b/src/libstd/sys/hermit/alloc.rs
@@ -13,11 +13,7 @@ unsafe impl GlobalAlloc for System {
         let addr = abi::malloc(layout.size(), layout.align());
 
         if !addr.is_null() {
-            ptr::write_bytes(
-                addr,
-                0x00,
-                layout.size()
-            );
+            ptr::write_bytes(addr, 0x00, layout.size());
         }
 
         addr

--- a/src/libstd/sys/hermit/args.rs
+++ b/src/libstd/sys/hermit/args.rs
@@ -3,10 +3,14 @@ use crate::marker::PhantomData;
 use crate::vec;
 
 /// One-time global initialization.
-pub unsafe fn init(argc: isize, argv: *const *const u8) { imp::init(argc, argv) }
+pub unsafe fn init(argc: isize, argv: *const *const u8) {
+    imp::init(argc, argv)
+}
 
 /// One-time global cleanup.
-pub unsafe fn cleanup() { imp::cleanup() }
+pub unsafe fn cleanup() {
+    imp::cleanup()
+}
 
 /// Returns the command line arguments
 pub fn args() -> Args {
@@ -26,24 +30,32 @@ impl Args {
 
 impl Iterator for Args {
     type Item = OsString;
-    fn next(&mut self) -> Option<OsString> { self.iter.next() }
-    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
+    fn next(&mut self) -> Option<OsString> {
+        self.iter.next()
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 impl ExactSizeIterator for Args {
-    fn len(&self) -> usize { self.iter.len() }
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
 }
 
 impl DoubleEndedIterator for Args {
-    fn next_back(&mut self) -> Option<OsString> { self.iter.next_back() }
+    fn next_back(&mut self) -> Option<OsString> {
+        self.iter.next_back()
+    }
 }
 
 mod imp {
-    use crate::sys_common::os_str_bytes::*;
-    use crate::ptr;
+    use super::Args;
     use crate::ffi::{CStr, OsString};
     use crate::marker::PhantomData;
-    use super::Args;
+    use crate::ptr;
+    use crate::sys_common::os_str_bytes::*;
 
     use crate::sys_common::mutex::Mutex;
 
@@ -64,19 +76,18 @@ mod imp {
     }
 
     pub fn args() -> Args {
-        Args {
-            iter: clone().into_iter(),
-            _dont_send_or_sync_me: PhantomData
-        }
+        Args { iter: clone().into_iter(), _dont_send_or_sync_me: PhantomData }
     }
 
     fn clone() -> Vec<OsString> {
         unsafe {
             let _guard = LOCK.lock();
-            (0..ARGC).map(|i| {
-                let cstr = CStr::from_ptr(*ARGV.offset(i) as *const i8);
-                OsStringExt::from_vec(cstr.to_bytes().to_vec())
-            }).collect()
+            (0..ARGC)
+                .map(|i| {
+                    let cstr = CStr::from_ptr(*ARGV.offset(i) as *const i8);
+                    OsStringExt::from_vec(cstr.to_bytes().to_vec())
+                })
+                .collect()
         }
     }
 }

--- a/src/libstd/sys/hermit/cmath.rs
+++ b/src/libstd/sys/hermit/cmath.rs
@@ -1,5 +1,5 @@
 // These symbols are all defined in `compiler-builtins`
-extern {
+extern "C" {
     pub fn acos(n: f64) -> f64;
     pub fn acosf(n: f32) -> f32;
     pub fn asin(n: f64) -> f64;

--- a/src/libstd/sys/hermit/condvar.rs
+++ b/src/libstd/sys/hermit/condvar.rs
@@ -18,12 +18,12 @@ impl Condvar {
     }
 
     pub unsafe fn notify_one(&self) {
-         let _ = abi::notify(self.id(), 1);
+        let _ = abi::notify(self.id(), 1);
     }
 
     #[inline]
     pub unsafe fn notify_all(&self) {
-         let _ = abi::notify(self.id(), -1 /* =all */);
+        let _ = abi::notify(self.id(), -1 /* =all */);
     }
 
     pub unsafe fn wait(&self, mutex: &Mutex) {

--- a/src/libstd/sys/hermit/fd.rs
+++ b/src/libstd/sys/hermit/fd.rs
@@ -1,6 +1,6 @@
 #![unstable(reason = "not public", issue = "0", feature = "fd")]
 
-use crate::io::{self, Read, ErrorKind};
+use crate::io::{self, ErrorKind, Read};
 use crate::mem;
 use crate::sys::cvt;
 use crate::sys::hermit::abi;
@@ -16,7 +16,9 @@ impl FileDesc {
         FileDesc { fd }
     }
 
-    pub fn raw(&self) -> i32 { self.fd }
+    pub fn raw(&self) -> i32 {
+        self.fd
+    }
 
     /// Extracts the actual file descriptor without closing it.
     pub fn into_raw(self) -> i32 {
@@ -67,7 +69,9 @@ impl<'a> Read for &'a FileDesc {
 }
 
 impl AsInner<i32> for FileDesc {
-    fn as_inner(&self) -> &i32 { &self.fd }
+    fn as_inner(&self) -> &i32 {
+        &self.fd
+    }
 }
 
 impl Drop for FileDesc {

--- a/src/libstd/sys/hermit/fs.rs
+++ b/src/libstd/sys/hermit/fs.rs
@@ -1,14 +1,14 @@
-use crate::ffi::{OsString, CString, CStr};
+use crate::ffi::{CStr, CString, OsString};
 use crate::fmt;
-use crate::io::{self, Error, ErrorKind};
 use crate::hash::{Hash, Hasher};
-use crate::io::{SeekFrom, IoSlice, IoSliceMut};
+use crate::io::{self, Error, ErrorKind};
+use crate::io::{IoSlice, IoSliceMut, SeekFrom};
 use crate::path::{Path, PathBuf};
-use crate::sys::time::SystemTime;
-use crate::sys::{unsupported, Void};
+use crate::sys::cvt;
 use crate::sys::hermit::abi;
 use crate::sys::hermit::fd::FileDesc;
-use crate::sys::cvt;
+use crate::sys::time::SystemTime;
+use crate::sys::{unsupported, Void};
 use crate::sys_common::os_str_bytes::OsStrExt;
 
 pub use crate::sys_common::fs::copy;
@@ -45,7 +45,7 @@ pub struct OpenOptions {
     create: bool,
     create_new: bool,
     // system-specific
-    mode: i32
+    mode: i32,
 }
 
 pub struct FilePermissions(Void);
@@ -53,7 +53,7 @@ pub struct FilePermissions(Void);
 pub struct FileType(Void);
 
 #[derive(Debug)]
-pub struct DirBuilder { }
+pub struct DirBuilder {}
 
 impl FileAttr {
     pub fn size(&self) -> u64 {
@@ -109,8 +109,7 @@ impl PartialEq for FilePermissions {
     }
 }
 
-impl Eq for FilePermissions {
-}
+impl Eq for FilePermissions {}
 
 impl fmt::Debug for FilePermissions {
     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -146,8 +145,7 @@ impl PartialEq for FileType {
     }
 }
 
-impl Eq for FileType {
-}
+impl Eq for FileType {}
 
 impl Hash for FileType {
     fn hash<H: Hasher>(&self, _h: &mut H) {
@@ -204,50 +202,64 @@ impl OpenOptions {
             create: false,
             create_new: false,
             // system-specific
-            mode: 0x777
+            mode: 0x777,
         }
     }
 
-    pub fn read(&mut self, read: bool) { self.read = read; }
-    pub fn write(&mut self, write: bool) { self.write = write; }
-    pub fn append(&mut self, append: bool) { self.append = append; }
-    pub fn truncate(&mut self, truncate: bool) { self.truncate = truncate; }
-    pub fn create(&mut self, create: bool) { self.create = create; }
-    pub fn create_new(&mut self, create_new: bool) { self.create_new = create_new; }
+    pub fn read(&mut self, read: bool) {
+        self.read = read;
+    }
+    pub fn write(&mut self, write: bool) {
+        self.write = write;
+    }
+    pub fn append(&mut self, append: bool) {
+        self.append = append;
+    }
+    pub fn truncate(&mut self, truncate: bool) {
+        self.truncate = truncate;
+    }
+    pub fn create(&mut self, create: bool) {
+        self.create = create;
+    }
+    pub fn create_new(&mut self, create_new: bool) {
+        self.create_new = create_new;
+    }
 
     fn get_access_mode(&self) -> io::Result<i32> {
         match (self.read, self.write, self.append) {
-            (true,  false, false) => Ok(O_RDONLY),
-            (false, true,  false) => Ok(O_WRONLY),
-            (true,  true,  false) => Ok(O_RDWR),
-            (false, _,     true)  => Ok(O_WRONLY | O_APPEND),
-            (true,  _,     true)  => Ok(O_RDWR | O_APPEND),
+            (true, false, false) => Ok(O_RDONLY),
+            (false, true, false) => Ok(O_WRONLY),
+            (true, true, false) => Ok(O_RDWR),
+            (false, _, true) => Ok(O_WRONLY | O_APPEND),
+            (true, _, true) => Ok(O_RDWR | O_APPEND),
             (false, false, false) => {
                 Err(io::Error::new(ErrorKind::InvalidInput, "invalid access mode"))
-            },
+            }
         }
     }
 
     fn get_creation_mode(&self) -> io::Result<i32> {
         match (self.write, self.append) {
             (true, false) => {}
-            (false, false) =>
+            (false, false) => {
                 if self.truncate || self.create || self.create_new {
                     return Err(io::Error::new(ErrorKind::InvalidInput, "invalid creation mode"));
-                },
-            (_, true) =>
+                }
+            }
+            (_, true) => {
                 if self.truncate && !self.create_new {
                     return Err(io::Error::new(ErrorKind::InvalidInput, "invalid creation mode"));
-                },
+                }
+            }
         }
 
         Ok(match (self.create, self.truncate, self.create_new) {
-                (false, false, false) => 0,
-                (true,  false, false) => O_CREAT,
-                (false, true,  false) => O_TRUNC,
-                (true,  true,  false) => O_CREAT | O_TRUNC,
-                (_,      _,    true)  => O_CREAT | O_EXCL,
-           })
+            (false, false, false) => 0,
+            (true, false, false) => O_CREAT,
+            (false, true, false) => O_TRUNC,
+            (true, true, false) => O_CREAT | O_TRUNC,
+            (_, _, true) => O_CREAT | O_EXCL,
+        })
     }
 }
 
@@ -327,7 +339,7 @@ impl File {
 
 impl DirBuilder {
     pub fn new() -> DirBuilder {
-        DirBuilder { }
+        DirBuilder {}
     }
 
     pub fn mkdir(&self, _p: &Path) -> io::Result<()> {

--- a/src/libstd/sys/hermit/mod.rs
+++ b/src/libstd/sys/hermit/mod.rs
@@ -13,34 +13,34 @@
 //! compiling for wasm. That way it's a compile time error for something that's
 //! guaranteed to be a runtime error!
 
-use crate::os::raw::c_char;
 use crate::intrinsics;
+use crate::os::raw::c_char;
 
 pub mod alloc;
 pub mod args;
-pub mod condvar;
-pub mod stdio;
-pub mod memchr;
-pub mod io;
-pub mod mutex;
-pub mod rwlock;
-pub mod os;
 pub mod cmath;
-pub mod thread;
+pub mod condvar;
 pub mod env;
-pub mod fs;
+pub mod fast_thread_local;
 pub mod fd;
+pub mod fs;
+pub mod io;
+pub mod memchr;
+pub mod mutex;
 pub mod net;
+pub mod os;
 pub mod path;
 pub mod pipe;
 pub mod process;
+pub mod rwlock;
 pub mod stack_overflow;
-pub mod time;
+pub mod stdio;
+pub mod thread;
 pub mod thread_local;
-pub mod fast_thread_local;
+pub mod time;
 
-pub use crate::sys_common::os_str_bytes as os_str;
 use crate::io::ErrorKind;
+pub use crate::sys_common::os_str_bytes as os_str;
 
 #[allow(unused_extern_crates)]
 pub extern crate hermit_abi as abi;
@@ -50,8 +50,7 @@ pub fn unsupported<T>() -> crate::io::Result<T> {
 }
 
 pub fn unsupported_err() -> crate::io::Error {
-    crate::io::Error::new(crate::io::ErrorKind::Other,
-           "operation not supported on HermitCore yet")
+    crate::io::Error::new(crate::io::ErrorKind::Other, "operation not supported on HermitCore yet")
 }
 
 // This enum is used as the storage for a bunch of types which can't actually
@@ -71,9 +70,7 @@ pub unsafe fn strlen(start: *const c_char) -> usize {
 
 #[no_mangle]
 pub extern "C" fn floor(x: f64) -> f64 {
-    unsafe {
-        intrinsics::floorf64(x)
-    }
+    unsafe { intrinsics::floorf64(x) }
 }
 
 pub unsafe fn abort_internal() -> ! {
@@ -103,8 +100,11 @@ pub fn init() {
 
 #[cfg(not(test))]
 #[no_mangle]
-pub unsafe extern "C" fn runtime_entry(argc: i32, argv: *const *const c_char,
-                                       env: *const *const c_char) -> ! {
+pub unsafe extern "C" fn runtime_entry(
+    argc: i32,
+    argv: *const *const c_char,
+    env: *const *const c_char,
+) -> ! {
     extern "C" {
         fn main(argc: isize, argv: *const *const c_char) -> i32;
     }
@@ -139,9 +139,5 @@ pub fn decode_error_kind(errno: i32) -> ErrorKind {
 }
 
 pub fn cvt(result: i32) -> crate::io::Result<usize> {
-    if result < 0 {
-        Err(crate::io::Error::from_raw_os_error(-result))
-    } else {
-        Ok(result as usize)
-    }
+    if result < 0 { Err(crate::io::Error::from_raw_os_error(-result)) } else { Ok(result as usize) }
 }

--- a/src/libstd/sys/hermit/mutex.rs
+++ b/src/libstd/sys/hermit/mutex.rs
@@ -1,9 +1,9 @@
-use crate::ptr;
 use crate::ffi::c_void;
+use crate::ptr;
 use crate::sys::hermit::abi;
 
 pub struct Mutex {
-    inner: *const c_void
+    inner: *const c_void,
 }
 
 unsafe impl Send for Mutex {}
@@ -42,7 +42,7 @@ impl Mutex {
 }
 
 pub struct ReentrantMutex {
-    inner: *const c_void
+    inner: *const c_void,
 }
 
 impl ReentrantMutex {

--- a/src/libstd/sys/hermit/net.rs
+++ b/src/libstd/sys/hermit/net.rs
@@ -1,7 +1,7 @@
-use crate::fmt;
 use crate::convert::TryFrom;
+use crate::fmt;
 use crate::io::{self, IoSlice, IoSliceMut};
-use crate::net::{SocketAddr, Shutdown, Ipv4Addr, Ipv6Addr};
+use crate::net::{Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr};
 use crate::str;
 use crate::sys::{unsupported, Void};
 use crate::time::Duration;
@@ -234,23 +234,19 @@ impl UdpSocket {
         match self.0 {}
     }
 
-    pub fn join_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr)
-                         -> io::Result<()> {
+    pub fn join_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr) -> io::Result<()> {
         match self.0 {}
     }
 
-    pub fn join_multicast_v6(&self, _: &Ipv6Addr, _: u32)
-                         -> io::Result<()> {
+    pub fn join_multicast_v6(&self, _: &Ipv6Addr, _: u32) -> io::Result<()> {
         match self.0 {}
     }
 
-    pub fn leave_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr)
-                          -> io::Result<()> {
+    pub fn leave_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr) -> io::Result<()> {
         match self.0 {}
     }
 
-    pub fn leave_multicast_v6(&self, _: &Ipv6Addr, _: u32)
-                          -> io::Result<()> {
+    pub fn leave_multicast_v6(&self, _: &Ipv6Addr, _: u32) -> io::Result<()> {
         match self.0 {}
     }
 
@@ -357,8 +353,7 @@ pub mod netc {
     }
 
     #[derive(Copy, Clone)]
-    pub struct sockaddr {
-    }
+    pub struct sockaddr {}
 
     pub type socklen_t = usize;
 }

--- a/src/libstd/sys/hermit/path.rs
+++ b/src/libstd/sys/hermit/path.rs
@@ -1,5 +1,5 @@
-use crate::path::Prefix;
 use crate::ffi::OsStr;
+use crate::path::Prefix;
 
 #[inline]
 pub fn is_sep_byte(b: u8) -> bool {

--- a/src/libstd/sys/hermit/pipe.rs
+++ b/src/libstd/sys/hermit/pipe.rs
@@ -25,9 +25,6 @@ impl AnonPipe {
     }
 }
 
-pub fn read2(p1: AnonPipe,
-             _v1: &mut Vec<u8>,
-             _p2: AnonPipe,
-             _v2: &mut Vec<u8>) -> io::Result<()> {
+pub fn read2(p1: AnonPipe, _v1: &mut Vec<u8>, _p2: AnonPipe, _v2: &mut Vec<u8>) -> io::Result<()> {
     match p1.0 {}
 }

--- a/src/libstd/sys/hermit/process.rs
+++ b/src/libstd/sys/hermit/process.rs
@@ -32,32 +32,28 @@ pub enum Stdio {
 
 impl Command {
     pub fn new(_program: &OsStr) -> Command {
-        Command {
-            env: Default::default()
-        }
+        Command { env: Default::default() }
     }
 
-    pub fn arg(&mut self, _arg: &OsStr) {
-    }
+    pub fn arg(&mut self, _arg: &OsStr) {}
 
     pub fn env_mut(&mut self) -> &mut CommandEnv {
         &mut self.env
     }
 
-    pub fn cwd(&mut self, _dir: &OsStr) {
-    }
+    pub fn cwd(&mut self, _dir: &OsStr) {}
 
-    pub fn stdin(&mut self, _stdin: Stdio) {
-    }
+    pub fn stdin(&mut self, _stdin: Stdio) {}
 
-    pub fn stdout(&mut self, _stdout: Stdio) {
-    }
+    pub fn stdout(&mut self, _stdout: Stdio) {}
 
-    pub fn stderr(&mut self, _stderr: Stdio) {
-    }
+    pub fn stderr(&mut self, _stderr: Stdio) {}
 
-    pub fn spawn(&mut self, _default: Stdio, _needs_stdin: bool)
-        -> io::Result<(Process, StdioPipes)> {
+    pub fn spawn(
+        &mut self,
+        _default: Stdio,
+        _needs_stdin: bool,
+    ) -> io::Result<(Process, StdioPipes)> {
         unsupported()
     }
 }
@@ -106,8 +102,7 @@ impl PartialEq for ExitStatus {
     }
 }
 
-impl Eq for ExitStatus {
-}
+impl Eq for ExitStatus {}
 
 impl fmt::Debug for ExitStatus {
     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/libstd/sys/hermit/rwlock.rs
+++ b/src/libstd/sys/hermit/rwlock.rs
@@ -1,7 +1,7 @@
 use super::mutex::Mutex;
 
 pub struct RWLock {
-    mutex: Mutex
+    mutex: Mutex,
 }
 
 unsafe impl Send for RWLock {}
@@ -9,9 +9,7 @@ unsafe impl Sync for RWLock {}
 
 impl RWLock {
     pub const fn new() -> RWLock {
-        RWLock {
-            mutex: Mutex::new()
-        }
+        RWLock { mutex: Mutex::new() }
     }
 
     #[inline]

--- a/src/libstd/sys/hermit/stack_overflow.rs
+++ b/src/libstd/sys/hermit/stack_overflow.rs
@@ -7,9 +7,7 @@ impl Handler {
 }
 
 #[inline]
-pub unsafe fn init() {
-}
+pub unsafe fn init() {}
 
 #[inline]
-pub unsafe fn cleanup() {
-}
+pub unsafe fn cleanup() {}

--- a/src/libstd/sys/hermit/stdio.rs
+++ b/src/libstd/sys/hermit/stdio.rs
@@ -20,7 +20,6 @@ impl Stdin {
         //    .read(data)
         Ok(0)
     }
-
 }
 
 impl Stdout {
@@ -31,9 +30,7 @@ impl Stdout {
     pub fn write(&self, data: &[u8]) -> io::Result<usize> {
         let len;
 
-        unsafe {
-            len = abi::write(1, data.as_ptr() as *const u8, data.len())
-        }
+        unsafe { len = abi::write(1, data.as_ptr() as *const u8, data.len()) }
 
         if len < 0 {
             Err(io::Error::new(io::ErrorKind::Other, "Stdout is not able to print"))
@@ -45,9 +42,7 @@ impl Stdout {
     pub fn write_vectored(&self, data: &[IoSlice<'_>]) -> io::Result<usize> {
         let len;
 
-        unsafe {
-            len = abi::write(1, data.as_ptr() as *const u8, data.len())
-        }
+        unsafe { len = abi::write(1, data.as_ptr() as *const u8, data.len()) }
 
         if len < 0 {
             Err(io::Error::new(io::ErrorKind::Other, "Stdout is not able to print"))
@@ -69,9 +64,7 @@ impl Stderr {
     pub fn write(&self, data: &[u8]) -> io::Result<usize> {
         let len;
 
-        unsafe {
-            len = abi::write(2, data.as_ptr() as *const u8, data.len())
-        }
+        unsafe { len = abi::write(2, data.as_ptr() as *const u8, data.len()) }
 
         if len < 0 {
             Err(io::Error::new(io::ErrorKind::Other, "Stderr is not able to print"))
@@ -83,9 +76,7 @@ impl Stderr {
     pub fn write_vectored(&self, data: &[IoSlice<'_>]) -> io::Result<usize> {
         let len;
 
-        unsafe {
-            len = abi::write(2, data.as_ptr() as *const u8, data.len())
-        }
+        unsafe { len = abi::write(2, data.as_ptr() as *const u8, data.len()) }
 
         if len < 0 {
             Err(io::Error::new(io::ErrorKind::Other, "Stderr is not able to print"))

--- a/src/libstd/sys/hermit/thread_local.rs
+++ b/src/libstd/sys/hermit/thread_local.rs
@@ -7,7 +7,7 @@ use crate::sys_common::mutex::Mutex;
 
 pub type Key = usize;
 
-type Dtor = unsafe extern fn(*mut u8);
+type Dtor = unsafe extern "C" fn(*mut u8);
 
 static NEXT_KEY: AtomicUsize = AtomicUsize::new(0);
 
@@ -41,11 +41,7 @@ pub unsafe fn create(dtor: Option<Dtor>) -> Key {
 
 #[inline]
 pub unsafe fn get(key: Key) -> *mut u8 {
-    if let Some(&entry) = locals().get(&key) {
-        entry
-    } else {
-        ptr::null_mut()
-    }
+    if let Some(&entry) = locals().get(&key) { entry } else { ptr::null_mut() }
 }
 
 #[inline]

--- a/src/libstd/sys/hermit/time.rs
+++ b/src/libstd/sys/hermit/time.rs
@@ -1,34 +1,35 @@
 #![allow(dead_code)]
 
-use crate::time::Duration;
 use crate::cmp::Ordering;
 use crate::convert::TryInto;
-use core::hash::{Hash, Hasher};
 use crate::sys::hermit::abi;
-use crate::sys::hermit::abi::{CLOCK_REALTIME, CLOCK_MONOTONIC, NSEC_PER_SEC};
 use crate::sys::hermit::abi::timespec;
+use crate::sys::hermit::abi::{CLOCK_MONOTONIC, CLOCK_REALTIME, NSEC_PER_SEC};
+use crate::time::Duration;
+use core::hash::{Hash, Hasher};
 
 #[derive(Copy, Clone, Debug)]
 struct Timespec {
-    t: timespec
+    t: timespec,
 }
 
 impl Timespec {
     const fn zero() -> Timespec {
-        Timespec {
-            t: timespec { tv_sec: 0, tv_nsec: 0 },
-        }
+        Timespec { t: timespec { tv_sec: 0, tv_nsec: 0 } }
     }
 
     fn sub_timespec(&self, other: &Timespec) -> Result<Duration, Duration> {
         if self >= other {
             Ok(if self.t.tv_nsec >= other.t.tv_nsec {
-                Duration::new((self.t.tv_sec - other.t.tv_sec) as u64,
-                              (self.t.tv_nsec - other.t.tv_nsec) as u32)
+                Duration::new(
+                    (self.t.tv_sec - other.t.tv_sec) as u64,
+                    (self.t.tv_nsec - other.t.tv_nsec) as u32,
+                )
             } else {
-                Duration::new((self.t.tv_sec - 1 - other.t.tv_sec) as u64,
-                              self.t.tv_nsec as u32 + (NSEC_PER_SEC as u32) -
-                              other.t.tv_nsec as u32)
+                Duration::new(
+                    (self.t.tv_sec - 1 - other.t.tv_sec) as u64,
+                    self.t.tv_nsec as u32 + (NSEC_PER_SEC as u32) - other.t.tv_nsec as u32,
+                )
             })
         } else {
             match other.sub_timespec(self) {
@@ -52,12 +53,7 @@ impl Timespec {
             nsec -= NSEC_PER_SEC as u32;
             secs = secs.checked_add(1)?;
         }
-        Some(Timespec {
-            t: timespec {
-                tv_sec: secs,
-                tv_nsec: nsec as _,
-            },
-        })
+        Some(Timespec { t: timespec { tv_sec: secs, tv_nsec: nsec as _ } })
     }
 
     fn checked_sub_duration(&self, other: &Duration) -> Option<Timespec> {
@@ -73,12 +69,7 @@ impl Timespec {
             nsec += NSEC_PER_SEC as i32;
             secs = secs.checked_sub(1)?;
         }
-        Some(Timespec {
-            t: timespec {
-                tv_sec: secs,
-                tv_nsec: nsec as _,
-            },
-        })
+        Some(Timespec { t: timespec { tv_sec: secs, tv_nsec: nsec as _ } })
     }
 }
 
@@ -105,7 +96,7 @@ impl Ord for Timespec {
 }
 
 impl Hash for Timespec {
-    fn hash<H : Hasher>(&self, state: &mut H) {
+    fn hash<H: Hasher>(&self, state: &mut H) {
         self.t.tv_sec.hash(state);
         self.t.tv_nsec.hash(state);
     }
@@ -150,9 +141,7 @@ pub struct SystemTime {
     t: Timespec,
 }
 
-pub const UNIX_EPOCH: SystemTime = SystemTime {
-    t: Timespec::zero(),
-};
+pub const UNIX_EPOCH: SystemTime = SystemTime { t: Timespec::zero() };
 
 impl SystemTime {
     pub fn now() -> SystemTime {

--- a/src/libstd/sys/sgx/abi/mod.rs
+++ b/src/libstd/sys/sgx/abi/mod.rs
@@ -1,11 +1,11 @@
 #![cfg_attr(test, allow(unused))] // RT initialization logic is not compiled for test
 
-use core::sync::atomic::{AtomicUsize, Ordering};
 use crate::io::Write;
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 // runtime features
-mod reloc;
 pub(super) mod panic;
+mod reloc;
 
 // library features
 pub mod mem;
@@ -38,14 +38,16 @@ unsafe extern "C" fn tcs_init(secondary: bool) {
         UNINIT => {
             reloc::relocate_elf_rela();
             RELOC_STATE.store(DONE, Ordering::Release);
-        },
+        }
         // We need to wait until the initialization is done.
-        BUSY => while RELOC_STATE.load(Ordering::Acquire) == BUSY  {
-            core::arch::x86_64::_mm_pause()
-        },
+        BUSY => {
+            while RELOC_STATE.load(Ordering::Acquire) == BUSY {
+                core::arch::x86_64::_mm_pause()
+            }
+        }
         // Initialization is done.
-        DONE => {},
-        _ => unreachable!()
+        DONE => {}
+        _ => unreachable!(),
     }
 }
 

--- a/src/libstd/sys/sgx/abi/panic.rs
+++ b/src/libstd/sys/sgx/abi/panic.rs
@@ -16,21 +16,13 @@ fn empty_user_slice() -> &'static mut UserRef<[u8]> {
 
 impl SgxPanicOutput {
     pub(crate) fn new() -> Option<Self> {
-        if unsafe { DEBUG == 0 } {
-            None
-        } else {
-            Some(SgxPanicOutput(None))
-        }
+        if unsafe { DEBUG == 0 } { None } else { Some(SgxPanicOutput(None)) }
     }
 
     fn init(&mut self) -> &mut &'static mut UserRef<[u8]> {
         self.0.get_or_insert_with(|| unsafe {
             let ptr = take_debug_panic_buf_ptr();
-            if ptr.is_null() {
-                empty_user_slice()
-            } else {
-                UserRef::from_raw_parts_mut(ptr, 1024)
-            }
+            if ptr.is_null() { empty_user_slice() } else { UserRef::from_raw_parts_mut(ptr, 1024) }
         })
     }
 }

--- a/src/libstd/sys/sgx/abi/reloc.rs
+++ b/src/libstd/sys/sgx/abi/reloc.rs
@@ -1,5 +1,5 @@
-use crate::slice::from_raw_parts;
 use super::mem;
+use crate::slice::from_raw_parts;
 
 const R_X86_64_RELATIVE: u32 = 8;
 
@@ -11,18 +11,20 @@ struct Rela<T> {
 }
 
 pub fn relocate_elf_rela() {
-    extern {
+    extern "C" {
         static RELA: u64;
         static RELACOUNT: usize;
     }
 
-    if unsafe { RELACOUNT } == 0 { return }  // unsafe ok: link-time constant
+    if unsafe { RELACOUNT } == 0 {
+        return;
+    } // unsafe ok: link-time constant
 
     let relas = unsafe {
-        from_raw_parts::<Rela<u64>>(mem::rel_ptr(RELA), RELACOUNT)  // unsafe ok: link-time constant
+        from_raw_parts::<Rela<u64>>(mem::rel_ptr(RELA), RELACOUNT) // unsafe ok: link-time constant
     };
     for rela in relas {
-        if rela.info != (/*0 << 32 |*/ R_X86_64_RELATIVE as u64) {
+        if rela.info != (/*0 << 32 |*/R_X86_64_RELATIVE as u64) {
             rtabort!("Invalid relocation");
         }
         unsafe { *mem::rel_ptr_mut::<*const ()>(rela.offset) = mem::rel_ptr(rela.addend) };

--- a/src/libstd/sys/sgx/abi/thread.rs
+++ b/src/libstd/sys/sgx/abi/thread.rs
@@ -6,6 +6,8 @@ use fortanix_sgx_abi::Tcs;
 /// is a one-to-one correspondence of the ID to the address of the TCS.
 #[unstable(feature = "sgx_platform", issue = "56975")]
 pub fn current() -> Tcs {
-    extern "C" { fn get_tcs_addr() -> Tcs; }
+    extern "C" {
+        fn get_tcs_addr() -> Tcs;
+    }
     unsafe { get_tcs_addr() }
 }

--- a/src/libstd/sys/sgx/abi/usercalls/raw.rs
+++ b/src/libstd/sys/sgx/abi/usercalls/raw.rs
@@ -3,8 +3,8 @@
 #[unstable(feature = "sgx_platform", issue = "56975")]
 pub use fortanix_sgx_abi::*;
 
-use crate::ptr::NonNull;
 use crate::num::NonZeroU64;
+use crate::ptr::NonNull;
 
 #[repr(C)]
 struct UsercallReturn(u64, u64);
@@ -25,9 +25,14 @@ extern "C" {
 /// Panics if `nr` is `0`.
 #[unstable(feature = "sgx_platform", issue = "56975")]
 #[inline]
-pub unsafe fn do_usercall(nr: NonZeroU64, p1: u64, p2: u64, p3: u64, p4: u64, abort: bool)
-    -> (u64, u64)
-{
+pub unsafe fn do_usercall(
+    nr: NonZeroU64,
+    p1: u64,
+    p2: u64,
+    p3: u64,
+    p4: u64,
+    abort: bool,
+) -> (u64, u64) {
     let UsercallReturn(a, b) = usercall(nr, p1, p2, abort as _, p3, p4);
     (a, b)
 }
@@ -109,11 +114,7 @@ define_ra!(<T> *mut T);
 
 impl RegisterArgument for bool {
     fn from_register(a: Register) -> bool {
-        if a != 0 {
-            true
-        } else {
-            false
-        }
+        if a != 0 { true } else { false }
     }
     fn into_register(self) -> Register {
         self as _
@@ -152,16 +153,17 @@ impl<T: RegisterArgument> ReturnValue for T {
 
 impl<T: RegisterArgument, U: RegisterArgument> ReturnValue for (T, U) {
     fn from_registers(_call: &'static str, regs: (Register, Register)) -> Self {
-        (
-            T::from_register(regs.0),
-            U::from_register(regs.1)
-        )
+        (T::from_register(regs.0), U::from_register(regs.1))
     }
 }
 
 macro_rules! return_type_is_abort {
-    (!) => { true };
-    ($r:ty) => { false };
+    (!) => {
+        true
+    };
+    ($r:ty) => {
+        false
+    };
 }
 
 // In this macro: using `$r:tt` because `$r:ty` doesn't match ! in `return_type_is_abort`

--- a/src/libstd/sys/sgx/args.rs
+++ b/src/libstd/sys/sgx/args.rs
@@ -1,9 +1,9 @@
 use super::abi::usercalls::{alloc, raw::ByteBuffer};
 use crate::ffi::OsString;
+use crate::slice;
 use crate::sync::atomic::{AtomicUsize, Ordering};
 use crate::sys::os_str::Buf;
 use crate::sys_common::FromInner;
-use crate::slice;
 
 #[cfg_attr(test, linkage = "available_externally")]
 #[export_name = "_ZN16__rust_internals3std3sys3sgx4args4ARGSE"]
@@ -14,8 +14,9 @@ type ArgsStore = Vec<OsString>;
 pub unsafe fn init(argc: isize, argv: *const *const u8) {
     if argc != 0 {
         let args = alloc::User::<[ByteBuffer]>::from_raw_parts(argv as _, argc as _);
-        let args = args.iter()
-            .map( |a| OsString::from_inner(Buf { inner: a.copy_user_buffer() }) )
+        let args = args
+            .iter()
+            .map(|a| OsString::from_inner(Buf { inner: a.copy_user_buffer() }))
             .collect::<ArgsStore>();
         ARGS.store(Box::into_raw(Box::new(args)) as _, Ordering::Relaxed);
     }
@@ -30,11 +31,7 @@ pub unsafe fn cleanup() {
 
 pub fn args() -> Args {
     let args = unsafe { (ARGS.load(Ordering::Relaxed) as *const ArgsStore).as_ref() };
-    if let Some(args) = args {
-        Args(args.iter())
-    } else {
-        Args([].iter())
-    }
+    if let Some(args) = args { Args(args.iter()) } else { Args([].iter()) }
 }
 
 pub struct Args(slice::Iter<'static, OsString>);

--- a/src/libstd/sys/sgx/cmath.rs
+++ b/src/libstd/sys/sgx/cmath.rs
@@ -1,7 +1,7 @@
 #![cfg(not(test))]
 
 // These symbols are all defined in `compiler-builtins`
-extern {
+extern "C" {
     pub fn acos(n: f64) -> f64;
     pub fn acosf(n: f32) -> f32;
     pub fn asin(n: f64) -> f64;

--- a/src/libstd/sys/sgx/ext/io.rs
+++ b/src/libstd/sys/sgx/ext/io.rs
@@ -4,8 +4,8 @@
 //! description of [`TryIntoRawFd`](trait.TryIntoRawFd.html) for more details.
 #![unstable(feature = "sgx_platform", issue = "56975")]
 
-pub use crate::sys::abi::usercalls::raw::Fd as RawFd;
 use crate::net;
+pub use crate::sys::abi::usercalls::raw::Fd as RawFd;
 use crate::sys::{self, AsInner, FromInner, IntoInner, TryIntoInner};
 
 /// A trait to extract the raw SGX file descriptor from an underlying
@@ -60,11 +60,15 @@ pub trait TryIntoRawFd: Sized {
 }
 
 impl AsRawFd for net::TcpStream {
-    fn as_raw_fd(&self) -> RawFd { *self.as_inner().as_inner().as_inner().as_inner() }
+    fn as_raw_fd(&self) -> RawFd {
+        *self.as_inner().as_inner().as_inner().as_inner()
+    }
 }
 
 impl AsRawFd for net::TcpListener {
-    fn as_raw_fd(&self) -> RawFd { *self.as_inner().as_inner().as_inner().as_inner() }
+    fn as_raw_fd(&self) -> RawFd {
+        *self.as_inner().as_inner().as_inner().as_inner()
+    }
 }
 
 impl FromRawFd for net::TcpStream {

--- a/src/libstd/sys/sgx/ext/mod.rs
+++ b/src/libstd/sys/sgx/ext/mod.rs
@@ -1,5 +1,5 @@
 #![unstable(feature = "sgx_platform", issue = "56975")]
 
 pub mod arch;
-pub mod io;
 pub mod ffi;
+pub mod io;

--- a/src/libstd/sys/sgx/fd.rs
+++ b/src/libstd/sys/sgx/fd.rs
@@ -1,9 +1,9 @@
 use fortanix_sgx_abi::Fd;
 
+use super::abi::usercalls;
 use crate::io::{self, IoSlice, IoSliceMut};
 use crate::mem;
 use crate::sys::{AsInner, FromInner, IntoInner};
-use super::abi::usercalls;
 
 #[derive(Debug)]
 pub struct FileDesc {
@@ -15,7 +15,9 @@ impl FileDesc {
         FileDesc { fd: fd }
     }
 
-    pub fn raw(&self) -> Fd { self.fd }
+    pub fn raw(&self) -> Fd {
+        self.fd
+    }
 
     /// Extracts the actual filedescriptor without closing it.
     pub fn into_raw(self) -> Fd {
@@ -46,7 +48,9 @@ impl FileDesc {
 }
 
 impl AsInner<Fd> for FileDesc {
-    fn as_inner(&self) -> &Fd { &self.fd }
+    fn as_inner(&self) -> &Fd {
+        &self.fd
+    }
 }
 
 impl IntoInner<Fd> for FileDesc {

--- a/src/libstd/sys/sgx/fs.rs
+++ b/src/libstd/sys/sgx/fs.rs
@@ -1,7 +1,7 @@
 use crate::ffi::OsString;
 use crate::fmt;
 use crate::hash::{Hash, Hasher};
-use crate::io::{self, SeekFrom, IoSlice, IoSliceMut};
+use crate::io::{self, IoSlice, IoSliceMut, SeekFrom};
 use crate::path::{Path, PathBuf};
 use crate::sys::time::SystemTime;
 use crate::sys::{unsupported, Void};
@@ -15,14 +15,14 @@ pub struct ReadDir(Void);
 pub struct DirEntry(Void);
 
 #[derive(Clone, Debug)]
-pub struct OpenOptions { }
+pub struct OpenOptions {}
 
 pub struct FilePermissions(Void);
 
 pub struct FileType(Void);
 
 #[derive(Debug)]
-pub struct DirBuilder { }
+pub struct DirBuilder {}
 
 impl FileAttr {
     pub fn size(&self) -> u64 {
@@ -78,8 +78,7 @@ impl PartialEq for FilePermissions {
     }
 }
 
-impl Eq for FilePermissions {
-}
+impl Eq for FilePermissions {}
 
 impl fmt::Debug for FilePermissions {
     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -115,8 +114,7 @@ impl PartialEq for FileType {
     }
 }
 
-impl Eq for FileType {
-}
+impl Eq for FileType {}
 
 impl Hash for FileType {
     fn hash<H: Hasher>(&self, _h: &mut H) {
@@ -164,15 +162,15 @@ impl DirEntry {
 
 impl OpenOptions {
     pub fn new() -> OpenOptions {
-        OpenOptions { }
+        OpenOptions {}
     }
 
-    pub fn read(&mut self, _read: bool) { }
-    pub fn write(&mut self, _write: bool) { }
-    pub fn append(&mut self, _append: bool) { }
-    pub fn truncate(&mut self, _truncate: bool) { }
-    pub fn create(&mut self, _create: bool) { }
-    pub fn create_new(&mut self, _create_new: bool) { }
+    pub fn read(&mut self, _read: bool) {}
+    pub fn write(&mut self, _write: bool) {}
+    pub fn append(&mut self, _append: bool) {}
+    pub fn truncate(&mut self, _truncate: bool) {}
+    pub fn create(&mut self, _create: bool) {}
+    pub fn create_new(&mut self, _create_new: bool) {}
 }
 
 impl File {
@@ -235,7 +233,7 @@ impl File {
 
 impl DirBuilder {
     pub fn new() -> DirBuilder {
-        DirBuilder { }
+        DirBuilder {}
     }
 
     pub fn mkdir(&self, _p: &Path) -> io::Result<()> {

--- a/src/libstd/sys/sgx/path.rs
+++ b/src/libstd/sys/sgx/path.rs
@@ -1,5 +1,5 @@
-use crate::path::Prefix;
 use crate::ffi::OsStr;
+use crate::path::Prefix;
 
 #[inline]
 pub fn is_sep_byte(b: u8) -> bool {

--- a/src/libstd/sys/sgx/process.rs
+++ b/src/libstd/sys/sgx/process.rs
@@ -32,32 +32,28 @@ pub enum Stdio {
 
 impl Command {
     pub fn new(_program: &OsStr) -> Command {
-        Command {
-            env: Default::default()
-        }
+        Command { env: Default::default() }
     }
 
-    pub fn arg(&mut self, _arg: &OsStr) {
-    }
+    pub fn arg(&mut self, _arg: &OsStr) {}
 
     pub fn env_mut(&mut self) -> &mut CommandEnv {
         &mut self.env
     }
 
-    pub fn cwd(&mut self, _dir: &OsStr) {
-    }
+    pub fn cwd(&mut self, _dir: &OsStr) {}
 
-    pub fn stdin(&mut self, _stdin: Stdio) {
-    }
+    pub fn stdin(&mut self, _stdin: Stdio) {}
 
-    pub fn stdout(&mut self, _stdout: Stdio) {
-    }
+    pub fn stdout(&mut self, _stdout: Stdio) {}
 
-    pub fn stderr(&mut self, _stderr: Stdio) {
-    }
+    pub fn stderr(&mut self, _stderr: Stdio) {}
 
-    pub fn spawn(&mut self, _default: Stdio, _needs_stdin: bool)
-        -> io::Result<(Process, StdioPipes)> {
+    pub fn spawn(
+        &mut self,
+        _default: Stdio,
+        _needs_stdin: bool,
+    ) -> io::Result<(Process, StdioPipes)> {
         unsupported()
     }
 }
@@ -106,8 +102,7 @@ impl PartialEq for ExitStatus {
     }
 }
 
-impl Eq for ExitStatus {
-}
+impl Eq for ExitStatus {}
 
 impl fmt::Debug for ExitStatus {
     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/libstd/sys/sgx/stack_overflow.rs
+++ b/src/libstd/sys/sgx/stack_overflow.rs
@@ -7,8 +7,6 @@ impl Handler {
 }
 
 #[cfg_attr(test, allow(dead_code))]
-pub unsafe fn init() {
-}
+pub unsafe fn init() {}
 
-pub unsafe fn cleanup() {
-}
+pub unsafe fn cleanup() {}

--- a/src/libstd/sys/sgx/stdio.rs
+++ b/src/libstd/sys/sgx/stdio.rs
@@ -1,11 +1,11 @@
 use fortanix_sgx_abi as abi;
 
 use crate::io;
-use crate::sys::fd::FileDesc;
 #[cfg(not(test))]
 use crate::slice;
 #[cfg(not(test))]
 use crate::str;
+use crate::sys::fd::FileDesc;
 
 pub struct Stdin(());
 pub struct Stdout(());
@@ -19,7 +19,9 @@ fn with_std_fd<F: FnOnce(&FileDesc) -> R, R>(fd: abi::Fd, f: F) -> R {
 }
 
 impl Stdin {
-    pub fn new() -> io::Result<Stdin> { Ok(Stdin(())) }
+    pub fn new() -> io::Result<Stdin> {
+        Ok(Stdin(()))
+    }
 }
 
 impl io::Read for Stdin {
@@ -29,7 +31,9 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> io::Result<Stdout> { Ok(Stdout(())) }
+    pub fn new() -> io::Result<Stdout> {
+        Ok(Stdout(()))
+    }
 }
 
 impl io::Write for Stdout {
@@ -43,7 +47,9 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> io::Result<Stderr> { Ok(Stderr(())) }
+    pub fn new() -> io::Result<Stderr> {
+        Ok(Stderr(()))
+    }
 }
 
 impl io::Write for Stderr {

--- a/src/libstd/sys/sgx/thread.rs
+++ b/src/libstd/sys/sgx/thread.rs
@@ -10,8 +10,8 @@ pub struct Thread(task_queue::JoinHandle);
 pub const DEFAULT_MIN_STACK_SIZE: usize = 4096;
 
 mod task_queue {
-    use crate::sync::{Mutex, MutexGuard, Once};
     use crate::sync::mpsc;
+    use crate::sync::{Mutex, MutexGuard, Once};
 
     pub type JoinHandle = mpsc::Receiver<()>;
 
@@ -41,7 +41,7 @@ mod task_queue {
 
     pub(super) fn lock() -> MutexGuard<'static, Vec<Task>> {
         unsafe {
-            TASK_QUEUE_INIT.call_once(|| TASK_QUEUE = Some(Default::default()) );
+            TASK_QUEUE_INIT.call_once(|| TASK_QUEUE = Some(Default::default()));
             TASK_QUEUE.as_ref().unwrap().lock().unwrap()
         }
     }
@@ -49,9 +49,7 @@ mod task_queue {
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
-    pub unsafe fn new(_stack: usize, p: Box<dyn FnOnce()>)
-        -> io::Result<Thread>
-    {
+    pub unsafe fn new(_stack: usize, p: Box<dyn FnOnce()>) -> io::Result<Thread> {
         let mut queue_lock = task_queue::lock();
         usercalls::launch_thread()?;
         let (task, handle) = task_queue::Task::new(p);
@@ -86,6 +84,10 @@ impl Thread {
 
 pub mod guard {
     pub type Guard = !;
-    pub unsafe fn current() -> Option<Guard> { None }
-    pub unsafe fn init() -> Option<Guard> { None }
+    pub unsafe fn current() -> Option<Guard> {
+        None
+    }
+    pub unsafe fn init() -> Option<Guard> {
+        None
+    }
 }

--- a/src/libstd/sys/sgx/thread_local.rs
+++ b/src/libstd/sys/sgx/thread_local.rs
@@ -1,9 +1,9 @@
-use super::abi::tls::{Tls, Key as AbiKey};
+use super::abi::tls::{Key as AbiKey, Tls};
 
 pub type Key = usize;
 
 #[inline]
-pub unsafe fn create(dtor: Option<unsafe extern fn(*mut u8)>) -> Key {
+pub unsafe fn create(dtor: Option<unsafe extern "C" fn(*mut u8)>) -> Key {
     Tls::create(dtor).as_usize()
 }
 

--- a/src/libstd/sys/sgx/time.rs
+++ b/src/libstd/sys/sgx/time.rs
@@ -1,5 +1,5 @@
-use crate::time::Duration;
 use super::abi::usercalls;
+use crate::time::Duration;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub struct Instant(Duration);
@@ -40,8 +40,7 @@ impl SystemTime {
         SystemTime(usercalls::insecure_time())
     }
 
-    pub fn sub_time(&self, other: &SystemTime)
-                    -> Result<Duration, Duration> {
+    pub fn sub_time(&self, other: &SystemTime) -> Result<Duration, Duration> {
         self.0.checked_sub(other.0).ok_or_else(|| other.0 - self.0)
     }
 

--- a/src/libstd/sys/unix/alloc.rs
+++ b/src/libstd/sys/unix/alloc.rs
@@ -1,6 +1,6 @@
-use crate::ptr;
-use crate::sys_common::alloc::{MIN_ALIGN, realloc_fallback};
 use crate::alloc::{GlobalAlloc, Layout, System};
+use crate::ptr;
+use crate::sys_common::alloc::{realloc_fallback, MIN_ALIGN};
 
 #[stable(feature = "alloc_system_type", since = "1.28.0")]
 unsafe impl GlobalAlloc for System {
@@ -16,7 +16,7 @@ unsafe impl GlobalAlloc for System {
             #[cfg(target_os = "macos")]
             {
                 if layout.align() > (1 << 31) {
-                    return ptr::null_mut()
+                    return ptr::null_mut();
                 }
             }
             aligned_malloc(&layout)
@@ -52,9 +52,7 @@ unsafe impl GlobalAlloc for System {
     }
 }
 
-#[cfg(any(target_os = "android",
-          target_os = "redox",
-          target_os = "solaris"))]
+#[cfg(any(target_os = "android", target_os = "redox", target_os = "solaris"))]
 #[inline]
 unsafe fn aligned_malloc(layout: &Layout) -> *mut u8 {
     // On android we currently target API level 9 which unfortunately
@@ -77,9 +75,7 @@ unsafe fn aligned_malloc(layout: &Layout) -> *mut u8 {
     libc::memalign(layout.align(), layout.size()) as *mut u8
 }
 
-#[cfg(not(any(target_os = "android",
-              target_os = "redox",
-              target_os = "solaris")))]
+#[cfg(not(any(target_os = "android", target_os = "redox", target_os = "solaris")))]
 #[inline]
 unsafe fn aligned_malloc(layout: &Layout) -> *mut u8 {
     let mut out = ptr::null_mut();
@@ -87,9 +83,5 @@ unsafe fn aligned_malloc(layout: &Layout) -> *mut u8 {
     // Since these are all powers of 2, we can just use max.
     let align = layout.align().max(crate::mem::size_of::<usize>());
     let ret = libc::posix_memalign(&mut out, align, layout.size());
-    if ret != 0 {
-        ptr::null_mut()
-    } else {
-        out as *mut u8
-    }
+    if ret != 0 { ptr::null_mut() } else { out as *mut u8 }
 }

--- a/src/libstd/sys/unix/android.rs
+++ b/src/libstd/sys/unix/android.rs
@@ -21,8 +21,8 @@
 use libc::{c_int, c_void, sighandler_t, size_t, ssize_t};
 use libc::{ftruncate, pread, pwrite};
 
-use crate::io;
 use super::{cvt, cvt_r};
+use crate::io;
 
 // The `log2` and `log2f` functions apparently appeared in android-18, or at
 // least you can see they're not present in the android-17 header [1] and they
@@ -96,8 +96,7 @@ pub fn ftruncate64(fd: c_int, size: u64) -> io::Result<()> {
             Some(f) => cvt_r(|| f(fd, size as i64)).map(|_| ()),
             None => {
                 if size > i32::max_value() as u64 {
-                    Err(io::Error::new(io::ErrorKind::InvalidInput,
-                                       "cannot truncate >2GB"))
+                    Err(io::Error::new(io::ErrorKind::InvalidInput, "cannot truncate >2GB"))
                 } else {
                     cvt_r(|| ftruncate(fd, size as i32)).map(|_| ())
                 }
@@ -108,53 +107,61 @@ pub fn ftruncate64(fd: c_int, size: u64) -> io::Result<()> {
 
 #[cfg(target_pointer_width = "64")]
 pub fn ftruncate64(fd: c_int, size: u64) -> io::Result<()> {
-    unsafe {
-        cvt_r(|| ftruncate(fd, size as i64)).map(|_| ())
-    }
+    unsafe { cvt_r(|| ftruncate(fd, size as i64)).map(|_| ()) }
 }
 
 #[cfg(target_pointer_width = "32")]
-pub unsafe fn cvt_pread64(fd: c_int, buf: *mut c_void, count: size_t, offset: i64)
-    -> io::Result<ssize_t>
-{
+pub unsafe fn cvt_pread64(
+    fd: c_int,
+    buf: *mut c_void,
+    count: size_t,
+    offset: i64,
+) -> io::Result<ssize_t> {
     use crate::convert::TryInto;
     weak!(fn pread64(c_int, *mut c_void, size_t, i64) -> ssize_t);
     pread64.get().map(|f| cvt(f(fd, buf, count, offset))).unwrap_or_else(|| {
         if let Ok(o) = offset.try_into() {
             cvt(pread(fd, buf, count, o))
         } else {
-            Err(io::Error::new(io::ErrorKind::InvalidInput,
-                               "cannot pread >2GB"))
+            Err(io::Error::new(io::ErrorKind::InvalidInput, "cannot pread >2GB"))
         }
     })
 }
 
 #[cfg(target_pointer_width = "32")]
-pub unsafe fn cvt_pwrite64(fd: c_int, buf: *const c_void, count: size_t, offset: i64)
-    -> io::Result<ssize_t>
-{
+pub unsafe fn cvt_pwrite64(
+    fd: c_int,
+    buf: *const c_void,
+    count: size_t,
+    offset: i64,
+) -> io::Result<ssize_t> {
     use crate::convert::TryInto;
     weak!(fn pwrite64(c_int, *const c_void, size_t, i64) -> ssize_t);
     pwrite64.get().map(|f| cvt(f(fd, buf, count, offset))).unwrap_or_else(|| {
         if let Ok(o) = offset.try_into() {
             cvt(pwrite(fd, buf, count, o))
         } else {
-            Err(io::Error::new(io::ErrorKind::InvalidInput,
-                               "cannot pwrite >2GB"))
+            Err(io::Error::new(io::ErrorKind::InvalidInput, "cannot pwrite >2GB"))
         }
     })
 }
 
 #[cfg(target_pointer_width = "64")]
-pub unsafe fn cvt_pread64(fd: c_int, buf: *mut c_void, count: size_t, offset: i64)
-    -> io::Result<ssize_t>
-{
+pub unsafe fn cvt_pread64(
+    fd: c_int,
+    buf: *mut c_void,
+    count: size_t,
+    offset: i64,
+) -> io::Result<ssize_t> {
     cvt(pread(fd, buf, count, offset))
 }
 
 #[cfg(target_pointer_width = "64")]
-pub unsafe fn cvt_pwrite64(fd: c_int, buf: *const c_void, count: size_t, offset: i64)
-    -> io::Result<ssize_t>
-{
+pub unsafe fn cvt_pwrite64(
+    fd: c_int,
+    buf: *const c_void,
+    count: size_t,
+    offset: i64,
+) -> io::Result<ssize_t> {
     cvt(pwrite(fd, buf, count, offset))
 }

--- a/src/libstd/sys/unix/cmath.rs
+++ b/src/libstd/sys/unix/cmath.rs
@@ -1,9 +1,9 @@
 #![cfg(not(test))]
 
-use libc::{c_float, c_double};
+use libc::{c_double, c_float};
 
 #[link_name = "m"]
-extern {
+extern "C" {
     pub fn acos(n: c_double) -> c_double;
     pub fn acosf(n: c_float) -> c_float;
     pub fn asin(n: c_double) -> c_double;

--- a/src/libstd/sys/unix/ext/fs.rs
+++ b/src/libstd/sys/unix/ext/fs.rs
@@ -2,12 +2,12 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use crate::fs::{self, Permissions, OpenOptions};
+use crate::fs::{self, OpenOptions, Permissions};
 use crate::io;
 use crate::path::Path;
 use crate::sys;
-use crate::sys_common::{FromInner, AsInner, AsInnerMut};
 use crate::sys::platform::fs::MetadataExt as UnixMetadataExt;
+use crate::sys_common::{AsInner, AsInnerMut, FromInner};
 
 /// Unix-specific extensions to [`File`].
 ///
@@ -112,8 +112,7 @@ pub trait FileExt {
             }
         }
         if !buf.is_empty() {
-            Err(io::Error::new(io::ErrorKind::UnexpectedEof,
-                               "failed to fill whole buffer"))
+            Err(io::Error::new(io::ErrorKind::UnexpectedEof, "failed to fill whole buffer"))
         } else {
             Ok(())
         }
@@ -195,8 +194,12 @@ pub trait FileExt {
     fn write_all_at(&self, mut buf: &[u8], mut offset: u64) -> io::Result<()> {
         while !buf.is_empty() {
             match self.write_at(buf, offset) {
-                Ok(0) => return Err(io::Error::new(io::ErrorKind::WriteZero,
-                                                   "failed to write whole buffer")),
+                Ok(0) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "failed to write whole buffer",
+                    ));
+                }
                 Ok(n) => {
                     buf = &buf[n..];
                     offset += n as u64
@@ -356,11 +359,13 @@ pub trait OpenOptionsExt {
 #[stable(feature = "fs_ext", since = "1.1.0")]
 impl OpenOptionsExt for OpenOptions {
     fn mode(&mut self, mode: u32) -> &mut OpenOptions {
-        self.as_inner_mut().mode(mode); self
+        self.as_inner_mut().mode(mode);
+        self
     }
 
     fn custom_flags(&mut self, flags: i32) -> &mut OpenOptions {
-        self.as_inner_mut().custom_flags(flags); self
+        self.as_inner_mut().custom_flags(flags);
+        self
     }
 }
 
@@ -657,22 +662,54 @@ pub trait MetadataExt {
 
 #[stable(feature = "metadata_ext", since = "1.1.0")]
 impl MetadataExt for fs::Metadata {
-    fn dev(&self) -> u64 { self.st_dev() }
-    fn ino(&self) -> u64 { self.st_ino() }
-    fn mode(&self) -> u32 { self.st_mode() }
-    fn nlink(&self) -> u64 { self.st_nlink() }
-    fn uid(&self) -> u32 { self.st_uid() }
-    fn gid(&self) -> u32 { self.st_gid() }
-    fn rdev(&self) -> u64 { self.st_rdev() }
-    fn size(&self) -> u64 { self.st_size() }
-    fn atime(&self) -> i64 { self.st_atime() }
-    fn atime_nsec(&self) -> i64 { self.st_atime_nsec() }
-    fn mtime(&self) -> i64 { self.st_mtime() }
-    fn mtime_nsec(&self) -> i64 { self.st_mtime_nsec() }
-    fn ctime(&self) -> i64 { self.st_ctime() }
-    fn ctime_nsec(&self) -> i64 { self.st_ctime_nsec() }
-    fn blksize(&self) -> u64 { self.st_blksize() }
-    fn blocks(&self) -> u64 { self.st_blocks() }
+    fn dev(&self) -> u64 {
+        self.st_dev()
+    }
+    fn ino(&self) -> u64 {
+        self.st_ino()
+    }
+    fn mode(&self) -> u32 {
+        self.st_mode()
+    }
+    fn nlink(&self) -> u64 {
+        self.st_nlink()
+    }
+    fn uid(&self) -> u32 {
+        self.st_uid()
+    }
+    fn gid(&self) -> u32 {
+        self.st_gid()
+    }
+    fn rdev(&self) -> u64 {
+        self.st_rdev()
+    }
+    fn size(&self) -> u64 {
+        self.st_size()
+    }
+    fn atime(&self) -> i64 {
+        self.st_atime()
+    }
+    fn atime_nsec(&self) -> i64 {
+        self.st_atime_nsec()
+    }
+    fn mtime(&self) -> i64 {
+        self.st_mtime()
+    }
+    fn mtime_nsec(&self) -> i64 {
+        self.st_mtime_nsec()
+    }
+    fn ctime(&self) -> i64 {
+        self.st_ctime()
+    }
+    fn ctime_nsec(&self) -> i64 {
+        self.st_ctime_nsec()
+    }
+    fn blksize(&self) -> u64 {
+        self.st_blksize()
+    }
+    fn blocks(&self) -> u64 {
+        self.st_blocks()
+    }
 }
 
 /// Unix-specific extensions for [`FileType`].
@@ -759,10 +796,18 @@ pub trait FileTypeExt {
 
 #[stable(feature = "file_type_ext", since = "1.5.0")]
 impl FileTypeExt for fs::FileType {
-    fn is_block_device(&self) -> bool { self.as_inner().is(libc::S_IFBLK) }
-    fn is_char_device(&self) -> bool { self.as_inner().is(libc::S_IFCHR) }
-    fn is_fifo(&self) -> bool { self.as_inner().is(libc::S_IFIFO) }
-    fn is_socket(&self) -> bool { self.as_inner().is(libc::S_IFSOCK) }
+    fn is_block_device(&self) -> bool {
+        self.as_inner().is(libc::S_IFBLK)
+    }
+    fn is_char_device(&self) -> bool {
+        self.as_inner().is(libc::S_IFCHR)
+    }
+    fn is_fifo(&self) -> bool {
+        self.as_inner().is(libc::S_IFIFO)
+    }
+    fn is_socket(&self) -> bool {
+        self.as_inner().is(libc::S_IFSOCK)
+    }
 }
 
 /// Unix-specific extension methods for [`fs::DirEntry`].
@@ -794,7 +839,9 @@ pub trait DirEntryExt {
 
 #[stable(feature = "dir_entry_ext", since = "1.1.0")]
 impl DirEntryExt for fs::DirEntry {
-    fn ino(&self) -> u64 { self.as_inner().ino() }
+    fn ino(&self) -> u64 {
+        self.as_inner().ino()
+    }
 }
 
 /// Creates a new symbolic link on the filesystem.
@@ -821,8 +868,7 @@ impl DirEntryExt for fs::DirEntry {
 /// }
 /// ```
 #[stable(feature = "symlink", since = "1.1.0")]
-pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()>
-{
+pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
     sys::fs::symlink(src.as_ref(), dst.as_ref())
 }
 

--- a/src/libstd/sys/unix/ext/io.rs
+++ b/src/libstd/sys/unix/ext/io.rs
@@ -3,9 +3,9 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::fs;
+use crate::io;
 use crate::os::raw;
 use crate::sys;
-use crate::io;
 use crate::sys_common::{AsInner, FromInner, IntoInner};
 
 /// Raw file descriptors.
@@ -83,30 +83,42 @@ impl IntoRawFd for fs::File {
 
 #[stable(feature = "asraw_stdio", since = "1.21.0")]
 impl AsRawFd for io::Stdin {
-    fn as_raw_fd(&self) -> RawFd { libc::STDIN_FILENO }
+    fn as_raw_fd(&self) -> RawFd {
+        libc::STDIN_FILENO
+    }
 }
 
 #[stable(feature = "asraw_stdio", since = "1.21.0")]
 impl AsRawFd for io::Stdout {
-    fn as_raw_fd(&self) -> RawFd { libc::STDOUT_FILENO }
+    fn as_raw_fd(&self) -> RawFd {
+        libc::STDOUT_FILENO
+    }
 }
 
 #[stable(feature = "asraw_stdio", since = "1.21.0")]
 impl AsRawFd for io::Stderr {
-    fn as_raw_fd(&self) -> RawFd { libc::STDERR_FILENO }
+    fn as_raw_fd(&self) -> RawFd {
+        libc::STDERR_FILENO
+    }
 }
 
 #[stable(feature = "asraw_stdio_locks", since = "1.35.0")]
 impl<'a> AsRawFd for io::StdinLock<'a> {
-    fn as_raw_fd(&self) -> RawFd { libc::STDIN_FILENO }
+    fn as_raw_fd(&self) -> RawFd {
+        libc::STDIN_FILENO
+    }
 }
 
 #[stable(feature = "asraw_stdio_locks", since = "1.35.0")]
 impl<'a> AsRawFd for io::StdoutLock<'a> {
-    fn as_raw_fd(&self) -> RawFd { libc::STDOUT_FILENO }
+    fn as_raw_fd(&self) -> RawFd {
+        libc::STDOUT_FILENO
+    }
 }
 
 #[stable(feature = "asraw_stdio_locks", since = "1.35.0")]
 impl<'a> AsRawFd for io::StderrLock<'a> {
-    fn as_raw_fd(&self) -> RawFd { libc::STDERR_FILENO }
+    fn as_raw_fd(&self) -> RawFd {
+        libc::STDERR_FILENO
+    }
 }

--- a/src/libstd/sys/unix/ext/process.rs
+++ b/src/libstd/sys/unix/ext/process.rs
@@ -4,10 +4,10 @@
 
 use crate::ffi::OsStr;
 use crate::io;
-use crate::os::unix::io::{FromRawFd, RawFd, AsRawFd, IntoRawFd};
+use crate::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use crate::process;
 use crate::sys;
-use crate::sys_common::{AsInnerMut, AsInner, FromInner, IntoInner};
+use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 
 /// Unix-specific extensions to the [`process::Command`] builder.
 ///
@@ -56,7 +56,8 @@ pub trait CommandExt {
     /// locations may not appear where intended.
     #[stable(feature = "process_pre_exec", since = "1.34.0")]
     unsafe fn pre_exec<F>(&mut self, f: F) -> &mut process::Command
-        where F: FnMut() -> io::Result<()> + Send + Sync + 'static;
+    where
+        F: FnMut() -> io::Result<()> + Send + Sync + 'static;
 
     /// Schedules a closure to be run just before the `exec` function is
     /// invoked.
@@ -68,7 +69,8 @@ pub trait CommandExt {
     #[stable(feature = "process_exec", since = "1.15.0")]
     #[rustc_deprecated(since = "1.37.0", reason = "should be unsafe, use `pre_exec` instead")]
     fn before_exec<F>(&mut self, f: F) -> &mut process::Command
-        where F: FnMut() -> io::Result<()> + Send + Sync + 'static
+    where
+        F: FnMut() -> io::Result<()> + Send + Sync + 'static,
     {
         unsafe { self.pre_exec(f) }
     }
@@ -111,7 +113,8 @@ pub trait CommandExt {
     /// default executable path.
     #[unstable(feature = "process_set_argv0", issue = "66510")]
     fn arg0<S>(&mut self, arg: S) -> &mut process::Command
-        where S: AsRef<OsStr>;
+    where
+        S: AsRef<OsStr>;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -127,7 +130,8 @@ impl CommandExt for process::Command {
     }
 
     unsafe fn pre_exec<F>(&mut self, f: F) -> &mut process::Command
-        where F: FnMut() -> io::Result<()> + Send + Sync + 'static
+    where
+        F: FnMut() -> io::Result<()> + Send + Sync + 'static,
     {
         self.as_inner_mut().pre_exec(Box::new(f));
         self
@@ -138,7 +142,8 @@ impl CommandExt for process::Command {
     }
 
     fn arg0<S>(&mut self, arg: S) -> &mut process::Command
-        where S: AsRef<OsStr>
+    where
+        S: AsRef<OsStr>,
     {
         self.as_inner_mut().set_arg_0(arg.as_ref());
         self

--- a/src/libstd/sys/unix/ext/raw.rs
+++ b/src/libstd/sys/unix/ext/raw.rs
@@ -1,23 +1,28 @@
 //! Unix-specific primitives available on all unix platforms
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
-#![rustc_deprecated(since = "1.8.0",
-                    reason = "these type aliases are no longer supported by \
-                              the standard library, the `libc` crate on \
-                              crates.io should be used instead for the correct \
-                              definitions")]
+#![rustc_deprecated(
+    since = "1.8.0",
+    reason = "these type aliases are no longer supported by \
+              the standard library, the `libc` crate on \
+              crates.io should be used instead for the correct \
+              definitions"
+)]
 #![allow(deprecated)]
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type uid_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type gid_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type pid_t = i32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type uid_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type gid_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type pid_t = i32;
 
 #[doc(inline)]
 #[stable(feature = "pthread_t", since = "1.8.0")]
 pub use crate::sys::platform::raw::pthread_t;
 #[doc(inline)]
 #[stable(feature = "raw_ext", since = "1.1.0")]
-pub use crate::sys::platform::raw::{dev_t, ino_t, mode_t, nlink_t, off_t, blksize_t};
+pub use crate::sys::platform::raw::{blkcnt_t, time_t};
 #[doc(inline)]
 #[stable(feature = "raw_ext", since = "1.1.0")]
-pub use crate::sys::platform::raw::{blkcnt_t, time_t};
+pub use crate::sys::platform::raw::{blksize_t, dev_t, ino_t, mode_t, nlink_t, off_t};

--- a/src/libstd/sys/unix/io.rs
+++ b/src/libstd/sys/unix/io.rs
@@ -1,7 +1,7 @@
 use crate::marker::PhantomData;
 use crate::slice;
 
-use libc::{iovec, c_void};
+use libc::{c_void, iovec};
 
 #[repr(transparent)]
 pub struct IoSlice<'a> {
@@ -13,10 +13,7 @@ impl<'a> IoSlice<'a> {
     #[inline]
     pub fn new(buf: &'a [u8]) -> IoSlice<'a> {
         IoSlice {
-            vec: iovec {
-                iov_base: buf.as_ptr() as *mut u8 as *mut c_void,
-                iov_len: buf.len()
-            },
+            vec: iovec { iov_base: buf.as_ptr() as *mut u8 as *mut c_void, iov_len: buf.len() },
             _p: PhantomData,
         }
     }
@@ -35,9 +32,7 @@ impl<'a> IoSlice<'a> {
 
     #[inline]
     pub fn as_slice(&self) -> &[u8] {
-        unsafe {
-            slice::from_raw_parts(self.vec.iov_base as *mut u8, self.vec.iov_len)
-        }
+        unsafe { slice::from_raw_parts(self.vec.iov_base as *mut u8, self.vec.iov_len) }
     }
 }
 
@@ -51,10 +46,7 @@ impl<'a> IoSliceMut<'a> {
     #[inline]
     pub fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
         IoSliceMut {
-            vec: iovec {
-                iov_base: buf.as_mut_ptr() as *mut c_void,
-                iov_len: buf.len()
-            },
+            vec: iovec { iov_base: buf.as_mut_ptr() as *mut c_void, iov_len: buf.len() },
             _p: PhantomData,
         }
     }
@@ -73,15 +65,11 @@ impl<'a> IoSliceMut<'a> {
 
     #[inline]
     pub fn as_slice(&self) -> &[u8] {
-        unsafe {
-            slice::from_raw_parts(self.vec.iov_base as *mut u8, self.vec.iov_len)
-        }
+        unsafe { slice::from_raw_parts(self.vec.iov_base as *mut u8, self.vec.iov_len) }
     }
 
     #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
-        unsafe {
-            slice::from_raw_parts_mut(self.vec.iov_base as *mut u8, self.vec.iov_len)
-        }
+        unsafe { slice::from_raw_parts_mut(self.vec.iov_base as *mut u8, self.vec.iov_len) }
     }
 }

--- a/src/libstd/sys/unix/l4re.rs
+++ b/src/libstd/sys/unix/l4re.rs
@@ -1,16 +1,18 @@
 macro_rules! unimpl {
-    () => (return Err(io::Error::new(io::ErrorKind::Other, "No networking available on L4Re."));)
+    () => {
+        return Err(io::Error::new(io::ErrorKind::Other, "No networking available on L4Re."));
+    };
 }
 
 pub mod net {
     #![allow(warnings)]
+    use crate::convert::TryFrom;
     use crate::fmt;
     use crate::io::{self, IoSlice, IoSliceMut};
-    use crate::net::{SocketAddr, Shutdown, Ipv4Addr, Ipv6Addr};
-    use crate::sys_common::{AsInner, FromInner, IntoInner};
+    use crate::net::{Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr};
     use crate::sys::fd::FileDesc;
+    use crate::sys_common::{AsInner, FromInner, IntoInner};
     use crate::time::Duration;
-    use crate::convert::TryFrom;
 
     #[allow(unused_extern_crates)]
     pub extern crate libc as netc;
@@ -33,8 +35,11 @@ pub mod net {
             unimpl!();
         }
 
-        pub fn accept(&self, _: *mut libc::sockaddr, _: *mut libc::socklen_t)
-                  -> io::Result<Socket> {
+        pub fn accept(
+            &self,
+            _: *mut libc::sockaddr,
+            _: *mut libc::socklen_t,
+        ) -> io::Result<Socket> {
             unimpl!();
         }
 
@@ -100,15 +105,21 @@ pub mod net {
     }
 
     impl AsInner<libc::c_int> for Socket {
-        fn as_inner(&self) -> &libc::c_int { self.0.as_inner() }
+        fn as_inner(&self) -> &libc::c_int {
+            self.0.as_inner()
+        }
     }
 
     impl FromInner<libc::c_int> for Socket {
-        fn from_inner(fd: libc::c_int) -> Socket { Socket(FileDesc::new(fd)) }
+        fn from_inner(fd: libc::c_int) -> Socket {
+            Socket(FileDesc::new(fd))
+        }
     }
 
     impl IntoInner<libc::c_int> for Socket {
-        fn into_inner(self) -> libc::c_int { self.0.into_raw() }
+        fn into_inner(self) -> libc::c_int {
+            self.0.into_raw()
+        }
     }
 
     pub struct TcpStream {
@@ -124,9 +135,13 @@ pub mod net {
             unimpl!();
         }
 
-        pub fn socket(&self) -> &Socket { &self.inner }
+        pub fn socket(&self) -> &Socket {
+            &self.inner
+        }
 
-        pub fn into_socket(self) -> Socket { self.inner }
+        pub fn into_socket(self) -> Socket {
+            self.inner
+        }
 
         pub fn set_read_timeout(&self, _: Option<Duration>) -> io::Result<()> {
             unimpl!();
@@ -226,9 +241,13 @@ pub mod net {
             unimpl!();
         }
 
-        pub fn socket(&self) -> &Socket { &self.inner }
+        pub fn socket(&self) -> &Socket {
+            &self.inner
+        }
 
-        pub fn into_socket(self) -> Socket { self.inner }
+        pub fn into_socket(self) -> Socket {
+            self.inner
+        }
 
         pub fn socket_addr(&self) -> io::Result<SocketAddr> {
             unimpl!();
@@ -288,9 +307,13 @@ pub mod net {
             unimpl!();
         }
 
-        pub fn socket(&self) -> &Socket { &self.inner }
+        pub fn socket(&self) -> &Socket {
+            &self.inner
+        }
 
-        pub fn into_socket(self) -> Socket { self.inner }
+        pub fn into_socket(self) -> Socket {
+            self.inner
+        }
 
         pub fn peer_addr(&self) -> io::Result<SocketAddr> {
             unimpl!();
@@ -364,24 +387,20 @@ pub mod net {
             unimpl!();
         }
 
-        pub fn join_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr)
-                             -> io::Result<()> {
-                                 unimpl!();
+        pub fn join_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr) -> io::Result<()> {
+            unimpl!();
         }
 
-        pub fn join_multicast_v6(&self, _: &Ipv6Addr, _: u32)
-                             -> io::Result<()> {
-                                 unimpl!();
+        pub fn join_multicast_v6(&self, _: &Ipv6Addr, _: u32) -> io::Result<()> {
+            unimpl!();
         }
 
-        pub fn leave_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr)
-                              -> io::Result<()> {
-                                  unimpl!();
+        pub fn leave_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr) -> io::Result<()> {
+            unimpl!();
         }
 
-        pub fn leave_multicast_v6(&self, _: &Ipv6Addr, _: u32)
-                              -> io::Result<()> {
-                                  unimpl!();
+        pub fn leave_multicast_v6(&self, _: &Ipv6Addr, _: u32) -> io::Result<()> {
+            unimpl!();
         }
 
         pub fn set_ttl(&self, _: u32) -> io::Result<()> {
@@ -449,7 +468,6 @@ pub mod net {
 
     unsafe impl Sync for LookupHost {}
     unsafe impl Send for LookupHost {}
-
 
     impl TryFrom<&str> for LookupHost {
         type Error = io::Error;

--- a/src/libstd/sys/unix/memchr.rs
+++ b/src/libstd/sys/unix/memchr.rs
@@ -6,32 +6,27 @@ pub fn memchr(needle: u8, haystack: &[u8]) -> Option<usize> {
         libc::memchr(
             haystack.as_ptr() as *const libc::c_void,
             needle as libc::c_int,
-            haystack.len())
+            haystack.len(),
+        )
     };
-    if p.is_null() {
-        None
-    } else {
-        Some(p as usize - (haystack.as_ptr() as usize))
-    }
+    if p.is_null() { None } else { Some(p as usize - (haystack.as_ptr() as usize)) }
 }
 
 pub fn memrchr(needle: u8, haystack: &[u8]) -> Option<usize> {
-
     #[cfg(target_os = "linux")]
     fn memrchr_specific(needle: u8, haystack: &[u8]) -> Option<usize> {
         // GNU's memrchr() will - unlike memchr() - error if haystack is empty.
-        if haystack.is_empty() {return None}
+        if haystack.is_empty() {
+            return None;
+        }
         let p = unsafe {
             libc::memrchr(
                 haystack.as_ptr() as *const libc::c_void,
                 needle as libc::c_int,
-                haystack.len())
+                haystack.len(),
+            )
         };
-        if p.is_null() {
-            None
-        } else {
-            Some(p as usize - (haystack.as_ptr() as usize))
-        }
+        if p.is_null() { None } else { Some(p as usize - (haystack.as_ptr() as usize)) }
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/src/libstd/sys/unix/path.rs
+++ b/src/libstd/sys/unix/path.rs
@@ -1,5 +1,5 @@
-use crate::path::Prefix;
 use crate::ffi::OsStr;
+use crate::path::Prefix;
 
 #[inline]
 pub fn is_sep_byte(b: u8) -> bool {

--- a/src/libstd/sys/unix/pipe.rs
+++ b/src/libstd/sys/unix/pipe.rs
@@ -22,15 +22,15 @@ pub fn anon_pipe() -> io::Result<(AnonPipe, AnonPipe)> {
     // CLOEXEC flag is to use the `pipe2` syscall on Linux. This was added in
     // 2.6.27, however, and because we support 2.6.18 we must detect this
     // support dynamically.
-    if cfg!(any(target_os = "dragonfly",
-                target_os = "freebsd",
-                target_os = "linux",
-                target_os = "netbsd",
-                target_os = "openbsd",
-                target_os = "redox")) &&
-       !INVALID.load(Ordering::SeqCst)
+    if cfg!(any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "redox"
+    )) && !INVALID.load(Ordering::SeqCst)
     {
-
         // Note that despite calling a glibc function here we may still
         // get ENOSYS. Glibc has `pipe2` since 2.9 and doesn't try to
         // emulate on older kernels, so if you happen to be running on
@@ -38,8 +38,7 @@ pub fn anon_pipe() -> io::Result<(AnonPipe, AnonPipe)> {
         // see the syscall.
         match cvt(unsafe { pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) }) {
             Ok(_) => {
-                return Ok((AnonPipe(FileDesc::new(fds[0])),
-                            AnonPipe(FileDesc::new(fds[1]))));
+                return Ok((AnonPipe(FileDesc::new(fds[0])), AnonPipe(FileDesc::new(fds[1]))));
             }
             Err(ref e) if e.raw_os_error() == Some(libc::ENOSYS) => {
                 INVALID.store(true, Ordering::SeqCst);
@@ -73,15 +72,15 @@ impl AnonPipe {
         self.0.write_vectored(bufs)
     }
 
-    pub fn fd(&self) -> &FileDesc { &self.0 }
-    pub fn into_fd(self) -> FileDesc { self.0 }
+    pub fn fd(&self) -> &FileDesc {
+        &self.0
+    }
+    pub fn into_fd(self) -> FileDesc {
+        self.0
+    }
 }
 
-pub fn read2(p1: AnonPipe,
-             v1: &mut Vec<u8>,
-             p2: AnonPipe,
-             v2: &mut Vec<u8>) -> io::Result<()> {
-
+pub fn read2(p1: AnonPipe, v1: &mut Vec<u8>, p2: AnonPipe, v2: &mut Vec<u8>) -> io::Result<()> {
     // Set both pipes into nonblocking mode as we're gonna be reading from both
     // in the `select` loop below, and we wouldn't want one to block the other!
     let p1 = p1.into_fd();
@@ -117,8 +116,9 @@ pub fn read2(p1: AnonPipe,
         match fd.read_to_end(dst) {
             Ok(_) => Ok(true),
             Err(e) => {
-                if e.raw_os_error() == Some(libc::EWOULDBLOCK) ||
-                   e.raw_os_error() == Some(libc::EAGAIN) {
+                if e.raw_os_error() == Some(libc::EWOULDBLOCK)
+                    || e.raw_os_error() == Some(libc::EAGAIN)
+                {
                     Ok(false)
                 } else {
                     Err(e)

--- a/src/libstd/sys/unix/process/process_common.rs
+++ b/src/libstd/sys/unix/process/process_common.rs
@@ -1,6 +1,7 @@
 use crate::os::unix::prelude::*;
 
-use crate::ffi::{OsString, OsStr, CString, CStr};
+use crate::collections::BTreeMap;
+use crate::ffi::{CStr, CString, OsStr, OsString};
 use crate::fmt;
 use crate::io;
 use crate::ptr;
@@ -8,12 +9,11 @@ use crate::sys::fd::FileDesc;
 use crate::sys::fs::File;
 use crate::sys::pipe::{self, AnonPipe};
 use crate::sys_common::process::CommandEnv;
-use crate::collections::BTreeMap;
 
 #[cfg(not(target_os = "fuchsia"))]
 use crate::sys::fs::OpenOptions;
 
-use libc::{c_int, gid_t, uid_t, c_char, EXIT_SUCCESS, EXIT_FAILURE};
+use libc::{c_char, c_int, gid_t, uid_t, EXIT_FAILURE, EXIT_SUCCESS};
 
 cfg_if::cfg_if! {
     if #[cfg(target_os = "fuchsia")] {
@@ -204,10 +204,7 @@ impl Command {
         &mut self.closures
     }
 
-    pub unsafe fn pre_exec(
-        &mut self,
-        f: Box<dyn FnMut() -> io::Result<()> + Send + Sync>,
-    ) {
+    pub unsafe fn pre_exec(&mut self, f: Box<dyn FnMut() -> io::Result<()> + Send + Sync>) {
         self.closures.push(f);
     }
 
@@ -236,26 +233,21 @@ impl Command {
         self.env.have_changed_path()
     }
 
-    pub fn setup_io(&self, default: Stdio, needs_stdin: bool)
-                -> io::Result<(StdioPipes, ChildPipes)> {
+    pub fn setup_io(
+        &self,
+        default: Stdio,
+        needs_stdin: bool,
+    ) -> io::Result<(StdioPipes, ChildPipes)> {
         let null = Stdio::Null;
-        let default_stdin = if needs_stdin {&default} else {&null};
+        let default_stdin = if needs_stdin { &default } else { &null };
         let stdin = self.stdin.as_ref().unwrap_or(default_stdin);
         let stdout = self.stdout.as_ref().unwrap_or(&default);
         let stderr = self.stderr.as_ref().unwrap_or(&default);
         let (their_stdin, our_stdin) = stdin.to_child_stdio(true)?;
         let (their_stdout, our_stdout) = stdout.to_child_stdio(false)?;
         let (their_stderr, our_stderr) = stderr.to_child_stdio(false)?;
-        let ours = StdioPipes {
-            stdin: our_stdin,
-            stdout: our_stdout,
-            stderr: our_stderr,
-        };
-        let theirs = ChildPipes {
-            stdin: their_stdin,
-            stdout: their_stdout,
-            stderr: their_stderr,
-        };
+        let ours = StdioPipes { stdin: our_stdin, stdout: our_stdout, stderr: our_stderr };
+        let theirs = ChildPipes { stdin: their_stdin, stdout: their_stdout, stderr: their_stderr };
         Ok((ours, theirs))
     }
 }
@@ -270,21 +262,21 @@ fn os2c(s: &OsStr, saw_nul: &mut bool) -> CString {
 // Helper type to manage ownership of the strings within a C-style array.
 pub struct CStringArray {
     items: Vec<CString>,
-    ptrs: Vec<*const c_char>
+    ptrs: Vec<*const c_char>,
 }
 
 impl CStringArray {
     pub fn with_capacity(capacity: usize) -> Self {
         let mut result = CStringArray {
             items: Vec::with_capacity(capacity),
-            ptrs: Vec::with_capacity(capacity+1)
+            ptrs: Vec::with_capacity(capacity + 1),
         };
         result.ptrs.push(ptr::null());
         result
     }
     pub fn push(&mut self, item: CString) {
         let l = self.ptrs.len();
-        self.ptrs[l-1] = item.as_ptr();
+        self.ptrs[l - 1] = item.as_ptr();
         self.ptrs.push(ptr::null());
         self.items.push(item);
     }
@@ -315,12 +307,9 @@ fn construct_envp(env: BTreeMap<OsString, OsString>, saw_nul: &mut bool) -> CStr
 }
 
 impl Stdio {
-    pub fn to_child_stdio(&self, readable: bool)
-                      -> io::Result<(ChildStdio, Option<AnonPipe>)> {
+    pub fn to_child_stdio(&self, readable: bool) -> io::Result<(ChildStdio, Option<AnonPipe>)> {
         match *self {
-            Stdio::Inherit => {
-                Ok((ChildStdio::Inherit, None))
-            },
+            Stdio::Inherit => Ok((ChildStdio::Inherit, None)),
 
             // Make sure that the source descriptors are not an stdio
             // descriptor, otherwise the order which we set the child's
@@ -339,11 +328,7 @@ impl Stdio {
 
             Stdio::MakePipe => {
                 let (reader, writer) = pipe::anon_pipe()?;
-                let (ours, theirs) = if readable {
-                    (writer, reader)
-                } else {
-                    (reader, writer)
-                };
+                let (ours, theirs) = if readable { (writer, reader) } else { (reader, writer) };
                 Ok((ChildStdio::Owned(theirs.into_fd()), Some(ours)))
             }
 
@@ -352,17 +337,13 @@ impl Stdio {
                 let mut opts = OpenOptions::new();
                 opts.read(readable);
                 opts.write(!readable);
-                let path = unsafe {
-                    CStr::from_ptr(DEV_NULL.as_ptr() as *const _)
-                };
+                let path = unsafe { CStr::from_ptr(DEV_NULL.as_ptr() as *const _) };
                 let fd = File::open_c(&path, &opts)?;
                 Ok((ChildStdio::Owned(fd.into_fd()), None))
             }
 
             #[cfg(target_os = "fuchsia")]
-            Stdio::Null => {
-                Ok((ChildStdio::Null, None))
-            }
+            Stdio::Null => Ok((ChildStdio::Null, None)),
         }
     }
 }
@@ -430,7 +411,7 @@ mod tests {
                 Ok(t) => t,
                 Err(e) => panic!("received error for `{}`: {}", stringify!($e), e),
             }
-        }
+        };
     }
 
     // See #14232 for more information, but it appears that signal delivery to a
@@ -461,8 +442,7 @@ mod tests {
             let stdin_write = pipes.stdin.take().unwrap();
             let stdout_read = pipes.stdout.take().unwrap();
 
-            t!(cvt(libc::pthread_sigmask(libc::SIG_SETMASK, old_set.as_ptr(),
-                                         ptr::null_mut())));
+            t!(cvt(libc::pthread_sigmask(libc::SIG_SETMASK, old_set.as_ptr(), ptr::null_mut())));
 
             t!(cvt(libc::kill(cat.id() as libc::pid_t, libc::SIGINT)));
             // We need to wait until SIGINT is definitely delivered. The

--- a/src/libstd/sys/unix/process/zircon.rs
+++ b/src/libstd/sys/unix/process/zircon.rs
@@ -1,8 +1,8 @@
 #![allow(non_camel_case_types, unused)]
 
 use crate::convert::TryInto;
-use crate::io;
 use crate::i64;
+use crate::io;
 use crate::mem::MaybeUninit;
 use crate::os::raw::c_char;
 
@@ -16,27 +16,26 @@ pub type zx_status_t = i32;
 pub const ZX_HANDLE_INVALID: zx_handle_t = 0;
 
 pub type zx_time_t = i64;
-pub const ZX_TIME_INFINITE : zx_time_t = i64::MAX;
+pub const ZX_TIME_INFINITE: zx_time_t = i64::MAX;
 
 pub type zx_signals_t = u32;
 
-pub const ZX_OBJECT_SIGNAL_3         : zx_signals_t = 1 << 3;
+pub const ZX_OBJECT_SIGNAL_3: zx_signals_t = 1 << 3;
 
-pub const ZX_TASK_TERMINATED        : zx_signals_t = ZX_OBJECT_SIGNAL_3;
+pub const ZX_TASK_TERMINATED: zx_signals_t = ZX_OBJECT_SIGNAL_3;
 
-pub const ZX_RIGHT_SAME_RIGHTS  : zx_rights_t = 1 << 31;
+pub const ZX_RIGHT_SAME_RIGHTS: zx_rights_t = 1 << 31;
 
 pub type zx_object_info_topic_t = u32;
 
-pub const ZX_INFO_PROCESS         : zx_object_info_topic_t = 3;
+pub const ZX_INFO_PROCESS: zx_object_info_topic_t = 3;
 
-pub fn zx_cvt<T>(t: T) -> io::Result<T> where T: TryInto<zx_status_t>+Copy {
+pub fn zx_cvt<T>(t: T) -> io::Result<T>
+where
+    T: TryInto<zx_status_t> + Copy,
+{
     if let Ok(status) = TryInto::try_into(t) {
-        if status < 0 {
-            Err(io::Error::from_raw_os_error(status))
-        } else {
-            Ok(t)
-        }
+        if status < 0 { Err(io::Error::from_raw_os_error(status)) } else { Ok(t) }
     } else {
         Err(io::Error::last_os_error())
     }
@@ -49,9 +48,7 @@ pub struct Handle {
 
 impl Handle {
     pub fn new(raw: zx_handle_t) -> Handle {
-        Handle {
-            raw,
-        }
+        Handle { raw }
     }
 
     pub fn raw(&self) -> zx_handle_t {
@@ -61,7 +58,9 @@ impl Handle {
 
 impl Drop for Handle {
     fn drop(&mut self) {
-        unsafe { zx_cvt(zx_handle_close(self.raw)).expect("Failed to close zx_handle_t"); }
+        unsafe {
+            zx_cvt(zx_handle_close(self.raw)).expect("Failed to close zx_handle_t");
+        }
     }
 }
 
@@ -75,22 +74,34 @@ pub struct zx_info_process_t {
     pub debugger_attached: bool,
 }
 
-extern {
+extern "C" {
     pub fn zx_job_default() -> zx_handle_t;
 
     pub fn zx_task_kill(handle: zx_handle_t) -> zx_status_t;
 
     pub fn zx_handle_close(handle: zx_handle_t) -> zx_status_t;
 
-    pub fn zx_handle_duplicate(handle: zx_handle_t, rights: zx_rights_t,
-                               out: *const zx_handle_t) -> zx_handle_t;
+    pub fn zx_handle_duplicate(
+        handle: zx_handle_t,
+        rights: zx_rights_t,
+        out: *const zx_handle_t,
+    ) -> zx_handle_t;
 
-    pub fn zx_object_wait_one(handle: zx_handle_t, signals: zx_signals_t, timeout: zx_time_t,
-                              pending: *mut zx_signals_t) -> zx_status_t;
+    pub fn zx_object_wait_one(
+        handle: zx_handle_t,
+        signals: zx_signals_t,
+        timeout: zx_time_t,
+        pending: *mut zx_signals_t,
+    ) -> zx_status_t;
 
-    pub fn zx_object_get_info(handle: zx_handle_t, topic: u32, buffer: *mut c_void,
-                              buffer_size: size_t, actual_size: *mut size_t,
-                              avail: *mut size_t) -> zx_status_t;
+    pub fn zx_object_get_info(
+        handle: zx_handle_t,
+        topic: u32,
+        buffer: *mut c_void,
+        buffer_size: size_t,
+        actual_size: *mut size_t,
+        avail: *mut size_t,
+    ) -> zx_status_t;
 }
 
 #[derive(Default)]
@@ -103,11 +114,18 @@ pub struct fdio_spawn_action_t {
     pub reserved1: u64,
 }
 
-extern {
-    pub fn fdio_spawn_etc(job: zx_handle_t, flags: u32, path: *const c_char,
-                          argv: *const *const c_char, envp: *const *const c_char,
-                          action_count: size_t, actions: *const fdio_spawn_action_t,
-                          process: *mut zx_handle_t, err_msg: *mut c_char) -> zx_status_t;
+extern "C" {
+    pub fn fdio_spawn_etc(
+        job: zx_handle_t,
+        flags: u32,
+        path: *const c_char,
+        argv: *const *const c_char,
+        envp: *const *const c_char,
+        action_count: size_t,
+        actions: *const fdio_spawn_action_t,
+        process: *mut zx_handle_t,
+        err_msg: *mut c_char,
+    ) -> zx_status_t;
 
     pub fn fdio_fd_clone(fd: c_int, out_handle: *mut zx_handle_t) -> zx_status_t;
     pub fn fdio_fd_create(handle: zx_handle_t, fd: *mut c_int) -> zx_status_t;
@@ -129,60 +147,74 @@ pub const FDIO_SPAWN_ACTION_TRANSFER_FD: u32 = 0x0002;
 
 // Errors
 
-#[allow(unused)] pub const ERR_INTERNAL: zx_status_t = -1;
+#[allow(unused)]
+pub const ERR_INTERNAL: zx_status_t = -1;
 
 // ERR_NOT_SUPPORTED: The operation is not implemented, supported,
 // or enabled.
-#[allow(unused)] pub const ERR_NOT_SUPPORTED: zx_status_t = -2;
+#[allow(unused)]
+pub const ERR_NOT_SUPPORTED: zx_status_t = -2;
 
 // ERR_NO_RESOURCES: The system was not able to allocate some resource
 // needed for the operation.
-#[allow(unused)] pub const ERR_NO_RESOURCES: zx_status_t = -3;
+#[allow(unused)]
+pub const ERR_NO_RESOURCES: zx_status_t = -3;
 
 // ERR_NO_MEMORY: The system was not able to allocate memory needed
 // for the operation.
-#[allow(unused)] pub const ERR_NO_MEMORY: zx_status_t = -4;
+#[allow(unused)]
+pub const ERR_NO_MEMORY: zx_status_t = -4;
 
 // ERR_CALL_FAILED: The second phase of zx_channel_call(; did not complete
 // successfully.
-#[allow(unused)] pub const ERR_CALL_FAILED: zx_status_t = -5;
+#[allow(unused)]
+pub const ERR_CALL_FAILED: zx_status_t = -5;
 
 // ERR_INTERRUPTED_RETRY: The system call was interrupted, but should be
 // retried.  This should not be seen outside of the VDSO.
-#[allow(unused)] pub const ERR_INTERRUPTED_RETRY: zx_status_t = -6;
+#[allow(unused)]
+pub const ERR_INTERRUPTED_RETRY: zx_status_t = -6;
 
 // ======= Parameter errors =======
 // ERR_INVALID_ARGS: an argument is invalid, ex. null pointer
-#[allow(unused)] pub const ERR_INVALID_ARGS: zx_status_t = -10;
+#[allow(unused)]
+pub const ERR_INVALID_ARGS: zx_status_t = -10;
 
 // ERR_BAD_HANDLE: A specified handle value does not refer to a handle.
-#[allow(unused)] pub const ERR_BAD_HANDLE: zx_status_t = -11;
+#[allow(unused)]
+pub const ERR_BAD_HANDLE: zx_status_t = -11;
 
 // ERR_WRONG_TYPE: The subject of the operation is the wrong type to
 // perform the operation.
 // Example: Attempting a message_read on a thread handle.
-#[allow(unused)] pub const ERR_WRONG_TYPE: zx_status_t = -12;
+#[allow(unused)]
+pub const ERR_WRONG_TYPE: zx_status_t = -12;
 
 // ERR_BAD_SYSCALL: The specified syscall number is invalid.
-#[allow(unused)] pub const ERR_BAD_SYSCALL: zx_status_t = -13;
+#[allow(unused)]
+pub const ERR_BAD_SYSCALL: zx_status_t = -13;
 
 // ERR_OUT_OF_RANGE: An argument is outside the valid range for this
 // operation.
-#[allow(unused)] pub const ERR_OUT_OF_RANGE: zx_status_t = -14;
+#[allow(unused)]
+pub const ERR_OUT_OF_RANGE: zx_status_t = -14;
 
 // ERR_BUFFER_TOO_SMALL: A caller provided buffer is too small for
 // this operation.
-#[allow(unused)] pub const ERR_BUFFER_TOO_SMALL: zx_status_t = -15;
+#[allow(unused)]
+pub const ERR_BUFFER_TOO_SMALL: zx_status_t = -15;
 
 // ======= Precondition or state errors =======
 // ERR_BAD_STATE: operation failed because the current state of the
 // object does not allow it, or a precondition of the operation is
 // not satisfied
-#[allow(unused)] pub const ERR_BAD_STATE: zx_status_t = -20;
+#[allow(unused)]
+pub const ERR_BAD_STATE: zx_status_t = -20;
 
 // ERR_TIMED_OUT: The time limit for the operation elapsed before
 // the operation completed.
-#[allow(unused)] pub const ERR_TIMED_OUT: zx_status_t = -21;
+#[allow(unused)]
+pub const ERR_TIMED_OUT: zx_status_t = -21;
 
 // ERR_SHOULD_WAIT: The operation cannot be performed currently but
 // potentially could succeed if the caller waits for a prerequisite
@@ -192,67 +224,84 @@ pub const FDIO_SPAWN_ACTION_TRANSFER_FD: u32 = 0x0002;
 // messages waiting but has an open remote will return ERR_SHOULD_WAIT.
 // Attempting to read from a message pipe that has no messages waiting
 // and has a closed remote end will return ERR_REMOTE_CLOSED.
-#[allow(unused)] pub const ERR_SHOULD_WAIT: zx_status_t = -22;
+#[allow(unused)]
+pub const ERR_SHOULD_WAIT: zx_status_t = -22;
 
 // ERR_CANCELED: The in-progress operation (e.g., a wait) has been
 // // canceled.
-#[allow(unused)] pub const ERR_CANCELED: zx_status_t = -23;
+#[allow(unused)]
+pub const ERR_CANCELED: zx_status_t = -23;
 
 // ERR_PEER_CLOSED: The operation failed because the remote end
 // of the subject of the operation was closed.
-#[allow(unused)] pub const ERR_PEER_CLOSED: zx_status_t = -24;
+#[allow(unused)]
+pub const ERR_PEER_CLOSED: zx_status_t = -24;
 
 // ERR_NOT_FOUND: The requested entity is not found.
-#[allow(unused)] pub const ERR_NOT_FOUND: zx_status_t = -25;
+#[allow(unused)]
+pub const ERR_NOT_FOUND: zx_status_t = -25;
 
 // ERR_ALREADY_EXISTS: An object with the specified identifier
 // already exists.
 // Example: Attempting to create a file when a file already exists
 // with that name.
-#[allow(unused)] pub const ERR_ALREADY_EXISTS: zx_status_t = -26;
+#[allow(unused)]
+pub const ERR_ALREADY_EXISTS: zx_status_t = -26;
 
 // ERR_ALREADY_BOUND: The operation failed because the named entity
 // is already owned or controlled by another entity. The operation
 // could succeed later if the current owner releases the entity.
-#[allow(unused)] pub const ERR_ALREADY_BOUND: zx_status_t = -27;
+#[allow(unused)]
+pub const ERR_ALREADY_BOUND: zx_status_t = -27;
 
 // ERR_UNAVAILABLE: The subject of the operation is currently unable
 // to perform the operation.
 // Note: This is used when there's no direct way for the caller to
 // observe when the subject will be able to perform the operation
 // and should thus retry.
-#[allow(unused)] pub const ERR_UNAVAILABLE: zx_status_t = -28;
+#[allow(unused)]
+pub const ERR_UNAVAILABLE: zx_status_t = -28;
 
 // ======= Permission check errors =======
 // ERR_ACCESS_DENIED: The caller did not have permission to perform
 // the specified operation.
-#[allow(unused)] pub const ERR_ACCESS_DENIED: zx_status_t = -30;
+#[allow(unused)]
+pub const ERR_ACCESS_DENIED: zx_status_t = -30;
 
 // ======= Input-output errors =======
 // ERR_IO: Otherwise unspecified error occurred during I/O.
-#[allow(unused)] pub const ERR_IO: zx_status_t = -40;
+#[allow(unused)]
+pub const ERR_IO: zx_status_t = -40;
 
 // ERR_REFUSED: The entity the I/O operation is being performed on
 // rejected the operation.
 // Example: an I2C device NAK'ing a transaction or a disk controller
 // rejecting an invalid command.
-#[allow(unused)] pub const ERR_IO_REFUSED: zx_status_t = -41;
+#[allow(unused)]
+pub const ERR_IO_REFUSED: zx_status_t = -41;
 
 // ERR_IO_DATA_INTEGRITY: The data in the operation failed an integrity
 // check and is possibly corrupted.
 // Example: CRC or Parity error.
-#[allow(unused)] pub const ERR_IO_DATA_INTEGRITY: zx_status_t = -42;
+#[allow(unused)]
+pub const ERR_IO_DATA_INTEGRITY: zx_status_t = -42;
 
 // ERR_IO_DATA_LOSS: The data in the operation is currently unavailable
 // and may be permanently lost.
 // Example: A disk block is irrecoverably damaged.
-#[allow(unused)] pub const ERR_IO_DATA_LOSS: zx_status_t = -43;
+#[allow(unused)]
+pub const ERR_IO_DATA_LOSS: zx_status_t = -43;
 
 // Filesystem specific errors
-#[allow(unused)] pub const ERR_BAD_PATH: zx_status_t = -50;
-#[allow(unused)] pub const ERR_NOT_DIR: zx_status_t = -51;
-#[allow(unused)] pub const ERR_NOT_FILE: zx_status_t = -52;
+#[allow(unused)]
+pub const ERR_BAD_PATH: zx_status_t = -50;
+#[allow(unused)]
+pub const ERR_NOT_DIR: zx_status_t = -51;
+#[allow(unused)]
+pub const ERR_NOT_FILE: zx_status_t = -52;
 // ERR_FILE_BIG: A file exceeds a filesystem-specific size limit.
-#[allow(unused)] pub const ERR_FILE_BIG: zx_status_t = -53;
+#[allow(unused)]
+pub const ERR_FILE_BIG: zx_status_t = -53;
 // ERR_NO_SPACE: Filesystem or device space is exhausted.
-#[allow(unused)] pub const ERR_NO_SPACE: zx_status_t = -54;
+#[allow(unused)]
+pub const ERR_NO_SPACE: zx_status_t = -54;

--- a/src/libstd/sys/unix/stdio.rs
+++ b/src/libstd/sys/unix/stdio.rs
@@ -1,13 +1,15 @@
 use crate::io::{self, IoSlice, IoSliceMut};
-use crate::sys::fd::FileDesc;
 use crate::mem::ManuallyDrop;
+use crate::sys::fd::FileDesc;
 
 pub struct Stdin(());
 pub struct Stdout(());
 pub struct Stderr(());
 
 impl Stdin {
-    pub fn new() -> io::Result<Stdin> { Ok(Stdin(())) }
+    pub fn new() -> io::Result<Stdin> {
+        Ok(Stdin(()))
+    }
 }
 
 impl io::Read for Stdin {
@@ -21,7 +23,9 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> io::Result<Stdout> { Ok(Stdout(())) }
+    pub fn new() -> io::Result<Stdout> {
+        Ok(Stdout(()))
+    }
 }
 
 impl io::Write for Stdout {
@@ -39,7 +43,9 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> io::Result<Stderr> { Ok(Stderr(())) }
+    pub fn new() -> io::Result<Stderr> {
+        Ok(Stderr(()))
+    }
 }
 
 impl io::Write for Stderr {

--- a/src/libstd/sys/unix/thread_local.rs
+++ b/src/libstd/sys/unix/thread_local.rs
@@ -5,7 +5,7 @@ use crate::mem;
 pub type Key = libc::pthread_key_t;
 
 #[inline]
-pub unsafe fn create(dtor: Option<unsafe extern fn(*mut u8)>) -> Key {
+pub unsafe fn create(dtor: Option<unsafe extern "C" fn(*mut u8)>) -> Key {
     let mut key = 0;
     assert_eq!(libc::pthread_key_create(&mut key, mem::transmute(dtor)), 0);
     key

--- a/src/libstd/sys/unix/weak.rs
+++ b/src/libstd/sys/unix/weak.rs
@@ -36,11 +36,7 @@ pub struct Weak<F> {
 
 impl<F> Weak<F> {
     pub const fn new(name: &'static str) -> Weak<F> {
-        Weak {
-            name,
-            addr: AtomicUsize::new(1),
-            _marker: marker::PhantomData,
-        }
+        Weak { name, addr: AtomicUsize::new(1), _marker: marker::PhantomData }
     }
 
     pub fn get(&self) -> Option<F> {

--- a/src/libstd/sys/vxworks/alloc.rs
+++ b/src/libstd/sys/vxworks/alloc.rs
@@ -1,6 +1,6 @@
-use crate::ptr;
-use crate::sys_common::alloc::{MIN_ALIGN, realloc_fallback};
 use crate::alloc::{GlobalAlloc, Layout, System};
+use crate::ptr;
+use crate::sys_common::alloc::{realloc_fallback, MIN_ALIGN};
 
 #[stable(feature = "alloc_system_type", since = "1.28.0")]
 unsafe impl GlobalAlloc for System {
@@ -45,9 +45,5 @@ unsafe impl GlobalAlloc for System {
 unsafe fn aligned_malloc(layout: &Layout) -> *mut u8 {
     let mut out = ptr::null_mut();
     let ret = libc::posix_memalign(&mut out, layout.align(), layout.size());
-    if ret != 0 {
-        ptr::null_mut()
-    } else {
-        out as *mut u8
-    }
+    if ret != 0 { ptr::null_mut() } else { out as *mut u8 }
 }

--- a/src/libstd/sys/vxworks/args.rs
+++ b/src/libstd/sys/vxworks/args.rs
@@ -4,10 +4,14 @@ use crate::marker::PhantomData;
 use crate::vec;
 
 /// One-time global initialization.
-pub unsafe fn init(argc: isize, argv: *const *const u8) { imp::init(argc, argv) }
+pub unsafe fn init(argc: isize, argv: *const *const u8) {
+    imp::init(argc, argv)
+}
 
 /// One-time global cleanup.
-pub unsafe fn cleanup() { imp::cleanup() }
+pub unsafe fn cleanup() {
+    imp::cleanup()
+}
 
 /// Returns the command line arguments
 pub fn args() -> Args {
@@ -27,24 +31,32 @@ impl Args {
 
 impl Iterator for Args {
     type Item = OsString;
-    fn next(&mut self) -> Option<OsString> { self.iter.next() }
-    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
+    fn next(&mut self) -> Option<OsString> {
+        self.iter.next()
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 impl ExactSizeIterator for Args {
-    fn len(&self) -> usize { self.iter.len() }
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
 }
 
 impl DoubleEndedIterator for Args {
-    fn next_back(&mut self) -> Option<OsString> { self.iter.next_back() }
+    fn next_back(&mut self) -> Option<OsString> {
+        self.iter.next_back()
+    }
 }
 
 mod imp {
-    use crate::ptr;
+    use super::Args;
     use crate::ffi::{CStr, OsString};
     use crate::marker::PhantomData;
+    use crate::ptr;
     use libc;
-    use super::Args;
 
     use crate::sys_common::mutex::Mutex;
 
@@ -65,21 +77,20 @@ mod imp {
     }
 
     pub fn args() -> Args {
-        Args {
-            iter: clone().into_iter(),
-            _dont_send_or_sync_me: PhantomData
-        }
+        Args { iter: clone().into_iter(), _dont_send_or_sync_me: PhantomData }
     }
 
     fn clone() -> Vec<OsString> {
         unsafe {
             let _guard = LOCK.lock();
-            let ret = (0..ARGC).map(|i| {
-                let cstr = CStr::from_ptr(*ARGV.offset(i) as *const libc::c_char);
-                use crate::sys::vxworks::ext::ffi::OsStringExt;
-                OsStringExt::from_vec(cstr.to_bytes().to_vec())
-            }).collect();
-            return ret
+            let ret = (0..ARGC)
+                .map(|i| {
+                    let cstr = CStr::from_ptr(*ARGV.offset(i) as *const libc::c_char);
+                    use crate::sys::vxworks::ext::ffi::OsStringExt;
+                    OsStringExt::from_vec(cstr.to_bytes().to_vec())
+                })
+                .collect();
+            return ret;
         }
     }
 }

--- a/src/libstd/sys/vxworks/cmath.rs
+++ b/src/libstd/sys/vxworks/cmath.rs
@@ -1,9 +1,9 @@
 #![cfg(not(test))]
 
-use libc::{c_float, c_double};
+use libc::{c_double, c_float};
 
 #[link_name = "m"]
-extern {
+extern "C" {
     pub fn acos(n: c_double) -> c_double;
     pub fn acosf(n: c_float) -> c_float;
     pub fn asin(n: c_double) -> c_double;

--- a/src/libstd/sys/vxworks/ext/fs.rs
+++ b/src/libstd/sys/vxworks/ext/fs.rs
@@ -2,11 +2,11 @@
 
 use crate::fs::{self, Permissions};
 use crate::io;
-use libc;
 use crate::path::Path;
 use crate::sys;
-use crate::sys_common::{FromInner, AsInner, AsInnerMut};
 use crate::sys::platform::fs::MetadataExt as UnixMetadataExt;
+use crate::sys_common::{AsInner, AsInnerMut, FromInner};
+use libc;
 
 /// Unix-specific extensions to [`File`].
 ///
@@ -112,8 +112,7 @@ pub trait FileExt {
             }
         }
         if !buf.is_empty() {
-            Err(io::Error::new(io::ErrorKind::UnexpectedEof,
-                               "failed to fill whole buffer"))
+            Err(io::Error::new(io::ErrorKind::UnexpectedEof, "failed to fill whole buffer"))
         } else {
             Ok(())
         }
@@ -196,8 +195,12 @@ pub trait FileExt {
     fn write_all_at(&self, mut buf: &[u8], mut offset: u64) -> io::Result<()> {
         while !buf.is_empty() {
             match self.write_at(buf, offset) {
-                Ok(0) => return Err(io::Error::new(io::ErrorKind::WriteZero,
-                                                   "failed to write whole buffer")),
+                Ok(0) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "failed to write whole buffer",
+                    ));
+                }
                 Ok(n) => {
                     buf = &buf[n..];
                     offset += n as u64
@@ -604,20 +607,48 @@ pub trait MetadataExt {
 
 #[stable(feature = "metadata_ext", since = "1.1.0")]
 impl MetadataExt for fs::Metadata {
-    fn dev(&self) -> u64 { self.st_dev() }
-    fn ino(&self) -> u64 { self.st_ino() }
-    fn mode(&self) -> u32 { self.st_mode() }
-    fn nlink(&self) -> u64 { self.st_nlink() }
-    fn uid(&self) -> u32 { self.st_uid() }
-    fn gid(&self) -> u32 { self.st_gid() }
-    fn rdev(&self) -> u64 { self.st_rdev() }
-    fn size(&self) -> u64 { self.st_size() }
-    fn atime(&self) -> i64 { self.st_atime() }
-    fn mtime(&self) -> i64 { self.st_mtime() }
-    fn ctime(&self) -> i64 { self.st_ctime() }
-    fn blksize(&self) -> u64 { self.st_blksize() }
-    fn blocks(&self) -> u64 { self.st_blocks() }
-    fn attrib(&self) -> u8 {self.st_attrib() }
+    fn dev(&self) -> u64 {
+        self.st_dev()
+    }
+    fn ino(&self) -> u64 {
+        self.st_ino()
+    }
+    fn mode(&self) -> u32 {
+        self.st_mode()
+    }
+    fn nlink(&self) -> u64 {
+        self.st_nlink()
+    }
+    fn uid(&self) -> u32 {
+        self.st_uid()
+    }
+    fn gid(&self) -> u32 {
+        self.st_gid()
+    }
+    fn rdev(&self) -> u64 {
+        self.st_rdev()
+    }
+    fn size(&self) -> u64 {
+        self.st_size()
+    }
+    fn atime(&self) -> i64 {
+        self.st_atime()
+    }
+    fn mtime(&self) -> i64 {
+        self.st_mtime()
+    }
+    fn ctime(&self) -> i64 {
+        self.st_ctime()
+    }
+    fn blksize(&self) -> u64 {
+        self.st_blksize()
+    }
+    fn blocks(&self) -> u64 {
+        self.st_blocks()
+    }
+    fn attrib(&self) -> u8 {
+        self.st_attrib()
+    }
 }
 
 /// Unix-specific extensions for [`FileType`].
@@ -704,10 +735,18 @@ pub trait FileTypeExt {
 
 #[stable(feature = "file_type_ext", since = "1.5.0")]
 impl FileTypeExt for fs::FileType {
-    fn is_block_device(&self) -> bool { self.as_inner().is(libc::S_IFBLK) }
-    fn is_char_device(&self) -> bool { self.as_inner().is(libc::S_IFCHR) }
-    fn is_fifo(&self) -> bool { self.as_inner().is(libc::S_IFIFO) }
-    fn is_socket(&self) -> bool { self.as_inner().is(libc::S_IFSOCK) }
+    fn is_block_device(&self) -> bool {
+        self.as_inner().is(libc::S_IFBLK)
+    }
+    fn is_char_device(&self) -> bool {
+        self.as_inner().is(libc::S_IFCHR)
+    }
+    fn is_fifo(&self) -> bool {
+        self.as_inner().is(libc::S_IFIFO)
+    }
+    fn is_socket(&self) -> bool {
+        self.as_inner().is(libc::S_IFSOCK)
+    }
 }
 
 /// Unix-specific extension methods for [`fs::DirEntry`].
@@ -739,7 +778,9 @@ pub trait DirEntryExt {
 
 #[stable(feature = "dir_entry_ext", since = "1.1.0")]
 impl DirEntryExt for fs::DirEntry {
-    fn ino(&self) -> u64 { self.as_inner().ino() }
+    fn ino(&self) -> u64 {
+        self.as_inner().ino()
+    }
 }
 
 /// Creates a new symbolic link on the filesystem.
@@ -766,8 +807,7 @@ impl DirEntryExt for fs::DirEntry {
 /// }
 /// ```
 #[stable(feature = "symlink", since = "1.1.0")]
-pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()>
-{
+pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
     sys::fs::symlink(src.as_ref(), dst.as_ref())
 }
 

--- a/src/libstd/sys/vxworks/ext/io.rs
+++ b/src/libstd/sys/vxworks/ext/io.rs
@@ -3,11 +3,11 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::fs;
+use crate::io;
+use crate::net;
 use crate::os::raw;
 use crate::sys;
-use crate::io;
 use crate::sys_common::{self, AsInner, FromInner, IntoInner};
-use crate::net;
 
 /// Raw file descriptors.
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -84,47 +84,65 @@ impl IntoRawFd for fs::File {
 
 #[stable(feature = "asraw_stdio", since = "1.21.0")]
 impl AsRawFd for io::Stdin {
-    fn as_raw_fd(&self) -> RawFd { libc::STDIN_FILENO }
+    fn as_raw_fd(&self) -> RawFd {
+        libc::STDIN_FILENO
+    }
 }
 
 #[stable(feature = "asraw_stdio", since = "1.21.0")]
 impl AsRawFd for io::Stdout {
-    fn as_raw_fd(&self) -> RawFd { libc::STDOUT_FILENO }
+    fn as_raw_fd(&self) -> RawFd {
+        libc::STDOUT_FILENO
+    }
 }
 
 #[stable(feature = "asraw_stdio", since = "1.21.0")]
 impl AsRawFd for io::Stderr {
-    fn as_raw_fd(&self) -> RawFd { libc::STDERR_FILENO }
+    fn as_raw_fd(&self) -> RawFd {
+        libc::STDERR_FILENO
+    }
 }
 
 #[stable(feature = "asraw_stdio_locks", since = "1.35.0")]
 impl<'a> AsRawFd for io::StdinLock<'a> {
-    fn as_raw_fd(&self) -> RawFd { libc::STDIN_FILENO }
+    fn as_raw_fd(&self) -> RawFd {
+        libc::STDIN_FILENO
+    }
 }
 
 #[stable(feature = "asraw_stdio_locks", since = "1.35.0")]
 impl<'a> AsRawFd for io::StdoutLock<'a> {
-    fn as_raw_fd(&self) -> RawFd { libc::STDOUT_FILENO }
+    fn as_raw_fd(&self) -> RawFd {
+        libc::STDOUT_FILENO
+    }
 }
 
 #[stable(feature = "asraw_stdio_locks", since = "1.35.0")]
 impl<'a> AsRawFd for io::StderrLock<'a> {
-    fn as_raw_fd(&self) -> RawFd { libc::STDERR_FILENO }
+    fn as_raw_fd(&self) -> RawFd {
+        libc::STDERR_FILENO
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl AsRawFd for net::TcpStream {
-    fn as_raw_fd(&self) -> RawFd { *self.as_inner().socket().as_inner() }
+    fn as_raw_fd(&self) -> RawFd {
+        *self.as_inner().socket().as_inner()
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl AsRawFd for net::TcpListener {
-    fn as_raw_fd(&self) -> RawFd { *self.as_inner().socket().as_inner() }
+    fn as_raw_fd(&self) -> RawFd {
+        *self.as_inner().socket().as_inner()
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl AsRawFd for net::UdpSocket {
-    fn as_raw_fd(&self) -> RawFd { *self.as_inner().socket().as_inner() }
+    fn as_raw_fd(&self) -> RawFd {
+        *self.as_inner().socket().as_inner()
+    }
 }
 
 #[stable(feature = "from_raw_os", since = "1.1.0")]

--- a/src/libstd/sys/vxworks/ext/mod.rs
+++ b/src/libstd/sys/vxworks/ext/mod.rs
@@ -1,18 +1,21 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 #![allow(missing_docs)]
 
-pub mod io;
 pub mod ffi;
 pub mod fs;
-pub mod raw;
+pub mod io;
 pub mod process;
+pub mod raw;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod prelude {
-    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
-    pub use super::io::{RawFd, AsRawFd, FromRawFd, IntoRawFd};
-    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(no_inline)]
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::ffi::{OsStrExt, OsStringExt};
-    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
-    pub use super::fs::{PermissionsExt, OpenOptionsExt, MetadataExt, FileTypeExt};
+    #[doc(no_inline)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use super::fs::{FileTypeExt, MetadataExt, OpenOptionsExt, PermissionsExt};
+    #[doc(no_inline)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use super::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 }

--- a/src/libstd/sys/vxworks/ext/process.rs
+++ b/src/libstd/sys/vxworks/ext/process.rs
@@ -3,10 +3,10 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::io;
-use crate::sys::vxworks::ext::io::{FromRawFd, RawFd, AsRawFd, IntoRawFd};
 use crate::process;
 use crate::sys;
-use crate::sys_common::{AsInnerMut, AsInner, FromInner, IntoInner};
+use crate::sys::vxworks::ext::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 
 /// Unix-specific extensions to the [`process::Command`] builder.
 ///
@@ -55,7 +55,8 @@ pub trait CommandExt {
     /// locations may not appear where intended.
     #[stable(feature = "process_pre_exec", since = "1.34.0")]
     unsafe fn pre_exec<F>(&mut self, f: F) -> &mut process::Command
-        where F: FnMut() -> io::Result<()> + Send + Sync + 'static;
+    where
+        F: FnMut() -> io::Result<()> + Send + Sync + 'static;
 
     /// Schedules a closure to be run just before the `exec` function is
     /// invoked.
@@ -67,7 +68,8 @@ pub trait CommandExt {
     #[stable(feature = "process_exec", since = "1.15.0")]
     #[rustc_deprecated(since = "1.37.0", reason = "should be unsafe, use `pre_exec` instead")]
     fn before_exec<F>(&mut self, f: F) -> &mut process::Command
-        where F: FnMut() -> io::Result<()> + Send + Sync + 'static
+    where
+        F: FnMut() -> io::Result<()> + Send + Sync + 'static,
     {
         unsafe { self.pre_exec(f) }
     }
@@ -118,7 +120,8 @@ impl CommandExt for process::Command {
     }
 
     unsafe fn pre_exec<F>(&mut self, f: F) -> &mut process::Command
-        where F: FnMut() -> io::Result<()> + Send + Sync + 'static
+    where
+        F: FnMut() -> io::Result<()> + Send + Sync + 'static,
     {
         self.as_inner_mut().pre_exec(Box::new(f));
         self

--- a/src/libstd/sys/vxworks/fast_thread_local.rs
+++ b/src/libstd/sys/vxworks/fast_thread_local.rs
@@ -1,7 +1,7 @@
 #![cfg(target_thread_local)]
 #![unstable(feature = "thread_local_internals", issue = "0")]
 
-pub unsafe fn register_dtor(t: *mut u8, dtor: unsafe extern fn(*mut u8)) {
+pub unsafe fn register_dtor(t: *mut u8, dtor: unsafe extern "C" fn(*mut u8)) {
     use crate::sys_common::thread_local::register_dtor_fallback;
     register_dtor_fallback(t, dtor);
 }

--- a/src/libstd/sys/vxworks/io.rs
+++ b/src/libstd/sys/vxworks/io.rs
@@ -1,7 +1,7 @@
 use crate::marker::PhantomData;
 use crate::slice;
 
-use libc::{iovec, c_void};
+use libc::{c_void, iovec};
 
 #[repr(transparent)]
 pub struct IoSlice<'a> {
@@ -13,10 +13,7 @@ impl<'a> IoSlice<'a> {
     #[inline]
     pub fn new(buf: &'a [u8]) -> IoSlice<'a> {
         IoSlice {
-            vec: iovec {
-                iov_base: buf.as_ptr() as *mut u8 as *mut c_void,
-                iov_len: buf.len()
-            },
+            vec: iovec { iov_base: buf.as_ptr() as *mut u8 as *mut c_void, iov_len: buf.len() },
             _p: PhantomData,
         }
     }
@@ -35,9 +32,7 @@ impl<'a> IoSlice<'a> {
 
     #[inline]
     pub fn as_slice(&self) -> &[u8] {
-        unsafe {
-            slice::from_raw_parts(self.vec.iov_base as *mut u8, self.vec.iov_len)
-        }
+        unsafe { slice::from_raw_parts(self.vec.iov_base as *mut u8, self.vec.iov_len) }
     }
 }
 
@@ -50,10 +45,7 @@ impl<'a> IoSliceMut<'a> {
     #[inline]
     pub fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
         IoSliceMut {
-            vec: iovec {
-                iov_base: buf.as_mut_ptr() as *mut c_void,
-                iov_len: buf.len()
-            },
+            vec: iovec { iov_base: buf.as_mut_ptr() as *mut c_void, iov_len: buf.len() },
             _p: PhantomData,
         }
     }
@@ -72,15 +64,11 @@ impl<'a> IoSliceMut<'a> {
 
     #[inline]
     pub fn as_slice(&self) -> &[u8] {
-        unsafe {
-            slice::from_raw_parts(self.vec.iov_base as *mut u8, self.vec.iov_len)
-        }
+        unsafe { slice::from_raw_parts(self.vec.iov_base as *mut u8, self.vec.iov_len) }
     }
 
     #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
-        unsafe {
-            slice::from_raw_parts_mut(self.vec.iov_base as *mut u8, self.vec.iov_len)
-        }
+        unsafe { slice::from_raw_parts_mut(self.vec.iov_base as *mut u8, self.vec.iov_len) }
     }
 }

--- a/src/libstd/sys/vxworks/memchr.rs
+++ b/src/libstd/sys/vxworks/memchr.rs
@@ -6,13 +6,10 @@ pub fn memchr(needle: u8, haystack: &[u8]) -> Option<usize> {
         libc::memchr(
             haystack.as_ptr() as *const libc::c_void,
             needle as libc::c_int,
-            haystack.len())
+            haystack.len(),
+        )
     };
-    if p.is_null() {
-        None
-    } else {
-        Some(p as usize - (haystack.as_ptr() as usize))
-    }
+    if p.is_null() { None } else { Some(p as usize - (haystack.as_ptr() as usize)) }
 }
 
 pub fn memrchr(needle: u8, haystack: &[u8]) -> Option<usize> {

--- a/src/libstd/sys/vxworks/mod.rs
+++ b/src/libstd/sys/vxworks/mod.rs
@@ -3,8 +3,8 @@
 
 use crate::io::ErrorKind;
 
-pub use crate::os::vxworks as platform;
 pub use self::rand::hashmap_random_keys;
+pub use crate::os::vxworks as platform;
 pub use libc::strlen;
 
 pub mod alloc;
@@ -16,8 +16,8 @@ pub mod ext;
 pub mod fast_thread_local;
 pub mod fd;
 pub mod fs;
-pub mod memchr;
 pub mod io;
+pub mod memchr;
 pub mod mutex;
 pub mod net;
 pub mod os;
@@ -27,10 +27,10 @@ pub mod process;
 pub mod rand;
 pub mod rwlock;
 pub mod stack_overflow;
+pub mod stdio;
 pub mod thread;
 pub mod thread_local;
 pub mod time;
-pub mod stdio;
 
 pub use crate::sys_common::os_str_bytes as os_str;
 
@@ -47,7 +47,7 @@ pub fn init() {
         reset_sigpipe();
     }
 
-    unsafe fn reset_sigpipe() { }
+    unsafe fn reset_sigpipe() {}
 }
 
 pub use libc::signal;
@@ -71,8 +71,7 @@ pub fn decode_error_kind(errno: i32) -> ErrorKind {
         // These two constants can have the same value on some systems,
         // but different values on others, so we can't use a match
         // clause
-        x if x == libc::EAGAIN || x == libc::EWOULDBLOCK =>
-            ErrorKind::WouldBlock,
+        x if x == libc::EAGAIN || x == libc::EWOULDBLOCK => ErrorKind::WouldBlock,
 
         _ => ErrorKind::Other,
     }
@@ -94,16 +93,13 @@ macro_rules! impl_is_minus_one {
 impl_is_minus_one! { i8 i16 i32 i64 isize }
 
 pub fn cvt<T: IsMinusOne>(t: T) -> crate::io::Result<T> {
-    if t.is_minus_one() {
-        Err(crate::io::Error::last_os_error())
-    } else {
-        Ok(t)
-    }
+    if t.is_minus_one() { Err(crate::io::Error::last_os_error()) } else { Ok(t) }
 }
 
 pub fn cvt_r<T, F>(mut f: F) -> crate::io::Result<T>
-    where T: IsMinusOne,
-          F: FnMut() -> T
+where
+    T: IsMinusOne,
+    F: FnMut() -> T,
 {
     loop {
         match cvt(f()) {

--- a/src/libstd/sys/vxworks/mutex.rs
+++ b/src/libstd/sys/vxworks/mutex.rs
@@ -1,7 +1,9 @@
 use crate::cell::UnsafeCell;
 use crate::mem::MaybeUninit;
 
-pub struct Mutex { inner: UnsafeCell<libc::pthread_mutex_t> }
+pub struct Mutex {
+    inner: UnsafeCell<libc::pthread_mutex_t>,
+}
 
 #[inline]
 pub unsafe fn raw(m: &Mutex) -> *mut libc::pthread_mutex_t {
@@ -82,7 +84,9 @@ impl Mutex {
     }
 }
 
-pub struct ReentrantMutex { inner: UnsafeCell<libc::pthread_mutex_t> }
+pub struct ReentrantMutex {
+    inner: UnsafeCell<libc::pthread_mutex_t>,
+}
 
 unsafe impl Send for ReentrantMutex {}
 unsafe impl Sync for ReentrantMutex {}
@@ -96,8 +100,8 @@ impl ReentrantMutex {
         let mut attr = MaybeUninit::<libc::pthread_mutexattr_t>::uninit();
         let result = libc::pthread_mutexattr_init(attr.as_mut_ptr());
         debug_assert_eq!(result, 0);
-        let result = libc::pthread_mutexattr_settype(attr.as_mut_ptr(),
-                                                    libc::PTHREAD_MUTEX_RECURSIVE);
+        let result =
+            libc::pthread_mutexattr_settype(attr.as_mut_ptr(), libc::PTHREAD_MUTEX_RECURSIVE);
         debug_assert_eq!(result, 0);
         let result = libc::pthread_mutex_init(self.inner.get(), attr.as_ptr());
         debug_assert_eq!(result, 0);

--- a/src/libstd/sys/vxworks/path.rs
+++ b/src/libstd/sys/vxworks/path.rs
@@ -1,5 +1,5 @@
-use crate::path::Prefix;
 use crate::ffi::OsStr;
+use crate::path::Prefix;
 
 #[inline]
 pub fn is_sep_byte(b: u8) -> bool {

--- a/src/libstd/sys/vxworks/pipe.rs
+++ b/src/libstd/sys/vxworks/pipe.rs
@@ -1,9 +1,9 @@
 use crate::io::{self, IoSlice, IoSliceMut};
-use libc::{self /*, c_int apparently not used? */};
 use crate::mem;
-use crate::sync::atomic::{AtomicBool};
+use crate::sync::atomic::AtomicBool;
 use crate::sys::fd::FileDesc;
 use crate::sys::{cvt, cvt_r};
+use libc::{self /*, c_int apparently not used? */};
 
 pub struct AnonPipe(FileDesc);
 
@@ -25,29 +25,29 @@ impl AnonPipe {
         self.0.read(buf)
     }
     pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
-                self.0.read_vectored(bufs)
-        }
+        self.0.read_vectored(bufs)
+    }
 
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
         self.0.write(buf)
     }
 
-        pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-                self.0.write_vectored(bufs)
-        }
+    pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        self.0.write_vectored(bufs)
+    }
 
-    pub fn fd(&self) -> &FileDesc { &self.0 }
-    pub fn into_fd(self) -> FileDesc { self.0 }
+    pub fn fd(&self) -> &FileDesc {
+        &self.0
+    }
+    pub fn into_fd(self) -> FileDesc {
+        self.0
+    }
     pub fn diverge(&self) -> ! {
         panic!()
-     }
+    }
 }
 
-pub fn read2(p1: AnonPipe,
-             v1: &mut Vec<u8>,
-             p2: AnonPipe,
-             v2: &mut Vec<u8>) -> io::Result<()> {
-
+pub fn read2(p1: AnonPipe, v1: &mut Vec<u8>, p2: AnonPipe, v2: &mut Vec<u8>) -> io::Result<()> {
     // Set both pipes into nonblocking mode as we're gonna be reading from both
     // in the `select` loop below, and we wouldn't want one to block the other!
     let p1 = p1.into_fd();
@@ -83,8 +83,9 @@ pub fn read2(p1: AnonPipe,
         match fd.read_to_end(dst) {
             Ok(_) => Ok(true),
             Err(e) => {
-                if e.raw_os_error() == Some(libc::EWOULDBLOCK) ||
-                   e.raw_os_error() == Some(libc::EAGAIN) {
+                if e.raw_os_error() == Some(libc::EWOULDBLOCK)
+                    || e.raw_os_error() == Some(libc::EAGAIN)
+                {
                     Ok(false)
                 } else {
                     Err(e)

--- a/src/libstd/sys/vxworks/process/mod.rs
+++ b/src/libstd/sys/vxworks/process/mod.rs
@@ -1,4 +1,4 @@
-pub use self::process_common::{Command, ExitStatus, ExitCode, Stdio, StdioPipes};
+pub use self::process_common::{Command, ExitCode, ExitStatus, Stdio, StdioPipes};
 pub use self::process_inner::Process;
 pub use crate::ffi::OsString as EnvKey;
 

--- a/src/libstd/sys/vxworks/rand.rs
+++ b/src/libstd/sys/vxworks/rand.rs
@@ -4,17 +4,16 @@ use crate::slice;
 pub fn hashmap_random_keys() -> (u64, u64) {
     let mut v = (0, 0);
     unsafe {
-        let view = slice::from_raw_parts_mut(&mut v as *mut _ as *mut u8,
-                                             mem::size_of_val(&v));
+        let view = slice::from_raw_parts_mut(&mut v as *mut _ as *mut u8, mem::size_of_val(&v));
         imp::fill_bytes(view);
     }
-    return v
+    return v;
 }
 
 mod imp {
-    use libc;
     use crate::io;
     use core::sync::atomic::{AtomicBool, Ordering::Relaxed};
+    use libc;
 
     pub fn fill_bytes(v: &mut [u8]) {
         static RNG_INIT: AtomicBool = AtomicBool::new(false);

--- a/src/libstd/sys/vxworks/rwlock.rs
+++ b/src/libstd/sys/vxworks/rwlock.rs
@@ -1,6 +1,6 @@
-use libc;
 use crate::cell::UnsafeCell;
 use crate::sync::atomic::{AtomicUsize, Ordering};
+use libc;
 
 pub struct RWLock {
     inner: UnsafeCell<libc::pthread_rwlock_t>,
@@ -29,7 +29,7 @@ impl RWLock {
             if r == 0 {
                 self.raw_unlock();
             }
-        panic!("rwlock read lock would result in deadlock");
+            panic!("rwlock read lock would result in deadlock");
         } else {
             debug_assert_eq!(r, 0);
             self.num_readers.fetch_add(1, Ordering::Relaxed);
@@ -57,12 +57,14 @@ impl RWLock {
         let r = libc::pthread_rwlock_wrlock(self.inner.get());
         // See comments above for why we check for EDEADLK and write_locked. We
         // also need to check that num_readers is 0.
-        if r == libc::EDEADLK || *self.write_locked.get() ||
-            self.num_readers.load(Ordering::Relaxed) != 0 {
+        if r == libc::EDEADLK
+            || *self.write_locked.get()
+            || self.num_readers.load(Ordering::Relaxed) != 0
+        {
             if r == 0 {
                 self.raw_unlock();
             }
-        panic!("rwlock write lock would result in deadlock");
+            panic!("rwlock write lock would result in deadlock");
         } else {
             debug_assert_eq!(r, 0);
         }
@@ -80,8 +82,8 @@ impl RWLock {
                 *self.write_locked.get() = true;
                 true
             }
-            } else {
-                false
+        } else {
+            false
         }
     }
 
@@ -98,7 +100,7 @@ impl RWLock {
         self.raw_unlock();
     }
 
-     #[inline]
+    #[inline]
     pub unsafe fn write_unlock(&self) {
         debug_assert_eq!(self.num_readers.load(Ordering::Relaxed), 0);
         debug_assert!(*self.write_locked.get());

--- a/src/libstd/sys/vxworks/stack_overflow.rs
+++ b/src/libstd/sys/vxworks/stack_overflow.rs
@@ -1,12 +1,12 @@
 #![cfg_attr(test, allow(dead_code))]
 
-use self::imp::{make_handler, drop_handler};
+use self::imp::{drop_handler, make_handler};
 
 pub use self::imp::cleanup;
 pub use self::imp::init;
 
 pub struct Handler {
-    _data: *mut libc::c_void
+    _data: *mut libc::c_void,
 }
 
 impl Handler {
@@ -26,16 +26,13 @@ impl Drop for Handler {
 mod imp {
     use crate::ptr;
 
-    pub unsafe fn init() {
-    }
+    pub unsafe fn init() {}
 
-    pub unsafe fn cleanup() {
-    }
+    pub unsafe fn cleanup() {}
 
     pub unsafe fn make_handler() -> super::Handler {
         super::Handler { _data: ptr::null_mut() }
     }
 
-    pub unsafe fn drop_handler(_handler: &mut super::Handler) {
-    }
+    pub unsafe fn drop_handler(_handler: &mut super::Handler) {}
 }

--- a/src/libstd/sys/vxworks/stdio.rs
+++ b/src/libstd/sys/vxworks/stdio.rs
@@ -6,7 +6,9 @@ pub struct Stdout(());
 pub struct Stderr(());
 
 impl Stdin {
-    pub fn new() -> io::Result<Stdin> { Ok(Stdin(())) }
+    pub fn new() -> io::Result<Stdin> {
+        Ok(Stdin(()))
+    }
 }
 
 impl io::Read for Stdin {
@@ -19,7 +21,9 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> io::Result<Stdout> { Ok(Stdout(())) }
+    pub fn new() -> io::Result<Stdout> {
+        Ok(Stdout(()))
+    }
 }
 
 impl io::Write for Stdout {
@@ -36,7 +40,9 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> io::Result<Stderr> { Ok(Stderr(())) }
+    pub fn new() -> io::Result<Stderr> {
+        Ok(Stderr(()))
+    }
 }
 
 impl io::Write for Stderr {

--- a/src/libstd/sys/vxworks/thread.rs
+++ b/src/libstd/sys/vxworks/thread.rs
@@ -21,15 +21,16 @@ unsafe impl Sync for Thread {}
 
 // The pthread_attr_setstacksize symbol doesn't exist in the emscripten libc,
 // so we have to not link to it to satisfy emcc's ERROR_ON_UNDEFINED_SYMBOLS.
-unsafe fn pthread_attr_setstacksize(attr: *mut libc::pthread_attr_t,
-                                    stack_size: libc::size_t) -> libc::c_int {
+unsafe fn pthread_attr_setstacksize(
+    attr: *mut libc::pthread_attr_t,
+    stack_size: libc::size_t,
+) -> libc::c_int {
     libc::pthread_attr_setstacksize(attr, stack_size)
 }
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
-    pub unsafe fn new(stack: usize, p: Box<dyn FnOnce()>)
-                          -> io::Result<Thread> {
+    pub unsafe fn new(stack: usize, p: Box<dyn FnOnce()>) -> io::Result<Thread> {
         let p = box p;
         let mut native: libc::pthread_t = mem::zeroed();
         let mut attr: libc::pthread_attr_t = mem::zeroed();
@@ -37,8 +38,7 @@ impl Thread {
 
         let stack_size = cmp::max(stack, min_stack_size(&attr));
 
-        match pthread_attr_setstacksize(&mut attr,
-                                        stack_size) {
+        match pthread_attr_setstacksize(&mut attr, stack_size) {
             0 => {}
             n => {
                 assert_eq!(n, libc::EINVAL);
@@ -47,15 +47,13 @@ impl Thread {
                 // >= PTHREAD_STACK_MIN, it must be an alignment issue.
                 // Round up to the nearest page and try again.
                 let page_size = os::page_size();
-                let stack_size = (stack_size + page_size - 1) &
-                                 (-(page_size as isize - 1) as usize - 1);
-                assert_eq!(libc::pthread_attr_setstacksize(&mut attr,
-                                                           stack_size), 0);
+                let stack_size =
+                    (stack_size + page_size - 1) & (-(page_size as isize - 1) as usize - 1);
+                assert_eq!(libc::pthread_attr_setstacksize(&mut attr, stack_size), 0);
             }
         };
 
-        let ret = libc::pthread_create(&mut native, &attr, thread_start,
-                                       &*p as *const _ as *mut _);
+        let ret = libc::pthread_create(&mut native, &attr, thread_start, &*p as *const _ as *mut _);
         assert_eq!(libc::pthread_attr_destroy(&mut attr), 0);
 
         return if ret != 0 {
@@ -65,8 +63,10 @@ impl Thread {
             Ok(Thread { id: native })
         };
 
-        extern fn thread_start(main: *mut libc::c_void) -> *mut libc::c_void {
-            unsafe { start_thread(main as *mut u8); }
+        extern "C" fn thread_start(main: *mut libc::c_void) -> *mut libc::c_void {
+            unsafe {
+                start_thread(main as *mut u8);
+            }
             ptr::null_mut()
         }
     }
@@ -108,12 +108,13 @@ impl Thread {
         unsafe {
             let ret = libc::pthread_join(self.id, ptr::null_mut());
             mem::forget(self);
-            assert!(ret == 0,
-                    "failed to join thread: {}", io::Error::from_raw_os_error(ret));
+            assert!(ret == 0, "failed to join thread: {}", io::Error::from_raw_os_error(ret));
         }
     }
 
-    pub fn id(&self) -> libc::pthread_t { self.id }
+    pub fn id(&self) -> libc::pthread_t {
+        self.id
+    }
 
     pub fn into_id(self) -> libc::pthread_t {
         let id = self.id;
@@ -133,8 +134,12 @@ impl Drop for Thread {
 pub mod guard {
     use crate::ops::Range;
     pub type Guard = Range<usize>;
-    pub unsafe fn current() -> Option<Guard> { None }
-    pub unsafe fn init() -> Option<Guard> { None }
+    pub unsafe fn current() -> Option<Guard> {
+        None
+    }
+    pub unsafe fn init() -> Option<Guard> {
+        None
+    }
     pub unsafe fn deinit() {}
 }
 

--- a/src/libstd/sys/vxworks/thread_local.rs
+++ b/src/libstd/sys/vxworks/thread_local.rs
@@ -5,7 +5,7 @@ use crate::mem;
 pub type Key = libc::pthread_key_t;
 
 #[inline]
-pub unsafe fn create(dtor: Option<unsafe extern fn(*mut u8)>) -> Key {
+pub unsafe fn create(dtor: Option<unsafe extern "C" fn(*mut u8)>) -> Key {
     let mut key = 0;
     assert_eq!(libc::pthread_key_create(&mut key, mem::transmute(dtor)), 0);
     key

--- a/src/libstd/sys/vxworks/weak.rs
+++ b/src/libstd/sys/vxworks/weak.rs
@@ -29,11 +29,7 @@ pub struct Weak<F> {
 
 impl<F> Weak<F> {
     pub const fn new(name: &'static str) -> Weak<F> {
-        Weak {
-            name,
-            addr: AtomicUsize::new(1),
-            _marker: marker::PhantomData,
-        }
+        Weak { name, addr: AtomicUsize::new(1), _marker: marker::PhantomData }
     }
 
     pub fn get(&self) -> Option<F> {
@@ -56,5 +52,5 @@ unsafe fn fetch(name: &str) -> usize {
         Err(..) => return 0,
     };
     assert!(false, "FIXME: fetch");
-   libc::dlsym(libc::RTLD_DEFAULT, name.as_ptr()) as usize
+    libc::dlsym(libc::RTLD_DEFAULT, name.as_ptr()) as usize
 }

--- a/src/libstd/sys/wasi/alloc.rs
+++ b/src/libstd/sys/wasi/alloc.rs
@@ -1,6 +1,6 @@
 use crate::alloc::{GlobalAlloc, Layout, System};
 use crate::ptr;
-use crate::sys_common::alloc::{MIN_ALIGN, realloc_fallback};
+use crate::sys_common::alloc::{realloc_fallback, MIN_ALIGN};
 use libc;
 
 #[stable(feature = "alloc_system_type", since = "1.28.0")]

--- a/src/libstd/sys/wasi/ext/mod.rs
+++ b/src/libstd/sys/wasi/ext/mod.rs
@@ -7,12 +7,16 @@ pub mod io;
 /// Includes all extension traits, and some important type definitions.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod prelude {
-    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
-    pub use crate::sys::ext::ffi::{OsStringExt, OsStrExt};
-    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
-    pub use crate::sys::ext::fs::{FileExt, DirEntryExt, MetadataExt, OpenOptionsExt};
-    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(no_inline)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use crate::sys::ext::ffi::{OsStrExt, OsStringExt};
+    #[doc(no_inline)]
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub use crate::sys::ext::fs::FileTypeExt;
-    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
-    pub use crate::sys::ext::io::{AsRawFd, IntoRawFd, FromRawFd};
+    #[doc(no_inline)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use crate::sys::ext::fs::{DirEntryExt, FileExt, MetadataExt, OpenOptionsExt};
+    #[doc(no_inline)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use crate::sys::ext::io::{AsRawFd, FromRawFd, IntoRawFd};
 }

--- a/src/libstd/sys/wasi/net.rs
+++ b/src/libstd/sys/wasi/net.rs
@@ -1,11 +1,11 @@
+use crate::convert::TryFrom;
 use crate::fmt;
 use crate::io::{self, IoSlice, IoSliceMut};
-use crate::net::{SocketAddr, Shutdown, Ipv4Addr, Ipv6Addr};
-use crate::time::Duration;
+use crate::net::{Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr};
+use crate::sys::fd::WasiFd;
 use crate::sys::{unsupported, Void};
-use crate::convert::TryFrom;
-use crate::sys::fd::{WasiFd};
 use crate::sys_common::FromInner;
+use crate::time::Duration;
 
 pub struct TcpStream {
     fd: WasiFd,
@@ -107,24 +107,18 @@ impl TcpStream {
 
 impl FromInner<u32> for TcpStream {
     fn from_inner(fd: u32) -> TcpStream {
-        unsafe {
-            TcpStream {
-                fd: WasiFd::from_raw(fd),
-            }
-        }
+        unsafe { TcpStream { fd: WasiFd::from_raw(fd) } }
     }
 }
 
 impl fmt::Debug for TcpStream {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TcpStream")
-            .field("fd", &self.fd.as_raw())
-            .finish()
+        f.debug_struct("TcpStream").field("fd", &self.fd.as_raw()).finish()
     }
 }
 
 pub struct TcpListener {
-    fd: WasiFd
+    fd: WasiFd,
 }
 
 impl TcpListener {
@@ -179,19 +173,13 @@ impl TcpListener {
 
 impl FromInner<u32> for TcpListener {
     fn from_inner(fd: u32) -> TcpListener {
-        unsafe {
-            TcpListener {
-                fd: WasiFd::from_raw(fd),
-            }
-        }
+        unsafe { TcpListener { fd: WasiFd::from_raw(fd) } }
     }
 }
 
 impl fmt::Debug for TcpListener {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TcpListener")
-            .field("fd", &self.fd.as_raw())
-            .finish()
+        f.debug_struct("TcpListener").field("fd", &self.fd.as_raw()).finish()
     }
 }
 
@@ -276,23 +264,19 @@ impl UdpSocket {
         unsupported()
     }
 
-    pub fn join_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr)
-                         -> io::Result<()> {
+    pub fn join_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr) -> io::Result<()> {
         unsupported()
     }
 
-    pub fn join_multicast_v6(&self, _: &Ipv6Addr, _: u32)
-                         -> io::Result<()> {
+    pub fn join_multicast_v6(&self, _: &Ipv6Addr, _: u32) -> io::Result<()> {
         unsupported()
     }
 
-    pub fn leave_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr)
-                          -> io::Result<()> {
+    pub fn leave_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr) -> io::Result<()> {
         unsupported()
     }
 
-    pub fn leave_multicast_v6(&self, _: &Ipv6Addr, _: u32)
-                          -> io::Result<()> {
+    pub fn leave_multicast_v6(&self, _: &Ipv6Addr, _: u32) -> io::Result<()> {
         unsupported()
     }
 
@@ -339,19 +323,13 @@ impl UdpSocket {
 
 impl FromInner<u32> for UdpSocket {
     fn from_inner(fd: u32) -> UdpSocket {
-        unsafe {
-            UdpSocket {
-                fd: WasiFd::from_raw(fd),
-            }
-        }
+        unsafe { UdpSocket { fd: WasiFd::from_raw(fd) } }
     }
 }
 
 impl fmt::Debug for UdpSocket {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("UdpSocket")
-            .field("fd", &self.fd.as_raw())
-            .finish()
+        f.debug_struct("UdpSocket").field("fd", &self.fd.as_raw()).finish()
     }
 }
 
@@ -419,8 +397,7 @@ pub mod netc {
     }
 
     #[derive(Copy, Clone)]
-    pub struct sockaddr {
-    }
+    pub struct sockaddr {}
 
     pub type socklen_t = usize;
 }

--- a/src/libstd/sys/wasi/path.rs
+++ b/src/libstd/sys/wasi/path.rs
@@ -1,5 +1,5 @@
-use crate::path::Prefix;
 use crate::ffi::OsStr;
+use crate::path::Prefix;
 
 #[inline]
 pub fn is_sep_byte(b: u8) -> bool {

--- a/src/libstd/sys/wasi/pipe.rs
+++ b/src/libstd/sys/wasi/pipe.rs
@@ -25,9 +25,6 @@ impl AnonPipe {
     }
 }
 
-pub fn read2(p1: AnonPipe,
-             _v1: &mut Vec<u8>,
-             _p2: AnonPipe,
-             _v2: &mut Vec<u8>) -> io::Result<()> {
+pub fn read2(p1: AnonPipe, _v1: &mut Vec<u8>, _p2: AnonPipe, _v2: &mut Vec<u8>) -> io::Result<()> {
     match p1.0 {}
 }

--- a/src/libstd/sys/wasi/process.rs
+++ b/src/libstd/sys/wasi/process.rs
@@ -13,7 +13,7 @@ pub use crate::ffi::OsString as EnvKey;
 ////////////////////////////////////////////////////////////////////////////////
 
 pub struct Command {
-    env: CommandEnv
+    env: CommandEnv,
 }
 
 // passed back to std::process with the pipes connected to the child, if any
@@ -32,32 +32,28 @@ pub enum Stdio {
 
 impl Command {
     pub fn new(_program: &OsStr) -> Command {
-        Command {
-            env: Default::default()
-        }
+        Command { env: Default::default() }
     }
 
-    pub fn arg(&mut self, _arg: &OsStr) {
-    }
+    pub fn arg(&mut self, _arg: &OsStr) {}
 
     pub fn env_mut(&mut self) -> &mut CommandEnv {
         &mut self.env
     }
 
-    pub fn cwd(&mut self, _dir: &OsStr) {
-    }
+    pub fn cwd(&mut self, _dir: &OsStr) {}
 
-    pub fn stdin(&mut self, _stdin: Stdio) {
-    }
+    pub fn stdin(&mut self, _stdin: Stdio) {}
 
-    pub fn stdout(&mut self, _stdout: Stdio) {
-    }
+    pub fn stdout(&mut self, _stdout: Stdio) {}
 
-    pub fn stderr(&mut self, _stderr: Stdio) {
-    }
+    pub fn stderr(&mut self, _stderr: Stdio) {}
 
-    pub fn spawn(&mut self, _default: Stdio, _needs_stdin: bool)
-        -> io::Result<(Process, StdioPipes)> {
+    pub fn spawn(
+        &mut self,
+        _default: Stdio,
+        _needs_stdin: bool,
+    ) -> io::Result<(Process, StdioPipes)> {
         unsupported()
     }
 }
@@ -106,8 +102,7 @@ impl PartialEq for ExitStatus {
     }
 }
 
-impl Eq for ExitStatus {
-}
+impl Eq for ExitStatus {}
 
 impl fmt::Debug for ExitStatus {
     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/libstd/sys/wasm/args.rs
+++ b/src/libstd/sys/wasm/args.rs
@@ -6,14 +6,10 @@ pub unsafe fn init(_argc: isize, _argv: *const *const u8) {
     // On wasm these should always be null, so there's nothing for us to do here
 }
 
-pub unsafe fn cleanup() {
-}
+pub unsafe fn cleanup() {}
 
 pub fn args() -> Args {
-    Args {
-        iter: Vec::new().into_iter(),
-        _dont_send_or_sync_me: PhantomData,
-    }
+    Args { iter: Vec::new().into_iter(), _dont_send_or_sync_me: PhantomData }
 }
 
 pub struct Args {

--- a/src/libstd/sys/wasm/cmath.rs
+++ b/src/libstd/sys/wasm/cmath.rs
@@ -1,5 +1,5 @@
 // These symbols are all defined in `compiler-builtins`
-extern {
+extern "C" {
     pub fn acos(n: f64) -> f64;
     pub fn acosf(n: f32) -> f32;
     pub fn asin(n: f64) -> f64;

--- a/src/libstd/sys/wasm/fs.rs
+++ b/src/libstd/sys/wasm/fs.rs
@@ -1,7 +1,7 @@
 use crate::ffi::OsString;
 use crate::fmt;
 use crate::hash::{Hash, Hasher};
-use crate::io::{self, SeekFrom, IoSlice, IoSliceMut};
+use crate::io::{self, IoSlice, IoSliceMut, SeekFrom};
 use crate::path::{Path, PathBuf};
 use crate::sys::time::SystemTime;
 use crate::sys::{unsupported, Void};
@@ -15,14 +15,14 @@ pub struct ReadDir(Void);
 pub struct DirEntry(Void);
 
 #[derive(Clone, Debug)]
-pub struct OpenOptions { }
+pub struct OpenOptions {}
 
 pub struct FilePermissions(Void);
 
 pub struct FileType(Void);
 
 #[derive(Debug)]
-pub struct DirBuilder { }
+pub struct DirBuilder {}
 
 impl FileAttr {
     pub fn size(&self) -> u64 {
@@ -78,8 +78,7 @@ impl PartialEq for FilePermissions {
     }
 }
 
-impl Eq for FilePermissions {
-}
+impl Eq for FilePermissions {}
 
 impl fmt::Debug for FilePermissions {
     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -115,8 +114,7 @@ impl PartialEq for FileType {
     }
 }
 
-impl Eq for FileType {
-}
+impl Eq for FileType {}
 
 impl Hash for FileType {
     fn hash<H: Hasher>(&self, _h: &mut H) {
@@ -164,15 +162,15 @@ impl DirEntry {
 
 impl OpenOptions {
     pub fn new() -> OpenOptions {
-        OpenOptions { }
+        OpenOptions {}
     }
 
-    pub fn read(&mut self, _read: bool) { }
-    pub fn write(&mut self, _write: bool) { }
-    pub fn append(&mut self, _append: bool) { }
-    pub fn truncate(&mut self, _truncate: bool) { }
-    pub fn create(&mut self, _create: bool) { }
-    pub fn create_new(&mut self, _create_new: bool) { }
+    pub fn read(&mut self, _read: bool) {}
+    pub fn write(&mut self, _write: bool) {}
+    pub fn append(&mut self, _append: bool) {}
+    pub fn truncate(&mut self, _truncate: bool) {}
+    pub fn create(&mut self, _create: bool) {}
+    pub fn create_new(&mut self, _create_new: bool) {}
 }
 
 impl File {
@@ -235,7 +233,7 @@ impl File {
 
 impl DirBuilder {
     pub fn new() -> DirBuilder {
-        DirBuilder { }
+        DirBuilder {}
     }
 
     pub fn mkdir(&self, _p: &Path) -> io::Result<()> {

--- a/src/libstd/sys/wasm/net.rs
+++ b/src/libstd/sys/wasm/net.rs
@@ -1,9 +1,9 @@
+use crate::convert::TryFrom;
 use crate::fmt;
 use crate::io::{self, IoSlice, IoSliceMut};
-use crate::net::{SocketAddr, Shutdown, Ipv4Addr, Ipv6Addr};
-use crate::time::Duration;
+use crate::net::{Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr};
 use crate::sys::{unsupported, Void};
-use crate::convert::TryFrom;
+use crate::time::Duration;
 
 pub struct TcpStream(Void);
 
@@ -228,23 +228,19 @@ impl UdpSocket {
         match self.0 {}
     }
 
-    pub fn join_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr)
-                         -> io::Result<()> {
+    pub fn join_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr) -> io::Result<()> {
         match self.0 {}
     }
 
-    pub fn join_multicast_v6(&self, _: &Ipv6Addr, _: u32)
-                         -> io::Result<()> {
+    pub fn join_multicast_v6(&self, _: &Ipv6Addr, _: u32) -> io::Result<()> {
         match self.0 {}
     }
 
-    pub fn leave_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr)
-                          -> io::Result<()> {
+    pub fn leave_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr) -> io::Result<()> {
         match self.0 {}
     }
 
-    pub fn leave_multicast_v6(&self, _: &Ipv6Addr, _: u32)
-                          -> io::Result<()> {
+    pub fn leave_multicast_v6(&self, _: &Ipv6Addr, _: u32) -> io::Result<()> {
         match self.0 {}
     }
 
@@ -351,8 +347,7 @@ pub mod netc {
     }
 
     #[derive(Copy, Clone)]
-    pub struct sockaddr {
-    }
+    pub struct sockaddr {}
 
     pub type socklen_t = usize;
 }

--- a/src/libstd/sys/wasm/os.rs
+++ b/src/libstd/sys/wasm/os.rs
@@ -1,5 +1,5 @@
 use crate::error::Error as StdError;
-use crate::ffi::{OsString, OsStr};
+use crate::ffi::{OsStr, OsString};
 use crate::fmt;
 use crate::io;
 use crate::path::{self, PathBuf};
@@ -39,7 +39,9 @@ impl<'a> Iterator for SplitPaths<'a> {
 pub struct JoinPathsError;
 
 pub fn join_paths<I, T>(_paths: I) -> Result<OsString, JoinPathsError>
-    where I: Iterator<Item=T>, T: AsRef<OsStr>
+where
+    I: Iterator<Item = T>,
+    T: AsRef<OsStr>,
 {
     Err(JoinPathsError)
 }

--- a/src/libstd/sys/wasm/path.rs
+++ b/src/libstd/sys/wasm/path.rs
@@ -1,5 +1,5 @@
-use crate::path::Prefix;
 use crate::ffi::OsStr;
+use crate::path::Prefix;
 
 #[inline]
 pub fn is_sep_byte(b: u8) -> bool {

--- a/src/libstd/sys/wasm/pipe.rs
+++ b/src/libstd/sys/wasm/pipe.rs
@@ -25,9 +25,6 @@ impl AnonPipe {
     }
 }
 
-pub fn read2(p1: AnonPipe,
-             _v1: &mut Vec<u8>,
-             _p2: AnonPipe,
-             _v2: &mut Vec<u8>) -> io::Result<()> {
+pub fn read2(p1: AnonPipe, _v1: &mut Vec<u8>, _p2: AnonPipe, _v2: &mut Vec<u8>) -> io::Result<()> {
     match p1.0 {}
 }

--- a/src/libstd/sys/wasm/process.rs
+++ b/src/libstd/sys/wasm/process.rs
@@ -32,32 +32,28 @@ pub enum Stdio {
 
 impl Command {
     pub fn new(_program: &OsStr) -> Command {
-        Command {
-            env: Default::default()
-        }
+        Command { env: Default::default() }
     }
 
-    pub fn arg(&mut self, _arg: &OsStr) {
-    }
+    pub fn arg(&mut self, _arg: &OsStr) {}
 
     pub fn env_mut(&mut self) -> &mut CommandEnv {
         &mut self.env
     }
 
-    pub fn cwd(&mut self, _dir: &OsStr) {
-    }
+    pub fn cwd(&mut self, _dir: &OsStr) {}
 
-    pub fn stdin(&mut self, _stdin: Stdio) {
-    }
+    pub fn stdin(&mut self, _stdin: Stdio) {}
 
-    pub fn stdout(&mut self, _stdout: Stdio) {
-    }
+    pub fn stdout(&mut self, _stdout: Stdio) {}
 
-    pub fn stderr(&mut self, _stderr: Stdio) {
-    }
+    pub fn stderr(&mut self, _stderr: Stdio) {}
 
-    pub fn spawn(&mut self, _default: Stdio, _needs_stdin: bool)
-        -> io::Result<(Process, StdioPipes)> {
+    pub fn spawn(
+        &mut self,
+        _default: Stdio,
+        _needs_stdin: bool,
+    ) -> io::Result<(Process, StdioPipes)> {
         unsupported()
     }
 }
@@ -106,8 +102,7 @@ impl PartialEq for ExitStatus {
     }
 }
 
-impl Eq for ExitStatus {
-}
+impl Eq for ExitStatus {}
 
 impl fmt::Debug for ExitStatus {
     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/libstd/sys/wasm/stack_overflow.rs
+++ b/src/libstd/sys/wasm/stack_overflow.rs
@@ -6,8 +6,6 @@ impl Handler {
     }
 }
 
-pub unsafe fn init() {
-}
+pub unsafe fn init() {}
 
-pub unsafe fn cleanup() {
-}
+pub unsafe fn cleanup() {}

--- a/src/libstd/sys/wasm/thread.rs
+++ b/src/libstd/sys/wasm/thread.rs
@@ -9,9 +9,7 @@ pub const DEFAULT_MIN_STACK_SIZE: usize = 4096;
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
-    pub unsafe fn new(_stack: usize, _p: Box<dyn FnOnce()>)
-        -> io::Result<Thread>
-    {
+    pub unsafe fn new(_stack: usize, _p: Box<dyn FnOnce()>) -> io::Result<Thread> {
         unsupported()
     }
 
@@ -55,8 +53,12 @@ impl Thread {
 
 pub mod guard {
     pub type Guard = !;
-    pub unsafe fn current() -> Option<Guard> { None }
-    pub unsafe fn init() -> Option<Guard> { None }
+    pub unsafe fn current() -> Option<Guard> {
+        None
+    }
+    pub unsafe fn init() -> Option<Guard> {
+        None
+    }
 }
 
 // This is only used by atomics primitives when the `atomics` feature is
@@ -84,9 +86,7 @@ pub fn my_id() -> u32 {
         if MY_ID == 0 {
             let mut cur = NEXT_ID.load(SeqCst);
             MY_ID = loop {
-                let next = cur.checked_add(1).unwrap_or_else(|| {
-                    crate::arch::wasm32::unreachable()
-                });
+                let next = cur.checked_add(1).unwrap_or_else(|| crate::arch::wasm32::unreachable());
                 match NEXT_ID.compare_exchange(cur, next, SeqCst, SeqCst) {
                     Ok(_) => break next,
                     Err(i) => cur = i,

--- a/src/libstd/sys/wasm/thread_local.rs
+++ b/src/libstd/sys/wasm/thread_local.rs
@@ -1,7 +1,7 @@
 pub type Key = usize;
 
 #[inline]
-pub unsafe fn create(_dtor: Option<unsafe extern fn(*mut u8)>) -> Key {
+pub unsafe fn create(_dtor: Option<unsafe extern "C" fn(*mut u8)>) -> Key {
     panic!("should not be used on the wasm target");
 }
 

--- a/src/libstd/sys/wasm/time.rs
+++ b/src/libstd/sys/wasm/time.rs
@@ -39,8 +39,7 @@ impl SystemTime {
         panic!("time not implemented on wasm32-unknown-unknown")
     }
 
-    pub fn sub_time(&self, other: &SystemTime)
-                    -> Result<Duration, Duration> {
+    pub fn sub_time(&self, other: &SystemTime) -> Result<Duration, Duration> {
         self.0.checked_sub(other.0).ok_or_else(|| other.0 - self.0)
     }
 

--- a/src/libstd/sys/windows/cmath.rs
+++ b/src/libstd/sys/windows/cmath.rs
@@ -1,9 +1,9 @@
 #![cfg(not(test))]
 
-use libc::{c_float, c_double};
+use libc::{c_double, c_float};
 
 #[link_name = "m"]
-extern {
+extern "C" {
     pub fn acos(n: c_double) -> c_double;
     pub fn asin(n: c_double) -> c_double;
     pub fn atan(n: c_double) -> c_double;
@@ -32,7 +32,7 @@ pub use self::shims::*;
 mod shims {
     use libc::c_float;
 
-    extern {
+    extern "C" {
         pub fn acosf(n: c_float) -> c_float;
         pub fn asinf(n: c_float) -> c_float;
         pub fn atan2f(a: c_float, b: c_float) -> c_float;

--- a/src/libstd/sys/windows/compat.rs
+++ b/src/libstd/sys/windows/compat.rs
@@ -28,8 +28,7 @@ pub fn lookup(module: &str, symbol: &str) -> Option<usize> {
     }
 }
 
-pub fn store_func(ptr: &AtomicUsize, module: &str, symbol: &str,
-                  fallback: usize) -> usize {
+pub fn store_func(ptr: &AtomicUsize, module: &str, symbol: &str, fallback: usize) -> usize {
     let value = lookup(module, symbol).unwrap_or(fallback);
     ptr.store(value, Ordering::SeqCst);
     value

--- a/src/libstd/sys/windows/ext/ffi.rs
+++ b/src/libstd/sys/windows/ext/ffi.rs
@@ -59,10 +59,10 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use crate::ffi::{OsString, OsStr};
+use crate::ffi::{OsStr, OsString};
 use crate::sys::os_str::Buf;
 use crate::sys_common::wtf8::Wtf8Buf;
-use crate::sys_common::{FromInner, AsInner};
+use crate::sys_common::{AsInner, FromInner};
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use crate::sys_common::wtf8::EncodeWide;

--- a/src/libstd/sys/windows/ext/fs.rs
+++ b/src/libstd/sys/windows/ext/fs.rs
@@ -2,11 +2,11 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use crate::fs::{self, OpenOptions, Metadata};
+use crate::fs::{self, Metadata, OpenOptions};
 use crate::io;
 use crate::path::Path;
 use crate::sys;
-use crate::sys_common::{AsInnerMut, AsInner};
+use crate::sys_common::{AsInner, AsInnerMut};
 
 /// Windows-specific extensions to [`File`].
 ///
@@ -265,23 +265,28 @@ pub trait OpenOptionsExt {
 #[stable(feature = "open_options_ext", since = "1.10.0")]
 impl OpenOptionsExt for OpenOptions {
     fn access_mode(&mut self, access: u32) -> &mut OpenOptions {
-        self.as_inner_mut().access_mode(access); self
+        self.as_inner_mut().access_mode(access);
+        self
     }
 
     fn share_mode(&mut self, share: u32) -> &mut OpenOptions {
-        self.as_inner_mut().share_mode(share); self
+        self.as_inner_mut().share_mode(share);
+        self
     }
 
     fn custom_flags(&mut self, flags: u32) -> &mut OpenOptions {
-        self.as_inner_mut().custom_flags(flags); self
+        self.as_inner_mut().custom_flags(flags);
+        self
     }
 
     fn attributes(&mut self, attributes: u32) -> &mut OpenOptions {
-        self.as_inner_mut().attributes(attributes); self
+        self.as_inner_mut().attributes(attributes);
+        self
     }
 
     fn security_qos_flags(&mut self, flags: u32) -> &mut OpenOptions {
-        self.as_inner_mut().security_qos_flags(flags); self
+        self.as_inner_mut().security_qos_flags(flags);
+        self
     }
 }
 
@@ -468,14 +473,30 @@ pub trait MetadataExt {
 
 #[stable(feature = "metadata_ext", since = "1.1.0")]
 impl MetadataExt for Metadata {
-    fn file_attributes(&self) -> u32 { self.as_inner().attrs() }
-    fn creation_time(&self) -> u64 { self.as_inner().created_u64() }
-    fn last_access_time(&self) -> u64 { self.as_inner().accessed_u64() }
-    fn last_write_time(&self) -> u64 { self.as_inner().modified_u64() }
-    fn file_size(&self) -> u64 { self.as_inner().size() }
-    fn volume_serial_number(&self) -> Option<u32> { self.as_inner().volume_serial_number() }
-    fn number_of_links(&self) -> Option<u32> { self.as_inner().number_of_links() }
-    fn file_index(&self) -> Option<u64> { self.as_inner().file_index() }
+    fn file_attributes(&self) -> u32 {
+        self.as_inner().attrs()
+    }
+    fn creation_time(&self) -> u64 {
+        self.as_inner().created_u64()
+    }
+    fn last_access_time(&self) -> u64 {
+        self.as_inner().accessed_u64()
+    }
+    fn last_write_time(&self) -> u64 {
+        self.as_inner().modified_u64()
+    }
+    fn file_size(&self) -> u64 {
+        self.as_inner().size()
+    }
+    fn volume_serial_number(&self) -> Option<u32> {
+        self.as_inner().volume_serial_number()
+    }
+    fn number_of_links(&self) -> Option<u32> {
+        self.as_inner().number_of_links()
+    }
+    fn file_index(&self) -> Option<u64> {
+        self.as_inner().file_index()
+    }
 }
 
 /// Windows-specific extensions to [`FileType`].
@@ -495,8 +516,12 @@ pub trait FileTypeExt {
 
 #[unstable(feature = "windows_file_type_ext", issue = "0")]
 impl FileTypeExt for fs::FileType {
-    fn is_symlink_dir(&self) -> bool { self.as_inner().is_symlink_dir() }
-    fn is_symlink_file(&self) -> bool { self.as_inner().is_symlink_file() }
+    fn is_symlink_dir(&self) -> bool {
+        self.as_inner().is_symlink_dir()
+    }
+    fn is_symlink_file(&self) -> bool {
+        self.as_inner().is_symlink_file()
+    }
 }
 
 /// Creates a new file symbolic link on the filesystem.
@@ -515,8 +540,7 @@ impl FileTypeExt for fs::FileType {
 /// }
 /// ```
 #[stable(feature = "symlink", since = "1.1.0")]
-pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q)
-                                                    -> io::Result<()> {
+pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
     sys::fs::symlink_inner(src.as_ref(), dst.as_ref(), false)
 }
 
@@ -536,7 +560,6 @@ pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q)
 /// }
 /// ```
 #[stable(feature = "symlink", since = "1.1.0")]
-pub fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q)
-                                                   -> io::Result<()> {
+pub fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
     sys::fs::symlink_inner(src.as_ref(), dst.as_ref(), true)
 }

--- a/src/libstd/sys/windows/ext/io.rs
+++ b/src/libstd/sys/windows/ext/io.rs
@@ -1,12 +1,12 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::fs;
-use crate::os::windows::raw;
+use crate::io;
 use crate::net;
-use crate::sys_common::{self, AsInner, FromInner, IntoInner};
+use crate::os::windows::raw;
 use crate::sys;
 use crate::sys::c;
-use crate::io;
+use crate::sys_common::{self, AsInner, FromInner, IntoInner};
 
 /// Raw HANDLEs.
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/sys/windows/ext/mod.rs
+++ b/src/libstd/sys/windows/ext/mod.rs
@@ -13,8 +13,8 @@
 pub mod ffi;
 pub mod fs;
 pub mod io;
-pub mod raw;
 pub mod process;
+pub mod raw;
 pub mod thread;
 
 /// A prelude for conveniently writing platform-specific code.
@@ -22,14 +22,19 @@ pub mod thread;
 /// Includes all extension traits, and some important type definitions.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod prelude {
-    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
-    pub use super::io::{RawSocket, RawHandle, AsRawSocket, AsRawHandle};
-    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
-    pub use super::io::{FromRawSocket, FromRawHandle, IntoRawSocket, IntoRawHandle};
-    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(no_inline)]
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::ffi::{OsStrExt, OsStringExt};
-    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
-    pub use super::fs::{OpenOptionsExt, MetadataExt};
-    #[doc(no_inline)] #[stable(feature = "file_offset", since = "1.15.0")]
+    #[doc(no_inline)]
+    #[stable(feature = "file_offset", since = "1.15.0")]
     pub use super::fs::FileExt;
+    #[doc(no_inline)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use super::fs::{MetadataExt, OpenOptionsExt};
+    #[doc(no_inline)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use super::io::{AsRawHandle, AsRawSocket, RawHandle, RawSocket};
+    #[doc(no_inline)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use super::io::{FromRawHandle, FromRawSocket, IntoRawHandle, IntoRawSocket};
 }

--- a/src/libstd/sys/windows/ext/process.rs
+++ b/src/libstd/sys/windows/ext/process.rs
@@ -2,10 +2,10 @@
 
 #![stable(feature = "process_extensions", since = "1.2.0")]
 
-use crate::os::windows::io::{FromRawHandle, RawHandle, AsRawHandle, IntoRawHandle};
+use crate::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle};
 use crate::process;
 use crate::sys;
-use crate::sys_common::{AsInnerMut, AsInner, FromInner, IntoInner};
+use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 
 #[stable(feature = "process_extensions", since = "1.2.0")]
 impl FromRawHandle for process::Stdio {

--- a/src/libstd/sys/windows/ext/raw.rs
+++ b/src/libstd/sys/windows/ext/raw.rs
@@ -4,8 +4,11 @@
 
 use crate::os::raw::c_void;
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type HANDLE = *mut c_void;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type HANDLE = *mut c_void;
 #[cfg(target_pointer_width = "32")]
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type SOCKET = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type SOCKET = u32;
 #[cfg(target_pointer_width = "64")]
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type SOCKET = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type SOCKET = u64;

--- a/src/libstd/sys/windows/ext/thread.rs
+++ b/src/libstd/sys/windows/ext/thread.rs
@@ -2,9 +2,9 @@
 
 #![stable(feature = "thread_extensions", since = "1.9.0")]
 
-use crate::os::windows::io::{RawHandle, AsRawHandle, IntoRawHandle};
-use crate::thread;
+use crate::os::windows::io::{AsRawHandle, IntoRawHandle, RawHandle};
 use crate::sys_common::{AsInner, IntoInner};
+use crate::thread;
 
 #[stable(feature = "thread_extensions", since = "1.9.0")]
 impl<T> AsRawHandle for thread::JoinHandle<T> {
@@ -14,7 +14,7 @@ impl<T> AsRawHandle for thread::JoinHandle<T> {
 }
 
 #[stable(feature = "thread_extensions", since = "1.9.0")]
-impl<T> IntoRawHandle for thread::JoinHandle<T>  {
+impl<T> IntoRawHandle for thread::JoinHandle<T> {
     fn into_raw_handle(self) -> RawHandle {
         self.into_inner().into_handle().into_raw() as *mut _
     }

--- a/src/libstd/sys/windows/handle.rs
+++ b/src/libstd/sys/windows/handle.rs
@@ -1,7 +1,7 @@
 #![unstable(issue = "0", feature = "windows_handle")]
 
 use crate::cmp;
-use crate::io::{self, ErrorKind, Read, IoSlice, IoSliceMut};
+use crate::io::{self, ErrorKind, IoSlice, IoSliceMut, Read};
 use crate::mem;
 use crate::ops::Deref;
 use crate::ptr;
@@ -31,15 +31,9 @@ impl Handle {
 
     pub fn new_event(manual: bool, init: bool) -> io::Result<Handle> {
         unsafe {
-            let event = c::CreateEventW(ptr::null_mut(),
-                                        manual as c::BOOL,
-                                        init as c::BOOL,
-                                        ptr::null());
-            if event.is_null() {
-                Err(io::Error::last_os_error())
-            } else {
-                Ok(Handle::new(event))
-            }
+            let event =
+                c::CreateEventW(ptr::null_mut(), manual as c::BOOL, init as c::BOOL, ptr::null());
+            if event.is_null() { Err(io::Error::last_os_error()) } else { Ok(Handle::new(event)) }
         }
     }
 
@@ -52,12 +46,16 @@ impl Handle {
 
 impl Deref for Handle {
     type Target = RawHandle;
-    fn deref(&self) -> &RawHandle { &self.0 }
+    fn deref(&self) -> &RawHandle {
+        &self.0
+    }
 }
 
 impl Drop for Handle {
     fn drop(&mut self) {
-        unsafe { let _ = c::CloseHandle(self.raw()); }
+        unsafe {
+            let _ = c::CloseHandle(self.raw());
+        }
     }
 }
 
@@ -66,14 +64,15 @@ impl RawHandle {
         RawHandle(handle)
     }
 
-    pub fn raw(&self) -> c::HANDLE { self.0 }
+    pub fn raw(&self) -> c::HANDLE {
+        self.0
+    }
 
     pub fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
         let mut read = 0;
         let len = cmp::min(buf.len(), <c::DWORD>::max_value() as usize) as c::DWORD;
         let res = cvt(unsafe {
-            c::ReadFile(self.0, buf.as_mut_ptr() as c::LPVOID,
-                        len, &mut read, ptr::null_mut())
+            c::ReadFile(self.0, buf.as_mut_ptr() as c::LPVOID, len, &mut read, ptr::null_mut())
         });
 
         match res {
@@ -85,7 +84,7 @@ impl RawHandle {
             // EOF on the pipe.
             Err(ref e) if e.kind() == ErrorKind::BrokenPipe => Ok(0),
 
-            Err(e) => Err(e)
+            Err(e) => Err(e),
         }
     }
 
@@ -100,8 +99,7 @@ impl RawHandle {
             let mut overlapped: c::OVERLAPPED = mem::zeroed();
             overlapped.Offset = offset as u32;
             overlapped.OffsetHigh = (offset >> 32) as u32;
-            cvt(c::ReadFile(self.0, buf.as_mut_ptr() as c::LPVOID,
-                            len, &mut read, &mut overlapped))
+            cvt(c::ReadFile(self.0, buf.as_mut_ptr() as c::LPVOID, len, &mut read, &mut overlapped))
         };
         match res {
             Ok(_) => Ok(read as usize),
@@ -110,16 +108,15 @@ impl RawHandle {
         }
     }
 
-    pub unsafe fn read_overlapped(&self,
-                                  buf: &mut [u8],
-                                  overlapped: *mut c::OVERLAPPED)
-                                  -> io::Result<Option<usize>> {
+    pub unsafe fn read_overlapped(
+        &self,
+        buf: &mut [u8],
+        overlapped: *mut c::OVERLAPPED,
+    ) -> io::Result<Option<usize>> {
         let len = cmp::min(buf.len(), <c::DWORD>::max_value() as usize) as c::DWORD;
         let mut amt = 0;
-        let res = cvt({
-            c::ReadFile(self.0, buf.as_ptr() as c::LPVOID,
-                        len, &mut amt, overlapped)
-        });
+        let res =
+            cvt({ c::ReadFile(self.0, buf.as_ptr() as c::LPVOID, len, &mut amt, overlapped) });
         match res {
             Ok(_) => Ok(Some(amt as usize)),
             Err(e) => {
@@ -134,20 +131,21 @@ impl RawHandle {
         }
     }
 
-    pub fn overlapped_result(&self,
-                             overlapped: *mut c::OVERLAPPED,
-                             wait: bool) -> io::Result<usize> {
+    pub fn overlapped_result(
+        &self,
+        overlapped: *mut c::OVERLAPPED,
+        wait: bool,
+    ) -> io::Result<usize> {
         unsafe {
             let mut bytes = 0;
-            let wait = if wait {c::TRUE} else {c::FALSE};
-            let res = cvt({
-                c::GetOverlappedResult(self.raw(), overlapped, &mut bytes, wait)
-            });
+            let wait = if wait { c::TRUE } else { c::FALSE };
+            let res = cvt({ c::GetOverlappedResult(self.raw(), overlapped, &mut bytes, wait) });
             match res {
                 Ok(_) => Ok(bytes as usize),
                 Err(e) => {
-                    if e.raw_os_error() == Some(c::ERROR_HANDLE_EOF as i32) ||
-                       e.raw_os_error() == Some(c::ERROR_BROKEN_PIPE as i32) {
+                    if e.raw_os_error() == Some(c::ERROR_HANDLE_EOF as i32)
+                        || e.raw_os_error() == Some(c::ERROR_BROKEN_PIPE as i32)
+                    {
                         Ok(0)
                     } else {
                         Err(e)
@@ -158,17 +156,14 @@ impl RawHandle {
     }
 
     pub fn cancel_io(&self) -> io::Result<()> {
-        unsafe {
-            cvt(c::CancelIo(self.raw())).map(|_| ())
-        }
+        unsafe { cvt(c::CancelIo(self.raw())).map(|_| ()) }
     }
 
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
         let mut amt = 0;
         let len = cmp::min(buf.len(), <c::DWORD>::max_value() as usize) as c::DWORD;
         cvt(unsafe {
-            c::WriteFile(self.0, buf.as_ptr() as c::LPVOID,
-                         len, &mut amt, ptr::null_mut())
+            c::WriteFile(self.0, buf.as_ptr() as c::LPVOID, len, &mut amt, ptr::null_mut())
         })?;
         Ok(amt as usize)
     }
@@ -184,20 +179,35 @@ impl RawHandle {
             let mut overlapped: c::OVERLAPPED = mem::zeroed();
             overlapped.Offset = offset as u32;
             overlapped.OffsetHigh = (offset >> 32) as u32;
-            cvt(c::WriteFile(self.0, buf.as_ptr() as c::LPVOID,
-                             len, &mut written, &mut overlapped))?;
+            cvt(c::WriteFile(
+                self.0,
+                buf.as_ptr() as c::LPVOID,
+                len,
+                &mut written,
+                &mut overlapped,
+            ))?;
         }
         Ok(written as usize)
     }
 
-    pub fn duplicate(&self, access: c::DWORD, inherit: bool,
-                     options: c::DWORD) -> io::Result<Handle> {
+    pub fn duplicate(
+        &self,
+        access: c::DWORD,
+        inherit: bool,
+        options: c::DWORD,
+    ) -> io::Result<Handle> {
         let mut ret = 0 as c::HANDLE;
         cvt(unsafe {
             let cur_proc = c::GetCurrentProcess();
-            c::DuplicateHandle(cur_proc, self.0, cur_proc, &mut ret,
-                            access, inherit as c::BOOL,
-                            options)
+            c::DuplicateHandle(
+                cur_proc,
+                self.0,
+                cur_proc,
+                &mut ret,
+                access,
+                inherit as c::BOOL,
+                options,
+            )
         })?;
         Ok(Handle::new(ret))
     }

--- a/src/libstd/sys/windows/io.rs
+++ b/src/libstd/sys/windows/io.rs
@@ -35,9 +35,7 @@ impl<'a> IoSlice<'a> {
 
     #[inline]
     pub fn as_slice(&self) -> &[u8] {
-        unsafe {
-            slice::from_raw_parts(self.vec.buf as *mut u8, self.vec.len as usize)
-        }
+        unsafe { slice::from_raw_parts(self.vec.buf as *mut u8, self.vec.len as usize) }
     }
 }
 
@@ -52,10 +50,7 @@ impl<'a> IoSliceMut<'a> {
     pub fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
         assert!(buf.len() <= c::ULONG::max_value() as usize);
         IoSliceMut {
-            vec: c::WSABUF {
-                len: buf.len() as c::ULONG,
-                buf: buf.as_mut_ptr() as *mut c::CHAR,
-            },
+            vec: c::WSABUF { len: buf.len() as c::ULONG, buf: buf.as_mut_ptr() as *mut c::CHAR },
             _p: PhantomData,
         }
     }
@@ -74,15 +69,11 @@ impl<'a> IoSliceMut<'a> {
 
     #[inline]
     pub fn as_slice(&self) -> &[u8] {
-        unsafe {
-            slice::from_raw_parts(self.vec.buf as *mut u8, self.vec.len as usize)
-        }
+        unsafe { slice::from_raw_parts(self.vec.buf as *mut u8, self.vec.len as usize) }
     }
 
     #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
-        unsafe {
-            slice::from_raw_parts_mut(self.vec.buf as *mut u8, self.vec.len as usize)
-        }
+        unsafe { slice::from_raw_parts_mut(self.vec.buf as *mut u8, self.vec.len as usize) }
     }
 }

--- a/src/libstd/sys/windows/os_str.rs
+++ b/src/libstd/sys/windows/os_str.rs
@@ -1,17 +1,16 @@
 /// The underlying OsString/OsStr implementation on Windows is a
 /// wrapper around the "WTF-8" encoding; see the `wtf8` module for more.
-
 use crate::borrow::Cow;
 use crate::fmt;
-use crate::sys_common::wtf8::{Wtf8, Wtf8Buf};
 use crate::mem;
 use crate::rc::Rc;
 use crate::sync::Arc;
-use crate::sys_common::{AsInner, IntoInner, FromInner};
+use crate::sys_common::wtf8::{Wtf8, Wtf8Buf};
+use crate::sys_common::{AsInner, FromInner, IntoInner};
 
 #[derive(Clone, Hash)]
 pub struct Buf {
-    pub inner: Wtf8Buf
+    pub inner: Wtf8Buf,
 }
 
 impl IntoInner<Wtf8Buf> for Buf {
@@ -45,7 +44,7 @@ impl fmt::Display for Buf {
 }
 
 pub struct Slice {
-    pub inner: Wtf8
+    pub inner: Wtf8,
 }
 
 impl fmt::Debug for Slice {
@@ -62,9 +61,7 @@ impl fmt::Display for Slice {
 
 impl Buf {
     pub fn with_capacity(capacity: usize) -> Buf {
-        Buf {
-            inner: Wtf8Buf::with_capacity(capacity)
-        }
+        Buf { inner: Wtf8Buf::with_capacity(capacity) }
     }
 
     pub fn clear(&mut self) {

--- a/src/libstd/sys/windows/path.rs
+++ b/src/libstd/sys/windows/path.rs
@@ -1,6 +1,6 @@
-use crate::path::Prefix;
 use crate::ffi::OsStr;
 use crate::mem;
+use crate::path::Prefix;
 
 fn os_str_as_u8_slice(s: &OsStr) -> &[u8] {
     unsafe { mem::transmute(s) }
@@ -38,8 +38,9 @@ pub fn parse_prefix(path: &OsStr) -> Option<Prefix<'_>> {
                     // \\?\UNC\server\share
                     path = &path[4..];
                     let (server, share) = match parse_two_comps(path, is_verbatim_sep) {
-                        Some((server, share)) =>
-                            (u8_slice_as_os_str(server), u8_slice_as_os_str(share)),
+                        Some((server, share)) => {
+                            (u8_slice_as_os_str(server), u8_slice_as_os_str(share))
+                        }
                         None => (u8_slice_as_os_str(path), u8_slice_as_os_str(&[])),
                     };
                     return Some(VerbatimUNC(server, share));
@@ -70,7 +71,7 @@ pub fn parse_prefix(path: &OsStr) -> Option<Prefix<'_>> {
                 }
                 _ => (),
             }
-        } else if path.get(1) == Some(& b':') {
+        } else if path.get(1) == Some(&b':') {
             // C:
             let c = path[0];
             if c.is_ascii() && (c as char).is_alphabetic() {

--- a/src/libstd/sys/windows/rand.rs
+++ b/src/libstd/sys/windows/rand.rs
@@ -5,13 +5,10 @@ use crate::sys::c;
 #[cfg(not(target_vendor = "uwp"))]
 pub fn hashmap_random_keys() -> (u64, u64) {
     let mut v = (0, 0);
-    let ret = unsafe {
-        c::RtlGenRandom(&mut v as *mut _ as *mut u8,
-                        mem::size_of_val(&v) as c::ULONG)
-    };
+    let ret =
+        unsafe { c::RtlGenRandom(&mut v as *mut _ as *mut u8, mem::size_of_val(&v) as c::ULONG) };
     if ret == 0 {
-        panic!("couldn't generate random bytes: {}",
-               io::Error::last_os_error());
+        panic!("couldn't generate random bytes: {}", io::Error::last_os_error());
     }
     v
 }
@@ -22,13 +19,15 @@ pub fn hashmap_random_keys() -> (u64, u64) {
 
     let mut v = (0, 0);
     let ret = unsafe {
-        c::BCryptGenRandom(ptr::null_mut(), &mut v as *mut _ as *mut u8,
-                           mem::size_of_val(&v) as c::ULONG,
-                           c::BCRYPT_USE_SYSTEM_PREFERRED_RNG)
+        c::BCryptGenRandom(
+            ptr::null_mut(),
+            &mut v as *mut _ as *mut u8,
+            mem::size_of_val(&v) as c::ULONG,
+            c::BCRYPT_USE_SYSTEM_PREFERRED_RNG,
+        )
     };
     if ret != 0 {
-        panic!("couldn't generate random bytes: {}",
-               io::Error::last_os_error());
+        panic!("couldn't generate random bytes: {}", io::Error::last_os_error());
     }
-    return v
+    return v;
 }

--- a/src/libstd/sys/windows/stack_overflow.rs
+++ b/src/libstd/sys/windows/stack_overflow.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(test, allow(dead_code))]
 
-use crate::sys_common::util::report_overflow;
 use crate::sys::c;
+use crate::sys_common::util::report_overflow;
 
 pub struct Handler;
 
@@ -18,8 +18,7 @@ impl Handler {
     }
 }
 
-extern "system" fn vectored_handler(ExceptionInfo: *mut c::EXCEPTION_POINTERS)
-                                    -> c::LONG {
+extern "system" fn vectored_handler(ExceptionInfo: *mut c::EXCEPTION_POINTERS) -> c::LONG {
     unsafe {
         let rec = &(*(*ExceptionInfo).ExceptionRecord);
         let code = rec.ExceptionCode;

--- a/src/libstd/sys/windows/stdio_uwp.rs
+++ b/src/libstd/sys/windows/stdio_uwp.rs
@@ -1,12 +1,11 @@
 #![unstable(issue = "0", feature = "windows_stdio")]
 
 use crate::io;
+use crate::mem::ManuallyDrop;
 use crate::sys::c;
 use crate::sys::handle::Handle;
-use crate::mem::ManuallyDrop;
 
-pub struct Stdin {
-}
+pub struct Stdin {}
 pub struct Stdout;
 pub struct Stderr;
 
@@ -32,7 +31,7 @@ fn write(handle_id: c::DWORD, data: &[u8]) -> io::Result<usize> {
 
 impl Stdin {
     pub fn new() -> io::Result<Stdin> {
-        Ok(Stdin { })
+        Ok(Stdin {})
     }
 }
 

--- a/src/libstd/sys/windows/thread.rs
+++ b/src/libstd/sys/windows/thread.rs
@@ -1,5 +1,5 @@
-use crate::io;
 use crate::ffi::CStr;
+use crate::io;
 use crate::mem;
 use crate::ptr;
 use crate::sys::c;
@@ -14,13 +14,12 @@ use super::to_u16s;
 pub const DEFAULT_MIN_STACK_SIZE: usize = 2 * 1024 * 1024;
 
 pub struct Thread {
-    handle: Handle
+    handle: Handle,
 }
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
-    pub unsafe fn new(stack: usize, p: Box<dyn FnOnce()>)
-                          -> io::Result<Thread> {
+    pub unsafe fn new(stack: usize, p: Box<dyn FnOnce()>) -> io::Result<Thread> {
         let p = box p;
 
         // FIXME On UNIX, we guard against stack sizes that are too small but
@@ -31,10 +30,14 @@ impl Thread {
         // Round up to the next 64 kB because that's what the NT kernel does,
         // might as well make it explicit.
         let stack_size = (stack + 0xfffe) & (!0xfffe);
-        let ret = c::CreateThread(ptr::null_mut(), stack_size,
-                                  thread_start, &*p as *const _ as *mut _,
-                                  c::STACK_SIZE_PARAM_IS_A_RESERVATION,
-                                  ptr::null_mut());
+        let ret = c::CreateThread(
+            ptr::null_mut(),
+            stack_size,
+            thread_start,
+            &*p as *const _ as *mut _,
+            c::STACK_SIZE_PARAM_IS_A_RESERVATION,
+            ptr::null_mut(),
+        );
 
         return if ret as usize == 0 {
             Err(io::Error::last_os_error())
@@ -44,7 +47,9 @@ impl Thread {
         };
 
         extern "system" fn thread_start(main: *mut c_void) -> c::DWORD {
-            unsafe { start_thread(main as *mut u8); }
+            unsafe {
+                start_thread(main as *mut u8);
+            }
             0
         }
     }
@@ -52,7 +57,9 @@ impl Thread {
     pub fn set_name(name: &CStr) {
         if let Ok(utf8) = name.to_str() {
             if let Ok(utf16) = to_u16s(utf8) {
-                unsafe { c::SetThreadDescription(c::GetCurrentThread(), utf16.as_ptr()); };
+                unsafe {
+                    c::SetThreadDescription(c::GetCurrentThread(), utf16.as_ptr());
+                };
             };
         };
     }
@@ -60,8 +67,7 @@ impl Thread {
     pub fn join(self) {
         let rc = unsafe { c::WaitForSingleObject(self.handle.raw(), c::INFINITE) };
         if rc == c::WAIT_FAILED {
-            panic!("failed to join on thread: {}",
-                   io::Error::last_os_error());
+            panic!("failed to join on thread: {}", io::Error::last_os_error());
         }
     }
 
@@ -69,23 +75,31 @@ impl Thread {
         // This function will return 0 if there are no other threads to execute,
         // but this also means that the yield was useless so this isn't really a
         // case that needs to be worried about.
-        unsafe { c::SwitchToThread(); }
-    }
-
-    pub fn sleep(dur: Duration) {
         unsafe {
-            c::Sleep(super::dur2timeout(dur))
+            c::SwitchToThread();
         }
     }
 
-    pub fn handle(&self) -> &Handle { &self.handle }
+    pub fn sleep(dur: Duration) {
+        unsafe { c::Sleep(super::dur2timeout(dur)) }
+    }
 
-    pub fn into_handle(self) -> Handle { self.handle }
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn into_handle(self) -> Handle {
+        self.handle
+    }
 }
 
 #[cfg_attr(test, allow(dead_code))]
 pub mod guard {
     pub type Guard = !;
-    pub unsafe fn current() -> Option<Guard> { None }
-    pub unsafe fn init() -> Option<Guard> { None }
+    pub unsafe fn current() -> Option<Guard> {
+        None
+    }
+    pub unsafe fn init() -> Option<Guard> {
+        None
+    }
 }


### PR DESCRIPTION
(Same strategy as #66691.)

This commit applies rustfmt with rust-lang/rust's default settings to files in src/libstd/sys *that are not involved in any currently open PR* to minimize merge conflicts. The list of files involved in open PRs was determined by querying GitHub's GraphQL API [with this script](https://gist.github.com/dtolnay/aa9c34993dc051a4f344d1b10e4487e8).

With the list of files from the script in outstanding_files, the relevant commands were:

    $ find src/libstd/sys -name '*.rs' \
        | xargs rustfmt --edition=2018 --unstable-features --skip-children
    $ rg libstd/sys outstanding_files | xargs git checkout --

Repeating this process several months apart should get us coverage of most of the rest of the files.

To confirm no funny business:

    $ git checkout $THIS_COMMIT^
    $ git show --pretty= --name-only $THIS_COMMIT \
        | xargs rustfmt --edition=2018 --unstable-features --skip-children
    $ git diff $THIS_COMMIT  # there should be no difference