### PR TITLE
Fix docs for formatting delegations

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -662,7 +662,7 @@ pub trait Display {
 ///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 ///         let val = self.0;
 ///
-///         write!(f, "{:o}", val) // delegate to i32's implementation
+///         fmt::Octal::fmt(&val, f) // delegate to i32's implementation
 ///     }
 /// }
 ///
@@ -712,7 +712,7 @@ pub trait Octal {
 ///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 ///         let val = self.0;
 ///
-///         write!(f, "{:b}", val) // delegate to i32's implementation
+///         fmt::Binary::fmt(&val, f) // delegate to i32's implementation
 ///     }
 /// }
 ///
@@ -771,7 +771,7 @@ pub trait Binary {
 ///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 ///         let val = self.0;
 ///
-///         write!(f, "{:x}", val) // delegate to i32's implementation
+///         fmt::LowerHex::fmt(&val, f) // delegate to i32's implementation
 ///     }
 /// }
 ///
@@ -824,7 +824,7 @@ pub trait LowerHex {
 ///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 ///         let val = self.0;
 ///
-///         write!(f, "{:X}", val) // delegate to i32's implementation
+///         fmt::UpperHex::fmt(&val, f) // delegate to i32's implementation
 ///     }
 /// }
 ///
@@ -869,7 +869,8 @@ pub trait UpperHex {
 ///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 ///         // use `as` to convert to a `*const T`, which implements Pointer, which we can use
 ///
-///         write!(f, "{:p}", self as *const Length)
+///         let ptr = self as *const Self;
+///         fmt::Pointer::fmt(&ptr, f)
 ///     }
 /// }
 ///


### PR DESCRIPTION
If you use the example in the docs right now it breaks all the options Formatters have to offer.
i.e. https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=214392ecc6eff73b4789c32568395f72 this should've padded the output with 4 zeros but didn't.

with the new example it does work: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=3bdfb29f395230c5129c5f56dcfcb2a9

The only thing i'm not quite sure about is what's the right way to do it in a loop (altough non of the docs talk about it people are doing it in the wild and there were a couple of attempts to include in libcore)
i.e. https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=4c4dca3c90ba36779ecd014f3899ab9c