### PR TITLE
Cleanup `lower_pattern_unadjusted` & Improve slice pat typeck

### DIFF
--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -620,10 +620,11 @@ impl<'a, 'tcx> MatchCheckCtxt<'a, 'tcx> {
 enum SliceKind {
     /// Patterns of length `n` (`[x, y]`).
     FixedLen(u64),
-    /// Patterns using the `..` notation (`[x, .., y]`). Captures any array constructor of `length
-    /// >= i + j`. In the case where `array_len` is `Some(_)`, this indicates that we only care
-    /// about the first `i` and the last `j` values of the array, and everything in between is a
-    /// wildcard `_`.
+    /// Patterns using the `..` notation (`[x, .., y]`).
+    /// Captures any array constructor of `length >= i + j`.
+    /// In the case where `array_len` is `Some(_)`,
+    /// this indicates that we only care about the first `i` and the last `j` values of the array,
+    /// and everything in between is a wildcard `_`.
     VarLen(u64, u64),
 }
 

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -629,11 +629,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                 self.lower_variant_or_leaf(res, pat.hir_id, pat.span, ty, subpatterns)
             }
 
-            hir::PatKind::Or(ref pats) => {
-                PatKind::Or {
-                    pats: pats.iter().map(|p| self.lower_pattern(p)).collect(),
-                }
-            }
+            hir::PatKind::Or(ref pats) => PatKind::Or { pats: self.lower_patterns(pats) },
         };
 
         Pat {

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -557,21 +557,19 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
             }
 
             hir::PatKind::Tuple(ref subpatterns, ddpos) => {
-                match ty.kind {
-                    ty::Tuple(ref tys) => {
-                        let subpatterns =
-                            subpatterns.iter()
-                                       .enumerate_and_adjust(tys.len(), ddpos)
-                                       .map(|(i, subpattern)| FieldPat {
-                                            field: Field::new(i),
-                                            pattern: self.lower_pattern(subpattern)
-                                       })
-                                       .collect();
-
-                        PatKind::Leaf { subpatterns }
-                    }
+                let tys = match ty.kind {
+                    ty::Tuple(ref tys) => tys,
                     _ => span_bug!(pat.span, "unexpected type for tuple pattern: {:?}", ty),
-                }
+                };
+                let subpatterns = subpatterns
+                    .iter()
+                    .enumerate_and_adjust(tys.len(), ddpos)
+                    .map(|(i, subpattern)| FieldPat {
+                        field: Field::new(i),
+                        pattern: self.lower_pattern(subpattern)
+                    })
+                    .collect();
+                PatKind::Leaf { subpatterns }
             }
 
             hir::PatKind::Binding(_, id, ident, ref sub) => {

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -573,7 +573,6 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
             }
 
             hir::PatKind::Binding(_, id, ident, ref sub) => {
-                let var_ty = self.tables.node_type(pat.hir_id);
                 let bm = *self.tables.pat_binding_modes().get(pat.hir_id)
                                                          .expect("missing binding mode");
                 let (mutability, mode) = match bm {
@@ -591,13 +590,14 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
 
                 // A ref x pattern is the same node used for x, and as such it has
                 // x's type, which is &T, where we want T (the type being matched).
+                let var_ty = ty;
                 if let ty::BindByReference(_) = bm {
                     if let ty::Ref(_, rty, _) = ty.kind {
                         ty = rty;
                     } else {
                         bug!("`ref {}` has wrong type {}", ident, ty);
                     }
-                }
+                };
 
                 PatKind::Binding {
                     mutability,

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -545,15 +545,6 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
 
             hir::PatKind::Slice(ref prefix, ref slice, ref suffix) => {
                 match ty.kind {
-                    ty::Ref(_, ty, _) =>
-                        PatKind::Deref {
-                            subpattern: Pat {
-                                ty,
-                                span: pat.span,
-                                kind: Box::new(self.slice_or_array_pattern(
-                                    pat.span, ty, prefix, slice, suffix))
-                            },
-                        },
                     ty::Slice(..) |
                     ty::Array(..) =>
                         self.slice_or_array_pattern(pat.span, ty, prefix, slice, suffix),

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -550,15 +550,10 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
 
             hir::PatKind::Slice(ref prefix, ref slice, ref suffix) => {
                 match ty.kind {
-                    ty::Slice(..) |
-                    ty::Array(..) =>
-                        self.slice_or_array_pattern(pat.span, ty, prefix, slice, suffix),
-                    _ => span_bug!(
-                        pat.span,
-                        "unexpanded type for vector pattern: {:?}",
-                        ty
-                    ),
+                    ty::Slice(..) | ty::Array(..) => {}
+                    _ => span_bug!(pat.span, "unexpanded type for vector pattern: {:?}", ty),
                 }
+                self.slice_or_array_pattern(pat.span, ty, prefix, slice, suffix)
             }
 
             hir::PatKind::Tuple(ref subpatterns, ddpos) => {

--- a/src/librustc_typeck/check/pat.rs
+++ b/src/librustc_typeck/check/pat.rs
@@ -1175,8 +1175,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         discrim_span: Option<Span>,
     ) -> Ty<'tcx> {
         let tcx = self.tcx;
-        let expected_ty = self.structurally_resolved_type(span, expected);
-        let (inner_ty, slice_ty) = match expected_ty.kind {
+        let expected = self.structurally_resolved_type(span, expected);
+        let (inner_ty, slice_ty) = match expected.kind {
             // An array, so we might have something like `let [a, b, c] = [0, 1, 2];`.
             ty::Array(inner_ty, size) => {
                 let slice_ty = if let Some(size) = size.try_eval_usize(tcx, self.param_env) {
@@ -1208,11 +1208,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 };
                 (inner_ty, slice_ty)
             }
-            ty::Slice(inner_ty) => (inner_ty, expected_ty),
+            ty::Slice(inner_ty) => (inner_ty, expected),
             // The expected type must be an array or slice, but was neither, so error.
             _ => {
-                if !expected_ty.references_error() {
-                    self.error_expected_array_or_slice(span, expected_ty);
+                if !expected.references_error() {
+                    self.error_expected_array_or_slice(span, expected);
                 }
                 (tcx.types.err, tcx.types.err)
             }
@@ -1230,7 +1230,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         for elt in after {
             self.check_pat(&elt, inner_ty, def_bm, discrim_span);
         }
-        expected_ty
+        expected
     }
 
     fn error_scrutinee_inconsistent_length(&self, span: Span, min_len: u64, size: u64) {

--- a/src/librustc_typeck/check/pat.rs
+++ b/src/librustc_typeck/check/pat.rs
@@ -1176,7 +1176,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> Ty<'tcx> {
         let tcx = self.tcx;
         let expected = self.structurally_resolved_type(span, expected);
-        let (inner_ty, slice_ty) = match expected.kind {
+        let (inner_ty, slice_ty, expected) = match expected.kind {
             // An array, so we might have something like `let [a, b, c] = [0, 1, 2];`.
             ty::Array(inner_ty, size) => {
                 let slice_ty = if let Some(size) = size.try_eval_usize(tcx, self.param_env) {
@@ -1206,15 +1206,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     self.error_scrutinee_unfixed_length(span);
                     tcx.types.err
                 };
-                (inner_ty, slice_ty)
+                (inner_ty, slice_ty, expected)
             }
-            ty::Slice(inner_ty) => (inner_ty, expected),
+            ty::Slice(inner_ty) => (inner_ty, expected, expected),
             // The expected type must be an array or slice, but was neither, so error.
             _ => {
                 if !expected.references_error() {
                     self.error_expected_array_or_slice(span, expected);
                 }
-                (tcx.types.err, tcx.types.err)
+                (tcx.types.err, tcx.types.err, tcx.types.err)
             }
         };
 

--- a/src/librustc_typeck/check/pat.rs
+++ b/src/librustc_typeck/check/pat.rs
@@ -1174,38 +1174,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         def_bm: BindingMode,
         discrim_span: Option<Span>,
     ) -> Ty<'tcx> {
-        let tcx = self.tcx;
+        let err = self.tcx.types.err;
         let expected = self.structurally_resolved_type(span, expected);
         let (inner_ty, slice_ty, expected) = match expected.kind {
             // An array, so we might have something like `let [a, b, c] = [0, 1, 2];`.
-            ty::Array(inner_ty, size) => {
-                let slice_ty = if let Some(size) = size.try_eval_usize(tcx, self.param_env) {
-                    // Now we know the length...
-                    let min_len = before.len() as u64 + after.len() as u64;
-                    if slice.is_none() {
-                        // ...and since there is no variable-length pattern,
-                        // we require an exact match between the number of elements
-                        // in the array pattern and as provided by the matched type.
-                        if min_len != size {
-                            self.error_scrutinee_inconsistent_length(span, min_len, size)
-                        }
-                        tcx.types.err
-                    } else if let Some(rest) = size.checked_sub(min_len) {
-                        // The variable-length pattern was there,
-                        // so it has an array type with the remaining elements left as its size...
-                        tcx.mk_array(inner_ty, rest)
-                    } else {
-                        // ...however, in this case, there were no remaining elements.
-                        // That is, the slice pattern requires more than the array type offers.
-                        self.error_scrutinee_with_rest_inconsistent_length(span, min_len, size);
-                        tcx.types.err
-                    }
-                } else {
-                    // No idea what the length is, which happens if we have e.g.,
-                    // `let [a, b] = arr` where `arr: [T; N]` where `const N: usize`.
-                    self.error_scrutinee_unfixed_length(span);
-                    tcx.types.err
-                };
+            ty::Array(inner_ty, len) => {
+                let min = before.len() as u64 + after.len() as u64;
+                let slice_ty = self.check_array_pat_len(span, slice, len, min)
+                    .map_or(err, |len| self.tcx.mk_array(inner_ty, len));
                 (inner_ty, slice_ty, expected)
             }
             ty::Slice(inner_ty) => (inner_ty, expected, expected),
@@ -1214,7 +1190,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 if !expected.references_error() {
                     self.error_expected_array_or_slice(span, expected);
                 }
-                (tcx.types.err, tcx.types.err, tcx.types.err)
+                (err, err, err)
             }
         };
 
@@ -1231,6 +1207,43 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.check_pat(&elt, inner_ty, def_bm, discrim_span);
         }
         expected
+    }
+
+    /// Type check the length of an array pattern.
+    ///
+    /// Return the length of the variable length pattern,
+    /// if it exists and there are no errors.
+    fn check_array_pat_len(
+        &self,
+        span: Span,
+        slice: Option<&'tcx Pat>,
+        len: &ty::Const<'tcx>,
+        min_len: u64,
+    ) -> Option<u64> {
+        if let Some(len) = len.try_eval_usize(self.tcx, self.param_env) {
+            // Now we know the length...
+            if slice.is_none() {
+                // ...and since there is no variable-length pattern,
+                // we require an exact match between the number of elements
+                // in the array pattern and as provided by the matched type.
+                if min_len != len {
+                    self.error_scrutinee_inconsistent_length(span, min_len, len);
+                }
+            } else if let r @ Some(_) = len.checked_sub(min_len) {
+                // The variable-length pattern was there,
+                // so it has an array type with the remaining elements left as its size...
+                return r;
+            } else {
+                // ...however, in this case, there were no remaining elements.
+                // That is, the slice pattern requires more than the array type offers.
+                self.error_scrutinee_with_rest_inconsistent_length(span, min_len, len);
+            }
+        } else {
+            // No idea what the length is, which happens if we have e.g.,
+            // `let [a, b] = arr` where `arr: [T; N]` where `const N: usize`.
+            self.error_scrutinee_unfixed_length(span);
+        }
+        None
     }
 
     fn error_scrutinee_inconsistent_length(&self, span: Span, min_len: u64, size: u64) {


### PR DESCRIPTION
Following up on https://github.com/rust-lang/rust/pull/67318, in this PR, the HAIR lowering of patterns (`lower_pattern_unadjusted`) is cleaned up with a focus on slice patterns (in particular, some dead code is removed). Moreover, `check_pat_slice` is refactored some more.

r? @matthewjasper 