### PR TITLE
doc comments: Less attribute mimicking

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -314,6 +314,10 @@ pub struct MissingDoc {
 impl_lint_pass!(MissingDoc => [MISSING_DOCS]);
 
 fn has_doc(attr: &ast::Attribute) -> bool {
+    if attr.is_doc_comment() {
+        return true;
+    }
+
     if !attr.check_name(sym::doc) {
         return false;
     }
@@ -768,7 +772,7 @@ impl UnusedDocComment {
 
             let span = sugared_span.take().unwrap_or_else(|| attr.span);
 
-            if attr.check_name(sym::doc) {
+            if attr.is_doc_comment() || attr.check_name(sym::doc) {
                 let mut err = cx.struct_span_lint(UNUSED_DOC_COMMENTS, span, "unused doc comment");
 
                 err.span_label(

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -271,6 +271,10 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedAttributes {
     fn check_attribute(&mut self, cx: &LateContext<'_, '_>, attr: &ast::Attribute) {
         debug!("checking attribute: {:?}", attr);
 
+        if attr.is_doc_comment() {
+            return;
+        }
+
         let attr_info = attr.ident().and_then(|ident| self.builtin_attributes.get(&ident.name));
 
         if let Some(&&(name, ty, ..)) = attr_info {

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -815,15 +815,15 @@ impl<'l, 'tcx> SaveContext<'l, 'tcx> {
         let mut result = String::new();
 
         for attr in attrs {
-            if attr.check_name(sym::doc) {
-                if let Some(val) = attr.value_str() {
-                    if attr.is_doc_comment() {
-                        result.push_str(&strip_doc_comment_decoration(&val.as_str()));
-                    } else {
-                        result.push_str(&val.as_str());
-                    }
-                    result.push('\n');
-                } else if let Some(meta_list) = attr.meta_item_list() {
+            if let Some(val) = attr.doc_str() {
+                if attr.is_doc_comment() {
+                    result.push_str(&strip_doc_comment_decoration(&val.as_str()));
+                } else {
+                    result.push_str(&val.as_str());
+                }
+                result.push('\n');
+            } else if attr.check_name(sym::doc) {
+                if let Some(meta_list) = attr.meta_item_list() {
                     meta_list
                         .into_iter()
                         .filter(|it| it.check_name(sym::include))

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -2364,10 +2364,6 @@ pub enum AttrKind {
     /// A doc comment (e.g. `/// ...`, `//! ...`, `/** ... */`, `/*! ... */`).
     /// Doc attributes (e.g. `#[doc="..."]`) are represented with the `Normal`
     /// variant (which is much less compact and thus more expensive).
-    ///
-    /// Note: `self.has_name(sym::doc)` and `self.check_name(sym::doc)` succeed
-    /// for this variant, but this may change in the future.
-    /// ```
     DocComment(Symbol),
 }
 

--- a/src/libsyntax/attr/builtin.rs
+++ b/src/libsyntax/attr/builtin.rs
@@ -16,7 +16,7 @@ use syntax_pos::{symbol::sym, symbol::Symbol, Span};
 use rustc_error_codes::*;
 
 pub fn is_builtin_attr(attr: &Attribute) -> bool {
-    attr.ident().filter(|ident| is_builtin_attr_name(ident.name)).is_some()
+    attr.is_doc_comment() || attr.ident().filter(|ident| is_builtin_attr_name(ident.name)).is_some()
 }
 
 enum AttrError {

--- a/src/libsyntax/attr/mod.rs
+++ b/src/libsyntax/attr/mod.rs
@@ -139,7 +139,7 @@ impl Attribute {
     pub fn has_name(&self, name: Symbol) -> bool {
         match self.kind {
             AttrKind::Normal(ref item) => item.path == name,
-            AttrKind::DocComment(_) => name == sym::doc,
+            AttrKind::DocComment(_) => false,
         }
     }
 
@@ -163,7 +163,7 @@ impl Attribute {
                     None
                 }
             }
-            AttrKind::DocComment(_) => Some(Ident::new(sym::doc, self.span)),
+            AttrKind::DocComment(_) => None,
         }
     }
     pub fn name_or_empty(&self) -> Symbol {
@@ -173,7 +173,7 @@ impl Attribute {
     pub fn value_str(&self) -> Option<Symbol> {
         match self.kind {
             AttrKind::Normal(ref item) => item.meta(self.span).and_then(|meta| meta.value_str()),
-            AttrKind::DocComment(comment) => Some(comment),
+            AttrKind::DocComment(..) => None,
         }
     }
 
@@ -279,17 +279,27 @@ impl Attribute {
         }
     }
 
+    pub fn doc_str(&self) -> Option<Symbol> {
+        match self.kind {
+            AttrKind::DocComment(symbol) => Some(symbol),
+            AttrKind::Normal(ref item) if item.path == sym::doc => {
+                item.meta(self.span).and_then(|meta| meta.value_str())
+            }
+            _ => None,
+        }
+    }
+
     pub fn get_normal_item(&self) -> &AttrItem {
         match self.kind {
             AttrKind::Normal(ref item) => item,
-            AttrKind::DocComment(_) => panic!("unexpected sugared doc"),
+            AttrKind::DocComment(_) => panic!("unexpected doc comment"),
         }
     }
 
     pub fn unwrap_normal_item(self) -> AttrItem {
         match self.kind {
             AttrKind::Normal(item) => item,
-            AttrKind::DocComment(_) => panic!("unexpected sugared doc"),
+            AttrKind::DocComment(_) => panic!("unexpected doc comment"),
         }
     }
 
@@ -297,9 +307,7 @@ impl Attribute {
     pub fn meta(&self) -> Option<MetaItem> {
         match self.kind {
             AttrKind::Normal(ref item) => item.meta(self.span),
-            AttrKind::DocComment(comment) => {
-                Some(mk_name_value_item_str(Ident::new(sym::doc, self.span), comment, self.span))
-            }
+            AttrKind::DocComment(..) => None,
         }
     }
 }

--- a/src/libsyntax_expand/parse/tests.rs
+++ b/src/libsyntax_expand/parse/tests.rs
@@ -3,12 +3,11 @@ use crate::tests::{matches_codepattern, string_to_stream, with_error_checking_pa
 use errors::PResult;
 use rustc_parse::new_parser_from_source_str;
 use syntax::ast::{self, Name, PatKind};
-use syntax::attr::first_attr_value_str_by_name;
 use syntax::print::pprust::item_to_string;
 use syntax::ptr::P;
 use syntax::sess::ParseSess;
 use syntax::source_map::FilePathMapping;
-use syntax::symbol::{kw, sym};
+use syntax::symbol::{kw, sym, Symbol};
 use syntax::token::{self, Token};
 use syntax::tokenstream::{DelimSpan, TokenStream, TokenTree};
 use syntax::visit;
@@ -244,25 +243,20 @@ fn crlf_doc_comments() {
         let name_1 = FileName::Custom("crlf_source_1".to_string());
         let source = "/// doc comment\r\nfn foo() {}".to_string();
         let item = parse_item_from_source_str(name_1, source, &sess).unwrap().unwrap();
-        let doc = first_attr_value_str_by_name(&item.attrs, sym::doc).unwrap();
+        let doc = item.attrs.iter().filter_map(|at| at.doc_str()).next().unwrap();
         assert_eq!(doc.as_str(), "/// doc comment");
 
         let name_2 = FileName::Custom("crlf_source_2".to_string());
         let source = "/// doc comment\r\n/// line 2\r\nfn foo() {}".to_string();
         let item = parse_item_from_source_str(name_2, source, &sess).unwrap().unwrap();
-        let docs = item
-            .attrs
-            .iter()
-            .filter(|a| a.has_name(sym::doc))
-            .map(|a| a.value_str().unwrap().to_string())
-            .collect::<Vec<_>>();
-        let b: &[_] = &["/// doc comment".to_string(), "/// line 2".to_string()];
+        let docs = item.attrs.iter().filter_map(|at| at.doc_str()).collect::<Vec<_>>();
+        let b: &[_] = &[Symbol::intern("/// doc comment"), Symbol::intern("/// line 2")];
         assert_eq!(&docs[..], b);
 
         let name_3 = FileName::Custom("clrf_source_3".to_string());
         let source = "/** doc comment\r\n *  with CRLF */\r\nfn foo() {}".to_string();
         let item = parse_item_from_source_str(name_3, source, &sess).unwrap().unwrap();
-        let doc = first_attr_value_str_by_name(&item.attrs, sym::doc).unwrap();
+        let doc = item.attrs.iter().filter_map(|at| at.doc_str()).next().unwrap();
         assert_eq!(doc.as_str(), "/** doc comment\n *  with CRLF */");
     });
 }


### PR DESCRIPTION
Make sure doc comments are not converted into intermediate meta-items, or not mixed with `doc(inline)` or something like that.

Follow-up to https://github.com/rust-lang/rust/pull/65750.