### PR TITLE
Enable rlib generation for librustc_driver

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -510,6 +510,9 @@ pub fn rustc_cargo(builder: &Builder<'_>, cargo: &mut Cargo, target: Interned<St
 }
 
 pub fn rustc_cargo_env(builder: &Builder<'_>, cargo: &mut Cargo, target: Interned<String>) {
+    // librustc_driver is linked as both an rlib and a dylib. Prefer the dylib.
+    cargo.rustflag("-Cprefer-dynamic");
+
     // Set some configuration variables picked up by build scripts and
     // the compiler alike
     cargo.env("CFG_RELEASE", builder.rust_release())

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -273,6 +273,10 @@ pub fn prepare_tool_cargo(
     if !features.is_empty() {
         cargo.arg("--features").arg(&features.join(", "));
     }
+
+    // librustc_driver is linked as both an rlib and a dylib. Prefer the dylib.
+    cargo.rustflag("-Cprefer-dynamic");
+
     cargo
 }
 

--- a/src/librustc_driver/Cargo.toml
+++ b/src/librustc_driver/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [lib]
 name = "rustc_driver"
 path = "lib.rs"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [dependencies]
 graphviz = { path = "../libgraphviz" }

--- a/src/test/run-make-fulldeps/issue-19371/Makefile
+++ b/src/test/run-make-fulldeps/issue-19371/Makefile
@@ -5,5 +5,5 @@
 # The program needs the path to rustc to get sysroot.
 
 all:
-	$(RUSTC) foo.rs
+	$(RUSTC) foo.rs -Cprefer-dynamic
 	$(call RUN,foo $(TMPDIR) $(RUSTC))


### PR DESCRIPTION
I'm working on [interfacing rustc with gcc](https://github.com/sapir/gcc-rust/tree/rust). Basically, I'm using librustc_driver to run rustc and generate MIR and then convert it to gcc's GENERIC. My own Rust code is compiled to a staticlib and then linked into the GCC binary. If I understand correctly, for this to work, librustc_driver needs to be compiled as an rlib, so I think this patch would be helpful. If I'm wrong, or if I'm doing this wrong, please direct me in the right direction.