### PR TITLE
Print the visibility in `print_variant`.

### DIFF
--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1518,6 +1518,7 @@ impl<'a> State<'a> {
 
     crate fn print_variant(&mut self, v: &ast::Variant) {
         self.head("");
+        self.print_visibility(&v.vis);
         let generics = ast::Generics::default();
         self.print_struct(&v.data, &generics, v.ident, v.span, false);
         match v.disr_expr {

--- a/src/test/pretty/enum-variant-vis.rs
+++ b/src/test/pretty/enum-variant-vis.rs
@@ -1,0 +1,8 @@
+// pp-exact
+
+// Check that the visibility is printed on an enum variant.
+
+fn main() { }
+
+#[cfg(FALSE)]
+enum Foo { pub V, }


### PR DESCRIPTION
r? @davidtwco 
cc @dtolnay for `syn` awareness.