### PR TITLE
Refactor libarena

### DIFF
--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -653,11 +653,13 @@ impl DroplessArena {
         // slice iterators
         loop {
             let value = iter.next();
-            if i >= len || value.is_none() {
+            if value.is_none() {
                 // We only return as many items as the iterator gave us, even
                 // though it was supposed to give us `len`
                 return slice::from_raw_parts_mut(mem, i);
             }
+            // The iterator is not supposed to give us more than `len`.
+            assert!(i < len);
             ptr::write(mem.add(i), value.unwrap());
             i += 1;
         }
@@ -803,11 +805,13 @@ impl SyncDroplessArena {
         // slice iterators
         loop {
             let value = iter.next();
-            if i >= len || value.is_none() {
+            if value.is_none() {
                 // We only return as many items as the iterator gave us, even
                 // though it was supposed to give us `len`
                 return slice::from_raw_parts_mut(mem, i);
             }
+            // The iterator is not supposed to give us more than `len`.
+            assert!(i < len);
             ptr::write(mem.add(i), value.unwrap());
             i += 1;
         }

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -13,6 +13,7 @@
 
 #![feature(core_intrinsics)]
 #![feature(dropck_eyepatch)]
+#![feature(iter_once_with)]
 #![feature(ptr_offset_from)]
 #![feature(raw_vec_internals)]
 #![feature(untagged_unions)]

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -446,6 +446,7 @@ pub union TypedArena<T> {
     zst: mem::ManuallyDrop<GenericArena<T, ZSTCurrentChunk<T>>>,
     dropless: mem::ManuallyDrop<GenericArena<T, DroplessCurrentChunk<T>>>,
     typed: mem::ManuallyDrop<GenericArena<T, TypedCurrentChunk<T>>>,
+    _own: PhantomData<T>,
 }
 
 impl<T> Default for TypedArena<T> {

--- a/src/libarena/tests.rs
+++ b/src/libarena/tests.rs
@@ -12,12 +12,6 @@ struct Point {
 }
 
 #[test]
-pub fn test_unused() {
-    let arena: TypedArena<Point> = TypedArena::default();
-    assert!(arena.chunks.borrow().is_empty());
-}
-
-#[test]
 fn test_arena_alloc_nested() {
     struct Inner {
         value: u8,

--- a/src/librustc_data_structures/sync.rs
+++ b/src/librustc_data_structures/sync.rs
@@ -428,6 +428,7 @@ cfg_if! {
         pub use rayon_core::WorkerLocal;
         pub use rayon_core::Registry;
         use rayon_core::current_thread_index;
+        use rayon_core::current_num_threads;
 
         #[derive(Debug)]
         pub struct SharedWorkerLocal<T>(Vec<T>);
@@ -437,7 +438,7 @@ cfg_if! {
             /// value this worker local should take for each thread in the thread pool.
             #[inline]
             pub fn new<F: FnMut(usize) -> T>(mut f: F) -> SharedWorkerLocal<T> {
-                SharedWorkerLocal((0..Registry::current_num_threads()).map(|i| f(i)).collect())
+                SharedWorkerLocal((0..current_num_threads()).map(|i| f(i)).collect())
             }
 
             #[inline]


### PR DESCRIPTION
Starting from some optimisation in libarena, I got a bit carried away.

This PR splits the logic into 4 basic allocation policies, depending on whether the allocated type is a ZST or needs dropping. I think splitting everything allows for more local reasoning, which is good for such tricky code.

A few tests have been added and bugs removed. 
I am still unhappy with the tests for `alloc_from_iter` methods.

r? @Zoxc
