### PR TITLE
Refactorings to borrowck region diagnostic reporting

### DIFF
--- a/src/librustc_mir/borrow_check/diagnostics/mod.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/mod.rs
@@ -32,7 +32,7 @@ mod region_errors;
 
 crate use mutability_errors::AccessKind;
 crate use outlives_suggestion::OutlivesSuggestionBuilder;
-crate use region_errors::{ErrorConstraintInfo, ErrorReportingCtx};
+crate use region_errors::{ErrorConstraintInfo, ErrorReportingCtx, RegionErrorKind, RegionErrors};
 crate use region_name::{RegionErrorNamingCtx, RegionName, RegionNameSource};
 
 pub(super) struct IncludingDowncast(pub(super) bool);

--- a/src/librustc_mir/borrow_check/diagnostics/outlives_suggestion.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/outlives_suggestion.rs
@@ -243,7 +243,9 @@ impl OutlivesSuggestionBuilder<'a> {
 
         // If there is only one constraint to suggest, then we already suggested it in the
         // intermediate suggestion above.
-        if self.constraints_to_add.len() == 1 {
+        if self.constraints_to_add.len() == 1
+            && self.constraints_to_add.values().next().unwrap().len() == 1
+        {
             debug!("Only 1 suggestion. Skipping.");
             return;
         }

--- a/src/librustc_mir/borrow_check/nll.rs
+++ b/src/librustc_mir/borrow_check/nll.rs
@@ -3,8 +3,8 @@
 use rustc::hir::def_id::DefId;
 use rustc::infer::InferCtxt;
 use rustc::mir::{
-    BasicBlock, Body, BodyAndCache, ClosureOutlivesSubject, ClosureRegionRequirements, Local,
-    LocalKind, Location, Promoted, ReadOnlyBodyAndCache,
+    BasicBlock, Body, BodyAndCache, ClosureOutlivesSubject, ClosureRegionRequirements, LocalKind,
+    Location, Promoted, ReadOnlyBodyAndCache,
 };
 use rustc::ty::{self, RegionKind, RegionVid};
 use rustc_errors::Diagnostic;
@@ -16,7 +16,6 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use std::str::FromStr;
 use syntax::symbol::sym;
-use syntax_pos::symbol::Symbol;
 
 use self::mir_util::PassWhere;
 use polonius_engine::{Algorithm, Output};
@@ -31,6 +30,7 @@ use crate::util::pretty;
 use crate::borrow_check::{
     borrow_set::BorrowSet,
     constraint_generation,
+    diagnostics::RegionErrors,
     facts::{AllFacts, AllFactsExt, RustcFacts},
     invalidation,
     location::LocationTable,
@@ -38,14 +38,21 @@ use crate::borrow_check::{
     renumber,
     type_check::{self, MirTypeckRegionConstraints, MirTypeckResults},
     universal_regions::UniversalRegions,
-    Upvar,
 };
 
 crate type PoloniusOutput = Output<RustcFacts>;
 
-/// Rewrites the regions in the MIR to use NLL variables, also
-/// scraping out the set of universal regions (e.g., region parameters)
-/// declared on the function. That set will need to be given to
+/// The output of `nll::compute_regions`. This includes the computed `RegionInferenceContext`, any
+/// closure requirements to propagate, and any generated errors.
+crate struct NllOutput<'tcx> {
+    pub regioncx: RegionInferenceContext<'tcx>,
+    pub polonius_output: Option<Rc<PoloniusOutput>>,
+    pub opt_closure_req: Option<ClosureRegionRequirements<'tcx>>,
+    pub nll_errors: RegionErrors<'tcx>,
+}
+
+/// Rewrites the regions in the MIR to use NLL variables, also scraping out the set of universal
+/// regions (e.g., region parameters) declared on the function. That set will need to be given to
 /// `compute_regions`.
 pub(in crate::borrow_check) fn replace_regions_in_mir<'cx, 'tcx>(
     infcx: &InferCtxt<'cx, 'tcx>,
@@ -140,19 +147,12 @@ pub(in crate::borrow_check) fn compute_regions<'cx, 'tcx>(
     universal_regions: UniversalRegions<'tcx>,
     body: ReadOnlyBodyAndCache<'_, 'tcx>,
     promoted: &IndexVec<Promoted, ReadOnlyBodyAndCache<'_, 'tcx>>,
-    local_names: &IndexVec<Local, Option<Symbol>>,
-    upvars: &[Upvar],
     location_table: &LocationTable,
     param_env: ty::ParamEnv<'tcx>,
     flow_inits: &mut FlowAtLocation<'tcx, MaybeInitializedPlaces<'cx, 'tcx>>,
     move_data: &MoveData<'tcx>,
     borrow_set: &BorrowSet<'tcx>,
-    errors_buffer: &mut Vec<Diagnostic>,
-) -> (
-    RegionInferenceContext<'tcx>,
-    Option<Rc<PoloniusOutput>>,
-    Option<ClosureRegionRequirements<'tcx>>,
-) {
+) -> NllOutput<'tcx> {
     let mut all_facts = AllFacts::enabled(infcx.tcx).then_some(AllFacts::default());
 
     let universal_regions = Rc::new(universal_regions);
@@ -284,34 +284,18 @@ pub(in crate::borrow_check) fn compute_regions<'cx, 'tcx>(
     });
 
     // Solve the region constraints.
-    let closure_region_requirements = regioncx.solve(
-        infcx,
-        &body,
-        local_names,
-        upvars,
-        def_id,
-        errors_buffer,
-        polonius_output.clone(),
-    );
+    let (closure_region_requirements, nll_errors) =
+        regioncx.solve(infcx, &body, def_id, polonius_output.clone());
 
-    // Dump MIR results into a file, if that is enabled. This let us
-    // write unit-tests, as well as helping with debugging.
-    dump_mir_results(
-        infcx,
-        MirSource::item(def_id),
-        &body,
-        &regioncx,
-        &closure_region_requirements,
-    );
-
-    // We also have a `#[rustc_nll]` annotation that causes us to dump
-    // information
-    dump_annotation(infcx, &body, def_id, &regioncx, &closure_region_requirements, errors_buffer);
-
-    (regioncx, polonius_output, closure_region_requirements)
+    NllOutput {
+        regioncx,
+        polonius_output,
+        opt_closure_req: closure_region_requirements,
+        nll_errors,
+    }
 }
 
