### PR TITLE
Bootstrap: change logic for choosing linker and rpath

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -980,7 +980,7 @@ impl<'a> Builder<'a> {
         // argument manually via `-C link-args=-Wl,-rpath,...`. Plus isn't it
         // fun to pass a flag to a tool to pass a flag to pass a flag to a tool
         // to change a flag in a binary?
-        if self.config.rust_rpath {
+        if self.config.rust_rpath && util::use_host_linker(&target) {
             let rpath = if target.contains("apple") {
 
                 // Note that we need to take one extra step on macOS to also pass
@@ -990,10 +990,7 @@ impl<'a> Builder<'a> {
                 // flesh out rpath support more fully in the future.
                 rustflags.arg("-Zosx-rpath-install-name");
                 Some("-Wl,-rpath,@loader_path/../lib")
-            } else if !target.contains("windows") &&
-                      !target.contains("wasm32") &&
-                      !target.contains("emscripten") &&
-                      !target.contains("fuchsia") {
+            } else if !target.contains("windows") {
                 Some("-Wl,-rpath,$ORIGIN/../lib")
             } else {
                 None

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -806,12 +806,8 @@ impl Build {
                                                        .and_then(|c| c.linker.as_ref()) {
             Some(linker)
         } else if target != self.config.build &&
-                  !target.contains("msvc") &&
-                  !target.contains("emscripten") &&
-                  !target.contains("wasm32") &&
-                  !target.contains("nvptx") &&
-                  !target.contains("fortanix") &&
-                  !target.contains("fuchsia") {
+                  util::use_host_linker(&target) &&
+                  !target.contains("msvc") {
             Some(self.cc(target))
         } else {
             None

--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -15,6 +15,7 @@ use build_helper::t;
 
 use crate::config::Config;
 use crate::builder::Builder;
+use crate::cache::Interned;
 
 /// Returns the `name` as the filename of a static library for `target`.
 pub fn staticlib(name: &str, target: &str) -> String {
@@ -305,4 +306,16 @@ pub fn forcing_clang_based_tests() -> bool {
     } else {
         false
     }
+}
+
+pub fn use_host_linker(target: &Interned<String>) -> bool {
+    // FIXME: this information should be gotten by checking the linker flavor
+    // of the rustc target
+    !(
+        target.contains("emscripten") ||
+        target.contains("wasm32") ||
+        target.contains("nvptx") ||
+        target.contains("fortanix") ||
+        target.contains("fuchsia")
+    )
 }


### PR DESCRIPTION
This is a follow-up from #66957 and #67023. Apparently there was one more location with a hard-coded list of targets to influence linking.

I've filed #67171 to track this madness.

r? @alexcrichton 