### PR TITLE
Tweak errors for missing associated types and type parameters

### DIFF
--- a/src/librustc_error_codes/error_codes.rs
+++ b/src/librustc_error_codes/error_codes.rs
@@ -116,6 +116,7 @@ E0211: include_str!("./error_codes/E0211.md"),
 E0214: include_str!("./error_codes/E0214.md"),
 E0220: include_str!("./error_codes/E0220.md"),
 E0221: include_str!("./error_codes/E0221.md"),
+E0222: include_str!("./error_codes/E0222.md"),
 E0223: include_str!("./error_codes/E0223.md"),
 E0225: include_str!("./error_codes/E0225.md"),
 E0229: include_str!("./error_codes/E0229.md"),
@@ -457,8 +458,6 @@ E0745: include_str!("./error_codes/E0745.md"),
 //  E0217, // ambiguous associated type, defined in multiple supertraits
 //  E0218, // no associated type defined
 //  E0219, // associated type defined in higher-ranked supertrait
-//  E0222, // Error code E0045 (variadic function must have C or cdecl calling
-           // convention) duplicate
     E0224, // at least one non-builtin train is required for an object type
     E0226, // only a single explicit lifetime bound is permitted
     E0227, // ambiguous lifetime bound, explicit lifetime bound required

--- a/src/librustc_error_codes/error_codes/E0222.md
+++ b/src/librustc_error_codes/error_codes/E0222.md
@@ -1,0 +1,51 @@
+An attempt was made to constrain an associated type.
+For example:
+
+```compile_fail,E0222
+pub trait Vehicle {
+    type Color;
+}
+
+pub trait Box {
+    type Color;
+}
+
+pub trait BoxCar : Box + Vehicle {}
+
+fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {} // Invalid constraint
+```
+
+In this example, `BoxCar` has two super-traits: `Vehicle` and `Box`. Both of
+these traits define an associated type `Color`. `BoxCar` inherits two types
+with that name from both super-traits. Because of this, we need to use the
+fully qualified path syntax to refer to the appropriate `Color` associated
+type, either `<BoxCar as Vehicle>::Color` or `<BoxCar as Box>::Color`, but this
+syntax is not allowed to be used in a function signature.
+
+In order to encode this kind of constraint, a `where` clause and a new type
+parameter are needed:
+
+```
+pub trait Vehicle {
+    type Color;
+}
+
+pub trait Box {
+    type Color;
+}
+
+pub trait BoxCar : Box + Vehicle {}
+
+// Introduce a new `CAR` type parameter
+fn foo<CAR, COLOR>(
+    c: CAR,
+) where
+    // Bind the type parameter `CAR` to the trait `BoxCar`
+    CAR: BoxCar,
+    // Further restrict `<BoxCar as Vehicle>::Color` to be the same as the
+    // type parameter `COLOR`
+    CAR: Vehicle<Color = COLOR>,
+    // We can also simultaneously restrict the other trait's associated type
+    CAR: Box<Color = COLOR>
+{}
+```

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -804,6 +804,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                         predicate.span,
                         "equality constraints are not yet supported in `where` clauses",
                     )
+                    .span_label(predicate.span, "not supported")
                     .note(
                         "for more information, see https://github.com/rust-lang/rust/issues/20041",
                     )

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -473,7 +473,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         self_ty: Option<Ty<'tcx>>,
         args_for_def_id: impl Fn(DefId) -> (Option<&'b GenericArgs>, bool),
         provided_kind: impl Fn(&GenericParamDef, &GenericArg) -> subst::GenericArg<'tcx>,
-        inferred_kind: impl Fn(
+        mut inferred_kind: impl FnMut(
             Option<&[subst::GenericArg<'tcx>]>,
             &GenericParamDef,
             bool,
@@ -674,6 +674,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             false
         };
 
+        let mut missing_type_params = vec![];
         let substs = Self::create_substs_for_generic_args(
             tcx,
             def_id,
@@ -709,19 +710,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                             // defaults. This will lead to an ICE if we are not
                             // careful!
                             if default_needs_object_self(param) {
-                                struct_span_err!(
-                                    tcx.sess,
-                                    span,
-                                    E0393,
-                                    "the type parameter `{}` must be explicitly specified",
-                                    param.name
-                                )
-                                .span_label(span, format!("missing reference to `{}`", param.name))
-                                .note(&format!(
-                                    "because of the default `Self` reference, type parameters \
-                                         must be specified on object types"
-                                ))
-                                .emit();
+                                missing_type_params.push(param.name.to_string());
                                 tcx.types.err.into()
                             } else {
                                 // This is a default type parameter.
@@ -759,6 +748,70 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 }
             },
         );
+        if !missing_type_params.is_empty() {
+            let display = missing_type_params
+                .iter()
+                .map(|n| format!("`{}`", n))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let mut err = struct_span_err!(
+                tcx.sess,
+                span,
+                E0393,
+                "the type parameter{} {} must be explicitly specified",
+                pluralize!(missing_type_params.len()),
+                display,
+            );
+            err.span_label(
+                self.tcx().def_span(def_id),
+                &format!(
+                    "type parameter{} {} must be specified for this",
+                    pluralize!(missing_type_params.len()),
+                    display,
+                ),
+            );
+            let mut suggested = false;
+            if let (Ok(snippet), true) = (
+                tcx.sess.source_map().span_to_snippet(span),
+                // Don't suggest setting the type params if there are some already: the order is
+                // tricky to get right and the user will already know what the syntax is.
+                generic_args.args.is_empty(),
+            ) {
+                if snippet.ends_with('>') {
+                    // The user wrote `Trait<'a, T>` or similar. To provide an accurate suggestion
+                    // we would have to preserve the right order. For now, as clearly the user is
+                    // aware of the syntax, we do nothing.
+                } else {
+                    // The user wrote `Iterator`, so we don't have a type we can suggest, but at
+                    // least we can clue them to the correct syntax `Iterator<Type>`.
+                    err.span_suggestion(
+                        span,
+                        &format!(
+                            "set the type parameter{plural} to the desired type{plural}",
+                            plural = pluralize!(missing_type_params.len()),
+                        ),
+                        format!("{}<{}>", snippet, missing_type_params.join(", ")),
+                        Applicability::HasPlaceholders,
+                    );
+                    suggested = true;
+                }
+            }
+            if !suggested {
+                err.span_label(
+                    span,
+                    format!(
+                        "missing reference{} to {}",
+                        pluralize!(missing_type_params.len()),
+                        display,
+                    ),
+                );
+            }
+            err.note(&format!(
+                "because of the default `Self` reference, type parameters must be \
+                               specified on object types"
+            ));
+            err.emit();
+        }
 
         // Convert associated-type bindings or constraints into a separate vector.
         // Example: Given this:
@@ -854,8 +907,18 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 
         self.prohibit_generics(trait_ref.path.segments.split_last().unwrap().1);
 
+        let path_span = if trait_ref.path.segments.len() == 1 {
+            // FIXME: `trait_ref.path.span` can point to a full path with multiple
+            // segments, even though `trait_ref.path.segments` is of length `1`. Work
+            // around that bug here, even though it should be fixed elsewhere.
+            // This would otherwise cause an invalid suggestion. For an example, look at
+            // `src/test/ui/issues/issue-28344.rs`.
+            trait_ref.path.segments[0].ident.span
+        } else {
+            trait_ref.path.span
+        };
         let (substs, assoc_bindings, potential_assoc_types) = self.create_substs_for_ast_trait_ref(
-            trait_ref.path.span,
+            path_span,
             trait_def_id,
             self_ty,
             trait_ref.path.segments.last().unwrap(),
@@ -947,13 +1010,21 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             && trait_segment.generic_args().parenthesized != trait_def.paren_sugar
         {
             // For now, require that parenthetical notation be used only with `Fn()` etc.
-            let msg = if trait_def.paren_sugar {
-                "the precise format of `Fn`-family traits' type parameters is subject to change. \
-                 Use parenthetical notation (Fn(Foo, Bar) -> Baz) instead"
+            let (msg, help) = if trait_def.paren_sugar {
+                (
+                    "the precise format of `Fn`-family traits' type parameters is subject to \
+                     change",
+                    Some("use parenthetical notation instead: `Fn(Foo, Bar) -> Baz`"),
+                )
             } else {
-                "parenthetical notation is only stable when used with `Fn`-family traits"
+                ("parenthetical notation is only stable when used with `Fn`-family traits", None)
             };
-            feature_err(&self.tcx().sess.parse_sess, sym::unboxed_closures, span, msg).emit();
+            let sess = &self.tcx().sess.parse_sess;
+            let mut err = feature_err(sess, sym::unboxed_closures, span, msg);
+            if let Some(help) = help {
+                err.help(help);
+            }
+            err.emit();
         }
 
         self.create_substs_for_ast_path(
@@ -1213,8 +1284,8 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                         self.tcx().sess,
                         binding.span,
                         E0719,
-                        "the value of the associated type `{}` (from the trait `{}`) \
-                                      is already specified",
+                        "the value of the associated type `{}` (from trait `{}`) \
+                         is already specified",
                         binding.item_name,
                         tcx.def_path_str(assoc_ty.container.id())
                     )
@@ -1378,65 +1449,123 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         }
 
         if !associated_types.is_empty() {
+            // Account for things like `dyn Foo + 'a` by pointing at the `TraitRef.path`
+            // `Span` instead of the `PolyTraitRef` `Span`. That way the suggestion will
+            // be valid, otherwise we would suggest `dyn Foo + 'a<A = Type>`. See tests
+            // `issue-22434.rs` and `issue-22560.rs` for examples.
+            let sugg_span = if potential_assoc_types.is_empty() && trait_bounds.len() == 1 {
+                if trait_bounds[0].trait_ref.path.segments.len() == 1
+                    && trait_bounds[0].trait_ref.path.segments[0].args.is_none()
+                {
+                    // FIXME: `trait_ref.path.span` can point to a full path with multiple
+                    // segments, even though `trait_ref.path.segments` is of length `1`. Work
+                    // around that bug here, even though it should be fixed elsewhere.
+                    // This would otherwise cause an invalid suggestion. For an example, look at
+                    // `src/test/ui/issues/issue-28344.rs`.
+                    trait_bounds[0].trait_ref.path.segments[0].ident.span
+                } else {
+                    trait_bounds[0].trait_ref.path.span
+                }
+            } else {
+                span
+            };
             let names = associated_types
                 .iter()
                 .map(|item_def_id| {
                     let assoc_item = tcx.associated_item(*item_def_id);
                     let trait_def_id = assoc_item.container.id();
                     format!(
-                        "`{}` (from the trait `{}`)",
+                        "`{}` (from trait `{}`)",
                         assoc_item.ident,
-                        tcx.def_path_str(trait_def_id),
+                        tcx.def_path_str(trait_def_id)
                     )
                 })
                 .collect::<Vec<_>>()
                 .join(", ");
             let mut err = struct_span_err!(
                 tcx.sess,
-                span,
+                sugg_span,
                 E0191,
                 "the value of the associated type{} {} must be specified",
                 pluralize!(associated_types.len()),
                 names,
             );
-            let (suggest, potential_assoc_types_spans) =
+            let mut suggestions = Vec::new();
+            let mut applicability = Applicability::MaybeIncorrect;
+            for (i, item_def_id) in associated_types.iter().enumerate() {
+                let assoc_item = tcx.associated_item(*item_def_id);
+                if let Some(sp) = tcx.hir().span_if_local(*item_def_id) {
+                    err.span_label(sp, format!("`{}` defined here", assoc_item.ident));
+                }
                 if potential_assoc_types.len() == associated_types.len() {
                     // Only suggest when the amount of missing associated types equals the number of
                     // extra type arguments present, as that gives us a relatively high confidence
                     // that the user forgot to give the associtated type's name. The canonical
                     // example would be trying to use `Iterator<isize>` instead of
                     // `Iterator<Item = isize>`.
-                    (true, potential_assoc_types)
-                } else {
-                    (false, Vec::new())
-                };
-            let mut suggestions = Vec::new();
-            for (i, item_def_id) in associated_types.iter().enumerate() {
-                let assoc_item = tcx.associated_item(*item_def_id);
-                err.span_label(
-                    span,
-                    format!("associated type `{}` must be specified", assoc_item.ident),
-                );
-                if let Some(sp) = tcx.hir().span_if_local(*item_def_id) {
-                    err.span_label(sp, format!("`{}` defined here", assoc_item.ident));
-                }
-                if suggest {
                     if let Ok(snippet) =
-                        tcx.sess.source_map().span_to_snippet(potential_assoc_types_spans[i])
+                        tcx.sess.source_map().span_to_snippet(potential_assoc_types[i])
                     {
                         suggestions.push((
-                            potential_assoc_types_spans[i],
+                            potential_assoc_types[i],
                             format!("{} = {}", assoc_item.ident, snippet),
                         ));
                     }
                 }
             }
-            if !suggestions.is_empty() {
-                let msg = format!(
-                    "if you meant to specify the associated {}, write",
-                    if suggestions.len() == 1 { "type" } else { "types" }
+            let mut suggestions_len = suggestions.len();
+            if let Ok(snippet) = tcx.sess.source_map().span_to_snippet(sugg_span) {
+                if potential_assoc_types.is_empty() && trait_bounds.len() == 1 &&
+                    // Do not attempt to suggest when we don't know which path segment needs the
+                    // type parameter set.
+                    trait_bounds[0].trait_ref.path.segments.len() == 1
+                {
+                    debug!("path segments {:?}", trait_bounds[0].trait_ref.path.segments);
+                    applicability = Applicability::HasPlaceholders;
+                    let assoc_types: Vec<String> = associated_types
+                        .iter()
+                        .map(|item_def_id| {
+                            let assoc_item = tcx.associated_item(*item_def_id);
+                            format!("{} = Type", assoc_item.ident)
+                        })
+                        .collect();
+                    let sugg = assoc_types.join(", ");
+                    if snippet.ends_with('>') {
+                        // The user wrote `Trait<'a>` or similar and we don't have a type we can
+                        // suggest, but at least we can clue them to the correct syntax
+                        // `Trait<'a, Item = Type>` while accounting for the `<'a>` in the
+                        // suggestion.
+                        suggestions.push((
+                            sugg_span,
+                            format!("{}, {}>", &snippet[..snippet.len() - 1], sugg,),
+                        ));
+                    } else {
+                        // The user wrote `Iterator`, so we don't have a type we can suggest, but at
+                        // least we can clue them to the correct syntax `Iterator<Item = Type>`.
+                        suggestions.push((sugg_span, format!("{}<{}>", snippet, sugg)));
+                    }
+                    suggestions_len = assoc_types.len();
+                }
+            }
+            if suggestions.len() != 1 {
+                // We don't need this label if there's an inline suggestion, show otherwise.
+                let names = associated_types
+                    .iter()
+                    .map(|t| format!("`{}`", tcx.associated_item(*t).ident))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                err.span_label(
+                    span,
+                    format!(
+                        "associated type{} {} must be specified",
+                        pluralize!(associated_types.len()),
+                        names,
+                    ),
                 );
-                err.multipart_suggestion(&msg, suggestions, Applicability::MaybeIncorrect);
+            }
+            if !suggestions.is_empty() {
+                let msg = format!("specify the associated type{}", pluralize!(suggestions_len));
+                err.multipart_suggestion(&msg, suggestions, applicability);
             }
             err.emit();
         }
@@ -1645,23 +1774,32 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     })
                     .and_then(|item| self.tcx().hir().span_if_local(item.def_id));
 
-                if let Some(span) = bound_span {
+                if let Some(bound_span) = bound_span {
                     err.span_label(
-                        span,
+                        bound_span,
                         format!(
                             "ambiguous `{}` from `{}`",
                             assoc_name,
-                            bound.print_only_trait_path()
+                            bound.print_only_trait_path(),
                         ),
                     );
-                } else {
-                    span_note!(
-                        &mut err,
+                    err.span_suggestion(
                         span,
+                        "use fully qualified syntax to disambiguate",
+                        format!(
+                            "<{} as {}>::{}",
+                            ty_param_name,
+                            bound.print_only_trait_path(),
+                            assoc_name,
+                        ),
+                        Applicability::MaybeIncorrect,
+                    );
+                } else {
+                    err.note(&format!(
                         "associated type `{}` could derive from `{}`",
                         ty_param_name,
-                        bound.print_only_trait_path()
-                    );
+                        bound.print_only_trait_path(),
+                    ));
                 }
             }
             err.emit();

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -937,6 +937,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 bounds,
                 speculative,
                 &mut dup_bindings,
+                span,
             );
             // Okay to ignore `Err` because of `ErrorReported` (see above).
         }
@@ -1189,6 +1190,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         bounds: &mut Bounds<'tcx>,
         speculative: bool,
         dup_bindings: &mut FxHashMap<DefId, Span>,
+        path_span: Span,
     ) -> Result<(), ErrorReported> {
         let tcx = self.tcx();
 
@@ -1259,7 +1261,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     || traits::supertraits(tcx, trait_ref),
                     &trait_ref.print_only_trait_path().to_string(),
                     binding.item_name,
-                    binding.span,
+                    path_span,
                 )
             }?;
 

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1686,6 +1686,8 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             },
             _ => {}
         }
