### PR TITLE
submodules: update clippy from 7b8e8293 to 45196cee

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,12 +468,14 @@ dependencies = [
  "clippy_lints",
  "compiletest_rs",
  "derive-new",
+ "git2",
  "lazy_static 1.3.0",
  "regex",
  "rustc-workspace-hack",
  "rustc_tools_util 0.2.0",
  "semver",
  "serde",
+ "tempfile",
  "tester",
 ]
 


### PR DESCRIPTION
Changes:
````
account for external macro in MISSING_INLINE_IN_PUBLIC_ITEMS lint
build(tests/fmt): use shared target dir
chore: fix and split some ui tests on 32bit system
build: set up build job for i686 targets
remove needless my_lint ui test
git quiet
deploy: cd to out/ before adding files to git
Less needless_doctest_main false positives
fmt
Feed the dog
Use rustc_env instead of exec_env for test
Make triggering this lint less likely :paperclip:
Use exec_env to set backtrace level and normalize output
Update custom ICE function with latest rustc
Use Clippy version in ICE message
Add custom ICE message that points to Clippy repo
Fix master deployment
Run update_lints
Add projections check to EUV for escape analysis
Use infer_ctxt
Move use_self to nursery
Use `println!` on success instead of `eprintln!`
Revert "Disable chalk integration test. Output too large"
Remove the old integration-tests.sh script
Use rust implementation for integration tests in CI
Rust implementation of integration test
Don't error on clippy.toml of dependencies
Fix categorizations
Fix arguments on ExprUseVisitor::new
euv moved from middle to typeck
cmt_ -> Place
build: check if RTIM is not installed
make use of Result::map_or
trigger string_lit_as_bytes when literal has escapes
Remove negative float literal checks.
Enable deny-warnings feature everywhere in CI
Remove unused debugging feature
implemented `as_conversions` lint
fixing a typo
[comparison_chain] #4827 Check `core::cmp::Ord` is implemented
add a good example for the approx_const lint
Add suggested good cases in docs for lifetimes lint
````
Fixes #66840