### PR TITLE
Fix outdated comment

### DIFF
--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -410,7 +410,8 @@ impl<'a> TraitDef<'a> {
                     _ => {
                         // Non-ADT derive is an error, but it should have been
                         // set earlier; see
-                        // libsyntax/ext/expand.rs:MacroExpander::expand()
+                        // libsyntax_expand/expand.rs:MacroExpander::fully_expand_fragment()
+                        // libsyntax_expand/base.rs:Annotatable::derive_allowed()
                         return;
                     }
                 };
@@ -461,7 +462,8 @@ impl<'a> TraitDef<'a> {
             _ => {
                 // Non-Item derive is an error, but it should have been
                 // set earlier; see
-                // libsyntax/ext/expand.rs:MacroExpander::expand()
+                // libsyntax_expand/expand.rs:MacroExpander::fully_expand_fragment()
+                // libsyntax_expand/base.rs:Annotatable::derive_allowed()
                 return;
             }
         }

--- a/src/libsyntax_ext/deriving/mod.rs
+++ b/src/libsyntax_ext/deriving/mod.rs
@@ -89,7 +89,8 @@ fn inject_impl_of_structural_trait(cx: &mut ExtCtxt<'_>,
         _ => {
             // Non-Item derive is an error, but it should have been
             // set earlier; see
-            // libsyntax/ext/expand.rs:MacroExpander::expand()
+            // libsyntax_expand/expand.rs:MacroExpander::fully_expand_fragment()
+            // libsyntax_expand/base.rs:Annotatable::derive_allowed()
             return;
         }
     };


### PR DESCRIPTION
Logics in `libsyntax/ext/expand.rs:MacroExpander::expand()` have been moved to `libsyntax_expand/expand.rs:MacroExpander::fully_expand_fragment()`  
This pull request fixs the dangling file path.

#### Old

https://github.com/rust-lang/rust/blob/35176867f62f76b9bc27267878f2d74d9c776221/src/libsyntax/ext/expand.rs#L285-L301

#### New

https://github.com/rust-lang/rust/blob/9ff30a7810c586819a78188c173a7b74adbb9730/src/libsyntax_expand/expand.rs#L421-L439

https://github.com/rust-lang/rust/blob/9ff30a7810c586819a78188c173a7b74adbb9730/src/libsyntax_expand/base.rs#L224-L234