### PR TITLE
rustc: hide HirId's fmt::Debug output from -Z span_free_formats.

### DIFF
--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -2302,10 +2302,14 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                         }
                     }
 
-                    AggregateKind::Closure(def_id, _) => ty::tls::with(|tcx| {
+                    AggregateKind::Closure(def_id, substs) => ty::tls::with(|tcx| {
                         if let Some(hir_id) = tcx.hir().as_local_hir_id(def_id) {
                             let name = if tcx.sess.opts.debugging_opts.span_free_formats {
-                                format!("[closure@{:?}]", hir_id)
+                                let substs = tcx.lift(&substs).unwrap();
+                                format!(
+                                    "[closure@{}]",
+                                    tcx.def_path_str_with_substs(def_id, substs),
+                                )
                             } else {
                                 format!("[closure@{:?}]", tcx.hir().span(hir_id))
                             };

--- a/src/librustc/ty/print/pretty.rs
+++ b/src/librustc/ty/print/pretty.rs
@@ -682,7 +682,7 @@ pub trait PrettyPrinter<'tcx>:
                 // FIXME(eddyb) should use `def_span`.
                 if let Some(hir_id) = self.tcx().hir().as_local_hir_id(did) {
                     if self.tcx().sess.opts.debugging_opts.span_free_formats {
-                        p!(write("@{:?}", hir_id));
+                        p!(write("@"), print_def_path(did, substs));
                     } else {
                         p!(write("@{:?}", self.tcx().hir().span(hir_id)));
                     }

--- a/src/test/mir-opt/inline-closure-borrows-arg.rs
+++ b/src/test/mir-opt/inline-closure-borrows-arg.rs
@@ -21,8 +21,8 @@ fn foo<T: Copy>(_t: T, q: &i32) -> i32 {
 //     debug _t => _1;
 //     debug q => _2;
 //     let mut _0: i32;
-//     let _3: [closure@HirId { owner: DefIndex(4), local_id: 31 }];
-//     let mut _4: &[closure@HirId { owner: DefIndex(4), local_id: 31 }];
+//     let _3: [closure@foo<T>::{{closure}}#0];
+//     let mut _4: &[closure@foo<T>::{{closure}}#0];
 //     let mut _5: (&i32, &i32);
 //     let mut _6: &i32;
 //     let mut _7: &i32;
@@ -40,7 +40,7 @@ fn foo<T: Copy>(_t: T, q: &i32) -> i32 {
 //     }
 //     bb0: {
 //         ...
-//         _3 = [closure@HirId { owner: DefIndex(4), local_id: 31 }];
+//         _3 = [closure@foo::<T>::{{closure}}#0];
 //         ...
 //         _4 = &_3;
 //         ...

--- a/src/test/mir-opt/inline-closure-captures.rs
+++ b/src/test/mir-opt/inline-closure-captures.rs
@@ -17,10 +17,10 @@ fn foo<T: Copy>(t: T, q: i32) -> (i32, T) {
 //     debug t => _1;
 //     debug q => _2;
 //     let mut _0: (i32, T);
-//     let _3: [closure@HirId { owner: DefIndex(4), local_id: 15 } q:&i32, t:&T];
+//     let _3: [closure@foo<T>::{{closure}}#0 q:&i32, t:&T];
 //     let mut _4: &i32;
 //     let mut _5: &T;
-//     let mut _6: &[closure@HirId { owner: DefIndex(4), local_id: 15 } q:&i32, t:&T];
+//     let mut _6: &[closure@foo<T>::{{closure}}#0 q:&i32, t:&T];
 //     let mut _7: (i32,);
 //     let mut _8: i32;
 //     let mut _11: i32;
@@ -39,7 +39,7 @@ fn foo<T: Copy>(t: T, q: i32) -> (i32, T) {
 //         _4 = &_2;
 //         ...
 //         _5 = &_1;
-//         _3 = [closure@HirId { owner: DefIndex(4), local_id: 15 }] { q: move _4, t: move _5 };
+//         _3 = [closure@foo::<T>::{{closure}}#0] { q: move _4, t: move _5 };
 //         ...
 //         _6 = &_3;
 //         ...

--- a/src/test/mir-opt/inline-closure.rs
+++ b/src/test/mir-opt/inline-closure.rs
@@ -17,8 +17,8 @@ fn foo<T: Copy>(_t: T, q: i32) -> i32 {
 //     debug _t => _1;
 //     debug q => _2;
 //     let mut _0: i32;
-//     let _3: [closure@HirId { owner: DefIndex(4), local_id: 15 }];
-//     let mut _4: &[closure@HirId { owner: DefIndex(4), local_id: 15 }];
+//     let _3: [closure@foo<T>::{{closure}}#0];
+//     let mut _4: &[closure@foo<T>::{{closure}}#0];
 //     let mut _5: (i32, i32);
 //     let mut _6: i32;
 //     let mut _7: i32;
@@ -33,7 +33,7 @@ fn foo<T: Copy>(_t: T, q: i32) -> i32 {
 //     }
 //     bb0: {
 //         ...
-//         _3 = [closure@HirId { owner: DefIndex(4), local_id: 15 }];
+//         _3 = [closure@foo::<T>::{{closure}}#0];
 //         ...
 //         _4 = &_3;
 //         ...

--- a/src/test/mir-opt/retag.rs
+++ b/src/test/mir-opt/retag.rs
@@ -100,7 +100,7 @@ fn main() {
 // }
 // END rustc.main.EraseRegions.after.mir
 // START rustc.main-{{closure}}.EraseRegions.after.mir
-// fn main::{{closure}}#0(_1: &[closure@HirId { owner: DefIndex(13), local_id: 72 }], _2: &i32) -> &i32 {
+// fn main::{{closure}}#0(_1: &[closure@main::{{closure}}#0], _2: &i32) -> &i32 {
 //     ...
 //     bb0: {
 //         Retag([fn entry] _1);


### PR DESCRIPTION
This replaces the only occurrences of `HirId {...}` from tests with paths, i.e.:
```rust
[closure@HirId { owner: DefIndex(4), local_id: 15 } q:&i32, t:&T]
```
becomes, after this PR:
```rust
[closure@foo<T>::{{closure}}#0 q:&i32, t:&T]
```

r? @oli-obk cc @michaelwoerister 