### PR TITLE
use `#[allow(unused_attributes)]` to paper over incr.comp problem

### DIFF
--- a/src/libcore/convert/mod.rs
+++ b/src/libcore/convert/mod.rs
@@ -567,7 +567,7 @@ impl<T> From<T> for T {
 ///
 /// [#64715]: https://github.com/rust-lang/rust/issues/64715
 #[stable(feature = "convert_infallible", since = "1.34.0")]
-#[allow(unused_attributes)]
+#[allow(unused_attributes)] // FIXME(#58633): do a principled fix instead.
 #[rustc_reservation_impl = "permitting this impl would forbid us from adding \
                             `impl<T> From<!> for T` later; see rust-lang/rust#64715 for details"]
 impl<T> From<!> for T {

--- a/src/libcore/convert/mod.rs
+++ b/src/libcore/convert/mod.rs
@@ -567,6 +567,7 @@ impl<T> From<T> for T {
 ///
 /// [#64715]: https://github.com/rust-lang/rust/issues/64715
 #[stable(feature = "convert_infallible", since = "1.34.0")]
+#[allow(unused_attributes)]
 #[rustc_reservation_impl = "permitting this impl would forbid us from adding \
                             `impl<T> From<!> for T` later; see rust-lang/rust#64715 for details"]
 impl<T> From<!> for T {


### PR DESCRIPTION
Paper over the problem in #58633.

r? @Mark-Simulacrum 