-fn dump_mir_results<'a, 'tcx>(
+pub(super) fn dump_mir_results<'a, 'tcx>(
     infcx: &InferCtxt<'a, 'tcx>,
     source: MirSource<'tcx>,
     body: &Body<'tcx>,
@@ -362,7 +346,7 @@ fn dump_mir_results<'a, 'tcx>(
     };
 }
 
-fn dump_annotation<'a, 'tcx>(
+pub(super) fn dump_annotation<'a, 'tcx>(
     infcx: &InferCtxt<'a, 'tcx>,
     body: &Body<'tcx>,
     mir_def_id: DefId,

--- a/src/test/ui/hrtb/hrtb-perfect-forwarding.nll.stderr
+++ b/src/test/ui/hrtb/hrtb-perfect-forwarding.nll.stderr
@@ -44,12 +44,6 @@ LL | | }
    |
    = help: a `loop` may express intention better if this is on purpose
 
-error: higher-ranked subtype error
-  --> $DIR/hrtb-perfect-forwarding.rs:46:5
-   |
-LL |     foo_hrtb_bar_not(&mut t);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
-
 error: lifetime may not live long enough
   --> $DIR/hrtb-perfect-forwarding.rs:46:5
    |
@@ -60,6 +54,12 @@ LL |     foo_hrtb_bar_not(&mut t);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'b` must outlive `'static`
    |
    = help: consider replacing `'b` with `'static`
+
+error: higher-ranked subtype error
+  --> $DIR/hrtb-perfect-forwarding.rs:46:5
+   |
+LL |     foo_hrtb_bar_not(&mut t);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: function cannot return without recursing
   --> $DIR/hrtb-perfect-forwarding.rs:49:1


### PR DESCRIPTION
This PR is a followup to #66886 and #67404 

EDIT: updated

In this PR:  Clean up how errors are collected from NLL: introduce `borrow_check::diagnostics::RegionErrors` to collect errors. This is later passed to `MirBorrowckCtx::report_region_errors` after the `MirBorrowckCtx` is created. This will allow us to refactor away some of the extra context structs floating around (but we don't do it in this PR).  `borrow_check::region_infer` is now mostly free of diagnostic generating code. The signatures of most of the functions in `region_infer` lose somewhere between 4 and 7 arguments :)

Left for future (feedback appreciated):

- Merge `ErrorRegionCtx` with `MirBorrowckCtx`, as suggested by @matthewjasper in https://github.com/rust-lang/rust/pull/66886#issuecomment-559949499
- Maybe move the contents of `borrow_check::nll` into `borrow_check` and remove the `nll` submodule altogether.
- Find a way to make `borrow_check::diagnostics::region_errors` less of a strange appendage to `RegionInferenceContext`. I'm not really sure how to do this yet. Ideas welcome.