### PR TITLE
Hide Error::description and cause methods

### DIFF
--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -67,6 +67,7 @@ pub trait Error: Debug + Display {
     /// }
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(hidden)]
     fn description(&self) -> &str {
         "description() is deprecated; use Display"
     }
@@ -132,6 +133,7 @@ pub trait Error: Debug + Display {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_deprecated(since = "1.33.0", reason = "replaced by Error::source, which can support \
                                                    downcasting")]
+    #[doc(hidden)]
     fn cause(&self) -> Option<&dyn Error> {
         self.source()
     }


### PR DESCRIPTION
`description` has been documented as soft-deprecated since 1.27.0, `cause` has been documented as deprecated since 1.30.0 and has produced deprecation warnings since 1.33.0. There is no longer any reason to call or implement either of these methods. Now it's a year or a year and a half later and there is less and less reason over time to even know about either one.

This commit adds `#[doc(hidden)]` to `Error::description` and `Error::cause` to keep them out of the standard library's API documentation.