### PR TITLE
Clearer error diagnostic on type mismatch within a range

### DIFF
--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -2273,7 +2273,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         match *cause_code {
             ObligationCauseCode::ExprAssignable |
             ObligationCauseCode::MatchExpressionArm { .. } |
-            ObligationCauseCode::MatchExpressionArmPattern { .. } |
+            ObligationCauseCode::PatternGuard { .. } |
             ObligationCauseCode::IfExpression { .. } |
             ObligationCauseCode::IfExpressionWithNoElse |
             ObligationCauseCode::MainFunctionType |

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -237,8 +237,8 @@ pub enum ObligationCauseCode<'tcx> {
     /// Computing common supertype in the arms of a match expression
     MatchExpressionArm(Box<MatchExpressionArmCause<'tcx>>),
 
-    /// Computing common supertype in the pattern guard for the arms of a match expression
-    MatchExpressionArmPattern { span: Span, ty: Ty<'tcx> },
+    /// Computing common supertype in a pattern guard
+    PatternGuard(Box<PatternGuardCause<'tcx>>),
 
     /// Constants in patterns must have `Structural` type.
     ConstPatternStructural,
@@ -297,6 +297,12 @@ pub struct MatchExpressionArmCause<'tcx> {
     pub prior_arms: Vec<Span>,
     pub last_ty: Ty<'tcx>,
     pub discrim_hir_id: hir::HirId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct PatternGuardCause<'tcx> {
+    pub match_expr_discrim: Option<(Span, Ty<'tcx>)>,
+    pub other_range_expr: Option<(Span, Ty<'tcx>)>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/librustc/traits/structural_impls.rs
+++ b/src/librustc/traits/structural_impls.rs
@@ -532,9 +532,12 @@ impl<'a, 'tcx> Lift<'tcx> for traits::ObligationCauseCode<'a> {
                     })
                 })
             }
-            super::MatchExpressionArmPattern { span, ty } => {
-                tcx.lift(&ty).map(|ty| super::MatchExpressionArmPattern { span, ty })
-            }
+            super::PatternGuard(box super::PatternGuardCause {
+                match_expr_discrim, other_range_expr,
+            }) => Some(super::PatternGuard(box super::PatternGuardCause {
+                match_expr_discrim: tcx.lift(&match_expr_discrim)?,
+                other_range_expr: tcx.lift(&other_range_expr)?,
+            })),
             super::IfExpression(box super::IfExpressionCause { then, outer, semicolon }) => {
                 Some(super::IfExpression(box super::IfExpressionCause {
                     then,

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -1,6 +1,6 @@
 use crate::check::FnCtxt;
 use rustc::infer::InferOk;
-use rustc::traits::{self, ObligationCause, ObligationCauseCode};
+use rustc::traits::{self, ObligationCause};
 
 use syntax::symbol::sym;
 use syntax::util::parser::PREC_POSTFIX;
@@ -88,14 +88,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         actual: Ty<'tcx>,
         match_expr_span: Option<Span>,
     ) -> Option<DiagnosticBuilder<'tcx>> {
-        let cause = if let Some(span) = match_expr_span {
-            self.cause(
-                cause_span,
-                ObligationCauseCode::MatchExpressionArmPattern { span, ty: expected },
-            )
-        } else {
-            self.misc(cause_span)
-        };
+        let cause = self.pat_guard_cause(None, cause_span, expected, match_expr_span);
         self.demand_eqtype_with_origin(&cause, expected, actual)
     }
 

--- a/src/test/ui/block-result/issue-13624.stderr
+++ b/src/test/ui/block-result/issue-13624.stderr
@@ -10,7 +10,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-13624.rs:20:9
    |
 LL |       match enum_struct_variant {
-   |             ------------------- this match expression has type `()`
+   |             ------------------- this match expression requires type `()`
 LL |         a::Enum::EnumStructVariant { x, y, z } => {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found enum `a::Enum`
 

--- a/src/test/ui/error-codes/E0308-4.stderr
+++ b/src/test/ui/error-codes/E0308-4.stderr
@@ -1,10 +1,12 @@
 error[E0308]: mismatched types
-  --> $DIR/E0308-4.rs:4:9
+  --> $DIR/E0308-4.rs:4:15
    |
 LL |     match x {
-   |           - this match expression has type `u8`
+   |           - this match expression requires type `u8`
 LL |         0u8..=3i8 => (),
-   |         ^^^^^^^^^ expected `u8`, found `i8`
+   |         ---   ^^^ expected `u8`, found `i8`
+   |         |
+   |         other endpoint has type `u8`
 
 error: aborting due to previous error
 

--- a/src/test/ui/exclusive-range/exclusive_range_pattern_syntax_collision.stderr
+++ b/src/test/ui/exclusive-range/exclusive_range_pattern_syntax_collision.stderr
@@ -8,9 +8,9 @@ error[E0308]: mismatched types
   --> $DIR/exclusive_range_pattern_syntax_collision.rs:5:13
    |
 LL |     match [5..4, 99..105, 43..44] {
-   |           ----------------------- this match expression has type `std::ops::Range<{integer}>`
+   |           ----------------------- this match expression requires type `std::ops::Range<{integer}>`
 LL |         [_, 99.., _] => {},
-   |             ^^^^ expected struct `std::ops::Range`, found integer
+   |             ^^ expected struct `std::ops::Range`, found integer
    |
    = note: expected struct `std::ops::Range<{integer}>`
                 found type `{integer}`

--- a/src/test/ui/exclusive-range/exclusive_range_pattern_syntax_collision2.stderr
+++ b/src/test/ui/exclusive-range/exclusive_range_pattern_syntax_collision2.stderr
@@ -14,9 +14,9 @@ error[E0308]: mismatched types
   --> $DIR/exclusive_range_pattern_syntax_collision2.rs:5:13
    |
 LL |     match [5..4, 99..105, 43..44] {
-   |           ----------------------- this match expression has type `std::ops::Range<{integer}>`
+   |           ----------------------- this match expression requires type `std::ops::Range<{integer}>`
 LL |         [_, 99..] => {},
-   |             ^^^^ expected struct `std::ops::Range`, found integer
+   |             ^^ expected struct `std::ops::Range`, found integer
    |
    = note: expected struct `std::ops::Range<{integer}>`
                 found type `{integer}`

--- a/src/test/ui/exclusive-range/exclusive_range_pattern_syntax_collision3.stderr
+++ b/src/test/ui/exclusive-range/exclusive_range_pattern_syntax_collision3.stderr
@@ -5,12 +5,12 @@ LL |         [..9, 99..100, _] => {},
    |          ^^^ help: try using the minimum value for the type: `MIN..9`
 
 error[E0308]: mismatched types
-  --> $DIR/exclusive_range_pattern_syntax_collision3.rs:5:10
+  --> $DIR/exclusive_range_pattern_syntax_collision3.rs:5:12
    |
 LL |     match [5..4, 99..105, 43..44] {
-   |           ----------------------- this match expression has type `std::ops::Range<{integer}>`
+   |           ----------------------- this match expression requires type `std::ops::Range<{integer}>`
 LL |         [..9, 99..100, _] => {},
-   |          ^^^ expected struct `std::ops::Range`, found integer
+   |            ^ expected struct `std::ops::Range`, found integer
    |
    = note: expected struct `std::ops::Range<{integer}>`
                 found type `{integer}`
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
   --> $DIR/exclusive_range_pattern_syntax_collision3.rs:5:15
    |
 LL |     match [5..4, 99..105, 43..44] {
-   |           ----------------------- this match expression has type `std::ops::Range<{integer}>`
+   |           ----------------------- this match expression requires type `std::ops::Range<{integer}>`
 LL |         [..9, 99..100, _] => {},
    |               ^^^^^^^ expected struct `std::ops::Range`, found integer
    |

--- a/src/test/ui/issues/issue-11844.stderr
+++ b/src/test/ui/issues/issue-11844.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-11844.rs:6:9
    |
 LL |     match a {
-   |           - this match expression has type `std::option::Option<std::boxed::Box<{integer}>>`
+   |           - this match expression requires type `std::option::Option<std::boxed::Box<{integer}>>`
 LL |         Ok(a) =>
    |         ^^^^^ expected enum `std::option::Option`, found enum `std::result::Result`
    |

--- a/src/test/ui/issues/issue-12552.stderr
+++ b/src/test/ui/issues/issue-12552.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-12552.rs:6:5
    |
 LL |   match t {
-   |         - this match expression has type `std::result::Result<_, {integer}>`
+   |         - this match expression requires type `std::result::Result<_, {integer}>`
 LL |     Some(k) => match k {
    |     ^^^^^^^ expected enum `std::result::Result`, found enum `std::option::Option`
    |

--- a/src/test/ui/issues/issue-13466.stderr
+++ b/src/test/ui/issues/issue-13466.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-13466.rs:8:9
    |
 LL |     let _x: usize = match Some(1) {
-   |                           ------- this match expression has type `std::option::Option<{integer}>`
+   |                           ------- this match expression requires type `std::option::Option<{integer}>`
 LL |         Ok(u) => u,
    |         ^^^^^ expected enum `std::option::Option`, found enum `std::result::Result`
    |
@@ -13,7 +13,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-13466.rs:14:9
    |
 LL |     let _x: usize = match Some(1) {
-   |                           ------- this match expression has type `std::option::Option<{integer}>`
+   |                           ------- this match expression requires type `std::option::Option<{integer}>`
 ...
 LL |         Err(e) => panic!(e)
    |         ^^^^^^ expected enum `std::option::Option`, found enum `std::result::Result`

--- a/src/test/ui/issues/issue-15896.stderr
+++ b/src/test/ui/issues/issue-15896.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-15896.rs:11:11
    |
 LL |     let u = match e {
-   |                   - this match expression has type `main::R`
+   |                   - this match expression requires type `main::R`
 LL |         E::B(
 LL |           Tau{t: x},
    |           ^^^^^^^^^ expected enum `main::R`, found struct `main::Tau`

--- a/src/test/ui/issues/issue-16401.stderr
+++ b/src/test/ui/issues/issue-16401.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-16401.rs:8:9
    |
 LL |     match () {
-   |           -- this match expression has type `()`
+   |           -- this match expression requires type `()`
 LL |         Slice { data: data, len: len } => (),
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found struct `Slice`
    |

--- a/src/test/ui/issues/issue-3680.stderr
+++ b/src/test/ui/issues/issue-3680.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-3680.rs:3:9
    |
 LL |     match None {
-   |           ---- this match expression has type `std::option::Option<_>`
+   |           ---- this match expression requires type `std::option::Option<_>`
 LL |         Err(_) => ()
    |         ^^^^^^ expected enum `std::option::Option`, found enum `std::result::Result`
    |

--- a/src/test/ui/issues/issue-5100.stderr
+++ b/src/test/ui/issues/issue-5100.stderr
@@ -29,7 +29,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-5100.rs:33:9
    |
 LL |     match (true, false) {
-   |           ------------- this match expression has type `(bool, bool)`
+   |           ------------- this match expression requires type `(bool, bool)`
 LL |         box (true, false) => ()
    |         ^^^^^^^^^^^^^^^^^ expected tuple, found struct `std::boxed::Box`
    |

--- a/src/test/ui/issues/issue-5358-1.stderr
+++ b/src/test/ui/issues/issue-5358-1.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-5358-1.rs:6:9
    |
 LL |     match S(Either::Left(5)) {
-   |           ------------------ this match expression has type `S`
+   |           ------------------ this match expression requires type `S`
 LL |         Either::Right(_) => {}
    |         ^^^^^^^^^^^^^^^^ expected struct `S`, found enum `Either`
    |

--- a/src/test/ui/issues/issue-57741-1.stderr
+++ b/src/test/ui/issues/issue-57741-1.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-57741-1.rs:14:9
    |
 LL |     let y = match x {
-   |                   - this match expression has type `std::boxed::Box<u32>`
+   |                   - this match expression requires type `std::boxed::Box<u32>`
 LL |         S::A { a } | S::B { b: a } => a,
    |         ^^^^^^^^^^ expected struct `std::boxed::Box`, found enum `S`
    |
@@ -13,7 +13,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-57741-1.rs:14:22
    |
 LL |     let y = match x {
-   |                   - this match expression has type `std::boxed::Box<u32>`
+   |                   - this match expression requires type `std::boxed::Box<u32>`
 LL |         S::A { a } | S::B { b: a } => a,
    |                      ^^^^^^^^^^^^^ expected struct `std::boxed::Box`, found enum `S`
    |

--- a/src/test/ui/issues/issue-57741.stderr
+++ b/src/test/ui/issues/issue-57741.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |     let y = match x {
    |                   -
    |                   |
-   |                   this match expression has type `std::boxed::Box<T>`
+   |                   this match expression requires type `std::boxed::Box<T>`
    |                   help: consider dereferencing the boxed value: `*x`
 LL |         T::A(a) | T::B(a) => a,
    |         ^^^^^^^ expected struct `std::boxed::Box`, found enum `T`
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL |     let y = match x {
    |                   -
    |                   |
-   |                   this match expression has type `std::boxed::Box<T>`
+   |                   this match expression requires type `std::boxed::Box<T>`
    |                   help: consider dereferencing the boxed value: `*x`
 LL |         T::A(a) | T::B(a) => a,
    |                   ^^^^^^^ expected struct `std::boxed::Box`, found enum `T`
@@ -32,7 +32,7 @@ error[E0308]: mismatched types
 LL |     let y = match x {
    |                   -
    |                   |
-   |                   this match expression has type `std::boxed::Box<S>`
+   |                   this match expression requires type `std::boxed::Box<S>`
    |                   help: consider dereferencing the boxed value: `*x`
 LL |         S::A { a } | S::B { b: a } => a,
    |         ^^^^^^^^^^ expected struct `std::boxed::Box`, found enum `S`
@@ -46,7 +46,7 @@ error[E0308]: mismatched types
 LL |     let y = match x {
    |                   -
    |                   |
-   |                   this match expression has type `std::boxed::Box<S>`
+   |                   this match expression requires type `std::boxed::Box<S>`
    |                   help: consider dereferencing the boxed value: `*x`
 LL |         S::A { a } | S::B { b: a } => a,
    |                      ^^^^^^^^^^^^^ expected struct `std::boxed::Box`, found enum `S`

--- a/src/test/ui/issues/issue-7092.stderr
+++ b/src/test/ui/issues/issue-7092.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-7092.rs:6:9
    |
 LL |     match x {
-   |           - this match expression has type `Whatever`
+   |           - this match expression requires type `Whatever`
 LL |         Some(field) =>
    |         ^^^^^^^^^^^ expected enum `Whatever`, found enum `std::option::Option`
    |

--- a/src/test/ui/match/match-range-fail.stderr
+++ b/src/test/ui/match/match-range-fail.stderr
@@ -28,7 +28,9 @@ error[E0308]: mismatched types
   --> $DIR/match-range-fail.rs:18:9
    |
 LL |         'c' ..= 100 => { }
-   |         ^^^^^^^^^^^ expected integer, found `char`
+   |         ^^^     --- other endpoint has type `{integer}`
+   |         |
+   |         expected integer, found `char`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/match/match-struct.stderr
+++ b/src/test/ui/match/match-struct.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/match-struct.rs:6:9
    |
 LL |     match (S { a: 1 }) {
-   |           ------------ this match expression has type `S`
+   |           ------------ this match expression requires type `S`
 LL |         E::C(_) => (),
    |         ^^^^^^^ expected struct `S`, found enum `E`
 

--- a/src/test/ui/match/match-tag-unary.stderr
+++ b/src/test/ui/match/match-tag-unary.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn main() { let x: A = A::A(0); match x { B::B(y) => { } } }
    |                                       -   ^^^^^^^ expected enum `A`, found enum `B`
    |                                       |
-   |                                       this match expression has type `A`
+   |                                       this match expression requires type `A`
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/pat-tuple-5.stderr
+++ b/src/test/ui/parser/pat-tuple-5.stderr
@@ -17,9 +17,9 @@ error[E0308]: mismatched types
   --> $DIR/pat-tuple-5.rs:5:10
    |
 LL |     match (0, 1) {
-   |           ------ this match expression has type `({integer}, {integer})`
+   |           ------ this match expression requires type `({integer}, {integer})`
 LL |         (PAT ..) => {}
-   |          ^^^^^^ expected tuple, found `u8`
+   |          ^^^ expected tuple, found `u8`
    |
    = note: expected tuple `({integer}, {integer})`
                found type `u8`

--- a/src/test/ui/parser/recover-range-pats.stderr
+++ b/src/test/ui/parser/recover-range-pats.stderr
@@ -417,13 +417,17 @@ error[E0308]: mismatched types
   --> $DIR/recover-range-pats.rs:21:12
    |
 LL |     if let .0..Y = 0 {}
-   |            ^^^^^ expected integer, found floating-point number
+   |            ^^  - other endpoint has type `u8`
+   |            |
+   |            expected integer, found floating-point number
 
 error[E0308]: mismatched types
-  --> $DIR/recover-range-pats.rs:23:12
+  --> $DIR/recover-range-pats.rs:23:16
    |
 LL |     if let X.. .0 = 0 {}
-   |            ^^^^^^ expected integer, found floating-point number
+   |            -   ^^ expected integer, found floating-point number
+   |            |
+   |            other endpoint has type `u8`
 
 error[E0029]: only char and numeric types are allowed in range patterns
   --> $DIR/recover-range-pats.rs:32:12
@@ -445,13 +449,17 @@ error[E0308]: mismatched types
   --> $DIR/recover-range-pats.rs:34:12
    |
 LL |     if let .0..=Y = 0 {}
-   |            ^^^^^^ expected integer, found floating-point number
+   |            ^^   - other endpoint has type `u8`
+   |            |
+   |            expected integer, found floating-point number
 
 error[E0308]: mismatched types
-  --> $DIR/recover-range-pats.rs:36:12
+  --> $DIR/recover-range-pats.rs:36:16
    |
 LL |     if let X..=.0 = 0 {}
-   |            ^^^^^^ expected integer, found floating-point number
+   |            -   ^^ expected integer, found floating-point number
+   |            |
+   |            other endpoint has type `u8`
 
 error[E0029]: only char and numeric types are allowed in range patterns
   --> $DIR/recover-range-pats.rs:45:12
@@ -473,13 +481,17 @@ error[E0308]: mismatched types
   --> $DIR/recover-range-pats.rs:49:12
    |
 LL |     if let .0...Y = 0 {}
-   |            ^^^^^^ expected integer, found floating-point number
+   |            ^^   - other endpoint has type `u8`
+   |            |
+   |            expected integer, found floating-point number
 
 error[E0308]: mismatched types
-  --> $DIR/recover-range-pats.rs:52:12
+  --> $DIR/recover-range-pats.rs:52:17
    |
 LL |     if let X... .0 = 0 {}
-   |            ^^^^^^^ expected integer, found floating-point number
+   |            -    ^^ expected integer, found floating-point number
+   |            |
+   |            other endpoint has type `u8`
 
 error[E0029]: only char and numeric types are allowed in range patterns
   --> $DIR/recover-range-pats.rs:60:12
@@ -491,7 +503,7 @@ error[E0308]: mismatched types
   --> $DIR/recover-range-pats.rs:62:12
    |
 LL |     if let .0.. = 0 {}
-   |            ^^^^ expected integer, found floating-point number
+   |            ^^ expected integer, found floating-point number
 
 error[E0029]: only char and numeric types are allowed in range patterns
   --> $DIR/recover-range-pats.rs:70:12
@@ -503,7 +515,7 @@ error[E0308]: mismatched types
   --> $DIR/recover-range-pats.rs:72:12
    |
 LL |     if let .0..= = 0 {}
-   |            ^^^^^ expected integer, found floating-point number
+   |            ^^ expected integer, found floating-point number
 
 error[E0029]: only char and numeric types are allowed in range patterns
   --> $DIR/recover-range-pats.rs:82:12
@@ -515,7 +527,7 @@ error[E0308]: mismatched types
   --> $DIR/recover-range-pats.rs:85:12
    |
 LL |     if let .0... = 0 {}
-   |            ^^^^^ expected integer, found floating-point number
+   |            ^^ expected integer, found floating-point number
 
 error[E0029]: only char and numeric types are allowed in range patterns
   --> $DIR/recover-range-pats.rs:94:14
@@ -524,10 +536,10 @@ LL |     if let ..true = 0 {}
    |              ^^^^ this is of type `bool` but it should be `char` or numeric
 
 error[E0308]: mismatched types
-  --> $DIR/recover-range-pats.rs:96:12
+  --> $DIR/recover-range-pats.rs:96:15
    |
 LL |     if let .. .0 = 0 {}
-   |            ^^^^^ expected integer, found floating-point number
+   |               ^^ expected integer, found floating-point number
 
 error[E0029]: only char and numeric types are allowed in range patterns
   --> $DIR/recover-range-pats.rs:104:15
@@ -536,10 +548,10 @@ LL |     if let ..=true = 0 {}
    |               ^^^^ this is of type `bool` but it should be `char` or numeric
 
 error[E0308]: mismatched types
-  --> $DIR/recover-range-pats.rs:106:12
+  --> $DIR/recover-range-pats.rs:106:15
    |
 LL |     if let ..=.0 = 0 {}
-   |            ^^^^^ expected integer, found floating-point number
+   |               ^^ expected integer, found floating-point number
 
 error[E0029]: only char and numeric types are allowed in range patterns
   --> $DIR/recover-range-pats.rs:116:15
@@ -548,10 +560,10 @@ LL |     if let ...true = 0 {}
    |               ^^^^ this is of type `bool` but it should be `char` or numeric
 
 error[E0308]: mismatched types
-  --> $DIR/recover-range-pats.rs:119:12
+  --> $DIR/recover-range-pats.rs:119:15
    |
 LL |     if let ....3 = 0 {}
-   |            ^^^^^ expected integer, found floating-point number
+   |               ^^ expected integer, found floating-point number
 
 error: aborting due to 85 previous errors
 

--- a/src/test/ui/pattern/pattern-error-continue.stderr
+++ b/src/test/ui/pattern/pattern-error-continue.stderr
@@ -28,7 +28,7 @@ error[E0308]: mismatched types
   --> $DIR/pattern-error-continue.rs:22:9
    |
 LL |     match 'c' {
-   |           --- this match expression has type `char`
+   |           --- this match expression requires type `char`
 LL |         S { .. } => (),
    |         ^^^^^^^^ expected `char`, found struct `S`
 

--- a/src/test/ui/pattern/pattern-tyvar.stderr
+++ b/src/test/ui/pattern/pattern-tyvar.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/pattern-tyvar.rs:5:18
    |
 LL |     match t {
-   |           - this match expression has type `std::option::Option<std::vec::Vec<isize>>`
+   |           - this match expression requires type `std::option::Option<std::vec::Vec<isize>>`
 LL |       Bar::T1(_, Some::<isize>(x)) => {
    |                  ^^^^^^^^^^^^^^^^ expected struct `std::vec::Vec`, found `isize`
    |

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -630,7 +630,7 @@ error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:67:12
    |
 LL |     if let Range { start: _, end: _ } = true..true && false {}
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression has type `bool`
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression requires type `bool`
    |            |
    |            expected `bool`, found struct `std::ops::Range`
    |
@@ -650,7 +650,7 @@ error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:71:12
    |
 LL |     if let Range { start: _, end: _ } = true..true || false {}
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression has type `bool`
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression requires type `bool`
    |            |
    |            expected `bool`, found struct `std::ops::Range`
    |
@@ -697,7 +697,7 @@ error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:86:12
    |
 LL |     if let Range { start: true, end } = t..&&false {}
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^   - this match expression has type `bool`
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^   - this match expression requires type `bool`
    |            |
    |            expected `bool`, found struct `std::ops::Range`
    |
@@ -818,7 +818,7 @@ error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:131:15
    |
 LL |     while let Range { start: _, end: _ } = true..true && false {}
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression has type `bool`
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression requires type `bool`
    |               |
    |               expected `bool`, found struct `std::ops::Range`
    |
@@ -838,7 +838,7 @@ error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:135:15
    |
 LL |     while let Range { start: _, end: _ } = true..true || false {}
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression has type `bool`
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression requires type `bool`
    |               |
    |               expected `bool`, found struct `std::ops::Range`
    |
@@ -885,7 +885,7 @@ error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:150:15
    |
 LL |     while let Range { start: true, end } = t..&&false {}
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^   - this match expression has type `bool`
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^   - this match expression requires type `bool`
    |               |
    |               expected `bool`, found struct `std::ops::Range`
    |
@@ -961,7 +961,7 @@ error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:198:10
    |
 LL |     (let Range { start: _, end: _ } = true..true || false);
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression has type `bool`
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression requires type `bool`
    |          |
    |          expected `bool`, found struct `std::ops::Range`
    |

--- a/src/test/ui/structs/structure-constructor-type-mismatch.stderr
+++ b/src/test/ui/structs/structure-constructor-type-mismatch.stderr
@@ -86,7 +86,7 @@ error[E0308]: mismatched types
   --> $DIR/structure-constructor-type-mismatch.rs:54:9
    |
 LL |     match (Point { x: 1, y: 2 }) {
-   |           ---------------------- this match expression has type `Point<{integer}>`
+   |           ---------------------- this match expression requires type `Point<{integer}>`
 LL |         PointF::<u32> { .. } => {}
    |         ^^^^^^^^^^^^^^^^^^^^ expected integer, found `f32`
    |
@@ -97,7 +97,7 @@ error[E0308]: mismatched types
   --> $DIR/structure-constructor-type-mismatch.rs:59:9
    |
 LL |     match (Point { x: 1, y: 2 }) {
-   |           ---------------------- this match expression has type `Point<{integer}>`
+   |           ---------------------- this match expression requires type `Point<{integer}>`
 LL |         PointF { .. } => {}
    |         ^^^^^^^^^^^^^ expected integer, found `f32`
    |
@@ -108,7 +108,7 @@ error[E0308]: mismatched types
   --> $DIR/structure-constructor-type-mismatch.rs:67:9
    |
 LL |     match (Pair { x: 1, y: 2 }) {
-   |           --------------------- this match expression has type `Pair<{integer}, {integer}>`
+   |           --------------------- this match expression requires type `Pair<{integer}, {integer}>`
 LL |         PairF::<u32> { .. } => {}
    |         ^^^^^^^^^^^^^^^^^^^ expected integer, found `f32`
    |


### PR DESCRIPTION
closes #57389.
I tried implementing the `expected because of this` note as shown in the example for the original issue, but I decided it would be easier and more useful to just annotate the type for the other endpoint of the range, no matter what.