### PR TITLE
SGX: Fix target linker used by bootstrap

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -810,6 +810,7 @@ impl Build {
                   !target.contains("emscripten") &&
                   !target.contains("wasm32") &&
                   !target.contains("nvptx") &&
+                  !target.contains("fortanix") &&
                   !target.contains("fuchsia") {
             Some(self.cc(target))
         } else {


### PR DESCRIPTION
Bootstrap, for some reason, overrides the target linker. This is not correct for x86_64-fortanix-unknown-sgx. Add such targets to the list of exceptions.

r? @alexcrichton 