### PR TITLE
const fn for SocketAddr::new, SocketAddrV4::new and SocketAddrV6::new

### DIFF
--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -125,7 +125,7 @@ impl SocketAddr {
     /// assert_eq!(socket.port(), 8080);
     /// ```
     #[stable(feature = "ip_addr", since = "1.7.0")]
-    pub fn new(ip: IpAddr, port: u16) -> SocketAddr {
+    pub const fn new(ip: IpAddr, port: u16) -> SocketAddr {
         match ip {
             IpAddr::V4(a) => SocketAddr::V4(SocketAddrV4::new(a, port)),
             IpAddr::V6(a) => SocketAddr::V6(SocketAddrV6::new(a, port, 0, 0)),
@@ -272,7 +272,7 @@ impl SocketAddrV4 {
     /// let socket = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn new(ip: Ipv4Addr, port: u16) -> SocketAddrV4 {
+    pub const fn new(ip: Ipv4Addr, port: u16) -> SocketAddrV4 {
         SocketAddrV4 {
             inner: c::sockaddr_in {
                 sin_family: c::AF_INET as c::sa_family_t,
@@ -364,7 +364,7 @@ impl SocketAddrV6 {
     /// let socket = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080, 0, 0);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn new(ip: Ipv6Addr, port: u16, flowinfo: u32, scope_id: u32) -> SocketAddrV6 {
+    pub const fn new(ip: Ipv6Addr, port: u16, flowinfo: u32, scope_id: u32) -> SocketAddrV6 {
         SocketAddrV6 {
             inner: c::sockaddr_in6 {
                 sin6_family: c::AF_INET6 as c::sa_family_t,

--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -125,6 +125,7 @@ impl SocketAddr {
     /// assert_eq!(socket.port(), 8080);
     /// ```
     #[stable(feature = "ip_addr", since = "1.7.0")]
+    #[rustc_const_unstable(feature = "const_socket_new", issue = "67390")]
     pub const fn new(ip: IpAddr, port: u16) -> SocketAddr {
         match ip {
             IpAddr::V4(a) => SocketAddr::V4(SocketAddrV4::new(a, port)),
@@ -272,6 +273,7 @@ impl SocketAddrV4 {
     /// let socket = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_const_unstable(feature = "const_socket_new", issue = "67390")]
     pub const fn new(ip: Ipv4Addr, port: u16) -> SocketAddrV4 {
         SocketAddrV4 {
             inner: c::sockaddr_in {
@@ -364,6 +366,7 @@ impl SocketAddrV6 {
     /// let socket = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080, 0, 0);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_const_unstable(feature = "const_socket_new", issue = "67390")]
     pub const fn new(ip: Ipv6Addr, port: u16, flowinfo: u32, scope_id: u32) -> SocketAddrV6 {
         SocketAddrV6 {
             inner: c::sockaddr_in6 {


### PR DESCRIPTION
Add `const fn` to `SocketAddr::new`, `SocketAddrV4::new` and `SocketAddrV6::new` to be able to initialize the socket address at compile time, for example:

```rust
use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6, SocketAddr};

const localhost_v4: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);
const socket_v4: SocketAddrV4 = SocketAddrV4::new(localhost_v4, 80);
const socket_add_v4: SocketAddr = SocketAddr::new(IpAddr::V4(localhost_v4), 80);

const localhost_v6: Ipv6Addr = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1);
const socket_v6: SocketAddrV6 = SocketAddrV6::new(localhost_v6, 80, 0, 0);
const socket_add_v6: SocketAddr = SocketAddr::new(IpAddr::V6(localhost_v6), 80);
```

This addition is probably still missing the right method attributes:

```
rustc_const_stable(feature = "const_X", since = "1.?"))
```

as I'm not aware of the procedure required to add const to an existing method in stable.