+        names.sort();
+        trait_bound_spans.sort();
         let mut err = struct_span_err!(
             tcx.sess,
             trait_bound_spans,

--- a/src/test/compile-fail/issue-23595-1.rs
+++ b/src/test/compile-fail/issue-23595-1.rs
@@ -1,12 +1,12 @@
 #![feature(associated_type_defaults)]
 
-use std::ops::{Index};
+use std::ops::Index;
 
 trait Hierarchy {
     type Value;
     type ChildKey;
     type Children = dyn Index<Self::ChildKey, Output=dyn Hierarchy>;
-    //~^ ERROR: the value of the associated types `Value` (from the trait `Hierarchy`), `ChildKey`
+    //~^ ERROR: the value of the associated types `Value` (from trait `Hierarchy`), `ChildKey`
 
     fn data(&self) -> Option<(Self::Value, Self::Children)>;
 }

--- a/src/test/compile-fail/issue-23595-1.rs
+++ b/src/test/compile-fail/issue-23595-1.rs
@@ -6,7 +6,7 @@ trait Hierarchy {
     type Value;
     type ChildKey;
     type Children = dyn Index<Self::ChildKey, Output=dyn Hierarchy>;
-    //~^ ERROR: the value of the associated types `Value` (from trait `Hierarchy`), `ChildKey`
+    //~^ ERROR: the value of the associated types
 
     fn data(&self) -> Option<(Self::Value, Self::Children)>;
 }

--- a/src/test/ui/associated-type-bounds/duplicate.rs
+++ b/src/test/ui/associated-type-bounds/duplicate.rs
@@ -9,175 +9,175 @@
 use std::iter;
 
 struct SI1<T: Iterator<Item: Copy, Item: Send>> { f: T }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 struct SI2<T: Iterator<Item: Copy, Item: Copy>> { f: T }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 struct SI3<T: Iterator<Item: 'static, Item: 'static>> { f: T }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 struct SW1<T> where T: Iterator<Item: Copy, Item: Send> { f: T }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 struct SW2<T> where T: Iterator<Item: Copy, Item: Copy> { f: T }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 struct SW3<T> where T: Iterator<Item: 'static, Item: 'static> { f: T }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 
 enum EI1<T: Iterator<Item: Copy, Item: Send>> { V(T) }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 enum EI2<T: Iterator<Item: Copy, Item: Copy>> { V(T) }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 enum EI3<T: Iterator<Item: 'static, Item: 'static>> { V(T) }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 enum EW1<T> where T: Iterator<Item: Copy, Item: Send> { V(T) }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 enum EW2<T> where T: Iterator<Item: Copy, Item: Copy> { V(T) }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 enum EW3<T> where T: Iterator<Item: 'static, Item: 'static> { V(T) }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 
 union UI1<T: Iterator<Item: Copy, Item: Send>> { f: T }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 union UI2<T: Iterator<Item: Copy, Item: Copy>> { f: T }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 union UI3<T: Iterator<Item: 'static, Item: 'static>> { f: T }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 union UW1<T> where T: Iterator<Item: Copy, Item: Send> { f: T }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 union UW2<T> where T: Iterator<Item: Copy, Item: Copy> { f: T }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 union UW3<T> where T: Iterator<Item: 'static, Item: 'static> { f: T }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 
 fn FI1<T: Iterator<Item: Copy, Item: Send>>() {}
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 fn FI2<T: Iterator<Item: Copy, Item: Copy>>() {}
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 fn FI3<T: Iterator<Item: 'static, Item: 'static>>() {}
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 fn FW1<T>() where T: Iterator<Item: Copy, Item: Send> {}
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 fn FW2<T>() where T: Iterator<Item: Copy, Item: Copy> {}
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 fn FW3<T>() where T: Iterator<Item: 'static, Item: 'static> {}
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 
 fn FRPIT1() -> impl Iterator<Item: Copy, Item: Send> { iter::empty() }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 fn FRPIT2() -> impl Iterator<Item: Copy, Item: Copy> { iter::empty() }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 fn FRPIT3() -> impl Iterator<Item: 'static, Item: 'static> { iter::empty() }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 fn FAPIT1(_: impl Iterator<Item: Copy, Item: Send>) {}
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 fn FAPIT2(_: impl Iterator<Item: Copy, Item: Copy>) {}
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 fn FAPIT3(_: impl Iterator<Item: 'static, Item: 'static>) {}
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 
 const CIT1: impl Iterator<Item: Copy, Item: Send> = iter::empty();
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 const CIT2: impl Iterator<Item: Copy, Item: Copy> = iter::empty();
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 const CIT3: impl Iterator<Item: 'static, Item: 'static> = iter::empty();
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 static SIT1: impl Iterator<Item: Copy, Item: Send> = iter::empty();
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 static SIT2: impl Iterator<Item: Copy, Item: Copy> = iter::empty();
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 static SIT3: impl Iterator<Item: 'static, Item: 'static> = iter::empty();
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 
 fn lit1() { let _: impl Iterator<Item: Copy, Item: Send> = iter::empty(); }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 fn lit2() { let _: impl Iterator<Item: Copy, Item: Copy> = iter::empty(); }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 fn lit3() { let _: impl Iterator<Item: 'static, Item: 'static> = iter::empty(); }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 
 type TAI1<T: Iterator<Item: Copy, Item: Send>> = T;
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 type TAI2<T: Iterator<Item: Copy, Item: Copy>> = T;
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 type TAI3<T: Iterator<Item: 'static, Item: 'static>> = T;
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 type TAW1<T> where T: Iterator<Item: Copy, Item: Send> = T;
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 type TAW2<T> where T: Iterator<Item: Copy, Item: Copy> = T;
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 type TAW3<T> where T: Iterator<Item: 'static, Item: 'static> = T;
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 
 type ETAI1<T: Iterator<Item: Copy, Item: Send>> = impl Copy;
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 //~| ERROR could not find defining uses
 //~| ERROR could not find defining uses
 //~| ERROR could not find defining uses
 type ETAI2<T: Iterator<Item: Copy, Item: Copy>> = impl Copy;
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 //~| ERROR could not find defining uses
 //~| ERROR could not find defining uses
 //~| ERROR could not find defining uses
 type ETAI3<T: Iterator<Item: 'static, Item: 'static>> = impl Copy;
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 //~| ERROR could not find defining uses
 //~| ERROR could not find defining uses
 //~| ERROR could not find defining uses
 type ETAI4 = impl Iterator<Item: Copy, Item: Send>;
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 //~| ERROR could not find defining uses
 //~| ERROR could not find defining uses
 //~| ERROR could not find defining uses
 type ETAI5 = impl Iterator<Item: Copy, Item: Copy>;
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 //~| ERROR could not find defining uses
 //~| ERROR could not find defining uses
 //~| ERROR could not find defining uses
 type ETAI6 = impl Iterator<Item: 'static, Item: 'static>;
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 //~| ERROR could not find defining uses
 //~| ERROR could not find defining uses
 //~| ERROR could not find defining uses
 
 trait TRI1<T: Iterator<Item: Copy, Item: Send>> {}
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 trait TRI2<T: Iterator<Item: Copy, Item: Copy>> {}
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 trait TRI3<T: Iterator<Item: 'static, Item: 'static>> {}
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 trait TRS1: Iterator<Item: Copy, Item: Send> {}
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 trait TRS2: Iterator<Item: Copy, Item: Copy> {}
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 trait TRS3: Iterator<Item: 'static, Item: 'static> {}
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 trait TRW1<T> where T: Iterator<Item: Copy, Item: Send> {}
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 trait TRW2<T> where T: Iterator<Item: Copy, Item: Copy> {}
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 trait TRW3<T> where T: Iterator<Item: 'static, Item: 'static> {}
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 trait TRSW1 where Self: Iterator<Item: Copy, Item: Send> {}
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 trait TRSW2 where Self: Iterator<Item: Copy, Item: Copy> {}
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 trait TRSW3 where Self: Iterator<Item: 'static, Item: 'static> {}
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 trait TRA1 { type A: Iterator<Item: Copy, Item: Send>; }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 trait TRA2 { type A: Iterator<Item: Copy, Item: Copy>; }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 trait TRA3 { type A: Iterator<Item: 'static, Item: 'static>; }
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 
 type TADyn1 = dyn Iterator<Item: Copy, Item: Send>;
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 //~| ERROR could not find defining uses
 //~| ERROR could not find defining uses
 type TADyn2 = Box<dyn Iterator<Item: Copy, Item: Copy>>;
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 //~| ERROR could not find defining uses
 //~| ERROR could not find defining uses
 type TADyn3 = dyn Iterator<Item: 'static, Item: 'static>;
-//~^ ERROR the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified [E0719]
 //~| ERROR could not find defining uses
 //~| ERROR could not find defining uses
 

--- a/src/test/ui/associated-type-bounds/duplicate.stderr
+++ b/src/test/ui/associated-type-bounds/duplicate.stderr
@@ -6,7 +6,7 @@ LL | #![feature(impl_trait_in_bindings)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:11:36
    |
 LL | struct SI1<T: Iterator<Item: Copy, Item: Send>> { f: T }
@@ -14,7 +14,7 @@ LL | struct SI1<T: Iterator<Item: Copy, Item: Send>> { f: T }
    |                        |
    |                        `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:13:36
    |
 LL | struct SI2<T: Iterator<Item: Copy, Item: Copy>> { f: T }
@@ -22,7 +22,7 @@ LL | struct SI2<T: Iterator<Item: Copy, Item: Copy>> { f: T }
    |                        |
    |                        `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:15:39
    |
 LL | struct SI3<T: Iterator<Item: 'static, Item: 'static>> { f: T }
@@ -30,7 +30,7 @@ LL | struct SI3<T: Iterator<Item: 'static, Item: 'static>> { f: T }
    |                        |
    |                        `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:17:45
    |
 LL | struct SW1<T> where T: Iterator<Item: Copy, Item: Send> { f: T }
@@ -38,7 +38,7 @@ LL | struct SW1<T> where T: Iterator<Item: Copy, Item: Send> { f: T }
    |                                 |
    |                                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:19:45
    |
 LL | struct SW2<T> where T: Iterator<Item: Copy, Item: Copy> { f: T }
@@ -46,7 +46,7 @@ LL | struct SW2<T> where T: Iterator<Item: Copy, Item: Copy> { f: T }
    |                                 |
    |                                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:21:48
    |
 LL | struct SW3<T> where T: Iterator<Item: 'static, Item: 'static> { f: T }
@@ -54,7 +54,7 @@ LL | struct SW3<T> where T: Iterator<Item: 'static, Item: 'static> { f: T }
    |                                 |
    |                                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:24:34
    |
 LL | enum EI1<T: Iterator<Item: Copy, Item: Send>> { V(T) }
@@ -62,7 +62,7 @@ LL | enum EI1<T: Iterator<Item: Copy, Item: Send>> { V(T) }
    |                      |
    |                      `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:26:34
    |
 LL | enum EI2<T: Iterator<Item: Copy, Item: Copy>> { V(T) }
@@ -70,7 +70,7 @@ LL | enum EI2<T: Iterator<Item: Copy, Item: Copy>> { V(T) }
    |                      |
    |                      `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:28:37
    |
 LL | enum EI3<T: Iterator<Item: 'static, Item: 'static>> { V(T) }
@@ -78,7 +78,7 @@ LL | enum EI3<T: Iterator<Item: 'static, Item: 'static>> { V(T) }
    |                      |
    |                      `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:30:43
    |
 LL | enum EW1<T> where T: Iterator<Item: Copy, Item: Send> { V(T) }
@@ -86,7 +86,7 @@ LL | enum EW1<T> where T: Iterator<Item: Copy, Item: Send> { V(T) }
    |                               |
    |                               `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:32:43
    |
 LL | enum EW2<T> where T: Iterator<Item: Copy, Item: Copy> { V(T) }
@@ -94,7 +94,7 @@ LL | enum EW2<T> where T: Iterator<Item: Copy, Item: Copy> { V(T) }
    |                               |
    |                               `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:34:46
    |
 LL | enum EW3<T> where T: Iterator<Item: 'static, Item: 'static> { V(T) }
@@ -102,7 +102,7 @@ LL | enum EW3<T> where T: Iterator<Item: 'static, Item: 'static> { V(T) }
    |                               |
    |                               `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:37:35
    |
 LL | union UI1<T: Iterator<Item: Copy, Item: Send>> { f: T }
@@ -110,7 +110,7 @@ LL | union UI1<T: Iterator<Item: Copy, Item: Send>> { f: T }
    |                       |
    |                       `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:39:35
    |
 LL | union UI2<T: Iterator<Item: Copy, Item: Copy>> { f: T }
@@ -118,7 +118,7 @@ LL | union UI2<T: Iterator<Item: Copy, Item: Copy>> { f: T }
    |                       |
    |                       `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:41:38
    |
 LL | union UI3<T: Iterator<Item: 'static, Item: 'static>> { f: T }
@@ -126,7 +126,7 @@ LL | union UI3<T: Iterator<Item: 'static, Item: 'static>> { f: T }
    |                       |
    |                       `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:43:44
    |
 LL | union UW1<T> where T: Iterator<Item: Copy, Item: Send> { f: T }
@@ -134,7 +134,7 @@ LL | union UW1<T> where T: Iterator<Item: Copy, Item: Send> { f: T }
    |                                |
    |                                `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:45:44
    |
 LL | union UW2<T> where T: Iterator<Item: Copy, Item: Copy> { f: T }
@@ -142,7 +142,7 @@ LL | union UW2<T> where T: Iterator<Item: Copy, Item: Copy> { f: T }
    |                                |
    |                                `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:47:47
    |
 LL | union UW3<T> where T: Iterator<Item: 'static, Item: 'static> { f: T }
@@ -150,7 +150,7 @@ LL | union UW3<T> where T: Iterator<Item: 'static, Item: 'static> { f: T }
    |                                |
    |                                `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:50:32
    |
 LL | fn FI1<T: Iterator<Item: Copy, Item: Send>>() {}
@@ -158,7 +158,7 @@ LL | fn FI1<T: Iterator<Item: Copy, Item: Send>>() {}
    |                    |
    |                    `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:52:32
    |
 LL | fn FI2<T: Iterator<Item: Copy, Item: Copy>>() {}
@@ -166,7 +166,7 @@ LL | fn FI2<T: Iterator<Item: Copy, Item: Copy>>() {}
    |                    |
    |                    `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:54:35
    |
 LL | fn FI3<T: Iterator<Item: 'static, Item: 'static>>() {}
@@ -174,7 +174,7 @@ LL | fn FI3<T: Iterator<Item: 'static, Item: 'static>>() {}
    |                    |
    |                    `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:56:43
    |
 LL | fn FW1<T>() where T: Iterator<Item: Copy, Item: Send> {}
@@ -182,7 +182,7 @@ LL | fn FW1<T>() where T: Iterator<Item: Copy, Item: Send> {}
    |                               |
    |                               `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:58:43
    |
 LL | fn FW2<T>() where T: Iterator<Item: Copy, Item: Copy> {}
@@ -190,7 +190,7 @@ LL | fn FW2<T>() where T: Iterator<Item: Copy, Item: Copy> {}
    |                               |
    |                               `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:60:46
    |
 LL | fn FW3<T>() where T: Iterator<Item: 'static, Item: 'static> {}
@@ -198,7 +198,7 @@ LL | fn FW3<T>() where T: Iterator<Item: 'static, Item: 'static> {}
    |                               |
    |                               `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:69:40
    |
 LL | fn FAPIT1(_: impl Iterator<Item: Copy, Item: Send>) {}
@@ -206,7 +206,7 @@ LL | fn FAPIT1(_: impl Iterator<Item: Copy, Item: Send>) {}
    |                            |
    |                            `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:71:40
    |
 LL | fn FAPIT2(_: impl Iterator<Item: Copy, Item: Copy>) {}
@@ -214,7 +214,7 @@ LL | fn FAPIT2(_: impl Iterator<Item: Copy, Item: Copy>) {}
    |                            |
    |                            `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:73:43
    |
 LL | fn FAPIT3(_: impl Iterator<Item: 'static, Item: 'static>) {}
@@ -222,7 +222,7 @@ LL | fn FAPIT3(_: impl Iterator<Item: 'static, Item: 'static>) {}
    |                            |
    |                            `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:63:42
    |
 LL | fn FRPIT1() -> impl Iterator<Item: Copy, Item: Send> { iter::empty() }
@@ -230,7 +230,7 @@ LL | fn FRPIT1() -> impl Iterator<Item: Copy, Item: Send> { iter::empty() }
    |                              |
    |                              `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:65:42
    |
 LL | fn FRPIT2() -> impl Iterator<Item: Copy, Item: Copy> { iter::empty() }
@@ -238,7 +238,7 @@ LL | fn FRPIT2() -> impl Iterator<Item: Copy, Item: Copy> { iter::empty() }
    |                              |
    |                              `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:67:45
    |
 LL | fn FRPIT3() -> impl Iterator<Item: 'static, Item: 'static> { iter::empty() }
@@ -246,7 +246,7 @@ LL | fn FRPIT3() -> impl Iterator<Item: 'static, Item: 'static> { iter::empty() 
    |                              |
    |                              `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:76:39
    |
 LL | const CIT1: impl Iterator<Item: Copy, Item: Send> = iter::empty();
@@ -254,7 +254,7 @@ LL | const CIT1: impl Iterator<Item: Copy, Item: Send> = iter::empty();
    |                           |
    |                           `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:78:39
    |
 LL | const CIT2: impl Iterator<Item: Copy, Item: Copy> = iter::empty();
@@ -262,7 +262,7 @@ LL | const CIT2: impl Iterator<Item: Copy, Item: Copy> = iter::empty();
    |                           |
    |                           `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:80:42
    |
 LL | const CIT3: impl Iterator<Item: 'static, Item: 'static> = iter::empty();
@@ -270,7 +270,7 @@ LL | const CIT3: impl Iterator<Item: 'static, Item: 'static> = iter::empty();
    |                           |
    |                           `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:82:40
    |
 LL | static SIT1: impl Iterator<Item: Copy, Item: Send> = iter::empty();
@@ -278,7 +278,7 @@ LL | static SIT1: impl Iterator<Item: Copy, Item: Send> = iter::empty();
    |                            |
    |                            `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:84:40
    |
 LL | static SIT2: impl Iterator<Item: Copy, Item: Copy> = iter::empty();
@@ -286,7 +286,7 @@ LL | static SIT2: impl Iterator<Item: Copy, Item: Copy> = iter::empty();
    |                            |
    |                            `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:86:43
    |
 LL | static SIT3: impl Iterator<Item: 'static, Item: 'static> = iter::empty();
@@ -294,7 +294,7 @@ LL | static SIT3: impl Iterator<Item: 'static, Item: 'static> = iter::empty();
    |                            |
    |                            `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:89:46
    |
 LL | fn lit1() { let _: impl Iterator<Item: Copy, Item: Send> = iter::empty(); }
@@ -302,7 +302,7 @@ LL | fn lit1() { let _: impl Iterator<Item: Copy, Item: Send> = iter::empty(); }
    |                                  |
    |                                  `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:91:46
    |
 LL | fn lit2() { let _: impl Iterator<Item: Copy, Item: Copy> = iter::empty(); }
@@ -310,7 +310,7 @@ LL | fn lit2() { let _: impl Iterator<Item: Copy, Item: Copy> = iter::empty(); }
    |                                  |
    |                                  `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:93:49
    |
 LL | fn lit3() { let _: impl Iterator<Item: 'static, Item: 'static> = iter::empty(); }
@@ -318,7 +318,7 @@ LL | fn lit3() { let _: impl Iterator<Item: 'static, Item: 'static> = iter::empt
    |                                  |
    |                                  `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:96:35
    |
 LL | type TAI1<T: Iterator<Item: Copy, Item: Send>> = T;
@@ -326,7 +326,7 @@ LL | type TAI1<T: Iterator<Item: Copy, Item: Send>> = T;
    |                       |
    |                       `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:98:35
    |
 LL | type TAI2<T: Iterator<Item: Copy, Item: Copy>> = T;
@@ -334,7 +334,7 @@ LL | type TAI2<T: Iterator<Item: Copy, Item: Copy>> = T;
    |                       |
    |                       `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:100:38
    |
 LL | type TAI3<T: Iterator<Item: 'static, Item: 'static>> = T;
@@ -342,7 +342,7 @@ LL | type TAI3<T: Iterator<Item: 'static, Item: 'static>> = T;
    |                       |
    |                       `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:102:44
    |
 LL | type TAW1<T> where T: Iterator<Item: Copy, Item: Send> = T;
@@ -350,7 +350,7 @@ LL | type TAW1<T> where T: Iterator<Item: Copy, Item: Send> = T;
    |                                |
    |                                `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:104:44
    |
 LL | type TAW2<T> where T: Iterator<Item: Copy, Item: Copy> = T;
@@ -358,7 +358,7 @@ LL | type TAW2<T> where T: Iterator<Item: Copy, Item: Copy> = T;
    |                                |
    |                                `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:106:47
    |
 LL | type TAW3<T> where T: Iterator<Item: 'static, Item: 'static> = T;
@@ -372,7 +372,7 @@ error: could not find defining uses
 LL | type ETAI1<T: Iterator<Item: Copy, Item: Send>> = impl Copy;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:109:36
    |
 LL | type ETAI1<T: Iterator<Item: Copy, Item: Send>> = impl Copy;
@@ -386,7 +386,7 @@ error: could not find defining uses
 LL | type ETAI2<T: Iterator<Item: Copy, Item: Copy>> = impl Copy;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:114:36
    |
 LL | type ETAI2<T: Iterator<Item: Copy, Item: Copy>> = impl Copy;
@@ -400,7 +400,7 @@ error: could not find defining uses
 LL | type ETAI3<T: Iterator<Item: 'static, Item: 'static>> = impl Copy;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:119:39
    |
 LL | type ETAI3<T: Iterator<Item: 'static, Item: 'static>> = impl Copy;
@@ -414,7 +414,7 @@ error: could not find defining uses
 LL | type ETAI4 = impl Iterator<Item: Copy, Item: Send>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:124:40
    |
 LL | type ETAI4 = impl Iterator<Item: Copy, Item: Send>;
@@ -428,7 +428,7 @@ error: could not find defining uses
 LL | type ETAI5 = impl Iterator<Item: Copy, Item: Copy>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:129:40
    |
 LL | type ETAI5 = impl Iterator<Item: Copy, Item: Copy>;
@@ -442,7 +442,7 @@ error: could not find defining uses
 LL | type ETAI6 = impl Iterator<Item: 'static, Item: 'static>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:134:43
    |
 LL | type ETAI6 = impl Iterator<Item: 'static, Item: 'static>;
@@ -450,7 +450,7 @@ LL | type ETAI6 = impl Iterator<Item: 'static, Item: 'static>;
    |                            |
    |                            `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:140:36
    |
 LL | trait TRI1<T: Iterator<Item: Copy, Item: Send>> {}
@@ -458,7 +458,7 @@ LL | trait TRI1<T: Iterator<Item: Copy, Item: Send>> {}
    |                        |
    |                        `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:142:36
    |
 LL | trait TRI2<T: Iterator<Item: Copy, Item: Copy>> {}
@@ -466,7 +466,7 @@ LL | trait TRI2<T: Iterator<Item: Copy, Item: Copy>> {}
    |                        |
    |                        `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:144:39
    |
 LL | trait TRI3<T: Iterator<Item: 'static, Item: 'static>> {}
@@ -474,7 +474,7 @@ LL | trait TRI3<T: Iterator<Item: 'static, Item: 'static>> {}
    |                        |
    |                        `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:146:34
    |
 LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
@@ -482,7 +482,7 @@ LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
    |                      |
    |                      `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:148:34
    |
 LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
@@ -490,7 +490,7 @@ LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
    |                      |
    |                      `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:150:37
    |
 LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
@@ -498,7 +498,7 @@ LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
    |                      |
    |                      `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:152:45
    |
 LL | trait TRW1<T> where T: Iterator<Item: Copy, Item: Send> {}
@@ -506,7 +506,7 @@ LL | trait TRW1<T> where T: Iterator<Item: Copy, Item: Send> {}
    |                                 |
    |                                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:154:45
    |
 LL | trait TRW2<T> where T: Iterator<Item: Copy, Item: Copy> {}
@@ -514,7 +514,7 @@ LL | trait TRW2<T> where T: Iterator<Item: Copy, Item: Copy> {}
    |                                 |
    |                                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:156:48
    |
 LL | trait TRW3<T> where T: Iterator<Item: 'static, Item: 'static> {}
@@ -522,7 +522,7 @@ LL | trait TRW3<T> where T: Iterator<Item: 'static, Item: 'static> {}
    |                                 |
    |                                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:158:46
    |
 LL | trait TRSW1 where Self: Iterator<Item: Copy, Item: Send> {}
@@ -530,7 +530,7 @@ LL | trait TRSW1 where Self: Iterator<Item: Copy, Item: Send> {}
    |                                  |
    |                                  `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:160:46
    |
 LL | trait TRSW2 where Self: Iterator<Item: Copy, Item: Copy> {}
@@ -538,7 +538,7 @@ LL | trait TRSW2 where Self: Iterator<Item: Copy, Item: Copy> {}
    |                                  |
    |                                  `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:162:49
    |
 LL | trait TRSW3 where Self: Iterator<Item: 'static, Item: 'static> {}
@@ -546,7 +546,7 @@ LL | trait TRSW3 where Self: Iterator<Item: 'static, Item: 'static> {}
    |                                  |
    |                                  `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:164:43
    |
 LL | trait TRA1 { type A: Iterator<Item: Copy, Item: Send>; }
@@ -554,7 +554,7 @@ LL | trait TRA1 { type A: Iterator<Item: Copy, Item: Send>; }
    |                               |
    |                               `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:166:43
    |
 LL | trait TRA2 { type A: Iterator<Item: Copy, Item: Copy>; }
@@ -562,7 +562,7 @@ LL | trait TRA2 { type A: Iterator<Item: Copy, Item: Copy>; }
    |                               |
    |                               `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:168:46
    |
 LL | trait TRA3 { type A: Iterator<Item: 'static, Item: 'static>; }
@@ -570,7 +570,7 @@ LL | trait TRA3 { type A: Iterator<Item: 'static, Item: 'static>; }
    |                               |
    |                               `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:171:40
    |
 LL | type TADyn1 = dyn Iterator<Item: Copy, Item: Send>;
@@ -578,7 +578,7 @@ LL | type TADyn1 = dyn Iterator<Item: Copy, Item: Send>;
    |                            |
    |                            `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:175:44
    |
 LL | type TADyn2 = Box<dyn Iterator<Item: Copy, Item: Copy>>;
@@ -586,7 +586,7 @@ LL | type TADyn2 = Box<dyn Iterator<Item: Copy, Item: Copy>>;
    |                                |
    |                                `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:179:43
    |
 LL | type TADyn3 = dyn Iterator<Item: 'static, Item: 'static>;

--- a/src/test/ui/associated-type/associated-type-projection-ambig-between-bound-and-where-clause.stderr
+++ b/src/test/ui/associated-type/associated-type-projection-ambig-between-bound-and-where-clause.stderr
@@ -9,6 +9,15 @@ LL |     type Color;
 ...
 LL | fn a<C:Vehicle+Box>(_: C::Color) {
    |                        ^^^^^^^^ ambiguous associated type `Color`
+   |
+help: use fully qualified syntax to disambiguate
+   |
+LL | fn a<C:Vehicle+Box>(_: <C as Box>::Color) {
+   |                        ^^^^^^^^^^^^^^^^^
+help: use fully qualified syntax to disambiguate
+   |
+LL | fn a<C:Vehicle+Box>(_: <C as Vehicle>::Color) {
+   |                        ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0221]: ambiguous associated type `Color` in bounds of `C`
   --> $DIR/associated-type-projection-ambig-between-bound-and-where-clause.rs:20:12
@@ -21,6 +30,15 @@ LL |     type Color;
 ...
 LL | fn b<C>(_: C::Color) where C : Vehicle+Box {
    |            ^^^^^^^^ ambiguous associated type `Color`
+   |
+help: use fully qualified syntax to disambiguate
+   |
+LL | fn b<C>(_: <C as Box>::Color) where C : Vehicle+Box {
+   |            ^^^^^^^^^^^^^^^^^
+help: use fully qualified syntax to disambiguate
+   |
+LL | fn b<C>(_: <C as Vehicle>::Color) where C : Vehicle+Box {
+   |            ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0221]: ambiguous associated type `Color` in bounds of `C`
   --> $DIR/associated-type-projection-ambig-between-bound-and-where-clause.rs:24:12
@@ -33,6 +51,15 @@ LL |     type Color;
 ...
 LL | fn c<C>(_: C::Color) where C : Vehicle, C : Box {
    |            ^^^^^^^^ ambiguous associated type `Color`
+   |
+help: use fully qualified syntax to disambiguate
+   |
+LL | fn c<C>(_: <C as Box>::Color) where C : Vehicle, C : Box {
+   |            ^^^^^^^^^^^^^^^^^
+help: use fully qualified syntax to disambiguate
+   |
+LL | fn c<C>(_: <C as Vehicle>::Color) where C : Vehicle, C : Box {
+   |            ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0221]: ambiguous associated type `Color` in bounds of `X`
   --> $DIR/associated-type-projection-ambig-between-bound-and-where-clause.rs:35:20
@@ -45,6 +72,15 @@ LL |     type Color;
 ...
 LL |     fn e(&self, _: X::Color) where X : Box;
    |                    ^^^^^^^^ ambiguous associated type `Color`
+   |
+help: use fully qualified syntax to disambiguate
+   |
+LL |     fn e(&self, _: <X as Box>::Color) where X : Box;
+   |                    ^^^^^^^^^^^^^^^^^
+help: use fully qualified syntax to disambiguate
+   |
+LL |     fn e(&self, _: <X as Vehicle>::Color) where X : Box;
+   |                    ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0221]: ambiguous associated type `Color` in bounds of `X`
   --> $DIR/associated-type-projection-ambig-between-bound-and-where-clause.rs:38:20
@@ -57,6 +93,15 @@ LL |     type Color;
 ...
 LL |     fn f(&self, _: X::Color) where X : Box { }
    |                    ^^^^^^^^ ambiguous associated type `Color`
+   |
+help: use fully qualified syntax to disambiguate
+   |
+LL |     fn f(&self, _: <X as Box>::Color) where X : Box { }
+   |                    ^^^^^^^^^^^^^^^^^
+help: use fully qualified syntax to disambiguate
+   |
+LL |     fn f(&self, _: <X as Vehicle>::Color) where X : Box { }
+   |                    ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0221]: ambiguous associated type `Color` in bounds of `X`
   --> $DIR/associated-type-projection-ambig-between-bound-and-where-clause.rs:30:20
@@ -69,6 +114,15 @@ LL |     type Color;
 ...
 LL |     fn d(&self, _: X::Color) where X : Box { }
    |                    ^^^^^^^^ ambiguous associated type `Color`
+   |
+help: use fully qualified syntax to disambiguate
+   |
+LL |     fn d(&self, _: <X as Box>::Color) where X : Box { }
+   |                    ^^^^^^^^^^^^^^^^^
+help: use fully qualified syntax to disambiguate
+   |
+LL |     fn d(&self, _: <X as Vehicle>::Color) where X : Box { }
+   |                    ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/associated-type/associated-type-projection-from-multiple-supertraits.rs
+++ b/src/test/ui/associated-type/associated-type-projection-from-multiple-supertraits.rs
@@ -20,11 +20,9 @@ fn dent<C:BoxCar>(c: C, color: C::Color) {
     //~^ ERROR ambiguous associated type `Color` in bounds of `C`
 }
 
-// FIXME: add error code to detect this case and explain that you'll want the approach in
-// `dent_object_3` of using a new type param and relying on the `where` clauses.
 fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
     //~^ ERROR ambiguous associated type
-    //~| ERROR the value of the associated type `Color` (from trait `Vehicle`) must be specified
+    //~| ERROR the value of the associated types `Color` (from trait `Vehicle`), `Color` (from
 }
 
 fn paint<C:BoxCar>(c: C, d: C::Color) {

--- a/src/test/ui/associated-type/associated-type-projection-from-multiple-supertraits.rs
+++ b/src/test/ui/associated-type/associated-type-projection-from-multiple-supertraits.rs
@@ -22,7 +22,7 @@ fn dent<C:BoxCar>(c: C, color: C::Color) {
 
 fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
     //~^ ERROR ambiguous associated type
-    //~| ERROR the value of the associated types `Color` (from trait `Vehicle`), `Color` (from
+    //~| ERROR the value of the associated types
 }
 
 fn paint<C:BoxCar>(c: C, d: C::Color) {
@@ -30,8 +30,8 @@ fn paint<C:BoxCar>(c: C, d: C::Color) {
 }
 
 fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
-    //~^ ERROR the value of the associated types `Color` (from trait `Vehicle`), `Color` (from
-    //~| ERROR equality constraints are not yet supported in where clauses
+    //~^ ERROR the value of the associated types
+    //~| ERROR equality constraints are not yet supported in `where` clauses
 }
 
 fn dent_object_3<X, COLOR>(c: X)

--- a/src/test/ui/associated-type/associated-type-projection-from-multiple-supertraits.rs
+++ b/src/test/ui/associated-type/associated-type-projection-from-multiple-supertraits.rs
@@ -20,13 +20,26 @@ fn dent<C:BoxCar>(c: C, color: C::Color) {
     //~^ ERROR ambiguous associated type `Color` in bounds of `C`
 }
 
+// FIXME: add error code to detect this case and explain that you'll want the approach in
+// `dent_object_3` of using a new type param and relying on the `where` clauses.
 fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
     //~^ ERROR ambiguous associated type
-    //~| ERROR the value of the associated type `Color` (from the trait `Vehicle`) must be specified
+    //~| ERROR the value of the associated type `Color` (from trait `Vehicle`) must be specified
 }
 
 fn paint<C:BoxCar>(c: C, d: C::Color) {
     //~^ ERROR ambiguous associated type `Color` in bounds of `C`
 }
+
+fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
+    //~^ ERROR the value of the associated types `Color` (from trait `Vehicle`), `Color` (from
+    //~| ERROR equality constraints are not yet supported in where clauses
+}
+
+fn dent_object_3<X, COLOR>(c: X)
+where X: BoxCar,
+    X: Vehicle<Color = COLOR>,
+    X: Box<Color = COLOR>
+{} // OK!
 
 pub fn main() { }

--- a/src/test/ui/associated-type/associated-type-projection-from-multiple-supertraits.stderr
+++ b/src/test/ui/associated-type/associated-type-projection-from-multiple-supertraits.stderr
@@ -1,10 +1,10 @@
-error: equality constraints are not yet supported in where clauses
+error: equality constraints are not yet supported in `where` clauses
   --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:46
    |
 LL | fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not supported
    |
-   = note: for more information, see #20041
+   = note: for more information, see https://github.com/rust-lang/rust/issues/20041
 
 error[E0221]: ambiguous associated type `Color` in bounds of `C`
   --> $DIR/associated-type-projection-from-multiple-supertraits.rs:19:32
@@ -45,7 +45,7 @@ LL | fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
                    T: Box::Color = COLOR,
                    T: Vehicle::Color = COLOR
 
-error[E0191]: the value of the associated types `Color` (from trait `Vehicle`), `Color` (from trait `Box`) must be specified
+error[E0191]: the value of the associated types `Color` (from trait `Box`), `Color` (from trait `Vehicle`) must be specified
   --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:30
    |
 LL |     type Color;
@@ -80,7 +80,7 @@ help: use fully qualified syntax to disambiguate
 LL | fn paint<C:BoxCar>(c: C, d: <C as Vehicle>::Color) {
    |                             ^^^^^^^^^^^^^^^^^^^^^
 
-error[E0191]: the value of the associated types `Color` (from trait `Vehicle`), `Color` (from trait `Box`) must be specified
+error[E0191]: the value of the associated types `Color` (from trait `Box`), `Color` (from trait `Vehicle`) must be specified
   --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:32
    |
 LL |     type Color;

--- a/src/test/ui/associated-type/associated-type-projection-from-multiple-supertraits.stderr
+++ b/src/test/ui/associated-type/associated-type-projection-from-multiple-supertraits.stderr
@@ -49,15 +49,15 @@ error[E0191]: the value of the associated types `Color` (from trait `Vehicle`), 
   --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:30
    |
 LL |     type Color;
-   |     ----------- `Color` defined here
+   |     ----------- `Vehicle::Color` defined here
 ...
 LL |     type Color;
-   |     ----------- `Color` defined here
+   |     ----------- `Box::Color` defined here
 ...
 LL | fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
-   |                              ^^^^^^^^^^^^^^^^^^^ associated types `Color`, `Color` must be specified
+   |                              ^^^^^^^^^^^^^^^^^^^ associated types `Color` (from trait `Vehicle`), `Color` (from trait `Box`) must be specified
    |
-   = help: consider introducing a new type parameter, adding `where` constraints using the fully-qualified path to the associated type
+   = help: consider introducing a new type parameter, adding `where` constraints using the fully-qualified path to the associated types
 
 error[E0221]: ambiguous associated type `Color` in bounds of `C`
   --> $DIR/associated-type-projection-from-multiple-supertraits.rs:28:29
@@ -84,15 +84,15 @@ error[E0191]: the value of the associated types `Color` (from trait `Vehicle`), 
   --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:32
    |
 LL |     type Color;
-   |     ----------- `Color` defined here
+   |     ----------- `Vehicle::Color` defined here
 ...
 LL |     type Color;
-   |     ----------- `Color` defined here
+   |     ----------- `Box::Color` defined here
 ...
 LL | fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
-   |                                ^^^^^^ associated types `Color`, `Color` must be specified
+   |                                ^^^^^^ associated types `Color` (from trait `Vehicle`), `Color` (from trait `Box`) must be specified
    |
-   = help: consider introducing a new type parameter, adding `where` constraints using the fully-qualified path to the associated type
+   = help: consider introducing a new type parameter, adding `where` constraints using the fully-qualified path to the associated types
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/associated-type/associated-type-projection-from-multiple-supertraits.stderr
+++ b/src/test/ui/associated-type/associated-type-projection-from-multiple-supertraits.stderr
@@ -1,3 +1,9 @@
+error: equality constraints are not yet supported in where clauses (see #20041)
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:34:46
+   |
+LL | fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0221]: ambiguous associated type `Color` in bounds of `C`
   --> $DIR/associated-type-projection-from-multiple-supertraits.rs:19:32
    |
@@ -9,9 +15,18 @@ LL |     type Color;
 ...
 LL | fn dent<C:BoxCar>(c: C, color: C::Color) {
    |                                ^^^^^^^^ ambiguous associated type `Color`
+   |
+help: use fully qualified syntax to disambiguate
+   |
+LL | fn dent<C:BoxCar>(c: C, color: <C as Box>::Color) {
+   |                                ^^^^^^^^^^^^^^^^^
+help: use fully qualified syntax to disambiguate
+   |
+LL | fn dent<C:BoxCar>(c: C, color: <C as Vehicle>::Color) {
+   |                                ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0221]: ambiguous associated type `Color` in bounds of `BoxCar`
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:37
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:25:37
    |
 LL |     type Color;
    |     ----------- ambiguous `Color` from `Vehicle`
@@ -21,18 +36,27 @@ LL |     type Color;
 ...
 LL | fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
    |                                     ^^^^^^^^^^^ ambiguous associated type `Color`
+   |
+help: use fully qualified syntax to disambiguate
+   |
+LL | fn dent_object<COLOR>(c: dyn BoxCar<<BoxCar as Box>::Color>) {
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^
+help: use fully qualified syntax to disambiguate
+   |
+LL | fn dent_object<COLOR>(c: dyn BoxCar<<BoxCar as Vehicle>::Color>) {
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0191]: the value of the associated type `Color` (from the trait `Vehicle`) must be specified
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:26
+error[E0191]: the value of the associated type `Color` (from trait `Vehicle`) must be specified
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:25:30
    |
 LL |     type Color;
    |     ----------- `Color` defined here
 ...
 LL | fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^ associated type `Color` must be specified
+   |                              ^^^^^^^^^^^^^^^^^^^ help: specify the associated type: `BoxCar<Color=COLOR, Color = Type>`
 
 error[E0221]: ambiguous associated type `Color` in bounds of `C`
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:28:29
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:30:29
    |
 LL |     type Color;
    |     ----------- ambiguous `Color` from `Vehicle`
@@ -42,8 +66,29 @@ LL |     type Color;
 ...
 LL | fn paint<C:BoxCar>(c: C, d: C::Color) {
    |                             ^^^^^^^^ ambiguous associated type `Color`
+   |
+help: use fully qualified syntax to disambiguate
+   |
+LL | fn paint<C:BoxCar>(c: C, d: <C as Box>::Color) {
+   |                             ^^^^^^^^^^^^^^^^^
+help: use fully qualified syntax to disambiguate
+   |
+LL | fn paint<C:BoxCar>(c: C, d: <C as Vehicle>::Color) {
+   |                             ^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+error[E0191]: the value of the associated types `Color` (from trait `Vehicle`), `Color` (from trait `Box`) must be specified
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:34:32
+   |
+LL |     type Color;
+   |     ----------- `Color` defined here
+...
+LL |     type Color;
+   |     ----------- `Color` defined here
+...
+LL | fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
+   |                                ^^^^^^ help: specify the associated types: `BoxCar<Color = Type, Color = Type>`
+
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0191, E0221.
 For more information about an error, try `rustc --explain E0191`.

--- a/src/test/ui/associated-type/associated-type-projection-from-multiple-supertraits.stderr
+++ b/src/test/ui/associated-type/associated-type-projection-from-multiple-supertraits.stderr
@@ -26,7 +26,7 @@ LL | fn dent<C:BoxCar>(c: C, color: <C as Vehicle>::Color) {
    |                                ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0221]: ambiguous associated type `Color` in bounds of `BoxCar`
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:25:37
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:25:30
    |
 LL |     type Color;
    |     ----------- ambiguous `Color` from `Vehicle`
@@ -35,16 +35,16 @@ LL |     type Color;
    |     ----------- ambiguous `Color` from `Box`
 ...
 LL | fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
-   |                                     ^^^^^^^^^^^ ambiguous associated type `Color`
+   |                              ^^^^^^^^^^^^^^^^^^^ ambiguous associated type `Color`
    |
 help: use fully qualified syntax to disambiguate
    |
-LL | fn dent_object<COLOR>(c: dyn BoxCar<<BoxCar as Box>::Color>) {
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^
+LL | fn dent_object<COLOR>(c: dyn <BoxCar as Box>::Color) {
+   |                              ^^^^^^^^^^^^^^^^^^^^^^
 help: use fully qualified syntax to disambiguate
    |
-LL | fn dent_object<COLOR>(c: dyn BoxCar<<BoxCar as Vehicle>::Color>) {
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn dent_object<COLOR>(c: dyn <BoxCar as Vehicle>::Color) {
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0191]: the value of the associated type `Color` (from trait `Vehicle`) must be specified
   --> $DIR/associated-type-projection-from-multiple-supertraits.rs:25:30

--- a/src/test/ui/associated-type/associated-type-projection-from-multiple-supertraits.stderr
+++ b/src/test/ui/associated-type/associated-type-projection-from-multiple-supertraits.stderr
@@ -1,8 +1,10 @@
-error: equality constraints are not yet supported in where clauses (see #20041)
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:34:46
+error: equality constraints are not yet supported in where clauses
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:46
    |
 LL | fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
-   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not supported
+   |
+   = note: for more information, see #20041
 
 error[E0221]: ambiguous associated type `Color` in bounds of `C`
   --> $DIR/associated-type-projection-from-multiple-supertraits.rs:19:32
@@ -25,8 +27,8 @@ help: use fully qualified syntax to disambiguate
 LL | fn dent<C:BoxCar>(c: C, color: <C as Vehicle>::Color) {
    |                                ^^^^^^^^^^^^^^^^^^^^^
 
-error[E0221]: ambiguous associated type `Color` in bounds of `BoxCar`
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:25:30
+error[E0222]: ambiguous associated type `Color` in bounds of `BoxCar`
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:30
    |
 LL |     type Color;
    |     ----------- ambiguous `Color` from `Vehicle`
@@ -37,26 +39,28 @@ LL |     type Color;
 LL | fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
    |                              ^^^^^^^^^^^^^^^^^^^ ambiguous associated type `Color`
    |
-help: use fully qualified syntax to disambiguate
-   |
-LL | fn dent_object<COLOR>(c: dyn <BoxCar as Box>::Color) {
-   |                              ^^^^^^^^^^^^^^^^^^^^^^
-help: use fully qualified syntax to disambiguate
-   |
-LL | fn dent_object<COLOR>(c: dyn <BoxCar as Vehicle>::Color) {
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: consider introducing a new type parameter `T` and adding `where` constraints:
+               where
+                   T: BoxCar,
+                   T: Box::Color = COLOR,
+                   T: Vehicle::Color = COLOR
 
-error[E0191]: the value of the associated type `Color` (from trait `Vehicle`) must be specified
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:25:30
+error[E0191]: the value of the associated types `Color` (from trait `Vehicle`), `Color` (from trait `Box`) must be specified
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:30
    |
 LL |     type Color;
    |     ----------- `Color` defined here
 ...
+LL |     type Color;
+   |     ----------- `Color` defined here
+...
 LL | fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
-   |                              ^^^^^^^^^^^^^^^^^^^ help: specify the associated type: `BoxCar<Color=COLOR, Color = Type>`
+   |                              ^^^^^^^^^^^^^^^^^^^ associated types `Color`, `Color` must be specified
+   |
+   = help: consider introducing a new type parameter, adding `where` constraints using the fully-qualified path to the associated type
 
 error[E0221]: ambiguous associated type `Color` in bounds of `C`
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:30:29
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:28:29
    |
 LL |     type Color;
    |     ----------- ambiguous `Color` from `Vehicle`
@@ -77,7 +81,7 @@ LL | fn paint<C:BoxCar>(c: C, d: <C as Vehicle>::Color) {
    |                             ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0191]: the value of the associated types `Color` (from trait `Vehicle`), `Color` (from trait `Box`) must be specified
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:34:32
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:32
    |
 LL |     type Color;
    |     ----------- `Color` defined here
@@ -86,9 +90,11 @@ LL |     type Color;
    |     ----------- `Color` defined here
 ...
 LL | fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
-   |                                ^^^^^^ help: specify the associated types: `BoxCar<Color = Type, Color = Type>`
+   |                                ^^^^^^ associated types `Color`, `Color` must be specified
+   |
+   = help: consider introducing a new type parameter, adding `where` constraints using the fully-qualified path to the associated type
 
 error: aborting due to 6 previous errors
 
-Some errors have detailed explanations: E0191, E0221.
+Some errors have detailed explanations: E0191, E0221, E0222.
 For more information about an error, try `rustc --explain E0191`.

--- a/src/test/ui/associated-types/associated-types-incomplete-object.rs
+++ b/src/test/ui/associated-types/associated-types-incomplete-object.rs
@@ -21,11 +21,11 @@ pub fn main() {
     let a = &42isize as &dyn Foo<A=usize, B=char>;
 
     let b = &42isize as &dyn Foo<A=usize>;
-    //~^ ERROR the value of the associated type `B` (from the trait `Foo`) must be specified
+    //~^ ERROR the value of the associated type `B` (from trait `Foo`) must be specified
 
     let c = &42isize as &dyn Foo<B=char>;
-    //~^ ERROR the value of the associated type `A` (from the trait `Foo`) must be specified
+    //~^ ERROR the value of the associated type `A` (from trait `Foo`) must be specified
 
     let d = &42isize as &dyn Foo;
-    //~^ ERROR the value of the associated types `A` (from the trait `Foo`), `B` (from the trait
+    //~^ ERROR the value of the associated types `A` (from trait `Foo`), `B` (from trait
 }

--- a/src/test/ui/associated-types/associated-types-incomplete-object.stderr
+++ b/src/test/ui/associated-types/associated-types-incomplete-object.stderr
@@ -1,23 +1,23 @@
-error[E0191]: the value of the associated type `B` (from the trait `Foo`) must be specified
-  --> $DIR/associated-types-incomplete-object.rs:23:26
+error[E0191]: the value of the associated type `B` (from trait `Foo`) must be specified
+  --> $DIR/associated-types-incomplete-object.rs:23:30
    |
 LL |     type B;
    |     ------- `B` defined here
 ...
 LL |     let b = &42isize as &dyn Foo<A=usize>;
-   |                          ^^^^^^^^^^^^^^^^ associated type `B` must be specified
+   |                              ^^^^^^^^^^^^ help: specify the associated type: `Foo<A=usize, B = Type>`
 
-error[E0191]: the value of the associated type `A` (from the trait `Foo`) must be specified
-  --> $DIR/associated-types-incomplete-object.rs:26:26
+error[E0191]: the value of the associated type `A` (from trait `Foo`) must be specified
+  --> $DIR/associated-types-incomplete-object.rs:26:30
    |
 LL |     type A;
    |     ------- `A` defined here
 ...
 LL |     let c = &42isize as &dyn Foo<B=char>;
-   |                          ^^^^^^^^^^^^^^^ associated type `A` must be specified
+   |                              ^^^^^^^^^^^ help: specify the associated type: `Foo<B=char, A = Type>`
 
-error[E0191]: the value of the associated types `A` (from the trait `Foo`), `B` (from the trait `Foo`) must be specified
-  --> $DIR/associated-types-incomplete-object.rs:29:26
+error[E0191]: the value of the associated types `A` (from trait `Foo`), `B` (from trait `Foo`) must be specified
+  --> $DIR/associated-types-incomplete-object.rs:29:30
    |
 LL |     type A;
    |     ------- `A` defined here
@@ -25,10 +25,7 @@ LL |     type B;
    |     ------- `B` defined here
 ...
 LL |     let d = &42isize as &dyn Foo;
-   |                          ^^^^^^^
-   |                          |
-   |                          associated type `A` must be specified
-   |                          associated type `B` must be specified
+   |                              ^^^ help: specify the associated types: `Foo<A = Type, B = Type>`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/associated-types/associated-types-path-1.stderr
+++ b/src/test/ui/associated-types/associated-types-path-1.stderr
@@ -1,8 +1,8 @@
 error[E0220]: associated type `A` not found for `T`
-  --> $DIR/associated-types-path-1.rs:10:23
+  --> $DIR/associated-types-path-1.rs:10:26
    |
 LL | pub fn f1<T>(a: T, x: T::A) {}
-   |                       ^^^^ associated type `A` not found
+   |                          ^ associated type `A` not found
 
 error[E0221]: ambiguous associated type `A` in bounds of `T`
   --> $DIR/associated-types-path-1.rs:11:34

--- a/src/test/ui/associated-types/associated-types-path-1.stderr
+++ b/src/test/ui/associated-types/associated-types-path-1.stderr
@@ -15,6 +15,15 @@ LL |     type A;
 ...
 LL | pub fn f2<T: Foo + Bar>(a: T, x: T::A) {}
    |                                  ^^^^ ambiguous associated type `A`
+   |
+help: use fully qualified syntax to disambiguate
+   |
+LL | pub fn f2<T: Foo + Bar>(a: T, x: <T as Bar>::A) {}
+   |                                  ^^^^^^^^^^^^^
+help: use fully qualified syntax to disambiguate
+   |
+LL | pub fn f2<T: Foo + Bar>(a: T, x: <T as Foo>::A) {}
+   |                                  ^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-types/missing-associated-types.rs
+++ b/src/test/ui/associated-types/missing-associated-types.rs
@@ -1,0 +1,27 @@
+use std::ops::{Add, Sub, Mul, Div};
+trait X<Rhs>: Mul<Rhs> + Div<Rhs> {}
+trait Y<Rhs>: Div<Rhs, Output = Rhs> {
+    type A;
+}
+trait Z<Rhs>: Div<Rhs> {
+    type A;
+    type B;
+}
+trait Fine<Rhs>: Div<Rhs, Output = Rhs> {}
+
+type Foo<Rhs> = dyn Add<Rhs> + Sub<Rhs> + X<Rhs> + Y<Rhs>;
+//~^ ERROR only auto traits can be used as additional traits in a trait object
+//~| ERROR the value of the associated types
+type Bar<Rhs> = dyn Add<Rhs> + Sub<Rhs> + X<Rhs> + Z<Rhs>;
+//~^ ERROR only auto traits can be used as additional traits in a trait object
+//~| ERROR the value of the associated types
+type Baz<Rhs> = dyn Add<Rhs> + Sub<Rhs> + Y<Rhs>;
+//~^ ERROR only auto traits can be used as additional traits in a trait object
+//~| ERROR the value of the associated types
+type Bat<Rhs> = dyn Add<Rhs> + Sub<Rhs> + Fine<Rhs>;
+//~^ ERROR only auto traits can be used as additional traits in a trait object
+//~| ERROR the value of the associated types
+type Bal<Rhs> = dyn X<Rhs>;
+//~^ ERROR the value of the associated types
+
+fn main() {}

--- a/src/test/ui/associated-types/missing-associated-types.stderr
+++ b/src/test/ui/associated-types/missing-associated-types.stderr
@@ -1,0 +1,129 @@
+error[E0225]: only auto traits can be used as additional traits in a trait object
+  --> $DIR/missing-associated-types.rs:12:32
+   |
+LL | type Foo<Rhs> = dyn Add<Rhs> + Sub<Rhs> + X<Rhs> + Y<Rhs>;
+   |                     --------   ^^^^^^^^
+   |                     |          |
+   |                     |          additional non-auto trait
+   |                     |          trait alias used in trait object type (additional use)
+   |                     first non-auto trait
+   |                     trait alias used in trait object type (first use)
+
+error[E0191]: the value of the associated types `A` (from trait `Y`), `Output` (from trait `std::ops::Mul`), `Output` (from trait `std::ops::Add`), `Output` (from trait `std::ops::Sub`) must be specified
+  --> $DIR/missing-associated-types.rs:12:52
+   |
+LL |     type A;
+   |     ------- `A` defined here
+...
+LL | type Foo<Rhs> = dyn Add<Rhs> + Sub<Rhs> + X<Rhs> + Y<Rhs>;
+   |                     ^^^^^^^^   ^^^^^^^^   ^^^^^^   ^^^^^^ associated type `A` must be specified
+   |                     |          |          |
+   |                     |          |          associated type `Output` must be specified
+   |                     |          associated type `Output` must be specified
+   |                     associated type `Output` must be specified
+   |
+help: specify the associated types
+   |
+LL | type Foo<Rhs> = dyn Add<Rhs, Output = Type> + Sub<Rhs, Output = Type> + X<Rhs, Output = Type> + Y<Rhs, A = Type>;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^
+
+error[E0225]: only auto traits can be used as additional traits in a trait object
+  --> $DIR/missing-associated-types.rs:15:32
+   |
+LL | type Bar<Rhs> = dyn Add<Rhs> + Sub<Rhs> + X<Rhs> + Z<Rhs>;
+   |                     --------   ^^^^^^^^
+   |                     |          |
+   |                     |          additional non-auto trait
+   |                     |          trait alias used in trait object type (additional use)
+   |                     first non-auto trait
+   |                     trait alias used in trait object type (first use)
+
+error[E0191]: the value of the associated types `Output` (from trait `std::ops::Add`), `Output` (from trait `std::ops::Sub`), `A` (from trait `Z`), `B` (from trait `Z`), `Output` (from trait `std::ops::Div`), `Output` (from trait `std::ops::Mul`), `Output` (from trait `std::ops::Div`) must be specified
+  --> $DIR/missing-associated-types.rs:15:21
+   |
+LL |     type A;
+   |     ------- `A` defined here
+LL |     type B;
+   |     ------- `B` defined here
+...
+LL | type Bar<Rhs> = dyn Add<Rhs> + Sub<Rhs> + X<Rhs> + Z<Rhs>;
+   |                     ^^^^^^^^   ^^^^^^^^   ^^^^^^   ^^^^^^ associated types `A`, `B`, `Output` must be specified
+   |                     |          |          |
+   |                     |          |          associated types `Output` (from trait `std::ops::Mul`), `Output` (from trait `std::ops::Div`) must be specified
+   |                     |          associated type `Output` must be specified
+   |                     associated type `Output` must be specified
+   |
+help: consider introducing a new type parameter, adding `where` constraints using the fully-qualified path to the associated types
+  --> $DIR/missing-associated-types.rs:15:43
+   |
+LL | type Bar<Rhs> = dyn Add<Rhs> + Sub<Rhs> + X<Rhs> + Z<Rhs>;
+   |                                           ^^^^^^
+help: specify the associated types
+   |
+LL | type Bar<Rhs> = dyn Add<Rhs, Output = Type> + Sub<Rhs, Output = Type> + X<Rhs> + Z<Rhs, A = Type, B = Type, Output = Type>;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0225]: only auto traits can be used as additional traits in a trait object
+  --> $DIR/missing-associated-types.rs:18:32
+   |
+LL | type Baz<Rhs> = dyn Add<Rhs> + Sub<Rhs> + Y<Rhs>;
+   |                     --------   ^^^^^^^^
+   |                     |          |
+   |                     |          additional non-auto trait
+   |                     |          trait alias used in trait object type (additional use)
+   |                     first non-auto trait
+   |                     trait alias used in trait object type (first use)
+
+error[E0191]: the value of the associated types `Output` (from trait `std::ops::Sub`), `A` (from trait `Y`), `Output` (from trait `std::ops::Add`) must be specified
+  --> $DIR/missing-associated-types.rs:18:32
+   |
+LL |     type A;
+   |     ------- `A` defined here
+...
+LL | type Baz<Rhs> = dyn Add<Rhs> + Sub<Rhs> + Y<Rhs>;
+   |                     ^^^^^^^^   ^^^^^^^^   ^^^^^^ associated type `A` must be specified
+   |                     |          |
+   |                     |          associated type `Output` must be specified
+   |                     associated type `Output` must be specified
+   |
+help: specify the associated types
+   |
+LL | type Baz<Rhs> = dyn Add<Rhs, Output = Type> + Sub<Rhs, Output = Type> + Y<Rhs, A = Type>;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^
+
+error[E0225]: only auto traits can be used as additional traits in a trait object
+  --> $DIR/missing-associated-types.rs:21:32
+   |
+LL | type Bat<Rhs> = dyn Add<Rhs> + Sub<Rhs> + Fine<Rhs>;
+   |                     --------   ^^^^^^^^
+   |                     |          |
+   |                     |          additional non-auto trait
+   |                     |          trait alias used in trait object type (additional use)
+   |                     first non-auto trait
+   |                     trait alias used in trait object type (first use)
+
+error[E0191]: the value of the associated types `Output` (from trait `std::ops::Sub`), `Output` (from trait `std::ops::Add`) must be specified
+  --> $DIR/missing-associated-types.rs:21:32
+   |
+LL | type Bat<Rhs> = dyn Add<Rhs> + Sub<Rhs> + Fine<Rhs>;
+   |                     ^^^^^^^^   ^^^^^^^^ associated type `Output` must be specified
+   |                     |
+   |                     associated type `Output` must be specified
+   |
+help: specify the associated types
+   |
+LL | type Bat<Rhs> = dyn Add<Rhs, Output = Type> + Sub<Rhs, Output = Type> + Fine<Rhs>;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0191]: the value of the associated types `Output` (from trait `std::ops::Mul`), `Output` (from trait `std::ops::Div`) must be specified
+  --> $DIR/missing-associated-types.rs:24:21
+   |
+LL | type Bal<Rhs> = dyn X<Rhs>;
+   |                     ^^^^^^ associated types `Output` (from trait `std::ops::Mul`), `Output` (from trait `std::ops::Div`) must be specified
+   |
+   = help: consider introducing a new type parameter, adding `where` constraints using the fully-qualified path to the associated types
+
+error: aborting due to 9 previous errors
+
+Some errors have detailed explanations: E0191, E0225.
+For more information about an error, try `rustc --explain E0191`.

--- a/src/test/ui/associated-types/missing-associated-types.stderr
+++ b/src/test/ui/associated-types/missing-associated-types.stderr
@@ -38,8 +38,8 @@ LL | type Bar<Rhs> = dyn Add<Rhs> + Sub<Rhs> + X<Rhs> + Z<Rhs>;
    |                     first non-auto trait
    |                     trait alias used in trait object type (first use)
 
-error[E0191]: the value of the associated types `Output` (from trait `std::ops::Add`), `Output` (from trait `std::ops::Sub`), `A` (from trait `Z`), `B` (from trait `Z`), `Output` (from trait `std::ops::Div`), `Output` (from trait `std::ops::Mul`), `Output` (from trait `std::ops::Div`) must be specified
-  --> $DIR/missing-associated-types.rs:15:21
+error[E0191]: the value of the associated types `Output` (from trait `std::ops::Mul`), `Output` (from trait `std::ops::Div`), `Output` (from trait `std::ops::Sub`), `A` (from trait `Z`), `B` (from trait `Z`), `Output` (from trait `std::ops::Div`), `Output` (from trait `std::ops::Add`) must be specified
+  --> $DIR/missing-associated-types.rs:15:43
    |
 LL |     type A;
    |     ------- `A` defined here

--- a/src/test/ui/associated-types/missing-associated-types.stderr
+++ b/src/test/ui/associated-types/missing-associated-types.stderr
@@ -9,8 +9,8 @@ LL | type Foo<Rhs> = dyn Add<Rhs> + Sub<Rhs> + X<Rhs> + Y<Rhs>;
    |                     first non-auto trait
    |                     trait alias used in trait object type (first use)
 
-error[E0191]: the value of the associated types `A` (from trait `Y`), `Output` (from trait `std::ops::Mul`), `Output` (from trait `std::ops::Add`), `Output` (from trait `std::ops::Sub`) must be specified
-  --> $DIR/missing-associated-types.rs:12:52
+error[E0191]: the value of the associated types `A` (from trait `Y`), `Output` (from trait `std::ops::Add`), `Output` (from trait `std::ops::Mul`), `Output` (from trait `std::ops::Sub`) must be specified
+  --> $DIR/missing-associated-types.rs:12:21
    |
 LL |     type A;
    |     ------- `A` defined here
@@ -38,8 +38,8 @@ LL | type Bar<Rhs> = dyn Add<Rhs> + Sub<Rhs> + X<Rhs> + Z<Rhs>;
    |                     first non-auto trait
    |                     trait alias used in trait object type (first use)
 
-error[E0191]: the value of the associated types `Output` (from trait `std::ops::Mul`), `Output` (from trait `std::ops::Div`), `Output` (from trait `std::ops::Sub`), `A` (from trait `Z`), `B` (from trait `Z`), `Output` (from trait `std::ops::Div`), `Output` (from trait `std::ops::Add`) must be specified
-  --> $DIR/missing-associated-types.rs:15:43
+error[E0191]: the value of the associated types `A` (from trait `Z`), `B` (from trait `Z`), `Output` (from trait `std::ops::Add`), `Output` (from trait `std::ops::Div`), `Output` (from trait `std::ops::Div`), `Output` (from trait `std::ops::Mul`), `Output` (from trait `std::ops::Sub`) must be specified
+  --> $DIR/missing-associated-types.rs:15:21
    |
 LL |     type A;
    |     ------- `A` defined here
@@ -74,8 +74,8 @@ LL | type Baz<Rhs> = dyn Add<Rhs> + Sub<Rhs> + Y<Rhs>;
    |                     first non-auto trait
    |                     trait alias used in trait object type (first use)
 
-error[E0191]: the value of the associated types `Output` (from trait `std::ops::Sub`), `A` (from trait `Y`), `Output` (from trait `std::ops::Add`) must be specified
-  --> $DIR/missing-associated-types.rs:18:32
+error[E0191]: the value of the associated types `A` (from trait `Y`), `Output` (from trait `std::ops::Add`), `Output` (from trait `std::ops::Sub`) must be specified
+  --> $DIR/missing-associated-types.rs:18:21
    |
 LL |     type A;
    |     ------- `A` defined here
@@ -102,8 +102,8 @@ LL | type Bat<Rhs> = dyn Add<Rhs> + Sub<Rhs> + Fine<Rhs>;
    |                     first non-auto trait
    |                     trait alias used in trait object type (first use)
 
-error[E0191]: the value of the associated types `Output` (from trait `std::ops::Sub`), `Output` (from trait `std::ops::Add`) must be specified
-  --> $DIR/missing-associated-types.rs:21:32
+error[E0191]: the value of the associated types `Output` (from trait `std::ops::Add`), `Output` (from trait `std::ops::Sub`) must be specified
+  --> $DIR/missing-associated-types.rs:21:21
    |
 LL | type Bat<Rhs> = dyn Add<Rhs> + Sub<Rhs> + Fine<Rhs>;
    |                     ^^^^^^^^   ^^^^^^^^ associated type `Output` must be specified
@@ -115,7 +115,7 @@ help: specify the associated types
 LL | type Bat<Rhs> = dyn Add<Rhs, Output = Type> + Sub<Rhs, Output = Type> + Fine<Rhs>;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0191]: the value of the associated types `Output` (from trait `std::ops::Mul`), `Output` (from trait `std::ops::Div`) must be specified
+error[E0191]: the value of the associated types `Output` (from trait `std::ops::Div`), `Output` (from trait `std::ops::Mul`) must be specified
   --> $DIR/missing-associated-types.rs:24:21
    |
 LL | type Bal<Rhs> = dyn X<Rhs>;

--- a/src/test/ui/error-codes/E0191.stderr
+++ b/src/test/ui/error-codes/E0191.stderr
@@ -1,11 +1,11 @@
-error[E0191]: the value of the associated type `Bar` (from the trait `Trait`) must be specified
-  --> $DIR/E0191.rs:5:12
+error[E0191]: the value of the associated type `Bar` (from trait `Trait`) must be specified
+  --> $DIR/E0191.rs:5:16
    |
 LL |     type Bar;
    |     --------- `Bar` defined here
 ...
 LL | type Foo = dyn Trait;
-   |            ^^^^^^^^^ associated type `Bar` must be specified
+   |                ^^^^^ help: specify the associated type: `Trait<Bar = Type>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0220.stderr
+++ b/src/test/ui/error-codes/E0220.stderr
@@ -1,8 +1,8 @@
 error[E0220]: associated type `F` not found for `Trait`
-  --> $DIR/E0220.rs:5:16
+  --> $DIR/E0220.rs:5:22
    |
 LL | type Foo = dyn Trait<F=i32>;
-   |                ^^^^^^^^^^^^ associated type `F` not found
+   |                      ^ associated type `F` not found
 
 error[E0191]: the value of the associated type `Bar` (from trait `Trait`) must be specified
   --> $DIR/E0220.rs:5:16

--- a/src/test/ui/error-codes/E0220.stderr
+++ b/src/test/ui/error-codes/E0220.stderr
@@ -1,8 +1,8 @@
 error[E0220]: associated type `F` not found for `Trait`
-  --> $DIR/E0220.rs:5:22
+  --> $DIR/E0220.rs:5:16
    |
 LL | type Foo = dyn Trait<F=i32>;
-   |                      ^^^^^ associated type `F` not found
+   |                ^^^^^^^^^^^^ associated type `F` not found
 
 error[E0191]: the value of the associated type `Bar` (from trait `Trait`) must be specified
   --> $DIR/E0220.rs:5:16

--- a/src/test/ui/error-codes/E0220.stderr
+++ b/src/test/ui/error-codes/E0220.stderr
@@ -4,14 +4,14 @@ error[E0220]: associated type `F` not found for `Trait`
 LL | type Foo = dyn Trait<F=i32>;
    |                      ^^^^^ associated type `F` not found
 
-error[E0191]: the value of the associated type `Bar` (from the trait `Trait`) must be specified
-  --> $DIR/E0220.rs:5:12
+error[E0191]: the value of the associated type `Bar` (from trait `Trait`) must be specified
+  --> $DIR/E0220.rs:5:16
    |
 LL |     type Bar;
    |     --------- `Bar` defined here
 ...
 LL | type Foo = dyn Trait<F=i32>;
-   |            ^^^^^^^^^^^^^^^^ associated type `Bar` must be specified
+   |                ^^^^^^^^^^^^ help: specify the associated type: `Trait<F=i32, Bar = Type>`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/error-codes/E0221.stderr
+++ b/src/test/ui/error-codes/E0221.stderr
@@ -9,6 +9,15 @@ LL |     type A: T2;
 LL |     fn do_something() {
 LL |         let _: Self::A;
    |                ^^^^^^^ ambiguous associated type `A`
+   |
+help: use fully qualified syntax to disambiguate
+   |
+LL |         let _: <Self as Foo>::A;
+   |                ^^^^^^^^^^^^^^^^
+help: use fully qualified syntax to disambiguate
+   |
+LL |         let _: <Self as Bar>::A;
+   |                ^^^^^^^^^^^^^^^^
 
 error[E0221]: ambiguous associated type `Err` in bounds of `Self`
   --> $DIR/E0221.rs:21:16
@@ -17,13 +26,12 @@ LL |     type Err: T3;
    |     ------------- ambiguous `Err` from `My`
 LL |     fn test() {
 LL |         let _: Self::Err;
-   |                ^^^^^^^^^ ambiguous associated type `Err`
-   |
-note: associated type `Self` could derive from `std::str::FromStr`
-  --> $DIR/E0221.rs:21:16
-   |
-LL |         let _: Self::Err;
    |                ^^^^^^^^^
+   |                |
+   |                ambiguous associated type `Err`
+   |                help: use fully qualified syntax to disambiguate: `<Self as My>::Err`
+   |
+   = note: associated type `Self` could derive from `std::str::FromStr`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/error-codes/E0393.stderr
+++ b/src/test/ui/error-codes/E0393.stderr
@@ -1,8 +1,11 @@
 error[E0393]: the type parameter `T` must be explicitly specified
   --> $DIR/E0393.rs:3:47
    |
+LL | trait A<T=Self> {}
+   | ------------------ type parameter `T` must be specified for this
+LL | 
 LL | fn together_we_will_rule_the_galaxy(son: &dyn A) {}
-   |                                               ^ missing reference to `T`
+   |                                               ^ help: set the type parameter to the desired type: `A<T>`
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
 

--- a/src/test/ui/error-codes/E0719.stderr
+++ b/src/test/ui/error-codes/E0719.stderr
@@ -1,4 +1,4 @@
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/E0719.rs:1:33
    |
 LL | trait Foo: Iterator<Item = i32, Item = i32> {}
@@ -6,7 +6,7 @@ LL | trait Foo: Iterator<Item = i32, Item = i32> {}
    |                     |
    |                     `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/E0719.rs:6:42
    |
 LL | fn test() -> Box<dyn Iterator<Item = (), Item = Unit>> {

--- a/src/test/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
@@ -38,11 +38,10 @@ error[E0658]: the precise format of `Fn`-family traits' type parameters is subje
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:9:6
    |
 LL | impl Fn<()> for Foo {
-   |      ^^^^^^
+   |      ^^^^^^ help: use parenthetical notation instead: `Fn() -> ()`
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
-   = help: use parenthetical notation instead: `Fn(Foo, Bar) -> Baz`
 
 error[E0229]: associated type bindings are not allowed here
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:15:6
@@ -54,21 +53,19 @@ error[E0658]: the precise format of `Fn`-family traits' type parameters is subje
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:21:6
    |
 LL | impl FnMut<()> for Bar {
-   |      ^^^^^^^^^
+   |      ^^^^^^^^^ help: use parenthetical notation instead: `FnMut() -> ()`
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
-   = help: use parenthetical notation instead: `Fn(Foo, Bar) -> Baz`
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:27:6
    |
 LL | impl FnOnce<()> for Baz {
-   |      ^^^^^^^^^^
+   |      ^^^^^^^^^^ help: use parenthetical notation instead: `FnOnce() -> ()`
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
-   = help: use parenthetical notation instead: `Fn(Foo, Bar) -> Baz`
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
@@ -34,7 +34,7 @@ LL |     extern "rust-call" fn call_once(&self, args: ()) -> () {}
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
-error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change. Use parenthetical notation (Fn(Foo, Bar) -> Baz) instead
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:9:6
    |
 LL | impl Fn<()> for Foo {
@@ -42,6 +42,7 @@ LL | impl Fn<()> for Foo {
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = help: use parenthetical notation instead: `Fn(Foo, Bar) -> Baz`
 
 error[E0229]: associated type bindings are not allowed here
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:15:6
@@ -49,7 +50,7 @@ error[E0229]: associated type bindings are not allowed here
 LL | impl FnOnce() for Foo1 {
    |      ^^^^^^^^ associated type not allowed here
 
-error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change. Use parenthetical notation (Fn(Foo, Bar) -> Baz) instead
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:21:6
    |
 LL | impl FnMut<()> for Bar {
@@ -57,8 +58,9 @@ LL | impl FnMut<()> for Bar {
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = help: use parenthetical notation instead: `Fn(Foo, Bar) -> Baz`
 
-error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change. Use parenthetical notation (Fn(Foo, Bar) -> Baz) instead
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:27:6
    |
 LL | impl FnOnce<()> for Baz {
@@ -66,6 +68,7 @@ LL | impl FnOnce<()> for Baz {
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = help: use parenthetical notation instead: `Fn(Foo, Bar) -> Baz`
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-unboxed-closures.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unboxed-closures.stderr
@@ -11,11 +11,10 @@ error[E0658]: the precise format of `Fn`-family traits' type parameters is subje
   --> $DIR/feature-gate-unboxed-closures.rs:5:6
    |
 LL | impl FnOnce<(u32, u32)> for Test {
-   |      ^^^^^^^^^^^^^^^^^^
+   |      ^^^^^^^^^^^^^^^^^^ help: use parenthetical notation instead: `FnOnce(u32, u32) -> ()`
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
-   = help: use parenthetical notation instead: `Fn(Foo, Bar) -> Baz`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-unboxed-closures.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unboxed-closures.stderr
@@ -7,7 +7,7 @@ LL |     extern "rust-call" fn call_once(self, (a, b): (u32, u32)) -> u32 {
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
-error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change. Use parenthetical notation (Fn(Foo, Bar) -> Baz) instead
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/feature-gate-unboxed-closures.rs:5:6
    |
 LL | impl FnOnce<(u32, u32)> for Test {
@@ -15,6 +15,7 @@ LL | impl FnOnce<(u32, u32)> for Test {
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = help: use parenthetical notation instead: `Fn(Foo, Bar) -> Baz`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-19482.rs
+++ b/src/test/ui/issues/issue-19482.rs
@@ -8,6 +8,6 @@ trait Foo {
 }
 
 fn bar(x: &dyn Foo) {}
-//~^ ERROR the associated type `A` (from the trait `Foo`) must be specified
+//~^ ERROR the associated type `A` (from trait `Foo`) must be specified
 
 pub fn main() {}

--- a/src/test/ui/issues/issue-19482.stderr
+++ b/src/test/ui/issues/issue-19482.stderr
@@ -1,11 +1,11 @@
-error[E0191]: the value of the associated type `A` (from the trait `Foo`) must be specified
-  --> $DIR/issue-19482.rs:10:12
+error[E0191]: the value of the associated type `A` (from trait `Foo`) must be specified
+  --> $DIR/issue-19482.rs:10:16
    |
 LL |     type A;
    |     ------- `A` defined here
 ...
 LL | fn bar(x: &dyn Foo) {}
-   |            ^^^^^^^ associated type `A` must be specified
+   |                ^^^ help: specify the associated type: `Foo<A = Type>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-21950.rs
+++ b/src/test/ui/issues/issue-21950.rs
@@ -1,8 +1,13 @@
-use std::ops::Add;
+trait Add<Rhs=Self> {
+    type Output;
+}
+
+impl Add for i32 {
+    type Output = i32;
+}
 
 fn main() {
-    let x = &10 as
-            &dyn Add;
-            //~^ ERROR E0393
-            //~| ERROR E0191
+    let x = &10 as &dyn Add;
+    //~^ ERROR E0393
+    //~| ERROR E0191
 }

--- a/src/test/ui/issues/issue-21950.stderr
+++ b/src/test/ui/issues/issue-21950.stderr
@@ -1,27 +1,24 @@
 error[E0393]: the type parameter `Rhs` must be explicitly specified
-  --> $DIR/issue-21950.rs:5:18
+  --> $DIR/issue-21950.rs:10:25
    |
-LL |               &dyn Add;
-   |                    ^^^ help: set the type parameter to the desired type: `Add<Rhs>`
-   | 
-  ::: $SRC_DIR/libcore/ops/arith.rs:LL:COL
-   |
-LL | / pub trait Add<Rhs = Self> {
-LL | |     /// The resulting type after applying the `+` operator.
-LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | / trait Add<Rhs=Self> {
 LL | |     type Output;
-...  |
-LL | |     fn add(self, rhs: Rhs) -> Self::Output;
 LL | | }
    | |_- type parameter `Rhs` must be specified for this
+...
+LL |       let x = &10 as &dyn Add;
+   |                           ^^^ help: set the type parameter to the desired type: `Add<Rhs>`
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
 
-error[E0191]: the value of the associated type `Output` (from trait `std::ops::Add`) must be specified
-  --> $DIR/issue-21950.rs:5:18
+error[E0191]: the value of the associated type `Output` (from trait `Add`) must be specified
+  --> $DIR/issue-21950.rs:10:25
    |
-LL |             &dyn Add;
-   |                  ^^^ help: specify the associated type: `Add<Output = Type>`
+LL |     type Output;
+   |     ------------ `Output` defined here
+...
+LL |     let x = &10 as &dyn Add;
+   |                         ^^^ help: specify the associated type: `Add<Output = Type>`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-21950.stderr
+++ b/src/test/ui/issues/issue-21950.stderr
@@ -1,16 +1,27 @@
 error[E0393]: the type parameter `Rhs` must be explicitly specified
   --> $DIR/issue-21950.rs:5:18
    |
-LL |             &dyn Add;
-   |                  ^^^ missing reference to `Rhs`
+LL |               &dyn Add;
+   |                    ^^^ help: set the type parameter to the desired type: `Add<Rhs>`
+   | 
+  ::: $SRC_DIR/libcore/ops/arith.rs:LL:COL
+   |
+LL | / pub trait Add<Rhs = Self> {
+LL | |     /// The resulting type after applying the `+` operator.
+LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | |     type Output;
+...  |
+LL | |     fn add(self, rhs: Rhs) -> Self::Output;
+LL | | }
+   | |_- type parameter `Rhs` must be specified for this
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
 
-error[E0191]: the value of the associated type `Output` (from the trait `std::ops::Add`) must be specified
-  --> $DIR/issue-21950.rs:5:14
+error[E0191]: the value of the associated type `Output` (from trait `std::ops::Add`) must be specified
+  --> $DIR/issue-21950.rs:5:18
    |
 LL |             &dyn Add;
-   |              ^^^^^^^ associated type `Output` must be specified
+   |                  ^^^ help: specify the associated type: `Add<Output = Type>`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-22370.stderr
+++ b/src/test/ui/issues/issue-22370.stderr
@@ -1,8 +1,11 @@
 error[E0393]: the type parameter `T` must be explicitly specified
   --> $DIR/issue-22370.rs:3:14
    |
+LL | trait A<T=Self> {}
+   | ------------------ type parameter `T` must be specified for this
+LL | 
 LL | fn f(a: &dyn A) {}
-   |              ^ missing reference to `T`
+   |              ^ help: set the type parameter to the desired type: `A<T>`
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
 

--- a/src/test/ui/issues/issue-22434.rs
+++ b/src/test/ui/issues/issue-22434.rs
@@ -3,6 +3,6 @@ pub trait Foo {
 }
 
 type I<'a> = &'a (dyn Foo + 'a);
-//~^ ERROR the value of the associated type `A` (from the trait `Foo`) must be specified
+//~^ ERROR the value of the associated type `A` (from trait `Foo`) must be specified
 
 fn main() {}

--- a/src/test/ui/issues/issue-22434.stderr
+++ b/src/test/ui/issues/issue-22434.stderr
@@ -1,11 +1,11 @@
-error[E0191]: the value of the associated type `A` (from the trait `Foo`) must be specified
-  --> $DIR/issue-22434.rs:5:19
+error[E0191]: the value of the associated type `A` (from trait `Foo`) must be specified
+  --> $DIR/issue-22434.rs:5:23
    |
 LL |     type A;
    |     ------- `A` defined here
 ...
 LL | type I<'a> = &'a (dyn Foo + 'a);
-   |                   ^^^^^^^^^^^^ associated type `A` must be specified
+   |                       ^^^ help: specify the associated type: `Foo<A = Type>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-22560.rs
+++ b/src/test/ui/issues/issue-22560.rs
@@ -1,10 +1,15 @@
-use std::ops::{Add, Sub};
+trait Add<Rhs=Self> {
+    type Output;
+}
 
-type Test = dyn Add +
-            //~^ ERROR E0393
-            //~| ERROR E0191
-            Sub;
-            //~^ ERROR E0393
-            //~| ERROR E0225
+trait Sub<Rhs=Self> {
+    type Output;
+}
+
+type Test = dyn Add + Sub;
+//~^ ERROR E0393
+//~| ERROR E0191
+//~| ERROR E0393
+//~| ERROR E0225
 
 fn main() { }

--- a/src/test/ui/issues/issue-22560.stderr
+++ b/src/test/ui/issues/issue-22560.stderr
@@ -1,65 +1,51 @@
 error[E0393]: the type parameter `Rhs` must be explicitly specified
-  --> $DIR/issue-22560.rs:6:13
+  --> $DIR/issue-22560.rs:9:23
    |
-LL |               Sub;
-   |               ^^^ help: set the type parameter to the desired type: `Sub<Rhs>`
-   | 
-  ::: $SRC_DIR/libcore/ops/arith.rs:LL:COL
-   |
-LL | / pub trait Sub<Rhs = Self> {
-LL | |     /// The resulting type after applying the `-` operator.
-LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | / trait Sub<Rhs=Self> {
 LL | |     type Output;
-...  |
-LL | |     fn sub(self, rhs: Rhs) -> Self::Output;
 LL | | }
    | |_- type parameter `Rhs` must be specified for this
+LL | 
+LL |   type Test = dyn Add + Sub;
+   |                         ^^^ help: set the type parameter to the desired type: `Sub<Rhs>`
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
 
 error[E0393]: the type parameter `Rhs` must be explicitly specified
-  --> $DIR/issue-22560.rs:3:17
+  --> $DIR/issue-22560.rs:9:17
    |
-LL |   type Test = dyn Add +
-   |                   ^^^ help: set the type parameter to the desired type: `Add<Rhs>`
-   | 
-  ::: $SRC_DIR/libcore/ops/arith.rs:LL:COL
-   |
-LL | / pub trait Add<Rhs = Self> {
-LL | |     /// The resulting type after applying the `+` operator.
-LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | / trait Add<Rhs=Self> {
 LL | |     type Output;
-...  |
-LL | |     fn add(self, rhs: Rhs) -> Self::Output;
 LL | | }
    | |_- type parameter `Rhs` must be specified for this
+...
+LL |   type Test = dyn Add + Sub;
+   |                   ^^^ help: set the type parameter to the desired type: `Add<Rhs>`
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
 
 error[E0225]: only auto traits can be used as additional traits in a trait object
-  --> $DIR/issue-22560.rs:6:13
+  --> $DIR/issue-22560.rs:9:23
    |
-LL | type Test = dyn Add +
-   |                 ---
-   |                 |
+LL | type Test = dyn Add + Sub;
+   |                 ---   ^^^
+   |                 |     |
+   |                 |     additional non-auto trait
+   |                 |     trait alias used in trait object type (additional use)
    |                 first non-auto trait
    |                 trait alias used in trait object type (first use)
-...
-LL |             Sub;
-   |             ^^^
-   |             |
-   |             additional non-auto trait
-   |             trait alias used in trait object type (additional use)
 
-error[E0191]: the value of the associated types `Output` (from trait `std::ops::Add`), `Output` (from trait `std::ops::Sub`) must be specified
-  --> $DIR/issue-22560.rs:3:13
+error[E0191]: the value of the associated types `Output` (from trait `Add`), `Output` (from trait `Sub`) must be specified
+  --> $DIR/issue-22560.rs:9:13
    |
-LL |   type Test = dyn Add +
-   |  _____________^
-LL | |
-LL | |
-LL | |             Sub;
-   | |_______________^ associated types `Output`, `Output` must be specified
+LL |     type Output;
+   |     ------------ `Output` defined here
+...
+LL |     type Output;
+   |     ------------ `Output` defined here
+...
+LL | type Test = dyn Add + Sub;
+   |             ^^^^^^^^^^^^^ associated types `Output`, `Output` must be specified
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/issues/issue-22560.stderr
+++ b/src/test/ui/issues/issue-22560.stderr
@@ -35,8 +35,8 @@ LL | type Test = dyn Add + Sub;
    |                 first non-auto trait
    |                 trait alias used in trait object type (first use)
 
-error[E0191]: the value of the associated types `Output` (from trait `Sub`), `Output` (from trait `Add`) must be specified
-  --> $DIR/issue-22560.rs:9:23
+error[E0191]: the value of the associated types `Output` (from trait `Add`), `Output` (from trait `Sub`) must be specified
+  --> $DIR/issue-22560.rs:9:17
    |
 LL |     type Output;
    |     ------------ `Output` defined here

--- a/src/test/ui/issues/issue-22560.stderr
+++ b/src/test/ui/issues/issue-22560.stderr
@@ -1,16 +1,38 @@
 error[E0393]: the type parameter `Rhs` must be explicitly specified
   --> $DIR/issue-22560.rs:6:13
    |
-LL |             Sub;
-   |             ^^^ missing reference to `Rhs`
+LL |               Sub;
+   |               ^^^ help: set the type parameter to the desired type: `Sub<Rhs>`
+   | 
+  ::: $SRC_DIR/libcore/ops/arith.rs:LL:COL
+   |
+LL | / pub trait Sub<Rhs = Self> {
+LL | |     /// The resulting type after applying the `-` operator.
+LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | |     type Output;
+...  |
+LL | |     fn sub(self, rhs: Rhs) -> Self::Output;
+LL | | }
+   | |_- type parameter `Rhs` must be specified for this
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
 
 error[E0393]: the type parameter `Rhs` must be explicitly specified
   --> $DIR/issue-22560.rs:3:17
    |
-LL | type Test = dyn Add +
-   |                 ^^^ missing reference to `Rhs`
+LL |   type Test = dyn Add +
+   |                   ^^^ help: set the type parameter to the desired type: `Add<Rhs>`
+   | 
+  ::: $SRC_DIR/libcore/ops/arith.rs:LL:COL
+   |
+LL | / pub trait Add<Rhs = Self> {
+LL | |     /// The resulting type after applying the `+` operator.
+LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | |     type Output;
+...  |
+LL | |     fn add(self, rhs: Rhs) -> Self::Output;
+LL | | }
+   | |_- type parameter `Rhs` must be specified for this
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
 
@@ -29,20 +51,15 @@ LL |             Sub;
    |             additional non-auto trait
    |             trait alias used in trait object type (additional use)
 
-error[E0191]: the value of the associated types `Output` (from the trait `std::ops::Add`), `Output` (from the trait `std::ops::Sub`) must be specified
+error[E0191]: the value of the associated types `Output` (from trait `std::ops::Add`), `Output` (from trait `std::ops::Sub`) must be specified
   --> $DIR/issue-22560.rs:3:13
    |
 LL |   type Test = dyn Add +
    |  _____________^
-   | |_____________|
-   | |
 LL | |
 LL | |
 LL | |             Sub;
-   | |               ^
-   | |_______________|
-   | |_______________associated type `Output` must be specified
-   |                 associated type `Output` must be specified
+   | |_______________^ associated types `Output`, `Output` must be specified
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/issues/issue-22560.stderr
+++ b/src/test/ui/issues/issue-22560.stderr
@@ -35,8 +35,8 @@ LL | type Test = dyn Add + Sub;
    |                 first non-auto trait
    |                 trait alias used in trait object type (first use)
 
-error[E0191]: the value of the associated types `Output` (from trait `Add`), `Output` (from trait `Sub`) must be specified
-  --> $DIR/issue-22560.rs:9:13
+error[E0191]: the value of the associated types `Output` (from trait `Sub`), `Output` (from trait `Add`) must be specified
+  --> $DIR/issue-22560.rs:9:23
    |
 LL |     type Output;
    |     ------------ `Output` defined here
@@ -45,7 +45,14 @@ LL |     type Output;
    |     ------------ `Output` defined here
 ...
 LL | type Test = dyn Add + Sub;
-   |             ^^^^^^^^^^^^^ associated types `Output`, `Output` must be specified
+   |                 ^^^   ^^^ associated type `Output` must be specified
+   |                 |
+   |                 associated type `Output` must be specified
+   |
+help: specify the associated types
+   |
+LL | type Test = dyn Add<Output = Type> + Sub<Output = Type>;
+   |                 ^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/issues/issue-23024.rs
+++ b/src/test/ui/issues/issue-23024.rs
@@ -9,5 +9,5 @@ fn main()
     println!("{:?}",(vfnfer[0] as dyn Fn)(3));
     //~^ ERROR the precise format of `Fn`-family traits'
     //~| ERROR wrong number of type arguments: expected 1, found 0 [E0107]
-    //~| ERROR the value of the associated type `Output` (from the trait `std::ops::FnOnce`)
+    //~| ERROR the value of the associated type `Output` (from trait `std::ops::FnOnce`)
 }

--- a/src/test/ui/issues/issue-23024.stderr
+++ b/src/test/ui/issues/issue-23024.stderr
@@ -2,11 +2,10 @@ error[E0658]: the precise format of `Fn`-family traits' type parameters is subje
   --> $DIR/issue-23024.rs:9:39
    |
 LL |     println!("{:?}",(vfnfer[0] as dyn Fn)(3));
-   |                                       ^^
+   |                                       ^^ help: use parenthetical notation instead: `Fn() -> ()`
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
-   = help: use parenthetical notation instead: `Fn(Foo, Bar) -> Baz`
 
 error[E0107]: wrong number of type arguments: expected 1, found 0
   --> $DIR/issue-23024.rs:9:39

--- a/src/test/ui/issues/issue-23024.stderr
+++ b/src/test/ui/issues/issue-23024.stderr
@@ -1,4 +1,4 @@
-error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change. Use parenthetical notation (Fn(Foo, Bar) -> Baz) instead
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/issue-23024.rs:9:39
    |
 LL |     println!("{:?}",(vfnfer[0] as dyn Fn)(3));
@@ -6,6 +6,7 @@ LL |     println!("{:?}",(vfnfer[0] as dyn Fn)(3));
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = help: use parenthetical notation instead: `Fn(Foo, Bar) -> Baz`
 
 error[E0107]: wrong number of type arguments: expected 1, found 0
   --> $DIR/issue-23024.rs:9:39
@@ -13,11 +14,11 @@ error[E0107]: wrong number of type arguments: expected 1, found 0
 LL |     println!("{:?}",(vfnfer[0] as dyn Fn)(3));
    |                                       ^^ expected 1 type argument
 
-error[E0191]: the value of the associated type `Output` (from the trait `std::ops::FnOnce`) must be specified
-  --> $DIR/issue-23024.rs:9:35
+error[E0191]: the value of the associated type `Output` (from trait `std::ops::FnOnce`) must be specified
+  --> $DIR/issue-23024.rs:9:39
    |
 LL |     println!("{:?}",(vfnfer[0] as dyn Fn)(3));
-   |                                   ^^^^^^ associated type `Output` must be specified
+   |                                       ^^ help: specify the associated type: `Fn<Output = Type>`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-23595-2.stderr
+++ b/src/test/ui/issues/issue-23595-2.stderr
@@ -1,8 +1,8 @@
 error[E0220]: associated type `anything_here_kills_it` not found for `Self`
-  --> $DIR/issue-23595-2.rs:6:16
+  --> $DIR/issue-23595-2.rs:6:22
    |
 LL |     type B = C<Self::anything_here_kills_it>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ associated type `anything_here_kills_it` not found
+   |                      ^^^^^^^^^^^^^^^^^^^^^^ associated type `anything_here_kills_it` not found
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-28344.stderr
+++ b/src/test/ui/issues/issue-28344.stderr
@@ -1,8 +1,8 @@
-error[E0191]: the value of the associated type `Output` (from the trait `std::ops::BitXor`) must be specified
+error[E0191]: the value of the associated type `Output` (from trait `std::ops::BitXor`) must be specified
   --> $DIR/issue-28344.rs:4:17
    |
 LL |     let x: u8 = BitXor::bitor(0 as u8, 0 as u8);
-   |                 ^^^^^^^^^^^^^ associated type `Output` must be specified
+   |                 ^^^^^^ help: specify the associated type: `BitXor<Output = Type>`
 
 error[E0599]: no function or associated item named `bitor` found for type `dyn std::ops::BitXor<_>` in the current scope
   --> $DIR/issue-28344.rs:4:25
@@ -13,11 +13,11 @@ LL |     let x: u8 = BitXor::bitor(0 as u8, 0 as u8);
    |                         function or associated item not found in `dyn std::ops::BitXor<_>`
    |                         help: there is a method with a similar name: `bitxor`
 
-error[E0191]: the value of the associated type `Output` (from the trait `std::ops::BitXor`) must be specified
+error[E0191]: the value of the associated type `Output` (from trait `std::ops::BitXor`) must be specified
   --> $DIR/issue-28344.rs:8:13
    |
 LL |     let g = BitXor::bitor;
-   |             ^^^^^^^^^^^^^ associated type `Output` must be specified
+   |             ^^^^^^ help: specify the associated type: `BitXor<Output = Type>`
 
 error[E0599]: no function or associated item named `bitor` found for type `dyn std::ops::BitXor<_>` in the current scope
   --> $DIR/issue-28344.rs:8:21

--- a/src/test/ui/issues/issue-39211.stderr
+++ b/src/test/ui/issues/issue-39211.stderr
@@ -1,8 +1,8 @@
 error[E0220]: associated type `Row` not found for `M`
-  --> $DIR/issue-39211.rs:11:17
+  --> $DIR/issue-39211.rs:11:20
    |
 LL |     let a = [3; M::Row::DIM];
-   |                 ^^^^^^^^^^^ associated type `Row` not found
+   |                    ^^^ associated type `Row` not found
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-59029-1.stderr
+++ b/src/test/ui/issues/issue-59029-1.stderr
@@ -1,8 +1,8 @@
 error[E0220]: associated type `Res` not found for `Self`
-  --> $DIR/issue-59029-1.rs:5:46
+  --> $DIR/issue-59029-1.rs:5:52
    |
 LL | trait MkSvc<Target, Req> = Svc<Target> where Self::Res: Svc<Req>;
-   |                                              ^^^^^^^^^ associated type `Res` not found
+   |                                                    ^^^ associated type `Res` not found
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/type-binding.stderr
+++ b/src/test/ui/span/type-binding.stderr
@@ -1,5 +1,5 @@
 error[E0220]: associated type `Trget` not found for `std::ops::Deref`
-  --> $DIR/type-binding.rs:6:20
+  --> $DIR/type-binding.rs:6:14
    |
 LL | fn homura<T: Deref<Trget = i32>>(_: T) {}
    |                    ^^^^^^^^^^^ help: there is an associated type with a similar name: `Target`

--- a/src/test/ui/span/type-binding.stderr
+++ b/src/test/ui/span/type-binding.stderr
@@ -1,8 +1,8 @@
 error[E0220]: associated type `Trget` not found for `std::ops::Deref`
-  --> $DIR/type-binding.rs:6:14
+  --> $DIR/type-binding.rs:6:20
    |
 LL | fn homura<T: Deref<Trget = i32>>(_: T) {}
-   |                    ^^^^^^^^^^^ help: there is an associated type with a similar name: `Target`
+   |                    ^^^^^ help: there is an associated type with a similar name: `Target`
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/use-type-argument-instead-of-assoc-type.stderr
+++ b/src/test/ui/suggestions/use-type-argument-instead-of-assoc-type.stderr
@@ -7,7 +7,7 @@ LL |     i: Box<dyn T<usize, usize, usize, usize, B=usize>>,
    |                                unexpected type argument
 
 error[E0191]: the value of the associated types `A` (from trait `T`), `C` (from trait `T`) must be specified
-  --> $DIR/use-type-argument-instead-of-assoc-type.rs:7:12
+  --> $DIR/use-type-argument-instead-of-assoc-type.rs:7:16
    |
 LL |     type A;
    |     ------- `A` defined here
@@ -16,7 +16,7 @@ LL |     type C;
    |     ------- `C` defined here
 ...
 LL |     i: Box<dyn T<usize, usize, usize, usize, B=usize>>,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ associated types `A`, `C` must be specified
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ associated types `A`, `C` must be specified
    |
 help: specify the associated types
    |

--- a/src/test/ui/suggestions/use-type-argument-instead-of-assoc-type.stderr
+++ b/src/test/ui/suggestions/use-type-argument-instead-of-assoc-type.stderr
@@ -6,7 +6,7 @@ LL |     i: Box<dyn T<usize, usize, usize, usize, B=usize>>,
    |                                |
    |                                unexpected type argument
 
-error[E0191]: the value of the associated types `A` (from the trait `T`), `C` (from the trait `T`) must be specified
+error[E0191]: the value of the associated types `A` (from trait `T`), `C` (from trait `T`) must be specified
   --> $DIR/use-type-argument-instead-of-assoc-type.rs:7:12
    |
 LL |     type A;
@@ -16,12 +16,9 @@ LL |     type C;
    |     ------- `C` defined here
 ...
 LL |     i: Box<dyn T<usize, usize, usize, usize, B=usize>>,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |            |
-   |            associated type `A` must be specified
-   |            associated type `C` must be specified
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ associated types `A`, `C` must be specified
    |
-help: if you meant to specify the associated types, write
+help: specify the associated types
    |
 LL |     i: Box<dyn T<usize, usize, A = usize, C = usize, B=usize>>,
    |                                ^^^^^^^^^  ^^^^^^^^^

--- a/src/test/ui/traits/trait-alias/trait-alias-object-fail.stderr
+++ b/src/test/ui/traits/trait-alias/trait-alias-object-fail.stderr
@@ -6,11 +6,11 @@ LL |     let _: &dyn EqAlias = &123;
    |
    = note: the trait cannot use `Self` as a type parameter in the supertraits or where-clauses
 
-error[E0191]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) must be specified
-  --> $DIR/trait-alias-object-fail.rs:9:13
+error[E0191]: the value of the associated type `Item` (from trait `std::iter::Iterator`) must be specified
+  --> $DIR/trait-alias-object-fail.rs:9:17
    |
 LL |     let _: &dyn IteratorAlias = &vec![123].into_iter();
-   |             ^^^^^^^^^^^^^^^^^ associated type `Item` must be specified
+   |                 ^^^^^^^^^^^^^ help: specify the associated type: `IteratorAlias<Item = Type>`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/trait-object-with-self-in-projection-output-bad.rs
+++ b/src/test/ui/traits/trait-object-with-self-in-projection-output-bad.rs
@@ -43,8 +43,8 @@ impl NormalizableHelper for u32
 
 fn main() {
     let _x: Box<dyn Helper<Target=i32>> = Box::new(2u32);
-    //~^ ERROR the value of the associated type `Output` (from the trait `Base`) must be specified
+    //~^ ERROR the value of the associated type `Output` (from trait `Base`) must be specified
 
     let _y: Box<dyn NormalizableHelper<Target=i32>> = Box::new(2u32);
-    //~^ ERROR the value of the associated type `Output` (from the trait `Base`) must be specified
+    //~^ ERROR the value of the associated type `Output` (from trait `Base`) must be specified
 }

--- a/src/test/ui/traits/trait-object-with-self-in-projection-output-bad.stderr
+++ b/src/test/ui/traits/trait-object-with-self-in-projection-output-bad.stderr
@@ -1,20 +1,20 @@
-error[E0191]: the value of the associated type `Output` (from the trait `Base`) must be specified
-  --> $DIR/trait-object-with-self-in-projection-output-bad.rs:45:17
+error[E0191]: the value of the associated type `Output` (from trait `Base`) must be specified
+  --> $DIR/trait-object-with-self-in-projection-output-bad.rs:45:21
    |
 LL |     type Output;
    |     ------------ `Output` defined here
 ...
 LL |     let _x: Box<dyn Helper<Target=i32>> = Box::new(2u32);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^ associated type `Output` must be specified
+   |                     ^^^^^^^^^^^^^^^^^^ help: specify the associated type: `Helper<Target=i32, Output = Type>`
 
-error[E0191]: the value of the associated type `Output` (from the trait `Base`) must be specified
-  --> $DIR/trait-object-with-self-in-projection-output-bad.rs:48:17
+error[E0191]: the value of the associated type `Output` (from trait `Base`) must be specified
+  --> $DIR/trait-object-with-self-in-projection-output-bad.rs:48:21
    |
 LL |     type Output;
    |     ------------ `Output` defined here
 ...
 LL |     let _y: Box<dyn NormalizableHelper<Target=i32>> = Box::new(2u32);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ associated type `Output` must be specified
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: specify the associated type: `NormalizableHelper<Target=i32, Output = Type>`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/type-alias-impl-trait/not_well_formed.stderr
+++ b/src/test/ui/type-alias-impl-trait/not_well_formed.stderr
@@ -1,8 +1,8 @@
 error[E0220]: associated type `Assoc` not found for `V`
-  --> $DIR/not_well_formed.rs:10:26
+  --> $DIR/not_well_formed.rs:10:29
    |
 LL | type Foo<V> = impl Trait<V::Assoc>;
-   |                          ^^^^^^^^ associated type `Assoc` not found
+   |                             ^^^^^ associated type `Assoc` not found
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/type-parameter-defaults-referencing-Self.stderr
+++ b/src/test/ui/type/type-parameter-defaults-referencing-Self.stderr
@@ -1,8 +1,13 @@
 error[E0393]: the type parameter `T` must be explicitly specified
   --> $DIR/type-parameter-defaults-referencing-Self.rs:10:16
    |
-LL | fn foo(x: &dyn Foo) { }
-   |                ^^^ missing reference to `T`
+LL | / trait Foo<T=Self> {
+LL | |     fn method(&self);
+LL | | }
+   | |_- type parameter `T` must be specified for this
+LL | 
+LL |   fn foo(x: &dyn Foo) { }
+   |                  ^^^ help: set the type parameter to the desired type: `Foo<T>`
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-feature-gate.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-feature-gate.stderr
@@ -2,7 +2,7 @@ error[E0658]: parenthetical notation is only stable when used with `Fn`-family t
   --> $DIR/unboxed-closure-feature-gate.rs:13:20
    |
 LL |     let x: Box<dyn Foo(isize)>;
-   |                    ^^^^^^^^^^
+   |                    ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-not-used-on-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-not-used-on-fn.stderr
@@ -1,20 +1,22 @@
-error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change. Use parenthetical notation (Fn(Foo, Bar) -> Baz) instead
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/unboxed-closure-sugar-not-used-on-fn.rs:3:17
    |
 LL | fn bar1(x: &dyn Fn<(), Output=()>) {
-   |                 ^^^^^^^^^^^^^^^^^
+   |                 ^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = help: use parenthetical notation instead: `Fn(Foo, Bar) -> Baz`
 
-error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change. Use parenthetical notation (Fn(Foo, Bar) -> Baz) instead
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/unboxed-closure-sugar-not-used-on-fn.rs:7:28
    |
 LL | fn bar2<T>(x: &T) where T: Fn<()> {
-   |                            ^^^^^^
+   |                            ^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = help: use parenthetical notation instead: `Fn(Foo, Bar) -> Baz`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-not-used-on-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-not-used-on-fn.stderr
@@ -2,21 +2,19 @@ error[E0658]: the precise format of `Fn`-family traits' type parameters is subje
   --> $DIR/unboxed-closure-sugar-not-used-on-fn.rs:3:17
    |
 LL | fn bar1(x: &dyn Fn<(), Output=()>) {
-   |                 ^^
+   |                 ^^ help: use parenthetical notation instead: `Fn() -> ()`
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
-   = help: use parenthetical notation instead: `Fn(Foo, Bar) -> Baz`
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/unboxed-closure-sugar-not-used-on-fn.rs:7:28
    |
 LL | fn bar2<T>(x: &T) where T: Fn<()> {
-   |                            ^^
+   |                            ^^ help: use parenthetical notation instead: `Fn() -> ()`
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
-   = help: use parenthetical notation instead: `Fn(Foo, Bar) -> Baz`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-region.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-region.stderr
@@ -2,7 +2,7 @@ error[E0107]: wrong number of lifetime arguments: expected 1, found 0
   --> $DIR/unboxed-closure-sugar-region.rs:30:51
    |
 LL | fn test2(x: &dyn Foo<(isize,),Output=()>, y: &dyn Foo(isize)) {
-   |                                                   ^^^^^^^^^^ expected 1 lifetime argument
+   |                                                   ^^^ expected 1 lifetime argument
 
 error: aborting due to previous error
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters-3.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters-3.stderr
@@ -2,7 +2,7 @@ error[E0107]: wrong number of type arguments: expected 3, found 1
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters-3.rs:5:16
    |
 LL | fn foo(_: &dyn Three())
-   |                ^^^^^^^ expected 3 type arguments
+   |                ^^^^^ expected 3 type arguments
 
 error[E0220]: associated type `Output` not found for `Three<(), [type error], [type error]>`
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters-3.rs:5:16

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-wrong-trait.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-wrong-trait.stderr
@@ -5,10 +5,10 @@ LL | fn f<F:Trait(isize) -> isize>(x: F) {}
    |        ^^^^^^^^^^^^ unexpected type argument
 
 error[E0220]: associated type `Output` not found for `Trait`
-  --> $DIR/unboxed-closure-sugar-wrong-trait.rs:5:24
+  --> $DIR/unboxed-closure-sugar-wrong-trait.rs:5:8
    |
 LL | fn f<F:Trait(isize) -> isize>(x: F) {}
-   |                        ^^^^^ associated type `Output` not found
+   |        ^^^^^^^^^^^^^^^^^^^^^ associated type `Output` not found
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/unspecified-self-in-trait-ref.stderr
+++ b/src/test/ui/unspecified-self-in-trait-ref.stderr
@@ -25,8 +25,13 @@ LL |     let d = Bar::<usize, _>::lol();
 error[E0393]: the type parameter `A` must be explicitly specified
   --> $DIR/unspecified-self-in-trait-ref.rs:18:13
    |
-LL |     let e = Bar::<usize>::lol();
-   |             ^^^^^^^^^^^^^^^^^ missing reference to `A`
+LL | / pub trait Bar<X=usize, A=Self> {
+LL | |     fn foo(&self);
+LL | | }
+   | |_- type parameter `A` must be specified for this
+...
+LL |       let e = Bar::<usize>::lol();
+   |               ^^^ missing reference to `A`
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
 

--- a/src/test/ui/where-clauses/where-equality-constraints.stderr
+++ b/src/test/ui/where-clauses/where-equality-constraints.stderr
@@ -2,7 +2,7 @@ error: equality constraints are not yet supported in `where` clauses
   --> $DIR/where-equality-constraints.rs:1:14
    |
 LL | fn f() where u8 = u16 {}
-   |              ^^^^^^^^
+   |              ^^^^^^^^ not supported
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/20041
 
@@ -10,7 +10,7 @@ error: equality constraints are not yet supported in `where` clauses
   --> $DIR/where-equality-constraints.rs:3:14
    |
 LL | fn g() where for<'a> &'static (u8,) == u16, {}
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not supported
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/20041
 


### PR DESCRIPTION
* On `dyn Trait` missing associated types, provide a structured suggestion for them
* On missing type parameters, provide structured suggestion for them
* Point at trait definition when missing required type parameter
* Tweak output of E0658
* Tweak wording of E0719
* Account for `Trait1 + Trait2` case

Fix #66380, fix #60595. CC #63711.