### PR TITLE
In which we start tracking polonius in `-Z self-profile`

### DIFF
--- a/src/librustc_mir/borrow_check/nll/constraint_generation.rs
+++ b/src/librustc_mir/borrow_check/nll/constraint_generation.rs
@@ -97,6 +97,7 @@ impl<'cg, 'cx, 'tcx> Visitor<'tcx> for ConstraintGeneration<'cg, 'cx, 'tcx> {
         location: Location,
     ) {
         if let Some(all_facts) = self.all_facts {
+            let _prof_timer = self.infcx.tcx.prof.generic_activity("polonius_fact_generation");
             all_facts.cfg_edge.push((
                 self.location_table.start_index(location),
                 self.location_table.mid_index(location),
@@ -142,6 +143,7 @@ impl<'cg, 'cx, 'tcx> Visitor<'tcx> for ConstraintGeneration<'cg, 'cx, 'tcx> {
         location: Location,
     ) {
         if let Some(all_facts) = self.all_facts {
+            let _prof_timer = self.infcx.tcx.prof.generic_activity("polonius_fact_generation");
             all_facts.cfg_edge.push((
                 self.location_table.start_index(location),
                 self.location_table.mid_index(location),
@@ -205,6 +207,8 @@ impl<'cx, 'cg, 'tcx> ConstraintGeneration<'cx, 'cg, 'tcx> {
     /// as `killed`. For example, when assigning to a local, or on a call's return destination.
     fn record_killed_borrows_for_place(&mut self, place: &Place<'tcx>, location: Location) {
         if let Some(all_facts) = self.all_facts {
+            let _prof_timer = self.infcx.tcx.prof.generic_activity("polonius_fact_generation");
+
             // Depending on the `Place` we're killing:
             // - if it's a local, or a single deref of a local,
             //   we kill all the borrows on the local.

--- a/src/librustc_mir/borrow_check/nll/invalidation.rs
+++ b/src/librustc_mir/borrow_check/nll/invalidation.rs
@@ -31,6 +31,7 @@ pub(super) fn generate_invalidates<'tcx>(
     }
 
     if let Some(all_facts) = all_facts {
+        let _prof_timer = tcx.prof.generic_activity("polonius_fact_generation");
         let dominators = body.dominators();
         let mut ig = InvalidationGenerator {
             all_facts,

--- a/src/librustc_mir/borrow_check/nll/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/mod.rs
@@ -201,6 +201,7 @@ pub(in crate::borrow_check) fn compute_regions<'cx, 'tcx>(
     );
 
     if let Some(all_facts) = &mut all_facts {
+        let _prof_timer = infcx.tcx.prof.generic_activity("polonius_fact_generation");
         all_facts
             .universal_region
             .extend(universal_regions.universal_regions());
@@ -302,6 +303,7 @@ pub(in crate::borrow_check) fn compute_regions<'cx, 'tcx>(
                 .unwrap_or_else(|_| String::from("Naive"));
             let algorithm = Algorithm::from_str(&algorithm).unwrap();
             debug!("compute_regions: using polonius algorithm {:?}", algorithm);
+            let _prof_timer = infcx.tcx.prof.generic_activity("polonius_analysis");
             Some(Rc::new(Output::compute(
                 &all_facts,
                 algorithm,

--- a/src/librustc_mir/borrow_check/nll/type_check/liveness/polonius.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/liveness/polonius.rs
@@ -27,22 +27,22 @@ impl UseFactsExtractor<'_> {
     }
 
     fn insert_def(&mut self, local: Local, location: Location) {
-        debug!("LivenessFactsExtractor::insert_def()");
+        debug!("UseFactsExtractor::insert_def()");
         self.var_defined.push((local, self.location_to_index(location)));
     }
 
     fn insert_use(&mut self, local: Local, location: Location) {
-        debug!("LivenessFactsExtractor::insert_use()");
+        debug!("UseFactsExtractor::insert_use()");
         self.var_used.push((local, self.location_to_index(location)));
     }
 
     fn insert_drop_use(&mut self, local: Local, location: Location) {
-        debug!("LivenessFactsExtractor::insert_drop_use()");
+        debug!("UseFactsExtractor::insert_drop_use()");
         self.var_drop_used.push((local, location));
     }
 
     fn insert_path_access(&mut self, path: MovePathIndex, location: Location) {
-        debug!("LivenessFactsExtractor::insert_path_access({:?}, {:?})", path, location);
+        debug!("UseFactsExtractor::insert_path_access({:?}, {:?})", path, location);
         self.path_accessed_at.push((path, self.location_to_index(location)));
     }
 
@@ -90,7 +90,7 @@ pub(super) fn populate_access_facts(
     move_data: &MoveData<'_>,
     drop_used: &mut Vec<(Local, Location)>,
 ) {
-    debug!("populate_var_liveness_facts()");
+    debug!("populate_access_facts()");
 
     if let Some(facts) = typeck.borrowck_context.all_facts.as_mut() {
         let mut extractor = UseFactsExtractor {

--- a/src/librustc_mir/borrow_check/nll/type_check/liveness/polonius.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/liveness/polonius.rs
@@ -8,16 +8,16 @@ use rustc::ty::subst::GenericArg;
 
 use super::TypeChecker;
 
-type VarPointRelations = Vec<(Local, LocationIndex)>;
-type MovePathPointRelations = Vec<(MovePathIndex, LocationIndex)>;
+type VarPointRelation = Vec<(Local, LocationIndex)>;
+type PathPointRelation = Vec<(MovePathIndex, LocationIndex)>;
 
 struct UseFactsExtractor<'me> {
-    var_defined: &'me mut VarPointRelations,
-    var_used: &'me mut VarPointRelations,
+    var_defined: &'me mut VarPointRelation,
+    var_used: &'me mut VarPointRelation,
     location_table: &'me LocationTable,
     var_drop_used: &'me mut Vec<(Local, Location)>,
     move_data: &'me MoveData<'me>,
-    path_accessed_at: &'me mut MovePathPointRelations,
+    path_accessed_at: &'me mut PathPointRelation,
 }
 
 // A Visitor to walk through the MIR and extract point-wise facts

--- a/src/librustc_mir/borrow_check/nll/type_check/liveness/polonius.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/liveness/polonius.rs
@@ -5,7 +5,6 @@ use crate::util::liveness::{categorize, DefUse};
 use rustc::mir::visit::{MutatingUseContext, PlaceContext, Visitor};
 use rustc::mir::{Local, Location, Place, ReadOnlyBodyAndCache};
 use rustc::ty::subst::GenericArg;
-use rustc::ty::Ty;
 
 use super::TypeChecker;
 
@@ -84,17 +83,6 @@ impl Visitor<'tcx> for UseFactsExtractor<'_> {
     }
 }
 
-fn add_var_uses_regions(typeck: &mut TypeChecker<'_, 'tcx>, local: Local, ty: Ty<'tcx>) {
-    debug!("add_regions(local={:?}, type={:?})", local, ty);
-    typeck.tcx().for_each_free_region(&ty, |region| {
-        let region_vid = typeck.borrowck_context.universal_regions.to_region_vid(region);
-        debug!("add_regions for region {:?}", region_vid);
-        if let Some(facts) = typeck.borrowck_context.all_facts {
-            facts.var_uses_region.push((local, region_vid));
-        }
-    });
-}
-
 pub(super) fn populate_access_facts(
     typeck: &mut TypeChecker<'_, 'tcx>,
     body: ReadOnlyBodyAndCache<'_, 'tcx>,
@@ -118,10 +106,15 @@ pub(super) fn populate_access_facts(
         facts.var_drop_used.extend(drop_used.iter().map(|&(local, location)| {
             (local, location_table.mid_index(location))
         }));
-    }
 
-    for (local, local_decl) in body.local_decls.iter_enumerated() {
-        add_var_uses_regions(typeck, local, local_decl.ty);
+        for (local, local_decl) in body.local_decls.iter_enumerated() {
+            debug!("add var_uses_regions facts - local={:?}, type={:?}", local, local_decl.ty);
+            let universal_regions = &typeck.borrowck_context.universal_regions;
+            typeck.infcx.tcx.for_each_free_region(&local_decl.ty, |region| {
+                let region_vid = universal_regions.to_region_vid(region);
+                facts.var_uses_region.push((local, region_vid));
+            });
+        }
     }
 }
 
@@ -133,12 +126,11 @@ pub(super) fn add_var_drops_regions(
     kind: &GenericArg<'tcx>,
 ) {
     debug!("add_var_drops_region(local={:?}, kind={:?}", local, kind);
-    let tcx = typeck.tcx();
-
-    tcx.for_each_free_region(kind, |drop_live_region| {
-        let region_vid = typeck.borrowck_context.universal_regions.to_region_vid(drop_live_region);
-        if let Some(facts) = typeck.borrowck_context.all_facts.as_mut() {
+    if let Some(facts) = typeck.borrowck_context.all_facts.as_mut() {
+        let universal_regions = &typeck.borrowck_context.universal_regions;
+        typeck.infcx.tcx.for_each_free_region(kind, |drop_live_region| {
+            let region_vid = universal_regions.to_region_vid(drop_live_region);
             facts.var_drops_region.push((local, region_vid));
-        };
-    });
+        });
+    }
 }

--- a/src/librustc_mir/borrow_check/nll/type_check/liveness/polonius.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/liveness/polonius.rs
@@ -109,6 +109,7 @@ pub(super) fn populate_access_facts(
 
         for (local, local_decl) in body.local_decls.iter_enumerated() {
             debug!("add var_uses_regions facts - local={:?}, type={:?}", local, local_decl.ty);
+            let _prof_timer = typeck.infcx.tcx.prof.generic_activity("polonius_fact_generation");
             let universal_regions = &typeck.borrowck_context.universal_regions;
             typeck.infcx.tcx.for_each_free_region(&local_decl.ty, |region| {
                 let region_vid = universal_regions.to_region_vid(region);
@@ -127,6 +128,7 @@ pub(super) fn add_var_drops_regions(
 ) {
     debug!("add_var_drops_region(local={:?}, kind={:?}", local, kind);
     if let Some(facts) = typeck.borrowck_context.all_facts.as_mut() {
+        let _prof_timer = typeck.infcx.tcx.prof.generic_activity("polonius_fact_generation");
         let universal_regions = &typeck.borrowck_context.universal_regions;
         typeck.infcx.tcx.for_each_free_region(kind, |drop_live_region| {
             let region_vid = universal_regions.to_region_vid(drop_live_region);

--- a/src/librustc_mir/borrow_check/nll/type_check/liveness/polonius.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/liveness/polonius.rs
@@ -93,15 +93,15 @@ pub(super) fn populate_access_facts(
     debug!("populate_var_liveness_facts()");
 
     if let Some(facts) = typeck.borrowck_context.all_facts.as_mut() {
-        UseFactsExtractor {
+        let mut extractor = UseFactsExtractor {
             var_defined: &mut facts.var_defined,
             var_used: &mut facts.var_used,
             var_drop_used: drop_used,
             path_accessed_at: &mut facts.path_accessed_at,
             location_table,
             move_data,
-        }
-        .visit_body(body);
+        };
+        extractor.visit_body(body);
 
         facts.var_drop_used.extend(drop_used.iter().map(|&(local, location)| {
             (local, location_table.mid_index(location))

--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -182,7 +182,7 @@ pub(crate) fn type_check<'tcx>(
                 move_data,
                 location_table);
 
-            translate_outlives_facts(cx.borrowck_context);
+            translate_outlives_facts(&mut cx);
         },
     );
 
@@ -228,8 +228,10 @@ fn type_check_internal<'a, 'tcx, R>(
     extra(&mut checker)
 }
 
-fn translate_outlives_facts(cx: &mut BorrowCheckContext<'_, '_>) {
+fn translate_outlives_facts(typeck: &mut TypeChecker<'_, '_>) {
+    let cx = &mut typeck.borrowck_context;
     if let Some(facts) = cx.all_facts {
+        let _prof_timer = typeck.infcx.tcx.prof.generic_activity("polonius_fact_generation");
         let location_table = cx.location_table;
         facts
             .outlives
@@ -2489,6 +2491,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         // that occurs when we are borrowing an unsafe place, for
         // example).
         if let Some(all_facts) = all_facts {
+            let _prof_timer = self.infcx.tcx.prof.generic_activity("polonius_fact_generation");
             if let Some(borrow_index) = borrow_set.location_map.get(&location) {
                 let region_vid = borrow_region.to_region_vid();
                 all_facts.borrow_region.push((


### PR DESCRIPTION
This PR adds 2 `-Z self-profile` activities:
- "polonius_fact_generation" to track the different places where we convert MIR/NLL data to polonius facts
- "polonius_analysis" to track the time polonius itself takes to do its job: some move/init analysis (and more to come soon), liveness, borrow checking.

cc @albins for the commits slightly refactoring the liveness fact generation (to make it easier to use the `measureme` profiler), what do you think ? I know you've wanted to refactor liveness fact generation in general (even though we'll do broader changes when that happens).  I also hope I haven't missed relations.

cc @rust-lang/wg-polonius in general: like most of `-Z self-profile` + `summarize`, the profiling is done per-session/per-crate (?) and thus here we won't differentiate between functions/`DefId`s either, but (depending on the tool) commonly aggregate the different polonius durations. While we know it'll be needed in the future, and should be relatively easy to track with the profiler, would the profiling information in this PR be worthwhile on its own until then ? (Or would you rather we try to do that now ?). It would seem useful to eventually have both: one view would be high-level (and helpful to compare and track performance over time), and the other fine-grained, knowing exactly what time each `def_id` took, to spot specific problems/outliers (either in rustc/polonius or in user code). Hence, this PR as a first step towards that.

Here are a couple examples (taken on _stage 1_) post-processed with `summarize`:

<details>
<summary>Example output for the polonius smoke-tests</summary>

```
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| Item                               | Self time | % of total time | Item count | Cache hits | Blocked time | Incremental load time |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| metadata_register_crate            | 34.10ms   | 27.052          | 14         | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| mir_borrowck                       | 27.05ms   | 21.459          | 7          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| metadata_decode_entry              | 17.12ms   | 13.583          | 1380       | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_liveness                 | 12.91ms   | 10.244          | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| macro_expand_crate                 | 4.25ms    | 3.375           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| metadata_load_macro                | 3.19ms    | 2.533           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| resolve_lifetimes                  | 2.96ms    | 2.344           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| polonius_analysis                  | 2.65ms    | 2.099           | 7          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| typeck_tables_of                   | 2.50ms    | 1.985           | 7          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| parse_crate                        | 1.61ms    | 1.279           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| mir_built                          | 1.26ms    | 0.996           | 7          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_item_well_formed             | 1.03ms    | 0.821           | 9          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| build_hir_map                      | 953.10µs  | 0.756           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_match                        | 913.60µs  | 0.725           | 7          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| item_attrs                         | 816.20µs  | 0.647           | 475        | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| analysis                           | 703.80µs  | 0.558           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| type_of                            | 684.80µs  | 0.543           | 381        | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| trait_impls_of                     | 679.20µs  | 0.539           | 4          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| resolve_crate                      | 641.30µs  | 0.509           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| adt_def                            | 588.30µs  | 0.467           | 332        | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| hir_lowering                       | 573.20µs  | 0.455           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| evaluate_obligation                | 521.10µs  | 0.413           | 22         | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| region_scope_tree                  | 484.10µs  | 0.384           | 7          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| target_features_whitelist          | 445.70µs  | 0.354           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| implied_outlives_bounds            | 309.50µs  | 0.246           | 6          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| mir_const                          | 289.60µs  | 0.230           | 7          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| param_env                          | 288.80µs  | 0.229           | 7          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| polonius_fact_generation           | 285.80µs  | 0.227           | 191        | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| type_check_crate                   | 239.80µs  | 0.190           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| mir_validated                      | 210.00µs  | 0.167           | 7          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| type_op_prove_predicate            | 178.10µs  | 0.141           | 5          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| generics_of                        | 174.10µs  | 0.138           | 36         | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| collect_mod_item_types             | 163.40µs  | 0.130           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| get_lang_items                     | 157.10µs  | 0.125           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| unsafety_check_result              | 150.50µs  | 0.119           | 7          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| codegen_fn_attrs                   | 140.60µs  | 0.112           | 7          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| predicates_of                      | 128.50µs  | 0.102           | 19         | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| fn_sig                             | 127.30µs  | 0.101           | 7          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| predicates_defined_on              | 114.90µs  | 0.091           | 19         | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| implementations_of_trait           | 113.20µs  | 0.090           | 56         | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_attrs                    | 95.30µs   | 0.076           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| mir_const_qualif                   | 74.40µs   | 0.059           | 7          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_copy_raw                        | 74.00µs   | 0.059           | 11         | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_unstable_api_usage       | 71.40µs   | 0.057           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_freeze_raw                      | 69.50µs   | 0.055           | 7          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| stability_index                    | 59.00µs   | 0.047           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| impl_trait_ref                     | 57.80µs   | 0.046           | 29         | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| layout_raw                         | 57.80µs   | 0.046           | 3          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_loops                    | 56.30µs   | 0.045           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_sized_raw                       | 50.20µs   | 0.040           | 9          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| def_kind                           | 46.60µs   | 0.037           | 25         | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_intrinsics               | 43.30µs   | 0.034           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| explicit_predicates_of             | 42.60µs   | 0.034           | 19         | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| typeck_item_bodies                 | 37.10µs   | 0.029           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| inferred_outlives_of               | 34.90µs   | 0.028           | 19         | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| lint_levels                        | 32.20µs   | 0.026           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| impl_polarity                      | 29.40µs   | 0.023           | 12         | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| defined_lang_items                 | 28.10µs   | 0.022           | 14         | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_const_bodies             | 27.80µs   | 0.022           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| entry_fn                           | 25.60µs   | 0.020           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| missing_lang_items                 | 25.10µs   | 0.020           | 14         | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| object_lifetime_defaults_map       | 23.60µs   | 0.019           | 7          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_late_bound_map                  | 23.10µs   | 0.018           | 7          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| needs_drop_raw                     | 20.40µs   | 0.016           | 15         | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_const_fn_raw                    | 18.00µs   | 0.014           | 7          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| upvars                             | 17.50µs   | 0.014           | 7          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| lookup_deprecation_entry           | 17.20µs   | 0.014           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| all_crate_nums                     | 16.70µs   | 0.013           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| proc_macro_decls_static            | 16.10µs   | 0.013           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_item_types               | 15.90µs   | 0.013           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| plugin_registrar_fn                | 12.60µs   | 0.010           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| trait_def                          | 11.60µs   | 0.009           | 3          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| used_trait_imports                 | 11.50µs   | 0.009           | 7          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| def_span                           | 10.20µs   | 0.008           | 7          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| crate_inherent_impls               | 10.00µs   | 0.008           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| features_query                     | 9.90µs    | 0.008           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| crate_inherent_impls_overlap_check | 9.80µs    | 0.008           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_impl_wf                  | 7.20µs    | 0.006           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| named_region_map                   | 6.60µs    | 0.005           | 4          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| trait_of_item                      | 5.10µs    | 0.004           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| lookup_stability                   | 4.00µs    | 0.003           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| erase_regions_ty                   | 3.00µs    | 0.002           | 2          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| maybe_unused_extern_crates         | 1.50µs    | 0.001           | 1          | 0          | 0.00ns       | 0.00ns                |
+------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
Total cpu time: 126.0543ms

```
</details>

<details>
<summary>Example output for one of the slow tests on the `Naive` variant: ui/dynamically-sized-types/dst-tuple.rs</summary>

```
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| Item                                        | Self time | % of total time | Item count | Cache hits | Blocked time | Incremental load time |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| polonius_analysis                           | 55.31s    | 98.090          | 11         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| link_crate                                  | 339.76ms  | 0.603           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| LLVM_module_codegen_emit_obj                | 303.58ms  | 0.538           | 17         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| metadata_decode_entry                       | 73.48ms   | 0.130           | 18662      | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| polonius_fact_generation                    | 32.85ms   | 0.058           | 5476       | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| typeck_tables_of                            | 32.55ms   | 0.058           | 11         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| mir_borrowck                                | 29.41ms   | 0.052           | 11         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| macro_expand_crate                          | 23.50ms   | 0.042           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| metadata_register_crate                     | 21.04ms   | 0.037           | 14         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| codegen_module                              | 19.84ms   | 0.035           | 16         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| LLVM_module_optimize_module_passes          | 13.91ms   | 0.025           | 16         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| mir_built                                   | 12.72ms   | 0.023           | 11         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| evaluate_obligation                         | 9.17ms    | 0.016           | 497        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| specialization_graph_of                     | 7.89ms    | 0.014           | 19         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| type_of                                     | 7.27ms    | 0.013           | 3736       | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| LLVM_module_optimize                        | 5.97ms    | 0.011           | 17         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| optimized_mir                               | 5.72ms    | 0.010           | 103        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| trait_impls_of                              | 5.37ms    | 0.010           | 35         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| item_children                               | 5.11ms    | 0.009           | 3094       | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| impl_trait_ref                              | 5.06ms    | 0.009           | 3134       | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| impl_parent                                 | 4.92ms    | 0.009           | 3046       | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| codegen_crate                               | 4.86ms    | 0.009           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| resolve_crate                               | 3.99ms    | 0.007           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| metadata_load_macro                         | 3.55ms    | 0.006           | 13         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| analysis                                    | 3.45ms    | 0.006           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| visible_parent_map                          | 3.25ms    | 0.006           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| parse_crate                                 | 3.17ms    | 0.006           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| build_hir_map                               | 3.10ms    | 0.006           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_item_well_formed                      | 2.97ms    | 0.005           | 17         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| monomorphization_collector_graph_walk       | 2.44ms    | 0.004           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| hir_lowering                                | 2.40ms    | 0.004           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| generics_of                                 | 2.37ms    | 0.004           | 1283       | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| adt_def                                     | 2.25ms    | 0.004           | 823        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| item_attrs                                  | 2.12ms    | 0.004           | 1167       | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| LLVM_module_codegen                         | 2.11ms    | 0.004           | 17         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| type_op_prove_predicate                     | 2.05ms    | 0.004           | 92         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| erase_regions_ty                            | 1.80ms    | 0.003           | 807        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| explicit_predicates_of                      | 1.73ms    | 0.003           | 203        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| crate_variances                             | 1.73ms    | 0.003           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| const_eval_raw                              | 1.69ms    | 0.003           | 90         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| layout_raw                                  | 1.59ms    | 0.003           | 390        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| symbol_name                                 | 1.48ms    | 0.003           | 150        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| resolve_lifetimes                           | 1.46ms    | 0.003           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| promoted_mir                                | 1.31ms    | 0.002           | 4          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_item_types                        | 1.23ms    | 0.002           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| param_env                                   | 1.17ms    | 0.002           | 102        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| collect_mod_item_types                      | 1.13ms    | 0.002           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| LLVM_module_optimize_function_passes        | 1.12ms    | 0.002           | 16         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| codegen_fulfill_obligation                  | 1.11ms    | 0.002           | 48         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| type_check_crate                            | 1.08ms    | 0.002           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| const_eval                                  | 1.06ms    | 0.002           | 175        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_freeze_raw                               | 1.03ms    | 0.002           | 225        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_sized_raw                                | 1.02ms    | 0.002           | 219        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| super_predicates_of                         | 968.90µs  | 0.002           | 15         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| type_op_ascribe_user_type                   | 891.00µs  | 0.002           | 11         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| needs_drop_raw                              | 882.90µs  | 0.002           | 522        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| predicates_of                               | 881.30µs  | 0.002           | 203        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_copy_raw                                 | 879.20µs  | 0.002           | 231        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| const_caller_location                       | 871.70µs  | 0.002           | 15         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_match                                 | 856.70µs  | 0.002           | 11         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| mir_const_qualif                            | 848.90µs  | 0.002           | 11         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| inferred_outlives_of                        | 838.90µs  | 0.001           | 203        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| predicates_defined_on                       | 822.40µs  | 0.001           | 203        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| implementations_of_trait                    | 805.00µs  | 0.001           | 476        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| unsafety_check_result                       | 804.50µs  | 0.001           | 11         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| mir_validated                               | 767.50µs  | 0.001           | 11         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_impl_wf                           | 758.20µs  | 0.001           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| codegen_fn_attrs                            | 740.50µs  | 0.001           | 133        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| mir_const                                   | 629.80µs  | 0.001           | 11         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_privacy                           | 609.90µs  | 0.001           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| mir_keys                                    | 603.90µs  | 0.001           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| inferred_outlives_crate                     | 586.10µs  | 0.001           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| def_kind                                    | 548.20µs  | 0.001           | 308        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| lint_mod                                    | 544.50µs  | 0.001           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| specializes                                 | 541.60µs  | 0.001           | 60         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| associated_item                             | 536.70µs  | 0.001           | 143        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_mir_available                            | 515.60µs  | 0.001           | 96         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| variances_of                                | 511.40µs  | 0.001           | 11         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| region_scope_tree                           | 459.60µs  | 0.001           | 22         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_private_in_public                     | 458.20µs  | 0.001           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| cgu_partitioning_place_roots                | 453.00µs  | 0.001           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_liveness                          | 446.80µs  | 0.001           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| fn_sig                                      | 445.70µs  | 0.001           | 143        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| method_autoderef_steps                      | 427.20µs  | 0.001           | 6          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| associated_item_def_ids                     | 412.00µs  | 0.001           | 64         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| coherent_trait                              | 380.40µs  | 0.001           | 9          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| trait_def                                   | 364.60µs  | 0.001           | 32         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| normalize_projection_ty                     | 341.50µs  | 0.001           | 3          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| privacy_access_levels                       | 334.50µs  | 0.001           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_unstable_api_usage                | 304.40µs  | 0.001           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| def_span                                    | 272.80µs  | 0.000           | 141        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| collect_and_partition_mono_items            | 262.90µs  | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| vtable_methods                              | 262.90µs  | 0.000           | 3          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| trait_of_item                               | 249.00µs  | 0.000           | 131        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| implied_outlives_bounds                     | 231.50µs  | 0.000           | 13         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| dropck_outlives                             | 217.70µs  | 0.000           | 18         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| mir_shims                                   | 215.50µs  | 0.000           | 9          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| impl_polarity                               | 202.40µs  | 0.000           | 96         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_impl_item_well_formed                 | 199.70µs  | 0.000           | 5          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_foreign_item                             | 192.40µs  | 0.000           | 107        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_reachable_non_generic                    | 187.30µs  | 0.000           | 101        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| get_lang_items                              | 158.40µs  | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| dependency_formats                          | 157.00µs  | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| adt_dtorck_constraint                       | 149.50µs  | 0.000           | 10         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| codegen_module_optimize                     | 143.60µs  | 0.000           | 17         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| cgu_partitioning                            | 139.90µs  | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| monomorphization_collector_root_collections | 118.20µs  | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_attrs                             | 118.00µs  | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| target_features_whitelist                   | 110.50µs  | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| codegen_unit                                | 101.00µs  | 0.000           | 16         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| reachable_non_generics                      | 98.40µs   | 0.000           | 4          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_trait_item_well_formed                | 94.50µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| adt_sized_constraint                        | 94.30µs   | 0.000           | 27         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| lint_levels                                 | 91.20µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| instance_def_size_estimate                  | 89.90µs   | 0.000           | 92         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| stability_index                             | 89.00µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| normalize_ty_after_erasing_regions          | 88.80µs   | 0.000           | 11         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_loops                             | 88.40µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_intrinsics                        | 83.30µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| upstream_monomorphizations_for              | 82.70µs   | 0.000           | 59         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_codegened_item                           | 78.10µs   | 0.000           | 34         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| exported_symbols                            | 78.00µs   | 0.000           | 15         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| lookup_deprecation_entry                    | 70.20µs   | 0.000           | 33         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| cgu_partitioning_merge_cgus                 | 65.20µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_panic_runtime                            | 62.00µs   | 0.000           | 15         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| upstream_monomorphizations                  | 61.60µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| lookup_stability                            | 59.60µs   | 0.000           | 30         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| reachable_set                               | 55.70µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| visibility                                  | 54.60µs   | 0.000           | 26         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| object_lifetime_defaults_map                | 53.80µs   | 0.000           | 23         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| adt_destructor                              | 49.30µs   | 0.000           | 10         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_const_bodies                      | 49.00µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| static_mutability                           | 48.80µs   | 0.000           | 24         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| cgu_partitioning_place_inline_items         | 46.50µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| issue33140_self_ty                          | 45.40µs   | 0.000           | 37         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| typeck_item_bodies                          | 44.10µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| cgu_partitioning_internalize_symbols        | 44.10µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| substitute_normalize_and_test_predicates    | 44.00µs   | 0.000           | 2          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| backend_optimization_level                  | 40.40µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| get_lib_features                            | 36.50µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| crate_name                                  | 35.00µs   | 0.000           | 15         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_compiler_builtins                        | 33.30µs   | 0.000           | 15         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| native_libraries                            | 32.90µs   | 0.000           | 15         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| missing_extern_crate_item                   | 31.70µs   | 0.000           | 14         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| has_typeck_tables                           | 29.70µs   | 0.000           | 25         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| entry_fn                                    | 29.30µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| defined_lang_items                          | 29.20µs   | 0.000           | 14         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_const_fn_raw                             | 28.30µs   | 0.000           | 13         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_no_builtins                              | 26.40µs   | 0.000           | 14         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_late_bound_map                           | 26.10µs   | 0.000           | 11         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| missing_lang_items                          | 25.30µs   | 0.000           | 14         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_profiler_runtime                         | 25.10µs   | 0.000           | 14         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_sanitizer_runtime                        | 25.10µs   | 0.000           | 14         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| crate_inherent_impls_overlap_check          | 24.30µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| panic_strategy                              | 23.30µs   | 0.000           | 14         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| dep_kind                                    | 23.20µs   | 0.000           | 14         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| used_crate_source                           | 22.50µs   | 0.000           | 14         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| crate_disambiguator                         | 21.80µs   | 0.000           | 4          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| inherent_impls                              | 20.90µs   | 0.000           | 7          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| proc_macro_decls_static                     | 19.50µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| diagnostic_items                            | 18.20µs   | 0.000           | 4          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| upvars                                      | 17.30µs   | 0.000           | 11         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| all_crate_nums                              | 17.10µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| module_exports                              | 16.30µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| named_region_map                            | 14.30µs   | 0.000           | 11         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_promotable_const_fn                      | 14.20µs   | 0.000           | 4          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| in_scope_traits_map                         | 13.50µs   | 0.000           | 5          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| plugin_registrar_fn                         | 13.50µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| used_trait_imports                          | 12.30µs   | 0.000           | 11         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| impl_defaultness                            | 12.10µs   | 0.000           | 3          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| crate_inherent_impls                        | 11.40µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| extern_crate                                | 10.80µs   | 0.000           | 2          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| features_query                              | 10.30µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| symbol_mangling_version                     | 9.80µs    | 0.000           | 3          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| original_crate_name                         | 7.60µs    | 0.000           | 4          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| crate_hash                                  | 6.90µs    | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| output_filenames                            | 4.00µs    | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| monomorphization_collector                  | 3.90µs    | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| postorder_cnums                             | 3.70µs    | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| link_args                                   | 2.20µs    | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| maybe_unused_extern_crates                  | 1.50µs    | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
Total cpu time: 56.388711s

```
</details>

<details>
<summary>Example output for one of the slow tests where fact generation is also slow: ui/intrinsics/intrinsics-integer.rs</summary>

```
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| Item                                        | Self time | % of total time | Item count | Cache hits | Blocked time | Incremental load time |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| polonius_analysis                           | 74.79s    | 91.839          | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| polonius_fact_generation                    | 3.10s     | 3.806           | 46553      | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| link_crate                                  | 921.59ms  | 1.132           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| LLVM_module_codegen_emit_obj                | 596.42ms  | 0.732           | 8          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| mir_borrowck                                | 532.24ms  | 0.654           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| typeck_tables_of                            | 296.73ms  | 0.364           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| metadata_decode_entry                       | 268.42ms  | 0.330           | 10176      | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| codegen_crate                               | 75.22ms   | 0.092           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| analysis                                    | 70.90ms   | 0.087           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| optimized_mir                               | 63.25ms   | 0.078           | 37         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| codegen_module                              | 46.51ms   | 0.057           | 7          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| macro_expand_crate                          | 40.81ms   | 0.050           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| LLVM_module_optimize_module_passes          | 35.78ms   | 0.044           | 7          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| mir_built                                   | 29.96ms   | 0.037           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_liveness                          | 29.18ms   | 0.036           | 2          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| LLVM_module_optimize                        | 21.44ms   | 0.026           | 8          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| metadata_register_crate                     | 19.75ms   | 0.024           | 14         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| erase_regions_ty                            | 18.45ms   | 0.023           | 7009       | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| const_eval_raw                              | 16.70ms   | 0.021           | 708        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| evaluate_obligation                         | 16.23ms   | 0.020           | 303        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| privacy_access_levels                       | 16.04ms   | 0.020           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| param_env                                   | 15.86ms   | 0.019           | 42         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| promoted_mir                                | 14.18ms   | 0.017           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| mir_validated                               | 12.75ms   | 0.016           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| symbol_name                                 | 12.58ms   | 0.015           | 75         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| lint_mod                                    | 11.89ms   | 0.015           | 2          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| LLVM_module_optimize_function_passes        | 10.39ms   | 0.013           | 7          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| build_hir_map                               | 9.87ms    | 0.012           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| monomorphization_collector_graph_walk       | 9.61ms    | 0.012           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| resolve_crate                               | 9.11ms    | 0.011           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| hir_lowering                                | 7.58ms    | 0.009           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| collect_and_partition_mono_items            | 7.50ms    | 0.009           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| const_eval                                  | 6.93ms    | 0.009           | 1399       | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| monomorphization_collector_root_collections | 6.89ms    | 0.008           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| layout_raw                                  | 6.25ms    | 0.008           | 293        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_privacy                           | 5.73ms    | 0.007           | 2          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| needs_drop_raw                              | 5.52ms    | 0.007           | 4386       | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| codegen_fulfill_obligation                  | 5.50ms    | 0.007           | 65         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| predicates_of                               | 5.48ms    | 0.007           | 143        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| lint_levels                                 | 5.34ms    | 0.007           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| item_children                               | 5.29ms    | 0.006           | 3094       | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| specialization_graph_of                     | 4.60ms    | 0.006           | 5          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_copy_raw                                 | 4.41ms    | 0.005           | 1853       | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_reachable_non_generic                    | 4.37ms    | 0.005           | 53         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| visible_parent_map                          | 4.20ms    | 0.005           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| generics_of                                 | 4.14ms    | 0.005           | 169        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| codegen_fn_attrs                            | 4.04ms    | 0.005           | 69         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| LLVM_module_codegen                         | 3.97ms    | 0.005           | 8          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| unsafety_check_result                       | 3.62ms    | 0.004           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_match                                 | 3.53ms    | 0.004           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| metadata_load_macro                         | 3.47ms    | 0.004           | 7          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| type_of                                     | 3.46ms    | 0.004           | 1928       | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| predicates_defined_on                       | 3.39ms    | 0.004           | 143        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| explicit_predicates_of                      | 2.98ms    | 0.004           | 143        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| cgu_partitioning_place_roots                | 2.97ms    | 0.004           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| reachable_non_generics                      | 2.84ms    | 0.003           | 3          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| trait_impls_of                              | 2.84ms    | 0.003           | 16         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_freeze_raw                               | 2.56ms    | 0.003           | 1412       | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| vtable_methods                              | 2.53ms    | 0.003           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| normalize_ty_after_erasing_regions          | 2.23ms    | 0.003           | 11         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| substitute_normalize_and_test_predicates    | 2.22ms    | 0.003           | 2          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| mir_const                                   | 2.13ms    | 0.003           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| normalize_projection_ty                     | 2.12ms    | 0.003           | 3          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| dependency_formats                          | 2.08ms    | 0.003           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| item_attrs                                  | 2.05ms    | 0.003           | 1065       | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| upstream_monomorphizations                  | 2.03ms    | 0.002           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| region_scope_tree                           | 2.01ms    | 0.002           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| impl_trait_ref                              | 1.75ms    | 0.002           | 911        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| adt_def                                     | 1.69ms    | 0.002           | 782        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| parse_crate                                 | 1.64ms    | 0.002           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| super_predicates_of                         | 1.61ms    | 0.002           | 4          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_private_in_public                     | 1.60ms    | 0.002           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| impl_parent                                 | 1.57ms    | 0.002           | 832        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_sized_raw                                | 1.33ms    | 0.002           | 144        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| exported_symbols                            | 1.27ms    | 0.002           | 15         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| get_lib_features                            | 1.17ms    | 0.001           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_foreign_item                             | 1.05ms    | 0.001           | 56         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| upstream_monomorphizations_for              | 1.04ms    | 0.001           | 6          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| def_kind                                    | 965.70µs  | 0.001           | 175        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| object_lifetime_defaults_map                | 933.70µs  | 0.001           | 6          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| mir_shims                                   | 876.50µs  | 0.001           | 3          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| inferred_outlives_of                        | 820.70µs  | 0.001           | 143        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| module_exports                              | 726.80µs  | 0.001           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| codegen_module_optimize                     | 673.30µs  | 0.001           | 8          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| adt_sized_constraint                        | 667.30µs  | 0.001           | 13         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| has_typeck_tables                           | 666.80µs  | 0.001           | 6          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| diagnostic_items                            | 651.50µs  | 0.001           | 3          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| codegen_unit                                | 618.00µs  | 0.001           | 7          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| type_op_prove_predicate                     | 617.50µs  | 0.001           | 50         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| target_features_whitelist                   | 538.80µs  | 0.001           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| original_crate_name                         | 514.30µs  | 0.001           | 3          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_unstable_api_usage                | 455.00µs  | 0.001           | 2          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| implementations_of_trait                    | 452.60µs  | 0.001           | 224        | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_intrinsics                        | 442.60µs  | 0.001           | 2          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| static_mutability                           | 428.60µs  | 0.001           | 19         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_panic_runtime                            | 425.40µs  | 0.001           | 15         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| resolve_lifetimes                           | 424.10µs  | 0.001           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_item_well_formed                      | 413.20µs  | 0.001           | 6          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| cgu_partitioning                            | 411.00µs  | 0.001           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| instance_def_size_estimate                  | 398.20µs  | 0.000           | 22         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| def_span                                    | 373.30µs  | 0.000           | 60         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| link_args                                   | 372.80µs  | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_loops                             | 361.80µs  | 0.000           | 2          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| reachable_set                               | 360.50µs  | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| monomorphization_collector                  | 347.60µs  | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| cgu_partitioning_internalize_symbols        | 344.50µs  | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| crate_hash                                  | 324.90µs  | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| trait_def                                   | 320.20µs  | 0.000           | 17         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| crate_disambiguator                         | 316.60µs  | 0.000           | 3          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| missing_extern_crate_item                   | 308.50µs  | 0.000           | 14         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| type_op_ascribe_user_type                   | 305.00µs  | 0.000           | 11         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| collect_mod_item_types                      | 291.70µs  | 0.000           | 2          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_attrs                             | 288.50µs  | 0.000           | 2          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| fn_sig                                      | 253.80µs  | 0.000           | 73         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| type_check_crate                            | 253.30µs  | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| stability_index                             | 203.60µs  | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| get_lang_items                              | 194.80µs  | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| impl_polarity                               | 173.60µs  | 0.000           | 80         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| implied_outlives_bounds                     | 168.50µs  | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_item_types                        | 148.20µs  | 0.000           | 2          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| associated_item                             | 143.80µs  | 0.000           | 67         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_const_bodies                      | 138.30µs  | 0.000           | 2          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| associated_item_def_ids                     | 128.00µs  | 0.000           | 57         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| adt_dtorck_constraint                       | 115.50µs  | 0.000           | 3          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| trait_of_item                               | 111.80µs  | 0.000           | 44         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| dropck_outlives                             | 105.60µs  | 0.000           | 3          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_mir_available                            | 88.40µs   | 0.000           | 36         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_codegened_item                           | 66.00µs   | 0.000           | 48         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| mir_const_qualif                            | 50.00µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| lookup_deprecation_entry                    | 43.40µs   | 0.000           | 21         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| native_libraries                            | 39.90µs   | 0.000           | 15         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_promotable_const_fn                      | 39.60µs   | 0.000           | 9          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_compiler_builtins                        | 34.30µs   | 0.000           | 15         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| crate_name                                  | 33.70µs   | 0.000           | 15         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| visibility                                  | 33.50µs   | 0.000           | 10         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| defined_lang_items                          | 29.20µs   | 0.000           | 14         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| coherent_trait                              | 28.10µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| cgu_partitioning_merge_cgus                 | 28.00µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| variances_of                                | 27.50µs   | 0.000           | 7          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_profiler_runtime                         | 27.10µs   | 0.000           | 14         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| panic_strategy                              | 26.70µs   | 0.000           | 14         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| entry_fn                                    | 26.00µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| missing_lang_items                          | 25.80µs   | 0.000           | 14         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_sanitizer_runtime                        | 25.30µs   | 0.000           | 14         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_no_builtins                              | 25.30µs   | 0.000           | 14         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| lookup_stability                            | 25.10µs   | 0.000           | 16         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| dep_kind                                    | 24.80µs   | 0.000           | 14         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| impl_defaultness                            | 24.50µs   | 0.000           | 6          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| typeck_item_bodies                          | 23.60µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| used_crate_source                           | 23.20µs   | 0.000           | 14         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| cgu_partitioning_place_inline_items         | 20.70µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_const_fn_raw                             | 20.00µs   | 0.000           | 10         | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| proc_macro_decls_static                     | 15.80µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| backend_optimization_level                  | 14.50µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| all_crate_nums                              | 14.10µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| extern_crate                                | 13.80µs   | 0.000           | 2          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| plugin_registrar_fn                         | 12.60µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| crate_inherent_impls                        | 10.10µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| features_query                              | 10.00µs   | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| inherent_impls                              | 9.70µs    | 0.000           | 2          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| crate_inherent_impls_overlap_check          | 9.70µs    | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| is_late_bound_map                           | 9.20µs    | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| check_mod_impl_wf                           | 8.20µs    | 0.000           | 2          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| symbol_mangling_version                     | 8.00µs    | 0.000           | 2          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| upvars                                      | 7.60µs    | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| used_trait_imports                          | 7.50µs    | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| adt_destructor                              | 7.00µs    | 0.000           | 3          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| output_filenames                            | 6.00µs    | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| named_region_map                            | 4.60µs    | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| postorder_cnums                             | 4.30µs    | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| in_scope_traits_map                         | 4.10µs    | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| maybe_unused_trait_import                   | 1.70µs    | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
| maybe_unused_extern_crates                  | 1.40µs    | 0.000           | 1          | 0          | 0.00ns       | 0.00ns                |
+---------------------------------------------+-----------+-----------------+------------+------------+--------------+-----------------------+
Total cpu time: 81.4315819s

```
</details>


r? @wesleywiser for the profiler usage