### PR TITLE
Make error codes into strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3855,7 +3855,10 @@ dependencies = [
  "rustc_ast_pretty",
  "rustc_attr",
  "rustc_data_structures",
+<<<<<<< HEAD
  "rustc_errors",
+=======
+>>>>>>> Update lock file
  "rustc_feature",
  "rustc_hir",
  "rustc_index",
@@ -4005,9 +4008,12 @@ name = "rustc_plugin_impl"
 version = "0.0.0"
 dependencies = [
  "rustc",
+<<<<<<< HEAD
  "rustc_errors",
  "rustc_hir",
  "rustc_lint",
+=======
+>>>>>>> Update lock file
  "rustc_metadata",
  "rustc_span",
  "syntax",
@@ -4021,9 +4027,12 @@ dependencies = [
  "rustc",
  "rustc_attr",
  "rustc_data_structures",
+<<<<<<< HEAD
  "rustc_errors",
  "rustc_hir",
  "rustc_span",
+=======
+>>>>>>> Update lock file
  "rustc_typeck",
  "syntax",
 ]
@@ -4696,6 +4705,58 @@ dependencies = [
  "scoped-tls",
  "serialize",
  "smallvec 1.0.0",
+<<<<<<< HEAD
+=======
+ "syntax_pos",
+]
+
+[[package]]
+name = "syntax_expand"
+version = "0.0.0"
+dependencies = [
+ "log",
+ "rustc_data_structures",
+ "rustc_errors",
+ "rustc_feature",
+ "rustc_lexer",
+ "rustc_parse",
+ "serialize",
+ "smallvec 1.0.0",
+ "syntax",
+ "syntax_pos",
+]
+
+[[package]]
+name = "syntax_ext"
+version = "0.0.0"
+dependencies = [
+ "fmt_macros",
+ "log",
+ "rustc_data_structures",
+ "rustc_errors",
+ "rustc_feature",
+ "rustc_parse",
+ "rustc_target",
+ "smallvec 1.0.0",
+ "syntax",
+ "syntax_expand",
+ "syntax_pos",
+]
+
+[[package]]
+name = "syntax_pos"
+version = "0.0.0"
+dependencies = [
+ "arena",
+ "cfg-if",
+ "log",
+ "rustc_data_structures",
+ "rustc_index",
+ "rustc_macros",
+ "scoped-tls",
+ "serialize",
+ "unicode-width",
+>>>>>>> Update lock file
 ]
 
 [[package]]

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -212,7 +212,7 @@ impl<'tcx> ConstEvalErr<'tcx> {
 }
 
 pub fn struct_error<'tcx>(tcx: TyCtxtAt<'tcx>, msg: &str) -> DiagnosticBuilder<'tcx> {
-    struct_span_err!(tcx.sess, tcx.span, E0080, "{}", msg)
+    struct_span_err!(tcx.sess, tcx.span, "E0080", "{}", msg)
 }
 
 /// Packages the kind of error we got from the const code interpreter

--- a/src/librustc/ty/query/plumbing.rs
+++ b/src/librustc/ty/query/plumbing.rs
@@ -346,7 +346,7 @@ impl<'tcx> TyCtxt<'tcx> {
             let mut err = struct_span_err!(
                 self.sess,
                 span,
-                E0391,
+                "E0391",
                 "cycle detected when {}",
                 stack[0].query.describe(self)
             );

--- a/src/librustc_ast_lowering/expr.rs
+++ b/src/librustc_ast_lowering/expr.rs
@@ -540,7 +540,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let mut err = struct_span_err!(
                     self.sess,
                     await_span,
-                    E0728,
+                    "E0728",
                     "`await` is only allowed inside `async` functions and blocks"
                 );
                 err.span_label(await_span, "only allowed inside `async` functions and blocks");
@@ -692,7 +692,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     struct_span_err!(
                         self.sess,
                         fn_decl_span,
-                        E0628,
+                        "E0628",
                         "too many parameters for a generator (expected 0 or 1 parameters)"
                     )
                     .emit();
@@ -704,7 +704,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             }
             None => {
                 if movability == Movability::Static {
-                    struct_span_err!(self.sess, fn_decl_span, E0697, "closures cannot be static")
+                    struct_span_err!(self.sess, fn_decl_span, "E0697", "closures cannot be static")
                         .emit();
                 }
                 None
@@ -733,7 +733,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 struct_span_err!(
                     this.sess,
                     fn_decl_span,
-                    E0708,
+                    "E0708",
                     "`async` non-`move` closures with parameters are not currently supported",
                 )
                 .help(
@@ -946,7 +946,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 struct_span_err!(
                     self.sess,
                     span,
-                    E0727,
+                    "E0727",
                     "`async` generators are not yet supported"
                 )
                 .emit();

--- a/src/librustc_ast_lowering/item.rs
+++ b/src/librustc_ast_lowering/item.rs
@@ -1269,7 +1269,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
     }
 
     fn error_on_invalid_abi(&self, abi: StrLit) {
-        struct_span_err!(self.sess, abi.span, E0703, "invalid ABI: found `{}`", abi.symbol)
+        struct_span_err!(self.sess, abi.span, "E0703", "invalid ABI: found `{}`", abi.symbol)
             .span_label(abi.span, "invalid ABI")
             .help(&format!("valid ABIs: {}", abi::all_names().join(", ")))
             .emit();

--- a/src/librustc_ast_lowering/lib.rs
+++ b/src/librustc_ast_lowering/lib.rs
@@ -1318,7 +1318,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         let mut err = struct_span_err!(
                             self.sess,
                             t.span,
-                            E0562,
+                            "E0562",
                             "`impl Trait` not allowed outside of {}",
                             allowed_in,
                         );
@@ -2532,7 +2532,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             ),
         };
 
-        let mut err = struct_span_err!(self.sess, span, E0637, "{}", msg,);
+        let mut err = struct_span_err!(self.sess, span, "E0637", "{}", msg,);
         err.span_label(span, label);
         err.emit();
 

--- a/src/librustc_ast_passes/ast_validation.rs
+++ b/src/librustc_ast_passes/ast_validation.rs
@@ -202,7 +202,7 @@ impl<'a> AstValidator<'a> {
         }
 
         let mut err =
-            struct_span_err!(self.session, vis.span, E0449, "unnecessary visibility qualifier");
+            struct_span_err!(self.session, vis.span, "E0449", "unnecessary visibility qualifier");
         if vis.node.is_pub() {
             err.span_label(vis.span, "`pub` not permitted here because it's implied");
         }
