### PR TITLE
Set release channel on non-dist builders

### DIFF
--- a/src/bootstrap/toolstate.rs
+++ b/src/bootstrap/toolstate.rs
@@ -13,13 +13,13 @@ use std::env;
 // Each cycle is 42 days long (6 weeks); the last week is 35..=42 then.
 const BETA_WEEK_START: u64 = 35;
 
-#[cfg(linux)]
+#[cfg(target_os = "linux")]
 const OS: Option<&str> = Some("linux");
 
 #[cfg(windows)]
 const OS: Option<&str> = Some("windows");
 
-#[cfg(all(not(linux), not(windows)))]
+#[cfg(all(not(target_os = "linux"), not(windows)))]
 const OS: Option<&str> = None;
 
 type ToolstateData = HashMap<Box<str>, ToolState>;
@@ -379,7 +379,7 @@ fn change_toolstate(
     let mut regressed = false;
     for repo_state in old_toolstate {
         let tool = &repo_state.tool;
-        let state = if cfg!(linux) {
+        let state = if cfg!(target_os = "linux") {
             &repo_state.linux
         } else if cfg!(windows) {
             &repo_state.windows

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -44,8 +44,13 @@ fi
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
 export RUST_RELEASE_CHANNEL=nightly
+
+# Always set the release channel for bootstrap; this is normally not important (i.e., only dist
+# builds would seem to matter) but in practice bootstrap wants to know whether we're targeting
+# master, beta, or stable with a build to determine whether to run some checks (notably toolstate).
+RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=$RUST_RELEASE_CHANNEL"
+
 if [ "$DEPLOY$DEPLOY_ALT" = "1" ]; then
-  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=$RUST_RELEASE_CHANNEL"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.remap-debuginfo"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --debuginfo-level-std=1"


### PR DESCRIPTION
Toolstate publication only runs if the channel is "nightly" and
previously the toolstate builders did not know that the channel was
nightly (since they are not dist builders).

A look through bootstrap seems to indicate that nothing should directly
depend on the channel being set to `-dev` on the test builders, though
this may cause some problems with UI tests (if for some reason they're
dumping the channel into stderr), but we cannot find evidence of such so
hopefully this is fine.

r? @pietroalbini