### PR TITLE
Deprecate Error::description for real

### DIFF
--- a/src/librustc_driver/args.rs
+++ b/src/librustc_driver/args.rs
@@ -2,7 +2,6 @@ use std::error;
 use std::fmt;
 use std::fs;
 use std::io;
-use std::str;
 
 pub fn arg_expand(arg: String) -> Result<Vec<String>, Error> {
     if arg.starts_with("@") {
@@ -36,8 +35,4 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &'static str {
-        "argument error"
-    }
-}
+impl error::Error for Error {}

--- a/src/librustc_error_codes/error_codes/E0638.md
+++ b/src/librustc_error_codes/error_codes/E0638.md
@@ -10,23 +10,23 @@ For example, in the below example, since the enum is marked as
 on it.
 
 ```rust,ignore (pseudo-Rust)
-use std::error::Error as StdError;
-
-#[non_exhaustive] pub enum Error {
-   Message(String),
-   Other,
+#[non_exhaustive]
+pub enum Error {
+    Message(String),
+    Other,
 }
 
-impl StdError for Error {
-   fn description(&self) -> &str {
+impl Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         // This will not error, despite being marked as non_exhaustive, as this
         // enum is defined within the current crate, it can be matched
         // exhaustively.
-        match *self {
-           Message(ref s) => s,
-           Other => "other or unknown error",
-        }
-   }
+        let display = match self {
+            Message(s) => s,
+            Other => "other or unknown error",
+        };
+        formatter.write_str(display)
+    }
 }
 ```
 
