### PR TITLE
Suggest calling method when first argument is `self`

### DIFF
--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -759,8 +759,8 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
             // These items live in both the type and value namespaces.
             ItemKind::Struct(ref vdata, _) => {
                 // Define a name in the type namespace.
-                let def_id = self.r.definitions.local_def_id(item.id);
-                let res = Res::Def(DefKind::Struct, def_id);
+                let item_def_id = self.r.definitions.local_def_id(item.id);
+                let res = Res::Def(DefKind::Struct, item_def_id);
                 self.r.define(parent, ident, TypeNS, (res, vis, sp, expansion));
 
                 // Record field names for error reporting.
@@ -798,12 +798,12 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
             }
 
             ItemKind::Union(ref vdata, _) => {
-                let def_id = self.r.definitions.local_def_id(item.id);
-                let res = Res::Def(DefKind::Union, def_id);
+                let item_def_id = self.r.definitions.local_def_id(item.id);
+                let res = Res::Def(DefKind::Union, item_def_id);
                 self.r.define(parent, ident, TypeNS, (res, vis, sp, expansion));
 
                 // Record field names for error reporting.
-                self.insert_field_names_local(def_id, vdata);
+                self.insert_field_names_local(item_def_id, vdata);
             }
 
             ItemKind::Trait(..) => {

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -759,8 +759,8 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
             // These items live in both the type and value namespaces.
             ItemKind::Struct(ref vdata, _) => {
                 // Define a name in the type namespace.
-                let item_def_id = self.r.definitions.local_def_id(item.id);
-                let res = Res::Def(DefKind::Struct, item_def_id);
+                let def_id = self.r.definitions.local_def_id(item.id);
+                let res = Res::Def(DefKind::Struct, def_id);
                 self.r.define(parent, ident, TypeNS, (res, vis, sp, expansion));
 
                 // Record field names for error reporting.
@@ -798,12 +798,12 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
             }
 
             ItemKind::Union(ref vdata, _) => {
-                let item_def_id = self.r.definitions.local_def_id(item.id);
-                let res = Res::Def(DefKind::Union, item_def_id);
+                let def_id = self.r.definitions.local_def_id(item.id);
+                let res = Res::Def(DefKind::Union, def_id);
                 self.r.define(parent, ident, TypeNS, (res, vis, sp, expansion));
 
                 // Record field names for error reporting.
-                self.insert_field_names_local(item_def_id, vdata);
+                self.insert_field_names_local(def_id, vdata);
             }
 
             ItemKind::Trait(..) => {

--- a/src/librustc_resolve/late.rs
+++ b/src/librustc_resolve/late.rs
@@ -345,7 +345,7 @@ struct DiagnosticMetadata {
     /// The current self item if inside an ADT (used for better errors).
     current_self_item: Option<NodeId>,
 
-    /// The current enclosing funciton (used for better errors).
+    /// The current enclosing function (used for better errors).
     current_function: Option<Span>,
 
     /// A list of labels as of yet unused. Labels will be removed from this map when

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -260,41 +260,9 @@ impl<'a> LateResolutionVisitor<'a, '_> {
                 return (err, candidates);
             }
 
-            // Check if the first argument is `self` and suggest calling a method.
-            let mut has_self_arg = None;
-            if let PathSource::Expr(parent) = source {
-                match &parent.map(|p| &p.kind) {
-                    Some(ExprKind::Call(_, args)) if args.len() > 0 => {
-                        let mut expr_kind = &args[0].kind;
-                        loop {
-                            match expr_kind {
-                                ExprKind::Path(_, arg_name) if arg_name.segments.len() == 1 => {
-                                    if arg_name.segments[0].ident.name == kw::SelfLower {
-                                        let call_span = parent.unwrap().span;
-                                        let args_span = if args.len() > 1 {
-                                            Some(Span::new(
-                                                args[1].span.lo(),
-                                                args.last().unwrap().span.hi(),
-                                                call_span.ctxt(),
-                                            ))
-                                        } else {
-                                            None
-                                        };
-                                        has_self_arg = Some((call_span, args_span));
-                                    }
-                                    break;
-                                },
-                                ExprKind::AddrOf(_, _, expr) => expr_kind = &expr.kind,
-                                _ => break,
-                            }
-                        }
-                    }
-                    _ => (),
-                }
-            };
-
-            if let Some((call_span, args_span)) = has_self_arg {
-                let mut args_snippet: String = String::from("");
+            // If the first argument in call is `self` suggest calling a method.
+            if let Some((call_span, args_span)) = self.call_has_self_arg(source) {
+                let mut args_snippet = String::new();
                 if let Some(args_span) = args_span {
                     if let Ok(snippet) = self.r.session.source_map().span_to_snippet(args_span) {
                         args_snippet = snippet;
@@ -346,6 +314,43 @@ impl<'a> LateResolutionVisitor<'a, '_> {
             }
         }
         (err, candidates)
+    }
+
+    /// Check if the source is call expression and the first argument is `self`. If true,
+    /// return the span of whole call and the span for all arguments expect the first one (`self`).
+    fn call_has_self_arg(&self, source: PathSource<'_>) -> Option<(Span, Option<Span>)> {
+        let mut has_self_arg = None;
+        if let PathSource::Expr(parent) = source {
+            match &parent.map(|p| &p.kind) {
+                Some(ExprKind::Call(_, args)) if args.len() > 0 => {
+                    let mut expr_kind = &args[0].kind;
+                    loop {
+                        match expr_kind {
+                            ExprKind::Path(_, arg_name) if arg_name.segments.len() == 1 => {
+                                if arg_name.segments[0].ident.name == kw::SelfLower {
+                                    let call_span = parent.unwrap().span;
+                                    let tail_args_span = if args.len() > 1 {
+                                        Some(Span::new(
+                                            args[1].span.lo(),
+                                            args.last().unwrap().span.hi(),
+                                            call_span.ctxt(),
+                                        ))
+                                    } else {
+                                        None
+                                    };
+                                    has_self_arg = Some((call_span, tail_args_span));
+                                }
+                                break;
+                            }
+                            ExprKind::AddrOf(_, _, expr) => expr_kind = &expr.kind,
+                            _ => break,
+                        }
+                    }
+                }
+                _ => (),
+            }
+        };
+        return has_self_arg;
     }
 
     fn followed_by_brace(&self, span: Span) -> (bool, Option<(Span, String)>) {

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -265,14 +265,14 @@ impl<'a> LateResolutionVisitor<'a, '_> {
             if let PathSource::Expr(parent) = source {
                 match &parent.map(|p| &p.kind) {
                     Some(ExprKind::Call(_, args)) if args.len() > 0 => {
-                        let mut expr_kind = &args.first().unwrap().kind;
+                        let mut expr_kind = &args[0].kind;
                         loop {
                             match expr_kind {
                                 ExprKind::Path(_, arg_name) if arg_name.segments.len() == 1 => {
                                     has_self_arg = arg_name.segments[0].ident.name == kw::SelfLower;
                                     break;
                                 },
-                                ExprKind::AddrOf(_, _, expr) => { expr_kind = &expr.kind; }
+                                ExprKind::AddrOf(_, _, expr) => expr_kind = &expr.kind,
                                 _ => break,
                             }
                         }
@@ -284,7 +284,7 @@ impl<'a> LateResolutionVisitor<'a, '_> {
             if has_self_arg {
                 err.span_suggestion(
                     span,
-                    &"try calling method instead of passing `self` as parameter",
+                    &format!("try calling `{}` as a method", ident),
                     format!("self.{}", path_str),
                     Applicability::MachineApplicable,
                 );

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -262,6 +262,7 @@ impl<'a> LateResolutionVisitor<'a, '_> {
 
             // Check if the first argument is `self` and suggest calling a method.
             let mut has_self_arg = false;
+            let mut args_span = None;
             if let PathSource::Expr(parent) = source {
                 match &parent.map(|p| &p.kind) {
                     Some(ExprKind::Call(_, args)) if args.len() > 0 => {
@@ -270,6 +271,13 @@ impl<'a> LateResolutionVisitor<'a, '_> {
                             match expr_kind {
                                 ExprKind::Path(_, arg_name) if arg_name.segments.len() == 1 => {
                                     has_self_arg = arg_name.segments[0].ident.name == kw::SelfLower;
+                                    if args.len() > 1 {
+                                        args_span = Some(Span::new(
+                                            args[1].span.lo(),
+                                            args.last().unwrap().span.hi(),
+                                            parent.unwrap().span.ctxt(),
+                                        ));
+                                    }
                                     break;
                                 },
                                 ExprKind::AddrOf(_, _, expr) => expr_kind = &expr.kind,
@@ -282,10 +290,17 @@ impl<'a> LateResolutionVisitor<'a, '_> {
             };
 
             if has_self_arg {
+                let mut args_snippet: String = String::from("");
+                if let Some(args_span) = args_span {
+                    if let Ok(snippet) = self.r.session.source_map().span_to_snippet(args_span) {
+                        args_snippet = snippet;
+                    }
+                }
+
                 err.span_suggestion(
                     span,
                     &format!("try calling `{}` as a method", ident),
-                    format!("self.{}", path_str),
+                    format!("self.{}({})", path_str, args_snippet),
                     Applicability::MachineApplicable,
                 );
                 return (err, candidates);

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -261,8 +261,7 @@ impl<'a> LateResolutionVisitor<'a, '_> {
             }
 
             // Check if the first argument is `self` and suggest calling a method.
-            let mut has_self_arg = false;
-            let mut args_span = None;
+            let mut has_self_arg = None;
             if let PathSource::Expr(parent) = source {
                 match &parent.map(|p| &p.kind) {
                     Some(ExprKind::Call(_, args)) if args.len() > 0 => {
@@ -270,13 +269,18 @@ impl<'a> LateResolutionVisitor<'a, '_> {
                         loop {
                             match expr_kind {
                                 ExprKind::Path(_, arg_name) if arg_name.segments.len() == 1 => {
-                                    has_self_arg = arg_name.segments[0].ident.name == kw::SelfLower;
-                                    if args.len() > 1 {
-                                        args_span = Some(Span::new(
-                                            args[1].span.lo(),
-                                            args.last().unwrap().span.hi(),
-                                            parent.unwrap().span.ctxt(),
-                                        ));
+                                    if arg_name.segments[0].ident.name == kw::SelfLower {
+                                        let call_span = parent.unwrap().span;
+                                        let args_span = if args.len() > 1 {
+                                            Some(Span::new(
+                                                args[1].span.lo(),
+                                                args.last().unwrap().span.hi(),
+                                                call_span.ctxt(),
+                                            ))
+                                        } else {
+                                            None
+                                        };
+                                        has_self_arg = Some((call_span, args_span));
                                     }
                                     break;
                                 },
@@ -289,7 +293,7 @@ impl<'a> LateResolutionVisitor<'a, '_> {
                 }
             };
 
-            if has_self_arg {
+            if let Some((call_span, args_span)) = has_self_arg {
                 let mut args_snippet: String = String::from("");
                 if let Some(args_span) = args_span {
                     if let Ok(snippet) = self.r.session.source_map().span_to_snippet(args_span) {
@@ -298,7 +302,7 @@ impl<'a> LateResolutionVisitor<'a, '_> {
                 }
 
                 err.span_suggestion(
-                    span,
+                    call_span,
                     &format!("try calling `{}` as a method", ident),
                     format!("self.{}({})", path_str, args_snippet),
                     Applicability::MachineApplicable,

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -259,6 +259,37 @@ impl<'a> LateResolutionVisitor<'a, '_> {
                 }
                 return (err, candidates);
             }
+
+            // Check if the first argument is `self` and suggest calling a method.
+            let mut has_self_arg = false;
+            if let PathSource::Expr(parent) = source {
+                match &parent.map(|p| &p.kind) {
+                    Some(ExprKind::Call(_, args)) if args.len() > 0 => {
+                        let mut expr_kind = &args.first().unwrap().kind;
+                        loop {
+                            match expr_kind {
+                                ExprKind::Path(_, arg_name) if arg_name.segments.len() == 1 => {
+                                    has_self_arg = arg_name.segments[0].ident.name == kw::SelfLower;
+                                    break;
+                                },
+                                ExprKind::AddrOf(_, _, expr) => { expr_kind = &expr.kind; }
+                                _ => break,
+                            }
+                        }
+                    }
+                    _ => (),
+                }
+            };
+
+            if has_self_arg {
+                err.span_suggestion(
+                    span,
+                    &"try calling method instead of passing `self` as parameter",
+                    format!("self.{}", path_str),
+                    Applicability::MachineApplicable,
+                );
+                return (err, candidates);
+            }
         }
 
         // Try Levenshtein algorithm.

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -321,8 +321,8 @@ impl<'a> LateResolutionVisitor<'a, '_> {
     fn call_has_self_arg(&self, source: PathSource<'_>) -> Option<(Span, Option<Span>)> {
         let mut has_self_arg = None;
         if let PathSource::Expr(parent) = source {
-            match &parent.map(|p| &p.kind) {
-                Some(ExprKind::Call(_, args)) if args.len() > 0 => {
+            match &parent?.kind {
+                ExprKind::Call(_, args) if args.len() > 0 => {
                     let mut expr_kind = &args[0].kind;
                     loop {
                         match expr_kind {

--- a/src/test/ui/self/suggest-self-2.rs
+++ b/src/test/ui/self/suggest-self-2.rs
@@ -1,0 +1,22 @@
+struct Foo {}
+
+impl Foo {
+    fn foo(&self) {
+        bar(self);
+        //~^ ERROR cannot find function `bar` in this scope
+        //~| HELP try calling method instead of passing `self` as parameter
+
+
+        bar(&self);
+        //~^ ERROR cannot find function `bar` in this scope
+        //~| HELP try calling method instead of passing `self` as parameter
+
+        bar();
+        //~^ ERROR cannot find function `bar` in this scope
+
+        self.bar();
+        //~^ ERROR no method named `bar` found for type
+    }
+}
+
+fn main() {}

--- a/src/test/ui/self/suggest-self-2.rs
+++ b/src/test/ui/self/suggest-self-2.rs
@@ -4,12 +4,15 @@ impl Foo {
     fn foo(&self) {
         bar(self);
         //~^ ERROR cannot find function `bar` in this scope
-        //~| HELP try calling method instead of passing `self` as parameter
+        //~| HELP try calling `bar` as a method
 
-
-        bar(&self);
+        bar(&&self, 102);
         //~^ ERROR cannot find function `bar` in this scope
-        //~| HELP try calling method instead of passing `self` as parameter
+        //~| HELP try calling `bar` as a method
+
+        bar(&mut self, 102, &"str");
+        //~^ ERROR cannot find function `bar` in this scope
+        //~| HELP try calling `bar` as a method
 
         bar();
         //~^ ERROR cannot find function `bar` in this scope

--- a/src/test/ui/self/suggest-self-2.stderr
+++ b/src/test/ui/self/suggest-self-2.stderr
@@ -2,19 +2,25 @@ error[E0425]: cannot find function `bar` in this scope
   --> $DIR/suggest-self-2.rs:5:9
    |
 LL |         bar(self);
-   |         ^^^ help: try calling `bar` as a method: `self.bar()`
+   |         ^^^------
+   |         |
+   |         help: try calling `bar` as a method: `self.bar()`
 
 error[E0425]: cannot find function `bar` in this scope
   --> $DIR/suggest-self-2.rs:9:9
    |
 LL |         bar(&&self, 102);
-   |         ^^^ help: try calling `bar` as a method: `self.bar(102)`
+   |         ^^^-------------
+   |         |
+   |         help: try calling `bar` as a method: `self.bar(102)`
 
 error[E0425]: cannot find function `bar` in this scope
   --> $DIR/suggest-self-2.rs:13:9
    |
 LL |         bar(&mut self, 102, &"str");
-   |         ^^^ help: try calling `bar` as a method: `self.bar(102, &"str")`
+   |         ^^^------------------------
+   |         |
+   |         help: try calling `bar` as a method: `self.bar(102, &"str")`
 
 error[E0425]: cannot find function `bar` in this scope
   --> $DIR/suggest-self-2.rs:17:9

--- a/src/test/ui/self/suggest-self-2.stderr
+++ b/src/test/ui/self/suggest-self-2.stderr
@@ -2,27 +2,33 @@ error[E0425]: cannot find function `bar` in this scope
   --> $DIR/suggest-self-2.rs:5:9
    |
 LL |         bar(self);
-   |         ^^^ help: try calling method instead of passing `self` as parameter: `self.bar`
+   |         ^^^ help: try calling `bar` as a method: `self.bar`
 
 error[E0425]: cannot find function `bar` in this scope
-  --> $DIR/suggest-self-2.rs:10:9
+  --> $DIR/suggest-self-2.rs:9:9
    |
-LL |         bar(&self);
-   |         ^^^ help: try calling method instead of passing `self` as parameter: `self.bar`
+LL |         bar(&&self, 102);
+   |         ^^^ help: try calling `bar` as a method: `self.bar`
 
 error[E0425]: cannot find function `bar` in this scope
-  --> $DIR/suggest-self-2.rs:14:9
+  --> $DIR/suggest-self-2.rs:13:9
+   |
+LL |         bar(&mut self, 102, &"str");
+   |         ^^^ help: try calling `bar` as a method: `self.bar`
+
+error[E0425]: cannot find function `bar` in this scope
+  --> $DIR/suggest-self-2.rs:17:9
    |
 LL |         bar();
    |         ^^^ not found in this scope
 
 error[E0599]: no method named `bar` found for type `&Foo` in the current scope
-  --> $DIR/suggest-self-2.rs:17:14
+  --> $DIR/suggest-self-2.rs:20:14
    |
 LL |         self.bar();
    |              ^^^ method not found in `&Foo`
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0425, E0599.
 For more information about an error, try `rustc --explain E0425`.

--- a/src/test/ui/self/suggest-self-2.stderr
+++ b/src/test/ui/self/suggest-self-2.stderr
@@ -2,19 +2,19 @@ error[E0425]: cannot find function `bar` in this scope
   --> $DIR/suggest-self-2.rs:5:9
    |
 LL |         bar(self);
-   |         ^^^ help: try calling `bar` as a method: `self.bar`
+   |         ^^^ help: try calling `bar` as a method: `self.bar()`
 
 error[E0425]: cannot find function `bar` in this scope
   --> $DIR/suggest-self-2.rs:9:9
    |
 LL |         bar(&&self, 102);
-   |         ^^^ help: try calling `bar` as a method: `self.bar`
+   |         ^^^ help: try calling `bar` as a method: `self.bar(102)`
 
 error[E0425]: cannot find function `bar` in this scope
   --> $DIR/suggest-self-2.rs:13:9
    |
 LL |         bar(&mut self, 102, &"str");
-   |         ^^^ help: try calling `bar` as a method: `self.bar`
+   |         ^^^ help: try calling `bar` as a method: `self.bar(102, &"str")`
 
 error[E0425]: cannot find function `bar` in this scope
   --> $DIR/suggest-self-2.rs:17:9

--- a/src/test/ui/self/suggest-self-2.stderr
+++ b/src/test/ui/self/suggest-self-2.stderr
@@ -1,0 +1,28 @@
+error[E0425]: cannot find function `bar` in this scope
+  --> $DIR/suggest-self-2.rs:5:9
+   |
+LL |         bar(self);
+   |         ^^^ help: try calling method instead of passing `self` as parameter: `self.bar`
+
+error[E0425]: cannot find function `bar` in this scope
+  --> $DIR/suggest-self-2.rs:10:9
+   |
+LL |         bar(&self);
+   |         ^^^ help: try calling method instead of passing `self` as parameter: `self.bar`
+
+error[E0425]: cannot find function `bar` in this scope
+  --> $DIR/suggest-self-2.rs:14:9
+   |
+LL |         bar();
+   |         ^^^ not found in this scope
+
+error[E0599]: no method named `bar` found for type `&Foo` in the current scope
+  --> $DIR/suggest-self-2.rs:17:14
+   |
+LL |         self.bar();
+   |              ^^^ method not found in `&Foo`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0425, E0599.
+For more information about an error, try `rustc --explain E0425`.


### PR DESCRIPTION
Closes: #66782 

I've explored different approaches for this MR but I think the most straightforward is the best one.

I've tried to find out if the methods for given type exist (to maybe have a better suggestion), but we don't collect them anywhere and collecting them is quite problematic. Moreover, collecting all the methods would require rewriting big part of the code and also could potentially include performance degradation, which I don't think is necessary for this simple case.