### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/src/liballoc/alloc/tests.rs
+++ b/src/liballoc/alloc/tests.rs
@@ -1,15 +1,15 @@
 use super::*;
 
 extern crate test;
-use test::Bencher;
 use crate::boxed::Box;
+use test::Bencher;
 
 #[test]
 fn allocate_zeroed() {
     unsafe {
         let layout = Layout::from_size_align(1024, 1).unwrap();
-        let ptr = Global.alloc_zeroed(layout.clone())
-            .unwrap_or_else(|_| handle_alloc_error(layout));
+        let ptr =
+            Global.alloc_zeroed(layout.clone()).unwrap_or_else(|_| handle_alloc_error(layout));
 
         let mut i = ptr.cast::<u8>().as_ptr();
         let end = i.add(layout.size());

--- a/src/liballoc/benches/btree/map.rs
+++ b/src/liballoc/benches/btree/map.rs
@@ -1,12 +1,12 @@
+use std::collections::BTreeMap;
 use std::iter::Iterator;
 use std::vec::Vec;
-use std::collections::BTreeMap;
 
-use rand::{Rng, seq::SliceRandom, thread_rng};
-use test::{Bencher, black_box};
+use rand::{seq::SliceRandom, thread_rng, Rng};
+use test::{black_box, Bencher};
 
 macro_rules! map_insert_rand_bench {
-    ($name: ident, $n: expr, $map: ident) => (
+    ($name: ident, $n: expr, $map: ident) => {
         #[bench]
         pub fn $name(b: &mut Bencher) {
             let n: usize = $n;
@@ -27,11 +27,11 @@ macro_rules! map_insert_rand_bench {
             });
             black_box(map);
         }
-    )
+    };
 }
 
 macro_rules! map_insert_seq_bench {
-    ($name: ident, $n: expr, $map: ident) => (
+    ($name: ident, $n: expr, $map: ident) => {
         #[bench]
         pub fn $name(b: &mut Bencher) {
             let mut map = $map::new();
@@ -50,11 +50,11 @@ macro_rules! map_insert_seq_bench {
             });
             black_box(map);
         }
-    )
+    };
 }
 
 macro_rules! map_find_rand_bench {
-    ($name: ident, $n: expr, $map: ident) => (
+    ($name: ident, $n: expr, $map: ident) => {
         #[bench]
         pub fn $name(b: &mut Bencher) {
             let mut map = $map::new();
@@ -78,11 +78,11 @@ macro_rules! map_find_rand_bench {
                 black_box(t);
             })
         }
-    )
+    };
 }
 
 macro_rules! map_find_seq_bench {
-    ($name: ident, $n: expr, $map: ident) => (
+    ($name: ident, $n: expr, $map: ident) => {
         #[bench]
         pub fn $name(b: &mut Bencher) {
             let mut map = $map::new();
@@ -101,20 +101,20 @@ macro_rules! map_find_seq_bench {
                 black_box(x);
             })
         }
-    )
+    };
 }
 
-map_insert_rand_bench!{insert_rand_100,    100,    BTreeMap}
-map_insert_rand_bench!{insert_rand_10_000, 10_000, BTreeMap}
+map_insert_rand_bench! {insert_rand_100,    100,    BTreeMap}
+map_insert_rand_bench! {insert_rand_10_000, 10_000, BTreeMap}
 
-map_insert_seq_bench!{insert_seq_100,    100,    BTreeMap}
-map_insert_seq_bench!{insert_seq_10_000, 10_000, BTreeMap}
+map_insert_seq_bench! {insert_seq_100,    100,    BTreeMap}
+map_insert_seq_bench! {insert_seq_10_000, 10_000, BTreeMap}
 
-map_find_rand_bench!{find_rand_100,    100,    BTreeMap}
-map_find_rand_bench!{find_rand_10_000, 10_000, BTreeMap}
+map_find_rand_bench! {find_rand_100,    100,    BTreeMap}
+map_find_rand_bench! {find_rand_10_000, 10_000, BTreeMap}
 
