### PR TITLE
add reusable MachineStop variant to Miri engine error enum

### DIFF
--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -396,7 +396,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
                     InterpError::*
                 };
                 match error.kind {
-                    Exit(_) => bug!("the CTFE program cannot exit"),
+                    MachineStop(_) => bug!("ConstProp does not stop"),
 
                     // Some error shouldn't come up because creating them causes
                     // an allocation, which we should avoid. When that happens,


### PR DESCRIPTION
Replace the Miri-tool-specific `Exit` error variant with something dynamically typed that all clients of the Miri engine can use.

r? @oli-obk 
Cc https://github.com/rust-lang/rust/issues/66902