### PR TITLE
Fix the configure.py TOML field for a couple LLVM options

### DIFF
--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -59,13 +59,13 @@ o("full-tools", None, "enable all tools")
 o("lld", "rust.lld", "build lld")
 o("lldb", "rust.lldb", "build lldb")
 o("missing-tools", "dist.missing-tools", "allow failures when building tools")
-o("use-libcxx", "llvm.use_libcxx", "build LLVM with libc++")
+o("use-libcxx", "llvm.use-libcxx", "build LLVM with libc++")
 
 o("cflags", "llvm.cflags", "build LLVM with these extra compiler flags")
 o("cxxflags", "llvm.cxxflags", "build LLVM with these extra compiler flags")
 o("ldflags", "llvm.ldflags", "build LLVM with these extra linker flags")
 
-o("llvm-libunwind", "rust.llvm_libunwind", "use LLVM libunwind")
+o("llvm-libunwind", "rust.llvm-libunwind", "use LLVM libunwind")
 
 # Optimization and debugging options. These may be overridden by the release
 # channel, etc.


### PR DESCRIPTION
The actual fields in `config.toml.example` have dashes, not underscores.