### PR TITLE
Revert stabilization of never type

### DIFF
--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -195,7 +195,7 @@ mod impls {
         bool char
     }
 
-    #[stable(feature = "never_type", since = "1.41.0")]
+    #[unstable(feature = "never_type", issue = "35121")]
     impl Clone for ! {
         #[inline]
         fn clone(&self) -> Self {

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -1141,24 +1141,24 @@ mod impls {
 
     ord_impl! { char usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 
-    #[stable(feature = "never_type", since = "1.41.0")]
+    #[unstable(feature = "never_type", issue = "35121")]
     impl PartialEq for ! {
         fn eq(&self, _: &!) -> bool {
             *self
         }
     }
 
-    #[stable(feature = "never_type", since = "1.41.0")]
+    #[unstable(feature = "never_type", issue = "35121")]
     impl Eq for ! {}
 
-    #[stable(feature = "never_type", since = "1.41.0")]
+    #[unstable(feature = "never_type", issue = "35121")]
     impl PartialOrd for ! {
         fn partial_cmp(&self, _: &!) -> Option<Ordering> {
             *self
         }
     }
 
-    #[stable(feature = "never_type", since = "1.41.0")]
+    #[unstable(feature = "never_type", issue = "35121")]
     impl Ord for ! {
         fn cmp(&self, _: &!) -> Ordering {
             *self

--- a/src/libcore/convert/mod.rs
+++ b/src/libcore/convert/mod.rs
@@ -40,6 +40,8 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+use crate::fmt;
+
 mod num;
 
 #[unstable(feature = "convert_float_to_int", issue = "67057")]
@@ -429,7 +431,9 @@ pub trait TryInto<T>: Sized {
 /// - `TryFrom<T> for U` implies [`TryInto`]`<U> for T`
 /// - [`try_from`] is reflexive, which means that `TryFrom<T> for T`
 /// is implemented and cannot fail -- the associated `Error` type for
-/// calling `T::try_from()` on a value of type `T` is [`!`].
+/// calling `T::try_from()` on a value of type `T` is [`Infallible`].
+/// When the [`!`] type is stabilized [`Infallible`] and [`!`] will be
+/// equivalent.
 ///
 /// `TryFrom<T>` can be implemented as follows:
 ///
@@ -478,6 +482,7 @@ pub trait TryInto<T>: Sized {
 /// [`TryInto`]: trait.TryInto.html
 /// [`i32::MAX`]: ../../std/i32/constant.MAX.html
 /// [`!`]: ../../std/primitive.never.html
+/// [`Infallible`]: enum.Infallible.html
 #[stable(feature = "try_from", since = "1.34.0")]
 pub trait TryFrom<T>: Sized {
     /// The type returned in the event of a conversion error.
@@ -633,9 +638,9 @@ impl AsRef<str> for str {
 // THE NO-ERROR ERROR TYPE
 ////////////////////////////////////////////////////////////////////////////////
 
-/// A type alias for [the `!` “never” type][never].
+/// The error type for errors that can never happen.
 ///
-/// `Infallible` represents types of errors that can never happen since `!` has no valid values.
+/// Since this enum has no variant, a value of this type can never actually exist.
 /// This can be useful for generic APIs that use [`Result`] and parameterize the error type,
 /// to indicate that the result is always [`Ok`].
 ///
@@ -652,10 +657,33 @@ impl AsRef<str> for str {
 /// }
 /// ```
 ///
-/// # Eventual deprecation
+/// # Future compatibility
 ///
-/// Previously, `Infallible` was defined as `enum Infallible {}`.
-/// Now that it is merely a type alias to `!`, we will eventually deprecate `Infallible`.
+/// This enum has the same role as [the `!` “never” type][never],
+/// which is unstable in this version of Rust.
+/// When `!` is stabilized, we plan to make `Infallible` a type alias to it:
+///
+/// ```ignore (illustrates future std change)
+/// pub type Infallible = !;
+/// ```
+///
+/// … and eventually deprecate `Infallible`.
+///
+///
+/// However there is one case where `!` syntax can be used
+/// before `!` is stabilized as a full-fleged type: in the position of a function’s return type.
+/// Specifically, it is possible implementations for two different function pointer types:
+///
+/// ```
+/// trait MyTrait {}
+/// impl MyTrait for fn() -> ! {}
+/// impl MyTrait for fn() -> std::convert::Infallible {}
+/// ```
+///
+/// With `Infallible` being an enum, this code is valid.
+/// However when `Infallible` becomes an alias for the never type,
+/// the two `impl`s will start to overlap
+/// and therefore will be disallowed by the language’s trait coherence rules.
 ///
 /// [`Ok`]: ../result/enum.Result.html#variant.Ok
 /// [`Result`]: ../result/enum.Result.html
@@ -663,4 +691,57 @@ impl AsRef<str> for str {
 /// [`Into`]: trait.Into.html
 /// [never]: ../../std/primitive.never.html
 #[stable(feature = "convert_infallible", since = "1.34.0")]
-pub type Infallible = !;
+#[derive(Copy)]
+pub enum Infallible {}
+
+#[stable(feature = "convert_infallible", since = "1.34.0")]
+impl Clone for Infallible {
+    fn clone(&self) -> Infallible {
+        match *self {}
+    }
+}
+
+#[stable(feature = "convert_infallible", since = "1.34.0")]
+impl fmt::Debug for Infallible {
+    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {}
+    }
+}
+
+#[stable(feature = "convert_infallible", since = "1.34.0")]
+impl fmt::Display for Infallible {
+    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {}
+    }
+}
+
+#[stable(feature = "convert_infallible", since = "1.34.0")]
+impl PartialEq for Infallible {
+    fn eq(&self, _: &Infallible) -> bool {
+        match *self {}
+    }
+}
+
+#[stable(feature = "convert_infallible", since = "1.34.0")]
+impl Eq for Infallible {}
+
+#[stable(feature = "convert_infallible", since = "1.34.0")]
+impl PartialOrd for Infallible {
+    fn partial_cmp(&self, _other: &Self) -> Option<crate::cmp::Ordering> {
+        match *self {}
+    }
+}
+
+#[stable(feature = "convert_infallible", since = "1.34.0")]
+impl Ord for Infallible {
+    fn cmp(&self, _other: &Self) -> crate::cmp::Ordering {
+        match *self {}
+    }
+}
+
+#[stable(feature = "convert_infallible", since = "1.34.0")]
+impl From<!> for Infallible {
+    fn from(x: !) -> Self {
+        x
+    }
+}

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1940,14 +1940,14 @@ macro_rules! fmt_refs {
 
 fmt_refs! { Debug, Display, Octal, Binary, LowerHex, UpperHex, LowerExp, UpperExp }
 
-#[stable(feature = "never_type", since = "1.41.0")]
+#[unstable(feature = "never_type", issue = "35121")]
 impl Debug for ! {
     fn fmt(&self, _: &mut Formatter<'_>) -> Result {
         *self
     }
 }
 
-#[stable(feature = "never_type", since = "1.41.0")]
+#[unstable(feature = "never_type", issue = "35121")]
 impl Display for ! {
     fn fmt(&self, _: &mut Formatter<'_>) -> Result {
         *self

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -87,7 +87,7 @@
 #![feature(iter_once_with)]
 #![feature(lang_items)]
 #![feature(link_llvm_intrinsics)]
-#![cfg_attr(bootstrap, feature(never_type))]
+#![feature(never_type)]
 #![feature(nll)]
 #![feature(exhaustive_patterns)]
 #![feature(no_core)]

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -776,7 +776,7 @@ mod copy_impls {
         bool char
     }
 
-    #[stable(feature = "never_type", since = "1.41.0")]
+    #[unstable(feature = "never_type", issue = "35121")]
     impl Copy for ! {}
 
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -4731,7 +4731,7 @@ impl From<Infallible> for TryFromIntError {
     }
 }
 
-#[stable(feature = "never_type", since = "1.41.0")]
+#[unstable(feature = "never_type", issue = "35121")]
 impl From<!> for TryFromIntError {
     fn from(never: !) -> TryFromIntError {
         // Match rather than coerce to make sure that code like

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -4,6 +4,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+use crate::convert::Infallible;
 use crate::fmt;
 use crate::intrinsics;
 use crate::mem;
@@ -4724,8 +4725,18 @@ impl fmt::Display for TryFromIntError {
 }
 
 #[stable(feature = "try_from", since = "1.34.0")]
+impl From<Infallible> for TryFromIntError {
+    fn from(x: Infallible) -> TryFromIntError {
+        match x {}
+    }
+}
+
+#[stable(feature = "never_type", since = "1.41.0")]
 impl From<!> for TryFromIntError {
     fn from(never: !) -> TryFromIntError {
+        // Match rather than coerce to make sure that code like
+        // `From<Infallible> for TryFromIntError` above will keep working
+        // when `Infallible` becomes an alias to `!`.
         match never {}
     }
 }

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -37,7 +37,7 @@
 #![feature(core_intrinsics)]
 #![feature(drain_filter)]
 #![cfg_attr(windows, feature(libc))]
-#![cfg_attr(bootstrap, feature(never_type))]
+#![feature(never_type)]
 #![feature(exhaustive_patterns)]
 #![feature(overlapping_marker_traits)]
 #![feature(extern_types)]

--- a/src/librustc_codegen_utils/lib.rs
+++ b/src/librustc_codegen_utils/lib.rs
@@ -8,7 +8,7 @@
 #![feature(box_patterns)]
 #![feature(box_syntax)]
 #![feature(core_intrinsics)]
-#![cfg_attr(bootstrap, feature(never_type))]
+#![feature(never_type)]
 #![feature(nll)]
 #![feature(in_band_lifetimes)]
 

--- a/src/librustc_error_codes/error_codes/E0725.md
+++ b/src/librustc_error_codes/error_codes/E0725.md
@@ -4,8 +4,8 @@ command line flags.
 Erroneous code example:
 
 ```ignore (can't specify compiler flags from doctests)
-#![feature(specialization)] // error: the feature `specialization` is not in
-                            // the list of allowed features
+#![feature(never_type)] // error: the feature `never_type` is not in
+                        // the list of allowed features
 ```
 
 Delete the offending feature attribute, or add it to the list of allowed

--- a/src/librustc_feature/accepted.rs
+++ b/src/librustc_feature/accepted.rs
@@ -253,8 +253,6 @@ declare_features! (
     (accepted, const_constructor, "1.40.0", Some(61456), None),
     /// Allows the use of `#[cfg(doctest)]`, set when rustdoc is collecting doctests.
     (accepted, cfg_doctest, "1.40.0", Some(62210), None),
-    /// Allows the `!` type. Does not imply 'exhaustive_patterns' any more.
-    (accepted, never_type, "1.41.0", Some(35121), None),
     /// Allows relaxing the coherence rules such that
     /// `impl<T> ForeignTrait<LocalType> for ForeignType<T>` is permitted.
     (accepted, re_rebalance_coherence, "1.41.0", Some(55437), None),

--- a/src/librustc_feature/active.rs
+++ b/src/librustc_feature/active.rs
@@ -307,6 +307,9 @@ declare_features! (
     /// Allows `X..Y` patterns.
     (active, exclusive_range_pattern, "1.11.0", Some(37854), None),
 
+    /// Allows the `!` type. Does not imply 'exhaustive_patterns' (below) any more.
+    (active, never_type, "1.13.0", Some(35121), None),
+
     /// Allows exhaustive pattern matching on types that contain uninhabited types.
     (active, exhaustive_patterns, "1.13.0", Some(51085), None),
 

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -18,7 +18,7 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 #![feature(drain_filter)]
 #![feature(exhaustive_patterns)]
 #![feature(iter_order_by)]
-#![cfg_attr(bootstrap, feature(never_type))]
+#![feature(never_type)]
 #![feature(specialization)]
 #![feature(try_trait)]
 #![feature(unicode_internals)]

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -67,7 +67,7 @@ This API is completely unstable and subject to change.
 #![feature(in_band_lifetimes)]
 #![feature(nll)]
 #![feature(slice_patterns)]
-#![cfg_attr(bootstrap, feature(never_type))]
+#![feature(never_type)]
 
 #![recursion_limit="256"]
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -14,7 +14,7 @@
 #![feature(crate_visibility_modifier)]
 #![feature(const_fn)]
 #![feature(drain_filter)]
-#![cfg_attr(bootstrap, feature(never_type))]
+#![feature(never_type)]
 #![feature(unicode_internals)]
 
 #![recursion_limit="256"]

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -11,7 +11,7 @@ Core encoding and decoding interfaces.
 #![feature(box_syntax)]
 #![feature(core_intrinsics)]
 #![feature(specialization)]
-#![cfg_attr(bootstrap, feature(never_type))]
+#![feature(never_type)]
 #![feature(nll)]
 #![feature(associated_type_bounds)]
 #![cfg_attr(test, feature(test))]

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -551,6 +551,13 @@ impl Error for string::FromUtf16Error {
     }
 }
 
+#[stable(feature = "str_parse_error2", since = "1.8.0")]
+impl Error for string::ParseError {
+    fn description(&self) -> &str {
+        match *self {}
+    }
+}
+
 #[stable(feature = "decode_utf16", since = "1.9.0")]
 impl Error for char::DecodeUtf16Error {
     fn description(&self) -> &str {

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -465,7 +465,7 @@ impl<'a> From<Cow<'a, str>> for Box<dyn Error> {
     }
 }
 
-#[stable(feature = "never_type", since = "1.41.0")]
+#[unstable(feature = "never_type", issue = "35121")]
 impl Error for ! {
     fn description(&self) -> &str { *self }
 }

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -281,7 +281,7 @@
 #![feature(maybe_uninit_ref)]
 #![feature(maybe_uninit_slice)]
 #![feature(needs_panic_runtime)]
-#![cfg_attr(bootstrap, feature(never_type))]
+#![feature(never_type)]
 #![feature(nll)]
 #![cfg_attr(bootstrap, feature(on_unimplemented))]
 #![feature(optin_builtin_traits)]

--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -71,6 +71,7 @@ mod prim_bool { }
 /// write:
 ///
 /// ```
+/// #![feature(never_type)]
 /// # fn foo() -> u32 {
 /// let x: ! = {
 ///     return 123
@@ -200,6 +201,7 @@ mod prim_bool { }
 /// for example:
 ///
 /// ```
+/// #![feature(never_type)]
 /// # use std::fmt;
 /// # trait Debug {
 /// # fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result;
@@ -237,7 +239,7 @@ mod prim_bool { }
 /// [`Default`]: default/trait.Default.html
 /// [`default()`]: default/trait.Default.html#tymethod.default
 ///
-#[stable(feature = "never_type", since = "1.41.0")]
+#[unstable(feature = "never_type", issue = "35121")]
 mod prim_never { }
 
 #[doc(primitive = "char")]

--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -464,9 +464,23 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
             ast::TyKind::BareFn(ref bare_fn_ty) => {
                 self.check_extern(bare_fn_ty.ext);
             }
+            ast::TyKind::Never => {
+                gate_feature_post!(&self, never_type, ty.span,
+                                   "The `!` type is experimental");
+            }
             _ => {}
         }
         visit::walk_ty(self, ty)
+    }
+
+    fn visit_fn_ret_ty(&mut self, ret_ty: &'a ast::FunctionRetTy) {
+        if let ast::FunctionRetTy::Ty(ref output_ty) = *ret_ty {
+            if let ast::TyKind::Never = output_ty.kind {
+                // Do nothing.
+            } else {
+                self.visit_ty(output_ty)
+            }
+        }
     }
 
     fn visit_expr(&mut self, e: &'a ast::Expr) {
@@ -497,6 +511,10 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
             _ => {}
         }
         visit::walk_expr(self, e)
+    }
+
+    fn visit_arm(&mut self, arm: &'a ast::Arm) {
+        visit::walk_arm(self, arm)
     }
 
     fn visit_pat(&mut self, pattern: &'a ast::Pat) {

--- a/src/test/codegen/enum-debug-niche-2.rs
+++ b/src/test/codegen/enum-debug-niche-2.rs
@@ -12,6 +12,8 @@
 // CHECK: {{.*}}DIDerivedType{{.*}}tag: DW_TAG_member,{{.*}}name: "Placeholder",{{.*}}extraData: i64 4294967295{{[,)].*}}
 // CHECK: {{.*}}DIDerivedType{{.*}}tag: DW_TAG_member,{{.*}}name: "Error",{{.*}}extraData: i64 0{{[,)].*}}
 
+#![feature(never_type)]
+
 #[derive(Copy, Clone)]
 pub struct Entity {
     private: std::num::NonZeroU32,

--- a/src/test/mir-opt/retain-never-const.rs
+++ b/src/test/mir-opt/retain-never-const.rs
@@ -5,6 +5,7 @@
 // compile-flags: --emit mir,link
 
 #![feature(const_panic)]
+#![feature(never_type)]
 
 struct PrintName<T>(T);
 

--- a/src/test/mir-opt/uninhabited-enum.rs
+++ b/src/test/mir-opt/uninhabited-enum.rs
@@ -1,3 +1,5 @@
+#![feature(never_type)]
+
 pub enum Void {}
 
 #[no_mangle]

--- a/src/test/ui/binding/empty-types-in-patterns.rs
+++ b/src/test/ui/binding/empty-types-in-patterns.rs
@@ -1,5 +1,5 @@
 // run-pass
-#![feature(never_type_fallback)]
+#![feature(never_type, never_type_fallback)]
 #![feature(exhaustive_patterns)]
 #![feature(slice_patterns)]
 #![allow(unreachable_patterns)]

--- a/src/test/ui/borrowck/assign-never-type.rs
+++ b/src/test/ui/borrowck/assign-never-type.rs
@@ -2,6 +2,8 @@
 
 // check-pass
 
+#![feature(never_type)]
+
 pub fn main() {
     loop {
         match None {

--- a/src/test/ui/break-while-condition.rs
+++ b/src/test/ui/break-while-condition.rs
@@ -1,3 +1,5 @@
+#![feature(never_type)]
+
 fn main() {
     // The `if false` expressions are simply to
     // make sure we don't avoid checking everything

--- a/src/test/ui/break-while-condition.stderr
+++ b/src/test/ui/break-while-condition.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/break-while-condition.rs:7:20
+  --> $DIR/break-while-condition.rs:9:20
    |
 LL |           let _: ! = {
    |  ____________________^
@@ -11,7 +11,7 @@ LL | |         };
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/break-while-condition.rs:14:13
+  --> $DIR/break-while-condition.rs:16:13
    |
 LL | /             while false {
 LL | |                 break
@@ -22,7 +22,7 @@ LL | |             }
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/break-while-condition.rs:22:13
+  --> $DIR/break-while-condition.rs:24:13
    |
 LL | /             while false {
 LL | |                 return

--- a/src/test/ui/coercion/coerce-issue-49593-box-never.rs
+++ b/src/test/ui/coercion/coerce-issue-49593-box-never.rs
@@ -1,5 +1,5 @@
 // check-pass
-#![feature(never_type_fallback)]
+#![feature(never_type, never_type_fallback)]
 #![allow(unreachable_code)]
 
 use std::error::Error;

--- a/src/test/ui/coercion/coerce-to-bang-cast.rs
+++ b/src/test/ui/coercion/coerce-to-bang-cast.rs
@@ -1,3 +1,5 @@
+#![feature(never_type)]
+
 fn foo(x: usize, y: !, z: usize) { }
 
 fn cast_a() {

--- a/src/test/ui/coercion/coerce-to-bang-cast.stderr
+++ b/src/test/ui/coercion/coerce-to-bang-cast.stderr
@@ -1,5 +1,5 @@
 error[E0605]: non-primitive cast: `i32` as `!`
-  --> $DIR/coerce-to-bang-cast.rs:4:13
+  --> $DIR/coerce-to-bang-cast.rs:6:13
    |
 LL |     let y = {return; 22} as !;
    |             ^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     let y = {return; 22} as !;
    = note: an `as` expression can only be used to convert between primitive types. Consider using the `From` trait
 
 error[E0605]: non-primitive cast: `i32` as `!`
-  --> $DIR/coerce-to-bang-cast.rs:9:13
+  --> $DIR/coerce-to-bang-cast.rs:11:13
    |
 LL |     let y = 22 as !;
    |             ^^^^^^^

--- a/src/test/ui/coercion/coerce-to-bang.rs
+++ b/src/test/ui/coercion/coerce-to-bang.rs
@@ -1,3 +1,5 @@
+#![feature(never_type)]
+
 fn foo(x: usize, y: !, z: usize) { }
 
 fn call_foo_a() {

--- a/src/test/ui/coercion/coerce-to-bang.stderr
+++ b/src/test/ui/coercion/coerce-to-bang.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/coerce-to-bang.rs:4:17
+  --> $DIR/coerce-to-bang.rs:6:17
    |
 LL |     foo(return, 22, 44);
    |                 ^^ expected `!`, found integer
@@ -8,7 +8,7 @@ LL |     foo(return, 22, 44);
               found type `{integer}`
 
 error[E0308]: mismatched types
-  --> $DIR/coerce-to-bang.rs:16:13
+  --> $DIR/coerce-to-bang.rs:18:13
    |
 LL |     foo(22, 44, return);
    |             ^^ expected `!`, found integer
@@ -17,7 +17,7 @@ LL |     foo(22, 44, return);
               found type `{integer}`
 
 error[E0308]: mismatched types
-  --> $DIR/coerce-to-bang.rs:24:12
+  --> $DIR/coerce-to-bang.rs:26:12
    |
 LL |     foo(a, b, c); // ... and hence a reference to `a` is expected to diverge.
    |            ^ expected `!`, found integer
@@ -26,7 +26,7 @@ LL |     foo(a, b, c); // ... and hence a reference to `a` is expected to diverg
               found type `{integer}`
 
 error[E0308]: mismatched types
-  --> $DIR/coerce-to-bang.rs:34:12
+  --> $DIR/coerce-to-bang.rs:36:12
    |
 LL |     foo(a, b, c);
    |            ^ expected `!`, found integer
@@ -35,7 +35,7 @@ LL |     foo(a, b, c);
               found type `{integer}`
 
 error[E0308]: mismatched types
-  --> $DIR/coerce-to-bang.rs:43:12
+  --> $DIR/coerce-to-bang.rs:45:12
    |
 LL |     foo(a, b, c);
    |            ^ expected `!`, found integer
@@ -44,7 +44,7 @@ LL |     foo(a, b, c);
               found type `{integer}`
 
 error[E0308]: mismatched types
-  --> $DIR/coerce-to-bang.rs:48:21
+  --> $DIR/coerce-to-bang.rs:50:21
    |
 LL |     let x: [!; 2] = [return, 22];
    |            ------   ^^^^^^^^^^^^ expected `!`, found integer
@@ -55,7 +55,7 @@ LL |     let x: [!; 2] = [return, 22];
               found array `[{integer}; 2]`
 
 error[E0308]: mismatched types
-  --> $DIR/coerce-to-bang.rs:53:22
+  --> $DIR/coerce-to-bang.rs:55:22
    |
 LL |     let x: [!; 2] = [22, return];
    |                      ^^ expected `!`, found integer
@@ -64,7 +64,7 @@ LL |     let x: [!; 2] = [22, return];
               found type `{integer}`
 
 error[E0308]: mismatched types
-  --> $DIR/coerce-to-bang.rs:58:37
+  --> $DIR/coerce-to-bang.rs:60:37
    |
 LL |     let x: (usize, !, usize) = (22, 44, 66);
    |                                     ^^ expected `!`, found integer
@@ -73,7 +73,7 @@ LL |     let x: (usize, !, usize) = (22, 44, 66);
               found type `{integer}`
 
 error[E0308]: mismatched types
-  --> $DIR/coerce-to-bang.rs:63:41
+  --> $DIR/coerce-to-bang.rs:65:41
    |
 LL |     let x: (usize, !, usize) = (return, 44, 66);
    |                                         ^^ expected `!`, found integer
@@ -82,7 +82,7 @@ LL |     let x: (usize, !, usize) = (return, 44, 66);
               found type `{integer}`
 
 error[E0308]: mismatched types
-  --> $DIR/coerce-to-bang.rs:74:37
+  --> $DIR/coerce-to-bang.rs:76:37
    |
 LL |     let x: (usize, !, usize) = (22, 44, return);
    |                                     ^^ expected `!`, found integer

--- a/src/test/ui/consts/const-eval/index-out-of-bounds-never-type.rs
+++ b/src/test/ui/consts/const-eval/index-out-of-bounds-never-type.rs
@@ -1,5 +1,6 @@
 // Regression test for #66975
 #![warn(const_err)]
+#![feature(never_type)]
 
 struct PrintName<T>(T);
 

--- a/src/test/ui/consts/const-eval/index-out-of-bounds-never-type.stderr
+++ b/src/test/ui/consts/const-eval/index-out-of-bounds-never-type.stderr
@@ -1,5 +1,5 @@
 warning: any use of this value will cause an error
-  --> $DIR/index-out-of-bounds-never-type.rs:7:61
+  --> $DIR/index-out-of-bounds-never-type.rs:8:61
    |
 LL |     const VOID: ! = { let x = 0 * std::mem::size_of::<T>(); [][x] };
    |     --------------------------------------------------------^^^^^---
@@ -13,7 +13,7 @@ LL | #![warn(const_err)]
    |         ^^^^^^^^^
 
 error: erroneous constant encountered
-  --> $DIR/index-out-of-bounds-never-type.rs:12:13
+  --> $DIR/index-out-of-bounds-never-type.rs:13:13
    |
 LL |     let _ = PrintName::<T>::VOID;
    |             ^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/consts/const-eval/panic-assoc-never-type.rs
+++ b/src/test/ui/consts/const-eval/panic-assoc-never-type.rs
@@ -1,6 +1,7 @@
 // Regression test for #66975
 #![warn(const_err)]
 #![feature(const_panic)]
+#![feature(never_type)]
 
 struct PrintName;
 

--- a/src/test/ui/consts/const-eval/panic-assoc-never-type.stderr
+++ b/src/test/ui/consts/const-eval/panic-assoc-never-type.stderr
@@ -1,10 +1,10 @@
 warning: any use of this value will cause an error
-  --> $DIR/panic-assoc-never-type.rs:8:21
+  --> $DIR/panic-assoc-never-type.rs:9:21
    |
 LL |     const VOID: ! = panic!();
    |     ----------------^^^^^^^^-
    |                     |
-   |                     the evaluated program panicked at 'explicit panic', $DIR/panic-assoc-never-type.rs:8:21
+   |                     the evaluated program panicked at 'explicit panic', $DIR/panic-assoc-never-type.rs:9:21
    |
 note: lint level defined here
   --> $DIR/panic-assoc-never-type.rs:2:9
@@ -14,7 +14,7 @@ LL | #![warn(const_err)]
    = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error[E0080]: erroneous constant used
-  --> $DIR/panic-assoc-never-type.rs:13:13
+  --> $DIR/panic-assoc-never-type.rs:14:13
    |
 LL |     let _ = PrintName::VOID;
    |             ^^^^^^^^^^^^^^^ referenced constant has errors

--- a/src/test/ui/consts/const-eval/panic-never-type.rs
+++ b/src/test/ui/consts/const-eval/panic-never-type.rs
@@ -1,6 +1,7 @@
 // Regression test for #66975
 #![warn(const_err)]
 #![feature(const_panic)]
+#![feature(never_type)]
 
 const VOID: ! = panic!();
 //~^ WARN any use of this value will cause an error

--- a/src/test/ui/consts/const-eval/panic-never-type.stderr
+++ b/src/test/ui/consts/const-eval/panic-never-type.stderr
@@ -1,10 +1,10 @@
 warning: any use of this value will cause an error
-  --> $DIR/panic-never-type.rs:5:17
+  --> $DIR/panic-never-type.rs:6:17
    |
 LL | const VOID: ! = panic!();
    | ----------------^^^^^^^^-
    |                 |
-   |                 the evaluated program panicked at 'explicit panic', $DIR/panic-never-type.rs:5:17
+   |                 the evaluated program panicked at 'explicit panic', $DIR/panic-never-type.rs:6:17
    |
 note: lint level defined here
   --> $DIR/panic-never-type.rs:2:9
@@ -14,7 +14,7 @@ LL | #![warn(const_err)]
    = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error[E0080]: erroneous constant used
-  --> $DIR/panic-never-type.rs:9:13
+  --> $DIR/panic-never-type.rs:10:13
    |
 LL |     let _ = VOID;
    |             ^^^^ referenced constant has errors

--- a/src/test/ui/consts/validate_never_arrays.rs
+++ b/src/test/ui/consts/validate_never_arrays.rs
@@ -1,4 +1,4 @@
-#![feature(const_raw_ptr_deref)]
+#![feature(const_raw_ptr_deref, never_type)]
 
 const FOO: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) }; //~ ERROR undefined behavior
 

--- a/src/test/ui/empty/empty-never-array.rs
+++ b/src/test/ui/empty/empty-never-array.rs
@@ -1,3 +1,5 @@
+#![feature(never_type)]
+
 enum Helper<T, U> {
     T(T, [!; 0]),
     #[allow(dead_code)]

--- a/src/test/ui/empty/empty-never-array.stderr
+++ b/src/test/ui/empty/empty-never-array.stderr
@@ -1,5 +1,5 @@
 error[E0005]: refutable pattern in local binding: `T(_, _)` not covered
-  --> $DIR/empty-never-array.rs:8:9
+  --> $DIR/empty-never-array.rs:10:9
    |
 LL | / enum Helper<T, U> {
 LL | |     T(T, [!; 0]),
@@ -20,7 +20,7 @@ LL |     if let Helper::U(u) = Helper::T(t, []) { /* */ }
    |
 
 error[E0381]: use of possibly-uninitialized variable: `u`
-  --> $DIR/empty-never-array.rs:10:5
+  --> $DIR/empty-never-array.rs:12:5
    |
 LL |     u
    |     ^ use of possibly-uninitialized `u`

--- a/src/test/ui/feature-gates/feature-gate-exhaustive-patterns.rs
+++ b/src/test/ui/feature-gates/feature-gate-exhaustive-patterns.rs
@@ -1,3 +1,5 @@
+#![feature(never_type)]
+
 fn foo() -> Result<u32, !> {
     Ok(123)
 }

--- a/src/test/ui/feature-gates/feature-gate-exhaustive-patterns.stderr
+++ b/src/test/ui/feature-gates/feature-gate-exhaustive-patterns.stderr
@@ -1,5 +1,5 @@
 error[E0005]: refutable pattern in local binding: `Err(_)` not covered
-  --> $DIR/feature-gate-exhaustive-patterns.rs:6:9
+  --> $DIR/feature-gate-exhaustive-patterns.rs:8:9
    |
 LL |     let Ok(_x) = foo();
    |         ^^^^^^ pattern `Err(_)` not covered

--- a/src/test/ui/feature-gates/feature-gate-never_type.rs
+++ b/src/test/ui/feature-gates/feature-gate-never_type.rs
@@ -1,0 +1,17 @@
+// Test that ! errors when used in illegal positions with feature(never_type) disabled
+
+trait Foo {
+    type Wub;
+}
+
+type Ma = (u32, !, i32); //~ ERROR type is experimental
+type Meeshka = Vec<!>; //~ ERROR type is experimental
+type Mow = &'static fn(!) -> !; //~ ERROR type is experimental
+type Skwoz = &'static mut !; //~ ERROR type is experimental
+
+impl Foo for Meeshka {
+    type Wub = !; //~ ERROR type is experimental
+}
+
+fn main() {
+}

--- a/src/test/ui/feature-gates/feature-gate-never_type.stderr
+++ b/src/test/ui/feature-gates/feature-gate-never_type.stderr
@@ -1,0 +1,48 @@
+error[E0658]: The `!` type is experimental
+  --> $DIR/feature-gate-never_type.rs:7:17
+   |
+LL | type Ma = (u32, !, i32);
+   |                 ^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/35121
+   = help: add `#![feature(never_type)]` to the crate attributes to enable
+
+error[E0658]: The `!` type is experimental
+  --> $DIR/feature-gate-never_type.rs:8:20
+   |
+LL | type Meeshka = Vec<!>;
+   |                    ^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/35121
+   = help: add `#![feature(never_type)]` to the crate attributes to enable
+
+error[E0658]: The `!` type is experimental
+  --> $DIR/feature-gate-never_type.rs:9:24
+   |
+LL | type Mow = &'static fn(!) -> !;
+   |                        ^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/35121
+   = help: add `#![feature(never_type)]` to the crate attributes to enable
+
+error[E0658]: The `!` type is experimental
+  --> $DIR/feature-gate-never_type.rs:10:27
+   |
+LL | type Skwoz = &'static mut !;
+   |                           ^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/35121
+   = help: add `#![feature(never_type)]` to the crate attributes to enable
+
+error[E0658]: The `!` type is experimental
+  --> $DIR/feature-gate-never_type.rs:13:16
+   |
+LL |     type Wub = !;
+   |                ^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/35121
+   = help: add `#![feature(never_type)]` to the crate attributes to enable
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/for-loop-while/loop-break-value.rs
+++ b/src/test/ui/for-loop-while/loop-break-value.rs
@@ -1,6 +1,7 @@
 // run-pass
 
 #![allow(unreachable_code)]
+#![feature(never_type)]
 
 #[allow(unused)]
 fn never_returns() {

--- a/src/test/ui/lint/must_use-unit.rs
+++ b/src/test/ui/lint/must_use-unit.rs
@@ -1,3 +1,4 @@
+#![feature(never_type)]
 #![deny(unused_must_use)]
 
 #[must_use]

--- a/src/test/ui/lint/must_use-unit.stderr
+++ b/src/test/ui/lint/must_use-unit.stderr
@@ -1,17 +1,17 @@
 error: unused return value of `foo` that must be used
-  --> $DIR/must_use-unit.rs:12:5
+  --> $DIR/must_use-unit.rs:13:5
    |
 LL |     foo();
    |     ^^^^^^
    |
 note: lint level defined here
-  --> $DIR/must_use-unit.rs:1:9
+  --> $DIR/must_use-unit.rs:2:9
    |
 LL | #![deny(unused_must_use)]
    |         ^^^^^^^^^^^^^^^
 
 error: unused return value of `bar` that must be used
-  --> $DIR/must_use-unit.rs:14:5
+  --> $DIR/must_use-unit.rs:15:5
    |
 LL |     bar();
    |     ^^^^^^

--- a/src/test/ui/lint/uninitialized-zeroed.rs
+++ b/src/test/ui/lint/uninitialized-zeroed.rs
@@ -2,7 +2,7 @@
 // This test checks that calling `mem::{uninitialized,zeroed}` with certain types results
 // in a lint.
 
-#![feature(rustc_attrs)]
+#![feature(never_type, rustc_attrs)]
 #![allow(deprecated)]
 #![deny(invalid_value)]
 

--- a/src/test/ui/loops/loop-break-value.rs
+++ b/src/test/ui/loops/loop-break-value.rs
@@ -1,3 +1,5 @@
+#![feature(never_type)]
+
 fn main() {
     let val: ! = loop { break break; };
     //~^ ERROR mismatched types

--- a/src/test/ui/loops/loop-break-value.stderr
+++ b/src/test/ui/loops/loop-break-value.stderr
@@ -1,5 +1,5 @@
 warning: denote infinite loops with `loop { ... }`
-  --> $DIR/loop-break-value.rs:24:5
+  --> $DIR/loop-break-value.rs:26:5
    |
 LL |     'while_loop: while true {
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use `loop`
@@ -7,7 +7,7 @@ LL |     'while_loop: while true {
    = note: `#[warn(while_true)]` on by default
 
 error[E0571]: `break` with value from a `while` loop
-  --> $DIR/loop-break-value.rs:26:9
+  --> $DIR/loop-break-value.rs:28:9
    |
 LL |         break ();
    |         ^^^^^^^^ can only break with a value inside `loop` or breakable block
@@ -18,7 +18,7 @@ LL |         break;
    |         ^^^^^
 
 error[E0571]: `break` with value from a `while` loop
-  --> $DIR/loop-break-value.rs:28:13
+  --> $DIR/loop-break-value.rs:30:13
    |
 LL |             break 'while_loop 123;
    |             ^^^^^^^^^^^^^^^^^^^^^ can only break with a value inside `loop` or breakable block
@@ -62,7 +62,7 @@ LL |             break;
    |             ^^^^^
 
 error[E0571]: `break` with value from a `for` loop
-  --> $DIR/loop-break-value.rs:54:9
+  --> $DIR/loop-break-value.rs:56:9
    |
 LL |         break ();
    |         ^^^^^^^^ can only break with a value inside `loop` or breakable block
@@ -73,7 +73,7 @@ LL |         break;
    |         ^^^^^
 
 error[E0571]: `break` with value from a `for` loop
-  --> $DIR/loop-break-value.rs:55:9
+  --> $DIR/loop-break-value.rs:57:9
    |
 LL |         break [()];
    |         ^^^^^^^^^^ can only break with a value inside `loop` or breakable block
@@ -84,7 +84,7 @@ LL |         break;
    |         ^^^^^
 
 error[E0571]: `break` with value from a `for` loop
-  --> $DIR/loop-break-value.rs:62:13
+  --> $DIR/loop-break-value.rs:64:13
    |
 LL |             break 'for_loop Some(17);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ can only break with a value inside `loop` or breakable block
@@ -95,7 +95,7 @@ LL |             break;
    |             ^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:2:31
+  --> $DIR/loop-break-value.rs:4:31
    |
 LL |     let val: ! = loop { break break; };
    |                               ^^^^^ expected `!`, found `()`
@@ -104,31 +104,31 @@ LL |     let val: ! = loop { break break; };
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:9:19
+  --> $DIR/loop-break-value.rs:11:19
    |
 LL |             break 123;
    |                   ^^^ expected `&str`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:14:15
+  --> $DIR/loop-break-value.rs:16:15
    |
 LL |         break "asdf";
    |               ^^^^^^ expected `i32`, found `&str`
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:19:31
+  --> $DIR/loop-break-value.rs:21:31
    |
 LL |             break 'outer_loop "nope";
    |                               ^^^^^^ expected `i32`, found `&str`
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:71:26
+  --> $DIR/loop-break-value.rs:73:26
    |
 LL |                 break 'c 123;
    |                          ^^^ expected `()`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:78:15
+  --> $DIR/loop-break-value.rs:80:15
    |
 LL |         break (break, break);
    |               ^^^^^^^^^^^^^^ expected `()`, found tuple
@@ -137,13 +137,13 @@ LL |         break (break, break);
                   found tuple `(!, !)`
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:83:15
+  --> $DIR/loop-break-value.rs:85:15
    |
 LL |         break 2;
    |               ^ expected `()`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:88:9
+  --> $DIR/loop-break-value.rs:90:9
    |
 LL |         break;
    |         ^^^^^

--- a/src/test/ui/loops/loop-break-value.stderr
+++ b/src/test/ui/loops/loop-break-value.stderr
@@ -29,7 +29,7 @@ LL |             break;
    |             ^^^^^
 
 error[E0571]: `break` with value from a `while` loop
-  --> $DIR/loop-break-value.rs:36:12
+  --> $DIR/loop-break-value.rs:38:12
    |
 LL |         if break () {
    |            ^^^^^^^^ can only break with a value inside `loop` or breakable block
@@ -40,7 +40,7 @@ LL |         if break {
    |            ^^^^^
 
 error[E0571]: `break` with value from a `while` loop
-  --> $DIR/loop-break-value.rs:41:9
+  --> $DIR/loop-break-value.rs:43:9
    |
 LL |         break None;
    |         ^^^^^^^^^^ can only break with a value inside `loop` or breakable block
@@ -51,7 +51,7 @@ LL |         break;
    |         ^^^^^
 
 error[E0571]: `break` with value from a `while` loop
-  --> $DIR/loop-break-value.rs:47:13
+  --> $DIR/loop-break-value.rs:49:13
    |
 LL |             break 'while_let_loop "nope";
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can only break with a value inside `loop` or breakable block

--- a/src/test/ui/mir/mir_calls_to_shims.rs
+++ b/src/test/ui/mir/mir_calls_to_shims.rs
@@ -2,6 +2,7 @@
 // ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(fn_traits)]
+#![feature(never_type)]
 
 use std::panic;
 

--- a/src/test/ui/never_type/adjust_never.rs
+++ b/src/test/ui/never_type/adjust_never.rs
@@ -2,6 +2,8 @@
 
 // check-pass
 
+#![feature(never_type)]
+
 fn main() {
     let x: ! = panic!();
     let y: u32 = x;

--- a/src/test/ui/never_type/auto-traits.rs
+++ b/src/test/ui/never_type/auto-traits.rs
@@ -1,6 +1,7 @@
 // check-pass
 
 #![feature(optin_builtin_traits)]
+#![feature(never_type)]
 
 fn main() {
     enum Void {}

--- a/src/test/ui/never_type/call-fn-never-arg-wrong-type.rs
+++ b/src/test/ui/never_type/call-fn-never-arg-wrong-type.rs
@@ -1,5 +1,7 @@
 // Test that we can't pass other types for !
 
+#![feature(never_type)]
+
 fn foo(x: !) -> ! {
     x
 }

--- a/src/test/ui/never_type/call-fn-never-arg-wrong-type.stderr
+++ b/src/test/ui/never_type/call-fn-never-arg-wrong-type.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/call-fn-never-arg-wrong-type.rs:8:9
+  --> $DIR/call-fn-never-arg-wrong-type.rs:10:9
    |
 LL |     foo("wow");
    |         ^^^^^ expected `!`, found `&str`

--- a/src/test/ui/never_type/call-fn-never-arg.rs
+++ b/src/test/ui/never_type/call-fn-never-arg.rs
@@ -2,6 +2,7 @@
 
 // check-pass
 
+#![feature(never_type)]
 #![allow(unreachable_code)]
 
 fn foo(x: !) -> ! {

--- a/src/test/ui/never_type/cast-never.rs
+++ b/src/test/ui/never_type/cast-never.rs
@@ -2,6 +2,8 @@
 
 // check-pass
 
+#![feature(never_type)]
+
 fn main() {
     let x: ! = panic!();
     let y: u32 = x as u32;

--- a/src/test/ui/never_type/defaulted-never-note.rs
+++ b/src/test/ui/never_type/defaulted-never-note.rs
@@ -1,6 +1,6 @@
 // We need to opt into the `never_type_fallback` feature
 // to trigger the requirement that this is testing.
-#![feature(never_type_fallback)]
+#![feature(never_type, never_type_fallback)]
 
 #![allow(unused)]
 

--- a/src/test/ui/never_type/dispatch_from_dyn_zst.rs
+++ b/src/test/ui/never_type/dispatch_from_dyn_zst.rs
@@ -1,6 +1,6 @@
 // run-pass
 
-#![feature(unsize, dispatch_from_dyn)]
+#![feature(unsize, dispatch_from_dyn, never_type)]
 
 #![allow(dead_code)]
 

--- a/src/test/ui/never_type/diverging-fallback-control-flow.rs
+++ b/src/test/ui/never_type/diverging-fallback-control-flow.rs
@@ -11,7 +11,7 @@
 // These represent current behavior, but are pretty dubious.  I would
 // like to revisit these and potentially change them. --nmatsakis
 
-#![feature(never_type_fallback)]
+#![feature(never_type, never_type_fallback)]
 
 trait BadDefault {
     fn default() -> Self;

--- a/src/test/ui/never_type/impl-for-never.rs
+++ b/src/test/ui/never_type/impl-for-never.rs
@@ -1,5 +1,7 @@
 // run-pass
 
+#![feature(never_type)]
+
 // Test that we can call static methods on ! both directly and when it appears in a generic
 
 trait StringifyType {

--- a/src/test/ui/never_type/issue-44402.rs
+++ b/src/test/ui/never_type/issue-44402.rs
@@ -1,6 +1,7 @@
 // check-pass
 
 #![allow(dead_code)]
+#![feature(never_type)]
 #![feature(exhaustive_patterns)]
 
 // Regression test for inhabitedness check. The old

--- a/src/test/ui/never_type/never-assign-dead-code.rs
+++ b/src/test/ui/never_type/never-assign-dead-code.rs
@@ -2,6 +2,7 @@
 
 // check-pass
 
+#![feature(never_type)]
 #![warn(unused)]
 
 fn main() {

--- a/src/test/ui/never_type/never-assign-dead-code.stderr
+++ b/src/test/ui/never_type/never-assign-dead-code.stderr
@@ -1,5 +1,5 @@
 warning: unreachable statement
-  --> $DIR/never-assign-dead-code.rs:9:5
+  --> $DIR/never-assign-dead-code.rs:10:5
    |
 LL |     let x: ! = panic!("aah");
    |                ------------- any code following this expression is unreachable
@@ -7,7 +7,7 @@ LL |     drop(x);
    |     ^^^^^^^^ unreachable statement
    |
 note: lint level defined here
-  --> $DIR/never-assign-dead-code.rs:5:9
+  --> $DIR/never-assign-dead-code.rs:6:9
    |
 LL | #![warn(unused)]
    |         ^^^^^^
@@ -15,7 +15,7 @@ LL | #![warn(unused)]
    = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 warning: unreachable call
-  --> $DIR/never-assign-dead-code.rs:9:5
+  --> $DIR/never-assign-dead-code.rs:10:5
    |
 LL |     drop(x);
    |     ^^^^ - any code following this expression is unreachable
@@ -23,13 +23,13 @@ LL |     drop(x);
    |     unreachable call
 
 warning: unused variable: `x`
-  --> $DIR/never-assign-dead-code.rs:8:9
+  --> $DIR/never-assign-dead-code.rs:9:9
    |
 LL |     let x: ! = panic!("aah");
    |         ^ help: consider prefixing with an underscore: `_x`
    |
 note: lint level defined here
-  --> $DIR/never-assign-dead-code.rs:5:9
+  --> $DIR/never-assign-dead-code.rs:6:9
    |
 LL | #![warn(unused)]
    |         ^^^^^^

--- a/src/test/ui/never_type/never-assign-wrong-type.rs
+++ b/src/test/ui/never_type/never-assign-wrong-type.rs
@@ -1,5 +1,6 @@
 // Test that we can't use another type in place of !
 
+#![feature(never_type)]
 #![deny(warnings)]
 
 fn main() {

--- a/src/test/ui/never_type/never-assign-wrong-type.stderr
+++ b/src/test/ui/never_type/never-assign-wrong-type.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/never-assign-wrong-type.rs:6:16
+  --> $DIR/never-assign-wrong-type.rs:7:16
    |
 LL |     let x: ! = "hello";
    |            -   ^^^^^^^ expected `!`, found `&str`

--- a/src/test/ui/never_type/never-associated-type.rs
+++ b/src/test/ui/never_type/never-associated-type.rs
@@ -2,6 +2,8 @@
 
 // check-pass
 
+#![feature(never_type)]
+
 trait Foo {
     type Wow;
 

--- a/src/test/ui/never_type/never-from-impl-is-reserved.rs
+++ b/src/test/ui/never_type/never-from-impl-is-reserved.rs
@@ -1,5 +1,7 @@
 // check that the `for<T> T: From<!>` impl is reserved
 
+#![feature(never_type)]
+
 pub struct MyFoo;
 pub trait MyTrait {}
 

--- a/src/test/ui/never_type/never-from-impl-is-reserved.stderr
+++ b/src/test/ui/never_type/never-from-impl-is-reserved.stderr
@@ -1,5 +1,5 @@
 error[E0119]: conflicting implementations of trait `MyTrait` for type `MyFoo`:
-  --> $DIR/never-from-impl-is-reserved.rs:8:1
+  --> $DIR/never-from-impl-is-reserved.rs:10:1
    |
 LL | impl MyTrait for MyFoo {}
    | ---------------------- first implementation here

--- a/src/test/ui/never_type/never-result.rs
+++ b/src/test/ui/never_type/never-result.rs
@@ -5,6 +5,8 @@
 
 // Test that we can extract a ! through pattern matching then use it as several different types.
 
+#![feature(never_type)]
+
 fn main() {
     let x: Result<u32, !> = Ok(123);
     match x {

--- a/src/test/ui/never_type/never-type-arg.rs
+++ b/src/test/ui/never_type/never-type-arg.rs
@@ -2,6 +2,8 @@
 
 // check-pass
 
+#![feature(never_type)]
+
 struct Wub;
 
 impl PartialEq<!> for Wub {

--- a/src/test/ui/never_type/never-type-rvalues.rs
+++ b/src/test/ui/never_type/never-type-rvalues.rs
@@ -1,5 +1,6 @@
 // run-pass
 
+#![feature(never_type)]
 #![allow(dead_code)]
 #![allow(path_statements)]
 #![allow(unreachable_patterns)]

--- a/src/test/ui/never_type/never-value-fallback-issue-66757.rs
+++ b/src/test/ui/never_type/never-value-fallback-issue-66757.rs
@@ -1,0 +1,29 @@
+// Regression test for #66757
+//
+// Test than when you have a `!` value (e.g., the local variable
+// never) and an uninferred variable (here the argument to `From`) it
+// doesn't fallback to `()` but rather `!`.
+//
+// run-pass
+
+#![feature(never_type)]
+
+// FIXME(#67225) -- this should be true even without the fallback gate.
+#![feature(never_type_fallback)]
+
+struct E;
+
+impl From<!> for E {
+    fn from(_: !) -> E {
+        E
+    }
+}
+
+#[allow(unreachable_code)]
+#[allow(dead_code)]
+fn foo(never: !) {
+    <E as From<!>>::from(never);  // Ok
+    <E as From<_>>::from(never);  // Inference fails here
+}
+
+fn main() { }

--- a/src/test/ui/never_type/never_transmute_never.rs
+++ b/src/test/ui/never_type/never_transmute_never.rs
@@ -2,6 +2,7 @@
 
 #![crate_type="lib"]
 
+#![feature(never_type)]
 #![allow(dead_code)]
 #![allow(unreachable_code)]
 #![allow(unused_variables)]

--- a/src/test/ui/never_type/panic-uninitialized-zeroed.rs
+++ b/src/test/ui/never_type/panic-uninitialized-zeroed.rs
@@ -3,6 +3,7 @@
 // This test checks that instantiating an uninhabited type via `mem::{uninitialized,zeroed}` results
 // in a runtime panic.
 
+#![feature(never_type)]
 #![allow(deprecated, invalid_value)]
 
 use std::{mem, panic};

--- a/src/test/ui/never_type/try_from.rs
+++ b/src/test/ui/never_type/try_from.rs
@@ -5,6 +5,8 @@
 // This test was added to show the motivation for doing this
 // over `TryFrom` being blanket impl for all `T: From`
 
+#![feature(never_type)]
+
 use std::convert::{TryInto, Infallible};
 
 struct Foo<T> {

--- a/src/test/ui/pattern/usefulness/match-privately-empty.rs
+++ b/src/test/ui/pattern/usefulness/match-privately-empty.rs
@@ -1,3 +1,4 @@
+#![feature(never_type)]
 #![feature(exhaustive_patterns)]
 
 mod private {

--- a/src/test/ui/pattern/usefulness/match-privately-empty.stderr
+++ b/src/test/ui/pattern/usefulness/match-privately-empty.stderr
@@ -1,5 +1,5 @@
 error[E0004]: non-exhaustive patterns: `Some(Private { misc: true, .. })` not covered
-  --> $DIR/match-privately-empty.rs:12:11
+  --> $DIR/match-privately-empty.rs:13:11
    |
 LL |     match private::DATA {
    |           ^^^^^^^^^^^^^ pattern `Some(Private { misc: true, .. })` not covered

--- a/src/test/ui/print_type_sizes/uninhabited.rs
+++ b/src/test/ui/print_type_sizes/uninhabited.rs
@@ -4,6 +4,7 @@
 // ^-- needed because `--pass check` does not emit the output needed.
 //     FIXME: consider using an attribute instead of side-effects.
 
+#![feature(never_type)]
 #![feature(start)]
 
 #[start]

--- a/src/test/ui/reachable/expr_add.rs
+++ b/src/test/ui/reachable/expr_add.rs
@@ -1,3 +1,4 @@
+#![feature(never_type)]
 #![allow(unused_variables)]
 #![deny(unreachable_code)]
 

--- a/src/test/ui/reachable/expr_add.stderr
+++ b/src/test/ui/reachable/expr_add.stderr
@@ -1,5 +1,5 @@
 error: unreachable expression
-  --> $DIR/expr_add.rs:16:13
+  --> $DIR/expr_add.rs:17:13
    |
 LL |     let x = Foo + return;
    |             ^^^^^^------
@@ -8,7 +8,7 @@ LL |     let x = Foo + return;
    |             unreachable expression
    |
 note: lint level defined here
-  --> $DIR/expr_add.rs:2:9
+  --> $DIR/expr_add.rs:3:9
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^

--- a/src/test/ui/reachable/expr_assign.rs
+++ b/src/test/ui/reachable/expr_assign.rs
@@ -1,3 +1,4 @@
+#![feature(never_type)]
 #![allow(unused_variables)]
 #![allow(unused_assignments)]
 #![allow(dead_code)]

--- a/src/test/ui/reachable/expr_assign.stderr
+++ b/src/test/ui/reachable/expr_assign.stderr
@@ -1,5 +1,5 @@
 error: unreachable expression
-  --> $DIR/expr_assign.rs:9:5
+  --> $DIR/expr_assign.rs:10:5
    |
 LL |     x = return;
    |     ^^^^------
@@ -8,13 +8,13 @@ LL |     x = return;
    |     unreachable expression
    |
 note: lint level defined here
-  --> $DIR/expr_assign.rs:4:9
+  --> $DIR/expr_assign.rs:5:9
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
 
 error: unreachable expression
-  --> $DIR/expr_assign.rs:19:14
+  --> $DIR/expr_assign.rs:20:14
    |
 LL |         *p = return;
    |         --   ^^^^^^ unreachable expression
@@ -22,7 +22,7 @@ LL |         *p = return;
    |         any code following this expression is unreachable
 
 error: unreachable expression
-  --> $DIR/expr_assign.rs:25:15
+  --> $DIR/expr_assign.rs:26:15
    |
 LL |     *{return; &mut i} = 22;
    |       ------  ^^^^^^ unreachable expression

--- a/src/test/ui/reachable/expr_call.rs
+++ b/src/test/ui/reachable/expr_call.rs
@@ -1,3 +1,4 @@
+#![feature(never_type)]
 #![allow(unused_variables)]
 #![allow(unused_assignments)]
 #![allow(dead_code)]

--- a/src/test/ui/reachable/expr_call.stderr
+++ b/src/test/ui/reachable/expr_call.stderr
@@ -1,5 +1,5 @@
 error: unreachable expression
-  --> $DIR/expr_call.rs:12:17
+  --> $DIR/expr_call.rs:13:17
    |
 LL |     foo(return, 22);
    |         ------  ^^ unreachable expression
@@ -7,13 +7,13 @@ LL |     foo(return, 22);
    |         any code following this expression is unreachable
    |
 note: lint level defined here
-  --> $DIR/expr_call.rs:4:9
+  --> $DIR/expr_call.rs:5:9
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
 
 error: unreachable call
-  --> $DIR/expr_call.rs:17:5
+  --> $DIR/expr_call.rs:18:5
    |
 LL |     bar(return);
    |     ^^^ ------ any code following this expression is unreachable

--- a/src/test/ui/reachable/expr_cast.rs
+++ b/src/test/ui/reachable/expr_cast.rs
@@ -2,7 +2,7 @@
 #![allow(unused_assignments)]
 #![allow(dead_code)]
 #![deny(unreachable_code)]
-#![feature(type_ascription)]
+#![feature(never_type, type_ascription)]
 
 fn a() {
     // the cast is unreachable:

--- a/src/test/ui/reachable/expr_method.rs
+++ b/src/test/ui/reachable/expr_method.rs
@@ -1,3 +1,4 @@
+#![feature(never_type)]
 #![allow(unused_variables)]
 #![allow(unused_assignments)]
 #![allow(dead_code)]

--- a/src/test/ui/reachable/expr_method.stderr
+++ b/src/test/ui/reachable/expr_method.stderr
@@ -1,5 +1,5 @@
 error: unreachable expression
-  --> $DIR/expr_method.rs:15:21
+  --> $DIR/expr_method.rs:16:21
    |
 LL |     Foo.foo(return, 22);
    |             ------  ^^ unreachable expression
@@ -7,13 +7,13 @@ LL |     Foo.foo(return, 22);
    |             any code following this expression is unreachable
    |
 note: lint level defined here
-  --> $DIR/expr_method.rs:4:9
+  --> $DIR/expr_method.rs:5:9
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
 
 error: unreachable call
-  --> $DIR/expr_method.rs:20:9
+  --> $DIR/expr_method.rs:21:9
    |
 LL |     Foo.bar(return);
    |         ^^^ ------ any code following this expression is unreachable

--- a/src/test/ui/reachable/expr_type.rs
+++ b/src/test/ui/reachable/expr_type.rs
@@ -2,7 +2,7 @@
 #![allow(unused_assignments)]
 #![allow(dead_code)]
 #![deny(unreachable_code)]
-#![feature(type_ascription)]
+#![feature(never_type, type_ascription)]
 
 fn a() {
     // the cast is unreachable:

--- a/src/test/ui/reachable/expr_unary.rs
+++ b/src/test/ui/reachable/expr_unary.rs
@@ -1,3 +1,4 @@
+#![feature(never_type)]
 #![allow(unused_variables)]
 #![allow(unused_assignments)]
 #![allow(dead_code)]

--- a/src/test/ui/reachable/expr_unary.stderr
+++ b/src/test/ui/reachable/expr_unary.stderr
@@ -1,11 +1,11 @@
 error[E0600]: cannot apply unary operator `!` to type `!`
-  --> $DIR/expr_unary.rs:7:16
+  --> $DIR/expr_unary.rs:8:16
    |
 LL |     let x: ! = ! { return; };
    |                ^^^^^^^^^^^^^ cannot apply unary operator `!`
 
 error: unreachable expression
-  --> $DIR/expr_unary.rs:7:16
+  --> $DIR/expr_unary.rs:8:16
    |
 LL |     let x: ! = ! { return; };
    |                ^^^^------^^^
@@ -14,7 +14,7 @@ LL |     let x: ! = ! { return; };
    |                unreachable expression
    |
 note: lint level defined here
-  --> $DIR/expr_unary.rs:4:9
+  --> $DIR/expr_unary.rs:5:9
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^

--- a/src/test/ui/reachable/unreachable-loop-patterns.rs
+++ b/src/test/ui/reachable/unreachable-loop-patterns.rs
@@ -1,4 +1,4 @@
-#![feature(never_type_fallback)]
+#![feature(never_type, never_type_fallback)]
 #![feature(exhaustive_patterns)]
 
 #![allow(unreachable_code)]

--- a/src/test/ui/reachable/unreachable-try-pattern.rs
+++ b/src/test/ui/reachable/unreachable-try-pattern.rs
@@ -1,5 +1,5 @@
 // check-pass
-#![feature(exhaustive_patterns)]
+#![feature(never_type, exhaustive_patterns)]
 #![warn(unreachable_code)]
 #![warn(unreachable_patterns)]
 

--- a/src/test/ui/reachable/unwarned-match-on-never.rs
+++ b/src/test/ui/reachable/unwarned-match-on-never.rs
@@ -1,6 +1,8 @@
 #![deny(unreachable_code)]
 #![allow(dead_code)]
 
+#![feature(never_type)]
+
 fn foo(x: !) -> bool {
     // Explicit matches on the never type are unwarned.
     match x {}

--- a/src/test/ui/reachable/unwarned-match-on-never.stderr
+++ b/src/test/ui/reachable/unwarned-match-on-never.stderr
@@ -1,5 +1,5 @@
 error: unreachable expression
-  --> $DIR/unwarned-match-on-never.rs:8:5
+  --> $DIR/unwarned-match-on-never.rs:10:5
    |
 LL |     match x {}
    |           - any code following this expression is unreachable
@@ -14,7 +14,7 @@ LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
 
 error: unreachable arm
-  --> $DIR/unwarned-match-on-never.rs:13:15
+  --> $DIR/unwarned-match-on-never.rs:15:15
    |
 LL |     match (return) {
    |           -------- any code following this expression is unreachable
@@ -22,7 +22,7 @@ LL |         () => ()
    |               ^^ unreachable arm
 
 error: unreachable expression
-  --> $DIR/unwarned-match-on-never.rs:19:5
+  --> $DIR/unwarned-match-on-never.rs:21:5
    |
 LL |       return;
    |       ------ any code following this expression is unreachable

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/auxiliary/uninhabited.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/auxiliary/uninhabited.rs
@@ -1,4 +1,5 @@
 #![crate_type = "rlib"]
+#![feature(never_type)]
 
 #[non_exhaustive]
 pub enum UninhabitedEnum {

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/coercions.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/coercions.rs
@@ -1,4 +1,5 @@
 // aux-build:uninhabited.rs
+#![feature(never_type)]
 
 extern crate uninhabited;
 

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/coercions.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/coercions.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/coercions.rs:22:5
+  --> $DIR/coercions.rs:23:5
    |
 LL | fn cannot_coerce_empty_enum_to_anything(x: UninhabitedEnum) -> A {
    |                                                                - expected `A` because of return type
@@ -7,7 +7,7 @@ LL |     x
    |     ^ expected struct `A`, found enum `uninhabited::UninhabitedEnum`
 
 error[E0308]: mismatched types
-  --> $DIR/coercions.rs:26:5
+  --> $DIR/coercions.rs:27:5
    |
 LL | fn cannot_coerce_empty_tuple_struct_to_anything(x: UninhabitedTupleStruct) -> A {
    |                                                                               - expected `A` because of return type
@@ -15,7 +15,7 @@ LL |     x
    |     ^ expected struct `A`, found struct `uninhabited::UninhabitedTupleStruct`
 
 error[E0308]: mismatched types
-  --> $DIR/coercions.rs:30:5
+  --> $DIR/coercions.rs:31:5
    |
 LL | fn cannot_coerce_empty_struct_to_anything(x: UninhabitedStruct) -> A {
    |                                                                    - expected `A` because of return type
@@ -23,7 +23,7 @@ LL |     x
    |     ^ expected struct `A`, found struct `uninhabited::UninhabitedStruct`
 
 error[E0308]: mismatched types
-  --> $DIR/coercions.rs:34:5
+  --> $DIR/coercions.rs:35:5
    |
 LL | fn cannot_coerce_enum_with_empty_variants_to_anything(x: UninhabitedVariants) -> A {
    |                                                                                  - expected `A` because of return type

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/coercions_same_crate.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/coercions_same_crate.rs
@@ -1,3 +1,5 @@
+#![feature(never_type)]
+
 #[non_exhaustive]
 pub enum UninhabitedEnum {
 }

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/coercions_same_crate.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/coercions_same_crate.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/coercions_same_crate.rs:28:5
+  --> $DIR/coercions_same_crate.rs:30:5
    |
 LL | fn cannot_coerce_empty_enum_to_anything(x: UninhabitedEnum) -> A {
    |                                                                - expected `A` because of return type
@@ -7,7 +7,7 @@ LL |     x
    |     ^ expected struct `A`, found enum `UninhabitedEnum`
 
 error[E0308]: mismatched types
-  --> $DIR/coercions_same_crate.rs:32:5
+  --> $DIR/coercions_same_crate.rs:34:5
    |
 LL | fn cannot_coerce_empty_tuple_struct_to_anything(x: UninhabitedTupleStruct) -> A {
    |                                                                               - expected `A` because of return type
@@ -15,7 +15,7 @@ LL |     x
    |     ^ expected struct `A`, found struct `UninhabitedTupleStruct`
 
 error[E0308]: mismatched types
-  --> $DIR/coercions_same_crate.rs:36:5
+  --> $DIR/coercions_same_crate.rs:38:5
    |
 LL | fn cannot_coerce_empty_struct_to_anything(x: UninhabitedStruct) -> A {
    |                                                                    - expected `A` because of return type
@@ -23,7 +23,7 @@ LL |     x
    |     ^ expected struct `A`, found struct `UninhabitedStruct`
 
 error[E0308]: mismatched types
-  --> $DIR/coercions_same_crate.rs:40:5
+  --> $DIR/coercions_same_crate.rs:42:5
    |
 LL | fn cannot_coerce_enum_with_empty_variants_to_anything(x: UninhabitedVariants) -> A {
    |                                                                                  - expected `A` because of return type

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match.rs
@@ -1,4 +1,5 @@
 // aux-build:uninhabited.rs
+#![feature(never_type)]
 
 extern crate uninhabited;
 

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match.stderr
@@ -1,61 +1,29 @@
-<<<<<<< HEAD
 error[E0004]: non-exhaustive patterns: type `uninhabited::IndirectUninhabitedEnum` is non-empty
-  --> $DIR/indirect_match.rs:18:11
-||||||| parent of bca33d7df4a... Revert "Remove `#![feature(never_type)]` from tests."
-error[E0004]: non-exhaustive patterns: pattern `IndirectUninhabitedEnum` of type `uninhabited::IndirectUninhabitedEnum` is not handled
-  --> $DIR/indirect_match.rs:18:11
-=======
-error[E0004]: non-exhaustive patterns: pattern `IndirectUninhabitedEnum` of type `uninhabited::IndirectUninhabitedEnum` is not handled
   --> $DIR/indirect_match.rs:19:11
->>>>>>> bca33d7df4a... Revert "Remove `#![feature(never_type)]` from tests."
    |
 LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
-<<<<<<< HEAD
 error[E0004]: non-exhaustive patterns: type `uninhabited::IndirectUninhabitedStruct` is non-empty
-  --> $DIR/indirect_match.rs:22:11
-||||||| parent of bca33d7df4a... Revert "Remove `#![feature(never_type)]` from tests."
-error[E0004]: non-exhaustive patterns: pattern `IndirectUninhabitedStruct` of type `uninhabited::IndirectUninhabitedStruct` is not handled
-  --> $DIR/indirect_match.rs:22:11
-=======
-error[E0004]: non-exhaustive patterns: pattern `IndirectUninhabitedStruct` of type `uninhabited::IndirectUninhabitedStruct` is not handled
   --> $DIR/indirect_match.rs:23:11
->>>>>>> bca33d7df4a... Revert "Remove `#![feature(never_type)]` from tests."
    |
 LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
-<<<<<<< HEAD
 error[E0004]: non-exhaustive patterns: type `uninhabited::IndirectUninhabitedTupleStruct` is non-empty
-  --> $DIR/indirect_match.rs:26:11
-||||||| parent of bca33d7df4a... Revert "Remove `#![feature(never_type)]` from tests."
-error[E0004]: non-exhaustive patterns: pattern `IndirectUninhabitedTupleStruct` of type `uninhabited::IndirectUninhabitedTupleStruct` is not handled
-  --> $DIR/indirect_match.rs:26:11
-=======
-error[E0004]: non-exhaustive patterns: pattern `IndirectUninhabitedTupleStruct` of type `uninhabited::IndirectUninhabitedTupleStruct` is not handled
   --> $DIR/indirect_match.rs:27:11
->>>>>>> bca33d7df4a... Revert "Remove `#![feature(never_type)]` from tests."
    |
 LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
-<<<<<<< HEAD
 error[E0004]: non-exhaustive patterns: type `uninhabited::IndirectUninhabitedVariants` is non-empty
-  --> $DIR/indirect_match.rs:32:11
-||||||| parent of bca33d7df4a... Revert "Remove `#![feature(never_type)]` from tests."
-error[E0004]: non-exhaustive patterns: pattern `IndirectUninhabitedVariants` of type `uninhabited::IndirectUninhabitedVariants` is not handled
-  --> $DIR/indirect_match.rs:32:11
-=======
-error[E0004]: non-exhaustive patterns: pattern `IndirectUninhabitedVariants` of type `uninhabited::IndirectUninhabitedVariants` is not handled
   --> $DIR/indirect_match.rs:33:11
->>>>>>> bca33d7df4a... Revert "Remove `#![feature(never_type)]` from tests."
    |
 LL |     match x {}
    |           ^

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match.stderr
@@ -1,29 +1,61 @@
+<<<<<<< HEAD
 error[E0004]: non-exhaustive patterns: type `uninhabited::IndirectUninhabitedEnum` is non-empty
   --> $DIR/indirect_match.rs:18:11
+||||||| parent of bca33d7df4a... Revert "Remove `#![feature(never_type)]` from tests."
+error[E0004]: non-exhaustive patterns: pattern `IndirectUninhabitedEnum` of type `uninhabited::IndirectUninhabitedEnum` is not handled
+  --> $DIR/indirect_match.rs:18:11
+=======
+error[E0004]: non-exhaustive patterns: pattern `IndirectUninhabitedEnum` of type `uninhabited::IndirectUninhabitedEnum` is not handled
+  --> $DIR/indirect_match.rs:19:11
+>>>>>>> bca33d7df4a... Revert "Remove `#![feature(never_type)]` from tests."
    |
 LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
+<<<<<<< HEAD
 error[E0004]: non-exhaustive patterns: type `uninhabited::IndirectUninhabitedStruct` is non-empty
   --> $DIR/indirect_match.rs:22:11
+||||||| parent of bca33d7df4a... Revert "Remove `#![feature(never_type)]` from tests."
+error[E0004]: non-exhaustive patterns: pattern `IndirectUninhabitedStruct` of type `uninhabited::IndirectUninhabitedStruct` is not handled
+  --> $DIR/indirect_match.rs:22:11
+=======
+error[E0004]: non-exhaustive patterns: pattern `IndirectUninhabitedStruct` of type `uninhabited::IndirectUninhabitedStruct` is not handled
+  --> $DIR/indirect_match.rs:23:11
+>>>>>>> bca33d7df4a... Revert "Remove `#![feature(never_type)]` from tests."
    |
 LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
+<<<<<<< HEAD
 error[E0004]: non-exhaustive patterns: type `uninhabited::IndirectUninhabitedTupleStruct` is non-empty
   --> $DIR/indirect_match.rs:26:11
+||||||| parent of bca33d7df4a... Revert "Remove `#![feature(never_type)]` from tests."
+error[E0004]: non-exhaustive patterns: pattern `IndirectUninhabitedTupleStruct` of type `uninhabited::IndirectUninhabitedTupleStruct` is not handled
+  --> $DIR/indirect_match.rs:26:11
+=======
+error[E0004]: non-exhaustive patterns: pattern `IndirectUninhabitedTupleStruct` of type `uninhabited::IndirectUninhabitedTupleStruct` is not handled
+  --> $DIR/indirect_match.rs:27:11
+>>>>>>> bca33d7df4a... Revert "Remove `#![feature(never_type)]` from tests."
    |
 LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
+<<<<<<< HEAD
 error[E0004]: non-exhaustive patterns: type `uninhabited::IndirectUninhabitedVariants` is non-empty
   --> $DIR/indirect_match.rs:32:11
+||||||| parent of bca33d7df4a... Revert "Remove `#![feature(never_type)]` from tests."
+error[E0004]: non-exhaustive patterns: pattern `IndirectUninhabitedVariants` of type `uninhabited::IndirectUninhabitedVariants` is not handled
+  --> $DIR/indirect_match.rs:32:11
+=======
+error[E0004]: non-exhaustive patterns: pattern `IndirectUninhabitedVariants` of type `uninhabited::IndirectUninhabitedVariants` is not handled
+  --> $DIR/indirect_match.rs:33:11
+>>>>>>> bca33d7df4a... Revert "Remove `#![feature(never_type)]` from tests."
    |
 LL |     match x {}
    |           ^

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match_same_crate.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match_same_crate.rs
@@ -1,3 +1,5 @@
+#![feature(never_type)]
+
 #[non_exhaustive]
 pub enum UninhabitedEnum {
 }

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match_same_crate.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match_same_crate.stderr
@@ -1,5 +1,5 @@
 error[E0004]: non-exhaustive patterns: type `IndirectUninhabitedEnum` is non-empty
-  --> $DIR/indirect_match_same_crate.rs:32:11
+  --> $DIR/indirect_match_same_crate.rs:34:11
    |
 LL | pub struct IndirectUninhabitedEnum(UninhabitedEnum);
    | ---------------------------------------------------- `IndirectUninhabitedEnum` defined here
@@ -10,7 +10,7 @@ LL |     match x {}
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: type `IndirectUninhabitedStruct` is non-empty
-  --> $DIR/indirect_match_same_crate.rs:36:11
+  --> $DIR/indirect_match_same_crate.rs:38:11
    |
 LL | pub struct IndirectUninhabitedStruct(UninhabitedStruct);
    | -------------------------------------------------------- `IndirectUninhabitedStruct` defined here
@@ -21,7 +21,7 @@ LL |     match x {}
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: type `IndirectUninhabitedTupleStruct` is non-empty
-  --> $DIR/indirect_match_same_crate.rs:40:11
+  --> $DIR/indirect_match_same_crate.rs:42:11
    |
 LL | pub struct IndirectUninhabitedTupleStruct(UninhabitedTupleStruct);
    | ------------------------------------------------------------------ `IndirectUninhabitedTupleStruct` defined here
@@ -32,7 +32,7 @@ LL |     match x {}
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: type `IndirectUninhabitedVariants` is non-empty
-  --> $DIR/indirect_match_same_crate.rs:46:11
+  --> $DIR/indirect_match_same_crate.rs:48:11
    |
 LL | pub struct IndirectUninhabitedVariants(UninhabitedVariants);
    | ------------------------------------------------------------ `IndirectUninhabitedVariants` defined here

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match_with_exhaustive_patterns.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match_with_exhaustive_patterns.rs
@@ -1,6 +1,7 @@
 // aux-build:uninhabited.rs
 #![deny(unreachable_patterns)]
 #![feature(exhaustive_patterns)]
+#![feature(never_type)]
 
 extern crate uninhabited;
 

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match_with_exhaustive_patterns.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match_with_exhaustive_patterns.stderr
@@ -1,5 +1,5 @@
 error[E0004]: non-exhaustive patterns: type `uninhabited::IndirectUninhabitedEnum` is non-empty
-  --> $DIR/indirect_match_with_exhaustive_patterns.rs:22:11
+  --> $DIR/indirect_match_with_exhaustive_patterns.rs:23:11
    |
 LL |     match x {}
    |           ^
@@ -7,7 +7,7 @@ LL |     match x {}
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: type `uninhabited::IndirectUninhabitedStruct` is non-empty
-  --> $DIR/indirect_match_with_exhaustive_patterns.rs:26:11
+  --> $DIR/indirect_match_with_exhaustive_patterns.rs:27:11
    |
 LL |     match x {}
    |           ^
@@ -15,7 +15,7 @@ LL |     match x {}
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: type `uninhabited::IndirectUninhabitedTupleStruct` is non-empty
-  --> $DIR/indirect_match_with_exhaustive_patterns.rs:30:11
+  --> $DIR/indirect_match_with_exhaustive_patterns.rs:31:11
    |
 LL |     match x {}
    |           ^
@@ -23,7 +23,7 @@ LL |     match x {}
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: type `uninhabited::IndirectUninhabitedVariants` is non-empty
-  --> $DIR/indirect_match_with_exhaustive_patterns.rs:36:11
+  --> $DIR/indirect_match_with_exhaustive_patterns.rs:37:11
    |
 LL |     match x {}
    |           ^

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match_with_exhaustive_patterns_same_crate.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match_with_exhaustive_patterns_same_crate.rs
@@ -2,6 +2,7 @@
 
 #![deny(unreachable_patterns)]
 #![feature(exhaustive_patterns)]
+#![feature(never_type)]
 
 #[non_exhaustive]
 pub enum UninhabitedEnum {

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match.rs
@@ -1,4 +1,5 @@
 // aux-build:uninhabited.rs
+#![feature(never_type)]
 
 extern crate uninhabited;
 

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match.stderr
@@ -1,5 +1,5 @@
 error[E0004]: non-exhaustive patterns: type `uninhabited::UninhabitedEnum` is non-empty
-  --> $DIR/match.rs:18:11
+  --> $DIR/match.rs:19:11
    |
 LL |     match x {}
    |           ^
@@ -7,7 +7,7 @@ LL |     match x {}
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: type `uninhabited::UninhabitedStruct` is non-empty
-  --> $DIR/match.rs:22:11
+  --> $DIR/match.rs:23:11
    |
 LL |     match x {}
    |           ^
@@ -15,7 +15,7 @@ LL |     match x {}
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: type `uninhabited::UninhabitedTupleStruct` is non-empty
-  --> $DIR/match.rs:26:11
+  --> $DIR/match.rs:27:11
    |
 LL |     match x {}
    |           ^
@@ -23,7 +23,7 @@ LL |     match x {}
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: `Tuple(_)` and `Struct { .. }` not covered
-  --> $DIR/match.rs:30:11
+  --> $DIR/match.rs:31:11
    |
 LL |     match x {}
    |           ^ patterns `Tuple(_)` and `Struct { .. }` not covered

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_same_crate.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_same_crate.rs
@@ -1,3 +1,5 @@
+#![feature(never_type)]
+
 #[non_exhaustive]
 pub enum UninhabitedEnum {
 }

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_same_crate.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_same_crate.stderr
@@ -1,5 +1,5 @@
 error[E0004]: non-exhaustive patterns: type `UninhabitedStruct` is non-empty
-  --> $DIR/match_same_crate.rs:28:11
+  --> $DIR/match_same_crate.rs:30:11
    |
 LL | / pub struct UninhabitedStruct {
 LL | |     _priv: !,
@@ -12,7 +12,7 @@ LL |       match x {}
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: type `UninhabitedTupleStruct` is non-empty
-  --> $DIR/match_same_crate.rs:32:11
+  --> $DIR/match_same_crate.rs:34:11
    |
 LL | pub struct UninhabitedTupleStruct(!);
    | ------------------------------------- `UninhabitedTupleStruct` defined here
@@ -23,7 +23,7 @@ LL |     match x {}
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: `Tuple(_)` and `Struct { .. }` not covered
-  --> $DIR/match_same_crate.rs:36:11
+  --> $DIR/match_same_crate.rs:38:11
    |
 LL | / pub enum UninhabitedVariants {
 LL | |     #[non_exhaustive] Tuple(!),

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns.rs
@@ -1,6 +1,7 @@
 // aux-build:uninhabited.rs
 #![deny(unreachable_patterns)]
 #![feature(exhaustive_patterns)]
+#![feature(never_type)]
 
 extern crate uninhabited;
 

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns.stderr
@@ -1,5 +1,5 @@
 error[E0004]: non-exhaustive patterns: type `uninhabited::UninhabitedEnum` is non-empty
-  --> $DIR/match_with_exhaustive_patterns.rs:21:11
+  --> $DIR/match_with_exhaustive_patterns.rs:22:11
    |
 LL |     match x {}
    |           ^
@@ -7,7 +7,7 @@ LL |     match x {}
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: type `uninhabited::UninhabitedStruct` is non-empty
-  --> $DIR/match_with_exhaustive_patterns.rs:25:11
+  --> $DIR/match_with_exhaustive_patterns.rs:26:11
    |
 LL |     match x {}
    |           ^
@@ -15,7 +15,7 @@ LL |     match x {}
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: type `uninhabited::UninhabitedTupleStruct` is non-empty
-  --> $DIR/match_with_exhaustive_patterns.rs:29:11
+  --> $DIR/match_with_exhaustive_patterns.rs:30:11
    |
 LL |     match x {}
    |           ^
@@ -23,7 +23,7 @@ LL |     match x {}
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: `Tuple(_)` and `Struct { .. }` not covered
-  --> $DIR/match_with_exhaustive_patterns.rs:33:11
+  --> $DIR/match_with_exhaustive_patterns.rs:34:11
    |
 LL |     match x {}
    |           ^ patterns `Tuple(_)` and `Struct { .. }` not covered

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns_same_crate.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns_same_crate.rs
@@ -2,6 +2,7 @@
 
 #![deny(unreachable_patterns)]
 #![feature(exhaustive_patterns)]
+#![feature(never_type)]
 
 #[non_exhaustive]
 pub enum UninhabitedEnum {

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/patterns_same_crate.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/patterns_same_crate.rs
@@ -1,5 +1,6 @@
 #![deny(unreachable_patterns)]
 #![feature(exhaustive_patterns)]
+#![feature(never_type)]
 
 #[non_exhaustive]
 pub enum UninhabitedEnum {

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/patterns_same_crate.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/patterns_same_crate.stderr
@@ -1,5 +1,5 @@
 error: unreachable pattern
-  --> $DIR/patterns_same_crate.rs:51:9
+  --> $DIR/patterns_same_crate.rs:52:9
    |
 LL |         Some(_x) => (),
    |         ^^^^^^^^
@@ -11,25 +11,25 @@ LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/patterns_same_crate.rs:56:9
+  --> $DIR/patterns_same_crate.rs:57:9
    |
 LL |         Some(_x) => (),
    |         ^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/patterns_same_crate.rs:60:15
+  --> $DIR/patterns_same_crate.rs:61:15
    |
 LL |     while let PartiallyInhabitedVariants::Struct { x } = partially_inhabited_variant() {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/patterns_same_crate.rs:64:15
+  --> $DIR/patterns_same_crate.rs:65:15
    |
 LL |     while let Some(_x) = uninhabited_struct() {
    |               ^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/patterns_same_crate.rs:67:15
+  --> $DIR/patterns_same_crate.rs:68:15
    |
 LL |     while let Some(_x) = uninhabited_tuple_struct() {
    |               ^^^^^^^^

--- a/src/test/ui/traits/reservation-impls/reservation-impl-non-lattice-ok.rs
+++ b/src/test/ui/traits/reservation-impls/reservation-impl-non-lattice-ok.rs
@@ -30,7 +30,7 @@
 //
 // [ii]: http://smallcultfollowing.com/babysteps/blog/2016/09/24/intersection-impls/
 
-#![feature(rustc_attrs)]
+#![feature(rustc_attrs, never_type)]
 
 trait MyTrait {}
 

--- a/src/test/ui/type-sizes.rs
+++ b/src/test/ui/type-sizes.rs
@@ -2,6 +2,7 @@
 
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
+#![feature(never_type)]
 
 use std::mem::size_of;
 

--- a/src/test/ui/uninhabited/uninhabited-irrefutable.rs
+++ b/src/test/ui/uninhabited/uninhabited-irrefutable.rs
@@ -1,3 +1,4 @@
+#![feature(never_type)]
 #![feature(exhaustive_patterns)]
 
 mod foo {

--- a/src/test/ui/uninhabited/uninhabited-irrefutable.stderr
+++ b/src/test/ui/uninhabited/uninhabited-irrefutable.stderr
@@ -1,5 +1,5 @@
 error[E0005]: refutable pattern in local binding: `A(_)` not covered
-  --> $DIR/uninhabited-irrefutable.rs:26:9
+  --> $DIR/uninhabited-irrefutable.rs:27:9
    |
 LL | / enum Foo {
 LL | |     A(foo::SecretlyEmpty),

--- a/src/test/ui/uninhabited/uninhabited-patterns.rs
+++ b/src/test/ui/uninhabited/uninhabited-patterns.rs
@@ -1,5 +1,6 @@
 #![feature(box_patterns)]
 #![feature(box_syntax)]
+#![feature(never_type)]
 #![feature(exhaustive_patterns)]
 #![feature(slice_patterns)]
 #![deny(unreachable_patterns)]

--- a/src/test/ui/uninhabited/uninhabited-patterns.stderr
+++ b/src/test/ui/uninhabited/uninhabited-patterns.stderr
@@ -1,35 +1,35 @@
 error: unreachable pattern
-  --> $DIR/uninhabited-patterns.rs:26:9
+  --> $DIR/uninhabited-patterns.rs:27:9
    |
 LL |         &[..] => (),
    |         ^^^^^
    |
 note: lint level defined here
-  --> $DIR/uninhabited-patterns.rs:5:9
+  --> $DIR/uninhabited-patterns.rs:6:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/uninhabited-patterns.rs:31:9
+  --> $DIR/uninhabited-patterns.rs:32:9
    |
 LL |         Ok(box _) => (),
    |         ^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/uninhabited-patterns.rs:33:9
+  --> $DIR/uninhabited-patterns.rs:34:9
    |
 LL |         Err(&[..]) => (),
    |         ^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/uninhabited-patterns.rs:40:9
+  --> $DIR/uninhabited-patterns.rs:41:9
    |
 LL |         Err(Ok(_y)) => (),
    |         ^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/uninhabited-patterns.rs:43:15
+  --> $DIR/uninhabited-patterns.rs:44:15
    |
 LL |     while let Some(_y) = foo() {
    |               ^^^^^^^^


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/66757

I decided to keep the separate `never-type-fallback` feature gate, but tried to otherwise revert https://github.com/rust-lang/rust/pull/65355. Seemed pretty clean.

( cc @Centril, author of #65355, you may want to check this over briefly )