### PR TITLE
Fix argument order in printed output on panic

### DIFF
--- a/src/libcore/panic.rs
+++ b/src/libcore/panic.rs
@@ -131,17 +131,17 @@ impl<'a> PanicInfo<'a> {
 impl fmt::Display for PanicInfo<'_> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("panicked at ")?;
+
+        self.location.fmt(formatter)
         if let Some(message) = self.message {
-            write!(formatter, "'{}', ", message)?
+            write!(formatter, ", '{}'", message)?
         } else if let Some(payload) = self.payload.downcast_ref::<&'static str>() {
-            write!(formatter, "'{}', ", payload)?
+            write!(formatter, ", '{}'", payload)?
         }
         // NOTE: we cannot use downcast_ref::<String>() here
         // since String is not available in libcore!
         // The payload is a String when `std::panic!` is called with multiple arguments,
         // but in that case the message is also available.
-
-        self.location.fmt(formatter)
     }
 }
 

--- a/src/libcore/panic.rs
+++ b/src/libcore/panic.rs
@@ -132,7 +132,7 @@ impl fmt::Display for PanicInfo<'_> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("panicked at ")?;
 
-        self.location.fmt(formatter)
+        self.location.fmt(formatter)?;
         if let Some(message) = self.message {
             write!(formatter, ", '{}'", message)?
         } else if let Some(payload) = self.payload.downcast_ref::<&'static str>() {
@@ -142,6 +142,8 @@ impl fmt::Display for PanicInfo<'_> {
         // since String is not available in libcore!
         // The payload is a String when `std::panic!` is called with multiple arguments,
         // but in that case the message is also available.
+
+        Ok(())
     }
 }
 

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -320,7 +320,7 @@ impl<O: fmt::Debug> fmt::Debug for PanicInfo<O> {
         use PanicInfo::*;
         match self {
             Panic { ref msg, line, col, ref file } =>
-                write!(f, "the evaluated program panicked at '{}', {}:{}:{}", msg, file, line, col),
+                write!(f, "the evaluated program panicked at {}:{}:{}, '{}'", file, line, col, msg),
             BoundsCheck { ref len, ref index } =>
                 write!(f, "index out of bounds: the len is {:?} but the index is {:?}", len, index),
             _ =>

--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -184,8 +184,8 @@ fn default_hook(info: &PanicInfo<'_>) {
     let name = thread.as_ref().and_then(|t| t.name()).unwrap_or("<unnamed>");
 
     let write = |err: &mut dyn crate::io::Write| {
-        let _ = writeln!(err, "thread '{}' panicked at '{}', {}",
-                         name, msg, location);
+        let _ = writeln!(err, "thread '{}' panicked at {}, '{}'",
+                         name, location, msg);
 
         static FIRST_PANIC: AtomicBool = AtomicBool::new(true);
 


### PR DESCRIPTION
Before this commit, the output printed when panicking was:

> Thread 'name' panicked at 'msg', location

when it should have been:

> Thread 'name' panicked at location, 'msg'

This bug was originally introduced in 576f59a. The message was changed
to something which implies the location comes before the message,
without changing the order of the arguments. A similar change was made
in f8a4d09, with the only reason given being consistency between the
Rust runtime and C++ runtime. We could also go back towards something
closer to that message ("Thread 'name' panicked: 'msg' at location"), I
don't really have any preference.

There are ~125 tests which will need to be updated as a result of this change, but I wanted to make sure folks were interested in fixing this before going through and updating them all. This bug has been here for 7.5 years, so I can't imagine I'm the first one to bring this up. However, I looked for an existing issue/PR and couldn't find one. I may have been searching for the wrong terms though