### PR TITLE
Update the minimum external LLVM to 7

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -294,11 +294,11 @@ fn check_llvm_version(builder: &Builder<'_>, llvm_config: &Path) {
     let mut parts = version.split('.').take(2)
         .filter_map(|s| s.parse::<u32>().ok());
     if let (Some(major), Some(_minor)) = (parts.next(), parts.next()) {
-        if major >= 6 {
+        if major >= 7 {
             return
         }
     }
-    panic!("\n\nbad LLVM version: {}, need >=6.0\n\n", version)
+    panic!("\n\nbad LLVM version: {}, need >=7.0\n\n", version)
 }
 
 fn configure_cmake(builder: &Builder<'_>,

--- a/src/ci/azure-pipelines/auto.yml
+++ b/src/ci/azure-pipelines/auto.yml
@@ -18,7 +18,7 @@ jobs:
   - template: steps/run.yml
   strategy:
     matrix:
-      x86_64-gnu-llvm-6.0:
+      x86_64-gnu-llvm-7:
         RUST_BACKTRACE: 1
       dist-x86_64-linux: {}
       dist-x86_64-linux-alt:

--- a/src/ci/azure-pipelines/pr.yml
+++ b/src/ci/azure-pipelines/pr.yml
@@ -18,7 +18,7 @@ jobs:
     - template: steps/run.yml
   strategy:
     matrix:
-      x86_64-gnu-llvm-6.0: {}
+      x86_64-gnu-llvm-7: {}
       mingw-check: {}
       x86_64-gnu-tools:
         CI_ONLY_WHEN_SUBMODULES_CHANGED: 1

--- a/src/ci/docker/x86_64-gnu-llvm-7/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-llvm-7/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   g++ \
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   cmake \
   sudo \
   gdb \
-  llvm-6.0-tools \
+  llvm-7-tools \
   libedit-dev \
   libssl-dev \
   pkg-config \
@@ -24,7 +24,7 @@ RUN sh /scripts/sccache.sh
 # using llvm-link-shared due to libffi issues -- see #34486
 ENV RUST_CONFIGURE_ARGS \
       --build=x86_64-unknown-linux-gnu \
-      --llvm-root=/usr/lib/llvm-6.0 \
+      --llvm-root=/usr/lib/llvm-7 \
       --enable-llvm-link-shared
 ENV SCRIPT python2.7 ../x.py test src/tools/tidy && python2.7 ../x.py test
 

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -101,11 +101,13 @@ extern "C" LLVMPassRef LLVMRustCreateModuleAddressSanitizerPass(bool Recover) {
 }
 
 extern "C" LLVMPassRef LLVMRustCreateMemorySanitizerPass(int TrackOrigins, bool Recover) {
-#if LLVM_VERSION_GE(8, 0)
+#if LLVM_VERSION_GE(9, 0)
   const bool CompileKernel = false;
 
   return wrap(createMemorySanitizerLegacyPassPass(
       MemorySanitizerOptions{TrackOrigins, Recover, CompileKernel}));
+#elif LLVM_VERSION_GE(8, 0)
+  return wrap(createMemorySanitizerLegacyPassPass(TrackOrigins, Recover));
 #else
   return wrap(createMemorySanitizerPass(TrackOrigins, Recover));
 #endif
@@ -449,9 +451,7 @@ extern "C" void LLVMRustConfigurePassManagerBuilder(
     LLVMPassManagerBuilderRef PMBR, LLVMRustCodeGenOptLevel OptLevel,
     bool MergeFunctions, bool SLPVectorize, bool LoopVectorize, bool PrepareForThinLTO,
     const char* PGOGenPath, const char* PGOUsePath) {
-#if LLVM_VERSION_GE(7, 0)
   unwrap(PMBR)->MergeFunctions = MergeFunctions;
-#endif
   unwrap(PMBR)->SLPVectorize = SLPVectorize;
   unwrap(PMBR)->OptLevel = fromRust(OptLevel);
   unwrap(PMBR)->LoopVectorize = LoopVectorize;
@@ -558,12 +558,8 @@ LLVMRustWriteOutputFile(LLVMTargetMachineRef Target, LLVMPassManagerRef PMR,
     return LLVMRustResult::Failure;
   }
 
-#if LLVM_VERSION_GE(7, 0)
   buffer_ostream BOS(OS);
   unwrap(Target)->addPassesToEmitFile(*PM, BOS, nullptr, FileType, false);
-#else
-  unwrap(Target)->addPassesToEmitFile(*PM, OS, FileType, false);
-#endif
   PM->run(*unwrap(M));
 
   // Apparently `addPassesToEmitFile` adds a pointer to our on-the-stack output
@@ -847,9 +843,7 @@ struct LLVMRustThinLTOData {
   StringMap<FunctionImporter::ExportSetTy> ExportLists;
   StringMap<GVSummaryMapTy> ModuleToDefinedGVSummaries;
 
-#if LLVM_VERSION_GE(7, 0)
   LLVMRustThinLTOData() : Index(/* HaveGVs = */ false) {}
-#endif
 };
 
 // Just an argument to the `LLVMRustCreateThinLTOData` function below.
@@ -920,7 +914,6 @@ LLVMRustCreateThinLTOData(LLVMRustThinLTOModule *modules,
   // combined index
   //
   // This is copied from `lib/LTO/ThinLTOCodeGenerator.cpp`
-#if LLVM_VERSION_GE(7, 0)
   auto deadIsPrevailing = [&](GlobalValue::GUID G) {
     return PrevailingType::Unknown;
   };
@@ -932,9 +925,6 @@ LLVMRustCreateThinLTOData(LLVMRustThinLTOModule *modules,
                                   deadIsPrevailing, /* ImportEnabled = */ false);
 #else
   computeDeadSymbols(Ret->Index, Ret->GUIDPreservedSymbols, deadIsPrevailing);
-#endif
-#else
-  computeDeadSymbols(Ret->Index, Ret->GUIDPreservedSymbols);
 #endif
   ComputeCrossModuleImport(
     Ret->Index,

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -88,11 +88,7 @@ extern "C" char *LLVMRustGetLastError(void) {
 }
 
 extern "C" unsigned int LLVMRustGetInstructionCount(LLVMModuleRef M) {
-#if LLVM_VERSION_GE(7, 0)
   return unwrap(M)->getInstructionCount();
-#else
-  report_fatal_error("Module::getInstructionCount not available before LLVM 7");
-#endif
 }
 
 extern "C" void LLVMRustSetLastError(const char *Err) {
@@ -761,14 +757,10 @@ extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateVariantPart(
     LLVMMetadataRef File, unsigned LineNumber, uint64_t SizeInBits,
     uint32_t AlignInBits, LLVMRustDIFlags Flags, LLVMMetadataRef Discriminator,
     LLVMMetadataRef Elements, const char *UniqueId) {
-#if LLVM_VERSION_GE(7, 0)
   return wrap(Builder->createVariantPart(
       unwrapDI<DIDescriptor>(Scope), Name, unwrapDI<DIFile>(File), LineNumber,
       SizeInBits, AlignInBits, fromRust(Flags), unwrapDI<DIDerivedType>(Discriminator),
       DINodeArray(unwrapDI<MDTuple>(Elements)), UniqueId));
-#else
-  abort();
-#endif
 }
 
 extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateMemberType(
@@ -787,7 +779,6 @@ extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateVariantMemberType(
     const char *Name, LLVMMetadataRef File, unsigned LineNo, uint64_t SizeInBits,
     uint32_t AlignInBits, uint64_t OffsetInBits, LLVMValueRef Discriminant,
     LLVMRustDIFlags Flags, LLVMMetadataRef Ty) {
-#if LLVM_VERSION_GE(7, 0)
   llvm::ConstantInt* D = nullptr;
   if (Discriminant) {
     D = unwrap<llvm::ConstantInt>(Discriminant);
@@ -796,12 +787,6 @@ extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateVariantMemberType(
                                                unwrapDI<DIFile>(File), LineNo,
                                                SizeInBits, AlignInBits, OffsetInBits, D,
                                                fromRust(Flags), unwrapDI<DIType>(Ty)));
-#else
-  return wrap(Builder->createMemberType(unwrapDI<DIDescriptor>(Scope), Name,
-                                        unwrapDI<DIFile>(File), LineNo,
-                                        SizeInBits, AlignInBits, OffsetInBits,
-                                        fromRust(Flags), unwrapDI<DIType>(Ty)));
-#endif
 }
 
 extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateLexicalBlock(
@@ -911,18 +896,10 @@ extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateEnumerationType(
     LLVMMetadataRef File, unsigned LineNumber, uint64_t SizeInBits,
     uint32_t AlignInBits, LLVMMetadataRef Elements,
     LLVMMetadataRef ClassTy, bool IsScoped) {
-#if LLVM_VERSION_GE(7, 0)
   return wrap(Builder->createEnumerationType(
       unwrapDI<DIDescriptor>(Scope), Name, unwrapDI<DIFile>(File), LineNumber,
       SizeInBits, AlignInBits, DINodeArray(unwrapDI<MDTuple>(Elements)),
       unwrapDI<DIType>(ClassTy), "", IsScoped));
-#else
-  // Ignore IsScoped on older LLVM.
-  return wrap(Builder->createEnumerationType(
-      unwrapDI<DIDescriptor>(Scope), Name, unwrapDI<DIFile>(File), LineNumber,
-      SizeInBits, AlignInBits, DINodeArray(unwrapDI<MDTuple>(Elements)),
-      unwrapDI<DIType>(ClassTy), ""));
-#endif
 }
 
 extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateUnionType(
@@ -1275,34 +1252,20 @@ extern "C" LLVMValueRef LLVMRustBuildMemCpy(LLVMBuilderRef B,
                                             LLVMValueRef Dst, unsigned DstAlign,
                                             LLVMValueRef Src, unsigned SrcAlign,
                                             LLVMValueRef Size, bool IsVolatile) {
-#if LLVM_VERSION_GE(7, 0)
   return wrap(unwrap(B)->CreateMemCpy(
       unwrap(Dst), DstAlign,
       unwrap(Src), SrcAlign,
       unwrap(Size), IsVolatile));
-#else
-  unsigned Align = std::min(DstAlign, SrcAlign);
-  return wrap(unwrap(B)->CreateMemCpy(
-      unwrap(Dst), unwrap(Src),
-      unwrap(Size), Align, IsVolatile));
-#endif
 }
 
 extern "C" LLVMValueRef LLVMRustBuildMemMove(LLVMBuilderRef B,
                                              LLVMValueRef Dst, unsigned DstAlign,
                                              LLVMValueRef Src, unsigned SrcAlign,
                                              LLVMValueRef Size, bool IsVolatile) {
-#if LLVM_VERSION_GE(7, 0)
   return wrap(unwrap(B)->CreateMemMove(
       unwrap(Dst), DstAlign,
       unwrap(Src), SrcAlign,
       unwrap(Size), IsVolatile));
-#else
-  unsigned Align = std::min(DstAlign, SrcAlign);
-  return wrap(unwrap(B)->CreateMemMove(
-      unwrap(Dst), unwrap(Src),
-      unwrap(Size), Align, IsVolatile));
-#endif
 }
 
 extern "C" LLVMValueRef

--- a/src/test/codegen/align-enum.rs
+++ b/src/test/codegen/align-enum.rs
@@ -1,6 +1,5 @@
 // compile-flags: -C no-prepopulate-passes
 // ignore-tidy-linelength
-// min-llvm-version 7.0
 
 #![crate_type = "lib"]
 

--- a/src/test/codegen/align-struct.rs
+++ b/src/test/codegen/align-struct.rs
@@ -1,6 +1,5 @@
 // compile-flags: -C no-prepopulate-passes
 // ignore-tidy-linelength
-// min-llvm-version 7.0
 
 #![crate_type = "lib"]
 

--- a/src/test/codegen/consts.rs
+++ b/src/test/codegen/consts.rs
@@ -1,6 +1,5 @@
 // compile-flags: -C no-prepopulate-passes
 // ignore-tidy-linelength
-// min-llvm-version 7.0
 
 #![crate_type = "lib"]
 

--- a/src/test/codegen/packed.rs
+++ b/src/test/codegen/packed.rs
@@ -1,6 +1,5 @@
 // ignore-tidy-linelength
 // compile-flags: -C no-prepopulate-passes
-// min-llvm-version 7.0
 
 #![crate_type = "lib"]
 

--- a/src/test/codegen/repeat-trusted-len.rs
+++ b/src/test/codegen/repeat-trusted-len.rs
@@ -1,6 +1,5 @@
 // compile-flags: -O
 // ignore-tidy-linelength
-// min-llvm-version 7.0
 
 #![crate_type = "lib"]
 

--- a/src/test/codegen/simd-intrinsic/simd-intrinsic-float-minmax.rs
+++ b/src/test/codegen/simd-intrinsic/simd-intrinsic-float-minmax.rs
@@ -1,5 +1,3 @@
-// min-llvm-version 7.0
-
 // compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]

--- a/src/test/codegen/stores.rs
+++ b/src/test/codegen/stores.rs
@@ -1,6 +1,5 @@
 // compile-flags: -C no-prepopulate-passes
 // ignore-tidy-linelength
-// min-llvm-version 7.0
 
 #![crate_type = "lib"]
 

--- a/src/test/run-make-fulldeps/emit-stack-sizes/Makefile
+++ b/src/test/run-make-fulldeps/emit-stack-sizes/Makefile
@@ -2,7 +2,6 @@
 
 # ignore-windows
 # ignore-macos
-# min-llvm-version 6.0
 #
 # This feature only works when the output object format is ELF so we ignore
 # macOS and Windows

--- a/src/test/ui/simd/simd-intrinsic-float-minmax.rs
+++ b/src/test/ui/simd/simd-intrinsic-float-minmax.rs
@@ -1,6 +1,5 @@
 // run-pass
 // ignore-emscripten
-// min-llvm-version 7.0
 
 // Test that the simd_f{min,max} intrinsics produce the correct results.
 

--- a/src/test/ui/target-feature/gate.rs
+++ b/src/test/ui/target-feature/gate.rs
@@ -25,7 +25,6 @@
 // gate-test-movbe_target_feature
 // gate-test-rtm_target_feature
 // gate-test-f16c_target_feature
-// min-llvm-version 6.0
 
 #[target_feature(enable = "avx512bw")]
 //~^ ERROR: currently unstable

--- a/src/test/ui/target-feature/gate.stderr
+++ b/src/test/ui/target-feature/gate.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the target feature `avx512bw` is currently unstable
-  --> $DIR/gate.rs:30:18
+  --> $DIR/gate.rs:29:18
    |
 LL | #[target_feature(enable = "avx512bw")]
    |                  ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
LLVM 7 is over a year old, which should be plenty for compatibility. The
last LLVM 6 holdout was llvm-emscripten, which went away in #65501.

I've also included a fix for LLVM 8 lacking `MemorySanitizerOptions`,
which was broken by #66522.