### PR TITLE
rustbuild fixes

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -643,7 +643,9 @@ class RustBuild(object):
         env["LIBRARY_PATH"] = os.path.join(self.bin_root(), "lib") + \
             (os.pathsep + env["LIBRARY_PATH"]) \
             if "LIBRARY_PATH" in env else ""
-        env["RUSTFLAGS"] = "-Cdebuginfo=2 "
+        # preserve existing RUSTFLAGS
+        env.setdefault("RUSTFLAGS", "")
+        env["RUSTFLAGS"] += " -Cdebuginfo=2"
 
         build_section = "target.{}".format(self.build_triple())
         target_features = []
@@ -652,13 +654,13 @@ class RustBuild(object):
         elif self.get_toml("crt-static", build_section) == "false":
             target_features += ["-crt-static"]
         if target_features:
-            env["RUSTFLAGS"] += "-C target-feature=" + (",".join(target_features)) + " "
+            env["RUSTFLAGS"] += " -C target-feature=" + (",".join(target_features))
         target_linker = self.get_toml("linker", build_section)
         if target_linker is not None:
-            env["RUSTFLAGS"] += "-C linker=" + target_linker + " "
-        env["RUSTFLAGS"] += " -Wrust_2018_idioms -Wunused_lifetimes "
+            env["RUSTFLAGS"] += " -C linker=" + target_linker
+        env["RUSTFLAGS"] += " -Wrust_2018_idioms -Wunused_lifetimes"
         if self.get_toml("deny-warnings", "rust") != "false":
-            env["RUSTFLAGS"] += "-Dwarnings "
+            env["RUSTFLAGS"] += " -Dwarnings"
 
         env["PATH"] = os.path.join(self.bin_root(), "bin") + \
             os.pathsep + env["PATH"]

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -260,7 +260,7 @@ install!((self, builder, _config),
     };
     Rustc, "src/librustc", true, only_hosts: true, {
         builder.ensure(dist::Rustc {
-            compiler: self.compiler,
+            compiler: builder.compiler(builder.top_stage, self.target),
         });
         install_rustc(builder, self.compiler.stage, self.target);
     };


### PR DESCRIPTION
When upgrading Debian's rustc to 1.38 I needed these patches:

(1) In order to cross-compile rustc 1.38 and take it through the full rustbuild process including install, I needed the first patch.

(2) In order to build rustc 1.38 using rustc 1.38 itself I need to set --cap-lints warn, otherwise I get this error:

~~~~
error: unnecessary `unsafe` block
   --> src/bootstrap/builder.rs:148:19
    |
148 |             name: unsafe { ::std::intrinsics::type_name::<S>() },
    |                   ^^^^^^ unnecessary `unsafe` block
    |
note: lint level defined here
   --> src/bootstrap/lib.rs:107:9
    |
107 | #![deny(warnings, rust_2018_idioms, unused_lifetimes)]
    |         ^^^^^^^^
    = note: `#[deny(unused_unsafe)]` implied by `#[deny(warnings)]`

error: aborting due to previous error

error: could not compile `bootstrap`.

~~~~

In order to set --cap-lints warn however, I need bootstrap.py not to clobber RUSTFLAGS. (This worked previously, not sure if it was broken intentionally but we would like support for it.)
