### PR TITLE
Include a span in more `expected...found` notes

### DIFF
--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -1809,12 +1809,17 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                             sub_region,
                             "...",
                         );
-                        err.note(&format!(
-                            "...so that the {}:\nexpected {}\n   found {}",
-                            sup_trace.cause.as_requirement_str(),
-                            sup_expected.content(),
-                            sup_found.content()
+                        err.span_note(sup_trace.cause.span, &format!(
+                            "...so that the {}",
+                            sup_trace.cause.as_requirement_str()
                         ));
+
+                        err.note_expected_found(
+                            &"",
+                            sup_expected,
+                            &"",
+                            sup_found
+                        );
                         err.emit();
                         return;
                     }

--- a/src/librustc/infer/error_reporting/note.rs
+++ b/src/librustc/infer/error_reporting/note.rs
@@ -13,12 +13,20 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         match *origin {
             infer::Subtype(ref trace) => {
                 if let Some((expected, found)) = self.values_str(&trace.values) {
-                    let expected = expected.content();
-                    let found = found.content();
-                    err.note(&format!("...so that the {}:\nexpected {}\n   found {}",
-                                      trace.cause.as_requirement_str(),
-                                      expected,
-                                      found));
+                    err.span_note(
+                        trace.cause.span,
+                        &format!(
+                            "...so that the {}",
+                            trace.cause.as_requirement_str()
+                        )
+                    );
+
+                    err.note_expected_found(
+                        &"",
+                        expected,
+                        &"",
+                        found
+                    );
                 } else {
                     // FIXME: this really should be handled at some earlier stage. Our
                     // handling of region checking when type errors are present is

--- a/src/test/ui/associated-types/cache/project-fn-ret-invariant.transmute.stderr
+++ b/src/test/ui/associated-types/cache/project-fn-ret-invariant.transmute.stderr
@@ -9,13 +9,21 @@ note: first, the lifetime cannot outlive the lifetime `'a` as defined on the fun
    |
 LL | fn baz<'a,'b>(x: Type<'a>) -> Type<'static> {
    |        ^^
-   = note: ...so that the expression is assignable:
-           expected Type<'_>
-              found Type<'a>
+note: ...so that the expression is assignable
+  --> $DIR/project-fn-ret-invariant.rs:48:13
+   |
+LL |    bar(foo, x)
+   |             ^
+   = note: expected  `Type<'_>`
+              found  `Type<'a>`
    = note: but, the lifetime must be valid for the static lifetime...
-   = note: ...so that the expression is assignable:
-           expected Type<'static>
-              found Type<'_>
+note: ...so that the expression is assignable
+  --> $DIR/project-fn-ret-invariant.rs:48:4
+   |
+LL |    bar(foo, x)
+   |    ^^^^^^^^^^^
+   = note: expected  `Type<'static>`
+              found  `Type<'_>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/c-variadic/variadic-ffi-4.stderr
+++ b/src/test/ui/c-variadic/variadic-ffi-4.stderr
@@ -49,9 +49,13 @@ note: first, the lifetime cannot outlive the anonymous lifetime #2 defined on th
    |
 LL |     let _ = ap.with_copy(|ap| { ap });
    |                          ^^^^^^^^^^^
-   = note: ...so that the expression is assignable:
-           expected core::ffi::VaList<'_, '_>
-              found core::ffi::VaList<'_, '_>
+note: ...so that the expression is assignable
+  --> $DIR/variadic-ffi-4.rs:16:33
+   |
+LL |     let _ = ap.with_copy(|ap| { ap });
+   |                                 ^^
+   = note: expected  `core::ffi::VaList<'_, '_>`
+              found  `core::ffi::VaList<'_, '_>`
 note: but, the lifetime must be valid for the method call at 16:13...
   --> $DIR/variadic-ffi-4.rs:16:13
    |

--- a/src/test/ui/impl-header-lifetime-elision/dyn-trait.stderr
+++ b/src/test/ui/impl-header-lifetime-elision/dyn-trait.stderr
@@ -9,13 +9,21 @@ note: first, the lifetime cannot outlive the lifetime `'a` as defined on the fun
    |
 LL | fn with_dyn_debug_static<'a>(x: Box<dyn Debug + 'a>) {
    |                          ^^
-   = note: ...so that the expression is assignable:
-           expected std::boxed::Box<dyn std::fmt::Debug>
-              found std::boxed::Box<(dyn std::fmt::Debug + 'a)>
+note: ...so that the expression is assignable
+  --> $DIR/dyn-trait.rs:20:16
+   |
+LL |     static_val(x);
+   |                ^
+   = note: expected  `std::boxed::Box<dyn std::fmt::Debug>`
+              found  `std::boxed::Box<(dyn std::fmt::Debug + 'a)>`
    = note: but, the lifetime must be valid for the static lifetime...
-   = note: ...so that the types are compatible:
-           expected StaticTrait
-              found StaticTrait
+note: ...so that the types are compatible
+  --> $DIR/dyn-trait.rs:20:5
+   |
+LL |     static_val(x);
+   |     ^^^^^^^^^^
+   = note: expected  `StaticTrait`
+              found  `StaticTrait`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-16683.stderr
+++ b/src/test/ui/issues/issue-16683.stderr
@@ -21,9 +21,13 @@ note: but, the lifetime must be valid for the lifetime `'a` as defined on the tr
    |
 LL | trait T<'a> {
    |         ^^
-   = note: ...so that the types are compatible:
-           expected &'a Self
-              found &Self
+note: ...so that the types are compatible
+  --> $DIR/issue-16683.rs:4:14
+   |
+LL |         self.a();
+   |              ^
+   = note: expected  `&'a Self`
+              found  `&Self`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17758.stderr
+++ b/src/test/ui/issues/issue-17758.stderr
@@ -22,9 +22,13 @@ note: but, the lifetime must be valid for the lifetime `'a` as defined on the tr
    |
 LL | trait Foo<'a> {
    |           ^^
-   = note: ...so that the types are compatible:
-           expected &'a Self
-              found &Self
+note: ...so that the types are compatible
+  --> $DIR/issue-17758.rs:7:14
+   |
+LL |         self.foo();
+   |              ^^^
+   = note: expected  `&'a Self`
+              found  `&Self`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-20831-debruijn.stderr
+++ b/src/test/ui/issues/issue-20831-debruijn.stderr
@@ -88,9 +88,19 @@ note: ...but the lifetime must also be valid for the lifetime `'a` as defined on
    |
 LL | impl<'a> Publisher<'a> for MyStruct<'a> {
    |      ^^
-   = note: ...so that the types are compatible:
-           expected Publisher<'_>
-              found Publisher<'_>
+note: ...so that the types are compatible
+  --> $DIR/issue-20831-debruijn.rs:28:5
+   |
+LL | /     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
+LL | |         // Not obvious, but there is an implicit lifetime here -------^
+LL | |
+LL | |
+...  |
+LL | |         self.sub = t;
+LL | |     }
+   | |_____^
+   = note: expected  `Publisher<'_>`
+              found  `Publisher<'_>`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-52213.stderr
+++ b/src/test/ui/issues/issue-52213.stderr
@@ -9,9 +9,13 @@ note: first, the lifetime cannot outlive the lifetime `'a` as defined on the fun
    |
 LL | fn transmute_lifetime<'a, 'b, T>(t: &'a (T,)) -> &'b T {
    |                       ^^
-   = note: ...so that the types are compatible:
-           expected (&&(T,),)
-              found (&&'a (T,),)
+note: ...so that the types are compatible
+  --> $DIR/issue-52213.rs:2:11
+   |
+LL |     match (&t,) {
+   |           ^^^^^
+   = note: expected  `(&&(T,),)`
+              found  `(&&'a (T,),)`
 note: but, the lifetime must be valid for the lifetime `'b` as defined on the function body at 1:27...
   --> $DIR/issue-52213.rs:1:27
    |

--- a/src/test/ui/issues/issue-55796.stderr
+++ b/src/test/ui/issues/issue-55796.stderr
@@ -15,9 +15,13 @@ note: ...so that the type `std::iter::Map<<Self as Graph<'a>>::EdgesIter, [closu
 LL |         Box::new(self.out_edges(u).map(|e| e.target()))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: but, the lifetime must be valid for the static lifetime...
-   = note: ...so that the expression is assignable:
-           expected std::boxed::Box<(dyn std::iter::Iterator<Item = <Self as Graph<'a>>::Node> + 'static)>
-              found std::boxed::Box<dyn std::iter::Iterator<Item = <Self as Graph<'a>>::Node>>
+note: ...so that the expression is assignable
+  --> $DIR/issue-55796.rs:16:9
+   |
+LL |         Box::new(self.out_edges(u).map(|e| e.target()))
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: expected  `std::boxed::Box<(dyn std::iter::Iterator<Item = <Self as Graph<'a>>::Node> + 'static)>`
+              found  `std::boxed::Box<dyn std::iter::Iterator<Item = <Self as Graph<'a>>::Node>>`
 
 error[E0495]: cannot infer an appropriate lifetime due to conflicting requirements
   --> $DIR/issue-55796.rs:21:9
@@ -36,9 +40,13 @@ note: ...so that the type `std::iter::Map<<Self as Graph<'a>>::EdgesIter, [closu
 LL |         Box::new(self.in_edges(u).map(|e| e.target()))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: but, the lifetime must be valid for the static lifetime...
-   = note: ...so that the expression is assignable:
-           expected std::boxed::Box<(dyn std::iter::Iterator<Item = <Self as Graph<'a>>::Node> + 'static)>
-              found std::boxed::Box<dyn std::iter::Iterator<Item = <Self as Graph<'a>>::Node>>
+note: ...so that the expression is assignable
+  --> $DIR/issue-55796.rs:21:9
+   |
+LL |         Box::new(self.in_edges(u).map(|e| e.target()))
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: expected  `std::boxed::Box<(dyn std::iter::Iterator<Item = <Self as Graph<'a>>::Node> + 'static)>`
+              found  `std::boxed::Box<dyn std::iter::Iterator<Item = <Self as Graph<'a>>::Node>>`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/issue-55394.stderr
+++ b/src/test/ui/nll/issue-55394.stderr
@@ -21,9 +21,13 @@ note: but, the lifetime must be valid for the lifetime `'_` as defined on the im
    |
 LL | impl Foo<'_> {
    |          ^^
-   = note: ...so that the expression is assignable:
-           expected Foo<'_>
-              found Foo<'_>
+note: ...so that the expression is assignable
+  --> $DIR/issue-55394.rs:9:9
+   |
+LL |         Foo { bar }
+   |         ^^^^^^^^^^^
+   = note: expected  `Foo<'_>`
+              found  `Foo<'_>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/normalization-bounds-error.stderr
+++ b/src/test/ui/nll/normalization-bounds-error.stderr
@@ -14,9 +14,13 @@ note: ...but the lifetime must also be valid for the lifetime `'a` as defined on
    |
 LL | fn visit_seq<'d, 'a: 'd>() -> <&'a () as Visitor<'d>>::Value {}
    |                  ^^
-   = note: ...so that the types are compatible:
-           expected Visitor<'d>
-              found Visitor<'_>
+note: ...so that the types are compatible
+  --> $DIR/normalization-bounds-error.rs:12:1
+   |
+LL | fn visit_seq<'d, 'a: 'd>() -> <&'a () as Visitor<'d>>::Value {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: expected  `Visitor<'d>`
+              found  `Visitor<'_>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/type-alias-free-regions.stderr
+++ b/src/test/ui/nll/type-alias-free-regions.stderr
@@ -11,17 +11,25 @@ LL | /     fn from_box(b: Box<B>) -> Self {
 LL | |         C { f: b }
 LL | |     }
    | |_____^
-   = note: ...so that the expression is assignable:
-           expected std::boxed::Box<std::boxed::Box<&isize>>
-              found std::boxed::Box<std::boxed::Box<&isize>>
+note: ...so that the expression is assignable
+  --> $DIR/type-alias-free-regions.rs:17:16
+   |
+LL |         C { f: b }
+   |                ^
+   = note: expected  `std::boxed::Box<std::boxed::Box<&isize>>`
+              found  `std::boxed::Box<std::boxed::Box<&isize>>`
 note: but, the lifetime must be valid for the lifetime `'a` as defined on the impl at 15:6...
   --> $DIR/type-alias-free-regions.rs:15:6
    |
 LL | impl<'a> FromBox<'a> for C<'a> {
    |      ^^
-   = note: ...so that the expression is assignable:
-           expected C<'a>
-              found C<'_>
+note: ...so that the expression is assignable
+  --> $DIR/type-alias-free-regions.rs:17:9
+   |
+LL |         C { f: b }
+   |         ^^^^^^^^^^
+   = note: expected  `C<'a>`
+              found  `C<'_>`
 
 error[E0495]: cannot infer an appropriate lifetime due to conflicting requirements
   --> $DIR/type-alias-free-regions.rs:27:16
@@ -36,17 +44,25 @@ LL | /     fn from_tuple(b: (B,)) -> Self {
 LL | |         C { f: Box::new(b.0) }
 LL | |     }
    | |_____^
-   = note: ...so that the expression is assignable:
-           expected std::boxed::Box<&isize>
-              found std::boxed::Box<&isize>
+note: ...so that the expression is assignable
+  --> $DIR/type-alias-free-regions.rs:27:25
+   |
+LL |         C { f: Box::new(b.0) }
+   |                         ^^^
+   = note: expected  `std::boxed::Box<&isize>`
+              found  `std::boxed::Box<&isize>`
 note: but, the lifetime must be valid for the lifetime `'a` as defined on the impl at 25:6...
   --> $DIR/type-alias-free-regions.rs:25:6
    |
 LL | impl<'a> FromTuple<'a> for C<'a> {
    |      ^^
-   = note: ...so that the expression is assignable:
-           expected C<'a>
-              found C<'_>
+note: ...so that the expression is assignable
+  --> $DIR/type-alias-free-regions.rs:27:9
+   |
+LL |         C { f: Box::new(b.0) }
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   = note: expected  `C<'a>`
+              found  `C<'_>`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/user-annotations/constant-in-expr-inherent-1.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-inherent-1.stderr
@@ -9,9 +9,13 @@ note: first, the lifetime cannot outlive the lifetime `'a` as defined on the fun
    |
 LL | fn foo<'a>(_: &'a u32) -> &'static u32 {
    |        ^^
-   = note: ...so that the types are compatible:
-           expected Foo<'_>
-              found Foo<'a>
+note: ...so that the types are compatible
+  --> $DIR/constant-in-expr-inherent-1.rs:8:5
+   |
+LL |     <Foo<'a>>::C
+   |     ^^^^^^^^^^^^
+   = note: expected  `Foo<'_>`
+              found  `Foo<'a>`
    = note: but, the lifetime must be valid for the static lifetime...
 note: ...so that reference does not outlive borrowed content
   --> $DIR/constant-in-expr-inherent-1.rs:8:5

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-3.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-3.stderr
@@ -9,9 +9,13 @@ note: first, the lifetime cannot outlive the lifetime `'a` as defined on the fun
    |
 LL | fn foo<'a, T: Foo<'a>>() -> &'static u32 {
    |        ^^
-   = note: ...so that the types are compatible:
-           expected Foo<'_>
-              found Foo<'a>
+note: ...so that the types are compatible
+  --> $DIR/constant-in-expr-trait-item-3.rs:10:5
+   |
+LL |     T::C
+   |     ^^^^
+   = note: expected  `Foo<'_>`
+              found  `Foo<'a>`
    = note: but, the lifetime must be valid for the static lifetime...
 note: ...so that reference does not outlive borrowed content
   --> $DIR/constant-in-expr-trait-item-3.rs:10:5

--- a/src/test/ui/object-lifetime/object-lifetime-default-elision.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-elision.stderr
@@ -19,9 +19,13 @@ note: but, the lifetime must be valid for the lifetime `'b` as defined on the fu
    |
 LL | fn load3<'a,'b>(ss: &'a dyn SomeTrait) -> &'b dyn SomeTrait {
    |             ^^
-   = note: ...so that the expression is assignable:
-           expected &'b (dyn SomeTrait + 'b)
-              found &dyn SomeTrait
+note: ...so that the expression is assignable
+  --> $DIR/object-lifetime-default-elision.rs:71:5
+   |
+LL |     ss
+   |     ^^
+   = note: expected  `&'b (dyn SomeTrait + 'b)`
+              found  `&dyn SomeTrait`
 
 error[E0495]: cannot infer an appropriate lifetime due to conflicting requirements
   --> $DIR/object-lifetime-default-elision.rs:71:5
@@ -44,9 +48,13 @@ note: but, the lifetime must be valid for the lifetime `'b` as defined on the fu
    |
 LL | fn load3<'a,'b>(ss: &'a dyn SomeTrait) -> &'b dyn SomeTrait {
    |             ^^
-   = note: ...so that the expression is assignable:
-           expected &'b (dyn SomeTrait + 'b)
-              found &dyn SomeTrait
+note: ...so that the expression is assignable
+  --> $DIR/object-lifetime-default-elision.rs:71:5
+   |
+LL |     ss
+   |     ^^
+   = note: expected  `&'b (dyn SomeTrait + 'b)`
+              found  `&dyn SomeTrait`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/regions/region-object-lifetime-in-coercion.stderr
+++ b/src/test/ui/regions/region-object-lifetime-in-coercion.stderr
@@ -34,17 +34,25 @@ note: first, the lifetime cannot outlive the lifetime `'a` as defined on the fun
    |
 LL | fn d<'a,'b>(v: &'a [u8]) -> Box<dyn Foo+'b> {
    |      ^^
-   = note: ...so that the expression is assignable:
-           expected &[u8]
-              found &'a [u8]
+note: ...so that the expression is assignable
+  --> $DIR/region-object-lifetime-in-coercion.rs:26:14
+   |
+LL |     Box::new(v)
+   |              ^
+   = note: expected  `&[u8]`
+              found  `&'a [u8]`
 note: but, the lifetime must be valid for the lifetime `'b` as defined on the function body at 25:9...
   --> $DIR/region-object-lifetime-in-coercion.rs:25:9
    |
 LL | fn d<'a,'b>(v: &'a [u8]) -> Box<dyn Foo+'b> {
    |         ^^
-   = note: ...so that the expression is assignable:
-           expected std::boxed::Box<(dyn Foo + 'b)>
-              found std::boxed::Box<dyn Foo>
+note: ...so that the expression is assignable
+  --> $DIR/region-object-lifetime-in-coercion.rs:26:5
+   |
+LL |     Box::new(v)
+   |     ^^^^^^^^^^^
+   = note: expected  `std::boxed::Box<(dyn Foo + 'b)>`
+              found  `std::boxed::Box<dyn Foo>`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/regions/regions-assoc-type-region-bound-in-trait-not-met.stderr
+++ b/src/test/ui/regions/regions-assoc-type-region-bound-in-trait-not-met.stderr
@@ -9,9 +9,13 @@ note: first, the lifetime cannot outlive the lifetime `'a` as defined on the imp
    |
 LL | impl<'a> Foo<'static> for &'a i32 {
    |      ^^
-   = note: ...so that the types are compatible:
-           expected Foo<'static>
-              found Foo<'static>
+note: ...so that the types are compatible
+  --> $DIR/regions-assoc-type-region-bound-in-trait-not-met.rs:14:10
+   |
+LL | impl<'a> Foo<'static> for &'a i32 {
+   |          ^^^^^^^^^^^^
+   = note: expected  `Foo<'static>`
+              found  `Foo<'static>`
    = note: but, the lifetime must be valid for the static lifetime...
 note: ...so that the type `&i32` will meet its required lifetime bounds
   --> $DIR/regions-assoc-type-region-bound-in-trait-not-met.rs:14:10
@@ -30,9 +34,13 @@ note: first, the lifetime cannot outlive the lifetime `'a` as defined on the imp
    |
 LL | impl<'a,'b> Foo<'b> for &'a i64 {
    |      ^^
-   = note: ...so that the types are compatible:
-           expected Foo<'b>
-              found Foo<'_>
+note: ...so that the types are compatible
+  --> $DIR/regions-assoc-type-region-bound-in-trait-not-met.rs:19:13
+   |
+LL | impl<'a,'b> Foo<'b> for &'a i64 {
+   |             ^^^^^^^
+   = note: expected  `Foo<'b>`
+              found  `Foo<'_>`
 note: but, the lifetime must be valid for the lifetime `'b` as defined on the impl at 19:9...
   --> $DIR/regions-assoc-type-region-bound-in-trait-not-met.rs:19:9
    |

--- a/src/test/ui/regions/regions-assoc-type-static-bound-in-trait-not-met.stderr
+++ b/src/test/ui/regions/regions-assoc-type-static-bound-in-trait-not-met.stderr
@@ -9,9 +9,13 @@ note: first, the lifetime cannot outlive the lifetime `'a` as defined on the imp
    |
 LL | impl<'a> Foo for &'a i32 {
    |      ^^
-   = note: ...so that the types are compatible:
-           expected Foo
-              found Foo
+note: ...so that the types are compatible
+  --> $DIR/regions-assoc-type-static-bound-in-trait-not-met.rs:9:10
+   |
+LL | impl<'a> Foo for &'a i32 {
+   |          ^^^
+   = note: expected  `Foo`
+              found  `Foo`
    = note: but, the lifetime must be valid for the static lifetime...
 note: ...so that the type `&i32` will meet its required lifetime bounds
   --> $DIR/regions-assoc-type-static-bound-in-trait-not-met.rs:9:10

--- a/src/test/ui/regions/regions-close-object-into-object-2.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-2.stderr
@@ -15,9 +15,13 @@ note: ...so that the type `(dyn A<T> + 'a)` is not borrowed for too long
 LL |     box B(&*v) as Box<dyn X>
    |           ^^^
    = note: but, the lifetime must be valid for the static lifetime...
-   = note: ...so that the expression is assignable:
-           expected std::boxed::Box<(dyn X + 'static)>
-              found std::boxed::Box<dyn X>
+note: ...so that the expression is assignable
+  --> $DIR/regions-close-object-into-object-2.rs:10:5
+   |
+LL |     box B(&*v) as Box<dyn X>
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: expected  `std::boxed::Box<(dyn X + 'static)>`
+              found  `std::boxed::Box<dyn X>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-close-object-into-object-4.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-4.stderr
@@ -15,9 +15,13 @@ note: ...so that the type `(dyn A<U> + 'a)` is not borrowed for too long
 LL |     box B(&*v) as Box<dyn X>
    |           ^^^
    = note: but, the lifetime must be valid for the static lifetime...
-   = note: ...so that the expression is assignable:
-           expected std::boxed::Box<(dyn X + 'static)>
-              found std::boxed::Box<dyn X>
+note: ...so that the expression is assignable
+  --> $DIR/regions-close-object-into-object-4.rs:10:5
+   |
+LL |     box B(&*v) as Box<dyn X>
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: expected  `std::boxed::Box<(dyn X + 'static)>`
+              found  `std::boxed::Box<dyn X>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-close-over-type-parameter-multiple.stderr
+++ b/src/test/ui/regions/regions-close-over-type-parameter-multiple.stderr
@@ -19,9 +19,13 @@ note: but, the lifetime must be valid for the lifetime `'c` as defined on the fu
    |
 LL | fn make_object_bad<'a,'b,'c,A:SomeTrait+'a+'b>(v: A) -> Box<dyn SomeTrait + 'c> {
    |                          ^^
-   = note: ...so that the expression is assignable:
-           expected std::boxed::Box<(dyn SomeTrait + 'c)>
-              found std::boxed::Box<dyn SomeTrait>
+note: ...so that the expression is assignable
+  --> $DIR/regions-close-over-type-parameter-multiple.rs:20:5
+   |
+LL |     box v as Box<dyn SomeTrait + 'a>
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: expected  `std::boxed::Box<(dyn SomeTrait + 'c)>`
+              found  `std::boxed::Box<dyn SomeTrait>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-creating-enums4.stderr
+++ b/src/test/ui/regions/regions-creating-enums4.stderr
@@ -9,17 +9,25 @@ note: first, the lifetime cannot outlive the lifetime `'a` as defined on the fun
    |
 LL | fn mk_add_bad2<'a,'b>(x: &'a Ast<'a>, y: &'a Ast<'a>, z: &Ast) -> Ast<'b> {
    |                ^^
-   = note: ...so that the expression is assignable:
-           expected &Ast<'_>
-              found &Ast<'a>
+note: ...so that the expression is assignable
+  --> $DIR/regions-creating-enums4.rs:7:14
+   |
+LL |     Ast::Add(x, y)
+   |              ^
+   = note: expected  `&Ast<'_>`
+              found  `&Ast<'a>`
 note: but, the lifetime must be valid for the lifetime `'b` as defined on the function body at 6:19...
   --> $DIR/regions-creating-enums4.rs:6:19
    |
 LL | fn mk_add_bad2<'a,'b>(x: &'a Ast<'a>, y: &'a Ast<'a>, z: &Ast) -> Ast<'b> {
    |                   ^^
-   = note: ...so that the expression is assignable:
-           expected Ast<'b>
-              found Ast<'_>
+note: ...so that the expression is assignable
+  --> $DIR/regions-creating-enums4.rs:7:5
+   |
+LL |     Ast::Add(x, y)
+   |     ^^^^^^^^^^^^^^
+   = note: expected  `Ast<'b>`
+              found  `Ast<'_>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-escape-method.stderr
+++ b/src/test/ui/regions/regions-escape-method.stderr
@@ -9,9 +9,13 @@ note: first, the lifetime cannot outlive the anonymous lifetime #2 defined on th
    |
 LL |     s.f(|p| p)
    |         ^^^^^
-   = note: ...so that the expression is assignable:
-           expected &i32
-              found &i32
+note: ...so that the expression is assignable
+  --> $DIR/regions-escape-method.rs:15:13
+   |
+LL |     s.f(|p| p)
+   |             ^
+   = note: expected  `&i32`
+              found  `&i32`
 note: but, the lifetime must be valid for the method call at 15:5...
   --> $DIR/regions-escape-method.rs:15:5
    |

--- a/src/test/ui/regions/regions-escape-via-trait-or-not.stderr
+++ b/src/test/ui/regions/regions-escape-via-trait-or-not.stderr
@@ -9,9 +9,13 @@ note: first, the lifetime cannot outlive the anonymous lifetime #2 defined on th
    |
 LL |     with(|o| o)
    |          ^^^^^
-   = note: ...so that the expression is assignable:
-           expected &isize
-              found &isize
+note: ...so that the expression is assignable
+  --> $DIR/regions-escape-via-trait-or-not.rs:18:14
+   |
+LL |     with(|o| o)
+   |              ^
+   = note: expected  `&isize`
+              found  `&isize`
 note: but, the lifetime must be valid for the expression at 18:5...
   --> $DIR/regions-escape-via-trait-or-not.rs:18:5
    |

--- a/src/test/ui/regions/regions-nested-fns.stderr
+++ b/src/test/ui/regions/regions-nested-fns.stderr
@@ -29,9 +29,18 @@ LL | |         if false { return ay; }
 LL | |         return z;
 LL | |     }));
    | |_____^
-   = note: ...so that the types are compatible:
-           expected &isize
-              found &isize
+note: ...so that the types are compatible
+  --> $DIR/regions-nested-fns.rs:13:76
+   |
+LL |       ignore::< Box<dyn for<'z> FnMut(&'z isize) -> &'z isize>>(Box::new(|z| {
+   |  ____________________________________________________________________________^
+LL | |         if false { return x; }
+LL | |         if false { return ay; }
+LL | |         return z;
+LL | |     }));
+   | |_____^
+   = note: expected  `&isize`
+              found  `&isize`
 
 error[E0312]: lifetime of reference outlives lifetime of borrowed content...
   --> $DIR/regions-nested-fns.rs:14:27

--- a/src/test/ui/regions/regions-normalize-in-where-clause-list.stderr
+++ b/src/test/ui/regions/regions-normalize-in-where-clause-list.stderr
@@ -17,9 +17,16 @@ note: ...but the lifetime must also be valid for the lifetime `'b` as defined on
    |
 LL | fn bar<'a, 'b>()
    |            ^^
-   = note: ...so that the types are compatible:
-           expected Project<'a, 'b>
-              found Project<'_, '_>
+note: ...so that the types are compatible
+  --> $DIR/regions-normalize-in-where-clause-list.rs:22:1
+   |
+LL | / fn bar<'a, 'b>()
+LL | |     where <() as Project<'a, 'b>>::Item : Eq
+LL | | {
+LL | | }
+   | |_^
+   = note: expected  `Project<'a, 'b>`
+              found  `Project<'_, '_>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-ret-borrowed-1.stderr
+++ b/src/test/ui/regions/regions-ret-borrowed-1.stderr
@@ -9,9 +9,13 @@ note: first, the lifetime cannot outlive the anonymous lifetime #2 defined on th
    |
 LL |     with(|o| o)
    |          ^^^^^
-   = note: ...so that the expression is assignable:
-           expected &isize
-              found &isize
+note: ...so that the expression is assignable
+  --> $DIR/regions-ret-borrowed-1.rs:10:14
+   |
+LL |     with(|o| o)
+   |              ^
+   = note: expected  `&isize`
+              found  `&isize`
 note: but, the lifetime must be valid for the lifetime `'a` as defined on the function body at 9:14...
   --> $DIR/regions-ret-borrowed-1.rs:9:14
    |

--- a/src/test/ui/regions/regions-ret-borrowed.stderr
+++ b/src/test/ui/regions/regions-ret-borrowed.stderr
@@ -9,9 +9,13 @@ note: first, the lifetime cannot outlive the anonymous lifetime #2 defined on th
    |
 LL |     with(|o| o)
    |          ^^^^^
-   = note: ...so that the expression is assignable:
-           expected &isize
-              found &isize
+note: ...so that the expression is assignable
+  --> $DIR/regions-ret-borrowed.rs:13:14
+   |
+LL |     with(|o| o)
+   |              ^
+   = note: expected  `&isize`
+              found  `&isize`
 note: but, the lifetime must be valid for the lifetime `'a` as defined on the function body at 12:14...
   --> $DIR/regions-ret-borrowed.rs:12:14
    |

--- a/src/test/ui/regions/regions-trait-object-subtyping.stderr
+++ b/src/test/ui/regions/regions-trait-object-subtyping.stderr
@@ -36,9 +36,13 @@ note: but, the lifetime must be valid for the lifetime `'b` as defined on the fu
    |
 LL | fn foo3<'a,'b>(x: &'a mut dyn Dummy) -> &'b mut dyn Dummy {
    |            ^^
-   = note: ...so that the expression is assignable:
-           expected &'b mut (dyn Dummy + 'b)
-              found &mut (dyn Dummy + 'b)
+note: ...so that the expression is assignable
+  --> $DIR/regions-trait-object-subtyping.rs:15:5
+   |
+LL |     x
+   |     ^
+   = note: expected  `&'b mut (dyn Dummy + 'b)`
+              found  `&mut (dyn Dummy + 'b)`
 
 error[E0308]: mismatched types
   --> $DIR/regions-trait-object-subtyping.rs:22:5

--- a/src/test/ui/reject-specialized-drops-8142.stderr
+++ b/src/test/ui/reject-specialized-drops-8142.stderr
@@ -105,9 +105,13 @@ note: ...but the lifetime must also be valid for the lifetime `'l2` as defined o
    |
 LL | struct W<'l1, 'l2> { x: &'l1 i8, y: &'l2 u8 }
    |               ^^^
-   = note: ...so that the types are compatible:
-           expected W<'l1, 'l2>
-              found W<'_, '_>
+note: ...so that the types are compatible
+  --> $DIR/reject-specialized-drops-8142.rs:54:1
+   |
+LL | impl<'lw>         Drop for W<'lw,'lw>     { fn drop(&mut self) { } } // REJECT
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: expected  `W<'l1, 'l2>`
+              found  `W<'_, '_>`
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/traits/trait-impl-of-supertrait-has-wrong-lifetime-parameters.stderr
+++ b/src/test/ui/traits/trait-impl-of-supertrait-has-wrong-lifetime-parameters.stderr
@@ -14,9 +14,13 @@ note: ...but the lifetime must also be valid for the lifetime `'b` as defined on
    |
 LL | impl<'a,'b> T2<'a, 'b> for S<'a, 'b> {
    |         ^^
-   = note: ...so that the types are compatible:
-           expected T1<'a>
-              found T1<'_>
+note: ...so that the types are compatible
+  --> $DIR/trait-impl-of-supertrait-has-wrong-lifetime-parameters.rs:24:13
+   |
+LL | impl<'a,'b> T2<'a, 'b> for S<'a, 'b> {
+   |             ^^^^^^^^^^
+   = note: expected  `T1<'a>`
+              found  `T1<'_>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/underscore-lifetime/dyn-trait-underscore.stderr
+++ b/src/test/ui/underscore-lifetime/dyn-trait-underscore.stderr
@@ -18,9 +18,13 @@ note: ...so that reference does not outlive borrowed content
 LL |     Box::new(items.iter())
    |              ^^^^^
    = note: but, the lifetime must be valid for the static lifetime...
-   = note: ...so that the expression is assignable:
-           expected std::boxed::Box<(dyn std::iter::Iterator<Item = &T> + 'static)>
-              found std::boxed::Box<dyn std::iter::Iterator<Item = &T>>
+note: ...so that the expression is assignable
+  --> $DIR/dyn-trait-underscore.rs:8:5
+   |
+LL |     Box::new(items.iter())
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   = note: expected  `std::boxed::Box<(dyn std::iter::Iterator<Item = &T> + 'static)>`
+              found  `std::boxed::Box<dyn std::iter::Iterator<Item = &T>>`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
In most places, we use a span when emitting `expected...found` errors.
However, there were a couple of places where we didn't use any span,
resulting in hard-to-interpret error messages.

This commit attaches the relevant span to these notes, and additionally
switches over to using `note_expected_found` instead of manually
formatting the message