### PR TITLE
Miri core engine: use throw_ub instead of throw_panic

### DIFF
--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -371,6 +371,14 @@ pub enum UndefinedBehaviorInfo {
     Unreachable,
     /// An enum discriminant was set to a value which was outside the range of valid values.
     InvalidDiscriminant(ScalarMaybeUndef),
+    /// A slice/array index projection went out-of-bounds.
+    BoundsCheckFailed { len: u64, index: u64 },
+    /// Something was divided by 0 (x / 0).
+    DivisionByZero,
+    /// Something was "remainded" by 0 (x % 0).
+    RemainderByZero,
+    /// Overflowing inbounds pointer arithmetic.
+    PointerArithOverflow,
 }
 
 impl fmt::Debug for UndefinedBehaviorInfo {
@@ -380,9 +388,18 @@ impl fmt::Debug for UndefinedBehaviorInfo {
             Ub(msg) | UbExperimental(msg) =>
                 write!(f, "{}", msg),
             Unreachable =>
-                write!(f, "entered unreachable code"),
+                write!(f, "entering unreachable code"),
             InvalidDiscriminant(val) =>
-                write!(f, "encountered invalid enum discriminant {}", val),
+                write!(f, "encountering invalid enum discriminant {}", val),
+            BoundsCheckFailed { ref len, ref index } =>
+                write!(f, "indexing out of bounds: the len is {:?} but the index is {:?}",
+                    len, index),
+            DivisionByZero =>
+                write!(f, "dividing by zero"),
+            RemainderByZero =>
+                write!(f, "calculating the remainder with a divisor of zero"),
+            PointerArithOverflow =>
+                write!(f, "overflowing in-bounds pointer arithmetic"),
         }
     }
 }

--- a/src/librustc/mir/interpret/pointer.rs
+++ b/src/librustc/mir/interpret/pointer.rs
@@ -1,6 +1,5 @@
 use super::{AllocId, InterpResult};
 
-use crate::mir;
 use crate::ty::layout::{self, HasDataLayout, Size};
 
 use rustc_macros::HashStable;
@@ -88,13 +87,13 @@ pub trait PointerArithmetic: layout::HasDataLayout {
     #[inline]
     fn offset<'tcx>(&self, val: u64, i: u64) -> InterpResult<'tcx, u64> {
         let (res, over) = self.overflowing_offset(val, i);
-        if over { throw_panic!(Overflow(mir::BinOp::Add)) } else { Ok(res) }
+        if over { throw_ub!(PointerArithOverflow) } else { Ok(res) }
     }
 
     #[inline]
     fn signed_offset<'tcx>(&self, val: u64, i: i64) -> InterpResult<'tcx, u64> {
         let (res, over) = self.overflowing_signed_offset(val, i128::from(i));
-        if over { throw_panic!(Overflow(mir::BinOp::Add)) } else { Ok(res) }
+        if over { throw_ub!(PointerArithOverflow) } else { Ok(res) }
     }
 }
 

