### PR TITLE
rustc_mir: use nicer path printing for #[rustc_regions] NLL tests.

### DIFF
--- a/src/librustc_mir/borrow_check/nll/universal_regions.rs
+++ b/src/librustc_mir/borrow_check/nll/universal_regions.rs
@@ -312,9 +312,9 @@ impl<'tcx> UniversalRegions<'tcx> {
         match self.defining_ty {
             DefiningTy::Closure(def_id, substs) => {
                 err.note(&format!(
-                    "defining type: {:?} with closure substs {:#?}",
-                    def_id,
-                    &substs[..]
+                    "defining type: {} with closure substs {:#?}",
+                    tcx.def_path_str_with_substs(def_id, substs),
+                    &substs[tcx.generics_of(def_id).parent_count..],
                 ));
 
                 // FIXME: It'd be nice to print the late-bound regions
@@ -332,9 +332,9 @@ impl<'tcx> UniversalRegions<'tcx> {
             }
             DefiningTy::Generator(def_id, substs, _) => {
                 err.note(&format!(
-                    "defining type: {:?} with generator substs {:#?}",
-                    def_id,
-                    &substs[..]
+                    "defining type: {} with generator substs {:#?}",
+                    tcx.def_path_str_with_substs(def_id, substs),
+                    &substs[tcx.generics_of(def_id).parent_count..],
                 ));
 
                 // FIXME: As above, we'd like to print out the region
@@ -350,16 +350,14 @@ impl<'tcx> UniversalRegions<'tcx> {
             }
             DefiningTy::FnDef(def_id, substs) => {
                 err.note(&format!(
-                    "defining type: {:?} with substs {:#?}",
-                    def_id,
-                    &substs[..]
+                    "defining type: {}",
+                    tcx.def_path_str_with_substs(def_id, substs),
                 ));
             }
             DefiningTy::Const(def_id, substs) => {
                 err.note(&format!(
-                    "defining constant type: {:?} with substs {:#?}",
-                    def_id,
-                    &substs[..]
+                    "defining constant type: {}",
+                    tcx.def_path_str_with_substs(def_id, substs),
                 ));
             }
         }

--- a/src/test/ui/nll/closure-requirements/escape-argument-callee.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-argument-callee.stderr
@@ -4,7 +4,7 @@ note: No external requirements
 LL |         let mut closure = expect_sig(|p, y| *p = y);
    |                                      ^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:4 ~ escape_argument_callee[317d]::test[0]::{{closure}}[0]) with closure substs [
+   = note: defining type: test::{{closure}}#0 with closure substs [
                i16,
                for<'r, 's, 't0> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 'r)) mut &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) i32, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't0)) i32)),
            ]
@@ -30,7 +30,7 @@ LL | |     deref(p);
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:3 ~ escape_argument_callee[317d]::test[0]) with substs []
+   = note: defining type: test
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closure-requirements/escape-argument.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-argument.stderr
@@ -4,7 +4,7 @@ note: No external requirements
 LL |         let mut closure = expect_sig(|p, y| *p = y);
    |                                      ^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:4 ~ escape_argument[317d]::test[0]::{{closure}}[0]) with closure substs [
+   = note: defining type: test::{{closure}}#0 with closure substs [
                i16,
                for<'r, 's> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 'r)) mut &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) i32, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) i32)),
            ]
@@ -21,7 +21,7 @@ LL | |     deref(p);
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:3 ~ escape_argument[317d]::test[0]) with substs []
+   = note: defining type: test
 
 error[E0597]: `y` does not live long enough
   --> $DIR/escape-argument.rs:27:25

--- a/src/test/ui/nll/closure-requirements/escape-upvar-nested.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-upvar-nested.stderr
@@ -4,7 +4,7 @@ note: External requirements
 LL |             let mut closure1 = || p = &y;
    |                                ^^^^^^^^^
    |
-   = note: defining type: DefId(0:5 ~ escape_upvar_nested[317d]::test[0]::{{closure}}[0]::{{closure}}[0]) with closure substs [
+   = note: defining type: test::{{closure}}#0::{{closure}}#0 with closure substs [
                i16,
                extern "rust-call" fn(()),
                &'_#1r i32,
@@ -23,7 +23,7 @@ LL | |             closure1();
 LL | |         };
    | |_________^
    |
-   = note: defining type: DefId(0:4 ~ escape_upvar_nested[317d]::test[0]::{{closure}}[0]) with closure substs [
+   = note: defining type: test::{{closure}}#0 with closure substs [
                i16,
                extern "rust-call" fn(()),
                &'_#1r i32,
@@ -44,7 +44,7 @@ LL | |     deref(p);
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:3 ~ escape_upvar_nested[317d]::test[0]) with substs []
+   = note: defining type: test
 
 error[E0597]: `y` does not live long enough
   --> $DIR/escape-upvar-nested.rs:21:40

