### PR TITLE
Enable or disable colored output according to CLICOLOR(_FORCE)

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -24,7 +24,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync::Lrc;
 use std::borrow::Cow;
 use std::io::prelude::*;
-use std::io;
+use std::{env, io};
 use std::cmp::{min, max, Reverse};
 use std::path::Path;
 use termcolor::{StandardStream, ColorChoice, ColorSpec, BufferWriter, Ansi};
@@ -458,7 +458,11 @@ impl ColorConfig {
                 }
             }
             ColorConfig::Never => ColorChoice::Never,
-            ColorConfig::Auto if atty::is(atty::Stream::Stderr) => {
+            ColorConfig::Auto
+                if env::var("CLICOLOR_FORCE").unwrap_or("0".to_string()) != "0"
+                    || (atty::is(atty::Stream::Stderr)
+                        && env::var("CLICOLOR").unwrap_or("1".to_string()) != "0") =>
+            {
                 ColorChoice::Auto
             }
             ColorConfig::Auto => ColorChoice::Never,

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -34,6 +34,7 @@
        html_playground_url = "https://play.rust-lang.org/",
        test(attr(deny(warnings))))]
 #![deny(missing_docs)]
+#![feature(result_map_or)]
 
 #![cfg_attr(windows, feature(libc))]
 

--- a/src/libterm/terminfo/mod.rs
+++ b/src/libterm/terminfo/mod.rs
@@ -13,7 +13,7 @@ use crate::color;
 use crate::Terminal;
 
 use searcher::get_dbpath_for_term;
-use parser::compiled::{parse, msys_terminfo};
+use parser::compiled::{parse, ansi_terminfo};
 use parm::{expand, Variables, Param};
 
 /// A parsed terminfo database entry.
@@ -69,14 +69,18 @@ impl fmt::Display for Error {
 impl TermInfo {
     /// Creates a TermInfo based on current environment.
     pub fn from_env() -> Result<TermInfo, Error> {
+        if env::var("CLICOLOR_FORCE").unwrap_or("0".to_string()) != "0" {
+            return Ok(ansi_terminfo());
+        }
         let term = match env::var("TERM") {
             Ok(name) => TermInfo::from_name(&name),
             Err(..) => return Err(Error::TermUnset),
         };
 
-        if term.is_err() && env::var("MSYSCON").ok().map_or(false, |s| "mintty.exe" == s) {
+        if term.is_err() && (env::var("MSYSCON").map_or(false, |s| "mintty.exe" == s) ||
+           env::var("CLICOLOR").unwrap_or("0".to_string()) != "0") {
             // msys terminal
-            Ok(msys_terminfo())
+            Ok(ansi_terminfo())
         } else {
             term
         }

--- a/src/libterm/terminfo/parser/compiled.rs
+++ b/src/libterm/terminfo/parser/compiled.rs
@@ -316,8 +316,9 @@ pub fn parse(file: &mut dyn io::Read, longnames: bool) -> Result<TermInfo, Strin
     })
 }
 
-/// Creates a dummy TermInfo struct for msys terminals
-pub fn msys_terminfo() -> TermInfo {
+/// Create a dummy TermInfo struct which only supports ISO 6429 (ANSI) color sequences. This is
+/// used for msys and when CLICOLOR(_FORCE) is set.
+pub fn ansi_terminfo() -> TermInfo {
     let mut strings = HashMap::new();
     strings.insert("sgr0".to_string(), b"\x1B[0m".to_vec());
     strings.insert("bold".to_string(), b"\x1B[1m".to_vec());


### PR DESCRIPTION
Updated version of #27867.

Also related: https://users.rust-lang.org/t/enable-or-disable-colored-output-according-to-clicolor--force/4445