### PR TITLE
Decouple `CrateNum` of `CrateInfo` from the compilation session

### DIFF
--- a/src/librustc_codegen_llvm/back/lto.rs
+++ b/src/librustc_codegen_llvm/back/lto.rs
@@ -68,7 +68,10 @@ fn prepare_lto(
     let exported_symbols = cgcx.exported_symbols.as_ref().expect("needs exported symbols for LTO");
     let mut symbol_white_list = {
         let _timer = cgcx.prof.generic_activity("LLVM_lto_generate_symbol_white_list");
-        exported_symbols[&LOCAL_CRATE].iter().filter_map(symbol_filter).collect::<Vec<CString>>()
+        exported_symbols[&LOCAL_CRATE.into()]
+            .iter()
+            .filter_map(symbol_filter)
+            .collect::<Vec<CString>>()
     };
     info!("{} symbols to preserve in this crate", symbol_white_list.len());
 

--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -9,7 +9,6 @@ use rustc::session::search_paths::PathKind;
 use rustc::session::{filesearch, Session};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_fs_util::fix_windows_verbatim_for_gcc;
-use rustc_hir::def_id::CrateNum;
 use rustc_span::symbol::Symbol;
 use rustc_target::spec::{LinkerFlavor, PanicStrategy, RelroLevel};
 
@@ -18,7 +17,7 @@ use super::command::Command;
 use super::linker::Linker;
 use super::rpath::{self, RPathConfig};
 use crate::{
-    looks_like_rust_object_file, CodegenResults, CrateInfo, METADATA_FILENAME,
+    looks_like_rust_object_file, CodegenResults, CrateInfo, CrateNum, METADATA_FILENAME,
     RLIB_BYTECODE_EXTENSION,
 };
 

--- a/src/librustc_codegen_ssa/back/rpath.rs
+++ b/src/librustc_codegen_ssa/back/rpath.rs
@@ -3,8 +3,8 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::CrateNum;
 use rustc::middle::cstore::LibSource;
-use rustc_hir::def_id::CrateNum;
 
 pub struct RPathConfig<'a> {
     pub used_crates: &'a [(CrateNum, LibSource)],

--- a/src/librustc_codegen_ssa/back/symbol_export.rs
+++ b/src/librustc_codegen_ssa/back/symbol_export.rs
@@ -16,7 +16,7 @@ use rustc_hir::Node;
 use rustc_index::vec::IndexVec;
 use syntax::expand::allocator::ALLOCATOR_METHODS;
 
-pub type ExportedSymbols = FxHashMap<CrateNum, Arc<Vec<(String, SymbolExportLevel)>>>;
+pub type ExportedSymbols = FxHashMap<crate::CrateNum, Arc<Vec<(String, SymbolExportLevel)>>>;
 
 pub fn threshold(tcx: TyCtxt<'_>) -> SymbolExportLevel {
     crates_export_threshold(&tcx.sess.crate_types.borrow())

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 use crate::traits::*;
+use crate::CrateNum;
 use jobserver::{Acquired, Client};
 use rustc::dep_graph::{WorkProduct, WorkProductFileKind, WorkProductId};
 use rustc::middle::cstore::EncodedMetadata;
@@ -994,7 +995,7 @@ fn start_executing_work<B: ExtraBackendMethods>(
         if link::ignored_for_lto(sess, crate_info, cnum) {
             return;
         }
-        each_linked_rlib_for_lto.push((cnum, path.to_path_buf()));
+        each_linked_rlib_for_lto.push((cnum.into(), path.to_path_buf()));
     }));
 
     let assembler_cmd = if modules_config.no_integrated_as {

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -26,7 +26,7 @@ use rustc_data_structures::sync::Lrc;
 use rustc_errors::emitter::Emitter;
 use rustc_errors::{DiagnosticId, FatalError, Handler, Level};
 use rustc_fs_util::link_or_copy;
-use rustc_hir::def_id::{CrateNum, LOCAL_CRATE};
+use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_incremental::{
     copy_cgu_workproducts_to_incr_comp_cache_dir, in_incr_comp_dir, in_incr_comp_dir_sess,
 };
@@ -965,13 +965,13 @@ fn start_executing_work<B: ExtraBackendMethods>(
         match sess.lto() {
             Lto::No => None,
             Lto::ThinLocal => {
-                exported_symbols.insert(LOCAL_CRATE, copy_symbols(LOCAL_CRATE));
+                exported_symbols.insert(LOCAL_CRATE.into(), copy_symbols(LOCAL_CRATE));
                 Some(Arc::new(exported_symbols))
             }
             Lto::Fat | Lto::Thin => {
-                exported_symbols.insert(LOCAL_CRATE, copy_symbols(LOCAL_CRATE));
+                exported_symbols.insert(LOCAL_CRATE.into(), copy_symbols(LOCAL_CRATE));
                 for &cnum in tcx.crates().iter() {
-                    exported_symbols.insert(cnum, copy_symbols(cnum));
+                    exported_symbols.insert(cnum.into(), copy_symbols(cnum));
                 }
                 Some(Arc::new(exported_symbols))
             }
@@ -995,7 +995,7 @@ fn start_executing_work<B: ExtraBackendMethods>(
         if link::ignored_for_lto(sess, crate_info, cnum) {
             return;
         }
-        each_linked_rlib_for_lto.push((cnum.into(), path.to_path_buf()));
+        each_linked_rlib_for_lto.push((cnum, path.to_path_buf()));
     }));
 
     let assembler_cmd = if modules_config.no_integrated_as {

--- a/src/librustc_codegen_ssa/lib.rs
+++ b/src/librustc_codegen_ssa/lib.rs
@@ -31,7 +31,7 @@ use rustc::ty::query::Providers;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::svh::Svh;
 use rustc_data_structures::sync::Lrc;
-use rustc_hir::def_id::CrateNum;
+use rustc_hir::def_id;
 use rustc_span::symbol::Symbol;
 use std::path::{Path, PathBuf};
 
@@ -113,6 +113,29 @@ bitflags::bitflags! {
         const VOLATILE = 1 << 0;
         const NONTEMPORAL = 1 << 1;
         const UNALIGNED = 1 << 2;
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CrateNum(pub u32);
+impl CrateNum {
+    pub fn as_usize(self) -> usize {
+        self.0 as usize
+    }
+}
+impl From<def_id::CrateNum> for CrateNum {
+    fn from(crate_num: def_id::CrateNum) -> Self {
+        CrateNum(crate_num.as_u32())
+    }
+}
+impl Into<def_id::CrateNum> for CrateNum {
+    fn into(self) -> def_id::CrateNum {
+        def_id::CrateNum::from_u32(self.0)
+    }
+}
+impl ::std::fmt::Debug for CrateNum {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(fmt, "crate{}", self.0)
     }
 }
 

--- a/src/librustc_codegen_ssa/lib.rs
+++ b/src/librustc_codegen_ssa/lib.rs
@@ -128,11 +128,6 @@ impl From<def_id::CrateNum> for CrateNum {
         CrateNum(crate_num.as_u32())
     }
 }
-impl Into<def_id::CrateNum> for CrateNum {
-    fn into(self) -> def_id::CrateNum {
-        def_id::CrateNum::from_u32(self.0)
-    }
-}
 impl ::std::fmt::Debug for CrateNum {
     fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(fmt, "crate{}", self.0)


### PR DESCRIPTION
`CrateNum` used inside a `CrateInfo` is self-contained and hence can be decoupled from the compilation session. By doing so, a compilation session can consume `CrateInfo` generated from a different compilation session. Ultimately, it allows splitting linker invocation into a separate compilation session.