### PR TITLE
Add crc and crypto to target feature whitelist on arm

### DIFF
--- a/src/librustc_codegen_llvm/llvm_util.rs
+++ b/src/librustc_codegen_llvm/llvm_util.rs
@@ -108,6 +108,8 @@ const ARM_WHITELIST: &[(&str, Option<Symbol>)] = &[
     ("rclass", Some(sym::arm_target_feature)),
     ("dsp", Some(sym::arm_target_feature)),
     ("neon", Some(sym::arm_target_feature)),
+    ("crc", Some(sym::arm_target_feature)),
+    ("crypto", Some(sym::arm_target_feature)),
     ("v5te", Some(sym::arm_target_feature)),
     ("v6", Some(sym::arm_target_feature)),
     ("v6k", Some(sym::arm_target_feature)),


### PR DESCRIPTION
aarch32 (ARMv8 32-bit) supports crc and crypto.