--- a/src/test/ui/nll/closure-requirements/escape-upvar-ref.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-upvar-ref.stderr
@@ -4,7 +4,7 @@ note: External requirements
 LL |         let mut closure = || p = &y;
    |                           ^^^^^^^^^
    |
-   = note: defining type: DefId(0:4 ~ escape_upvar_ref[317d]::test[0]::{{closure}}[0]) with closure substs [
+   = note: defining type: test::{{closure}}#0 with closure substs [
                i16,
                extern "rust-call" fn(()),
                &'_#1r i32,
@@ -25,7 +25,7 @@ LL | |     deref(p);
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:3 ~ escape_upvar_ref[317d]::test[0]) with substs []
+   = note: defining type: test
 
 error[E0597]: `y` does not live long enough
   --> $DIR/escape-upvar-ref.rs:23:35

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-fail-no-postdom.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-fail-no-postdom.stderr
@@ -8,7 +8,7 @@ LL | |             demand_y(x, y, p)
 LL | |         },
    | |_________^
    |
-   = note: defining type: DefId(0:18 ~ propagate_approximated_fail_no_postdom[317d]::supply[0]::{{closure}}[0]) with closure substs [
+   = note: defining type: supply::{{closure}}#0 with closure substs [
                i16,
                for<'r, 's> extern "rust-call" fn((std::cell::Cell<&'_#1r &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 'r)) u32>, std::cell::Cell<&'_#2r &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 'r)) u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) &'_#3r u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 'r)) u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) u32>)),
            ]
@@ -39,7 +39,7 @@ LL | |     );
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:14 ~ propagate_approximated_fail_no_postdom[317d]::supply[0]) with substs []
+   = note: defining type: supply
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-ref.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-ref.stderr
@@ -9,7 +9,7 @@ LL | |
 LL | |     });
    | |_____^
    |
-   = note: defining type: DefId(0:16 ~ propagate_approximated_ref[317d]::supply[0]::{{closure}}[0]) with closure substs [
+   = note: defining type: supply::{{closure}}#0 with closure substs [
                i16,
                for<'r, 's, 't0, 't1, 't2, 't3> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 'r)) std::cell::Cell<&'_#1r &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) u32>, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't0)) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't1)) &'_#2r u32>, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't2)) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) u32>, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't3)) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't1)) u32>)),
            ]
@@ -30,7 +30,7 @@ LL | |     });
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:13 ~ propagate_approximated_ref[317d]::supply[0]) with substs []
+   = note: defining type: supply
 
 error: lifetime may not live long enough
   --> $DIR/propagate-approximated-ref.rs:45:9

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -8,7 +8,7 @@ LL | |
 LL | |     })
    | |_____^
    |
-   = note: defining type: DefId(0:9 ~ propagate_approximated_shorter_to_static_comparing_against_free[317d]::case1[0]::{{closure}}[0]) with closure substs [
+   = note: defining type: case1::{{closure}}#0 with closure substs [
                i32,
                for<'r> extern "rust-call" fn((std::cell::Cell<&'_#1r u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 'r)) u32>)),
            ]
@@ -35,7 +35,7 @@ LL | |     })
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:8 ~ propagate_approximated_shorter_to_static_comparing_against_free[317d]::case1[0]) with substs []
+   = note: defining type: case1
 
 note: External requirements
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:35:15
@@ -46,7 +46,7 @@ LL | |         cell_x.set(cell_a.get()); // forces 'a: 'x, implies 'a = 'static 
 LL | |     })
    | |_____^
    |
-   = note: defining type: DefId(0:11 ~ propagate_approximated_shorter_to_static_comparing_against_free[317d]::case2[0]::{{closure}}[0]) with closure substs [
+   = note: defining type: case2::{{closure}}#0 with closure substs [
                i32,
                for<'r> extern "rust-call" fn((std::cell::Cell<&'_#1r u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 'r)) u32>)),
            ]
@@ -65,7 +65,7 @@ LL | |     })
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:10 ~ propagate_approximated_shorter_to_static_comparing_against_free[317d]::case2[0]) with substs []
+   = note: defining type: case2
 
 error[E0597]: `a` does not live long enough
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:30:26

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
@@ -10,7 +10,7 @@ LL | |         demand_y(x, y, x.get())
 LL | |     });
    | |_____^
    |
-   = note: defining type: DefId(0:16 ~ propagate_approximated_shorter_to_static_no_bound[317d]::supply[0]::{{closure}}[0]) with closure substs [
+   = note: defining type: supply::{{closure}}#0 with closure substs [
                i16,
                for<'r, 's, 't0, 't1, 't2> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 'r)) std::cell::Cell<&'_#1r &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) u32>, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't0)) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) u32>, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't1)) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't2)) u32>)),
            ]
