### PR TITLE
syntax: Box `ast::MacArgs` in attributes

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1017,14 +1017,14 @@ impl<'a> LoweringContext<'a> {
         }
     }
 
-    fn lower_mac_args(&mut self, args: &MacArgs) -> MacArgs {
-        match *args {
+    fn lower_mac_args(&mut self, args: &MacArgs) -> AstP<MacArgs> {
+        AstP(match *args {
             MacArgs::Empty => MacArgs::Empty,
             MacArgs::Delimited(dspan, delim, ref tokens) =>
                 MacArgs::Delimited(dspan, delim, self.lower_token_stream(tokens.clone())),
             MacArgs::Eq(eq_span, ref tokens) =>
                 MacArgs::Eq(eq_span, self.lower_token_stream(tokens.clone())),
-        }
+        })
     }
 
     fn lower_token_stream(&mut self, tokens: TokenStream) -> TokenStream {

--- a/src/librustc_parse/config.rs
+++ b/src/librustc_parse/config.rs
@@ -101,7 +101,7 @@ impl<'a> StripUnconfigured<'a> {
         if !attr.has_name(sym::cfg_attr) {
             return vec![attr];
         }
-        if let ast::MacArgs::Empty = attr.get_normal_item().args {
+        if let ast::MacArgs::Empty = *attr.get_normal_item().args {
             self.sess.span_diagnostic
                 .struct_span_err(
                     attr.span,

--- a/src/librustc_parse/parser/mod.rs
+++ b/src/librustc_parse/parser/mod.rs
@@ -1011,15 +1011,15 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_mac_args(&mut self) -> PResult<'a, P<MacArgs>> {
-        self.parse_mac_args_common(true).map(P)
+        self.parse_mac_args_common(true)
     }
 
-    fn parse_attr_args(&mut self) -> PResult<'a, MacArgs> {
+    fn parse_attr_args(&mut self) -> PResult<'a, P<MacArgs>> {
         self.parse_mac_args_common(false)
     }
 
-    fn parse_mac_args_common(&mut self, delimited_only: bool) -> PResult<'a, MacArgs> {
-        Ok(if self.check(&token::OpenDelim(DelimToken::Paren)) ||
+    fn parse_mac_args_common(&mut self, delimited_only: bool) -> PResult<'a, P<MacArgs>> {
+        Ok(P(if self.check(&token::OpenDelim(DelimToken::Paren)) ||
                        self.check(&token::OpenDelim(DelimToken::Bracket)) ||
                        self.check(&token::OpenDelim(DelimToken::Brace)) {
             match self.parse_token_tree() {
@@ -1052,7 +1052,7 @@ impl<'a> Parser<'a> {
             }
         } else {
             return self.unexpected();
-        })
+        }))
     }
 
     fn parse_or_use_outer_attributes(

--- a/src/librustc_parse/parser/path.rs
+++ b/src/librustc_parse/parser/path.rs
@@ -115,7 +115,7 @@ impl<'a> Parser<'a> {
     fn parse_path_allowing_meta(&mut self, style: PathStyle) -> PResult<'a, Path> {
         let meta_ident = match self.token.kind {
             token::Interpolated(ref nt) => match **nt {
-                token::NtMeta(ref item) => match item.args {
+                token::NtMeta(ref item) => match *item.args {
                     MacArgs::Empty => Some(item.path.clone()),
                     _ => None,
                 },

--- a/src/librustc_parse/validate_attr.rs
+++ b/src/librustc_parse/validate_attr.rs
@@ -17,7 +17,7 @@ pub fn check_meta(sess: &ParseSess, attr: &Attribute) {
         // `rustc_dummy` doesn't have any restrictions specific to built-in attributes.
         Some((name, _, template, _)) if name != sym::rustc_dummy =>
             check_builtin_attribute(sess, attr, name, template),
-        _ => if let MacArgs::Eq(..) = attr.get_normal_item().args {
+        _ => if let MacArgs::Eq(..) = *attr.get_normal_item().args {
             // All key-value attributes are restricted to meta-item syntax.
             parse_meta(sess, attr).map_err(|mut err| err.emit()).ok();
         }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -2411,6 +2411,10 @@ pub enum AttrKind {
     DocComment(Symbol),
 }
 
+// Receive notifications about the doc comment size changes.
+#[cfg(target_arch = "x86_64")]
+rustc_data_structures::static_assert_size!(AttrKind, 72);
+
 /// `TraitRef`s appear in impls.
 ///
 /// Resolution maps each `TraitRef`'s `ref_id` to its defining trait; that's all

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -2382,7 +2382,7 @@ impl rustc_serialize::Decodable for AttrId {
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug, HashStable_Generic)]
 pub struct AttrItem {
     pub path: Path,
-    pub args: MacArgs,
+    pub args: P<MacArgs>,
 }
 
 /// Metadata associated with an item.
@@ -2413,7 +2413,7 @@ pub enum AttrKind {
 
 // Receive notifications about the doc comment size changes.
 #[cfg(target_arch = "x86_64")]
-rustc_data_structures::static_assert_size!(AttrKind, 72);
+rustc_data_structures::static_assert_size!(AttrKind, 48);
 
 /// `TraitRef`s appear in impls.
 ///

--- a/src/libsyntax/attr/mod.rs
+++ b/src/libsyntax/attr/mod.rs
@@ -198,7 +198,7 @@ impl Attribute {
 
     pub fn is_word(&self) -> bool {
         if let AttrKind::Normal(item) = &self.kind {
-            matches!(item.args, MacArgs::Empty)
+            matches!(*item.args, MacArgs::Empty)
         } else {
             false
         }
@@ -354,7 +354,7 @@ crate fn mk_attr_id() -> AttrId {
     AttrId(id)
 }
 
-pub fn mk_attr(style: AttrStyle, path: Path, args: MacArgs, span: Span) -> Attribute {
+pub fn mk_attr(style: AttrStyle, path: Path, args: P<MacArgs>, span: Span) -> Attribute {
     mk_attr_from_item(style, AttrItem { path, args }, span)
 }
 
@@ -512,8 +512,8 @@ impl MetaItem {
 }
 
 impl MetaItemKind {
-    pub fn mac_args(&self, span: Span) -> MacArgs {
-        match self {
+    pub fn mac_args(&self, span: Span) -> P<MacArgs> {
+        P(match self {
             MetaItemKind::Word => MacArgs::Empty,
             MetaItemKind::NameValue(lit) => MacArgs::Eq(span, lit.token_tree().into()),
             MetaItemKind::List(list) => {
@@ -528,7 +528,7 @@ impl MetaItemKind {
                     DelimSpan::from_single(span), MacDelimiter::Parenthesis, TokenStream::new(tts)
                 )
             }
-        }
+        })
     }
 
     fn token_trees_and_joints(&self, span: Span) -> Vec<TreeAndJoint> {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -639,7 +639,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
 
     fn print_attr_item(&mut self, item: &ast::AttrItem, span: Span) {
         self.ibox(0);
-        match &item.args {
+        match &*item.args {
             MacArgs::Delimited(_, delim, tokens) => self.print_mac_common(
                 Some(MacHeader::Path(&item.path)),
                 false,
@@ -651,7 +651,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
             ),
             MacArgs::Empty | MacArgs::Eq(..) => {
                 self.print_path(&item.path, false, 0);
-                if let MacArgs::Eq(_, tokens) = &item.args {
+                if let MacArgs::Eq(_, tokens) = &*item.args {
                     self.space();
                     self.word_space("=");
                     self.print_tts(tokens.clone(), true);

--- a/src/libsyntax_expand/expand.rs
+++ b/src/libsyntax_expand/expand.rs
@@ -642,7 +642,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                             => panic!("unexpected annotatable"),
                     })), DUMMY_SP).into();
                     let item = attr.unwrap_normal_item();
-                    if let MacArgs::Eq(..) = item.args {
+                    if let MacArgs::Eq(..) = *item.args {
                         self.cx.span_err(span, "key-value macro attributes are not supported");
                     }
                     let tok_result =

--- a/src/libsyntax_expand/proc_macro.rs
+++ b/src/libsyntax_expand/proc_macro.rs
@@ -183,7 +183,7 @@ crate fn collect_derives(cx: &mut ExtCtxt<'_>, attrs: &mut Vec<ast::Attribute>) 
         }
 
         let parse_derive_paths = |attr: &ast::Attribute| {
-            if let MacArgs::Empty = attr.get_normal_item().args {
+            if let MacArgs::Empty = *attr.get_normal_item().args {
                 return Ok(Vec::new());
             }
             rustc_parse::parse_in_attr(cx.parse_sess, attr, |p| p.parse_derive_paths())


### PR DESCRIPTION
This reduces size of doc comments at cost of an allocation / indirection in regular attributes.
Fn-like macros already have `MacArgs` boxed.

Follow-up to https://github.com/rust-lang/rust/pull/66935.