### PR TITLE
Const qualification for `StructuralEq`

### DIFF
--- a/src/librustc_middle/mir/query.rs
+++ b/src/librustc_middle/mir/query.rs
@@ -80,6 +80,7 @@ pub struct BorrowCheckResult<'tcx> {
 pub struct ConstQualifs {
     pub has_mut_interior: bool,
     pub needs_drop: bool,
+    pub custom_eq: bool,
 }
 
 /// After we borrow check a closure, we are left with various

--- a/src/librustc_mir/transform/check_consts/qualifs.rs
+++ b/src/librustc_mir/transform/check_consts/qualifs.rs
@@ -2,9 +2,11 @@
 //!
 //! See the `Qualif` trait for more info.
 
+use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::mir::*;
 use rustc_middle::ty::{self, subst::SubstsRef, AdtDef, Ty};
 use rustc_span::DUMMY_SP;
+use rustc_trait_selection::traits;
 
 use super::ConstCx;
 
@@ -12,6 +14,7 @@ pub fn in_any_value_of_ty(cx: &ConstCx<'_, 'tcx>, ty: Ty<'tcx>) -> ConstQualifs 
     ConstQualifs {
         has_mut_interior: HasMutInterior::in_any_value_of_ty(cx, ty),
         needs_drop: NeedsDrop::in_any_value_of_ty(cx, ty),
+        custom_eq: CustomEq::in_any_value_of_ty(cx, ty),
     }
 }
 
@@ -105,6 +108,39 @@ impl Qualif for NeedsDrop {
 
     fn in_adt_inherently(cx: &ConstCx<'_, 'tcx>, adt: &'tcx AdtDef, _: SubstsRef<'tcx>) -> bool {
         adt.has_dtor(cx.tcx)
+    }
+}
+
+/// A constant that cannot be used as part of a pattern in a `match` expression.
+pub struct CustomEq;
+
+impl Qualif for CustomEq {
+    const ANALYSIS_NAME: &'static str = "flow_custom_eq";
+
+    fn in_qualifs(qualifs: &ConstQualifs) -> bool {
+        qualifs.custom_eq
+    }
+
+    fn in_any_value_of_ty(cx: &ConstCx<'_, 'tcx>, ty: Ty<'tcx>) -> bool {
+        // If *any* component of a composite data type does not implement `Structural{Partial,}Eq`,
+        // we know that at least some values of that type are not structural-match. I say "some"
+        // because that component may be part of an enum variant (e.g.,
+        // `Option::<NonStructuralMatchTy>::Some`), in which case some values of this type may be
+        // structural-match (`Option::None`).
+        let id = cx.tcx.hir().local_def_id_to_hir_id(cx.def_id.as_local().unwrap());
+        traits::search_for_structural_match_violation(id, cx.body.span, cx.tcx, ty).is_some()
+    }
+
+    fn in_adt_inherently(
+        cx: &ConstCx<'_, 'tcx>,
+        adt: &'tcx AdtDef,
+        substs: SubstsRef<'tcx>,
+    ) -> bool {
+        let ty = cx.tcx.mk_ty(ty::Adt(adt, substs));
+        let id = cx.tcx.hir().local_def_id_to_hir_id(cx.def_id.as_local().unwrap());
+        cx.tcx
+            .infer_ctxt()
+            .enter(|infcx| !traits::type_marked_structural(id, cx.body.span, &infcx, ty))
     }
 }
 

