### PR TITLE
Simplify {IoSlice, IoSliceMut}::advance examples and tests

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -987,7 +987,6 @@ impl<'a> IoSliceMut<'a> {
     /// #![feature(io_slice_advance)]
     ///
     /// use std::io::IoSliceMut;
-    /// use std::mem;
     /// use std::ops::Deref;
     ///
     /// let mut buf1 = [1; 8];
@@ -1000,7 +999,7 @@ impl<'a> IoSliceMut<'a> {
     /// ][..];
     ///
     /// // Mark 10 bytes as read.
-    /// bufs = IoSliceMut::advance(mem::replace(&mut bufs, &mut []), 10);
+    /// bufs = IoSliceMut::advance(bufs, 10);
     /// assert_eq!(bufs[0].deref(), [2; 14].as_ref());
     /// assert_eq!(bufs[1].deref(), [3; 8].as_ref());
     /// ```
@@ -1090,20 +1089,19 @@ impl<'a> IoSlice<'a> {
     /// #![feature(io_slice_advance)]
     ///
     /// use std::io::IoSlice;
-    /// use std::mem;
     /// use std::ops::Deref;
     ///
-    /// let mut buf1 = [1; 8];
-    /// let mut buf2 = [2; 16];
-    /// let mut buf3 = [3; 8];
+    /// let buf1 = [1; 8];
+    /// let buf2 = [2; 16];
+    /// let buf3 = [3; 8];
     /// let mut bufs = &mut [
-    ///     IoSlice::new(&mut buf1),
-    ///     IoSlice::new(&mut buf2),
-    ///     IoSlice::new(&mut buf3),
+    ///     IoSlice::new(&buf1),
+    ///     IoSlice::new(&buf2),
+    ///     IoSlice::new(&buf3),
     /// ][..];
     ///
     /// // Mark 10 bytes as written.
-    /// bufs = IoSlice::advance(mem::replace(&mut bufs, &mut []), 10);
+    /// bufs = IoSlice::advance(bufs, 10);
     /// assert_eq!(bufs[0].deref(), [2; 14].as_ref());
     /// assert_eq!(bufs[1].deref(), [3; 8].as_ref());
     #[unstable(feature = "io_slice_advance", issue = "62726")]
@@ -2415,7 +2413,6 @@ mod tests {
     use crate::cmp;
     use crate::io::prelude::*;
     use crate::io::{self, IoSlice, IoSliceMut};
-    use crate::mem;
     use crate::ops::Deref;
 
     #[test]
@@ -2731,26 +2728,26 @@ mod tests {
         ][..];
 
         // Only in a single buffer..
-        bufs = IoSliceMut::advance(mem::replace(&mut bufs, &mut []), 1);
+        bufs = IoSliceMut::advance(bufs, 1);
         assert_eq!(bufs[0].deref(), [1; 7].as_ref());
         assert_eq!(bufs[1].deref(), [2; 16].as_ref());
         assert_eq!(bufs[2].deref(), [3; 8].as_ref());
 
         // Removing a buffer, leaving others as is.
-        bufs = IoSliceMut::advance(mem::replace(&mut bufs, &mut []), 7);
+        bufs = IoSliceMut::advance(bufs, 7);
         assert_eq!(bufs[0].deref(), [2; 16].as_ref());
         assert_eq!(bufs[1].deref(), [3; 8].as_ref());
 
         // Removing a buffer and removing from the next buffer.
-        bufs = IoSliceMut::advance(mem::replace(&mut bufs, &mut []), 18);
+        bufs = IoSliceMut::advance(bufs, 18);
         assert_eq!(bufs[0].deref(), [3; 6].as_ref());
     }
 
     #[test]
     fn io_slice_mut_advance_empty_slice() {
-        let mut empty_bufs = &mut [][..];
+        let empty_bufs = &mut [][..];
         // Shouldn't panic.
-        IoSliceMut::advance(&mut empty_bufs, 1);
+        IoSliceMut::advance(empty_bufs, 1);
     }
 
     #[test]
@@ -2759,48 +2756,48 @@ mod tests {
         let mut bufs = &mut [IoSliceMut::new(&mut buf1)][..];
 
         // Going beyond the total length should be ok.
-        bufs = IoSliceMut::advance(mem::replace(&mut bufs, &mut []), 9);
+        bufs = IoSliceMut::advance(bufs, 9);
         assert!(bufs.is_empty());
     }
 
     #[test]
     fn io_slice_advance() {
-        let mut buf1 = [1; 8];
-        let mut buf2 = [2; 16];
-        let mut buf3 = [3; 8];
+        let buf1 = [1; 8];
+        let buf2 = [2; 16];
+        let buf3 = [3; 8];
         let mut bufs =
-            &mut [IoSlice::new(&mut buf1), IoSlice::new(&mut buf2), IoSlice::new(&mut buf3)][..];
+            &mut [IoSlice::new(&buf1), IoSlice::new(&buf2), IoSlice::new(&buf3)][..];
 
         // Only in a single buffer..
-        bufs = IoSlice::advance(mem::replace(&mut bufs, &mut []), 1);
+        bufs = IoSlice::advance(bufs, 1);
         assert_eq!(bufs[0].deref(), [1; 7].as_ref());
         assert_eq!(bufs[1].deref(), [2; 16].as_ref());
         assert_eq!(bufs[2].deref(), [3; 8].as_ref());
 
         // Removing a buffer, leaving others as is.
-        bufs = IoSlice::advance(mem::replace(&mut bufs, &mut []), 7);
+        bufs = IoSlice::advance(bufs, 7);
         assert_eq!(bufs[0].deref(), [2; 16].as_ref());
         assert_eq!(bufs[1].deref(), [3; 8].as_ref());
 
         // Removing a buffer and removing from the next buffer.
-        bufs = IoSlice::advance(mem::replace(&mut bufs, &mut []), 18);
+        bufs = IoSlice::advance(bufs, 18);
         assert_eq!(bufs[0].deref(), [3; 6].as_ref());
     }
 
     #[test]
     fn io_slice_advance_empty_slice() {
-        let mut empty_bufs = &mut [][..];
+        let empty_bufs = &mut [][..];
         // Shouldn't panic.
-        IoSlice::advance(&mut empty_bufs, 1);
+        IoSlice::advance(empty_bufs, 1);
     }
 
     #[test]
     fn io_slice_advance_beyond_total_length() {
-        let mut buf1 = [1; 8];
-        let mut bufs = &mut [IoSlice::new(&mut buf1)][..];
+        let buf1 = [1; 8];
+        let mut bufs = &mut [IoSlice::new(&buf1)][..];
 
         // Going beyond the total length should be ok.
-        bufs = IoSlice::advance(mem::replace(&mut bufs, &mut []), 9);
+        bufs = IoSlice::advance(bufs, 9);
         assert!(bufs.is_empty());
     }
 }


### PR DESCRIPTION
Remove unnecessary calls to `std::mem::replace` and make variables immutable.