### PR TITLE
Allow for setting a ThinLTO import limit during bootstrap

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -406,6 +406,13 @@
 # Whether to verify generated LLVM IR
 #verify-llvm-ir = false
 
+# Compile the compiler with a non-default ThinLTO import limit. This import
+# limit controls the maximum size of functions imported by ThinLTO. Decreasing
+# will make code compile faster at the expense of lower runtime performance.
+# If `incremental` is set to true above, the import limit will default to 10
+# instead of LLVM's default of 100.
+#thin-lto-import-instr-limit = 100
+
 # Map all debuginfo paths for libstd and crates to `/rust/$sha/$crate/...`,
 # generally only set for releases
 #remap-debuginfo = false

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1183,6 +1183,21 @@ impl<'a> Builder<'a> {
             rustflags.arg("-Cprefer-dynamic");
         }
 
+        // When building incrementally we default to a lower ThinLTO import limit
+        // (unless explicitly specified otherwise). This will produce a somewhat
+        // slower code but give way better compile times.
+        {
+            let limit = match self.config.rust_thin_lto_import_instr_limit {
+                Some(limit) => Some(limit),
+                None if self.config.incremental => Some(10),
+                _ => None,
+            };
+
+            if let Some(limit) = limit {
+                rustflags.arg(&format!("-Cllvm-args=-import-instr-limit={}", limit));
+            }
+        }
+
         Cargo { command: cargo, rustflags }
     }
 

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -108,6 +108,7 @@ pub struct Config {
     pub rust_dist_src: bool,
     pub rust_codegen_backends: Vec<Interned<String>>,
     pub rust_verify_llvm_ir: bool,
+    pub rust_thin_lto_import_instr_limit: Option<u32>,
     pub rust_remap_debuginfo: bool,
 
     pub build: Interned<String>,
@@ -325,6 +326,7 @@ struct Rust {
     deny_warnings: Option<bool>,
     backtrace_on_ice: Option<bool>,
     verify_llvm_ir: Option<bool>,
+    thin_lto_import_instr_limit: Option<u32>,
     remap_debuginfo: Option<bool>,
     jemalloc: Option<bool>,
     test_compare_mode: Option<bool>,
@@ -569,6 +571,7 @@ impl Config {
             set(&mut config.deny_warnings, flags.deny_warnings.or(rust.deny_warnings));
             set(&mut config.backtrace_on_ice, rust.backtrace_on_ice);
             set(&mut config.rust_verify_llvm_ir, rust.verify_llvm_ir);
+            config.rust_thin_lto_import_instr_limit = rust.thin_lto_import_instr_limit;
             set(&mut config.rust_remap_debuginfo, rust.remap_debuginfo);
 
             if let Some(ref backends) = rust.codegen_backends {

--- a/src/ci/docker/x86_64-gnu-llvm-7/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-llvm-7/Dockerfile
@@ -25,7 +25,9 @@ RUN sh /scripts/sccache.sh
 ENV RUST_CONFIGURE_ARGS \
       --build=x86_64-unknown-linux-gnu \
       --llvm-root=/usr/lib/llvm-7 \
-      --enable-llvm-link-shared
+      --enable-llvm-link-shared \
+      --set rust.thin-lto-import-instr-limit=10
+
 ENV SCRIPT python2.7 ../x.py test src/tools/tidy && python2.7 ../x.py test
 
 # The purpose of this container isn't to test with debug assertions and


### PR DESCRIPTION
The benchmarks in https://github.com/rust-lang/rust/pull/66625 have shown that a lower ThinLTO import limit can be a net win for bootstrap times. This PR:
- exposes the setting to `config.toml`,
- defaults to a lower limit if `incremental = true` in `config.toml`, and
- sets a lower limit for `x86_64-gnu-llvm-7` CI image in order to make the jobs complete more quickly (which remains to be tested).

This setting will affect how the compiler and it's tools are compiled. It will not affect the settings the compiler uses when compiling user code. 

r? @pietroalbini 
cc @rust-lang/infra 