@@ -31,7 +31,7 @@ LL | |     });
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:13 ~ propagate_approximated_shorter_to_static_no_bound[317d]::supply[0]) with substs []
+   = note: defining type: supply
 
 error[E0521]: borrowed data escapes outside of function
   --> $DIR/propagate-approximated-shorter-to-static-no-bound.rs:32:5

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
@@ -10,7 +10,7 @@ LL | |         demand_y(x, y, x.get())
 LL | |     });
    | |_____^
    |
-   = note: defining type: DefId(0:16 ~ propagate_approximated_shorter_to_static_wrong_bound[317d]::supply[0]::{{closure}}[0]) with closure substs [
+   = note: defining type: supply::{{closure}}#0 with closure substs [
                i16,
                for<'r, 's, 't0, 't1, 't2, 't3> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 'r)) std::cell::Cell<&'_#1r &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) u32>, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't0)) std::cell::Cell<&'_#2r &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't1)) u32>, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't2)) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) u32>, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't3)) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't1)) u32>)),
            ]
@@ -31,7 +31,7 @@ LL | |     });
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:13 ~ propagate_approximated_shorter_to_static_wrong_bound[317d]::supply[0]) with substs []
+   = note: defining type: supply
 
 error[E0521]: borrowed data escapes outside of function
   --> $DIR/propagate-approximated-shorter-to-static-wrong-bound.rs:35:5

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-val.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-val.stderr
@@ -9,7 +9,7 @@ LL | |
 LL | |     });
    | |_____^
    |
-   = note: defining type: DefId(0:16 ~ propagate_approximated_val[317d]::test[0]::{{closure}}[0]) with closure substs [
+   = note: defining type: test::{{closure}}#0 with closure substs [
                i16,
                for<'r, 's> extern "rust-call" fn((std::cell::Cell<&'_#1r &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 'r)) u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) &'_#2r u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 'r)) u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) u32>)),
            ]
@@ -30,7 +30,7 @@ LL | |     });
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:13 ~ propagate_approximated_val[317d]::test[0]) with substs []
+   = note: defining type: test
 
 error: lifetime may not live long enough
   --> $DIR/propagate-approximated-val.rs:38:9

--- a/src/test/ui/nll/closure-requirements/propagate-despite-same-free-region.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-despite-same-free-region.stderr
@@ -8,7 +8,7 @@ LL | |             demand_y(x, y, p)
 LL | |         },
    | |_________^
    |
-   = note: defining type: DefId(0:14 ~ propagate_despite_same_free_region[317d]::supply[0]::{{closure}}[0]) with closure substs [
+   = note: defining type: supply::{{closure}}#0 with closure substs [
                i16,
                for<'r, 's> extern "rust-call" fn((std::cell::Cell<&'_#1r &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 'r)) u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) &'_#2r u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 'r)) u32>, std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) u32>)),
            ]
@@ -28,5 +28,5 @@ LL | |     );
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:12 ~ propagate_despite_same_free_region[317d]::supply[0]) with substs []
+   = note: defining type: supply
 

--- a/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
@@ -9,7 +9,7 @@ LL | |
 LL | |     });
    | |_____^
    |
-   = note: defining type: DefId(0:16 ~ propagate_fail_to_approximate_longer_no_bounds[317d]::supply[0]::{{closure}}[0]) with closure substs [
+   = note: defining type: supply::{{closure}}#0 with closure substs [
                i16,
                for<'r, 's, 't0, 't1, 't2> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 'r)) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) &'_#1r u32>, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't0)) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't1)) u32>, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't2)) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) u32>)),
            ]
@@ -39,7 +39,7 @@ LL | |     });
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:13 ~ propagate_fail_to_approximate_longer_no_bounds[317d]::supply[0]) with substs []
+   = note: defining type: supply
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
@@ -9,7 +9,7 @@ LL | |
 LL | |     });
    | |_____^
    |
-   = note: defining type: DefId(0:16 ~ propagate_fail_to_approximate_longer_wrong_bounds[317d]::supply[0]::{{closure}}[0]) with closure substs [
+   = note: defining type: supply::{{closure}}#0 with closure substs [
                i16,
                for<'r, 's, 't0, 't1, 't2, 't3> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 'r)) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) &'_#1r u32>, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't0)) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't1)) &'_#2r u32>, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't2)) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) u32>, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't3)) std::cell::Cell<&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 't1)) u32>)),
            ]