-map_find_seq_bench!{find_seq_100,    100,    BTreeMap}
-map_find_seq_bench!{find_seq_10_000, 10_000, BTreeMap}
+map_find_seq_bench! {find_seq_100,    100,    BTreeMap}
+map_find_seq_bench! {find_seq_10_000, 10_000, BTreeMap}
 
 fn bench_iter(b: &mut Bencher, size: i32) {
     let mut map = BTreeMap::<i32, i32>::new();

--- a/src/liballoc/benches/str.rs
+++ b/src/liballoc/benches/str.rs
@@ -1,4 +1,4 @@
-use test::{Bencher, black_box};
+use test::{black_box, Bencher};
 
 #[bench]
 fn char_iterator(b: &mut Bencher) {
@@ -12,7 +12,9 @@ fn char_iterator_for(b: &mut Bencher) {
     let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
 
     b.iter(|| {
-        for ch in s.chars() { black_box(ch); }
+        for ch in s.chars() {
+            black_box(ch);
+        }
     });
 }
 
@@ -40,7 +42,9 @@ fn char_iterator_rev_for(b: &mut Bencher) {
     let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
 
     b.iter(|| {
-        for ch in s.chars().rev() { black_box(ch); }
+        for ch in s.chars().rev() {
+            black_box(ch);
+        }
     });
 }
 
@@ -79,7 +83,9 @@ fn split_ascii(b: &mut Bencher) {
 fn split_extern_fn(b: &mut Bencher) {
     let s = "Mary had a little lamb, Little lamb, little-lamb.";
     let len = s.split(' ').count();
-    fn pred(c: char) -> bool { c == ' ' }
+    fn pred(c: char) -> bool {
+        c == ' '
+    }
 
     b.iter(|| assert_eq!(s.split(pred).count(), len));
 }
@@ -185,16 +191,19 @@ fn bench_contains_equal(b: &mut Bencher) {
     })
 }
 
-
 macro_rules! make_test_inner {
     ($s:ident, $code:expr, $name:ident, $str:expr, $iters:expr) => {
         #[bench]
         fn $name(bencher: &mut Bencher) {
             let mut $s = $str;
             black_box(&mut $s);
-            bencher.iter(|| for _ in 0..$iters { black_box($code); });
+            bencher.iter(|| {
+                for _ in 0..$iters {
+                    black_box($code);
+                }
+            });
         }
-    }
+    };
 }
 
 macro_rules! make_test {
@@ -261,15 +270,9 @@ make_test!(match_indices_a_str, s, s.match_indices("a").count());
 
 make_test!(split_a_str, s, s.split("a").count());
 
-make_test!(trim_ascii_char, s, {
-    s.trim_matches(|c: char| c.is_ascii())
-});
-make_test!(trim_start_ascii_char, s, {
-    s.trim_start_matches(|c: char| c.is_ascii())
-});
-make_test!(trim_end_ascii_char, s, {
-    s.trim_end_matches(|c: char| c.is_ascii())
-});
+make_test!(trim_ascii_char, s, { s.trim_matches(|c: char| c.is_ascii()) });
+make_test!(trim_start_ascii_char, s, { s.trim_start_matches(|c: char| c.is_ascii()) });
+make_test!(trim_end_ascii_char, s, { s.trim_end_matches(|c: char| c.is_ascii()) });
 
 make_test!(find_underscore_char, s, s.find('_'));
 make_test!(rfind_underscore_char, s, s.rfind('_'));

--- a/src/liballoc/benches/vec_deque.rs
+++ b/src/liballoc/benches/vec_deque.rs
@@ -1,5 +1,5 @@
 use std::collections::VecDeque;
-use test::{Bencher, black_box};
+use test::{black_box, Bencher};
 
 #[bench]
 fn bench_new(b: &mut Bencher) {

--- a/src/liballoc/benches/vec_deque_append.rs
+++ b/src/liballoc/benches/vec_deque_append.rs
@@ -30,8 +30,5 @@ fn main() {
 
     assert!(BENCH_N % 2 == 0);
     let median = (durations[(l / 2) - 1] + durations[l / 2]) / 2;
-    println!(
-        "\ncustom-bench vec_deque_append {:?} ns/iter\n",
-        median.as_nanos()
-    );
+    println!("\ncustom-bench vec_deque_append {:?} ns/iter\n", median.as_nanos());
 }

--- a/src/liballoc/collections/btree/mod.rs
+++ b/src/liballoc/collections/btree/mod.rs
@@ -1,6 +1,6 @@
+pub mod map;
 mod node;
 mod search;
-pub mod map;
 pub mod set;
 
 #[doc(hidden)]

--- a/src/liballoc/collections/btree/search.rs
+++ b/src/liballoc/collections/btree/search.rs
@@ -1,21 +1,23 @@
 use core::borrow::Borrow;
 use core::cmp::Ordering;
 
-use super::node::{Handle, NodeRef, marker, ForceResult::*};
+use super::node::{marker, ForceResult::*, Handle, NodeRef};
 
 use SearchResult::*;
 
 pub enum SearchResult<BorrowType, K, V, FoundType, GoDownType> {
     Found(Handle<NodeRef<BorrowType, K, V, FoundType>, marker::KV>),
-    GoDown(Handle<NodeRef<BorrowType, K, V, GoDownType>, marker::Edge>)
+    GoDown(Handle<NodeRef<BorrowType, K, V, GoDownType>, marker::Edge>),
 }
 
 pub fn search_tree<BorrowType, K, V, Q: ?Sized>(
     mut node: NodeRef<BorrowType, K, V, marker::LeafOrInternal>,
-    key: &Q
+    key: &Q,
 ) -> SearchResult<BorrowType, K, V, marker::LeafOrInternal, marker::Leaf>
-        where Q: Ord, K: Borrow<Q> {
-
+where
+    Q: Ord,
+    K: Borrow<Q>,
+{
     loop {
         match search_node(node, key) {
             Found(handle) => return Found(handle),
@@ -25,38 +27,38 @@ pub fn search_tree<BorrowType, K, V, Q: ?Sized>(
                     node = internal.descend();
                     continue;
                 }
-            }
+            },
         }
     }
 }
 
 pub fn search_node<BorrowType, K, V, Type, Q: ?Sized>(
     node: NodeRef<BorrowType, K, V, Type>,
-    key: &Q
+    key: &Q,
 ) -> SearchResult<BorrowType, K, V, Type, Type>
-        where Q: Ord, K: Borrow<Q> {
-
+where
+    Q: Ord,
+    K: Borrow<Q>,
+{
     match search_linear(&node, key) {
-        (idx, true) => Found(
-            Handle::new_kv(node, idx)
-        ),
-        (idx, false) => SearchResult::GoDown(
-            Handle::new_edge(node, idx)
-        )
+        (idx, true) => Found(Handle::new_kv(node, idx)),
+        (idx, false) => SearchResult::GoDown(Handle::new_edge(node, idx)),
     }
 }
 
 pub fn search_linear<BorrowType, K, V, Type, Q: ?Sized>(
     node: &NodeRef<BorrowType, K, V, Type>,
-    key: &Q
+    key: &Q,
 ) -> (usize, bool)
-        where Q: Ord, K: Borrow<Q> {
-
+where
+    Q: Ord,
+    K: Borrow<Q>,
+{
     for (i, k) in node.keys().iter().enumerate() {
         match key.cmp(k.borrow()) {
-            Ordering::Greater => {},
+            Ordering::Greater => {}
             Ordering::Equal => return (i, true),
-            Ordering::Less => return (i, false)
+            Ordering::Less => return (i, false),
         }
     }
     (node.keys().len(), false)

--- a/src/liballoc/collections/linked_list/tests.rs
+++ b/src/liballoc/collections/linked_list/tests.rs
@@ -177,8 +177,7 @@ fn test_insert_prev() {
     }
     check_links(&m);
     assert_eq!(m.len(), 3 + len * 2);
-    assert_eq!(m.into_iter().collect::<Vec<_>>(),
-                [-2, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1]);
+    assert_eq!(m.into_iter().collect::<Vec<_>>(), [-2, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1]);
 }
 
 #[test]
@@ -187,13 +186,13 @@ fn test_insert_prev() {
 fn test_send() {
     let n = list_from(&[1, 2, 3]);
     thread::spawn(move || {
-            check_links(&n);
-            let a: &[_] = &[&1, &2, &3];
-            assert_eq!(a, &*n.iter().collect::<Vec<_>>());
-        })
-        .join()
-        .ok()
-        .unwrap();
+        check_links(&n);
+        let a: &[_] = &[&1, &2, &3];
+        assert_eq!(a, &*n.iter().collect::<Vec<_>>());
+    })
+    .join()
+    .ok()
+    .unwrap();
 }
 
 #[test]

--- a/src/liballoc/collections/vec_deque/tests.rs
+++ b/src/liballoc/collections/vec_deque/tests.rs
@@ -66,11 +66,8 @@ fn test_swap_front_back_remove() {
         let final_len = usable_cap / 2;
 
         for len in 0..final_len {
-            let expected: VecDeque<_> = if back {
-                (0..len).collect()
-            } else {
-                (0..len).rev().collect()
-            };
+            let expected: VecDeque<_> =
+                if back { (0..len).collect() } else { (0..len).rev().collect() };
             for tail_pos in 0..usable_cap {
                 tester.tail = tail_pos;
                 tester.head = tail_pos;
@@ -110,7 +107,6 @@ fn test_insert() {
     // 15 would be great, but we will definitely get 2^k - 1, for k >= 4, or else
     // this test isn't covering what it wants to
     let cap = tester.capacity();
-
 
     // len is the length *after* insertion
     for len in 1..cap {
@@ -198,9 +194,7 @@ fn test_drain() {
                     assert!(tester.head < tester.cap());
 
                     // We should see the correct values in the VecDeque
-                    let expected: VecDeque<_> = (0..drain_start)
-                        .chain(drain_end..len)
-                        .collect();
+                    let expected: VecDeque<_> = (0..drain_start).chain(drain_end..len).collect();
                     assert_eq!(expected, tester);
                 }
             }

--- a/src/liballoc/fmt.rs
+++ b/src/liballoc/fmt.rs
@@ -516,24 +516,24 @@
 
 #[unstable(feature = "fmt_internals", issue = "0")]
 pub use core::fmt::rt;
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::fmt::{Formatter, Result, Write};
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::fmt::{Binary, Octal};
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::fmt::{Debug, Display};
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::fmt::{LowerHex, Pointer, UpperHex};
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::fmt::{LowerExp, UpperExp};
+#[stable(feature = "fmt_flags_align", since = "1.28.0")]
+pub use core::fmt::Alignment;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::Error;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{write, ArgumentV1, Arguments};
 #[stable(feature = "rust1", since = "1.0.0")]
+pub use core::fmt::{Binary, Octal};
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use core::fmt::{Debug, Display};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{DebugList, DebugMap, DebugSet, DebugStruct, DebugTuple};
-#[stable(feature = "fmt_flags_align", since = "1.28.0")]
-pub use core::fmt::{Alignment};
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use core::fmt::{Formatter, Result, Write};
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use core::fmt::{LowerExp, UpperExp};
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use core::fmt::{LowerHex, Pointer, UpperHex};
 
 use crate::string;
 
@@ -568,8 +568,6 @@ use crate::string;
 pub fn format(args: Arguments<'_>) -> string::String {
     let capacity = args.estimated_capacity();
     let mut output = string::String::with_capacity(capacity);
-    output
-        .write_fmt(args)
-        .expect("a formatting trait implementation returned an error");
+    output.write_fmt(args).expect("a formatting trait implementation returned an error");
     output
 }

--- a/src/liballoc/prelude/v1.rs
+++ b/src/liballoc/prelude/v1.rs
@@ -4,7 +4,11 @@
 
 #![unstable(feature = "alloc_prelude", issue = "58935")]
 
-#[unstable(feature = "alloc_prelude", issue = "58935")] pub use crate::borrow::ToOwned;
-#[unstable(feature = "alloc_prelude", issue = "58935")] pub use crate::boxed::Box;
-#[unstable(feature = "alloc_prelude", issue = "58935")] pub use crate::string::{String, ToString};
-#[unstable(feature = "alloc_prelude", issue = "58935")] pub use crate::vec::Vec;
+#[unstable(feature = "alloc_prelude", issue = "58935")]
+pub use crate::borrow::ToOwned;
+#[unstable(feature = "alloc_prelude", issue = "58935")]
+pub use crate::boxed::Box;
+#[unstable(feature = "alloc_prelude", issue = "58935")]
+pub use crate::string::{String, ToString};
+#[unstable(feature = "alloc_prelude", issue = "58935")]
+pub use crate::vec::Vec;

--- a/src/liballoc/raw_vec/tests.rs
+++ b/src/liballoc/raw_vec/tests.rs
@@ -16,7 +16,9 @@ fn allocator_param() {
 
     // A dumb allocator that consumes a fixed amount of fuel
     // before allocation attempts start failing.
-    struct BoundedAlloc { fuel: usize }
+    struct BoundedAlloc {
+        fuel: usize,
+    }
     unsafe impl Alloc for BoundedAlloc {
         unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
             let size = layout.size();
@@ -24,7 +26,10 @@ fn allocator_param() {
                 return Err(AllocErr);
             }
             match Global.alloc(layout) {
-                ok @ Ok(_) => { self.fuel -= size; ok }
+                ok @ Ok(_) => {
+                    self.fuel -= size;
+                    ok
+                }
                 err @ Err(_) => err,
             }
         }

--- a/src/liballoc/tests.rs
+++ b/src/liballoc/tests.rs
@@ -1,12 +1,12 @@
 //! Test for `boxed` mod.
 
 use core::any::Any;
-use core::convert::TryInto;
-use core::ops::Deref;
-use core::result::Result::{Err, Ok};
 use core::clone::Clone;
+use core::convert::TryInto;
 use core::f64;
 use core::i64;
+use core::ops::Deref;
+use core::result::Result::{Err, Ok};
 
 use std::boxed::Box;
 

--- a/src/liballoc/tests/arc.rs
+++ b/src/liballoc/tests/arc.rs
@@ -1,9 +1,9 @@
 use std::any::Any;
-use std::sync::{Arc, Weak};
 use std::cell::RefCell;
 use std::cmp::PartialEq;
 use std::iter::TrustedLen;
 use std::mem;
+use std::sync::{Arc, Weak};
 
 #[test]
 fn uninhabited() {
@@ -12,7 +12,7 @@ fn uninhabited() {
     a = a.clone();
     assert!(a.upgrade().is_none());
 
-    let mut a: Weak<dyn Any> = a;  // Unsizing
+    let mut a: Weak<dyn Any> = a; // Unsizing
     a = a.clone();
     assert!(a.upgrade().is_none());
 }
@@ -20,8 +20,8 @@ fn uninhabited() {
 #[test]
 fn slice() {
     let a: Arc<[u32; 3]> = Arc::new([3, 2, 1]);
-    let a: Arc<[u32]> = a;  // Unsizing
-    let b: Arc<[u32]> = Arc::from(&[3, 2, 1][..]);  // Conversion
+    let a: Arc<[u32]> = a; // Unsizing
+    let b: Arc<[u32]> = Arc::from(&[3, 2, 1][..]); // Conversion
     assert_eq!(a, b);
 
     // Exercise is_dangling() with a DST
@@ -33,7 +33,7 @@ fn slice() {
 #[test]
 fn trait_object() {
     let a: Arc<u32> = Arc::new(4);
-    let a: Arc<dyn Any> = a;  // Unsizing
+    let a: Arc<dyn Any> = a; // Unsizing
 
     // Exercise is_dangling() with a DST
     let mut a = Arc::downgrade(&a);
@@ -43,7 +43,7 @@ fn trait_object() {
     let mut b = Weak::<u32>::new();
     b = b.clone();
     assert!(b.upgrade().is_none());
-    let mut b: Weak<dyn Any> = b;  // Unsizing
+    let mut b: Weak<dyn Any> = b; // Unsizing
     b = b.clone();
     assert!(b.upgrade().is_none());
 }
@@ -57,7 +57,7 @@ fn float_nan_ne() {
 
 #[test]
 fn partial_eq() {
-    struct TestPEq (RefCell<usize>);
+    struct TestPEq(RefCell<usize>);
     impl PartialEq for TestPEq {
         fn eq(&self, other: &TestPEq) -> bool {
             *self.0.borrow_mut() += 1;
@@ -74,7 +74,7 @@ fn partial_eq() {
 #[test]
 fn eq() {
     #[derive(Eq)]
-    struct TestEq (RefCell<usize>);
+    struct TestEq(RefCell<usize>);
     impl PartialEq for TestEq {
         fn eq(&self, other: &TestEq) -> bool {
             *self.0.borrow_mut() += 1;
@@ -160,13 +160,10 @@ fn shared_from_iter_trustedlen_normal() {
 fn shared_from_iter_trustedlen_panic() {
     // Exercise the `TrustedLen` implementation when `size_hint()` matches
     // `(_, Some(exact_len))` but where `.next()` drops before the last iteration.
-    let iter = (0..SHARED_ITER_MAX)
-        .map(|val| {
-            match val {
-                98 => panic!("I've almost got 99 problems."),
-                _ => Box::new(val),
-            }
-        });
+    let iter = (0..SHARED_ITER_MAX).map(|val| match val {
+        98 => panic!("I've almost got 99 problems."),
+        _ => Box::new(val),
+    });
     assert_trusted_len(&iter);
     let _ = iter.collect::<Rc<[_]>>();
 
@@ -193,16 +190,8 @@ fn shared_from_iter_trustedlen_no_fuse() {
         }
     }
 
-    let vec = vec![
-        Some(Box::new(42)),
-        Some(Box::new(24)),
-        None,
-        Some(Box::new(12)),
-    ];
+    let vec = vec![Some(Box::new(42)), Some(Box::new(24)), None, Some(Box::new(12))];
     let iter = Iter(vec.into_iter());
     assert_trusted_len(&iter);
-    assert_eq!(
-        &[Box::new(42), Box::new(24)],
-        &*iter.collect::<Rc<[_]>>()
-    );
+    assert_eq!(&[Box::new(42), Box::new(24)], &*iter.collect::<Rc<[_]>>());
 }

--- a/src/liballoc/tests/binary_heap.rs
+++ b/src/liballoc/tests/binary_heap.rs
@@ -376,7 +376,10 @@ fn panic_safe() {
     }
     let mut rng = thread_rng();
     const DATASZ: usize = 32;
+    #[cfg(not(miri))] // Miri is too slow
     const NTEST: usize = 10;
+    #[cfg(miri)]
+    const NTEST: usize = 1;
 
     // don't use 0 in the data -- we want to catch the zeroed-out case.
     let data = (1..=DATASZ).collect::<Vec<_>>();

--- a/src/liballoc/tests/binary_heap.rs
+++ b/src/liballoc/tests/binary_heap.rs
@@ -347,7 +347,7 @@ fn assert_covariance() {
 // Destructors must be called exactly once per element.
 // FIXME: re-enable emscripten once it can unwind again
 #[test]
-#[cfg(not(any(miri, target_os = "emscripten")))] // Miri does not support catching panics
+#[cfg(not(target_os = "emscripten"))]
 fn panic_safe() {
     use std::cmp;
     use std::panic::{self, AssertUnwindSafe};

--- a/src/liballoc/tests/boxed.rs
+++ b/src/liballoc/tests/boxed.rs
@@ -1,5 +1,5 @@
-use std::ptr::NonNull;
 use std::mem::MaybeUninit;
+use std::ptr::NonNull;
 
 #[test]
 fn unitialized_zero_size_box() {

--- a/src/liballoc/tests/btree/mod.rs
+++ b/src/liballoc/tests/btree/mod.rs
@@ -11,12 +11,7 @@ struct DeterministicRng {
 
 impl DeterministicRng {
     fn new() -> Self {
-        DeterministicRng {
-            x: 0x193a6754,
-            y: 0xa8a7d469,
-            z: 0x97830e05,
-            w: 0x113ba7bb,
-        }
+        DeterministicRng { x: 0x193a6754, y: 0xa8a7d469, z: 0x97830e05, w: 0x113ba7bb }
     }
 
     fn next(&mut self) -> u32 {

--- a/src/liballoc/tests/linked_list.rs
+++ b/src/liballoc/tests/linked_list.rs
@@ -102,7 +102,6 @@ fn test_split_off() {
         assert_eq!(m.back(), Some(&1));
         assert_eq!(m.front(), Some(&1));
     }
-
 }
 
 #[test]
@@ -305,8 +304,7 @@ fn test_show() {
     assert_eq!(format!("{:?}", list), "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]");
 
     let list: LinkedList<_> = vec!["just", "one", "test", "more"].iter().cloned().collect();
-    assert_eq!(format!("{:?}", list),
-               "[\"just\", \"one\", \"test\", \"more\"]");
+    assert_eq!(format!("{:?}", list), "[\"just\", \"one\", \"test\", \"more\"]");
 }
 
 #[test]
@@ -446,19 +444,14 @@ fn drain_filter_true() {
 
 #[test]
 fn drain_filter_complex() {
-
-    {   //                [+xxx++++++xxxxx++++x+x++]
+    {
+        //                [+xxx++++++xxxxx++++x+x++]
         let mut list = vec![
-            1,
-            2, 4, 6,
-            7, 9, 11, 13, 15, 17,
-            18, 20, 22, 24, 26,
-            27, 29, 31, 33,
-            34,
-            35,
-            36,
-            37, 39
-        ].into_iter().collect::<LinkedList<_>>();
+            1, 2, 4, 6, 7, 9, 11, 13, 15, 17, 18, 20, 22, 24, 26, 27, 29, 31, 33, 34, 35, 36, 37,
+            39,
+        ]
+        .into_iter()
+        .collect::<LinkedList<_>>();
 
         let removed = list.drain_filter(|x| *x % 2 == 0).collect::<Vec<_>>();
         assert_eq!(removed.len(), 10);
@@ -471,17 +464,13 @@ fn drain_filter_complex() {
         );
     }
 
-    {   // [xxx++++++xxxxx++++x+x++]
+    {
+        // [xxx++++++xxxxx++++x+x++]
         let mut list = vec![
-            2, 4, 6,
-            7, 9, 11, 13, 15, 17,
-            18, 20, 22, 24, 26,
-            27, 29, 31, 33,
-            34,
-            35,
-            36,
-            37, 39
-        ].into_iter().collect::<LinkedList<_>>();
+            2, 4, 6, 7, 9, 11, 13, 15, 17, 18, 20, 22, 24, 26, 27, 29, 31, 33, 34, 35, 36, 37, 39,
+        ]
+        .into_iter()
+        .collect::<LinkedList<_>>();
 
         let removed = list.drain_filter(|x| *x % 2 == 0).collect::<Vec<_>>();
         assert_eq!(removed.len(), 10);
@@ -494,16 +483,12 @@ fn drain_filter_complex() {
         );
     }
 
-    {   // [xxx++++++xxxxx++++x+x]
-        let mut list = vec![
-            2, 4, 6,
-            7, 9, 11, 13, 15, 17,
-            18, 20, 22, 24, 26,
-            27, 29, 31, 33,
-            34,
-            35,
-            36
-        ].into_iter().collect::<LinkedList<_>>();
+    {
+        // [xxx++++++xxxxx++++x+x]
+        let mut list =
+            vec![2, 4, 6, 7, 9, 11, 13, 15, 17, 18, 20, 22, 24, 26, 27, 29, 31, 33, 34, 35, 36]
+                .into_iter()
+                .collect::<LinkedList<_>>();
 
         let removed = list.drain_filter(|x| *x % 2 == 0).collect::<Vec<_>>();
         assert_eq!(removed.len(), 10);
@@ -516,11 +501,11 @@ fn drain_filter_complex() {
         );
     }
 
-    {   // [xxxxxxxxxx+++++++++++]
-        let mut list = vec![
-            2, 4, 6, 8, 10, 12, 14, 16, 18, 20,
-            1, 3, 5, 7, 9, 11, 13, 15, 17, 19
-        ].into_iter().collect::<LinkedList<_>>();
+    {
+        // [xxxxxxxxxx+++++++++++]
+        let mut list = vec![2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19]
+            .into_iter()
+            .collect::<LinkedList<_>>();
 
         let removed = list.drain_filter(|x| *x % 2 == 0).collect::<Vec<_>>();
         assert_eq!(removed.len(), 10);
@@ -530,11 +515,11 @@ fn drain_filter_complex() {
         assert_eq!(list.into_iter().collect::<Vec<_>>(), vec![1, 3, 5, 7, 9, 11, 13, 15, 17, 19]);
     }
 
-    {   // [+++++++++++xxxxxxxxxx]
-        let mut list = vec![
-            1, 3, 5, 7, 9, 11, 13, 15, 17, 19,
-            2, 4, 6, 8, 10, 12, 14, 16, 18, 20
-        ].into_iter().collect::<LinkedList<_>>();
+    {
+        // [+++++++++++xxxxxxxxxx]
+        let mut list = vec![1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+            .into_iter()
+            .collect::<LinkedList<_>>();
 
         let removed = list.drain_filter(|x| *x % 2 == 0).collect::<Vec<_>>();
         assert_eq!(removed.len(), 10);

--- a/src/liballoc/tests/rc.rs
+++ b/src/liballoc/tests/rc.rs
@@ -1,9 +1,9 @@
 use std::any::Any;
-use std::rc::{Rc, Weak};
 use std::cell::RefCell;
 use std::cmp::PartialEq;
-use std::mem;
 use std::iter::TrustedLen;
+use std::mem;
+use std::rc::{Rc, Weak};
 
 #[test]
 fn uninhabited() {
@@ -12,7 +12,7 @@ fn uninhabited() {
     a = a.clone();
     assert!(a.upgrade().is_none());
 
-    let mut a: Weak<dyn Any> = a;  // Unsizing
+    let mut a: Weak<dyn Any> = a; // Unsizing
     a = a.clone();
     assert!(a.upgrade().is_none());
 }
@@ -20,8 +20,8 @@ fn uninhabited() {
 #[test]
 fn slice() {
     let a: Rc<[u32; 3]> = Rc::new([3, 2, 1]);
-    let a: Rc<[u32]> = a;  // Unsizing
-    let b: Rc<[u32]> = Rc::from(&[3, 2, 1][..]);  // Conversion
+    let a: Rc<[u32]> = a; // Unsizing
+    let b: Rc<[u32]> = Rc::from(&[3, 2, 1][..]); // Conversion
     assert_eq!(a, b);
 
     // Exercise is_dangling() with a DST
@@ -33,7 +33,7 @@ fn slice() {
 #[test]
 fn trait_object() {
     let a: Rc<u32> = Rc::new(4);
-    let a: Rc<dyn Any> = a;  // Unsizing
+    let a: Rc<dyn Any> = a; // Unsizing
 
     // Exercise is_dangling() with a DST
     let mut a = Rc::downgrade(&a);
@@ -43,7 +43,7 @@ fn trait_object() {
     let mut b = Weak::<u32>::new();
     b = b.clone();
     assert!(b.upgrade().is_none());
-    let mut b: Weak<dyn Any> = b;  // Unsizing
+    let mut b: Weak<dyn Any> = b; // Unsizing
     b = b.clone();
     assert!(b.upgrade().is_none());
 }
@@ -57,7 +57,7 @@ fn float_nan_ne() {
 
 #[test]
 fn partial_eq() {
-    struct TestPEq (RefCell<usize>);
+    struct TestPEq(RefCell<usize>);
     impl PartialEq for TestPEq {
         fn eq(&self, other: &TestPEq) -> bool {
             *self.0.borrow_mut() += 1;
@@ -74,7 +74,7 @@ fn partial_eq() {
 #[test]
 fn eq() {
     #[derive(Eq)]
-    struct TestEq (RefCell<usize>);
+    struct TestEq(RefCell<usize>);
     impl PartialEq for TestEq {
         fn eq(&self, other: &TestEq) -> bool {
             *self.0.borrow_mut() += 1;
@@ -156,13 +156,10 @@ fn shared_from_iter_trustedlen_normal() {
 fn shared_from_iter_trustedlen_panic() {
     // Exercise the `TrustedLen` implementation when `size_hint()` matches
     // `(_, Some(exact_len))` but where `.next()` drops before the last iteration.
-    let iter = (0..SHARED_ITER_MAX)
-        .map(|val| {
-            match val {
-                98 => panic!("I've almost got 99 problems."),
-                _ => Box::new(val),
-            }
-        });
+    let iter = (0..SHARED_ITER_MAX).map(|val| match val {
+        98 => panic!("I've almost got 99 problems."),
+        _ => Box::new(val),
+    });
     assert_trusted_len(&iter);
     let _ = iter.collect::<Rc<[_]>>();
 
@@ -189,16 +186,8 @@ fn shared_from_iter_trustedlen_no_fuse() {
         }
     }
 
-    let vec = vec![
-        Some(Box::new(42)),
-        Some(Box::new(24)),
-        None,
-        Some(Box::new(12)),
-    ];
+    let vec = vec![Some(Box::new(42)), Some(Box::new(24)), None, Some(Box::new(12))];
     let iter = Iter(vec.into_iter());
     assert_trusted_len(&iter);
-    assert_eq!(
-        &[Box::new(42), Box::new(24)],
-        &*iter.collect::<Rc<[_]>>()
-    );
+    assert_eq!(&[Box::new(42), Box::new(24)], &*iter.collect::<Rc<[_]>>());
 }

--- a/src/liballoc/tests/slice.rs
+++ b/src/liballoc/tests/slice.rs
@@ -1605,12 +1605,17 @@ fn panic_safe() {
     let mut rng = thread_rng();
 
     #[cfg(not(miri))] // Miri is too slow
-    let large_range = 70..MAX_LEN;
-    #[cfg(miri)]
-    let large_range = 0..0; // empty range
+    let lens = (1..20).chain(70..MAX_LEN);
+    #[cfg(not(miri))] // Miri is too slow
+    let moduli = &[5, 20, 50];
 
-    for len in (1..20).chain(large_range) {
-        for &modulus in &[5, 20, 50] {
+    #[cfg(miri)]
+    let lens = (1..13);
+    #[cfg(miri)]
+    let moduli = &[10];
+
+    for len in lens {
+        for &modulus in moduli {
             for &has_runs in &[false, true] {
                 let mut input = (0..len)
                     .map(|id| {
@@ -1643,6 +1648,9 @@ fn panic_safe() {
             }
         }
     }
+
+    // Set default panic hook again.
+    drop(panic::take_hook());
 }
 
 #[test]

--- a/src/liballoc/tests/vec.rs
+++ b/src/liballoc/tests/vec.rs
@@ -944,10 +944,9 @@ fn drain_filter_complex() {
     }
 }
 
-// Miri does not support catching panics
 // FIXME: re-enable emscripten once it can unwind again
 #[test]
-#[cfg(not(any(miri, target_os = "emscripten")))]
+#[cfg(not(target_os = "emscripten"))]
 fn drain_filter_consumed_panic() {
     use std::rc::Rc;
     use std::sync::Mutex;
@@ -999,7 +998,7 @@ fn drain_filter_consumed_panic() {
 
 // FIXME: Re-enable emscripten once it can catch panics
 #[test]
-#[cfg(not(any(miri, target_os = "emscripten")))] // Miri does not support catching panics
+#[cfg(not(target_os = "emscripten"))]
 fn drain_filter_unconsumed_panic() {
     use std::rc::Rc;
     use std::sync::Mutex;

--- a/src/liballoc/tests/vec_deque.rs
+++ b/src/liballoc/tests/vec_deque.rs
@@ -1,8 +1,8 @@
-use std::fmt::Debug;
-use std::collections::{VecDeque, vec_deque::Drain};
 use std::collections::TryReserveError::*;
+use std::collections::{vec_deque::Drain, VecDeque};
+use std::fmt::Debug;
 use std::mem::size_of;
-use std::{usize, isize};
+use std::{isize, usize};
 
 use crate::hash;
 
@@ -148,34 +148,20 @@ fn test_param_taggy() {
 
 #[test]
 fn test_param_taggypar() {
-    test_parameterized::<Taggypar<i32>>(Onepar::<i32>(1),
-                                        Twopar::<i32>(1, 2),
-                                        Threepar::<i32>(1, 2, 3),
-                                        Twopar::<i32>(17, 42));
+    test_parameterized::<Taggypar<i32>>(
+        Onepar::<i32>(1),
+        Twopar::<i32>(1, 2),
+        Threepar::<i32>(1, 2, 3),
+        Twopar::<i32>(17, 42),
+    );
 }
 
 #[test]
 fn test_param_reccy() {
-    let reccy1 = RecCy {
-        x: 1,
-        y: 2,
-        t: One(1),
-    };
-    let reccy2 = RecCy {
-        x: 345,
-        y: 2,
-        t: Two(1, 2),
-    };
-    let reccy3 = RecCy {
-        x: 1,
-        y: 777,
-        t: Three(1, 2, 3),
-    };
-    let reccy4 = RecCy {
-        x: 19,
-        y: 252,
-        t: Two(17, 42),
-    };
+    let reccy1 = RecCy { x: 1, y: 2, t: One(1) };
+    let reccy2 = RecCy { x: 345, y: 2, t: Two(1, 2) };
+    let reccy3 = RecCy { x: 1, y: 777, t: Three(1, 2, 3) };
+    let reccy4 = RecCy { x: 19, y: 252, t: Two(17, 42) };
     test_parameterized::<RecCy>(reccy1, reccy2, reccy3, reccy4);
 }
 
@@ -320,8 +306,7 @@ fn test_mut_rev_iter_wrap() {
     assert_eq!(d.pop_front(), Some(1));
     d.push_back(4);
 
-    assert_eq!(d.iter_mut().rev().map(|x| *x).collect::<Vec<_>>(),
-               vec![4, 3, 2]);
+    assert_eq!(d.iter_mut().rev().map(|x| *x).collect::<Vec<_>>(), vec![4, 3, 2]);
 }
 
 #[test]
@@ -372,7 +357,6 @@ fn test_mut_rev_iter() {
 
 #[test]
 fn test_into_iter() {
-
     // Empty iter
     {
         let d: VecDeque<i32> = VecDeque::new();
@@ -431,7 +415,6 @@ fn test_into_iter() {
 
 #[test]
 fn test_drain() {
-
     // Empty iter
     {
         let mut d: VecDeque<i32> = VecDeque::new();
@@ -650,12 +633,8 @@ fn test_show() {
     let ringbuf: VecDeque<_> = (0..10).collect();
     assert_eq!(format!("{:?}", ringbuf), "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]");
 
-    let ringbuf: VecDeque<_> = vec!["just", "one", "test", "more"]
-        .iter()
-        .cloned()
-        .collect();
-    assert_eq!(format!("{:?}", ringbuf),
-               "[\"just\", \"one\", \"test\", \"more\"]");
+    let ringbuf: VecDeque<_> = vec!["just", "one", "test", "more"].iter().cloned().collect();
+    assert_eq!(format!("{:?}", ringbuf), "[\"just\", \"one\", \"test\", \"more\"]");
 }
 
 #[test]
@@ -955,7 +934,6 @@ fn test_append_permutations() {
             // doesn't pop more values than are pushed
             for src_pop_back in 0..(src_push_back + src_push_front) {
                 for src_pop_front in 0..(src_push_back + src_push_front - src_pop_back) {
-
                     let src = construct_vec_deque(
                         src_push_back,
                         src_pop_back,
@@ -966,8 +944,8 @@ fn test_append_permutations() {
                     for dst_push_back in 0..MAX {
                         for dst_push_front in 0..MAX {
                             for dst_pop_back in 0..(dst_push_back + dst_push_front) {
-                                for dst_pop_front
-                                    in 0..(dst_push_back + dst_push_front - dst_pop_back)
+                                for dst_pop_front in
+                                    0..(dst_push_back + dst_push_front - dst_pop_back)
                                 {
                                     let mut dst = construct_vec_deque(
                                         dst_push_back,
@@ -1124,7 +1102,6 @@ fn test_reserve_exact_2() {
 #[test]
 #[cfg(not(miri))] // Miri does not support signalling OOM
 fn test_try_reserve() {
-
     // These are the interesting cases:
     // * exactly isize::MAX should never trigger a CapacityOverflow (can be OOM)
     // * > isize::MAX should always fail
@@ -1158,21 +1135,26 @@ fn test_try_reserve() {
         if guards_against_isize {
             // Check isize::MAX + 1 does count as overflow
             if let Err(CapacityOverflow) = empty_bytes.try_reserve(MAX_CAP + 1) {
-            } else { panic!("isize::MAX + 1 should trigger an overflow!") }
+            } else {
+                panic!("isize::MAX + 1 should trigger an overflow!")
+            }
 
             // Check usize::MAX does count as overflow
             if let Err(CapacityOverflow) = empty_bytes.try_reserve(MAX_USIZE) {
-            } else { panic!("usize::MAX should trigger an overflow!") }
+            } else {
+                panic!("usize::MAX should trigger an overflow!")
+            }
         } else {
             // Check isize::MAX is an OOM
             // VecDeque starts with capacity 7, always adds 1 to the capacity
             // and also rounds the number to next power of 2 so this is the
             // furthest we can go without triggering CapacityOverflow
             if let Err(AllocError { .. }) = empty_bytes.try_reserve(MAX_CAP) {
-            } else { panic!("isize::MAX + 1 should trigger an OOM!") }
+            } else {
+                panic!("isize::MAX + 1 should trigger an OOM!")
+            }
         }
     }
-
 
     {
         // Same basic idea, but with non-zero len
@@ -1186,33 +1168,42 @@ fn test_try_reserve() {
         }
         if guards_against_isize {
             if let Err(CapacityOverflow) = ten_bytes.try_reserve(MAX_CAP - 9) {
-            } else { panic!("isize::MAX + 1 should trigger an overflow!"); }
+            } else {
+                panic!("isize::MAX + 1 should trigger an overflow!");
+            }
         } else {
             if let Err(AllocError { .. }) = ten_bytes.try_reserve(MAX_CAP - 9) {
-            } else { panic!("isize::MAX + 1 should trigger an OOM!") }
+            } else {
+                panic!("isize::MAX + 1 should trigger an OOM!")
+            }
         }
         // Should always overflow in the add-to-len
         if let Err(CapacityOverflow) = ten_bytes.try_reserve(MAX_USIZE) {
-        } else { panic!("usize::MAX should trigger an overflow!") }
+        } else {
+            panic!("usize::MAX should trigger an overflow!")
+        }
     }
-
 
     {
         // Same basic idea, but with interesting type size
         let mut ten_u32s: VecDeque<u32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10].into_iter().collect();
 
-        if let Err(CapacityOverflow) = ten_u32s.try_reserve(MAX_CAP/4 - 10) {
+        if let Err(CapacityOverflow) = ten_u32s.try_reserve(MAX_CAP / 4 - 10) {
             panic!("isize::MAX shouldn't trigger an overflow!");
         }
-        if let Err(CapacityOverflow) = ten_u32s.try_reserve(MAX_CAP/4 - 10) {
+        if let Err(CapacityOverflow) = ten_u32s.try_reserve(MAX_CAP / 4 - 10) {
             panic!("isize::MAX shouldn't trigger an overflow!");
         }
         if guards_against_isize {
-            if let Err(CapacityOverflow) = ten_u32s.try_reserve(MAX_CAP/4 - 9) {
-            } else { panic!("isize::MAX + 1 should trigger an overflow!"); }
+            if let Err(CapacityOverflow) = ten_u32s.try_reserve(MAX_CAP / 4 - 9) {
+            } else {
+                panic!("isize::MAX + 1 should trigger an overflow!");
+            }
         } else {
-            if let Err(AllocError { .. }) = ten_u32s.try_reserve(MAX_CAP/4 - 9) {
-            } else { panic!("isize::MAX + 1 should trigger an OOM!") }
+            if let Err(AllocError { .. }) = ten_u32s.try_reserve(MAX_CAP / 4 - 9) {
+            } else {
+                panic!("isize::MAX + 1 should trigger an OOM!")
+            }
         }
         // Should fail in the mul-by-size
         if let Err(CapacityOverflow) = ten_u32s.try_reserve(MAX_USIZE - 20) {
@@ -1220,13 +1211,11 @@ fn test_try_reserve() {
             panic!("usize::MAX should trigger an overflow!");
         }
     }
-
 }
 
 #[test]
 #[cfg(not(miri))] // Miri does not support signalling OOM
 fn test_try_reserve_exact() {
-
     // This is exactly the same as test_try_reserve with the method changed.
     // See that test for comments.
 
@@ -1247,20 +1236,25 @@ fn test_try_reserve_exact() {
 
         if guards_against_isize {
             if let Err(CapacityOverflow) = empty_bytes.try_reserve_exact(MAX_CAP + 1) {
-            } else { panic!("isize::MAX + 1 should trigger an overflow!") }
+            } else {
+                panic!("isize::MAX + 1 should trigger an overflow!")
+            }
 
             if let Err(CapacityOverflow) = empty_bytes.try_reserve_exact(MAX_USIZE) {
-            } else { panic!("usize::MAX should trigger an overflow!") }
+            } else {
+                panic!("usize::MAX should trigger an overflow!")
+            }
         } else {
             // Check isize::MAX is an OOM
             // VecDeque starts with capacity 7, always adds 1 to the capacity
             // and also rounds the number to next power of 2 so this is the
             // furthest we can go without triggering CapacityOverflow
             if let Err(AllocError { .. }) = empty_bytes.try_reserve_exact(MAX_CAP) {
-            } else { panic!("isize::MAX + 1 should trigger an OOM!") }
+            } else {
+                panic!("isize::MAX + 1 should trigger an OOM!")
+            }
         }
     }
-
 
     {
         let mut ten_bytes: VecDeque<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10].into_iter().collect();
@@ -1273,36 +1267,46 @@ fn test_try_reserve_exact() {
         }
         if guards_against_isize {
             if let Err(CapacityOverflow) = ten_bytes.try_reserve_exact(MAX_CAP - 9) {
-            } else { panic!("isize::MAX + 1 should trigger an overflow!"); }
+            } else {
+                panic!("isize::MAX + 1 should trigger an overflow!");
+            }
         } else {
             if let Err(AllocError { .. }) = ten_bytes.try_reserve_exact(MAX_CAP - 9) {
-            } else { panic!("isize::MAX + 1 should trigger an OOM!") }
+            } else {
+                panic!("isize::MAX + 1 should trigger an OOM!")
+            }
         }
         if let Err(CapacityOverflow) = ten_bytes.try_reserve_exact(MAX_USIZE) {
-        } else { panic!("usize::MAX should trigger an overflow!") }
+        } else {
+            panic!("usize::MAX should trigger an overflow!")
+        }
     }
-
 
     {
         let mut ten_u32s: VecDeque<u32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10].into_iter().collect();
 
-        if let Err(CapacityOverflow) = ten_u32s.try_reserve_exact(MAX_CAP/4 - 10) {
+        if let Err(CapacityOverflow) = ten_u32s.try_reserve_exact(MAX_CAP / 4 - 10) {
             panic!("isize::MAX shouldn't trigger an overflow!");
         }
-        if let Err(CapacityOverflow) = ten_u32s.try_reserve_exact(MAX_CAP/4 - 10) {
+        if let Err(CapacityOverflow) = ten_u32s.try_reserve_exact(MAX_CAP / 4 - 10) {
             panic!("isize::MAX shouldn't trigger an overflow!");
         }
         if guards_against_isize {
-            if let Err(CapacityOverflow) = ten_u32s.try_reserve_exact(MAX_CAP/4 - 9) {
-            } else { panic!("isize::MAX + 1 should trigger an overflow!"); }
+            if let Err(CapacityOverflow) = ten_u32s.try_reserve_exact(MAX_CAP / 4 - 9) {
+            } else {
+                panic!("isize::MAX + 1 should trigger an overflow!");
+            }
         } else {
-            if let Err(AllocError { .. }) = ten_u32s.try_reserve_exact(MAX_CAP/4 - 9) {
-            } else { panic!("isize::MAX + 1 should trigger an OOM!") }
+            if let Err(AllocError { .. }) = ten_u32s.try_reserve_exact(MAX_CAP / 4 - 9) {
+            } else {
+                panic!("isize::MAX + 1 should trigger an OOM!")
+            }
         }
         if let Err(CapacityOverflow) = ten_u32s.try_reserve_exact(MAX_USIZE - 20) {
-        } else { panic!("usize::MAX should trigger an overflow!") }
+        } else {
+            panic!("usize::MAX should trigger an overflow!")
+        }
     }
-
 }
 
 #[test]
@@ -1404,9 +1408,8 @@ fn test_rotate_right_parts() {
 #[test]
 fn test_rotate_left_random() {
     let shifts = [
-        6, 1, 0, 11, 12, 1, 11, 7, 9, 3, 6, 1,
-        4, 0, 5, 1, 3, 1, 12, 8, 3, 1, 11, 11,
-        9, 4, 12, 3, 12, 9, 11, 1, 7, 9, 7, 2,
+        6, 1, 0, 11, 12, 1, 11, 7, 9, 3, 6, 1, 4, 0, 5, 1, 3, 1, 12, 8, 3, 1, 11, 11, 9, 4, 12, 3,
+        12, 9, 11, 1, 7, 9, 7, 2,
     ];
     let n = 12;
     let mut v: VecDeque<_> = (0..n).collect();
@@ -1423,9 +1426,8 @@ fn test_rotate_left_random() {
 #[test]
 fn test_rotate_right_random() {
     let shifts = [
-        6, 1, 0, 11, 12, 1, 11, 7, 9, 3, 6, 1,
-        4, 0, 5, 1, 3, 1, 12, 8, 3, 1, 11, 11,
-        9, 4, 12, 3, 12, 9, 11, 1, 7, 9, 7, 2,
+        6, 1, 0, 11, 12, 1, 11, 7, 9, 3, 6, 1, 4, 0, 5, 1, 3, 1, 12, 8, 3, 1, 11, 11, 9, 4, 12, 3,
+        12, 9, 11, 1, 7, 9, 7, 2,
     ];
     let n = 12;
     let mut v: VecDeque<_> = (0..n).collect();
@@ -1447,8 +1449,7 @@ fn test_try_fold_empty() {
 #[test]
 fn test_try_fold_none() {
     let v: VecDeque<u32> = (0..12).collect();
-    assert_eq!(None, v.into_iter().try_fold(0, |a, b|
-        if b < 11 { Some(a + b) } else { None }));
+    assert_eq!(None, v.into_iter().try_fold(0, |a, b| if b < 11 { Some(a + b) } else { None }));
 }
 
 #[test]
@@ -1462,7 +1463,6 @@ fn test_try_fold_unit() {
     let v: VecDeque<()> = std::iter::repeat(()).take(42).collect();
     assert_eq!(Some(()), v.into_iter().try_fold((), |(), ()| Some(())));
 }
-
 
 #[test]
 fn test_try_fold_unit_none() {
@@ -1534,7 +1534,7 @@ fn test_try_rfold_rotated() {
 
 #[test]
 fn test_try_rfold_moves_iter() {
-    let v : VecDeque<_> = [10, 20, 30, 40, 100, 60, 70, 80, 90].iter().collect();
+    let v: VecDeque<_> = [10, 20, 30, 40, 100, 60, 70, 80, 90].iter().collect();
     let mut iter = v.into_iter();
     assert_eq!(iter.try_rfold(0_i8, |acc, &x| acc.checked_add(x)), None);
     assert_eq!(iter.next_back(), Some(&70));

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -44,14 +44,14 @@ CloneTypeFoldableImpls! {
 pub type ConstEvalRawResult<'tcx> = Result<RawConst<'tcx>, ErrorHandled>;
 pub type ConstEvalResult<'tcx> = Result<&'tcx ty::Const<'tcx>, ErrorHandled>;
 
-#[derive(Clone, Debug, RustcEncodable, RustcDecodable)]
+#[derive(Clone, Debug)]
 pub struct ConstEvalErr<'tcx> {
     pub span: Span,
     pub error: crate::mir::interpret::InterpError<'tcx>,
     pub stacktrace: Vec<FrameInfo<'tcx>>,
 }
 
-#[derive(Clone, Debug, RustcEncodable, RustcDecodable, HashStable)]
+#[derive(Clone, Debug)]
 pub struct FrameInfo<'tcx> {
     /// This span is in the caller.
     pub call_site: Span,
@@ -327,7 +327,7 @@ impl<O: fmt::Debug> fmt::Debug for PanicInfo<O> {
 /// Error information for when the program we executed turned out not to actually be a valid
 /// program. This cannot happen in stand-alone Miri, but it can happen during CTFE/ConstProp
 /// where we work on generic code or execution does not have all information available.
-#[derive(Clone, RustcEncodable, RustcDecodable, HashStable)]
+#[derive(Clone, HashStable)]
 pub enum InvalidProgramInfo<'tcx> {
     /// Resolution can fail if we are in a too generic context.
     TooGeneric,
@@ -357,7 +357,7 @@ impl fmt::Debug for InvalidProgramInfo<'tcx> {
 }
 
 /// Error information for when the program caused Undefined Behavior.
-#[derive(Clone, RustcEncodable, RustcDecodable, HashStable)]
+#[derive(Clone, HashStable)]
 pub enum UndefinedBehaviorInfo {
     /// Free-form case. Only for errors that are never caught!
     Ub(String),
@@ -390,10 +390,14 @@ impl fmt::Debug for UndefinedBehaviorInfo {
 ///
 /// Currently, we also use this as fall-back error kind for errors that have not been
 /// categorized yet.
-#[derive(Clone, RustcEncodable, RustcDecodable, HashStable)]
+#[derive(Clone, HashStable)]
 pub enum UnsupportedOpInfo<'tcx> {
     /// Free-form case. Only for errors that are never caught!
     Unsupported(String),
+
+    /// When const-prop encounters a situation it does not support, it raises this error.
+    /// This must not allocate for performance reasons.
+    ConstPropUnsupported(&'tcx str),
 
     // -- Everything below is not categorized yet --
     FunctionAbiMismatch(Abi, Abi),
@@ -555,13 +559,15 @@ impl fmt::Debug for UnsupportedOpInfo<'tcx> {
                     not a power of two"),
             Unsupported(ref msg) =>
                 write!(f, "{}", msg),
+            ConstPropUnsupported(ref msg) =>
+                write!(f, "Constant propagation encountered an unsupported situation: {}", msg),
         }
     }
 }
 
 /// Error information for when the program exhausted the resources granted to it
 /// by the interpreter.
-#[derive(Clone, RustcEncodable, RustcDecodable, HashStable)]
+#[derive(Clone, HashStable)]
 pub enum ResourceExhaustionInfo {
     /// The stack grew too big.
     StackFrameLimitReached,
@@ -582,7 +588,7 @@ impl fmt::Debug for ResourceExhaustionInfo {
     }
 }
 
-#[derive(Clone, RustcEncodable, RustcDecodable, HashStable)]
+#[derive(Clone, HashStable)]
 pub enum InterpError<'tcx> {
     /// The program panicked.
     Panic(PanicInfo<u64>),

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -95,9 +95,6 @@ pub struct Session {
     /// The maximum length of types during monomorphization.
     pub type_length_limit: Once<usize>,
 
-    /// The maximum number of stackframes allowed in const eval.
-    pub const_eval_stack_frame_limit: usize,
-
     /// Map from imported macro spans (which consist of
     /// the localized span for the macro body) to the
     /// macro name and definition span in the source crate.
@@ -1159,7 +1156,6 @@ fn build_session_(
         features: Once::new(),
         recursion_limit: Once::new(),
         type_length_limit: Once::new(),
-        const_eval_stack_frame_limit: 100,
         imported_macro_spans: OneThread::new(RefCell::new(FxHashMap::default())),
         incr_comp_session: OneThread::new(RefCell::new(IncrCompSession::NotInitialized)),
         cgu_reuse_tracker,

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -69,7 +69,7 @@ pub enum BoundRegion {
 impl BoundRegion {
     pub fn is_named(&self) -> bool {
         match *self {
-            BoundRegion::BrNamed(..) => true,
+            BoundRegion::BrNamed(_, name) => name != kw::UnderscoreLifetime,
             _ => false,
         }
     }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -41,7 +41,7 @@ use rustc::util::common::{set_time_depth, time, print_time_passes_entry, ErrorRe
 use rustc_metadata::locator;
 use rustc_codegen_utils::codegen_backend::CodegenBackend;
 use errors::{PResult, registry::Registry};
-use rustc_interface::interface;
+use rustc_interface::{interface, Queries};
 use rustc_interface::util::get_codegen_sysroot;
 use rustc_data_structures::sync::SeqCst;
 
@@ -99,17 +99,29 @@ pub trait Callbacks {
     fn config(&mut self, _config: &mut interface::Config) {}
     /// Called after parsing. Return value instructs the compiler whether to
     /// continue the compilation afterwards (defaults to `Compilation::Continue`)
-    fn after_parsing(&mut self, _compiler: &interface::Compiler) -> Compilation {
+    fn after_parsing<'tcx>(
+        &mut self,
+        _compiler: &interface::Compiler,
+        _queries: &'tcx Queries<'tcx>,
+    ) -> Compilation {
         Compilation::Continue
     }
     /// Called after expansion. Return value instructs the compiler whether to
     /// continue the compilation afterwards (defaults to `Compilation::Continue`)
-    fn after_expansion(&mut self, _compiler: &interface::Compiler) -> Compilation {
+    fn after_expansion<'tcx>(
+        &mut self,
+        _compiler: &interface::Compiler,
+        _queries: &'tcx Queries<'tcx>,
+    ) -> Compilation {
         Compilation::Continue
     }
     /// Called after analysis. Return value instructs the compiler whether to
     /// continue the compilation afterwards (defaults to `Compilation::Continue`)
-    fn after_analysis(&mut self, _compiler: &interface::Compiler) -> Compilation {
+    fn after_analysis<'tcx>(
+        &mut self,
+        _compiler: &interface::Compiler,
+        _queries: &'tcx Queries<'tcx>,
+    ) -> Compilation {
         Compilation::Continue
     }
 }
@@ -313,7 +325,7 @@ pub fn run_compiler(
                 return early_exit();
             }
 
-            if callbacks.after_parsing(compiler) == Compilation::Stop {
+            if callbacks.after_parsing(compiler, queries) == Compilation::Stop {
                 return early_exit();
             }
 
@@ -334,7 +346,7 @@ pub fn run_compiler(
             }
 
             queries.expansion()?;
-            if callbacks.after_expansion(compiler) == Compilation::Stop {
+            if callbacks.after_expansion(compiler, queries) == Compilation::Stop {
                 return early_exit();
             }
 
@@ -383,7 +395,7 @@ pub fn run_compiler(
 
             queries.global_ctxt()?.peek_mut().enter(|tcx| tcx.analysis(LOCAL_CRATE))?;
 
-            if callbacks.after_analysis(compiler) == Compilation::Stop {
+            if callbacks.after_analysis(compiler, queries) == Compilation::Stop {
                 return early_exit();
             }
 

--- a/src/librustc_error_codes/error_codes.rs
+++ b/src/librustc_error_codes/error_codes.rs
@@ -107,6 +107,7 @@ E0199: include_str!("./error_codes/E0199.md"),
 E0200: include_str!("./error_codes/E0200.md"),
 E0201: include_str!("./error_codes/E0201.md"),
 E0202: include_str!("./error_codes/E0202.md"),
+E0203: include_str!("./error_codes/E0203.md"),
 E0204: include_str!("./error_codes/E0204.md"),
 E0205: include_str!("./error_codes/E0205.md"),
 E0206: include_str!("./error_codes/E0206.md"),
@@ -446,8 +447,6 @@ E0745: include_str!("./error_codes/E0745.md"),
 //  E0190, // deprecated: can only cast a &-pointer to an &-object
 //  E0194, // merged into E0403
 //  E0196, // cannot determine a type for this closure
-    E0203, // type parameter has more than one relaxed default bound,
-           // and only one is supported
     E0208,
 //  E0209, // builtin traits can only be implemented on structs or enums
     E0212, // cannot extract an associated type from a higher-ranked trait bound

--- a/src/librustc_error_codes/error_codes/E0203.md
+++ b/src/librustc_error_codes/error_codes/E0203.md
@@ -1,12 +1,18 @@
-Having multiple relaxed default bounds is unsuported.
+Having multiple relaxed default bounds is unsupported.
 
 Erroneous code example:
 
 ```compile_fail,E0203
-
-trait Foo {}
-
-struct S5<T>(*const T) where T: ?Foo + ?Sized;
+struct Bad<T: ?Sized + ?Send>{
+    inner: T
+}
 ```
 
-Here the type `T` cannot have a relaxed bound for both `Foo` and `Sized`
+Here the type `T` cannot have a relaxed bound for multiple default traits
+(`Sized` and `Send`). This can be fixed by only using one relaxed bound.
+
+```
+struct Good<T: ?Sized>{
+    inner: T
+}
+```

--- a/src/librustc_error_codes/error_codes/E0203.md
+++ b/src/librustc_error_codes/error_codes/E0203.md
@@ -1,0 +1,12 @@
+Having multiple relaxed default bounds is unsuported.
+
+Erroneous code example:
+
+```compile_fail,E0203
+
+trait Foo {}
+
+struct S5<T>(*const T) where T: ?Foo + ?Sized;
+```
+
+Here the type `T` cannot have a relaxed bound for both `Foo` and `Sized`

--- a/src/librustc_interface/lib.rs
+++ b/src/librustc_interface/lib.rs
@@ -18,6 +18,7 @@ pub mod util;
 mod proc_macro_decls;
 
 pub use interface::{run_compiler, Config};
+pub use queries::Queries;
 
 #[cfg(test)]
 mod tests;

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/outlives_suggestion.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/outlives_suggestion.rs
@@ -89,7 +89,7 @@ impl OutlivesSuggestionBuilder<'a> {
             | RegionNameSource::AnonRegionFromUpvar(..)
             | RegionNameSource::AnonRegionFromOutput(..)
             | RegionNameSource::AnonRegionFromYieldTy(..)
-            | RegionNameSource::AnonRegionFromTraitObjAsync(..) => {
+            | RegionNameSource::AnonRegionFromAsyncFn(..) => {
                 debug!("Region {:?} is NOT suggestable", name);
                 false
             }

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/outlives_suggestion.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/outlives_suggestion.rs
@@ -78,17 +78,7 @@ impl OutlivesSuggestionBuilder<'a> {
         match name.source {
             RegionNameSource::NamedEarlyBoundRegion(..)
             | RegionNameSource::NamedFreeRegion(..)
-            | RegionNameSource::Static => {
-                // FIXME: This is a bit hacky. We should ideally have a semantic way for checking
-                // if the name is `'_`...
-                if name.name().with(|name| name != "'_") {
-                    debug!("Region {:?} is suggestable", name);
-                    true
-                } else {
-                    debug!("Region {:?} is NOT suggestable", name);
-                    false
-                }
-            }
+            | RegionNameSource::Static => true,
 
             // Don't give suggestions for upvars, closure return types, or other unnamable
             // regions.
@@ -98,7 +88,8 @@ impl OutlivesSuggestionBuilder<'a> {
             | RegionNameSource::MatchedAdtAndSegment(..)
             | RegionNameSource::AnonRegionFromUpvar(..)
             | RegionNameSource::AnonRegionFromOutput(..)
-            | RegionNameSource::AnonRegionFromYieldTy(..) => {
+            | RegionNameSource::AnonRegionFromYieldTy(..)
+            | RegionNameSource::AnonRegionFromTraitObjAsync(..) => {
                 debug!("Region {:?} is NOT suggestable", name);
                 false
             }

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/region_name.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/region_name.rs
@@ -57,8 +57,8 @@ crate enum RegionNameSource {
     AnonRegionFromOutput(Span, String, String),
     /// The region from a type yielded by a generator.
     AnonRegionFromYieldTy(Span, String),
-    /// An anonymous region from a trait object in an async fn.
-    AnonRegionFromTraitObjAsync(Span),
+    /// An anonymous region from an async fn.
+    AnonRegionFromAsyncFn(Span),
 }
 
 /// Records region names that have been assigned before so that we can use the same ones in later
@@ -117,7 +117,7 @@ impl RegionName {
             RegionNameSource::AnonRegionFromUpvar(..) |
             RegionNameSource::AnonRegionFromOutput(..) |
             RegionNameSource::AnonRegionFromYieldTy(..) |
-            RegionNameSource::AnonRegionFromTraitObjAsync(..) => false,
+            RegionNameSource::AnonRegionFromAsyncFn(..) => false,
         }
     }
 
@@ -142,7 +142,7 @@ impl RegionName {
                 diag.span_label(*span, format!("has type `{}`", type_name));
             }
             RegionNameSource::MatchedHirTy(span) |
-            RegionNameSource::AnonRegionFromTraitObjAsync(span) => {
+            RegionNameSource::AnonRegionFromAsyncFn(span) => {
                 diag.span_label(
                     *span,
                     format!("let's call the lifetime of this reference `{}`", self),
@@ -306,14 +306,13 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                     } else {
                         // If we spuriously thought that the region is named, we should let the
                         // system generate a true name for error messages. Currently this can
-                        // happen if we have an elided name in a trait object used in an async fn
-                        // for example: the compiler will generate a region named `'_`, but
-                        // reporting such a name is not actually useful, so we synthesize a name
-                        // for it instead.
+                        // happen if we have an elided name in an async fn for example: the
+                        // compiler will generate a region named `'_`, but reporting such a name is
+                        // not actually useful, so we synthesize a name for it instead.
                         let name = self.synthesize_region_name(renctx);
                         Some(RegionName {
                             name,
-                            source: RegionNameSource::AnonRegionFromTraitObjAsync(span),
+                            source: RegionNameSource::AnonRegionFromAsyncFn(span),
                         })
                     }
                 }

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/region_name.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/region_name.rs
@@ -121,10 +121,6 @@ impl RegionName {
         }
     }
 
-    crate fn name(&self) -> Symbol {
-        self.name
-    }
-
     crate fn highlight_region_name(&self, diag: &mut DiagnosticBuilder<'_>) {
         match &self.source {
             RegionNameSource::NamedFreeRegion(span)
@@ -309,7 +305,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                         // happen if we have an elided name in an async fn for example: the
                         // compiler will generate a region named `'_`, but reporting such a name is
                         // not actually useful, so we synthesize a name for it instead.
-                        let name = self.synthesize_region_name(renctx);
+                        let name = renctx.synthesize_region_name();
                         Some(RegionName {
                             name,
                             source: RegionNameSource::AnonRegionFromAsyncFn(span),

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/region_name.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/region_name.rs
@@ -13,13 +13,13 @@ use rustc::hir::def_id::DefId;
 use rustc::infer::InferCtxt;
 use rustc::mir::{Local, Body};
 use rustc::ty::subst::{SubstsRef, GenericArgKind};
-use rustc::ty::{self, RegionKind, RegionVid, Ty, TyCtxt};
+use rustc::ty::{self, RegionVid, Ty, TyCtxt};
 use rustc::ty::print::RegionHighlightMode;
 use rustc_index::vec::IndexVec;
 use rustc_errors::DiagnosticBuilder;
 use syntax::symbol::kw;
 use rustc_data_structures::fx::FxHashMap;
-use syntax_pos::{Span, symbol::Symbol};
+use syntax_pos::{Span, symbol::Symbol, DUMMY_SP};
 
 /// A name for a particular region used in emitting diagnostics. This name could be a generated
 /// name like `'1`, a name used by the user like `'a`, or a name like `'static`.
@@ -275,7 +275,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         match error_region {
             ty::ReEarlyBound(ebr) => {
                 if ebr.has_name() {
-                    let span = self.get_named_span(tcx, error_region, ebr.name);
+                    let span = tcx.hir().span_if_local(ebr.def_id).unwrap_or(DUMMY_SP);
                     Some(RegionName {
                         name: ebr.name,
                         source: RegionNameSource::NamedEarlyBoundRegion(span),
@@ -291,9 +291,9 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             }),
 
             ty::ReFree(free_region) => match free_region.bound_region {
-                ty::BoundRegion::BrNamed(_, name) => {
+                ty::BoundRegion::BrNamed(region_def_id, name) => {
                     // Get the span to point to, even if we don't use the name.
-                    let span = self.get_named_span(tcx, error_region, name);
+                    let span = tcx.hir().span_if_local(region_def_id).unwrap_or(DUMMY_SP);
                     debug!("bound region named: {:?}, is_named: {:?}",
                         name, free_region.bound_region.is_named());
 
@@ -370,40 +370,6 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             | ty::ReEmpty
             | ty::ReErased
             | ty::ReClosureBound(..) => None,
-        }
-    }
-
-    /// Gets a span of a named region to provide context for error messages that
-    /// mention that span, for example:
-    ///
-    /// ```
-    ///  |
-    ///  | fn two_regions<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
-    ///  |                --  -- lifetime `'b` defined here
-    ///  |                |
-    ///  |                lifetime `'a` defined here
-    ///  |
-    ///  |     with_signature(cell, t, |cell, t| require(cell, t));
-    ///  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must
-    ///  |                                                         outlive `'a`
-    /// ```
-    fn get_named_span(
-        &self,
-        tcx: TyCtxt<'tcx>,
-        error_region: &RegionKind,
-        name: Symbol,
-    ) -> Span {
-        let scope = error_region.free_region_binding_scope(tcx);
-        let node = tcx.hir().as_local_hir_id(scope).unwrap_or(hir::DUMMY_HIR_ID);
-
-        let span = tcx.sess.source_map().def_span(tcx.hir().span(node));
-        if let Some(param) = tcx.hir()
-            .get_generics(scope)
-            .and_then(|generics| generics.get_named(name))
-        {
-            param.span
-        } else {
-            span
         }
     }
 

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -548,7 +548,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
         info!("ENTERING({}) {}", self.cur_frame(), self.frame().instance);
 
-        if self.stack.len() > self.tcx.sess.const_eval_stack_frame_limit {
+        if self.stack.len() > *self.tcx.sess.recursion_limit.get() {
             throw_exhaust!(StackFrameLimitReached)
         } else {
             Ok(())

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -566,9 +566,12 @@ impl Visitor<'tcx> for Validator<'_, 'mir, 'tcx> {
             StatementKind::FakeRead(FakeReadCause::ForMatchedPlace, _) => {
                 self.check_op(ops::IfOrMatch);
             }
+            StatementKind::SetDiscriminant { ref place, .. } => {
+                let ctx = PlaceContext::MutatingUse(MutatingUseContext::Projection);
+                self.visit_place(&place, ctx, location)
+            }
             // FIXME(eddyb) should these really do nothing?
             StatementKind::FakeRead(..) |
-            StatementKind::SetDiscriminant { .. } |
             StatementKind::StorageLive(_) |
             StatementKind::StorageDead(_) |
             StatementKind::InlineAsm {..} |

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -566,9 +566,8 @@ impl Visitor<'tcx> for Validator<'_, 'mir, 'tcx> {
             StatementKind::FakeRead(FakeReadCause::ForMatchedPlace, _) => {
                 self.check_op(ops::IfOrMatch);
             }
-            StatementKind::SetDiscriminant { ref place, .. } => {
-                let ctx = PlaceContext::MutatingUse(MutatingUseContext::Projection);
-                self.visit_place(&place, ctx, location)
+            StatementKind::SetDiscriminant { .. } => {
+                self.super_statement(statement, location)
             }
             // FIXME(eddyb) should these really do nothing?
             StatementKind::FakeRead(..) |

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -560,14 +560,11 @@ impl Visitor<'tcx> for Validator<'_, 'mir, 'tcx> {
         trace!("visit_statement: statement={:?} location={:?}", statement, location);
 
         match statement.kind {
-            StatementKind::Assign(..) => {
+            StatementKind::Assign(..) | StatementKind::SetDiscriminant { .. } => {
                 self.super_statement(statement, location);
             }
             StatementKind::FakeRead(FakeReadCause::ForMatchedPlace, _) => {
                 self.check_op(ops::IfOrMatch);
-            }
-            StatementKind::SetDiscriminant { .. } => {
-                self.super_statement(statement, location)
             }
             // FIXME(eddyb) should these really do nothing?
             StatementKind::FakeRead(..) |

--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -225,7 +225,7 @@ fn check_statement(
         StatementKind::FakeRead(_, place) => check_place(tcx, place, span, def_id, body),
 
         // just an assignment
-        StatementKind::SetDiscriminant { .. } => Ok(()),
+        StatementKind::SetDiscriminant { place, .. } => check_place(tcx, place, span, def_id, body),
 
         | StatementKind::InlineAsm { .. } => {
             Err((span, "cannot use inline assembly in const fn".into()))

--- a/src/libtest/test_result.rs
+++ b/src/libtest/test_result.rs
@@ -42,29 +42,25 @@ pub fn calc_result<'a>(
                 .map(|e| &**e)
                 .or_else(|| err.downcast_ref::<&'static str>().map(|e| *e));
 
-            if maybe_panic_str
-                .map(|e| e.contains(msg))
-                .unwrap_or(false)
-            {
+            if maybe_panic_str.map(|e| e.contains(msg)).unwrap_or(false) {
                 TestResult::TrOk
-            } else {
-                if desc.allow_fail {
-                    TestResult::TrAllowedFail
-                } else {
-                    if let Some(panic_str) = maybe_panic_str{
-                        TestResult::TrFailedMsg(
-                            format!(r#"panic did not contain expected string
+            } else if desc.allow_fail {
+                TestResult::TrAllowedFail
+            } else if let Some(panic_str) = maybe_panic_str {
+                TestResult::TrFailedMsg(format!(
+                    r#"panic did not contain expected string
       panic message: `{:?}`,
- expected substring: `{:?}`"#, panic_str, &*msg)
-                        )
-                    } else {
-                        TestResult::TrFailedMsg(
-                            format!(r#"expected panic with string value,
+ expected substring: `{:?}`"#,
+                    panic_str, msg
+                ))
+            } else {
+                TestResult::TrFailedMsg(format!(
+                    r#"expected panic with string value,
  found non-string value: `{:?}`
-     expected substring: `{:?}`"#, (**err).type_id(), &*msg)
-                        )
-                    }
-                }
+     expected substring: `{:?}`"#,
+                    (**err).type_id(),
+                    msg
+                ))
             }
         }
         (&ShouldPanic::Yes, Ok(())) => {

--- a/src/libtest/test_result.rs
+++ b/src/libtest/test_result.rs
@@ -37,10 +37,12 @@ pub fn calc_result<'a>(
     let result = match (&desc.should_panic, task_result) {
         (&ShouldPanic::No, Ok(())) | (&ShouldPanic::Yes, Err(_)) => TestResult::TrOk,
         (&ShouldPanic::YesWithMessage(msg), Err(ref err)) => {
-            if err
+            let maybe_panic_str = err
                 .downcast_ref::<String>()
                 .map(|e| &**e)
-                .or_else(|| err.downcast_ref::<&'static str>().map(|e| *e))
+                .or_else(|| err.downcast_ref::<&'static str>().map(|e| *e));
+
+            if maybe_panic_str
                 .map(|e| e.contains(msg))
                 .unwrap_or(false)
             {
@@ -49,9 +51,19 @@ pub fn calc_result<'a>(
                 if desc.allow_fail {
                     TestResult::TrAllowedFail
                 } else {
-                    TestResult::TrFailedMsg(
-                        format!("panic did not include expected string '{}'", msg)
-                    )
+                    if let Some(panic_str) = maybe_panic_str{
+                        TestResult::TrFailedMsg(
+                            format!(r#"panic did not contain expected string
+      panic message: `{:?}`,
+ expected substring: `{:?}`"#, panic_str, &*msg)
+                        )
+                    } else {
+                        TestResult::TrFailedMsg(
+                            format!(r#"expected panic with string value,
+ found non-string value: `{:?}`
+     expected substring: `{:?}`"#, (**err).type_id(), &*msg)
+                        )
+                    }
                 }
             }
         }

--- a/src/libtest/tests.rs
+++ b/src/libtest/tests.rs
@@ -15,6 +15,7 @@ use crate::{
         // TestType, TrFailedMsg, TrIgnored, TrOk,
     },
 };
+use std::any::TypeId;
 use std::sync::mpsc::channel;
 use std::time::Duration;
 
@@ -161,7 +162,9 @@ fn test_should_panic_bad_message() {
         panic!("an error message");
     }
     let expected = "foobar";
-    let failed_msg = "panic did not include expected string";
+    let failed_msg = r#"panic did not contain expected string
+      panic message: `"an error message"`,
+ expected substring: `"foobar"`"#;
     let desc = TestDescAndFn {
         desc: TestDesc {
             name: StaticTestName("whatever"),
@@ -175,7 +178,35 @@ fn test_should_panic_bad_message() {
     let (tx, rx) = channel();
     run_test(&TestOpts::new(), false, desc, RunStrategy::InProcess, tx, Concurrent::No);
     let result = rx.recv().unwrap().result;
-    assert!(result == TrFailedMsg(format!("{} '{}'", failed_msg, expected)));
+    assert_eq!(result, TrFailedMsg(failed_msg.to_string()));
+}
+
+// FIXME: Re-enable emscripten once it can catch panics again (introduced by #65251)
+#[test]
+#[cfg(not(target_os = "emscripten"))]
+fn test_should_panic_non_string_message_type() {
+    use crate::tests::TrFailedMsg;
+    fn f() {
+        panic!(1i32);
+    }
+    let expected = "foobar";
+    let failed_msg = format!(r#"expected panic with string value,
+ found non-string value: `{:?}`
+     expected substring: `"foobar"`"#, TypeId::of::<i32>());
+    let desc = TestDescAndFn {
+        desc: TestDesc {
+            name: StaticTestName("whatever"),
+            ignore: false,
+            should_panic: ShouldPanic::YesWithMessage(expected),
+            allow_fail: false,
+            test_type: TestType::Unknown,
+        },
+        testfn: DynTestFn(Box::new(f)),
+    };
+    let (tx, rx) = channel();
+    run_test(&TestOpts::new(), false, desc, RunStrategy::InProcess, tx, Concurrent::No);
+    let result = rx.recv().unwrap().result;
+    assert_eq!(result, TrFailedMsg(failed_msg));
 }
 
 // FIXME: Re-enable emscripten once it can catch panics again (introduced by #65251)

--- a/src/libtest/tests.rs
+++ b/src/libtest/tests.rs
@@ -85,7 +85,7 @@ pub fn do_not_run_ignored_tests() {
     let (tx, rx) = channel();
     run_test(&TestOpts::new(), false, desc, RunStrategy::InProcess, tx, Concurrent::No);
     let result = rx.recv().unwrap().result;
-    assert!(result != TrOk);
+    assert_ne!(result, TrOk);
 }
 
 #[test]
@@ -104,7 +104,7 @@ pub fn ignored_tests_result_in_ignored() {
     let (tx, rx) = channel();
     run_test(&TestOpts::new(), false, desc, RunStrategy::InProcess, tx, Concurrent::No);
     let result = rx.recv().unwrap().result;
-    assert!(result == TrIgnored);
+    assert_eq!(result, TrIgnored);
 }
 
 // FIXME: Re-enable emscripten once it can catch panics again (introduced by #65251)
@@ -127,7 +127,7 @@ fn test_should_panic() {
     let (tx, rx) = channel();
     run_test(&TestOpts::new(), false, desc, RunStrategy::InProcess, tx, Concurrent::No);
     let result = rx.recv().unwrap().result;
-    assert!(result == TrOk);
+    assert_eq!(result, TrOk);
 }
 
 // FIXME: Re-enable emscripten once it can catch panics again (introduced by #65251)
@@ -150,7 +150,7 @@ fn test_should_panic_good_message() {
     let (tx, rx) = channel();
     run_test(&TestOpts::new(), false, desc, RunStrategy::InProcess, tx, Concurrent::No);
     let result = rx.recv().unwrap().result;
-    assert!(result == TrOk);
+    assert_eq!(result, TrOk);
 }
 
 // FIXME: Re-enable emscripten once it can catch panics again (introduced by #65251)
@@ -227,7 +227,7 @@ fn test_should_panic_but_succeeds() {
     let (tx, rx) = channel();
     run_test(&TestOpts::new(), false, desc, RunStrategy::InProcess, tx, Concurrent::No);
     let result = rx.recv().unwrap().result;
-    assert!(result == TrFailedMsg("test did not panic as expected".to_string()));
+    assert_eq!(result, TrFailedMsg("test did not panic as expected".to_string()));
 }
 
 fn report_time_test_template(report_time: bool) -> Option<TestExecTime> {
@@ -601,7 +601,7 @@ pub fn sort_tests() {
     ];
 
     for (a, b) in expected.iter().zip(filtered) {
-        assert!(*a == b.desc.name.to_string());
+        assert_eq!(*a, b.desc.name.to_string());
     }
 }
 

--- a/src/test/ui/async-await/issues/issue-63388-1.nll.stderr
+++ b/src/test/ui/async-await/issues/issue-63388-1.nll.stderr
@@ -12,12 +12,12 @@ error: lifetime may not live long enough
 LL |       async fn do_sth<'a>(
    |                       -- lifetime `'a` defined here
 LL |           &'a self, foo: &dyn Foo
-   |                          - lifetime `'_` defined here
+   |                          - let's call the lifetime of this reference `'1`
 LL |       ) -> &dyn Foo
 LL | /     {
 LL | |         foo
 LL | |     }
-   | |_____^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'_`
+   | |_____^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/maybe-bounds-where.stderr
+++ b/src/test/ui/maybe-bounds-where.stderr
@@ -42,3 +42,4 @@ LL | struct S5<T>(*const T) where T: ?Trait<'static> + ?Sized;
 
 error: aborting due to 6 previous errors
 
+For more information about this error, try `rustc --explain E0203`.

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_impl_trait-async.nll.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_impl_trait-async.nll.stderr
@@ -2,11 +2,11 @@ error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_impl_trait-async.rs:8:48
    |
 LL |     async fn f(self: Pin<&Self>) -> impl Clone { self }
-   |                          -                     ^^^^^^^^ returning this value requires that `'_` must outlive `'static`
+   |                          -                     ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
    |                          |
-   |                          lifetime `'_` defined here
+   |                          let's call the lifetime of this reference `'1`
    |
-help: to allow this `impl Trait` to capture borrowed data with lifetime `'_`, add `'_` as a constraint
+help: to allow this `impl Trait` to capture borrowed data with lifetime `'1`, add `'_` as a constraint
    |
 LL |     async fn f(self: Pin<&Self>) -> impl Clone + '_ { self }
    |                                     ^^^^^^^^^^^^^^^

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.nll.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.nll.stderr
@@ -10,19 +10,19 @@ error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:8:52
    |
 LL |     async fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
-   |                          -                         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |                          -                         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |                          |
-   |                          lifetime `'_` defined here
-   |                          lifetime `'_` defined here
+   |                          let's call the lifetime of this reference `'1`
+   |                          let's call the lifetime of this reference `'2`
 
 error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:11:75
    |
 LL |     async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
-   |                          -                                                ^^^^^^^^^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |                          -                                                ^^^^^^^^^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |                          |
-   |                          lifetime `'_` defined here
-   |                          lifetime `'_` defined here
+   |                          let's call the lifetime of this reference `'1`
+   |                          let's call the lifetime of this reference `'2`
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:17:58
@@ -36,8 +36,9 @@ error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:17:64
    |
 LL |     async fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }
-   |                  --              - lifetime `'_` defined here  ^^^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'a`
-   |                  |
+   |                  --              -                             ^^^ function was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
+   |                  |               |
+   |                  |               let's call the lifetime of this reference `'1`
    |                  lifetime `'a` defined here
 
 error: aborting due to 5 previous errors

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.nll.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.nll.stderr
@@ -10,18 +10,18 @@ error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:8:52
    |
 LL |     async fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
-   |                          -                         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
-   |                          |
-   |                          let's call the lifetime of this reference `'1`
+   |                          -         -               ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |                          |         |
+   |                          |         let's call the lifetime of this reference `'1`
    |                          let's call the lifetime of this reference `'2`
 
 error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:11:75
    |
 LL |     async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
-   |                          -                                                ^^^^^^^^^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
-   |                          |
-   |                          let's call the lifetime of this reference `'1`
+   |                          -          -                                     ^^^^^^^^^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |                          |          |
+   |                          |          let's call the lifetime of this reference `'1`
    |                          let's call the lifetime of this reference `'2`
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds

--- a/src/test/ui/self/elision/lt-ref-self-async.nll.stderr
+++ b/src/test/ui/self/elision/lt-ref-self-async.nll.stderr
@@ -10,9 +10,8 @@ error: lifetime may not live long enough
   --> $DIR/lt-ref-self-async.rs:13:9
    |
 LL |     async fn ref_self(&self, f: &u32) -> &u32 {
-   |                       -
+   |                       -         - let's call the lifetime of this reference `'1`
    |                       |
-   |                       let's call the lifetime of this reference `'1`
    |                       let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
@@ -29,9 +28,8 @@ error: lifetime may not live long enough
   --> $DIR/lt-ref-self-async.rs:19:9
    |
 LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
-   |                             -
+   |                             -         - let's call the lifetime of this reference `'1`
    |                             |
-   |                             let's call the lifetime of this reference `'1`
    |                             let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
@@ -48,9 +46,8 @@ error: lifetime may not live long enough
   --> $DIR/lt-ref-self-async.rs:23:9
    |
 LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
-   |                                     -
+   |                                     -          - let's call the lifetime of this reference `'1`
    |                                     |
-   |                                     let's call the lifetime of this reference `'1`
    |                                     let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
@@ -67,9 +64,8 @@ error: lifetime may not live long enough
   --> $DIR/lt-ref-self-async.rs:27:9
    |
 LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
-   |                                     -
+   |                                     -          - let's call the lifetime of this reference `'1`
    |                                     |
-   |                                     let's call the lifetime of this reference `'1`
    |                                     let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
@@ -86,9 +82,8 @@ error: lifetime may not live long enough
   --> $DIR/lt-ref-self-async.rs:31:9
    |
 LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
-   |                                             -
+   |                                             -           - let's call the lifetime of this reference `'1`
    |                                             |
-   |                                             let's call the lifetime of this reference `'1`
    |                                             let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
@@ -105,9 +100,8 @@ error: lifetime may not live long enough
   --> $DIR/lt-ref-self-async.rs:35:9
    |
 LL |     async fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
-   |                                         -
+   |                                         -           - let's call the lifetime of this reference `'1`
    |                                         |
-   |                                         let's call the lifetime of this reference `'1`
    |                                         let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`

--- a/src/test/ui/self/elision/lt-ref-self-async.nll.stderr
+++ b/src/test/ui/self/elision/lt-ref-self-async.nll.stderr
@@ -12,10 +12,10 @@ error: lifetime may not live long enough
 LL |     async fn ref_self(&self, f: &u32) -> &u32 {
    |                       -
    |                       |
-   |                       lifetime `'_` defined here
-   |                       lifetime `'_` defined here
+   |                       let's call the lifetime of this reference `'1`
+   |                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/lt-ref-self-async.rs:18:48
@@ -31,10 +31,10 @@ error: lifetime may not live long enough
 LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                             -
    |                             |
-   |                             lifetime `'_` defined here
-   |                             lifetime `'_` defined here
+   |                             let's call the lifetime of this reference `'1`
+   |                             let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/lt-ref-self-async.rs:22:57
@@ -50,10 +50,10 @@ error: lifetime may not live long enough
 LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                                     -
    |                                     |
-   |                                     lifetime `'_` defined here
-   |                                     lifetime `'_` defined here
+   |                                     let's call the lifetime of this reference `'1`
+   |                                     let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/lt-ref-self-async.rs:26:57
@@ -69,10 +69,10 @@ error: lifetime may not live long enough
 LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                                     -
    |                                     |
-   |                                     lifetime `'_` defined here
-   |                                     lifetime `'_` defined here
+   |                                     let's call the lifetime of this reference `'1`
+   |                                     let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/lt-ref-self-async.rs:30:66
@@ -88,10 +88,10 @@ error: lifetime may not live long enough
 LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                             -
    |                                             |
-   |                                             lifetime `'_` defined here
-   |                                             lifetime `'_` defined here
+   |                                             let's call the lifetime of this reference `'1`
+   |                                             let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/lt-ref-self-async.rs:34:62
@@ -107,10 +107,10 @@ error: lifetime may not live long enough
 LL |     async fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                         -
    |                                         |
-   |                                         lifetime `'_` defined here
-   |                                         lifetime `'_` defined here
+   |                                         let's call the lifetime of this reference `'1`
+   |                                         let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/self/elision/ref-mut-self-async.nll.stderr
+++ b/src/test/ui/self/elision/ref-mut-self-async.nll.stderr
@@ -12,10 +12,10 @@ error: lifetime may not live long enough
 LL |     async fn ref_self(&mut self, f: &u32) -> &u32 {
    |                       -
    |                       |
-   |                       lifetime `'_` defined here
-   |                       lifetime `'_` defined here
+   |                       let's call the lifetime of this reference `'1`
+   |                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/ref-mut-self-async.rs:18:52
@@ -31,10 +31,10 @@ error: lifetime may not live long enough
 LL |     async fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
    |                             -
    |                             |
-   |                             lifetime `'_` defined here
-   |                             lifetime `'_` defined here
+   |                             let's call the lifetime of this reference `'1`
+   |                             let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/ref-mut-self-async.rs:22:61
@@ -50,10 +50,10 @@ error: lifetime may not live long enough
 LL |     async fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
    |                                     -
    |                                     |
-   |                                     lifetime `'_` defined here
-   |                                     lifetime `'_` defined here
+   |                                     let's call the lifetime of this reference `'1`
+   |                                     let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/ref-mut-self-async.rs:26:61
@@ -69,10 +69,10 @@ error: lifetime may not live long enough
 LL |     async fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
    |                                     -
    |                                     |
-   |                                     lifetime `'_` defined here
-   |                                     lifetime `'_` defined here
+   |                                     let's call the lifetime of this reference `'1`
+   |                                     let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/ref-mut-self-async.rs:30:70
@@ -88,10 +88,10 @@ error: lifetime may not live long enough
 LL |     async fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
    |                                             -
    |                                             |
-   |                                             lifetime `'_` defined here
-   |                                             lifetime `'_` defined here
+   |                                             let's call the lifetime of this reference `'1`
+   |                                             let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/ref-mut-self-async.rs:34:70
@@ -107,10 +107,10 @@ error: lifetime may not live long enough
 LL |     async fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 {
    |                                             -
    |                                             |
-   |                                             lifetime `'_` defined here
-   |                                             lifetime `'_` defined here
+   |                                             let's call the lifetime of this reference `'1`
+   |                                             let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/self/elision/ref-mut-self-async.nll.stderr
+++ b/src/test/ui/self/elision/ref-mut-self-async.nll.stderr
@@ -10,9 +10,8 @@ error: lifetime may not live long enough
   --> $DIR/ref-mut-self-async.rs:13:9
    |
 LL |     async fn ref_self(&mut self, f: &u32) -> &u32 {
-   |                       -
+   |                       -             - let's call the lifetime of this reference `'1`
    |                       |
-   |                       let's call the lifetime of this reference `'1`
    |                       let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
@@ -29,9 +28,8 @@ error: lifetime may not live long enough
   --> $DIR/ref-mut-self-async.rs:19:9
    |
 LL |     async fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
-   |                             -
+   |                             -             - let's call the lifetime of this reference `'1`
    |                             |
-   |                             let's call the lifetime of this reference `'1`
    |                             let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
@@ -48,9 +46,8 @@ error: lifetime may not live long enough
   --> $DIR/ref-mut-self-async.rs:23:9
    |
 LL |     async fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
-   |                                     -
+   |                                     -              - let's call the lifetime of this reference `'1`
    |                                     |
-   |                                     let's call the lifetime of this reference `'1`
    |                                     let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
@@ -67,9 +64,8 @@ error: lifetime may not live long enough
   --> $DIR/ref-mut-self-async.rs:27:9
    |
 LL |     async fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
-   |                                     -
+   |                                     -              - let's call the lifetime of this reference `'1`
    |                                     |
-   |                                     let's call the lifetime of this reference `'1`
    |                                     let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
@@ -86,9 +82,8 @@ error: lifetime may not live long enough
   --> $DIR/ref-mut-self-async.rs:31:9
    |
 LL |     async fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
-   |                                             -
+   |                                             -               - let's call the lifetime of this reference `'1`
    |                                             |
-   |                                             let's call the lifetime of this reference `'1`
    |                                             let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
@@ -105,9 +100,8 @@ error: lifetime may not live long enough
   --> $DIR/ref-mut-self-async.rs:35:9
    |
 LL |     async fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 {
-   |                                             -
+   |                                             -               - let's call the lifetime of this reference `'1`
    |                                             |
-   |                                             let's call the lifetime of this reference `'1`
    |                                             let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`

--- a/src/test/ui/self/elision/ref-mut-struct-async.nll.stderr
+++ b/src/test/ui/self/elision/ref-mut-struct-async.nll.stderr
@@ -10,9 +10,8 @@ error: lifetime may not live long enough
   --> $DIR/ref-mut-struct-async.rs:13:9
    |
 LL |     async fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
-   |                               -
+   |                               -               - let's call the lifetime of this reference `'1`
    |                               |
-   |                               let's call the lifetime of this reference `'1`
    |                               let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
@@ -29,9 +28,8 @@ error: lifetime may not live long enough
   --> $DIR/ref-mut-struct-async.rs:17:9
    |
 LL |     async fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
-   |                                       -
+   |                                       -                - let's call the lifetime of this reference `'1`
    |                                       |
-   |                                       let's call the lifetime of this reference `'1`
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
@@ -48,9 +46,8 @@ error: lifetime may not live long enough
   --> $DIR/ref-mut-struct-async.rs:21:9
    |
 LL |     async fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
-   |                                       -
+   |                                       -                - let's call the lifetime of this reference `'1`
    |                                       |
-   |                                       let's call the lifetime of this reference `'1`
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
@@ -67,9 +64,8 @@ error: lifetime may not live long enough
   --> $DIR/ref-mut-struct-async.rs:25:9
    |
 LL |     async fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
-   |                                               -
+   |                                               -                 - let's call the lifetime of this reference `'1`
    |                                               |
-   |                                               let's call the lifetime of this reference `'1`
    |                                               let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
@@ -86,9 +82,8 @@ error: lifetime may not live long enough
   --> $DIR/ref-mut-struct-async.rs:29:9
    |
 LL |     async fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {
-   |                                               -
+   |                                               -                 - let's call the lifetime of this reference `'1`
    |                                               |
-   |                                               let's call the lifetime of this reference `'1`
    |                                               let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`

--- a/src/test/ui/self/elision/ref-mut-struct-async.nll.stderr
+++ b/src/test/ui/self/elision/ref-mut-struct-async.nll.stderr
@@ -12,10 +12,10 @@ error: lifetime may not live long enough
 LL |     async fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
    |                               -
    |                               |
-   |                               lifetime `'_` defined here
-   |                               lifetime `'_` defined here
+   |                               let's call the lifetime of this reference `'1`
+   |                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/ref-mut-struct-async.rs:16:65
@@ -31,10 +31,10 @@ error: lifetime may not live long enough
 LL |     async fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
    |                                       -
    |                                       |
-   |                                       lifetime `'_` defined here
-   |                                       lifetime `'_` defined here
+   |                                       let's call the lifetime of this reference `'1`
+   |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/ref-mut-struct-async.rs:20:65
@@ -50,10 +50,10 @@ error: lifetime may not live long enough
 LL |     async fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
    |                                       -
    |                                       |
-   |                                       lifetime `'_` defined here
-   |                                       lifetime `'_` defined here
+   |                                       let's call the lifetime of this reference `'1`
+   |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/ref-mut-struct-async.rs:24:74
@@ -69,10 +69,10 @@ error: lifetime may not live long enough
 LL |     async fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
    |                                               -
    |                                               |
-   |                                               lifetime `'_` defined here
-   |                                               lifetime `'_` defined here
+   |                                               let's call the lifetime of this reference `'1`
+   |                                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/ref-mut-struct-async.rs:28:74
@@ -88,10 +88,10 @@ error: lifetime may not live long enough
 LL |     async fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {
    |                                               -
    |                                               |
-   |                                               lifetime `'_` defined here
-   |                                               lifetime `'_` defined here
+   |                                               let's call the lifetime of this reference `'1`
+   |                                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/self/elision/ref-struct-async.nll.stderr
+++ b/src/test/ui/self/elision/ref-struct-async.nll.stderr
@@ -10,9 +10,8 @@ error: lifetime may not live long enough
   --> $DIR/ref-struct-async.rs:13:9
    |
 LL |     async fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
-   |                               -
+   |                               -           - let's call the lifetime of this reference `'1`
    |                               |
-   |                               let's call the lifetime of this reference `'1`
    |                               let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
@@ -29,9 +28,8 @@ error: lifetime may not live long enough
   --> $DIR/ref-struct-async.rs:17:9
    |
 LL |     async fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
-   |                                       -
+   |                                       -            - let's call the lifetime of this reference `'1`
    |                                       |
-   |                                       let's call the lifetime of this reference `'1`
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
@@ -48,9 +46,8 @@ error: lifetime may not live long enough
   --> $DIR/ref-struct-async.rs:21:9
    |
 LL |     async fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
-   |                                       -
+   |                                       -            - let's call the lifetime of this reference `'1`
    |                                       |
-   |                                       let's call the lifetime of this reference `'1`
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
@@ -67,9 +64,8 @@ error: lifetime may not live long enough
   --> $DIR/ref-struct-async.rs:25:9
    |
 LL |     async fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
-   |                                               -
+   |                                               -             - let's call the lifetime of this reference `'1`
    |                                               |
-   |                                               let's call the lifetime of this reference `'1`
    |                                               let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
@@ -86,9 +82,8 @@ error: lifetime may not live long enough
   --> $DIR/ref-struct-async.rs:29:9
    |
 LL |     async fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {
-   |                                           -
+   |                                           -             - let's call the lifetime of this reference `'1`
    |                                           |
-   |                                           let's call the lifetime of this reference `'1`
    |                                           let's call the lifetime of this reference `'2`
 LL |         f
    |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`

--- a/src/test/ui/self/elision/ref-struct-async.nll.stderr
+++ b/src/test/ui/self/elision/ref-struct-async.nll.stderr
@@ -12,10 +12,10 @@ error: lifetime may not live long enough
 LL |     async fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |                               -
    |                               |
-   |                               lifetime `'_` defined here
-   |                               lifetime `'_` defined here
+   |                               let's call the lifetime of this reference `'1`
+   |                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/ref-struct-async.rs:16:61
@@ -31,10 +31,10 @@ error: lifetime may not live long enough
 LL |     async fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
    |                                       -
    |                                       |
-   |                                       lifetime `'_` defined here
-   |                                       lifetime `'_` defined here
+   |                                       let's call the lifetime of this reference `'1`
+   |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/ref-struct-async.rs:20:61
@@ -50,10 +50,10 @@ error: lifetime may not live long enough
 LL |     async fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
    |                                       -
    |                                       |
-   |                                       lifetime `'_` defined here
-   |                                       lifetime `'_` defined here
+   |                                       let's call the lifetime of this reference `'1`
+   |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/ref-struct-async.rs:24:70
@@ -69,10 +69,10 @@ error: lifetime may not live long enough
 LL |     async fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
    |                                               -
    |                                               |
-   |                                               lifetime `'_` defined here
-   |                                               lifetime `'_` defined here
+   |                                               let's call the lifetime of this reference `'1`
+   |                                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/ref-struct-async.rs:28:66
@@ -88,10 +88,10 @@ error: lifetime may not live long enough
 LL |     async fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {
    |                                           -
    |                                           |
-   |                                           lifetime `'_` defined here
-   |                                           lifetime `'_` defined here
+   |                                           let's call the lifetime of this reference `'1`
+   |                                           let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ function was supposed to return data with lifetime `'_` but it is returning data with lifetime `'_`
+   |         ^ function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: aborting due to 10 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #66503 (More useful test error messages on should_panic(expected=...) mismatch)
 - #66662 (Miri: run panic-catching tests in liballoc)
 - #66679 (Improve lifetime errors with implicit trait object lifetimes)
 - #66726 (Use recursion_limit for const eval stack limit)
 - #66790 (Do `min_const_fn` checks for `SetDiscriminant`s target)
 - #66832 (const_prop: detect and avoid catching Miri errors that require allocation)
 - #66880 (Add long error code explanation message for E0203)
 - #66890 (Format liballoc with rustfmt)
 - #66896 (pass Queries to compiler callbacks)

Failed merges:


r? @ghost