### PR TITLE
[rustdoc] Prevent ICE when path is Err

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2043,8 +2043,13 @@ impl Clean<Visibility> for hir::Visibility {
             hir::VisibilityKind::Crate(_) => Visibility::Crate,
             hir::VisibilityKind::Restricted { ref path, .. } => {
                 let path = path.clean(cx);
-                let did = register_res(cx, path.res);
-                Visibility::Restricted(did, path)
+                if let Res::Err = path.res {
+                    // Ugly fix to prevent ICE.
+                    Visibility::Inherited
+                } else {
+                    let did = register_res(cx, path.res);
+                    Visibility::Restricted(did, path)
+                }
             }
         }
     }

--- a/src/test/rustdoc-ui/impl-fn-macro-item-ice.rs
+++ b/src/test/rustdoc-ui/impl-fn-macro-item-ice.rs
@@ -1,0 +1,15 @@
+// build-pass
+
+macro_rules! perftools_inline {
+    ($($item:tt)*) => (
+        $($item)*
+    );
+}
+mod state {
+    pub struct RawFloatState;
+    impl RawFloatState {
+        perftools_inline! {
+            pub(super) fn new() {}
+        }
+    }
+}


### PR DESCRIPTION
This PR prevents the ICE from https://github.com/rust-lang/rust/issues/64705 but doesn't fix it.

cc @rust-lang/compiler 
r? @kinnison 