### PR TITLE
Refactor the `Qualif` trait

### DIFF
--- a/src/librustc_mir/transform/check_consts/resolver.rs
+++ b/src/librustc_mir/transform/check_consts/resolver.rs
@@ -8,7 +8,7 @@ use rustc_index::bit_set::BitSet;
 
 use std::marker::PhantomData;
 
-use super::{Item, Qualif};
+use super::{qualifs, Item, Qualif};
 use crate::dataflow::{self as old_dataflow, generic as dataflow};
 
 /// A `Visitor` that propagates qualifs between locals. This defines the transfer function of
@@ -66,18 +66,15 @@ where
     fn apply_call_return_effect(
         &mut self,
         _block: BasicBlock,
-        func: &mir::Operand<'tcx>,
-        args: &[mir::Operand<'tcx>],
+        _func: &mir::Operand<'tcx>,
+        _args: &[mir::Operand<'tcx>],
         return_place: &mir::Place<'tcx>,
     ) {
+        // We cannot reason about another function's internals, so use conservative type-based
+        // qualification for the result of a function call.
         let return_ty = return_place.ty(*self.item.body, self.item.tcx).ty;
-        let qualif = Q::in_call(
-            self.item,
-            &mut |l| self.qualifs_per_local.contains(l),
-            func,
-            args,
-            return_ty,
-        );
+        let qualif = Q::in_any_value_of_ty(self.item, return_ty);
+
         if !return_place.is_indirect() {
             self.assign_qualif_direct(return_place, qualif);
         }
@@ -110,7 +107,11 @@ where
         rvalue: &mir::Rvalue<'tcx>,
         location: Location,
     ) {
-        let qualif = Q::in_rvalue(self.item, &mut |l| self.qualifs_per_local.contains(l), rvalue);
+        let qualif = qualifs::in_rvalue::<Q, _>(
+            self.item,
+            &mut |l| self.qualifs_per_local.contains(l),
+            rvalue,
+        );
         if !place.is_indirect() {
             self.assign_qualif_direct(place, qualif);
         }
@@ -125,8 +126,12 @@ where
         // here; that occurs in `apply_call_return_effect`.
 
         if let mir::TerminatorKind::DropAndReplace { value, location: dest, .. } = kind {
-            let qualif =
-                Q::in_operand(self.item, &mut |l| self.qualifs_per_local.contains(l), value);
+            let qualif = qualifs::in_operand::<Q, _>(
+                self.item,
+                &mut |l| self.qualifs_per_local.contains(l),
+                value,
+            );
+
             if !dest.is_indirect() {
                 self.assign_qualif_direct(dest, qualif);
             }

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -344,7 +344,7 @@ impl Visitor<'tcx> for Validator<'_, 'mir, 'tcx> {
             Rvalue::Ref(_, BorrowKind::Shared, ref place)
             | Rvalue::Ref(_, BorrowKind::Shallow, ref place)
             | Rvalue::AddressOf(Mutability::Not, ref place) => {
-                let borrowed_place_has_mut_interior = HasMutInterior::in_place(
+                let borrowed_place_has_mut_interior = qualifs::in_place::<HasMutInterior, _>(
                     &self.item,
                     &mut |local| self.qualifs.has_mut_interior(local, location),
                     place.as_ref(),


### PR DESCRIPTION
This PR attempts to preserve the existing semantics of the `Qualif` trait while reducing its API to two significant methods with descriptive names, `in_any_value_of_ty` and `in_adt_inherently`. The other `in_*` methods have been made into free functions, since they should never be overloaded. Finally, I changed the bounds on the `in_local` argument to be less restrictive (`FnMut` instead of `Fn`), which addresses a FIXME in the const-checker.

r? @eddyb 
cc @pnkfelix @oli-obk 