@@ -39,7 +39,7 @@ LL | |     });
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:13 ~ propagate_fail_to_approximate_longer_wrong_bounds[317d]::supply[0]) with substs []
+   = note: defining type: supply
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closure-requirements/propagate-from-trait-match.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-from-trait-match.stderr
@@ -11,9 +11,7 @@ LL | |         require(value);
 LL | |     });
    | |_____^
    |
-   = note: defining type: DefId(0:14 ~ propagate_from_trait_match[317d]::supply[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               T,
+   = note: defining type: supply::<'_#1r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((T,)),
            ]
@@ -32,10 +30,7 @@ LL | |     });
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:11 ~ propagate_from_trait_match[317d]::supply[0]) with substs [
-               '_#1r,
-               T,
-           ]
+   = note: defining type: supply::<'_#1r, T>
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/propagate-from-trait-match.rs:32:36

--- a/src/test/ui/nll/closure-requirements/return-wrong-bound-region.stderr
+++ b/src/test/ui/nll/closure-requirements/return-wrong-bound-region.stderr
@@ -4,7 +4,7 @@ note: No external requirements
 LL |     expect_sig(|a, b| b); // ought to return `a`
    |                ^^^^^^^^
    |
-   = note: defining type: DefId(0:4 ~ return_wrong_bound_region[317d]::test[0]::{{closure}}[0]) with closure substs [
+   = note: defining type: test::{{closure}}#0 with closure substs [
                i16,
                for<'r, 's> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 'r)) i32, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) i32)) -> &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 'r)) i32,
            ]
@@ -27,7 +27,7 @@ LL | |
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:3 ~ return_wrong_bound_region[317d]::test[0]) with substs []
+   = note: defining type: test
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/ty-outlives/projection-no-regions-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-no-regions-closure.stderr
@@ -4,9 +4,7 @@ note: External requirements
 LL |     with_signature(x, |mut y| Box::new(y.next()))
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:13 ~ projection_no_regions_closure[317d]::no_region[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               T,
+   = note: defining type: no_region::<'_#1r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '_#2r)>,
            ]
@@ -25,10 +23,7 @@ LL | |
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:10 ~ projection_no_regions_closure[317d]::no_region[0]) with substs [
-               '_#1r,
-               T,
-           ]
+   = note: defining type: no_region::<'_#1r, T>
 
 error[E0309]: the associated type `<T as std::iter::Iterator>::Item` may not live long enough
   --> $DIR/projection-no-regions-closure.rs:25:23
@@ -44,9 +39,7 @@ note: External requirements
 LL |     with_signature(x, |mut y| Box::new(y.next()))
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:17 ~ projection_no_regions_closure[317d]::correct_region[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               T,
+   = note: defining type: correct_region::<'_#1r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '_#2r)>,
            ]
@@ -64,10 +57,7 @@ LL | |     with_signature(x, |mut y| Box::new(y.next()))
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:14 ~ projection_no_regions_closure[317d]::correct_region[0]) with substs [
-               '_#1r,
-               T,
-           ]
+   = note: defining type: correct_region::<'_#1r, T>
 
 note: External requirements
   --> $DIR/projection-no-regions-closure.rs:42:23
@@ -75,10 +65,7 @@ note: External requirements
 LL |     with_signature(x, |mut y| Box::new(y.next()))
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:22 ~ projection_no_regions_closure[317d]::wrong_region[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
+   = note: defining type: wrong_region::<'_#1r, '_#2r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '_#3r)>,
            ]
@@ -97,11 +84,7 @@ LL | |
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:18 ~ projection_no_regions_closure[317d]::wrong_region[0]) with substs [
-               '_#1r,
-               '_#2r,
-               T,
-           ]
+   = note: defining type: wrong_region::<'_#1r, '_#2r, T>
 
 error[E0309]: the associated type `<T as std::iter::Iterator>::Item` may not live long enough
   --> $DIR/projection-no-regions-closure.rs:42:23
@@ -117,10 +100,7 @@ note: External requirements
 LL |     with_signature(x, |mut y| Box::new(y.next()))
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:27 ~ projection_no_regions_closure[317d]::outlives_region[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
+   = note: defining type: outlives_region::<'_#1r, '_#2r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '_#3r)>,
            ]
@@ -139,11 +119,7 @@ LL | |     with_signature(x, |mut y| Box::new(y.next()))
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:23 ~ projection_no_regions_closure[317d]::outlives_region[0]) with substs [
-               '_#1r,
-               '_#2r,
-               T,
-           ]
+   = note: defining type: outlives_region::<'_#1r, '_#2r, T>
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
@@ -4,9 +4,7 @@ note: External requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:19 ~ projection_one_region_closure[317d]::no_relationships_late[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               T,
+   = note: defining type: no_relationships_late::<'_#1r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T)),
            ]
