### PR TITLE
Clarify `{f32,f64}::EPSILON` docs

### DIFF
--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -26,7 +26,7 @@ pub const DIGITS: u32 = 6;
 
 /// [Machine epsilon] value for `f32`.
 ///
-/// This is the difference between `1.0` and the next largest representable number.
+/// This is the difference between `1.0` and the next larger representable number.
 ///
 /// [Machine epsilon]: https://en.wikipedia.org/wiki/Machine_epsilon
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -26,7 +26,7 @@ pub const DIGITS: u32 = 15;
 
 /// [Machine epsilon] value for `f64`.
 ///
-/// This is the difference between `1.0` and the next largest representable number.
+/// This is the difference between `1.0` and the next larger representable number.
 ///
 /// [Machine epsilon]: https://en.wikipedia.org/wiki/Machine_epsilon
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
The doc for `EPSILON` says:
>  This is the difference between `1.0` and the next **largest** representable number.

Which is a bit unclear.

[Wikipedia](https://en.wikipedia.org/wiki/Machine_epsilon) says
> Machine epsilon is defined as the difference between 1 and the next **larger** floating point number

So this PR update the docs to match the Wikipedia version.

The original PR also has this in a [comment](https://github.com/rust-lang/rust/pull/50919#discussion_r192600209).