### PR TITLE
Reenable static linking of libstdc++ on windows-gnu

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -563,7 +563,7 @@ pub fn rustc_cargo_env(builder: &Builder<'_>, cargo: &mut Cargo, target: Interne
         // not for MSVC or macOS
         if builder.config.llvm_static_stdcpp &&
            !target.contains("freebsd") &&
-           !target.contains("windows") &&
+           !target.contains("msvc") &&
            !target.contains("apple") {
             let file = compiler_file(builder,
                                      builder.cxx(target).unwrap(),


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/67408

Verified locally that `rustc_driver` is now statically linked to libstdc++.