### PR TITLE
Fix example code of OpenOptions::open

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -936,7 +936,7 @@ impl OpenOptions {
     /// ```no_run
     /// use std::fs::OpenOptions;
     ///
-    /// let file = OpenOptions::new().open("foo.txt");
+    /// let file = OpenOptions::new().read(true).open("foo.txt");
     /// ```
     ///
     /// [`ErrorKind`]: ../io/enum.ErrorKind.html


### PR DESCRIPTION
The example didn't set the access mode flag, which resulted in an `Err(InvalidInput)`.

r? @steveklabnik