### PR TITLE
Require issue = "none" over issue = "0" in unstable attributes

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -476,7 +476,7 @@ impl<T: ?Sized> Box<T> {
         Box::into_unique(b).into()
     }
 
-    #[unstable(feature = "ptr_internals", issue = "0", reason = "use into_raw_non_null instead")]
+    #[unstable(feature = "ptr_internals", issue = "none", reason = "use into_raw_non_null instead")]
     #[inline]
     #[doc(hidden)]
     pub fn into_unique(b: Box<T>) -> Unique<T> {
@@ -830,7 +830,7 @@ impl From<Box<str>> for Box<[u8]> {
     }
 }
 
-#[unstable(feature = "boxed_slice_try_from", issue = "0")]
+#[unstable(feature = "boxed_slice_try_from", issue = "none")]
 impl<T, const N: usize> TryFrom<Box<[T]>> for Box<[T; N]>
 where
     [T; N]: LengthAtMost32,
@@ -946,7 +946,7 @@ impl<T: ?Sized> DerefMut for Box<T> {
     }
 }
 
-#[unstable(feature = "receiver_trait", issue = "0")]
+#[unstable(feature = "receiver_trait", issue = "none")]
 impl<T: ?Sized> Receiver for Box<T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1040,7 +1040,7 @@ impl<A, F: Fn<A> + ?Sized> Fn<A> for Box<F> {
 #[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Box<U>> for Box<T> {}
 
-#[unstable(feature = "dispatch_from_dyn", issue = "0")]
+#[unstable(feature = "dispatch_from_dyn", issue = "none")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Box<U>> for Box<T> {}
 
 #[stable(feature = "boxed_slice_from_iter", since = "1.32.0")]

--- a/src/liballoc/collections/mod.rs
+++ b/src/liballoc/collections/mod.rs
@@ -57,7 +57,7 @@ pub enum TryReserveError {
         layout: Layout,
 
         #[doc(hidden)]
-        #[unstable(feature = "container_error_extra", issue = "0", reason = "\
+        #[unstable(feature = "container_error_extra", issue = "none", reason = "\
             Enable exposing the allocator’s custom error value \
             if an associated type is added in the future: \
             https://github.com/rust-lang/wg-allocators/issues/23")]

--- a/src/liballoc/fmt.rs
+++ b/src/liballoc/fmt.rs
@@ -514,7 +514,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-#[unstable(feature = "fmt_internals", issue = "0")]
+#[unstable(feature = "fmt_internals", issue = "none")]
 pub use core::fmt::rt;
 #[stable(feature = "fmt_flags_align", since = "1.28.0")]
 pub use core::fmt::Alignment;

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -171,7 +171,7 @@ mod std {
 }
 
 #[doc(hidden)]
-#[unstable(feature = "liballoc_internals", issue = "0", reason = "implementation detail")]
+#[unstable(feature = "liballoc_internals", issue = "none", reason = "implementation detail")]
 pub mod __export {
     pub use core::format_args;
 }

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -1,4 +1,4 @@
-#![unstable(feature = "raw_vec_internals", reason = "implementation detail", issue = "0")]
+#![unstable(feature = "raw_vec_internals", reason = "implementation detail", issue = "none")]
 #![doc(hidden)]
 
 use core::cmp;

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -291,7 +291,7 @@ impl<T: ?Sized> !marker::Sync for Rc<T> {}
 #[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Rc<U>> for Rc<T> {}
 
-#[unstable(feature = "dispatch_from_dyn", issue = "0")]
+#[unstable(feature = "dispatch_from_dyn", issue = "none")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Rc<U>> for Rc<T> {}
 
 impl<T: ?Sized> Rc<T> {
@@ -1090,7 +1090,7 @@ impl<T: ?Sized> Deref for Rc<T> {
     }
 }
 
-#[unstable(feature = "receiver_trait", issue = "0")]
+#[unstable(feature = "receiver_trait", issue = "none")]
 impl<T: ?Sized> Receiver for Rc<T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1471,7 +1471,7 @@ impl<T> From<Vec<T>> for Rc<[T]> {
     }
 }
 
-#[unstable(feature = "boxed_slice_try_from", issue = "0")]
+#[unstable(feature = "boxed_slice_try_from", issue = "none")]
 impl<T, const N: usize> TryFrom<Rc<[T]>> for Rc<[T; N]>
 where
     [T; N]: LengthAtMost32,
@@ -1621,7 +1621,7 @@ impl<T: ?Sized> !marker::Sync for Weak<T> {}
 #[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Weak<U>> for Weak<T> {}
 
-#[unstable(feature = "dispatch_from_dyn", issue = "0")]
+#[unstable(feature = "dispatch_from_dyn", issue = "none")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Weak<U>> for Weak<T> {}
 
 impl<T> Weak<T> {

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -206,7 +206,7 @@ unsafe impl<T: ?Sized + Sync + Send> Sync for Arc<T> {}
 #[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Arc<U>> for Arc<T> {}
 
-#[unstable(feature = "dispatch_from_dyn", issue = "0")]
+#[unstable(feature = "dispatch_from_dyn", issue = "none")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Arc<U>> for Arc<T> {}
 
 impl<T: ?Sized> Arc<T> {
@@ -263,7 +263,7 @@ unsafe impl<T: ?Sized + Sync + Send> Sync for Weak<T> {}
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Weak<U>> for Weak<T> {}
-#[unstable(feature = "dispatch_from_dyn", issue = "0")]
+#[unstable(feature = "dispatch_from_dyn", issue = "none")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Weak<U>> for Weak<T> {}
 
 #[stable(feature = "arc_weak", since = "1.4.0")]
@@ -993,7 +993,7 @@ impl<T: ?Sized> Deref for Arc<T> {
     }
 }
 
-#[unstable(feature = "receiver_trait", issue = "0")]
+#[unstable(feature = "receiver_trait", issue = "none")]
 impl<T: ?Sized> Receiver for Arc<T> {}
 
 impl<T: Clone> Arc<T> {
@@ -2032,7 +2032,7 @@ impl<T> From<Vec<T>> for Arc<[T]> {
     }
 }
 
-#[unstable(feature = "boxed_slice_try_from", issue = "0")]
+#[unstable(feature = "boxed_slice_try_from", issue = "none")]
 impl<T, const N: usize> TryFrom<Arc<[T]>> for Arc<[T; N]>
 where
     [T; N]: LengthAtMost32,

--- a/src/libcore/array/mod.rs
+++ b/src/libcore/array/mod.rs
@@ -74,7 +74,7 @@ impl TryFromSliceError {
     #[unstable(feature = "array_error_internals",
            reason = "available through Error trait and this method should not \
                      be exposed publicly",
-           issue = "0")]
+           issue = "none")]
     #[inline]
     #[doc(hidden)]
     pub fn __description(&self) -> &str {
@@ -388,14 +388,14 @@ where
 #[rustc_on_unimplemented(
     message="arrays only have std trait implementations for lengths 0..=32",
 )]
-#[unstable(feature = "const_generic_impls_guard", issue = "0",
+#[unstable(feature = "const_generic_impls_guard", issue = "none",
     reason = "will never be stable, just a temporary step until const generics are stable")]
 pub trait LengthAtMost32 {}
 
 macro_rules! array_impls {
     ($($N:literal)+) => {
         $(
-            #[unstable(feature = "const_generic_impls_guard", issue = "0")]
+            #[unstable(feature = "const_generic_impls_guard", issue = "none")]
             impl<T> LengthAtMost32 for [T; $N] {}
         )+
     }

--- a/src/libcore/char/convert.rs
+++ b/src/libcore/char/convert.rs
@@ -169,7 +169,7 @@ impl ParseCharError {
     #[unstable(
         feature = "char_error_internals",
         reason = "this method should not be available publicly",
-        issue = "0"
+        issue = "none"
     )]
     #[doc(hidden)]
     pub fn __description(&self) -> &str {

--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -150,7 +150,7 @@ pub macro Clone($item:item) {
 #[unstable(
     feature = "derive_clone_copy",
     reason = "deriving hack, should not be public",
-    issue = "0"
+    issue = "none"
 )]
 pub struct AssertParamIsClone<T: Clone + ?Sized> {
     _field: crate::marker::PhantomData<T>,
@@ -160,7 +160,7 @@ pub struct AssertParamIsClone<T: Clone + ?Sized> {
 #[unstable(
     feature = "derive_clone_copy",
     reason = "deriving hack, should not be public",
-    issue = "0"
+    issue = "none"
 )]
 pub struct AssertParamIsCopy<T: Copy + ?Sized> {
     _field: crate::marker::PhantomData<T>,

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -288,7 +288,7 @@ pub macro Eq($item:item) { /* compiler built-in */ }
 #[allow(missing_debug_implementations)]
 #[unstable(feature = "derive_eq",
            reason = "deriving hack, should not be public",
-           issue = "0")]
+           issue = "none")]
 pub struct AssertParamIsEq<T: Eq + ?Sized> { _field: crate::marker::PhantomData<T> }
 
 /// An `Ordering` is the result of a comparison between two values.

--- a/src/libcore/ffi.rs
+++ b/src/libcore/ffi.rs
@@ -38,14 +38,14 @@ pub enum c_void {
     #[unstable(
         feature = "c_void_variant",
         reason = "temporary implementation detail",
-        issue = "0"
+        issue = "none"
     )]
     #[doc(hidden)]
     __variant1,
     #[unstable(
         feature = "c_void_variant",
         reason = "temporary implementation detail",
-        issue = "0"
+        issue = "none"
     )]
     #[doc(hidden)]
     __variant2,

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -35,7 +35,7 @@ pub enum Alignment {
 #[stable(feature = "debug_builders", since = "1.2.0")]
 pub use self::builders::{DebugList, DebugMap, DebugSet, DebugStruct, DebugTuple};
 
-#[unstable(feature = "fmt_internals", reason = "internal to format_args!", issue = "0")]
+#[unstable(feature = "fmt_internals", reason = "internal to format_args!", issue = "none")]
 #[doc(hidden)]
 pub mod rt {
     pub mod v1;
@@ -259,7 +259,7 @@ struct Void {
 /// types, and then this struct is used to canonicalize arguments to one type.
 #[derive(Copy, Clone)]
 #[allow(missing_debug_implementations)]
-#[unstable(feature = "fmt_internals", reason = "internal to format_args!", issue = "0")]
+#[unstable(feature = "fmt_internals", reason = "internal to format_args!", issue = "none")]
 #[doc(hidden)]
 pub struct ArgumentV1<'a> {
     value: &'a Void,
@@ -273,13 +273,13 @@ impl<'a> ArgumentV1<'a> {
     }
 
     #[doc(hidden)]
-    #[unstable(feature = "fmt_internals", reason = "internal to format_args!", issue = "0")]
+    #[unstable(feature = "fmt_internals", reason = "internal to format_args!", issue = "none")]
     pub fn new<'b, T>(x: &'b T, f: fn(&T, &mut Formatter<'_>) -> Result) -> ArgumentV1<'b> {
         unsafe { ArgumentV1 { formatter: mem::transmute(f), value: mem::transmute(x) } }
     }
 
     #[doc(hidden)]
-    #[unstable(feature = "fmt_internals", reason = "internal to format_args!", issue = "0")]
+    #[unstable(feature = "fmt_internals", reason = "internal to format_args!", issue = "none")]
     pub fn from_usize(x: &usize) -> ArgumentV1<'_> {
         ArgumentV1::new(x, ArgumentV1::show_usize)
     }
@@ -309,7 +309,7 @@ impl<'a> Arguments<'a> {
     /// Arguments structure.
     #[doc(hidden)]
     #[inline]
-    #[unstable(feature = "fmt_internals", reason = "internal to format_args!", issue = "0")]
+    #[unstable(feature = "fmt_internals", reason = "internal to format_args!", issue = "none")]
     pub fn new_v1(pieces: &'a [&'a str], args: &'a [ArgumentV1<'a>]) -> Arguments<'a> {
         Arguments { pieces, fmt: None, args }
     }
@@ -322,7 +322,7 @@ impl<'a> Arguments<'a> {
     /// unsafety, but will ignore invalid .
     #[doc(hidden)]
     #[inline]
-    #[unstable(feature = "fmt_internals", reason = "internal to format_args!", issue = "0")]
+    #[unstable(feature = "fmt_internals", reason = "internal to format_args!", issue = "none")]
     pub fn new_v1_formatted(
         pieces: &'a [&'a str],
         args: &'a [ArgumentV1<'a>],
@@ -337,7 +337,7 @@ impl<'a> Arguments<'a> {
     /// when using `format!`. Note: this is neither the lower nor upper bound.
     #[doc(hidden)]
     #[inline]
-    #[unstable(feature = "fmt_internals", reason = "internal to format_args!", issue = "0")]
+    #[unstable(feature = "fmt_internals", reason = "internal to format_args!", issue = "none")]
     pub fn estimated_capacity(&self) -> usize {
         let pieces_length: usize = self.pieces.iter().map(|x| x.len()).sum();
 

--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -90,7 +90,7 @@ use crate::marker;
 #[allow(deprecated)]
 pub use self::sip::SipHasher;
 
-#[unstable(feature = "hashmap_internals", issue = "0")]
+#[unstable(feature = "hashmap_internals", issue = "none")]
 #[allow(deprecated)]
 #[doc(hidden)]
 pub use self::sip::SipHasher13;

--- a/src/libcore/hash/sip.rs
+++ b/src/libcore/hash/sip.rs
@@ -15,7 +15,7 @@ use crate::ptr;
 /// (e.g., `collections::HashMap` uses it by default).
 ///
 /// See: <https://131002.net/siphash>
-#[unstable(feature = "hashmap_internals", issue = "0")]
+#[unstable(feature = "hashmap_internals", issue = "none")]
 #[rustc_deprecated(
     since = "1.13.0",
     reason = "use `std::collections::hash_map::DefaultHasher` instead"
@@ -29,7 +29,7 @@ pub struct SipHasher13 {
 /// An implementation of SipHash 2-4.
 ///
 /// See: <https://131002.net/siphash/>
-#[unstable(feature = "hashmap_internals", issue = "0")]
+#[unstable(feature = "hashmap_internals", issue = "none")]
 #[rustc_deprecated(
     since = "1.13.0",
     reason = "use `std::collections::hash_map::DefaultHasher` instead"
@@ -172,7 +172,7 @@ impl SipHasher {
 impl SipHasher13 {
     /// Creates a new `SipHasher13` with the two initial keys set to 0.
     #[inline]
-    #[unstable(feature = "hashmap_internals", issue = "0")]
+    #[unstable(feature = "hashmap_internals", issue = "none")]
     #[rustc_deprecated(
         since = "1.13.0",
         reason = "use `std::collections::hash_map::DefaultHasher` instead"
@@ -183,7 +183,7 @@ impl SipHasher13 {
 
     /// Creates a `SipHasher13` that is keyed off the provided keys.
     #[inline]
-    #[unstable(feature = "hashmap_internals", issue = "0")]
+    #[unstable(feature = "hashmap_internals", issue = "none")]
     #[rustc_deprecated(
         since = "1.13.0",
         reason = "use `std::collections::hash_map::DefaultHasher` instead"
@@ -264,7 +264,7 @@ impl super::Hasher for SipHasher {
     }
 }
 
-#[unstable(feature = "hashmap_internals", issue = "0")]
+#[unstable(feature = "hashmap_internals", issue = "none")]
 impl super::Hasher for SipHasher13 {
     #[inline]
     fn write(&mut self, msg: &[u8]) {

--- a/src/libcore/internal_macros.rs
+++ b/src/libcore/internal_macros.rs
@@ -77,7 +77,7 @@ macro_rules! forward_ref_op_assign {
 }
 
 /// Create a zero-size type similar to a closure type, but named.
-#[unstable(feature = "std_internals", issue = "0")]
+#[unstable(feature = "std_internals", issue = "none")]
 macro_rules! impl_fn_for_zst {
     ($(
         $( #[$attr: meta] )*

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -33,7 +33,7 @@
             reason = "intrinsics are unlikely to ever be stabilized, instead \
                       they should be used through stabilized interfaces \
                       in the rest of the standard library",
-            issue = "0")]
+            issue = "none")]
 #![allow(missing_docs)]
 
 use crate::mem;
@@ -709,7 +709,7 @@ extern "rust-intrinsic" {
                reason = "intrinsics are unlikely to ever be stabilized, instead \
                          they should be used through stabilized interfaces \
                          in the rest of the standard library",
-               issue = "0")]
+               issue = "none")]
     #[rustc_deprecated(reason = "superseded by MaybeUninit, removal planned",
                        since = "1.38.0")]
     pub fn init<T>() -> T;
@@ -725,7 +725,7 @@ extern "rust-intrinsic" {
                reason = "intrinsics are unlikely to ever be stabilized, instead \
                          they should be used through stabilized interfaces \
                          in the rest of the standard library",
-               issue = "0")]
+               issue = "none")]
     #[rustc_deprecated(reason = "superseded by MaybeUninit, removal planned",
                        since = "1.38.0")]
     pub fn uninit<T>() -> T;

