### PR TITLE
resolve: Always resolve visibilities on impl items

### DIFF
--- a/src/test/ui/resolve/impl-items-vis-unresolved.rs
+++ b/src/test/ui/resolve/impl-items-vis-unresolved.rs
@@ -1,0 +1,25 @@
+// Visibilities on impl items expanded from macros are resolved (issue #64705).
+
+macro_rules! perftools_inline {
+    ($($item:tt)*) => (
+        $($item)*
+    );
+}
+
+mod state {
+    pub struct RawFloatState;
+    impl RawFloatState {
+        perftools_inline! {
+            pub(super) fn new() {} // OK
+        }
+    }
+}
+
+pub struct RawFloatState;
+impl RawFloatState {
+    perftools_inline! {
+        pub(super) fn new() {} //~ ERROR failed to resolve: there are too many initial `super`s
+    }
+}
+
+fn main() {}

--- a/src/test/ui/resolve/impl-items-vis-unresolved.stderr
+++ b/src/test/ui/resolve/impl-items-vis-unresolved.stderr
@@ -1,0 +1,9 @@
+error[E0433]: failed to resolve: there are too many initial `super`s.
+  --> $DIR/impl-items-vis-unresolved.rs:21:13
+   |
+LL |         pub(super) fn new() {}
+   |             ^^^^^ there are too many initial `super`s.
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/64705.

Similarly to https://github.com/rust-lang/rust/pull/67106 this was an issue with visitor discipline.
Impl items were visited as a part of visiting `ast::ItemKind::Impl`, but they should be visit-able in isolation  from their parents as well, because that's how they are visited when they are expanded from macros.

I've checked that all the remaining `resolve_visibility` calls are used correctly.

r? @matthewjasper 