### PR TITLE
Standard library support for riscv64gc-unknown-linux-gnu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,9 +395,9 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa87058dce70a3ff5621797f1506cb837edd02ac4c0ae642b4542dce802908b8"
+checksum = "e450b8da92aa6f274e7c6437692f9f2ce6d701fb73bacfcf87897b3f89a4c20e"
 dependencies = [
  "jobserver",
  "num_cpus",

--- a/src/libpanic_unwind/gcc.rs
+++ b/src/libpanic_unwind/gcc.rs
@@ -130,6 +130,9 @@ const UNWIND_DATA_REG: (i32, i32) = (24, 25); // I0, I1
 #[cfg(target_arch = "hexagon")]
 const UNWIND_DATA_REG: (i32, i32) = (0, 1); // R0, R1
 
+#[cfg(target_arch = "riscv64")]
+const UNWIND_DATA_REG: (i32, i32) = (10, 11); // x10, x11
+
 // The following code is based on GCC's C and C++ personality routines.  For reference, see:
 // https://github.com/gcc-mirror/gcc/blob/master/libstdc++-v3/libsupc++/eh_personality.cc
 // https://github.com/gcc-mirror/gcc/blob/trunk/libgcc/unwind-c.c

--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -878,6 +878,7 @@ pub mod consts {
     /// - mips64
     /// - powerpc
     /// - powerpc64
+    /// - riscv64
     /// - s390x
     /// - sparc64
     #[stable(feature = "env", since = "1.0.0")]
@@ -1033,6 +1034,11 @@ mod arch {
 #[cfg(target_arch = "hexagon")]
 mod arch {
     pub const ARCH: &'static str = "hexagon";
+}
+
+#[cfg(target_arch = "riscv64")]
+mod arch {
+    pub const ARCH: &'static str = "riscv64";
 }
 
 #[cfg(test)]

--- a/src/libstd/os/linux/raw.rs
+++ b/src/libstd/os/linux/raw.rs
@@ -230,7 +230,12 @@ mod arch {
     }
 }
 
-#[cfg(any(target_arch = "mips64", target_arch = "s390x", target_arch = "sparc64"))]
+#[cfg(any(
+    target_arch = "mips64",
+    target_arch = "s390x",
+    target_arch = "sparc64",
+    target_arch = "riscv64"
+))]
 mod arch {
     pub use libc::{blkcnt_t, blksize_t, ino_t, nlink_t, off_t, stat, time_t};
 }

--- a/src/libstd/os/raw/mod.rs
+++ b/src/libstd/os/raw/mod.rs
@@ -18,7 +18,8 @@
             target_arch = "hexagon",
             target_arch = "powerpc",
             target_arch = "powerpc64",
-            target_arch = "s390x"
+            target_arch = "s390x",
+            target_arch = "riscv64"
         )
     ),
     all(target_os = "android", any(target_arch = "aarch64", target_arch = "arm")),
@@ -60,7 +61,8 @@ pub type c_char = u8;
             target_arch = "hexagon",
             target_arch = "powerpc",
             target_arch = "powerpc64",
-            target_arch = "s390x"
+            target_arch = "s390x",
+            target_arch = "riscv64"
         )
     ),
     all(target_os = "android", any(target_arch = "aarch64", target_arch = "arm")),

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -67,6 +67,7 @@ macro_rules! cfg_has_statx {
                 // target_arch = "mips64",
                 // target_arch = "s390x",
                 target_arch = "sparc64",
+                target_arch = "riscv64",
             )))] {
                 $($then_tt)*
             } else {
@@ -86,6 +87,7 @@ macro_rules! cfg_has_statx {
             // target_arch = "mips64",
             // target_arch = "s390x",
             target_arch = "sparc64",
+            target_arch = "riscv64",
         )))]
         {
             $($block_inner)*

--- a/src/libstd/sys_common/alloc.rs
+++ b/src/libstd/sys_common/alloc.rs
@@ -22,7 +22,8 @@ pub const MIN_ALIGN: usize = 8;
     target_arch = "aarch64",
     target_arch = "mips64",
     target_arch = "s390x",
-    target_arch = "sparc64"
+    target_arch = "sparc64",
+    target_arch = "riscv64"
 )))]
 pub const MIN_ALIGN: usize = 16;
 

--- a/src/libunwind/libunwind.rs
+++ b/src/libunwind/libunwind.rs
@@ -53,6 +53,9 @@ pub const unwinder_private_data_size: usize = 2;
 #[cfg(target_arch = "sparc64")]
 pub const unwinder_private_data_size: usize = 2;
 
+#[cfg(target_arch = "riscv64")]
+pub const unwinder_private_data_size: usize = 2;
+
 #[cfg(target_os = "emscripten")]
 pub const unwinder_private_data_size: usize = 20;
 


### PR DESCRIPTION
Add std support for RISC-V 64-bit GNU/Linux and update libc for RISC-V support.

r? @alexcrichton