--- a/src/libcore/macros/mod.rs
+++ b/src/libcore/macros/mod.rs
@@ -799,7 +799,7 @@ pub(crate) mod builtin {
     /// Same as `format_args`, but adds a newline in the end.
     #[unstable(
         feature = "format_args_nl",
-        issue = "0",
+        issue = "none",
         reason = "`format_args_nl` is only for internal \
                   language use and is subject to change"
     )]

--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -301,7 +301,7 @@ impl<T> MaybeUninit<T> {
     /// let mut buf: [MaybeUninit<u8>; 32] = MaybeUninit::uninit_array();
     /// let data = read(&mut buf);
     /// ```
-    #[unstable(feature = "maybe_uninit_uninit_array", issue = "0")]
+    #[unstable(feature = "maybe_uninit_uninit_array", issue = "none")]
     #[inline(always)]
     pub fn uninit_array<const LEN: usize>() -> [Self; LEN] {
         unsafe {
@@ -310,7 +310,7 @@ impl<T> MaybeUninit<T> {
     }
 
     /// A promotable constant, equivalent to `uninit()`.
-    #[unstable(feature = "internal_uninit_const", issue = "0",
+    #[unstable(feature = "internal_uninit_const", issue = "none",
         reason = "hack to work around promotability")]
     pub const UNINIT: Self = Self::uninit();
 
@@ -749,7 +749,7 @@ impl<T> MaybeUninit<T> {
     /// It is up to the caller to guarantee that the `MaybeUninit<T>` elements
     /// really are in an initialized state.
     /// Calling this when the content is not yet fully initialized causes undefined behavior.
-    #[unstable(feature = "maybe_uninit_slice_assume_init", issue = "0")]
+    #[unstable(feature = "maybe_uninit_slice_assume_init", issue = "none")]
     #[inline(always)]
     pub unsafe fn slice_get_ref(slice: &[Self]) -> &[T] {
         &*(slice as *const [Self] as *const [T])
@@ -762,7 +762,7 @@ impl<T> MaybeUninit<T> {
     /// It is up to the caller to guarantee that the `MaybeUninit<T>` elements
     /// really are in an initialized state.
     /// Calling this when the content is not yet fully initialized causes undefined behavior.
-    #[unstable(feature = "maybe_uninit_slice_assume_init", issue = "0")]
+    #[unstable(feature = "maybe_uninit_slice_assume_init", issue = "none")]
     #[inline(always)]
     pub unsafe fn slice_get_mut(slice: &mut [Self]) -> &mut [T] {
         &mut *(slice as *mut [Self] as *mut [T])

--- a/src/libcore/mem/mod.rs
+++ b/src/libcore/mem/mod.rs
@@ -121,7 +121,7 @@ pub fn forget<T>(t: T) {
 ///
 /// [`forget`]: fn.forget.html
 #[inline]
-#[unstable(feature = "forget_unsized", issue = "0")]
+#[unstable(feature = "forget_unsized", issue = "none")]
 pub fn forget_unsized<T: ?Sized>(t: T) {
     // SAFETY: the forget intrinsic could be safe, but there's no point in making it safe since
     // we'll be implementing this function soon via `ManuallyDrop`

--- a/src/libcore/num/bignum.rs
+++ b/src/libcore/num/bignum.rs
@@ -15,7 +15,7 @@
 #![unstable(
     feature = "core_private_bignum",
     reason = "internal routines only exposed for testing",
-    issue = "0"
+    issue = "none"
 )]
 #![macro_use]
 

--- a/src/libcore/num/dec2flt/mod.rs
+++ b/src/libcore/num/dec2flt/mod.rs
@@ -81,7 +81,7 @@
 #![unstable(
     feature = "dec2flt",
     reason = "internal routines only exposed for testing",
-    issue = "0"
+    issue = "none"
 )]
 
 use crate::fmt;
@@ -187,7 +187,7 @@ impl ParseFloatError {
         feature = "int_error_internals",
         reason = "available through Error trait and this method should \
                   not be exposed publicly",
-        issue = "0"
+        issue = "none"
     )]
     #[doc(hidden)]
     pub fn __description(&self) -> &str {

--- a/src/libcore/num/diy_float.rs
+++ b/src/libcore/num/diy_float.rs
@@ -6,7 +6,7 @@
 #![unstable(
     feature = "core_private_diy_float",
     reason = "internal routines only exposed for testing",
-    issue = "0"
+    issue = "none"
 )]
 
 /// A custom 64-bit floating point type, representing `f * 2^e`.

--- a/src/libcore/num/flt2dec/mod.rs
+++ b/src/libcore/num/flt2dec/mod.rs
@@ -119,7 +119,7 @@ functions.
 #![unstable(
     feature = "flt2dec",
     reason = "internal routines only exposed for testing",
-    issue = "0"
+    issue = "none"
 )]
 
 pub use self::decoder::{decode, DecodableFloat, Decoded, FullDecoded};

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -4769,7 +4769,7 @@ impl TryFromIntError {
         feature = "int_error_internals",
         reason = "available through Error trait and this method should \
                   not be exposed publicly",
-        issue = "0"
+        issue = "none"
     )]
     #[doc(hidden)]
     pub fn __description(&self) -> &str {
@@ -4968,7 +4968,7 @@ impl ParseIntError {
         feature = "int_error_internals",
         reason = "available through Error trait and this method should \
                   not be exposed publicly",
-        issue = "0"
+        issue = "none"
     )]
     #[doc(hidden)]
     pub fn __description(&self) -> &str {

--- a/src/libcore/ops/deref.rs
+++ b/src/libcore/ops/deref.rs
@@ -178,14 +178,14 @@ impl<T: ?Sized> DerefMut for &mut T {
 /// `arbitrary_self_types` feature. This is implemented by stdlib pointer types like `Box<T>`,
 /// `Rc<T>`, `&T`, and `Pin<P>`.
 #[lang = "receiver"]
-#[unstable(feature = "receiver_trait", issue = "0")]
+#[unstable(feature = "receiver_trait", issue = "none")]
 #[doc(hidden)]
 pub trait Receiver {
     // Empty.
 }
 
-#[unstable(feature = "receiver_trait", issue = "0")]
+#[unstable(feature = "receiver_trait", issue = "none")]
 impl<T: ?Sized> Receiver for &T {}
 
-#[unstable(feature = "receiver_trait", issue = "0")]
+#[unstable(feature = "receiver_trait", issue = "none")]
 impl<T: ?Sized> Receiver for &mut T {}

--- a/src/libcore/ops/mod.rs
+++ b/src/libcore/ops/mod.rs
@@ -168,7 +168,7 @@ pub use self::bit::{BitAndAssign, BitOrAssign, BitXorAssign, ShlAssign, ShrAssig
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::deref::{Deref, DerefMut};
 
-#[unstable(feature = "receiver_trait", issue = "0")]
+#[unstable(feature = "receiver_trait", issue = "none")]
 pub use self::deref::Receiver;
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -195,5 +195,5 @@ pub use self::generator::{Generator, GeneratorState};
 #[unstable(feature = "coerce_unsized", issue = "27732")]
 pub use self::unsize::CoerceUnsized;
 
-#[unstable(feature = "dispatch_from_dyn", issue = "0")]
+#[unstable(feature = "dispatch_from_dyn", issue = "none")]
 pub use self::unsize::DispatchFromDyn;

--- a/src/libcore/ops/unsize.rs
+++ b/src/libcore/ops/unsize.rs
@@ -81,21 +81,21 @@ impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *const T {}
 ///     T: Unsize<U>,
 /// {}
 /// ```
-#[unstable(feature = "dispatch_from_dyn", issue = "0")]
+#[unstable(feature = "dispatch_from_dyn", issue = "none")]
 #[lang = "dispatch_from_dyn"]
 pub trait DispatchFromDyn<T> {
     // Empty.
 }
 
 // &T -> &U
-#[unstable(feature = "dispatch_from_dyn", issue = "0")]
+#[unstable(feature = "dispatch_from_dyn", issue = "none")]
 impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<&'a U> for &'a T {}
 // &mut T -> &mut U
-#[unstable(feature = "dispatch_from_dyn", issue = "0")]
+#[unstable(feature = "dispatch_from_dyn", issue = "none")]
 impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<&'a mut U> for &'a mut T {}
 // *const T -> *const U
-#[unstable(feature = "dispatch_from_dyn", issue = "0")]
+#[unstable(feature = "dispatch_from_dyn", issue = "none")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<*const U> for *const T {}
 // *mut T -> *mut U
-#[unstable(feature = "dispatch_from_dyn", issue = "0")]
+#[unstable(feature = "dispatch_from_dyn", issue = "none")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<*mut U> for *mut T {}

--- a/src/libcore/panic.rs
+++ b/src/libcore/panic.rs
@@ -40,7 +40,7 @@ impl<'a> PanicInfo<'a> {
     #[unstable(feature = "panic_internals",
                reason = "internal details of the implementation of the `panic!` \
                          and related macros",
-               issue = "0")]
+               issue = "none")]
     #[doc(hidden)]
     #[inline]
     pub fn internal_constructor(
@@ -58,7 +58,7 @@ impl<'a> PanicInfo<'a> {
     #[unstable(feature = "panic_internals",
                reason = "internal details of the implementation of the `panic!` \
                          and related macros",
-               issue = "0")]
+               issue = "none")]
     #[doc(hidden)]
     #[inline]
     pub fn set_payload(&mut self, info: &'a (dyn Any + Send)) {
@@ -235,7 +235,7 @@ impl<'a> Location<'a> {
     #![unstable(feature = "panic_internals",
                 reason = "internal details of the implementation of the `panic!` \
                           and related macros",
-                issue = "0")]
+                issue = "none")]
     #[doc(hidden)]
     pub const fn internal_constructor(file: &'a str, line: u32, col: u32) -> Self {
         Location { file, line, col }
@@ -318,7 +318,7 @@ impl fmt::Display for Location<'_> {
 /// An internal trait used by libstd to pass data from libstd to `panic_unwind`
 /// and other panic runtimes. Not intended to be stabilized any time soon, do
 /// not use.
-#[unstable(feature = "std_internals", issue = "0")]
+#[unstable(feature = "std_internals", issue = "none")]
 #[doc(hidden)]
 pub unsafe trait BoxMeUp {
     /// Take full ownership of the contents.

--- a/src/libcore/panicking.rs
+++ b/src/libcore/panicking.rs
@@ -26,7 +26,7 @@
     feature = "core_panic",
     reason = "internal details of the implementation of the `panic!` \
               and related macros",
-    issue = "0"
+    issue = "none"
 )]
 
 use crate::fmt;