@@ -27,10 +25,7 @@ LL | |
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:15 ~ projection_one_region_closure[317d]::no_relationships_late[0]) with substs [
-               '_#1r,
-               T,
-           ]
+   = note: defining type: no_relationships_late::<'_#1r, T>
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/projection-one-region-closure.rs:45:29
@@ -59,10 +54,7 @@ note: External requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:24 ~ projection_one_region_closure[317d]::no_relationships_early[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
+   = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
            ]
@@ -82,11 +74,7 @@ LL | |
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:20 ~ projection_one_region_closure[317d]::no_relationships_early[0]) with substs [
-               '_#1r,
-               '_#2r,
-               T,
-           ]
+   = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/projection-one-region-closure.rs:56:29
@@ -115,10 +103,7 @@ note: External requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:29 ~ projection_one_region_closure[317d]::projection_outlives[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
+   = note: defining type: projection_outlives::<'_#1r, '_#2r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
            ]
@@ -137,11 +122,7 @@ LL | |     with_signature(cell, t, |cell, t| require(cell, t));
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:25 ~ projection_one_region_closure[317d]::projection_outlives[0]) with substs [
-               '_#1r,
-               '_#2r,
-               T,
-           ]
+   = note: defining type: projection_outlives::<'_#1r, '_#2r, T>
 
 note: External requirements
   --> $DIR/projection-one-region-closure.rs:80:29
@@ -149,10 +130,7 @@ note: External requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:34 ~ projection_one_region_closure[317d]::elements_outlive[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
+   = note: defining type: elements_outlive::<'_#1r, '_#2r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
            ]
@@ -172,11 +150,7 @@ LL | |     with_signature(cell, t, |cell, t| require(cell, t));
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:30 ~ projection_one_region_closure[317d]::elements_outlive[0]) with substs [
-               '_#1r,
-               '_#2r,
-               T,
-           ]
+   = note: defining type: elements_outlive::<'_#1r, '_#2r, T>
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
@@ -4,9 +4,7 @@ note: External requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:19 ~ projection_one_region_trait_bound_closure[317d]::no_relationships_late[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               T,
+   = note: defining type: no_relationships_late::<'_#1r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T)),
            ]
@@ -26,10 +24,7 @@ LL | |
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:15 ~ projection_one_region_trait_bound_closure[317d]::no_relationships_late[0]) with substs [
-               '_#1r,
-               T,
-           ]
+   = note: defining type: no_relationships_late::<'_#1r, T>
 
 error: lifetime may not live long enough
   --> $DIR/projection-one-region-trait-bound-closure.rs:37:39
@@ -50,10 +45,7 @@ note: External requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:24 ~ projection_one_region_trait_bound_closure[317d]::no_relationships_early[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
+   = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
            ]
@@ -72,11 +64,7 @@ LL | |
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:20 ~ projection_one_region_trait_bound_closure[317d]::no_relationships_early[0]) with substs [
-               '_#1r,
-               '_#2r,
-               T,
-           ]
+   = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>
 
 error: lifetime may not live long enough
   --> $DIR/projection-one-region-trait-bound-closure.rs:47:39
@@ -97,10 +85,7 @@ note: External requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:29 ~ projection_one_region_trait_bound_closure[317d]::projection_outlives[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
+   = note: defining type: projection_outlives::<'_#1r, '_#2r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
            ]
@@ -119,11 +104,7 @@ LL | |     with_signature(cell, t, |cell, t| require(cell, t));
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:25 ~ projection_one_region_trait_bound_closure[317d]::projection_outlives[0]) with substs [
-               '_#1r,
-               '_#2r,
-               T,
-           ]
+   = note: defining type: projection_outlives::<'_#1r, '_#2r, T>
 
 note: External requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:69:29
@@ -131,10 +112,7 @@ note: External requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:34 ~ projection_one_region_trait_bound_closure[317d]::elements_outlive[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
+   = note: defining type: elements_outlive::<'_#1r, '_#2r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
            ]
@@ -153,11 +131,7 @@ LL | |     with_signature(cell, t, |cell, t| require(cell, t));
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:30 ~ projection_one_region_trait_bound_closure[317d]::elements_outlive[0]) with substs [
-               '_#1r,
-               '_#2r,
-               T,
-           ]
+   = note: defining type: elements_outlive::<'_#1r, '_#2r, T>
 
 note: External requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:81:29
@@ -165,9 +139,7 @@ note: External requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:38 ~ projection_one_region_trait_bound_closure[317d]::one_region[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               T,
+   = note: defining type: one_region::<'_#1r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T)),
            ]
