### PR TITLE
doc: minus (U+2212) instead of dash (U+002D) for negative infinity

### DIFF
--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -62,7 +62,7 @@ pub const NAN: f32 = 0.0_f32 / 0.0_f32;
 /// Infinity (∞).
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const INFINITY: f32 = 1.0_f32 / 0.0_f32;
-/// Negative infinity (-∞).
+/// Negative infinity (−∞).
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const NEG_INFINITY: f32 = -1.0_f32 / 0.0_f32;
 

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -62,7 +62,7 @@ pub const NAN: f64 = 0.0_f64 / 0.0_f64;
 /// Infinity (∞).
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const INFINITY: f64 = 1.0_f64 / 0.0_f64;
-/// Negative infinity (-∞).
+/// Negative infinity (−∞).
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const NEG_INFINITY: f64 = -1.0_f64 / 0.0_f64;
 


### PR DESCRIPTION
The documentation for [`f32::NEG_INFINITY`](https://doc.rust-lang.org/std/f32/constant.NEG_INFINITY.html) contains “-∞” with a dash instead of a minus sign, “−∞” with a proper minus sign looks better with the used Source Serif Pro font. Similarly for [`f64::NEG_INFINITY`](https://doc.rust-lang.org/std/f64/constant.NEG_INFINITY.html).