--- a/src/librustc_mir/interpret/operator.rs
+++ b/src/librustc_mir/interpret/operator.rs
@@ -177,8 +177,8 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 return Ok((Scalar::from_bool(op(&l, &r)), false, self.tcx.types.bool));
             }
             let op: Option<fn(i128, i128) -> (i128, bool)> = match bin_op {
-                Div if r == 0 => throw_panic!(DivisionByZero),
-                Rem if r == 0 => throw_panic!(RemainderByZero),
+                Div if r == 0 => throw_ub!(DivisionByZero),
+                Rem if r == 0 => throw_ub!(RemainderByZero),
                 Div => Some(i128::overflowing_div),
                 Rem => Some(i128::overflowing_rem),
                 Add => Some(i128::overflowing_add),
@@ -234,8 +234,8 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     Add => u128::overflowing_add,
                     Sub => u128::overflowing_sub,
                     Mul => u128::overflowing_mul,
-                    Div if r == 0 => throw_panic!(DivisionByZero),
-                    Rem if r == 0 => throw_panic!(RemainderByZero),
+                    Div if r == 0 => throw_ub!(DivisionByZero),
+                    Rem if r == 0 => throw_ub!(RemainderByZero),
                     Div => u128::overflowing_div,
                     Rem => u128::overflowing_rem,
                     _ => bug!(),

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -384,10 +384,8 @@ where
             layout::FieldPlacement::Array { stride, .. } => {
                 let len = base.len(self)?;
                 if field >= len {
-                    // This can be violated because the index (field) can be a runtime value
-                    // provided by the user.
-                    debug!("tried to access element {} of array/slice with length {}", field, len);
-                    throw_panic!(BoundsCheck { len, index: field });
+                    // This can only be reached in ConstProp and non-rustc-MIR.
+                    throw_ub!(BoundsCheckFailed { len, index: field });
                 }
                 stride * field
             }

--- a/src/test/compile-fail/consts/const-err3.rs
+++ b/src/test/compile-fail/consts/const-err3.rs
@@ -14,7 +14,6 @@ fn main() {
     //~^ ERROR const_err
     let _e = [5u8][1];
     //~^ ERROR const_err
-    //~| ERROR this expression will panic at runtime
     black_box(b);
     black_box(c);
     black_box(d);

--- a/src/test/ui/consts/array-literal-index-oob.stderr
+++ b/src/test/ui/consts/array-literal-index-oob.stderr
@@ -12,7 +12,7 @@ error: reaching this expression at runtime will panic or abort
 LL |     &{[1, 2, 3][4]};
    |     --^^^^^^^^^^^^-
    |       |
-   |       index out of bounds: the len is 3 but the index is 4
+   |       indexing out of bounds: the len is 3 but the index is 4
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/const-err2.rs
+++ b/src/test/ui/consts/const-err2.rs
@@ -23,7 +23,6 @@ fn main() {
     //~^ ERROR const_err
     let _e = [5u8][1];
     //~^ ERROR index out of bounds
-    //~| ERROR this expression will panic at runtime
     black_box(a);
     black_box(b);
     black_box(c);

--- a/src/test/ui/consts/const-err2.stderr
+++ b/src/test/ui/consts/const-err2.stderr
@@ -34,11 +34,5 @@ error: index out of bounds: the len is 1 but the index is 1
 LL |     let _e = [5u8][1];
    |              ^^^^^^^^
 
-error: this expression will panic at runtime
-  --> $DIR/const-err2.rs:24:14
-   |
-LL |     let _e = [5u8][1];
-   |              ^^^^^^^^ index out of bounds: the len is 1 but the index is 1
-
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 

--- a/src/test/ui/consts/const-err3.rs
+++ b/src/test/ui/consts/const-err3.rs
@@ -23,7 +23,6 @@ fn main() {
     //~^ ERROR const_err
     let _e = [5u8][1];
     //~^ ERROR const_err
-    //~| ERROR this expression will panic at runtime
     black_box(a);
     black_box(b);
     black_box(c);

--- a/src/test/ui/consts/const-err3.stderr
+++ b/src/test/ui/consts/const-err3.stderr
@@ -34,11 +34,5 @@ error: index out of bounds: the len is 1 but the index is 1
 LL |     let _e = [5u8][1];
    |              ^^^^^^^^
 
-error: this expression will panic at runtime
-  --> $DIR/const-err3.rs:24:14
-   |
-LL |     let _e = [5u8][1];
-   |              ^^^^^^^^ index out of bounds: the len is 1 but the index is 1
-
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 

--- a/src/test/ui/consts/const-eval/promoted_errors.rs
+++ b/src/test/ui/consts/const-eval/promoted_errors.rs
@@ -8,14 +8,12 @@ fn main() {
     //~^ ERROR const_err
     println!("{}", 1/(1-1));
     //~^ ERROR attempt to divide by zero [const_err]
-    //~| ERROR reaching this expression at runtime will panic or abort [const_err]
+    //~| ERROR const_err
     let _x = 1/(1-1);
     //~^ ERROR const_err
-    //~| ERROR const_err
     println!("{}", 1/(false as u32));
     //~^ ERROR attempt to divide by zero [const_err]
-    //~| ERROR reaching this expression at runtime will panic or abort [const_err]
+    //~| ERROR const_err
     let _x = 1/(false as u32);
     //~^ ERROR const_err
-    //~| ERROR const_err
 }

--- a/src/test/ui/consts/const-eval/promoted_errors.stderr
+++ b/src/test/ui/consts/const-eval/promoted_errors.stderr
@@ -20,7 +20,7 @@ error: reaching this expression at runtime will panic or abort
   --> $DIR/promoted_errors.rs:9:20
    |
 LL |     println!("{}", 1/(1-1));
-   |                    ^^^^^^^ attempt to divide by zero
+   |                    ^^^^^^^ dividing by zero
 
 error: attempt to divide by zero
   --> $DIR/promoted_errors.rs:12:14
@@ -28,35 +28,23 @@ error: attempt to divide by zero
 LL |     let _x = 1/(1-1);
    |              ^^^^^^^
 
-error: this expression will panic at runtime
-  --> $DIR/promoted_errors.rs:12:14
-   |
-LL |     let _x = 1/(1-1);
-   |              ^^^^^^^ attempt to divide by zero
-
 error: attempt to divide by zero
-  --> $DIR/promoted_errors.rs:15:20
+  --> $DIR/promoted_errors.rs:14:20
    |
 LL |     println!("{}", 1/(false as u32));
    |                    ^^^^^^^^^^^^^^^^
 
 error: reaching this expression at runtime will panic or abort
-  --> $DIR/promoted_errors.rs:15:20
+  --> $DIR/promoted_errors.rs:14:20
    |
 LL |     println!("{}", 1/(false as u32));
-   |                    ^^^^^^^^^^^^^^^^ attempt to divide by zero
+   |                    ^^^^^^^^^^^^^^^^ dividing by zero
 
 error: attempt to divide by zero
-  --> $DIR/promoted_errors.rs:18:14
+  --> $DIR/promoted_errors.rs:17:14
    |
 LL |     let _x = 1/(false as u32);
    |              ^^^^^^^^^^^^^^^^
 
-error: this expression will panic at runtime
-  --> $DIR/promoted_errors.rs:18:14
-   |
-LL |     let _x = 1/(false as u32);
-   |              ^^^^^^^^^^^^^^^^ attempt to divide by zero
-
-error: aborting due to 9 previous errors
+error: aborting due to 7 previous errors
 

--- a/src/test/ui/consts/const-eval/promoted_errors2.rs
+++ b/src/test/ui/consts/const-eval/promoted_errors2.rs
@@ -9,14 +9,12 @@ fn main() {
     //~^ ERROR attempt to subtract with overflow
     println!("{}", 1/(1-1));
     //~^ ERROR attempt to divide by zero [const_err]
-    //~| ERROR reaching this expression at runtime will panic or abort [const_err]
+    //~| ERROR const_err
     let _x = 1/(1-1);
     //~^ ERROR const_err
-    //~| ERROR const_err
     println!("{}", 1/(false as u32));
     //~^ ERROR attempt to divide by zero [const_err]
-    //~| ERROR reaching this expression at runtime will panic or abort [const_err]
+    //~| ERROR const_err
     let _x = 1/(false as u32);
     //~^ ERROR const_err
-    //~| ERROR const_err
 }

--- a/src/test/ui/consts/const-eval/promoted_errors2.stderr
+++ b/src/test/ui/consts/const-eval/promoted_errors2.stderr
@@ -26,7 +26,7 @@ error: reaching this expression at runtime will panic or abort
   --> $DIR/promoted_errors2.rs:10:20
    |
 LL |     println!("{}", 1/(1-1));
-   |                    ^^^^^^^ attempt to divide by zero
+   |                    ^^^^^^^ dividing by zero
 
 error: attempt to divide by zero
   --> $DIR/promoted_errors2.rs:13:14
@@ -34,35 +34,23 @@ error: attempt to divide by zero
 LL |     let _x = 1/(1-1);
    |              ^^^^^^^
 
-error: this expression will panic at runtime
-  --> $DIR/promoted_errors2.rs:13:14
-   |
-LL |     let _x = 1/(1-1);
-   |              ^^^^^^^ attempt to divide by zero
-
 error: attempt to divide by zero
-  --> $DIR/promoted_errors2.rs:16:20
+  --> $DIR/promoted_errors2.rs:15:20
    |
 LL |     println!("{}", 1/(false as u32));
    |                    ^^^^^^^^^^^^^^^^
 
 error: reaching this expression at runtime will panic or abort
-  --> $DIR/promoted_errors2.rs:16:20
+  --> $DIR/promoted_errors2.rs:15:20
    |
 LL |     println!("{}", 1/(false as u32));
-   |                    ^^^^^^^^^^^^^^^^ attempt to divide by zero
+   |                    ^^^^^^^^^^^^^^^^ dividing by zero
 
 error: attempt to divide by zero
-  --> $DIR/promoted_errors2.rs:19:14
+  --> $DIR/promoted_errors2.rs:18:14
    |
 LL |     let _x = 1/(false as u32);
    |              ^^^^^^^^^^^^^^^^
 
-error: this expression will panic at runtime
-  --> $DIR/promoted_errors2.rs:19:14
-   |
-LL |     let _x = 1/(false as u32);
-   |              ^^^^^^^^^^^^^^^^ attempt to divide by zero
-
-error: aborting due to 10 previous errors
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/consts/const-prop-ice.rs
+++ b/src/test/ui/consts/const-prop-ice.rs
@@ -1,4 +1,3 @@
 fn main() {
     [0; 3][3u64 as usize]; //~ ERROR the len is 3 but the index is 3
-    //~| ERROR this expression will panic at runtime
 }

--- a/src/test/ui/consts/const-prop-ice.stderr
+++ b/src/test/ui/consts/const-prop-ice.stderr
@@ -6,11 +6,5 @@ LL |     [0; 3][3u64 as usize];
    |
    = note: `#[deny(const_err)]` on by default
 
-error: this expression will panic at runtime
-  --> $DIR/const-prop-ice.rs:2:5
-   |
-LL |     [0; 3][3u64 as usize];
-   |     ^^^^^^^^^^^^^^^^^^^^^ index out of bounds: the len is 3 but the index is 3
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-54348.rs
+++ b/src/test/ui/issues/issue-54348.rs
@@ -1,7 +1,5 @@
 fn main() {
     [1][0u64 as usize];
     [1][1.5 as usize]; //~ ERROR index out of bounds
-    //~| ERROR this expression will panic at runtime
     [1][1u64 as usize]; //~ ERROR index out of bounds
-    //~| ERROR this expression will panic at runtime
 }

--- a/src/test/ui/issues/issue-54348.stderr
+++ b/src/test/ui/issues/issue-54348.stderr
@@ -6,23 +6,11 @@ LL |     [1][1.5 as usize];
    |
    = note: `#[deny(const_err)]` on by default
 
-error: this expression will panic at runtime
-  --> $DIR/issue-54348.rs:3:5
-   |
-LL |     [1][1.5 as usize];
-   |     ^^^^^^^^^^^^^^^^^ index out of bounds: the len is 1 but the index is 1
-
 error: index out of bounds: the len is 1 but the index is 1
-  --> $DIR/issue-54348.rs:5:5
+  --> $DIR/issue-54348.rs:4:5
    |
 LL |     [1][1u64 as usize];
    |     ^^^^^^^^^^^^^^^^^^
 
-error: this expression will panic at runtime
-  --> $DIR/issue-54348.rs:5:5
-   |
-LL |     [1][1u64 as usize];
-   |     ^^^^^^^^^^^^^^^^^^ index out of bounds: the len is 1 but the index is 1
-
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-8460-const.rs
+++ b/src/test/ui/issues/issue-8460-const.rs
@@ -23,19 +23,14 @@ fn main() {
     //~| ERROR this expression will panic at runtime
     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
     //~^ ERROR attempt to divide by zero
-    //~| ERROR this expression will panic at runtime
     assert!(thread::spawn(move|| { 1i8 / 0; }).join().is_err());
     //~^ ERROR attempt to divide by zero
-    //~| ERROR this expression will panic at runtime
     assert!(thread::spawn(move|| { 1i16 / 0; }).join().is_err());
     //~^ ERROR attempt to divide by zero
-    //~| ERROR this expression will panic at runtime
     assert!(thread::spawn(move|| { 1i32 / 0; }).join().is_err());
     //~^ ERROR attempt to divide by zero
-    //~| ERROR this expression will panic at runtime
     assert!(thread::spawn(move|| { 1i64 / 0; }).join().is_err());
     //~^ ERROR attempt to divide by zero
-    //~| ERROR this expression will panic at runtime
     assert!(thread::spawn(move|| { isize::MIN % -1; }).join().is_err());
     //~^ ERROR attempt to calculate the remainder with overflow
     //~| ERROR this expression will panic at runtime
@@ -53,17 +48,12 @@ fn main() {
     //~| ERROR this expression will panic at runtime
     assert!(thread::spawn(move|| { 1isize % 0; }).join().is_err());
     //~^ ERROR attempt to calculate the remainder with a divisor of zero
-    //~| ERROR this expression will panic at runtime
     assert!(thread::spawn(move|| { 1i8 % 0; }).join().is_err());
     //~^ ERROR attempt to calculate the remainder with a divisor of zero
-    //~| ERROR this expression will panic at runtime
     assert!(thread::spawn(move|| { 1i16 % 0; }).join().is_err());
     //~^ ERROR attempt to calculate the remainder with a divisor of zero
-    //~| ERROR this expression will panic at runtime
     assert!(thread::spawn(move|| { 1i32 % 0; }).join().is_err());
     //~^ ERROR attempt to calculate the remainder with a divisor of zero
-    //~| ERROR this expression will panic at runtime
     assert!(thread::spawn(move|| { 1i64 % 0; }).join().is_err());
     //~^ ERROR attempt to calculate the remainder with a divisor of zero
-    //~| ERROR this expression will panic at runtime
 }

--- a/src/test/ui/issues/issue-8460-const.stderr
+++ b/src/test/ui/issues/issue-8460-const.stderr
@@ -70,179 +70,119 @@ error: attempt to divide by zero
 LL |     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
    |                                    ^^^^^^^^^^
 
-error: this expression will panic at runtime
-  --> $DIR/issue-8460-const.rs:24:36
-   |
-LL |     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
-   |                                    ^^^^^^^^^^ attempt to divide by zero
-
 error: attempt to divide by zero
-  --> $DIR/issue-8460-const.rs:27:36
+  --> $DIR/issue-8460-const.rs:26:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 / 0; }).join().is_err());
    |                                    ^^^^^^^
 
-error: this expression will panic at runtime
-  --> $DIR/issue-8460-const.rs:27:36
-   |
-LL |     assert!(thread::spawn(move|| { 1i8 / 0; }).join().is_err());
-   |                                    ^^^^^^^ attempt to divide by zero
-
 error: attempt to divide by zero
-  --> $DIR/issue-8460-const.rs:30:36
+  --> $DIR/issue-8460-const.rs:28:36
    |
 LL |     assert!(thread::spawn(move|| { 1i16 / 0; }).join().is_err());
    |                                    ^^^^^^^^
 
-error: this expression will panic at runtime
+error: attempt to divide by zero
   --> $DIR/issue-8460-const.rs:30:36
    |
-LL |     assert!(thread::spawn(move|| { 1i16 / 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to divide by zero
-
-error: attempt to divide by zero
-  --> $DIR/issue-8460-const.rs:33:36
-   |
 LL |     assert!(thread::spawn(move|| { 1i32 / 0; }).join().is_err());
    |                                    ^^^^^^^^
 
-error: this expression will panic at runtime
-  --> $DIR/issue-8460-const.rs:33:36
-   |
-LL |     assert!(thread::spawn(move|| { 1i32 / 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to divide by zero
-
 error: attempt to divide by zero
-  --> $DIR/issue-8460-const.rs:36:36
+  --> $DIR/issue-8460-const.rs:32:36
    |
 LL |     assert!(thread::spawn(move|| { 1i64 / 0; }).join().is_err());
    |                                    ^^^^^^^^
-
-error: this expression will panic at runtime
-  --> $DIR/issue-8460-const.rs:36:36
-   |
-LL |     assert!(thread::spawn(move|| { 1i64 / 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to divide by zero
 
 error: attempt to calculate the remainder with overflow
-  --> $DIR/issue-8460-const.rs:39:36
+  --> $DIR/issue-8460-const.rs:34:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^
 
 error: this expression will panic at runtime
-  --> $DIR/issue-8460-const.rs:39:36
+  --> $DIR/issue-8460-const.rs:34:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^ attempt to calculate the remainder with overflow
 
 error: attempt to calculate the remainder with overflow
-  --> $DIR/issue-8460-const.rs:42:36
+  --> $DIR/issue-8460-const.rs:37:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^
 
 error: this expression will panic at runtime
-  --> $DIR/issue-8460-const.rs:42:36
+  --> $DIR/issue-8460-const.rs:37:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^ attempt to calculate the remainder with overflow
 
 error: attempt to calculate the remainder with overflow
-  --> $DIR/issue-8460-const.rs:45:36
+  --> $DIR/issue-8460-const.rs:40:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^
 
 error: this expression will panic at runtime
-  --> $DIR/issue-8460-const.rs:45:36
+  --> $DIR/issue-8460-const.rs:40:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to calculate the remainder with overflow
 
 error: attempt to calculate the remainder with overflow
-  --> $DIR/issue-8460-const.rs:48:36
+  --> $DIR/issue-8460-const.rs:43:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^
 
 error: this expression will panic at runtime
-  --> $DIR/issue-8460-const.rs:48:36
+  --> $DIR/issue-8460-const.rs:43:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to calculate the remainder with overflow
 
 error: attempt to calculate the remainder with overflow
-  --> $DIR/issue-8460-const.rs:51:36
+  --> $DIR/issue-8460-const.rs:46:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^
 
 error: this expression will panic at runtime
-  --> $DIR/issue-8460-const.rs:51:36
+  --> $DIR/issue-8460-const.rs:46:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to calculate the remainder with overflow
 
 error: attempt to calculate the remainder with a divisor of zero
-  --> $DIR/issue-8460-const.rs:54:36
+  --> $DIR/issue-8460-const.rs:49:36
    |
 LL |     assert!(thread::spawn(move|| { 1isize % 0; }).join().is_err());
    |                                    ^^^^^^^^^^
 
-error: this expression will panic at runtime
-  --> $DIR/issue-8460-const.rs:54:36
-   |
-LL |     assert!(thread::spawn(move|| { 1isize % 0; }).join().is_err());
-   |                                    ^^^^^^^^^^ attempt to calculate the remainder with a divisor of zero
-
 error: attempt to calculate the remainder with a divisor of zero
-  --> $DIR/issue-8460-const.rs:57:36
+  --> $DIR/issue-8460-const.rs:51:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 % 0; }).join().is_err());
    |                                    ^^^^^^^
 
-error: this expression will panic at runtime
+error: attempt to calculate the remainder with a divisor of zero
+  --> $DIR/issue-8460-const.rs:53:36
+   |
+LL |     assert!(thread::spawn(move|| { 1i16 % 0; }).join().is_err());
+   |                                    ^^^^^^^^
+
+error: attempt to calculate the remainder with a divisor of zero
+  --> $DIR/issue-8460-const.rs:55:36
+   |
+LL |     assert!(thread::spawn(move|| { 1i32 % 0; }).join().is_err());
+   |                                    ^^^^^^^^
+
+error: attempt to calculate the remainder with a divisor of zero
   --> $DIR/issue-8460-const.rs:57:36
    |
-LL |     assert!(thread::spawn(move|| { 1i8 % 0; }).join().is_err());
-   |                                    ^^^^^^^ attempt to calculate the remainder with a divisor of zero
-
-error: attempt to calculate the remainder with a divisor of zero
-  --> $DIR/issue-8460-const.rs:60:36
-   |
-LL |     assert!(thread::spawn(move|| { 1i16 % 0; }).join().is_err());
-   |                                    ^^^^^^^^
-
-error: this expression will panic at runtime
-  --> $DIR/issue-8460-const.rs:60:36
-   |
-LL |     assert!(thread::spawn(move|| { 1i16 % 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to calculate the remainder with a divisor of zero
-
-error: attempt to calculate the remainder with a divisor of zero
-  --> $DIR/issue-8460-const.rs:63:36
-   |
-LL |     assert!(thread::spawn(move|| { 1i32 % 0; }).join().is_err());
-   |                                    ^^^^^^^^
-
-error: this expression will panic at runtime
-  --> $DIR/issue-8460-const.rs:63:36
-   |
-LL |     assert!(thread::spawn(move|| { 1i32 % 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to calculate the remainder with a divisor of zero
-
-error: attempt to calculate the remainder with a divisor of zero
-  --> $DIR/issue-8460-const.rs:66:36
-   |
 LL |     assert!(thread::spawn(move|| { 1i64 % 0; }).join().is_err());
    |                                    ^^^^^^^^
 
-error: this expression will panic at runtime
-  --> $DIR/issue-8460-const.rs:66:36
-   |
-LL |     assert!(thread::spawn(move|| { 1i64 % 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to calculate the remainder with a divisor of zero
-
-error: aborting due to 40 previous errors
+error: aborting due to 30 previous errors
 

--- a/src/test/ui/issues/issue-8460-const2.rs
+++ b/src/test/ui/issues/issue-8460-const2.rs
@@ -18,19 +18,14 @@ fn main() {
     //~^ ERROR attempt to divide with overflow
     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
     //~^ ERROR attempt to divide by zero
-    //~| ERROR this expression will panic at runtime
     assert!(thread::spawn(move|| { 1i8 / 0; }).join().is_err());
     //~^ ERROR attempt to divide by zero
-    //~| ERROR this expression will panic at runtime
     assert!(thread::spawn(move|| { 1i16 / 0; }).join().is_err());
     //~^ ERROR attempt to divide by zero
-    //~| ERROR this expression will panic at runtime
     assert!(thread::spawn(move|| { 1i32 / 0; }).join().is_err());
     //~^ ERROR attempt to divide by zero
-    //~| ERROR this expression will panic at runtime
     assert!(thread::spawn(move|| { 1i64 / 0; }).join().is_err());
     //~^ ERROR attempt to divide by zero
-    //~| ERROR this expression will panic at runtime
     assert!(thread::spawn(move|| { isize::MIN % -1; }).join().is_err());
     //~^ ERROR attempt to calculate the remainder with overflow
     assert!(thread::spawn(move|| { i8::MIN % -1; }).join().is_err());
@@ -43,17 +38,12 @@ fn main() {
     //~^ ERROR attempt to calculate the remainder with overflow
     assert!(thread::spawn(move|| { 1isize % 0; }).join().is_err());
     //~^ ERROR attempt to calculate the remainder with a divisor of zero
-    //~| ERROR this expression will panic at runtime
     assert!(thread::spawn(move|| { 1i8 % 0; }).join().is_err());
     //~^ ERROR attempt to calculate the remainder with a divisor of zero
-    //~| ERROR this expression will panic at runtime
     assert!(thread::spawn(move|| { 1i16 % 0; }).join().is_err());
     //~^ ERROR attempt to calculate the remainder with a divisor of zero
-    //~| ERROR this expression will panic at runtime
     assert!(thread::spawn(move|| { 1i32 % 0; }).join().is_err());
     //~^ ERROR attempt to calculate the remainder with a divisor of zero
-    //~| ERROR this expression will panic at runtime
     assert!(thread::spawn(move|| { 1i64 % 0; }).join().is_err());
     //~^ ERROR attempt to calculate the remainder with a divisor of zero
-    //~| ERROR this expression will panic at runtime
 }

--- a/src/test/ui/issues/issue-8460-const2.stderr
+++ b/src/test/ui/issues/issue-8460-const2.stderr
@@ -40,149 +40,89 @@ error: attempt to divide by zero
 LL |     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
    |                                    ^^^^^^^^^^
 
-error: this expression will panic at runtime
-  --> $DIR/issue-8460-const2.rs:19:36
-   |
-LL |     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
-   |                                    ^^^^^^^^^^ attempt to divide by zero
-
 error: attempt to divide by zero
-  --> $DIR/issue-8460-const2.rs:22:36
+  --> $DIR/issue-8460-const2.rs:21:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 / 0; }).join().is_err());
    |                                    ^^^^^^^
 
-error: this expression will panic at runtime
-  --> $DIR/issue-8460-const2.rs:22:36
-   |
-LL |     assert!(thread::spawn(move|| { 1i8 / 0; }).join().is_err());
-   |                                    ^^^^^^^ attempt to divide by zero
-
 error: attempt to divide by zero
-  --> $DIR/issue-8460-const2.rs:25:36
+  --> $DIR/issue-8460-const2.rs:23:36
    |
 LL |     assert!(thread::spawn(move|| { 1i16 / 0; }).join().is_err());
    |                                    ^^^^^^^^
 
-error: this expression will panic at runtime
+error: attempt to divide by zero
   --> $DIR/issue-8460-const2.rs:25:36
    |
-LL |     assert!(thread::spawn(move|| { 1i16 / 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to divide by zero
-
-error: attempt to divide by zero
-  --> $DIR/issue-8460-const2.rs:28:36
-   |
 LL |     assert!(thread::spawn(move|| { 1i32 / 0; }).join().is_err());
    |                                    ^^^^^^^^
 
-error: this expression will panic at runtime
-  --> $DIR/issue-8460-const2.rs:28:36
-   |
-LL |     assert!(thread::spawn(move|| { 1i32 / 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to divide by zero
-
 error: attempt to divide by zero
-  --> $DIR/issue-8460-const2.rs:31:36
+  --> $DIR/issue-8460-const2.rs:27:36
    |
 LL |     assert!(thread::spawn(move|| { 1i64 / 0; }).join().is_err());
    |                                    ^^^^^^^^
-
-error: this expression will panic at runtime
-  --> $DIR/issue-8460-const2.rs:31:36
-   |
-LL |     assert!(thread::spawn(move|| { 1i64 / 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to divide by zero
 
 error: attempt to calculate the remainder with overflow
-  --> $DIR/issue-8460-const2.rs:34:36
+  --> $DIR/issue-8460-const2.rs:29:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^
 
 error: attempt to calculate the remainder with overflow
-  --> $DIR/issue-8460-const2.rs:36:36
+  --> $DIR/issue-8460-const2.rs:31:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^
 
 error: attempt to calculate the remainder with overflow
-  --> $DIR/issue-8460-const2.rs:38:36
+  --> $DIR/issue-8460-const2.rs:33:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^
 
 error: attempt to calculate the remainder with overflow
-  --> $DIR/issue-8460-const2.rs:40:36
+  --> $DIR/issue-8460-const2.rs:35:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^
 
 error: attempt to calculate the remainder with overflow
-  --> $DIR/issue-8460-const2.rs:42:36
+  --> $DIR/issue-8460-const2.rs:37:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^
 
 error: attempt to calculate the remainder with a divisor of zero
-  --> $DIR/issue-8460-const2.rs:44:36
+  --> $DIR/issue-8460-const2.rs:39:36
    |
 LL |     assert!(thread::spawn(move|| { 1isize % 0; }).join().is_err());
    |                                    ^^^^^^^^^^
 
-error: this expression will panic at runtime
-  --> $DIR/issue-8460-const2.rs:44:36
-   |
-LL |     assert!(thread::spawn(move|| { 1isize % 0; }).join().is_err());
-   |                                    ^^^^^^^^^^ attempt to calculate the remainder with a divisor of zero
-
 error: attempt to calculate the remainder with a divisor of zero
-  --> $DIR/issue-8460-const2.rs:47:36
+  --> $DIR/issue-8460-const2.rs:41:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 % 0; }).join().is_err());
    |                                    ^^^^^^^
 
-error: this expression will panic at runtime
+error: attempt to calculate the remainder with a divisor of zero
+  --> $DIR/issue-8460-const2.rs:43:36
+   |
+LL |     assert!(thread::spawn(move|| { 1i16 % 0; }).join().is_err());
+   |                                    ^^^^^^^^
+
+error: attempt to calculate the remainder with a divisor of zero
+  --> $DIR/issue-8460-const2.rs:45:36
+   |
+LL |     assert!(thread::spawn(move|| { 1i32 % 0; }).join().is_err());
+   |                                    ^^^^^^^^
+
+error: attempt to calculate the remainder with a divisor of zero
   --> $DIR/issue-8460-const2.rs:47:36
    |
-LL |     assert!(thread::spawn(move|| { 1i8 % 0; }).join().is_err());
-   |                                    ^^^^^^^ attempt to calculate the remainder with a divisor of zero
-
-error: attempt to calculate the remainder with a divisor of zero
-  --> $DIR/issue-8460-const2.rs:50:36
-   |
-LL |     assert!(thread::spawn(move|| { 1i16 % 0; }).join().is_err());
-   |                                    ^^^^^^^^
-
-error: this expression will panic at runtime
-  --> $DIR/issue-8460-const2.rs:50:36
-   |
-LL |     assert!(thread::spawn(move|| { 1i16 % 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to calculate the remainder with a divisor of zero
-
-error: attempt to calculate the remainder with a divisor of zero
-  --> $DIR/issue-8460-const2.rs:53:36
-   |
-LL |     assert!(thread::spawn(move|| { 1i32 % 0; }).join().is_err());
-   |                                    ^^^^^^^^
-
-error: this expression will panic at runtime
-  --> $DIR/issue-8460-const2.rs:53:36
-   |
-LL |     assert!(thread::spawn(move|| { 1i32 % 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to calculate the remainder with a divisor of zero
-
-error: attempt to calculate the remainder with a divisor of zero
-  --> $DIR/issue-8460-const2.rs:56:36
-   |
 LL |     assert!(thread::spawn(move|| { 1i64 % 0; }).join().is_err());
    |                                    ^^^^^^^^
 
-error: this expression will panic at runtime
-  --> $DIR/issue-8460-const2.rs:56:36
-   |
-LL |     assert!(thread::spawn(move|| { 1i64 % 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to calculate the remainder with a divisor of zero
-
-error: aborting due to 30 previous errors
+error: aborting due to 20 previous errors
 


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/66902 for context: panicking is not really an "interpreter error", but just part of a normal Rust execution. This is a first step towards removing the `InterpError::Panic` variant: the core Miri engine does not use it any more.

ConstProp and ConstEval still use it, though. This will be addressed in future PRs.

From what I can tell, all the error messages this removes are actually duplicates.

r? @oli-obk @wesleywiser 