### PR TITLE
Remove hack for top-level or-patterns in match checking

### DIFF
--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -425,16 +425,12 @@ impl<'p, 'tcx> PatStack<'p, 'tcx> {
     }
 
     /// This computes `S(constructor, self)`. See top of the file for explanations.
-    fn specialize_constructor<'a, 'q>(
+    fn specialize_constructor(
         &self,
-        cx: &mut MatchCheckCtxt<'a, 'tcx>,
+        cx: &mut MatchCheckCtxt<'p, 'tcx>,
         constructor: &Constructor<'tcx>,
-        ctor_wild_subpatterns: &[&'q Pat<'tcx>],
-    ) -> Option<PatStack<'q, 'tcx>>
-    where
-        'a: 'q,
-        'p: 'q,
-    {
+        ctor_wild_subpatterns: &'p [Pat<'tcx>],
+    ) -> Option<PatStack<'p, 'tcx>> {
         let new_heads = specialize_one_pattern(cx, self.head(), constructor, ctor_wild_subpatterns);
         new_heads.map(|mut new_head| {
             new_head.0.extend_from_slice(&self.0[1..]);
@@ -486,16 +482,12 @@ impl<'p, 'tcx> Matrix<'p, 'tcx> {
     }
 
     /// This computes `S(constructor, self)`. See top of the file for explanations.
-    fn specialize_constructor<'a, 'q>(
+    fn specialize_constructor(
         &self,
-        cx: &mut MatchCheckCtxt<'a, 'tcx>,
+        cx: &mut MatchCheckCtxt<'p, 'tcx>,
         constructor: &Constructor<'tcx>,
-        ctor_wild_subpatterns: &[&'q Pat<'tcx>],
-    ) -> Matrix<'q, 'tcx>
-    where
-        'a: 'q,
-        'p: 'q,
-    {
+        ctor_wild_subpatterns: &'p [Pat<'tcx>],
+    ) -> Matrix<'p, 'tcx> {
         self.0
             .iter()
             .filter_map(|r| r.specialize_constructor(cx, constructor, ctor_wild_subpatterns))
@@ -1604,10 +1596,10 @@ impl<'tcx> fmt::Debug for MissingConstructors<'tcx> {
 /// relation to preceding patterns, it is not reachable) and exhaustiveness
 /// checking (if a wildcard pattern is useful in relation to a matrix, the
 /// matrix isn't exhaustive).
-pub fn is_useful<'p, 'a, 'tcx>(
-    cx: &mut MatchCheckCtxt<'a, 'tcx>,
+pub fn is_useful<'p, 'tcx>(
+    cx: &mut MatchCheckCtxt<'p, 'tcx>,
     matrix: &Matrix<'p, 'tcx>,
-    v: &PatStack<'_, 'tcx>,
+    v: &PatStack<'p, 'tcx>,
     witness_preference: WitnessPreference,
     hir_id: HirId,
 ) -> Usefulness<'tcx> {
@@ -1768,10 +1760,10 @@ pub fn is_useful<'p, 'a, 'tcx>(
 
 /// A shorthand for the `U(S(c, P), S(c, q))` operation from the paper. I.e., `is_useful` applied
 /// to the specialised version of both the pattern matrix `P` and the new pattern `q`.
-fn is_useful_specialized<'p, 'a, 'tcx>(
-    cx: &mut MatchCheckCtxt<'a, 'tcx>,
+fn is_useful_specialized<'p, 'tcx>(
+    cx: &mut MatchCheckCtxt<'p, 'tcx>,
     matrix: &Matrix<'p, 'tcx>,
-    v: &PatStack<'_, 'tcx>,
+    v: &PatStack<'p, 'tcx>,
     ctor: Constructor<'tcx>,
     lty: Ty<'tcx>,
     witness_preference: WitnessPreference,
@@ -1779,10 +1771,10 @@ fn is_useful_specialized<'p, 'a, 'tcx>(
 ) -> Usefulness<'tcx> {
     debug!("is_useful_specialized({:#?}, {:#?}, {:?})", v, ctor, lty);
 
-    let ctor_wild_subpatterns_owned: Vec<_> = ctor.wildcard_subpatterns(cx, lty);
-    let ctor_wild_subpatterns: Vec<_> = ctor_wild_subpatterns_owned.iter().collect();
-    let matrix = matrix.specialize_constructor(cx, &ctor, &ctor_wild_subpatterns);
-    v.specialize_constructor(cx, &ctor, &ctor_wild_subpatterns)
+    let ctor_wild_subpatterns =
+        cx.pattern_arena.alloc_from_iter(ctor.wildcard_subpatterns(cx, lty));
+    let matrix = matrix.specialize_constructor(cx, &ctor, ctor_wild_subpatterns);
+    v.specialize_constructor(cx, &ctor, ctor_wild_subpatterns)
         .map(|v| is_useful(cx, &matrix, &v, witness_preference, hir_id))
         .map(|u| u.apply_constructor(cx, &ctor, lty))
         .unwrap_or(NotUseful)
@@ -2250,13 +2242,13 @@ fn constructor_covered_by_range<'tcx>(
     if intersects { Some(()) } else { None }
 }
 
-fn patterns_for_variant<'p, 'a: 'p, 'tcx>(
-    cx: &mut MatchCheckCtxt<'a, 'tcx>,
+fn patterns_for_variant<'p, 'tcx>(
+    cx: &mut MatchCheckCtxt<'p, 'tcx>,
     subpatterns: &'p [FieldPat<'tcx>],
-    ctor_wild_subpatterns: &[&'p Pat<'tcx>],
+    ctor_wild_subpatterns: &'p [Pat<'tcx>],
     is_non_exhaustive: bool,
 ) -> PatStack<'p, 'tcx> {
-    let mut result = SmallVec::from_slice(ctor_wild_subpatterns);
+    let mut result: SmallVec<_> = ctor_wild_subpatterns.iter().collect();
 
     for subpat in subpatterns {
         if !is_non_exhaustive || !cx.is_uninhabited(subpat.pattern.ty) {
@@ -2280,11 +2272,11 @@ fn patterns_for_variant<'p, 'a: 'p, 'tcx>(
 /// different patterns.
 /// Structure patterns with a partial wild pattern (Foo { a: 42, .. }) have their missing
 /// fields filled with wild patterns.
-fn specialize_one_pattern<'p, 'a: 'p, 'q: 'p, 'tcx>(
-    cx: &mut MatchCheckCtxt<'a, 'tcx>,
-    pat: &'q Pat<'tcx>,
+fn specialize_one_pattern<'p, 'tcx>(
+    cx: &mut MatchCheckCtxt<'p, 'tcx>,
+    pat: &'p Pat<'tcx>,
     constructor: &Constructor<'tcx>,
-    ctor_wild_subpatterns: &[&'p Pat<'tcx>],
+    ctor_wild_subpatterns: &'p [Pat<'tcx>],
 ) -> Option<PatStack<'p, 'tcx>> {
     if let NonExhaustive = constructor {
         // Only a wildcard pattern can match the special extra constructor
@@ -2294,9 +2286,7 @@ fn specialize_one_pattern<'p, 'a: 'p, 'q: 'p, 'tcx>(
     let result = match *pat.kind {
         PatKind::AscribeUserType { .. } => bug!(), // Handled by `expand_pattern`
 
-        PatKind::Binding { .. } | PatKind::Wild => {
-            Some(PatStack::from_slice(ctor_wild_subpatterns))
-        }
+        PatKind::Binding { .. } | PatKind::Wild => Some(ctor_wild_subpatterns.iter().collect()),
 
         PatKind::Variant { adt_def, variant_index, ref subpatterns, .. } => {
             let ref variant = adt_def.variants[variant_index];
@@ -2406,7 +2396,6 @@ fn specialize_one_pattern<'p, 'a: 'p, 'q: 'p, 'tcx>(
                                 .chain(
                                     ctor_wild_subpatterns
                                         .iter()
-                                        .map(|p| *p)
                                         .skip(prefix.len())
                                         .take(slice_count)
                                         .chain(suffix.iter()),

--- a/src/librustc_mir/hair/pattern/check_match.rs
+++ b/src/librustc_mir/hair/pattern/check_match.rs
@@ -468,7 +468,16 @@ fn check_arms<'p, 'tcx>(
                         hir::MatchSource::AwaitDesugar | hir::MatchSource::TryDesugar => {}
                     }
                 }
-                Useful => (),
+                Useful(unreachable_subpatterns) => {
+                    for pat in unreachable_subpatterns {
+                        cx.tcx.lint_hir(
+                            lint::builtin::UNREACHABLE_PATTERNS,
+                            hir_pat.hir_id,
+                            pat.span,
+                            "unreachable pattern",
+                        );
+                    }
+                }
                 UsefulWithWitness(_) => bug!(),
             }
             if guard.is_none() {
@@ -496,7 +505,7 @@ fn check_not_useful<'p, 'tcx>(
         } else {
             pats.into_iter().map(|w| w.single_pattern()).collect()
         }),
-        Useful => bug!(),
+        Useful(_) => bug!(),
     }
 }
 

--- a/src/librustc_mir/hair/pattern/check_match.rs
+++ b/src/librustc_mir/hair/pattern/check_match.rs
@@ -414,16 +414,9 @@ fn check_arms<'p, 'tcx>(
                         hir::MatchSource::IfDesugar { .. } | hir::MatchSource::WhileDesugar => {
                             bug!()
                         }
-                        hir::MatchSource::IfLetDesugar { .. } => {
-                            cx.tcx.lint_hir(
-                                lint::builtin::IRREFUTABLE_LET_PATTERNS,
-                                hir_pat.hir_id,
-                                pat.span,
-                                "irrefutable if-let pattern",
-                            );
-                        }
 
-                        hir::MatchSource::WhileLetDesugar => {
+                        hir::MatchSource::IfLetDesugar { .. }
+                        | hir::MatchSource::WhileLetDesugar => {
                             // check which arm we're on.
                             match arm_index {
                                 // The arm with the user-specified pattern.
@@ -437,11 +430,20 @@ fn check_arms<'p, 'tcx>(
                                 }
                                 // The arm with the wildcard pattern.
                                 1 => {
+                                    let msg = match source {
+                                        hir::MatchSource::IfLetDesugar { .. } => {
+                                            "irrefutable if-let pattern"
+                                        }
+                                        hir::MatchSource::WhileLetDesugar => {
+                                            "irrefutable while-let pattern"
+                                        }
+                                        _ => bug!(),
+                                    };
                                     cx.tcx.lint_hir(
                                         lint::builtin::IRREFUTABLE_LET_PATTERNS,
                                         hir_pat.hir_id,
                                         pat.span,
-                                        "irrefutable while-let pattern",
+                                        msg,
                                     );
                                 }
                                 _ => bug!(),

--- a/src/librustc_mir/hair/pattern/check_match.rs
+++ b/src/librustc_mir/hair/pattern/check_match.rs
@@ -492,7 +492,7 @@ fn check_not_useful(
     match is_useful(cx, matrix, &PatStack::from_pattern(&wild_pattern), ConstructWitness, hir_id) {
         NotUseful => Ok(()), // This is good, wildcard pattern isn't reachable.
         UsefulWithWitness(pats) => Err(if pats.is_empty() {
-            vec![wild_pattern]
+            bug!("Exhaustiveness check returned no witnesses")
         } else {
             pats.into_iter().map(|w| w.single_pattern()).collect()
         }),

--- a/src/test/ui/or-patterns/exhaustiveness-pass.rs
+++ b/src/test/ui/or-patterns/exhaustiveness-pass.rs
@@ -6,35 +6,63 @@
 // We wrap patterns in a tuple because top-level or-patterns are special-cased for now.
 fn main() {
     // Get the fatal error out of the way
-    match (0u8,) {
+    match (0,) {
         (0 | _,) => {}
         //~^ ERROR or-patterns are not fully implemented yet
     }
 
-    match (0u8,) {
+    match (0,) {
         (1 | 2,) => {}
         _ => {}
     }
 
-    match (0u8,) {
-        (1 | 1,) => {} // FIXME(or_patterns): redundancy not detected for now.
-        _ => {}
-    }
-    match (0u8, 0u8) {
+    match (0, 0) {
         (1 | 2, 3 | 4) => {}
         (1, 2) => {}
-        (2, 1) => {}
+        (3, 1) => {}
         _ => {}
     }
     match (Some(0u8),) {
         (None | Some(0 | 1),) => {}
         (Some(2..=255),) => {}
     }
-    match ((0u8,),) {
+    match ((0,),) {
         ((0 | 1,) | (2 | 3,),) => {},
         ((_,),) => {},
     }
     match (&[0u8][..],) {
         ([] | [0 | 1..=255] | [_, ..],) => {},
+    }
+
+    match ((0, 0),) {
+        ((0, 0) | (0, 1),) => {}
+        _ => {}
+    }
+    match ((0, 0),) {
+        ((0, 0) | (1, 0),) => {}
+        _ => {}
+    }
+
+     // FIXME(or_patterns): Redundancies not detected for now.
+    match (0,) {
+        (1 | 1,) => {}
+        _ => {}
+    }
+    match [0; 2] {
+        [0 | 0, 0 | 0] => {}
+        _ => {}
+    }
+    match &[][..] {
+        [0] => {}
+        [0, _] => {}
+        [0, _, _] => {}
+        [1, ..] => {}
+        [1 | 2, ..] => {}
+        _ => {}
+    }
+    match Some(0) {
+        Some(0) => {}
+        Some(0 | 1) => {}
+        _ => {}
     }
 }

--- a/src/test/ui/or-patterns/exhaustiveness-pass.rs
+++ b/src/test/ui/or-patterns/exhaustiveness-pass.rs
@@ -43,13 +43,16 @@ fn main() {
         _ => {}
     }
 
-     // FIXME(or_patterns): Redundancies not detected for now.
     match (0,) {
-        (1 | 1,) => {}
+        (1
+         | 1,) => {} //~ ERROR unreachable
         _ => {}
     }
     match [0; 2] {
-        [0 | 0, 0 | 0] => {}
+        [0
+            | 0 //~ ERROR unreachable
+        , 0
+            | 0] => {} //~ ERROR unreachable
         _ => {}
     }
     match &[][..] {
@@ -57,12 +60,14 @@ fn main() {
         [0, _] => {}
         [0, _, _] => {}
         [1, ..] => {}
-        [1 | 2, ..] => {}
+        [1 //~ ERROR unreachable
+            | 2, ..] => {}
         _ => {}
     }
     match Some(0) {
         Some(0) => {}
-        Some(0 | 1) => {}
+        Some(0 //~ ERROR unreachable
+             | 1) => {}
         _ => {}
     }
 }

--- a/src/test/ui/or-patterns/exhaustiveness-pass.rs
+++ b/src/test/ui/or-patterns/exhaustiveness-pass.rs
@@ -42,32 +42,4 @@ fn main() {
         ((0, 0) | (1, 0),) => {}
         _ => {}
     }
-
-    match (0,) {
-        (1
-         | 1,) => {} //~ ERROR unreachable
-        _ => {}
-    }
-    match [0; 2] {
-        [0
-            | 0 //~ ERROR unreachable
-        , 0
-            | 0] => {} //~ ERROR unreachable
-        _ => {}
-    }
-    match &[][..] {
-        [0] => {}
-        [0, _] => {}
-        [0, _, _] => {}
-        [1, ..] => {}
-        [1 //~ ERROR unreachable
-            | 2, ..] => {}
-        _ => {}
-    }
-    match Some(0) {
-        Some(0) => {}
-        Some(0 //~ ERROR unreachable
-             | 1) => {}
-        _ => {}
-    }
 }

--- a/src/test/ui/or-patterns/exhaustiveness-pass.stderr
+++ b/src/test/ui/or-patterns/exhaustiveness-pass.stderr
@@ -1,44 +1,8 @@
-error: unreachable pattern
-  --> $DIR/exhaustiveness-pass.rs:48:12
-   |
-LL |          | 1,) => {}
-   |            ^
-   |
-note: lint level defined here
-  --> $DIR/exhaustiveness-pass.rs:4:9
-   |
-LL | #![deny(unreachable_patterns)]
-   |         ^^^^^^^^^^^^^^^^^^^^
-
-error: unreachable pattern
-  --> $DIR/exhaustiveness-pass.rs:55:15
-   |
-LL |             | 0] => {}
-   |               ^
-
-error: unreachable pattern
-  --> $DIR/exhaustiveness-pass.rs:53:15
-   |
-LL |             | 0
-   |               ^
-
-error: unreachable pattern
-  --> $DIR/exhaustiveness-pass.rs:63:10
-   |
-LL |         [1
-   |          ^
-
-error: unreachable pattern
-  --> $DIR/exhaustiveness-pass.rs:69:14
-   |
-LL |         Some(0
-   |              ^
-
 error: or-patterns are not fully implemented yet
   --> $DIR/exhaustiveness-pass.rs:10:10
    |
 LL |         (0 | _,) => {}
    |          ^^^^^
 
-error: aborting due to 6 previous errors
+error: aborting due to previous error
 

--- a/src/test/ui/or-patterns/exhaustiveness-pass.stderr
+++ b/src/test/ui/or-patterns/exhaustiveness-pass.stderr
@@ -1,8 +1,44 @@
+error: unreachable pattern
+  --> $DIR/exhaustiveness-pass.rs:48:12
+   |
+LL |          | 1,) => {}
+   |            ^
+   |
+note: lint level defined here
+  --> $DIR/exhaustiveness-pass.rs:4:9
+   |
+LL | #![deny(unreachable_patterns)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-pass.rs:55:15
+   |
+LL |             | 0] => {}
+   |               ^
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-pass.rs:53:15
+   |
+LL |             | 0
+   |               ^
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-pass.rs:63:10
+   |
+LL |         [1
+   |          ^
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-pass.rs:69:14
+   |
+LL |         Some(0
+   |              ^
+
 error: or-patterns are not fully implemented yet
   --> $DIR/exhaustiveness-pass.rs:10:10
    |
 LL |         (0 | _,) => {}
    |          ^^^^^
 
-error: aborting due to previous error
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.rs
+++ b/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.rs
@@ -48,4 +48,32 @@ fn main() {
         ((1..=4,),) => {}, //~ ERROR unreachable pattern
         _ => {},
     }
+
+    match (0,) {
+        (1
+         | 1,) => {} //~ ERROR unreachable
+        _ => {}
+    }
+    match [0; 2] {
+        [0
+            | 0 //~ ERROR unreachable
+        , 0
+            | 0] => {} //~ ERROR unreachable
+        _ => {}
+    }
+    match &[][..] {
+        [0] => {}
+        [0, _] => {}
+        [0, _, _] => {}
+        [1, ..] => {}
+        [1 //~ ERROR unreachable
+            | 2, ..] => {}
+        _ => {}
+    }
+    match Some(0) {
+        Some(0) => {}
+        Some(0 //~ ERROR unreachable
+             | 1) => {}
+        _ => {}
+    }
 }

--- a/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
+++ b/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
@@ -70,11 +70,41 @@ error: unreachable pattern
 LL |         ((1..=4,),) => {},
    |         ^^^^^^^^^^^
 
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:54:12
+   |
+LL |          | 1,) => {}
+   |            ^
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:61:15
+   |
+LL |             | 0] => {}
+   |               ^
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:59:15
+   |
+LL |             | 0
+   |               ^
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:69:10
+   |
+LL |         [1
+   |          ^
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:75:14
+   |
+LL |         Some(0
+   |              ^
+
 error: or-patterns are not fully implemented yet
   --> $DIR/exhaustiveness-unreachable-pattern.rs:10:10
    |
 LL |         (0 | _,) => {}
    |          ^^^^^
 
-error: aborting due to 12 previous errors
+error: aborting due to 17 previous errors
 

--- a/src/test/ui/pattern/usefulness/top-level-alternation.rs
+++ b/src/test/ui/pattern/usefulness/top-level-alternation.rs
@@ -46,8 +46,7 @@ fn main() {
     match Some(0u8) {
         Some(_) => {}
         None => {}
-        None //~ ERROR unreachable pattern
-            | Some(_) => {} //~ ERROR unreachable pattern
+        None | Some(_) => {} //~ ERROR unreachable pattern
     }
     match 0u8 {
         1 | 2 => {},

--- a/src/test/ui/pattern/usefulness/top-level-alternation.rs
+++ b/src/test/ui/pattern/usefulness/top-level-alternation.rs
@@ -2,8 +2,7 @@
 
 fn main() {
     while let 0..=2 | 1 = 0 {} //~ ERROR unreachable pattern
-    if let 0..=2 | 1 = 0 {} //~ WARN irrefutable if-let pattern
-    // this one ^ is incorrect
+    if let 0..=2 | 1 = 0 {} //~ ERROR unreachable pattern
 
     match 0u8 {
         0

--- a/src/test/ui/pattern/usefulness/top-level-alternation.rs
+++ b/src/test/ui/pattern/usefulness/top-level-alternation.rs
@@ -1,0 +1,58 @@
+#![deny(unreachable_patterns)]
+
+fn main() {
+    while let 0..=2 | 1 = 0 {} //~ ERROR unreachable pattern
+    if let 0..=2 | 1 = 0 {} //~ WARN irrefutable if-let pattern
+    // this one ^ is incorrect
+
+    match 0u8 {
+        0
+            | 0 => {} //~ ERROR unreachable pattern
+        _ => {}
+    }
+    match Some(0u8) {
+        Some(0)
+            | Some(0) => {} //~ ERROR unreachable pattern
+        _ => {}
+    }
+    match (0u8, 0u8) {
+        (0, _) | (_, 0) => {}
+        (0, 0) => {} //~ ERROR unreachable pattern
+        (1, 1) => {}
+        _ => {}
+    }
+    match (0u8, 0u8) {
+        (0, 1) | (2, 3) => {}
+        (0, 3) => {}
+        (2, 1) => {}
+        _ => {}
+    }
+    match (0u8, 0u8) {
+        (_, 0) | (_, 1) => {}
+        _ => {}
+    }
+    match (0u8, 0u8) {
+        (0, _) | (1, _) => {}
+        _ => {}
+    }
+    match Some(0u8) {
+        None | Some(_) => {}
+        _ => {} //~ ERROR unreachable pattern
+    }
+    match Some(0u8) {
+        None | Some(_) => {}
+        Some(_) => {} //~ ERROR unreachable pattern
+        None => {} //~ ERROR unreachable pattern
+    }
+    match Some(0u8) {
+        Some(_) => {}
+        None => {}
+        None //~ ERROR unreachable pattern
+            | Some(_) => {} //~ ERROR unreachable pattern
+    }
+    match 0u8 {
+        1 | 2 => {},
+        1..=2 => {}, //~ ERROR unreachable pattern
+        _ => {},
+    }
+}

--- a/src/test/ui/pattern/usefulness/top-level-alternation.stderr
+++ b/src/test/ui/pattern/usefulness/top-level-alternation.stderr
@@ -1,0 +1,76 @@
+error: unreachable pattern
+  --> $DIR/top-level-alternation.rs:4:23
+   |
+LL |     while let 0..=2 | 1 = 0 {}
+   |                       ^
+   |
+note: lint level defined here
+  --> $DIR/top-level-alternation.rs:1:9
+   |
+LL | #![deny(unreachable_patterns)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+
+warning: irrefutable if-let pattern
+  --> $DIR/top-level-alternation.rs:5:20
+   |
+LL |     if let 0..=2 | 1 = 0 {}
+   |                    ^
+   |
+   = note: `#[warn(irrefutable_let_patterns)]` on by default
+
+error: unreachable pattern
+  --> $DIR/top-level-alternation.rs:10:15
+   |
+LL |             | 0 => {}
+   |               ^
+
+error: unreachable pattern
+  --> $DIR/top-level-alternation.rs:15:15
+   |
+LL |             | Some(0) => {}
+   |               ^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/top-level-alternation.rs:20:9
+   |
+LL |         (0, 0) => {}
+   |         ^^^^^^
+
+error: unreachable pattern
+  --> $DIR/top-level-alternation.rs:40:9
+   |
+LL |         _ => {}
+   |         ^
+
+error: unreachable pattern
+  --> $DIR/top-level-alternation.rs:44:9
+   |
+LL |         Some(_) => {}
+   |         ^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/top-level-alternation.rs:45:9
+   |
+LL |         None => {}
+   |         ^^^^
+
+error: unreachable pattern
+  --> $DIR/top-level-alternation.rs:50:9
+   |
+LL |         None
+   |         ^^^^
+
+error: unreachable pattern
+  --> $DIR/top-level-alternation.rs:51:15
+   |
+LL |             | Some(_) => {}
+   |               ^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/top-level-alternation.rs:55:9
+   |
+LL |         1..=2 => {},
+   |         ^^^^^
+
+error: aborting due to 10 previous errors
+

--- a/src/test/ui/pattern/usefulness/top-level-alternation.stderr
+++ b/src/test/ui/pattern/usefulness/top-level-alternation.stderr
@@ -55,20 +55,14 @@ LL |         None => {}
 error: unreachable pattern
   --> $DIR/top-level-alternation.rs:49:9
    |
-LL |         None
-   |         ^^^^
+LL |         None | Some(_) => {}
+   |         ^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/top-level-alternation.rs:50:15
-   |
-LL |             | Some(_) => {}
-   |               ^^^^^^^
-
-error: unreachable pattern
-  --> $DIR/top-level-alternation.rs:54:9
+  --> $DIR/top-level-alternation.rs:53:9
    |
 LL |         1..=2 => {},
    |         ^^^^^
 
-error: aborting due to 11 previous errors
+error: aborting due to 10 previous errors
 

--- a/src/test/ui/pattern/usefulness/top-level-alternation.stderr
+++ b/src/test/ui/pattern/usefulness/top-level-alternation.stderr
@@ -10,67 +10,65 @@ note: lint level defined here
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
-warning: irrefutable if-let pattern
+error: unreachable pattern
   --> $DIR/top-level-alternation.rs:5:20
    |
 LL |     if let 0..=2 | 1 = 0 {}
    |                    ^
-   |
-   = note: `#[warn(irrefutable_let_patterns)]` on by default
 
 error: unreachable pattern
-  --> $DIR/top-level-alternation.rs:10:15
+  --> $DIR/top-level-alternation.rs:9:15
    |
 LL |             | 0 => {}
    |               ^
 
 error: unreachable pattern
-  --> $DIR/top-level-alternation.rs:15:15
+  --> $DIR/top-level-alternation.rs:14:15
    |
 LL |             | Some(0) => {}
    |               ^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/top-level-alternation.rs:20:9
+  --> $DIR/top-level-alternation.rs:19:9
    |
 LL |         (0, 0) => {}
    |         ^^^^^^
 
 error: unreachable pattern
-  --> $DIR/top-level-alternation.rs:40:9
+  --> $DIR/top-level-alternation.rs:39:9
    |
 LL |         _ => {}
    |         ^
 
 error: unreachable pattern
-  --> $DIR/top-level-alternation.rs:44:9
+  --> $DIR/top-level-alternation.rs:43:9
    |
 LL |         Some(_) => {}
    |         ^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/top-level-alternation.rs:45:9
+  --> $DIR/top-level-alternation.rs:44:9
    |
 LL |         None => {}
    |         ^^^^
 
 error: unreachable pattern
-  --> $DIR/top-level-alternation.rs:50:9
+  --> $DIR/top-level-alternation.rs:49:9
    |
 LL |         None
    |         ^^^^
 
 error: unreachable pattern
-  --> $DIR/top-level-alternation.rs:51:15
+  --> $DIR/top-level-alternation.rs:50:15
    |
 LL |             | Some(_) => {}
    |               ^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/top-level-alternation.rs:55:9
+  --> $DIR/top-level-alternation.rs:54:9
    |
 LL |         1..=2 => {},
    |         ^^^^^
 
-error: aborting due to 10 previous errors
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
Follow-up to #66612.

Or-patterns are now truly first-class in match checking. As a side-effect, redundant subpatterns are linted as such, making the `unreachable_patterns` lint a bit more general.

cc #54883

r? @varkor