### PR TITLE
std:win: avoid WSA_FLAG_NO_INHERIT flag and don't use SetHandleInformation on UWP

### DIFF
--- a/src/libstd/sys/windows/net.rs
+++ b/src/libstd/sys/windows/net.rs
@@ -100,7 +100,7 @@ impl Socket {
                                 c::WSA_FLAG_OVERLAPPED | c::WSA_FLAG_NO_HANDLE_INHERIT) {
                 c::INVALID_SOCKET => {
                     match c::WSAGetLastError() {
-                        c::WSAEPROTOTYPE => {
+                        c::WSAEPROTOTYPE | c::WSAEINVAL => {
                             match c::WSASocketW(fam, ty, 0, ptr::null_mut(), 0,
                                                 c::WSA_FLAG_OVERLAPPED) {
                                 c::INVALID_SOCKET => Err(last_error()),
@@ -199,7 +199,7 @@ impl Socket {
                                 c::WSA_FLAG_OVERLAPPED | c::WSA_FLAG_NO_HANDLE_INHERIT) {
                 c::INVALID_SOCKET => {
                     match c::WSAGetLastError() {
-                        c::WSAEPROTOTYPE => {
+                        c::WSAEPROTOTYPE | c::WSAEINVAL => {
                             match c::WSASocketW(info.iAddressFamily,
                                                 info.iSocketType,
                                                 info.iProtocol,


### PR DESCRIPTION
This flag is not supported on Windows 7 before SP1, and on windows server 2008 SP2. This breaks Socket creation & duplication.
This was fixed in a previous PR. cc #26658

This PR: cc #60260 reuses this flag to support UWP, and makes an attempt to handle the potential error.
This version still fails to create a socket, as the error returned by WSA on this case is WSAEINVAL (invalid argument). and not WSAEPROTOTYPE.

MSDN page for WSASocketW (that states the platform support for WSA_FLAG_NO_HANDLE_INHERIT): https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw

CC #26543
CC #26518 