### PR TITLE
 Refactor type & bounds parsing thoroughly

### DIFF
--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -5,7 +5,7 @@ use crate::maybe_whole;
 
 use rustc_errors::{PResult, Applicability, DiagnosticBuilder, StashKey};
 use rustc_error_codes::*;
-use syntax::ast::{self, DUMMY_NODE_ID, Ident, AttrVec, Attribute, AttrKind, AttrStyle, AnonConst};
+use syntax::ast::{self, DUMMY_NODE_ID, Ident, AttrVec, Attribute, AttrKind, AttrStyle};
 use syntax::ast::{AssocItem, AssocItemKind, Item, ItemKind, UseTree, UseTreeKind};
 use syntax::ast::{PathSegment, IsAuto, Constness, IsAsync, Unsafety, Defaultness, Extern, StrLit};
 use syntax::ast::{Visibility, VisibilityKind, Mutability, FnHeader, ForeignItem, ForeignItemKind};
@@ -1317,10 +1317,7 @@ impl<'a> Parser<'a> {
         };
 
         let disr_expr = if self.eat(&token::Eq) {
-            Some(AnonConst {
-                id: DUMMY_NODE_ID,
-                value: self.parse_expr()?,
-            })
+            Some(self.parse_anon_const_expr()?)
         } else {
             None
         };

--- a/src/librustc_parse/parser/ty.rs
+++ b/src/librustc_parse/parser/ty.rs
@@ -514,6 +514,7 @@ impl<'a> Parser<'a> {
         Ok(GenericBound::Trait(poly_trait, modifier))
     }
 
