### PR TITLE
pass Queries to compiler callbacks

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -41,7 +41,7 @@ use rustc::util::common::{set_time_depth, time, print_time_passes_entry, ErrorRe
 use rustc_metadata::locator;
 use rustc_codegen_utils::codegen_backend::CodegenBackend;
 use errors::{PResult, registry::Registry};
-use rustc_interface::interface;
+use rustc_interface::{interface, Queries};
 use rustc_interface::util::get_codegen_sysroot;
 use rustc_data_structures::sync::SeqCst;
 
@@ -99,17 +99,29 @@ pub trait Callbacks {
     fn config(&mut self, _config: &mut interface::Config) {}
     /// Called after parsing. Return value instructs the compiler whether to
     /// continue the compilation afterwards (defaults to `Compilation::Continue`)
-    fn after_parsing(&mut self, _compiler: &interface::Compiler) -> Compilation {
+    fn after_parsing<'tcx>(
+        &mut self,
+        _compiler: &interface::Compiler,
+        _queries: &'tcx Queries<'tcx>,
+    ) -> Compilation {
         Compilation::Continue
     }
     /// Called after expansion. Return value instructs the compiler whether to
     /// continue the compilation afterwards (defaults to `Compilation::Continue`)
-    fn after_expansion(&mut self, _compiler: &interface::Compiler) -> Compilation {
+    fn after_expansion<'tcx>(
+        &mut self,
+        _compiler: &interface::Compiler,
+        _queries: &'tcx Queries<'tcx>,
+    ) -> Compilation {
         Compilation::Continue
     }
     /// Called after analysis. Return value instructs the compiler whether to
     /// continue the compilation afterwards (defaults to `Compilation::Continue`)
-    fn after_analysis(&mut self, _compiler: &interface::Compiler) -> Compilation {
+    fn after_analysis<'tcx>(
+        &mut self,
+        _compiler: &interface::Compiler,
+        _queries: &'tcx Queries<'tcx>,
+    ) -> Compilation {
         Compilation::Continue
     }
 }
@@ -313,7 +325,7 @@ pub fn run_compiler(
                 return early_exit();
             }
 
-            if callbacks.after_parsing(compiler) == Compilation::Stop {
+            if callbacks.after_parsing(compiler, queries) == Compilation::Stop {
                 return early_exit();
             }
 
@@ -334,7 +346,7 @@ pub fn run_compiler(
             }
 
             queries.expansion()?;
-            if callbacks.after_expansion(compiler) == Compilation::Stop {
+            if callbacks.after_expansion(compiler, queries) == Compilation::Stop {
                 return early_exit();
             }
 
@@ -383,7 +395,7 @@ pub fn run_compiler(
 
             queries.global_ctxt()?.peek_mut().enter(|tcx| tcx.analysis(LOCAL_CRATE))?;
 
-            if callbacks.after_analysis(compiler) == Compilation::Stop {
+            if callbacks.after_analysis(compiler, queries) == Compilation::Stop {
                 return early_exit();
             }
 

--- a/src/librustc_interface/lib.rs
+++ b/src/librustc_interface/lib.rs
@@ -18,6 +18,7 @@ pub mod util;
 mod proc_macro_decls;
 
 pub use interface::{run_compiler, Config};
+pub use queries::Queries;
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/66791 made it impossible to access the tcx in the callbacks; this should fix that.

r? @Zoxc