### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/libcore/convert/mod.rs
+++ b/src/libcore/convert/mod.rs
@@ -567,7 +567,7 @@ impl<T> From<T> for T {
 ///
 /// [#64715]: https://github.com/rust-lang/rust/issues/64715
 #[stable(feature = "convert_infallible", since = "1.34.0")]
-#[allow(unused_attributes)]
+#[allow(unused_attributes)] // FIXME(#58633): do a principled fix instead.
 #[rustc_reservation_impl = "permitting this impl would forbid us from adding \
                             `impl<T> From<!> for T` later; see rust-lang/rust#64715 for details"]
 impl<T> From<!> for T {

--- a/src/libcore/convert/mod.rs
+++ b/src/libcore/convert/mod.rs
@@ -567,6 +567,7 @@ impl<T> From<T> for T {
 ///
 /// [#64715]: https://github.com/rust-lang/rust/issues/64715
 #[stable(feature = "convert_infallible", since = "1.34.0")]
+#[allow(unused_attributes)]
 #[rustc_reservation_impl = "permitting this impl would forbid us from adding \
                             `impl<T> From<!> for T` later; see rust-lang/rust#64715 for details"]
 impl<T> From<!> for T {

--- a/src/librustc/arena.rs
+++ b/src/librustc/arena.rs
@@ -23,17 +23,17 @@ macro_rules! arena_types {
             [] generics: rustc::ty::Generics,
             [] trait_def: rustc::ty::TraitDef,
             [] adt_def: rustc::ty::AdtDef,
-            [] steal_mir: rustc::ty::steal::Steal<rustc::mir::BodyCache<$tcx>>,
-            [] mir: rustc::mir::BodyCache<$tcx>,
+            [] steal_mir: rustc::ty::steal::Steal<rustc::mir::BodyAndCache<$tcx>>,
+            [] mir: rustc::mir::BodyAndCache<$tcx>,
             [] steal_promoted: rustc::ty::steal::Steal<
                 rustc_index::vec::IndexVec<
                     rustc::mir::Promoted,
-                    rustc::mir::BodyCache<$tcx>
+                    rustc::mir::BodyAndCache<$tcx>
                 >
             >,
             [] promoted: rustc_index::vec::IndexVec<
                 rustc::mir::Promoted,
-                rustc::mir::BodyCache<$tcx>
+                rustc::mir::BodyAndCache<$tcx>
             >,
             [] tables: rustc::ty::TypeckTables<$tcx>,
             [] const_allocs: rustc::mir::interpret::Allocation,

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -327,7 +327,7 @@ declare_lint! {
 
 declare_lint! {
     pub UNUSED_LABELS,
-    Allow,
+    Warn,
     "detects labels that are never used"
 }
 

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -38,7 +38,7 @@ use syntax::symbol::Symbol;
 use syntax_pos::{Span, DUMMY_SP};
 
 pub use crate::mir::interpret::AssertMessage;
-pub use crate::mir::cache::{BodyCache, ReadOnlyBodyCache};
+pub use crate::mir::cache::{BodyAndCache, ReadOnlyBodyAndCache};
 pub use crate::read_only;
 
 mod cache;
@@ -108,7 +108,7 @@ pub struct Body<'tcx> {
     pub yield_ty: Option<Ty<'tcx>>,
 
     /// Generator drop glue.
-    pub generator_drop: Option<Box<BodyCache<'tcx>>>,
+    pub generator_drop: Option<Box<BodyAndCache<'tcx>>>,
 
     /// The layout of a generator. Produced by the state transformation.
     pub generator_layout: Option<GeneratorLayout<'tcx>>,
@@ -2601,7 +2601,7 @@ impl Location {
     pub fn is_predecessor_of<'tcx>(
         &self,
         other: Location,
-        body: ReadOnlyBodyCache<'_, 'tcx>
+        body: ReadOnlyBodyAndCache<'_, 'tcx>
     ) -> bool {
         // If we are in the same block as the other location and are an earlier statement
         // then we are a predecessor of `other`.

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -67,10 +67,10 @@ use syntax_pos::Span;
 
 macro_rules! body_cache_type {
     (mut $a:lifetime, $tcx:lifetime) => {
-        &mut BodyCache<$tcx>
+        &mut BodyAndCache<$tcx>
     };
     ($a:lifetime, $tcx:lifetime) => {
-        ReadOnlyBodyCache<$a, $tcx>
+        ReadOnlyBodyAndCache<$a, $tcx>
     };
 }
 

--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -106,30 +106,30 @@ rustc_queries! {
 
         /// Fetch the MIR for a given `DefId` right after it's built - this includes
         /// unreachable code.
-        query mir_built(_: DefId) -> &'tcx Steal<mir::BodyCache<'tcx>> {}
+        query mir_built(_: DefId) -> &'tcx Steal<mir::BodyAndCache<'tcx>> {}
 
         /// Fetch the MIR for a given `DefId` up till the point where it is
         /// ready for const evaluation.
         ///
         /// See the README for the `mir` module for details.
-        query mir_const(_: DefId) -> &'tcx Steal<mir::BodyCache<'tcx>> {
+        query mir_const(_: DefId) -> &'tcx Steal<mir::BodyAndCache<'tcx>> {
             no_hash
         }
 
         query mir_validated(_: DefId) ->
             (
-                &'tcx Steal<mir::BodyCache<'tcx>>,
-                &'tcx Steal<IndexVec<mir::Promoted, mir::BodyCache<'tcx>>>
+                &'tcx Steal<mir::BodyAndCache<'tcx>>,
+                &'tcx Steal<IndexVec<mir::Promoted, mir::BodyAndCache<'tcx>>>
             ) {
             no_hash
         }
 
         /// MIR after our optimization passes have run. This is MIR that is ready
         /// for codegen. This is also the only query that can fetch non-local MIR, at present.
-        query optimized_mir(key: DefId) -> &'tcx mir::BodyCache<'tcx> {
+        query optimized_mir(key: DefId) -> &'tcx mir::BodyAndCache<'tcx> {
             cache_on_disk_if { key.is_local() }
             load_cached(tcx, id) {
-                let mir: Option<crate::mir::BodyCache<'tcx>>
+                let mir: Option<crate::mir::BodyAndCache<'tcx>>
                     = tcx.queries.on_disk_cache.try_load_query_result(tcx, id);
                 mir.map(|x| {
                     let cache = tcx.arena.alloc(x);
@@ -139,13 +139,13 @@ rustc_queries! {
             }
         }
 
-        query promoted_mir(key: DefId) -> &'tcx IndexVec<mir::Promoted, mir::BodyCache<'tcx>> {
+        query promoted_mir(key: DefId) -> &'tcx IndexVec<mir::Promoted, mir::BodyAndCache<'tcx>> {
             cache_on_disk_if { key.is_local() }
             load_cached(tcx, id) {
                 let promoted: Option<
                     rustc_index::vec::IndexVec<
                         crate::mir::Promoted,
-                        crate::mir::BodyCache<'tcx>
+                        crate::mir::BodyAndCache<'tcx>
                     >> = tcx.queries.on_disk_cache.try_load_query_result(tcx, id);
                 promoted.map(|p| {
                     let cache = tcx.arena.alloc(p);
@@ -512,7 +512,7 @@ rustc_queries! {
         /// in the case of closures, this will be redirected to the enclosing function.
         query region_scope_tree(_: DefId) -> &'tcx region::ScopeTree {}
 
-        query mir_shims(key: ty::InstanceDef<'tcx>) -> &'tcx mir::BodyCache<'tcx> {
+        query mir_shims(key: ty::InstanceDef<'tcx>) -> &'tcx mir::BodyAndCache<'tcx> {
             no_force
             desc { |tcx| "generating MIR shim for `{}`", tcx.def_path_str(key.def_id()) }
         }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -22,7 +22,7 @@ use crate::middle::cstore::EncodedMetadata;
 use crate::middle::lang_items;
 use crate::middle::resolve_lifetime::{self, ObjectLifetimeDefault};
 use crate::middle::stability;
-use crate::mir::{BodyCache, Field, interpret, Local, Place, PlaceElem, ProjectionKind, Promoted};
+use crate::mir::{BodyAndCache, Field, interpret, Local, Place, PlaceElem, ProjectionKind, Promoted};
 use crate::mir::interpret::{ConstValue, Allocation, Scalar};
 use crate::ty::subst::{GenericArg, InternalSubsts, SubstsRef, Subst};
 use crate::ty::ReprOptions;
@@ -1083,17 +1083,17 @@ impl<'tcx> TyCtxt<'tcx> {
         &self.hir_map
     }
 
-    pub fn alloc_steal_mir(self, mir: BodyCache<'tcx>) -> &'tcx Steal<BodyCache<'tcx>> {
+    pub fn alloc_steal_mir(self, mir: BodyAndCache<'tcx>) -> &'tcx Steal<BodyAndCache<'tcx>> {
         self.arena.alloc(Steal::new(mir))
     }
 
-    pub fn alloc_steal_promoted(self, promoted: IndexVec<Promoted, BodyCache<'tcx>>) ->
-        &'tcx Steal<IndexVec<Promoted, BodyCache<'tcx>>> {
+    pub fn alloc_steal_promoted(self, promoted: IndexVec<Promoted, BodyAndCache<'tcx>>) ->
+        &'tcx Steal<IndexVec<Promoted, BodyAndCache<'tcx>>> {
         self.arena.alloc(Steal::new(promoted))
     }
 
-    pub fn intern_promoted(self, promoted: IndexVec<Promoted, BodyCache<'tcx>>) ->
-        &'tcx IndexVec<Promoted, BodyCache<'tcx>> {
+    pub fn intern_promoted(self, promoted: IndexVec<Promoted, BodyAndCache<'tcx>>) ->
+        &'tcx IndexVec<Promoted, BodyAndCache<'tcx>> {
         self.arena.alloc(promoted)
     }
 

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -2557,7 +2557,7 @@ where
                     'descend_newtypes: while !fat_pointer_layout.ty.is_unsafe_ptr()
                         && !fat_pointer_layout.ty.is_region_ptr()
                     {
-                        'iter_fields: for i in 0..fat_pointer_layout.fields.count() {
+                        for i in 0..fat_pointer_layout.fields.count() {
                             let field_layout = fat_pointer_layout.field(cx, i);
 
                             if !field_layout.is_zst() {

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -18,7 +18,7 @@ use crate::infer::canonical::Canonical;
 use crate::middle::cstore::CrateStoreDyn;
 use crate::middle::lang_items::{FnTraitLangItem, FnMutTraitLangItem, FnOnceTraitLangItem};
 use crate::middle::resolve_lifetime::ObjectLifetimeDefault;
-use crate::mir::ReadOnlyBodyCache;
+use crate::mir::ReadOnlyBodyAndCache;
 use crate::mir::interpret::{GlobalId, ErrorHandled};
 use crate::mir::GeneratorLayout;
 use crate::session::CrateDisambiguator;
@@ -2985,7 +2985,7 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     /// Returns the possibly-auto-generated MIR of a `(DefId, Subst)` pair.
-    pub fn instance_mir(self, instance: ty::InstanceDef<'tcx>) -> ReadOnlyBodyCache<'tcx, 'tcx> {
+    pub fn instance_mir(self, instance: ty::InstanceDef<'tcx>) -> ReadOnlyBodyAndCache<'tcx, 'tcx> {
         match instance {
             ty::InstanceDef::Item(did) => {
                 self.optimized_mir(did).unwrap_read_only()

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -153,7 +153,7 @@ impl<'a, 'tcx> TerminatorCodegenHelper<'tcx> {
     // a loop.
     fn maybe_sideeffect<Bx: BuilderMethods<'a, 'tcx>>(
         &self,
-        mir: mir::ReadOnlyBodyCache<'tcx, 'tcx>,
+        mir: mir::ReadOnlyBodyAndCache<'tcx, 'tcx>,
         bx: &mut Bx,
         targets: &[mir::BasicBlock],
     ) {

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -721,7 +721,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     'descend_newtypes: while !op.layout.ty.is_unsafe_ptr()
                                     && !op.layout.ty.is_region_ptr()
                     {
-                        'iter_fields: for i in 0..op.layout.fields.count() {
+                        for i in 0..op.layout.fields.count() {
                             let field = op.extract_field(&mut bx, i);
                             if !field.layout.is_zst() {
                                 // we found the one non-zero-sized field that is allowed

--- a/src/librustc_codegen_ssa/mir/mod.rs
+++ b/src/librustc_codegen_ssa/mir/mod.rs
@@ -21,7 +21,7 @@ use self::operand::{OperandRef, OperandValue};
 pub struct FunctionCx<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> {
     instance: Instance<'tcx>,
 
-    mir: mir::ReadOnlyBodyCache<'tcx, 'tcx>,
+    mir: mir::ReadOnlyBodyAndCache<'tcx, 'tcx>,
 
     debug_context: Option<FunctionDebugContext<Bx::DIScope>>,
 

--- a/src/librustc_codegen_ssa/mir/mod.rs
+++ b/src/librustc_codegen_ssa/mir/mod.rs
@@ -156,7 +156,7 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         }).collect();
 
     let (landing_pads, funclets) = create_funclets(&mir, &mut bx, &cleanup_kinds, &block_bxs);
-    let mir_body: &mir::Body<'_> = mir.body();
+    let mir_body: &mir::Body<'_> = *mir;
     let mut fx = FunctionCx {
         instance,
         mir,

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -341,7 +341,7 @@ fn register_builtins(store: &mut lint::LintStore, no_interleave_lints: bool) {
         "converted into hard error, see https://github.com/rust-lang/rust/issues/46205");
     store.register_removed("legacy_constructor_visibility",
         "converted into hard error, see https://github.com/rust-lang/rust/issues/39207");
-    store.register_removed("legacy_disrectory_ownership",
+    store.register_removed("legacy_directory_ownership",
         "converted into hard error, see https://github.com/rust-lang/rust/issues/37872");
     store.register_removed("safe_extern_statics",
         "converted into hard error, see https://github.com/rust-lang/rust/issues/36247");

--- a/src/librustc_metadata/rmeta/decoder.rs
+++ b/src/librustc_metadata/rmeta/decoder.rs
@@ -18,7 +18,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::svh::Svh;
 use rustc::dep_graph::{self, DepNodeIndex};
 use rustc::middle::lang_items;
-use rustc::mir::{self, BodyCache, interpret, Promoted};
+use rustc::mir::{self, BodyAndCache, interpret, Promoted};
 use rustc::mir::interpret::{AllocDecodingSession, AllocDecodingState};
 use rustc::session::Session;
 use rustc::ty::{self, Ty, TyCtxt};
@@ -1079,7 +1079,7 @@ impl<'a, 'tcx> CrateMetadata {
             self.root.per_def.mir.get(self, id).is_some()
     }
 
-    fn get_optimized_mir(&self, tcx: TyCtxt<'tcx>, id: DefIndex) -> BodyCache<'tcx> {
+    fn get_optimized_mir(&self, tcx: TyCtxt<'tcx>, id: DefIndex) -> BodyAndCache<'tcx> {
         let mut cache = self.root.per_def.mir.get(self, id)
             .filter(|_| !self.is_proc_macro(id))
             .unwrap_or_else(|| {
@@ -1094,7 +1094,7 @@ impl<'a, 'tcx> CrateMetadata {
         &self,
         tcx: TyCtxt<'tcx>,
         id: DefIndex,
-    ) -> IndexVec<Promoted, BodyCache<'tcx>> {
+    ) -> IndexVec<Promoted, BodyAndCache<'tcx>> {
         let mut cache = self.root.per_def.promoted_mir.get(self, id)
             .filter(|_| !self.is_proc_macro(id))
             .unwrap_or_else(|| {

--- a/src/librustc_metadata/rmeta/mod.rs
+++ b/src/librustc_metadata/rmeta/mod.rs
@@ -276,8 +276,8 @@ define_per_def_tables! {
     // Also, as an optimization, a missing entry indicates an empty `&[]`.
     inferred_outlives: Table<DefIndex, Lazy!(&'tcx [(ty::Predicate<'tcx>, Span)])>,
     super_predicates: Table<DefIndex, Lazy!(ty::GenericPredicates<'tcx>)>,
-    mir: Table<DefIndex, Lazy!(mir::BodyCache<'tcx>)>,
-    promoted_mir: Table<DefIndex, Lazy!(IndexVec<mir::Promoted, mir::BodyCache<'tcx>>)>,
+    mir: Table<DefIndex, Lazy!(mir::BodyAndCache<'tcx>)>,
+    promoted_mir: Table<DefIndex, Lazy!(IndexVec<mir::Promoted, mir::BodyAndCache<'tcx>>)>,
 }
 
 #[derive(Copy, Clone, RustcEncodable, RustcDecodable)]

--- a/src/librustc_mir/borrow_check/borrow_set.rs
+++ b/src/librustc_mir/borrow_check/borrow_set.rs
@@ -5,7 +5,7 @@ use crate::dataflow::indexes::BorrowIndex;
 use crate::dataflow::move_paths::MoveData;
 use rustc::mir::traversal;
 use rustc::mir::visit::{PlaceContext, Visitor, NonUseContext, MutatingUseContext};
-use rustc::mir::{self, Location, Body, Local, ReadOnlyBodyCache};
+use rustc::mir::{self, Location, Body, Local, ReadOnlyBodyAndCache};
 use rustc::ty::{RegionVid, TyCtxt};
 use rustc::util::nodemap::{FxHashMap, FxHashSet};
 use rustc_index::vec::IndexVec;
@@ -90,7 +90,7 @@ crate enum LocalsStateAtExit {
 impl LocalsStateAtExit {
     fn build(
         locals_are_invalidated_at_exit: bool,
-        body: ReadOnlyBodyCache<'_, 'tcx>,
+        body: ReadOnlyBodyAndCache<'_, 'tcx>,
         move_data: &MoveData<'tcx>
     ) -> Self {
         struct HasStorageDead(BitSet<Local>);
@@ -124,7 +124,7 @@ impl LocalsStateAtExit {
 impl<'tcx> BorrowSet<'tcx> {
     pub fn build(
         tcx: TyCtxt<'tcx>,
-        body: ReadOnlyBodyCache<'_, 'tcx>,
+        body: ReadOnlyBodyAndCache<'_, 'tcx>,
         locals_are_invalidated_at_exit: bool,
         move_data: &MoveData<'tcx>,
     ) -> Self {

--- a/src/librustc_mir/borrow_check/diagnostics/mutability_errors.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/mutability_errors.rs
@@ -1,6 +1,6 @@
 use rustc::hir;
 use rustc::hir::Node;
-use rustc::mir::{self, ClearCrossCrate, Local, LocalInfo, Location, ReadOnlyBodyCache};
+use rustc::mir::{self, ClearCrossCrate, Local, LocalInfo, Location, ReadOnlyBodyAndCache};
 use rustc::mir::{Mutability, Place, PlaceRef, PlaceBase, ProjectionElem};
 use rustc::ty::{self, Ty, TyCtxt};
 use rustc_index::vec::Idx;
@@ -533,7 +533,7 @@ fn suggest_ampmut_self<'tcx>(
 // by trying (3.), then (2.) and finally falling back on (1.).
 fn suggest_ampmut<'tcx>(
     tcx: TyCtxt<'tcx>,
-    body: ReadOnlyBodyCache<'_, 'tcx>,
+    body: ReadOnlyBodyAndCache<'_, 'tcx>,
     local: Local,
     local_decl: &mir::LocalDecl<'tcx>,
     opt_ty_info: Option<Span>,

--- a/src/librustc_mir/borrow_check/nll/invalidation.rs
+++ b/src/librustc_mir/borrow_check/nll/invalidation.rs
@@ -11,7 +11,7 @@ use crate::borrow_check::path_utils::*;
 use crate::dataflow::indexes::BorrowIndex;
 use rustc::ty::{self, TyCtxt};
 use rustc::mir::visit::Visitor;
-use rustc::mir::{BasicBlock, Location, Body, Place, ReadOnlyBodyCache, Rvalue};
+use rustc::mir::{BasicBlock, Location, Body, Place, ReadOnlyBodyAndCache, Rvalue};
 use rustc::mir::{Statement, StatementKind};
 use rustc::mir::TerminatorKind;
 use rustc::mir::{Operand, BorrowKind};
@@ -22,7 +22,7 @@ pub(super) fn generate_invalidates<'tcx>(
     param_env: ty::ParamEnv<'tcx>,
     all_facts: &mut Option<AllFacts>,
     location_table: &LocationTable,
-    body: ReadOnlyBodyCache<'_, 'tcx>,
+    body: ReadOnlyBodyAndCache<'_, 'tcx>,
     borrow_set: &BorrowSet<'tcx>,
 ) {
     if all_facts.is_none() {

--- a/src/librustc_mir/borrow_check/nll/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/mod.rs
@@ -12,8 +12,8 @@ use crate::borrow_check::Upvar;
 use rustc::hir::def_id::DefId;
 use rustc::infer::InferCtxt;
 use rustc::mir::{ClosureOutlivesSubject, ClosureRegionRequirements,
-                 Local, Location, Body, BodyCache, LocalKind, BasicBlock,
-                 Promoted, ReadOnlyBodyCache};
+                 Local, Location, Body, BodyAndCache, LocalKind, BasicBlock,
+                 Promoted, ReadOnlyBodyAndCache};
 use rustc::ty::{self, RegionKind, RegionVid};
 use rustc_index::vec::IndexVec;
 use rustc_errors::Diagnostic;
@@ -55,8 +55,8 @@ pub(in crate::borrow_check) fn replace_regions_in_mir<'cx, 'tcx>(
     infcx: &InferCtxt<'cx, 'tcx>,
     def_id: DefId,
     param_env: ty::ParamEnv<'tcx>,
-    body: &mut BodyCache<'tcx>,
-    promoted: &mut IndexVec<Promoted, BodyCache<'tcx>>,
+    body: &mut BodyAndCache<'tcx>,
+    promoted: &mut IndexVec<Promoted, BodyAndCache<'tcx>>,
 ) -> UniversalRegions<'tcx> {
     debug!("replace_regions_in_mir(def_id={:?})", def_id);
 
@@ -158,8 +158,8 @@ pub(in crate::borrow_check) fn compute_regions<'cx, 'tcx>(
     infcx: &InferCtxt<'cx, 'tcx>,
     def_id: DefId,
     universal_regions: UniversalRegions<'tcx>,
-    body: ReadOnlyBodyCache<'_, 'tcx>,
-    promoted: &IndexVec<Promoted, ReadOnlyBodyCache<'_, 'tcx>>,
+    body: ReadOnlyBodyAndCache<'_, 'tcx>,
+    promoted: &IndexVec<Promoted, ReadOnlyBodyAndCache<'_, 'tcx>>,
     local_names: &IndexVec<Local, Option<Symbol>>,
     upvars: &[Upvar],
     location_table: &LocationTable,

--- a/src/librustc_mir/borrow_check/nll/region_infer/values.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/values.rs
@@ -1,4 +1,4 @@
-use rustc::mir::{BasicBlock, Location, Body, ReadOnlyBodyCache};
+use rustc::mir::{BasicBlock, Location, Body, ReadOnlyBodyAndCache};
 use rustc::ty::{self, RegionVid};
 use rustc_index::bit_set::{HybridBitSet, SparseBitMatrix};
 use rustc_data_structures::fx::FxHashMap;
@@ -92,7 +92,7 @@ impl RegionValueElements {
     /// Pushes all predecessors of `index` onto `stack`.
     crate fn push_predecessors(
         &self,
-        body: ReadOnlyBodyCache<'_, '_>,
+        body: ReadOnlyBodyAndCache<'_, '_>,
         index: PointIndex,
         stack: &mut Vec<PointIndex>,
     ) {

--- a/src/librustc_mir/borrow_check/nll/renumber.rs
+++ b/src/librustc_mir/borrow_check/nll/renumber.rs
@@ -1,6 +1,6 @@
 use rustc::ty::subst::SubstsRef;
 use rustc::ty::{self, Ty, TyCtxt, TypeFoldable};
-use rustc::mir::{BodyCache, Location, PlaceElem, Promoted};
+use rustc::mir::{BodyAndCache, Location, PlaceElem, Promoted};
 use rustc::mir::visit::{MutVisitor, TyContext};
 use rustc::infer::{InferCtxt, NLLRegionVariableOrigin};
 use rustc_index::vec::IndexVec;
@@ -9,8 +9,8 @@ use rustc_index::vec::IndexVec;
 /// inference variables, returning the number of variables created.
 pub fn renumber_mir<'tcx>(
     infcx: &InferCtxt<'_, 'tcx>,
-    body: &mut BodyCache<'tcx>,
-    promoted: &mut IndexVec<Promoted, BodyCache<'tcx>>,
+    body: &mut BodyAndCache<'tcx>,
+    promoted: &mut IndexVec<Promoted, BodyAndCache<'tcx>>,
 ) {
     debug!("renumber_mir()");
     debug!("renumber_mir: body.arg_count={:?}", body.arg_count);

--- a/src/librustc_mir/borrow_check/nll/type_check/liveness/local_use_map.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/liveness/local_use_map.rs
@@ -1,7 +1,7 @@
 use crate::borrow_check::nll::region_infer::values::{PointIndex, RegionValueElements};
 use crate::util::liveness::{categorize, DefUse};
 use rustc::mir::visit::{PlaceContext, Visitor};
-use rustc::mir::{Local, Location, ReadOnlyBodyCache};
+use rustc::mir::{Local, Location, ReadOnlyBodyAndCache};
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_data_structures::vec_linked_list as vll;
 
@@ -60,7 +60,7 @@ impl LocalUseMap {
     crate fn build(
         live_locals: &Vec<Local>,
         elements: &RegionValueElements,
-        body: ReadOnlyBodyCache<'_, '_>,
+        body: ReadOnlyBodyAndCache<'_, '_>,
     ) -> Self {
         let nones = IndexVec::from_elem_n(None, body.local_decls.len());
         let mut local_use_map = LocalUseMap {

--- a/src/librustc_mir/borrow_check/nll/type_check/liveness/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/liveness/mod.rs
@@ -7,7 +7,7 @@ use crate::borrow_check::nll::ToRegionVid;
 use crate::dataflow::move_paths::MoveData;
 use crate::dataflow::FlowAtLocation;
 use crate::dataflow::MaybeInitializedPlaces;
-use rustc::mir::{Body, Local, ReadOnlyBodyCache};
+use rustc::mir::{Body, Local, ReadOnlyBodyAndCache};
 use rustc::ty::{RegionVid, TyCtxt};
 use rustc_data_structures::fx::FxHashSet;
 use std::rc::Rc;
@@ -28,7 +28,7 @@ mod trace;
 /// performed before
 pub(super) fn generate<'tcx>(
     typeck: &mut TypeChecker<'_, 'tcx>,
-    body: ReadOnlyBodyCache<'_, 'tcx>,
+    body: ReadOnlyBodyAndCache<'_, 'tcx>,
     elements: &Rc<RegionValueElements>,
     flow_inits: &mut FlowAtLocation<'tcx, MaybeInitializedPlaces<'_, 'tcx>>,
     move_data: &MoveData<'tcx>,

--- a/src/librustc_mir/borrow_check/nll/type_check/liveness/polonius.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/liveness/polonius.rs
@@ -3,7 +3,7 @@ use crate::dataflow::indexes::MovePathIndex;
 use crate::dataflow::move_paths::{LookupResult, MoveData};
 use crate::util::liveness::{categorize, DefUse};
 use rustc::mir::visit::{MutatingUseContext, PlaceContext, Visitor};
-use rustc::mir::{Local, Location, Place, ReadOnlyBodyCache};
+use rustc::mir::{Local, Location, Place, ReadOnlyBodyAndCache};
 use rustc::ty::subst::GenericArg;
 use rustc::ty::Ty;
 
@@ -97,7 +97,7 @@ fn add_var_uses_regions(typeck: &mut TypeChecker<'_, 'tcx>, local: Local, ty: Ty
 
 pub(super) fn populate_access_facts(
     typeck: &mut TypeChecker<'_, 'tcx>,
-    body: ReadOnlyBodyCache<'_, 'tcx>,
+    body: ReadOnlyBodyAndCache<'_, 'tcx>,
     location_table: &LocationTable,
     move_data: &MoveData<'_>,
     drop_used: &mut Vec<(Local, Location)>,

--- a/src/librustc_mir/borrow_check/nll/type_check/liveness/trace.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/liveness/trace.rs
@@ -7,7 +7,7 @@ use crate::dataflow::indexes::MovePathIndex;
 use crate::dataflow::move_paths::MoveData;
 use crate::dataflow::{FlowAtLocation, FlowsAtLocation, MaybeInitializedPlaces};
 use rustc::infer::canonical::QueryRegionConstraints;
-use rustc::mir::{BasicBlock, ConstraintCategory, Local, Location, ReadOnlyBodyCache};
+use rustc::mir::{BasicBlock, ConstraintCategory, Local, Location, ReadOnlyBodyAndCache};
 use rustc::traits::query::dropck_outlives::DropckOutlivesResult;
 use rustc::traits::query::type_op::outlives::DropckOutlives;
 use rustc::traits::query::type_op::TypeOp;
@@ -32,7 +32,7 @@ use std::rc::Rc;
 /// this respects `#[may_dangle]` annotations).
 pub(super) fn trace(
     typeck: &mut TypeChecker<'_, 'tcx>,
-    body: ReadOnlyBodyCache<'_, 'tcx>,
+    body: ReadOnlyBodyAndCache<'_, 'tcx>,
     elements: &Rc<RegionValueElements>,
     flow_inits: &mut FlowAtLocation<'tcx, MaybeInitializedPlaces<'_, 'tcx>>,
     move_data: &MoveData<'tcx>,
@@ -71,7 +71,7 @@ struct LivenessContext<'me, 'typeck, 'flow, 'tcx> {
     elements: &'me RegionValueElements,
 
     /// MIR we are analyzing.
-    body: ReadOnlyBodyCache<'me, 'tcx>,
+    body: ReadOnlyBodyAndCache<'me, 'tcx>,
 
     /// Mapping to/from the various indices used for initialization tracking.
     move_data: &'me MoveData<'tcx>,

--- a/src/librustc_mir/borrow_check/nll/type_check/liveness/trace.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/liveness/trace.rs
@@ -249,7 +249,7 @@ impl LivenessResults<'me, 'typeck, 'flow, 'tcx> {
         // Reverse DFS. But for drops, we do it a bit differently.
         // The stack only ever stores *terminators of blocks*. Within
         // a block, we walk back the statements in an inner loop.
-        'next_block: while let Some(term_point) = self.stack.pop() {
+        while let Some(term_point) = self.stack.pop() {
             self.compute_drop_live_points_for_block(mpi, term_point);
         }
     }

--- a/src/librustc_mir/borrow_check/prefixes.rs
+++ b/src/librustc_mir/borrow_check/prefixes.rs
@@ -11,7 +11,7 @@ use super::MirBorrowckCtxt;
 
 use rustc::hir;
 use rustc::ty::{self, TyCtxt};
-use rustc::mir::{Place, PlaceBase, PlaceRef, ProjectionElem, ReadOnlyBodyCache};
+use rustc::mir::{Place, PlaceBase, PlaceRef, ProjectionElem, ReadOnlyBodyAndCache};
 
 pub trait IsPrefixOf<'cx, 'tcx> {
     fn is_prefix_of(&self, other: PlaceRef<'cx, 'tcx>) -> bool;
@@ -26,7 +26,7 @@ impl<'cx, 'tcx> IsPrefixOf<'cx, 'tcx> for PlaceRef<'cx, 'tcx> {
 }
 
 pub(super) struct Prefixes<'cx, 'tcx> {
-    body: ReadOnlyBodyCache<'cx, 'tcx>,
+    body: ReadOnlyBodyAndCache<'cx, 'tcx>,
     tcx: TyCtxt<'tcx>,
     kind: PrefixSet,
     next: Option<PlaceRef<'cx, 'tcx>>,

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -24,7 +24,7 @@ use syntax_pos::Span;
 use super::lints;
 
 /// Construct the MIR for a given `DefId`.
-pub fn mir_build(tcx: TyCtxt<'_>, def_id: DefId) -> BodyCache<'_> {
+pub fn mir_build(tcx: TyCtxt<'_>, def_id: DefId) -> BodyAndCache<'_> {
     let id = tcx.hir().as_local_hir_id(def_id).unwrap();
 
     // Figure out what primary body this item has.
@@ -196,7 +196,7 @@ pub fn mir_build(tcx: TyCtxt<'_>, def_id: DefId) -> BodyCache<'_> {
 
         lints::check(tcx, &body, def_id);
 
-        let mut body = BodyCache::new(body);
+        let mut body = BodyAndCache::new(body);
         body.ensure_predecessors();
         body
     })

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -366,7 +366,7 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
         }
         // This is a const fn. Call it.
         Ok(Some(match ecx.load_mir(instance.def, None) {
-            Ok(body) => body.body(),
+            Ok(body) => *body,
             Err(err) => {
                 if let err_unsup!(NoMirFor(ref path)) = err.kind {
                     return Err(
@@ -743,7 +743,7 @@ pub fn const_eval_raw_provider<'tcx>(
 
     let res = ecx.load_mir(cid.instance.def, cid.promoted);
     res.and_then(
-        |body| eval_body_using_ecx(&mut ecx, cid, body.body())
+        |body| eval_body_using_ecx(&mut ecx, cid, *body)
     ).and_then(|place| {
         Ok(RawConst {
             alloc_id: place.ptr.assert_ptr().alloc_id,

--- a/src/librustc_mir/dataflow/impls/storage_liveness.rs
+++ b/src/librustc_mir/dataflow/impls/storage_liveness.rs
@@ -75,20 +75,20 @@ impl<'a, 'tcx> BottomValue for MaybeStorageLive<'a, 'tcx> {
 /// Dataflow analysis that determines whether each local requires storage at a
 /// given location; i.e. whether its storage can go away without being observed.
 pub struct RequiresStorage<'mir, 'tcx> {
-    body: ReadOnlyBodyCache<'mir, 'tcx>,
+    body: ReadOnlyBodyAndCache<'mir, 'tcx>,
     borrowed_locals:
         RefCell<DataflowResultsRefCursor<'mir, 'tcx, HaveBeenBorrowedLocals<'mir, 'tcx>>>,
 }
 
 impl<'mir, 'tcx: 'mir> RequiresStorage<'mir, 'tcx> {
     pub fn new(
-        body: ReadOnlyBodyCache<'mir, 'tcx>,
+        body: ReadOnlyBodyAndCache<'mir, 'tcx>,
         borrowed_locals: &'mir DataflowResults<'tcx, HaveBeenBorrowedLocals<'mir, 'tcx>>,
     ) -> Self {
         RequiresStorage {
             body,
             borrowed_locals: RefCell::new(
-                DataflowResultsCursor::new(borrowed_locals, body.body())
+                DataflowResultsCursor::new(borrowed_locals, *body)
             ),
         }
     }

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -312,7 +312,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         &self,
         instance: ty::InstanceDef<'tcx>,
         promoted: Option<mir::Promoted>,
-    ) -> InterpResult<'tcx, mir::ReadOnlyBodyCache<'tcx, 'tcx>> {
+    ) -> InterpResult<'tcx, mir::ReadOnlyBodyAndCache<'tcx, 'tcx>> {
         // do not continue if typeck errors occurred (can only occur in local crate)
         let did = instance.def_id();
         if did.is_local()

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -26,7 +26,7 @@ pub fn provide(providers: &mut Providers<'_>) {
     providers.mir_shims = make_shim;
 }
 
-fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceDef<'tcx>) -> &'tcx BodyCache<'tcx> {
+fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceDef<'tcx>) -> &'tcx BodyAndCache<'tcx> {
     debug!("make_shim({:?})", instance);
 
     let mut result = match instance {
@@ -170,7 +170,7 @@ fn local_decls_for_sig<'tcx>(sig: &ty::FnSig<'tcx>, span: Span)
 
 fn build_drop_shim<'tcx>(
     tcx: TyCtxt<'tcx>, def_id: DefId, ty: Option<Ty<'tcx>>
-) -> BodyCache<'tcx> {
+) -> BodyAndCache<'tcx> {
     debug!("build_drop_shim(def_id={:?}, ty={:?})", def_id, ty);
 
     // Check if this is a generator, if so, return the drop glue for it
@@ -208,7 +208,7 @@ fn build_drop_shim<'tcx>(
         sig.inputs().len(),
         span);
 
-    let mut body = BodyCache::new(body);
+    let mut body = BodyAndCache::new(body);
 
     if let Some(..) = ty {
         // The first argument (index 0), but add 1 for the return value.
@@ -322,7 +322,7 @@ impl<'a, 'tcx> DropElaborator<'a, 'tcx> for DropShimElaborator<'a, 'tcx> {
 }
 
 /// Builds a `Clone::clone` shim for `self_ty`. Here, `def_id` is `Clone::clone`.
-fn build_clone_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, self_ty: Ty<'tcx>) -> BodyCache<'tcx> {
+fn build_clone_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, self_ty: Ty<'tcx>) -> BodyAndCache<'tcx> {
     debug!("build_clone_shim(def_id={:?})", def_id);
 
     let param_env = tcx.param_env(def_id);
@@ -351,7 +351,7 @@ fn build_clone_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, self_ty: Ty<'tcx>) -
         }
     };
 
-    BodyCache::new(builder.into_mir())
+    BodyAndCache::new(builder.into_mir())
 }
 
 struct CloneShimBuilder<'tcx> {
@@ -712,7 +712,7 @@ fn build_call_shim<'tcx>(
     rcvr_adjustment: Adjustment,
     call_kind: CallKind,
     untuple_args: Option<&[Ty<'tcx>]>,
-) -> BodyCache<'tcx> {
+) -> BodyAndCache<'tcx> {
     debug!("build_call_shim(instance={:?}, rcvr_adjustment={:?}, \
             call_kind={:?}, untuple_args={:?})",
            instance, rcvr_adjustment, call_kind, untuple_args);
@@ -853,10 +853,10 @@ fn build_call_shim<'tcx>(
     if let Abi::RustCall = sig.abi {
         body.spread_arg = Some(Local::new(sig.inputs().len()));
     }
-    BodyCache::new(body)
+    BodyAndCache::new(body)
 }
 
-pub fn build_adt_ctor(tcx: TyCtxt<'_>, ctor_id: DefId) -> &BodyCache<'_> {
+pub fn build_adt_ctor(tcx: TyCtxt<'_>, ctor_id: DefId) -> &BodyAndCache<'_> {
     debug_assert!(tcx.is_constructor(ctor_id));
 
     let span = tcx.hir().span_if_local(ctor_id)
@@ -940,7 +940,7 @@ pub fn build_adt_ctor(tcx: TyCtxt<'_>, ctor_id: DefId) -> &BodyCache<'_> {
         |_, _| Ok(()),
     );
 
-    let mut body = BodyCache::new(body);
+    let mut body = BodyAndCache::new(body);
     body.ensure_predecessors();
     tcx.arena.alloc(body)
 }

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -322,7 +322,11 @@ impl<'a, 'tcx> DropElaborator<'a, 'tcx> for DropShimElaborator<'a, 'tcx> {
 }
 
 /// Builds a `Clone::clone` shim for `self_ty`. Here, `def_id` is `Clone::clone`.
-fn build_clone_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, self_ty: Ty<'tcx>) -> BodyAndCache<'tcx> {
+fn build_clone_shim<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    def_id: DefId,
+    self_ty: Ty<'tcx>,
+) -> BodyAndCache<'tcx> {
     debug!("build_clone_shim(def_id={:?})", def_id);
 
     let param_env = tcx.param_env(def_id);

--- a/src/librustc_mir/transform/add_call_guards.rs
+++ b/src/librustc_mir/transform/add_call_guards.rs
@@ -32,14 +32,14 @@ pub use self::AddCallGuards::*;
 
 impl<'tcx> MirPass<'tcx> for AddCallGuards {
     fn run_pass(
-        &self, _tcx: TyCtxt<'tcx>, _src: MirSource<'tcx>, body: &mut BodyCache<'tcx>
+        &self, _tcx: TyCtxt<'tcx>, _src: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>
     ) {
         self.add_call_guards(body);
     }
 }
 
 impl AddCallGuards {
-    pub fn add_call_guards(&self, body: &mut BodyCache<'_>) {
+    pub fn add_call_guards(&self, body: &mut BodyAndCache<'_>) {
         let pred_count: IndexVec<_, _> = body.predecessors().iter().map(|ps| ps.len()).collect();
 
         // We need a place to store the new blocks generated

--- a/src/librustc_mir/transform/add_moves_for_packed_drops.rs
+++ b/src/librustc_mir/transform/add_moves_for_packed_drops.rs
@@ -40,14 +40,14 @@ use crate::util;
 pub struct AddMovesForPackedDrops;
 
 impl<'tcx> MirPass<'tcx> for AddMovesForPackedDrops {
-    fn run_pass(&self, tcx: TyCtxt<'tcx>, src: MirSource<'tcx>, body: &mut BodyCache<'tcx>) {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, src: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>) {
         debug!("add_moves_for_packed_drops({:?} @ {:?})", src, body.span);
         add_moves_for_packed_drops(tcx, body, src.def_id());
     }
 }
 
 pub fn add_moves_for_packed_drops<'tcx>(
-    tcx: TyCtxt<'tcx>, body: &mut BodyCache<'tcx>, def_id: DefId
+    tcx: TyCtxt<'tcx>, body: &mut BodyAndCache<'tcx>, def_id: DefId
 ) {
     let patch = add_moves_for_packed_drops_patch(tcx, body, def_id);
     patch.apply(body);

--- a/src/librustc_mir/transform/add_retag.rs
+++ b/src/librustc_mir/transform/add_retag.rs
@@ -59,7 +59,7 @@ fn may_be_reference<'tcx>(ty: Ty<'tcx>) -> bool {
 }
 
 impl<'tcx> MirPass<'tcx> for AddRetag {
-    fn run_pass(&self, tcx: TyCtxt<'tcx>, _src: MirSource<'tcx>, body: &mut BodyCache<'tcx>) {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, _src: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>) {
         if !tcx.sess.opts.debugging_opts.mir_emit_retag {
             return;
         }

--- a/src/librustc_mir/transform/check_consts/mod.rs
+++ b/src/librustc_mir/transform/check_consts/mod.rs
@@ -20,7 +20,7 @@ pub mod validation;
 /// Information about the item currently being const-checked, as well as a reference to the global
 /// context.
 pub struct Item<'mir, 'tcx> {
-    pub body: mir::ReadOnlyBodyCache<'mir, 'tcx>,
+    pub body: mir::ReadOnlyBodyAndCache<'mir, 'tcx>,
     pub tcx: TyCtxt<'tcx>,
     pub def_id: DefId,
     pub param_env: ty::ParamEnv<'tcx>,
@@ -31,7 +31,7 @@ impl Item<'mir, 'tcx> {
     pub fn new(
         tcx: TyCtxt<'tcx>,
         def_id: DefId,
-        body: mir::ReadOnlyBodyCache<'mir, 'tcx>,
+        body: mir::ReadOnlyBodyAndCache<'mir, 'tcx>,
     ) -> Self {
         let param_env = tcx.param_env(def_id);
         let const_kind = ConstKind::for_item(tcx, def_id);

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -40,7 +40,7 @@ impl<Q: Qualif> QualifCursor<'a, 'mir, 'tcx, Q> {
         let results =
             dataflow::Engine::new(item.tcx, &item.body, item.def_id, dead_unwinds, analysis)
                 .iterate_to_fixpoint();
-        let cursor = dataflow::ResultsCursor::new(item.body.body(), results);
+        let cursor = dataflow::ResultsCursor::new(*item.body, results);
 
         let mut in_any_value_of_ty = BitSet::new_empty(item.body.local_decls.len());
         for (local, decl) in item.body.local_decls.iter_enumerated() {
@@ -175,13 +175,13 @@ impl Validator<'a, 'mir, 'tcx> {
             item.def_id,
             &item.tcx.get_attrs(item.def_id),
             &dead_unwinds,
-            old_dataflow::IndirectlyMutableLocals::new(item.tcx, item.body.body(), item.param_env),
+            old_dataflow::IndirectlyMutableLocals::new(item.tcx, *item.body, item.param_env),
             |_, local| old_dataflow::DebugFormatted::new(&local),
         );
 
         let indirectly_mutable = old_dataflow::DataflowResultsCursor::new(
             indirectly_mutable,
-            item.body.body(),
+            *item.body,
         );
 
         let qualifs = Qualifs {

--- a/src/librustc_mir/transform/cleanup_post_borrowck.rs
+++ b/src/librustc_mir/transform/cleanup_post_borrowck.rs
@@ -16,7 +16,7 @@
 //! [`FakeRead`]: rustc::mir::StatementKind::FakeRead
 //! [`Nop`]: rustc::mir::StatementKind::Nop
 
-use rustc::mir::{BodyCache, BorrowKind, Rvalue, Location};
+use rustc::mir::{BodyAndCache, BorrowKind, Rvalue, Location};
 use rustc::mir::{Statement, StatementKind};
 use rustc::mir::visit::MutVisitor;
 use rustc::ty::TyCtxt;
@@ -30,7 +30,7 @@ pub struct DeleteNonCodegenStatements<'tcx> {
 
 impl<'tcx> MirPass<'tcx> for CleanupNonCodegenStatements {
     fn run_pass(
-        &self, tcx: TyCtxt<'tcx>, _source: MirSource<'tcx>, body: &mut BodyCache<'tcx>
+        &self, tcx: TyCtxt<'tcx>, _source: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>
     ) {
         let mut delete = DeleteNonCodegenStatements { tcx };
         delete.visit_body(body);

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -7,9 +7,9 @@ use std::cell::Cell;
 use rustc::hir::def::DefKind;
 use rustc::hir::def_id::DefId;
 use rustc::mir::{
-    AggregateKind, Constant, Location, Place, PlaceBase, Body, BodyCache, Operand, Local, UnOp,
-    Rvalue, StatementKind, Statement, LocalKind, TerminatorKind, Terminator,  ClearCrossCrate,
-    SourceInfo, BinOp, SourceScope, SourceScopeData, LocalDecl, BasicBlock, ReadOnlyBodyCache,
+    AggregateKind, Constant, Location, Place, PlaceBase, Body, BodyAndCache, Operand, Local, UnOp,
+    Rvalue, StatementKind, Statement, LocalKind, TerminatorKind, Terminator, ClearCrossCrate,
+    SourceInfo, BinOp, SourceScope, SourceScopeData, LocalDecl, BasicBlock, ReadOnlyBodyAndCache,
     read_only, RETURN_PLACE
 };
 use rustc::mir::visit::{
@@ -43,7 +43,7 @@ pub struct ConstProp;
 
 impl<'tcx> MirPass<'tcx> for ConstProp {
     fn run_pass(
-        &self, tcx: TyCtxt<'tcx>, source: MirSource<'tcx>, body: &mut BodyCache<'tcx>
+        &self, tcx: TyCtxt<'tcx>, source: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>
     ) {
         // will be evaluated by miri and produce its errors there
         if source.promoted.is_some() {
@@ -296,7 +296,7 @@ impl<'mir, 'tcx> HasTyCtxt<'tcx> for ConstPropagator<'mir, 'tcx> {
 
 impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
     fn new(
-        body: ReadOnlyBodyCache<'_, 'tcx>,
+        body: ReadOnlyBodyAndCache<'_, 'tcx>,
         dummy_body: &'mir Body<'tcx>,
         tcx: TyCtxt<'tcx>,
         source: MirSource<'tcx>,
@@ -690,7 +690,7 @@ struct CanConstProp {
 
 impl CanConstProp {
     /// returns true if `local` can be propagated
-    fn check(body: ReadOnlyBodyCache<'_, '_>) -> IndexVec<Local, bool> {
+    fn check(body: ReadOnlyBodyAndCache<'_, '_>) -> IndexVec<Local, bool> {
         let mut cpv = CanConstProp {
             can_const_prop: IndexVec::from_elem(true, &body.local_decls),
             found_assignment: IndexVec::from_elem(false, &body.local_decls),

--- a/src/librustc_mir/transform/copy_prop.rs
+++ b/src/librustc_mir/transform/copy_prop.rs
@@ -20,7 +20,7 @@
 //! future.
 
 use rustc::mir::{
-    Constant, Local, LocalKind, Location, Place, Body, BodyCache, Operand, Rvalue,
+    Constant, Local, LocalKind, Location, Place, Body, BodyAndCache, Operand, Rvalue,
     StatementKind, read_only
 };
 use rustc::mir::visit::MutVisitor;
@@ -32,7 +32,7 @@ pub struct CopyPropagation;
 
 impl<'tcx> MirPass<'tcx> for CopyPropagation {
     fn run_pass(
-        &self, tcx: TyCtxt<'tcx>, _source: MirSource<'tcx>, body: &mut BodyCache<'tcx>
+        &self, tcx: TyCtxt<'tcx>, _source: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>
     ) {
         // We only run when the MIR optimization level is > 1.
         // This avoids a slow pass, and messing up debug info.
@@ -250,7 +250,7 @@ impl<'tcx> Action<'tcx> {
     }
 
     fn perform(self,
-               body: &mut BodyCache<'tcx>,
+               body: &mut BodyAndCache<'tcx>,
                def_use_analysis: &DefUseAnalysis,
                dest_local: Local,
                location: Location,

--- a/src/librustc_mir/transform/deaggregator.rs
+++ b/src/librustc_mir/transform/deaggregator.rs
@@ -7,7 +7,7 @@ pub struct Deaggregator;
 
 impl<'tcx> MirPass<'tcx> for Deaggregator {
     fn run_pass(
-        &self, tcx: TyCtxt<'tcx>, _source: MirSource<'tcx>, body: &mut BodyCache<'tcx>
+        &self, tcx: TyCtxt<'tcx>, _source: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>
     ) {
         let (basic_blocks, local_decls) = body.basic_blocks_and_local_decls_mut();
         let local_decls = &*local_decls;

--- a/src/librustc_mir/transform/dump_mir.rs
+++ b/src/librustc_mir/transform/dump_mir.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::fs::File;
 use std::io;
 
-use rustc::mir::{Body, BodyCache};
+use rustc::mir::{Body, BodyAndCache};
 use rustc::session::config::{OutputFilenames, OutputType};
 use rustc::ty::TyCtxt;
 use crate::transform::{MirPass, MirSource};
@@ -19,7 +19,7 @@ impl<'tcx> MirPass<'tcx> for Marker {
     }
 
     fn run_pass(
-        &self, _tcx: TyCtxt<'tcx>, _source: MirSource<'tcx>, _body: &mut BodyCache<'tcx>
+        &self, _tcx: TyCtxt<'tcx>, _source: MirSource<'tcx>, _body: &mut BodyAndCache<'tcx>
     ) {}
 }
 

--- a/src/librustc_mir/transform/elaborate_drops.rs
+++ b/src/librustc_mir/transform/elaborate_drops.rs
@@ -21,7 +21,7 @@ use syntax_pos::Span;
 pub struct ElaborateDrops;
 
 impl<'tcx> MirPass<'tcx> for ElaborateDrops {
-    fn run_pass(&self, tcx: TyCtxt<'tcx>, src: MirSource<'tcx>, body: &mut BodyCache<'tcx>) {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, src: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>) {
         debug!("elaborate_drops({:?} @ {:?})", src, body.span);
 
         let def_id = src.def_id();

--- a/src/librustc_mir/transform/erase_regions.rs
+++ b/src/librustc_mir/transform/erase_regions.rs
@@ -62,7 +62,7 @@ impl MutVisitor<'tcx> for EraseRegionsVisitor<'tcx> {
 pub struct EraseRegions;
 
 impl<'tcx> MirPass<'tcx> for EraseRegions {
-    fn run_pass(&self, tcx: TyCtxt<'tcx>, _: MirSource<'tcx>, body: &mut BodyCache<'tcx>) {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, _: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>) {
         EraseRegionsVisitor::new(tcx).visit_body(body);
     }
 }

--- a/src/librustc_mir/transform/inline.rs
+++ b/src/librustc_mir/transform/inline.rs
@@ -39,7 +39,7 @@ struct CallSite<'tcx> {
 
 impl<'tcx> MirPass<'tcx> for Inline {
     fn run_pass(
-        &self, tcx: TyCtxt<'tcx>, source: MirSource<'tcx>, body: &mut BodyCache<'tcx>
+        &self, tcx: TyCtxt<'tcx>, source: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>
     ) {
         if tcx.sess.opts.debugging_opts.mir_opt_level >= 2 {
             Inliner { tcx, source }.run_pass(body);
@@ -53,7 +53,7 @@ struct Inliner<'tcx> {
 }
 
 impl Inliner<'tcx> {
-    fn run_pass(&self, caller_body: &mut BodyCache<'tcx>) {
+    fn run_pass(&self, caller_body: &mut BodyAndCache<'tcx>) {
         // Keep a queue of callsites to try inlining on. We take
         // advantage of the fact that queries detect cycles here to
         // allow us to try and fetch the fully optimized MIR of a
@@ -380,8 +380,8 @@ impl Inliner<'tcx> {
 
     fn inline_call(&self,
                    callsite: CallSite<'tcx>,
-                   caller_body: &mut BodyCache<'tcx>,
-                   mut callee_body: BodyCache<'tcx>) -> bool {
+                   caller_body: &mut BodyAndCache<'tcx>,
+                   mut callee_body: BodyAndCache<'tcx>) -> bool {
         let terminator = caller_body[callsite.bb].terminator.take().unwrap();
         match terminator.kind {
             // FIXME: Handle inlining of diverging calls
@@ -517,7 +517,7 @@ impl Inliner<'tcx> {
         &self,
         args: Vec<Operand<'tcx>>,
         callsite: &CallSite<'tcx>,
-        caller_body: &mut BodyCache<'tcx>,
+        caller_body: &mut BodyAndCache<'tcx>,
     ) -> Vec<Local> {
         let tcx = self.tcx;
 
@@ -590,7 +590,7 @@ impl Inliner<'tcx> {
         &self,
         arg: Operand<'tcx>,
         callsite: &CallSite<'tcx>,
-        caller_body: &mut BodyCache<'tcx>,
+        caller_body: &mut BodyAndCache<'tcx>,
     ) -> Local {
         // FIXME: Analysis of the usage of the arguments to avoid
         // unnecessary temporaries.

--- a/src/librustc_mir/transform/instcombine.rs
+++ b/src/librustc_mir/transform/instcombine.rs
@@ -1,7 +1,7 @@
 //! Performs various peephole optimizations.
 
 use rustc::mir::{
-    Constant, Location, Place, PlaceBase, PlaceRef, Body, BodyCache, Operand, ProjectionElem,
+    Constant, Location, Place, PlaceBase, PlaceRef, Body, BodyAndCache, Operand, ProjectionElem,
     Rvalue, Local, read_only
 };
 use rustc::mir::visit::{MutVisitor, Visitor};
@@ -14,7 +14,7 @@ use crate::transform::{MirPass, MirSource};
 pub struct InstCombine;
 
 impl<'tcx> MirPass<'tcx> for InstCombine {
-    fn run_pass(&self, tcx: TyCtxt<'tcx>, _: MirSource<'tcx>, body: &mut BodyCache<'tcx>) {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, _: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>) {
         // We only run when optimizing MIR (at any level).
         if tcx.sess.opts.debugging_opts.mir_opt_level == 0 {
             return

--- a/src/librustc_mir/transform/no_landing_pads.rs
+++ b/src/librustc_mir/transform/no_landing_pads.rs
@@ -17,12 +17,12 @@ impl<'tcx> NoLandingPads<'tcx> {
 }
 
 impl<'tcx> MirPass<'tcx> for NoLandingPads<'tcx> {
-    fn run_pass(&self, tcx: TyCtxt<'tcx>, _: MirSource<'tcx>, body: &mut BodyCache<'tcx>) {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, _: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>) {
         no_landing_pads(tcx, body)
     }
 }
 
-pub fn no_landing_pads<'tcx>(tcx: TyCtxt<'tcx>, body: &mut BodyCache<'tcx>) {
+pub fn no_landing_pads<'tcx>(tcx: TyCtxt<'tcx>, body: &mut BodyAndCache<'tcx>) {
     if tcx.sess.no_landing_pads() {
         NoLandingPads::new(tcx).visit_body(body);
     }

--- a/src/librustc_mir/transform/remove_noop_landing_pads.rs
+++ b/src/librustc_mir/transform/remove_noop_landing_pads.rs
@@ -9,7 +9,7 @@ use crate::util::patch::MirPatch;
 /// code for these.
 pub struct RemoveNoopLandingPads;
 
-pub fn remove_noop_landing_pads<'tcx>(tcx: TyCtxt<'tcx>, body: &mut BodyCache<'tcx>) {
+pub fn remove_noop_landing_pads<'tcx>(tcx: TyCtxt<'tcx>, body: &mut BodyAndCache<'tcx>) {
     if tcx.sess.no_landing_pads() {
         return
     }
@@ -19,7 +19,7 @@ pub fn remove_noop_landing_pads<'tcx>(tcx: TyCtxt<'tcx>, body: &mut BodyCache<'t
 }
 
 impl<'tcx> MirPass<'tcx> for RemoveNoopLandingPads {
-    fn run_pass(&self, tcx: TyCtxt<'tcx>, _src: MirSource<'tcx>, body: &mut BodyCache<'tcx>) {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, _src: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>) {
         remove_noop_landing_pads(tcx, body);
     }
 }
@@ -84,7 +84,7 @@ impl RemoveNoopLandingPads {
         }
     }
 
-    fn remove_nop_landing_pads(&self, body: &mut BodyCache<'_>) {
+    fn remove_nop_landing_pads(&self, body: &mut BodyAndCache<'_>) {
         // make sure there's a single resume block
         let resume_block = {
             let patch = MirPatch::new(body);

--- a/src/librustc_mir/transform/rustc_peek.rs
+++ b/src/librustc_mir/transform/rustc_peek.rs
@@ -5,7 +5,7 @@ use syntax_pos::Span;
 
 use rustc::ty::{self, TyCtxt, Ty};
 use rustc::hir::def_id::DefId;
-use rustc::mir::{self, Body, BodyCache, Location, Local};
+use rustc::mir::{self, Body, BodyAndCache, Location, Local};
 use rustc_index::bit_set::BitSet;
 use crate::transform::{MirPass, MirSource};
 
@@ -26,7 +26,7 @@ use crate::dataflow::has_rustc_mir_with;
 pub struct SanityCheck;
 
 impl<'tcx> MirPass<'tcx> for SanityCheck {
-    fn run_pass(&self, tcx: TyCtxt<'tcx>, src: MirSource<'tcx>, body: &mut BodyCache<'tcx>) {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, src: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>) {
         let def_id = src.def_id();
         if !tcx.has_attr(def_id, sym::rustc_mir) {
             debug!("skipping rustc_peek::SanityCheck on {}", tcx.def_path_str(def_id));

--- a/src/librustc_mir/transform/simplify.rs
+++ b/src/librustc_mir/transform/simplify.rs
@@ -43,7 +43,7 @@ impl SimplifyCfg {
     }
 }
 
-pub fn simplify_cfg(body: &mut BodyCache<'_>) {
+pub fn simplify_cfg(body: &mut BodyAndCache<'_>) {
     CfgSimplifier::new(body).simplify();
     remove_dead_blocks(body);
 
@@ -57,7 +57,7 @@ impl<'tcx> MirPass<'tcx> for SimplifyCfg {
     }
 
     fn run_pass(
-        &self, _tcx: TyCtxt<'tcx>, _src: MirSource<'tcx>, body: &mut BodyCache<'tcx>
+        &self, _tcx: TyCtxt<'tcx>, _src: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>
     ) {
         debug!("SimplifyCfg({:?}) - simplifying {:?}", self.label, body);
         simplify_cfg(body);
@@ -70,7 +70,7 @@ pub struct CfgSimplifier<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> CfgSimplifier<'a, 'tcx> {
-    pub fn new(body: &'a mut BodyCache<'tcx>) -> Self {
+    pub fn new(body: &'a mut BodyAndCache<'tcx>) -> Self {
         let mut pred_count = IndexVec::from_elem(0u32, body.basic_blocks());
 
         // we can't use mir.predecessors() here because that counts
@@ -262,7 +262,7 @@ impl<'a, 'tcx> CfgSimplifier<'a, 'tcx> {
     }
 }
 
-pub fn remove_dead_blocks(body: &mut BodyCache<'_>) {
+pub fn remove_dead_blocks(body: &mut BodyAndCache<'_>) {
     let mut seen = BitSet::new_empty(body.basic_blocks().len());
     for (bb, _) in traversal::preorder(body) {
         seen.insert(bb.index());
@@ -296,7 +296,7 @@ pub struct SimplifyLocals;
 
 impl<'tcx> MirPass<'tcx> for SimplifyLocals {
     fn run_pass(
-        &self, tcx: TyCtxt<'tcx>, source: MirSource<'tcx>, body: &mut BodyCache<'tcx>
+        &self, tcx: TyCtxt<'tcx>, source: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>
     ) {
         trace!("running SimplifyLocals on {:?}", source);
         let locals = {

--- a/src/librustc_mir/transform/simplify_branches.rs
+++ b/src/librustc_mir/transform/simplify_branches.rs
@@ -19,7 +19,7 @@ impl<'tcx> MirPass<'tcx> for SimplifyBranches {
         Cow::Borrowed(&self.label)
     }
 
-    fn run_pass(&self, tcx: TyCtxt<'tcx>, src: MirSource<'tcx>, body: &mut BodyCache<'tcx>) {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, src: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>) {
         let param_env = tcx.param_env(src.def_id());
         for block in body.basic_blocks_mut() {
             let terminator = block.terminator_mut();

--- a/src/librustc_mir/transform/simplify_try.rs
+++ b/src/librustc_mir/transform/simplify_try.rs
@@ -33,7 +33,7 @@ use itertools::Itertools as _;
 pub struct SimplifyArmIdentity;
 
 impl<'tcx> MirPass<'tcx> for SimplifyArmIdentity {
-    fn run_pass(&self, _: TyCtxt<'tcx>, _: MirSource<'tcx>, body: &mut BodyCache<'tcx>) {
+    fn run_pass(&self, _: TyCtxt<'tcx>, _: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>) {
         let (basic_blocks, local_decls) = body.basic_blocks_and_local_decls_mut();
         for bb in basic_blocks {
             // Need 3 statements:
@@ -151,7 +151,7 @@ fn match_variant_field_place<'tcx>(place: &Place<'tcx>) -> Option<(Local, VarFie
 pub struct SimplifyBranchSame;
 
 impl<'tcx> MirPass<'tcx> for SimplifyBranchSame {
-    fn run_pass(&self, _: TyCtxt<'tcx>, _: MirSource<'tcx>, body: &mut BodyCache<'tcx>) {
+    fn run_pass(&self, _: TyCtxt<'tcx>, _: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>) {
         let mut did_remove_blocks = false;
         let bbs = body.basic_blocks_mut();
         for bb_idx in bbs.indices() {

--- a/src/librustc_mir/transform/uniform_array_move_out.rs
+++ b/src/librustc_mir/transform/uniform_array_move_out.rs
@@ -37,7 +37,7 @@ use crate::util::patch::MirPatch;
 pub struct UniformArrayMoveOut;
 
 impl<'tcx> MirPass<'tcx> for UniformArrayMoveOut {
-    fn run_pass(&self, tcx: TyCtxt<'tcx>, src: MirSource<'tcx>, body: &mut BodyCache<'tcx>) {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, src: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>) {
         let mut patch = MirPatch::new(body);
         let param_env = tcx.param_env(src.def_id());
         {
@@ -186,7 +186,7 @@ pub struct RestoreSubsliceArrayMoveOut<'tcx> {
 }
 
 impl<'tcx> MirPass<'tcx> for RestoreSubsliceArrayMoveOut<'tcx> {
-    fn run_pass(&self, tcx: TyCtxt<'tcx>, src: MirSource<'tcx>, body: &mut BodyCache<'tcx>) {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, src: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>) {
         let mut patch = MirPatch::new(body);
         let param_env = tcx.param_env(src.def_id());
         {

--- a/src/librustc_mir/transform/uninhabited_enum_branching.rs
+++ b/src/librustc_mir/transform/uninhabited_enum_branching.rs
@@ -2,7 +2,7 @@
 
 use crate::transform::{MirPass, MirSource};
 use rustc::mir::{
-    BasicBlock, BasicBlockData, Body, BodyCache, Local, Operand, Rvalue, StatementKind,
+    BasicBlock, BasicBlockData, Body, BodyAndCache, Local, Operand, Rvalue, StatementKind,
     TerminatorKind,
 };
 use rustc::ty::layout::{Abi, TyLayout, Variants};
@@ -66,7 +66,7 @@ fn variant_discriminants<'tcx>(
 }
 
 impl<'tcx> MirPass<'tcx> for UninhabitedEnumBranching {
-    fn run_pass(&self, tcx: TyCtxt<'tcx>, source: MirSource<'tcx>, body: &mut BodyCache<'tcx>) {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, source: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>) {
         if source.promoted.is_some() {
             return;
         }

--- a/src/librustc_mir/util/collect_writes.rs
+++ b/src/librustc_mir/util/collect_writes.rs
@@ -1,5 +1,5 @@
 use rustc::mir::{Local, Location};
-use rustc::mir::ReadOnlyBodyCache;
+use rustc::mir::ReadOnlyBodyAndCache;
 use rustc::mir::visit::PlaceContext;
 use rustc::mir::visit::Visitor;
 
@@ -9,7 +9,7 @@ crate trait FindAssignments {
     fn find_assignments(&self, local: Local) -> Vec<Location>;
 }
 
-impl<'a, 'tcx> FindAssignments for ReadOnlyBodyCache<'a, 'tcx>{
+impl<'a, 'tcx> FindAssignments for ReadOnlyBodyAndCache<'a, 'tcx>{
     fn find_assignments(&self, local: Local) -> Vec<Location>{
             let mut visitor = FindLocalAssignmentVisitor{ needle: local, locations: vec![]};
             visitor.visit_body(*self);

--- a/src/librustc_mir/util/def_use.rs
+++ b/src/librustc_mir/util/def_use.rs
@@ -1,6 +1,8 @@
 //! Def-use analysis.
 
-use rustc::mir::{Body, BodyAndCache, Local, Location, PlaceElem, ReadOnlyBodyAndCache, VarDebugInfo};
+use rustc::mir::{
+    Body, BodyAndCache, Local, Location, PlaceElem, ReadOnlyBodyAndCache, VarDebugInfo,
+};
 use rustc::mir::visit::{PlaceContext, MutVisitor, Visitor};
 use rustc::ty::TyCtxt;
 use rustc_index::vec::IndexVec;

--- a/src/librustc_mir/util/def_use.rs
+++ b/src/librustc_mir/util/def_use.rs
@@ -1,6 +1,6 @@
 //! Def-use analysis.
 
-use rustc::mir::{Body, BodyCache, Local, Location, PlaceElem, ReadOnlyBodyCache, VarDebugInfo};
+use rustc::mir::{Body, BodyAndCache, Local, Location, PlaceElem, ReadOnlyBodyAndCache, VarDebugInfo};
 use rustc::mir::visit::{PlaceContext, MutVisitor, Visitor};
 use rustc::ty::TyCtxt;
 use rustc_index::vec::IndexVec;
@@ -30,7 +30,7 @@ impl DefUseAnalysis {
         }
     }
 
-    pub fn analyze(&mut self, body: ReadOnlyBodyCache<'_, '_>) {
+    pub fn analyze(&mut self, body: ReadOnlyBodyAndCache<'_, '_>) {
         self.clear();
 
         let mut finder = DefUseFinder {
@@ -55,7 +55,7 @@ impl DefUseAnalysis {
     fn mutate_defs_and_uses(
         &self,
         local: Local,
-        body: &mut BodyCache<'tcx>,
+        body: &mut BodyAndCache<'tcx>,
         new_local: Local,
         tcx: TyCtxt<'tcx>,
     ) {
@@ -73,7 +73,7 @@ impl DefUseAnalysis {
     // FIXME(pcwalton): this should update the def-use chains.
     pub fn replace_all_defs_and_uses_with(&self,
                                           local: Local,
-                                          body: &mut BodyCache<'tcx>,
+                                          body: &mut BodyAndCache<'tcx>,
                                           new_local: Local,
                                           tcx: TyCtxt<'tcx>) {
         self.mutate_defs_and_uses(local, body, new_local, tcx)

--- a/src/librustc_mir/util/liveness.rs
+++ b/src/librustc_mir/util/liveness.rs
@@ -57,7 +57,7 @@ pub struct LivenessResult {
 /// Computes which local variables are live within the given function
 /// `mir`, including drops.
 pub fn liveness_of_locals(
-    body: ReadOnlyBodyCache<'_, '_>,
+    body: ReadOnlyBodyAndCache<'_, '_>,
 ) -> LivenessResult {
     let num_live_vars = body.local_decls.len();
 

--- a/src/librustc_mir/util/patch.rs
+++ b/src/librustc_mir/util/patch.rs
@@ -127,7 +127,7 @@ impl<'tcx> MirPatch<'tcx> {
         self.make_nop.push(loc);
     }
 
-    pub fn apply(self, body: &mut BodyCache<'tcx>) {
+    pub fn apply(self, body: &mut BodyAndCache<'tcx>) {
         debug!("MirPatch: make nops at: {:?}", self.make_nop);
         for loc in self.make_nop {
             body.make_statement_nop(loc);

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -1181,6 +1181,7 @@ impl<'a> Parser<'a> {
                         attrs,
                         vis: visibility,
                         kind: ForeignItemKind::Macro(mac),
+                        tokens: None,
                     }
                 )
             }
@@ -1211,6 +1212,7 @@ impl<'a> Parser<'a> {
             id: DUMMY_NODE_ID,
             span: lo.to(hi),
             vis,
+            tokens: None,
         })
     }
 
@@ -1228,7 +1230,8 @@ impl<'a> Parser<'a> {
             kind: ForeignItemKind::Ty,
             id: DUMMY_NODE_ID,
             span: lo.to(hi),
-            vis
+            vis,
+            tokens: None,
         })
     }
 
@@ -1826,6 +1829,7 @@ impl<'a> Parser<'a> {
             id: DUMMY_NODE_ID,
             span,
             vis,
+            tokens: None,
         })
     }
 

--- a/src/libstd/keyword_docs.rs
+++ b/src/libstd/keyword_docs.rs
@@ -57,7 +57,7 @@ mod as_keyword { }
 /// 'outer: for i in 1..=5 {
 ///     println!("outer iteration (i): {}", i);
 ///
-///     'inner: for j in 1..=200 {
+///     '_inner: for j in 1..=200 {
 ///         println!("    inner iteration (j): {}", j);
 ///         if j >= 3 {
 ///             // breaks from inner loop, let's outer loop continue.
@@ -178,7 +178,7 @@ mod const_keyword { }
 ///```rust
 /// // Print Odd numbers under 30 with unit <= 5
 /// 'tens: for ten in 0..3 {
-///     'units: for unit in 0..=9 {
+///     '_units: for unit in 0..=9 {
 ///         if unit % 2 == 0 {
 ///             continue;
 ///         }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -2488,14 +2488,14 @@ impl VariantData {
 ///
 /// The name might be a dummy name in case of anonymous items.
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
-pub struct Item {
+pub struct Item<K = ItemKind> {
     pub attrs: Vec<Attribute>,
     pub id: NodeId,
     pub span: Span,
     pub vis: Visibility,
     pub ident: Ident,
 
-    pub kind: ItemKind,
+    pub kind: K,
 
     /// Original tokens this item was parsed from. This isn't necessarily
     /// available for all items, although over time more and more items should
@@ -2650,16 +2650,7 @@ impl ItemKind {
     }
 }
 
-#[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
-pub struct ForeignItem {
-    pub attrs: Vec<Attribute>,
-    pub id: NodeId,
-    pub span: Span,
-    pub vis: Visibility,
-    pub ident: Ident,
-
-    pub kind: ForeignItemKind,
-}
+pub type ForeignItem = Item<ForeignItemKind>;
 
 /// An item within an `extern` block.
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug)]

--- a/src/libsyntax/mut_visit.rs
+++ b/src/libsyntax/mut_visit.rs
@@ -1053,7 +1053,7 @@ pub fn noop_flat_map_item<T: MutVisitor>(mut item: P<Item>, visitor: &mut T)
 pub fn noop_flat_map_foreign_item<T: MutVisitor>(mut item: ForeignItem, visitor: &mut T)
     -> SmallVec<[ForeignItem; 1]>
 {
-    let ForeignItem { ident, attrs, kind, id, span, vis } = &mut item;
+    let ForeignItem { ident, attrs, id, kind, vis, span, tokens: _ } = &mut item;
     visitor.visit_ident(ident);
     visit_attrs(attrs, visitor);
     match kind {

--- a/src/libsyntax_expand/placeholders.rs
+++ b/src/libsyntax_expand/placeholders.rs
@@ -65,6 +65,7 @@ pub fn placeholder(kind: AstFragmentKind, id: ast::NodeId, vis: Option<ast::Visi
             AstFragment::ForeignItems(smallvec![ast::ForeignItem {
                 id, span, ident, vis, attrs,
                 kind: ast::ForeignItemKind::Macro(mac_placeholder()),
+                tokens: None,
             }]),
         AstFragmentKind::Pat => AstFragment::Pat(P(ast::Pat {
             id, span, kind: ast::PatKind::Mac(mac_placeholder()),

--- a/src/test/ui/for-loop-while/label_break_value.rs
+++ b/src/test/ui/for-loop-while/label_break_value.rs
@@ -77,7 +77,7 @@ fn label_break_mixed(v: u32) -> u32 {
         }
         // Labeled breaking an outer loop still works
         'd: loop {
-            'e: {
+            {
                 if v == r {
                     break 'b;
                 }

--- a/src/test/ui/for-loop-while/loop-label-shadowing.rs
+++ b/src/test/ui/for-loop-while/loop-label-shadowing.rs
@@ -5,6 +5,7 @@
 
 fn main() {
     let mut foo = Vec::new();
+    #[allow(unused_labels)]
     'foo: for i in &[1, 2, 3] {
         foo.push(*i);
     }

--- a/src/test/ui/hygiene/hygienic-labels-in-let.rs
+++ b/src/test/ui/hygiene/hygienic-labels-in-let.rs
@@ -1,5 +1,6 @@
 // run-pass
 #![allow(unreachable_code)]
+#![allow(unused_labels)]
 
 // Test that labels injected by macros do not break hygiene.  This
 // checks cases where the macros invocations are under the rhs of a

--- a/src/test/ui/hygiene/hygienic-labels-in-let.stderr
+++ b/src/test/ui/hygiene/hygienic-labels-in-let.stderr
@@ -1,5 +1,5 @@
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:15:9
+  --> $DIR/hygienic-labels-in-let.rs:16:9
    |
 LL |         'x: loop { $e }
    |         ^^ lifetime 'x already in scope
@@ -11,7 +11,7 @@ LL |             loop_x!(break 'x);
    |             ------------------ in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:63:9
+  --> $DIR/hygienic-labels-in-let.rs:64:9
    |
 LL |         'x: loop {
    |         -- first declared here
@@ -20,7 +20,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:63:9
+  --> $DIR/hygienic-labels-in-let.rs:64:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -29,7 +29,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:15:9
+  --> $DIR/hygienic-labels-in-let.rs:16:9
    |
 LL |         'x: loop { $e }
    |         ^^ lifetime 'x already in scope
@@ -41,7 +41,7 @@ LL |             loop_x!(break 'x);
    |             ------------------ in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:15:9
+  --> $DIR/hygienic-labels-in-let.rs:16:9
    |
 LL |         'x: loop { $e }
    |         ^^
@@ -53,7 +53,7 @@ LL |             loop_x!(break 'x);
    |             ------------------ in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:15:9
+  --> $DIR/hygienic-labels-in-let.rs:16:9
    |
 LL |         'x: loop { $e }
    |         ^^ lifetime 'x already in scope
@@ -65,7 +65,7 @@ LL |             loop_x!(break 'x);
    |             ------------------ in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:75:9
+  --> $DIR/hygienic-labels-in-let.rs:76:9
    |
 LL |         'x: loop {
    |         -- first declared here
@@ -74,7 +74,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:75:9
+  --> $DIR/hygienic-labels-in-let.rs:76:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -83,7 +83,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:75:9
+  --> $DIR/hygienic-labels-in-let.rs:76:9
    |
 LL |         'x: for _ in 0..1 {
    |         -- first declared here
@@ -92,7 +92,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:75:9
+  --> $DIR/hygienic-labels-in-let.rs:76:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -101,7 +101,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:26:9
+  --> $DIR/hygienic-labels-in-let.rs:27:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ lifetime 'x already in scope
@@ -113,7 +113,7 @@ LL |             while_true!(break 'x);
    |             ---------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:26:9
+  --> $DIR/hygienic-labels-in-let.rs:27:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -125,7 +125,7 @@ LL |             while_true!(break 'x);
    |             ---------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:26:9
+  --> $DIR/hygienic-labels-in-let.rs:27:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ lifetime 'x already in scope
@@ -137,7 +137,7 @@ LL |             while_true!(break 'x);
    |             ---------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:26:9
+  --> $DIR/hygienic-labels-in-let.rs:27:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -149,7 +149,7 @@ LL |             while_true!(break 'x);
    |             ---------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:26:9
+  --> $DIR/hygienic-labels-in-let.rs:27:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ lifetime 'x already in scope
@@ -161,7 +161,7 @@ LL |             while_true!(break 'x);
    |             ---------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:89:9
+  --> $DIR/hygienic-labels-in-let.rs:90:9
    |
 LL |         'x: loop {
    |         -- first declared here
@@ -170,7 +170,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:89:9
+  --> $DIR/hygienic-labels-in-let.rs:90:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -179,7 +179,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:89:9
+  --> $DIR/hygienic-labels-in-let.rs:90:9
    |
 LL |         'x: for _ in 0..1 {
    |         -- first declared here
@@ -188,7 +188,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:89:9
+  --> $DIR/hygienic-labels-in-let.rs:90:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -197,7 +197,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:89:9
+  --> $DIR/hygienic-labels-in-let.rs:90:9
    |
 LL |         'x: for _ in 0..1 {
    |         -- first declared here
@@ -206,7 +206,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:89:9
+  --> $DIR/hygienic-labels-in-let.rs:90:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         -- first declared here
@@ -215,7 +215,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:38:9
+  --> $DIR/hygienic-labels-in-let.rs:39:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
@@ -227,7 +227,7 @@ LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:38:9
+  --> $DIR/hygienic-labels-in-let.rs:39:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -239,7 +239,7 @@ LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:38:9
+  --> $DIR/hygienic-labels-in-let.rs:39:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
@@ -251,7 +251,7 @@ LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:38:9
+  --> $DIR/hygienic-labels-in-let.rs:39:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -263,7 +263,7 @@ LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:38:9
+  --> $DIR/hygienic-labels-in-let.rs:39:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
@@ -275,7 +275,7 @@ LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:38:9
+  --> $DIR/hygienic-labels-in-let.rs:39:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         -- first declared here
@@ -287,7 +287,7 @@ LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:38:9
+  --> $DIR/hygienic-labels-in-let.rs:39:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope

--- a/src/test/ui/hygiene/hygienic-labels.rs
+++ b/src/test/ui/hygiene/hygienic-labels.rs
@@ -1,5 +1,6 @@
 // run-pass
 #![allow(unreachable_code)]
+#![allow(unused_labels)]
 // Test that labels injected by macros do not break hygiene.
 
 // Issue #24278: The label/lifetime shadowing checker from #24162

--- a/src/test/ui/hygiene/hygienic-labels.stderr
+++ b/src/test/ui/hygiene/hygienic-labels.stderr
@@ -1,5 +1,5 @@
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:12:9
+  --> $DIR/hygienic-labels.rs:13:9
    |
 LL |         'x: loop { $e }
    |         ^^ lifetime 'x already in scope
@@ -11,7 +11,7 @@ LL |         loop_x!(break 'x);
    |         ------------------ in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:53:5
+  --> $DIR/hygienic-labels.rs:54:5
    |
 LL |     'x: for _ in 0..1 {
    |     -- first declared here
@@ -20,7 +20,7 @@ LL |     'x: loop {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:53:5
+  --> $DIR/hygienic-labels.rs:54:5
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -29,7 +29,7 @@ LL |     'x: loop {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:12:9
+  --> $DIR/hygienic-labels.rs:13:9
    |
 LL |         'x: loop { $e }
    |         ^^ lifetime 'x already in scope
@@ -41,7 +41,7 @@ LL |         loop_x!(break 'x);
    |         ------------------ in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:12:9
+  --> $DIR/hygienic-labels.rs:13:9
    |
 LL |         'x: loop { $e }
    |         ^^
@@ -53,7 +53,7 @@ LL |         loop_x!(break 'x);
    |         ------------------ in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:12:9
+  --> $DIR/hygienic-labels.rs:13:9
    |
 LL |         'x: loop { $e }
    |         ^^ lifetime 'x already in scope
@@ -65,7 +65,7 @@ LL |         loop_x!(break 'x);
    |         ------------------ in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:62:5
+  --> $DIR/hygienic-labels.rs:63:5
    |
 LL |     'x: for _ in 0..1 {
    |     -- first declared here
@@ -74,7 +74,7 @@ LL |     'x: while 1 + 1 == 2 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:62:5
+  --> $DIR/hygienic-labels.rs:63:5
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -83,7 +83,7 @@ LL |     'x: while 1 + 1 == 2 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:62:5
+  --> $DIR/hygienic-labels.rs:63:5
    |
 LL |     'x: loop {
    |     -- first declared here
@@ -92,7 +92,7 @@ LL |     'x: while 1 + 1 == 2 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:62:5
+  --> $DIR/hygienic-labels.rs:63:5
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -101,7 +101,7 @@ LL |     'x: while 1 + 1 == 2 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:37:9
+  --> $DIR/hygienic-labels.rs:38:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ lifetime 'x already in scope
@@ -113,7 +113,7 @@ LL |         while_x!(break 'x);
    |         ------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:37:9
+  --> $DIR/hygienic-labels.rs:38:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -125,7 +125,7 @@ LL |         while_x!(break 'x);
    |         ------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:37:9
+  --> $DIR/hygienic-labels.rs:38:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ lifetime 'x already in scope
@@ -137,7 +137,7 @@ LL |         while_x!(break 'x);
    |         ------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:37:9
+  --> $DIR/hygienic-labels.rs:38:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -149,7 +149,7 @@ LL |         while_x!(break 'x);
    |         ------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:37:9
+  --> $DIR/hygienic-labels.rs:38:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ lifetime 'x already in scope
@@ -161,7 +161,7 @@ LL |         while_x!(break 'x);
    |         ------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:72:5
+  --> $DIR/hygienic-labels.rs:73:5
    |
 LL |     'x: for _ in 0..1 {
    |     -- first declared here
@@ -170,7 +170,7 @@ LL |     'x: for _ in 0..1 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:72:5
+  --> $DIR/hygienic-labels.rs:73:5
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -179,7 +179,7 @@ LL |     'x: for _ in 0..1 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:72:5
+  --> $DIR/hygienic-labels.rs:73:5
    |
 LL |     'x: loop {
    |     -- first declared here
@@ -188,7 +188,7 @@ LL |     'x: for _ in 0..1 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:72:5
+  --> $DIR/hygienic-labels.rs:73:5
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -197,7 +197,7 @@ LL |     'x: for _ in 0..1 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:72:5
+  --> $DIR/hygienic-labels.rs:73:5
    |
 LL |     'x: while 1 + 1 == 2 {
    |     -- first declared here
@@ -206,7 +206,7 @@ LL |     'x: for _ in 0..1 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:72:5
+  --> $DIR/hygienic-labels.rs:73:5
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         -- first declared here
@@ -215,7 +215,7 @@ LL |     'x: for _ in 0..1 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:23:9
+  --> $DIR/hygienic-labels.rs:24:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
@@ -227,7 +227,7 @@ LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:23:9
+  --> $DIR/hygienic-labels.rs:24:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -239,7 +239,7 @@ LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:23:9
+  --> $DIR/hygienic-labels.rs:24:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
@@ -251,7 +251,7 @@ LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:23:9
+  --> $DIR/hygienic-labels.rs:24:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -263,7 +263,7 @@ LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:23:9
+  --> $DIR/hygienic-labels.rs:24:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
@@ -275,7 +275,7 @@ LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:23:9
+  --> $DIR/hygienic-labels.rs:24:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
@@ -287,7 +287,7 @@ LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:23:9
+  --> $DIR/hygienic-labels.rs:24:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope

--- a/src/test/ui/issues/issue-2216.rs
+++ b/src/test/ui/issues/issue-2216.rs
@@ -5,7 +5,7 @@ pub fn main() {
 
     'foo: loop {
         'bar: loop {
-            'quux: loop {
+            loop {
                 if 1 == 2 {
                     break 'foo;
                 }

--- a/src/test/ui/macros/macro-lifetime-used-with-labels.rs
+++ b/src/test/ui/macros/macro-lifetime-used-with-labels.rs
@@ -1,6 +1,6 @@
 // run-pass
 #![allow(stable_features)]
-
+#![allow(unused_labels)]
 #![allow(unreachable_code)]
 
 macro_rules! x {


### PR DESCRIPTION
Successful merges:

 - #66325 (Change unused_labels from allow to warn)
 - #66991 (Cleanup BodyCache)
 - #67101 (use `#[allow(unused_attributes)]` to paper over incr.comp problem)
 - #67114 (Make `ForeignItem` an alias of `Item`.)
 - #67129 (Fixes typo)

Failed merges:

 - #66886 (Remove the borrow check::nll submodule)

r? @ghost