@@ -229,7 +229,7 @@ impl<'a> AstValidator<'a> {
             struct_span_err!(
                 self.session,
                 fn_span,
-                E0706,
+                "E0706",
                 "functions in traits cannot be declared `async`"
             )
             .span_label(span, "`async` because of this")
@@ -244,7 +244,7 @@ impl<'a> AstValidator<'a> {
             struct_span_err!(
                 self.session,
                 span,
-                E0379,
+                "E0379",
                 "functions in traits cannot be declared const"
             )
             .span_label(span, "functions in traits cannot be const")
@@ -700,7 +700,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 struct_span_err!(
                     self.session,
                     expr.span,
-                    E0472,
+                    "E0472",
                     "asm! is unsupported on this target"
                 )
                 .emit();
@@ -719,7 +719,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     struct_span_err!(
                         self.session,
                         span,
-                        E0561,
+                        "E0561",
                         "patterns aren't allowed in function pointer types"
                     )
                     .emit();
@@ -734,7 +734,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                             struct_span_err!(
                                 self.session,
                                 lifetime.ident.span,
-                                E0226,
+                                "E0226",
                                 "only a single explicit lifetime bound is permitted"
                             )
                             .emit();
@@ -750,7 +750,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     struct_span_err!(
                         self.session,
                         ty.span,
-                        E0667,
+                        "E0667",
                         "`impl Trait` is not allowed in path parameters"
                     )
                     .emit();
@@ -760,7 +760,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     struct_span_err!(
                         self.session,
                         ty.span,
-                        E0666,
+                        "E0666",
                         "nested `impl Trait` is not allowed"
                     )
                     .span_label(outer_impl_trait_sp, "outer `impl Trait`")
@@ -854,7 +854,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     struct_span_err!(
                         self.session,
                         item.span,
-                        E0197,
+                        "E0197",
                         "inherent impls cannot be unsafe"
                     )
                     .span_label(span, "unsafe because of this")
@@ -910,7 +910,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                         struct_span_err!(
                             self.session,
                             item.span,
-                            E0567,
+                            "E0567",
                             "auto traits cannot have generic parameters"
                         )
                         .emit();
@@ -919,7 +919,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                         struct_span_err!(
                             self.session,
                             item.span,
-                            E0568,
+                            "E0568",
                             "auto traits cannot have super traits"
                         )
                         .emit();
@@ -928,7 +928,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                         struct_span_err!(
                             self.session,
                             item.span,
-                            E0380,
+                            "E0380",
                             "auto traits cannot have methods or associated items"
                         )
                         .emit();

--- a/src/librustc_attr/builtin.rs
+++ b/src/librustc_attr/builtin.rs
@@ -29,25 +29,25 @@ fn handle_errors(sess: &ParseSess, span: Span, error: AttrError) {
     let diag = &sess.span_diagnostic;
     match error {
         AttrError::MultipleItem(item) => {
-            struct_span_err!(diag, span, E0538, "multiple '{}' items", item).emit();
+            struct_span_err!(diag, span, "E0538", "multiple '{}' items", item).emit();
         }
         AttrError::UnknownMetaItem(item, expected) => {
             let expected = expected.iter().map(|name| format!("`{}`", name)).collect::<Vec<_>>();
-            struct_span_err!(diag, span, E0541, "unknown meta item '{}'", item)
+            struct_span_err!(diag, span, "E0541", "unknown meta item '{}'", item)
                 .span_label(span, format!("expected one of {}", expected.join(", ")))
                 .emit();
         }
         AttrError::MissingSince => {
-            struct_span_err!(diag, span, E0542, "missing 'since'").emit();
+            struct_span_err!(diag, span, "E0542", "missing 'since'").emit();
         }
         AttrError::MissingFeature => {
-            struct_span_err!(diag, span, E0546, "missing 'feature'").emit();
+            struct_span_err!(diag, span, "E0546", "missing 'feature'").emit();
         }
         AttrError::MultipleStabilityLevels => {
-            struct_span_err!(diag, span, E0544, "multiple stability levels").emit();
+            struct_span_err!(diag, span, "E0544", "multiple stability levels").emit();
         }
         AttrError::UnsupportedLiteral(msg, is_bytestr) => {
-            let mut err = struct_span_err!(diag, span, E0565, "{}", msg);
+            let mut err = struct_span_err!(diag, span, "E0565", "{}", msg);
             if is_bytestr {
                 if let Ok(lint_str) = sess.source_map().span_to_snippet(span) {
                     err.span_suggestion(
@@ -99,7 +99,8 @@ pub fn find_unwind_attr(diagnostic: Option<&Handler>, attrs: &[Attribute]) -> Op
                     }
 
                     diagnostic.map(|d| {
-                        struct_span_err!(d, attr.span, E0633, "malformed `unwind` attribute input")
+                        struct_span_err!(d, attr.span, "E0633",
+                                         "malformed `unwind` attribute input")
                             .span_label(attr.span, "invalid argument")
                             .span_suggestions(
                                 attr.span,
@@ -286,7 +287,7 @@ where
                     *item = Some(v);
                     true
                 } else {
-                    struct_span_err!(diagnostic, meta.span, E0539, "incorrect meta item").emit();
+                    struct_span_err!(diagnostic, meta.span, "E0539", "incorrect meta item").emit();
                     false
                 }
             };
@@ -337,7 +338,7 @@ where
                         struct_span_err!(
                             diagnostic,
                             item_sp,
-                            E0540,
+                            "E0540",
                             "multiple rustc_deprecated attributes"
                         )
                         .emit();
@@ -355,7 +356,7 @@ where
                             continue;
                         }
                         _ => {
-                            struct_span_err!(diagnostic, attr.span, E0543, "missing 'reason'")
+                            struct_span_err!(diagnostic, attr.span, "E0543", "missing 'reason'")
                                 .emit();
                             continue;
                         }
@@ -477,7 +478,7 @@ where
                             continue;
                         }
                         _ => {
-                            struct_span_err!(diagnostic, attr.span, E0547, "missing 'issue'")
+                            struct_span_err!(diagnostic, attr.span, "E0547", "missing 'issue'")
                                 .emit();
                             continue;
                         }
@@ -567,7 +568,7 @@ where
             struct_span_err!(
                 diagnostic,
                 item_sp,
-                E0549,
+                "E0549",
                 "rustc_deprecated attribute must be paired with \
                        either stable or unstable attribute"
             )
@@ -584,7 +585,7 @@ where
             struct_span_err!(
                 diagnostic,
                 item_sp,
-                E0717,
+                "E0717",
                 "rustc_promotable and rustc_allow_const_fn_ptr attributes \
                       must be paired with either a rustc_const_unstable or a rustc_const_stable \
                       attribute"
@@ -679,7 +680,7 @@ pub fn eval_condition(
                         struct_span_err!(
                             sess.span_diagnostic,
                             cfg.span,
-                            E0536,
+                            "E0536",
                             "expected 1 cfg-pattern"
                         )
                         .emit();
@@ -692,7 +693,7 @@ pub fn eval_condition(
                     struct_span_err!(
                         sess.span_diagnostic,
                         cfg.span,
-                        E0537,
+                        "E0537",
                         "invalid predicate `{}`",
                         pprust::path_to_string(&cfg.path)
                     )
@@ -737,7 +738,7 @@ where
         }
 
         if depr.is_some() {
-            struct_span_err!(diagnostic, item_sp, E0550, "multiple deprecated attributes").emit();
+            struct_span_err!(diagnostic, item_sp, "E0550", "multiple deprecated attributes").emit();
             break;
         }
 
@@ -775,7 +776,7 @@ where
                                 ),
                             );
                         } else {
-                            struct_span_err!(diagnostic, meta.span, E0551, "incorrect meta item")
+                            struct_span_err!(diagnostic, meta.span, "E0551", "incorrect meta item")
                                 .emit();
                         }
 
@@ -940,7 +941,7 @@ pub fn find_repr_attrs(sess: &ParseSess, attr: &Attribute) -> Vec<ReprAttr> {
                         struct_span_err!(
                             diagnostic,
                             item.span(),
-                            E0589,
+                            "E0589",
                             "invalid `repr(align)` attribute: {}",
                             literal_error
                         )
@@ -954,7 +955,7 @@ pub fn find_repr_attrs(sess: &ParseSess, attr: &Attribute) -> Vec<ReprAttr> {
                                 let mut err = struct_span_err!(
                                     diagnostic,
                                     item.span(),
-                                    E0693,
+                                    "E0693",
                                     "incorrect `repr(align)` attribute format"
                                 );
                                 match value.kind {
@@ -986,7 +987,7 @@ pub fn find_repr_attrs(sess: &ParseSess, attr: &Attribute) -> Vec<ReprAttr> {
                     struct_span_err!(
                         diagnostic,
                         item.span(),
-                        E0552,
+                        "E0552",
                         "unrecognized representation hint"
                     )
                     .emit();

--- a/src/librustc_builtin_macros/asm.rs
+++ b/src/librustc_builtin_macros/asm.rs
@@ -112,7 +112,7 @@ fn parse_inline_asm<'a>(
                     return Err(struct_span_err!(
                         cx.parse_sess.span_diagnostic,
                         sp,
-                        E0660,
+                        "E0660",
                         "malformed inline assembly"
                     ));
                 }
@@ -173,7 +173,7 @@ fn parse_inline_asm<'a>(
                             struct_span_err!(
                                 cx.parse_sess.span_diagnostic,
                                 span,
-                                E0661,
+                                "E0661",
                                 "output operand constraint lacks '=' or '+'"
                             )
                             .emit();
@@ -203,7 +203,7 @@ fn parse_inline_asm<'a>(
                         struct_span_err!(
                             cx.parse_sess.span_diagnostic,
                             p.prev_span,
-                            E0662,
+                            "E0662",
                             "input operand constraint contains '='"
                         )
                         .emit();
@@ -211,7 +211,7 @@ fn parse_inline_asm<'a>(
                         struct_span_err!(
                             cx.parse_sess.span_diagnostic,
                             p.prev_span,
-                            E0663,
+                            "E0663",
                             "input operand constraint contains '+'"
                         )
                         .emit();
@@ -238,7 +238,7 @@ fn parse_inline_asm<'a>(
                         struct_span_err!(
                             cx.parse_sess.span_diagnostic,
                             p.prev_span,
-                            E0664,
+                            "E0664",
                             "clobber should not be surrounded by braces"
                         )
                         .emit();

--- a/src/librustc_codegen_ssa/common.rs
+++ b/src/librustc_codegen_ssa/common.rs
@@ -195,5 +195,5 @@ pub fn shift_mask_val<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
 }
 
 pub fn span_invalid_monomorphization_error(a: &Session, b: Span, c: &str) {
-    struct_span_err!(a, b, E0511, "{}", c).emit();
+    struct_span_err!(a, b, "E0511", "{}", c).emit();
 }

--- a/src/librustc_codegen_ssa/mir/statement.rs
+++ b/src/librustc_codegen_ssa/mir/statement.rs
@@ -83,7 +83,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                             struct_span_err!(
                                 bx.sess(),
                                 span.to_owned(),
-                                E0669,
+                                "E0669",
                                 "invalid value for constraint in inline assembly"
                             )
                             .emit();
@@ -103,7 +103,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         struct_span_err!(
                             bx.sess(),
                             statement.source_info.span,
-                            E0668,
+                            "E0668",
                             "malformed inline assembly"
                         )
                         .emit();

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -407,7 +407,7 @@ impl<'a> Drop for DiagnosticBuilder<'a> {
 
 #[macro_export]
 macro_rules! struct_span_err {
-    ($session:expr, $span:expr, $code:ident, $($message:tt)*) => ({
+    ($session:expr, $span:expr, $code:expr, $($message:tt)*) => ({
         $session.struct_span_err_with_code(
             $span,
             &format!($($message)*),
@@ -418,5 +418,5 @@ macro_rules! struct_span_err {
 
 #[macro_export]
 macro_rules! error_code {
-    ($code:ident) => {{ $crate::DiagnosticId::Error(stringify!($code).to_owned()) }};
+    ($code:expr) => {{ $crate::DiagnosticId::Error(stringify!($code).to_owned()) }};
 }

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -802,14 +802,12 @@ impl HandlerInner {
                         if error_codes.len() > 9 { "..." } else { "." }
                     ));
                     self.failure(&format!(
-                        "For more information about an error, try \
-                                           `rustc --explain {}`.",
+                        "For more information about an error, try `rustc --explain {}`.",
                         &error_codes[0]
                     ));
                 } else {
                     self.failure(&format!(
-                        "For more information about this error, try \
-                                           `rustc --explain {}`.",
+                        "For more information about this error, try `rustc --explain {}`.",
                         &error_codes[0]
                     ));
                 }

--- a/src/librustc_infer/infer/error_reporting/mod.rs
+++ b/src/librustc_infer/infer/error_reporting/mod.rs
@@ -1622,16 +1622,16 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 report_object_safety_error(self.tcx, span, did, violations)
             }
             FailureCode::Error0317(failure_str) => {
-                struct_span_err!(self.tcx.sess, span, E0317, "{}", failure_str)
+                struct_span_err!(self.tcx.sess, span, "E0317", "{}", failure_str)
             }
             FailureCode::Error0580(failure_str) => {
-                struct_span_err!(self.tcx.sess, span, E0580, "{}", failure_str)
+                struct_span_err!(self.tcx.sess, span, "E0580", "{}", failure_str)
             }
             FailureCode::Error0308(failure_str) => {
-                struct_span_err!(self.tcx.sess, span, E0308, "{}", failure_str)
+                struct_span_err!(self.tcx.sess, span, "E0308", "{}", failure_str)
             }
             FailureCode::Error0644(failure_str) => {
-                struct_span_err!(self.tcx.sess, span, E0644, "{}", failure_str)
+                struct_span_err!(self.tcx.sess, span, "E0644", "{}", failure_str)
             }
         };
         self.note_type_err(&mut diag, &trace.cause, None, Some(trace.values), terr);
@@ -1816,7 +1816,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0309,
+                    "E0309",
                     "{} may not live long enough",
                     labeled_user_string
                 );
@@ -1833,7 +1833,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0310,
+                    "E0310",
                     "{} may not live long enough",
                     labeled_user_string
                 );
@@ -1846,7 +1846,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0311,
+                    "E0311",
                     "{} may not live long enough",
                     labeled_user_string
                 );
@@ -1992,7 +1992,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         struct_span_err!(
             self.tcx.sess,
             var_origin.span(),
-            E0495,
+            "E0495",
             "cannot infer an appropriate lifetime{} \
              due to conflicting requirements",
             var_description

--- a/src/librustc_infer/infer/error_reporting/need_type_info.rs
+++ b/src/librustc_infer/infer/error_reporting/need_type_info.rs
@@ -517,7 +517,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         let mut err = struct_span_err!(
             self.tcx.sess,
             span,
-            E0698,
+            "E0698",
             "type inside {} must be known in this context",
             kind,
         );

--- a/src/librustc_infer/infer/error_reporting/nice_region_error/different_lifetimes.rs
+++ b/src/librustc_infer/infer/error_reporting/nice_region_error/different_lifetimes.rs
@@ -126,7 +126,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
             ),
         };
 
-        struct_span_err!(self.tcx().sess, span, E0623, "lifetime mismatch")
+        struct_span_err!(self.tcx().sess, span, "E0623", "lifetime mismatch")
             .span_label(span_1, main_label)
             .span_label(span_2, String::new())
             .span_label(span, span_label)

--- a/src/librustc_infer/infer/error_reporting/nice_region_error/named_anon_conflict.rs
+++ b/src/librustc_infer/infer/error_reporting/nice_region_error/named_anon_conflict.rs
@@ -99,7 +99,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         let mut diag = struct_span_err!(
             self.tcx().sess,
             span,
-            E0621,
+            "E0621",
             "explicit lifetime required in {}",
             error_var
         );

--- a/src/librustc_infer/infer/error_reporting/note.rs
+++ b/src/librustc_infer/infer/error_reporting/note.rs
@@ -181,7 +181,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0312,
+                    "E0312",
                     "lifetime of reference outlives lifetime of \
                                                 borrowed content..."
                 );
@@ -208,7 +208,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0313,
+                    "E0313",
                     "lifetime of borrowed pointer outlives lifetime \
                                                 of captured variable `{}`...",
                     var_name
@@ -233,7 +233,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             }
             infer::InfStackClosure(span) => {
                 let mut err =
-                    struct_span_err!(self.tcx.sess, span, E0314, "closure outlives stack frame");
+                    struct_span_err!(self.tcx.sess, span, "E0314", "closure outlives stack frame");
                 note_and_explain_region(
                     self.tcx,
                     region_scope_tree,
@@ -257,7 +257,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0315,
+                    "E0315",
                     "cannot invoke closure outside of its lifetime"
                 );
                 note_and_explain_region(
@@ -274,7 +274,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0473,
+                    "E0473",
                     "dereference of reference outside its lifetime"
                 );
                 note_and_explain_region(
@@ -291,7 +291,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0474,
+                    "E0474",
                     "captured variable `{}` does not outlive the \
                                                 enclosing closure",
                     self.tcx.hir().name(id)
@@ -318,7 +318,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0475,
+                    "E0475",
                     "index of slice outside its lifetime"
                 );
                 note_and_explain_region(
@@ -335,7 +335,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0476,
+                    "E0476",
                     "lifetime of the source pointer does not outlive \
                                                 lifetime bound of the object type"
                 );
@@ -361,7 +361,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0477,
+                    "E0477",
                     "the type `{}` does not fulfill the required \
                                                 lifetime",
                     self.ty_to_string(ty)
@@ -388,7 +388,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             }
             infer::RelateRegionParamBound(span) => {
                 let mut err =
-                    struct_span_err!(self.tcx.sess, span, E0478, "lifetime bound not satisfied");
+                    struct_span_err!(self.tcx.sess, span, "E0478", "lifetime bound not satisfied");
                 note_and_explain_region(
                     self.tcx,
                     region_scope_tree,
@@ -411,7 +411,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0479,
+                    "E0479",
                     "the type `{}` (provided as the value of a type \
                                                 parameter) is not valid at this point",
                     self.ty_to_string(ty)
@@ -430,7 +430,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0480,
+                    "E0480",
                     "lifetime of method receiver does not outlive the \
                                                 method call"
                 );
@@ -448,7 +448,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0481,
+                    "E0481",
                     "lifetime of function argument does not outlive \
                                                 the function call"
                 );
@@ -466,7 +466,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0482,
+                    "E0482",
                     "lifetime of return value does not outlive the \
                                                 function call"
                 );
@@ -484,7 +484,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0483,
+                    "E0483",
                     "lifetime of operand does not outlive the \
                                                 operation"
                 );
@@ -502,7 +502,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0484,
+                    "E0484",
                     "reference is not valid at the time of borrow"
                 );
                 note_and_explain_region(
@@ -519,7 +519,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0485,
+                    "E0485",
                     "automatically reference is not valid at the time \
                                                 of borrow"
                 );
@@ -537,7 +537,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0486,
+                    "E0486",
                     "type of expression contains references that are \
                                                 not valid during the expression: `{}`",
                     self.ty_to_string(t)
@@ -556,7 +556,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0487,
+                    "E0487",
                     "unsafe use of destructor: destructor might be \
                                                 called while references are dead"
                 );
@@ -583,7 +583,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0488,
+                    "E0488",
                     "lifetime of variable does not enclose its \
                                                 declaration"
                 );
@@ -601,7 +601,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0489,
+                    "E0489",
                     "type/lifetime parameter not in scope here"
                 );
                 note_and_explain_region(
@@ -618,7 +618,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0490,
+                    "E0490",
                     "a value of type `{}` is borrowed for too long",
                     self.ty_to_string(ty)
                 );
@@ -644,7 +644,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0491,
+                    "E0491",
                     "in type `{}`, reference has a longer lifetime \
                                                 than the data it references",
                     self.ty_to_string(ty)

