### PR TITLE
Bump compiler-builtins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,9 +570,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.18"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1c086a06d6f52f9c0d50cacdc021bfb6034ddeec9fb7e62f099f13f65472f4"
+checksum = "e6f083abf9bb9005a27d2da62706f661245278cb7096da37ab27410eaf60f2c1"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",


### PR DESCRIPTION
- https://github.com/rust-lang/compiler-builtins/pull/306
- https://github.com/rust-lang/compiler-builtins/pull/309
- https://github.com/rust-lang/compiler-builtins/pull/310
- https://github.com/rust-lang/compiler-builtins/pull/311
- https://github.com/rust-lang/compiler-builtins/pull/312
- https://github.com/rust-lang/compiler-builtins/pull/313
- https://github.com/rust-lang/compiler-builtins/pull/315
- https://github.com/rust-lang/compiler-builtins/pull/317
- https://github.com/rust-lang/compiler-builtins/pull/323
- https://github.com/rust-lang/compiler-builtins/pull/324
- https://github.com/rust-lang/compiler-builtins/pull/328

Adds support for backtraces from `__rust_probestack` plus other goodies.

r? @alexcrichton 