### PR TITLE
Account for unicode confusables on typoed identifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3871,6 +3871,7 @@ dependencies = [
  "syntax",
  "syntax_expand",
  "syntax_pos",
+ "unicode_skeleton",
 ]
 
 [[package]]
@@ -4471,6 +4472,7 @@ dependencies = [
  "serialize",
  "smallvec 1.0.0",
  "syntax_pos",
+ "unicode_skeleton",
 ]
 
 [[package]]
@@ -5044,6 +5046,15 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unicode_skeleton"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66bd74db2c088d393d1fbf83db2cd5663137640f072d128287dd53c882a0f412"
+dependencies = [
+ "unicode-normalization",
+]
 
 [[package]]
 name = "unstable-book-gen"

--- a/src/librustc_resolve/Cargo.toml
+++ b/src/librustc_resolve/Cargo.toml
@@ -23,3 +23,4 @@ rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_metadata = { path = "../librustc_metadata" }
 rustc_error_codes = { path = "../librustc_error_codes" }
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }
+unicode_skeleton = "0.1.1"

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -488,9 +488,11 @@ impl<'a> Resolver<'a> {
             &ident.as_str(),
             None,
         ) {
-            Some(found) if found != ident.name => suggestions
-                .into_iter()
-                .find(|suggestion| suggestion.candidate == found),
+            Some(found) if found != ident.name => suggestions.into_iter()
+                .find(|suggestion| unicode_skeleton::confusable(
+                    suggestion.candidate.as_str().chars(),
+                    found.as_str().chars(),
+                )),
             _ => None,
         }
     }

--- a/src/libsyntax/Cargo.toml
+++ b/src/libsyntax/Cargo.toml
@@ -23,3 +23,4 @@ rustc_lexer = { path = "../librustc_lexer" }
 rustc_macros = { path = "../librustc_macros" }
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }
 rustc_error_codes = { path = "../librustc_error_codes" }
+unicode_skeleton = "0.1.1"

--- a/src/test/ui/suggestions/unicode-confusable-typo.fixed
+++ b/src/test/ui/suggestions/unicode-confusable-typo.fixed
@@ -1,0 +1,11 @@
+// run-rustfix
+#![feature(non_ascii_idents)]
+
+struct ℝ𝓊𝓈𝓉;
+
+fn main() {
+    let ü = ℝ𝓊𝓈𝓉;
+    //~^ ERROR cannot find value `Rust` in this scope
+    let _ = ü;
+    //~^ ERROR cannot find value `u` in this scope
+}

--- a/src/test/ui/suggestions/unicode-confusable-typo.rs
+++ b/src/test/ui/suggestions/unicode-confusable-typo.rs
@@ -1,0 +1,11 @@
+// run-rustfix
+#![feature(non_ascii_idents)]
+
+struct ℝ𝓊𝓈𝓉;
+
+fn main() {
+    let ü = Rust;
+    //~^ ERROR cannot find value `Rust` in this scope
+    let _ = u;
+    //~^ ERROR cannot find value `u` in this scope
+}

--- a/src/test/ui/suggestions/unicode-confusable-typo.stderr
+++ b/src/test/ui/suggestions/unicode-confusable-typo.stderr
@@ -1,0 +1,18 @@
+error[E0425]: cannot find value `Rust` in this scope
+  --> $DIR/unicode-confusable-typo.rs:7:13
+   |
+LL | struct ℝ𝓊𝓈𝓉;
+   | ------------ similarly named unit struct `ℝ𝓊𝓈𝓉` defined here
+...
+LL |     let ü = Rust;
+   |             ^^^^ help: a unit struct with a similar name exists: `ℝ𝓊𝓈𝓉`
+
+error[E0425]: cannot find value `u` in this scope
+  --> $DIR/unicode-confusable-typo.rs:9:13
+   |
+LL |     let _ = u;
+   |             ^ help: a local variable with a similar name exists: `ü`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
When a name can't be matched to any existing identifier, we look for
identifiers that have the same "skeleton" for possible suggestions,
instead of relying only on Levenshtein distance.

CC #55467