--- a/src/librustc_infer/infer/opaque_types/mod.rs
+++ b/src/librustc_infer/infer/opaque_types/mod.rs
@@ -628,7 +628,7 @@ pub fn unexpected_hidden_region_diagnostic(
     let mut err = struct_span_err!(
         tcx.sess,
         span,
-        E0700,
+        "E0700",
         "hidden type for `impl Trait` captures lifetime that does not appear in bounds",
     );
 

--- a/src/librustc_infer/traits/on_unimplemented.rs
+++ b/src/librustc_infer/traits/on_unimplemented.rs
@@ -39,7 +39,7 @@ fn parse_error(
     label: &str,
     note: Option<&str>,
 ) -> ErrorReported {
-    let mut diag = struct_span_err!(tcx.sess, span, E0232, "{}", message);
+    let mut diag = struct_span_err!(tcx.sess, span, "E0232", "{}", message);
     diag.span_label(span, label);
     if let Some(note) = note {
         diag.note(note);
@@ -295,7 +295,7 @@ impl<'tcx> OnUnimplementedFormatString {
                                 struct_span_err!(
                                     tcx.sess,
                                     span,
-                                    E0230,
+                                    "E0230",
                                     "there is no parameter `{}` on trait `{}`",
                                     s,
                                     name
@@ -310,7 +310,7 @@ impl<'tcx> OnUnimplementedFormatString {
                         struct_span_err!(
                             tcx.sess,
                             span,
-                            E0231,
+                            "E0231",
                             "only named substitution parameters are allowed"
                         )
                         .emit();

--- a/src/librustc_infer/traits/specialize/mod.rs
+++ b/src/librustc_infer/traits/specialize/mod.rs
@@ -380,7 +380,7 @@ pub(super) fn specialization_graph_provider(
 
                 match used_to_be_allowed {
                     None => {
-                        let err = struct_span_err!(tcx.sess, impl_span, E0119, "");
+                        let err = struct_span_err!(tcx.sess, impl_span, "E0119", "");
                         decorate(LintDiagnosticBuilder::new(err));
                     }
                     Some(kind) => {

--- a/src/librustc_lint/levels.rs
+++ b/src/librustc_lint/levels.rs
@@ -110,7 +110,7 @@ impl<'s> LintLevelsBuilder<'s> {
     pub fn push(&mut self, attrs: &[ast::Attribute], store: &LintStore) -> BuilderPush {
         let mut specs = FxHashMap::default();
         let sess = self.sess;
-        let bad_attr = |span| struct_span_err!(sess, span, E0452, "malformed lint attribute input");
+        let bad_attr = |span| struct_span_err!(sess, span, "E0452", "malformed lint attribute input");
         for attr in attrs {
             let level = match Level::from_symbol(attr.name_or_empty()) {
                 None => continue,
@@ -196,7 +196,7 @@ impl<'s> LintLevelsBuilder<'s> {
                         struct_span_err!(
                             sess,
                             tool_ident.span,
-                            E0710,
+                            "E0710",
                             "an unknown tool name found in scoped lint: `{}`",
                             pprust::path_to_string(&meta_item.path),
                         )
@@ -350,7 +350,7 @@ impl<'s> LintLevelsBuilder<'s> {
             let mut diag_builder = struct_span_err!(
                 self.sess,
                 lint_attr_span,
-                E0453,
+                "E0453",
                 "{}({}) overruled by outer forbid({})",
                 level.as_str(),
                 lint_attr_name,

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -260,7 +260,7 @@ impl<'a> CrateLoader<'a> {
             struct_span_err!(
                 self.sess,
                 span,
-                E0519,
+                "E0519",
                 "the current crate is indistinguishable from one of its \
                          dependencies: it has the same crate-name `{}` and was \
                          compiled with the same `-C metadata` arguments. This \
@@ -280,7 +280,7 @@ impl<'a> CrateLoader<'a> {
                 struct_span_err!(
                     self.sess,
                     span,
-                    E0523,
+                    "E0523",
                     "found two different crates with name `{}` that are \
                          not distinguished by differing `-C metadata`. This \
                          will result in symbol conflicts between the two.",

--- a/src/librustc_metadata/locator.rs
+++ b/src/librustc_metadata/locator.rs
@@ -390,7 +390,7 @@ impl<'a> CrateLocator<'a> {
             let mut err = struct_span_err!(
                 self.sess,
                 self.span,
-                E0460,
+                "E0460",
                 "found possibly newer version of crate `{}`{}",
                 self.crate_name,
                 add
@@ -414,9 +414,8 @@ impl<'a> CrateLocator<'a> {
             let mut err = struct_span_err!(
                 self.sess,
                 self.span,
-                E0461,
-                "couldn't find crate `{}` \
-                                            with expected target triple {}{}",
+                "E0461",
+                "couldn't find crate `{}` with expected target triple {}{}",
                 self.crate_name,
                 self.triple,
                 add
@@ -436,7 +435,7 @@ impl<'a> CrateLocator<'a> {
             let mut err = struct_span_err!(
                 self.sess,
                 self.span,
-                E0462,
+                "E0462",
                 "found staticlib `{}` instead of rlib or dylib{}",
                 self.crate_name,
                 add
@@ -452,9 +451,8 @@ impl<'a> CrateLocator<'a> {
             let mut err = struct_span_err!(
                 self.sess,
                 self.span,
-                E0514,
-                "found crate `{}` compiled by an incompatible version \
-                                            of rustc{}",
+                "E0514",
+                "found crate `{}` compiled by an incompatible version of rustc{}",
                 self.crate_name,
                 add
             );
@@ -477,7 +475,7 @@ impl<'a> CrateLocator<'a> {
             let mut err = struct_span_err!(
                 self.sess,
                 self.span,
-                E0463,
+                "E0463",
                 "can't find crate for `{}`{}",
                 self.crate_name,
                 add
@@ -617,7 +615,7 @@ impl<'a> CrateLocator<'a> {
                 let mut err = struct_span_err!(
                     self.sess,
                     self.span,
-                    E0464,
+                    "E0464",
                     "multiple matching crates for `{}`",
                     self.crate_name
                 );
@@ -746,7 +744,7 @@ impl<'a> CrateLocator<'a> {
                 let mut e = struct_span_err!(
                     self.sess,
                     self.span,
-                    E0465,
+                    "E0465",
                     "multiple {} candidates for `{}` found",
                     flavor,
                     self.crate_name
@@ -1071,7 +1069,7 @@ pub fn find_plugin_registrar(
             config::host_triple(),
             sess.opts.target_triple
         );
-        struct_span_err!(sess, span, E0456, "{}", &message).emit();
+        struct_span_err!(sess, span, "E0456", "{}", &message).emit();
         return None;
     }
 
@@ -1081,9 +1079,8 @@ pub fn find_plugin_registrar(
             struct_span_err!(
                 sess,
                 span,
-                E0457,
-                "plugin `{}` only found in rlib format, but must be available \
-                        in dylib format",
+                "E0457",
+                "plugin `{}` only found in rlib format, but must be available in dylib format",
                 name
             )
             .emit();

--- a/src/librustc_metadata/native_libs.rs
+++ b/src/librustc_metadata/native_libs.rs
@@ -73,7 +73,7 @@ impl ItemLikeVisitor<'tcx> for Collector<'tcx> {
                             struct_span_err!(
                                 self.tcx.sess,
                                 item.span(),
-                                E0458,
+                                "E0458",
                                 "unknown kind: `{}`",
                                 k
                             )
@@ -118,7 +118,7 @@ impl ItemLikeVisitor<'tcx> for Collector<'tcx> {
                 struct_span_err!(
                     self.tcx.sess,
                     m.span,
-                    E0459,
+                    "E0459",
                     "`#[link(...)]` specified without \
                                   `name = \"foo\"`"
                 )
@@ -141,7 +141,7 @@ impl Collector<'tcx> {
                     struct_span_err!(
                         self.tcx.sess,
                         span,
-                        E0454,
+                        "E0454",
                         "`#[link(name = \"\")]` given with empty name"
                     )
                     .span_label(span, "empty name given")
@@ -157,7 +157,7 @@ impl Collector<'tcx> {
         if lib.kind == cstore::NativeFramework && !is_osx {
             let msg = "native frameworks are only available on macOS targets";
             match span {
-                Some(span) => struct_span_err!(self.tcx.sess, span, E0455, "{}", msg).emit(),
+                Some(span) => struct_span_err!(self.tcx.sess, span, "E0455", "{}", msg).emit(),
                 None => self.tcx.sess.err(msg),
             }
         }

--- a/src/librustc_mir/borrow_check/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/type_check/mod.rs
@@ -1909,7 +1909,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 let mut diag = struct_span_err!(
                     self.tcx().sess,
                     span,
-                    E0161,
+                    "E0161",
                     "cannot move a value of type {0}: the size of {0} \
                      cannot be statically determined",
                     ty

--- a/src/librustc_mir/transform/check_consts/ops.rs
+++ b/src/librustc_mir/transform/check_consts/ops.rs
@@ -33,7 +33,7 @@ pub trait NonConstOp: std::fmt::Debug {
         let mut err = struct_span_err!(
             item.tcx.sess,
             span,
-            E0019,
+            "E0019",
             "{} contains unimplemented expression type",
             item.const_kind()
         );
@@ -81,7 +81,7 @@ impl NonConstOp for FnCallNonConst {
         let mut err = struct_span_err!(
             item.tcx.sess,
             span,
-            E0015,
+            "E0015",
             "calls in {}s are limited to constant functions, \
              tuple structs and tuple variants",
             item.const_kind(),
@@ -129,7 +129,7 @@ impl NonConstOp for HeapAllocation {
         let mut err = struct_span_err!(
             item.tcx.sess,
             span,
-            E0010,
+            "E0010",
             "allocations are not allowed in {}s",
             item.const_kind()
         );
@@ -166,7 +166,7 @@ impl NonConstOp for LiveDrop {
         struct_span_err!(
             item.tcx.sess,
             span,
-            E0493,
+            "E0493",
             "destructors cannot be evaluated at compile-time"
         )
         .span_label(span, format!("{}s cannot evaluate destructors", item.const_kind()))
@@ -347,7 +347,7 @@ impl NonConstOp for StaticAccess {
         let mut err = struct_span_err!(
             item.tcx.sess,
             span,
-            E0013,
+            "E0013",
             "{}s cannot refer to statics",
             item.const_kind()
         );
@@ -375,7 +375,7 @@ impl NonConstOp for ThreadLocalAccess {
         struct_span_err!(
             item.tcx.sess,
             span,
-            E0625,
+            "E0625",
             "thread-local statics cannot be \
             accessed at compile-time"
         )

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -581,7 +581,7 @@ impl Visitor<'tcx> for Validator<'_, 'mir, 'tcx> {
 }
 
 fn error_min_const_fn_violation(tcx: TyCtxt<'_>, span: Span, msg: Cow<'_, str>) {
-    struct_span_err!(tcx.sess, span, E0723, "{}", msg)
+    struct_span_err!(tcx.sess, span, "E0723", "{}", msg)
         .note(
             "see issue #57563 <https://github.com/rust-lang/rust/issues/57563> \
              for more information",

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -614,7 +614,7 @@ pub fn check_unsafety(tcx: TyCtxt<'_>, def_id: DefId) {
                 struct_span_err!(
                     tcx.sess,
                     source_info.span,
-                    E0133,
+                    "E0133",
                     "{} is unsafe and requires unsafe function or block",
                     description
                 )

--- a/src/librustc_mir/util/borrowck_errors.rs
+++ b/src/librustc_mir/util/borrowck_errors.rs
@@ -4,7 +4,13 @@ use rustc_span::{MultiSpan, Span};
 
 impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
     crate fn cannot_move_when_borrowed(&self, span: Span, desc: &str) -> DiagnosticBuilder<'cx> {
-        struct_span_err!(self, span, E0505, "cannot move out of `{}` because it is borrowed", desc,)
+        struct_span_err!(
+            self,
+            span,
+            "E0505",
+            "cannot move out of `{}` because it is borrowed",
+            desc,
+        )
     }
 
     crate fn cannot_use_when_mutably_borrowed(
@@ -17,7 +23,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         let mut err = struct_span_err!(
             self,
             span,
-            E0503,
+            "E0503",
             "cannot use `{}` because it was mutably borrowed",
             desc,
         );
@@ -36,7 +42,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         struct_span_err!(
             self,
             span,
-            E0381,
+            "E0381",
             "{} of possibly-uninitialized variable: `{}`",
             verb,
             desc,
@@ -57,7 +63,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         let mut err = struct_span_err!(
             self,
             new_loan_span,
-            E0499,
+            "E0499",
             "cannot borrow `{}`{} as mutable more than once at a time",
             desc,
             via(opt_via),
@@ -102,7 +108,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         let mut err = struct_span_err!(
             self,
             new_loan_span,
-            E0524,
+            "E0524",
             "two closures require unique access to `{}` at the same time",
             desc,
         );
@@ -135,7 +141,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         let mut err = struct_span_err!(
             self,
             new_loan_span,
-            E0500,
+            "E0500",
             "closure requires unique access to `{}` but {} is already borrowed{}",
             desc_new,
             noun_old,
@@ -167,7 +173,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         let mut err = struct_span_err!(
             self,
             new_loan_span,
-            E0501,
+            "E0501",
             "cannot borrow `{}`{} as {} because previous closure \
              requires unique access",
             desc_new,
@@ -205,7 +211,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         let mut err = struct_span_err!(
             self,
             span,
-            E0502,
+            "E0502",
             "cannot borrow `{}`{} as {} because {} is also borrowed \
              as {}{}",
             desc_new,
@@ -247,7 +253,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         let mut err = struct_span_err!(
             self,
             span,
-            E0506,
+            "E0506",
             "cannot assign to `{}` because it is borrowed",
             desc,
         );
@@ -264,11 +270,11 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         is_arg: bool,
     ) -> DiagnosticBuilder<'cx> {
         let msg = if is_arg { "to immutable argument" } else { "twice to immutable variable" };
-        struct_span_err!(self, span, E0384, "cannot assign {} `{}`", msg, desc,)
+        struct_span_err!(self, span, "E0384", "cannot assign {} `{}`", msg, desc,)
     }
 
     crate fn cannot_assign(&self, span: Span, desc: &str) -> DiagnosticBuilder<'cx> {
-        struct_span_err!(self, span, E0594, "cannot assign to {}", desc)
+        struct_span_err!(self, span, "E0594", "cannot assign to {}", desc)
     }
 
     crate fn cannot_move_out_of(
@@ -276,7 +282,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         move_from_span: Span,
         move_from_desc: &str,
     ) -> DiagnosticBuilder<'cx> {
-        struct_span_err!(self, move_from_span, E0507, "cannot move out of {}", move_from_desc,)
+        struct_span_err!(self, move_from_span, "E0507", "cannot move out of {}", move_from_desc,)
     }
 
     /// Signal an error due to an attempt to move out of the interior
@@ -296,7 +302,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         let mut err = struct_span_err!(
             self,
             move_from_span,
-            E0508,
+            "E0508",
             "cannot move out of type `{}`, a non-copy {}",
             ty,
             type_name,
@@ -313,7 +319,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         let mut err = struct_span_err!(
             self,
             move_from_span,
-            E0509,
+            "E0509",
             "cannot move out of type `{}`, which implements the `Drop` trait",
             container_ty,
         );
@@ -333,7 +339,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         struct_span_err!(
             self,
             use_span,
-            E0382,
+            "E0382",
             "{} of {}moved value{}",
             verb,
             optional_adverb_for_moved,
@@ -347,7 +353,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         path: &str,
         reason: &str,
     ) -> DiagnosticBuilder<'cx> {
-        struct_span_err!(self, span, E0596, "cannot borrow {} as mutable{}", path, reason,)
+        struct_span_err!(self, span, "E0596", "cannot borrow {} as mutable{}", path, reason,)
     }
 
     crate fn cannot_mutate_in_immutable_section(
@@ -361,7 +367,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         let mut err = struct_span_err!(
             self,
             mutate_span,
-            E0510,
+            "E0510",
             "cannot {} `{}` in {}",
             action,
             immutable_place,
@@ -380,7 +386,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         let mut err = struct_span_err!(
             self,
             span,
-            E0626,
+            "E0626",
             "borrow may still be in use when generator yields",
         );
         err.span_label(yield_span, "possible yield occurs here");
@@ -391,7 +397,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         struct_span_err!(
             self,
             borrow_span,
-            E0713,
+            "E0713",
             "borrow may still be in use when destructor runs",
         )
     }
@@ -401,7 +407,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         span: Span,
         path: &str,
     ) -> DiagnosticBuilder<'cx> {
-        struct_span_err!(self, span, E0597, "{} does not live long enough", path,)
+        struct_span_err!(self, span, "E0597", "{} does not live long enough", path,)
     }
 
     crate fn cannot_return_reference_to_local(
@@ -414,7 +420,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         let mut err = struct_span_err!(
             self,
             span,
-            E0515,
+            "E0515",
             "cannot {RETURN} {REFERENCE} {LOCAL}",
             RETURN = return_kind,
             REFERENCE = reference_desc,
@@ -438,7 +444,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         let mut err = struct_span_err!(
             self,
             closure_span,
-            E0373,
+            "E0373",
             "closure may outlive the current function, \
              but it borrows {}, \
              which is owned by the current function",
@@ -453,11 +459,11 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         &self,
         span: Span,
     ) -> DiagnosticBuilder<'cx> {
-        struct_span_err!(self, span, E0712, "thread-local variable borrowed past end of function",)
+        struct_span_err!(self, span, "E0712", "thread-local variable borrowed past end of function",)
     }
 
     crate fn temporary_value_borrowed_for_too_long(&self, span: Span) -> DiagnosticBuilder<'cx> {
-        struct_span_err!(self, span, E0716, "temporary value dropped while borrowed",)
+        struct_span_err!(self, span, "E0716", "temporary value dropped while borrowed",)
     }
 
     fn struct_span_err_with_code<S: Into<MultiSpan>>(
@@ -478,7 +484,7 @@ crate fn borrowed_data_escapes_closure<'tcx>(
     struct_span_err!(
         tcx.sess,
         escape_span,
-        E0521,
+        "E0521",
         "borrowed data escapes outside of {}",
         escapes_from,
     )

--- a/src/librustc_mir_build/hair/pattern/check_match.rs
+++ b/src/librustc_mir_build/hair/pattern/check_match.rs
@@ -33,7 +33,7 @@ crate fn check_match(tcx: TyCtxt<'_>, def_id: DefId) {
 }
 
 fn create_e0004(sess: &Session, sp: Span, error_message: String) -> DiagnosticBuilder<'_> {
-    struct_span_err!(sess, sp, E0004, "{}", &error_message)
+    struct_span_err!(sess, sp, "E0004", "{}", &error_message)
 }
 
 struct MatchVisitor<'a, 'tcx> {
@@ -107,7 +107,7 @@ impl PatCtxt<'_, '_> {
     }
 
     fn span_e0158(&self, span: Span, text: &str) {
-        struct_span_err!(self.tcx.sess, span, E0158, "{}", text).emit();
+        struct_span_err!(self.tcx.sess, span, "E0158", "{}", text).emit();
     }
 }
 
@@ -198,7 +198,7 @@ impl<'tcx> MatchVisitor<'_, 'tcx> {
             let mut err = struct_span_err!(
                 self.tcx.sess,
                 pat.span,
-                E0005,
+                "E0005",
                 "refutable pattern in {}: {} not covered",
                 origin,
                 joined_patterns
@@ -297,7 +297,7 @@ fn check_for_bindings_named_same_as_variants(cx: &MatchVisitor<'_, '_>, pat: &Pa
                                                 of the variants of the type `{}`",
                                     ident, ty_path
                                 ))
-                                .code(error_code!(E0170))
+                                .code(error_code!("E0170"))
                                 .span_suggestion(
                                     p.span,
                                     "to match on the variant, qualify the path",
@@ -590,7 +590,7 @@ fn check_legality_of_move_bindings(cx: &mut MatchVisitor<'_, '_>, has_guard: boo
         //
         // `x @ Foo(..)` is legal, but `x @ Foo(y)` isn't.
         if sub.map_or(false, |p| p.contains_bindings()) {
-            struct_span_err!(sess, p.span, E0007, "cannot bind by-move with sub-bindings")
+            struct_span_err!(sess, p.span, "E0007", "cannot bind by-move with sub-bindings")
                 .span_label(p.span, "binds an already bound by-move value by moving it")
                 .emit();
         } else if !has_guard && !by_ref_spans.is_empty() {

--- a/src/librustc_mir_build/hair/pattern/mod.rs
+++ b/src/librustc_mir_build/hair/pattern/mod.rs
@@ -446,7 +446,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                 struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0579,
+                    "E0579",
                     "lower range bound must be less than upper"
                 )
                 .emit();
@@ -461,7 +461,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0030,
+                    "E0030",
                     "lower range bound must be less than or equal to upper"
                 );
                 err.span_label(span, "lower bound larger than upper bound");

--- a/src/librustc_parse/parser/diagnostics.rs
+++ b/src/librustc_parse/parser/diagnostics.rs
@@ -66,7 +66,7 @@ impl Error {
                 let mut err = struct_span_err!(
                     handler,
                     sp,
-                    E0583,
+                    "E0583",
                     "file not found for module `{}`",
                     mod_name,
                 );
@@ -80,7 +80,7 @@ impl Error {
                 let mut err = struct_span_err!(
                     handler,
                     sp,
-                    E0584,
+                    "E0584",
                     "file for module `{}` found at both {} and {}",
                     mod_name,
                     default_path,
@@ -93,7 +93,7 @@ impl Error {
                 let mut err = struct_span_err!(
                     handler,
                     sp,
-                    E0585,
+                    "E0585",
                     "found a documentation comment that doesn't document anything",
                 );
                 err.help(
@@ -728,7 +728,7 @@ impl<'a> Parser<'a> {
         let mut err = struct_span_err!(
             self.sess.span_diagnostic,
             sum_span,
-            E0178,
+            "E0178",
             "expected a path on the left-hand side of `+`, not `{}`",
             pprust::ty_to_string(ty)
         );
@@ -1362,7 +1362,7 @@ impl<'a> Parser<'a> {
         struct_span_err!(
             self.diagnostic(),
             pat.span,
-            E0642,
+            "E0642",
             "patterns aren't allowed in methods without bodies",
         )
         .span_suggestion_short(

--- a/src/librustc_parse/parser/mod.rs
+++ b/src/librustc_parse/parser/mod.rs
@@ -1206,7 +1206,7 @@ impl<'a> Parser<'a> {
 
         let path_str = pprust::path_to_string(&path);
 
-        struct_span_err!(self.sess.span_diagnostic, path.span, E0704, "{}", msg)
+        struct_span_err!(self.sess.span_diagnostic, path.span, "E0704", "{}", msg)
             .help(suggestion)
             .span_suggestion(
                 path.span,

--- a/src/librustc_passes/check_attr.rs
+++ b/src/librustc_passes/check_attr.rs
@@ -122,7 +122,7 @@ impl CheckAttrVisitor<'tcx> {
                 struct_span_err!(
                     self.tcx.sess,
                     attr.span,
-                    E0518,
+                    "E0518",
                     "attribute should be applied to function or closure",
                 )
                 .span_label(*span, "not a function or closure")
@@ -145,7 +145,7 @@ impl CheckAttrVisitor<'tcx> {
                 struct_span_err!(
                     self.tcx.sess,
                     *attr_span,
-                    E0736,
+                    "E0736",
                     "cannot use `#[track_caller]` with `#[naked]`",
                 )
                 .emit();
@@ -156,7 +156,7 @@ impl CheckAttrVisitor<'tcx> {
                 struct_span_err!(
                     self.tcx.sess,
                     *attr_span,
-                    E0738,
+                    "E0738",
                     "`#[track_caller]` may not be used on trait methods",
                 )
                 .emit();
@@ -166,7 +166,7 @@ impl CheckAttrVisitor<'tcx> {
                 struct_span_err!(
                     self.tcx.sess,
                     *attr_span,
-                    E0739,
+                    "E0739",
                     "attribute should be applied to function"
                 )
                 .span_label(*span, "not a function")
@@ -184,7 +184,7 @@ impl CheckAttrVisitor<'tcx> {
                 struct_span_err!(
                     self.tcx.sess,
                     attr.span,
-                    E0701,
+                    "E0701",
                     "attribute can only be applied to a struct or enum"
                 )
                 .span_label(*span, "not a struct or enum")
@@ -329,7 +329,7 @@ impl CheckAttrVisitor<'tcx> {
             struct_span_err!(
                 self.tcx.sess,
                 hint_spans,
-                E0692,
+                "E0692",
                 "transparent {} cannot have other repr hints",
                 target
             )
@@ -346,7 +346,7 @@ impl CheckAttrVisitor<'tcx> {
                 hint_spans.collect::<Vec<Span>>(),
                 |lint| {
                     lint.build("conflicting representation hints")
-                        .code(rustc_errors::error_code!(E0566))
+                        .code(rustc_errors::error_code!("E0566"))
                         .emit();
                 },
             );
@@ -360,7 +360,7 @@ impl CheckAttrVisitor<'tcx> {
         hint_message: &str,
         label_message: &str,
     ) {
-        struct_span_err!(self.tcx.sess, hint_span, E0517, "{}", hint_message)
+        struct_span_err!(self.tcx.sess, hint_span, "E0517", "{}", hint_message)
             .span_label(label_span, label_message)
             .emit();
     }

--- a/src/librustc_passes/entry.rs
+++ b/src/librustc_passes/entry.rs
@@ -107,7 +107,7 @@ fn find_item(item: &Item<'_>, ctxt: &mut EntryContext<'_, '_>, at_root: bool) {
             if ctxt.main_fn.is_none() {
                 ctxt.main_fn = Some((item.hir_id, item.span));
             } else {
-                struct_span_err!(ctxt.session, item.span, E0136, "multiple `main` functions")
+                struct_span_err!(ctxt.session, item.span, "E0136", "multiple `main` functions")
                     .emit();
             }
         }
@@ -121,7 +121,7 @@ fn find_item(item: &Item<'_>, ctxt: &mut EntryContext<'_, '_>, at_root: bool) {
                 struct_span_err!(
                     ctxt.session,
                     item.span,
-                    E0137,
+                    "E0137",
                     "multiple functions with a `#[main]` attribute"
                 )
                 .span_label(item.span, "additional `#[main]` function")
@@ -133,7 +133,7 @@ fn find_item(item: &Item<'_>, ctxt: &mut EntryContext<'_, '_>, at_root: bool) {
             if ctxt.start_fn.is_none() {
                 ctxt.start_fn = Some((item.hir_id, item.span));
             } else {
-                struct_span_err!(ctxt.session, item.span, E0138, "multiple `start` functions")
+                struct_span_err!(ctxt.session, item.span, "E0138", "multiple `start` functions")
                     .span_label(ctxt.start_fn.unwrap().1, "previous `#[start]` function here")
                     .span_label(item.span, "multiple `start` functions")
                     .emit();
@@ -169,7 +169,7 @@ fn no_main_err(tcx: TyCtxt<'_>, visitor: &EntryContext<'_, '_>) {
     let mut err = struct_span_err!(
         tcx.sess,
         DUMMY_SP,
-        E0601,
+        "E0601",
         "`main` function not found in crate `{}`",
         tcx.crate_name(LOCAL_CRATE)
     );

--- a/src/librustc_passes/intrinsicck.rs
+++ b/src/librustc_passes/intrinsicck.rs
@@ -80,7 +80,7 @@ impl ExprVisitor<'tcx> {
             let from = unpack_option_like(self.tcx, from);
             if let (&ty::FnDef(..), SizeSkeleton::Known(size_to)) = (&from.kind, sk_to) {
                 if size_to == Pointer.size(&self.tcx) {
-                    struct_span_err!(self.tcx.sess, span, E0591, "can't transmute zero-sized type")
+                    struct_span_err!(self.tcx.sess, span, "E0591", "can't transmute zero-sized type")
                         .note(&format!("source type: {}", from))
                         .note(&format!("target type: {}", to))
                         .help("cast with `as` to a pointer instead")
@@ -107,7 +107,7 @@ impl ExprVisitor<'tcx> {
         let mut err = struct_span_err!(
             self.tcx.sess,
             span,
-            E0512,
+            "E0512",
             "cannot transmute between types of different sizes, \
                                         or dependently-sized types"
         );

--- a/src/librustc_passes/lib_features.rs
+++ b/src/librustc_passes/lib_features.rs
@@ -107,7 +107,7 @@ impl LibFeatureCollector<'tcx> {
     }
 
     fn span_feature_error(&self, span: Span, msg: &str) {
-        struct_span_err!(self.tcx.sess, span, E0711, "{}", &msg,).emit();
+        struct_span_err!(self.tcx.sess, span, "E0711", "{}", &msg,).emit();
     }
 }
 

--- a/src/librustc_passes/loops.rs
+++ b/src/librustc_passes/loops.rs
@@ -110,7 +110,7 @@ impl<'a, 'hir> Visitor<'hir> for CheckLoopVisitor<'a, 'hir> {
                             struct_span_err!(
                                 self.sess,
                                 e.span,
-                                E0571,
+                                "E0571",
                                 "`break` with value from a `{}` loop",
                                 kind.name()
                             )
@@ -145,7 +145,7 @@ impl<'a, 'hir> Visitor<'hir> for CheckLoopVisitor<'a, 'hir> {
                             struct_span_err!(
                                 self.sess,
                                 e.span,
-                                E0696,
+                                "E0696",
                                 "`continue` pointing to a labeled block"
                             )
                             .span_label(e.span, "labeled blocks cannot be `continue`'d")
@@ -178,7 +178,7 @@ impl<'a, 'hir> CheckLoopVisitor<'a, 'hir> {
 
     fn require_break_cx(&self, name: &str, span: Span) {
         let err_inside_of = |article, ty, closure_span| {
-            struct_span_err!(self.sess, span, E0267, "`{}` inside of {} {}", name, article, ty)
+            struct_span_err!(self.sess, span, "E0267", "`{}` inside of {} {}", name, article, ty)
                 .span_label(span, format!("cannot `{}` inside of {} {}", name, article, ty))
                 .span_label(closure_span, &format!("enclosing {}", ty))
                 .emit();
@@ -189,7 +189,7 @@ impl<'a, 'hir> CheckLoopVisitor<'a, 'hir> {
             Closure(closure_span) => err_inside_of("a", "closure", closure_span),
             AsyncClosure(closure_span) => err_inside_of("an", "`async` block", closure_span),
             Normal | AnonConst => {
-                struct_span_err!(self.sess, span, E0268, "`{}` outside of a loop", name)
+                struct_span_err!(self.sess, span, "E0268", "`{}` outside of a loop", name)
                     .span_label(span, format!("cannot `{}` outside of a loop", name))
                     .emit();
             }
@@ -207,7 +207,7 @@ impl<'a, 'hir> CheckLoopVisitor<'a, 'hir> {
                 struct_span_err!(
                     self.sess,
                     span,
-                    E0695,
+                    "E0695",
                     "unlabeled `{}` inside of a labeled block",
                     cf_type
                 )
@@ -229,7 +229,7 @@ impl<'a, 'hir> CheckLoopVisitor<'a, 'hir> {
         struct_span_err!(
             self.sess,
             span,
-            E0590,
+            "E0590",
             "`break` or `continue` with no label in the condition of a `while` loop"
         )
         .span_label(span, format!("unlabeled `{}` in the condition of a `while` loop", cf_type))

--- a/src/librustc_plugin_impl/load.rs
+++ b/src/librustc_plugin_impl/load.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 type PluginRegistrarFn = fn(&mut Registry<'_>);
 
 fn call_malformed_plugin_attribute(sess: &Session, span: Span) {
-    struct_span_err!(sess, span, E0498, "malformed `plugin` attribute")
+    struct_span_err!(sess, span, "E0498", "malformed `plugin` attribute")
         .span_label(span, "malformed attribute")
         .emit();
 }

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -1032,7 +1032,7 @@ impl<'a, 'tcx> NamePrivacyVisitor<'a, 'tcx> {
             struct_span_err!(
                 self.tcx.sess,
                 span,
-                E0451,
+                "E0451",
                 "field `{}` of {} `{}` is private",
                 field.ident,
                 def.variant_descr(),
@@ -1808,9 +1808,9 @@ impl SearchInterfaceForPrivateItemsVisitor<'tcx> {
             let make_msg = || format!("{} {} `{}` in public interface", vis_descr, kind, descr);
             if self.has_pub_restricted || self.has_old_errors || self.in_assoc_ty {
                 let mut err = if kind == "trait" {
-                    struct_span_err!(self.tcx.sess, self.span, E0445, "{}", make_msg())
+                    struct_span_err!(self.tcx.sess, self.span, "E0445", "{}", make_msg())
                 } else {
-                    struct_span_err!(self.tcx.sess, self.span, E0446, "{}", make_msg())
+                    struct_span_err!(self.tcx.sess, self.span, "E0446", "{}", make_msg())
                 };
                 err.span_label(self.span, format!("can't leak {} {}", vis_descr, kind));
                 err.span_label(vis_span, format!("`{}` declared as {}", descr, vis_descr));

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -951,7 +951,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
                     struct_span_err!(
                         self.r.session,
                         item.span,
-                        E0468,
+                        "E0468",
                         "an `extern crate` loading macros must be at the crate root"
                     )
                     .emit();
@@ -968,7 +968,10 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
                     }
                 }
                 let ill_formed =
-                    |span| struct_span_err!(self.r.session, span, E0466, "bad macro import").emit();
+                    |span| {
+                        struct_span_err!(self.r.session, span, "E0466", "bad macro import")
+                            .emit();
+                    };
                 match attr.meta() {
                     Some(meta) => match meta.kind {
                         MetaItemKind::Word => {
@@ -1041,7 +1044,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
                         allow_shadowing,
                     );
                 } else {
-                    struct_span_err!(self.r.session, ident.span, E0469, "imported macro not found")
+                    struct_span_err!(self.r.session, ident.span, "E0469", "imported macro not found")
                         .emit();
                 }
             }

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -131,7 +131,7 @@ impl<'a> Resolver<'a> {
                 let mut err = struct_span_err!(
                     self.session,
                     span,
-                    E0401,
+                    "E0401",
                     "can't use generic parameters from outer function",
                 );
                 err.span_label(span, format!("use of generic parameter from outer function"));
@@ -204,7 +204,7 @@ impl<'a> Resolver<'a> {
                 let mut err = struct_span_err!(
                     self.session,
                     span,
-                    E0403,
+                    "E0403",
                     "the name `{}` is already used for a generic \
                      parameter in this item's generic parameters",
                     name,
@@ -217,7 +217,7 @@ impl<'a> Resolver<'a> {
                 let mut err = struct_span_err!(
                     self.session,
                     span,
-                    E0407,
+                    "E0407",
                     "method `{}` is not a member of trait `{}`",
                     method,
                     trait_
@@ -229,7 +229,7 @@ impl<'a> Resolver<'a> {
                 let mut err = struct_span_err!(
                     self.session,
                     span,
-                    E0437,
+                    "E0437",
                     "type `{}` is not a member of trait `{}`",
                     type_,
                     trait_
@@ -241,7 +241,7 @@ impl<'a> Resolver<'a> {
                 let mut err = struct_span_err!(
                     self.session,
                     span,
-                    E0438,
+                    "E0438",
                     "const `{}` is not a member of trait `{}`",
                     const_,
                     trait_
@@ -259,7 +259,7 @@ impl<'a> Resolver<'a> {
                 let mut err = struct_span_err!(
                     self.session,
                     msp,
-                    E0408,
+                    "E0408",
                     "variable `{}` is not bound in all patterns",
                     name,
                 );
@@ -283,7 +283,7 @@ impl<'a> Resolver<'a> {
                 let mut err = struct_span_err!(
                     self.session,
                     span,
-                    E0409,
+                    "E0409",
                     "variable `{}` is bound in inconsistent \
                                 ways within the same match arm",
                     variable_name
@@ -296,7 +296,7 @@ impl<'a> Resolver<'a> {
                 let mut err = struct_span_err!(
                     self.session,
                     span,
-                    E0415,
+                    "E0415",
                     "identifier `{}` is bound more than once in this parameter list",
                     identifier
                 );
@@ -307,7 +307,7 @@ impl<'a> Resolver<'a> {
                 let mut err = struct_span_err!(
                     self.session,
                     span,
-                    E0416,
+                    "E0416",
                     "identifier `{}` is bound more than once in the same pattern",
                     identifier
                 );
@@ -318,7 +318,7 @@ impl<'a> Resolver<'a> {
                 let mut err = struct_span_err!(
                     self.session,
                     span,
-                    E0426,
+                    "E0426",
                     "use of undeclared label `{}`",
                     name
                 );
@@ -337,7 +337,7 @@ impl<'a> Resolver<'a> {
             ResolutionError::SelfImportsOnlyAllowedWithin => struct_span_err!(
                 self.session,
                 span,
-                E0429,
+                "E0429",
                 "{}",
                 "`self` imports are only allowed within a { } list"
             ),
@@ -355,7 +355,7 @@ impl<'a> Resolver<'a> {
                 let mut err = struct_span_err!(
                     self.session,
                     span,
-                    E0431,
+                    "E0431",
                     "`self` import can only appear in an import list with \
                                                 a non-empty prefix"
                 );
@@ -364,7 +364,7 @@ impl<'a> Resolver<'a> {
             }
             ResolutionError::FailedToResolve { label, suggestion } => {
                 let mut err =
-                    struct_span_err!(self.session, span, E0433, "failed to resolve: {}", &label);
+                    struct_span_err!(self.session, span, "E0433", "failed to resolve: {}", &label);
                 err.span_label(span, label);
 
                 if let Some((suggestions, msg, applicability)) = suggestion {
@@ -377,7 +377,7 @@ impl<'a> Resolver<'a> {
                 let mut err = struct_span_err!(
                     self.session,
                     span,
-                    E0434,
+                    "E0434",
                     "{}",
                     "can't capture dynamic environment in a fn item"
                 );
@@ -388,7 +388,7 @@ impl<'a> Resolver<'a> {
                 let mut err = struct_span_err!(
                     self.session,
                     span,
-                    E0435,
+                    "E0435",
                     "attempt to use a non-constant value in a constant"
                 );
                 err.span_label(span, "non-constant value");
@@ -400,7 +400,7 @@ impl<'a> Resolver<'a> {
                 let mut err = struct_span_err!(
                     self.session,
                     span,
-                    E0530,
+                    "E0530",
                     "{}s cannot shadow {}s",
                     what_binding,
                     shadows_what
@@ -418,7 +418,7 @@ impl<'a> Resolver<'a> {
                 let mut err = struct_span_err!(
                     self.session,
                     span,
-                    E0128,
+                    "E0128",
                     "type parameters with a default cannot use \
                                                 forward declared identifiers"
                 );
@@ -432,7 +432,7 @@ impl<'a> Resolver<'a> {
                 let mut err = struct_span_err!(
                     self.session,
                     span,
-                    E0735,
+                    "E0735",
                     "type parameters cannot use `Self` in their defaults"
                 );
                 err.span_label(span, "`Self` in type parameter default".to_string());

--- a/src/librustc_resolve/imports.rs
+++ b/src/librustc_resolve/imports.rs
@@ -744,7 +744,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
             (span, msg)
         };
 
-        let mut diag = struct_span_err!(self.r.session, span, E0432, "{}", &msg);
+        let mut diag = struct_span_err!(self.r.session, span, "E0432", "{}", &msg);
 
         if let Some((_, UnresolvedImportError { note, .. })) = errors.iter().last() {
             for message in note {
@@ -850,7 +850,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
                     }
                     Ok(binding) if !binding.is_importable() => {
                         let msg = format!("`{}` is not directly importable", target);
-                        struct_span_err!(this.session, directive.span, E0253, "{}", &msg)
+                        struct_span_err!(this.session, directive.span, "E0253", "{}", &msg)
                             .span_label(directive.span, "cannot be imported directly")
                             .emit();
                         // Do not import this illegal binding. Import a dummy binding and pretend
@@ -1214,7 +1214,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
                 struct_span_err!(
                     self.r.session,
                     directive.span,
-                    E0365,
+                    "E0365",
                     "`{}` is private, and cannot be re-exported",
                     ident
                 )
@@ -1225,7 +1225,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
                 let msg = format!("`{}` is private, and cannot be re-exported", ident);
                 let note_msg =
                     format!("consider marking `{}` as `pub` in the imported module", ident,);
-                struct_span_err!(self.r.session, directive.span, E0364, "{}", &msg)
+                struct_span_err!(self.r.session, directive.span, "E0364", "{}", &msg)
                     .span_note(directive.span, &note_msg)
                     .emit();
             }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2538,15 +2538,15 @@ impl<'a> Resolver<'a> {
         let msg = format!("the name `{}` is defined multiple times", name);
 
         let mut err = match (old_binding.is_extern_crate(), new_binding.is_extern_crate()) {
-            (true, true) => struct_span_err!(self.session, span, E0259, "{}", msg),
+            (true, true) => struct_span_err!(self.session, span, "E0259", "{}", msg),
             (true, _) | (_, true) => match new_binding.is_import() && old_binding.is_import() {
-                true => struct_span_err!(self.session, span, E0254, "{}", msg),
-                false => struct_span_err!(self.session, span, E0260, "{}", msg),
+                true => struct_span_err!(self.session, span, "E0254", "{}", msg),
+                false => struct_span_err!(self.session, span, "E0260", "{}", msg),
             },
             _ => match (old_binding.is_import(), new_binding.is_import()) {
-                (false, false) => struct_span_err!(self.session, span, E0428, "{}", msg),
-                (true, true) => struct_span_err!(self.session, span, E0252, "{}", msg),
-                _ => struct_span_err!(self.session, span, E0255, "{}", msg),
+                (false, false) => struct_span_err!(self.session, span, "E0428", "{}", msg),
+                (true, true) => struct_span_err!(self.session, span, "E0252", "{}", msg),
+                _ => struct_span_err!(self.session, span, "E0255", "{}", msg),
             },
         };
 

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -239,7 +239,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             let mut err = struct_span_err! {
                 tcx.sess,
                 spans.clone(),
-                E0632,
+                "E0632",
                 "cannot provide explicit generic arguments when `impl Trait` is \
                 used in argument position"
             };
@@ -839,7 +839,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         let mut err = struct_span_err!(
             self.tcx().sess,
             span,
-            E0393,
+            "E0393",
             "the type parameter{} {} must be explicitly specified",
             pluralize!(missing_type_params.len()),
             display,
@@ -1128,7 +1128,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     struct_span_err!(
                         tcx.sess,
                         span,
-                        E0203,
+                        "E0203",
                         "type parameter has more than one relaxed default \
                         bound, only one is supported"
                     )
@@ -1312,7 +1312,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     struct_span_err!(
                         tcx.sess,
                         binding.span,
-                        E0582,
+                        "E0582",
                         "binding for associated type `{}` references lifetime `{}`, \
                          which does not appear in the trait input types",
                         binding.item_name,
@@ -1366,7 +1366,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     struct_span_err!(
                         self.tcx().sess,
                         binding.span,
-                        E0719,
+                        "E0719",
                         "the value of the associated type `{}` (from trait `{}`) \
                          is already specified",
                         binding.item_name,
@@ -1454,7 +1454,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             let mut err = struct_span_err!(
                 tcx.sess,
                 additional_trait.bottom().1,
-                E0225,
+                "E0225",
                 "only auto traits can be used as additional traits in a trait object"
             );
             additional_trait.label_with_exp_info(
@@ -1470,7 +1470,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             struct_span_err!(
                 tcx.sess,
                 span,
-                E0224,
+                "E0224",
                 "at least one trait is required for an object type"
             )
             .emit();
@@ -1635,7 +1635,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                         struct_span_err!(
                             tcx.sess,
                             span,
-                            E0228,
+                            "E0228",
                             "the lifetime bound for this object type cannot be deduced \
                              from context; please supply an explicit bound"
                         )
@@ -1734,7 +1734,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         let mut err = struct_span_err!(
             tcx.sess,
             trait_bound_spans,
-            E0191,
+            "E0191",
             "the value of the associated type{} {} must be specified",
             pluralize!(names.len()),
             names.join(", "),
@@ -1851,7 +1851,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         trait_str: &str,
         name: ast::Name,
     ) {
-        let mut err = struct_span_err!(self.tcx().sess, span, E0223, "ambiguous associated type");
+        let mut err = struct_span_err!(self.tcx().sess, span, "E0223", "ambiguous associated type");
         if let (Some(_), Ok(snippet)) = (
             self.tcx().sess.confused_type_with_std_module.borrow().get(&span),
             self.tcx().sess.source_map().span_to_snippet(span),
@@ -1951,7 +1951,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 struct_span_err!(
                     self.tcx().sess,
                     span,
-                    E0222,
+                    "E0222",
                     "ambiguous associated type `{}` in bounds of `{}`",
                     assoc_name,
                     ty_param_name()
@@ -1960,7 +1960,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 struct_span_err!(
                     self.tcx().sess,
                     span,
-                    E0221,
+                    "E0221",
                     "ambiguous associated type `{}` in bounds of `{}`",
                     assoc_name,
                     ty_param_name()
@@ -2045,7 +2045,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         let mut err = struct_span_err!(
             self.tcx().sess,
             span,
-            E0220,
+            "E0220",
             "associated type `{}` not found for `{}`",
             assoc_name,
             ty_param_name
@@ -2151,7 +2151,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     let mut err = struct_span_err!(
                         tcx.sess,
                         assoc_ident.span,
-                        E0599,
+                        "E0599",
                         "no variant named `{}` found for enum `{}`",
                         assoc_ident,
                         qself_ty,
@@ -2348,7 +2348,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 let mut err = struct_span_err!(
                     self.tcx().sess,
                     span,
-                    E0109,
+                    "E0109",
                     "{} arguments are not allowed for this type",
                     kind,
                 );
@@ -2371,7 +2371,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         let mut err = struct_span_err!(
             tcx.sess,
             span,
-            E0229,
+            "E0229",
             "associated type bindings are not allowed here"
         );
         err.span_label(span, "associated type not allowed here").emit();
@@ -2670,7 +2670,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 struct_span_err!(
                     tcx.sess,
                     ast_ty.span,
-                    E0516,
+                    "E0516",
                     "`typeof` is a reserved keyword but unimplemented"
                 )
                 .span_label(ast_ty.span, "reserved keyword")
@@ -2873,9 +2873,8 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             let mut err = struct_span_err!(
                 tcx.sess,
                 decl.output.span(),
-                E0581,
-                "return type references {} \
-                                            which is not constrained by the fn input types",
+                "E0581",
+                "return type references {} which is not constrained by the fn input types",
                 lifetime_name
             );
             if let ty::BrAnon(_) = *br {
@@ -2935,7 +2934,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             struct_span_err!(
                 tcx.sess,
                 span,
-                E0227,
+                "E0227",
                 "ambiguous lifetime bound, explicit lifetime bound required"
             )
             .emit();

--- a/src/librustc_typeck/check/autoderef.rs
+++ b/src/librustc_typeck/check/autoderef.rs
@@ -244,7 +244,7 @@ pub fn report_autoderef_recursion_limit_error<'tcx>(tcx: TyCtxt<'tcx>, span: Spa
         struct_span_err!(
             tcx.sess,
             span,
-            E0055,
+            "E0055",
             "reached the recursion limit while auto-dereferencing `{:?}`",
             ty
         )

--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -21,7 +21,7 @@ use syntax::ast::Ident;
 /// method that is called).
 pub fn check_legal_trait_for_method_call(tcx: TyCtxt<'_>, span: Span, trait_id: DefId) {
     if tcx.lang_items().drop_trait() == Some(trait_id) {
-        struct_span_err!(tcx.sess, span, E0040, "explicit use of destructor method")
+        struct_span_err!(tcx.sess, span, "E0040", "explicit use of destructor method")
             .span_label(span, "explicit destructor calls not allowed")
             .emit();
     }
@@ -276,7 +276,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         self.tcx.sess,
                         callee.span,
                         callee_ty,
-                        E0618,
+                        "E0618",
                         "expected function, found {}",
                         match unit_variant {
                             Some(ref path) => format!("enum variant `{}`", path),

--- a/src/librustc_typeck/check/cast.rs
+++ b/src/librustc_typeck/check/cast.rs
@@ -184,7 +184,7 @@ fn make_invalid_casting_error<'a, 'tcx>(
         sess,
         span,
         expr_ty,
-        E0606,
+        "E0606",
         "casting `{}` as `{}` is invalid",
         fcx.ty_to_string(expr_ty),
         fcx.ty_to_string(cast_ty)
@@ -305,7 +305,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
             }
             CastError::CastToBool => {
                 let mut err =
-                    struct_span_err!(fcx.tcx.sess, self.span, E0054, "cannot cast as `bool`");
+                    struct_span_err!(fcx.tcx.sess, self.span, "E0054", "cannot cast as `bool`");
 
                 if self.expr_ty.is_numeric() {
                     match fcx.tcx.sess.source_map().span_to_snippet(self.expr.span) {
@@ -332,7 +332,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                     fcx.tcx.sess,
                     self.span,
                     self.expr_ty,
-                    E0604,
+                    "E0604",
                     "only `u8` can be cast as `char`, not `{}`",
                     self.expr_ty
                 )
@@ -343,7 +343,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                     fcx.tcx.sess,
                     self.span,
                     self.expr_ty,
-                    E0605,
+                    "E0605",
                     "non-primitive cast: `{}` as `{}`",
                     self.expr_ty,
                     fcx.ty_to_string(self.cast_ty)
@@ -374,7 +374,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                 let mut err = struct_span_err!(
                     fcx.tcx.sess,
                     self.span,
-                    E0641,
+                    "E0641",
                     "cannot cast {} a pointer of an unknown kind",
                     if unknown_cast_to { "to" } else { "from" }
                 );
@@ -405,7 +405,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
             fcx.tcx.sess,
             self.span,
             self.expr_ty,
-            E0620,
+            "E0620",
             "cast to unsized type: `{}` as `{}`",
             fcx.resolve_vars_if_possible(&self.expr_ty),
             tstr

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -1229,7 +1229,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
                         err = struct_span_err!(
                             fcx.tcx.sess,
                             cause.span,
-                            E0069,
+                            "E0069",
                             "`return;` in a function whose return type is not `()`"
                         );
                         err.span_label(cause.span, "return type is not `()`");

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -286,7 +286,7 @@ fn compare_predicate_entailment<'tcx>(
             let mut diag = struct_span_err!(
                 tcx.sess,
                 cause.span(tcx),
-                E0053,
+                "E0053",
                 "method `{}` has an incompatible type for trait",
                 trait_m.ident
             );
@@ -368,7 +368,7 @@ fn check_region_bounds_on_impl_item<'tcx>(
         let mut err = struct_span_err!(
             tcx.sess,
             span,
-            E0195,
+            "E0195",
             "lifetime parameters or bounds on {} `{}` do not match the trait declaration",
             item_kind,
             impl_m.ident,
@@ -525,9 +525,8 @@ fn compare_self_type<'tcx>(
             let mut err = struct_span_err!(
                 tcx.sess,
                 impl_m_span,
-                E0185,
-                "method `{}` has a `{}` declaration in the impl, but \
-                                            not in the trait",
+                "E0185",
+                "method `{}` has a `{}` declaration in the impl, but not in the trait",
                 trait_m.ident,
                 self_descr
             );
@@ -546,9 +545,8 @@ fn compare_self_type<'tcx>(
             let mut err = struct_span_err!(
                 tcx.sess,
                 impl_m_span,
-                E0186,
-                "method `{}` has a `{}` declaration in the trait, but \
-                                            not in the impl",
+                "E0186",
+                "method `{}` has a `{}` declaration in the trait, but not in the impl",
                 trait_m.ident,
                 self_descr
             );
@@ -752,9 +750,8 @@ fn compare_number_of_method_arguments<'tcx>(
         let mut err = struct_span_err!(
             tcx.sess,
             impl_span,
-            E0050,
-            "method `{}` has {} but the declaration in \
-                                        trait `{}` has {}",
+            "E0050",
+            "method `{}` has {} but the declaration in trait `{}` has {}",
             trait_m.ident,
             potentially_plural_count(impl_number_args, "parameter"),
             tcx.def_path_str(trait_m.def_id),
@@ -817,7 +814,7 @@ fn compare_synthetic_generics<'tcx>(
             let mut err = struct_span_err!(
                 tcx.sess,
                 impl_span,
-                E0643,
+                "E0643",
                 "method `{}` has incompatible signature for trait",
                 trait_m.ident
             );
@@ -1000,9 +997,8 @@ crate fn compare_const_impl<'tcx>(
             let mut diag = struct_span_err!(
                 tcx.sess,
                 cause.span,
-                E0326,
-                "implemented const `{}` has an incompatible type for \
-                                             trait",
+                "E0326",
+                "implemented const `{}` has an incompatible type for trait",
                 trait_c.ident
             );
 

--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -98,7 +98,7 @@ fn ensure_drop_params_and_item_params_correspond<'tcx>(
                 struct_span_err!(
                     tcx.sess,
                     drop_impl_span,
-                    E0366,
+                    "E0366",
                     "`Drop` impls cannot be specialized"
                 )
                 .span_note(
@@ -246,7 +246,7 @@ fn ensure_drop_predicates_are_implied_by_item_defn<'tcx>(
             struct_span_err!(
                 tcx.sess,
                 *predicate_sp,
-                E0367,
+                "E0367",
                 "`Drop` impl requires `{}` but the {} it is implemented for does not",
                 predicate,
                 self_descr,

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -345,7 +345,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             tcx.sess,
                             expr.span,
                             oprnd_t,
-                            E0614,
+                            "E0614",
                             "type `{}` cannot be dereferenced",
                             oprnd_t,
                         );
@@ -458,7 +458,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             struct_span_err!(
                 self.tcx.sess,
                 oprnd.span,
-                E0745,
+                "E0745",
                 "cannot take address of a temporary"
             )
             .span_label(oprnd.span, "temporary value")
@@ -676,7 +676,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             struct_span_err!(
                 self.tcx.sess,
                 expr.span,
-                E0572,
+                "E0572",
                 "return statement outside of function body",
             )
             .emit();
@@ -1109,7 +1109,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             struct_span_err!(
                 self.tcx.sess,
                 expr.span,
-                E0639,
+                "E0639",
                 "cannot create non-exhaustive {} using struct expression",
                 adt.variant_descr()
             )
@@ -1154,7 +1154,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         struct_span_err!(
                             self.tcx.sess,
                             base_expr.span,
-                            E0436,
+                            "E0436",
                             "functional record update syntax requires a struct"
                         )
                         .emit();
@@ -1223,7 +1223,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     let mut err = struct_span_err!(
                         self.tcx.sess,
                         field.ident.span,
-                        E0062,
+                        "E0062",
                         "field `{}` specified more than once",
                         ident
                     );
@@ -1273,7 +1273,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             struct_span_err!(
                 tcx.sess,
                 span,
-                E0063,
+                "E0063",
                 "missing field{} {}{} in initializer of `{}`",
                 pluralize!(remaining_fields.len()),
                 remaining_fields_names,
@@ -1320,7 +1320,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 ty::Adt(adt, ..) if adt.is_enum() => struct_span_err!(
                     self.tcx.sess,
                     field.ident.span,
-                    E0559,
+                    "E0559",
                     "{} `{}::{}` has no field named `{}`",
                     kind_name,
                     actual,
@@ -1330,7 +1330,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 _ => struct_span_err!(
                     self.tcx.sess,
                     field.ident.span,
-                    E0560,
+                    "E0560",
                     "{} `{}` has no field named `{}`",
                     kind_name,
                     actual,
@@ -1512,7 +1512,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 self.tcx().sess,
                 field.span,
                 expr_t,
-                E0610,
+                "E0610",
                 "`{}` is a primitive type and therefore doesn't have fields",
                 expr_t
             )
@@ -1573,7 +1573,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let mut err = struct_span_err!(
             self.tcx().sess,
             expr.span,
-            E0616,
+            "E0616",
             "field `{}` of {} `{}` is private",
             field,
             kind_name,
@@ -1598,7 +1598,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.tcx().sess,
             field.span,
             expr_t,
-            E0615,
+            "E0615",
             "attempted to take value of method `{}` on type `{}`",
             field,
             expr_t
@@ -1720,7 +1720,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.tcx().sess,
             span,
             expr_t,
-            E0609,
+            "E0609",
             "no field `{}` on type `{}`",
             field,
             expr_t
@@ -1754,7 +1754,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         self.tcx.sess,
                         expr.span,
                         base_t,
-                        E0608,
+                        "E0608",
                         "cannot index into a value of type `{}`",
                         base_t
                     );
@@ -1815,7 +1815,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 struct_span_err!(
                     self.tcx.sess,
                     expr.span,
-                    E0627,
+                    "E0627",
                     "yield expression outside of generator literal"
                 )
                 .emit();

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -27,7 +27,7 @@ fn equate_intrinsic_type<'tcx>(
     match it.kind {
         hir::ForeignItemKind::Fn(..) => {}
         _ => {
-            struct_span_err!(tcx.sess, it.span, E0622, "intrinsic must be a function")
+            struct_span_err!(tcx.sess, it.span, "E0622", "intrinsic must be a function")
                 .span_label(it.span, "expected a function")
                 .emit();
             return;
@@ -44,9 +44,8 @@ fn equate_intrinsic_type<'tcx>(
         struct_span_err!(
             tcx.sess,
             span,
-            E0094,
-            "intrinsic has wrong number of type \
-                         parameters: found {}, expected {}",
+            "E0094",
+            "intrinsic has wrong number of type parameters: found {}, expected {}",
             i_n_tps,
             n_tps
         )
@@ -120,7 +119,7 @@ pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem<'_>) {
                 struct_span_err!(
                     tcx.sess,
                     it.span,
-                    E0092,
+                    "E0092",
                     "unrecognized atomic operation function: `{}`",
                     op
                 )
@@ -337,7 +336,7 @@ pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem<'_>) {
                 struct_span_err!(
                     tcx.sess,
                     it.span,
-                    E0093,
+                    "E0093",
                     "unrecognized intrinsic function: `{}`",
                     *other
                 )
@@ -414,7 +413,7 @@ pub fn check_platform_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem<'_>)
                 struct_span_err!(
                     tcx.sess,
                     it.span,
-                    E0439,
+                    "E0439",
                     "invalid `simd_shuffle`, needs length: `{}`",
                     name
                 )

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -376,7 +376,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     struct_span_err!(
                         self.tcx.sess,
                         span,
-                        E0699,
+                        "E0699",
                         "the type of this value must be known \
                                to call a method on a raw pointer on it"
                     )

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -274,7 +274,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         let mut err = struct_span_err!(
                             tcx.sess,
                             span,
-                            E0689,
+                            "E0689",
                             "can't call {} `{}` on ambiguous numeric type `{}`",
                             item_kind,
                             item_name,
@@ -356,7 +356,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         let mut err = struct_span_err!(
                             tcx.sess,
                             span,
-                            E0599,
+                            "E0599",
                             "no {} named `{}` found for {} `{}` in the current scope",
                             item_kind,
                             item_name,
@@ -617,7 +617,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.sess(),
                     span,
-                    E0034,
+                    "E0034",
                     "multiple applicable items in scope"
                 );
                 err.span_label(span, format!("multiple `{}` found", item_name));
@@ -630,7 +630,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0624,
+                    "E0624",
                     "{} `{}` is private",
                     kind.descr(def_id),
                     item_name

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -158,7 +158,7 @@ use self::TupleArgumentsFlag::*;
 
 #[macro_export]
 macro_rules! type_error_struct {
-    ($session:expr, $span:expr, $typ:expr, $code:ident, $($message:tt)*) => ({
+    ($session:expr, $span:expr, $typ:expr, $code:expr, $($message:tt)*) => ({
         if $typ.references_error() {
             $session.diagnostic().struct_dummy()
         } else {
@@ -1134,7 +1134,7 @@ fn check_abi(tcx: TyCtxt<'_>, span: Span, abi: Abi) {
         struct_span_err!(
             tcx.sess,
             span,
-            E0570,
+            "E0570",
             "The ABI `{}` is not supported for the current target",
             abi
         )
@@ -1566,7 +1566,7 @@ fn check_union_fields(tcx: TyCtxt<'_>, span: Span, item_def_id: DefId) -> bool {
                 struct_span_err!(
                     tcx.sess,
                     field_span,
-                    E0740,
+                    "E0740",
                     "unions may not contain fields that need dropping"
                 )
                 .span_note(field_span, "`std::mem::ManuallyDrop` can be used to wrap the type")
@@ -1671,13 +1671,14 @@ fn check_opaque_for_cycles<'tcx>(
 ) {
     if let Err(partially_expanded_type) = tcx.try_expand_impl_trait_type(def_id, substs) {
         if let hir::OpaqueTyOrigin::AsyncFn = origin {
-            struct_span_err!(tcx.sess, span, E0733, "recursion in an `async fn` requires boxing",)
+            struct_span_err!(tcx.sess, span, "E0733", "recursion in an `async fn` requires boxing",)
                 .span_label(span, "recursive `async fn`")
                 .note("a recursive `async fn` must be rewritten to return a boxed `dyn Future`")
                 .emit();
         } else {
             let mut err =
-                struct_span_err!(tcx.sess, span, E0720, "opaque type expands to a recursive type",);
+                struct_span_err!(tcx.sess, span, "E0720",
+                                 "opaque type expands to a recursive type",);
             err.span_label(span, "expands to a recursive type");
             if let ty::Opaque(..) = partially_expanded_type.kind {
                 err.note("type resolves to itself");
@@ -1783,7 +1784,7 @@ pub fn check_item_type<'tcx>(tcx: TyCtxt<'tcx>, it: &'tcx hir::Item<'tcx>) {
                         struct_span_err!(
                             tcx.sess,
                             item.span,
-                            E0044,
+                            "E0044",
                             "foreign items may not have {} parameters",
                             kinds,
                         )
@@ -1859,7 +1860,7 @@ fn report_forbidden_specialization(
     let mut err = struct_span_err!(
         tcx.sess,
         impl_item.span,
-        E0520,
+        "E0520",
         "`{}` specializes an item from a parent `impl`, but \
          that item is not marked `default`",
         impl_item.ident
@@ -2000,7 +2001,7 @@ fn check_impl_items_against_trait<'tcx>(
                         let mut err = struct_span_err!(
                             tcx.sess,
                             impl_item.span,
-                            E0323,
+                            "E0323",
                             "item `{}` is an associated const, \
                               which doesn't match its trait `{}`",
                             ty_impl_item.ident,
@@ -2030,7 +2031,7 @@ fn check_impl_items_against_trait<'tcx>(
                         let mut err = struct_span_err!(
                             tcx.sess,
                             impl_item.span,
-                            E0324,
+                            "E0324",
                             "item `{}` is an associated method, \
                              which doesn't match its trait `{}`",
                             ty_impl_item.ident,
@@ -2061,7 +2062,7 @@ fn check_impl_items_against_trait<'tcx>(
                         let mut err = struct_span_err!(
                             tcx.sess,
                             impl_item.span,
-                            E0325,
+                            "E0325",
                             "item `{}` is an associated type, \
                              which doesn't match its trait `{}`",
                             ty_impl_item.ident,
@@ -2109,7 +2110,7 @@ fn check_impl_items_against_trait<'tcx>(
         struct_span_err!(
             tcx.sess,
             invalidator.span,
-            E0399,
+            "E0399",
             "the following trait items need to be reimplemented as `{}` was overridden: `{}`",
             invalidator.ident,
             invalidated_items.iter().map(|name| name.to_string()).collect::<Vec<_>>().join("`, `")
@@ -2133,7 +2134,7 @@ fn missing_items_err(
     let mut err = struct_span_err!(
         tcx.sess,
         impl_span,
-        E0046,
+        "E0046",
         "not all trait items implemented, missing: `{}`",
         missing_items_msg
     );
@@ -2336,12 +2337,12 @@ pub fn check_simd(tcx: TyCtxt<'_>, sp: Span, def_id: DefId) {
         if def.is_struct() {
             let fields = &def.non_enum_variant().fields;
             if fields.is_empty() {
-                struct_span_err!(tcx.sess, sp, E0075, "SIMD vector cannot be empty").emit();
+                struct_span_err!(tcx.sess, sp, "E0075", "SIMD vector cannot be empty").emit();
                 return;
             }
             let e = fields[0].ty(tcx, substs);
             if !fields.iter().all(|f| f.ty(tcx, substs) == e) {
-                struct_span_err!(tcx.sess, sp, E0076, "SIMD vector should be homogeneous")
+                struct_span_err!(tcx.sess, sp, "E0076", "SIMD vector should be homogeneous")
                     .span_label(sp, "SIMD elements must have the same type")
                     .emit();
                 return;
@@ -2353,7 +2354,7 @@ pub fn check_simd(tcx: TyCtxt<'_>, sp: Span, def_id: DefId) {
                     struct_span_err!(
                         tcx.sess,
                         sp,
-                        E0077,
+                        "E0077",
                         "SIMD vector element type should be machine type"
                     )
                     .emit();
@@ -2375,7 +2376,7 @@ fn check_packed(tcx: TyCtxt<'_>, sp: Span, def_id: DefId) {
                             struct_span_err!(
                                 tcx.sess,
                                 sp,
-                                E0634,
+                                "E0634",
                                 "type has conflicting packed representation hints"
                             )
                             .emit();
@@ -2388,7 +2389,7 @@ fn check_packed(tcx: TyCtxt<'_>, sp: Span, def_id: DefId) {
             struct_span_err!(
                 tcx.sess,
                 sp,
-                E0587,
+                "E0587",
                 "type has conflicting packed and align representation hints"
             )
             .emit();
@@ -2397,7 +2398,7 @@ fn check_packed(tcx: TyCtxt<'_>, sp: Span, def_id: DefId) {
                 let mut err = struct_span_err!(
                     tcx.sess,
                     sp,
-                    E0588,
+                    "E0588",
                     "packed type cannot transitively contain a `#[repr(align)]` type"
                 );
 
@@ -2477,7 +2478,7 @@ fn bad_variant_count<'tcx>(tcx: TyCtxt<'tcx>, adt: &'tcx ty::AdtDef, sp: Span, d
         .map(|variant| tcx.hir().span_if_local(variant.def_id).unwrap())
         .collect();
     let msg = format!("needs exactly one variant, but has {}", adt.variants.len(),);
-    let mut err = struct_span_err!(tcx.sess, sp, E0731, "transparent enum {}", msg);
+    let mut err = struct_span_err!(tcx.sess, sp, "E0731", "transparent enum {}", msg);
     err.span_label(sp, &msg);
     if let [start @ .., end] = &*variant_spans {
         for variant_span in start {
@@ -2501,7 +2502,7 @@ fn bad_non_zero_sized_fields<'tcx>(
     let mut err = struct_span_err!(
         tcx.sess,
         sp,
-        E0690,
+        "E0690",
         "{}transparent {} {}",
         if adt.is_enum() { "the variant of a " } else { "" },
         adt.descr(),
@@ -2562,7 +2563,7 @@ fn check_transparent(tcx: TyCtxt<'_>, sp: Span, def_id: DefId) {
             struct_span_err!(
                 tcx.sess,
                 span,
-                E0691,
+                "E0691",
                 "zero-sized field in transparent {} has alignment larger than 1",
                 adt.descr(),
             )
@@ -2589,7 +2590,7 @@ pub fn check_enum<'tcx>(
             struct_span_err!(
                 tcx.sess,
                 attr.span,
-                E0084,
+                "E0084",
                 "unsupported representation for zero-variant enum"
             )
             .span_label(sp, "zero-variant enum")
@@ -2629,7 +2630,7 @@ pub fn check_enum<'tcx>(
 
         if disr_non_unit || (disr_units && has_non_units) {
             let mut err =
-                struct_span_err!(tcx.sess, sp, E0732, "`#[repr(inttype)]` must be specified");
+                struct_span_err!(tcx.sess, sp, "E0732", "`#[repr(inttype)]` must be specified");
             err.emit();
         }
     }
@@ -2652,7 +2653,7 @@ pub fn check_enum<'tcx>(
             struct_span_err!(
                 tcx.sess,
                 span,
-                E0081,
+                "E0081",
                 "discriminant value `{}` already exists",
                 disr_vals[i]
             )
@@ -2671,7 +2672,7 @@ fn report_unexpected_variant_res(tcx: TyCtxt<'_>, res: Res, span: Span, qpath: &
     struct_span_err!(
         tcx.sess,
         span,
-        E0533,
+        "E0533",
         "expected unit struct, unit variant or constant, found {} `{}`",
         res.descr(),
         hir::print::to_string(&tcx.hir(), |s| s.print_qpath(qpath, false))
@@ -3942,7 +3943,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     struct_span_err!(
                         tcx.sess,
                         sp,
-                        E0059,
+                        "E0059",
                         "cannot use call notation; the first type parameter \
                          for the function trait is neither a tuple nor unit"
                     )
@@ -4360,7 +4361,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             struct_span_err!(
                 self.tcx.sess,
                 path_span,
-                E0071,
+                "E0071",
                 "expected struct, variant or union type, found {}",
                 ty.sort_string(self.tcx)
             )
@@ -5783,7 +5784,7 @@ pub fn check_bounds_are_used<'tcx>(tcx: TyCtxt<'tcx>, generics: &ty::Generics, t
         if !used {
             let id = tcx.hir().as_local_hir_id(param.def_id).unwrap();
             let span = tcx.hir().span(id);
-            struct_span_err!(tcx.sess, span, E0091, "type parameter `{}` is unused", param.name)
+            struct_span_err!(tcx.sess, span, "E0091", "type parameter `{}` is unused", param.name)
                 .span_label(span, "unused type parameter")
                 .emit();
         }

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -255,7 +255,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             let mut err = struct_span_err!(
                                 self.tcx.sess,
                                 expr.span,
-                                E0368,
+                                "E0368",
                                 "binary assignment operation `{}=` cannot be applied to type `{}`",
                                 op.node.as_str(),
                                 lhs_ty,
@@ -399,7 +399,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             let mut err = struct_span_err!(
                                 self.tcx.sess,
                                 op.span,
-                                E0369,
+                                "E0369",
                                 "{}",
                                 message.as_str()
                             );
@@ -674,7 +674,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     let mut err = struct_span_err!(
                         self.tcx.sess,
                         ex.span,
-                        E0600,
+                        "E0600",
                         "cannot apply unary operator `{}` to type `{}`",
                         op.as_str(),
                         actual

--- a/src/librustc_typeck/check/pat.rs
+++ b/src/librustc_typeck/check/pat.rs
@@ -469,7 +469,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let mut err = struct_span_err!(
             self.tcx.sess,
             span,
-            E0029,
+            "E0029",
             "only char and numeric types are allowed in range patterns"
         );
         let msg = |ty| format!("this is of type `{}` but it should be `char` or numeric", ty);
@@ -603,7 +603,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     let mut err = struct_span_err!(
                         self.tcx.sess,
                         span,
-                        E0033,
+                        "E0033",
                         "type `{}` cannot be dereferenced",
                         type_str
                     );
@@ -710,7 +710,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 res.descr(),
                 hir::print::to_string(&tcx.hir(), |s| s.print_qpath(qpath, false)),
             );
-            let mut err = struct_span_err!(tcx.sess, pat.span, E0164, "{}", msg);
+            let mut err = struct_span_err!(tcx.sess, pat.span, "E0164", "{}", msg);
             match (res, &pat.kind) {
                 (Res::Def(DefKind::Fn, _), _) | (Res::Def(DefKind::Method, _), _) => {
                     err.span_label(pat.span, "`fn` calls are not allowed in patterns");
@@ -805,7 +805,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let mut err = struct_span_err!(
             self.tcx.sess,
             pat_span,
-            E0023,
+            "E0023",
             "this pattern has {} field{}, but the corresponding {} has {} field{}",
             subpats.len(),
             subpats_ending,
@@ -1001,7 +1001,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             struct_span_err!(
                 tcx.sess,
                 span,
-                E0638,
+                "E0638",
                 "`..` required with {} marked as non-exhaustive",
                 kind_name
             )
@@ -1028,7 +1028,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         struct_span_err!(
             self.tcx.sess,
             span,
-            E0025,
+            "E0025",
             "field `{}` bound multiple times in the pattern",
             ident
         )
@@ -1065,7 +1065,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let mut err = struct_span_err!(
             tcx.sess,
             spans,
-            E0026,
+            "E0026",
             "{} `{}` does not have {}",
             kind_name,
             tcx.def_path_str(variant.def_id),
@@ -1132,7 +1132,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let mut diag = struct_span_err!(
             self.tcx.sess,
             span,
-            E0027,
+            "E0027",
             "pattern does not mention {}",
             field_names
         );
@@ -1327,7 +1327,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         struct_span_err!(
             self.tcx.sess,
             span,
-            E0527,
+            "E0527",
             "pattern requires {} element{} but array has {}",
             min_len,
             pluralize!(min_len),
@@ -1341,7 +1341,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         struct_span_err!(
             self.tcx.sess,
             span,
-            E0528,
+            "E0528",
             "pattern requires at least {} element{} but array has {}",
             min_len,
             pluralize!(min_len),
@@ -1358,7 +1358,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         struct_span_err!(
             self.tcx.sess,
             span,
-            E0730,
+            "E0730",
             "cannot pattern-match on an array without a fixed length",
         )
         .emit();
@@ -1368,7 +1368,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let mut err = struct_span_err!(
             self.tcx.sess,
             span,
-            E0529,
+            "E0529",
             "expected an array or slice, found `{}`",
             expected_ty
         );

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -115,7 +115,7 @@ pub fn check_item_well_formed(tcx: TyCtxt<'_>, def_id: DefId) {
                         struct_span_err!(
                             tcx.sess,
                             item.span,
-                            E0192,
+                            "E0192",
                             "negative impls are only allowed for \
                                    auto traits (e.g., `Send` and `Sync`)"
                         )
@@ -416,7 +416,7 @@ fn check_trait(tcx: TyCtxt<'_>, item: &hir::Item<'_>) {
             struct_span_err!(
                 tcx.sess,
                 tcx.def_span(*associated_def_id),
-                E0714,
+                "E0714",
                 "marker traits cannot have associated items",
             )
             .emit();
@@ -930,7 +930,7 @@ fn e0307(fcx: &FnCtxt<'fcx, 'tcx>, span: Span, receiver_ty: Ty<'_>) {
     struct_span_err!(
         fcx.tcx.sess.diagnostic(),
         span,
-        E0307,
+        "E0307",
         "invalid `self` parameter type: {:?}",
         receiver_ty,
     )
@@ -1219,7 +1219,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
 fn error_392(tcx: TyCtxt<'_>, span: Span, param_name: ast::Name) -> DiagnosticBuilder<'_> {
     let mut err =
-        struct_span_err!(tcx.sess, span, E0392, "parameter `{}` is never used", param_name);
+        struct_span_err!(tcx.sess, span, "E0392", "parameter `{}` is never used", param_name);
     err.span_label(span, "unused parameter");
     err
 }

--- a/src/librustc_typeck/coherence/builtin.rs
+++ b/src/librustc_typeck/coherence/builtin.rs
@@ -61,7 +61,7 @@ fn visit_implementation_of_drop(tcx: TyCtxt<'_>, impl_did: DefId) {
     struct_span_err!(
         tcx.sess,
         sp,
-        E0120,
+        "E0120",
         "the `Drop` trait may only be implemented for structs, enums, and unions",
     )
     .span_label(sp, "must be a struct, enum, or union")
@@ -100,7 +100,7 @@ fn visit_implementation_of_copy(tcx: TyCtxt<'_>, impl_did: DefId) {
             let mut err = struct_span_err!(
                 tcx.sess,
                 span,
-                E0204,
+                "E0204",
                 "the trait `Copy` may not be implemented for this type"
             );
             for span in fields.iter().map(|f| tcx.def_span(f.did)) {
@@ -116,7 +116,7 @@ fn visit_implementation_of_copy(tcx: TyCtxt<'_>, impl_did: DefId) {
             struct_span_err!(
                 tcx.sess,
                 span,
-                E0206,
+                "E0206",
                 "the trait `Copy` may not be implemented for this type"
             )
             .span_label(span, "type is not a structure or enumeration")
@@ -126,7 +126,7 @@ fn visit_implementation_of_copy(tcx: TyCtxt<'_>, impl_did: DefId) {
             struct_span_err!(
                 tcx.sess,
                 span,
-                E0184,
+                "E0184",
                 "the trait `Copy` may not be implemented for this type; the \
                               type has a destructor"
             )
@@ -169,7 +169,7 @@ fn visit_implementation_of_dispatch_from_dyn(tcx: TyCtxt<'_>, impl_did: DefId) {
 
         let param_env = tcx.param_env(impl_did);
 
-        let create_err = |msg: &str| struct_span_err!(tcx.sess, span, E0378, "{}", msg);
+        let create_err = |msg: &str| struct_span_err!(tcx.sess, span, "E0378", "{}", msg);
 
         tcx.infer_ctxt().enter(|infcx| {
             let cause = ObligationCause::misc(span, impl_hir_id);
@@ -392,7 +392,7 @@ pub fn coerce_unsized_info<'tcx>(tcx: TyCtxt<'tcx>, impl_did: DefId) -> CoerceUn
                     struct_span_err!(
                         tcx.sess,
                         span,
-                        E0377,
+                        "E0377",
                         "the trait `CoerceUnsized` may only be implemented \
                                for a coercion between structures with the same \
                                definition; expected `{}`, found `{}`",
@@ -479,7 +479,7 @@ pub fn coerce_unsized_info<'tcx>(tcx: TyCtxt<'tcx>, impl_did: DefId) -> CoerceUn
                     struct_span_err!(
                         tcx.sess,
                         span,
-                        E0374,
+                        "E0374",
                         "the trait `CoerceUnsized` may only be implemented \
                                for a coercion between structures with one field \
                                being coerced, none found"
@@ -497,10 +497,8 @@ pub fn coerce_unsized_info<'tcx>(tcx: TyCtxt<'tcx>, impl_did: DefId) -> CoerceUn
                     struct_span_err!(
                         tcx.sess,
                         span,
-                        E0375,
-                        "implementing the trait \
-                                                    `CoerceUnsized` requires multiple \
-                                                    coercions"
+                        "E0375",
+                        "implementing the trait `CoerceUnsized` requires multiple coercions"
                     )
                     .note(
                         "`CoerceUnsized` may only be implemented for \
@@ -531,7 +529,7 @@ pub fn coerce_unsized_info<'tcx>(tcx: TyCtxt<'tcx>, impl_did: DefId) -> CoerceUn
                 struct_span_err!(
                     tcx.sess,
                     span,
-                    E0376,
+                    "E0376",
                     "the trait `CoerceUnsized` may only be implemented \
                            for a coercion between structures"
                 )

--- a/src/librustc_typeck/coherence/inherent_impls.rs
+++ b/src/librustc_typeck/coherence/inherent_impls.rs
@@ -279,7 +279,7 @@ impl ItemLikeVisitor<'v> for InherentCollect<'tcx> {
                 struct_span_err!(
                     self.tcx.sess,
                     ty.span,
-                    E0118,
+                    "E0118",
                     "no base type found for inherent implementation"
                 )
                 .span_label(ty.span, "impl requires a base type")
@@ -311,7 +311,7 @@ impl InherentCollect<'tcx> {
             struct_span_err!(
                 self.tcx.sess,
                 item.span,
-                E0116,
+                "E0116",
                 "cannot define inherent `impl` for a type outside of the crate \
                               where the type is defined"
             )
@@ -341,7 +341,7 @@ impl InherentCollect<'tcx> {
                 struct_span_err!(
                     self.tcx.sess,
                     span,
-                    E0390,
+                    "E0390",
                     "only a single inherent implementation marked with `#[lang = \
                                   \"{}\"]` is allowed for the `{}` primitive",
                     lang,

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -50,7 +50,7 @@ fn enforce_trait_manually_implementable(tcx: TyCtxt<'_>, impl_def_id: DefId, tra
         struct_span_err!(
             tcx.sess,
             span,
-            E0322,
+            "E0322",
             "explicit impls for the `Sized` trait are not permitted"
         )
         .span_label(span, "impl of 'Sized' not allowed")
@@ -63,7 +63,7 @@ fn enforce_trait_manually_implementable(tcx: TyCtxt<'_>, impl_def_id: DefId, tra
         struct_span_err!(
             tcx.sess,
             span,
-            E0328,
+            "E0328",
             "explicit impls for the `Unsize` trait are not permitted"
         )
         .span_label(span, "impl of `Unsize` not allowed")
@@ -90,7 +90,7 @@ fn enforce_trait_manually_implementable(tcx: TyCtxt<'_>, impl_def_id: DefId, tra
     struct_span_err!(
         tcx.sess,
         span,
-        E0183,
+        "E0183",
         "manual implementations of `{}` are experimental",
         trait_name
     )
@@ -111,7 +111,8 @@ fn enforce_empty_impls_for_marker_traits(tcx: TyCtxt<'_>, impl_def_id: DefId, tr
     }
 
     let span = impl_header_span(tcx, impl_def_id);
-    struct_span_err!(tcx.sess, span, E0715, "impls for marker traits cannot contain items").emit();
+    struct_span_err!(tcx.sess, span, "E0715", "impls for marker traits cannot contain items")
+        .emit();
 }
 
 pub fn provide(providers: &mut Providers<'_>) {
@@ -200,7 +201,7 @@ fn check_object_overlap<'tcx>(
                     struct_span_err!(
                         tcx.sess,
                         span,
-                        E0371,
+                        "E0371",
                         "the object type `{}` automatically implements the trait `{}`",
                         trait_ref.self_ty(),
                         tcx.def_path_str(trait_def_id)

--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -41,7 +41,7 @@ impl ItemLikeVisitor<'v> for OrphanChecker<'tcx> {
                     let mut err = struct_span_err!(
                         self.tcx.sess,
                         sp,
-                        E0117,
+                        "E0117",
                         "only traits defined in the current crate can be implemented for \
                          arbitrary types"
                     );
@@ -94,7 +94,7 @@ impl ItemLikeVisitor<'v> for OrphanChecker<'tcx> {
                             struct_span_err!(
                                 self.tcx.sess,
                                 sp,
-                                E0210,
+                                "E0210",
                                 "type parameter `{}` must be covered by another type \
                                 when it appears before the first local type (`{}`)",
                                 param_ty,
@@ -125,7 +125,7 @@ impl ItemLikeVisitor<'v> for OrphanChecker<'tcx> {
                             struct_span_err!(
                                 self.tcx.sess,
                                 sp,
-                                E0210,
+                                "E0210",
                                 "type parameter `{}` must be used as the type parameter for some \
                                 local type (e.g., `MyStruct<{}>`)",
                                 param_ty,
@@ -224,7 +224,7 @@ impl ItemLikeVisitor<'v> for OrphanChecker<'tcx> {
                 };
 
                 if let Some((msg, label)) = msg {
-                    struct_span_err!(self.tcx.sess, sp, E0321, "{}", msg)
+                    struct_span_err!(self.tcx.sess, sp, "E0321", "{}", msg)
                         .span_label(sp, label)
                         .emit();
                     return;

--- a/src/librustc_typeck/coherence/unsafety.rs
+++ b/src/librustc_typeck/coherence/unsafety.rs
@@ -35,7 +35,7 @@ impl UnsafetyChecker<'tcx> {
                     struct_span_err!(
                         self.tcx.sess,
                         item.span,
-                        E0199,
+                        "E0199",
                         "implementing the trait `{}` is not unsafe",
                         trait_ref.print_only_trait_path()
                     )
@@ -46,7 +46,7 @@ impl UnsafetyChecker<'tcx> {
                     struct_span_err!(
                         self.tcx.sess,
                         item.span,
-                        E0200,
+                        "E0200",
                         "the trait `{}` requires an `unsafe impl` declaration",
                         trait_ref.print_only_trait_path()
                     )
@@ -62,7 +62,7 @@ impl UnsafetyChecker<'tcx> {
                     struct_span_err!(
                         self.tcx.sess,
                         item.span,
-                        E0569,
+                        "E0569",
                         "requires an `unsafe impl` declaration due to `#[{}]` attribute",
                         attr_name
                     )

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -259,7 +259,7 @@ fn bad_placeholder_type(
     let mut err = struct_span_err!(
         tcx.sess,
         spans.clone(),
-        E0121,
+        "E0121",
         "the type placeholder `_` is not allowed within types on item signatures",
     );
     for span in spans {
@@ -356,7 +356,7 @@ impl AstConv<'tcx> for ItemCtxt<'tcx> {
             let mut err = struct_span_err!(
                 self.tcx().sess,
                 span,
-                E0212,
+                "E0212",
                 "cannot extract an associated type from a higher-ranked trait bound \
                  in this context"
             );
@@ -762,7 +762,7 @@ fn convert_enum_variant_types(tcx: TyCtxt<'_>, def_id: DefId, variants: &[hir::V
             } else if let Some(discr) = repr_type.disr_incr(tcx, prev_discr) {
                 Some(discr)
             } else {
-                struct_span_err!(tcx.sess, variant.span, E0370, "enum discriminant overflowed")
+                struct_span_err!(tcx.sess, variant.span, "E0370", "enum discriminant overflowed")
                     .span_label(
                         variant.span,
                         format!("overflowed on value after {}", prev_discr.unwrap()),
@@ -814,7 +814,7 @@ fn convert_variant(
                 struct_span_err!(
                     tcx.sess,
                     f.span,
-                    E0124,
+                    "E0124",
                     "field `{}` is already declared",
                     f.ident
                 )
@@ -2298,7 +2298,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
                 struct_span_err!(
                     tcx.sess,
                     attr.span,
-                    E0724,
+                    "E0724",
                     "`#[ffi_returns_twice]` may only be used on foreign functions"
                 )
                 .emit();
@@ -2319,7 +2319,12 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
             codegen_fn_attrs.flags |= CodegenFnAttrFlags::THREAD_LOCAL;
         } else if attr.check_name(sym::track_caller) {
             if tcx.is_closure(id) || tcx.fn_sig(id).abi() != abi::Abi::Rust {
-                struct_span_err!(tcx.sess, attr.span, E0737, "`#[track_caller]` requires Rust ABI")
+                struct_span_err!(
+                    tcx.sess,
+                    attr.span,
+                    "E0737",
+                    "`#[track_caller]` requires Rust ABI",
+                )
                     .emit();
             }
             codegen_fn_attrs.flags |= CodegenFnAttrFlags::TRACK_CALLER;
@@ -2331,7 +2336,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
                     struct_span_err!(
                         tcx.sess,
                         attr.span,
-                        E0648,
+                        "E0648",
                         "`export_name` may not contain null characters"
                     )
                     .emit();
@@ -2409,7 +2414,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
                     struct_span_err!(
                         tcx.sess.diagnostic(),
                         attr.span,
-                        E0534,
+                        "E0534",
                         "expected one argument"
                     )
                     .emit();
@@ -2422,7 +2427,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
                     struct_span_err!(
                         tcx.sess.diagnostic(),
                         items[0].span(),
-                        E0535,
+                        "E0535",
                         "invalid argument"
                     )
                     .emit();
@@ -2439,7 +2444,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
         if !attr.has_name(sym::optimize) {
             return ia;
         }
-        let err = |sp, s| struct_span_err!(tcx.sess.diagnostic(), sp, E0722, "{}", s).emit();
+        let err = |sp, s| struct_span_err!(tcx.sess.diagnostic(), sp, "E0722", "{}", s).emit();
         match attr.meta().map(|i| i.kind) {
             Some(MetaItemKind::Word) => {
                 err(attr.span, "expected one argument");

--- a/src/librustc_typeck/impl_wf_check.rs
+++ b/src/librustc_typeck/impl_wf_check.rs
@@ -207,7 +207,7 @@ fn report_unused_parameter(tcx: TyCtxt<'_>, span: Span, kind: &str, name: &str) 
     struct_span_err!(
         tcx.sess,
         span,
-        E0207,
+        "E0207",
         "the {} parameter `{}` is not constrained by the \
         impl trait, self type, or predicates",
         kind,
@@ -232,7 +232,7 @@ fn enforce_impl_items_are_distinct(tcx: TyCtxt<'_>, impl_item_refs: &[hir::ImplI
                 let mut err = struct_span_err!(
                     tcx.sess,
                     impl_item.span,
-                    E0201,
+                    "E0201",
                     "duplicate definitions with name `{}`:",
                     impl_item.ident
                 );

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -118,7 +118,7 @@ fn require_c_abi_if_c_variadic(tcx: TyCtxt<'_>, decl: &hir::FnDecl<'_>, abi: Abi
         let mut err = struct_span_err!(
             tcx.sess,
             span,
-            E0045,
+            "E0045",
             "C-variadic function must have C or cdecl calling convention"
         );
         err.span_label(span, "C-variadics require C or cdecl calling convention").emit();
@@ -168,7 +168,7 @@ fn check_main_fn_ty(tcx: TyCtxt<'_>, main_def_id: DefId) {
                                    parameters"
                             .to_owned();
                         let label = "`main` cannot have generic parameters".to_string();
-                        struct_span_err!(tcx.sess, generics.span, E0131, "{}", msg)
+                        struct_span_err!(tcx.sess, generics.span, "E0131", "{}", msg)
                             .span_label(generics.span, label)
                             .emit();
                         error = true;
@@ -177,7 +177,7 @@ fn check_main_fn_ty(tcx: TyCtxt<'_>, main_def_id: DefId) {
                         struct_span_err!(
                             tcx.sess,
                             sp,
-                            E0646,
+                            "E0646",
                             "`main` function is not allowed to have a `where` clause"
                         )
                         .span_label(sp, "`main` cannot have a `where` clause")
@@ -234,7 +234,7 @@ fn check_start_fn_ty(tcx: TyCtxt<'_>, start_def_id: DefId) {
                         struct_span_err!(
                             tcx.sess,
                             generics.span,
-                            E0132,
+                            "E0132",
                             "start function is not allowed to have type parameters"
                         )
                         .span_label(generics.span, "start function cannot have type parameters")
@@ -245,7 +245,7 @@ fn check_start_fn_ty(tcx: TyCtxt<'_>, start_def_id: DefId) {
                         struct_span_err!(
                             tcx.sess,
                             sp,
-                            E0647,
+                            "E0647",
                             "start function is not allowed to have a `where` clause"
                         )
                         .span_label(sp, "start function cannot have a `where` clause")

--- a/src/librustc_typeck/outlives/test.rs
+++ b/src/librustc_typeck/outlives/test.rs
@@ -20,7 +20,13 @@ impl ItemLikeVisitor<'tcx> for OutlivesTest<'tcx> {
         // attribute and report an error with various results if found.
         if self.tcx.has_attr(item_def_id, sym::rustc_outlives) {
             let inferred_outlives_of = self.tcx.inferred_outlives_of(item_def_id);
-            struct_span_err!(self.tcx.sess, item.span, E0640, "{:?}", inferred_outlives_of).emit();
+            struct_span_err!(
+                self.tcx.sess,
+                item.span,
+                "E0640",
+                "{:?}",
+                inferred_outlives_of
+            ).emit();
         }
     }
 

--- a/src/librustc_typeck/structured_errors.rs
+++ b/src/librustc_typeck/structured_errors.rs
@@ -48,7 +48,7 @@ impl<'tcx> StructuredDiagnostic<'tcx> for VariadicError<'tcx> {
     }
 
     fn code(&self) -> DiagnosticId {
-        rustc_errors::error_code!(E0617)
+        rustc_errors::error_code!("E0617")
     }
 
     fn common(&self) -> DiagnosticBuilder<'tcx> {
@@ -109,7 +109,7 @@ impl<'tcx> StructuredDiagnostic<'tcx> for SizedUnsizedCastError<'tcx> {
     }
 
     fn code(&self) -> DiagnosticId {
-        rustc_errors::error_code!(E0607)
+        rustc_errors::error_code!("E0607")
     }
 
     fn common(&self) -> DiagnosticBuilder<'tcx> {

--- a/src/librustc_typeck/variance/test.rs
+++ b/src/librustc_typeck/variance/test.rs
@@ -20,7 +20,7 @@ impl ItemLikeVisitor<'tcx> for VarianceTest<'tcx> {
         // attribute and report an error with various results if found.
         if self.tcx.has_attr(item_def_id, sym::rustc_variance) {
             let variances_of = self.tcx.variances_of(item_def_id);
-            struct_span_err!(self.tcx.sess, item.span, E0208, "{:?}", variances_of).emit();
+            struct_span_err!(self.tcx.sess, item.span, "E0208", "{:?}", variances_of).emit();
         }
     }
 

--- a/src/tools/tidy/src/error_codes_check.rs
+++ b/src/tools/tidy/src/error_codes_check.rs
@@ -93,10 +93,41 @@ fn extract_error_codes_from_tests(f: &str, error_codes: &mut HashMap<String, boo
     }
 }
 
+fn check_used_error_codes(
+    file_path: &Path,
+    f: &str,
+    error_codes: &HashMap<String, bool>,
+    errors: &mut usize,
+) {
+    for (line_number, line) in f.lines().enumerate() {
+        let s = line.trim();
+        let c = if s.contains(" \"E0") {
+            ' '
+        } else if s.contains("(\"E0") {
+            '('
+        } else {
+            continue
+        };
+        let parts = s.split(&format!("{}\"E0", c)).collect::<Vec<_>>();
+        if let Some(err_code) = parts[1].split('"').next() {
+            let err_code = format!("E0{}", err_code);
+            if error_codes.get(&err_code).is_none() {
+                eprintln!("Error code `{}` used but hasn't been declared in `{}:{}`",
+                    err_code, file_path.display(), line_number + 1);
+                *errors += 1;
+            }
+        }
+    }
+}
+
 pub fn check(path: &Path, bad: &mut bool) {
     println!("Checking which error codes lack tests...");
     let mut error_codes: HashMap<String, bool> = HashMap::new();
-    super::walk(path, &mut |path| super::filter_dirs(path), &mut |entry, contents| {
+    let mut errors_count: usize = 0;
+
+    super::walk(path,
+                &mut |path| super::filter_dirs(path),
+                &mut |entry, contents| {
         let file_name = entry.file_name();
         if file_name == "error_codes.rs" {
             extract_error_codes(contents, &mut error_codes, entry.path());
@@ -105,6 +136,16 @@ pub fn check(path: &Path, bad: &mut bool) {
         }
     });
     println!("Found {} error codes", error_codes.len());
+
+    super::walk(path,
+                &mut |path| super::filter_dirs(path),
+                &mut |entry, contents| {
+        let file_name = entry.file_name();
+        if entry.path().extension() == Some(OsStr::new("rs"))
+            && file_name != "error_codes_check.rs" {
+            check_used_error_codes(entry.path(), contents, &error_codes, &mut errors_count);
+        }
+    });
 
     let mut errors = Vec::new();
     for (err_code, nb) in &error_codes {
@@ -117,7 +158,7 @@ pub fn check(path: &Path, bad: &mut bool) {
         eprintln!("{}", err);
     }
     println!("Found {} error codes with no tests", errors.len());
-    if !errors.is_empty() {
+    if !errors.is_empty() || errors_count != 0 {
         *bad = true;
     }
     println!("Done!");


### PR DESCRIPTION
Part of #67061.

I used this script to convert all error codes into strings:

<details>

```python
from os import listdir
from os.path import isdir, isfile, join


def remove_import_and_replace_err_codes(f_path):
    result = []
    with open(f_path) as f:
        lines = f.read().split("\n")
        i = 0
        found = False
        while i < len(lines):
            if lines[i] == 'use rustc_error_codes::*;':
                found = True
                pass
            elif ' E0' in lines[i] and not lines[i].strip().startswith('//') and not lines[i].endswith('\\') and not '"' in lines[i]:
                found = False
                parts = lines[i].split(' E0')
                p = parts[1].split(',', 1)
                if len(p) < 2:
                    result.append(lines[i])
                else:
                    result.append('{} "E0{}",{}'.format(parts[0], p[0], p[1]))
            elif '(E0' in lines[i] and not lines[i].strip().startswith('//') and not lines[i].endswith('
\\') and not '"' in lines[i]:
                found = False
                parts = lines[i].split('(E0')
                p = parts[1].split(')', 1)
                p2 = parts[1].split(',', 1)
                if len(p2[0]) < len(p[0]) and len(p2) > 1:
                    p = p2
                if len(p) < 2:
                    result.append(lines[i])
                else:
                    result.append('{}("E0{}"){}'.format(parts[0], p[0], p[1]))
            else:
                if len(lines[i]) != 0 or found is False:
                    result.append(lines[i])
                found = False
            i += 1
    with open(f_path, 'w') as f:
        f.write('\n'.join(result))


def remove_dependency(f_path):
    result = []
    with open(f_path) as f:
        lines = f.read().split("\n")
        i = 0
        while i < len(lines):
            if lines[i].startswith('rustc_error_codes = '):
      	        pass
            else:
                result.append(lines[i])
            i += 1
    with open(f_path, 'w') as f:
        f.write('\n'.join(result))


def loop_dirs(cur_dir):
    for entry in listdir(cur_dir):
        f = join(cur_dir, entry)
        if isfile(f):
            if entry.endswith(".rs"):
                remove_import_and_replace_err_codes(f)
            elif entry.endswith("Cargo.toml"):
                remove_dependency(f)
        elif isdir(f) and not entry.startswith("librustc_error_codes") and f.startswith('src/lib'):
            loop_dirs(f)


loop_dirs('src')
```
</details>

r? @Centril 