### PR TITLE
Rustdoc mutability removal

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -7,7 +7,7 @@ use syntax::symbol::sym;
 use syntax_pos::hygiene::MacroKind;
 use syntax_pos::Span;
 
-use rustc::hir;
+use rustc::hir::{self, Mutability};
 use rustc::hir::def::{Res, DefKind, CtorKind};
 use rustc::hir::def_id::DefId;
 use rustc_metadata::creader::LoadedMacro;
@@ -472,7 +472,7 @@ fn build_const(cx: &DocContext<'_>, did: DefId) -> clean::Constant {
 fn build_static(cx: &DocContext<'_>, did: DefId, mutable: bool) -> clean::Static {
     clean::Static {
         type_: cx.tcx.type_of(did).clean(cx),
-        mutability: if mutable {clean::Mutable} else {clean::Immutable},
+        mutability: if mutable { Mutability::Mutable } else { Mutability::Immutable },
         expr: "\n\n\n".to_string(), // trigger the "[definition]" links
     }
 }

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -472,7 +472,7 @@ fn build_const(cx: &DocContext<'_>, did: DefId) -> clean::Constant {
 fn build_static(cx: &DocContext<'_>, did: DefId, mutable: bool) -> clean::Static {
     clean::Static {
         type_: cx.tcx.type_of(did).clean(cx),
-        mutability: if mutable { Mutability::Mutable } else { Mutability::Immutable },
+        mutability: if mutable { Mutability::Mut } else { Mutability::Not },
         expr: "\n\n\n".to_string(), // trigger the "[definition]" links
     }
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -46,7 +46,6 @@ pub use utils::{get_auto_trait_and_blanket_impls, krate, register_res};
 
 pub use self::types::*;
 pub use self::types::Type::*;
-pub use self::types::Mutability::*;
 pub use self::types::ItemEnum::*;
 pub use self::types::SelfTy::*;
 pub use self::types::FunctionRetTy::*;
@@ -1321,15 +1320,14 @@ impl Clean<Type> for hir::Ty {
 
         match self.kind {
             TyKind::Never => Never,
-            TyKind::Ptr(ref m) => RawPointer(m.mutbl.clean(cx), box m.ty.clean(cx)),
+            TyKind::Ptr(ref m) => RawPointer(m.mutbl, box m.ty.clean(cx)),
             TyKind::Rptr(ref l, ref m) => {
                 let lifetime = if l.is_elided() {
                     None
                 } else {
                     Some(l.clean(cx))
                 };
-                BorrowedRef {lifetime, mutability: m.mutbl.clean(cx),
-                             type_: box m.ty.clean(cx)}
+                BorrowedRef {lifetime, mutability: m.mutbl, type_: box m.ty.clean(cx)}
             }
             TyKind::Slice(ref ty) => Slice(box ty.clean(cx)),
             TyKind::Array(ref ty, ref length) => {
@@ -1547,10 +1545,10 @@ impl<'tcx> Clean<Type> for Ty<'tcx> {
                 let n = print_const(cx, n);
                 Array(box ty.clean(cx), n)
             }
-            ty::RawPtr(mt) => RawPointer(mt.mutbl.clean(cx), box mt.ty.clean(cx)),
+            ty::RawPtr(mt) => RawPointer(mt.mutbl, box mt.ty.clean(cx)),
             ty::Ref(r, ty, mutbl) => BorrowedRef {
                 lifetime: r.clean(cx),
-                mutability: mutbl.clean(cx),
+                mutability: mutbl,
                 type_: box ty.clean(cx),
             },
             ty::FnDef(..) |
@@ -2073,7 +2071,7 @@ impl Clean<Item> for doctree::Static<'_> {
             deprecation: cx.deprecation(self.id).clean(cx),
             inner: StaticItem(Static {
                 type_: self.type_.clean(cx),
-                mutability: self.mutability.clean(cx),
+                mutability: self.mutability,
                 expr: print_const_expr(cx, self.expr),
             }),
         }
@@ -2094,15 +2092,6 @@ impl Clean<Item> for doctree::Constant<'_> {
                 type_: self.type_.clean(cx),
                 expr: print_const_expr(cx, self.expr),
             }),
-        }
-    }
-}
-
-impl Clean<Mutability> for hir::Mutability {
-    fn clean(&self, _: &DocContext<'_>) -> Mutability {
-        match self {
-            &hir::Mutability::Mut => Mutable,
-            &hir::Mutability::Not => Immutable,
         }
     }
 }
