### PR TITLE
Fix ICE in mir interpretation

### DIFF
--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -530,11 +530,12 @@ where
                     // This can only be reached in ConstProp and non-rustc-MIR.
                     throw_ub!(BoundsCheckFailed { len: min_length as u64, index: n as u64 });
                 }
-                assert!(offset < min_length);
 
                 let index = if from_end {
+                    assert!(offset - 1 < min_length);
                     n - u64::from(offset)
                 } else {
+                    assert!(offset < min_length);
                     u64::from(offset)
                 };
 

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -532,7 +532,7 @@ where
                 }
 
                 let index = if from_end {
-                    assert!(offset - 1 < min_length);
+                    assert!(0 < offset && offset - 1 < min_length);
                     n - u64::from(offset)
                 } else {
                     assert!(offset < min_length);

--- a/src/test/ui/consts/const_prop_slice_pat_ice.rs
+++ b/src/test/ui/consts/const_prop_slice_pat_ice.rs
@@ -1,0 +1,9 @@
+// check-pass
+#![feature(slice_patterns)]
+
+fn main() {
+    match &[0, 1] as &[i32] {
+        [a @ .., x] => {}
+        &[] => {}
+    }
+}


### PR DESCRIPTION
Indices from the end start at 1 so you can immediately subtract them from the length to get the index instead of having to do an additional `-1`. Kinda documented in https://doc.rust-lang.org/nightly/nightly-rustc/rustc/mir/enum.ProjectionElem.html#variant.ConstantIndex