@@ -186,10 +158,7 @@ LL | |     with_signature(cell, t, |cell, t| require(cell, t));
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:35 ~ projection_one_region_trait_bound_closure[317d]::one_region[0]) with substs [
-               '_#1r,
-               T,
-           ]
+   = note: defining type: one_region::<'_#1r, T>
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.stderr
@@ -4,9 +4,7 @@ note: No external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:19 ~ projection_one_region_trait_bound_static_closure[317d]::no_relationships_late[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               T,
+   = note: defining type: no_relationships_late::<'_#1r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T)),
            ]
@@ -23,10 +21,7 @@ LL | |     with_signature(cell, t, |cell, t| require(cell, t));
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:15 ~ projection_one_region_trait_bound_static_closure[317d]::no_relationships_late[0]) with substs [
-               '_#1r,
-               T,
-           ]
+   = note: defining type: no_relationships_late::<'_#1r, T>
 
 note: No external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:45:29
@@ -34,10 +29,7 @@ note: No external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:24 ~ projection_one_region_trait_bound_static_closure[317d]::no_relationships_early[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
+   = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
            ]
@@ -54,11 +46,7 @@ LL | |     with_signature(cell, t, |cell, t| require(cell, t));
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:20 ~ projection_one_region_trait_bound_static_closure[317d]::no_relationships_early[0]) with substs [
-               '_#1r,
-               '_#2r,
-               T,
-           ]
+   = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>
 
 note: No external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:64:29
@@ -66,10 +54,7 @@ note: No external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:29 ~ projection_one_region_trait_bound_static_closure[317d]::projection_outlives[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
+   = note: defining type: projection_outlives::<'_#1r, '_#2r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
            ]
@@ -86,11 +71,7 @@ LL | |     with_signature(cell, t, |cell, t| require(cell, t));
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:25 ~ projection_one_region_trait_bound_static_closure[317d]::projection_outlives[0]) with substs [
-               '_#1r,
-               '_#2r,
-               T,
-           ]
+   = note: defining type: projection_outlives::<'_#1r, '_#2r, T>
 
 note: No external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:73:29
@@ -98,10 +79,7 @@ note: No external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:34 ~ projection_one_region_trait_bound_static_closure[317d]::elements_outlive[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
+   = note: defining type: elements_outlive::<'_#1r, '_#2r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
            ]
@@ -118,11 +96,7 @@ LL | |     with_signature(cell, t, |cell, t| require(cell, t));
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:30 ~ projection_one_region_trait_bound_static_closure[317d]::elements_outlive[0]) with substs [
-               '_#1r,
-               '_#2r,
-               T,
-           ]
+   = note: defining type: elements_outlive::<'_#1r, '_#2r, T>
 
 note: No external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:85:29
@@ -130,9 +104,7 @@ note: No external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:38 ~ projection_one_region_trait_bound_static_closure[317d]::one_region[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               T,
+   = note: defining type: one_region::<'_#1r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T)),
            ]
@@ -149,8 +121,5 @@ LL | |     with_signature(cell, t, |cell, t| require(cell, t));
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:35 ~ projection_one_region_trait_bound_static_closure[317d]::one_region[0]) with substs [
-               '_#1r,
-               T,
-           ]
+   = note: defining type: one_region::<'_#1r, T>
 

--- a/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
@@ -4,10 +4,7 @@ note: External requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:22 ~ projection_two_region_trait_bound_closure[317d]::no_relationships_late[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
+   = note: defining type: no_relationships_late::<'_#1r, '_#2r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
            ]
@@ -27,11 +24,7 @@ LL | |
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:17 ~ projection_two_region_trait_bound_closure[317d]::no_relationships_late[0]) with substs [
-               '_#1r,
-               '_#2r,
-               T,
-           ]
+   = note: defining type: no_relationships_late::<'_#1r, '_#2r, T>
 
 error[E0309]: the associated type `<T as Anything<'_#5r, '_#6r>>::AssocType` may not live long enough
   --> $DIR/projection-two-region-trait-bound-closure.rs:38:29
@@ -47,11 +40,7 @@ note: External requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:28 ~ projection_two_region_trait_bound_closure[317d]::no_relationships_early[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               '_#3r,
-               T,
+   = note: defining type: no_relationships_early::<'_#1r, '_#2r, '_#3r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#4r ()>, T)),
            ]
@@ -70,12 +59,7 @@ LL | |
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:23 ~ projection_two_region_trait_bound_closure[317d]::no_relationships_early[0]) with substs [
-               '_#1r,
-               '_#2r,
-               '_#3r,
-               T,
-           ]
+   = note: defining type: no_relationships_early::<'_#1r, '_#2r, '_#3r, T>
 
 error[E0309]: the associated type `<T as Anything<'_#6r, '_#7r>>::AssocType` may not live long enough
   --> $DIR/projection-two-region-trait-bound-closure.rs:48:29
