### PR TITLE
Add LLVM `skip-rebuild` option to `x.py`

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -14,6 +14,12 @@
 # =============================================================================
 [llvm]
 
+# Indicates whether LLVM rebuild should be skipped when running bootstrap. If
+# this is `false` then the compiler's LLVM will be rebuilt whenever the built
+# version doesn't have the correct hash. If it is `true` then LLVM will never
+# be rebuilt. The default value is `false`.
+#skip-rebuild = false
+
 # Indicates whether the LLVM build is a Release or Debug build
 #optimize = true
 

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -67,6 +67,7 @@ pub struct Config {
     pub backtrace_on_ice: bool,
 
     // llvm codegen options
+    pub llvm_skip_rebuild: bool,
     pub llvm_assertions: bool,
     pub llvm_optimize: bool,
     pub llvm_thin_lto: bool,
@@ -244,6 +245,7 @@ struct Install {
 #[derive(Deserialize, Default)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 struct Llvm {
+    skip_rebuild: Option<bool>,
     optimize: Option<bool>,
     thin_lto: Option<bool>,
     release_debuginfo: Option<bool>,
@@ -490,6 +492,7 @@ impl Config {
 
         // Store off these values as options because if they're not provided
         // we'll infer default values for them later
+        let mut llvm_skip_rebuild = None;
         let mut llvm_assertions = None;
         let mut debug = None;
         let mut debug_assertions = None;
@@ -511,6 +514,7 @@ impl Config {
             }
             set(&mut config.ninja, llvm.ninja);
             llvm_assertions = llvm.assertions;
+            llvm_skip_rebuild = llvm.skip_rebuild;
             set(&mut config.llvm_optimize, llvm.optimize);
             set(&mut config.llvm_thin_lto, llvm.thin_lto);
             set(&mut config.llvm_release_debuginfo, llvm.release_debuginfo);
@@ -616,6 +620,8 @@ impl Config {
 
         set(&mut config.initial_rustc, build.rustc.map(PathBuf::from));
         set(&mut config.initial_cargo, build.cargo.map(PathBuf::from));
+
+        config.llvm_skip_rebuild = llvm_skip_rebuild.unwrap_or(false);
 
         let default = false;
         config.llvm_assertions = llvm_assertions.unwrap_or(default);

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -70,6 +70,15 @@ impl Step for Llvm {
         let done_stamp = out_dir.join("llvm-finished-building");
 
         if done_stamp.exists() {
+            if builder.config.llvm_skip_rebuild {
+                builder.info(
+                    "Warning: \
+                    Using a potentially stale build of LLVM; \
+                    This may not behave well.",
+                );
+                return build_llvm_config;
+            }
+
             if let Some(llvm_commit) = llvm_info.sha() {
                 let done_contents = t!(fs::read(&done_stamp));
 


### PR DESCRIPTION
This PR reimplements parts of @Walther's work from #65848, and closes #65612.

I decided not to implement the [arguments to override this setting](https://github.com/rust-lang/rust/issues/65612#issuecomment-544247546) in this PR. If there's strong feeling that this change shouldn't be merged without the overrides then I'm happy to close this until I've had a chance to add them in. Otherwise I'll aim to submit a second PR with those this weekend.

I'd have liked to have tested the change in `native.rs`, but there didn't seem to be any existing test infrastructure. I ran this a few times manually and it _worked on my machine_ though... 😬 