### PR TITLE
Add inherent `try_from` and `try_into` methods to integer types

### DIFF
--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -451,8 +451,6 @@ pub trait TryInto<T>: Sized {
 /// As described, [`i32`] implements `TryFrom<`[`i64`]`>`:
 ///
 /// ```
-/// use std::convert::TryFrom;
-///
 /// let big_number = 1_000_000_000_000i64;
 /// // Silently truncates `big_number`, requires detecting
 /// // and handling the truncation after the fact.

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -1,4 +1,3 @@
-use crate::convert::TryFrom;
 use crate::mem;
 use crate::ops::{self, Add, Sub, Try};
 use crate::usize;

--- a/src/libcore/num/dec2flt/rawfp.rs
+++ b/src/libcore/num/dec2flt/rawfp.rs
@@ -18,7 +18,7 @@
 //! take the universally-correct slow path (Algorithm M) for very small and very large numbers.
 //! That algorithm needs only next_float() which does handle subnormals and zeros.
 use crate::cmp::Ordering::{Equal, Greater, Less};
-use crate::convert::{TryFrom, TryInto};
+use crate::convert::TryFrom;
 use crate::fmt::{Debug, LowerExp};
 use crate::num::dec2flt::num::{self, Big};
 use crate::num::dec2flt::table;

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -4,7 +4,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use crate::convert::TryFrom;
+use crate::convert::{TryFrom, TryInto};
 use crate::fmt;
 use crate::intrinsics;
 use crate::mem;
@@ -275,6 +275,28 @@ $EndFeature, "
             #[rustc_promotable]
             pub const fn max_value() -> Self {
                 !Self::min_value()
+            }
+        }
+
+        doc_comment! {
+            "FIXME docs",
+            #[stable(feature = "int_inherent_try_from_try_into", since = "1.41.0")]
+            #[inline]
+            pub fn try_from<T>(value: T) -> Result<Self, <Self as TryFrom<T>>::Error>
+                where Self: TryFrom<T>
+            {
+                TryFrom::try_from(value)
+            }
+        }
+
+        doc_comment! {
+            "FIXME docs",
+            #[stable(feature = "int_inherent_try_from_try_into", since = "1.41.0")]
+            #[inline]
+            pub fn try_into<T>(self) -> Result<T, <Self as TryInto<T>>::Error>
+                where Self: TryInto<T>
+            {
+                TryInto::try_into(self)
             }
         }
 
@@ -2338,6 +2360,28 @@ stringify!($MaxV), ");", $EndFeature, "
             #[rustc_promotable]
             #[inline(always)]
             pub const fn max_value() -> Self { !0 }
