### PR TITLE
Add option for deterministic hashing

### DIFF
--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -2464,7 +2464,7 @@ pub struct RandomState {
 }
 
 pub(super) const DETERMINISTIC_HASHING_ENABLED: u8 = 0x01;
-pub(super) const RANDOM_STATE_CONSTRUCTED: u8 = 0x02;
+pub(super) const RANDOM_STATE_CONSTRUCTED_BEFORE_DETERMINISTIC_HASHING_ENABLED: u8 = 0x02;
 
 pub(super) static HASHING_FLAGS: AtomicU8 = AtomicU8::new(0);
 
@@ -2483,7 +2483,11 @@ impl RandomState {
     // rand
     #[stable(feature = "hashmap_build_hasher", since = "1.7.0")]
     pub fn new() -> RandomState {
-        let flags = HASHING_FLAGS.fetch_or(RANDOM_STATE_CONSTRUCTED, Ordering::SeqCst);
+        let flags = HASHING_FLAGS.compare_and_swap(
+            0,
+            RANDOM_STATE_CONSTRUCTED_BEFORE_DETERMINISTIC_HASHING_ENABLED,
+            Ordering::SeqCst,
+        );
         if (flags & DETERMINISTIC_HASHING_ENABLED) != 0 {
             RandomState { k0: 0, k1: 0 }
         } else {

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -2463,10 +2463,10 @@ pub struct RandomState {
     k1: u64,
 }
 
-pub(crate) const DETERMINISTIC_HASHING_ENABLED: u8 = 0x01;
-pub(crate) const RANDOM_STATE_CONSTRUCTED: u8 = 0x02;
+pub(super) const DETERMINISTIC_HASHING_ENABLED: u8 = 0x01;
+pub(super) const RANDOM_STATE_CONSTRUCTED: u8 = 0x02;
 
-pub(crate) static HASHING_FLAGS: AtomicU8 = AtomicU8::new(0);
+pub(super) static HASHING_FLAGS: AtomicU8 = AtomicU8::new(0);
 
 impl RandomState {
     /// Constructs a new `RandomState` that is initialized with random keys.

--- a/src/libstd/collections/hash/mod.rs
+++ b/src/libstd/collections/hash/mod.rs
@@ -2,3 +2,34 @@
 
 pub mod map;
 pub mod set;
+
+/// Returns `true` if deterministic hashing was successfully
+/// enabled. A call to `enable_deterministic_hashing` will fail (i.e.,
+/// return `false`) if a `RandomState` instance was already constructed
+/// while deterministic hashing was disabled.
+///
+/// Deterministic hashing is useful when repeatability is desired,
+/// e.g., during debugging. The intended use is to put a call of the
+/// following form near the start of `main`:
+///
+/// ```
+/// debug_assert!(std::collections::enable_deterministic_hashing());
+/// ```
+///
+/// In this way, deterministic hashing will be enabled for debug
+/// builds, but not for release builds.
+///
+/// Warning: `hash_builder` is normally randomly generated, and is
+/// designed to allow HashMaps to be resistant to attacks that cause
+/// many collisions and very poor performance. Using this function
+/// can expose a DoS attack vector.
+#[unstable(feature = "deterministic_hashing", reason = "new API", issue = "0")]
+pub fn enable_deterministic_hashing() -> bool {
+    use crate::sync::atomic::Ordering;
+    let flags = map::HASHING_FLAGS.compare_and_swap(
+        0,
+        map::DETERMINISTIC_HASHING_ENABLED,
+        Ordering::SeqCst,
+    );
+    flags == 0 || (flags & map::DETERMINISTIC_HASHING_ENABLED) != 0
+}

--- a/src/libstd/collections/hash/mod.rs
+++ b/src/libstd/collections/hash/mod.rs
@@ -9,11 +9,16 @@ pub mod set;
 /// while deterministic hashing was disabled.
 ///
 /// Deterministic hashing is useful when repeatability is desired,
-/// e.g., during debugging. The intended use is to put a call of the
-/// following form near the start of `main`:
+/// e.g., during debugging. A possible use is to structure one's
+/// program as follows:
 ///
 /// ```
-/// debug_assert!(std::collections::enable_deterministic_hashing());
+/// #![feature(deterministic_hashing)]
+///
+/// fn main() {
+///    debug_assert!(std::collections::enable_deterministic_hashing());
+///    // ...
+/// }
 /// ```
 ///
 /// In this way, deterministic hashing will be enabled for debug

--- a/src/libstd/collections/mod.rs
+++ b/src/libstd/collections/mod.rs
@@ -431,6 +431,9 @@ pub use alloc_crate::collections::TryReserveError;
 
 mod hash;
 
+#[unstable(feature = "deterministic_hashing", reason = "new API", issue = "0")]
+pub use hash::enable_deterministic_hashing;
+
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod hash_map {
     //! A hash map implemented with linear probing and Robin Hood bucket stealing.


### PR DESCRIPTION
Currently, all `HashMap`/`HashSet`s' `hasher`s are randomly generated in order to [deter certain denial-of-service attacks](https://doc.rust-lang.org/src/std/collections/hash/map.rs.html#477-480). While this makes sense for release builds, the use of randomness can cause a program to behave differently across runs, making debugging more difficult.

Also currently, one can disable this use of randomness for a *single* instance of `HashMap`/`HashSet` by, e.g., changing its third type parameter from the default (`RandomState`) to something else. But it is painful to make such changes piecemeal. It is especially painful to have to patch a dependency in order to make such a change.

The present PR is an approach to making such a change program wide. Specifically, it adds a function `enable_deterministic_hashing` to `std::collections`. Calling this function causes all `RandomState` instances to be constructed with a single, fixed key (`(0, 0)`). The intent is that this function be called early on in a program. To this aim, the function fails (and returns `false`) if a `RandomState` instance was already constructed while deterministic hashing was disabled.

So, for example, one might put the following near the start of `main`:
```
debug_assert!(std::collections::enable_deterministic_hashing());
```
In this way, deterministic hashing will be enabled for debug builds, but not for release builds.