@@ -38,9 +38,9 @@ use mycrate::Error;
 // This will not error as the non_exhaustive Error enum has been matched with a
 // wildcard.
 match error {
-   Message(ref s) => ...,
-   Other => ...,
-   _ => ...,
+    Message(s) => ...,
+    Other => ...,
+    _ => ...,
 }
 ```
 

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -253,11 +253,7 @@ impl fmt::Display for ExplicitBug {
     }
 }
 
-impl error::Error for ExplicitBug {
-    fn description(&self) -> &str {
-        "The parser has encountered an internal bug"
-    }
-}
+impl error::Error for ExplicitBug {}
 
 pub use diagnostic::{Diagnostic, DiagnosticId, DiagnosticStyledString, SubDiagnostic};
 pub use diagnostic_builder::DiagnosticBuilder;

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -197,19 +197,7 @@ impl fmt::Display for ConstEvalError {
     }
 }
 
-impl Error for ConstEvalError {
-    fn description(&self) -> &str {
-        use self::ConstEvalError::*;
-        match *self {
-            NeedsRfc(_) => "this feature needs an rfc before being allowed inside constants",
-            ConstAccessesStatic => "constant accesses static",
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn Error> {
-        None
-    }
-}
+impl Error for ConstEvalError {}
 
 // Extra machine state for CTFE, and the Machine instance
 pub struct CompileTimeInterpreter<'mir, 'tcx> {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -98,11 +98,7 @@ pub struct Error {
     pub error: io::Error,
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        self.error.description()
-    }
-}
+impl error::Error for Error {}
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/src/libserialize/hex.rs
+++ b/src/libserialize/hex.rs
@@ -68,14 +68,7 @@ impl fmt::Display for FromHexError {
     }
 }
 
-impl error::Error for FromHexError {
-    fn description(&self) -> &str {
-        match *self {
-            InvalidHexCharacter(..) => "invalid character",
-            InvalidHexLength => "invalid length",
-        }
-    }
-}
+impl error::Error for FromHexError {}
 
 impl FromHex for str {
     /// Converts any hexadecimal encoded string (literal, `@`, `&`, or `~`)

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -345,11 +345,7 @@ impl fmt::Display for DecoderError {
     }
 }
 
-impl std::error::Error for DecoderError {
-    fn description(&self) -> &str {
-        "decoder error"
-    }
-}
+impl std::error::Error for DecoderError {}
 
 impl fmt::Display for EncoderError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -358,11 +354,7 @@ impl fmt::Display for EncoderError {
     }
 }
 
-impl std::error::Error for EncoderError {
-    fn description(&self) -> &str {
-        "encoder error"
-    }
-}
+impl std::error::Error for EncoderError {}
 
 impl From<fmt::Error> for EncoderError {
     /// Converts a [`fmt::Error`] into `EncoderError`

--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -284,6 +284,7 @@ impl fmt::Display for VarError {
 
 #[stable(feature = "env", since = "1.0.0")]
 impl Error for VarError {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         match *self {
             VarError::NotPresent => "environment variable not found",
@@ -526,6 +527,7 @@ impl fmt::Display for JoinPathsError {
 
 #[stable(feature = "env", since = "1.0.0")]
 impl Error for JoinPathsError {
+    #[allow(deprecated, deprecated_in_future)]
     fn description(&self) -> &str {
         self.inner.description()
     }

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -878,6 +878,7 @@ impl NulError {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Error for NulError {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         "nul byte found in data"
     }
@@ -903,6 +904,7 @@ impl From<NulError> for io::Error {
 
 #[stable(feature = "frombyteswithnulerror_impls", since = "1.17.0")]
 impl Error for FromBytesWithNulError {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         match self.kind {
             FromBytesWithNulErrorKind::InteriorNul(..) => {
@@ -915,6 +917,7 @@ impl Error for FromBytesWithNulError {
 
 #[stable(feature = "frombyteswithnulerror_impls", since = "1.17.0")]
 impl fmt::Display for FromBytesWithNulError {
+    #[allow(deprecated, deprecated_in_future)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.description())?;
         if let FromBytesWithNulErrorKind::InteriorNul(pos) = self.kind {
@@ -943,6 +946,7 @@ impl IntoStringError {
 
 #[stable(feature = "cstring_into", since = "1.7.0")]
 impl Error for IntoStringError {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         "C string contained non-utf8 bytes"
     }
@@ -954,6 +958,7 @@ impl Error for IntoStringError {
 
 #[stable(feature = "cstring_into", since = "1.7.0")]
 impl fmt::Display for IntoStringError {
+    #[allow(deprecated, deprecated_in_future)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.description().fmt(f)
     }

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -752,6 +752,7 @@ impl<W> From<IntoInnerError<W>> for Error {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<W: Send + fmt::Debug> error::Error for IntoInnerError<W> {
+    #[allow(deprecated, deprecated_in_future)]
     fn description(&self) -> &str {
         error::Error::description(self.error())
     }

--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -534,6 +534,7 @@ impl fmt::Display for Error {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl error::Error for Error {
+    #[allow(deprecated, deprecated_in_future)]
     fn description(&self) -> &str {
         match self.repr {
             Repr::Os(..) | Repr::Simple(..) => self.kind().as_str(),
@@ -603,22 +604,18 @@ mod test {
         struct TestError;
 
         impl fmt::Display for TestError {
-            fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
-                Ok(())
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("asdf")
             }
         }
 
-        impl error::Error for TestError {
-            fn description(&self) -> &str {
-                "asdf"
-            }
-        }
+        impl error::Error for TestError {}
 
         // we have to call all of these UFCS style right now since method
         // resolution won't implicitly drop the Send+Sync bounds
         let mut err = Error::new(ErrorKind::Other, TestError);
         assert!(err.get_ref().unwrap().is::<TestError>());
-        assert_eq!("asdf", err.get_ref().unwrap().description());
+        assert_eq!("asdf", err.get_ref().unwrap().to_string());
         assert!(err.get_mut().unwrap().is::<TestError>());
         let extracted = err.into_inner().unwrap();
         extracted.downcast::<TestError>().unwrap();

--- a/src/libstd/net/parser.rs
+++ b/src/libstd/net/parser.rs
@@ -363,6 +363,7 @@ pub struct AddrParseError(());
 
 #[stable(feature = "addr_parse_error_error", since = "1.4.0")]
 impl fmt::Display for AddrParseError {
+    #[allow(deprecated, deprecated_in_future)]
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.write_str(self.description())
     }
@@ -370,6 +371,7 @@ impl fmt::Display for AddrParseError {
 
 #[stable(feature = "addr_parse_error_error", since = "1.4.0")]
 impl Error for AddrParseError {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         "invalid IP address syntax"
     }

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -2786,6 +2786,7 @@ impl_cmp_os_str!(Cow<'a, Path>, OsString);
 
 #[stable(since = "1.7.0", feature = "strip_prefix")]
 impl fmt::Display for StripPrefixError {
+    #[allow(deprecated, deprecated_in_future)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.description().fmt(f)
     }
@@ -2793,6 +2794,7 @@ impl fmt::Display for StripPrefixError {
 
 #[stable(since = "1.7.0", feature = "strip_prefix")]
 impl Error for StripPrefixError {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         "prefix not found"
     }

--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -1550,6 +1550,7 @@ impl<T> fmt::Display for SendError<T> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Send> error::Error for SendError<T> {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         "sending on a closed channel"
     }
@@ -1577,6 +1578,7 @@ impl<T> fmt::Display for TrySendError<T> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Send> error::Error for TrySendError<T> {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         match *self {
             TrySendError::Full(..) => "sending on a full channel",
@@ -1603,6 +1605,7 @@ impl fmt::Display for RecvError {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl error::Error for RecvError {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         "receiving on a closed channel"
     }
@@ -1620,6 +1623,7 @@ impl fmt::Display for TryRecvError {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl error::Error for TryRecvError {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         match *self {
             TryRecvError::Empty => "receiving on an empty channel",
@@ -1649,6 +1653,7 @@ impl fmt::Display for RecvTimeoutError {
 
 #[stable(feature = "mpsc_recv_timeout_error", since = "1.15.0")]
 impl error::Error for RecvTimeoutError {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         match *self {
             RecvTimeoutError::Timeout => "timed out waiting on channel",

--- a/src/libstd/sys/cloudabi/shims/os.rs
+++ b/src/libstd/sys/cloudabi/shims/os.rs
@@ -63,6 +63,7 @@ impl fmt::Display for JoinPathsError {
 }
 
 impl StdError for JoinPathsError {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         "not supported on CloudABI yet"
     }

--- a/src/libstd/sys/hermit/os.rs
+++ b/src/libstd/sys/hermit/os.rs
@@ -61,6 +61,7 @@ impl fmt::Display for JoinPathsError {
 }
 
 impl StdError for JoinPathsError {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         "not supported on hermit yet"
     }

--- a/src/libstd/sys/sgx/net.rs
+++ b/src/libstd/sys/sgx/net.rs
@@ -440,6 +440,7 @@ pub struct NonIpSockAddr {
 }
 
 impl error::Error for NonIpSockAddr {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         "Failed to convert address to SocketAddr"
     }

--- a/src/libstd/sys/sgx/os.rs
+++ b/src/libstd/sys/sgx/os.rs
@@ -66,6 +66,7 @@ impl fmt::Display for JoinPathsError {
 }
 
 impl StdError for JoinPathsError {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         "not supported in SGX yet"
     }

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -213,6 +213,7 @@ impl fmt::Display for JoinPathsError {
 }
 
 impl StdError for JoinPathsError {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         "failed to join paths"
     }

--- a/src/libstd/sys/vxworks/os.rs
+++ b/src/libstd/sys/vxworks/os.rs
@@ -173,6 +173,7 @@ impl fmt::Display for JoinPathsError {
 }
 
 impl StdError for JoinPathsError {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         "failed to join paths"
     }

--- a/src/libstd/sys/wasi/os.rs
+++ b/src/libstd/sys/wasi/os.rs
@@ -78,6 +78,7 @@ impl fmt::Display for JoinPathsError {
 }
 
 impl StdError for JoinPathsError {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         "not supported on wasm yet"
     }

--- a/src/libstd/sys/wasm/os.rs
+++ b/src/libstd/sys/wasm/os.rs
@@ -53,6 +53,7 @@ impl fmt::Display for JoinPathsError {
 }
 
 impl StdError for JoinPathsError {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         "not supported on wasm yet"
     }

--- a/src/libstd/sys/windows/os.rs
+++ b/src/libstd/sys/windows/os.rs
@@ -225,6 +225,7 @@ impl fmt::Display for JoinPathsError {
 }
 
 impl StdError for JoinPathsError {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         "failed to join paths"
     }

--- a/src/libstd/sys_common/poison.rs
+++ b/src/libstd/sys_common/poison.rs
@@ -148,6 +148,7 @@ impl<T> fmt::Display for PoisonError<T> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Error for PoisonError<T> {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         "poisoned lock: another task failed inside"
     }
@@ -239,6 +240,7 @@ impl<T> fmt::Display for TryLockError<T> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Error for TryLockError<T> {
+    #[allow(deprecated, deprecated_in_future)]
     fn description(&self) -> &str {
         match *self {
             TryLockError::Poisoned(ref p) => p.description(),
@@ -246,6 +248,7 @@ impl<T> Error for TryLockError<T> {
         }
     }
 
+    #[allow(deprecated)]
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
             TryLockError::Poisoned(ref p) => Some(p),

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -621,6 +621,7 @@ impl SystemTimeError {
 
 #[stable(feature = "time2", since = "1.8.0")]
 impl Error for SystemTimeError {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         "other time was not earlier than self"
     }

--- a/src/libsyntax_pos/fatal_error.rs
+++ b/src/libsyntax_pos/fatal_error.rs
@@ -23,8 +23,4 @@ impl std::fmt::Display for FatalError {
     }
 }
 
-impl std::error::Error for FatalError {
-    fn description(&self) -> &str {
-        "The parser has encountered a fatal error"
-    }
-}
+impl std::error::Error for FatalError {}

--- a/src/libterm/terminfo/mod.rs
+++ b/src/libterm/terminfo/mod.rs
@@ -42,14 +42,10 @@ pub enum Error {
 }
 
 impl error::Error for Error {
-    fn description(&self) -> &str {
-        "failed to create TermInfo"
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         use Error::*;
-        match *self {
-            IoError(ref e) => Some(e),
+        match self {
+            IoError(e) => Some(e),
             _ => None,
         }
     }

--- a/src/test/ui/consts/miri_unleashed/mutable_const2.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_const2.stderr
@@ -10,7 +10,7 @@ error: internal compiler error: mutable allocation in constant
 LL | const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-thread 'rustc' panicked at 'no errors encountered even though `delay_span_bug` issued', src/librustc_errors/lib.rs:349:17
+thread 'rustc' panicked at 'no errors encountered even though `delay_span_bug` issued', src/librustc_errors/lib.rs:345:17
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 
 error: internal compiler error: unexpected panic

--- a/src/tools/error_index_generator/main.rs
+++ b/src/tools/error_index_generator/main.rs
@@ -286,7 +286,7 @@ fn main() {
     let (format, dst) = parse_args();
     let result = syntax::with_default_globals(move || main_with_result(format, &dst));
     if let Err(e) = result {
-        panic!("{}", e.description());
+        panic!("{}", e.to_string());
     }
 }
 


### PR DESCRIPTION
`description` has been documented as soft-deprecated since 1.27.0 (17 months ago). There is no longer any reason to call it or implement it.

This PR:

- adds `#[rustc_deprecated(since = "1.41.0")]` to `Error::description`;
- moves `description` (and `cause`, which is also deprecated) below the `source` and `backtrace` methods in the Error trait;
- reduces documentation of `description` and `cause` to take up much less vertical real estate in rustdocs, while preserving the example that shows how to render errors without needing to call `description`;
- removes the description function of all *currently unstable* Error impls in the standard library;
- marks `#[allow(deprecated)]` the description function of all *stable* Error impls in the standard library;
- replaces miscellaneous uses of `description` in example code and the compiler.

---

![description](https://user-images.githubusercontent.com/1940490/69910369-3bbaca80-13bf-11ea-94f7-2fe27a7ea333.png)