+        }
+
+        doc_comment! {
+            "FIXME docs",
+            #[stable(feature = "int_inherent_try_from_try_into", since = "1.41.0")]
+            #[inline]
+            pub fn try_from<T>(value: T) -> Result<Self, <Self as TryFrom<T>>::Error>
+                where Self: TryFrom<T>
+            {
+                TryFrom::try_from(value)
+            }
+        }
+
+        doc_comment! {
+            "FIXME docs",
+            #[stable(feature = "int_inherent_try_from_try_into", since = "1.41.0")]
+            #[inline]
+            pub fn try_into<T>(self) -> Result<T, <Self as TryInto<T>>::Error>
+                where Self: TryInto<T>
+            {
+                TryInto::try_into(self)
+            }
         }
 
         doc_comment! {

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1,5 +1,4 @@
 use core::cell::Cell;
-use core::convert::TryFrom;
 use core::iter::*;
 use core::{i8, i16, isize};
 use core::usize;

--- a/src/libcore/tests/num/mod.rs
+++ b/src/libcore/tests/num/mod.rs
@@ -1,4 +1,4 @@
-use core::convert::{TryFrom, TryInto};
+use core::convert::TryFrom;
 use core::cmp::PartialEq;
 use core::fmt::Debug;
 use core::marker::Copy;

--- a/src/librustc/mir/interpret/pointer.rs
+++ b/src/librustc/mir/interpret/pointer.rs
@@ -5,7 +5,6 @@ use crate::ty::layout::{self, HasDataLayout, Size};
 
 use rustc_macros::HashStable;
 
-use std::convert::TryFrom;
 use std::fmt::{self, Display};
 
 /// Used by `check_in_alloc` to indicate context of check

--- a/src/librustc_apfloat/ieee.rs
+++ b/src/librustc_apfloat/ieee.rs
@@ -2,7 +2,6 @@ use crate::{Category, ExpInt, IEK_INF, IEK_NAN, IEK_ZERO};
 use crate::{Float, FloatConvert, ParseError, Round, Status, StatusAnd};
 
 use core::cmp::{self, Ordering};
-use core::convert::TryFrom;
 use core::fmt::{self, Write};
 use core::marker::PhantomData;
 use core::mem;

--- a/src/librustc_metadata/rmeta/table.rs
+++ b/src/librustc_metadata/rmeta/table.rs
@@ -2,7 +2,6 @@ use crate::rmeta::*;
 
 use rustc_index::vec::Idx;
 use rustc_serialize::{Encodable, opaque::Encoder};
-use std::convert::TryInto;
 use std::marker::PhantomData;
 use std::num::NonZeroUsize;
 use log::debug;

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -26,8 +26,6 @@ mod simplify;
 mod test;
 mod util;
 
-use std::convert::TryFrom;
-
 impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// Generates MIR for a `match` expression.
     ///

--- a/src/librustc_mir/build/matches/util.rs
+++ b/src/librustc_mir/build/matches/util.rs
@@ -4,7 +4,6 @@ use crate::hair::*;
 use rustc::mir::*;
 use smallvec::SmallVec;
 use std::u32;
-use std::convert::TryInto;
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {
     pub fn field_match_pairs<'pat>(

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -5,7 +5,6 @@ use std::error::Error;
 use std::borrow::{Borrow, Cow};
 use std::hash::Hash;
 use std::collections::hash_map::Entry;
-use std::convert::TryInto;
 
 use rustc::hir::def::DefKind;
 use rustc::hir::def_id::DefId;

--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -253,7 +253,6 @@ use arena::TypedArena;
 
 use smallvec::{smallvec, SmallVec};
 use std::cmp::{self, max, min, Ordering};
-use std::convert::TryInto;
 use std::fmt;
 use std::iter::{FromIterator, IntoIterator};
 use std::ops::RangeInclusive;

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -1,8 +1,6 @@
 //! Functions concerning immediate values and operands, and reading from operands.
 //! All high-level functions to read from memory work on operands as sources.
 
-use std::convert::{TryInto, TryFrom};
-
 use rustc::{mir, ty};
 use rustc::ty::layout::{
     self, Size, LayoutOf, TyLayout, HasDataLayout, IntegerExt, PrimitiveExt, VariantIdx,

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -2,7 +2,6 @@
 //! into a place.
 //! All high-level functions to write to memory work on places as destinations.
 
-use std::convert::TryFrom;
 use std::hash::Hash;
 
 use rustc::mir;

--- a/src/librustc_mir/util/elaborate_drops.rs
+++ b/src/librustc_mir/util/elaborate_drops.rs
@@ -10,8 +10,6 @@ use rustc::ty::util::IntTypeExt;
 use rustc_index::vec::Idx;
 use crate::util::patch::MirPatch;
 
-use std::convert::TryInto;
-
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum DropFlagState {
     Present, // i.e., initialized

--- a/src/librustc_parse/lexer/mod.rs
+++ b/src/librustc_parse/lexer/mod.rs
@@ -9,7 +9,6 @@ use rustc_lexer::Base;
 use rustc_lexer::unescape;
 
 use std::char;
-use std::convert::TryInto;
 use rustc_data_structures::sync::Lrc;
 use log::debug;
 

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -3,8 +3,6 @@ use crate::io::prelude::*;
 use crate::cmp;
 use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoSlice, IoSliceMut};
 
-use core::convert::TryInto;
-
 /// A `Cursor` wraps an in-memory buffer and provides it with a
 /// [`Seek`] implementation.
 ///

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -752,7 +752,6 @@ impl File {
 
         #[cfg(not(target_os = "android"))]
         {
-            use crate::convert::TryInto;
             let size: off64_t = size
                 .try_into()
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;

--- a/src/libstd/sys/unix/time.rs
+++ b/src/libstd/sys/unix/time.rs
@@ -4,7 +4,6 @@ use crate::time::Duration;
 use core::hash::{Hash, Hasher};
 
 pub use self::inner::{Instant, SystemTime, UNIX_EPOCH};
-use crate::convert::TryInto;
 
 const NSEC_PER_SEC: u64 = 1_000_000_000;
 

--- a/src/libstd/sys/windows/time.rs
+++ b/src/libstd/sys/windows/time.rs
@@ -3,7 +3,6 @@ use crate::fmt;
 use crate::mem;
 use crate::sys::c;
 use crate::time::Duration;
-use crate::convert::TryInto;
 
 use core::hash::{Hash, Hasher};
 

--- a/src/test/ui/const-generics/invalid-const-arg-for-type-param.rs
+++ b/src/test/ui/const-generics/invalid-const-arg-for-type-param.rs
@@ -1,9 +1,8 @@
-use std::convert::TryInto;
-
 struct S;
 
 fn main() {
     let _: u32 = 5i32.try_into::<32>().unwrap(); //~ ERROR wrong number of const arguments
+    //~^ ERROR wrong number of type arguments
     S.f::<0>(); //~ ERROR no method named `f`
     S::<0>; //~ ERROR  wrong number of const arguments
 }

--- a/src/test/ui/const-generics/invalid-const-arg-for-type-param.stderr
+++ b/src/test/ui/const-generics/invalid-const-arg-for-type-param.stderr
@@ -1,11 +1,17 @@
 error[E0107]: wrong number of const arguments: expected 0, found 1
-  --> $DIR/invalid-const-arg-for-type-param.rs:6:34
+  --> $DIR/invalid-const-arg-for-type-param.rs:4:34
    |
 LL |     let _: u32 = 5i32.try_into::<32>().unwrap();
    |                                  ^^ unexpected const argument
 
+error[E0107]: wrong number of type arguments: expected 1, found 0
+  --> $DIR/invalid-const-arg-for-type-param.rs:4:23
+   |
+LL |     let _: u32 = 5i32.try_into::<32>().unwrap();
+   |                       ^^^^^^^^ expected 1 type argument
+
 error[E0599]: no method named `f` found for type `S` in the current scope
-  --> $DIR/invalid-const-arg-for-type-param.rs:7:7
+  --> $DIR/invalid-const-arg-for-type-param.rs:6:7
    |
 LL | struct S;
    | --------- method `f` not found for this
@@ -14,12 +20,12 @@ LL |     S.f::<0>();
    |       ^ method not found in `S`
 
 error[E0107]: wrong number of const arguments: expected 0, found 1
-  --> $DIR/invalid-const-arg-for-type-param.rs:8:9
+  --> $DIR/invalid-const-arg-for-type-param.rs:7:9
    |
 LL |     S::<0>;
    |         ^ unexpected const argument
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0107, E0599.
 For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/numeric/numeric-cast.fixed
+++ b/src/test/ui/numeric/numeric-cast.fixed
@@ -1,8 +1,5 @@
 // run-rustfix
 
-// The `try_into` suggestion doesn't include this, but we do suggest it after applying it
-use std::convert::TryInto;
-
 fn foo<N>(_x: N) {}
 
 fn main() {

--- a/src/test/ui/numeric/numeric-cast.rs
+++ b/src/test/ui/numeric/numeric-cast.rs
@@ -1,8 +1,5 @@
 // run-rustfix
 
-// The `try_into` suggestion doesn't include this, but we do suggest it after applying it
-use std::convert::TryInto;
-
 fn foo<N>(_x: N) {}
 
 fn main() {

--- a/src/test/ui/numeric/numeric-cast.stderr
+++ b/src/test/ui/numeric/numeric-cast.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:23:18
+  --> $DIR/numeric-cast.rs:20:18
    |
 LL |     foo::<usize>(x_u64);
    |                  ^^^^^ expected `usize`, found `u64`
@@ -10,7 +10,7 @@ LL |     foo::<usize>(x_u64.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:25:18
+  --> $DIR/numeric-cast.rs:22:18
    |
 LL |     foo::<usize>(x_u32);
    |                  ^^^^^ expected `usize`, found `u32`
@@ -21,7 +21,7 @@ LL |     foo::<usize>(x_u32.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:27:18
+  --> $DIR/numeric-cast.rs:24:18
    |
 LL |     foo::<usize>(x_u16);
    |                  ^^^^^ expected `usize`, found `u16`
@@ -32,7 +32,7 @@ LL |     foo::<usize>(x_u16.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:29:18
+  --> $DIR/numeric-cast.rs:26:18
    |
 LL |     foo::<usize>(x_u8);
    |                  ^^^^ expected `usize`, found `u8`
@@ -43,7 +43,7 @@ LL |     foo::<usize>(x_u8.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:31:18
+  --> $DIR/numeric-cast.rs:28:18
    |
 LL |     foo::<usize>(x_isize);
    |                  ^^^^^^^ expected `usize`, found `isize`
@@ -54,7 +54,7 @@ LL |     foo::<usize>(x_isize.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:33:18
+  --> $DIR/numeric-cast.rs:30:18
    |
 LL |     foo::<usize>(x_i64);
    |                  ^^^^^ expected `usize`, found `i64`
@@ -65,7 +65,7 @@ LL |     foo::<usize>(x_i64.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:35:18
+  --> $DIR/numeric-cast.rs:32:18
    |
 LL |     foo::<usize>(x_i32);
    |                  ^^^^^ expected `usize`, found `i32`
@@ -76,7 +76,7 @@ LL |     foo::<usize>(x_i32.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:37:18
+  --> $DIR/numeric-cast.rs:34:18
    |
 LL |     foo::<usize>(x_i16);
    |                  ^^^^^ expected `usize`, found `i16`
@@ -87,7 +87,7 @@ LL |     foo::<usize>(x_i16.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:39:18
+  --> $DIR/numeric-cast.rs:36:18
    |
 LL |     foo::<usize>(x_i8);
    |                  ^^^^ expected `usize`, found `i8`
@@ -98,7 +98,7 @@ LL |     foo::<usize>(x_i8.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:44:18
+  --> $DIR/numeric-cast.rs:41:18
    |
 LL |     foo::<isize>(x_usize);
    |                  ^^^^^^^ expected `isize`, found `usize`
@@ -109,7 +109,7 @@ LL |     foo::<isize>(x_usize.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:46:18
+  --> $DIR/numeric-cast.rs:43:18
    |
 LL |     foo::<isize>(x_u64);
    |                  ^^^^^ expected `isize`, found `u64`
@@ -120,7 +120,7 @@ LL |     foo::<isize>(x_u64.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:48:18
+  --> $DIR/numeric-cast.rs:45:18
    |
 LL |     foo::<isize>(x_u32);
    |                  ^^^^^ expected `isize`, found `u32`
@@ -131,7 +131,7 @@ LL |     foo::<isize>(x_u32.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:50:18
+  --> $DIR/numeric-cast.rs:47:18
    |
 LL |     foo::<isize>(x_u16);
    |                  ^^^^^ expected `isize`, found `u16`
@@ -142,7 +142,7 @@ LL |     foo::<isize>(x_u16.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:52:18
+  --> $DIR/numeric-cast.rs:49:18
    |
 LL |     foo::<isize>(x_u8);
    |                  ^^^^ expected `isize`, found `u8`
@@ -153,7 +153,7 @@ LL |     foo::<isize>(x_u8.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:55:18
+  --> $DIR/numeric-cast.rs:52:18
    |
 LL |     foo::<isize>(x_i64);
    |                  ^^^^^ expected `isize`, found `i64`
@@ -164,7 +164,7 @@ LL |     foo::<isize>(x_i64.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:57:18
+  --> $DIR/numeric-cast.rs:54:18
    |
 LL |     foo::<isize>(x_i32);
    |                  ^^^^^ expected `isize`, found `i32`
@@ -175,7 +175,7 @@ LL |     foo::<isize>(x_i32.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:59:18
+  --> $DIR/numeric-cast.rs:56:18
    |
 LL |     foo::<isize>(x_i16);
    |                  ^^^^^ expected `isize`, found `i16`
@@ -186,7 +186,7 @@ LL |     foo::<isize>(x_i16.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:61:18
+  --> $DIR/numeric-cast.rs:58:18
    |
 LL |     foo::<isize>(x_i8);
    |                  ^^^^ expected `isize`, found `i8`
@@ -197,7 +197,7 @@ LL |     foo::<isize>(x_i8.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:66:16
+  --> $DIR/numeric-cast.rs:63:16
    |
 LL |     foo::<u64>(x_usize);
    |                ^^^^^^^ expected `u64`, found `usize`
@@ -208,7 +208,7 @@ LL |     foo::<u64>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:69:16
+  --> $DIR/numeric-cast.rs:66:16
    |
 LL |     foo::<u64>(x_u32);
    |                ^^^^^
@@ -217,7 +217,7 @@ LL |     foo::<u64>(x_u32);
    |                help: you can convert an `u32` to `u64`: `x_u32.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:71:16
+  --> $DIR/numeric-cast.rs:68:16
    |
 LL |     foo::<u64>(x_u16);
    |                ^^^^^
@@ -226,7 +226,7 @@ LL |     foo::<u64>(x_u16);
    |                help: you can convert an `u16` to `u64`: `x_u16.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:73:16
+  --> $DIR/numeric-cast.rs:70:16
    |
 LL |     foo::<u64>(x_u8);
    |                ^^^^
@@ -235,7 +235,7 @@ LL |     foo::<u64>(x_u8);
    |                help: you can convert an `u8` to `u64`: `x_u8.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:75:16
+  --> $DIR/numeric-cast.rs:72:16
    |
 LL |     foo::<u64>(x_isize);
    |                ^^^^^^^ expected `u64`, found `isize`
@@ -246,7 +246,7 @@ LL |     foo::<u64>(x_isize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:77:16
+  --> $DIR/numeric-cast.rs:74:16
    |
 LL |     foo::<u64>(x_i64);
    |                ^^^^^ expected `u64`, found `i64`
@@ -257,7 +257,7 @@ LL |     foo::<u64>(x_i64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:79:16
+  --> $DIR/numeric-cast.rs:76:16
    |
 LL |     foo::<u64>(x_i32);
    |                ^^^^^ expected `u64`, found `i32`
@@ -268,7 +268,7 @@ LL |     foo::<u64>(x_i32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:81:16
+  --> $DIR/numeric-cast.rs:78:16
    |
 LL |     foo::<u64>(x_i16);
    |                ^^^^^ expected `u64`, found `i16`
@@ -279,7 +279,7 @@ LL |     foo::<u64>(x_i16.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:83:16
+  --> $DIR/numeric-cast.rs:80:16
    |
 LL |     foo::<u64>(x_i8);
    |                ^^^^ expected `u64`, found `i8`
@@ -290,7 +290,7 @@ LL |     foo::<u64>(x_i8.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:88:16
+  --> $DIR/numeric-cast.rs:85:16
    |
 LL |     foo::<i64>(x_usize);
    |                ^^^^^^^ expected `i64`, found `usize`
@@ -301,7 +301,7 @@ LL |     foo::<i64>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:90:16
+  --> $DIR/numeric-cast.rs:87:16
    |
 LL |     foo::<i64>(x_u64);
    |                ^^^^^ expected `i64`, found `u64`
@@ -312,7 +312,7 @@ LL |     foo::<i64>(x_u64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:92:16
+  --> $DIR/numeric-cast.rs:89:16
    |
 LL |     foo::<i64>(x_u32);
    |                ^^^^^ expected `i64`, found `u32`
@@ -323,7 +323,7 @@ LL |     foo::<i64>(x_u32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:94:16
+  --> $DIR/numeric-cast.rs:91:16
    |
 LL |     foo::<i64>(x_u16);
    |                ^^^^^ expected `i64`, found `u16`
@@ -334,7 +334,7 @@ LL |     foo::<i64>(x_u16.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:96:16
+  --> $DIR/numeric-cast.rs:93:16
    |
 LL |     foo::<i64>(x_u8);
    |                ^^^^ expected `i64`, found `u8`
@@ -345,7 +345,7 @@ LL |     foo::<i64>(x_u8.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:98:16
+  --> $DIR/numeric-cast.rs:95:16
    |
 LL |     foo::<i64>(x_isize);
    |                ^^^^^^^ expected `i64`, found `isize`
@@ -356,7 +356,7 @@ LL |     foo::<i64>(x_isize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:101:16
+  --> $DIR/numeric-cast.rs:98:16
    |
 LL |     foo::<i64>(x_i32);
    |                ^^^^^
@@ -365,7 +365,7 @@ LL |     foo::<i64>(x_i32);
    |                help: you can convert an `i32` to `i64`: `x_i32.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:103:16
+  --> $DIR/numeric-cast.rs:100:16
    |
 LL |     foo::<i64>(x_i16);
    |                ^^^^^
@@ -374,7 +374,7 @@ LL |     foo::<i64>(x_i16);
    |                help: you can convert an `i16` to `i64`: `x_i16.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:105:16
+  --> $DIR/numeric-cast.rs:102:16
    |
 LL |     foo::<i64>(x_i8);
    |                ^^^^
@@ -383,7 +383,7 @@ LL |     foo::<i64>(x_i8);
    |                help: you can convert an `i8` to `i64`: `x_i8.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:110:16
+  --> $DIR/numeric-cast.rs:107:16
    |
 LL |     foo::<u32>(x_usize);
    |                ^^^^^^^ expected `u32`, found `usize`
@@ -394,7 +394,7 @@ LL |     foo::<u32>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:112:16
+  --> $DIR/numeric-cast.rs:109:16
    |
 LL |     foo::<u32>(x_u64);
    |                ^^^^^ expected `u32`, found `u64`
@@ -405,7 +405,7 @@ LL |     foo::<u32>(x_u64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:115:16
+  --> $DIR/numeric-cast.rs:112:16
    |
 LL |     foo::<u32>(x_u16);
    |                ^^^^^
@@ -414,7 +414,7 @@ LL |     foo::<u32>(x_u16);
    |                help: you can convert an `u16` to `u32`: `x_u16.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:117:16
+  --> $DIR/numeric-cast.rs:114:16
    |
 LL |     foo::<u32>(x_u8);
    |                ^^^^
@@ -423,7 +423,7 @@ LL |     foo::<u32>(x_u8);
    |                help: you can convert an `u8` to `u32`: `x_u8.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:119:16
+  --> $DIR/numeric-cast.rs:116:16
    |
 LL |     foo::<u32>(x_isize);
    |                ^^^^^^^ expected `u32`, found `isize`
@@ -434,7 +434,7 @@ LL |     foo::<u32>(x_isize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:121:16
+  --> $DIR/numeric-cast.rs:118:16
    |
 LL |     foo::<u32>(x_i64);
    |                ^^^^^ expected `u32`, found `i64`
@@ -445,7 +445,7 @@ LL |     foo::<u32>(x_i64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:123:16
+  --> $DIR/numeric-cast.rs:120:16
    |
 LL |     foo::<u32>(x_i32);
    |                ^^^^^ expected `u32`, found `i32`
@@ -456,7 +456,7 @@ LL |     foo::<u32>(x_i32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:125:16
+  --> $DIR/numeric-cast.rs:122:16
    |
 LL |     foo::<u32>(x_i16);
    |                ^^^^^ expected `u32`, found `i16`
@@ -467,7 +467,7 @@ LL |     foo::<u32>(x_i16.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:127:16
+  --> $DIR/numeric-cast.rs:124:16
    |
 LL |     foo::<u32>(x_i8);
    |                ^^^^ expected `u32`, found `i8`
@@ -478,7 +478,7 @@ LL |     foo::<u32>(x_i8.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:132:16
+  --> $DIR/numeric-cast.rs:129:16
    |
 LL |     foo::<i32>(x_usize);
    |                ^^^^^^^ expected `i32`, found `usize`
@@ -489,7 +489,7 @@ LL |     foo::<i32>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:134:16
+  --> $DIR/numeric-cast.rs:131:16
    |
 LL |     foo::<i32>(x_u64);
    |                ^^^^^ expected `i32`, found `u64`
@@ -500,7 +500,7 @@ LL |     foo::<i32>(x_u64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:136:16
+  --> $DIR/numeric-cast.rs:133:16
    |
 LL |     foo::<i32>(x_u32);
    |                ^^^^^ expected `i32`, found `u32`
@@ -511,7 +511,7 @@ LL |     foo::<i32>(x_u32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:138:16
+  --> $DIR/numeric-cast.rs:135:16
    |
 LL |     foo::<i32>(x_u16);
    |                ^^^^^ expected `i32`, found `u16`
@@ -522,7 +522,7 @@ LL |     foo::<i32>(x_u16.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:140:16
+  --> $DIR/numeric-cast.rs:137:16
    |
 LL |     foo::<i32>(x_u8);
    |                ^^^^ expected `i32`, found `u8`
@@ -533,7 +533,7 @@ LL |     foo::<i32>(x_u8.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:142:16
+  --> $DIR/numeric-cast.rs:139:16
    |
 LL |     foo::<i32>(x_isize);
    |                ^^^^^^^ expected `i32`, found `isize`
@@ -544,7 +544,7 @@ LL |     foo::<i32>(x_isize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:144:16
+  --> $DIR/numeric-cast.rs:141:16
    |
 LL |     foo::<i32>(x_i64);
    |                ^^^^^ expected `i32`, found `i64`
@@ -555,7 +555,7 @@ LL |     foo::<i32>(x_i64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:147:16
+  --> $DIR/numeric-cast.rs:144:16
    |
 LL |     foo::<i32>(x_i16);
    |                ^^^^^
@@ -564,7 +564,7 @@ LL |     foo::<i32>(x_i16);
    |                help: you can convert an `i16` to `i32`: `x_i16.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:149:16
+  --> $DIR/numeric-cast.rs:146:16
    |
 LL |     foo::<i32>(x_i8);
    |                ^^^^
@@ -573,7 +573,7 @@ LL |     foo::<i32>(x_i8);
    |                help: you can convert an `i8` to `i32`: `x_i8.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:154:16
+  --> $DIR/numeric-cast.rs:151:16
    |
 LL |     foo::<u16>(x_usize);
    |                ^^^^^^^ expected `u16`, found `usize`
@@ -584,7 +584,7 @@ LL |     foo::<u16>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:156:16
+  --> $DIR/numeric-cast.rs:153:16
    |
 LL |     foo::<u16>(x_u64);
    |                ^^^^^ expected `u16`, found `u64`
@@ -595,7 +595,7 @@ LL |     foo::<u16>(x_u64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:158:16
+  --> $DIR/numeric-cast.rs:155:16
    |
 LL |     foo::<u16>(x_u32);
    |                ^^^^^ expected `u16`, found `u32`
@@ -606,7 +606,7 @@ LL |     foo::<u16>(x_u32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:161:16
+  --> $DIR/numeric-cast.rs:158:16
    |
 LL |     foo::<u16>(x_u8);
    |                ^^^^
@@ -615,7 +615,7 @@ LL |     foo::<u16>(x_u8);
    |                help: you can convert an `u8` to `u16`: `x_u8.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:163:16
+  --> $DIR/numeric-cast.rs:160:16
    |
 LL |     foo::<u16>(x_isize);
    |                ^^^^^^^ expected `u16`, found `isize`
@@ -626,7 +626,7 @@ LL |     foo::<u16>(x_isize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:165:16
+  --> $DIR/numeric-cast.rs:162:16
    |
 LL |     foo::<u16>(x_i64);
    |                ^^^^^ expected `u16`, found `i64`
@@ -637,7 +637,7 @@ LL |     foo::<u16>(x_i64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:167:16
+  --> $DIR/numeric-cast.rs:164:16
    |
 LL |     foo::<u16>(x_i32);
    |                ^^^^^ expected `u16`, found `i32`
@@ -648,7 +648,7 @@ LL |     foo::<u16>(x_i32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:169:16
+  --> $DIR/numeric-cast.rs:166:16
    |
 LL |     foo::<u16>(x_i16);
    |                ^^^^^ expected `u16`, found `i16`
@@ -659,7 +659,7 @@ LL |     foo::<u16>(x_i16.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:171:16
+  --> $DIR/numeric-cast.rs:168:16
    |
 LL |     foo::<u16>(x_i8);
    |                ^^^^ expected `u16`, found `i8`
@@ -670,7 +670,7 @@ LL |     foo::<u16>(x_i8.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:176:16
+  --> $DIR/numeric-cast.rs:173:16
    |
 LL |     foo::<i16>(x_usize);
    |                ^^^^^^^ expected `i16`, found `usize`
@@ -681,7 +681,7 @@ LL |     foo::<i16>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:178:16
+  --> $DIR/numeric-cast.rs:175:16
    |
 LL |     foo::<i16>(x_u64);
    |                ^^^^^ expected `i16`, found `u64`
@@ -692,7 +692,7 @@ LL |     foo::<i16>(x_u64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:180:16
+  --> $DIR/numeric-cast.rs:177:16
    |
 LL |     foo::<i16>(x_u32);
    |                ^^^^^ expected `i16`, found `u32`
@@ -703,7 +703,7 @@ LL |     foo::<i16>(x_u32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:182:16
+  --> $DIR/numeric-cast.rs:179:16
    |
 LL |     foo::<i16>(x_u16);
    |                ^^^^^ expected `i16`, found `u16`
@@ -714,7 +714,7 @@ LL |     foo::<i16>(x_u16.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:184:16
+  --> $DIR/numeric-cast.rs:181:16
    |
 LL |     foo::<i16>(x_u8);
    |                ^^^^ expected `i16`, found `u8`
@@ -725,7 +725,7 @@ LL |     foo::<i16>(x_u8.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:186:16
+  --> $DIR/numeric-cast.rs:183:16
    |
 LL |     foo::<i16>(x_isize);
    |                ^^^^^^^ expected `i16`, found `isize`
@@ -736,7 +736,7 @@ LL |     foo::<i16>(x_isize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:188:16
+  --> $DIR/numeric-cast.rs:185:16
    |
 LL |     foo::<i16>(x_i64);
    |                ^^^^^ expected `i16`, found `i64`
@@ -747,7 +747,7 @@ LL |     foo::<i16>(x_i64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:190:16
+  --> $DIR/numeric-cast.rs:187:16
    |
 LL |     foo::<i16>(x_i32);
    |                ^^^^^ expected `i16`, found `i32`
@@ -758,7 +758,7 @@ LL |     foo::<i16>(x_i32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:193:16
+  --> $DIR/numeric-cast.rs:190:16
    |
 LL |     foo::<i16>(x_i8);
    |                ^^^^
@@ -767,7 +767,7 @@ LL |     foo::<i16>(x_i8);
    |                help: you can convert an `i8` to `i16`: `x_i8.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:198:15
+  --> $DIR/numeric-cast.rs:195:15
    |
 LL |     foo::<u8>(x_usize);
    |               ^^^^^^^ expected `u8`, found `usize`
@@ -778,7 +778,7 @@ LL |     foo::<u8>(x_usize.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:200:15
+  --> $DIR/numeric-cast.rs:197:15
    |
 LL |     foo::<u8>(x_u64);
    |               ^^^^^ expected `u8`, found `u64`
@@ -789,7 +789,7 @@ LL |     foo::<u8>(x_u64.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:202:15
+  --> $DIR/numeric-cast.rs:199:15
    |
 LL |     foo::<u8>(x_u32);
    |               ^^^^^ expected `u8`, found `u32`
@@ -800,7 +800,7 @@ LL |     foo::<u8>(x_u32.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:204:15
+  --> $DIR/numeric-cast.rs:201:15
    |
 LL |     foo::<u8>(x_u16);
    |               ^^^^^ expected `u8`, found `u16`
@@ -811,7 +811,7 @@ LL |     foo::<u8>(x_u16.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:207:15
+  --> $DIR/numeric-cast.rs:204:15
    |
 LL |     foo::<u8>(x_isize);
    |               ^^^^^^^ expected `u8`, found `isize`
@@ -822,7 +822,7 @@ LL |     foo::<u8>(x_isize.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:209:15
+  --> $DIR/numeric-cast.rs:206:15
    |
 LL |     foo::<u8>(x_i64);
    |               ^^^^^ expected `u8`, found `i64`
@@ -833,7 +833,7 @@ LL |     foo::<u8>(x_i64.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:211:15
+  --> $DIR/numeric-cast.rs:208:15
    |
 LL |     foo::<u8>(x_i32);
    |               ^^^^^ expected `u8`, found `i32`
@@ -844,7 +844,7 @@ LL |     foo::<u8>(x_i32.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:213:15
+  --> $DIR/numeric-cast.rs:210:15
    |
 LL |     foo::<u8>(x_i16);
    |               ^^^^^ expected `u8`, found `i16`
@@ -855,7 +855,7 @@ LL |     foo::<u8>(x_i16.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:215:15
+  --> $DIR/numeric-cast.rs:212:15
    |
 LL |     foo::<u8>(x_i8);
    |               ^^^^ expected `u8`, found `i8`
@@ -866,7 +866,7 @@ LL |     foo::<u8>(x_i8.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:220:15
+  --> $DIR/numeric-cast.rs:217:15
    |
 LL |     foo::<i8>(x_usize);
    |               ^^^^^^^ expected `i8`, found `usize`
@@ -877,7 +877,7 @@ LL |     foo::<i8>(x_usize.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:222:15
+  --> $DIR/numeric-cast.rs:219:15
    |
 LL |     foo::<i8>(x_u64);
    |               ^^^^^ expected `i8`, found `u64`
@@ -888,7 +888,7 @@ LL |     foo::<i8>(x_u64.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:224:15
+  --> $DIR/numeric-cast.rs:221:15
    |
 LL |     foo::<i8>(x_u32);
    |               ^^^^^ expected `i8`, found `u32`
@@ -899,7 +899,7 @@ LL |     foo::<i8>(x_u32.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:226:15
+  --> $DIR/numeric-cast.rs:223:15
    |
 LL |     foo::<i8>(x_u16);
    |               ^^^^^ expected `i8`, found `u16`
@@ -910,7 +910,7 @@ LL |     foo::<i8>(x_u16.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:228:15
+  --> $DIR/numeric-cast.rs:225:15
    |
 LL |     foo::<i8>(x_u8);
    |               ^^^^ expected `i8`, found `u8`
@@ -921,7 +921,7 @@ LL |     foo::<i8>(x_u8.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:230:15
+  --> $DIR/numeric-cast.rs:227:15
    |
 LL |     foo::<i8>(x_isize);
    |               ^^^^^^^ expected `i8`, found `isize`
@@ -932,7 +932,7 @@ LL |     foo::<i8>(x_isize.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:232:15
+  --> $DIR/numeric-cast.rs:229:15
    |
 LL |     foo::<i8>(x_i64);
    |               ^^^^^ expected `i8`, found `i64`
@@ -943,7 +943,7 @@ LL |     foo::<i8>(x_i64.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:234:15
+  --> $DIR/numeric-cast.rs:231:15
    |
 LL |     foo::<i8>(x_i32);
    |               ^^^^^ expected `i8`, found `i32`
@@ -954,7 +954,7 @@ LL |     foo::<i8>(x_i32.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:236:15
+  --> $DIR/numeric-cast.rs:233:15
    |
 LL |     foo::<i8>(x_i16);
    |               ^^^^^ expected `i8`, found `i16`
@@ -965,7 +965,7 @@ LL |     foo::<i8>(x_i16.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:242:16
+  --> $DIR/numeric-cast.rs:239:16
    |
 LL |     foo::<f64>(x_usize);
    |                ^^^^^^^ expected `f64`, found `usize`
@@ -976,7 +976,7 @@ LL |     foo::<f64>(x_usize as f64);
    |                ^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:244:16
+  --> $DIR/numeric-cast.rs:241:16
    |
 LL |     foo::<f64>(x_u64);
    |                ^^^^^ expected `f64`, found `u64`
@@ -987,7 +987,7 @@ LL |     foo::<f64>(x_u64 as f64);
    |                ^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:246:16
+  --> $DIR/numeric-cast.rs:243:16
    |
 LL |     foo::<f64>(x_u32);
    |                ^^^^^ expected `f64`, found `u32`
@@ -998,7 +998,7 @@ LL |     foo::<f64>(x_u32.into());
    |                ^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:248:16
+  --> $DIR/numeric-cast.rs:245:16
    |
 LL |     foo::<f64>(x_u16);
    |                ^^^^^ expected `f64`, found `u16`
@@ -1009,7 +1009,7 @@ LL |     foo::<f64>(x_u16.into());
    |                ^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:250:16
+  --> $DIR/numeric-cast.rs:247:16
    |
 LL |     foo::<f64>(x_u8);
    |                ^^^^ expected `f64`, found `u8`
@@ -1020,7 +1020,7 @@ LL |     foo::<f64>(x_u8.into());
    |                ^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:252:16
+  --> $DIR/numeric-cast.rs:249:16
    |
 LL |     foo::<f64>(x_isize);
    |                ^^^^^^^ expected `f64`, found `isize`
@@ -1031,7 +1031,7 @@ LL |     foo::<f64>(x_isize as f64);
    |                ^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:254:16
+  --> $DIR/numeric-cast.rs:251:16
    |
 LL |     foo::<f64>(x_i64);
    |                ^^^^^ expected `f64`, found `i64`
@@ -1042,7 +1042,7 @@ LL |     foo::<f64>(x_i64 as f64);
    |                ^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:256:16
+  --> $DIR/numeric-cast.rs:253:16
    |
 LL |     foo::<f64>(x_i32);
    |                ^^^^^ expected `f64`, found `i32`
@@ -1053,7 +1053,7 @@ LL |     foo::<f64>(x_i32.into());
    |                ^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:258:16
+  --> $DIR/numeric-cast.rs:255:16
    |
 LL |     foo::<f64>(x_i16);
    |                ^^^^^ expected `f64`, found `i16`
@@ -1064,7 +1064,7 @@ LL |     foo::<f64>(x_i16.into());
    |                ^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:260:16
+  --> $DIR/numeric-cast.rs:257:16
    |
 LL |     foo::<f64>(x_i8);
    |                ^^^^ expected `f64`, found `i8`
@@ -1075,7 +1075,7 @@ LL |     foo::<f64>(x_i8.into());
    |                ^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:263:16
+  --> $DIR/numeric-cast.rs:260:16
    |
 LL |     foo::<f64>(x_f32);
    |                ^^^^^
@@ -1084,7 +1084,7 @@ LL |     foo::<f64>(x_f32);
    |                help: you can convert an `f32` to `f64`: `x_f32.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:266:16
+  --> $DIR/numeric-cast.rs:263:16
    |
 LL |     foo::<f32>(x_usize);
    |                ^^^^^^^ expected `f32`, found `usize`
@@ -1095,7 +1095,7 @@ LL |     foo::<f32>(x_usize as f32);
    |                ^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:268:16
+  --> $DIR/numeric-cast.rs:265:16
    |
 LL |     foo::<f32>(x_u64);
    |                ^^^^^ expected `f32`, found `u64`
@@ -1106,7 +1106,7 @@ LL |     foo::<f32>(x_u64 as f32);
    |                ^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:270:16
+  --> $DIR/numeric-cast.rs:267:16
    |
 LL |     foo::<f32>(x_u32);
    |                ^^^^^ expected `f32`, found `u32`
@@ -1117,7 +1117,7 @@ LL |     foo::<f32>(x_u32 as f32);
    |                ^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:272:16
+  --> $DIR/numeric-cast.rs:269:16
    |
 LL |     foo::<f32>(x_u16);
    |                ^^^^^ expected `f32`, found `u16`
@@ -1128,7 +1128,7 @@ LL |     foo::<f32>(x_u16.into());
    |                ^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:274:16
+  --> $DIR/numeric-cast.rs:271:16
    |
 LL |     foo::<f32>(x_u8);
    |                ^^^^ expected `f32`, found `u8`
@@ -1139,7 +1139,7 @@ LL |     foo::<f32>(x_u8.into());
    |                ^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:276:16
+  --> $DIR/numeric-cast.rs:273:16
    |
 LL |     foo::<f32>(x_isize);
    |                ^^^^^^^ expected `f32`, found `isize`
@@ -1150,7 +1150,7 @@ LL |     foo::<f32>(x_isize as f32);
    |                ^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:278:16
+  --> $DIR/numeric-cast.rs:275:16
    |
 LL |     foo::<f32>(x_i64);
    |                ^^^^^ expected `f32`, found `i64`
@@ -1161,7 +1161,7 @@ LL |     foo::<f32>(x_i64 as f32);
    |                ^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:280:16
+  --> $DIR/numeric-cast.rs:277:16
    |
 LL |     foo::<f32>(x_i32);
    |                ^^^^^ expected `f32`, found `i32`
@@ -1172,7 +1172,7 @@ LL |     foo::<f32>(x_i32 as f32);
    |                ^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:282:16
+  --> $DIR/numeric-cast.rs:279:16
    |
 LL |     foo::<f32>(x_i16);
    |                ^^^^^ expected `f32`, found `i16`
@@ -1183,7 +1183,7 @@ LL |     foo::<f32>(x_i16.into());
    |                ^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:284:16
+  --> $DIR/numeric-cast.rs:281:16
    |
 LL |     foo::<f32>(x_i8);
    |                ^^^^ expected `f32`, found `i8`
@@ -1194,7 +1194,7 @@ LL |     foo::<f32>(x_i8.into());
    |                ^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:289:16
+  --> $DIR/numeric-cast.rs:286:16
    |
 LL |     foo::<u32>(x_u8 as u16);
    |                ^^^^^^^^^^^
@@ -1203,7 +1203,7 @@ LL |     foo::<u32>(x_u8 as u16);
    |                help: you can convert an `u16` to `u32`: `(x_u8 as u16).into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast.rs:291:16
+  --> $DIR/numeric-cast.rs:288:16
    |
 LL |     foo::<i32>(-x_i8);
    |                ^^^^^

--- a/src/test/ui/try-from-int-error-partial-eq.rs
+++ b/src/test/ui/try-from-int-error-partial-eq.rs
@@ -2,7 +2,6 @@
 
 #![allow(unused_must_use)]
 
-use std::convert::TryFrom;
 use std::num::TryFromIntError;
 
 fn main() {


### PR DESCRIPTION
This allows these methods to be used without importing the corresponding traits.

This causes new `unused-imports` warnings for existing imports used only by method calls. This is a non-trivial amount of churn, maybe worth it?

The warnings can be fixed by removing imports (like this PR does in rustc and tests), or by adding `#[allow(unused_import)]` to them until the minimum supported Rust version is incremented to one that has this PR.

The new methods are insta-stable in order to avoid causing `unstable-name-collisions` warnings. These would be harder to deal with since they happen at calls sites rather than trait imports.