### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,6 @@ config.mk
 config.stamp
 Session.vim
 .cargo
+!/src/test/run-make/thumb-none-qemu/example/.cargo
 no_llvm_build
 # Before adding new lines, see the comment at the top.

--- a/src/libcore/alloc.rs
+++ b/src/libcore/alloc.rs
@@ -17,7 +17,7 @@ use crate::num::NonZeroUsize;
 #[derive(Debug)]
 pub struct Excess(pub NonNull<u8>, pub usize);
 
-fn size_align<T>() -> (usize, usize) {
+const fn size_align<T>() -> (usize, usize) {
     (mem::size_of::<T>(), mem::align_of::<T>())
 }
 
@@ -118,13 +118,12 @@ impl Layout {
     /// Constructs a `Layout` suitable for holding a value of type `T`.
     #[stable(feature = "alloc_layout", since = "1.28.0")]
     #[inline]
-    pub fn new<T>() -> Self {
+    pub const fn new<T>() -> Self {
         let (size, align) = size_align::<T>();
         // Note that the align is guaranteed by rustc to be a power of two and
         // the size+align combo is guaranteed to fit in our address space. As a
         // result use the unchecked constructor here to avoid inserting code
         // that panics if it isn't optimized well enough.
-        debug_assert!(Layout::from_size_align(size, align).is_ok());
         unsafe {
             Layout::from_size_align_unchecked(size, align)
         }

--- a/src/libcore/benches/lib.rs
+++ b/src/libcore/benches/lib.rs
@@ -11,4 +11,5 @@ mod hash;
 mod iter;
 mod num;
 mod ops;
+mod pattern;
 mod slice;

--- a/src/libcore/benches/pattern.rs
+++ b/src/libcore/benches/pattern.rs
@@ -1,0 +1,43 @@
+use test::black_box;
+use test::Bencher;
+
+#[bench]
+fn starts_with_char(b: &mut Bencher) {
+    let text = black_box("kdjsfhlakfhlsghlkvcnljknfqiunvcijqenwodind");
+    b.iter(|| {
+        for _ in 0..1024 {
+            black_box(text.starts_with('k'));
+        }
+    })
+}
+
+#[bench]
+fn starts_with_str(b: &mut Bencher) {
+    let text = black_box("kdjsfhlakfhlsghlkvcnljknfqiunvcijqenwodind");
+    b.iter(|| {
+        for _ in 0..1024 {
+            black_box(text.starts_with("k"));
+        }
+    })
+}
+
+
+#[bench]
+fn ends_with_char(b: &mut Bencher) {
+    let text = black_box("kdjsfhlakfhlsghlkvcnljknfqiunvcijqenwodind");
+    b.iter(|| {
+        for _ in 0..1024 {
+            black_box(text.ends_with('k'));
+        }
+    })
+}
+
+#[bench]
+fn ends_with_str(b: &mut Bencher) {
+    let text = black_box("kdjsfhlakfhlsghlkvcnljknfqiunvcijqenwodind");
+    b.iter(|| {
+        for _ in 0..1024 {
+            black_box(text.ends_with("k"));
+        }
+    })
+}

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -97,7 +97,7 @@ pub trait Sized {
 /// Types that can be "unsized" to a dynamically-sized type.
 ///
 /// For example, the sized array type `[i8; 2]` implements `Unsize<[i8]>` and
-/// `Unsize<fmt::Debug>`.
+/// `Unsize<dyn fmt::Debug>`.
 ///
 /// All implementations of `Unsize` are provided automatically by the compiler.
 ///

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -67,7 +67,7 @@ assert_eq!(size_of::<Option<core::num::", stringify!($Ty), ">>(), size_of::<", s
                 )]
                 #[inline]
                 pub const unsafe fn new_unchecked(n: $Int) -> Self {
-                    $Ty(n)
+                    Self(n)
                 }
 
                 /// Creates a non-zero if the given value is not zero.
@@ -76,7 +76,7 @@ assert_eq!(size_of::<Option<core::num::", stringify!($Ty), ">>(), size_of::<", s
                 pub fn new(n: $Int) -> Option<Self> {
                     if n != 0 {
                         // SAFETY: we just checked that there's no `0`
-                        Some(unsafe { $Ty(n) })
+                        Some(unsafe { Self(n) })
                     } else {
                         None
                     }

--- a/src/libcore/str/pattern.rs
+++ b/src/libcore/str/pattern.rs
@@ -450,21 +450,15 @@ impl<'a> Pattern<'a> for char {
 
     #[inline]
     fn is_prefix_of(self, haystack: &'a str) -> bool {
-        if let Some(ch) = haystack.chars().next() {
-            self == ch
-        } else {
-            false
-        }
+        let mut buffer = [0u8; 4];
+        self.encode_utf8(&mut buffer).is_prefix_of(haystack)
     }
 
     #[inline]
     fn is_suffix_of(self, haystack: &'a str) -> bool where Self::Searcher: ReverseSearcher<'a>
     {
-        if let Some(ch) = haystack.chars().next_back() {
-            self == ch
-        } else {
-            false
-        }
+        let mut buffer = [0u8; 4];
+        self.encode_utf8(&mut buffer).is_suffix_of(haystack)
     }
 }
 

--- a/src/libcore/str/pattern.rs
+++ b/src/libcore/str/pattern.rs
@@ -715,16 +715,13 @@ impl<'a, 'b> Pattern<'a> for &'b str {
     /// Checks whether the pattern matches at the front of the haystack
     #[inline]
     fn is_prefix_of(self, haystack: &'a str) -> bool {
-        haystack.is_char_boundary(self.len()) &&
-            self == &haystack[..self.len()]
+        haystack.as_bytes().starts_with(self.as_bytes())
     }
 
     /// Checks whether the pattern matches at the back of the haystack
     #[inline]
     fn is_suffix_of(self, haystack: &'a str) -> bool {
-        self.len() <= haystack.len() &&
-            haystack.is_char_boundary(haystack.len() - self.len()) &&
-            self == &haystack[haystack.len() - self.len()..]
+        haystack.as_bytes().ends_with(self.as_bytes())
     }
 }
 

--- a/src/libcore/str/pattern.rs
+++ b/src/libcore/str/pattern.rs
@@ -450,15 +450,13 @@ impl<'a> Pattern<'a> for char {
 
     #[inline]
     fn is_prefix_of(self, haystack: &'a str) -> bool {
-        let mut buffer = [0u8; 4];
-        self.encode_utf8(&mut buffer).is_prefix_of(haystack)
+        self.encode_utf8(&mut [0u8; 4]).is_prefix_of(haystack)
     }
 
     #[inline]
     fn is_suffix_of(self, haystack: &'a str) -> bool where Self::Searcher: ReverseSearcher<'a>
     {
-        let mut buffer = [0u8; 4];
-        self.encode_utf8(&mut buffer).is_suffix_of(haystack)
+        self.encode_utf8(&mut [0u8; 4]).is_suffix_of(haystack)
     }
 }
 

--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -1263,7 +1263,7 @@ let atomic_forty_two = ", stringify!($atomic_type), "::new(42);
                 #[$stable]
                 #[cfg_attr(not(bootstrap), $const_stable)]
                 pub const fn new(v: $int_type) -> Self {
-                    $atomic_type {v: UnsafeCell::new(v)}
+                    Self {v: UnsafeCell::new(v)}
                 }
             }
 

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1048,8 +1048,15 @@ pub enum PatKind {
     /// A range pattern (e.g., `1..=2` or `1..2`).
     Range(P<Expr>, P<Expr>, RangeEnd),
 
-    /// `[a, b, ..i, y, z]` is represented as:
-    ///     `PatKind::Slice(box [a, b], Some(i), box [y, z])`.
+    /// A slice pattern, `[before_0, ..., before_n, (slice, after_0, ..., after_n)?]`.
+    ///
+    /// Here, `slice` is lowered from the syntax `($binding_mode $ident @)? ..`.
+    /// If `slice` exists, then `after` can be non-empty.
+    ///
+    /// The representation for e.g., `[a, b, .., c, d]` is:
+    /// ```
+    /// PatKind::Slice([Binding(a), Binding(b)], Some(Wild), [Binding(c), Binding(d)])
+    /// ```
     Slice(HirVec<P<Pat>>, Option<P<Pat>>, HirVec<P<Pat>>),
 }
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2330,7 +2330,7 @@ fn bad_variant_count<'tcx>(tcx: TyCtxt<'tcx>, adt: &'tcx ty::AdtDef, sp: Span, d
     );
     let mut err = struct_span_err!(tcx.sess, sp, E0731, "transparent enum {}", msg);
     err.span_label(sp, &msg);
-    if let &[ref start @ .., ref end] = &variant_spans[..] {
+    if let [start @ .., end] = &*variant_spans {
         for variant_span in start {
             err.span_label(*variant_span, "");
         }
@@ -2372,23 +2372,14 @@ fn check_transparent(tcx: TyCtxt<'_>, sp: Span, def_id: DefId) {
     }
     let sp = tcx.sess.source_map().def_span(sp);
 
-    if adt.is_enum() {
-        if !tcx.features().transparent_enums {
-            feature_err(
-                &tcx.sess.parse_sess,
-                sym::transparent_enums,
-                sp,
-                "transparent enums are unstable",
-            )
-            .emit();
-        }
-        if adt.variants.len() != 1 {
-            bad_variant_count(tcx, adt, sp, def_id);
-            if adt.variants.is_empty() {
-                // Don't bother checking the fields. No variants (and thus no fields) exist.
-                return;
-            }
-        }
+    if adt.is_enum() && !tcx.features().transparent_enums {
+        feature_err(
+            &tcx.sess.parse_sess,
+            sym::transparent_enums,
+            sp,
+            "transparent enums are unstable",
+        )
+        .emit();
     }
 
     if adt.is_union() && !tcx.features().transparent_unions {
@@ -2399,6 +2390,14 @@ fn check_transparent(tcx: TyCtxt<'_>, sp: Span, def_id: DefId) {
             "transparent unions are unstable",
         )
         .emit();
+    }
+
+    if adt.variants.len() != 1 {
+        bad_variant_count(tcx, adt, sp, def_id);
+        if adt.variants.is_empty() {
+            // Don't bother checking the fields. No variants (and thus no fields) exist.
+            return;
+        }
     }
 
     // For each field, figure out if it's known to be a ZST and align(1)

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -5351,9 +5351,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                       directly, not through a function pointer");
     }
 
-    // Resolves `typ` by a single level if `typ` is a type variable.
-    // If no resolution is possible, then an error is reported.
-    // Numeric inference variables may be left unresolved.
+    /// Resolves `typ` by a single level if `typ` is a type variable.
+    /// If no resolution is possible, then an error is reported.
+    /// Numeric inference variables may be left unresolved.
     pub fn structurally_resolved_type(&self, sp: Span, ty: Ty<'tcx>) -> Ty<'tcx> {
         let ty = self.resolve_vars_with_obligations(ty);
         if !ty.is_ty_var() {

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2683,7 +2683,7 @@ function getSearchElement() {
         insertAfter(popup, getSearchElement());
     }
 
-    onHashChange();
+    onHashChange(null);
     window.onhashchange = onHashChange;
 
     buildHelperPopup();

--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -1313,21 +1313,6 @@ mod tests {
     }
 
     #[test]
-    fn fast_rebind() {
-        each_ip(&mut |addr| {
-            let acceptor = t!(TcpListener::bind(&addr));
-
-            let _t = thread::spawn(move || {
-                t!(TcpStream::connect(&addr));
-            });
-
-            t!(acceptor.accept());
-            drop(acceptor);
-            t!(TcpListener::bind(&addr));
-        });
-    }
-
-    #[test]
     fn tcp_clone_smoke() {
         each_ip(&mut |addr| {
             let acceptor = t!(TcpListener::bind(&addr));


### PR DESCRIPTION
Successful merges:

 - #66254 (Make Layout::new const)
 - #67249 (Improve code generated for `starts_with(<literal char>)`)
 - #67308 (Delete flaky test net::tcp::tests::fast_rebind)
 - #67318 (Improve typeck & lowering docs for slice patterns)
 - #67322 (use Self alias in place of macros)
 - #67323 (make transparent enums more ordinary)
 - #67336 (Fix JS error when loading page with search)
 - #67344 (.gitignore: Don't ignore a file that exists in the repository)
 - #67349 (Minor: update Unsize docs for dyn syntax)

Failed merges:


r? @ghost