### PR TITLE
Make ptr::slice_from_raw_parts a const fn available under a feature flag

### DIFF
--- a/src/libcore/ptr/mod.rs
+++ b/src/libcore/ptr/mod.rs
@@ -257,7 +257,8 @@ pub(crate) struct FatPtr<T> {
 /// ```
 #[inline]
 #[unstable(feature = "slice_from_raw_parts", reason = "recently added", issue = "36925")]
-pub fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {
+#[rustc_const_unstable(feature = "const_slice_from_raw_parts", issue = "67456")]
+pub const fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {
     unsafe { Repr { raw: FatPtr { data, len } }.rust }
 }
 
@@ -273,7 +274,8 @@ pub fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {
 /// [`from_raw_parts_mut`]: ../../std/slice/fn.from_raw_parts_mut.html
 #[inline]
 #[unstable(feature = "slice_from_raw_parts", reason = "recently added", issue = "36925")]
-pub fn slice_from_raw_parts_mut<T>(data: *mut T, len: usize) -> *mut [T] {
+#[rustc_const_unstable(feature = "const_slice_from_raw_parts", issue = "67456")]
+pub const fn slice_from_raw_parts_mut<T>(data: *mut T, len: usize) -> *mut [T] {
     unsafe { Repr { raw: FatPtr { data, len } }.rust_mut }
 }
 

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -36,6 +36,9 @@
 #![feature(iter_is_partitioned)]
 #![feature(iter_order_by)]
 #![feature(cmp_min_max_by)]
+#![feature(slice_from_raw_parts)]
+#![feature(const_slice_from_raw_parts)]
+#![feature(const_raw_ptr_deref)]
 
 extern crate test;
 

--- a/src/libcore/tests/ptr.rs
+++ b/src/libcore/tests/ptr.rs
@@ -2,6 +2,17 @@ use core::cell::RefCell;
 use core::ptr::*;
 
 #[test]
+fn test_const_from_raw_parts() {
+    const SLICE: &[u8] = &[1, 2, 3, 4];
+    const FROM_RAW: &[u8] = unsafe { &*slice_from_raw_parts(SLICE.as_ptr(), SLICE.len()) };
+    assert_eq!(SLICE, FROM_RAW);
+
+    let slice = &[1, 2, 3, 4, 5];
+    let from_raw = unsafe { &*slice_from_raw_parts(slice.as_ptr(), 2) } ;
+    assert_eq!(&slice[..2], from_raw);
+}
+
+#[test]
 fn test() {
     unsafe {
         struct Pair {


### PR DESCRIPTION
A first step in the direction of https://github.com/rust-lang/rust/issues/67456 .
This makes `ptr::slice_from_raw_parts` and `ptr::slice_from_raw_parts_mut` available as a const fn under a feature flag.