### PR TITLE
.gitignore: Don't ignore a file that exists in the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,6 @@ config.mk
 config.stamp
 Session.vim
 .cargo
+!/src/test/run-make/thumb-none-qemu/example/.cargo
 no_llvm_build
 # Before adding new lines, see the comment at the top.


### PR DESCRIPTION
.gitignore should not ignore files that exist in the repository. The
ignore of .cargo applies to the committed .cargo directory used in an
example:

$ git ls-files --exclude-standard --ignored
src/test/run-make/thumb-none-qemu/example/.cargo/config

Explicitly un-ignore that file.