### PR TITLE
Fix angle bracket formatting when dumping MIR debug vars

### DIFF
--- a/src/librustc_mir/util/graphviz.rs
+++ b/src/librustc_mir/util/graphviz.rs
@@ -202,7 +202,7 @@ fn write_graph_label<'tcx, W: Write>(
     }
 
     for var_debug_info in &body.var_debug_info {
-        write!(w, r#"debug {} => {};<br align="left"/>"#,
+        write!(w, r#"debug {} =&gt; {};<br align="left"/>"#,
                var_debug_info.name, escape(&var_debug_info.place))?;
     }
 


### PR DESCRIPTION
Fixes #66985