@@ -2296,7 +2285,7 @@ impl Clean<Item> for doctree::ForeignItem<'_> {
             hir::ForeignItemKind::Static(ref ty, mutbl) => {
                 ForeignStaticItem(Static {
                     type_: ty.clean(cx),
-                    mutability: mutbl.clean(cx),
+                    mutability: *mutbl,
                     expr: String::new(),
                 })
             }

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use rustc::middle::lang_items;
 use rustc::middle::stability;
-use rustc::hir;
+use rustc::hir::{self, Mutability};
 use rustc::hir::def::Res;
 use rustc::hir::def_id::{CrateNum, DefId};
 use rustc::ty::layout::VariantIdx;
@@ -1448,12 +1448,6 @@ pub struct Static {
 pub struct Constant {
     pub type_: Type,
     pub expr: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Copy, Hash)]
-pub enum Mutability {
-    Mutable,
-    Immutable,
 }
 
 #[derive(Clone, PartialEq, Debug)]

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -670,8 +670,8 @@ fn fmt_type(t: &clean::Type, f: &mut fmt::Formatter<'_>, use_absolute: bool) -> 
         clean::Never => primitive_link(f, PrimitiveType::Never, "!"),
         clean::RawPointer(m, ref t) => {
             let m = match m {
-                clean::Immutable => "const",
-                clean::Mutable => "mut",
+                hir::Mutability::Mut => "mut",
+                hir::Mutability::Not => "const",
             };
             match **t {
                 clean::Generic(_) | clean::ResolvedPath {is_generic: true, ..} => {
@@ -1082,6 +1082,15 @@ impl PrintWithSpace for hir::IsAsync {
     }
 }
 
+impl PrintWithSpace for hir::Mutability {
+    fn print_with_space(&self) -> &str {
+        match self {
+            hir::Mutability::Not => "",
+            hir::Mutability::Mut => "mut ",
+        }
+    }
+}
+
 impl clean::Import {
     crate fn print(&self) -> impl fmt::Display + '_ {
         display_fn(move |f| {
@@ -1148,15 +1157,6 @@ impl clean::TypeBinding {
             }
             Ok(())
         })
-    }
-}
-
-impl clean::Mutability {
-    crate fn print_with_space(&self) -> &str {
-        match self {
-            clean::Immutable => "",
-            clean::Mutable => "mut ",
-        }
     }
 }
 

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -54,12 +54,12 @@ use syntax_pos::hygiene::MacroKind;
 use rustc::hir::def_id::DefId;
 use rustc::middle::privacy::AccessLevels;
 use rustc::middle::stability;
-use rustc::hir;
+use rustc::hir::{self, Mutability};
 use rustc::util::nodemap::{FxHashMap, FxHashSet};
 use rustc_data_structures::flock;
 use rustc_feature::UnstableFeatures;
 
-use crate::clean::{self, AttributesExt, Deprecation, GetDefId, SelfTy, Mutability};
+use crate::clean::{self, AttributesExt, Deprecation, GetDefId, SelfTy};
 use crate::config::RenderOptions;
 use crate::docfs::{DocFS, ErrorStorage, PathError};
 use crate::doctree;

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -3298,7 +3298,7 @@ fn should_render_item(item: &clean::Item, deref_mut_: bool) -> bool {
         let (by_mut_ref, by_box, by_value) = match self_ty {
             SelfTy::SelfBorrowed(_, mutability) |
             SelfTy::SelfExplicit(clean::BorrowedRef { mutability, .. }) => {
-                (mutability == Mutability::Mutable, false, false)
+                (mutability == Mutability::Mut, false, false)
             },
             SelfTy::SelfExplicit(clean::ResolvedPath { did, .. }) => {
                 (false, Some(did) == cache().owned_box_did, false)


### PR DESCRIPTION
Fixes #67470.

As discussed in another PR, the `clean::Mutability` type in rustdoc is useless. So let's remove it!

r? @Centril 