### PR TITLE
Miri: do not consider memory allocated by caller_location leaked

### DIFF
--- a/src/librustc_mir/interpret/intern.rs
+++ b/src/librustc_mir/interpret/intern.rs
@@ -100,7 +100,7 @@ fn intern_shallow<'rt, 'mir, 'tcx, M: CompileTimeMachine<'mir, 'tcx>>(
     // This match is just a canary for future changes to `MemoryKind`, which most likely need
     // changes in this function.
     match kind {
-        MemoryKind::Stack | MemoryKind::Vtable => {},
+        MemoryKind::Stack | MemoryKind::Vtable | MemoryKind::CallerLocation => {},
     }
     // Set allocation mutability as appropriate. This is used by LLVM to put things into
     // read-only memory, and also by Miri when evluating other constants/statics that

--- a/src/librustc_mir/interpret/intrinsics/caller_location.rs
+++ b/src/librustc_mir/interpret/intrinsics/caller_location.rs
@@ -28,7 +28,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let file = Scalar::Ptr(self.tag_static_base_pointer(file_ptr));
         let file_len = Scalar::from_uint(filename.as_str().len() as u128, ptr_size);
 
-        let location = self.allocate(loc_layout, MemoryKind::Stack);
+        let location = self.allocate(loc_layout, MemoryKind::CallerLocation);
 
         let file_out = self.mplace_field(location, 0)?;
         let file_ptr_out = self.force_ptr(self.mplace_field(file_out, 0)?.ptr)?;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/miri/issues/1071

r? @oli-obk 

I am not sure if this is the best approach, but it certainly is the easiest.