--- a/src/libcore/pin.rs
+++ b/src/libcore/pin.rs
@@ -786,7 +786,7 @@ impl<P: DerefMut<Target: Unpin>> DerefMut for Pin<P> {
     }
 }
 
-#[unstable(feature = "receiver_trait", issue = "0")]
+#[unstable(feature = "receiver_trait", issue = "none")]
 impl<P: Receiver> Receiver for Pin<P> {}
 
 #[stable(feature = "pin", since = "1.33.0")]

--- a/src/libcore/ptr/mod.rs
+++ b/src/libcore/ptr/mod.rs
@@ -89,7 +89,7 @@ mod non_null;
 pub use non_null::NonNull;
 
 mod unique;
-#[unstable(feature = "ptr_internals", issue = "0")]
+#[unstable(feature = "ptr_internals", issue = "none")]
 pub use unique::Unique;
 
 mod const_ptr;

--- a/src/libcore/ptr/non_null.rs
+++ b/src/libcore/ptr/non_null.rs
@@ -149,7 +149,7 @@ impl<T: ?Sized> Copy for NonNull<T> {}
 #[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: ?Sized, U: ?Sized> CoerceUnsized<NonNull<U>> for NonNull<T> where T: Unsize<U> {}
 
-#[unstable(feature = "dispatch_from_dyn", issue = "0")]
+#[unstable(feature = "dispatch_from_dyn", issue = "none")]
 impl<T: ?Sized, U: ?Sized> DispatchFromDyn<NonNull<U>> for NonNull<T> where T: Unsize<U> {}
 
 #[stable(feature = "nonnull", since = "1.25.0")]
@@ -201,7 +201,7 @@ impl<T: ?Sized> hash::Hash for NonNull<T> {
     }
 }
 
-#[unstable(feature = "ptr_internals", issue = "0")]
+#[unstable(feature = "ptr_internals", issue = "none")]
 impl<T: ?Sized> From<Unique<T>> for NonNull<T> {
     #[inline]
     fn from(unique: Unique<T>) -> Self {

--- a/src/libcore/ptr/unique.rs
+++ b/src/libcore/ptr/unique.rs
@@ -29,7 +29,7 @@ use crate::ptr::NonNull;
 /// for any type which upholds Unique's aliasing requirements.
 #[unstable(
     feature = "ptr_internals",
-    issue = "0",
+    issue = "none",
     reason = "use `NonNull` instead and consider `PhantomData<T>` \
               (if you also use `#[may_dangle]`), `Send`, and/or `Sync`"
 )]
@@ -50,17 +50,17 @@ pub struct Unique<T: ?Sized> {
 /// reference is unaliased. Note that this aliasing invariant is
 /// unenforced by the type system; the abstraction using the
 /// `Unique` must enforce it.
-#[unstable(feature = "ptr_internals", issue = "0")]
+#[unstable(feature = "ptr_internals", issue = "none")]
 unsafe impl<T: Send + ?Sized> Send for Unique<T> {}
 
 /// `Unique` pointers are `Sync` if `T` is `Sync` because the data they
 /// reference is unaliased. Note that this aliasing invariant is
 /// unenforced by the type system; the abstraction using the
 /// `Unique` must enforce it.
-#[unstable(feature = "ptr_internals", issue = "0")]
+#[unstable(feature = "ptr_internals", issue = "none")]
 unsafe impl<T: Sync + ?Sized> Sync for Unique<T> {}
 
-#[unstable(feature = "ptr_internals", issue = "0")]
+#[unstable(feature = "ptr_internals", issue = "none")]
 impl<T: Sized> Unique<T> {
     /// Creates a new `Unique` that is dangling, but well-aligned.
     ///
@@ -78,7 +78,7 @@ impl<T: Sized> Unique<T> {
     }
 }
 
-#[unstable(feature = "ptr_internals", issue = "0")]
+#[unstable(feature = "ptr_internals", issue = "none")]
 impl<T: ?Sized> Unique<T> {
     /// Creates a new `Unique`.
     ///
@@ -133,7 +133,7 @@ impl<T: ?Sized> Unique<T> {
     }
 }
 
-#[unstable(feature = "ptr_internals", issue = "0")]
+#[unstable(feature = "ptr_internals", issue = "none")]
 impl<T: ?Sized> Clone for Unique<T> {
     #[inline]
     fn clone(&self) -> Self {
@@ -141,30 +141,30 @@ impl<T: ?Sized> Clone for Unique<T> {
     }
 }
 
-#[unstable(feature = "ptr_internals", issue = "0")]
+#[unstable(feature = "ptr_internals", issue = "none")]
 impl<T: ?Sized> Copy for Unique<T> {}
 
-#[unstable(feature = "ptr_internals", issue = "0")]
+#[unstable(feature = "ptr_internals", issue = "none")]
 impl<T: ?Sized, U: ?Sized> CoerceUnsized<Unique<U>> for Unique<T> where T: Unsize<U> {}
 
-#[unstable(feature = "ptr_internals", issue = "0")]
+#[unstable(feature = "ptr_internals", issue = "none")]
 impl<T: ?Sized, U: ?Sized> DispatchFromDyn<Unique<U>> for Unique<T> where T: Unsize<U> {}
 
-#[unstable(feature = "ptr_internals", issue = "0")]
+#[unstable(feature = "ptr_internals", issue = "none")]
 impl<T: ?Sized> fmt::Debug for Unique<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Pointer::fmt(&self.as_ptr(), f)
     }
 }
 
-#[unstable(feature = "ptr_internals", issue = "0")]
+#[unstable(feature = "ptr_internals", issue = "none")]
 impl<T: ?Sized> fmt::Pointer for Unique<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Pointer::fmt(&self.as_ptr(), f)
     }
 }
 
-#[unstable(feature = "ptr_internals", issue = "0")]
+#[unstable(feature = "ptr_internals", issue = "none")]
 impl<T: ?Sized> From<&mut T> for Unique<T> {
     #[inline]
     fn from(reference: &mut T) -> Self {
@@ -172,7 +172,7 @@ impl<T: ?Sized> From<&mut T> for Unique<T> {
     }
 }
 
-#[unstable(feature = "ptr_internals", issue = "0")]
+#[unstable(feature = "ptr_internals", issue = "none")]
 impl<T: ?Sized> From<&T> for Unique<T> {
     #[inline]
     fn from(reference: &T) -> Self {
@@ -180,7 +180,7 @@ impl<T: ?Sized> From<&T> for Unique<T> {
     }
 }
 
-#[unstable(feature = "ptr_internals", issue = "0")]
+#[unstable(feature = "ptr_internals", issue = "none")]
 impl<T: ?Sized> From<NonNull<T>> for Unique<T> {
     #[inline]
     fn from(p: NonNull<T>) -> Self {

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -38,7 +38,7 @@ use crate::ptr;
 use crate::mem;
 use crate::marker::{Copy, Send, Sync, Sized, self};
 
-#[unstable(feature = "slice_internals", issue = "0",
+#[unstable(feature = "slice_internals", issue = "none",
            reason = "exposed from core to be reused in std; use the memchr crate")]
 /// Pure rust memchr implementation, taken from rust-memchr
 pub mod memchr;
@@ -2723,12 +2723,12 @@ pub trait SliceIndex<T: ?Sized>: private_slice_index::Sealed {
 
     /// Returns a shared reference to the output at this location, if in
     /// bounds.
-    #[unstable(feature = "slice_index_methods", issue = "0")]
+    #[unstable(feature = "slice_index_methods", issue = "none")]
     fn get(self, slice: &T) -> Option<&Self::Output>;
 
     /// Returns a mutable reference to the output at this location, if in
     /// bounds.
-    #[unstable(feature = "slice_index_methods", issue = "0")]
+    #[unstable(feature = "slice_index_methods", issue = "none")]
     fn get_mut(self, slice: &mut T) -> Option<&mut Self::Output>;
 
     /// Returns a shared reference to the output at this location, without
@@ -2736,7 +2736,7 @@ pub trait SliceIndex<T: ?Sized>: private_slice_index::Sealed {
     /// Calling this method with an out-of-bounds index is *[undefined behavior]*
     /// even if the resulting reference is not used.
     /// [undefined behavior]: ../../reference/behavior-considered-undefined.html
-    #[unstable(feature = "slice_index_methods", issue = "0")]
+    #[unstable(feature = "slice_index_methods", issue = "none")]
     unsafe fn get_unchecked(self, slice: &T) -> &Self::Output;
 
     /// Returns a mutable reference to the output at this location, without
@@ -2744,17 +2744,17 @@ pub trait SliceIndex<T: ?Sized>: private_slice_index::Sealed {
     /// Calling this method with an out-of-bounds index is *[undefined behavior]*
     /// even if the resulting reference is not used.
     /// [undefined behavior]: ../../reference/behavior-considered-undefined.html
-    #[unstable(feature = "slice_index_methods", issue = "0")]
+    #[unstable(feature = "slice_index_methods", issue = "none")]
     unsafe fn get_unchecked_mut(self, slice: &mut T) -> &mut Self::Output;
 
     /// Returns a shared reference to the output at this location, panicking
     /// if out of bounds.
-    #[unstable(feature = "slice_index_methods", issue = "0")]
+    #[unstable(feature = "slice_index_methods", issue = "none")]
     fn index(self, slice: &T) -> &Self::Output;
 
     /// Returns a mutable reference to the output at this location, panicking
     /// if out of bounds.
-    #[unstable(feature = "slice_index_methods", issue = "0")]
+    #[unstable(feature = "slice_index_methods", issue = "none")]
     fn index_mut(self, slice: &mut T) -> &mut Self::Output;
 }
 
@@ -5382,7 +5382,7 @@ pub fn from_mut<T>(s: &mut T) -> &mut [T] {
 }
 
 // This function is public only because there is no other way to unit test heapsort.
-#[unstable(feature = "sort_internals", reason = "internal to sort module", issue = "0")]
+#[unstable(feature = "sort_internals", reason = "internal to sort module", issue = "none")]
 #[doc(hidden)]
 pub fn heapsort<T, F>(v: &mut [T], mut is_less: F)
     where F: FnMut(&T, &T) -> bool

--- a/src/libcore/str/lossy.rs
+++ b/src/libcore/str/lossy.rs
@@ -6,7 +6,7 @@ use crate::mem;
 // ignore-tidy-undocumented-unsafe
 
 /// Lossy UTF-8 string.
-#[unstable(feature = "str_internals", issue = "0")]
+#[unstable(feature = "str_internals", issue = "none")]
 pub struct Utf8Lossy {
     bytes: [u8]
 }
@@ -27,13 +27,13 @@ impl Utf8Lossy {
 
 
 /// Iterator over lossy UTF-8 string
-#[unstable(feature = "str_internals", issue = "0")]
+#[unstable(feature = "str_internals", issue = "none")]
 #[allow(missing_debug_implementations)]
 pub struct Utf8LossyChunksIter<'a> {
     source: &'a [u8],
 }
 
-#[unstable(feature = "str_internals", issue = "0")]
+#[unstable(feature = "str_internals", issue = "none")]
 #[derive(PartialEq, Eq, Debug)]
 pub struct Utf8LossyChunk<'a> {
     /// Sequence of valid chars.

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -21,7 +21,7 @@ use crate::option;
 
 pub mod pattern;
 
-#[unstable(feature = "str_internals", issue = "0")]
+#[unstable(feature = "str_internals", issue = "none")]
 #[allow(missing_docs)]
 pub mod lossy;
 
@@ -496,7 +496,7 @@ fn unwrap_or_0(opt: Option<&u8>) -> u8 {
 
 /// Reads the next code point out of a byte iterator (assuming a
 /// UTF-8-like encoding).
-#[unstable(feature = "str_internals", issue = "0")]
+#[unstable(feature = "str_internals", issue = "none")]
 #[inline]
 pub fn next_code_point<'a, I: Iterator<Item = &'a u8>>(bytes: &mut I) -> Option<u32> {
     // Decode UTF-8
@@ -1583,7 +1583,7 @@ static UTF8_CHAR_WIDTH: [u8; 256] = [
 ];
 
 /// Given a first byte, determines how many bytes are in this UTF-8 character.
-#[unstable(feature = "str_internals", issue = "0")]
+#[unstable(feature = "str_internals", issue = "none")]
 #[inline]
 pub fn utf8_char_width(b: u8) -> usize {
     UTF8_CHAR_WIDTH[b as usize] as usize

--- a/src/libcore/unicode/mod.rs
+++ b/src/libcore/unicode/mod.rs
@@ -1,4 +1,4 @@
-#![unstable(feature = "unicode_internals", issue = "0")]
+#![unstable(feature = "unicode_internals", issue = "none")]
 #![allow(missing_docs)]
 
 mod bool_trie;

--- a/src/libprofiler_builtins/lib.rs
+++ b/src/libprofiler_builtins/lib.rs
@@ -3,7 +3,7 @@
 #![profiler_runtime]
 #![unstable(feature = "profiler_runtime_lib",
             reason = "internal implementation detail of rustc right now",
-            issue = "0")]
+            issue = "none")]
 #![allow(unused_features)]
 #![feature(nll)]
 #![feature(staged_api)]

--- a/src/librustc_asan/lib.rs
+++ b/src/librustc_asan/lib.rs
@@ -5,4 +5,4 @@
 #![no_std]
 #![unstable(feature = "sanitizer_runtime_lib",
             reason = "internal implementation detail of sanitizers",
-            issue = "0")]
+            issue = "none")]

