### PR TITLE
Add long error for E0631 and update ui tests.

### DIFF
--- a/src/librustc_error_codes/error_codes.rs
+++ b/src/librustc_error_codes/error_codes.rs
@@ -347,6 +347,7 @@ E0622: include_str!("./error_codes/E0622.md"),
 E0623: include_str!("./error_codes/E0623.md"),
 E0624: include_str!("./error_codes/E0624.md"),
 E0626: include_str!("./error_codes/E0626.md"),
+E0631: include_str!("./error_codes/E0631.md"),
 E0633: include_str!("./error_codes/E0633.md"),
 E0635: include_str!("./error_codes/E0635.md"),
 E0636: include_str!("./error_codes/E0636.md"),
@@ -580,7 +581,6 @@ E0745: include_str!("./error_codes/E0745.md"),
     // rustc_const_unstable attribute must be paired with stable/unstable
     // attribute
     E0630,
-    E0631, // type mismatch in closure arguments
     E0632, // cannot provide explicit generic arguments when `impl Trait` is
            // used in argument position
     E0634, // type has conflicting packed representaton hints

--- a/src/librustc_error_codes/error_codes/E0631.md
+++ b/src/librustc_error_codes/error_codes/E0631.md
@@ -1,0 +1,29 @@
+This error indicates a type mismatch in closure arguments.
+
+Erroneous code example:
+
+```compile_fail,E0631
+fn test_strings(string_vec: Vec<String>) -> Vec<bool> {
+  string_vec
+    .iter()
+    .map(|arg: &i32| arg.eq("Test String"))
+    .collect()
+}
+```
+
+The closure passed to `map` expects a `&String` argument, since `some_vec`
+has the type `Vec<String>`.
+However, the closure argument is annotated as an `&i32`, which does not match
+the type of the iterable.
+
+This can be resolved by changing the type annotation or removing it entirely
+if it can be inferred.
+
+```
+fn test_strings(string_vec: Vec<String>) -> Vec<bool> {
+  string_vec
+    .iter()
+    .map(|arg| arg.eq("Test String"))
+    .collect()
+}
+```

--- a/src/librustc_error_codes/error_codes/E0631.md
+++ b/src/librustc_error_codes/error_codes/E0631.md
@@ -3,27 +3,25 @@ This error indicates a type mismatch in closure arguments.
 Erroneous code example:
 
 ```compile_fail,E0631
-fn test_strings(string_vec: Vec<String>) -> Vec<bool> {
-  string_vec
-    .iter()
-    .map(|arg: &i32| arg.eq("Test String"))
-    .collect()
+fn foo<F: Fn(i32)>(f: F) {
+}
+
+fn main() {
+    foo(|x: &str| {});
 }
 ```
 
-The closure passed to `map` expects a `&String` argument, since `some_vec`
-has the type `Vec<String>`.
-However, the closure argument is annotated as an `&i32`, which does not match
-the type of the iterable.
+The error occurs because `foo` accepts a closure that takes an `i32` argument,
+but in `main`, it is passed a closure with a `&str` argument.
 
 This can be resolved by changing the type annotation or removing it entirely
 if it can be inferred.
 
 ```
-fn test_strings(string_vec: Vec<String>) -> Vec<bool> {
-  string_vec
-    .iter()
-    .map(|arg| arg.eq("Test String"))
-    .collect()
+fn foo<F: Fn(i32)>(f: F) {
+}
+
+fn main() {
+    foo(|x: i32| {});
 }
 ```

