### PR TITLE
Fix handling of wasm import modules and names

### DIFF
--- a/src/librustc_codegen_llvm/attributes.rs
+++ b/src/librustc_codegen_llvm/attributes.rs
@@ -343,6 +343,17 @@ pub fn from_fn_attrs(
                 const_cstr!("wasm-import-module"),
                 &module,
             );
+
+            let name = codegen_fn_attrs.link_name.unwrap_or_else(|| {
+                cx.tcx.item_name(instance.def_id())
+            });
+            let name = CString::new(&name.as_str()[..]).unwrap();
+            llvm::AddFunctionAttrStringValue(
+                llfn,
+                llvm::AttributePlace::Function,
+                const_cstr!("wasm-import-name"),
+                &name,
+            );
         }
     }
 }

--- a/src/test/run-make/wasm-symbols-different-module/Makefile
+++ b/src/test/run-make/wasm-symbols-different-module/Makefile
@@ -1,0 +1,28 @@
+-include ../../run-make-fulldeps/tools.mk
+
+# only-wasm32-bare
+
+all:
+	$(RUSTC) foo.rs --target wasm32-unknown-unknown
+	$(NODE) verify-imports.js $(TMPDIR)/foo.wasm a/foo b/foo
+	$(RUSTC) foo.rs --target wasm32-unknown-unknown -C lto
+	$(NODE) verify-imports.js $(TMPDIR)/foo.wasm a/foo b/foo
+	$(RUSTC) foo.rs --target wasm32-unknown-unknown -O
+	$(NODE) verify-imports.js $(TMPDIR)/foo.wasm a/foo b/foo
+	$(RUSTC) foo.rs --target wasm32-unknown-unknown -O -C lto
+	$(NODE) verify-imports.js $(TMPDIR)/foo.wasm a/foo b/foo
+
+	$(RUSTC) bar.rs --target wasm32-unknown-unknown
+	$(NODE) verify-imports.js $(TMPDIR)/bar.wasm m1/f m1/g m2/f
+	$(RUSTC) bar.rs --target wasm32-unknown-unknown -C lto
+	$(NODE) verify-imports.js $(TMPDIR)/bar.wasm m1/f m1/g m2/f
+	$(RUSTC) bar.rs --target wasm32-unknown-unknown -O
+	$(NODE) verify-imports.js $(TMPDIR)/bar.wasm m1/f m1/g m2/f
+	$(RUSTC) bar.rs --target wasm32-unknown-unknown -O -C lto
+	$(NODE) verify-imports.js $(TMPDIR)/bar.wasm m1/f m1/g m2/f
+
+	$(RUSTC) baz.rs --target wasm32-unknown-unknown
+	$(NODE) verify-imports.js $(TMPDIR)/baz.wasm sqlite/allocate sqlite/deallocate
+
+	$(RUSTC) log.rs --target wasm32-unknown-unknown
+	$(NODE) verify-imports.js $(TMPDIR)/log.wasm test/log

--- a/src/test/run-make/wasm-symbols-different-module/bar.rs
+++ b/src/test/run-make/wasm-symbols-different-module/bar.rs
@@ -1,0 +1,33 @@
+//! Issue #50021
+
+#![crate_type = "cdylib"]
+
+mod m1 {
+    #[link(wasm_import_module = "m1")]
+    extern "C" {
+        pub fn f();
+    }
+    #[link(wasm_import_module = "m1")]
+    extern "C" {
+        pub fn g();
+    }
+}
+
+mod m2 {
+    #[link(wasm_import_module = "m2")]
+    extern "C" {
+        pub fn f(_: i32);
+    }
+}
+
+#[no_mangle]
+pub unsafe fn run() {
+    m1::f();
+    m1::g();
+
+    // In generated code, expected:
+    // (import "m2" "f" (func $f (param i32)))
+    // but got:
+    // (import "m1" "f" (func $f (param i32)))
+    m2::f(0);
+}

