### PR TITLE
More const int functions

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -128,7 +128,7 @@
 #![feature(maybe_uninit_slice)]
 #![feature(external_doc)]
 #![feature(associated_type_bounds)]
-#![cfg_attr(not(bootstrap), feature(const_if_match))]
+#![feature(const_if_match)]
 
 #[prelude_import]
 #[allow(unused)]

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -128,6 +128,7 @@
 #![feature(maybe_uninit_slice)]
 #![feature(external_doc)]
 #![feature(associated_type_bounds)]
+#![cfg_attr(not(bootstrap), feature(const_if_match))]
 
 #[prelude_import]
 #[allow(unused)]

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -70,6 +70,21 @@ assert_eq!(size_of::<Option<core::num::", stringify!($Ty), ">>(), size_of::<", s
                 /// Creates a non-zero if the given value is not zero.
                 #[$stability]
                 #[inline]
+                #[rustc_const_unstable(feature = "const_int_nonzero")]
+                #[cfg(not(bootstrap))]
+                pub const fn new(n: $Int) -> Option<Self> {
+                    if n != 0 {
+                        // SAFETY: we just checked that there's no `0`
+                        Some(unsafe { $Ty(n) })
+                    } else {
+                        None
+                    }
+                }
+
+                /// No docs for bootstrap.
+                #[$stability]
+                #[inline]
+                #[cfg(bootstrap)]
                 pub fn new(n: $Int) -> Option<Self> {
                     if n != 0 {
                         // SAFETY: we just checked that there's no `0`

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -816,12 +816,28 @@ assert_eq!((1", stringify!($SelfT), ").checked_div_euclid(0), None);
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn checked_div_euclid(self, rhs: Self) -> Option<Self> {
+            #[rustc_const_unstable(feature = "const_int_euclidean")]
+            #[cfg(not(bootstrap))]
+            pub const fn checked_div_euclid(self, rhs: Self) -> Option<Self> {
                 if rhs == 0 || (self == Self::min_value() && rhs == -1) {
                     None
                 } else {
                     Some(self.div_euclid(rhs))
                 }
+            }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "euclidean_division", since = "1.38.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn checked_div_euclid(self, rhs: Self) -> Option<Self> {
+            if rhs == 0 || (self == Self::min_value() && rhs == -1) {
+                None
+            } else {
+                Some(self.div_euclid(rhs))
             }
         }
 
@@ -874,12 +890,28 @@ assert_eq!(", stringify!($SelfT), "::MIN.checked_rem_euclid(-1), None);
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn checked_rem_euclid(self, rhs: Self) -> Option<Self> {
+            #[rustc_const_unstable(feature = "const_int_euclidean")]
+            #[cfg(not(bootstrap))]
+            pub const fn checked_rem_euclid(self, rhs: Self) -> Option<Self> {
                 if rhs == 0 || (self == Self::min_value() && rhs == -1) {
                     None
                 } else {
                     Some(self.rem_euclid(rhs))
                 }
+            }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "euclidean_division", since = "1.38.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn checked_rem_euclid(self, rhs: Self) -> Option<Self> {
+            if rhs == 0 || (self == Self::min_value() && rhs == -1) {
+                None
+            } else {
+                Some(self.rem_euclid(rhs))
             }
         }
 
@@ -1406,9 +1438,21 @@ assert_eq!((-128i8).wrapping_div_euclid(-1), -128);
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn wrapping_div_euclid(self, rhs: Self) -> Self {
+            #[rustc_const_unstable(feature = "const_int_euclidean")]
+            #[cfg(not(bootstrap))]
+            pub const fn wrapping_div_euclid(self, rhs: Self) -> Self {
                 self.overflowing_div_euclid(rhs).0
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "euclidean_division", since = "1.38.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn wrapping_div_euclid(self, rhs: Self) -> Self {
+            self.overflowing_div_euclid(rhs).0
         }
 
         doc_comment! {
@@ -1476,9 +1520,21 @@ assert_eq!((-128i8).wrapping_rem_euclid(-1), 0);
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn wrapping_rem_euclid(self, rhs: Self) -> Self {
+            #[rustc_const_unstable(feature = "const_int_euclidean")]
+            #[cfg(not(bootstrap))]
+            pub const fn wrapping_rem_euclid(self, rhs: Self) -> Self {
                 self.overflowing_rem_euclid(rhs).0
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "euclidean_division", since = "1.38.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn wrapping_rem_euclid(self, rhs: Self) -> Self {
+            self.overflowing_rem_euclid(rhs).0
         }
 
         doc_comment! {
@@ -1807,12 +1863,28 @@ assert_eq!(", stringify!($SelfT), "::MIN.overflowing_div_euclid(-1), (", stringi
             #[stable(feature = "euclidean_division", since = "1.38.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            pub fn overflowing_div_euclid(self, rhs: Self) -> (Self, bool) {
+            #[rustc_const_unstable(feature = "const_int_euclidean")]
+            #[cfg(not(bootstrap))]
+            pub const fn overflowing_div_euclid(self, rhs: Self) -> (Self, bool) {
                 if self == Self::min_value() && rhs == -1 {
                     (self, true)
                 } else {
                     (self.div_euclid(rhs), false)
                 }
+            }
+        }
+
+        /// No docs for bootstrap.
+        #[inline]
+        #[stable(feature = "euclidean_division", since = "1.38.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[cfg(bootstrap)]
+        pub fn overflowing_div_euclid(self, rhs: Self) -> (Self, bool) {
+            if self == Self::min_value() && rhs == -1 {
+                (self, true)
+            } else {
+                (self.div_euclid(rhs), false)
             }
         }
 
@@ -1890,12 +1962,28 @@ assert_eq!(", stringify!($SelfT), "::MIN.overflowing_rem_euclid(-1), (0, true));
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn overflowing_rem_euclid(self, rhs: Self) -> (Self, bool) {
+            #[rustc_const_unstable(feature = "const_int_euclidean")]
+            #[cfg(not(bootstrap))]
+            pub const fn overflowing_rem_euclid(self, rhs: Self) -> (Self, bool) {
                 if self == Self::min_value() && rhs == -1 {
                     (0, true)
                 } else {
                     (self.rem_euclid(rhs), false)
                 }
+            }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "euclidean_division", since = "1.38.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn overflowing_rem_euclid(self, rhs: Self) -> (Self, bool) {
+            if self == Self::min_value() && rhs == -1 {
+                (0, true)
+            } else {
+                (self.rem_euclid(rhs), false)
             }
         }
 
@@ -2130,13 +2218,30 @@ assert_eq!((-a).div_euclid(-b), 2); // -7 >= -4 * 2
                           without modifying the original"]
             #[inline]
             #[rustc_inherit_overflow_checks]
-            pub fn div_euclid(self, rhs: Self) -> Self {
+            #[rustc_const_unstable(feature = "const_int_euclidean")]
+            #[cfg(not(bootstrap))]
+            pub const fn div_euclid(self, rhs: Self) -> Self {
                 let q = self / rhs;
                 if self % rhs < 0 {
                     return if rhs > 0 { q - 1 } else { q + 1 }
                 }
                 q
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "euclidean_division", since = "1.38.0")]
+        #[must_use = "this returns the result of the operation, \
+                        without modifying the original"]
+        #[inline]
+        #[rustc_inherit_overflow_checks]
+        #[cfg(bootstrap)]
+        pub fn div_euclid(self, rhs: Self) -> Self {
+            let q = self / rhs;
+            if self % rhs < 0 {
+                return if rhs > 0 { q - 1 } else { q + 1 }
+            }
+            q
         }
 
 
@@ -2169,7 +2274,9 @@ assert_eq!((-a).rem_euclid(-b), 1);
                           without modifying the original"]
             #[inline]
             #[rustc_inherit_overflow_checks]
-            pub fn rem_euclid(self, rhs: Self) -> Self {
+            #[rustc_const_unstable(feature = "const_int_euclidean")]
+            #[cfg(not(bootstrap))]
+            pub const fn rem_euclid(self, rhs: Self) -> Self {
                 let r = self % rhs;
                 if r < 0 {
                     if rhs < 0 {
@@ -2180,6 +2287,26 @@ assert_eq!((-a).rem_euclid(-b), 1);
                 } else {
                     r
                 }
+            }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "euclidean_division", since = "1.38.0")]
+        #[must_use = "this returns the result of the operation, \
+                        without modifying the original"]
+        #[inline]
+        #[rustc_inherit_overflow_checks]
+        #[cfg(bootstrap)]
+        pub fn rem_euclid(self, rhs: Self) -> Self {
+            let r = self % rhs;
+            if r < 0 {
+                if rhs < 0 {
+                    r - rhs
+                } else {
+                    r + rhs
+                }
+            } else {
+                r
             }
         }
 
@@ -3092,12 +3219,28 @@ assert_eq!(1", stringify!($SelfT), ".checked_div_euclid(0), None);
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn checked_div_euclid(self, rhs: Self) -> Option<Self> {
+            #[rustc_const_unstable(feature = "const_int_euclidean")]
+            #[cfg(not(bootstrap))]
+            pub const fn checked_div_euclid(self, rhs: Self) -> Option<Self> {
                 if rhs == 0 {
                     None
                 } else {
                     Some(self.div_euclid(rhs))
                 }
+            }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "euclidean_division", since = "1.38.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn checked_div_euclid(self, rhs: Self) -> Option<Self> {
+            if rhs == 0 {
+                None
+            } else {
+                Some(self.div_euclid(rhs))
             }
         }
 
@@ -3163,12 +3306,28 @@ assert_eq!(5", stringify!($SelfT), ".checked_rem_euclid(0), None);
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn checked_rem_euclid(self, rhs: Self) -> Option<Self> {
+            #[rustc_const_unstable(feature = "const_int_euclidean")]
+            #[cfg(not(bootstrap))]
+            pub const fn checked_rem_euclid(self, rhs: Self) -> Option<Self> {
                 if rhs == 0 {
                     None
                 } else {
                     Some(self.rem_euclid(rhs))
                 }
+            }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "euclidean_division", since = "1.38.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn checked_rem_euclid(self, rhs: Self) -> Option<Self> {
+            if rhs == 0 {
+                None
+            } else {
+                Some(self.rem_euclid(rhs))
             }
         }
 
@@ -3547,9 +3706,21 @@ assert_eq!(100", stringify!($SelfT), ".wrapping_div_euclid(10), 10);
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn wrapping_div_euclid(self, rhs: Self) -> Self {
+            #[rustc_const_unstable(feature = "const_int_euclidean")]
+            #[cfg(not(bootstrap))]
+            pub const fn wrapping_div_euclid(self, rhs: Self) -> Self {
                 self / rhs
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "euclidean_division", since = "1.38.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn wrapping_div_euclid(self, rhs: Self) -> Self {
+            self / rhs
         }
 
         doc_comment! {
@@ -3610,9 +3781,21 @@ assert_eq!(100", stringify!($SelfT), ".wrapping_rem_euclid(10), 0);
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn wrapping_rem_euclid(self, rhs: Self) -> Self {
+            #[rustc_const_unstable(feature = "const_int_euclidean")]
+            #[cfg(not(bootstrap))]
+            pub const fn wrapping_rem_euclid(self, rhs: Self) -> Self {
                 self % rhs
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "euclidean_division", since = "1.38.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn wrapping_rem_euclid(self, rhs: Self) -> Self {
+            self % rhs
         }
 
         /// Wrapping (modular) negation. Computes `-self`,
@@ -3900,9 +4083,20 @@ assert_eq!(5", stringify!($SelfT), ".overflowing_div_euclid(2), (2, false));
             #[stable(feature = "euclidean_division", since = "1.38.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            pub fn overflowing_div_euclid(self, rhs: Self) -> (Self, bool) {
+            #[rustc_const_unstable(feature = "const_int_euclidean")]
+            #[cfg(not(bootstrap))]
+            pub const fn overflowing_div_euclid(self, rhs: Self) -> (Self, bool) {
                 (self / rhs, false)
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "euclidean_division", since = "1.38.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[cfg(bootstrap)]
+        pub fn overflowing_div_euclid(self, rhs: Self) -> (Self, bool) {
+            (self / rhs, false)
         }
 
         doc_comment! {
@@ -3971,9 +4165,21 @@ assert_eq!(5", stringify!($SelfT), ".overflowing_rem_euclid(2), (1, false));
             #[stable(feature = "euclidean_division", since = "1.38.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            pub fn overflowing_rem_euclid(self, rhs: Self) -> (Self, bool) {
+            #[rustc_const_unstable(feature = "const_int_euclidean")]
+            #[cfg(not(bootstrap))]
+            pub const fn overflowing_rem_euclid(self, rhs: Self) -> (Self, bool) {
                 (self % rhs, false)
             }
+        }
+
+        /// No docs for bootstrap.
+        #[inline]
+        #[stable(feature = "euclidean_division", since = "1.38.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[cfg(bootstrap)]
+        pub fn overflowing_rem_euclid(self, rhs: Self) -> (Self, bool) {
+            (self % rhs, false)
         }
 
         doc_comment! {
@@ -4166,9 +4372,22 @@ assert_eq!(7", stringify!($SelfT), ".div_euclid(4), 1); // or any other integer 
                           without modifying the original"]
             #[inline]
             #[rustc_inherit_overflow_checks]
-            pub fn div_euclid(self, rhs: Self) -> Self {
+            #[rustc_const_unstable(feature = "const_int_euclidean")]
+            #[cfg(not(bootstrap))]
+            pub const fn div_euclid(self, rhs: Self) -> Self {
                 self / rhs
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "euclidean_division", since = "1.38.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[rustc_inherit_overflow_checks]
+        #[cfg(bootstrap)]
+        pub fn div_euclid(self, rhs: Self) -> Self {
+            self / rhs
         }
 
 

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1338,9 +1338,21 @@ $EndFeature, "
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn wrapping_div(self, rhs: Self) -> Self {
+            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg(not(bootstrap))]
+            pub const fn wrapping_div(self, rhs: Self) -> Self {
                 self.overflowing_div(rhs).0
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "num_wrapping", since = "1.2.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn wrapping_div(self, rhs: Self) -> Self {
+            self.overflowing_div(rhs).0
         }
 
         doc_comment! {
@@ -1397,9 +1409,21 @@ $EndFeature, "
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn wrapping_rem(self, rhs: Self) -> Self {
+            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg(not(bootstrap))]
+            pub const fn wrapping_rem(self, rhs: Self) -> Self {
                 self.overflowing_rem(rhs).0
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "num_wrapping", since = "1.2.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn wrapping_rem(self, rhs: Self) -> Self {
+            self.overflowing_rem(rhs).0
         }
 
         doc_comment! {
@@ -3422,7 +3446,7 @@ $EndFeature, "
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_stable(feature = "const_wrapping_math", since = "1.32.0")]
         #[must_use = "this returns the result of the operation, \
-                          without modifying the original"]
+                      without modifying the original"]
         #[inline]
         pub const fn wrapping_mul(self, rhs: Self) -> Self {
             intrinsics::wrapping_mul(self, rhs)
@@ -3446,9 +3470,21 @@ Basic usage:
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn wrapping_div(self, rhs: Self) -> Self {
+            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg(not(bootstrap))]
+            pub const fn wrapping_div(self, rhs: Self) -> Self {
                 self / rhs
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "num_wrapping", since = "1.2.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn wrapping_div(self, rhs: Self) -> Self {
+            self / rhs
         }
 
         doc_comment! {
@@ -3496,9 +3532,21 @@ Basic usage:
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn wrapping_rem(self, rhs: Self) -> Self {
+            #[rustc_const_unstable(feature = "const_int_wrapping")]
+            #[cfg(not(bootstrap))]
+            pub const fn wrapping_rem(self, rhs: Self) -> Self {
                 self % rhs
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "num_wrapping", since = "1.2.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn wrapping_rem(self, rhs: Self) -> Self {
+            self % rhs
         }
 
         doc_comment! {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -659,10 +659,23 @@ $EndFeature, "
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn checked_add(self, rhs: Self) -> Option<Self> {
+            #[rustc_const_unstable(feature = "const_int_checked")]
+            #[cfg(not(bootstrap))]
+            pub const fn checked_add(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_add(rhs);
                 if b {None} else {Some(a)}
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn checked_add(self, rhs: Self) -> Option<Self> {
+            let (a, b) = self.overflowing_add(rhs);
+            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -683,10 +696,23 @@ $EndFeature, "
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn checked_sub(self, rhs: Self) -> Option<Self> {
+            #[rustc_const_unstable(feature = "const_int_checked")]
+            #[cfg(not(bootstrap))]
+            pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_sub(rhs);
                 if b {None} else {Some(a)}
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn checked_sub(self, rhs: Self) -> Option<Self> {
+            let (a, b) = self.overflowing_sub(rhs);
+            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -707,10 +733,23 @@ $EndFeature, "
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn checked_mul(self, rhs: Self) -> Option<Self> {
+            #[rustc_const_unstable(feature = "const_int_checked")]
+            #[cfg(not(bootstrap))]
+            pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_mul(rhs);
                 if b {None} else {Some(a)}
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn checked_mul(self, rhs: Self) -> Option<Self> {
+            let (a, b) = self.overflowing_mul(rhs);
+            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -732,13 +771,30 @@ $EndFeature, "
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn checked_div(self, rhs: Self) -> Option<Self> {
+            #[rustc_const_unstable(feature = "const_int_checked")]
+            #[cfg(not(bootstrap))]
+            pub const fn checked_div(self, rhs: Self) -> Option<Self> {
                 if rhs == 0 || (self == Self::min_value() && rhs == -1) {
                     None
                 } else {
                     // SAFETY: div by zero and by INT_MIN have been checked above
                     Some(unsafe { intrinsics::unchecked_div(self, rhs) })
                 }
+            }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn checked_div(self, rhs: Self) -> Option<Self> {
+            if rhs == 0 || (self == Self::min_value() && rhs == -1) {
+                None
+            } else {
+                // SAFETY: div by zero and by INT_MIN have been checked above
+                Some(unsafe { intrinsics::unchecked_div(self, rhs) })
             }
         }
 
@@ -843,10 +899,21 @@ $EndFeature, "
 ```"),
             #[stable(feature = "wrapping", since = "1.7.0")]
             #[inline]
-            pub fn checked_neg(self) -> Option<Self> {
+            #[rustc_const_unstable(feature = "const_int_checked")]
+            #[cfg(not(bootstrap))]
+            pub const fn checked_neg(self) -> Option<Self> {
                 let (a, b) = self.overflowing_neg();
                 if b {None} else {Some(a)}
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "wrapping", since = "1.7.0")]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn checked_neg(self) -> Option<Self> {
+            let (a, b) = self.overflowing_neg();
+            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -866,10 +933,24 @@ $EndFeature, "
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn checked_shl(self, rhs: u32) -> Option<Self> {
+            #[rustc_const_unstable(feature = "const_int_checked")]
+            #[cfg(not(bootstrap))]
+            pub const fn checked_shl(self, rhs: u32) -> Option<Self> {
                 let (a, b) = self.overflowing_shl(rhs);
                 if b {None} else {Some(a)}
             }
+        }
+
+
+        /// No docs for bootstrap.
+        #[stable(feature = "wrapping", since = "1.7.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn checked_shl(self, rhs: u32) -> Option<Self> {
+            let (a, b) = self.overflowing_shl(rhs);
+            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -889,10 +970,23 @@ $EndFeature, "
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn checked_shr(self, rhs: u32) -> Option<Self> {
+            #[rustc_const_unstable(feature = "const_int_checked")]
+            #[cfg(not(bootstrap))]
+            pub const fn checked_shr(self, rhs: u32) -> Option<Self> {
                 let (a, b) = self.overflowing_shr(rhs);
                 if b {None} else {Some(a)}
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "wrapping", since = "1.7.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn checked_shr(self, rhs: u32) -> Option<Self> {
+            let (a, b) = self.overflowing_shr(rhs);
+            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -912,12 +1006,26 @@ $EndFeature, "
 ```"),
             #[stable(feature = "no_panic_abs", since = "1.13.0")]
             #[inline]
-            pub fn checked_abs(self) -> Option<Self> {
+            #[rustc_const_unstable(feature = "const_int_checked")]
+            #[cfg(not(bootstrap))]
+            pub const fn checked_abs(self) -> Option<Self> {
                 if self.is_negative() {
                     self.checked_neg()
                 } else {
                     Some(self)
                 }
+            }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "no_panic_abs", since = "1.13.0")]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn checked_abs(self) -> Option<Self> {
+            if self.is_negative() {
+                self.checked_neg()
+            } else {
+                Some(self)
             }
         }
 
@@ -1035,8 +1143,11 @@ $EndFeature, "
 ```"),
 
             #[unstable(feature = "saturating_neg", issue = "59983")]
+            #[rustc_const_unstable(feature = "const_saturating_int_methods")]
+            #[must_use = "this returns the result of the operation, \
+                          without modifying the original"]
             #[inline]
-            pub fn saturating_neg(self) -> Self {
+            pub const fn saturating_neg(self) -> Self {
                 intrinsics::saturating_sub(0, self)
             }
         }
@@ -2782,10 +2893,23 @@ assert_eq!((", stringify!($SelfT), "::max_value() - 2).checked_add(3), None);", 
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn checked_add(self, rhs: Self) -> Option<Self> {
+            #[rustc_const_unstable(feature = "const_int_checked")]
+            #[cfg(not(bootstrap))]
+            pub const fn checked_add(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_add(rhs);
                 if b {None} else {Some(a)}
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn checked_add(self, rhs: Self) -> Option<Self> {
+            let (a, b) = self.overflowing_add(rhs);
+            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -2804,10 +2928,23 @@ assert_eq!(0", stringify!($SelfT), ".checked_sub(1), None);", $EndFeature, "
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn checked_sub(self, rhs: Self) -> Option<Self> {
+            #[rustc_const_unstable(feature = "const_int_checked")]
+            #[cfg(not(bootstrap))]
+            pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_sub(rhs);
                 if b {None} else {Some(a)}
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn checked_sub(self, rhs: Self) -> Option<Self> {
+            let (a, b) = self.overflowing_sub(rhs);
+            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -2826,10 +2963,23 @@ assert_eq!(", stringify!($SelfT), "::max_value().checked_mul(2), None);", $EndFe
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn checked_mul(self, rhs: Self) -> Option<Self> {
+            #[rustc_const_unstable(feature = "const_int_checked")]
+            #[cfg(not(bootstrap))]
+            pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_mul(rhs);
                 if b {None} else {Some(a)}
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn checked_mul(self, rhs: Self) -> Option<Self> {
+            let (a, b) = self.overflowing_mul(rhs);
+            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -2848,13 +2998,30 @@ assert_eq!(1", stringify!($SelfT), ".checked_div(0), None);", $EndFeature, "
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn checked_div(self, rhs: Self) -> Option<Self> {
+            #[rustc_const_unstable(feature = "const_int_checked")]
+            #[cfg(not(bootstrap))]
+            pub const fn checked_div(self, rhs: Self) -> Option<Self> {
                 match rhs {
                     0 => None,
                     // SAFETY: div by zero has been checked above and unsigned types have no other
                     // failure modes for division
                     rhs => Some(unsafe { intrinsics::unchecked_div(self, rhs) }),
                 }
+            }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn checked_div(self, rhs: Self) -> Option<Self> {
+            match rhs {
+                0 => None,
+                // SAFETY: div by zero has been checked above and unsigned types have no other
+                // failure modes for division
+                rhs => Some(unsafe { intrinsics::unchecked_div(self, rhs) }),
             }
         }
 
@@ -2900,7 +3067,9 @@ assert_eq!(5", stringify!($SelfT), ".checked_rem(0), None);", $EndFeature, "
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn checked_rem(self, rhs: Self) -> Option<Self> {
+            #[rustc_const_unstable(feature = "const_int_checked")]
+            #[cfg(not(bootstrap))]
+            pub const fn checked_rem(self, rhs: Self) -> Option<Self> {
                 if rhs == 0 {
                     None
                 } else {
@@ -2908,6 +3077,22 @@ assert_eq!(5", stringify!($SelfT), ".checked_rem(0), None);", $EndFeature, "
                     // failure modes for division
                     Some(unsafe { intrinsics::unchecked_rem(self, rhs) })
                 }
+            }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "wrapping", since = "1.7.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn checked_rem(self, rhs: Self) -> Option<Self> {
+            if rhs == 0 {
+                None
+            } else {
+                // SAFETY: div by zero has been checked above and unsigned types have no other
+                // failure modes for division
+                Some(unsafe { intrinsics::unchecked_rem(self, rhs) })
             }
         }
 
@@ -2952,10 +3137,21 @@ assert_eq!(1", stringify!($SelfT), ".checked_neg(), None);", $EndFeature, "
 ```"),
             #[stable(feature = "wrapping", since = "1.7.0")]
             #[inline]
-            pub fn checked_neg(self) -> Option<Self> {
+            #[rustc_const_unstable(feature = "const_int_checked")]
+            #[cfg(not(bootstrap))]
+            pub const fn checked_neg(self) -> Option<Self> {
                 let (a, b) = self.overflowing_neg();
                 if b {None} else {Some(a)}
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "wrapping", since = "1.7.0")]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn checked_neg(self) -> Option<Self> {
+            let (a, b) = self.overflowing_neg();
+            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -2974,10 +3170,23 @@ assert_eq!(0x10", stringify!($SelfT), ".checked_shl(129), None);", $EndFeature, 
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn checked_shl(self, rhs: u32) -> Option<Self> {
+            #[rustc_const_unstable(feature = "const_int_checked")]
+            #[cfg(not(bootstrap))]
+            pub const fn checked_shl(self, rhs: u32) -> Option<Self> {
                 let (a, b) = self.overflowing_shl(rhs);
                 if b {None} else {Some(a)}
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "wrapping", since = "1.7.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn checked_shl(self, rhs: u32) -> Option<Self> {
+            let (a, b) = self.overflowing_shl(rhs);
+            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -2996,10 +3205,23 @@ assert_eq!(0x10", stringify!($SelfT), ".checked_shr(129), None);", $EndFeature, 
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub fn checked_shr(self, rhs: u32) -> Option<Self> {
+            #[rustc_const_unstable(feature = "const_int_checked")]
+            #[cfg(not(bootstrap))]
+            pub const fn checked_shr(self, rhs: u32) -> Option<Self> {
                 let (a, b) = self.overflowing_shr(rhs);
                 if b {None} else {Some(a)}
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "wrapping", since = "1.7.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[cfg(bootstrap)]
+        pub fn checked_shr(self, rhs: u32) -> Option<Self> {
+            let (a, b) = self.overflowing_shr(rhs);
+            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -3518,7 +3740,7 @@ $EndFeature, "
         #[stable(feature = "wrapping", since = "1.7.0")]
         #[rustc_const_stable(feature = "const_wrapping_math", since = "1.32.0")]
         #[must_use = "this returns the result of the operation, \
-                          without modifying the original"]
+                      without modifying the original"]
         #[inline]
         pub const fn overflowing_mul(self, rhs: Self) -> (Self, bool) {
             let (a, b) = intrinsics::mul_with_overflow(self as $ActualT, rhs as $ActualT);
@@ -3808,7 +4030,7 @@ Basic usage:
 ```"),
         #[stable(feature = "rust1", since = "1.0.0")]
         #[must_use = "this returns the result of the operation, \
-                          without modifying the original"]
+                      without modifying the original"]
         #[inline]
         #[rustc_inherit_overflow_checks]
         pub fn pow(self, mut exp: u32) -> Self {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -2232,7 +2232,7 @@ assert_eq!((-a).div_euclid(-b), 2); // -7 >= -4 * 2
         /// No docs for bootstrap.
         #[stable(feature = "euclidean_division", since = "1.38.0")]
         #[must_use = "this returns the result of the operation, \
-                        without modifying the original"]
+                      without modifying the original"]
         #[inline]
         #[rustc_inherit_overflow_checks]
         #[cfg(bootstrap)]
@@ -4414,9 +4414,22 @@ assert_eq!(7", stringify!($SelfT), ".rem_euclid(4), 3); // or any other integer 
                           without modifying the original"]
             #[inline]
             #[rustc_inherit_overflow_checks]
-            pub fn rem_euclid(self, rhs: Self) -> Self {
+            #[rustc_const_unstable(feature = "const_int_euclidean")]
+            #[cfg(not(bootstrap))]
+            pub const fn rem_euclid(self, rhs: Self) -> Self {
                 self % rhs
             }
+        }
+
+        /// No docs for bootstrap.
+        #[stable(feature = "euclidean_division", since = "1.38.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[rustc_inherit_overflow_checks]
+        #[cfg(bootstrap)]
+        pub fn rem_euclid(self, rhs: Self) -> Self {
+            self % rhs
         }
 
         doc_comment! {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1595,12 +1595,28 @@ $EndFeature, "
             #[stable(feature = "wrapping", since = "1.7.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            pub fn overflowing_div(self, rhs: Self) -> (Self, bool) {
+            #[rustc_const_unstable(feature = "const_int_overflowing")]
+            #[cfg(not(bootstrap))]
+            pub const fn overflowing_div(self, rhs: Self) -> (Self, bool) {
                 if self == Self::min_value() && rhs == -1 {
                     (self, true)
                 } else {
                     (self / rhs, false)
                 }
+            }
+        }
+
+        /// No docs for bootstrap.
+        #[inline]
+        #[stable(feature = "wrapping", since = "1.7.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[cfg(bootstrap)]
+        pub fn overflowing_div(self, rhs: Self) -> (Self, bool) {
+            if self == Self::min_value() && rhs == -1 {
+                (self, true)
+            } else {
+                (self / rhs, false)
             }
         }
 
@@ -1663,7 +1679,9 @@ $EndFeature, "
             #[stable(feature = "wrapping", since = "1.7.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            pub fn overflowing_rem(self, rhs: Self) -> (Self, bool) {
+            #[rustc_const_unstable(feature = "const_int_overflowing")]
+            #[cfg(not(bootstrap))]
+            pub const fn overflowing_rem(self, rhs: Self) -> (Self, bool) {
                 if self == Self::min_value() && rhs == -1 {
                     (0, true)
                 } else {
@@ -1672,6 +1690,19 @@ $EndFeature, "
             }
         }
 
+        /// No docs for bootstrap.
+        #[inline]
+        #[stable(feature = "wrapping", since = "1.7.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[cfg(bootstrap)]
+        pub fn overflowing_rem(self, rhs: Self) -> (Self, bool) {
+            if self == Self::min_value() && rhs == -1 {
+                (0, true)
+            } else {
+                (self % rhs, false)
+            }
+        }
 
         doc_comment! {
             concat!("Overflowing Euclidean remainder. Calculates `self.rem_euclid(rhs)`.
@@ -3517,9 +3548,21 @@ Basic usage
             #[stable(feature = "wrapping", since = "1.7.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            pub fn overflowing_div(self, rhs: Self) -> (Self, bool) {
+            #[rustc_const_unstable(feature = "const_int_overflowing")]
+            #[cfg(not(bootstrap))]
+            pub const fn overflowing_div(self, rhs: Self) -> (Self, bool) {
                 (self / rhs, false)
             }
+        }
+
+        /// No docs for bootstrap.
+        #[inline]
+        #[stable(feature = "wrapping", since = "1.7.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[cfg(bootstrap)]
+        pub fn overflowing_div(self, rhs: Self) -> (Self, bool) {
+            (self / rhs, false)
         }
 
         doc_comment! {
@@ -3576,9 +3619,21 @@ Basic usage
             #[stable(feature = "wrapping", since = "1.7.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            pub fn overflowing_rem(self, rhs: Self) -> (Self, bool) {
+            #[rustc_const_unstable(feature = "const_int_overflowing")]
+            #[cfg(not(bootstrap))]
+            pub const fn overflowing_rem(self, rhs: Self) -> (Self, bool) {
                 (self % rhs, false)
             }
+        }
+
+        /// No docs for bootstrap.
+        #[inline]
+        #[stable(feature = "wrapping", since = "1.7.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[cfg(bootstrap)]
+        pub fn overflowing_rem(self, rhs: Self) -> (Self, bool) {
+            (self % rhs, false)
         }
 
         doc_comment! {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -71,24 +71,10 @@ assert_eq!(size_of::<Option<core::num::", stringify!($Ty), ">>(), size_of::<", s
                 #[$stability]
                 #[inline]
                 #[rustc_const_unstable(feature = "const_int_nonzero")]
-                #[cfg(not(bootstrap))]
                 pub const fn new(n: $Int) -> Option<Self> {
                     if n != 0 {
                         // SAFETY: we just checked that there's no `0`
                         Some(unsafe { $Ty(n) })
-                    } else {
-                        None
-                    }
-                }
-
-                /// No docs for bootstrap.
-                #[$stability]
-                #[inline]
-                #[cfg(bootstrap)]
-                pub fn new(n: $Int) -> Option<Self> {
-                    if n != 0 {
-                        // SAFETY: we just checked that there's no `0`
-                        Some(unsafe { Self(n) })
                     } else {
                         None
                     }
@@ -660,22 +646,10 @@ $EndFeature, "
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_checked")]
-            #[cfg(not(bootstrap))]
             pub const fn checked_add(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_add(rhs);
                 if b {None} else {Some(a)}
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn checked_add(self, rhs: Self) -> Option<Self> {
-            let (a, b) = self.overflowing_add(rhs);
-            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -697,22 +671,10 @@ $EndFeature, "
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_checked")]
-            #[cfg(not(bootstrap))]
             pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_sub(rhs);
                 if b {None} else {Some(a)}
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn checked_sub(self, rhs: Self) -> Option<Self> {
-            let (a, b) = self.overflowing_sub(rhs);
-            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -734,22 +696,10 @@ $EndFeature, "
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_checked")]
-            #[cfg(not(bootstrap))]
             pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_mul(rhs);
                 if b {None} else {Some(a)}
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn checked_mul(self, rhs: Self) -> Option<Self> {
-            let (a, b) = self.overflowing_mul(rhs);
-            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -772,7 +722,6 @@ $EndFeature, "
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_checked")]
-            #[cfg(not(bootstrap))]
             pub const fn checked_div(self, rhs: Self) -> Option<Self> {
                 if rhs == 0 || (self == Self::min_value() && rhs == -1) {
                     None
@@ -780,21 +729,6 @@ $EndFeature, "
                     // SAFETY: div by zero and by INT_MIN have been checked above
                     Some(unsafe { intrinsics::unchecked_div(self, rhs) })
                 }
-            }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn checked_div(self, rhs: Self) -> Option<Self> {
-            if rhs == 0 || (self == Self::min_value() && rhs == -1) {
-                None
-            } else {
-                // SAFETY: div by zero and by INT_MIN have been checked above
-                Some(unsafe { intrinsics::unchecked_div(self, rhs) })
             }
         }
 
@@ -817,27 +751,12 @@ assert_eq!((1", stringify!($SelfT), ").checked_div_euclid(0), None);
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_euclidean")]
-            #[cfg(not(bootstrap))]
             pub const fn checked_div_euclid(self, rhs: Self) -> Option<Self> {
                 if rhs == 0 || (self == Self::min_value() && rhs == -1) {
                     None
                 } else {
                     Some(self.div_euclid(rhs))
                 }
-            }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "euclidean_division", since = "1.38.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn checked_div_euclid(self, rhs: Self) -> Option<Self> {
-            if rhs == 0 || (self == Self::min_value() && rhs == -1) {
-                None
-            } else {
-                Some(self.div_euclid(rhs))
             }
         }
 
@@ -891,27 +810,12 @@ assert_eq!(", stringify!($SelfT), "::MIN.checked_rem_euclid(-1), None);
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_euclidean")]
-            #[cfg(not(bootstrap))]
             pub const fn checked_rem_euclid(self, rhs: Self) -> Option<Self> {
                 if rhs == 0 || (self == Self::min_value() && rhs == -1) {
                     None
                 } else {
                     Some(self.rem_euclid(rhs))
                 }
-            }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "euclidean_division", since = "1.38.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn checked_rem_euclid(self, rhs: Self) -> Option<Self> {
-            if rhs == 0 || (self == Self::min_value() && rhs == -1) {
-                None
-            } else {
-                Some(self.rem_euclid(rhs))
             }
         }
 
@@ -932,20 +836,10 @@ $EndFeature, "
             #[stable(feature = "wrapping", since = "1.7.0")]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_checked")]
-            #[cfg(not(bootstrap))]
             pub const fn checked_neg(self) -> Option<Self> {
                 let (a, b) = self.overflowing_neg();
                 if b {None} else {Some(a)}
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "wrapping", since = "1.7.0")]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn checked_neg(self) -> Option<Self> {
-            let (a, b) = self.overflowing_neg();
-            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -966,24 +860,12 @@ $EndFeature, "
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_checked")]
-            #[cfg(not(bootstrap))]
             pub const fn checked_shl(self, rhs: u32) -> Option<Self> {
                 let (a, b) = self.overflowing_shl(rhs);
                 if b {None} else {Some(a)}
             }
         }
 
-
-        /// No docs for bootstrap.
-        #[stable(feature = "wrapping", since = "1.7.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn checked_shl(self, rhs: u32) -> Option<Self> {
-            let (a, b) = self.overflowing_shl(rhs);
-            if b {None} else {Some(a)}
-        }
 
         doc_comment! {
             concat!("Checked shift right. Computes `self >> rhs`, returning `None` if `rhs` is
@@ -1003,22 +885,10 @@ $EndFeature, "
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_checked")]
-            #[cfg(not(bootstrap))]
             pub const fn checked_shr(self, rhs: u32) -> Option<Self> {
                 let (a, b) = self.overflowing_shr(rhs);
                 if b {None} else {Some(a)}
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "wrapping", since = "1.7.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn checked_shr(self, rhs: u32) -> Option<Self> {
-            let (a, b) = self.overflowing_shr(rhs);
-            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -1039,25 +909,12 @@ $EndFeature, "
             #[stable(feature = "no_panic_abs", since = "1.13.0")]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_checked")]
-            #[cfg(not(bootstrap))]
             pub const fn checked_abs(self) -> Option<Self> {
                 if self.is_negative() {
                     self.checked_neg()
                 } else {
                     Some(self)
                 }
-            }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "no_panic_abs", since = "1.13.0")]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn checked_abs(self) -> Option<Self> {
-            if self.is_negative() {
-                self.checked_neg()
-            } else {
-                Some(self)
             }
         }
 
@@ -1238,7 +1095,6 @@ $EndFeature, "
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_saturating")]
-            #[cfg(not(bootstrap))]
             pub const fn saturating_mul(self, rhs: Self) -> Self {
                 match self.checked_mul(rhs) {
                     Some(r) => r,
@@ -1250,25 +1106,6 @@ $EndFeature, "
                         }
                     },
                 }
-            }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "wrapping", since = "1.7.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn saturating_mul(self, rhs: Self) -> Self {
-            match self.checked_mul(rhs) {
-                Some(r) => r,
-                None => {
-                    if (self < 0) == (rhs < 0) {
-                        Self::max_value()
-                    } else {
-                        Self::min_value()
-                    }
-                },
             }
         }
 
@@ -1398,20 +1235,9 @@ $EndFeature, "
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_wrapping")]
-            #[cfg(not(bootstrap))]
             pub const fn wrapping_div(self, rhs: Self) -> Self {
                 self.overflowing_div(rhs).0
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "num_wrapping", since = "1.2.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn wrapping_div(self, rhs: Self) -> Self {
-            self.overflowing_div(rhs).0
         }
 
         doc_comment! {
@@ -1439,20 +1265,9 @@ assert_eq!((-128i8).wrapping_div_euclid(-1), -128);
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_euclidean")]
-            #[cfg(not(bootstrap))]
             pub const fn wrapping_div_euclid(self, rhs: Self) -> Self {
                 self.overflowing_div_euclid(rhs).0
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "euclidean_division", since = "1.38.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn wrapping_div_euclid(self, rhs: Self) -> Self {
-            self.overflowing_div_euclid(rhs).0
         }
 
         doc_comment! {
@@ -1481,20 +1296,9 @@ $EndFeature, "
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_wrapping")]
-            #[cfg(not(bootstrap))]
             pub const fn wrapping_rem(self, rhs: Self) -> Self {
                 self.overflowing_rem(rhs).0
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "num_wrapping", since = "1.2.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn wrapping_rem(self, rhs: Self) -> Self {
-            self.overflowing_rem(rhs).0
         }
 
         doc_comment! {
@@ -1521,20 +1325,9 @@ assert_eq!((-128i8).wrapping_rem_euclid(-1), 0);
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_euclidean")]
-            #[cfg(not(bootstrap))]
             pub const fn wrapping_rem_euclid(self, rhs: Self) -> Self {
                 self.overflowing_rem_euclid(rhs).0
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "euclidean_division", since = "1.38.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn wrapping_rem_euclid(self, rhs: Self) -> Self {
-            self.overflowing_rem_euclid(rhs).0
         }
 
         doc_comment! {
@@ -1814,27 +1607,12 @@ $EndFeature, "
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[rustc_const_unstable(feature = "const_int_overflowing")]
-            #[cfg(not(bootstrap))]
             pub const fn overflowing_div(self, rhs: Self) -> (Self, bool) {
                 if self == Self::min_value() && rhs == -1 {
                     (self, true)
                 } else {
                     (self / rhs, false)
                 }
-            }
-        }
-
-        /// No docs for bootstrap.
-        #[inline]
-        #[stable(feature = "wrapping", since = "1.7.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[cfg(bootstrap)]
-        pub fn overflowing_div(self, rhs: Self) -> (Self, bool) {
-            if self == Self::min_value() && rhs == -1 {
-                (self, true)
-            } else {
-                (self / rhs, false)
             }
         }
 
@@ -1864,27 +1642,12 @@ assert_eq!(", stringify!($SelfT), "::MIN.overflowing_div_euclid(-1), (", stringi
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[rustc_const_unstable(feature = "const_int_euclidean")]
-            #[cfg(not(bootstrap))]
             pub const fn overflowing_div_euclid(self, rhs: Self) -> (Self, bool) {
                 if self == Self::min_value() && rhs == -1 {
                     (self, true)
                 } else {
                     (self.div_euclid(rhs), false)
                 }
-            }
-        }
-
-        /// No docs for bootstrap.
-        #[inline]
-        #[stable(feature = "euclidean_division", since = "1.38.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[cfg(bootstrap)]
-        pub fn overflowing_div_euclid(self, rhs: Self) -> (Self, bool) {
-            if self == Self::min_value() && rhs == -1 {
-                (self, true)
-            } else {
-                (self.div_euclid(rhs), false)
             }
         }
 
@@ -1914,27 +1677,12 @@ $EndFeature, "
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[rustc_const_unstable(feature = "const_int_overflowing")]
-            #[cfg(not(bootstrap))]
             pub const fn overflowing_rem(self, rhs: Self) -> (Self, bool) {
                 if self == Self::min_value() && rhs == -1 {
                     (0, true)
                 } else {
                     (self % rhs, false)
                 }
-            }
-        }
-
-        /// No docs for bootstrap.
-        #[inline]
-        #[stable(feature = "wrapping", since = "1.7.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[cfg(bootstrap)]
-        pub fn overflowing_rem(self, rhs: Self) -> (Self, bool) {
-            if self == Self::min_value() && rhs == -1 {
-                (0, true)
-            } else {
-                (self % rhs, false)
             }
         }
 
@@ -1963,7 +1711,6 @@ assert_eq!(", stringify!($SelfT), "::MIN.overflowing_rem_euclid(-1), (0, true));
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_euclidean")]
-            #[cfg(not(bootstrap))]
             pub const fn overflowing_rem_euclid(self, rhs: Self) -> (Self, bool) {
                 if self == Self::min_value() && rhs == -1 {
                     (0, true)
@@ -1972,21 +1719,6 @@ assert_eq!(", stringify!($SelfT), "::MIN.overflowing_rem_euclid(-1), (0, true));
                 }
             }
         }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "euclidean_division", since = "1.38.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn overflowing_rem_euclid(self, rhs: Self) -> (Self, bool) {
-            if self == Self::min_value() && rhs == -1 {
-                (0, true)
-            } else {
-                (self.rem_euclid(rhs), false)
-            }
-        }
-
 
         doc_comment! {
             concat!("Negates self, overflowing if this is equal to the minimum value.
@@ -2219,7 +1951,6 @@ assert_eq!((-a).div_euclid(-b), 2); // -7 >= -4 * 2
             #[inline]
             #[rustc_inherit_overflow_checks]
             #[rustc_const_unstable(feature = "const_int_euclidean")]
-            #[cfg(not(bootstrap))]
             pub const fn div_euclid(self, rhs: Self) -> Self {
                 let q = self / rhs;
                 if self % rhs < 0 {
@@ -2228,22 +1959,6 @@ assert_eq!((-a).div_euclid(-b), 2); // -7 >= -4 * 2
                 q
             }
         }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "euclidean_division", since = "1.38.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[rustc_inherit_overflow_checks]
-        #[cfg(bootstrap)]
-        pub fn div_euclid(self, rhs: Self) -> Self {
-            let q = self / rhs;
-            if self % rhs < 0 {
-                return if rhs > 0 { q - 1 } else { q + 1 }
-            }
-            q
-        }
-
 
         doc_comment! {
             concat!("Calculates the least nonnegative remainder of `self (mod rhs)`.
@@ -2275,7 +1990,6 @@ assert_eq!((-a).rem_euclid(-b), 1);
             #[inline]
             #[rustc_inherit_overflow_checks]
             #[rustc_const_unstable(feature = "const_int_euclidean")]
-            #[cfg(not(bootstrap))]
             pub const fn rem_euclid(self, rhs: Self) -> Self {
                 let r = self % rhs;
                 if r < 0 {
@@ -2287,26 +2001,6 @@ assert_eq!((-a).rem_euclid(-b), 1);
                 } else {
                     r
                 }
-            }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "euclidean_division", since = "1.38.0")]
-        #[must_use = "this returns the result of the operation, \
-                        without modifying the original"]
-        #[inline]
-        #[rustc_inherit_overflow_checks]
-        #[cfg(bootstrap)]
-        pub fn rem_euclid(self, rhs: Self) -> Self {
-            let r = self % rhs;
-            if r < 0 {
-                if rhs < 0 {
-                    r - rhs
-                } else {
-                    r + rhs
-                }
-            } else {
-                r
             }
         }
 
@@ -3072,22 +2766,10 @@ assert_eq!((", stringify!($SelfT), "::max_value() - 2).checked_add(3), None);", 
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_checked")]
-            #[cfg(not(bootstrap))]
             pub const fn checked_add(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_add(rhs);
                 if b {None} else {Some(a)}
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn checked_add(self, rhs: Self) -> Option<Self> {
-            let (a, b) = self.overflowing_add(rhs);
-            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -3107,22 +2789,10 @@ assert_eq!(0", stringify!($SelfT), ".checked_sub(1), None);", $EndFeature, "
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_checked")]
-            #[cfg(not(bootstrap))]
             pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_sub(rhs);
                 if b {None} else {Some(a)}
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn checked_sub(self, rhs: Self) -> Option<Self> {
-            let (a, b) = self.overflowing_sub(rhs);
-            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -3142,22 +2812,10 @@ assert_eq!(", stringify!($SelfT), "::max_value().checked_mul(2), None);", $EndFe
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_checked")]
-            #[cfg(not(bootstrap))]
             pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_mul(rhs);
                 if b {None} else {Some(a)}
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn checked_mul(self, rhs: Self) -> Option<Self> {
-            let (a, b) = self.overflowing_mul(rhs);
-            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -3177,7 +2835,6 @@ assert_eq!(1", stringify!($SelfT), ".checked_div(0), None);", $EndFeature, "
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_checked")]
-            #[cfg(not(bootstrap))]
             pub const fn checked_div(self, rhs: Self) -> Option<Self> {
                 match rhs {
                     0 => None,
@@ -3185,21 +2842,6 @@ assert_eq!(1", stringify!($SelfT), ".checked_div(0), None);", $EndFeature, "
                     // failure modes for division
                     rhs => Some(unsafe { intrinsics::unchecked_div(self, rhs) }),
                 }
-            }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn checked_div(self, rhs: Self) -> Option<Self> {
-            match rhs {
-                0 => None,
-                // SAFETY: div by zero has been checked above and unsigned types have no other
-                // failure modes for division
-                rhs => Some(unsafe { intrinsics::unchecked_div(self, rhs) }),
             }
         }
 
@@ -3220,7 +2862,6 @@ assert_eq!(1", stringify!($SelfT), ".checked_div_euclid(0), None);
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_euclidean")]
-            #[cfg(not(bootstrap))]
             pub const fn checked_div_euclid(self, rhs: Self) -> Option<Self> {
                 if rhs == 0 {
                     None
@@ -3229,21 +2870,6 @@ assert_eq!(1", stringify!($SelfT), ".checked_div_euclid(0), None);
                 }
             }
         }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "euclidean_division", since = "1.38.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn checked_div_euclid(self, rhs: Self) -> Option<Self> {
-            if rhs == 0 {
-                None
-            } else {
-                Some(self.div_euclid(rhs))
-            }
-        }
-
 
         doc_comment! {
             concat!("Checked integer remainder. Computes `self % rhs`, returning `None`
@@ -3262,7 +2888,6 @@ assert_eq!(5", stringify!($SelfT), ".checked_rem(0), None);", $EndFeature, "
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_checked")]
-            #[cfg(not(bootstrap))]
             pub const fn checked_rem(self, rhs: Self) -> Option<Self> {
                 if rhs == 0 {
                     None
@@ -3271,22 +2896,6 @@ assert_eq!(5", stringify!($SelfT), ".checked_rem(0), None);", $EndFeature, "
                     // failure modes for division
                     Some(unsafe { intrinsics::unchecked_rem(self, rhs) })
                 }
-            }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "wrapping", since = "1.7.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn checked_rem(self, rhs: Self) -> Option<Self> {
-            if rhs == 0 {
-                None
-            } else {
-                // SAFETY: div by zero has been checked above and unsigned types have no other
-                // failure modes for division
-                Some(unsafe { intrinsics::unchecked_rem(self, rhs) })
             }
         }
 
@@ -3307,27 +2916,12 @@ assert_eq!(5", stringify!($SelfT), ".checked_rem_euclid(0), None);
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_euclidean")]
-            #[cfg(not(bootstrap))]
             pub const fn checked_rem_euclid(self, rhs: Self) -> Option<Self> {
                 if rhs == 0 {
                     None
                 } else {
                     Some(self.rem_euclid(rhs))
                 }
-            }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "euclidean_division", since = "1.38.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn checked_rem_euclid(self, rhs: Self) -> Option<Self> {
-            if rhs == 0 {
-                None
-            } else {
-                Some(self.rem_euclid(rhs))
             }
         }
 
@@ -3348,20 +2942,10 @@ assert_eq!(1", stringify!($SelfT), ".checked_neg(), None);", $EndFeature, "
             #[stable(feature = "wrapping", since = "1.7.0")]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_checked")]
-            #[cfg(not(bootstrap))]
             pub const fn checked_neg(self) -> Option<Self> {
                 let (a, b) = self.overflowing_neg();
                 if b {None} else {Some(a)}
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "wrapping", since = "1.7.0")]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn checked_neg(self) -> Option<Self> {
-            let (a, b) = self.overflowing_neg();
-            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -3381,22 +2965,10 @@ assert_eq!(0x10", stringify!($SelfT), ".checked_shl(129), None);", $EndFeature, 
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_checked")]
-            #[cfg(not(bootstrap))]
             pub const fn checked_shl(self, rhs: u32) -> Option<Self> {
                 let (a, b) = self.overflowing_shl(rhs);
                 if b {None} else {Some(a)}
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "wrapping", since = "1.7.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn checked_shl(self, rhs: u32) -> Option<Self> {
-            let (a, b) = self.overflowing_shl(rhs);
-            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -3416,22 +2988,10 @@ assert_eq!(0x10", stringify!($SelfT), ".checked_shr(129), None);", $EndFeature, 
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_checked")]
-            #[cfg(not(bootstrap))]
             pub const fn checked_shr(self, rhs: u32) -> Option<Self> {
                 let (a, b) = self.overflowing_shr(rhs);
                 if b {None} else {Some(a)}
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "wrapping", since = "1.7.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn checked_shr(self, rhs: u32) -> Option<Self> {
-            let (a, b) = self.overflowing_shr(rhs);
-            if b {None} else {Some(a)}
         }
 
         doc_comment! {
@@ -3538,20 +3098,9 @@ assert_eq!((", stringify!($SelfT), "::MAX).saturating_mul(10), ", stringify!($Se
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_saturating")]
-            #[cfg(not(bootstrap))]
             pub const fn saturating_mul(self, rhs: Self) -> Self {
                 self.checked_mul(rhs).unwrap_or(Self::max_value())
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "wrapping", since = "1.7.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn saturating_mul(self, rhs: Self) -> Self {
-            self.checked_mul(rhs).unwrap_or(Self::max_value())
         }
 
         doc_comment! {
@@ -3669,20 +3218,9 @@ Basic usage:
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_wrapping")]
-            #[cfg(not(bootstrap))]
             pub const fn wrapping_div(self, rhs: Self) -> Self {
                 self / rhs
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "num_wrapping", since = "1.2.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn wrapping_div(self, rhs: Self) -> Self {
-            self / rhs
         }
 
         doc_comment! {
@@ -3707,20 +3245,9 @@ assert_eq!(100", stringify!($SelfT), ".wrapping_div_euclid(10), 10);
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_euclidean")]
-            #[cfg(not(bootstrap))]
             pub const fn wrapping_div_euclid(self, rhs: Self) -> Self {
                 self / rhs
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "euclidean_division", since = "1.38.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn wrapping_div_euclid(self, rhs: Self) -> Self {
-            self / rhs
         }
 
         doc_comment! {
@@ -3743,20 +3270,9 @@ Basic usage:
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_wrapping")]
-            #[cfg(not(bootstrap))]
             pub const fn wrapping_rem(self, rhs: Self) -> Self {
                 self % rhs
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "num_wrapping", since = "1.2.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn wrapping_rem(self, rhs: Self) -> Self {
-            self % rhs
         }
 
         doc_comment! {
@@ -3782,20 +3298,9 @@ assert_eq!(100", stringify!($SelfT), ".wrapping_rem_euclid(10), 0);
                           without modifying the original"]
             #[inline]
             #[rustc_const_unstable(feature = "const_int_euclidean")]
-            #[cfg(not(bootstrap))]
             pub const fn wrapping_rem_euclid(self, rhs: Self) -> Self {
                 self % rhs
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "euclidean_division", since = "1.38.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[cfg(bootstrap)]
-        pub fn wrapping_rem_euclid(self, rhs: Self) -> Self {
-            self % rhs
         }
 
         /// Wrapping (modular) negation. Computes `-self`,
@@ -4041,20 +3546,9 @@ Basic usage
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[rustc_const_unstable(feature = "const_int_overflowing")]
-            #[cfg(not(bootstrap))]
             pub const fn overflowing_div(self, rhs: Self) -> (Self, bool) {
                 (self / rhs, false)
             }
-        }
-
-        /// No docs for bootstrap.
-        #[inline]
-        #[stable(feature = "wrapping", since = "1.7.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[cfg(bootstrap)]
-        pub fn overflowing_div(self, rhs: Self) -> (Self, bool) {
-            (self / rhs, false)
         }
 
         doc_comment! {
@@ -4084,19 +3578,9 @@ assert_eq!(5", stringify!($SelfT), ".overflowing_div_euclid(2), (2, false));
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[rustc_const_unstable(feature = "const_int_euclidean")]
-            #[cfg(not(bootstrap))]
             pub const fn overflowing_div_euclid(self, rhs: Self) -> (Self, bool) {
                 (self / rhs, false)
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "euclidean_division", since = "1.38.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[cfg(bootstrap)]
-        pub fn overflowing_div_euclid(self, rhs: Self) -> (Self, bool) {
-            (self / rhs, false)
         }
 
         doc_comment! {
@@ -4123,20 +3607,9 @@ Basic usage
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[rustc_const_unstable(feature = "const_int_overflowing")]
-            #[cfg(not(bootstrap))]
             pub const fn overflowing_rem(self, rhs: Self) -> (Self, bool) {
                 (self % rhs, false)
             }
-        }
-
-        /// No docs for bootstrap.
-        #[inline]
-        #[stable(feature = "wrapping", since = "1.7.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[cfg(bootstrap)]
-        pub fn overflowing_rem(self, rhs: Self) -> (Self, bool) {
-            (self % rhs, false)
         }
 
         doc_comment! {
@@ -4166,20 +3639,9 @@ assert_eq!(5", stringify!($SelfT), ".overflowing_rem_euclid(2), (1, false));
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[rustc_const_unstable(feature = "const_int_euclidean")]
-            #[cfg(not(bootstrap))]
             pub const fn overflowing_rem_euclid(self, rhs: Self) -> (Self, bool) {
                 (self % rhs, false)
             }
-        }
-
-        /// No docs for bootstrap.
-        #[inline]
-        #[stable(feature = "euclidean_division", since = "1.38.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[cfg(bootstrap)]
-        pub fn overflowing_rem_euclid(self, rhs: Self) -> (Self, bool) {
-            (self % rhs, false)
         }
 
         doc_comment! {
@@ -4373,23 +3835,10 @@ assert_eq!(7", stringify!($SelfT), ".div_euclid(4), 1); // or any other integer 
             #[inline]
             #[rustc_inherit_overflow_checks]
             #[rustc_const_unstable(feature = "const_int_euclidean")]
-            #[cfg(not(bootstrap))]
             pub const fn div_euclid(self, rhs: Self) -> Self {
                 self / rhs
             }
         }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "euclidean_division", since = "1.38.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[rustc_inherit_overflow_checks]
-        #[cfg(bootstrap)]
-        pub fn div_euclid(self, rhs: Self) -> Self {
-            self / rhs
-        }
-
 
         doc_comment! {
             concat!("Calculates the least remainder of `self (mod rhs)`.
@@ -4415,21 +3864,9 @@ assert_eq!(7", stringify!($SelfT), ".rem_euclid(4), 3); // or any other integer 
             #[inline]
             #[rustc_inherit_overflow_checks]
             #[rustc_const_unstable(feature = "const_int_euclidean")]
-            #[cfg(not(bootstrap))]
             pub const fn rem_euclid(self, rhs: Self) -> Self {
                 self % rhs
             }
-        }
-
-        /// No docs for bootstrap.
-        #[stable(feature = "euclidean_division", since = "1.38.0")]
-        #[must_use = "this returns the result of the operation, \
-                      without modifying the original"]
-        #[inline]
-        #[rustc_inherit_overflow_checks]
-        #[cfg(bootstrap)]
-        pub fn rem_euclid(self, rhs: Self) -> Self {
-            self % rhs
         }
 
         doc_comment! {

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1396,6 +1396,20 @@ impl<T, E> Option<Result<T, E>> {
     /// ```
     #[inline]
     #[stable(feature = "transpose_result", since = "1.33.0")]
+    #[rustc_const_unstable(feature = "const_option_match")]
+    #[cfg(not(bootstrap))]
+    pub const fn transpose(self) -> Result<Option<T>, E> {
+        match self {
+            Some(Ok(x)) => Ok(Some(x)),
+            Some(Err(e)) => Err(e),
+            None => Ok(None),
+        }
+    }
+
+    /// No docs for bootstrap.
+    #[inline]
+    #[stable(feature = "transpose_result", since = "1.33.0")]
+    #[cfg(bootstrap)]
     pub fn transpose(self) -> Result<Option<T>, E> {
         match self {
             Some(Ok(x)) => Ok(Some(x)),
@@ -1834,6 +1848,16 @@ impl<T> Option<Option<T>> {
     /// ```
     #[inline]
     #[stable(feature = "option_flattening", since = "1.40.0")]
+    #[rustc_const_unstable(feature = "const_option_match")]
+    #[cfg(not(bootstrap))]
+    pub const fn flatten(self) -> Option<T> {
+        self.and_then(convert::identity)
+    }
+
+    /// No docs for bootstrap.
+    #[inline]
+    #[stable(feature = "option_flattening", since = "1.40.0")]
+    #[cfg(bootstrap)]
     pub fn flatten(self) -> Option<T> {
         self.and_then(convert::identity)
     }

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -479,19 +479,6 @@ impl<T> Option<T> {
     /// assert_eq!(Some(4).unwrap_or_else(|| 2 * k), 4);
     /// assert_eq!(None.unwrap_or_else(|| 2 * k), 20);
     /// ```
-    #[rustc_const_unstable(feature = "const_option_match")]
-    #[cfg(not(bootstrap))]
-    #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    pub const fn unwrap_or_else<F: FnOnce() -> T>(self, f: F) -> T {
-        match self {
-            Some(x) => x,
-            None => f(),
-        }
-    }
-
-    /// No docs for bootstrap.
-    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn unwrap_or_else<F: FnOnce() -> T>(self, f: F) -> T {
@@ -521,19 +508,6 @@ impl<T> Option<T> {
     ///
     /// assert_eq!(maybe_some_len, Some(13));
     /// ```
-    #[rustc_const_unstable(feature = "const_option_match")]
-    #[cfg(not(bootstrap))]
-    #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    pub const fn map<U, F: FnOnce(T) -> U>(self, f: F) -> Option<U> {
-        match self {
-            Some(x) => Some(f(x)),
-            None => None,
-        }
-    }
-
-    /// No docs for bootstrap.
-    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> Option<U> {
@@ -555,19 +529,6 @@ impl<T> Option<T> {
     /// let x: Option<&str> = None;
     /// assert_eq!(x.map_or(42, |v| v.len()), 42);
     /// ```
-    #[rustc_const_unstable(feature = "const_option_match")]
-    #[cfg(not(bootstrap))]
-    #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    pub const fn map_or<U, F: FnOnce(T) -> U>(self, default: U, f: F) -> U {
-        match self {
-            Some(t) => f(t),
-            None => default,
-        }
-    }
-
-    /// No docs for bootstrap.
-    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn map_or<U, F: FnOnce(T) -> U>(self, default: U, f: F) -> U {
@@ -591,19 +552,6 @@ impl<T> Option<T> {
     /// let x: Option<&str> = None;
     /// assert_eq!(x.map_or_else(|| 2 * k, |v| v.len()), 42);
     /// ```
-    #[rustc_const_unstable(feature = "const_option_match")]
-    #[cfg(not(bootstrap))]
-    #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    pub const fn map_or_else<U, D: FnOnce() -> U, F: FnOnce(T) -> U>(self, default: D, f: F) -> U {
-        match self {
-            Some(t) => f(t),
-            None => default(),
-        }
-    }
-
-    /// No docs for bootstrap.
-    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn map_or_else<U, D: FnOnce() -> U, F: FnOnce(T) -> U>(self, default: D, f: F) -> U {
@@ -676,19 +624,6 @@ impl<T> Option<T> {
     /// let x: Option<&str> = None;
     /// assert_eq!(x.ok_or_else(|| 0), Err(0));
     /// ```
-    #[rustc_const_unstable(feature = "const_option_match")]
-    #[cfg(not(bootstrap))]
-    #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    pub const fn ok_or_else<E, F: FnOnce() -> E>(self, err: F) -> Result<T, E> {
-        match self {
-            Some(v) => Ok(v),
-            None => Err(err()),
-        }
-    }
-
-    /// No docs for bootstrap.
-    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn ok_or_else<E, F: FnOnce() -> E>(self, err: F) -> Result<T, E> {
@@ -807,19 +742,6 @@ impl<T> Option<T> {
     /// assert_eq!(Some(2).and_then(nope).and_then(sq), None);
     /// assert_eq!(None.and_then(sq).and_then(sq), None);
     /// ```
-    #[rustc_const_unstable(feature = "const_option_match")]
-    #[cfg(not(bootstrap))]
-    #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    pub const fn and_then<U, F: FnOnce(T) -> Option<U>>(self, f: F) -> Option<U> {
-        match self {
-            Some(x) => f(x),
-            None => None,
-        }
-    }
-
-    /// No docs for bootstrap.
-    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn and_then<U, F: FnOnce(T) -> Option<U>>(self, f: F) -> Option<U> {
@@ -855,21 +777,6 @@ impl<T> Option<T> {
     /// [`None`]: #variant.None
     /// [`Some(t)`]: #variant.Some
     /// [`Iterator::filter()`]: ../../std/iter/trait.Iterator.html#method.filter
-    #[rustc_const_unstable(feature = "const_option_match")]
-    #[cfg(not(bootstrap))]
-    #[inline]
-    #[stable(feature = "option_filter", since = "1.27.0")]
-    pub const fn filter<P: FnOnce(&T) -> bool>(self, predicate: P) -> Self {
-        if let Some(x) = self {
-            if predicate(&x) {
-                return Some(x);
-            }
-        }
-        None
-    }
-
-    /// No docs for bootstrap.
-    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "option_filter", since = "1.27.0")]
     pub fn filter<P: FnOnce(&T) -> bool>(self, predicate: P) -> Self {
@@ -943,19 +850,6 @@ impl<T> Option<T> {
     /// assert_eq!(None.or_else(vikings), Some("vikings"));
     /// assert_eq!(None.or_else(nobody), None);
     /// ```
-    #[rustc_const_unstable(feature = "const_option_match")]
-    #[cfg(not(bootstrap))]
-    #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    pub const fn or_else<F: FnOnce() -> Option<T>>(self, f: F) -> Option<T> {
-        match self {
-            Some(_) => self,
-            None => f(),
-        }
-    }
-
-    /// No docs for bootstrap.
-    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn or_else<F: FnOnce() -> Option<T>>(self, f: F) -> Option<T> {

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1742,16 +1742,6 @@ impl<T> Option<Option<T>> {
     /// ```
     #[inline]
     #[stable(feature = "option_flattening", since = "1.40.0")]
-    #[rustc_const_unstable(feature = "const_option_match")]
-    #[cfg(not(bootstrap))]
-    pub const fn flatten(self) -> Option<T> {
-        self.and_then(convert::identity)
-    }
-
-    /// No docs for bootstrap.
-    #[inline]
-    #[stable(feature = "option_flattening", since = "1.40.0")]
-    #[cfg(bootstrap)]
     pub fn flatten(self) -> Option<T> {
         self.and_then(convert::identity)
     }

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -183,6 +183,20 @@ impl<T> Option<T> {
     /// ```
     ///
     /// [`Some`]: #variant.Some
+    #[rustc_const_unstable(feature = "const_option_match")]
+    #[cfg(not(bootstrap))]
+    #[must_use = "if you intended to assert that this has a value, consider `.unwrap()` instead"]
+    #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub const fn is_some(&self) -> bool {
+        match *self {
+            Some(_) => true,
+            None => false,
+        }
+    }
+
+    /// No docs for bootstrap.
+    #[cfg(bootstrap)]
     #[must_use = "if you intended to assert that this has a value, consider `.unwrap()` instead"]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -206,6 +220,18 @@ impl<T> Option<T> {
     /// ```
     ///
     /// [`None`]: #variant.None
+    #[rustc_const_unstable(feature = "const_option_match")]
+    #[cfg(not(bootstrap))]
+    #[must_use = "if you intended to assert that this doesn't have a value, consider \
+                  `.and_then(|| panic!(\"`Option` had a value when expected `None`\"))` instead"]
+    #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub const fn is_none(&self) -> bool {
+        !self.is_some()
+    }
+
+    /// No docs for bootstrap.
+    #[cfg(bootstrap)]
     #[must_use = "if you intended to assert that this doesn't have a value, consider \
                   `.and_then(|| panic!(\"`Option` had a value when expected `None`\"))` instead"]
     #[inline]
@@ -267,6 +293,19 @@ impl<T> Option<T> {
     /// let text_length: Option<usize> = text.as_ref().map(|s| s.len());
     /// println!("still can print text: {:?}", text);
     /// ```
+    #[rustc_const_unstable(feature = "const_option_match")]
+    #[cfg(not(bootstrap))]
+    #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub const fn as_ref(&self) -> Option<&T> {
+        match *self {
+            Some(ref x) => Some(x),
+            None => None,
+        }
+    }
+
+    /// No docs for bootstrap.
+    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn as_ref(&self) -> Option<&T> {
@@ -340,6 +379,19 @@ impl<T> Option<T> {
     /// let x: Option<&str> = None;
     /// x.expect("the world is ending"); // panics with `the world is ending`
     /// ```
+    #[rustc_const_unstable(feature = "const_option_match")]
+    #[cfg(not(bootstrap))]
+    #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub const fn expect(self, msg: &str) -> T {
+        match self {
+            Some(val) => val,
+            None => expect_failed(msg),
+        }
+    }
+
+    /// No docs for bootstrap.
+    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn expect(self, msg: &str) -> T {
@@ -396,6 +448,19 @@ impl<T> Option<T> {
     /// assert_eq!(Some("car").unwrap_or("bike"), "car");
     /// assert_eq!(None.unwrap_or("bike"), "bike");
     /// ```
+    #[rustc_const_unstable(feature = "const_option_match")]
+    #[cfg(not(bootstrap))]
+    #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub const fn unwrap_or(self, default: T) -> T {
+        match self {
+            Some(x) => x,
+            None => default,
+        }
+    }
+
+    /// No docs for bootstrap.
+    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn unwrap_or(self, default: T) -> T {
@@ -414,6 +479,19 @@ impl<T> Option<T> {
     /// assert_eq!(Some(4).unwrap_or_else(|| 2 * k), 4);
     /// assert_eq!(None.unwrap_or_else(|| 2 * k), 20);
     /// ```
+    #[rustc_const_unstable(feature = "const_option_match")]
+    #[cfg(not(bootstrap))]
+    #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub const fn unwrap_or_else<F: FnOnce() -> T>(self, f: F) -> T {
+        match self {
+            Some(x) => x,
+            None => f(),
+        }
+    }
+
+    /// No docs for bootstrap.
+    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn unwrap_or_else<F: FnOnce() -> T>(self, f: F) -> T {
@@ -443,6 +521,19 @@ impl<T> Option<T> {
     ///
     /// assert_eq!(maybe_some_len, Some(13));
     /// ```
+    #[rustc_const_unstable(feature = "const_option_match")]
+    #[cfg(not(bootstrap))]
+    #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub const fn map<U, F: FnOnce(T) -> U>(self, f: F) -> Option<U> {
+        match self {
+            Some(x) => Some(f(x)),
+            None => None,
+        }
+    }
+
+    /// No docs for bootstrap.
+    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> Option<U> {
@@ -464,6 +555,19 @@ impl<T> Option<T> {
     /// let x: Option<&str> = None;
     /// assert_eq!(x.map_or(42, |v| v.len()), 42);
     /// ```
+    #[rustc_const_unstable(feature = "const_option_match")]
+    #[cfg(not(bootstrap))]
+    #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub const fn map_or<U, F: FnOnce(T) -> U>(self, default: U, f: F) -> U {
+        match self {
+            Some(t) => f(t),
+            None => default,
+        }
+    }
+
+    /// No docs for bootstrap.
+    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn map_or<U, F: FnOnce(T) -> U>(self, default: U, f: F) -> U {
@@ -487,6 +591,19 @@ impl<T> Option<T> {
     /// let x: Option<&str> = None;
     /// assert_eq!(x.map_or_else(|| 2 * k, |v| v.len()), 42);
     /// ```
+    #[rustc_const_unstable(feature = "const_option_match")]
+    #[cfg(not(bootstrap))]
+    #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub const fn map_or_else<U, D: FnOnce() -> U, F: FnOnce(T) -> U>(self, default: D, f: F) -> U {
+        match self {
+            Some(t) => f(t),
+            None => default(),
+        }
+    }
+
+    /// No docs for bootstrap.
+    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn map_or_else<U, D: FnOnce() -> U, F: FnOnce(T) -> U>(self, default: D, f: F) -> U {
@@ -519,6 +636,19 @@ impl<T> Option<T> {
     /// let x: Option<&str> = None;
     /// assert_eq!(x.ok_or(0), Err(0));
     /// ```
+    #[rustc_const_unstable(feature = "const_option_match")]
+    #[cfg(not(bootstrap))]
+    #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub const fn ok_or<E>(self, err: E) -> Result<T, E> {
+        match self {
+            Some(v) => Ok(v),
+            None => Err(err),
+        }
+    }
+
+    /// No docs for bootstrap.
+    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn ok_or<E>(self, err: E) -> Result<T, E> {
@@ -546,6 +676,19 @@ impl<T> Option<T> {
     /// let x: Option<&str> = None;
     /// assert_eq!(x.ok_or_else(|| 0), Err(0));
     /// ```
+    #[rustc_const_unstable(feature = "const_option_match")]
+    #[cfg(not(bootstrap))]
+    #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub const fn ok_or_else<E, F: FnOnce() -> E>(self, err: F) -> Result<T, E> {
+        match self {
+            Some(v) => Ok(v),
+            None => Err(err()),
+        }
+    }
+
+    /// No docs for bootstrap.
+    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn ok_or_else<E, F: FnOnce() -> E>(self, err: F) -> Result<T, E> {
@@ -624,6 +767,19 @@ impl<T> Option<T> {
     /// let y: Option<&str> = None;
     /// assert_eq!(x.and(y), None);
     /// ```
+    #[rustc_const_unstable(feature = "const_option_match")]
+    #[cfg(not(bootstrap))]
+    #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub const fn and<U>(self, optb: Option<U>) -> Option<U> {
+        match self {
+            Some(_) => optb,
+            None => None,
+        }
+    }
+
+    /// No docs for bootstrap.
+    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn and<U>(self, optb: Option<U>) -> Option<U> {
@@ -651,6 +807,19 @@ impl<T> Option<T> {
     /// assert_eq!(Some(2).and_then(nope).and_then(sq), None);
     /// assert_eq!(None.and_then(sq).and_then(sq), None);
     /// ```
+    #[rustc_const_unstable(feature = "const_option_match")]
+    #[cfg(not(bootstrap))]
+    #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub const fn and_then<U, F: FnOnce(T) -> Option<U>>(self, f: F) -> Option<U> {
+        match self {
+            Some(x) => f(x),
+            None => None,
+        }
+    }
+
+    /// No docs for bootstrap.
+    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn and_then<U, F: FnOnce(T) -> Option<U>>(self, f: F) -> Option<U> {
@@ -686,6 +855,21 @@ impl<T> Option<T> {
     /// [`None`]: #variant.None
     /// [`Some(t)`]: #variant.Some
     /// [`Iterator::filter()`]: ../../std/iter/trait.Iterator.html#method.filter
+    #[rustc_const_unstable(feature = "const_option_match")]
+    #[cfg(not(bootstrap))]
+    #[inline]
+    #[stable(feature = "option_filter", since = "1.27.0")]
+    pub const fn filter<P: FnOnce(&T) -> bool>(self, predicate: P) -> Self {
+        if let Some(x) = self {
+            if predicate(&x) {
+                return Some(x);
+            }
+        }
+        None
+    }
+
+    /// No docs for bootstrap.
+    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "option_filter", since = "1.27.0")]
     pub fn filter<P: FnOnce(&T) -> bool>(self, predicate: P) -> Self {
@@ -724,6 +908,19 @@ impl<T> Option<T> {
     /// let y = None;
     /// assert_eq!(x.or(y), None);
     /// ```
+    #[rustc_const_unstable(feature = "const_option_match")]
+    #[cfg(not(bootstrap))]
+    #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub const fn or(self, optb: Option<T>) -> Option<T> {
+        match self {
+            Some(_) => self,
+            None => optb,
+        }
+    }
+
+    /// No docs for bootstrap.
+    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn or(self, optb: Option<T>) -> Option<T> {
@@ -746,6 +943,19 @@ impl<T> Option<T> {
     /// assert_eq!(None.or_else(vikings), Some("vikings"));
     /// assert_eq!(None.or_else(nobody), None);
     /// ```
+    #[rustc_const_unstable(feature = "const_option_match")]
+    #[cfg(not(bootstrap))]
+    #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub const fn or_else<F: FnOnce() -> Option<T>>(self, f: F) -> Option<T> {
+        match self {
+            Some(_) => self,
+            None => f(),
+        }
+    }
+
+    /// No docs for bootstrap.
+    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn or_else<F: FnOnce() -> Option<T>>(self, f: F) -> Option<T> {
@@ -779,6 +989,20 @@ impl<T> Option<T> {
     /// let y: Option<u32> = None;
     /// assert_eq!(x.xor(y), None);
     /// ```
+    #[rustc_const_unstable(feature = "const_option_match")]
+    #[cfg(not(bootstrap))]
+    #[inline]
+    #[stable(feature = "option_xor", since = "1.37.0")]
+    pub const fn xor(self, optb: Option<T>) -> Option<T> {
+        match (self, optb) {
+            (Some(a), None) => Some(a),
+            (None, Some(b)) => Some(b),
+            _ => None,
+        }
+    }
+
+    /// No docs for bootstrap.
+    #[cfg(bootstrap)]
     #[inline]
     #[stable(feature = "option_xor", since = "1.37.0")]
     pub fn xor(self, optb: Option<T>) -> Option<T> {

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -184,23 +184,10 @@ impl<T> Option<T> {
     ///
     /// [`Some`]: #variant.Some
     #[rustc_const_unstable(feature = "const_option_match")]
-    #[cfg(not(bootstrap))]
     #[must_use = "if you intended to assert that this has a value, consider `.unwrap()` instead"]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const fn is_some(&self) -> bool {
-        match *self {
-            Some(_) => true,
-            None => false,
-        }
-    }
-
-    /// No docs for bootstrap.
-    #[cfg(bootstrap)]
-    #[must_use = "if you intended to assert that this has a value, consider `.unwrap()` instead"]
-    #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn is_some(&self) -> bool {
         match *self {
             Some(_) => true,
             None => false,
@@ -221,22 +208,11 @@ impl<T> Option<T> {
     ///
     /// [`None`]: #variant.None
     #[rustc_const_unstable(feature = "const_option_match")]
-    #[cfg(not(bootstrap))]
     #[must_use = "if you intended to assert that this doesn't have a value, consider \
                   `.and_then(|| panic!(\"`Option` had a value when expected `None`\"))` instead"]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const fn is_none(&self) -> bool {
-        !self.is_some()
-    }
-
-    /// No docs for bootstrap.
-    #[cfg(bootstrap)]
-    #[must_use = "if you intended to assert that this doesn't have a value, consider \
-                  `.and_then(|| panic!(\"`Option` had a value when expected `None`\"))` instead"]
-    #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn is_none(&self) -> bool {
         !self.is_some()
     }
 
@@ -294,21 +270,9 @@ impl<T> Option<T> {
     /// println!("still can print text: {:?}", text);
     /// ```
     #[rustc_const_unstable(feature = "const_option_match")]
-    #[cfg(not(bootstrap))]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const fn as_ref(&self) -> Option<&T> {
-        match *self {
-            Some(ref x) => Some(x),
-            None => None,
-        }
-    }
-
-    /// No docs for bootstrap.
-    #[cfg(bootstrap)]
-    #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn as_ref(&self) -> Option<&T> {
         match *self {
             Some(ref x) => Some(x),
             None => None,
@@ -380,21 +344,9 @@ impl<T> Option<T> {
     /// x.expect("the world is ending"); // panics with `the world is ending`
     /// ```
     #[rustc_const_unstable(feature = "const_option_match")]
-    #[cfg(not(bootstrap))]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const fn expect(self, msg: &str) -> T {
-        match self {
-            Some(val) => val,
-            None => expect_failed(msg),
-        }
-    }
-
-    /// No docs for bootstrap.
-    #[cfg(bootstrap)]
-    #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn expect(self, msg: &str) -> T {
         match self {
             Some(val) => val,
             None => expect_failed(msg),
@@ -449,21 +401,9 @@ impl<T> Option<T> {
     /// assert_eq!(None.unwrap_or("bike"), "bike");
     /// ```
     #[rustc_const_unstable(feature = "const_option_match")]
-    #[cfg(not(bootstrap))]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const fn unwrap_or(self, default: T) -> T {
-        match self {
-            Some(x) => x,
-            None => default,
-        }
-    }
-
-    /// No docs for bootstrap.
-    #[cfg(bootstrap)]
-    #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn unwrap_or(self, default: T) -> T {
         match self {
             Some(x) => x,
             None => default,
@@ -585,21 +525,9 @@ impl<T> Option<T> {
     /// assert_eq!(x.ok_or(0), Err(0));
     /// ```
     #[rustc_const_unstable(feature = "const_option_match")]
-    #[cfg(not(bootstrap))]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const fn ok_or<E>(self, err: E) -> Result<T, E> {
-        match self {
-            Some(v) => Ok(v),
-            None => Err(err),
-        }
-    }
-
-    /// No docs for bootstrap.
-    #[cfg(bootstrap)]
-    #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn ok_or<E>(self, err: E) -> Result<T, E> {
         match self {
             Some(v) => Ok(v),
             None => Err(err),
@@ -703,21 +631,9 @@ impl<T> Option<T> {
     /// assert_eq!(x.and(y), None);
     /// ```
     #[rustc_const_unstable(feature = "const_option_match")]
-    #[cfg(not(bootstrap))]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const fn and<U>(self, optb: Option<U>) -> Option<U> {
-        match self {
-            Some(_) => optb,
-            None => None,
-        }
-    }
-
-    /// No docs for bootstrap.
-    #[cfg(bootstrap)]
-    #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn and<U>(self, optb: Option<U>) -> Option<U> {
         match self {
             Some(_) => optb,
             None => None,
@@ -816,21 +732,9 @@ impl<T> Option<T> {
     /// assert_eq!(x.or(y), None);
     /// ```
     #[rustc_const_unstable(feature = "const_option_match")]
-    #[cfg(not(bootstrap))]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const fn or(self, optb: Option<T>) -> Option<T> {
-        match self {
-            Some(_) => self,
-            None => optb,
-        }
-    }
-
-    /// No docs for bootstrap.
-    #[cfg(bootstrap)]
-    #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn or(self, optb: Option<T>) -> Option<T> {
         match self {
             Some(_) => self,
             None => optb,
@@ -884,22 +788,9 @@ impl<T> Option<T> {
     /// assert_eq!(x.xor(y), None);
     /// ```
     #[rustc_const_unstable(feature = "const_option_match")]
-    #[cfg(not(bootstrap))]
     #[inline]
     #[stable(feature = "option_xor", since = "1.37.0")]
     pub const fn xor(self, optb: Option<T>) -> Option<T> {
-        match (self, optb) {
-            (Some(a), None) => Some(a),
-            (None, Some(b)) => Some(b),
-            _ => None,
-        }
-    }
-
-    /// No docs for bootstrap.
-    #[cfg(bootstrap)]
-    #[inline]
-    #[stable(feature = "option_xor", since = "1.37.0")]
-    pub fn xor(self, optb: Option<T>) -> Option<T> {
         match (self, optb) {
             (Some(a), None) => Some(a),
             (None, Some(b)) => Some(b),
@@ -1291,7 +1182,6 @@ impl<T, E> Option<Result<T, E>> {
     #[inline]
     #[stable(feature = "transpose_result", since = "1.33.0")]
     #[rustc_const_unstable(feature = "const_option_match")]
-    #[cfg(not(bootstrap))]
     pub const fn transpose(self) -> Result<Option<T>, E> {
         match self {
             Some(Ok(x)) => Ok(Some(x)),
@@ -1299,19 +1189,6 @@ impl<T, E> Option<Result<T, E>> {
             None => Ok(None),
         }
     }
-
-    /// No docs for bootstrap.
-    #[inline]
-    #[stable(feature = "transpose_result", since = "1.33.0")]
-    #[cfg(bootstrap)]
-    pub fn transpose(self) -> Result<Option<T>, E> {
-        match self {
-            Some(Ok(x)) => Ok(Some(x)),
-            Some(Err(e)) => Err(e),
-            None => Ok(None),
-        }
-    }
-}
 
 // This is a separate function to reduce the code size of .expect() itself.
 #[inline(never)]

--- a/src/test/ui/consts/auxiliary/const_assert_lib.rs
+++ b/src/test/ui/consts/auxiliary/const_assert_lib.rs
@@ -1,0 +1,17 @@
+/// Given a block of const bindings, asserts that their values (calculated at runtime) are the
+/// same as their values (calculated at compile-time).
+macro_rules! assert_same_const {
+    ($(const $ident:ident: $ty:ty = $exp:expr;)+) => {
+        $(const $ident: $ty = $exp;)+
+
+        pub fn main() {
+            $({
+                // Assign the expr to a variable at runtime; otherwise, the argument is
+                // calculated at compile-time, making the test useless.
+                let tmp = $exp;
+                assert_eq!(tmp, $ident);
+            })+
+        }
+    }
+}
+

--- a/src/test/ui/consts/const-int-checked.rs
+++ b/src/test/ui/consts/const-int-checked.rs
@@ -1,0 +1,57 @@
+// run-pass
+#![feature(const_int_checked)]
+
+macro_rules! assert_same_const {
+    ($(const $ident:ident: $ty:ty = $exp:expr;)+) => {
+        $(const $ident: $ty = $exp;)+
+
+        pub fn main() {
+            $(assert_eq!($exp, $ident);)+
+        }
+    }
+}
+
+assert_same_const! {
+    const CHECKED_ADD_I32_A: Option<i32> = 5i32.checked_add(2);
+    const CHECKED_ADD_I8_A: Option<i8> = 127i8.checked_add(2);
+    const CHECKED_ADD_U8_A: Option<u8> = 255u8.checked_add(2);
+
+    const CHECKED_SUB_I32_A: Option<i32> = 5i32.checked_sub(2);
+    const CHECKED_SUB_I8_A: Option<i8> = (-127 as i8).checked_sub(2);
+    const CHECKED_SUB_U8_A: Option<u8> = 1u8.checked_sub(2);
+
+    const CHECKED_MUL_I32_A: Option<i32> = 5i32.checked_mul(7777);
+    const CHECKED_MUL_I8_A: Option<i8> = (-127 as i8).checked_mul(-99);
+    const CHECKED_MUL_U8_A: Option<u8> = 1u8.checked_mul(3);
+
+    // Needs intrinsics::unchecked_div.
+    // const CHECKED_DIV_I32_A: Option<i32> = 5i32.checked_div(7777);
+    // const CHECKED_DIV_I8_A: Option<i8> = (-127 as i8).checked_div(-99);
+    // const CHECKED_DIV_U8_A: Option<u8> = 1u8.checked_div(3);
+
+    // Needs intrinsics::unchecked_rem.
+    // const CHECKED_REM_I32_A: Option<i32> = 5i32.checked_rem(7777);
+    // const CHECKED_REM_I8_A: Option<i8> = (-127 as i8).checked_rem(-99);
+    // const CHECKED_REM_U8_A: Option<u8> = 1u8.checked_rem(3);
+    // const CHECKED_REM_U8_B: Option<u8> = 1u8.checked_rem(0);
+
+    const CHECKED_NEG_I32_A: Option<i32> = 5i32.checked_neg();
+    const CHECKED_NEG_I8_A: Option<i8> = (-127 as i8).checked_neg();
+    const CHECKED_NEG_U8_A: Option<u8> = 1u8.checked_neg();
+    const CHECKED_NEG_U8_B: Option<u8> = u8::min_value().checked_neg();
+
+    const CHECKED_SHL_I32_A: Option<i32> = 5i32.checked_shl(77777);
+    const CHECKED_SHL_I8_A: Option<i8> = (-127 as i8).checked_shl(2);
+    const CHECKED_SHL_U8_A: Option<u8> = 1u8.checked_shl(8);
+    const CHECKED_SHL_U8_B: Option<u8> = 1u8.checked_shl(0);
+
+    const CHECKED_SHR_I32_A: Option<i32> = 5i32.checked_shr(77777);
+    const CHECKED_SHR_I8_A: Option<i8> = (-127 as i8).checked_shr(2);
+    const CHECKED_SHR_U8_A: Option<u8> = 1u8.checked_shr(8);
+    const CHECKED_SHR_U8_B: Option<u8> = 1u8.checked_shr(0);
+
+    const CHECKED_ABS_I32_A: Option<i32> = 5i32.checked_abs();
+    const CHECKED_ABS_I8_A: Option<i8> = (-127 as i8).checked_abs();
+    const CHECKED_ABS_I8_B: Option<i8> = 1i8.checked_abs();
+    const CHECKED_ABS_I8_C: Option<i8> = i8::min_value().checked_abs();
+}

--- a/src/test/ui/consts/const-int-euclidean.rs
+++ b/src/test/ui/consts/const-int-euclidean.rs
@@ -1,0 +1,51 @@
+// run-pass
+#![feature(const_int_euclidean)]
+#![feature(saturating_neg)]
+
+macro_rules! assert_same_const {
+    ($(const $ident:ident: $ty:ty = $exp:expr;)+) => {
+        $(const $ident: $ty = $exp;)+
+
+        pub fn main() {
+            $(assert_eq!($exp, $ident);)+
+        }
+    }
+}
+
+assert_same_const! {
+    const CHECKED_DIV_I32_A: Option<i32> = 5i32.checked_div_euclid(7777);
+    const CHECKED_DIV_I8_A: Option<i8> = (-127 as i8).checked_div_euclid(-99);
+    const CHECKED_DIV_I8_B: Option<i8> = (-127 as i8).checked_div_euclid(1);
+    const CHECKED_DIV_I8_C: Option<i8> = i8::min_value().checked_div_euclid(-1);
+    const CHECKED_DIV_U8_A: Option<u8> = 1u8.checked_div_euclid(3);
+
+    const CHECKED_REM_I32_A: Option<i32> = 5i32.checked_rem_euclid(7777);
+    const CHECKED_REM_I8_A: Option<i8> = (-127 as i8).checked_rem_euclid(-99);
+    const CHECKED_REM_I8_B: Option<i8> = (-127 as i8).checked_rem_euclid(0);
+    const CHECKED_REM_I8_C: Option<i8> = i8::min_value().checked_rem_euclid(-1);
+    const CHECKED_REM_U8_A: Option<u8> = 1u8.checked_rem_euclid(3);
+
+    const WRAPPING_DIV_I32_A: i32 = 5i32.wrapping_div_euclid(7777);
+    const WRAPPING_DIV_I8_A: i8 = (-127 as i8).wrapping_div_euclid(-99);
+    const WRAPPING_DIV_I8_B: i8 = (-127 as i8).wrapping_div_euclid(1);
+    const WRAPPING_DIV_I8_C: i8 = i8::min_value().wrapping_div_euclid(-1);
+    const WRAPPING_DIV_U8_A: u8 = 1u8.wrapping_div_euclid(3);
+
+    const WRAPPING_REM_I32_A: i32 = 5i32.wrapping_rem_euclid(7777);
+    const WRAPPING_REM_I8_A: i8 = (-127 as i8).wrapping_rem_euclid(-99);
+    const WRAPPING_REM_I8_B: i8 = (-127 as i8).wrapping_rem_euclid(1);
+    const WRAPPING_REM_I8_C: i8 = i8::min_value().wrapping_rem_euclid(-1);
+    const WRAPPING_REM_U8_A: u8 = 1u8.wrapping_rem_euclid(3);
+
+    const OVERFLOWING_DIV_I32_A: (i32, bool) = 5i32.overflowing_div_euclid(7777);
+    const OVERFLOWING_DIV_I8_A: (i8, bool) = (-127 as i8).overflowing_div_euclid(-99);
+    const OVERFLOWING_DIV_I8_B: (i8, bool) = (-127 as i8).overflowing_div_euclid(1);
+    const OVERFLOWING_DIV_I8_C: (i8, bool) = i8::min_value().overflowing_div_euclid(-1);
+    const OVERFLOWING_DIV_U8_A: (u8, bool) = 1u8.overflowing_div_euclid(3);
+
+    const OVERFLOWING_REM_I32_A: (i32, bool) = 5i32.overflowing_rem_euclid(7777);
+    const OVERFLOWING_REM_I8_A: (i8, bool) = (-127 as i8).overflowing_rem_euclid(-99);
+    const OVERFLOWING_REM_I8_B: (i8, bool) = (-127 as i8).overflowing_rem_euclid(1);
+    const OVERFLOWING_REM_I8_C: (i8, bool) = i8::min_value().overflowing_rem_euclid(-1);
+    const OVERFLOWING_REM_U8_A: (u8, bool) = 1u8.overflowing_rem_euclid(3);
+}

--- a/src/test/ui/consts/const-int-euclidean.rs
+++ b/src/test/ui/consts/const-int-euclidean.rs
@@ -1,16 +1,9 @@
 // run-pass
+// aux-build:const_assert_lib.rs
+use const_assert_lib::assert_same_const;
+
 #![feature(const_int_euclidean)]
 #![feature(saturating_neg)]
-
-macro_rules! assert_same_const {
-    ($(const $ident:ident: $ty:ty = $exp:expr;)+) => {
-        $(const $ident: $ty = $exp;)+
-
-        pub fn main() {
-            $(assert_eq!($exp, $ident);)+
-        }
-    }
-}
 
 assert_same_const! {
     const CHECKED_DIV_I32_A: Option<i32> = 5i32.checked_div_euclid(7777);

--- a/src/test/ui/consts/const-int-nonzero.rs
+++ b/src/test/ui/consts/const-int-nonzero.rs
@@ -1,4 +1,7 @@
 // run-pass
+// aux-build:const_assert_lib.rs
+use const_assert_lib::assert_same_const;
+
 #![feature(const_int_nonzero)]
 
 use std::num::{
@@ -7,16 +10,6 @@ use std::num::{
     NonZeroI32,
     NonZeroUsize,
 };
-
-macro_rules! assert_same_const {
-    ($(const $ident:ident: $ty:ty = $exp:expr;)+) => {
-        $(const $ident: $ty = $exp;)+
-
-        pub fn main() {
-            $(assert_eq!($exp, $ident);)+
-        }
-    }
-}
 
 assert_same_const! {
     const NON_ZERO_NEW_1: Option<NonZeroI8> = NonZeroI8::new(1);

--- a/src/test/ui/consts/const-int-nonzero.rs
+++ b/src/test/ui/consts/const-int-nonzero.rs
@@ -1,0 +1,47 @@
+// run-pass
+#![feature(const_int_nonzero)]
+
+use std::num::{
+    NonZeroI8,
+    NonZeroU8,
+    NonZeroI32,
+    NonZeroUsize,
+};
+
+macro_rules! assert_same_const {
+    ($(const $ident:ident: $ty:ty = $exp:expr;)+) => {
+        $(const $ident: $ty = $exp;)+
+
+        pub fn main() {
+            $(assert_eq!($exp, $ident);)+
+        }
+    }
+}
+
+assert_same_const! {
+    const NON_ZERO_NEW_1: Option<NonZeroI8> = NonZeroI8::new(1);
+    const NON_ZERO_NEW_2: Option<NonZeroI8> = NonZeroI8::new(0);
+    const NON_ZERO_NEW_3: Option<NonZeroI8> = NonZeroI8::new(-38);
+    const NON_ZERO_NEW_4: Option<NonZeroU8> = NonZeroU8::new(1);
+    const NON_ZERO_NEW_5: Option<NonZeroU8> = NonZeroU8::new(0);
+    const NON_ZERO_NEW_6: Option<NonZeroI32> = NonZeroI32::new(1);
+    const NON_ZERO_NEW_7: Option<NonZeroI32> = NonZeroI32::new(0);
+    const NON_ZERO_NEW_8: Option<NonZeroI32> = NonZeroI32::new(-38);
+    const NON_ZERO_NEW_9: Option<NonZeroUsize> = NonZeroUsize::new(1);
+    const NON_ZERO_NEW_10: Option<NonZeroUsize> = NonZeroUsize::new(0);
+
+    // Option::unwrap isn't supported in const yet, so we use new_unchecked.
+    const NON_ZERO_GET_1: i8 = unsafe { NonZeroI8::new_unchecked(1) }.get();
+    const NON_ZERO_GET_2: i8 = unsafe { NonZeroI8::new_unchecked(-38) }.get();
+    const NON_ZERO_GET_3: u8 = unsafe { NonZeroU8::new_unchecked(1) }.get();
+    const NON_ZERO_GET_4: i32 = unsafe { NonZeroI32::new_unchecked(1) }.get();
+    const NON_ZERO_GET_5: i32 = unsafe { NonZeroI32::new_unchecked(-38) }.get();
+    const NON_ZERO_GET_6: usize = unsafe { NonZeroUsize::new_unchecked(1) }.get();
+
+    const NON_ZERO_NEW_UNCHECKED_1: NonZeroI8 = unsafe { NonZeroI8::new_unchecked(1) };
+    const NON_ZERO_NEW_UNCHECKED_2: NonZeroI8 = unsafe { NonZeroI8::new_unchecked(-38) };
+    const NON_ZERO_NEW_UNCHECKED_3: NonZeroU8 = unsafe { NonZeroU8::new_unchecked(1) };
+    const NON_ZERO_NEW_UNCHECKED_4: NonZeroI32 = unsafe { NonZeroI32::new_unchecked(1) };
+    const NON_ZERO_NEW_UNCHECKED_5: NonZeroI32 = unsafe { NonZeroI32::new_unchecked(-38) };
+    const NON_ZERO_NEW_UNCHECKED_6: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(1) };
+}

--- a/src/test/ui/consts/const-int-overflowing-rpass.rs
+++ b/src/test/ui/consts/const-int-overflowing-rpass.rs
@@ -1,4 +1,5 @@
 // run-pass
+#![feature(const_int_overflowing)]
 
 const ADD_A: (u32, bool) = 5u32.overflowing_add(2);
 const ADD_B: (u32, bool) = u32::max_value().overflowing_add(1);
@@ -22,6 +23,18 @@ const ABS_POS: (i32, bool) = 10i32.overflowing_abs();
 const ABS_NEG: (i32, bool) = (-10i32).overflowing_abs();
 const ABS_MIN: (i32, bool) = i32::min_value().overflowing_abs();
 
+const DIV_A: (i8, bool) = 8i8.overflowing_div(2);
+const DIV_B: (i8, bool) = 8i8.overflowing_div(3);
+const DIV_C: (i8, bool) = i8::min_value().overflowing_div(-1i8);
+const DIV_D: (u8, bool) = 8u8.overflowing_div(2);
+const DIV_E: (u8, bool) = 8u8.overflowing_div(3);
+
+const REM_A: (i8, bool) = 8i8.overflowing_rem(2);
+const REM_B: (i8, bool) = 8i8.overflowing_rem(3);
+const REM_C: (i8, bool) = i8::min_value().overflowing_rem(-1i8);
+const REM_D: (u8, bool) = 8u8.overflowing_rem(2);
+const REM_E: (u8, bool) = 8u8.overflowing_rem(3);
+
 fn main() {
     assert_eq!(ADD_A, (7, false));
     assert_eq!(ADD_B, (0, true));
@@ -44,4 +57,16 @@ fn main() {
     assert_eq!(ABS_POS, (10, false));
     assert_eq!(ABS_NEG, (10, false));
     assert_eq!(ABS_MIN, (i32::min_value(), true));
+
+    assert_eq!(DIV_A, (4i8, false));
+    assert_eq!(DIV_B, (2i8, false));
+    assert_eq!(DIV_C, (i8::min_value(), true));
+    assert_eq!(DIV_D, (4u8, false));
+    assert_eq!(DIV_E, (2u8, false));
+
+    assert_eq!(REM_A, (0i8, false));
+    assert_eq!(REM_B, (2i8, false));
+    assert_eq!(REM_C, (0i8, true));
+    assert_eq!(REM_D, (0u8, false));
+    assert_eq!(REM_E, (2u8, false));
 }

--- a/src/test/ui/consts/const-int-pow-rpass.rs
+++ b/src/test/ui/consts/const-int-pow-rpass.rs
@@ -1,11 +1,47 @@
 // run-pass
+// #![feature(const_int_pow)]
+#![feature(wrapping_next_power_of_two)]
 
 const IS_POWER_OF_TWO_A: bool = 0u32.is_power_of_two();
 const IS_POWER_OF_TWO_B: bool = 32u32.is_power_of_two();
 const IS_POWER_OF_TWO_C: bool = 33u32.is_power_of_two();
 
+const NEXT_POWER_OF_TWO_A: u32 = 0u32.next_power_of_two();
+const NEXT_POWER_OF_TWO_B: u8 = 2u8.next_power_of_two();
+const NEXT_POWER_OF_TWO_C: u8 = 3u8.next_power_of_two();
+const NEXT_POWER_OF_TWO_D: u8 = 127u8.next_power_of_two();
+
+const CHECKED_NEXT_POWER_OF_TWO_A: Option<u32> = 0u32.checked_next_power_of_two();
+const CHECKED_NEXT_POWER_OF_TWO_B: Option<u8> = 2u8.checked_next_power_of_two();
+const CHECKED_NEXT_POWER_OF_TWO_C: Option<u8> = 3u8.checked_next_power_of_two();
+const CHECKED_NEXT_POWER_OF_TWO_D: Option<u8> = 127u8.checked_next_power_of_two();
+const CHECKED_NEXT_POWER_OF_TWO_E: Option<u8> = 129u8.checked_next_power_of_two();
+
+const WRAPPING_NEXT_POWER_OF_TWO_A: u32 = 0u32.wrapping_next_power_of_two();
+const WRAPPING_NEXT_POWER_OF_TWO_B: u8 = 2u8.wrapping_next_power_of_two();
+const WRAPPING_NEXT_POWER_OF_TWO_C: u8 = 3u8.wrapping_next_power_of_two();
+const WRAPPING_NEXT_POWER_OF_TWO_D: u8 = 127u8.wrapping_next_power_of_two();
+const WRAPPING_NEXT_POWER_OF_TWO_E: u8 = u8::max_value().wrapping_next_power_of_two();
+
 fn main() {
     assert!(!IS_POWER_OF_TWO_A);
     assert!(IS_POWER_OF_TWO_B);
     assert!(!IS_POWER_OF_TWO_C);
+
+    assert_eq!(NEXT_POWER_OF_TWO_A, 2);
+    assert_eq!(NEXT_POWER_OF_TWO_B, 2);
+    assert_eq!(NEXT_POWER_OF_TWO_C, 4);
+    assert_eq!(NEXT_POWER_OF_TWO_D, 128);
+
+    assert_eq!(CHECKED_NEXT_POWER_OF_TWO_A, Some(2));
+    assert_eq!(CHECKED_NEXT_POWER_OF_TWO_B, Some(2));
+    assert_eq!(CHECKED_NEXT_POWER_OF_TWO_C, Some(4));
+    assert_eq!(CHECKED_NEXT_POWER_OF_TWO_D, Some(128));
+    assert_eq!(CHECKED_NEXT_POWER_OF_TWO_E, None);
+
+    assert_eq!(WRAPPING_NEXT_POWER_OF_TWO_A, 2);
+    assert_eq!(WRAPPING_NEXT_POWER_OF_TWO_B, 2);
+    assert_eq!(WRAPPING_NEXT_POWER_OF_TWO_C, 4);
+    assert_eq!(WRAPPING_NEXT_POWER_OF_TWO_D, 128);
+    assert_eq!(WRAPPING_NEXT_POWER_OF_TWO_E, 0);
 }

--- a/src/test/ui/consts/const-int-pow-rpass.rs
+++ b/src/test/ui/consts/const-int-pow-rpass.rs
@@ -5,43 +5,11 @@
 const IS_POWER_OF_TWO_A: bool = 0u32.is_power_of_two();
 const IS_POWER_OF_TWO_B: bool = 32u32.is_power_of_two();
 const IS_POWER_OF_TWO_C: bool = 33u32.is_power_of_two();
-
-const NEXT_POWER_OF_TWO_A: u32 = 0u32.next_power_of_two();
-const NEXT_POWER_OF_TWO_B: u8 = 2u8.next_power_of_two();
-const NEXT_POWER_OF_TWO_C: u8 = 3u8.next_power_of_two();
-const NEXT_POWER_OF_TWO_D: u8 = 127u8.next_power_of_two();
-
-const CHECKED_NEXT_POWER_OF_TWO_A: Option<u32> = 0u32.checked_next_power_of_two();
-const CHECKED_NEXT_POWER_OF_TWO_B: Option<u8> = 2u8.checked_next_power_of_two();
-const CHECKED_NEXT_POWER_OF_TWO_C: Option<u8> = 3u8.checked_next_power_of_two();
-const CHECKED_NEXT_POWER_OF_TWO_D: Option<u8> = 127u8.checked_next_power_of_two();
-const CHECKED_NEXT_POWER_OF_TWO_E: Option<u8> = 129u8.checked_next_power_of_two();
-
-const WRAPPING_NEXT_POWER_OF_TWO_A: u32 = 0u32.wrapping_next_power_of_two();
-const WRAPPING_NEXT_POWER_OF_TWO_B: u8 = 2u8.wrapping_next_power_of_two();
-const WRAPPING_NEXT_POWER_OF_TWO_C: u8 = 3u8.wrapping_next_power_of_two();
-const WRAPPING_NEXT_POWER_OF_TWO_D: u8 = 127u8.wrapping_next_power_of_two();
-const WRAPPING_NEXT_POWER_OF_TWO_E: u8 = u8::max_value().wrapping_next_power_of_two();
+const IS_POWER_OF_TWO_D: bool = 3u8.is_power_of_two();
 
 fn main() {
     assert!(!IS_POWER_OF_TWO_A);
     assert!(IS_POWER_OF_TWO_B);
     assert!(!IS_POWER_OF_TWO_C);
-
-    assert_eq!(NEXT_POWER_OF_TWO_A, 2);
-    assert_eq!(NEXT_POWER_OF_TWO_B, 2);
-    assert_eq!(NEXT_POWER_OF_TWO_C, 4);
-    assert_eq!(NEXT_POWER_OF_TWO_D, 128);
-
-    assert_eq!(CHECKED_NEXT_POWER_OF_TWO_A, Some(2));
-    assert_eq!(CHECKED_NEXT_POWER_OF_TWO_B, Some(2));
-    assert_eq!(CHECKED_NEXT_POWER_OF_TWO_C, Some(4));
-    assert_eq!(CHECKED_NEXT_POWER_OF_TWO_D, Some(128));
-    assert_eq!(CHECKED_NEXT_POWER_OF_TWO_E, None);
-
-    assert_eq!(WRAPPING_NEXT_POWER_OF_TWO_A, 2);
-    assert_eq!(WRAPPING_NEXT_POWER_OF_TWO_B, 2);
-    assert_eq!(WRAPPING_NEXT_POWER_OF_TWO_C, 4);
-    assert_eq!(WRAPPING_NEXT_POWER_OF_TWO_D, 128);
-    assert_eq!(WRAPPING_NEXT_POWER_OF_TWO_E, 0);
+    assert!(!IS_POWER_OF_TWO_D);
 }

--- a/src/test/ui/consts/const-int-saturating-arith.rs
+++ b/src/test/ui/consts/const-int-saturating-arith.rs
@@ -1,34 +1,88 @@
 // run-pass
 #![feature(const_saturating_int_methods)]
+#![feature(const_int_saturating)]
+#![feature(saturating_neg)]
 
-const INT_U32_NO: u32 = (42 as u32).saturating_add(2);
-const INT_U32: u32 = u32::max_value().saturating_add(1);
-const INT_U128: u128 = u128::max_value().saturating_add(1);
-const INT_I128: i128 = i128::max_value().saturating_add(1);
-const INT_I128_NEG: i128 = i128::min_value().saturating_add(-1);
+const ADD_INT_U32_NO: u32 = (42 as u32).saturating_add(2);
+const ADD_INT_U32: u32 = u32::max_value().saturating_add(1);
+const ADD_INT_U128: u128 = u128::max_value().saturating_add(1);
+const ADD_INT_I128: i128 = i128::max_value().saturating_add(1);
+const ADD_INT_I128_NEG: i128 = i128::min_value().saturating_add(-1);
 
-const INT_U32_NO_SUB: u32 = (42 as u32).saturating_sub(2);
-const INT_U32_SUB: u32 = (1 as u32).saturating_sub(2);
-const INT_I32_NO_SUB: i32 = (-42 as i32).saturating_sub(2);
-const INT_I32_NEG_SUB: i32 = i32::min_value().saturating_sub(1);
-const INT_I32_POS_SUB: i32 = i32::max_value().saturating_sub(-1);
-const INT_U128_SUB: u128 = (0 as u128).saturating_sub(1);
-const INT_I128_NEG_SUB: i128 = i128::min_value().saturating_sub(1);
-const INT_I128_POS_SUB: i128 = i128::max_value().saturating_sub(-1);
+const SUB_INT_U32_NO: u32 = (42 as u32).saturating_sub(2);
+const SUB_INT_U32: u32 = (1 as u32).saturating_sub(2);
+const SUB_INT_I32_NO: i32 = (-42 as i32).saturating_sub(2);
+const SUB_INT_I32_NEG: i32 = i32::min_value().saturating_sub(1);
+const SUB_INT_I32_POS: i32 = i32::max_value().saturating_sub(-1);
+const SUB_INT_U128: u128 = (0 as u128).saturating_sub(1);
+const SUB_INT_I128_NEG: i128 = i128::min_value().saturating_sub(1);
+const SUB_INT_I128_POS: i128 = i128::max_value().saturating_sub(-1);
+
+const MUL_INT_U32_NO: u32 = (42 as u32).saturating_mul(2);
+const MUL_INT_U32: u32 = (1 as u32).saturating_mul(2);
+const MUL_INT_I32_NO: i32 = (-42 as i32).saturating_mul(2);
+const MUL_INT_I32_NEG: i32 = i32::min_value().saturating_mul(1);
+const MUL_INT_I32_POS: i32 = i32::max_value().saturating_mul(2);
+const MUL_INT_U128: u128 = (0 as u128).saturating_mul(1);
+const MUL_INT_I128_NEG: i128 = i128::min_value().saturating_mul(2);
+const MUL_INT_I128_POS: i128 = i128::max_value().saturating_mul(2);
+
+const NEG_INT_I8: i8 = (-42i8).saturating_neg();
+const NEG_INT_I8_B: i8 = i8::min_value().saturating_neg();
+const NEG_INT_I32: i32 = i32::min_value().saturating_neg();
+const NEG_INT_I32_B: i32 = i32::max_value().saturating_neg();
+const NEG_INT_I128: i128 = i128::min_value().saturating_neg();
+const NEG_INT_I128_B: i128 = i128::max_value().saturating_neg();
+
+const ABS_INT_I8_A: i8 = 4i8.saturating_abs();
+const ABS_INT_I8_B: i8 = -4i8.saturating_abs();
+const ABS_INT_I8_C: i8 = i8::min_value().saturating_abs();
+const ABS_INT_I32_A: i32 = 4i32.saturating_abs();
+const ABS_INT_I32_B: i32 = -4i32.saturating_abs();
+const ABS_INT_I32_C: i32 = i32::min_value().saturating_abs();
+const ABS_INT_I128_A: i128 = 4i128.saturating_abs();
+const ABS_INT_I128_B: i128 = -4i128.saturating_abs();
+const ABS_INT_I128_C: i128 = i128::min_value().saturating_abs();
 
 fn main() {
-    assert_eq!(INT_U32_NO, 44);
-    assert_eq!(INT_U32, u32::max_value());
-    assert_eq!(INT_U128, u128::max_value());
-    assert_eq!(INT_I128, i128::max_value());
-    assert_eq!(INT_I128_NEG, i128::min_value());
+    assert_eq!(ADD_INT_U32_NO, 44);
+    assert_eq!(ADD_INT_U32, u32::max_value());
+    assert_eq!(ADD_INT_U128, u128::max_value());
+    assert_eq!(ADD_INT_I128, i128::max_value());
+    assert_eq!(ADD_INT_I128_NEG, i128::min_value());
 
-    assert_eq!(INT_U32_NO_SUB, 40);
-    assert_eq!(INT_U32_SUB, 0);
-    assert_eq!(INT_I32_NO_SUB, -44);
-    assert_eq!(INT_I32_NEG_SUB, i32::min_value());
-    assert_eq!(INT_I32_POS_SUB, i32::max_value());
-    assert_eq!(INT_U128_SUB, 0);
-    assert_eq!(INT_I128_NEG_SUB, i128::min_value());
-    assert_eq!(INT_I128_POS_SUB, i128::max_value());
+    assert_eq!(SUB_INT_U32_NO, 40);
+    assert_eq!(SUB_INT_U32, 0);
+    assert_eq!(SUB_INT_I32_NO, -44);
+    assert_eq!(SUB_INT_I32_NEG, i32::min_value());
+    assert_eq!(SUB_INT_I32_POS, i32::max_value());
+    assert_eq!(SUB_INT_U128, 0);
+    assert_eq!(SUB_INT_I128_NEG, i128::min_value());
+    assert_eq!(SUB_INT_I128_POS, i128::max_value());
+
+    assert_eq!(MUL_INT_U32_NO, 84);
+    assert_eq!(MUL_INT_U32, 2);
+    assert_eq!(MUL_INT_I32_NO, -84);
+    assert_eq!(MUL_INT_I32_NEG, i32::min_value());
+    assert_eq!(MUL_INT_I32_POS, i32::max_value());
+    assert_eq!(MUL_INT_U128, 0);
+    assert_eq!(MUL_INT_I128_NEG, i128::min_value());
+    assert_eq!(MUL_INT_I128_POS, i128::max_value());
+
+    assert_eq!(NEG_INT_I8, 42);
+    assert_eq!(NEG_INT_I8_B, i8::max_value());
+    assert_eq!(NEG_INT_I32, i32::max_value());
+    assert_eq!(NEG_INT_I32_B, i32::min_value() + 1);
+    assert_eq!(NEG_INT_I128, i128::max_value());
+    assert_eq!(NEG_INT_I128_B, i128::min_value() + 1);
+
+    assert_eq!(ABS_INT_I8_A, 4i8);
+    assert_eq!(ABS_INT_I8_B, -4i8);
+    assert_eq!(ABS_INT_I8_C, i8::max_value());
+    assert_eq!(ABS_INT_I32_A, 4i32);
+    assert_eq!(ABS_INT_I32_B, -4i32);
+    assert_eq!(ABS_INT_I32_C, i32::max_value());
+    assert_eq!(ABS_INT_I128_A, 4i128);
+    assert_eq!(ABS_INT_I128_B, -4i128);
+    assert_eq!(ABS_INT_I128_C, i128::max_value());
 }

--- a/src/test/ui/consts/const-int-wrapping-rpass.rs
+++ b/src/test/ui/consts/const-int-wrapping-rpass.rs
@@ -1,4 +1,5 @@
 // run-pass
+#![feature(const_int_wrapping)]
 
 const ADD_A: u32 = 200u32.wrapping_add(55);
 const ADD_B: u32 = 200u32.wrapping_add(u32::max_value());
@@ -22,6 +23,18 @@ const ABS_POS: i32 = 10i32.wrapping_abs();
 const ABS_NEG: i32 = (-10i32).wrapping_abs();
 const ABS_MIN: i32 = i32::min_value().wrapping_abs();
 
+const DIV_A: i8 = 8i8.wrapping_div(2);
+const DIV_B: i8 = 8i8.wrapping_div(3);
+const DIV_C: i8 = i8::min_value().wrapping_div(-1i8);
+const DIV_D: u8 = 8u8.wrapping_div(2);
+const DIV_E: u8 = 8u8.wrapping_div(3);
+
+const REM_A: i8 = 8i8.wrapping_rem(2);
+const REM_B: i8 = 8i8.wrapping_rem(3);
+const REM_C: i8 = i8::min_value().wrapping_rem(-1i8);
+const REM_D: u8 = 8u8.wrapping_rem(2);
+const REM_E: u8 = 8u8.wrapping_rem(3);
+
 fn main() {
     assert_eq!(ADD_A, 255);
     assert_eq!(ADD_B, 199);
@@ -44,4 +57,16 @@ fn main() {
     assert_eq!(ABS_POS, 10);
     assert_eq!(ABS_NEG, 10);
     assert_eq!(ABS_MIN, i32::min_value());
+
+    assert_eq!(DIV_A, 4i8);
+    assert_eq!(DIV_B, 2i8);
+    assert_eq!(DIV_C, i8::min_value());
+    assert_eq!(DIV_D, 4u8);
+    assert_eq!(DIV_E, 2u8);
+
+    assert_eq!(REM_A, 0i8);
+    assert_eq!(REM_B, 2i8);
+    assert_eq!(REM_C, 0i8);
+    assert_eq!(REM_D, 0u8);
+    assert_eq!(REM_E, 2u8);
 }

--- a/src/test/ui/consts/const-nonzero.rs
+++ b/src/test/ui/consts/const-nonzero.rs
@@ -1,9 +1,0 @@
-// build-pass (FIXME(62277): could be check-pass?)
-
-use std::num::NonZeroU8;
-
-const X: NonZeroU8 = unsafe { NonZeroU8::new_unchecked(5) };
-const Y: u8 = X.get();
-
-fn main() {
-}

--- a/src/test/ui/consts/const-option.rs
+++ b/src/test/ui/consts/const-option.rs
@@ -51,8 +51,4 @@ assert_same_const! {
     const TRANSPOSE_A: Result<Option<i32>, bool> = Some(Ok(2)).transpose();
     const TRANSPOSE_B: Result<Option<i32>, bool> = Some(Err(false)).transpose();
     const TRANSPOSE_C: Result<Option<i32>, bool> = None.transpose();
-
-    const FLATTEN_A: Option<i32> = Some(Some(2)).flatten();
-    const FLATTEN_B: Option<i32> = Some(None).flatten();
-    const FLATTEN_C: Option<i32> = None.flatten();
 }

--- a/src/test/ui/consts/const-option.rs
+++ b/src/test/ui/consts/const-option.rs
@@ -1,0 +1,120 @@
+// run-pass
+#![feature(const_option_match)]
+#![feature(option_result_contains)]
+
+macro_rules! assert_same_const {
+    ($(const $ident:ident: $ty:ty = $exp:expr;)+) => {
+        $(const $ident: $ty = $exp;)+
+
+        pub fn main() {
+            $(assert_eq!($exp, $ident);)+
+        }
+    }
+}
+
+// These functions let us use the functional interfaces of Option (like unwrap_or_else, map_or,
+// map, etc.) without using closures, which aren't implemented in const contexts yet; see
+// https://github.com/rust-lang/rust/issues/63997
+
+const fn is_zero(i: i32) -> bool {
+    i == 0i32
+}
+
+const fn get_zero() -> i32 {
+    0
+}
+
+const fn get_false() -> bool {
+    false
+}
+
+const fn get_some() -> Option<i32> {
+    Some(2)
+}
+
+const fn get_none() -> Option<i32> {
+    None
+}
+
+const fn is_pos(i: &i32) -> bool {
+    i.is_positive()
+}
+
+const fn is_neg(i: &i32) -> bool {
+    i.is_negative()
+}
+
+const fn i32_to_some(i: i32) -> Option<i32> {
+    Some(i * 2)
+}
+
+const fn i32_to_none(_i: i32) -> Option<i32> {
+    None
+}
+
+assert_same_const! {
+    const SOME: Option<i32> = Some(3);
+    const NONE: Option<i32> = None;
+
+    const IS_SOME_A: bool = SOME.is_some();
+    const IS_SOME_B: bool = NONE.is_some();
+
+    const IS_NONE_A: bool = SOME.is_none();
+    const IS_NONE_B: bool = NONE.is_none();
+
+    const AS_REF_A: Option<&i32> = SOME.as_ref();
+    const AS_REF_B: Option<&i32> = NONE.as_ref();
+
+    const EXPECT_A: i32 = SOME.expect("This is dangerous!");
+
+    const UNWRAP_OR_A: i32 = SOME.unwrap_or(0);
+    const UNWRAP_OR_B: i32 = NONE.unwrap_or(0);
+
+    const UNWRAP_OR_ELSE_A: i32 = SOME.unwrap_or_else(get_zero);
+    const UNWRAP_OR_ELSE_B: i32 = NONE.unwrap_or_else(get_zero);
+
+    const MAP_A: Option<bool> = SOME.map(is_zero);
+    const MAP_B: Option<bool> = NONE.map(is_zero);
+
+    const MAP_OR_A: bool = SOME.map_or(false, is_zero);
+    const MAP_OR_B: bool = NONE.map_or(false, is_zero);
+
+    const MAP_OR_ELSE_A: bool = SOME.map_or_else(get_false, is_zero);
+    const MAP_OR_ELSE_B: bool = NONE.map_or_else(get_false, is_zero);
+
+    const OK_OR_A: Result<i32, bool> = SOME.ok_or(false);
+    const OK_OR_B: Result<i32, bool> = NONE.ok_or(false);
+
+    const OK_OR_ELSE_A: Result<i32, bool> = SOME.ok_or_else(get_false);
+    const OK_OR_ELSE_B: Result<i32, bool> = NONE.ok_or_else(get_false);
+
+    const AND_A: Option<bool> = SOME.and(Some(true));
+    const AND_B: Option<bool> = SOME.and(None);
+    const AND_C: Option<bool> = NONE.and(Some(true));
+    const AND_D: Option<bool> = NONE.and(None);
+
+    const AND_THEN_A: Option<i32> = SOME.and_then(i32_to_some);
+    const AND_THEN_B: Option<i32> = SOME.and_then(i32_to_none);
+    const AND_THEN_C: Option<i32> = NONE.and_then(i32_to_some);
+    const AND_THEN_D: Option<i32> = NONE.and_then(i32_to_none);
+
+    const FILTER_A: Option<i32> = SOME.filter(is_pos);
+    const FILTER_B: Option<i32> = SOME.filter(is_neg);
+    const FILTER_C: Option<i32> = NONE.filter(is_pos);
+    const FILTER_D: Option<i32> = NONE.filter(is_neg);
+
+    const OR_A: Option<i32> = SOME.or(Some(1));
+    const OR_B: Option<i32> = SOME.or(None);
+    const OR_C: Option<i32> = NONE.or(Some(1));
+    const OR_D: Option<i32> = NONE.or(None);
+
+    const OR_ELSE_A: Option<i32> = SOME.or_else(get_some);
+    const OR_ELSE_B: Option<i32> = SOME.or_else(get_none);
+    const OR_ELSE_C: Option<i32> = NONE.or_else(get_some);
+    const OR_ELSE_D: Option<i32> = NONE.or_else(get_none);
+
+    const XOR_A: Option<i32> = SOME.xor(Some(1));
+    const XOR_B: Option<i32> = SOME.xor(None);
+    const XOR_C: Option<i32> = NONE.xor(Some(1));
+    const XOR_D: Option<i32> = NONE.xor(None);
+}

--- a/src/test/ui/consts/const-option.rs
+++ b/src/test/ui/consts/const-option.rs
@@ -12,46 +12,6 @@ macro_rules! assert_same_const {
     }
 }
 
-// These functions let us use the functional interfaces of Option (like unwrap_or_else, map_or,
-// map, etc.) without using closures, which aren't implemented in const contexts yet; see
-// https://github.com/rust-lang/rust/issues/63997
-
-const fn is_zero(i: i32) -> bool {
-    i == 0i32
-}
-
-const fn get_zero() -> i32 {
-    0
-}
-
-const fn get_false() -> bool {
-    false
-}
-
-const fn get_some() -> Option<i32> {
-    Some(2)
-}
-
-const fn get_none() -> Option<i32> {
-    None
-}
-
-const fn is_pos(i: &i32) -> bool {
-    i.is_positive()
-}
-
-const fn is_neg(i: &i32) -> bool {
-    i.is_negative()
-}
-
-const fn i32_to_some(i: i32) -> Option<i32> {
-    Some(i * 2)
-}
-
-const fn i32_to_none(_i: i32) -> Option<i32> {
-    None
-}
-
 assert_same_const! {
     const SOME: Option<i32> = Some(3);
     const NONE: Option<i32> = None;
@@ -70,48 +30,18 @@ assert_same_const! {
     const UNWRAP_OR_A: i32 = SOME.unwrap_or(0);
     const UNWRAP_OR_B: i32 = NONE.unwrap_or(0);
 
-    const UNWRAP_OR_ELSE_A: i32 = SOME.unwrap_or_else(get_zero);
-    const UNWRAP_OR_ELSE_B: i32 = NONE.unwrap_or_else(get_zero);
-
-    const MAP_A: Option<bool> = SOME.map(is_zero);
-    const MAP_B: Option<bool> = NONE.map(is_zero);
-
-    const MAP_OR_A: bool = SOME.map_or(false, is_zero);
-    const MAP_OR_B: bool = NONE.map_or(false, is_zero);
-
-    const MAP_OR_ELSE_A: bool = SOME.map_or_else(get_false, is_zero);
-    const MAP_OR_ELSE_B: bool = NONE.map_or_else(get_false, is_zero);
-
     const OK_OR_A: Result<i32, bool> = SOME.ok_or(false);
     const OK_OR_B: Result<i32, bool> = NONE.ok_or(false);
-
-    const OK_OR_ELSE_A: Result<i32, bool> = SOME.ok_or_else(get_false);
-    const OK_OR_ELSE_B: Result<i32, bool> = NONE.ok_or_else(get_false);
 
     const AND_A: Option<bool> = SOME.and(Some(true));
     const AND_B: Option<bool> = SOME.and(None);
     const AND_C: Option<bool> = NONE.and(Some(true));
     const AND_D: Option<bool> = NONE.and(None);
 
-    const AND_THEN_A: Option<i32> = SOME.and_then(i32_to_some);
-    const AND_THEN_B: Option<i32> = SOME.and_then(i32_to_none);
-    const AND_THEN_C: Option<i32> = NONE.and_then(i32_to_some);
-    const AND_THEN_D: Option<i32> = NONE.and_then(i32_to_none);
-
-    const FILTER_A: Option<i32> = SOME.filter(is_pos);
-    const FILTER_B: Option<i32> = SOME.filter(is_neg);
-    const FILTER_C: Option<i32> = NONE.filter(is_pos);
-    const FILTER_D: Option<i32> = NONE.filter(is_neg);
-
     const OR_A: Option<i32> = SOME.or(Some(1));
     const OR_B: Option<i32> = SOME.or(None);
     const OR_C: Option<i32> = NONE.or(Some(1));
     const OR_D: Option<i32> = NONE.or(None);
-
-    const OR_ELSE_A: Option<i32> = SOME.or_else(get_some);
-    const OR_ELSE_B: Option<i32> = SOME.or_else(get_none);
-    const OR_ELSE_C: Option<i32> = NONE.or_else(get_some);
-    const OR_ELSE_D: Option<i32> = NONE.or_else(get_none);
 
     const XOR_A: Option<i32> = SOME.xor(Some(1));
     const XOR_B: Option<i32> = SOME.xor(None);

--- a/src/test/ui/consts/const-option.rs
+++ b/src/test/ui/consts/const-option.rs
@@ -117,4 +117,12 @@ assert_same_const! {
     const XOR_B: Option<i32> = SOME.xor(None);
     const XOR_C: Option<i32> = NONE.xor(Some(1));
     const XOR_D: Option<i32> = NONE.xor(None);
+
+    const TRANSPOSE_A: Result<Option<i32>, bool> = Some(Ok(2)).transpose();
+    const TRANSPOSE_B: Result<Option<i32>, bool> = Some(Err(false)).transpose();
+    const TRANSPOSE_C: Result<Option<i32>, bool> = None.transpose();
+
+    const FLATTEN_A: Option<i32> = Some(Some(2)).flatten();
+    const FLATTEN_B: Option<i32> = Some(None).flatten();
+    const FLATTEN_C: Option<i32> = None.flatten();
 }

--- a/src/test/ui/consts/const-option.rs
+++ b/src/test/ui/consts/const-option.rs
@@ -1,16 +1,9 @@
 // run-pass
+// aux-build:const_assert_lib.rs
+use const_assert_lib::assert_same_const;
+
 #![feature(const_option_match)]
 #![feature(option_result_contains)]
-
-macro_rules! assert_same_const {
-    ($(const $ident:ident: $ty:ty = $exp:expr;)+) => {
-        $(const $ident: $ty = $exp;)+
-
-        pub fn main() {
-            $(assert_eq!($exp, $ident);)+
-        }
-    }
-}
 
 assert_same_const! {
     const SOME: Option<i32> = Some(3);


### PR DESCRIPTION
Constifies the int arithmetic functions from #53718 that were blocked on #49146.

- `feature = const_int_checked`
  - `checked_add`
  - `checked_sub`
  - `checked_mul`
  - ~~`checked_div`~~ Uses `intrinsics::unchecked_div` internally.
  - ~~`checked_rem`~~ Uses `intrinsics::unchecked_rem` internally; needs #66275.
  - `checked_neg`
  - `checked_shl`
  - `checked_shr`
  - `checked_abs`

- `feature = const_int_saturating` / `feature = const_saturating_int_methods`
  - `saturating_mul`
  - `saturating_neg`
  - `saturating_abs`

- `feature = const_int_wrapping`
  - `wrapping_div`
  - `wrapping_rem`

- `feature = const_int_overflowing`
  - `overflowing_div`
  - `overflowing_rem`

- `feature = const_int_euclidean`
  - `checked_div_euclid`
  - `checked_rem_euclid`
  - `wrapping_div_euclid`
  - `wrapping_rem_euclid`
  - `overflowing_div_euclid`
  - `overflowing_rem_euclid`

- `feature = const_int_pow`
  - ~~`next_power_of_two`~~ Uses `intrinsics::ctlz_nonzero` internally; needs #66275.
  - ~~`checked_next_power_of_two`~~ Ditto.
  - ~~`wrapping_next_power_of_two`~~ Ditto.
  - ~~`checked_pow`~~ Uses `while`; needs #52000?

- `feature = const_int_nonzero`
  - `NonZero*::new` (implementation in `macro_rules! nonzero_integers`)

I converted some of the `Option` functions as well; this is a new `#![feature]`, should it be in a different PR?
- `feature = const_option`
  - `is_some`, `is_none`
  - `as_ref`
  - `expect`
  - `unwrap_or`, ~~`unwrap_or_else`~~ Requires rust-lang/rfcs#2632 to use functional interfaces (in specific, trait bounds on generic fns).
  - `ok_or`, ~~`ok_or_else`~~
  - `and`, ~~`and_then`~~
  - `filter`
  - `or`, ~~`or_else`~~
  - `xor`
  - `transpose`

cc @oli-obk, who has kindly been helping me start work on this on Twitter! 🙂