--- a/src/librustc_error_codes/error_codes/E0734.md
+++ b/src/librustc_error_codes/error_codes/E0734.md
@@ -5,7 +5,7 @@ Erroneous code examples:
 ```compile_fail,E0734
 #[rustc_deprecated(since = "b", reason = "text")] // invalid
 #[stable(feature = "a", since = "b")] // invalid
-#[unstable(feature = "b", issue = "0")] // invalid
+#[unstable(feature = "b", issue = "none")] // invalid
 fn foo(){}
 ```
 

--- a/src/librustc_lsan/lib.rs
+++ b/src/librustc_lsan/lib.rs
@@ -5,4 +5,4 @@
 #![no_std]
 #![unstable(feature = "sanitizer_runtime_lib",
             reason = "internal implementation detail of sanitizers",
-            issue = "0")]
+            issue = "none")]

--- a/src/librustc_msan/lib.rs
+++ b/src/librustc_msan/lib.rs
@@ -5,4 +5,4 @@
 #![no_std]
 #![unstable(feature = "sanitizer_runtime_lib",
             reason = "internal implementation detail of sanitizers",
-            issue = "0")]
+            issue = "none")]

--- a/src/librustc_tsan/lib.rs
+++ b/src/librustc_tsan/lib.rs
@@ -5,4 +5,4 @@
 #![no_std]
 #![unstable(feature = "sanitizer_runtime_lib",
             reason = "internal implementation detail of sanitizers",
-            issue = "0")]
+            issue = "none")]

--- a/src/libstd/alloc.rs
+++ b/src/libstd/alloc.rs
@@ -205,7 +205,7 @@ fn default_alloc_error_hook(layout: Layout) {
 #[cfg(not(test))]
 #[doc(hidden)]
 #[alloc_error_handler]
-#[unstable(feature = "alloc_internals", issue = "0")]
+#[unstable(feature = "alloc_internals", issue = "none")]
 pub fn rust_oom(layout: Layout) -> ! {
     let hook = HOOK.load(Ordering::SeqCst);
     let hook: fn(Layout) = if hook.is_null() {
@@ -220,7 +220,7 @@ pub fn rust_oom(layout: Layout) -> ! {
 #[cfg(not(test))]
 #[doc(hidden)]
 #[allow(unused_attributes)]
-#[unstable(feature = "alloc_internals", issue = "0")]
+#[unstable(feature = "alloc_internals", issue = "none")]
 pub mod __default_lib_allocator {
     use super::{System, Layout, GlobalAlloc};
     // These magic symbol names are used as a fallback for implementing the

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -1065,7 +1065,7 @@ impl CStr {
     /// ```
     #[inline]
     #[stable(feature = "cstr_from_bytes", since = "1.10.0")]
-    #[rustc_const_unstable(feature = "const_cstr_unchecked", issue = "0")]
+    #[rustc_const_unstable(feature = "const_cstr_unchecked", issue = "none")]
     pub const unsafe fn from_bytes_with_nul_unchecked(bytes: &[u8]) -> &CStr {
         &*(bytes as *const [u8] as *const CStr)
     }

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -280,7 +280,7 @@ pub use self::error::{Error, ErrorKind, Result};
 pub use self::stdio::{stderr, stdin, stdout, Stderr, Stdin, Stdout};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::stdio::{StderrLock, StdinLock, StdoutLock};
-#[unstable(feature = "print_internals", issue = "0")]
+#[unstable(feature = "print_internals", issue = "none")]
 pub use self::stdio::{_eprint, _print};
 #[unstable(feature = "libstd_io_internals", issue = "42788")]
 #[doc(no_inline, hidden)]

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -723,7 +723,7 @@ impl fmt::Debug for StderrLock<'_> {
 #[unstable(feature = "set_stdio",
            reason = "this function may disappear completely or be replaced \
                      with a more general mechanism",
-           issue = "0")]
+           issue = "none")]
 #[doc(hidden)]
 pub fn set_panic(sink: Option<Box<dyn Write + Send>>) -> Option<Box<dyn Write + Send>> {
     use crate::mem;
@@ -746,7 +746,7 @@ pub fn set_panic(sink: Option<Box<dyn Write + Send>>) -> Option<Box<dyn Write + 
 #[unstable(feature = "set_stdio",
            reason = "this function may disappear completely or be replaced \
                      with a more general mechanism",
-           issue = "0")]
+           issue = "none")]
 #[doc(hidden)]
 pub fn set_print(sink: Option<Box<dyn Write + Send>>) -> Option<Box<dyn Write + Send>> {
     use crate::mem;
@@ -795,7 +795,7 @@ where
 
 #[unstable(feature = "print_internals",
            reason = "implementation detail which may disappear or be replaced at any time",
-           issue = "0")]
+           issue = "none")]
 #[doc(hidden)]
 #[cfg(not(test))]
 pub fn _print(args: fmt::Arguments<'_>) {
@@ -804,7 +804,7 @@ pub fn _print(args: fmt::Arguments<'_>) {
 
 #[unstable(feature = "print_internals",
            reason = "implementation detail which may disappear or be replaced at any time",
-           issue = "0")]
+           issue = "none")]
 #[doc(hidden)]
 #[cfg(not(test))]
 pub fn _eprint(args: fmt::Arguments<'_>) {

--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -205,7 +205,7 @@ impl<T: RefUnwindSafe + ?Sized> UnwindSafe for &T {}
 impl<T: RefUnwindSafe + ?Sized> UnwindSafe for *const T {}
 #[stable(feature = "catch_unwind", since = "1.9.0")]
 impl<T: RefUnwindSafe + ?Sized> UnwindSafe for *mut T {}
-#[unstable(feature = "ptr_internals", issue = "0")]
+#[unstable(feature = "ptr_internals", issue = "none")]
 impl<T: UnwindSafe + ?Sized> UnwindSafe for Unique<T> {}
 #[stable(feature = "nonnull", since = "1.25.0")]
 impl<T: RefUnwindSafe + ?Sized> UnwindSafe for NonNull<T> {}

--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -214,7 +214,7 @@ fn default_hook(info: &PanicInfo<'_>) {
 
 #[cfg(not(test))]
 #[doc(hidden)]
-#[unstable(feature = "update_panic_count", issue = "0")]
+#[unstable(feature = "update_panic_count", issue = "none")]
 pub fn update_panic_count(amt: isize) -> usize {
     use crate::cell::Cell;
     thread_local! { static PANIC_COUNT: Cell<usize> = Cell::new(0) }
@@ -307,7 +307,7 @@ pub fn panicking() -> bool {
 /// the actual formatting into this shared place.
 #[unstable(feature = "libstd_sys_internals",
            reason = "used by the panic! macro",
-           issue = "0")]
+           issue = "none")]
 #[cold]
 // If panic_immediate_abort, inline the abort call,
 // otherwise avoid inlining because of it is cold path.
@@ -383,7 +383,7 @@ pub fn begin_panic_handler(info: &PanicInfo<'_>) -> ! {
 /// arbitrary payloads, not just format strings.
 #[unstable(feature = "libstd_sys_internals",
            reason = "used by the panic! macro",
-           issue = "0")]
+           issue = "none")]
 #[cfg_attr(not(test), lang = "begin_panic")] // lang item for CTFE panic support
 // never inline unless panic_immediate_abort to avoid code
 // bloat at the call sites as much as possible

--- a/src/libstd/rt.rs
+++ b/src/libstd/rt.rs
@@ -10,7 +10,7 @@
     feature = "rt",
     reason = "this public module should not exist and is highly likely \
               to disappear",
-    issue = "0"
+    issue = "none"
 )]
 #![doc(hidden)]
 

--- a/src/libstd/sys/hermit/fast_thread_local.rs
+++ b/src/libstd/sys/hermit/fast_thread_local.rs
@@ -1,4 +1,4 @@
 #![cfg(target_thread_local)]
-#![unstable(feature = "thread_local_internals", issue = "0")]
+#![unstable(feature = "thread_local_internals", issue = "none")]
 
 pub use crate::sys_common::thread_local::register_dtor_fallback as register_dtor;

--- a/src/libstd/sys/hermit/fd.rs
+++ b/src/libstd/sys/hermit/fd.rs
@@ -1,4 +1,4 @@
-#![unstable(reason = "not public", issue = "0", feature = "fd")]
+#![unstable(reason = "not public", issue = "none", feature = "fd")]
 
 use crate::io::{self, ErrorKind, Read};
 use crate::mem;