--- a/src/test/ui/anonymous-higher-ranked-lifetime.stderr
+++ b/src/test/ui/anonymous-higher-ranked-lifetime.stderr
@@ -121,3 +121,4 @@ LL | fn h2<F>(_: F) where F: for<'t0> Fn(&(), Box<dyn Fn(&())>, &'t0 (), fn(&(),
 
 error: aborting due to 11 previous errors
 
+For more information about this error, try `rustc --explain E0631`.

--- a/src/test/ui/closure-expected-type/expect-fn-supply-fn.nll.stderr
+++ b/src/test/ui/closure-expected-type/expect-fn-supply-fn.nll.stderr
@@ -39,3 +39,4 @@ LL |     with_closure_expecting_fn_with_bound_region(|x: Foo<'_>, y| {
 
 error: aborting due to 3 previous errors
 
+For more information about this error, try `rustc --explain E0631`.

--- a/src/test/ui/closure-expected-type/expect-fn-supply-fn.stderr
+++ b/src/test/ui/closure-expected-type/expect-fn-supply-fn.stderr
@@ -77,4 +77,5 @@ LL |     with_closure_expecting_fn_with_bound_region(|x: Foo<'_>, y| {
 
 error: aborting due to 5 previous errors
 
-For more information about this error, try `rustc --explain E0308`.
+Some errors have detailed explanations: E0308, E0631.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/closure-expected-type/expect-infer-var-appearing-twice.stderr
+++ b/src/test/ui/closure-expected-type/expect-infer-var-appearing-twice.stderr
@@ -13,3 +13,4 @@ LL |     with_closure(|x: u32, y: i32| {
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0631`.

--- a/src/test/ui/closures/issue-41366.stderr
+++ b/src/test/ui/closures/issue-41366.stderr
@@ -19,4 +19,5 @@ LL |     (&|_|()) as &dyn for<'x> Fn(<u32 as T<'x>>::V);
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0271`.
+Some errors have detailed explanations: E0271, E0631.
+For more information about an error, try `rustc --explain E0271`.

--- a/src/test/ui/issues/issue-43623.stderr
+++ b/src/test/ui/issues/issue-43623.stderr
@@ -25,4 +25,5 @@ LL |     break_me::<Type, fn(_)>;
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0271`.
+Some errors have detailed explanations: E0271, E0631.
+For more information about an error, try `rustc --explain E0271`.

--- a/src/test/ui/issues/issue-60283.stderr
+++ b/src/test/ui/issues/issue-60283.stderr
@@ -27,4 +27,5 @@ LL |     foo((), drop)
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0271`.
+Some errors have detailed explanations: E0271, E0631.
+For more information about an error, try `rustc --explain E0271`.

--- a/src/test/ui/mismatched_types/E0631.stderr
+++ b/src/test/ui/mismatched_types/E0631.stderr
@@ -46,3 +46,4 @@ LL |     bar(f);
 
 error: aborting due to 4 previous errors
 
+For more information about this error, try `rustc --explain E0631`.

--- a/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
@@ -45,4 +45,5 @@ LL |     baz(f);
 
 error: aborting due to 5 previous errors
 
-For more information about this error, try `rustc --explain E0271`.
+Some errors have detailed explanations: E0271, E0631.
+For more information about an error, try `rustc --explain E0271`.

--- a/src/test/ui/mismatched_types/closure-mismatch.stderr
+++ b/src/test/ui/mismatched_types/closure-mismatch.stderr
@@ -24,4 +24,5 @@ LL |     baz(|_| ());
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0271`.
+Some errors have detailed explanations: E0271, E0631.
+For more information about an error, try `rustc --explain E0271`.

--- a/src/test/ui/mismatched_types/fn-variance-1.stderr
+++ b/src/test/ui/mismatched_types/fn-variance-1.stderr
@@ -24,3 +24,4 @@ LL |     apply(&mut 3, takes_imm);
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0631`.

--- a/src/test/ui/mismatched_types/issue-36053-2.stderr
+++ b/src/test/ui/mismatched_types/issue-36053-2.stderr
@@ -18,4 +18,5 @@ LL |     once::<&str>("str").fuse().filter(|a: &str| true).count();
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0599`.
+Some errors have detailed explanations: E0599, E0631.
+For more information about an error, try `rustc --explain E0599`.

--- a/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
+++ b/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
@@ -12,3 +12,4 @@ LL |     let z = call_it(3, f);
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0631`.


### PR DESCRIPTION
This PR adds a long error for `E0631`, which covers errors where closure argument types are mismatched. It also updates UI tests where this error is applicable.

Part of #61137 