### PR TITLE
use type alias Result<T, E> to be compatible with default Result type

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -66,7 +66,7 @@ pub mod rt {
 /// println!("{}", pythagorean_triple);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub type Result = result::Result<(), Error>;
+pub type Result<T = (), E = Error> = result::Result<T, E>;
 
 /// The error type which is returned from formatting a message into a stream.
 ///

--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -39,7 +39,7 @@ use crate::sys;
 /// }
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub type Result<T> = result::Result<T, Error>;
+pub type Result<T, E = Error> = result::Result<T, E>;
 
 /// The error type for I/O operations of the [`Read`], [`Write`], [`Seek`], and
 /// associated traits.

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -1305,7 +1305,7 @@ impl fmt::Debug for Thread {
 ///
 /// [`Result`]: ../../std/result/enum.Result.html
 #[stable(feature = "rust1", since = "1.0.0")]
-pub type Result<T> = crate::result::Result<T, Box<dyn Any + Send + 'static>>;
+pub type Result<T, E = Box<dyn Any + Send + 'static>> = crate::result::Result<T, E>;
 
 // This packet is used to communicate the return value between the child thread
 // and the parent thread. Memory is shared through the `Arc` within and there's


### PR DESCRIPTION
This helps people accidentally import `fmt::Result` or `io::Result`
could use those type aliases like default `result::Result<T, E>` type
for returning and propagating errors.

r? @dtolnay
