### PR TITLE
Ensure that we get a hard error on generic ZST constants if their bod…

### DIFF
--- a/src/test/ui/consts/assoc_const_generic_impl.rs
+++ b/src/test/ui/consts/assoc_const_generic_impl.rs
@@ -1,0 +1,19 @@
+#![allow(const_err)]
+
+trait ZeroSized: Sized {
+    const I_AM_ZERO_SIZED: ();
+    fn requires_zero_size(self);
+}
+
+impl<T: Sized> ZeroSized for T {
+    const I_AM_ZERO_SIZED: ()  = [()][std::mem::size_of::<Self>()];
+    fn requires_zero_size(self) {
+        let () = Self::I_AM_ZERO_SIZED; //~ ERROR erroneous constant encountered
+        println!("requires_zero_size called");
+    }
+}
+
+fn main() {
+    ().requires_zero_size();
+    42_u32.requires_zero_size();
+}

--- a/src/test/ui/consts/assoc_const_generic_impl.rs
+++ b/src/test/ui/consts/assoc_const_generic_impl.rs
@@ -1,4 +1,4 @@
-#![allow(const_err)]
+#![warn(const_err)]
 
 trait ZeroSized: Sized {
     const I_AM_ZERO_SIZED: ();
@@ -6,7 +6,7 @@ trait ZeroSized: Sized {
 }
 
 impl<T: Sized> ZeroSized for T {
-    const I_AM_ZERO_SIZED: ()  = [()][std::mem::size_of::<Self>()];
+    const I_AM_ZERO_SIZED: ()  = [()][std::mem::size_of::<Self>()]; //~ WARN any use of this value
     fn requires_zero_size(self) {
         let () = Self::I_AM_ZERO_SIZED; //~ ERROR erroneous constant encountered
         println!("requires_zero_size called");

--- a/src/test/ui/consts/assoc_const_generic_impl.stderr
+++ b/src/test/ui/consts/assoc_const_generic_impl.stderr
@@ -1,0 +1,8 @@
+error: erroneous constant encountered
+  --> $DIR/assoc_const_generic_impl.rs:11:18
+   |
+LL |         let () = Self::I_AM_ZERO_SIZED;
+   |                  ^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/consts/assoc_const_generic_impl.stderr
+++ b/src/test/ui/consts/assoc_const_generic_impl.stderr
@@ -1,3 +1,17 @@
+warning: any use of this value will cause an error
+  --> $DIR/assoc_const_generic_impl.rs:9:34
+   |
+LL |     const I_AM_ZERO_SIZED: ()  = [()][std::mem::size_of::<Self>()];
+   |     -----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
+   |                                  |
+   |                                  index out of bounds: the len is 1 but the index is 4
+   |
+note: lint level defined here
+  --> $DIR/assoc_const_generic_impl.rs:1:9
+   |
+LL | #![warn(const_err)]
+   |         ^^^^^^^^^
+
 error: erroneous constant encountered
   --> $DIR/assoc_const_generic_impl.rs:11:18
    |


### PR DESCRIPTION
…y causes an error during evaluation

cc #67083 (does not fix because we still need the beta backport)

r? @wesleywiser 

cc @RalfJung