### PR TITLE
Add regression tests for fixed ICEs

### DIFF
--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -2289,7 +2289,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         let span = self.tcx.def_span(generator_did);
 
         // Do not ICE on closure typeck (#66868).
-        if let None = self.tcx.hir().as_local_hir_id(generator_did) {
+        if self.tcx.hir().as_local_hir_id(generator_did).is_none() {
             return false;
         }
 

--- a/src/test/ui/const-generics/issues/issue-61747.rs
+++ b/src/test/ui/const-generics/issues/issue-61747.rs
@@ -1,0 +1,16 @@
+// check-pass
+
+#![feature(const_generics)]
+//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+
+struct Const<const N: usize>;
+
+impl<const C: usize> Const<{C}> {
+    fn successor() -> Const<{C + 1}> {
+        Const
+    }
+}
+
+fn main() {
+    Const::<1>::successor();
+}

--- a/src/test/ui/const-generics/issues/issue-61747.rs
+++ b/src/test/ui/const-generics/issues/issue-61747.rs
@@ -12,5 +12,5 @@ impl<const C: usize> Const<{C}> {
 }
 
 fn main() {
-    Const::<1>::successor();
+    let _x: Const::<2> = Const::<1>::successor();
 }

--- a/src/test/ui/const-generics/issues/issue-61747.stderr
+++ b/src/test/ui/const-generics/issues/issue-61747.stderr
@@ -1,0 +1,8 @@
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/issue-61747.rs:3:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+

--- a/src/test/ui/const-generics/issues/issue-66205.rs
+++ b/src/test/ui/const-generics/issues/issue-66205.rs
@@ -1,0 +1,10 @@
+// check-pass
+
+#![allow(incomplete_features, dead_code, unconditional_recursion)]
+#![feature(const_generics)]
+
+fn fact<const N: usize>() {
+    fact::<{ N - 1 }>();
+}
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/issue-67424.rs
+++ b/src/test/ui/generic-associated-types/issue-67424.rs
@@ -1,0 +1,13 @@
+// Fixed by #67160
+
+trait Trait1 {
+    type A;
+}
+
+trait Trait2 {
+    type Type1<B>: Trait1<A=B>;
+    //~^ ERROR: generic associated types are unstable
+    //~| ERROR: type-generic associated types are not yet implemented
+}
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/issue-67424.stderr
+++ b/src/test/ui/generic-associated-types/issue-67424.stderr
@@ -1,0 +1,20 @@
+error[E0658]: generic associated types are unstable
+  --> $DIR/issue-67424.rs:8:5
+   |
+LL |     type Type1<B>: Trait1<A=B>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable
+
+error: type-generic associated types are not yet implemented
+  --> $DIR/issue-67424.rs:8:5
+   |
+LL |     type Type1<B>: Trait1<A=B>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/pattern/issue-66270-pat-struct-parser-recovery.rs
+++ b/src/test/ui/pattern/issue-66270-pat-struct-parser-recovery.rs
@@ -1,0 +1,14 @@
+// Regression test for #66270, fixed by #66246
+
+struct Bug {
+    incorrect_field: 0,
+    //~^ ERROR expected type
+}
+
+struct Empty {}
+
+fn main() {
+    let Bug {
+        any_field: Empty {},
+    } = Bug {};
+}

--- a/src/test/ui/pattern/issue-66270-pat-struct-parser-recovery.stderr
+++ b/src/test/ui/pattern/issue-66270-pat-struct-parser-recovery.stderr
@@ -1,0 +1,8 @@
+error: expected type, found `0`
+  --> $DIR/issue-66270-pat-struct-parser-recovery.rs:4:22
+   |
+LL |     incorrect_field: 0,
+   |                      ^ expected type
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Closes #61747 (fixed from 1.41.0-nightly (4007d4ef2 2019-12-01))
Closes #66205 (fixed from 1.41.0-nightly (4007d4ef2 2019-12-01))
Closes #66270 (fixed by #66246)
Closes #67424 (fixed by #67160)

Also picking a minor nit up from #67071 with 101dd7bad9432730fa2f625ae43afcc2929457d4

r? @Centril