@@ -91,11 +75,7 @@ note: External requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:34 ~ projection_two_region_trait_bound_closure[317d]::projection_outlives[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               '_#3r,
-               T,
+   = note: defining type: projection_outlives::<'_#1r, '_#2r, '_#3r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#4r ()>, T)),
            ]
@@ -114,12 +94,7 @@ LL | |     with_signature(cell, t, |cell, t| require(cell, t));
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:29 ~ projection_two_region_trait_bound_closure[317d]::projection_outlives[0]) with substs [
-               '_#1r,
-               '_#2r,
-               '_#3r,
-               T,
-           ]
+   = note: defining type: projection_outlives::<'_#1r, '_#2r, '_#3r, T>
 
 note: External requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:70:29
@@ -127,11 +102,7 @@ note: External requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:40 ~ projection_two_region_trait_bound_closure[317d]::elements_outlive1[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               '_#3r,
-               T,
+   = note: defining type: elements_outlive1::<'_#1r, '_#2r, '_#3r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#4r ()>, T)),
            ]
@@ -150,12 +121,7 @@ LL | |     with_signature(cell, t, |cell, t| require(cell, t));
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:35 ~ projection_two_region_trait_bound_closure[317d]::elements_outlive1[0]) with substs [
-               '_#1r,
-               '_#2r,
-               '_#3r,
-               T,
-           ]
+   = note: defining type: elements_outlive1::<'_#1r, '_#2r, '_#3r, T>
 
 note: External requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:79:29
@@ -163,11 +129,7 @@ note: External requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:46 ~ projection_two_region_trait_bound_closure[317d]::elements_outlive2[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               '_#3r,
-               T,
+   = note: defining type: elements_outlive2::<'_#1r, '_#2r, '_#3r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#4r ()>, T)),
            ]
@@ -186,12 +148,7 @@ LL | |     with_signature(cell, t, |cell, t| require(cell, t));
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:41 ~ projection_two_region_trait_bound_closure[317d]::elements_outlive2[0]) with substs [
-               '_#1r,
-               '_#2r,
-               '_#3r,
-               T,
-           ]
+   = note: defining type: elements_outlive2::<'_#1r, '_#2r, '_#3r, T>
 
 note: External requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:87:29
@@ -199,9 +156,7 @@ note: External requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:51 ~ projection_two_region_trait_bound_closure[317d]::two_regions[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               T,
+   = note: defining type: two_regions::<'_#1r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T)),
            ]
@@ -221,10 +176,7 @@ LL | |
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:47 ~ projection_two_region_trait_bound_closure[317d]::two_regions[0]) with substs [
-               '_#1r,
-               T,
-           ]
+   = note: defining type: two_regions::<'_#1r, T>
 
 error: lifetime may not live long enough
   --> $DIR/projection-two-region-trait-bound-closure.rs:87:29
@@ -245,10 +197,7 @@ note: External requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:56 ~ projection_two_region_trait_bound_closure[317d]::two_regions_outlive[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
+   = note: defining type: two_regions_outlive::<'_#1r, '_#2r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
            ]
@@ -267,11 +216,7 @@ LL | |     with_signature(cell, t, |cell, t| require(cell, t));
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:52 ~ projection_two_region_trait_bound_closure[317d]::two_regions_outlive[0]) with substs [
-               '_#1r,
-               '_#2r,
-               T,
-           ]
+   = note: defining type: two_regions_outlive::<'_#1r, '_#2r, T>
 
 note: External requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:109:29
@@ -279,9 +224,7 @@ note: External requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:60 ~ projection_two_region_trait_bound_closure[317d]::one_region[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               T,
+   = note: defining type: one_region::<'_#1r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T)),
            ]
@@ -300,10 +243,7 @@ LL | |     with_signature(cell, t, |cell, t| require(cell, t));
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:57 ~ projection_two_region_trait_bound_closure[317d]::one_region[0]) with substs [
-               '_#1r,
-               T,
-           ]
+   = note: defining type: one_region::<'_#1r, T>
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
@@ -4,8 +4,7 @@ note: External requirements
 LL |     twice(cell, value, |a, b| invoke(a, b));
    |                        ^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:11 ~ ty_param_closure_approximate_lower_bound[317d]::generic[0]::{{closure}}[0]) with closure substs [
-               T,
+   = note: defining type: generic::<T>::{{closure}}#0 with closure substs [
                i16,
                for<'r, 's> extern "rust-call" fn((std::option::Option<std::cell::Cell<&'_#1r &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 'r)) ()>>, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) T)),
            ]