--- a/src/libstd/sys/mod.rs
+++ b/src/libstd/sys/mod.rs
@@ -69,7 +69,7 @@ cfg_if::cfg_if! {
         // On CloudABI and wasm right now the module below doesn't compile
         // (missing things in `libc` which is empty) so just omit everything
         // with an empty module
-        #[unstable(issue = "0", feature = "std_internals")]
+        #[unstable(issue = "none", feature = "std_internals")]
         #[allow(missing_docs)]
         pub mod unix_ext {}
     } else {
@@ -92,7 +92,7 @@ cfg_if::cfg_if! {
                         all(target_vendor = "fortanix", target_env = "sgx")))] {
         // On CloudABI and wasm right now the shim below doesn't compile, so
         // just omit it
-        #[unstable(issue = "0", feature = "std_internals")]
+        #[unstable(issue = "none", feature = "std_internals")]
         #[allow(missing_docs)]
         pub mod windows_ext {}
     } else {

--- a/src/libstd/sys/unix/fast_thread_local.rs
+++ b/src/libstd/sys/unix/fast_thread_local.rs
@@ -1,5 +1,5 @@
 #![cfg(target_thread_local)]
-#![unstable(feature = "thread_local_internals", issue = "0")]
+#![unstable(feature = "thread_local_internals", issue = "none")]
 
 // Since what appears to be glibc 2.18 this symbol has been shipped which
 // GCC and clang both use to invoke destructors in thread_local globals, so

--- a/src/libstd/sys/unix/fd.rs
+++ b/src/libstd/sys/unix/fd.rs
@@ -1,4 +1,4 @@
-#![unstable(reason = "not public", issue = "0", feature = "fd")]
+#![unstable(reason = "not public", issue = "none", feature = "fd")]
 
 use crate::cmp;
 use crate::io::{self, Initializer, IoSlice, IoSliceMut, Read};

--- a/src/libstd/sys/vxworks/fast_thread_local.rs
+++ b/src/libstd/sys/vxworks/fast_thread_local.rs
@@ -1,5 +1,5 @@
 #![cfg(target_thread_local)]
-#![unstable(feature = "thread_local_internals", issue = "0")]
+#![unstable(feature = "thread_local_internals", issue = "none")]
 
 pub unsafe fn register_dtor(t: *mut u8, dtor: unsafe extern "C" fn(*mut u8)) {
     use crate::sys_common::thread_local::register_dtor_fallback;

--- a/src/libstd/sys/vxworks/fd.rs
+++ b/src/libstd/sys/vxworks/fd.rs
@@ -1,4 +1,4 @@
-#![unstable(reason = "not public", issue = "0", feature = "fd")]
+#![unstable(reason = "not public", issue = "none", feature = "fd")]
 
 use crate::cmp;
 use crate::io::{self, Initializer, IoSlice, IoSliceMut, Read};

--- a/src/libstd/sys/wasi/ext/fs.rs
+++ b/src/libstd/sys/wasi/ext/fs.rs
@@ -1,6 +1,6 @@
 //! WASI-specific extensions to primitives in the `std::fs` module.
 
-#![unstable(feature = "wasi_ext", issue = "0")]
+#![unstable(feature = "wasi_ext", issue = "none")]
 
 use crate::fs::{self, File, Metadata, OpenOptions};
 use crate::io::{self, IoSlice, IoSliceMut};

--- a/src/libstd/sys/wasi/ext/io.rs
+++ b/src/libstd/sys/wasi/ext/io.rs
@@ -1,6 +1,6 @@
 //! WASI-specific extensions to general I/O primitives
 
-#![unstable(feature = "wasi_ext", issue = "0")]
+#![unstable(feature = "wasi_ext", issue = "none")]
 
 use crate::fs;
 use crate::io;

--- a/src/libstd/sys/wasm/fast_thread_local.rs
+++ b/src/libstd/sys/wasm/fast_thread_local.rs
@@ -1,4 +1,4 @@
-#![unstable(feature = "thread_local_internals", issue = "0")]
+#![unstable(feature = "thread_local_internals", issue = "none")]
 
 pub unsafe fn register_dtor(_t: *mut u8, _dtor: unsafe extern fn(*mut u8)) {
     // FIXME: right now there is no concept of "thread exit", but this is likely

--- a/src/libstd/sys/windows/c.rs
+++ b/src/libstd/sys/windows/c.rs
@@ -2,7 +2,7 @@
 
 #![allow(nonstandard_style)]
 #![cfg_attr(test, allow(dead_code))]
-#![unstable(issue = "0", feature = "windows_c")]
+#![unstable(issue = "none", feature = "windows_c")]
 
 use crate::os::raw::{c_int, c_uint, c_ulong, c_long, c_longlong, c_ushort, c_char};
 use crate::ptr;

--- a/src/libstd/sys/windows/ext/fs.rs
+++ b/src/libstd/sys/windows/ext/fs.rs
@@ -504,17 +504,17 @@ impl MetadataExt for Metadata {
 /// On Windows, a symbolic link knows whether it is a file or directory.
 ///
 /// [`FileType`]: ../../../../std/fs/struct.FileType.html
-#[unstable(feature = "windows_file_type_ext", issue = "0")]
+#[unstable(feature = "windows_file_type_ext", issue = "none")]
 pub trait FileTypeExt {
     /// Returns `true` if this file type is a symbolic link that is also a directory.
-    #[unstable(feature = "windows_file_type_ext", issue = "0")]
+    #[unstable(feature = "windows_file_type_ext", issue = "none")]
     fn is_symlink_dir(&self) -> bool;
     /// Returns `true` if this file type is a symbolic link that is also a file.
-    #[unstable(feature = "windows_file_type_ext", issue = "0")]
+    #[unstable(feature = "windows_file_type_ext", issue = "none")]
     fn is_symlink_file(&self) -> bool;
 }
 
-#[unstable(feature = "windows_file_type_ext", issue = "0")]
+#[unstable(feature = "windows_file_type_ext", issue = "none")]
 impl FileTypeExt for fs::FileType {
     fn is_symlink_dir(&self) -> bool {
         self.as_inner().is_symlink_dir()

--- a/src/libstd/sys/windows/fast_thread_local.rs
+++ b/src/libstd/sys/windows/fast_thread_local.rs
@@ -1,4 +1,4 @@
-#![unstable(feature = "thread_local_internals", issue = "0")]
+#![unstable(feature = "thread_local_internals", issue = "none")]
 #![cfg(target_thread_local)]
 
 pub use crate::sys_common::thread_local::register_dtor_fallback as register_dtor;

--- a/src/libstd/sys/windows/handle.rs
+++ b/src/libstd/sys/windows/handle.rs
@@ -1,4 +1,4 @@
-#![unstable(issue = "0", feature = "windows_handle")]
+#![unstable(issue = "none", feature = "windows_handle")]
 
 use crate::cmp;
 use crate::io::{self, ErrorKind, IoSlice, IoSliceMut, Read};

--- a/src/libstd/sys/windows/net.rs
+++ b/src/libstd/sys/windows/net.rs
@@ -1,4 +1,4 @@
-#![unstable(issue = "0", feature = "windows_net")]
+#![unstable(issue = "none", feature = "windows_net")]
 
 use crate::cmp;
 use crate::io::{self, Read, IoSlice, IoSliceMut};
@@ -395,7 +395,7 @@ impl Socket {
     }
 }
 
-#[unstable(reason = "not public", issue = "0", feature = "fd_read")]
+#[unstable(reason = "not public", issue = "none", feature = "fd_read")]
 impl<'a> Read for &'a Socket {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         (**self).read(buf)

--- a/src/libstd/sys/windows/process.rs
+++ b/src/libstd/sys/windows/process.rs
@@ -1,4 +1,4 @@
-#![unstable(feature = "process_internals", issue = "0")]
+#![unstable(feature = "process_internals", issue = "none")]
 
 use crate::collections::BTreeMap;
 use crate::env::split_paths;

--- a/src/libstd/sys/windows/stdio.rs
+++ b/src/libstd/sys/windows/stdio.rs
@@ -1,4 +1,4 @@
-#![unstable(issue = "0", feature = "windows_stdio")]
+#![unstable(issue = "none", feature = "windows_stdio")]
 
 use crate::char::decode_utf16;
 use crate::cmp;

--- a/src/libstd/sys/windows/stdio_uwp.rs
+++ b/src/libstd/sys/windows/stdio_uwp.rs
@@ -1,4 +1,4 @@
-#![unstable(issue = "0", feature = "windows_stdio")]
+#![unstable(issue = "none", feature = "windows_stdio")]
 
 use crate::io;
 use crate::mem::ManuallyDrop;

--- a/src/libstd/sys_common/process.rs
+++ b/src/libstd/sys_common/process.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-#![unstable(feature = "process_internals", issue = "0")]
+#![unstable(feature = "process_internals", issue = "none")]
 
 use crate::collections::BTreeMap;
 use crate::env;

--- a/src/libstd/sys_common/thread_local.rs
+++ b/src/libstd/sys_common/thread_local.rs
@@ -45,7 +45,7 @@
 //! ```
 
 #![allow(non_camel_case_types)]
-#![unstable(feature = "thread_local_internals", issue = "0")]
+#![unstable(feature = "thread_local_internals", issue = "none")]
 #![allow(dead_code)] // sys isn't exported yet
 
 use crate::ptr;

--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -1,6 +1,6 @@
 //! Thread local storage
 
-#![unstable(feature = "thread_local_internals", issue = "0")]
+#![unstable(feature = "thread_local_internals", issue = "none")]
 
 use crate::error::Error;
 use crate::fmt;
@@ -142,7 +142,7 @@ macro_rules! thread_local {
 }
 
 #[doc(hidden)]
-#[unstable(feature = "thread_local_internals", reason = "should not be necessary", issue = "0")]
+#[unstable(feature = "thread_local_internals", reason = "should not be necessary", issue = "none")]
 #[macro_export]
 #[allow_internal_unstable(thread_local_internals, cfg_target_thread_local, thread_local)]
 #[allow_internal_unsafe]
@@ -215,7 +215,7 @@ impl<T: 'static> LocalKey<T> {
     #[unstable(
         feature = "thread_local_internals",
         reason = "recently added to create a key",
-        issue = "0"
+        issue = "none"
     )]
     pub const unsafe fn new(inner: unsafe fn() -> Option<&'static T>) -> LocalKey<T> {
         LocalKey { inner }

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -194,13 +194,13 @@ pub use self::local::{LocalKey, AccessError};
 // where fast TLS was not available; end-user code is compiled with fast TLS
 // where available, but both are needed.
 
-#[unstable(feature = "libstd_thread_internals", issue = "0")]
+#[unstable(feature = "libstd_thread_internals", issue = "none")]
 #[cfg(all(target_arch = "wasm32", not(target_feature = "atomics")))]
 #[doc(hidden)] pub use self::local::statik::Key as __StaticLocalKeyInner;
-#[unstable(feature = "libstd_thread_internals", issue = "0")]
+#[unstable(feature = "libstd_thread_internals", issue = "none")]
 #[cfg(target_thread_local)]
 #[doc(hidden)] pub use self::local::fast::Key as __FastLocalKeyInner;
-#[unstable(feature = "libstd_thread_internals", issue = "0")]
+#[unstable(feature = "libstd_thread_internals", issue = "none")]
 #[doc(hidden)] pub use self::local::os::Key as __OsLocalKeyInner;
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/libsyntax/attr/builtin.rs
+++ b/src/libsyntax/attr/builtin.rs
@@ -376,11 +376,11 @@ fn find_stability_generic<'a, I>(sess: &ParseSess,
                     match (feature, reason, issue) {
                         (Some(feature), reason, Some(issue)) => {
                             let issue = match &*issue.as_str() {
-                                // FIXME(rossmacarthur): remove "0" because "none" should be used
-                                // See #41260
-                                "none" | "0" => None,
+                                "none" => None,
                                 issue => {
                                     if let Ok(num) = issue.parse() {
+                                        // FIXME(rossmacarthur): disallow 0
+                                        // Disallowing this requires updates to some submodules
                                         NonZeroU32::new(num)
                                     } else {
                                         span_err!(

--- a/src/test/run-make-fulldeps/allow-warnings-cmdline-stability/bar.rs
+++ b/src/test/run-make-fulldeps/allow-warnings-cmdline-stability/bar.rs
@@ -1,5 +1,5 @@
 #![crate_type = "lib"]
 #![feature(staged_api)]
-#![unstable(feature = "unstable_test_feature", issue = "0")]
+#![unstable(feature = "unstable_test_feature", issue = "none")]
 
 pub fn baz() {}

--- a/src/test/rustdoc/const-display.rs
+++ b/src/test/rustdoc/const-display.rs
@@ -2,18 +2,18 @@
 
 #![unstable(feature = "humans",
             reason = "who ever let humans program computers, we're apparently really bad at it",
-            issue = "0")]
+            issue = "none")]
 
 #![feature(foo, foo2)]
 #![feature(staged_api)]
 
 // @has 'foo/fn.foo.html' '//pre' 'pub unsafe fn foo() -> u32'
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature="foo", issue = "0")]
+#[rustc_const_unstable(feature="foo", issue = "none")]
 pub const unsafe fn foo() -> u32 { 42 }
 
 // @has 'foo/fn.foo2.html' '//pre' 'pub fn foo2() -> u32'
-#[unstable(feature = "humans", issue="0")]
+#[unstable(feature = "humans", issue = "none")]
 pub const fn foo2() -> u32 { 42 }
 
 // @has 'foo/fn.bar2.html' '//pre' 'pub const fn bar2() -> u32'
@@ -22,7 +22,7 @@ pub const fn foo2() -> u32 { 42 }
 pub const fn bar2() -> u32 { 42 }
 
 // @has 'foo/fn.foo2_gated.html' '//pre' 'pub unsafe fn foo2_gated() -> u32'
-#[unstable(feature = "foo2", issue="0")]
+#[unstable(feature = "foo2", issue = "none")]
 pub const unsafe fn foo2_gated() -> u32 { 42 }
 
 // @has 'foo/fn.bar2_gated.html' '//pre' 'pub const unsafe fn bar2_gated() -> u32'

--- a/src/test/rustdoc/inline_cross/auxiliary/macros.rs
+++ b/src/test/rustdoc/inline_cross/auxiliary/macros.rs
@@ -3,7 +3,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 /// docs for my_macro
-#[unstable(feature = "macro_test", issue = "0")]
+#[unstable(feature = "macro_test", issue = "none")]
 #[rustc_deprecated(since = "1.2.3", reason = "text")]
 #[macro_export]
 macro_rules! my_macro {

--- a/src/test/rustdoc/stability.rs
+++ b/src/test/rustdoc/stability.rs
@@ -1,6 +1,6 @@
 #![feature(staged_api)]
 
-#![unstable(feature = "test", issue = "0")]
+#![unstable(feature = "test", issue = "none")]
 
 pub struct Unstable {
     // @has stability/struct.Unstable.html \

--- a/src/test/ui/auxiliary/stability-cfg2.rs
+++ b/src/test/ui/auxiliary/stability-cfg2.rs
@@ -1,5 +1,5 @@
 // compile-flags:--cfg foo
 
-#![cfg_attr(foo, unstable(feature = "unstable_test_feature", issue = "0"))]
+#![cfg_attr(foo, unstable(feature = "unstable_test_feature", issue = "none"))]
 #![cfg_attr(not(foo), stable(feature = "test_feature", since = "1.0.0"))]
 #![feature(staged_api)]

--- a/src/test/ui/consts/const-eval/auxiliary/stability.rs
+++ b/src/test/ui/consts/const-eval/auxiliary/stability.rs
@@ -7,5 +7,5 @@
 #![feature(staged_api)]
 
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature="foo", issue = "0")]
+#[rustc_const_unstable(feature="foo", issue = "none")]
 pub const fn foo() -> u32 { 42 }

--- a/src/test/ui/consts/const-eval/dont_promote_unstable_const_fn.rs
+++ b/src/test/ui/consts/const-eval/dont_promote_unstable_const_fn.rs
@@ -1,13 +1,13 @@
 #![unstable(feature = "humans",
             reason = "who ever let humans program computers,
             we're apparently really bad at it",
-            issue = "0")]
+            issue = "none")]
 
 #![feature(const_fn)]
 #![feature(staged_api)]
 
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature="foo", issue = "0")]
+#[rustc_const_unstable(feature="foo", issue = "none")]
 const fn foo() -> u32 { 42 }
 
 fn meh() -> u32 { 42 }

--- a/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.rs
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.rs
@@ -1,13 +1,13 @@
 #![unstable(feature = "humans",
             reason = "who ever let humans program computers,
             we're apparently really bad at it",
