### PR TITLE
Delete flaky test net::tcp::tests::fast_rebind

### DIFF
--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -1313,21 +1313,6 @@ mod tests {
     }
 
     #[test]
-    fn fast_rebind() {
-        each_ip(&mut |addr| {
-            let acceptor = t!(TcpListener::bind(&addr));
-
-            let _t = thread::spawn(move || {
-                t!(TcpStream::connect(&addr));
-            });
-
-            t!(acceptor.accept());
-            drop(acceptor);
-            t!(TcpListener::bind(&addr));
-        });
-    }
-
-    #[test]
     fn tcp_clone_smoke() {
         each_ip(&mut |addr| {
             let acceptor = t!(TcpListener::bind(&addr));


### PR DESCRIPTION
This test is unreliable for at least 3 users on two platforms: see #57509 and #51006. It was added 5 years ago in #22015. Do we know whether this is testing something important that would indicate a bug in our implementation, or if it's fine to remove?

r? @sfackler @alexcrichton because this somewhat resembles #59018

Closes #57509. Closes #51006.