### PR TITLE
de-macro-ize feature gate checking

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -834,7 +834,7 @@ impl<'a> LoweringContext<'a> {
             return;
         }
 
-        if !self.sess.features_untracked().in_band_lifetimes {
+        if !self.sess.features_untracked().on(sym::in_band_lifetimes) {
             return;
         }
 
@@ -1394,7 +1394,7 @@ impl<'a> LoweringContext<'a> {
                     }
                     ImplTraitContext::Disallowed(pos) => {
                         let allowed_in = if self.sess.features_untracked()
-                                                .impl_trait_in_bindings {
+                                                .on(sym::impl_trait_in_bindings) {
                             "bindings or function and inherent method return types"
                         } else {
                             "function and inherent method return types"
@@ -2118,7 +2118,7 @@ impl<'a> LoweringContext<'a> {
 
     fn lower_local(&mut self, l: &Local) -> (hir::Local, SmallVec<[NodeId; 1]>) {
         let mut ids = SmallVec::<[NodeId; 1]>::new();
-        if self.sess.features_untracked().impl_trait_in_bindings {
+        if self.sess.features_untracked().on(sym::impl_trait_in_bindings) {
             if let Some(ref ty) = l.ty {
                 let mut visitor = ImplTraitTypeIdVisitor { ids: &mut ids };
                 visitor.visit_ty(ty);
@@ -2130,7 +2130,7 @@ impl<'a> LoweringContext<'a> {
             ty: l.ty
                 .as_ref()
                 .map(|t| self.lower_ty(t,
-                    if self.sess.features_untracked().impl_trait_in_bindings {
+                    if self.sess.features_untracked().on(sym::impl_trait_in_bindings) {
                         ImplTraitContext::OpaqueTy(Some(parent_def_id))
                     } else {
                         ImplTraitContext::Disallowed(ImplTraitPosition::Binding)

--- a/src/librustc/hir/lowering/item.rs
+++ b/src/librustc/hir/lowering/item.rs
@@ -181,7 +181,7 @@ impl LoweringContext<'_> {
             ItemKind::Impl(.., None, _, _) => smallvec![i.id],
             ItemKind::Static(ref ty, ..) => {
                 let mut ids = smallvec![i.id];
-                if self.sess.features_untracked().impl_trait_in_bindings {
+                if self.sess.features_untracked().on(sym::impl_trait_in_bindings) {
                     let mut visitor = ImplTraitTypeIdVisitor { ids: &mut ids };
                     visitor.visit_ty(ty);
                 }
@@ -189,7 +189,7 @@ impl LoweringContext<'_> {
             },
             ItemKind::Const(ref ty, ..) => {
                 let mut ids = smallvec![i.id];
-                if self.sess.features_untracked().impl_trait_in_bindings {
+                if self.sess.features_untracked().on(sym::impl_trait_in_bindings) {
                     let mut visitor = ImplTraitTypeIdVisitor { ids: &mut ids };
                     visitor.visit_ty(ty);
                 }
@@ -285,7 +285,7 @@ impl LoweringContext<'_> {
                 hir::ItemKind::Static(
                     self.lower_ty(
                         t,
-                        if self.sess.features_untracked().impl_trait_in_bindings {
+                        if self.sess.features_untracked().on(sym::impl_trait_in_bindings) {
                             ImplTraitContext::OpaqueTy(None)
                         } else {
                             ImplTraitContext::Disallowed(ImplTraitPosition::Binding)
@@ -299,7 +299,7 @@ impl LoweringContext<'_> {
                 hir::ItemKind::Const(
                     self.lower_ty(
                         t,
-                        if self.sess.features_untracked().impl_trait_in_bindings {
+                        if self.sess.features_untracked().on(sym::impl_trait_in_bindings) {
                             ImplTraitContext::OpaqueTy(None)
                         } else {
                             ImplTraitContext::Disallowed(ImplTraitPosition::Binding)

--- a/src/librustc/infer/error_reporting/need_type_info.rs
+++ b/src/librustc/infer/error_reporting/need_type_info.rs
@@ -5,8 +5,8 @@ use crate::infer::InferCtxt;
 use crate::infer::type_variable::TypeVariableOriginKind;
 use crate::ty::{self, Ty, Infer, TyVar};
 use crate::ty::print::Print;
-use syntax::source_map::DesugaringKind;
-use syntax_pos::Span;
+use syntax_pos::source_map::DesugaringKind;
+use syntax_pos::{Span, symbol::sym};
 use errors::{Applicability, DiagnosticBuilder};
 
 use rustc_error_codes::*;
@@ -217,7 +217,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         let is_named_and_not_impl_trait = |ty: Ty<'_>| {
             &ty.to_string() != "_" &&
                 // FIXME: Remove this check after `impl_trait_in_bindings` is stabilized. #63527
-                (!ty.is_impl_trait() || self.tcx.features().impl_trait_in_bindings)
+                (!ty.is_impl_trait() || self.tcx.features().on(sym::impl_trait_in_bindings))
         };
 
         let ty_msg = match local_visitor.found_ty {

--- a/src/librustc/infer/opaque_types/mod.rs
+++ b/src/librustc/infer/opaque_types/mod.rs
@@ -13,7 +13,7 @@ use errors::DiagnosticBuilder;
 use rustc::session::config::nightly_options;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync::Lrc;
-use syntax_pos::Span;
+use syntax_pos::{Span, symbol::sym};
 
 use rustc_error_codes::*;
 
@@ -488,7 +488,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         conflict2: ty::Region<'tcx>,
     ) -> bool {
         // If we have `#![feature(member_constraints)]`, no problems.
-        if self.tcx.features().member_constraints {
+        if self.tcx.features().on(sym::member_constraints) {
             return false;
         }
 

--- a/src/librustc/lint/levels.rs
+++ b/src/librustc/lint/levels.rs
@@ -231,15 +231,13 @@ impl<'a> LintLevelsBuilder<'a> {
                             // FIXME (#55112): issue unused-attributes lint if we thereby
                             // don't have any lint names (`#[level(reason = "foo")]`)
                             if let ast::LitKind::Str(rationale, _) = name_value.kind {
-                                if !self.sess.features_untracked().lint_reasons {
-                                    feature_gate::feature_err(
-                                        &self.sess.parse_sess,
-                                        sym::lint_reasons,
-                                        item.span,
-                                        "lint reasons are experimental"
-                                    )
-                                    .emit();
-                                }
+                                feature_gate::gate_feature(
+                                    &self.sess.parse_sess,
+                                    self.sess.features_untracked(),
+                                    item.span,
+                                    sym::lint_reasons,
+                                    "lint reasons are experimental"
+                                );
                                 reason = Some(rationale);
                             } else {
                                 bad_attr(name_value.span)

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -116,7 +116,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
                    item_sp: Span, kind: AnnotationKind, visit_children: F)
         where F: FnOnce(&mut Self)
     {
-        if self.tcx.features().staged_api {
+        if self.tcx.features().on(sym::staged_api) {
             // This crate explicitly wants staged API.
             debug!("annotate(id = {:?}, attrs = {:?})", hir_id, attrs);
             if let Some(..) = attr::find_deprecation(&self.tcx.sess.parse_sess, attrs, item_sp) {
@@ -393,7 +393,7 @@ impl<'tcx> Index<'tcx> {
     pub fn new(tcx: TyCtxt<'tcx>) -> Index<'tcx> {
         let is_staged_api =
             tcx.sess.opts.debugging_opts.force_unstable_if_unmarked ||
-            tcx.features().staged_api;
+            tcx.features().on(sym::staged_api);
         let mut staged_api = FxHashMap::default();
         staged_api.insert(LOCAL_CRATE, is_staged_api);
         let mut index = Index {
@@ -836,7 +836,7 @@ impl Visitor<'tcx> for Checker<'tcx> {
 
             // There's no good place to insert stability check for non-Copy unions,
             // so semi-randomly perform it here in stability.rs
-            hir::ItemKind::Union(..) if !self.tcx.features().untagged_unions => {
+            hir::ItemKind::Union(..) if !self.tcx.features().on(sym::untagged_unions) => {
                 let def_id = self.tcx.hir().local_def_id(item.hir_id);
                 let adt_def = self.tcx.adt_def(def_id);
                 let ty = self.tcx.type_of(def_id);

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -2353,13 +2353,13 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             }
             ObligationCauseCode::VariableType(_) => {
                 err.note("all local variables must have a statically known size");
-                if !self.tcx.features().unsized_locals {
+                if !self.tcx.features().on(sym::unsized_locals) {
                     err.help("unsized locals are gated as an unstable feature");
                 }
             }
             ObligationCauseCode::SizedArgumentType => {
                 err.note("all function arguments must have a statically known size");
-                if !self.tcx.features().unsized_locals {
+                if !self.tcx.features().on(sym::unsized_locals) {
                     err.help("unsized locals are gated as an unstable feature");
                 }
             }

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -2215,7 +2215,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     }
 
                     if let Some(principal) = data.principal() {
-                        if !self.infcx.tcx.features().object_safe_for_dispatch {
+                        if !self.infcx.tcx.features().on(sym::object_safe_for_dispatch) {
                             principal.with_self_ty(self.tcx(), self_ty)
                         } else if self.tcx().is_object_safe(principal.def_id()) {
                             principal.with_self_ty(self.tcx(), self_ty)

--- a/src/librustc/traits/specialize/mod.rs
+++ b/src/librustc/traits/specialize/mod.rs
@@ -16,7 +16,7 @@ use crate::infer::{InferCtxt, InferOk};
 use crate::lint;
 use crate::traits::{self, coherence, FutureCompatOverlapErrorKind, ObligationCause, TraitEngine};
 use rustc_data_structures::fx::FxHashSet;
-use syntax_pos::DUMMY_SP;
+use syntax_pos::{DUMMY_SP, symbol::sym};
 use crate::traits::select::IntercrateAmbiguityCause;
 use crate::ty::{self, TyCtxt, TypeFoldable};
 use crate::ty::subst::{Subst, InternalSubsts, SubstsRef};
@@ -155,7 +155,7 @@ pub(super) fn specializes(
 
     // The feature gate should prevent introducing new specializations, but not
     // taking advantage of upstream ones.
-    if !tcx.features().specialization &&
+    if !tcx.features().on(sym::specialization) &&
         (impl1_def_id.is_local() || impl2_def_id.is_local()) {
         return false;
     }

--- a/src/librustc/ty/constness.rs
+++ b/src/librustc/ty/constness.rs
@@ -2,7 +2,7 @@ use crate::ty::query::Providers;
 use crate::hir::def_id::DefId;
 use crate::hir;
 use crate::ty::TyCtxt;
-use syntax_pos::symbol::Symbol;
+use syntax_pos::symbol::{sym, Symbol};
 use crate::hir::map::blocks::FnLikeNode;
 use syntax::attr;
 
@@ -42,7 +42,7 @@ impl<'tcx> TyCtxt<'tcx> {
             return false;
         }
 
-        if self.features().staged_api {
+        if self.features().on(sym::staged_api) {
             // in order for a libstd function to be considered min_const_fn
             // it needs to be stable and have no `rustc_const_unstable` attribute
             match self.lookup_stability(def_id) {
@@ -56,7 +56,7 @@ impl<'tcx> TyCtxt<'tcx> {
             }
         } else {
             // users enabling the `const_fn` feature gate can do what they want
-            !self.features().const_fn
+            !self.features().on(sym::const_fn)
         }
     }
 }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1473,7 +1473,7 @@ impl<'tcx> TyCtxt<'tcx> {
         //
         // * Otherwise, use the behavior requested via `-Z borrowck=...`
 
-        if self.features().nll { return BorrowckMode::Mir; }
+        if self.features().on(sym::nll) { return BorrowckMode::Mir; }
 
         self.sess.opts.borrowck_mode
     }
@@ -2437,7 +2437,7 @@ impl<'tcx> TyCtxt<'tcx> {
 
     #[inline]
     pub fn mk_diverging_default(self) -> Ty<'tcx> {
-        if self.features().never_type_fallback {
+        if self.features().on(sym::never_type_fallback) {
             self.types.never
         } else {
             self.types.unit

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2898,7 +2898,7 @@ impl<'tcx> TyCtxt<'tcx> {
             (ImplPolarity::Negative, ImplPolarity::Negative) => {}
         };
 
-        let is_marker_overlap = if self.features().overlapping_marker_traits {
+        let is_marker_overlap = if self.features().on(sym::overlapping_marker_traits) {
             let trait1_is_empty = self.impl_trait_ref(def_id1)
                 .map_or(false, |trait_ref| {
                     self.associated_item_def_ids(trait_ref.def_id).is_empty()

--- a/src/librustc/ty/wf.rs
+++ b/src/librustc/ty/wf.rs
@@ -5,7 +5,7 @@ use crate::ty::subst::SubstsRef;
 use crate::traits::{self, AssocTypeBoundData};
 use crate::ty::{self, ToPredicate, Ty, TyCtxt, TypeFoldable};
 use std::iter::once;
-use syntax::symbol::{kw, Ident};
+use syntax::symbol::{kw, sym, Ident};
 use syntax_pos::Span;
 use crate::middle::lang_items;
 
@@ -538,7 +538,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
                     // checking those
 
                     let defer_to_coercion =
-                        self.infcx.tcx.features().object_safe_for_dispatch;
+                        self.infcx.tcx.features().on(sym::object_safe_for_dispatch);
 
                     if !defer_to_coercion {
                         let cause = self.cause(traits::MiscObligation);

--- a/src/librustc_codegen_utils/symbol_names_test.rs
+++ b/src/librustc_codegen_utils/symbol_names_test.rs
@@ -15,7 +15,7 @@ pub fn report_symbol_names(tcx: TyCtxt<'_>) {
     // if the `rustc_attrs` feature is not enabled, then the
     // attributes we are interested in cannot be present anyway, so
     // skip the walk.
-    if !tcx.features().rustc_attrs {
+    if !tcx.features().on(sym::rustc_attrs) {
         return;
     }
 

--- a/src/librustc_feature/builtin_attrs.rs
+++ b/src/librustc_feature/builtin_attrs.rs
@@ -3,29 +3,21 @@
 use AttributeType::*;
 use AttributeGate::*;
 
-use crate::{Features, Stability};
+use crate::Stability;
 
 use rustc_data_structures::fx::FxHashMap;
 use syntax_pos::symbol::{Symbol, sym};
 use lazy_static::lazy_static;
 
-type GateFn = fn(&Features) -> bool;
-
-macro_rules! cfg_fn {
-    ($field: ident) => {
-        (|features| { features.$field }) as GateFn
-    }
-}
-
-pub type GatedCfg = (Symbol, Symbol, GateFn);
+pub type GatedCfg = (Symbol, Symbol);
 
 /// `cfg(...)`'s that are feature gated.
 const GATED_CFGS: &[GatedCfg] = &[
-    // (name in cfg, feature, function to check if the feature is enabled)
-    (sym::target_thread_local, sym::cfg_target_thread_local, cfg_fn!(cfg_target_thread_local)),
-    (sym::target_has_atomic, sym::cfg_target_has_atomic, cfg_fn!(cfg_target_has_atomic)),
-    (sym::target_has_atomic_load_store, sym::cfg_target_has_atomic, cfg_fn!(cfg_target_has_atomic)),
-    (sym::sanitize, sym::cfg_sanitize, cfg_fn!(cfg_sanitize)),
+    // (name in cfg, feature)
+    (sym::target_thread_local, sym::cfg_target_thread_local),
+    (sym::target_has_atomic, sym::cfg_target_has_atomic),
+    (sym::target_has_atomic_load_store, sym::cfg_target_has_atomic),
+    (sym::sanitize, sym::cfg_sanitize),
 ];
 
 /// Find a gated cfg determined by the `pred`icate which is given the cfg's name.
@@ -52,25 +44,13 @@ pub enum AttributeType {
     CrateLevel,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum AttributeGate {
     /// Is gated by a given feature gate, reason
-    /// and function to check if enabled
-    Gated(Stability, Symbol, &'static str, fn(&Features) -> bool),
+    Gated(Stability, Symbol, &'static str),
 
     /// Ungated attribute, can be used on all release channels
     Ungated,
-}
-
-// fn() is not Debug
-impl std::fmt::Debug for AttributeGate {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            Self::Gated(ref stab, name, expl, _) =>
-                write!(fmt, "Gated({:?}, {}, {})", stab, name, expl),
-            Self::Ungated => write!(fmt, "Ungated")
-        }
-    }
 }
 
 impl AttributeGate {
@@ -125,10 +105,10 @@ macro_rules! ungated {
 
 macro_rules! gated {
     ($attr:ident, $typ:expr, $tpl:expr, $gate:ident, $msg:expr $(,)?) => {
-        (sym::$attr, $typ, $tpl, Gated(Stability::Unstable, sym::$gate, $msg, cfg_fn!($gate)))
+        (sym::$attr, $typ, $tpl, Gated(Stability::Unstable, sym::$gate, $msg))
     };
     ($attr:ident, $typ:expr, $tpl:expr, $msg:expr $(,)?) => {
-        (sym::$attr, $typ, $tpl, Gated(Stability::Unstable, sym::$attr, $msg, cfg_fn!($attr)))
+        (sym::$attr, $typ, $tpl, Gated(Stability::Unstable, sym::$attr, $msg))
     };
 }
 
@@ -142,8 +122,7 @@ macro_rules! rustc_attr {
         )
     };
     ($attr:ident, $typ:expr, $tpl:expr, $msg:expr $(,)?) => {
-        (sym::$attr, $typ, $tpl,
-         Gated(Stability::Unstable, sym::rustc_attrs, $msg, cfg_fn!(rustc_attrs)))
+        (sym::$attr, $typ, $tpl, Gated(Stability::Unstable, sym::rustc_attrs, $msg))
     };
 }
 
@@ -280,7 +259,6 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             ),
             sym::plugin_registrar,
             "compiler plugins are deprecated",
-            cfg_fn!(plugin_registrar)
         )
     ),
     (
@@ -292,7 +270,6 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             ),
             sym::plugin,
             "compiler plugins are deprecated",
-            cfg_fn!(plugin)
         )
     ),
 
@@ -489,7 +466,6 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             Stability::Unstable,
             sym::rustc_attrs,
             "diagnostic items compiler internal support for linting",
-            cfg_fn!(rustc_attrs),
         ),
     ),
     (
@@ -499,7 +475,6 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             sym::no_debug,
             "the `#[no_debug]` attribute was an experimental feature that has been \
             deprecated due to lack of demand",
-            cfg_fn!(no_debug)
         )
     ),
     gated!(

--- a/src/librustc_feature/lib.rs
+++ b/src/librustc_feature/lib.rs
@@ -17,12 +17,12 @@ mod builtin_attrs;
 
 use std::fmt;
 use std::num::NonZeroU32;
-use syntax_pos::{Span, edition::Edition, symbol::Symbol};
+use syntax_pos::{edition::Edition, symbol::Symbol};
 
 #[derive(Clone, Copy)]
 pub enum State {
     Accepted,
-    Active { set: fn(&mut Features, Span) },
+    Active,
     Removed { reason: Option<&'static str> },
     Stabilized { reason: Option<&'static str> },
 }

--- a/src/librustc_incremental/assert_dep_graph.rs
+++ b/src/librustc_incremental/assert_dep_graph.rs
@@ -49,7 +49,7 @@ use std::env;
 use std::fs::{self, File};
 use std::io::Write;
 use syntax::ast;
-use syntax_pos::Span;
+use syntax_pos::{Span, symbol::sym};
 
 pub fn assert_dep_graph(tcx: TyCtxt<'_>) {
     tcx.dep_graph.with_ignore(|| {
@@ -60,7 +60,7 @@ pub fn assert_dep_graph(tcx: TyCtxt<'_>) {
         // if the `rustc_attrs` feature is not enabled, then the
         // attributes we are interested in cannot be present anyway, so
         // skip the walk.
-        if !tcx.features().rustc_attrs {
+        if !tcx.features().on(sym::rustc_attrs) {
             return;
         }
 

--- a/src/librustc_incremental/persist/dirty_clean.rs
+++ b/src/librustc_incremental/persist/dirty_clean.rs
@@ -210,7 +210,7 @@ impl Assertion {
 
 pub fn check_dirty_clean_annotations(tcx: TyCtxt<'_>) {
     // can't add `#[rustc_dirty]` etc without opting in to this feature
-    if !tcx.features().rustc_attrs {
+    if !tcx.features().on(sym::rustc_attrs) {
         return;
     }
 

--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -32,7 +32,7 @@ use rustc::ty::subst::{GenericArgKind, Subst, SubstsRef, UserSubsts};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_error_codes::*;
 use rustc_index::vec::{Idx, IndexVec};
-use syntax_pos::{DUMMY_SP, Span};
+use syntax_pos::{DUMMY_SP, Span, symbol::sym};
 
 use crate::borrow_check::borrow_set::BorrowSet;
 use crate::borrow_check::location::LocationTable;
@@ -1451,7 +1451,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 }
 
                 self.check_rvalue(body, rv, location);
-                if !self.tcx().features().unsized_locals {
+                if !self.tcx().features().on(sym::unsized_locals) {
                     let trait_ref = ty::TraitRef {
                         def_id: tcx.lang_items().sized_trait().unwrap(),
                         substs: tcx.mk_substs_trait(place_ty, &[]),
@@ -1736,7 +1736,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
 
                 // When `#![feature(unsized_locals)]` is not enabled,
                 // this check is done at `check_local`.
-                if self.tcx().features().unsized_locals {
+                if self.tcx().features().on(sym::unsized_locals) {
                     let span = term.source_info.span;
                     self.ensure_place_sized(dest_ty, span);
                 }
@@ -1907,7 +1907,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
 
         // When `#![feature(unsized_locals)]` is enabled, only function calls
         // and nullary ops are checked in `check_call_dest`.
-        if !self.tcx().features().unsized_locals {
+        if !self.tcx().features().on(sym::unsized_locals) {
             let span = local_decl.source_info.span;
             let ty = local_decl.ty;
             self.ensure_place_sized(ty, span);
@@ -2044,7 +2044,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
 
             Rvalue::NullaryOp(_, ty) => {
                 // Even with unsized locals cannot box an unsized value.
-                if self.tcx().features().unsized_locals {
+                if self.tcx().features().on(sym::unsized_locals) {
                     let span = body.source_info(location).span;
                     self.ensure_place_sized(ty, span);
                 }

--- a/src/librustc_mir/build/matches/simplify.rs
+++ b/src/librustc_mir/build/matches/simplify.rs
@@ -20,6 +20,7 @@ use rustc::ty::layout::{Integer, IntegerExt, Size};
 use syntax::attr::{SignedInt, UnsignedInt};
 use rustc::hir::RangeEnd;
 use rustc::mir::interpret::truncate;
+use syntax_pos::symbol::sym;
 
 use std::mem;
 
@@ -161,7 +162,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             PatKind::Variant { adt_def, substs, variant_index, ref subpatterns } => {
                 let irrefutable = adt_def.variants.iter_enumerated().all(|(i, v)| {
                     i == variant_index || {
-                        self.hir.tcx().features().exhaustive_patterns &&
+                        self.hir.tcx().features().on(sym::exhaustive_patterns) &&
                         !v.uninhabited_from(self.hir.tcx(), substs, adt_def.adt_kind()).is_empty()
                     }
                 }) && (adt_def.did.is_local() || !adt_def.is_variant_list_non_exhaustive());

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -12,7 +12,7 @@ use rustc::ty::subst::{InternalSubsts, SubstsRef};
 use rustc::hir;
 use rustc::hir::def_id::LocalDefId;
 use rustc::mir::BorrowKind;
-use syntax_pos::Span;
+use syntax_pos::{Span, symbol::sym};
 
 impl<'tcx> Mirror<'tcx> for &'tcx hir::Expr {
     type Output = Expr<'tcx>;
@@ -309,7 +309,7 @@ fn make_mirror_unadjusted<'a, 'tcx>(
                 match (op.node, cx.constness) {
                     // Destroy control flow if `#![feature(const_if_match)]` is not enabled.
                     (hir::BinOpKind::And, hir::Constness::Const)
-                        if !cx.tcx.features().const_if_match =>
+                        if !cx.tcx.features().on(sym::const_if_match) =>
                     {
                         cx.control_flow_destroyed.push((
                             op.span,
@@ -322,7 +322,7 @@ fn make_mirror_unadjusted<'a, 'tcx>(
                         }
                     }
                     (hir::BinOpKind::Or, hir::Constness::Const)
-                        if !cx.tcx.features().const_if_match =>
+                        if !cx.tcx.features().on(sym::const_if_match) =>
                     {
                         cx.control_flow_destroyed.push((
                             op.span,

--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -247,7 +247,7 @@ use rustc::util::captures::Captures;
 use rustc::util::common::ErrorReported;
 
 use syntax::attr::{SignedInt, UnsignedInt};
-use syntax_pos::{Span, DUMMY_SP};
+use syntax_pos::{Span, DUMMY_SP, symbol::sym};
 
 use arena::TypedArena;
 
@@ -589,7 +589,7 @@ impl<'a, 'tcx> MatchCheckCtxt<'a, 'tcx> {
     }
 
     fn is_uninhabited(&self, ty: Ty<'tcx>) -> bool {
-        if self.tcx.features().exhaustive_patterns {
+        if self.tcx.features().on(sym::exhaustive_patterns) {
             self.tcx.is_ty_uninhabited_from(self.module, ty)
         } else {
             false
@@ -1239,7 +1239,7 @@ fn all_constructors<'a, 'tcx>(
                 .variants
                 .iter()
                 .filter(|v| {
-                    !cx.tcx.features().exhaustive_patterns
+                    !cx.tcx.features().on(sym::exhaustive_patterns)
                         || !v
                             .uninhabited_from(cx.tcx, substs, def.adt_kind())
                             .contains(cx.tcx, cx.module)
@@ -1286,7 +1286,7 @@ fn all_constructors<'a, 'tcx>(
         }
         ty::Int(_) | ty::Uint(_)
             if pcx.ty.is_ptr_sized_integral()
-                && !cx.tcx.features().precise_pointer_size_matching =>
+                && !cx.tcx.features().on(sym::precise_pointer_size_matching) =>
         {
             // `usize`/`isize` are not allowed to be matched exhaustively unless the
             // `precise_pointer_size_matching` feature is enabled. So we treat those types like
@@ -1351,7 +1351,7 @@ impl<'tcx> IntRange<'tcx> {
     /// Don't treat `usize`/`isize` exhaustively unless the `precise_pointer_size_matching` feature
     /// is enabled.
     fn treat_exhaustively(&self, tcx: TyCtxt<'tcx>) -> bool {
-        !self.ty.is_ptr_sized_integral() || tcx.features().precise_pointer_size_matching
+        !self.ty.is_ptr_sized_integral() || tcx.features().on(sym::precise_pointer_size_matching)
     }
 
     #[inline]

--- a/src/librustc_mir/hair/pattern/check_match.rs
+++ b/src/librustc_mir/hair/pattern/check_match.rs
@@ -18,7 +18,7 @@ use rustc::hir::{self, Pat};
 
 use std::slice;
 
-use syntax_pos::{MultiSpan, Span};
+use syntax_pos::{MultiSpan, Span, symbol::sym};
 
 use rustc_error_codes::*;
 
@@ -173,7 +173,7 @@ impl<'tcx> MatchVisitor<'_, 'tcx> {
             let mut def_span = None;
             let mut missing_variants = vec![];
             if inlined_arms.is_empty() {
-                let scrutinee_is_uninhabited = if self.tcx.features().exhaustive_patterns {
+                let scrutinee_is_uninhabited = if self.tcx.features().on(sym::exhaustive_patterns) {
                     self.tcx.is_ty_uninhabited_from(module, pat_ty)
                 } else {
                     match pat_ty.kind {

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -253,7 +253,7 @@ impl Validator<'a, 'mir, 'tcx> {
         // If an operation is supported in miri (and is not already controlled by a feature gate) it
         // can be turned on with `-Zunleash-the-miri-inside-of-you`.
         let is_unleashable = O::IS_SUPPORTED_IN_MIRI
-            && O::feature_gate(self.tcx).is_none();
+            && O::feature_gate().is_none();
 
         if is_unleashable && self.tcx.sess.opts.debugging_opts.unleash_the_miri_inside_of_you {
             self.tcx.sess.span_warn(span, "skipping const checks");

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -155,7 +155,7 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
             // possibly know what the result of various operations like `address / 2` would be
             // pointers during const evaluation have no integral address, only an abstract one
             Rvalue::Cast(CastKind::Misc, ref operand, cast_ty)
-            if self.const_context && self.tcx.features().const_raw_ptr_to_usize_cast => {
+            if self.const_context && self.tcx.features().on(sym::const_raw_ptr_to_usize_cast) => {
                 let operand_ty = operand.ty(self.body, self.tcx);
                 let cast_in = CastTy::from_ty(operand_ty).expect("bad input type for cast");
                 let cast_out = CastTy::from_ty(cast_ty).expect("bad output type for cast");
@@ -177,7 +177,7 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
             // or the linker will place various statics in memory. Without this information the
             // result of a comparison of addresses would differ between runtime and compile-time.
             Rvalue::BinaryOp(_, ref lhs, _)
-            if self.const_context && self.tcx.features().const_compare_raw_pointers => {
+            if self.const_context && self.tcx.features().on(sym::const_compare_raw_pointers) => {
                 if let ty::RawPtr(_) | ty::FnPtr(..) = lhs.ty(self.body, self.tcx).kind {
                     self.register_violations(&[UnsafetyViolation {
                         source_info: self.source_info,

--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -217,7 +217,7 @@ fn check_statement(
         }
 
         | StatementKind::FakeRead(FakeReadCause::ForMatchedPlace, _)
-        if !tcx.features().const_if_match
+        if !tcx.features().on(sym::const_if_match)
         => {
             Err((span, "loops and conditional expressions are not stable in const fn".into()))
         }
@@ -269,7 +269,7 @@ fn check_place(
     while let &[ref proj_base @ .., elem] = cursor {
         cursor = proj_base;
         match elem {
-            ProjectionElem::Downcast(..) if !tcx.features().const_if_match
+            ProjectionElem::Downcast(..) if !tcx.features().on(sym::const_if_match)
                 => return Err((span, "`match` or `if let` in `const fn` is unstable".into())),
             ProjectionElem::Downcast(_symbol, _variant_index) => {}
 
@@ -326,7 +326,7 @@ fn check_terminator(
 
         | TerminatorKind::FalseEdges { .. }
         | TerminatorKind::SwitchInt { .. }
-        if !tcx.features().const_if_match
+        if !tcx.features().on(sym::const_if_match)
         => Err((
             span,
             "loops and conditional expressions are not stable in const fn".into(),
@@ -338,7 +338,7 @@ fn check_terminator(
         }
 
         // FIXME(ecstaticmorse): We probably want to allow `Unreachable` unconditionally.
-        TerminatorKind::Unreachable if tcx.features().const_if_match => Ok(()),
+        TerminatorKind::Unreachable if tcx.features().on(sym::const_if_match) => Ok(()),
 
         | TerminatorKind::Abort | TerminatorKind::Unreachable => {
             Err((span, "const fn with unreachable code is not stable".into()))

--- a/src/librustc_parse/config.rs
+++ b/src/librustc_parse/config.rs
@@ -208,7 +208,7 @@ impl<'a> StripUnconfigured<'a> {
 
     /// If attributes are not allowed on expressions, emit an error for `attr`
     pub fn maybe_emit_expr_attr_err(&self, attr: &ast::Attribute) {
-        if !self.features.map(|features| features.stmt_expr_attributes).unwrap_or(true) {
+        if !self.features.map(|features| features.on(sym::stmt_expr_attributes)).unwrap_or(true) {
             let mut err = feature_err(self.sess,
                                       sym::stmt_expr_attributes,
                                       attr.span,

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -356,7 +356,11 @@ fn validate_generics_order<'a>(
                 &format!(
                     "reorder the {}s: lifetimes, then types{}",
                     pos_str,
-                    if sess.features_untracked().const_generics { ", then consts" } else { "" },
+                    if sess.features_untracked().on(sym::const_generics) {
+                        ", then consts"
+                    } else {
+                        ""
+                    },
                 ),
                 ordered_params.clone(),
                 Applicability::MachineApplicable,

--- a/src/librustc_passes/check_const.rs
+++ b/src/librustc_passes/check_const.rs
@@ -45,7 +45,7 @@ impl NonConstExpr {
             | Self::Match(Normal)
             | Self::Match(IfDesugar { .. })
             | Self::Match(IfLetDesugar { .. })
-            => Some(features.const_if_match),
+            => Some(features.on(sym::const_if_match)),
 
             _ => None,
         }

--- a/src/librustc_passes/layout_test.rs
+++ b/src/librustc_passes/layout_test.rs
@@ -15,7 +15,7 @@ use syntax::ast::Attribute;
 use syntax::symbol::sym;
 
 pub fn test_layout(tcx: TyCtxt<'_>) {
-    if tcx.features().rustc_attrs {
+    if tcx.features().on(sym::rustc_attrs) {
         // if the `rustc_attrs` feature is not enabled, don't bother testing layout
         tcx.hir()
             .krate()

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -342,7 +342,7 @@ impl<'a> Resolver<'a> {
             if let Some(args) = &segment.args {
                 self.session.span_err(args.span(), "generic arguments in macro path");
             }
-            if kind == MacroKind::Attr && !features.rustc_attrs &&
+            if kind == MacroKind::Attr && !features.on(sym::rustc_attrs) &&
                segment.ident.as_str().starts_with("rustc") {
                 let msg =
                     "attributes starting with `rustc` are reserved for use by the `rustc` compiler";

--- a/src/librustc_traits/lowering/mod.rs
+++ b/src/librustc_traits/lowering/mod.rs
@@ -612,7 +612,7 @@ pub fn program_clauses_for_associated_type_value(
 }
 
 pub fn dump_program_clauses(tcx: TyCtxt<'_>) {
-    if !tcx.features().rustc_attrs {
+    if !tcx.features().on(sym::rustc_attrs) {
         return;
     }
 

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -904,7 +904,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 
         let trait_def = self.tcx().trait_def(trait_def_id);
 
-        if !self.tcx().features().unboxed_closures &&
+        if !self.tcx().features().on(sym::unboxed_closures) &&
             trait_segment.generic_args().parenthesized != trait_def.paren_sugar
         {
             // For now, require that parenthetical notation be used only with `Fn()` etc.

--- a/src/librustc_typeck/check/cast.rs
+++ b/src/librustc_typeck/check/cast.rs
@@ -43,7 +43,7 @@ use rustc::ty::cast::{CastKind, CastTy};
 use rustc::ty::error::TypeError;
 use rustc::middle::lang_items;
 use syntax::ast;
-use syntax_pos::Span;
+use syntax_pos::{Span, symbol::sym};
 use crate::util::common::ErrorReported;
 
 use rustc_error_codes::*;
@@ -391,7 +391,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
     fn trivial_cast_lint(&self, fcx: &FnCtxt<'a, 'tcx>) {
         let t_cast = self.cast_ty;
         let t_expr = self.expr_ty;
-        let type_asc_or = if fcx.tcx.features().type_ascription {
+        let type_asc_or = if fcx.tcx.features().on(sym::type_ascription) {
             "type ascription or "
         } else {
             ""

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -643,14 +643,14 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
             }
         }
 
-        if has_unsized_tuple_coercion && !self.tcx.features().unsized_tuple_coercion {
-            feature_gate::feature_err(
+        if has_unsized_tuple_coercion {
+            feature_gate::gate_feature(
                 &self.tcx.sess.parse_sess,
-                sym::unsized_tuple_coercion,
+                self.tcx.features(),
                 self.cause.span,
+                sym::unsized_tuple_coercion,
                 "unsized tuple coercion is not stable enough for use and is subject to change",
-            )
-            .emit();
+            );
         }
 
         Ok(coercion)

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -526,7 +526,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         if let ty::FnDef(..) = ty.kind {
             let fn_sig = ty.fn_sig(tcx);
-            if !tcx.features().unsized_locals {
+            if !tcx.features().on(sym::unsized_locals) {
                 // We want to remove some Sized bounds from std functions,
                 // but don't want to expose the removal to stable Rust.
                 // i.e., we don't want to allow

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -29,7 +29,7 @@ use rustc::infer::canonical::{OriginalQueryValues};
 use rustc::middle::stability;
 use syntax::ast;
 use syntax::util::lev_distance::{lev_distance, find_best_match_for_name};
-use syntax_pos::{DUMMY_SP, Span, symbol::Symbol};
+use syntax_pos::{DUMMY_SP, Span, symbol::{sym, Symbol}};
 use std::iter;
 use std::mem;
 use std::ops::Deref;
@@ -338,7 +338,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             if is_suggestion.0 {
                 // Ambiguity was encountered during a suggestion. Just keep going.
                 debug!("ProbeContext: encountered ambiguity in suggestion");
-            } else if bad_ty.reached_raw_pointer && !self.tcx.features().arbitrary_self_types {
+            } else if bad_ty.reached_raw_pointer
+                && !self.tcx.features().on(sym::arbitrary_self_types)
+            {
                 // this case used to be allowed by the compiler,
                 // so we do a future-compat lint here for the 2015 edition
                 // (see https://github.com/rust-lang/rust/issues/46906)

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -43,7 +43,7 @@ impl<'tcx> CheckWfFcxBuilder<'tcx> {
         let param_env = self.param_env;
         self.inherited.enter(|inh| {
             let fcx = FnCtxt::new(&inh, param_env, id);
-            if !inh.tcx.features().trivial_bounds {
+            if !inh.tcx.features().on(sym::trivial_bounds) {
                 // As predicates are cached rather than obligations, this
                 // needsto be called first so that they are checked with an
                 // empty `param_env`.
@@ -817,7 +817,7 @@ fn check_method_receiver<'fcx, 'tcx>(
         &ty::Binder::bind(receiver_ty)
     );
 
-    if fcx.tcx.features().arbitrary_self_types {
+    if fcx.tcx.features().on(sym::arbitrary_self_types) {
         if !receiver_is_valid(fcx, span, receiver_ty, self_ty, true) {
             // Report error; `arbitrary_self_types` was enabled.
             e0307(fcx, span, receiver_ty);

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -11,6 +11,7 @@ use rustc::traits;
 use rustc::ty::{self, TyCtxt, TypeFoldable};
 use rustc::ty::query::Providers;
 use rustc::util::common::time;
+use syntax_pos::symbol::sym;
 
 use rustc_error_codes::*;
 
@@ -68,7 +69,7 @@ fn enforce_trait_manually_implementable(tcx: TyCtxt<'_>, impl_def_id: DefId, tra
         return;
     }
 
-    if tcx.features().unboxed_closures {
+    if tcx.features().on(sym::unboxed_closures) {
         // the feature gate allows all Fn traits
         return;
     }

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -105,7 +105,7 @@ use rustc::ty::subst::SubstsRef;
 use rustc::ty::{self, Ty, TyCtxt};
 use rustc::ty::query::Providers;
 use rustc::util;
-use syntax_pos::{DUMMY_SP, Span};
+use syntax_pos::{DUMMY_SP, Span, symbol::sym};
 use util::common::time;
 
 use rustc_error_codes::*;
@@ -308,7 +308,7 @@ pub fn check_crate(tcx: TyCtxt<'_>) -> Result<(), ErrorReported> {
         });
     })?;
 
-    if tcx.features().rustc_attrs {
+    if tcx.features().on(sym::rustc_attrs) {
         tcx.sess.track_errors(|| {
             time(tcx.sess, "outlives testing", ||
                 outlives::test::test_inferred_outlives(tcx));
@@ -325,7 +325,7 @@ pub fn check_crate(tcx: TyCtxt<'_>) -> Result<(), ErrorReported> {
           coherence::check_coherence(tcx));
     })?;
 
-    if tcx.features().rustc_attrs {
+    if tcx.features().on(sym::rustc_attrs) {
         tcx.sess.track_errors(|| {
             time(tcx.sess, "variance testing", ||
                 variance::test::test_variance(tcx));

--- a/src/librustc_typeck/outlives/utils.rs
+++ b/src/librustc_typeck/outlives/utils.rs
@@ -3,7 +3,7 @@ use rustc::ty::subst::{GenericArg, GenericArgKind};
 use rustc::ty::{self, Region, RegionKind, Ty, TyCtxt};
 use smallvec::smallvec;
 use std::collections::BTreeMap;
-use syntax_pos::Span;
+use syntax_pos::{Span, symbol::sym};
 
 /// Tracks the `T: 'a` or `'a: 'a` predicates that we have inferred
 /// must be added to the struct header.
@@ -154,7 +154,7 @@ fn is_free_region(tcx: TyCtxt<'_>, region: Region<'_>) -> bool {
         RegionKind::ReStatic => {
             tcx.sess
                .features_untracked()
-               .infer_static_outlives_requirements
+               .on(sym::infer_static_outlives_requirements)
         }
 
         // Late-bound regions can appear in `fn` types:

--- a/src/libsyntax/attr/builtin.rs
+++ b/src/libsyntax/attr/builtin.rs
@@ -566,8 +566,8 @@ pub fn cfg_matches(cfg: &ast::MetaItem, sess: &ParseSess, features: Option<&Feat
 }
 
 fn gate_cfg(gated_cfg: &GatedCfg, cfg_span: Span, sess: &ParseSess, features: &Features) {
-    let (cfg, feature, has_feature) = gated_cfg;
-    if !has_feature(features) && !cfg_span.allows_unstable(*feature) {
+    let (cfg, feature) = gated_cfg;
+    if !features.on(*feature) && !cfg_span.allows_unstable(*feature) {
         let explain = format!("`cfg({})` is experimental and subject to change", cfg);
         feature_err(sess, *feature, cfg_span, &explain).emit()
     }

--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -6,42 +6,18 @@ use rustc_feature::{find_feature_issue, GateIssue};
 use crate::ast::{self, AssocTyConstraint, AssocTyConstraintKind, NodeId};
 use crate::ast::{GenericParam, GenericParamKind, PatKind, RangeEnd, VariantData};
 use crate::attr;
-use crate::source_map::Spanned;
-use crate::edition::{ALL_EDITIONS, Edition};
 use crate::visit::{self, FnKind, Visitor};
 use crate::sess::ParseSess;
-use crate::symbol::{Symbol, sym};
 
 use errors::{Applicability, DiagnosticBuilder, Handler};
 use rustc_data_structures::fx::FxHashMap;
 use syntax_pos::{Span, DUMMY_SP, MultiSpan};
+use syntax_pos::edition::{ALL_EDITIONS, Edition};
+use syntax_pos::source_map::Spanned;
+use syntax_pos::symbol::{Symbol, sym};
 use log::debug;
 
 use rustc_error_codes::*;
-
-macro_rules! gate_feature_fn {
-    ($cx: expr, $has_feature: expr, $span: expr, $name: expr, $explain: expr, $level: expr) => {{
-        let (cx, has_feature, span,
-             name, explain, level) = (&*$cx, $has_feature, $span, $name, $explain, $level);
-        let has_feature: bool = has_feature(&$cx.features);
-        debug!("gate_feature(feature = {:?}, span = {:?}); has? {}", name, span, has_feature);
-        if !has_feature && !span.allows_unstable($name) {
-            leveled_feature_err(cx.parse_sess, name, span, GateIssue::Language, explain, level)
-                .emit();
-        }
-    }}
-}
-
-macro_rules! gate_feature {
-    ($cx: expr, $feature: ident, $span: expr, $explain: expr) => {
-        gate_feature_fn!($cx, |x:&Features| x.$feature, $span,
-                         sym::$feature, $explain, GateStrength::Hard)
-    };
-    ($cx: expr, $feature: ident, $span: expr, $explain: expr, $level: expr) => {
-        gate_feature_fn!($cx, |x:&Features| x.$feature, $span,
-                         sym::$feature, $explain, $level)
-    };
-}
 
 pub fn check_attribute(attr: &ast::Attribute, parse_sess: &ParseSess, features: &Features) {
     PostExpansionVisitor { parse_sess, features }.visit_attribute(attr)
@@ -114,31 +90,36 @@ fn leveled_feature_err<'a>(
 
 }
 
+pub fn gate_feature(
+    parse_sess: &ParseSess,
+    features: &Features,
+    span: Span,
+    feature: Symbol,
+    explain: &str,
+) {
+    PostExpansionVisitor { parse_sess, features }.gate(span, feature, explain)
+}
+
 struct PostExpansionVisitor<'a> {
     parse_sess: &'a ParseSess,
     features: &'a Features,
 }
 
-macro_rules! gate_feature_post {
-    ($cx: expr, $feature: ident, $span: expr, $explain: expr) => {{
-        let (cx, span) = ($cx, $span);
-        if !span.allows_unstable(sym::$feature) {
-            gate_feature!(cx, $feature, span, $explain)
-        }
-    }};
-    ($cx: expr, $feature: ident, $span: expr, $explain: expr, $level: expr) => {{
-        let (cx, span) = ($cx, $span);
-        if !span.allows_unstable(sym::$feature) {
-            gate_feature!(cx, $feature, span, $explain, $level)
-        }
-    }}
-}
-
 impl<'a> PostExpansionVisitor<'a> {
+    fn gate(&self, span: Span, feature: Symbol, explain: &str) {
+        if !span.allows_unstable(feature) {
+            let has: bool = self.features.on(feature);
+            debug!("gate_feature(feature = {:?}, span = {:?}); has? {}", feature, span, has);
+            if !has && !span.allows_unstable(feature) {
+               feature_err(self.parse_sess, feature, span, explain).emit();
+            }
+        }
+    }
+
     fn check_abi(&self, abi: ast::StrLit) {
         let ast::StrLit { symbol_unescaped, span, .. } = abi;
 
-        match &*symbol_unescaped.as_str() {
+        let (feature, explain) = match &*symbol_unescaped.as_str() {
             // Stable
             "Rust" |
             "C" |
@@ -148,58 +129,60 @@ impl<'a> PostExpansionVisitor<'a> {
             "aapcs" |
             "win64" |
             "sysv64" |
-            "system" => {}
-            "rust-intrinsic" => {
-                gate_feature_post!(&self, intrinsics, span,
-                                   "intrinsics are subject to change");
-            },
-            "platform-intrinsic" => {
-                gate_feature_post!(&self, platform_intrinsics, span,
-                                   "platform intrinsics are experimental and possibly buggy");
-            },
-            "vectorcall" => {
-                gate_feature_post!(&self, abi_vectorcall, span,
-                                   "vectorcall is experimental and subject to change");
-            },
-            "thiscall" => {
-                gate_feature_post!(&self, abi_thiscall, span,
-                                   "thiscall is experimental and subject to change");
-            },
-            "rust-call" => {
-                gate_feature_post!(&self, unboxed_closures, span,
-                                   "rust-call ABI is subject to change");
-            },
-            "ptx-kernel" => {
-                gate_feature_post!(&self, abi_ptx, span,
-                                   "PTX ABIs are experimental and subject to change");
-            },
-            "unadjusted" => {
-                gate_feature_post!(&self, abi_unadjusted, span,
-                                   "unadjusted ABI is an implementation detail and perma-unstable");
-            },
-            "msp430-interrupt" => {
-                gate_feature_post!(&self, abi_msp430_interrupt, span,
-                                   "msp430-interrupt ABI is experimental and subject to change");
-            },
-            "x86-interrupt" => {
-                gate_feature_post!(&self, abi_x86_interrupt, span,
-                                   "x86-interrupt ABI is experimental and subject to change");
-            },
-            "amdgpu-kernel" => {
-                gate_feature_post!(&self, abi_amdgpu_kernel, span,
-                                   "amdgpu-kernel ABI is experimental and subject to change");
-            },
-            "efiapi" => {
-                gate_feature_post!(&self, abi_efiapi, span,
-                                   "efiapi ABI is experimental and subject to change");
-            },
+            "system" => return,
+            "rust-intrinsic" => (
+                sym::intrinsics,
+                "intrinsics are subject to change",
+            ),
+            "platform-intrinsic" => (
+                sym::platform_intrinsics,
+                "platform intrinsics are experimental and possibly buggy",
+            ),
+            "vectorcall" => (
+                sym::abi_vectorcall,
+                "vectorcall is experimental and subject to change",
+            ),
+            "thiscall" => (
+                sym::abi_thiscall,
+                "thiscall is experimental and subject to change",
+            ),
+            "rust-call" => (
+                sym::unboxed_closures,
+                "rust-call ABI is subject to change",
+            ),
+            "ptx-kernel" => (
+                sym::abi_ptx,
+                "PTX ABIs are experimental and subject to change",
+            ),
+            "unadjusted" => (
+                sym::abi_unadjusted,
+                "unadjusted ABI is an implementation detail and perma-unstable",
+            ),
+            "msp430-interrupt" => (
+                sym::abi_msp430_interrupt,
+                "msp430-interrupt ABI is experimental and subject to change",
+            ),
+            "x86-interrupt" => (
+                sym::abi_x86_interrupt,
+                "x86-interrupt ABI is experimental and subject to change",
+            ),
+            "amdgpu-kernel" => (
+                sym::abi_amdgpu_kernel,
+                "amdgpu-kernel ABI is experimental and subject to change",
+            ),
+            "efiapi" => (
+                sym::abi_efiapi,
+                "efiapi ABI is experimental and subject to change",
+            ),
             abi => {
                 self.parse_sess.span_diagnostic.delay_span_bug(
                     span,
                     &format!("unrecognized ABI not caught in lowering: {}", abi),
-                )
+                );
+                return;
             }
-        }
+        };
+        self.gate(span, feature, explain);
     }
 
     fn check_extern(&self, ext: ast::Extern) {
@@ -254,19 +237,12 @@ impl<'a> PostExpansionVisitor<'a> {
 
     fn check_gat(&self, generics: &ast::Generics, span: Span) {
         if !generics.params.is_empty() {
-            gate_feature_post!(
-                &self,
-                generic_associated_types,
-                span,
-                "generic associated types are unstable"
-            );
+            self.gate(span, sym::generic_associated_types, "generic associated types are unstable");
         }
         if !generics.where_clause.predicates.is_empty() {
-            gate_feature_post!(
-                &self,
-                generic_associated_types,
-                span,
-                "where clauses on associated types are unstable"
+            self.gate(
+                span, sym::generic_associated_types,
+                "where clauses on associated types are unstable",
             );
         }
     }
@@ -279,17 +255,21 @@ impl<'a> PostExpansionVisitor<'a> {
         impl Visitor<'_> for ImplTraitVisitor<'_> {
             fn visit_ty(&mut self, ty: &ast::Ty) {
                 if let ast::TyKind::ImplTrait(..) = ty.kind {
-                    gate_feature_post!(
-                        &self.vis,
-                        type_alias_impl_trait,
-                        ty.span,
-                        "`impl Trait` in type aliases is unstable"
+                    self.vis.gate(
+                        ty.span, sym::type_alias_impl_trait,
+                        "`impl Trait` in type aliases is unstable",
                     );
                 }
                 visit::walk_ty(self, ty);
             }
         }
         ImplTraitVisitor { vis: self }.visit_ty(ty);
+    }
+
+    fn check_c_variadic(&self, span: Span, decl: &ast::FnDecl) {
+        if decl.c_variadic() {
+            self.gate(span, sym::c_variadic, "C-variadic functions are unstable");
+        }
     }
 }
 
@@ -298,38 +278,34 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
         let attr_info =
             attr.ident().and_then(|ident| BUILTIN_ATTRIBUTE_MAP.get(&ident.name)).map(|a| **a);
         // Check feature gates for built-in attributes.
-        if let Some((.., AttributeGate::Gated(_, name, descr, has_feature))) = attr_info {
-            gate_feature_fn!(self, has_feature, attr.span, name, descr, GateStrength::Hard);
+        if let Some((.., AttributeGate::Gated(_, feature, descr))) = attr_info {
+            self.gate(attr.span, feature, descr);
         }
         // Check unstable flavors of the `#[doc]` attribute.
         if attr.check_name(sym::doc) {
             for nested_meta in attr.meta_item_list().unwrap_or_default() {
-                macro_rules! gate_doc { ($($name:ident => $feature:ident)*) => {
-                    $(if nested_meta.check_name(sym::$name) {
-                        let msg = concat!("`#[doc(", stringify!($name), ")]` is experimental");
-                        gate_feature!(self, $feature, attr.span, msg);
-                    })*
-                }}
-
-                gate_doc!(
-                    include => external_doc
-                    cfg => doc_cfg
-                    masked => doc_masked
-                    spotlight => doc_spotlight
-                    alias => doc_alias
-                    keyword => doc_keyword
-                );
+                const GATED_DOC_FEATURES: &[(Symbol, Symbol, &str)] = &[
+                    (sym::include, sym::external_doc, "`#[doc(include)]` is experimental"),
+                    (sym::cfg, sym::doc_cfg, "`#[doc(cfg)]` is experimental"),
+                    (sym::masked, sym::doc_masked, "`#[doc(masked)]` is experimental"),
+                    (sym::spotlight, sym::doc_spotlight, "`#[doc(spotlight)]` is experimental"),
+                    (sym::alias, sym::doc_alias, "`#[doc(alias)]` is experimental"),
+                    (sym::keyword, sym::doc_keyword, "`#[doc(keyword)]` is experimental"),
+                ];
+                for (name, feature, explain) in GATED_DOC_FEATURES {
+                    if nested_meta.check_name(*name) {
+                        self.gate(attr.span, *feature, explain);
+                    }
+                }
             }
         }
     }
 
     fn visit_name(&mut self, sp: Span, name: ast::Name) {
         if !name.as_str().is_ascii() {
-            gate_feature_post!(
-                &self,
-                non_ascii_idents,
-                self.parse_sess.source_map().def_span(sp),
-                "non-ascii idents are not fully supported"
+            self.gate(
+                self.parse_sess.source_map().def_span(sp), sym::non_ascii_idents,
+                "non-ascii idents are not fully supported",
             );
         }
     }
@@ -344,20 +320,24 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
 
             ast::ItemKind::Fn(..) => {
                 if attr::contains_name(&i.attrs[..], sym::plugin_registrar) {
-                    gate_feature_post!(&self, plugin_registrar, i.span,
-                                       "compiler plugins are experimental and possibly buggy");
+                    self.gate(
+                        i.span, sym::plugin_registrar,
+                        "compiler plugins are experimental and possibly buggy",
+                    );
                 }
                 if attr::contains_name(&i.attrs[..], sym::start) {
-                    gate_feature_post!(&self, start, i.span,
-                                      "a `#[start]` function is an experimental \
-                                       feature whose signature may change \
-                                       over time");
+                    self.gate(
+                        i.span, sym::start,
+                        "a `#[start]` function is an experimental \
+                        feature whose signature may change over time",
+                    );
                 }
                 if attr::contains_name(&i.attrs[..], sym::main) {
-                    gate_feature_post!(&self, main, i.span,
-                                       "declaration of a non-standard `#[main]` \
-                                        function may change over time, for now \
-                                        a top-level `fn main()` is required");
+                    self.gate(
+                        i.span, sym::main,
+                        "declaration of a non-standard `#[main]` function may change over time, \
+                        for now a top-level `fn main()` is required",
+                    );
                 }
             }
 
@@ -365,8 +345,10 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 for attr in attr::filter_by_name(&i.attrs[..], sym::repr) {
                     for item in attr.meta_item_list().unwrap_or_else(Vec::new) {
                         if item.check_name(sym::simd) {
-                            gate_feature_post!(&self, repr_simd, attr.span,
-                                               "SIMD types are experimental and possibly buggy");
+                            self.gate(
+                                attr.span, sym::repr_simd,
+                                "SIMD types are experimental and possibly buggy",
+                            );
                         }
                     }
                 }
@@ -376,17 +358,15 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 for variant in variants {
                     match (&variant.data, &variant.disr_expr) {
                         (ast::VariantData::Unit(..), _) => {},
-                        (_, Some(disr_expr)) =>
-                            gate_feature_post!(
-                                &self,
-                                arbitrary_enum_discriminant,
-                                disr_expr.value.span,
-                                "discriminants on non-unit variants are experimental"),
+                        (_, Some(disr_expr)) => self.gate(
+                            disr_expr.value.span, sym::arbitrary_enum_discriminant,
+                            "discriminants on non-unit variants are experimental",
+                        ),
                         _ => {},
                     }
                 }
 
-                let has_feature = self.features.arbitrary_enum_discriminant;
+                let has_feature = self.features.on(sym::arbitrary_enum_discriminant);
                 if !has_feature && !i.span.allows_unstable(sym::arbitrary_enum_discriminant) {
                     self.maybe_report_invalid_custom_discriminants(&variants);
                 }
@@ -394,37 +374,31 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
 
             ast::ItemKind::Impl(_, polarity, defaultness, ..) => {
                 if polarity == ast::ImplPolarity::Negative {
-                    gate_feature_post!(&self, optin_builtin_traits,
-                                       i.span,
-                                       "negative trait bounds are not yet fully implemented; \
-                                        use marker types for now");
+                    self.gate(
+                        i.span, sym::optin_builtin_traits,
+                        "negative trait bounds are not yet fully implemented; \
+                        use marker types for now",
+                    );
                 }
 
                 if let ast::Defaultness::Default = defaultness {
-                    gate_feature_post!(&self, specialization,
-                                       i.span,
-                                       "specialization is unstable");
+                    self.gate(i.span, sym::specialization, "specialization is unstable");
                 }
             }
 
             ast::ItemKind::Trait(ast::IsAuto::Yes, ..) => {
-                gate_feature_post!(&self, optin_builtin_traits,
-                                   i.span,
-                                   "auto traits are experimental and possibly buggy");
-            }
-
-            ast::ItemKind::TraitAlias(..) => {
-                gate_feature_post!(
-                    &self,
-                    trait_alias,
-                    i.span,
-                    "trait aliases are experimental"
+                self.gate(
+                    i.span, sym::optin_builtin_traits,
+                    "auto traits are experimental and possibly buggy",
                 );
             }
 
+            ast::ItemKind::TraitAlias(..) => {
+                self.gate(i.span, sym::trait_alias, "trait aliases are experimental");
+            }
+
             ast::ItemKind::MacroDef(ast::MacroDef { legacy: false, .. }) => {
-                let msg = "`macro` is experimental";
-                gate_feature_post!(&self, decl_macro, i.span, msg);
+                self.gate(i.span, sym::decl_macro, "`macro` is experimental");
             }
 
             ast::ItemKind::TyAlias(ref ty, ..) => self.check_impl_trait(&ty),
@@ -445,13 +419,14 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                     _ => false
                 };
                 if links_to_llvm {
-                    gate_feature_post!(&self, link_llvm_intrinsics, i.span,
-                                       "linking to LLVM intrinsics is experimental");
+                    self.gate(
+                        i.span, sym::link_llvm_intrinsics,
+                        "linking to LLVM intrinsics is experimental",
+                    );
                 }
             }
             ast::ForeignItemKind::Ty => {
-                    gate_feature_post!(&self, extern_types, i.span,
-                                       "extern types are experimental");
+                self.gate(i.span, sym::extern_types, "extern types are experimental");
             }
             ast::ForeignItemKind::Macro(..) => {}
         }
@@ -472,26 +447,27 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
     fn visit_expr(&mut self, e: &'a ast::Expr) {
         match e.kind {
             ast::ExprKind::Box(_) => {
-                gate_feature_post!(
-                    &self, box_syntax, e.span,
-                    "box expression syntax is experimental; you can call `Box::new` instead"
+                self.gate(
+                    e.span, sym::box_syntax,
+                    "box expression syntax is experimental; you can call `Box::new` instead",
                 );
             }
             ast::ExprKind::Type(..) => {
                 // To avoid noise about type ascription in common syntax errors, only emit if it
                 // is the *only* error.
                 if self.parse_sess.span_diagnostic.err_count() == 0 {
-                    gate_feature_post!(&self, type_ascription, e.span,
-                                       "type ascription is experimental");
+                    self.gate(e.span, sym::type_ascription, "type ascription is experimental");
                 }
             }
             ast::ExprKind::TryBlock(_) => {
-                gate_feature_post!(&self, try_blocks, e.span, "`try` expression is experimental");
+                self.gate(e.span, sym::try_blocks, "`try` expression is experimental");
             }
             ast::ExprKind::Block(_, opt_label) => {
                 if let Some(label) = opt_label {
-                    gate_feature_post!(&self, label_break_value, label.ident.span,
-                                    "labels on blocks are unstable");
+                    self.gate(
+                        label.ident.span, sym::label_break_value,
+                        "labels on blocks are unstable",
+                    );
                 }
             }
             _ => {}
@@ -509,23 +485,18 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                         _ => pat,
                     };
                     if inner_pat.is_rest() {
-                        gate_feature_post!(
-                            &self,
-                            slice_patterns,
-                            span,
-                            "subslice patterns are unstable"
-                        );
+                        self.gate(span, sym::slice_patterns, "subslice patterns are unstable");
                     }
                 }
             }
             PatKind::Box(..) => {
-                gate_feature_post!(&self, box_patterns,
-                                  pattern.span,
-                                  "box pattern syntax is experimental");
+                self.gate(pattern.span, sym::box_patterns, "box pattern syntax is experimental");
             }
             PatKind::Range(_, _, Spanned { node: RangeEnd::Excluded, .. }) => {
-                gate_feature_post!(&self, exclusive_range_pattern, pattern.span,
-                                   "exclusive range pattern syntax is experimental");
+                self.gate(
+                    pattern.span, sym::exclusive_range_pattern,
+                    "exclusive range pattern syntax is experimental",
+                );
             }
             _ => {}
         }
@@ -544,18 +515,16 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
             self.check_extern(header.ext);
         }
 
-        if fn_decl.c_variadic() {
-            gate_feature_post!(&self, c_variadic, span, "C-variadic functions are unstable");
-        }
+        self.check_c_variadic(span, fn_decl);
 
         visit::walk_fn(self, fn_kind, fn_decl, span)
     }
 
     fn visit_generic_param(&mut self, param: &'a GenericParam) {
         match param.kind {
-            GenericParamKind::Const { .. } =>
-                gate_feature_post!(&self, const_generics, param.ident.span,
-                    "const generics are unstable"),
+            GenericParamKind::Const { .. } => {
+                self.gate(param.ident.span, sym::const_generics, "const generics are unstable");
+            }
             _ => {}
         }
         visit::walk_generic_param(self, param)
@@ -563,9 +532,12 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
 
     fn visit_assoc_ty_constraint(&mut self, constraint: &'a AssocTyConstraint) {
         match constraint.kind {
-            AssocTyConstraintKind::Bound { .. } =>
-                gate_feature_post!(&self, associated_type_bounds, constraint.span,
-                    "associated type bounds are unstable"),
+            AssocTyConstraintKind::Bound { .. } => {
+                self.gate(
+                    constraint.span, sym::associated_type_bounds,
+                    "associated type bounds are unstable",
+                );
+            }
             _ => {}
         }
         visit::walk_assoc_ty_constraint(self, constraint)
@@ -577,19 +549,18 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 if block.is_none() {
                     self.check_extern(sig.header.ext);
                 }
-                if sig.decl.c_variadic() {
-                    gate_feature_post!(&self, c_variadic, ti.span,
-                                       "C-variadic functions are unstable");
-                }
+                self.check_c_variadic(ti.span, &sig.decl);
                 if sig.header.constness.node == ast::Constness::Const {
-                    gate_feature_post!(&self, const_fn, ti.span, "const fn is unstable");
+                    self.gate(ti.span, sym::const_fn, "const fn is unstable");
                 }
             }
             ast::TraitItemKind::Type(_, ref default) => {
                 if let Some(ty) = default {
                     self.check_impl_trait(ty);
-                    gate_feature_post!(&self, associated_type_defaults, ti.span,
-                                       "associated type defaults are unstable");
+                    self.gate(
+                        ti.span, sym::associated_type_defaults,
+                        "associated type defaults are unstable",
+                    );
                 }
                 self.check_gat(&ti.generics, ti.span);
             }
@@ -600,18 +571,13 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
 
     fn visit_impl_item(&mut self, ii: &'a ast::ImplItem) {
         if ii.defaultness == ast::Defaultness::Default {
-            gate_feature_post!(&self, specialization,
-                              ii.span,
-                              "specialization is unstable");
+            self.gate(ii.span, sym::specialization, "specialization is unstable");
         }
 
         match ii.kind {
             ast::ImplItemKind::Method(ref sig, _) => {
-                if sig.decl.c_variadic() {
-                    gate_feature_post!(&self, c_variadic, ii.span,
-                                       "C-variadic functions are unstable");
-                }
-            }
+                self.check_c_variadic(ii.span, &sig.decl);
+            },
             ast::ImplItemKind::TyAlias(ref ty) => {
                 self.check_impl_trait(ty);
                 self.check_gat(&ii.generics, ii.span);
@@ -623,8 +589,10 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
 
     fn visit_vis(&mut self, vis: &'a ast::Visibility) {
         if let ast::VisibilityKind::Crate(ast::CrateSugar::JustCrate) = vis.node {
-            gate_feature_post!(&self, crate_visibility_modifier, vis.span,
-                               "`crate` visibility modifier is experimental");
+            self.gate(
+                vis.span, sym::crate_visibility_modifier,
+                "`crate` visibility modifier is experimental",
+            );
         }
         visit::walk_vis(self, vis)
     }
@@ -653,7 +621,7 @@ pub fn get_features(span_handler: &Handler, krate_attrs: &[ast::Attribute],
     }
 
     for feature in active_features_up_to(crate_edition) {
-        feature.set(&mut features, DUMMY_SP);
+        features.enable(feature, DUMMY_SP);
         edition_enabled_features.insert(feature.name, crate_edition);
     }
 
@@ -685,7 +653,7 @@ pub fn get_features(span_handler: &Handler, krate_attrs: &[ast::Attribute],
                 for feature in active_features_up_to(edition) {
                     // FIXME(Manishearth) there is currently no way to set
                     // lib features by edition
-                    feature.set(&mut features, DUMMY_SP);
+                    features.enable(feature, DUMMY_SP);
                     edition_enabled_features.insert(feature.name, edition);
                 }
             }
@@ -768,7 +736,7 @@ pub fn get_features(span_handler: &Handler, krate_attrs: &[ast::Attribute],
             }
 
             if let Some(f) = ACTIVE_FEATURES.iter().find(|f| name == f.name) {
-                f.set(&mut features, mi.span());
+                features.enable(f, mi.span());
                 features.declared_lang_features.push((name, mi.span(), None));
                 continue;
             }
@@ -799,48 +767,44 @@ pub fn check_crate(krate: &ast::Crate,
     let mut visitor = PostExpansionVisitor { parse_sess, features };
 
     let spans = parse_sess.gated_spans.spans.borrow();
-    macro_rules! gate_all {
-        ($gate:ident, $msg:literal) => {
-            for span in spans.get(&sym::$gate).unwrap_or(&vec![]) {
-                gate_feature!(&visitor, $gate, *span, $msg);
-            }
+    let gate_all = |gate, msg| {
+        for span in spans.get(&gate).unwrap_or(&vec![]) {
+            visitor.gate(*span, gate, msg);
         }
-    }
-    gate_all!(let_chains, "`let` expressions in this position are experimental");
-    gate_all!(async_closure, "async closures are unstable");
-    gate_all!(generators, "yield syntax is experimental");
-    gate_all!(or_patterns, "or-patterns syntax is experimental");
-    gate_all!(const_extern_fn, "`const extern fn` definitions are unstable");
-    gate_all!(raw_ref_op, "raw address of syntax is experimental");
+    };
+
+    gate_all(sym::let_chains, "`let` expressions in this position are experimental");
+    gate_all(sym::async_closure, "async closures are unstable");
+    gate_all(sym::generators, "yield syntax is experimental");
+    gate_all(sym::or_patterns, "or-patterns syntax is experimental");
+    gate_all(sym::const_extern_fn, "`const extern fn` definitions are unstable");
+    gate_all(sym::raw_ref_op, "raw address of syntax is experimental");
 
     // All uses of `gate_all!` below this point were added in #65742,
     // and subsequently disabled (with the non-early gating readded).
-    macro_rules! gate_all {
-        ($gate:ident, $msg:literal) => {
-            // FIXME(eddyb) do something more useful than always
-            // disabling these uses of early feature-gatings.
-            if false {
-                for span in spans.get(&sym::$gate).unwrap_or(&vec![]) {
-                    gate_feature!(&visitor, $gate, *span, $msg);
-                }
-            }
-        }
-    }
+    let gate_all = |gate, msg| {
+        // FIXME(eddyb) do something more useful than always
+        // disabling these uses of early feature-gatings.
+        if false { gate_all(gate, msg); }
+    };
 
-    gate_all!(trait_alias, "trait aliases are experimental");
-    gate_all!(associated_type_bounds, "associated type bounds are unstable");
-    gate_all!(crate_visibility_modifier, "`crate` visibility modifier is experimental");
-    gate_all!(const_generics, "const generics are unstable");
-    gate_all!(decl_macro, "`macro` is experimental");
-    gate_all!(box_patterns, "box pattern syntax is experimental");
-    gate_all!(exclusive_range_pattern, "exclusive range pattern syntax is experimental");
-    gate_all!(try_blocks, "`try` blocks are unstable");
-    gate_all!(label_break_value, "labels on blocks are unstable");
-    gate_all!(box_syntax, "box expression syntax is experimental; you can call `Box::new` instead");
+    gate_all(sym::trait_alias, "trait aliases are experimental");
+    gate_all(sym::associated_type_bounds, "associated type bounds are unstable");
+    gate_all(sym::crate_visibility_modifier, "`crate` visibility modifier is experimental");
+    gate_all(sym::const_generics, "const generics are unstable");
+    gate_all(sym::decl_macro, "`macro` is experimental");
+    gate_all(sym::box_patterns, "box pattern syntax is experimental");
+    gate_all(sym::exclusive_range_pattern, "exclusive range pattern syntax is experimental");
+    gate_all(sym::try_blocks, "`try` blocks are unstable");
+    gate_all(sym::label_break_value, "labels on blocks are unstable");
+    gate_all(
+        sym::box_syntax,
+        "box expression syntax is experimental; you can call `Box::new` instead",
+    );
     // To avoid noise about type ascription in common syntax errors,
     // only emit if it is the *only* error. (Also check it last.)
     if parse_sess.span_diagnostic.err_count() == 0 {
-        gate_all!(type_ascription, "type ascription is experimental");
+        gate_all(sym::type_ascription, "type ascription is experimental");
     }
 
     visit::walk_crate(&mut visitor, krate);

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -96,6 +96,7 @@ pub mod entry;
 pub mod feature_gate {
     mod check;
     pub use check::{check_crate, check_attribute, get_features, feature_err, feature_err_issue};
+    pub use check::gate_feature;
 }
 pub mod mut_visit;
 pub mod ptr;

--- a/src/libsyntax_expand/expand.rs
+++ b/src/libsyntax_expand/expand.rs
@@ -1594,9 +1594,9 @@ impl<'feat> ExpansionConfig<'feat> {
     }
 
     fn proc_macro_hygiene(&self) -> bool {
-        self.features.map_or(false, |features| features.proc_macro_hygiene)
+        self.features.map_or(false, |features| features.on(sym::proc_macro_hygiene))
     }
     fn custom_inner_attributes(&self) -> bool {
-        self.features.map_or(false, |features| features.custom_inner_attributes)
+        self.features.map_or(false, |features| features.on(sym::custom_inner_attributes))
     }
 }


### PR DESCRIPTION
This PR removes the usage of macros in feature gating preferring to take in symbols instead. The aim is to make feature gating more understandable overall while also reducing some duplication.

To check whether a feature gate is active, `tcx.features().on(sym::my_feature)` can be used.
Inside `PostExpansionVisitor` it's however better to use `self.gate(...)` which provides a nicer API atop of that. Outside of the visitor, if `gate_feature` can be used, it should be preferred over `feature_err`.

As a follow-up, and once #66878 is merged, it might be a good idea to add a method to `Session` for more convenient access to `gate_feature` and `feature_err` respectively.

Originally I intended to go for a `HashSet` representation, but this felt like a smaller change to just expand to a `match` on the symbol => field pairs.

r? @oli-obk 