-            issue = "0")]
+            issue = "none")]
 
 #![feature(const_fn, foo, foo2)]
 #![feature(staged_api)]
 
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature="foo", issue = "0")]
+#[rustc_const_unstable(feature="foo", issue = "none")]
 const fn foo() -> u32 { 42 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -15,7 +15,7 @@ const fn foo() -> u32 { 42 }
 // can't call non-min_const_fn
 const fn bar() -> u32 { foo() } //~ ERROR can only call other `const fn`
 
-#[unstable(feature = "rust1", issue="0")]
+#[unstable(feature = "rust1", issue = "none")]
 const fn foo2() -> u32 { 42 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -29,7 +29,7 @@ const fn bar2() -> u32 { foo2() } //~ ERROR can only call other `const fn`
 const fn bar3() -> u32 { (5f32 + 6f32) as u32 } //~ ERROR only int, `bool` and `char` operations
 
 // check whether this function cannot be called even with the feature gate active
-#[unstable(feature = "foo2", issue="0")]
+#[unstable(feature = "foo2", issue = "none")]
 const fn foo2_gated() -> u32 { 42 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.rs
+++ b/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.rs
@@ -1,13 +1,13 @@
 #![unstable(feature = "humans",
             reason = "who ever let humans program computers,
             we're apparently really bad at it",
-            issue = "0")]
+            issue = "none")]
 
 #![feature(const_fn, foo, foo2)]
 #![feature(staged_api)]
 
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature="foo", issue = "0")]
+#[rustc_const_unstable(feature="foo", issue = "none")]
 const unsafe fn foo() -> u32 { 42 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -15,7 +15,7 @@ const unsafe fn foo() -> u32 { 42 }
 // can't call non-min_const_fn
 const unsafe fn bar() -> u32 { unsafe { foo() } } //~ ERROR can only call other `const fn`
 
-#[unstable(feature = "rust1", issue="0")]
+#[unstable(feature = "rust1", issue = "none")]
 const unsafe fn foo2() -> u32 { 42 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -29,7 +29,7 @@ const unsafe fn bar2() -> u32 { unsafe { foo2() } } //~ ERROR can only call othe
 const unsafe fn bar3() -> u32 { (5f32 + 6f32) as u32 } //~ ERROR only int, `bool` and `char` op
 
 // check whether this function cannot be called even with the feature gate active
-#[unstable(feature = "foo2", issue="0")]
+#[unstable(feature = "foo2", issue = "none")]
 const unsafe fn foo2_gated() -> u32 { 42 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability2.rs
+++ b/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability2.rs
@@ -1,13 +1,13 @@
 #![unstable(feature = "humans",
             reason = "who ever let humans program computers,
             we're apparently really bad at it",
-            issue = "0")]
+            issue = "none")]
 
 #![feature(const_fn, foo, foo2)]
 #![feature(staged_api)]
 
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature="foo", issue = "0")]
+#[rustc_const_unstable(feature="foo", issue = "none")]
 const fn foo() -> u32 { 42 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -15,7 +15,7 @@ const fn foo() -> u32 { 42 }
 // can't call non-min_const_fn
 const unsafe fn bar() -> u32 { foo() } //~ ERROR can only call other `const fn`
 
-#[unstable(feature = "rust1", issue="0")]
+#[unstable(feature = "rust1", issue = "none")]
 const fn foo2() -> u32 { 42 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -24,7 +24,7 @@ const fn foo2() -> u32 { 42 }
 const unsafe fn bar2() -> u32 { foo2() } //~ ERROR can only call other `const fn`
 
 // check whether this function cannot be called even with the feature gate active
-#[unstable(feature = "foo2", issue="0")]
+#[unstable(feature = "foo2", issue = "none")]
 const fn foo2_gated() -> u32 { 42 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/test/ui/consts/unstable-const-fn-in-libcore.rs
+++ b/src/test/ui/consts/unstable-const-fn-in-libcore.rs
@@ -14,7 +14,7 @@ enum Opt<T> {
 }
 
 impl<T> Opt<T> {
-    #[rustc_const_unstable(feature = "foo", issue = "0")]
+    #[rustc_const_unstable(feature = "foo", issue = "none")]
     #[stable(feature = "rust1", since = "1.0.0")]
     const fn unwrap_or_else<F: FnOnce() -> T>(self, f: F) -> T {
     //~^ ERROR destructors cannot be evaluated at compile-time

--- a/src/test/ui/feature-gate/stability-attribute-consistency.rs
+++ b/src/test/ui/feature-gate/stability-attribute-consistency.rs
@@ -9,7 +9,7 @@ fn foo_stable_1_0_0() {}
 //~^ ERROR feature `foo` is declared stable since 1.29.0
 fn foo_stable_1_29_0() {}
 
-#[unstable(feature = "foo", issue = "0")]
+#[unstable(feature = "foo", issue = "none")]
 //~^ ERROR feature `foo` is declared unstable
 fn foo_unstable() {}
 

--- a/src/test/ui/feature-gate/stability-attribute-consistency.stderr
+++ b/src/test/ui/feature-gate/stability-attribute-consistency.stderr
@@ -7,8 +7,8 @@ LL | #[stable(feature = "foo", since = "1.29.0")]
 error[E0711]: feature `foo` is declared unstable, but was previously declared stable
   --> $DIR/stability-attribute-consistency.rs:12:1
    |
-LL | #[unstable(feature = "foo", issue = "0")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[unstable(feature = "foo", issue = "none")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/feature-gate/unstable-attribute-allow-issue-0.rs
+++ b/src/test/ui/feature-gate/unstable-attribute-allow-issue-0.rs
@@ -1,4 +1,4 @@
-// Check that an issue value can be explicitly set to "none" instead of "0"
+// Check that an issue value can be explicitly set to "0" instead of "none"
 #![crate_type = "lib"]
 #![feature(staged_api)]
 #![stable(feature = "stable_test_feature", since = "1.0.0")]

--- a/src/test/ui/feature-gate/unstable-attribute-allow-issue-0.stderr
+++ b/src/test/ui/feature-gate/unstable-attribute-allow-issue-0.stderr
@@ -1,5 +1,5 @@
 error[E0545]: incorrect 'issue'
-  --> $DIR/unstable-attribute-allow-issue-none.rs:12:1
+  --> $DIR/unstable-attribute-allow-issue-0.rs:12:1
    |
 LL | #[unstable(feature = "unstable_test_feature", issue = "something")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/internal/auxiliary/internal_unstable.rs
+++ b/src/test/ui/internal/auxiliary/internal_unstable.rs
@@ -1,24 +1,24 @@
 #![feature(staged_api, allow_internal_unstable)]
 #![stable(feature = "stable", since = "1.0.0")]
 
-#[unstable(feature = "function", issue = "0")]
+#[unstable(feature = "function", issue = "none")]
 pub fn unstable() {}
 
 
 #[stable(feature = "stable", since = "1.0.0")]
 pub struct Foo {
-    #[unstable(feature = "struct_field", issue = "0")]
+    #[unstable(feature = "struct_field", issue = "none")]
     pub x: u8
 }
 
 impl Foo {
-    #[unstable(feature = "method", issue = "0")]
+    #[unstable(feature = "method", issue = "none")]
     pub fn method(&self) {}
 }
 
 #[stable(feature = "stable", since = "1.0.0")]
 pub struct Bar {
-    #[unstable(feature = "struct2_field", issue = "0")]
+    #[unstable(feature = "struct2_field", issue = "none")]
     pub x: u8
 }
 

--- a/src/test/ui/issues/auxiliary/issue-52489.rs
+++ b/src/test/ui/issues/auxiliary/issue-52489.rs
@@ -1,3 +1,3 @@
 #![crate_type = "lib"]
-#![unstable(feature = "issue_52489_unstable", issue = "0")]
+#![unstable(feature = "issue_52489_unstable", issue = "none")]
 #![feature(staged_api)]

--- a/src/test/ui/issues/auxiliary/lint-stability.rs
+++ b/src/test/ui/issues/auxiliary/lint-stability.rs
@@ -15,16 +15,16 @@ pub fn deprecated_text() {}
 #[rustc_deprecated(since = "99.99.99", reason = "text")]
 pub fn deprecated_future() {}
 
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 #[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub fn deprecated_unstable() {}
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 #[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub fn deprecated_unstable_text() {}
 
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 pub fn unstable() {}
-#[unstable(feature = "unstable_test_feature", reason = "text", issue = "0")]
+#[unstable(feature = "unstable_test_feature", reason = "text", issue = "none")]
 pub fn unstable_text() {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -43,16 +43,16 @@ impl MethodTester {
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub fn method_deprecated_text(&self) {}
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub fn method_deprecated_unstable(&self) {}
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub fn method_deprecated_unstable_text(&self) {}
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     pub fn method_unstable(&self) {}
-    #[unstable(feature = "unstable_test_feature", reason = "text", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", reason = "text", issue = "none")]
     pub fn method_unstable_text(&self) {}
 
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -70,16 +70,16 @@ pub trait Trait {
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     fn trait_deprecated_text(&self) {}
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     fn trait_deprecated_unstable(&self) {}
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     fn trait_deprecated_unstable_text(&self) {}
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     fn trait_unstable(&self) {}
-    #[unstable(feature = "unstable_test_feature", reason = "text", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", reason = "text", issue = "none")]
     fn trait_unstable_text(&self) {}
 
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -90,7 +90,7 @@ pub trait Trait {
 
 #[stable(feature = "stable_test_feature", since = "1.0.0")]
 pub trait TraitWithAssociatedTypes {
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     type TypeUnstable = u8;
     #[stable(feature = "stable_test_feature", since = "1.0.0")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
@@ -100,7 +100,7 @@ pub trait TraitWithAssociatedTypes {
 #[stable(feature = "stable_test_feature", since = "1.0.0")]
 impl Trait for MethodTester {}
 
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 pub trait UnstableTrait { fn dummy(&self) { } }
 
 #[stable(feature = "stable_test_feature", since = "1.0.0")]
@@ -114,12 +114,12 @@ pub trait DeprecatedTrait {
 pub struct DeprecatedStruct {
     #[stable(feature = "stable_test_feature", since = "1.0.0")] pub i: isize
 }
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 #[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub struct DeprecatedUnstableStruct {
     #[stable(feature = "stable_test_feature", since = "1.0.0")] pub i: isize
 }
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 pub struct UnstableStruct {
     #[stable(feature = "stable_test_feature", since = "1.0.0")] pub i: isize
 }
@@ -127,7 +127,7 @@ pub struct UnstableStruct {
 pub struct StableStruct {
     #[stable(feature = "stable_test_feature", since = "1.0.0")] pub i: isize
 }
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 pub enum UnstableEnum {}
 #[stable(feature = "rust1", since = "1.0.0")]
 pub enum StableEnum {}
@@ -135,10 +135,10 @@ pub enum StableEnum {}
 #[stable(feature = "stable_test_feature", since = "1.0.0")]
 #[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub struct DeprecatedUnitStruct;
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 #[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub struct DeprecatedUnstableUnitStruct;
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 pub struct UnstableUnitStruct;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct StableUnitStruct;
@@ -148,10 +148,10 @@ pub enum Enum {
     #[stable(feature = "stable_test_feature", since = "1.0.0")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     DeprecatedVariant,
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     DeprecatedUnstableVariant,
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     UnstableVariant,
 
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -161,10 +161,10 @@ pub enum Enum {
 #[stable(feature = "stable_test_feature", since = "1.0.0")]
 #[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub struct DeprecatedTupleStruct(#[stable(feature = "rust1", since = "1.0.0")] pub isize);
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 #[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub struct DeprecatedUnstableTupleStruct(#[stable(feature = "rust1", since = "1.0.0")] pub isize);
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 pub struct UnstableTupleStruct(#[stable(feature = "rust1", since = "1.0.0")] pub isize);
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct StableTupleStruct(#[stable(feature = "rust1", since = "1.0.0")] pub isize);

--- a/src/test/ui/issues/issue-17337.rs
+++ b/src/test/ui/issues/issue-17337.rs
@@ -1,12 +1,12 @@
 #![feature(staged_api)]
 #![deny(deprecated)]
 
-#![unstable(feature = "unstable_test_feature", issue = "0")]
+#![unstable(feature = "unstable_test_feature", issue = "none")]
 
 struct Foo;
 
 impl Foo {
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     fn foo(self) {}
 }

--- a/src/test/ui/lint/auxiliary/inherited_stability.rs
+++ b/src/test/ui/lint/auxiliary/inherited_stability.rs
@@ -1,6 +1,6 @@
 #![crate_name="inherited_stability"]
 #![crate_type = "lib"]
-#![unstable(feature = "unstable_test_feature", issue = "0")]
+#![unstable(feature = "unstable_test_feature", issue = "none")]
 #![feature(staged_api)]
 
 pub fn unstable() {}
@@ -10,14 +10,14 @@ pub fn stable() {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod stable_mod {
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     pub fn unstable() {}
 
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn stable() {}
 }
 
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 pub mod unstable_mod {
     #[stable(feature = "stable_test_feature", since = "1.0.0")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
@@ -28,7 +28,7 @@ pub mod unstable_mod {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Stable {
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     fn unstable(&self);
 
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/test/ui/lint/auxiliary/lint_output_format.rs
+++ b/src/test/ui/lint/auxiliary/lint_output_format.rs
@@ -1,7 +1,7 @@
 #![crate_name="lint_output_format"]
 #![crate_type = "lib"]
 #![feature(staged_api)]
-#![unstable(feature = "unstable_test_feature", issue = "0")]
+#![unstable(feature = "unstable_test_feature", issue = "none")]
 
 #[stable(feature = "stable_test_feature", since = "1.0.0")]
 #[rustc_deprecated(since = "1.0.0", reason = "text")]
@@ -9,12 +9,12 @@ pub fn foo() -> usize {
     20
 }
 
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 pub fn bar() -> usize {
     40
 }
 
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 pub fn baz() -> usize {
     30
 }

--- a/src/test/ui/lint/auxiliary/lint_stability.rs
+++ b/src/test/ui/lint/auxiliary/lint_stability.rs
@@ -15,16 +15,16 @@ pub fn deprecated_text() {}
 #[rustc_deprecated(since = "99.99.99", reason = "text")]
 pub fn deprecated_future() {}
 
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 #[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub fn deprecated_unstable() {}
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 #[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub fn deprecated_unstable_text() {}
 
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 pub fn unstable() {}
-#[unstable(feature = "unstable_test_feature", reason = "text", issue = "0")]
+#[unstable(feature = "unstable_test_feature", reason = "text", issue = "none")]
 pub fn unstable_text() {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -43,16 +43,16 @@ impl MethodTester {
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub fn method_deprecated_text(&self) {}
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub fn method_deprecated_unstable(&self) {}
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub fn method_deprecated_unstable_text(&self) {}
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     pub fn method_unstable(&self) {}
-    #[unstable(feature = "unstable_test_feature", reason = "text", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", reason = "text", issue = "none")]
     pub fn method_unstable_text(&self) {}
 
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -70,16 +70,16 @@ pub trait Trait {
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     fn trait_deprecated_text(&self) {}
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     fn trait_deprecated_unstable(&self) {}
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     fn trait_deprecated_unstable_text(&self) {}
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     fn trait_unstable(&self) {}
-    #[unstable(feature = "unstable_test_feature", reason = "text", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", reason = "text", issue = "none")]
     fn trait_unstable_text(&self) {}
 
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -90,7 +90,7 @@ pub trait Trait {
 
 #[stable(feature = "stable_test_feature", since = "1.0.0")]
 pub trait TraitWithAssociatedTypes {
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     type TypeUnstable = u8;
     #[stable(feature = "stable_test_feature", since = "1.0.0")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
@@ -100,7 +100,7 @@ pub trait TraitWithAssociatedTypes {
 #[stable(feature = "stable_test_feature", since = "1.0.0")]
 impl Trait for MethodTester {}
 
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 pub trait UnstableTrait { fn dummy(&self) { } }
 
 #[stable(feature = "stable_test_feature", since = "1.0.0")]
@@ -114,12 +114,12 @@ pub trait DeprecatedTrait {
 pub struct DeprecatedStruct {
     #[stable(feature = "stable_test_feature", since = "1.0.0")] pub i: isize
 }
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 #[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub struct DeprecatedUnstableStruct {
     #[stable(feature = "stable_test_feature", since = "1.0.0")] pub i: isize
 }
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 pub struct UnstableStruct {
     #[stable(feature = "stable_test_feature", since = "1.0.0")] pub i: isize
 }
@@ -127,7 +127,7 @@ pub struct UnstableStruct {
 pub struct StableStruct {
     #[stable(feature = "stable_test_feature", since = "1.0.0")] pub i: isize
 }
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 pub enum UnstableEnum {}
 #[stable(feature = "rust1", since = "1.0.0")]
 pub enum StableEnum {}
@@ -135,10 +135,10 @@ pub enum StableEnum {}
 #[stable(feature = "stable_test_feature", since = "1.0.0")]
 #[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub struct DeprecatedUnitStruct;
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 #[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub struct DeprecatedUnstableUnitStruct;
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 pub struct UnstableUnitStruct;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct StableUnitStruct;
@@ -148,10 +148,10 @@ pub enum Enum {
     #[stable(feature = "stable_test_feature", since = "1.0.0")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     DeprecatedVariant,
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     DeprecatedUnstableVariant,
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     UnstableVariant,
 
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -161,10 +161,10 @@ pub enum Enum {
 #[stable(feature = "stable_test_feature", since = "1.0.0")]
 #[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub struct DeprecatedTupleStruct(#[stable(feature = "rust1", since = "1.0.0")] pub isize);
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 #[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub struct DeprecatedUnstableTupleStruct(#[stable(feature = "rust1", since = "1.0.0")] pub isize);
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 pub struct UnstableTupleStruct(#[stable(feature = "rust1", since = "1.0.0")] pub isize);
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct StableTupleStruct(#[stable(feature = "rust1", since = "1.0.0")] pub isize);

--- a/src/test/ui/lint/auxiliary/lint_stability_fields.rs
+++ b/src/test/ui/lint/auxiliary/lint_stability_fields.rs
@@ -5,47 +5,47 @@
 pub struct Stable {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub inherit: u8, // it's a lie (stable doesn't inherit)
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     pub override1: u8,
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     pub override2: u8,
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Stable2(#[stable(feature = "rust1", since = "1.0.0")] pub u8,
-                   #[unstable(feature = "unstable_test_feature", issue = "0")] pub u8,
-                   #[unstable(feature = "unstable_test_feature", issue = "0")]
+                   #[unstable(feature = "unstable_test_feature", issue = "none")] pub u8,
+                   #[unstable(feature = "unstable_test_feature", issue = "none")]
                    #[rustc_deprecated(since = "1.0.0", reason = "text")] pub u8);
 
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 pub struct Unstable {
     pub inherit: u8,
     #[stable(feature = "rust1", since = "1.0.0")]
     pub override1: u8,
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     pub override2: u8,
 }
 
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 pub struct Unstable2(pub u8,
                      #[stable(feature = "rust1", since = "1.0.0")] pub u8,
-                     #[unstable(feature = "unstable_test_feature", issue = "0")]
+                     #[unstable(feature = "unstable_test_feature", issue = "none")]
                      #[rustc_deprecated(since = "1.0.0", reason = "text")] pub u8);
 
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 #[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub struct Deprecated {
     pub inherit: u8,
     #[stable(feature = "rust1", since = "1.0.0")]
     pub override1: u8,
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     pub override2: u8,
 }
 
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 #[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub struct Deprecated2(pub u8,
                        #[stable(feature = "rust1", since = "1.0.0")] pub u8,
-                       #[unstable(feature = "unstable_test_feature", issue = "0")] pub u8);
+                       #[unstable(feature = "unstable_test_feature", issue = "none")] pub u8);

--- a/src/test/ui/lint/auxiliary/stability-cfg2.rs
+++ b/src/test/ui/lint/auxiliary/stability-cfg2.rs
@@ -1,5 +1,5 @@
 // compile-flags:--cfg foo
 
-#![cfg_attr(foo, unstable(feature = "unstable_test_feature", issue = "0"))]
+#![cfg_attr(foo, unstable(feature = "unstable_test_feature", issue = "none"))]
 #![cfg_attr(not(foo), stable(feature = "test_feature", since = "1.0.0"))]
 #![feature(staged_api)]

--- a/src/test/ui/lint/auxiliary/stability_cfg2.rs
+++ b/src/test/ui/lint/auxiliary/stability_cfg2.rs
@@ -1,5 +1,5 @@
 // compile-flags:--cfg foo
 
-#![cfg_attr(foo, unstable(feature = "unstable_test_feature", issue = "0"))]
+#![cfg_attr(foo, unstable(feature = "unstable_test_feature", issue = "none"))]
 #![cfg_attr(not(foo), stable(feature = "test_feature", since = "1.0.0"))]
 #![feature(staged_api)]

--- a/src/test/ui/lint/lint-stability-2.rs
+++ b/src/test/ui/lint/lint-stability-2.rs
@@ -168,16 +168,16 @@ mod cross_crate {
 }
 
 mod this_crate {
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub fn deprecated() {}
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub fn deprecated_text() {}
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     pub fn unstable() {}
-    #[unstable(feature = "unstable_test_feature", reason = "text", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", reason = "text", issue = "none")]
     pub fn unstable_text() {}
 
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -189,16 +189,16 @@ mod this_crate {
     pub struct MethodTester;
 
     impl MethodTester {
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
         pub fn method_deprecated(&self) {}
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
         pub fn method_deprecated_text(&self) {}
 
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         pub fn method_unstable(&self) {}
-        #[unstable(feature = "unstable_test_feature", reason = "text", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", reason = "text", issue = "none")]
         pub fn method_unstable_text(&self) {}
 
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -208,16 +208,16 @@ mod this_crate {
     }
 
     pub trait Trait {
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
         fn trait_deprecated(&self) {}
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
         fn trait_deprecated_text(&self) {}
 
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         fn trait_unstable(&self) {}
-        #[unstable(feature = "unstable_test_feature", reason = "text", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", reason = "text", issue = "none")]
         fn trait_unstable_text(&self) {}
 
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -228,12 +228,12 @@ mod this_crate {
 
     impl Trait for MethodTester {}
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub struct DeprecatedStruct {
         #[stable(feature = "stable_test_feature", since = "1.0.0")] i: isize
     }
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     pub struct UnstableStruct {
         #[stable(feature = "stable_test_feature", since = "1.0.0")] i: isize
     }
@@ -242,29 +242,29 @@ mod this_crate {
         #[stable(feature = "stable_test_feature", since = "1.0.0")] i: isize
     }
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub struct DeprecatedUnitStruct;
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     pub struct UnstableUnitStruct;
     #[stable(feature = "rust1", since = "1.0.0")]
     pub struct StableUnitStruct;
 
     pub enum Enum {
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
         DeprecatedVariant,
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         UnstableVariant,
 
         #[stable(feature = "rust1", since = "1.0.0")]
         StableVariant,
     }
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub struct DeprecatedTupleStruct(isize);
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     pub struct UnstableTupleStruct(isize);
     #[stable(feature = "rust1", since = "1.0.0")]
     pub struct StableTupleStruct(isize);
@@ -381,7 +381,7 @@ mod this_crate {
         foo.trait_stable();
     }
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     fn test_fn_body() {
         fn fn_in_body() {}
@@ -389,7 +389,7 @@ mod this_crate {
     }
 
     impl MethodTester {
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
         fn test_method_body(&self) {
             fn fn_in_body() {}
@@ -397,7 +397,7 @@ mod this_crate {
         }
     }
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub trait DeprecatedTrait {
         fn dummy(&self) { }

--- a/src/test/ui/lint/lint-stability-deprecated.rs
+++ b/src/test/ui/lint/lint-stability-deprecated.rs
@@ -216,16 +216,16 @@ mod inheritance {
 }
 
 mod this_crate {
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub fn deprecated() {}
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub fn deprecated_text() {}
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     pub fn unstable() {}
-    #[unstable(feature = "unstable_test_feature", reason = "text", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", reason = "text", issue = "none")]
     pub fn unstable_text() {}
 
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -237,16 +237,16 @@ mod this_crate {
     pub struct MethodTester;
 
     impl MethodTester {
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
         pub fn method_deprecated(&self) {}
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
         pub fn method_deprecated_text(&self) {}
 
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         pub fn method_unstable(&self) {}
-        #[unstable(feature = "unstable_test_feature", reason = "text", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", reason = "text", issue = "none")]
         pub fn method_unstable_text(&self) {}
 
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -256,16 +256,16 @@ mod this_crate {
     }
 
     pub trait Trait {
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
         fn trait_deprecated(&self) {}
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
         fn trait_deprecated_text(&self) {}
 
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         fn trait_unstable(&self) {}
-        #[unstable(feature = "unstable_test_feature", reason = "text", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", reason = "text", issue = "none")]
         fn trait_unstable_text(&self) {}
 
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -276,12 +276,12 @@ mod this_crate {
 
     impl Trait for MethodTester {}
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub struct DeprecatedStruct {
         #[stable(feature = "stable_test_feature", since = "1.0.0")] i: isize
     }
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     pub struct UnstableStruct {
         #[stable(feature = "stable_test_feature", since = "1.0.0")] i: isize
     }
@@ -290,29 +290,29 @@ mod this_crate {
         #[stable(feature = "stable_test_feature", since = "1.0.0")] i: isize
     }
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub struct DeprecatedUnitStruct;
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     pub struct UnstableUnitStruct;
     #[stable(feature = "rust1", since = "1.0.0")]
     pub struct StableUnitStruct;
 
     pub enum Enum {
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
         DeprecatedVariant,
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         UnstableVariant,
 
         #[stable(feature = "rust1", since = "1.0.0")]
         StableVariant,
     }
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub struct DeprecatedTupleStruct(isize);
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     pub struct UnstableTupleStruct(isize);
     #[stable(feature = "rust1", since = "1.0.0")]
     pub struct StableTupleStruct(isize);
@@ -430,7 +430,7 @@ mod this_crate {
         foo.trait_stable();
     }
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     fn test_fn_body() {
         fn fn_in_body() {}
@@ -438,7 +438,7 @@ mod this_crate {
     }
 
     impl MethodTester {
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
         fn test_method_body(&self) {
             fn fn_in_body() {}
@@ -446,7 +446,7 @@ mod this_crate {
         }
     }
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub trait DeprecatedTrait {
         fn dummy(&self) { }

--- a/src/test/ui/lint/lint-stability-fields-deprecated.rs
+++ b/src/test/ui/lint/lint-stability-fields-deprecated.rs
@@ -153,50 +153,50 @@ mod this_crate {
     #[stable(feature = "rust1", since = "1.0.0")]
     struct Stable {
         inherit: u8,
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         override1: u8,
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         override2: u8,
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
     struct Stable2(u8,
                    #[stable(feature = "rust1", since = "1.0.0")] u8,
-                   #[unstable(feature = "unstable_test_feature", issue = "0")]
+                   #[unstable(feature = "unstable_test_feature", issue = "none")]
                    #[rustc_deprecated(since = "1.0.0", reason = "text")] u8);
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     struct Unstable {
         inherit: u8,
         #[stable(feature = "rust1", since = "1.0.0")]
         override1: u8,
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         override2: u8,
     }
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     struct Unstable2(u8,
                      #[stable(feature = "rust1", since = "1.0.0")] u8,
-                     #[unstable(feature = "unstable_test_feature", issue = "0")]
+                     #[unstable(feature = "unstable_test_feature", issue = "none")]
                      #[rustc_deprecated(since = "1.0.0", reason = "text")] u8);
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     struct Deprecated {
         inherit: u8,
         #[stable(feature = "rust1", since = "1.0.0")]
         override1: u8,
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         override2: u8,
     }
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     struct Deprecated2(u8,
                        #[stable(feature = "rust1", since = "1.0.0")] u8,
-                       #[unstable(feature = "unstable_test_feature", issue = "0")] u8);
+                       #[unstable(feature = "unstable_test_feature", issue = "none")] u8);
 
     pub fn foo() {
         let x = Stable {

--- a/src/test/ui/lint/lint-stability-fields.rs
+++ b/src/test/ui/lint/lint-stability-fields.rs
@@ -128,50 +128,50 @@ mod this_crate {
     #[stable(feature = "rust1", since = "1.0.0")]
     struct Stable {
         inherit: u8,
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         override1: u8,
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         override2: u8,
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
     struct Stable2(u8,
                    #[stable(feature = "rust1", since = "1.0.0")] u8,
-                   #[unstable(feature = "unstable_test_feature", issue = "0")]
+                   #[unstable(feature = "unstable_test_feature", issue = "none")]
                    #[rustc_deprecated(since = "1.0.0", reason = "text")] u8);
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     struct Unstable {
         inherit: u8,
         #[stable(feature = "rust1", since = "1.0.0")]
         override1: u8,
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         override2: u8,
     }
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     struct Unstable2(u8,
                      #[stable(feature = "rust1", since = "1.0.0")] u8,
-                     #[unstable(feature = "unstable_test_feature", issue = "0")]
+                     #[unstable(feature = "unstable_test_feature", issue = "none")]
                      #[rustc_deprecated(since = "1.0.0", reason = "text")] u8);
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     struct Deprecated {
         inherit: u8,
         #[stable(feature = "rust1", since = "1.0.0")]
         override1: u8,
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         override2: u8,
     }
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     struct Deprecated2(u8,
                        #[stable(feature = "rust1", since = "1.0.0")] u8,
-                       #[unstable(feature = "unstable_test_feature", issue = "0")] u8);
+                       #[unstable(feature = "unstable_test_feature", issue = "none")] u8);
 
     pub fn foo() {
         let x = Stable {

--- a/src/test/ui/lint/lint-stability.rs
+++ b/src/test/ui/lint/lint-stability.rs
@@ -203,10 +203,10 @@ mod inheritance {
 }
 
 mod this_crate {
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub fn deprecated() {}
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub fn deprecated_text() {}
 
@@ -214,9 +214,9 @@ mod this_crate {
     #[rustc_deprecated(since = "99.99.99", reason = "text")]
     pub fn deprecated_future() {}
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     pub fn unstable() {}
-    #[unstable(feature = "unstable_test_feature", reason = "text", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", reason = "text", issue = "none")]
     pub fn unstable_text() {}
 
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -228,16 +228,16 @@ mod this_crate {
     pub struct MethodTester;
 
     impl MethodTester {
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
         pub fn method_deprecated(&self) {}
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
         pub fn method_deprecated_text(&self) {}
 
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         pub fn method_unstable(&self) {}
-        #[unstable(feature = "unstable_test_feature", reason = "text", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", reason = "text", issue = "none")]
         pub fn method_unstable_text(&self) {}
 
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -247,16 +247,16 @@ mod this_crate {
     }
 
     pub trait Trait {
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
         fn trait_deprecated(&self) {}
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
         fn trait_deprecated_text(&self) {}
 
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         fn trait_unstable(&self) {}
-        #[unstable(feature = "unstable_test_feature", reason = "text", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", reason = "text", issue = "none")]
         fn trait_unstable_text(&self) {}
 
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -267,12 +267,12 @@ mod this_crate {
 
     impl Trait for MethodTester {}
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub struct DeprecatedStruct {
         #[stable(feature = "stable_test_feature", since = "1.0.0")] i: isize
     }
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     pub struct UnstableStruct {
         #[stable(feature = "stable_test_feature", since = "1.0.0")] i: isize
     }
@@ -281,29 +281,29 @@ mod this_crate {
         #[stable(feature = "stable_test_feature", since = "1.0.0")] i: isize
     }
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub struct DeprecatedUnitStruct;
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     pub struct UnstableUnitStruct;
     #[stable(feature = "rust1", since = "1.0.0")]
     pub struct StableUnitStruct;
 
     pub enum Enum {
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
         DeprecatedVariant,
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         UnstableVariant,
 
         #[stable(feature = "rust1", since = "1.0.0")]
         StableVariant,
     }
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub struct DeprecatedTupleStruct(isize);
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     pub struct UnstableTupleStruct(isize);
     #[stable(feature = "rust1", since = "1.0.0")]
     pub struct StableTupleStruct(isize);
@@ -422,7 +422,7 @@ mod this_crate {
         foo.trait_stable();
     }
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     fn test_fn_body() {
         fn fn_in_body() {}
@@ -430,7 +430,7 @@ mod this_crate {
     }
 
     impl MethodTester {
-        #[unstable(feature = "unstable_test_feature", issue = "0")]
+        #[unstable(feature = "unstable_test_feature", issue = "none")]
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
         fn test_method_body(&self) {
             fn fn_in_body() {}
@@ -438,7 +438,7 @@ mod this_crate {
         }
     }
 
-    #[unstable(feature = "unstable_test_feature", issue = "0")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub trait DeprecatedTrait {
         fn dummy(&self) { }

--- a/src/test/ui/macros/auxiliary/unstable-macros.rs
+++ b/src/test/ui/macros/auxiliary/unstable-macros.rs
@@ -2,7 +2,7 @@
 #![feature(staged_api)]
 #![stable(feature = "unit_test", since = "1.0.0")]
 
-#[unstable(feature = "unstable_macros", issue = "0")]
+#[unstable(feature = "unstable_macros", issue = "none")]
 #[macro_export]
 macro_rules! unstable_macro{ () => () }
 
@@ -12,5 +12,5 @@ macro_rules! unstable_macro{ () => () }
 macro_rules! deprecated_macro{ () => () }
 
 // FIXME: Cannot use a `pub` macro 2.0 in a staged API crate due to reachability issues.
-// #[unstable(feature = "unstable_macros", issue = "0")]
+// #[unstable(feature = "unstable_macros", issue = "none")]
 // pub macro unstable_macro_modern() {}

--- a/src/test/ui/macros/macro-stability-rpass.rs
+++ b/src/test/ui/macros/macro-stability-rpass.rs
@@ -5,7 +5,7 @@
 
 #[macro_use] extern crate unstable_macros;
 
-#[unstable(feature = "local_unstable", issue = "0")]
+#[unstable(feature = "local_unstable", issue = "none")]
 macro_rules! local_unstable { () => () }
 
 fn main() {

--- a/src/test/ui/macros/macro-stability.rs
+++ b/src/test/ui/macros/macro-stability.rs
@@ -4,10 +4,10 @@
 #![feature(staged_api)]
 #[macro_use] extern crate unstable_macros;
 
-#[unstable(feature = "local_unstable", issue = "0")]
+#[unstable(feature = "local_unstable", issue = "none")]
 macro_rules! local_unstable { () => () }
 
-#[unstable(feature = "local_unstable", issue = "0")]
+#[unstable(feature = "local_unstable", issue = "none")]
 macro local_unstable_modern() {}
 
 #[stable(feature = "deprecated_macros", since = "1.0.0")]

--- a/src/test/ui/missing/missing-stability.rs
+++ b/src/test/ui/missing/missing-stability.rs
@@ -10,7 +10,7 @@ pub fn unmarked() {
     ()
 }
 
-#[unstable(feature = "unstable_test_feature", issue = "0")]
+#[unstable(feature = "unstable_test_feature", issue = "none")]
 pub mod foo {
     // #[unstable] is inherited
     pub fn unmarked() {}

--- a/src/test/ui/stability-attribute/stability-attribute-sanity.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity.rs
@@ -22,7 +22,7 @@ mod bogus_attribute_types_1 {
 }
 
 mod missing_feature_names {
-    #[unstable(issue = "0")] //~ ERROR missing 'feature' [E0546]
+    #[unstable(issue = "none")] //~ ERROR missing 'feature' [E0546]
     fn f1() { }
 
     #[unstable(feature = "b")] //~ ERROR missing 'issue' [E0547]
@@ -45,12 +45,12 @@ mod missing_version {
     fn f3() { }
 }
 
-#[unstable(feature = "b", issue = "0")]
+#[unstable(feature = "b", issue = "none")]
 #[stable(feature = "a", since = "b")] //~ ERROR multiple stability levels [E0544]
 fn multiple1() { }
 
-#[unstable(feature = "b", issue = "0")]
-#[unstable(feature = "b", issue = "0")] //~ ERROR multiple stability levels [E0544]
+#[unstable(feature = "b", issue = "none")]
+#[unstable(feature = "b", issue = "none")] //~ ERROR multiple stability levels [E0544]
 fn multiple2() { }
 
 #[stable(feature = "a", since = "b")]
@@ -60,8 +60,8 @@ fn multiple3() { }
 #[stable(feature = "a", since = "b")]
 #[rustc_deprecated(since = "b", reason = "text")]
 #[rustc_deprecated(since = "b", reason = "text")]
-#[rustc_const_unstable(feature = "c", issue = "0")]
-#[rustc_const_unstable(feature = "d", issue = "0")] //~ ERROR multiple stability levels
+#[rustc_const_unstable(feature = "c", issue = "none")]
+#[rustc_const_unstable(feature = "d", issue = "none")] //~ ERROR multiple stability levels
 pub const fn multiple4() { } //~ ERROR multiple rustc_deprecated attributes [E0540]
 //~^ ERROR Invalid stability or deprecation version found
 

--- a/src/test/ui/stability-attribute/stability-attribute-sanity.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity.stderr
@@ -31,8 +31,8 @@ LL |     #[stable(feature(b), since = "a")]
 error[E0546]: missing 'feature'
   --> $DIR/stability-attribute-sanity.rs:25:5
    |
-LL |     #[unstable(issue = "0")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[unstable(issue = "none")]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0547]: missing 'issue'
   --> $DIR/stability-attribute-sanity.rs:28:5
@@ -73,8 +73,8 @@ LL | #[stable(feature = "a", since = "b")]
 error[E0544]: multiple stability levels
   --> $DIR/stability-attribute-sanity.rs:53:1
    |
-LL | #[unstable(feature = "b", issue = "0")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[unstable(feature = "b", issue = "none")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0544]: multiple stability levels
   --> $DIR/stability-attribute-sanity.rs:57:1
@@ -91,8 +91,8 @@ LL | pub const fn multiple4() { }
 error[E0544]: multiple stability levels
   --> $DIR/stability-attribute-sanity.rs:64:1
    |
-LL | #[rustc_const_unstable(feature = "d", issue = "0")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[rustc_const_unstable(feature = "d", issue = "none")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Invalid stability or deprecation version found
   --> $DIR/stability-attribute-sanity.rs:65:1

--- a/src/tools/unstable-book-gen/src/main.rs
+++ b/src/tools/unstable-book-gen/src/main.rs
@@ -2,7 +2,7 @@
 
 #![deny(warnings)]
 
-use tidy::features::{Feature, Features, collect_lib_features, collect_lang_features};
+use tidy::features::{Features, collect_lib_features, collect_lang_features};
 use tidy::unstable_book::{collect_unstable_feature_names, collect_unstable_book_section_file_names,
                           PATH_STR, LANG_FEATURES_DIR, LIB_FEATURES_DIR};
 use std::collections::BTreeSet;
@@ -70,15 +70,6 @@ fn generate_summary(path: &Path, lang_features: &Features, lib_features: &Featur
 
 }
 
-fn has_valid_tracking_issue(f: &Feature) -> bool {
-    if let Some(n) = f.tracking_issue {
-        if n > 0 {
-            return true;
-        }
-    }
-    false
-}
-
 fn generate_unstable_book_files(src :&Path, out: &Path, features :&Features) {
     let unstable_features = collect_unstable_feature_names(features);
     let unstable_section_file_names = collect_unstable_book_section_file_names(src);
@@ -89,10 +80,10 @@ fn generate_unstable_book_files(src :&Path, out: &Path, features :&Features) {
         let out_file_path = out.join(&file_name);
         let feature = &features[&feature_name_underscore];
 
-        if has_valid_tracking_issue(&feature) {
+        if let Some(issue) = feature.tracking_issue {
             generate_stub_issue(&out_file_path,
                                 &feature_name_underscore,
-                                feature.tracking_issue.unwrap());
+                                issue.get());
         } else {
             generate_stub_no_issue(&out_file_path, &feature_name_underscore);
         }


### PR DESCRIPTION
These changes make the use of `issue = "none"` required in unstable attributes throughout the compiler.

Notes:
- #66299 is now in beta so `issue = "none"` is accepted.
- The `tidy` tool now fails on `issue = "0"`.
- Tests that used `issue = "0"` were changed to use `issue = "none"`, except for _one_ that asserts `issue = "0"` can still be used.
- The compiler still allows `issue = "0"` because some submodules require it, this could be disallowed once these are updated.

Resolves #41260

r? @varkor
