### PR TITLE
For dylib crates, warn about GNU ld <=2.28

### DIFF
--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -541,6 +541,12 @@ fn check_for_buggy_ld_version(sess: &Session,
     };
     debug!("check_for_buggy_ld_version first_line: {:?}", first_line);
 
+    if !first_line.contains("GNU ld") {
+        // If we cannot find "GNU ld" in the version string, then assume that
+        // this is not actually GNU ld; no need for warning.
+        return;
+    }
+
     let version_suffix_start = match first_line.find(" 2.") {
         None => {
             // if we cannot find ` 2.`, then assume that this an ld version that


### PR DESCRIPTION
This is a heuristic diagnostic to try to help prevent issues related to issue #61539.