### PR TITLE
Fix fetching arguments on the wasm32-wasi target

### DIFF
--- a/src/libstd/sys/wasi/args.rs
+++ b/src/libstd/sys/wasi/args.rs
@@ -26,6 +26,7 @@ fn maybe_args() -> Option<Vec<OsString>> {
         let mut argv = Vec::with_capacity(argc);
         let mut buf = Vec::with_capacity(buf_size);
         wasi::args_get(argv.as_mut_ptr(), buf.as_mut_ptr()).ok()?;
+        argv.set_len(argc);
         let mut ret = Vec::with_capacity(argc);
         for ptr in argv {
             let s = CStr::from_ptr(ptr.cast());


### PR DESCRIPTION
Fixes an error introduced in #66750 where wasi executables always think
they have zero arguments because one of the vectors returned here
accidentally thought it was length 0.