### PR TITLE
[experiment] Expand macros in inert key-value attributes

### DIFF
--- a/src/librustc/hir/lowering/expr.rs
+++ b/src/librustc/hir/lowering/expr.rs
@@ -192,7 +192,7 @@ impl LoweringContext<'_> {
             hir_id: self.lower_node_id(e.id),
             kind,
             span: e.span,
-            attrs: e.attrs.clone(),
+            attrs: self.lower_attrs_extendable(&e.attrs).into(),
         }
     }
 

--- a/src/test/rustdoc/external-doc.rs
+++ b/src/test/rustdoc/external-doc.rs
@@ -6,3 +6,10 @@
 #[doc(include = "auxiliary/external-doc.md")]
 /// ## Inline Docs
 pub struct CanHasDocs;
+
+// @has external_doc/struct.IncludeStrDocs.html
+// @has - '//h1' 'External Docs'
+// @has - '//h2' 'Inline Docs'
+#[doc = include_str!("auxiliary/external-doc.md")]
+/// ## Inline Docs
+pub struct IncludeStrDocs;

--- a/src/test/ui/attr-eq-token-tree.rs
+++ b/src/test/ui/attr-eq-token-tree.rs
@@ -1,2 +1,2 @@
-#[my_attr = !] //~ ERROR unexpected token: `!`
+#[my_attr = !] //~ ERROR expected expression, found `]`
 fn main() {}

--- a/src/test/ui/attr-eq-token-tree.stderr
+++ b/src/test/ui/attr-eq-token-tree.stderr
@@ -1,8 +1,8 @@
-error: unexpected token: `!`
-  --> $DIR/attr-eq-token-tree.rs:1:13
+error: expected expression, found `]`
+  --> $DIR/attr-eq-token-tree.rs:1:14
    |
 LL | #[my_attr = !]
-   |             ^
+   |              ^ expected expression
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/macro-attribute.rs
+++ b/src/test/ui/macros/macro-attribute.rs
@@ -1,2 +1,2 @@
-#[doc = $not_there] //~ ERROR unexpected token: `$`
+#[doc = $not_there] //~ ERROR expected expression, found `$`
 fn main() { }

--- a/src/test/ui/macros/macro-attribute.stderr
+++ b/src/test/ui/macros/macro-attribute.stderr
@@ -1,8 +1,8 @@
-error: unexpected token: `$`
+error: expected expression, found `$`
   --> $DIR/macro-attribute.rs:1:9
    |
 LL | #[doc = $not_there]
-   |         ^
+   |         ^ expected expression
 
 error: aborting due to previous error
 

--- a/src/test/ui/malformed/malformed-interpolated.rs
+++ b/src/test/ui/malformed/malformed-interpolated.rs
@@ -2,8 +2,7 @@
 
 macro_rules! check {
     ($expr: expr) => (
-        #[rustc_dummy = $expr] //~ ERROR unexpected token: `-0`
-                               //~| ERROR unexpected token: `0 + 0`
+        #[rustc_dummy = $expr]
         use main as _;
     );
 }
@@ -11,7 +10,7 @@ macro_rules! check {
 check!("0"); // OK
 check!(0); // OK
 check!(0u8); //~ ERROR suffixed literals are not allowed in attributes
-check!(-0); // ERROR, see above
-check!(0 + 0); // ERROR, see above
+check!(-0); //~ ERROR unexpected token: `-0`
+check!(0 + 0); //~ ERROR unexpected token: `0 + 0`
 
 fn main() {}

--- a/src/test/ui/malformed/malformed-interpolated.stderr
+++ b/src/test/ui/malformed/malformed-interpolated.stderr
@@ -1,5 +1,5 @@
 error: suffixed literals are not allowed in attributes
-  --> $DIR/malformed-interpolated.rs:13:8
+  --> $DIR/malformed-interpolated.rs:12:8
    |
 LL | check!(0u8);
    |        ^^^
@@ -7,22 +7,16 @@ LL | check!(0u8);
    = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
 
 error: unexpected token: `-0`
-  --> $DIR/malformed-interpolated.rs:5:25
+  --> $DIR/malformed-interpolated.rs:13:8
    |
-LL |         #[rustc_dummy = $expr]
-   |                         ^^^^^
-...
-LL | check!(-0); // ERROR, see above
-   | ----------- in this macro invocation
+LL | check!(-0);
+   |        ^^
 
 error: unexpected token: `0 + 0`
-  --> $DIR/malformed-interpolated.rs:5:25
+  --> $DIR/malformed-interpolated.rs:14:8
    |
-LL |         #[rustc_dummy = $expr]
-   |                         ^^^^^
-...
-LL | check!(0 + 0); // ERROR, see above
-   | -------------- in this macro invocation
+LL | check!(0 + 0);
+   |        ^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/parser/attr-bad-meta-2.rs
+++ b/src/test/ui/parser/attr-bad-meta-2.rs
@@ -1,2 +1,2 @@
-#[path =] //~ ERROR unexpected token: `]`
+#[path =] //~ ERROR expected expression, found `]`
 mod m {}

--- a/src/test/ui/parser/attr-bad-meta-2.stderr
+++ b/src/test/ui/parser/attr-bad-meta-2.stderr
@@ -1,8 +1,8 @@
-error: unexpected token: `]`
+error: expected expression, found `]`
   --> $DIR/attr-bad-meta-2.rs:1:9
    |
 LL | #[path =]
-   |         ^
+   |         ^ expected expression
 
 error: aborting due to previous error
 

--- a/src/test/ui/proc-macro/attributes-included.rs
+++ b/src/test/ui/proc-macro/attributes-included.rs
@@ -10,11 +10,11 @@ use attributes_included::*;
 #[bar]
 #[inline]
 /// doc
-#[foo]
+#[foo] //~ WARN unused variable: `a`
 #[inline]
 /// doc
 fn foo() {
-    let a: i32 = "foo"; //~ WARN: unused variable
+    let a: i32 = "foo";
 }
 
 fn main() {

--- a/src/test/ui/proc-macro/attributes-included.stderr
+++ b/src/test/ui/proc-macro/attributes-included.stderr
@@ -1,8 +1,8 @@
 warning: unused variable: `a`
-  --> $DIR/attributes-included.rs:17:9
+  --> $DIR/attributes-included.rs:13:1
    |
-LL |     let a: i32 = "foo";
-   |         ^ help: consider prefixing with an underscore: `_a`
+LL | #[foo]
+   | ^^^^^^ help: consider prefixing with an underscore: `_a`
    |
 note: lint level defined here
   --> $DIR/attributes-included.rs:4:9


### PR DESCRIPTION
Example:
```rust
#[doc = include_str!("my_doc.md")]
struct S;
```

This is a general-purpose feature that is supposed to supersede [`#[doc(include = "my_doc.md")]`](https://github.com/rust-lang/rust/issues/44732).

The grammar of key-value attributes turns from
```
PATH `=` UNSUFFIXED_LITERAL | EXPR_NONTERMINAL
```
to
```
PATH `=` EXPR
```
, but the restriction requiring `EXPR` to be an unsuffixed literal after expansion is still kept.
The expression goes through macro expansion as any other expression would do.

---
From the implementation point of view the PR still uses the "expansion in nonterminals" hack that currently powers `#[doc = $expr]`, but my plan is to keep an actual `ast::Expr` in attributes to avoid the hack and expand in a natural way in the future.

r? @ghost