+    /// Optionally parses `for<$generic_params>`.
     pub(super) fn parse_late_bound_lifetime_defs(&mut self) -> PResult<'a, Vec<GenericParam>> {
         if self.eat_keyword(kw::For) {
             self.expect_lt()?;

--- a/src/librustc_parse/parser/ty.rs
+++ b/src/librustc_parse/parser/ty.rs
@@ -367,19 +367,7 @@ impl<'a> Parser<'a> {
         let mut negative_bounds = Vec::new();
         let mut last_plus_span = None;
         let mut was_negative = false;
-        loop {
-            // This needs to be synchronized with `TokenKind::can_begin_bound`.
-            let is_bound_start = self.check_path()
-                || self.check_lifetime()
-                || self.check(&token::Not) // Used for error reporting only.
-                || self.check(&token::Question)
-                || self.check_keyword(kw::For)
-                || self.check(&token::OpenDelim(token::Paren));
-
-            if !is_bound_start {
-                break;
-            }
-
+        while self.can_begin_bound() {
             let lo = self.token.span;
             let has_parens = self.eat(&token::OpenDelim(token::Paren));
             let inner_lo = self.token.span;
@@ -454,6 +442,17 @@ impl<'a> Parser<'a> {
         }
 
         return Ok(bounds);
+    }
+
+    /// Can the current token begin a bound?
+    fn can_begin_bound(&mut self) -> bool {
+        // This needs to be synchronized with `TokenKind::can_begin_bound`.
+        self.check_path()
+        || self.check_lifetime()
+        || self.check(&token::Not) // Used for error reporting only.
+        || self.check(&token::Question)
+        || self.check_keyword(kw::For)
+        || self.check(&token::OpenDelim(token::Paren))
     }
 
     fn error_opt_out_lifetime(&self, question: Option<Span>) {

--- a/src/librustc_parse/parser/ty.rs
+++ b/src/librustc_parse/parser/ty.rs
@@ -448,6 +448,8 @@ impl<'a> Parser<'a> {
             self.error_opt_out_lifetime(question);
             let bound = GenericBound::Outlives(self.expect_lifetime());
             if has_parens {
+                // FIXME(Centril): Consider not erroring here and accepting `('lt)` instead,
+                // possibly introducing `GenericBound::Paren(P<GenericBound>)`?
                 self.recover_paren_lifetime(lo, inner_lo)?;
             }
             Ok(Ok(bound))

--- a/src/librustc_parse/parser/ty.rs
+++ b/src/librustc_parse/parser/ty.rs
@@ -383,10 +383,7 @@ impl<'a> Parser<'a> {
                 let is_negative = self.eat(&token::Not);
                 let question = if self.eat(&token::Question) { Some(self.prev_span) } else { None };
                 if self.token.is_lifetime() {
-                    if let Some(question_span) = question {
-                        self.span_err(question_span,
-                                      "`?` may only modify trait bounds, not lifetime bounds");
-                    }
+                    self.error_opt_out_lifetime(question);
                     bounds.push(GenericBound::Outlives(self.expect_lifetime()));
                     if has_parens {
                         let inner_span = inner_lo.to(self.prev_span);
@@ -471,6 +468,13 @@ impl<'a> Parser<'a> {
         }
 
         return Ok(bounds);
+    }
+
+    fn error_opt_out_lifetime(&self, question: Option<Span>) {
+        if let Some(span) = question {
+            self.struct_span_err(span, "`?` may only modify trait bounds, not lifetime bounds")
+                .emit();
+        }
     }
 
     pub(super) fn parse_late_bound_lifetime_defs(&mut self) -> PResult<'a, Vec<GenericParam>> {

--- a/src/librustc_parse/parser/ty.rs
+++ b/src/librustc_parse/parser/ty.rs
@@ -133,7 +133,7 @@ impl<'a> Parser<'a> {
             }
         } else {
             let msg = format!("expected type, found {}", self.this_token_descr());
-            let mut err = self.fatal(&msg);
+            let mut err = self.struct_span_err(self.token.span, &msg);
             err.span_label(self.token.span, "expected type");
             self.maybe_annotate_with_ascription(&mut err, true);
             return Err(err);

--- a/src/librustc_parse/parser/ty.rs
+++ b/src/librustc_parse/parser/ty.rs
@@ -250,20 +250,15 @@ impl<'a> Parser<'a> {
             self.check_keyword(kw::Extern)
     }
 
-    /// Parses a `TyKind::BareFn` type.
+    /// Parses a function pointer type (`TyKind::BareFn`).
+    /// ```
+    /// [unsafe] [extern "ABI"] fn (S) -> T
+    ///  ^~~~~^          ^~~~^     ^~^    ^
+    ///    |               |        |     |
+    ///    |               |        |   Return type
+    /// Function Style    ABI  Parameter types
+    /// ```
     fn parse_ty_bare_fn(&mut self, generic_params: Vec<GenericParam>) -> PResult<'a, TyKind> {
-        /*
-
-        [unsafe] [extern "ABI"] fn (S) -> T
-         ^~~~^           ^~~~^     ^~^    ^
-           |               |        |     |
-           |               |        |   Return type
-           |               |      Argument types
-           |               |
-           |              ABI
-        Function Style
-        */
-
         let unsafety = self.parse_unsafety();
         let ext = self.parse_extern()?;
         self.expect_keyword(kw::Fn)?;

--- a/src/librustc_parse/parser/ty.rs
+++ b/src/librustc_parse/parser/ty.rs
@@ -183,8 +183,13 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_remaining_bounds(&mut self, generic_params: Vec<GenericParam>, path: ast::Path,
-                              lo: Span, parse_plus: bool) -> PResult<'a, TyKind> {
+    fn parse_remaining_bounds(
+        &mut self,
+        generic_params: Vec<GenericParam>,
+        path: ast::Path,
+        lo: Span,
+        parse_plus: bool,
+    ) -> PResult<'a, TyKind> {
         let poly_trait_ref = PolyTraitRef::new(generic_params, path, lo.to(self.prev_span));
         let mut bounds = vec![GenericBound::Trait(poly_trait_ref, TraitBoundModifier::None)];
         if parse_plus {
@@ -338,8 +343,10 @@ impl<'a> Parser<'a> {
         .emit();
     }
 
-    pub(super) fn parse_generic_bounds(&mut self,
-                                  colon_span: Option<Span>) -> PResult<'a, GenericBounds> {
+    pub(super) fn parse_generic_bounds(
+        &mut self,
+        colon_span: Option<Span>,
+    ) -> PResult<'a, GenericBounds> {
         self.parse_generic_bounds_common(true, colon_span)
     }
 
@@ -351,20 +358,24 @@ impl<'a> Parser<'a> {
     /// TY_BOUND = TY_BOUND_NOPAREN | (TY_BOUND_NOPAREN)
     /// TY_BOUND_NOPAREN = [?] [for<LT_PARAM_DEFS>] SIMPLE_PATH (e.g., `?for<'a: 'b> m::Trait<'a>`)
     /// ```
-    fn parse_generic_bounds_common(&mut self,
-                                   allow_plus: bool,
-                                   colon_span: Option<Span>) -> PResult<'a, GenericBounds> {
+    fn parse_generic_bounds_common(
+        &mut self,
+        allow_plus: bool,
+        colon_span: Option<Span>,
+    ) -> PResult<'a, GenericBounds> {
         let mut bounds = Vec::new();
         let mut negative_bounds = Vec::new();
         let mut last_plus_span = None;
         let mut was_negative = false;
         loop {
             // This needs to be synchronized with `TokenKind::can_begin_bound`.
-            let is_bound_start = self.check_path() || self.check_lifetime() ||
-                                 self.check(&token::Not) || // used for error reporting only
-                                 self.check(&token::Question) ||
-                                 self.check_keyword(kw::For) ||
-                                 self.check(&token::OpenDelim(token::Paren));
+            let is_bound_start = self.check_path()
+                || self.check_lifetime()
+                || self.check(&token::Not) // Used for error reporting only.
+                || self.check(&token::Question)
+                || self.check_keyword(kw::For)
+                || self.check(&token::OpenDelim(token::Paren));
+
             if is_bound_start {
                 let lo = self.token.span;
                 let has_parens = self.eat(&token::OpenDelim(token::Paren));

--- a/src/librustc_parse/parser/ty.rs
+++ b/src/librustc_parse/parser/ty.rs
@@ -128,14 +128,7 @@ impl<'a> Parser<'a> {
             } else {
                 // FIXME(Centril): Should we just allow `...` syntactically
                 // anywhere in a type and use semantic restrictions instead?
-                struct_span_err!(
-                    self.sess.span_diagnostic,
-                    lo.to(self.prev_span),
-                    E0743,
-                    "C-variadic type `...` may not be nested inside another type",
-                )
-                .emit();
-
+                self.error_illegal_c_varadic_ty(lo);
                 TyKind::Err
             }
         } else {
@@ -333,6 +326,16 @@ impl<'a> Parser<'a> {
             // Just a type path.
             Ok(TyKind::Path(None, path))
         }
+    }
+
+    fn error_illegal_c_varadic_ty(&self, lo: Span) {
+        struct_span_err!(
+            self.sess.span_diagnostic,
+            lo.to(self.prev_span),
+            E0743,
+            "C-variadic type `...` may not be nested inside another type",
+        )
+        .emit();
     }
 
     pub(super) fn parse_generic_bounds(&mut self,

--- a/src/librustc_parse/parser/ty.rs
+++ b/src/librustc_parse/parser/ty.rs
@@ -426,7 +426,7 @@ impl<'a> Parser<'a> {
         let has_parens = self.eat(&token::OpenDelim(token::Paren));
         let inner_lo = self.token.span;
         let is_negative = self.eat(&token::Not);
-        let question = if self.eat(&token::Question) { Some(self.prev_span) } else { None };
+        let question = self.eat(&token::Question).then_some(self.prev_span);
         if self.token.is_lifetime() {
             Ok(Ok(self.parse_generic_lt_bound(lo, inner_lo, has_parens, question)?))
         } else {

--- a/src/librustc_parse/parser/ty.rs
+++ b/src/librustc_parse/parser/ty.rs
@@ -390,7 +390,7 @@ impl<'a> Parser<'a> {
         negative_bounds: Vec<Span>,
     ) {
         let negative_bounds_len = negative_bounds.len();
-        let last_span = *negative_bounds.last().unwrap();
+        let last_span = *negative_bounds.last().expect("no negative bounds, but still error?");
         let mut err = self.struct_span_err(
             negative_bounds,
             "negative bounds are not supported",

--- a/src/librustc_parse/parser/ty.rs
+++ b/src/librustc_parse/parser/ty.rs
@@ -407,7 +407,7 @@ impl<'a> Parser<'a> {
                 }
                 new_bound_list = new_bound_list.replacen(" +", ":", 1);
             }
-            err.span_suggestion_hidden(
+            err.tool_only_span_suggestion(
                 bound_list,
                 &format!("remove the bound{}", pluralize!(negative_bounds_len)),
                 new_bound_list,

--- a/src/test/ui/issues/issue-58857.rs
+++ b/src/test/ui/issues/issue-58857.rs
@@ -2,6 +2,6 @@ struct Conj<A> {a : A}
 trait Valid {}
 
 impl<A: !Valid> Conj<A>{}
-//~^ ERROR negative trait bounds are not supported
+//~^ ERROR negative bounds are not supported
 
 fn main() {}

--- a/src/test/ui/issues/issue-58857.stderr
+++ b/src/test/ui/issues/issue-58857.stderr
@@ -3,8 +3,6 @@ error: negative bounds are not supported
    |
 LL | impl<A: !Valid> Conj<A>{}
    |       ^^^^^^^^ negative bounds are not supported
-   |
-   = help: remove the bound
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-58857.stderr
+++ b/src/test/ui/issues/issue-58857.stderr
@@ -1,10 +1,10 @@
-error: negative trait bounds are not supported
+error: negative bounds are not supported
   --> $DIR/issue-58857.rs:4:7
    |
 LL | impl<A: !Valid> Conj<A>{}
-   |       ^^^^^^^^ negative trait bounds are not supported
+   |       ^^^^^^^^ negative bounds are not supported
    |
-   = help: remove the trait bound
+   = help: remove the bound
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issue-33418.fixed
+++ b/src/test/ui/parser/issue-33418.fixed
@@ -1,15 +1,15 @@
 // run-rustfix
 
 trait Tr {}
-//~^ ERROR negative trait bounds are not supported
+//~^ ERROR negative bounds are not supported
 trait Tr2: SuperA {}
-//~^ ERROR negative trait bounds are not supported
+//~^ ERROR negative bounds are not supported
 trait Tr3: SuperB {}
-//~^ ERROR negative trait bounds are not supported
+//~^ ERROR negative bounds are not supported
 trait Tr4: SuperB + SuperD {}
-//~^ ERROR negative trait bounds are not supported
+//~^ ERROR negative bounds are not supported
 trait Tr5 {}
-//~^ ERROR negative trait bounds are not supported
+//~^ ERROR negative bounds are not supported
 
 trait SuperA {}
 trait SuperB {}

--- a/src/test/ui/parser/issue-33418.rs
+++ b/src/test/ui/parser/issue-33418.rs
@@ -1,17 +1,17 @@
 // run-rustfix
 
 trait Tr: !SuperA {}
-//~^ ERROR negative trait bounds are not supported
+//~^ ERROR negative bounds are not supported
 trait Tr2: SuperA + !SuperB {}
-//~^ ERROR negative trait bounds are not supported
+//~^ ERROR negative bounds are not supported
 trait Tr3: !SuperA + SuperB {}
-//~^ ERROR negative trait bounds are not supported
+//~^ ERROR negative bounds are not supported
 trait Tr4: !SuperA + SuperB
     + !SuperC + SuperD {}
-//~^ ERROR negative trait bounds are not supported
+//~^ ERROR negative bounds are not supported
 trait Tr5: !SuperA
     + !SuperB {}
-//~^ ERROR negative trait bounds are not supported
+//~^ ERROR negative bounds are not supported
 
 trait SuperA {}
 trait SuperB {}

--- a/src/test/ui/parser/issue-33418.stderr
+++ b/src/test/ui/parser/issue-33418.stderr
@@ -1,46 +1,46 @@
-error: negative trait bounds are not supported
+error: negative bounds are not supported
   --> $DIR/issue-33418.rs:3:9
    |
 LL | trait Tr: !SuperA {}
-   |         ^^^^^^^^^ negative trait bounds are not supported
+   |         ^^^^^^^^^ negative bounds are not supported
    |
-   = help: remove the trait bound
+   = help: remove the bound
 
-error: negative trait bounds are not supported
+error: negative bounds are not supported
   --> $DIR/issue-33418.rs:5:19
    |
 LL | trait Tr2: SuperA + !SuperB {}
-   |                   ^^^^^^^^^ negative trait bounds are not supported
+   |                   ^^^^^^^^^ negative bounds are not supported
    |
-   = help: remove the trait bound
+   = help: remove the bound
 
-error: negative trait bounds are not supported
+error: negative bounds are not supported
   --> $DIR/issue-33418.rs:7:10
    |
 LL | trait Tr3: !SuperA + SuperB {}
-   |          ^^^^^^^^^ negative trait bounds are not supported
+   |          ^^^^^^^^^ negative bounds are not supported
    |
-   = help: remove the trait bound
+   = help: remove the bound
 
-error: negative trait bounds are not supported
+error: negative bounds are not supported
   --> $DIR/issue-33418.rs:9:10
    |
 LL | trait Tr4: !SuperA + SuperB
    |          ^^^^^^^^^
 LL |     + !SuperC + SuperD {}
-   |     ^^^^^^^^^ negative trait bounds are not supported
+   |     ^^^^^^^^^ negative bounds are not supported
    |
-   = help: remove the trait bounds
+   = help: remove the bounds
 
-error: negative trait bounds are not supported
+error: negative bounds are not supported
   --> $DIR/issue-33418.rs:12:10
    |
 LL | trait Tr5: !SuperA
    |          ^^^^^^^^^
 LL |     + !SuperB {}
-   |     ^^^^^^^^^ negative trait bounds are not supported
+   |     ^^^^^^^^^ negative bounds are not supported
    |
-   = help: remove the trait bounds
+   = help: remove the bounds
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/parser/issue-33418.stderr
+++ b/src/test/ui/parser/issue-33418.stderr
@@ -3,24 +3,18 @@ error: negative bounds are not supported
    |
 LL | trait Tr: !SuperA {}
    |         ^^^^^^^^^ negative bounds are not supported
-   |
-   = help: remove the bound
 
 error: negative bounds are not supported
   --> $DIR/issue-33418.rs:5:19
    |
 LL | trait Tr2: SuperA + !SuperB {}
    |                   ^^^^^^^^^ negative bounds are not supported
-   |
-   = help: remove the bound
 
 error: negative bounds are not supported
   --> $DIR/issue-33418.rs:7:10
    |
 LL | trait Tr3: !SuperA + SuperB {}
    |          ^^^^^^^^^ negative bounds are not supported
-   |
-   = help: remove the bound
 
 error: negative bounds are not supported
   --> $DIR/issue-33418.rs:9:10
@@ -29,8 +23,6 @@ LL | trait Tr4: !SuperA + SuperB
    |          ^^^^^^^^^
 LL |     + !SuperC + SuperD {}
    |     ^^^^^^^^^ negative bounds are not supported
-   |
-   = help: remove the bounds
 
 error: negative bounds are not supported
   --> $DIR/issue-33418.rs:12:10
@@ -39,8 +31,6 @@ LL | trait Tr5: !SuperA
    |          ^^^^^^^^^
 LL |     + !SuperB {}
    |     ^^^^^^^^^ negative bounds are not supported
-   |
-   = help: remove the bounds
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/parser/issue-67146-negative-outlives-bound-syntactic-fail.rs
+++ b/src/test/ui/parser/issue-67146-negative-outlives-bound-syntactic-fail.rs
@@ -1,0 +1,12 @@
+// In this regression test for #67146, we check that the
+// negative outlives bound `!'a` is rejected by the parser.
+// This regression was first introduced in PR #57364.
+
+fn main() {}
+
+fn f1<T: !'static>() {}
+//~^ ERROR negative bounds are not supported
+fn f2<'a, T: Ord + !'a>() {}
+//~^ ERROR negative bounds are not supported
+fn f3<'a, T: !'a + Ord>() {}
+//~^ ERROR negative bounds are not supported

--- a/src/test/ui/parser/issue-67146-negative-outlives-bound-syntactic-fail.stderr
+++ b/src/test/ui/parser/issue-67146-negative-outlives-bound-syntactic-fail.stderr
@@ -3,24 +3,18 @@ error: negative bounds are not supported
    |
 LL | fn f1<T: !'static>() {}
    |        ^^^^^^^^^^ negative bounds are not supported
-   |
-   = help: remove the bound
 
 error: negative bounds are not supported
   --> $DIR/issue-67146-negative-outlives-bound-syntactic-fail.rs:9:18
    |
 LL | fn f2<'a, T: Ord + !'a>() {}
    |                  ^^^^^ negative bounds are not supported
-   |
-   = help: remove the bound
 
 error: negative bounds are not supported
   --> $DIR/issue-67146-negative-outlives-bound-syntactic-fail.rs:11:12
    |
 LL | fn f3<'a, T: !'a + Ord>() {}
    |            ^^^^^ negative bounds are not supported
-   |
-   = help: remove the bound
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/parser/issue-67146-negative-outlives-bound-syntactic-fail.stderr
+++ b/src/test/ui/parser/issue-67146-negative-outlives-bound-syntactic-fail.stderr
@@ -1,0 +1,26 @@
+error: negative bounds are not supported
+  --> $DIR/issue-67146-negative-outlives-bound-syntactic-fail.rs:7:8
+   |
+LL | fn f1<T: !'static>() {}
+   |        ^^^^^^^^^^ negative bounds are not supported
+   |
+   = help: remove the bound
+
+error: negative bounds are not supported
+  --> $DIR/issue-67146-negative-outlives-bound-syntactic-fail.rs:9:18
+   |
+LL | fn f2<'a, T: Ord + !'a>() {}
+   |                  ^^^^^ negative bounds are not supported
+   |
+   = help: remove the bound
+
+error: negative bounds are not supported
+  --> $DIR/issue-67146-negative-outlives-bound-syntactic-fail.rs:11:12
+   |
+LL | fn f3<'a, T: !'a + Ord>() {}
+   |            ^^^^^ negative bounds are not supported
+   |
+   = help: remove the bound
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/type/ascription/issue-47666.stderr
+++ b/src/test/ui/type/ascription/issue-47666.stderr
@@ -11,7 +11,7 @@ LL |     let _ = Option:Some(vec![0, 1]);
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
    = note: for more information, see https://github.com/rust-lang/rust/issues/23416
-   = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error
 


### PR DESCRIPTION
PR is based on https://github.com/rust-lang/rust/pull/67131 with first one from this PR being ` extract parse_ty_tuple_or_parens`.

Also fixes #67146.

r? @estebank 