### PR TITLE
Improve code generated for `starts_with(<literal char>)`

### DIFF
--- a/src/libcore/benches/lib.rs
+++ b/src/libcore/benches/lib.rs
@@ -11,4 +11,5 @@ mod hash;
 mod iter;
 mod num;
 mod ops;
+mod pattern;
 mod slice;

--- a/src/libcore/benches/pattern.rs
+++ b/src/libcore/benches/pattern.rs
@@ -1,0 +1,43 @@
+use test::black_box;
+use test::Bencher;
+
+#[bench]
+fn starts_with_char(b: &mut Bencher) {
+    let text = black_box("kdjsfhlakfhlsghlkvcnljknfqiunvcijqenwodind");
+    b.iter(|| {
+        for _ in 0..1024 {
+            black_box(text.starts_with('k'));
+        }
+    })
+}
+
+#[bench]
+fn starts_with_str(b: &mut Bencher) {
+    let text = black_box("kdjsfhlakfhlsghlkvcnljknfqiunvcijqenwodind");
+    b.iter(|| {
+        for _ in 0..1024 {
+            black_box(text.starts_with("k"));
+        }
+    })
+}
+
+
+#[bench]
+fn ends_with_char(b: &mut Bencher) {
+    let text = black_box("kdjsfhlakfhlsghlkvcnljknfqiunvcijqenwodind");
+    b.iter(|| {
+        for _ in 0..1024 {
+            black_box(text.ends_with('k'));
+        }
+    })
+}
+
+#[bench]
+fn ends_with_str(b: &mut Bencher) {
+    let text = black_box("kdjsfhlakfhlsghlkvcnljknfqiunvcijqenwodind");
+    b.iter(|| {
+        for _ in 0..1024 {
+            black_box(text.ends_with("k"));
+        }
+    })
+}

--- a/src/libcore/str/pattern.rs
+++ b/src/libcore/str/pattern.rs
@@ -450,21 +450,15 @@ impl<'a> Pattern<'a> for char {
 
     #[inline]
     fn is_prefix_of(self, haystack: &'a str) -> bool {
-        if let Some(ch) = haystack.chars().next() {
-            self == ch
-        } else {
-            false
-        }
+        let mut buffer = [0u8; 4];
+        self.encode_utf8(&mut buffer).is_prefix_of(haystack)
     }
 
     #[inline]
     fn is_suffix_of(self, haystack: &'a str) -> bool where Self::Searcher: ReverseSearcher<'a>
     {
-        if let Some(ch) = haystack.chars().next_back() {
-            self == ch
-        } else {
-            false
-        }
+        let mut buffer = [0u8; 4];
+        self.encode_utf8(&mut buffer).is_suffix_of(haystack)
     }
 }
 

--- a/src/libcore/str/pattern.rs
+++ b/src/libcore/str/pattern.rs
@@ -715,16 +715,13 @@ impl<'a, 'b> Pattern<'a> for &'b str {
     /// Checks whether the pattern matches at the front of the haystack
     #[inline]
     fn is_prefix_of(self, haystack: &'a str) -> bool {
-        haystack.is_char_boundary(self.len()) &&
-            self == &haystack[..self.len()]
+        haystack.as_bytes().starts_with(self.as_bytes())
     }
 
     /// Checks whether the pattern matches at the back of the haystack
     #[inline]
     fn is_suffix_of(self, haystack: &'a str) -> bool {
-        self.len() <= haystack.len() &&
-            haystack.is_char_boundary(haystack.len() - self.len()) &&
-            self == &haystack[haystack.len() - self.len()..]
+        haystack.as_bytes().ends_with(self.as_bytes())
     }
 }
 

--- a/src/libcore/str/pattern.rs
+++ b/src/libcore/str/pattern.rs
@@ -450,15 +450,13 @@ impl<'a> Pattern<'a> for char {
 
     #[inline]
     fn is_prefix_of(self, haystack: &'a str) -> bool {
-        let mut buffer = [0u8; 4];
-        self.encode_utf8(&mut buffer).is_prefix_of(haystack)
+        self.encode_utf8(&mut [0u8; 4]).is_prefix_of(haystack)
     }
 
     #[inline]
     fn is_suffix_of(self, haystack: &'a str) -> bool where Self::Searcher: ReverseSearcher<'a>
     {
-        let mut buffer = [0u8; 4];
-        self.encode_utf8(&mut buffer).is_suffix_of(haystack)
+        self.encode_utf8(&mut [0u8; 4]).is_suffix_of(haystack)
     }
 }
 


### PR DESCRIPTION
This PR includes two minor improvements to the code generated when checking for string prefix/suffix.

The first commit simplifies the str/str operation, by taking advantage of the raw UTF-8 representation.

The second commit replaces the current str/char matching logic with a char->str encoding and then the previous method.

The resulting code should be equivalent in the generic case (one char is being encoded versus one char being decoded), but it becomes easy to optimize in the case of a literal char, which in most cases a developer might expect to be at least as simple as that of a literal string.

This PR should fix #41993