### PR TITLE
Drop petgraph dependency from bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,6 @@ dependencies = [
  "lazy_static 1.3.0",
  "libc",
  "num_cpus",
- "petgraph",
  "pretty_assertions",
  "serde",
  "serde_json",
@@ -1080,12 +1079,6 @@ dependencies = [
  "libc",
  "redox_syscall",
 ]
-
-[[package]]
-name = "fixedbitset"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 
 [[package]]
 name = "flate2"
@@ -2289,12 +2282,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordermap"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
-
-[[package]]
 name = "ordslice"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,16 +2414,6 @@ dependencies = [
  "maplit",
  "pest",
  "sha-1",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
-dependencies = [
- "fixedbitset",
- "ordermap",
 ]
 
 [[package]]

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -47,7 +47,6 @@ serde_json = "1.0.2"
 toml = "0.5"
 lazy_static = "1.3.0"
 time = "0.1"
-petgraph = "0.4.13"
 
 [dev-dependencies]
 pretty_assertions = "0.5"


### PR DESCRIPTION
It was essentially unused, likely leftover from a previous refactoring iteration. This should hopefully help reduce bootstrap build times a little, dropping petgraph, fixedbitset, and ordermap from the dependency set.

r? @alexcrichton 

