### PR TITLE
doc: inline collections at reexport module

### DIFF
--- a/src/libstd/collections/mod.rs
+++ b/src/libstd/collections/mod.rs
@@ -412,18 +412,25 @@
 #[rustc_deprecated(reason = "moved to `std::ops::Bound`", since = "1.26.0")]
 #[doc(hidden)]
 pub use crate::ops::Bound;
+
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use alloc_crate::collections::{binary_heap, btree_map, btree_set};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use alloc_crate::collections::{linked_list, vec_deque};
+
 #[stable(feature = "rust1", since = "1.0.0")]
+#[doc(inline)]
 pub use alloc_crate::collections::{BTreeMap, BTreeSet, BinaryHeap};
+
 #[stable(feature = "rust1", since = "1.0.0")]
+#[doc(inline)]
 pub use alloc_crate::collections::{LinkedList, VecDeque};
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[doc(inline)]
 pub use self::hash_map::HashMap;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[doc(inline)]
 pub use self::hash_set::HashSet;
 
 #[unstable(feature = "try_reserve", reason = "new API", issue = "48043")]


### PR DESCRIPTION
For example, when one searchs for "hashmap", there are two results returned.
This PR makes the result to contain only one.
[![https://imgur.com/TkkiEV6.png](https://imgur.com/TkkiEV6.png)](https://imgur.com/TkkiEV6.png)