### PR TITLE
Remove unneeded prelude imports in libcore tests

### DIFF
--- a/src/libcore/tests/num/bignum.rs
+++ b/src/libcore/tests/num/bignum.rs
@@ -1,4 +1,3 @@
-use std::prelude::v1::*;
 use core::num::bignum::tests::Big8x3 as Big;
 
 #[test]

--- a/src/libcore/tests/num/flt2dec/mod.rs
+++ b/src/libcore/tests/num/flt2dec/mod.rs
@@ -1,4 +1,3 @@
-use std::prelude::v1::*;
 use std::{str, i16, f32, f64, fmt};
 
 use core::num::flt2dec::{decode, DecodableFloat, FullDecoded, Decoded};

--- a/src/libcore/tests/num/flt2dec/strategy/dragon.rs
+++ b/src/libcore/tests/num/flt2dec/strategy/dragon.rs
@@ -1,4 +1,3 @@
-use std::prelude::v1::*;
 use super::super::*;
 use core::num::bignum::Big32x40 as Big;
 use core::num::flt2dec::strategy::dragon::*;


### PR DESCRIPTION
These three lines are from c82da7a54b9efb1a0ccbe11de66c71f547bf7db9 dating back to 2015.

They cause problems when applying rustfmt to the codebase, because reordering wildcard imports can trigger new unused import warnings.

As a minimized example, the following program compiles successfully:

```rust
#![deny(unused_imports)]

use std::fmt::Debug;
use std::marker::Send;

pub mod repro {
    use std::prelude::v1::*;
    use super::*;

    pub type D = dyn Debug;
    pub type S = dyn Send;
}

pub type S = dyn Send;
```

but putting it through rustfmt produces a program that fails to compile:

```rust
#![deny(unused_imports)]

use std::fmt::Debug;
use std::marker::Send;

pub mod repro {
    use super::*;
    use std::prelude::v1::*;

    pub type D = dyn Debug;
    pub type S = dyn Send;
}

pub type S = dyn Send;
```

The error is:

```console
error: unused import: `std::prelude::v1::*`
 --> src/main.rs:8:9
  |
8 |     use std::prelude::v1::*;
  |         ^^^^^^^^^^^^^^^^^^^
```