--- a/src/test/run-make/wasm-symbols-different-module/baz.rs
+++ b/src/test/run-make/wasm-symbols-different-module/baz.rs
@@ -1,0 +1,22 @@
+//! Issue #63562
+
+#![crate_type = "cdylib"]
+
+mod foo {
+    #[link(wasm_import_module = "sqlite")]
+    extern "C" {
+        pub fn allocate(size: usize) -> i32;
+        pub fn deallocate(ptr: i32, size: usize);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn allocate() {
+    unsafe {
+        foo::allocate(1);
+        foo::deallocate(1, 2);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn deallocate() {}

--- a/src/test/run-make/wasm-symbols-different-module/foo.rs
+++ b/src/test/run-make/wasm-symbols-different-module/foo.rs
@@ -1,0 +1,23 @@
+#![crate_type = "cdylib"]
+
+mod a {
+    #[link(wasm_import_module = "a")]
+    extern "C" {
+        pub fn foo();
+    }
+}
+
+mod b {
+    #[link(wasm_import_module = "b")]
+    extern "C" {
+        pub fn foo();
+    }
+}
+
+#[no_mangle]
+pub fn start() {
+    unsafe {
+        a::foo();
+        b::foo();
+    }
+}

--- a/src/test/run-make/wasm-symbols-different-module/log.rs
+++ b/src/test/run-make/wasm-symbols-different-module/log.rs
@@ -1,0 +1,16 @@
+//! Issue #56309
+
+#![crate_type = "cdylib"]
+
+#[link(wasm_import_module = "test")]
+extern "C" {
+    fn log(message_data: u32, message_size: u32);
+}
+
+#[no_mangle]
+pub fn main() {
+    let message = "Hello, world!";
+    unsafe {
+        log(message.as_ptr() as u32, message.len() as u32);
+    }
+}

--- a/src/test/run-make/wasm-symbols-different-module/verify-imports.js
+++ b/src/test/run-make/wasm-symbols-different-module/verify-imports.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const process = require('process');
+const assert = require('assert');
+const buffer = fs.readFileSync(process.argv[2]);
+
+let m = new WebAssembly.Module(buffer);
+let list = WebAssembly.Module.imports(m);
+console.log('imports', list);
+if (list.length !== process.argv.length - 3)
+  throw new Error("wrong number of imports")
+
+const imports = new Map();
+for (let i = 3; i < process.argv.length; i++) {
+  const [module, name] = process.argv[i].split('/');
+  if (!imports.has(module))
+    imports.set(module, new Map());
+  imports.get(module).set(name, true);
+}
+
+for (let i of list) {
+  if (imports.get(i.module) === undefined || imports.get(i.module).get(i.name) === undefined)
+    throw new Error(`didn't find import of ${i.module}::${i.name}`);
+  imports.get(i.module).delete(i.name);
+
+  if (imports.get(i.module).size === 0)
+    imports.delete(i.module);
+}
+
+console.log(imports);
+if (imports.size !== 0) {
+  throw new Error('extra imports');
+}


### PR DESCRIPTION
The WebAssembly targets of rustc have weird issues around name mangling
and import the same name from different modules. This all largely stems
from the fact that we're using literal symbol names in LLVM IR to
represent what a function is called when it's imported, and we're not
using the wasm-specific `wasm-import-name` attribute. This in turn leads
to two issues:

* If, in the same codegen unit, the same FFI symbol is referenced twice
  then rustc, when translating to LLVM IR, will only reference one
  symbol from the first wasm module referenced.

* There's also a bug in LLD [1] where even if two codegen units
  reference different modules, having the same symbol names means that
  LLD coalesces the symbols and only refers to one wasm module.

Put another way, all our imported wasm symbols from the environment are
keyed off their LLVM IR symbol name, which has lots of collisions today.
This commit fixes the issue by implementing two changes:

1. All wasm symbols with `#[link(wasm_import_module = "...")]` are
   mangled by default in LLVM IR. This means they're all given unique names.

2. Symbols then use the `wasm-import-name` attribute to ensure that the
   WebAssembly file uses the correct import name.

When put together this should ensure we don't trip over the LLD bug [1]
and we also codegen IR correctly always referencing the right symbols
with the right import module/name pairs.

Closes #50021
Closes #56309
Closes #63562

[1]: https://bugs.llvm.org/show_bug.cgi?id=44316