### PR TITLE
[CI] fix the `! isCI` check in src/ci/run.sh

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -23,7 +23,7 @@ fi
 ci_dir=`cd $(dirname $0) && pwd`
 source "$ci_dir/shared.sh"
 
-if [ ! isCI ] || isCiBranch auto || isCiBranch beta; then
+if ! isCI || isCiBranch auto || isCiBranch beta; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set build.print-step-timings --enable-verbose-tests"
 fi
 


### PR DESCRIPTION
Using `if [ ! isCI ] || ...` doesn't run any command, just tests `isCI`
as a string, whereas `if ! isCI || ...` will actually run the `isCI`
command and negate its exit status.