@@ -21,9 +20,7 @@ LL | |     twice(cell, value, |a, b| invoke(a, b));
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:9 ~ ty_param_closure_approximate_lower_bound[317d]::generic[0]) with substs [
-               T,
-           ]
+   = note: defining type: generic::<T>
 
 note: External requirements
   --> $DIR/ty-param-closure-approximate-lower-bound.rs:29:24
@@ -31,8 +28,7 @@ note: External requirements
 LL |     twice(cell, value, |a, b| invoke(a, b));
    |                        ^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: DefId(0:15 ~ ty_param_closure_approximate_lower_bound[317d]::generic_fail[0]::{{closure}}[0]) with closure substs [
-               T,
+   = note: defining type: generic_fail::<T>::{{closure}}#0 with closure substs [
                i16,
                for<'r, 's> extern "rust-call" fn((std::option::Option<std::cell::Cell<&'_#1r &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 'r)) ()>>, &ReLateBound(DebruijnIndex(0), BrNamed(crate0:DefIndex(0), 's)) T)),
            ]
@@ -49,9 +45,7 @@ LL | |
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:12 ~ ty_param_closure_approximate_lower_bound[317d]::generic_fail[0]) with substs [
-               T,
-           ]
+   = note: defining type: generic_fail::<T>
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-closure-approximate-lower-bound.rs:29:24

--- a/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
@@ -4,9 +4,7 @@ note: External requirements
 LL |     with_signature(x, |y| y)
    |                       ^^^^^
    |
-   = note: defining type: DefId(0:11 ~ ty_param_closure_outlives_from_return_type[317d]::no_region[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               T,
+   = note: defining type: no_region::<'_#1r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn std::fmt::Debug + '_#2r)>,
            ]
@@ -25,10 +23,7 @@ LL | |
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:8 ~ ty_param_closure_outlives_from_return_type[317d]::no_region[0]) with substs [
-               '_#1r,
-               T,
-           ]
+   = note: defining type: no_region::<'_#1r, T>
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-closure-outlives-from-return-type.rs:26:23

--- a/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
@@ -11,8 +11,7 @@ LL | |         require(&x, &y)
 LL | |     })
    | |_____^
    |
-   = note: defining type: DefId(0:14 ~ ty_param_closure_outlives_from_where_clause[317d]::no_region[0]::{{closure}}[0]) with closure substs [
-               T,
+   = note: defining type: no_region::<T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#1r ()>, T)),
            ]
@@ -32,9 +31,7 @@ LL | |     })
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:11 ~ ty_param_closure_outlives_from_where_clause[317d]::no_region[0]) with substs [
-               T,
-           ]
+   = note: defining type: no_region::<T>
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:27:26
@@ -64,9 +61,7 @@ LL | |         require(&x, &y)
 LL | |     })
    | |_____^
    |
-   = note: defining type: DefId(0:18 ~ ty_param_closure_outlives_from_where_clause[317d]::correct_region[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               T,
+   = note: defining type: correct_region::<'_#1r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T)),
            ]
@@ -85,10 +80,7 @@ LL | |     })
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:15 ~ ty_param_closure_outlives_from_where_clause[317d]::correct_region[0]) with substs [
-               '_#1r,
-               T,
-           ]
+   = note: defining type: correct_region::<'_#1r, T>
 
 note: External requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:64:26
@@ -101,9 +93,7 @@ LL | |         require(&x, &y)
 LL | |     })
    | |_____^
    |
-   = note: defining type: DefId(0:23 ~ ty_param_closure_outlives_from_where_clause[317d]::wrong_region[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               T,
+   = note: defining type: wrong_region::<'_#1r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T)),
            ]
@@ -123,10 +113,7 @@ LL | |     })
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:19 ~ ty_param_closure_outlives_from_where_clause[317d]::wrong_region[0]) with substs [
-               '_#1r,
-               T,
-           ]
+   = note: defining type: wrong_region::<'_#1r, T>
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:64:26
@@ -151,10 +138,7 @@ LL | |         require(&x, &y)
 LL | |     })
    | |_____^
    |
-   = note: defining type: DefId(0:28 ~ ty_param_closure_outlives_from_where_clause[317d]::outlives_region[0]::{{closure}}[0]) with closure substs [
-               '_#1r,
-               '_#2r,
-               T,
+   = note: defining type: outlives_region::<'_#1r, '_#2r, T>::{{closure}}#0 with closure substs [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
            ]
@@ -173,11 +157,7 @@ LL | |     })
 LL | | }
    | |_^
    |
-   = note: defining type: DefId(0:24 ~ ty_param_closure_outlives_from_where_clause[317d]::outlives_region[0]) with substs [
-               '_#1r,
-               '_#2r,
-               T,
-           ]
+   = note: defining type: outlives_region::<'_#1r, '_#2r, T>
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Similar to #66850, spotted while working on #66907.

r? @matthewjasper