### PR TITLE
Fix JS error when loading page with search

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2683,7 +2683,7 @@ function getSearchElement() {
         insertAfter(popup, getSearchElement());
     }
 
-    onHashChange();
+    onHashChange(null);
     window.onhashchange = onHashChange;
 
     buildHelperPopup();


### PR DESCRIPTION
For example when you load this page: https://doc.rust-lang.org/nightly/std/num/struct.NonZeroI8.html?search=foo, you get a nice JS error:

```
TypeError: ev is undefined
```

r? @kinnison 