--- a/src/test/ui/consts/const_in_pattern/accept_structural.rs
+++ b/src/test/ui/consts/const_in_pattern/accept_structural.rs
@@ -1,0 +1,66 @@
+// run-pass
+
+#![warn(indirect_structural_match)]
+
+// This test is checking our logic for structural match checking by enumerating
+// the different kinds of const expressions. This test is collecting cases where
+// we have accepted the const expression as a pattern in the past and wish to
+// continue doing so.
+//
+// Even if a non-structural-match type is part of an expression in a const's
+// definition, that does not necessarily disqualify the const from being a match
+// pattern: in principle, we just need the types involved in the final value to
+// be structurally matchable.
+
+// See also RFC 1445
+
+#![feature(type_ascription)]
+
+#[derive(Copy, Clone, Debug)]
+struct NoPartialEq(u32);
+
+#[derive(Copy, Clone, Debug)]
+struct NoDerive(u32);
+
+// This impl makes `NoDerive` irreflexive.
+impl PartialEq for NoDerive { fn eq(&self, _: &Self) -> bool { false } }
+impl Eq for NoDerive { }
+
+type OND = Option<NoDerive>;
+
+fn main() {
+    const FIELD1: u32 = NoPartialEq(1).0;
+    match 1 { FIELD1 => dbg!(FIELD1), _ => panic!("whoops"), };
+    const FIELD2: u32 = NoDerive(1).0;
+    match 1 { FIELD2 => dbg!(FIELD2), _ => panic!("whoops"), };
+
+    enum CLike { One = 1, #[allow(dead_code)] Two = 2, }
+    const ONE_CAST: u32 = CLike::One as u32;
+    match 1 { ONE_CAST => dbg!(ONE_CAST), _ => panic!("whoops"), };
+
+    const NO_DERIVE_NONE: OND = None;
+    const INDIRECT: OND = NO_DERIVE_NONE;
+    match None { INDIRECT => dbg!(INDIRECT), _ => panic!("whoops"), };
+
+    const TUPLE: (OND, OND) = (None, None);
+    match (None, None) { TUPLE => dbg!(TUPLE), _ => panic!("whoops"), };
+
+    const TYPE: OND = None: OND;
+    match None { TYPE => dbg!(TYPE), _ => panic!("whoops"), };
+
+    const ARRAY: [OND; 2] = [None, None];
+    match [None; 2] { ARRAY => dbg!(ARRAY), _ => panic!("whoops"), };
+
+    const REPEAT: [OND; 2] = [None; 2];
+    match [None, None] { REPEAT => dbg!(REPEAT), _ => panic!("whoops"), };
+
+    trait Trait: Sized { const ASSOC: Option<Self>; }
+    impl Trait for NoDerive { const ASSOC: Option<NoDerive> = None; }
+    match None { NoDerive::ASSOC => dbg!(NoDerive::ASSOC), _ => panic!("whoops"), };
+
+    const BLOCK: OND = { NoDerive(10); None };
+    match None { BLOCK => dbg!(BLOCK), _ => panic!("whoops"), };
+
+    const ADDR_OF: &OND = &None;
+    match &None { ADDR_OF => dbg!(ADDR_OF),  _ => panic!("whoops"), };
+}

--- a/src/test/ui/consts/const_in_pattern/accept_structural.rs
+++ b/src/test/ui/consts/const_in_pattern/accept_structural.rs
@@ -45,8 +45,8 @@ fn main() {
     const TUPLE: (OND, OND) = (None, None);
     match (None, None) { TUPLE => dbg!(TUPLE), _ => panic!("whoops"), };
 
-    const TYPE: OND = None: OND;
-    match None { TYPE => dbg!(TYPE), _ => panic!("whoops"), };
+    const TYPE_ASCRIPTION: OND = None: OND;
+    match None { TYPE_ASCRIPTION => dbg!(TYPE_ASCRIPTION), _ => panic!("whoops"), };
 
     const ARRAY: [OND; 2] = [None, None];
     match [None; 2] { ARRAY => dbg!(ARRAY), _ => panic!("whoops"), };

--- a/src/test/ui/consts/const_in_pattern/auxiliary/consts.rs
+++ b/src/test/ui/consts/const_in_pattern/auxiliary/consts.rs
@@ -1,0 +1,11 @@
+pub struct CustomEq;
+
+impl Eq for CustomEq {}
+impl PartialEq for CustomEq {
+    fn eq(&self, _: &Self) -> bool {
+        false
+    }
+}
+
+pub const NONE: Option<CustomEq> = None;
+pub const SOME: Option<CustomEq> = Some(CustomEq);

--- a/src/test/ui/consts/const_in_pattern/cross-crate-fail.rs
+++ b/src/test/ui/consts/const_in_pattern/cross-crate-fail.rs
@@ -3,11 +3,10 @@
 #![warn(indirect_structural_match)]
 
 extern crate consts;
-use consts::*;
 
 fn main() {
     match None {
-        SOME => panic!(),
+        consts::SOME => panic!(),
         //~^ must be annotated with `#[derive(PartialEq, Eq)]`
         //~| must be annotated with `#[derive(PartialEq, Eq)]`
 

--- a/src/test/ui/consts/const_in_pattern/cross-crate-fail.rs
+++ b/src/test/ui/consts/const_in_pattern/cross-crate-fail.rs
@@ -1,0 +1,16 @@
+// aux-build:consts.rs
+
+#![warn(indirect_structural_match)]
+
+extern crate consts;
+use consts::*;
+
+fn main() {
+    match None {
+        SOME => panic!(),
+        //~^ must be annotated with `#[derive(PartialEq, Eq)]`
+        //~| must be annotated with `#[derive(PartialEq, Eq)]`
+
+        _ => {}
+    }
+}

--- a/src/test/ui/consts/const_in_pattern/cross-crate-fail.stderr
+++ b/src/test/ui/consts/const_in_pattern/cross-crate-fail.stderr
@@ -1,14 +1,14 @@
 error: to use a constant of type `consts::CustomEq` in a pattern, `consts::CustomEq` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/cross-crate-fail.rs:10:9
+  --> $DIR/cross-crate-fail.rs:9:9
    |
-LL |         SOME => panic!(),
-   |         ^^^^
+LL |         consts::SOME => panic!(),
+   |         ^^^^^^^^^^^^
 
 error: to use a constant of type `consts::CustomEq` in a pattern, `consts::CustomEq` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/cross-crate-fail.rs:10:9
+  --> $DIR/cross-crate-fail.rs:9:9
    |
-LL |         SOME => panic!(),
-   |         ^^^^
+LL |         consts::SOME => panic!(),
+   |         ^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/const_in_pattern/cross-crate-fail.stderr
+++ b/src/test/ui/consts/const_in_pattern/cross-crate-fail.stderr
@@ -1,0 +1,14 @@
+error: to use a constant of type `consts::CustomEq` in a pattern, `consts::CustomEq` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/cross-crate-fail.rs:10:9
+   |
+LL |         SOME => panic!(),
+   |         ^^^^
+
+error: to use a constant of type `consts::CustomEq` in a pattern, `consts::CustomEq` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/cross-crate-fail.rs:10:9
+   |
+LL |         SOME => panic!(),
+   |         ^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/consts/const_in_pattern/cross-crate-pass.rs
+++ b/src/test/ui/consts/const_in_pattern/cross-crate-pass.rs
@@ -1,0 +1,14 @@
+// run-pass
+// aux-build:consts.rs
+
+#![warn(indirect_structural_match)]
+
+extern crate consts;
+use consts::*;
+
+fn main() {
+    match Some(CustomEq) {
+        NONE => panic!(),
+        _ => {}
+    }
+}

--- a/src/test/ui/consts/const_in_pattern/cross-crate-pass.rs
+++ b/src/test/ui/consts/const_in_pattern/cross-crate-pass.rs
@@ -4,11 +4,11 @@
 #![warn(indirect_structural_match)]
 
 extern crate consts;
-use consts::*;
+use consts::CustomEq;
 
 fn main() {
     match Some(CustomEq) {
-        NONE => panic!(),
+        consts::NONE => panic!(),
         _ => {}
     }
 }

--- a/src/test/ui/consts/const_in_pattern/custom-eq-branch-pass.rs
+++ b/src/test/ui/consts/const_in_pattern/custom-eq-branch-pass.rs
@@ -1,0 +1,33 @@
+// run-pass
+
+#![feature(const_if_match)]
+#![warn(indirect_structural_match)]
+
+struct CustomEq;
+
+impl Eq for CustomEq {}
+impl PartialEq for CustomEq {
+    fn eq(&self, _: &Self) -> bool {
+        false
+    }
+}
+
+#[derive(PartialEq, Eq)]
+enum Foo {
+    Bar,
+    Baz,
+    Qux(CustomEq),
+}
+
+const BAR_BAZ: Foo = if 42 == 42 {
+    Foo::Bar
+} else {
+    Foo::Baz
+};
+
+fn main() {
+    match Foo::Qux(CustomEq) {
+        BAR_BAZ => panic!(),
+        _ => {}
+    }
+}

--- a/src/test/ui/consts/const_in_pattern/custom-eq-branch-warn.rs
+++ b/src/test/ui/consts/const_in_pattern/custom-eq-branch-warn.rs
@@ -1,0 +1,39 @@
+// check-pass
+
+#![feature(const_if_match)]
+#![warn(indirect_structural_match)]
+//~^ NOTE lint level is defined here
+
+struct CustomEq;
+
+impl Eq for CustomEq {}
+impl PartialEq for CustomEq {
+    fn eq(&self, _: &Self) -> bool {
+        false
+    }
+}
+
+#[derive(PartialEq, Eq)]
+enum Foo {
+    Bar,
+    Baz,
+    Qux(CustomEq),
+}
+
+// We know that `BAR_BAZ` will always be `Foo::Bar` and thus eligible for structural matching, but
+// dataflow will be more conservative.
+const BAR_BAZ: Foo = if 42 == 42 {
+    Foo::Bar
+} else {
+    Foo::Qux(CustomEq)
+};
+
+fn main() {
+    match Foo::Qux(CustomEq) {
+        BAR_BAZ => panic!(),
+        //~^ WARN must be annotated with `#[derive(PartialEq, Eq)]`
+        //~| WARN this was previously accepted
+        //~| NOTE see issue #62411
+        _ => {}
+    }
+}

--- a/src/test/ui/consts/const_in_pattern/custom-eq-branch-warn.stderr
+++ b/src/test/ui/consts/const_in_pattern/custom-eq-branch-warn.stderr
@@ -1,0 +1,16 @@
+warning: to use a constant of type `CustomEq` in a pattern, `CustomEq` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/custom-eq-branch-warn.rs:33:9
+   |
+LL |         BAR_BAZ => panic!(),
+   |         ^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/custom-eq-branch-warn.rs:4:9
+   |
+LL | #![warn(indirect_structural_match)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
+
+warning: 1 warning emitted
+

--- a/src/test/ui/consts/const_in_pattern/issue-62614.rs
+++ b/src/test/ui/consts/const_in_pattern/issue-62614.rs
@@ -1,0 +1,24 @@
+// run-pass
+
+struct Sum(u32, u32);
+
+impl PartialEq for Sum {
+    fn eq(&self, other: &Self) -> bool { self.0 + self.1 == other.0 + other.1 }
+}
+
+impl Eq for Sum { }
+
+#[derive(PartialEq, Eq)]
+enum Eek {
+    TheConst,
+    UnusedByTheConst(Sum)
+}
+
+const THE_CONST: Eek = Eek::TheConst;
+
+pub fn main() {
+    match Eek::UnusedByTheConst(Sum(1,2)) {
+        THE_CONST => { panic!(); }
+        _ => {}
+    }
+}

--- a/src/test/ui/consts/const_in_pattern/issue-65466.rs
+++ b/src/test/ui/consts/const_in_pattern/issue-65466.rs
@@ -1,3 +1,7 @@
+// FIXME: This still ICEs.
+//
+// ignore-test
+
 #![deny(indirect_structural_match)]
 
 #[derive(PartialEq, Eq)]

--- a/src/test/ui/consts/const_in_pattern/issue-65466.rs
+++ b/src/test/ui/consts/const_in_pattern/issue-65466.rs
@@ -1,0 +1,19 @@
+#![deny(indirect_structural_match)]
+
+#[derive(PartialEq, Eq)]
+enum O<T> {
+    Some(*const T), // Can also use PhantomData<T>
+    None,
+}
+
+struct B;
+
+const C: &[O<B>] = &[O::None];
+
+fn main() {
+    let x = O::None;
+    match &[x][..] {
+        C => (),
+        _ => (),
+    }
+}

--- a/src/test/ui/consts/const_in_pattern/issue-65466.stderr
+++ b/src/test/ui/consts/const_in_pattern/issue-65466.stderr
@@ -1,0 +1,15 @@
+error[E0601]: `main` function not found in crate `issue_65466`
+  --> $DIR/issue-65466.rs:1:1
+   |
+LL | / #![deny(indirect_structural_match)]
+LL | |
+LL | | #[derive(PartialEq, Eq)]
+LL | | enum O<T> {
+...  |
+LL | |     }
+LL | | }
+   | |_^ consider adding a `main` function to `$DIR/issue-65466.rs`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0601`.

--- a/src/test/ui/consts/const_in_pattern/no-eq-branch-fail.rs
+++ b/src/test/ui/consts/const_in_pattern/no-eq-branch-fail.rs
@@ -1,0 +1,27 @@
+#![feature(const_if_match)]
+#![warn(indirect_structural_match)]
+
+struct NoEq;
+
+enum Foo {
+    Bar,
+    Baz,
+    Qux(NoEq),
+}
+
+// Even though any of these values can be compared structurally, we still disallow it in a pattern
+// because `Foo` does not impl `PartialEq`.
+const BAR_BAZ: Foo = if 42 == 42 {
+    Foo::Baz
+} else {
+    Foo::Bar
+};
+
+fn main() {
+    match Foo::Qux(NoEq) {
+        BAR_BAZ => panic!(),
+        //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+        //~| ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+        _ => {}
+    }
+}

--- a/src/test/ui/consts/const_in_pattern/no-eq-branch-fail.stderr
+++ b/src/test/ui/consts/const_in_pattern/no-eq-branch-fail.stderr
@@ -1,0 +1,14 @@
+error: to use a constant of type `Foo` in a pattern, `Foo` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/no-eq-branch-fail.rs:22:9
+   |
+LL |         BAR_BAZ => panic!(),
+   |         ^^^^^^^
+
+error: to use a constant of type `Foo` in a pattern, `Foo` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/no-eq-branch-fail.rs:22:9
+   |
+LL |         BAR_BAZ => panic!(),
+   |         ^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/consts/const_in_pattern/reject_non_partial_eq.rs
+++ b/src/test/ui/consts/const_in_pattern/reject_non_partial_eq.rs
@@ -1,0 +1,32 @@
+// This test is illustrating the difference between how failing to derive
+// `PartialEq` is handled compared to failing to implement it at all.
+
+// See also RFC 1445
+
+#[derive(PartialEq, Eq)]
+struct Structural(u32);
+
+struct NoPartialEq(u32);
+
+struct NoDerive(u32);
+
+// This impl makes NoDerive irreflexive.
+impl PartialEq for NoDerive { fn eq(&self, _: &Self) -> bool { false } }
+
+impl Eq for NoDerive { }
+
+const NO_DERIVE_NONE: Option<NoDerive> = None;
+const NO_PARTIAL_EQ_NONE: Option<NoPartialEq> = None;
+
+fn main() {
+    match None {
+        NO_DERIVE_NONE => println!("NO_DERIVE_NONE"),
+        _ => panic!("whoops"),
+    }
+
+    match None {
+        NO_PARTIAL_EQ_NONE => println!("NO_PARTIAL_EQ_NONE"),
+        //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+        _ => panic!("whoops"),
+    }
+}

--- a/src/test/ui/consts/const_in_pattern/reject_non_partial_eq.stderr
+++ b/src/test/ui/consts/const_in_pattern/reject_non_partial_eq.stderr
@@ -1,0 +1,8 @@
+error: to use a constant of type `NoPartialEq` in a pattern, `NoPartialEq` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_partial_eq.rs:28:9
+   |
+LL |         NO_PARTIAL_EQ_NONE => println!("NO_PARTIAL_EQ_NONE"),
+   |         ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/consts/const_in_pattern/reject_non_structural.rs
+++ b/src/test/ui/consts/const_in_pattern/reject_non_structural.rs
@@ -57,8 +57,8 @@ fn main() {
     //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
     //~| ERROR must be annotated with `#[derive(PartialEq, Eq)]`
 
-    const TYPE: OND = Some(NoDerive): OND;
-    match Some(NoDerive) { TYPE => dbg!(TYPE), _ => panic!("whoops"), };
+    const TYPE_ASCRIPTION: OND = Some(NoDerive): OND;
+    match Some(NoDerive) { TYPE_ASCRIPTION => dbg!(TYPE_ASCRIPTION), _ => panic!("whoops"), };
     //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
     //~| ERROR must be annotated with `#[derive(PartialEq, Eq)]`
 

--- a/src/test/ui/consts/const_in_pattern/reject_non_structural.rs
+++ b/src/test/ui/consts/const_in_pattern/reject_non_structural.rs
@@ -1,0 +1,93 @@
+// This test of structural match checking enumerates the different kinds of
+// const definitions, collecting cases where the const pattern is rejected.
+//
+// Note: Even if a non-structural-match type is part of an expression in a
+// const's definition, that does not necessarily disqualify the const from being
+// a match pattern: in principle, we just need the types involved in the final
+// value to be structurally matchable.
+
+// See also RFC 1445
+
+#![feature(type_ascription)]
+#![warn(indirect_structural_match)]
+//~^ NOTE lint level is defined here
+
+#[derive(Copy, Clone, Debug)]
+struct NoPartialEq;
+
+#[derive(Copy, Clone, Debug)]
+struct NoDerive;
+
+// This impl makes `NoDerive` irreflexive.
+impl PartialEq for NoDerive { fn eq(&self, _: &Self) -> bool { false } }
+
+impl Eq for NoDerive { }
+
+type OND = Option<NoDerive>;
+
+struct TrivialEq(OND);
+
+// This impl makes `TrivialEq` trivial.
+impl PartialEq for TrivialEq { fn eq(&self, _: &Self) -> bool { true } }
+
+impl Eq for TrivialEq { }
+
+fn main() {
+    #[derive(PartialEq, Eq, Debug)]
+    enum Derive<X> { Some(X), None, }
+
+    const ENUM: Derive<NoDerive> = Derive::Some(NoDerive);
+    match Derive::Some(NoDerive) { ENUM => dbg!(ENUM), _ => panic!("whoops"), };
+    //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+
+    const FIELD: OND = TrivialEq(Some(NoDerive)).0;
+    match Some(NoDerive) { FIELD => dbg!(FIELD), _ => panic!("whoops"), };
+    //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+
+    const NO_DERIVE_SOME: OND = Some(NoDerive);
+    const INDIRECT: OND = NO_DERIVE_SOME;
+    match Some(NoDerive) {INDIRECT => dbg!(INDIRECT), _ => panic!("whoops"), };
+    //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+
+    const TUPLE: (OND, OND) = (None, Some(NoDerive));
+    match (None, Some(NoDerive)) { TUPLE => dbg!(TUPLE), _ => panic!("whoops"), };
+    //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+
+    const TYPE: OND = Some(NoDerive): OND;
+    match Some(NoDerive) { TYPE => dbg!(TYPE), _ => panic!("whoops"), };
+    //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+
+    const ARRAY: [OND; 2] = [None, Some(NoDerive)];
+    match [None, Some(NoDerive)] { ARRAY => dbg!(ARRAY), _ => panic!("whoops"), };
+    //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+
+    const REPEAT: [OND; 2] = [Some(NoDerive); 2];
+    match [Some(NoDerive); 2] { REPEAT => dbg!(REPEAT), _ => panic!("whoops"), };
+    //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+
+    trait Trait: Sized { const ASSOC: Option<Self>; }
+    impl Trait for NoDerive { const ASSOC: Option<NoDerive> = Some(NoDerive); }
+    match Some(NoDerive) { NoDerive::ASSOC => dbg!(NoDerive::ASSOC), _ => panic!("whoops"), };
+    //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+
+    const BLOCK: OND = { NoDerive; Some(NoDerive) };
+    match Some(NoDerive) { BLOCK => dbg!(BLOCK), _ => panic!("whoops"), };
+    //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+
+    const ADDR_OF: &OND = &Some(NoDerive);
+    match &Some(NoDerive) { ADDR_OF => dbg!(ADDR_OF), _ => panic!("whoops"), };
+    //~^ WARN must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| WARN previously accepted by the compiler but is being phased out
+    //~| NOTE for more information, see issue #62411
+}

--- a/src/test/ui/consts/const_in_pattern/reject_non_structural.stderr
+++ b/src/test/ui/consts/const_in_pattern/reject_non_structural.stderr
@@ -1,0 +1,136 @@
+error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_structural.rs:40:36
+   |
+LL |     match Derive::Some(NoDerive) { ENUM => dbg!(ENUM), _ => panic!("whoops"), };
+   |                                    ^^^^
+
+error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_structural.rs:45:28
+   |
+LL |     match Some(NoDerive) { FIELD => dbg!(FIELD), _ => panic!("whoops"), };
+   |                            ^^^^^
+
+error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_structural.rs:51:27
+   |
+LL |     match Some(NoDerive) {INDIRECT => dbg!(INDIRECT), _ => panic!("whoops"), };
+   |                           ^^^^^^^^
+
+error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_structural.rs:56:36
+   |
+LL |     match (None, Some(NoDerive)) { TUPLE => dbg!(TUPLE), _ => panic!("whoops"), };
+   |                                    ^^^^^
+
+error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_structural.rs:61:28
+   |
+LL |     match Some(NoDerive) { TYPE => dbg!(TYPE), _ => panic!("whoops"), };
+   |                            ^^^^
+
+error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_structural.rs:66:36
+   |
+LL |     match [None, Some(NoDerive)] { ARRAY => dbg!(ARRAY), _ => panic!("whoops"), };
+   |                                    ^^^^^
+
+error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_structural.rs:71:33
+   |
+LL |     match [Some(NoDerive); 2] { REPEAT => dbg!(REPEAT), _ => panic!("whoops"), };
+   |                                 ^^^^^^
+
+error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_structural.rs:71:33
+   |
+LL |     match [Some(NoDerive); 2] { REPEAT => dbg!(REPEAT), _ => panic!("whoops"), };
+   |                                 ^^^^^^
+
+error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_structural.rs:79:28
+   |
+LL |     match Some(NoDerive) { NoDerive::ASSOC => dbg!(NoDerive::ASSOC), _ => panic!("whoops"), };
+   |                            ^^^^^^^^^^^^^^^
+
+error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_structural.rs:84:28
+   |
+LL |     match Some(NoDerive) { BLOCK => dbg!(BLOCK), _ => panic!("whoops"), };
+   |                            ^^^^^
+
+warning: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_structural.rs:89:29
+   |
+LL |     match &Some(NoDerive) { ADDR_OF => dbg!(ADDR_OF), _ => panic!("whoops"), };
+   |                             ^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/reject_non_structural.rs:12:9
+   |
+LL | #![warn(indirect_structural_match)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
+
+error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_structural.rs:40:36
+   |
+LL |     match Derive::Some(NoDerive) { ENUM => dbg!(ENUM), _ => panic!("whoops"), };
+   |                                    ^^^^
+
+error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_structural.rs:45:28
+   |
+LL |     match Some(NoDerive) { FIELD => dbg!(FIELD), _ => panic!("whoops"), };
+   |                            ^^^^^
+
+error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_structural.rs:51:27
+   |
+LL |     match Some(NoDerive) {INDIRECT => dbg!(INDIRECT), _ => panic!("whoops"), };
+   |                           ^^^^^^^^
+
+error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_structural.rs:56:36
+   |
+LL |     match (None, Some(NoDerive)) { TUPLE => dbg!(TUPLE), _ => panic!("whoops"), };
+   |                                    ^^^^^
+
+error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_structural.rs:61:28
+   |
+LL |     match Some(NoDerive) { TYPE => dbg!(TYPE), _ => panic!("whoops"), };
+   |                            ^^^^
+
+error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_structural.rs:66:36
+   |
+LL |     match [None, Some(NoDerive)] { ARRAY => dbg!(ARRAY), _ => panic!("whoops"), };
+   |                                    ^^^^^
+
+error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_structural.rs:71:33
+   |
+LL |     match [Some(NoDerive); 2] { REPEAT => dbg!(REPEAT), _ => panic!("whoops"), };
+   |                                 ^^^^^^
+
+error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_structural.rs:71:33
+   |
+LL |     match [Some(NoDerive); 2] { REPEAT => dbg!(REPEAT), _ => panic!("whoops"), };
+   |                                 ^^^^^^
+
+error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_structural.rs:79:28
+   |
+LL |     match Some(NoDerive) { NoDerive::ASSOC => dbg!(NoDerive::ASSOC), _ => panic!("whoops"), };
+   |                            ^^^^^^^^^^^^^^^
+
+error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/reject_non_structural.rs:84:28
+   |
+LL |     match Some(NoDerive) { BLOCK => dbg!(BLOCK), _ => panic!("whoops"), };
+   |                            ^^^^^
+
+error: aborting due to 20 previous errors; 1 warning emitted
+

--- a/src/test/ui/consts/const_in_pattern/reject_non_structural.stderr
+++ b/src/test/ui/consts/const_in_pattern/reject_non_structural.stderr
@@ -25,8 +25,8 @@ LL |     match (None, Some(NoDerive)) { TUPLE => dbg!(TUPLE), _ => panic!("whoop
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
   --> $DIR/reject_non_structural.rs:61:28
    |
-LL |     match Some(NoDerive) { TYPE => dbg!(TYPE), _ => panic!("whoops"), };
-   |                            ^^^^
+LL |     match Some(NoDerive) { TYPE_ASCRIPTION => dbg!(TYPE_ASCRIPTION), _ => panic!("whoops"), };
+   |                            ^^^^^^^^^^^^^^^
 
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
   --> $DIR/reject_non_structural.rs:66:36
@@ -99,8 +99,8 @@ LL |     match (None, Some(NoDerive)) { TUPLE => dbg!(TUPLE), _ => panic!("whoop
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
   --> $DIR/reject_non_structural.rs:61:28
    |
-LL |     match Some(NoDerive) { TYPE => dbg!(TYPE), _ => panic!("whoops"), };
-   |                            ^^^^
+LL |     match Some(NoDerive) { TYPE_ASCRIPTION => dbg!(TYPE_ASCRIPTION), _ => panic!("whoops"), };
+   |                            ^^^^^^^^^^^^^^^
 
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
   --> $DIR/reject_non_structural.rs:66:36

--- a/src/test/ui/consts/const_in_pattern/warn_corner_cases.rs
+++ b/src/test/ui/consts/const_in_pattern/warn_corner_cases.rs
@@ -1,0 +1,41 @@
+// run-pass
+
+// This test is checking our logic for structural match checking by enumerating
+// the different kinds of const expressions. This test is collecting cases where
+// we have accepted the const expression as a pattern in the past but we want
+// to begin warning the user that a future version of Rust may start rejecting
+// such const expressions.
+
+// The specific corner cases we are exploring here are instances where the
+// const-evaluator computes a value that *does* meet the conditions for
+// structural-match, but the const expression itself has abstractions (like
+// calls to const functions) that may fit better with a type-based analysis
+// rather than a committment to a specific value.
+
+#![warn(indirect_structural_match)]
+
+#[derive(Copy, Clone, Debug)]
+struct NoDerive(u32);
+
+// This impl makes `NoDerive` irreflexive.
+impl PartialEq for NoDerive { fn eq(&self, _: &Self) -> bool { false } }
+impl Eq for NoDerive { }
+
+fn main() {
+    const INDEX: Option<NoDerive> = [None, Some(NoDerive(10))][0];
+    match None { Some(_) => panic!("whoops"), INDEX => dbg!(INDEX), };
+    //~^ WARN must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| WARN this was previously accepted
+
+    const fn build() -> Option<NoDerive> { None }
+    const CALL: Option<NoDerive> = build();
+    match None { Some(_) => panic!("whoops"), CALL => dbg!(CALL), };
+    //~^ WARN must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| WARN this was previously accepted
+
+    impl NoDerive { const fn none() -> Option<NoDerive> { None } }
+    const METHOD_CALL: Option<NoDerive> = NoDerive::none();
+    match None { Some(_) => panic!("whoops"), METHOD_CALL => dbg!(METHOD_CALL), };
+    //~^ WARN must be annotated with `#[derive(PartialEq, Eq)]`
+    //~| WARN this was previously accepted
+}

--- a/src/test/ui/consts/const_in_pattern/warn_corner_cases.stderr
+++ b/src/test/ui/consts/const_in_pattern/warn_corner_cases.stderr
@@ -1,0 +1,34 @@
+warning: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/warn_corner_cases.rs:26:47
+   |
+LL |     match None { Some(_) => panic!("whoops"), INDEX => dbg!(INDEX), };
+   |                                               ^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/warn_corner_cases.rs:15:9
+   |
+LL | #![warn(indirect_structural_match)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
+
+warning: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/warn_corner_cases.rs:32:47
+   |
+LL |     match None { Some(_) => panic!("whoops"), CALL => dbg!(CALL), };
+   |                                               ^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
+
+warning: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/warn_corner_cases.rs:38:47
+   |
+LL |     match None { Some(_) => panic!("whoops"), METHOD_CALL => dbg!(METHOD_CALL), };
+   |                                               ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
+
+warning: 3 warnings emitted
+

--- a/src/test/ui/issues/issue-55511.rs
+++ b/src/test/ui/issues/issue-55511.rs
@@ -14,8 +14,6 @@ fn main() {
     //~^ ERROR `a` does not live long enough [E0597]
     match b {
         <() as Foo<'static>>::C => { }
-        //~^ WARN must be annotated with `#[derive(PartialEq, Eq)]`
-        //~| WARN will become a hard error in a future release
         _ => { }
     }
 }

--- a/src/test/ui/issues/issue-55511.stderr
+++ b/src/test/ui/issues/issue-55511.stderr
@@ -1,17 +1,3 @@
-warning: to use a constant of type `std::cell::Cell` in a pattern, `std::cell::Cell` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/issue-55511.rs:16:9
-   |
-LL |         <() as Foo<'static>>::C => { }
-   |         ^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: the lint level is defined here
-  --> $DIR/issue-55511.rs:1:9
-   |
-LL | #![warn(indirect_structural_match)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
-
 error[E0597]: `a` does not live long enough
   --> $DIR/issue-55511.rs:13:28
    |

--- a/src/test/ui/issues/issue-55511.stderr
+++ b/src/test/ui/issues/issue-55511.stderr
@@ -10,6 +10,6 @@ LL |         <() as Foo<'static>>::C => { }
 LL | }
    | - `a` dropped here while still borrowed
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0597`.


### PR DESCRIPTION
Furthers #62411. Resolves #62614.

The goal of this PR is to implement the logic in #67088 on the MIR instead of the HIR. It uses the `Qualif` trait to track `StructuralPartialEq`/`StructuralEq` in the final value of a `const`. Then, if we encounter a constant during HAIR lowering whose value may not be structurally matchable, we emit the `indirect_structural_match` lint.

This PR contains all the tests present in #67088 and emits the proper warnings for the corner cases. This PR does not handle #65466, which would require that we be [more aggressive](https://github.com/rust-lang/rust/blob/42abbd8878d3b67238f3611b0587c704ba94f39c/src/librustc_mir_build/hair/pattern/const_to_pat.rs#L126-L130) when checking matched types for `PartialEq`. I think that should be done separately.

Because this works on MIR and uses dataflow, this PR should accept more cases than #67088. Notably, the qualifs in the final value of a const are encoded cross-crate, so matching on a constant whose value is defined in another crate to be `Option::<TyWithCustomEqImpl>::None` should work. Additionally, if a `const` has branching/looping, we will only emit the warning if any possible control flow path could result in a type with a custom `PartialEq` impl ending up as the final value of a `const`. I'm not sure how #67088 handled this.

AFAIK, it's not settled that these are the semantics we actually want: it's just how the `Qualif` framework happens to work. If the cross-crate part is undesirable, it would be quite easy to change the result of `mir_const_qualif().custom_eq` to `true` before encoding it in the crate metadata. This way, other crates would have to assume that all publicly exported constants may not be safe for matching.

r? @pnkfelix 
cc @eddyb