### PR TITLE
prune ill-conceived BTreeMap iter_mut assertion and test its mutability

### DIFF
--- a/src/liballoc/tests/btree/set.rs
+++ b/src/liballoc/tests/btree/set.rs
@@ -303,6 +303,15 @@ fn test_is_subset() {
 }
 
 #[test]
+fn test_clear() {
+    let mut x = BTreeSet::new();
+    x.insert(1);
+
+    x.clear();
+    assert!(x.is_empty());
+}
+
+#[test]
 fn test_zip() {
     let mut x = BTreeSet::new();
     x.insert(5);


### PR DESCRIPTION
Proposal to deal with #67438 (and I'm more sure now that this is the right thing to do).
Passes testing with miri.