### PR TITLE
Clarifies how to tag users for assigning PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,7 @@ documentation changes. So if you were to make a documentation change, add
 
     r? @steveklabnik
 
-to the end of the pull request message, and [@rust-highfive][rust-highfive] will assign
+to the end of the pull request description, and [@rust-highfive][rust-highfive] will assign
 [@steveklabnik][steveklabnik] instead of a random person. This is entirely optional.
 
 After someone has reviewed your pull request, they will leave an annotation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ All pull requests are reviewed by another person. We have a bot,
 request.
 
 If you want to request that a specific person reviews your pull request,
-you can add an `r?` to the pull request message. For example, [Steve][steveklabnik] usually reviews
+you can add an `r?` to the pull request description. For example, [Steve][steveklabnik] usually reviews
 documentation changes. So if you were to make a documentation change, add
 
     r? @steveklabnik

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,13 +150,13 @@ All pull requests are reviewed by another person. We have a bot,
 request.
 
 If you want to request that a specific person reviews your pull request,
-you can add an `r?` to the message. For example, [Steve][steveklabnik] usually reviews
+you can add an `r?` to the pull request message. For example, [Steve][steveklabnik] usually reviews
 documentation changes. So if you were to make a documentation change, add
 
     r? @steveklabnik
 
-to the end of the message, and @rust-highfive will assign [@steveklabnik][steveklabnik] instead
-of a random person. This is entirely optional.
+to the end of the pull request message, and [@rust-highfive][rust-highfive] will assign
+[@steveklabnik][steveklabnik] instead of a random person. This is entirely optional.
 
 After someone has reviewed your pull request, they will leave an annotation
 on the pull request with an `r+`. It will look something like this:


### PR DESCRIPTION
Clarifies language of where to put `r?` text to assign a particular user. Mostly a follow up of [this discussion](https://github.com/rust-lang/rust/pull/66797#issuecomment-559153444).