### PR TITLE
Simplify or-patterns in MIR building

### DIFF
--- a/src/librustc_mir/build/matches/simplify.rs
+++ b/src/librustc_mir/build/matches/simplify.rs
@@ -35,6 +35,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         changed = true;
                     }
                     Err(match_pair) => {
+                        // Re-add the `match_pair` we were unable to simplify.
                         candidate.match_pairs.push(match_pair);
                     }
                 }
@@ -198,7 +199,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 Ok(())
             }
 
-            PatKind::Or { .. } => Err(match_pair),
+            PatKind::Or { ref pats } => {
+                candidate
+                    .match_pairs
+                    .extend(pats.iter().map(|pat| MatchPair::new(match_pair.place.clone(), pat)));
+                Ok(())
+            }
         }
     }
 }

--- a/src/test/ui/or-patterns/exhaustiveness-non-exhaustive.rs
+++ b/src/test/ui/or-patterns/exhaustiveness-non-exhaustive.rs
@@ -5,12 +5,6 @@
 
 // We wrap patterns in a tuple because top-level or-patterns are special-cased for now.
 fn main() {
-    // Get the fatal error out of the way
-    match (0u8,) {
-        (0 | _,) => {}
-        //~^ ERROR or-patterns are not fully implemented yet
-    }
-
     match (0u8, 0u8) {
         //~^ ERROR non-exhaustive patterns: `(2u8..=std::u8::MAX, _)`
         (0 | 1, 2 | 3) => {}

--- a/src/test/ui/or-patterns/exhaustiveness-non-exhaustive.stderr
+++ b/src/test/ui/or-patterns/exhaustiveness-non-exhaustive.stderr
@@ -1,5 +1,5 @@
 error[E0004]: non-exhaustive patterns: `(2u8..=std::u8::MAX, _)` not covered
-  --> $DIR/exhaustiveness-non-exhaustive.rs:14:11
+  --> $DIR/exhaustiveness-non-exhaustive.rs:8:11
    |
 LL |     match (0u8, 0u8) {
    |           ^^^^^^^^^^ pattern `(2u8..=std::u8::MAX, _)` not covered
@@ -7,7 +7,7 @@ LL |     match (0u8, 0u8) {
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: `((4u8..=std::u8::MAX))` not covered
-  --> $DIR/exhaustiveness-non-exhaustive.rs:18:11
+  --> $DIR/exhaustiveness-non-exhaustive.rs:12:11
    |
 LL |     match ((0u8,),) {
    |           ^^^^^^^^^ pattern `((4u8..=std::u8::MAX))` not covered
@@ -15,19 +15,13 @@ LL |     match ((0u8,),) {
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
 error[E0004]: non-exhaustive patterns: `(Some(2u8..=std::u8::MAX))` not covered
-  --> $DIR/exhaustiveness-non-exhaustive.rs:22:11
+  --> $DIR/exhaustiveness-non-exhaustive.rs:16:11
    |
 LL |     match (Some(0u8),) {
    |           ^^^^^^^^^^^^ pattern `(Some(2u8..=std::u8::MAX))` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
-error: or-patterns are not fully implemented yet
-  --> $DIR/exhaustiveness-non-exhaustive.rs:10:10
-   |
-LL |         (0 | _,) => {}
-   |          ^^^^^
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0004`.

--- a/src/test/ui/or-patterns/exhaustiveness-pass.rs
+++ b/src/test/ui/or-patterns/exhaustiveness-pass.rs
@@ -1,3 +1,5 @@
+// check-pass
+
 #![feature(or_patterns)]
 #![feature(slice_patterns)]
 #![allow(incomplete_features)]
@@ -5,12 +7,6 @@
 
 // We wrap patterns in a tuple because top-level or-patterns are special-cased for now.
 fn main() {
-    // Get the fatal error out of the way
-    match (0,) {
-        (0 | _,) => {}
-        //~^ ERROR or-patterns are not fully implemented yet
-    }
-
     match (0,) {
         (1 | 2,) => {}
         _ => {}
@@ -38,6 +34,7 @@ fn main() {
         ((0, 0) | (0, 1),) => {}
         _ => {}
     }
+
     match ((0, 0),) {
         ((0, 0) | (1, 0),) => {}
         _ => {}

--- a/src/test/ui/or-patterns/exhaustiveness-pass.stderr
+++ b/src/test/ui/or-patterns/exhaustiveness-pass.stderr
@@ -1,8 +1,0 @@
-error: or-patterns are not fully implemented yet
-  --> $DIR/exhaustiveness-pass.rs:10:10
-   |
-LL |         (0 | _,) => {}
-   |          ^^^^^
-
-error: aborting due to previous error
-

--- a/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.rs
+++ b/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.rs
@@ -5,12 +5,6 @@
 
 // We wrap patterns in a tuple because top-level or-patterns are special-cased for now.
 fn main() {
-    // Get the fatal error out of the way
-    match (0u8,) {
-        (0 | _,) => {}
-        //~^ ERROR or-patterns are not fully implemented yet
-    }
-
     match (0u8,) {
         (1 | 2,) => {}
         (1,) => {} //~ ERROR unreachable pattern

--- a/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
+++ b/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
@@ -1,5 +1,5 @@
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:16:9
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:10:9
    |
 LL |         (1,) => {}
    |         ^^^^
@@ -11,100 +11,94 @@ LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:21:9
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:15:9
    |
 LL |         (2,) => {}
    |         ^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:27:9
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:21:9
    |
 LL |         (1 | 2,) => {}
    |         ^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:32:9
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:26:9
    |
 LL |         (1, 3) => {}
    |         ^^^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:33:9
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:27:9
    |
 LL |         (1, 4) => {}
    |         ^^^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:34:9
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:28:9
    |
 LL |         (2, 4) => {}
    |         ^^^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:35:9
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:29:9
    |
 LL |         (2 | 1, 4) => {}
    |         ^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:37:9
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:31:9
    |
 LL |         (1, 4 | 5) => {}
    |         ^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:42:9
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:36:9
    |
 LL |         (Some(1),) => {}
    |         ^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:43:9
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:37:9
    |
 LL |         (None,) => {}
    |         ^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:48:9
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:42:9
    |
 LL |         ((1..=4,),) => {},
    |         ^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:54:12
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:48:12
    |
 LL |          | 1,) => {}
    |            ^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:61:15
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:55:15
    |
 LL |             | 0] => {}
    |               ^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:59:15
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:53:15
    |
 LL |             | 0
    |               ^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:69:10
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:63:10
    |
 LL |         [1
    |          ^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:75:14
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:69:14
    |
 LL |         Some(0
    |              ^
 
-error: or-patterns are not fully implemented yet
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:10:10
-   |
-LL |         (0 | _,) => {}
-   |          ^^^^^
-
-error: aborting due to 17 previous errors
+error: aborting due to 16 previous errors
 

--- a/src/test/ui/or-patterns/irrefutable-or-binding.rs
+++ b/src/test/ui/or-patterns/irrefutable-or-binding.rs
@@ -1,0 +1,8 @@
+// run-pass
+
+#![feature(or_patterns)]
+//~^ WARN the feature `or_patterns` is incomplete and may cause the compiler to crash
+
+fn main() {
+    let _ | _ = (); // ok
+}

--- a/src/test/ui/or-patterns/irrefutable-or-binding.stderr
+++ b/src/test/ui/or-patterns/irrefutable-or-binding.stderr
@@ -1,0 +1,8 @@
+warning: the feature `or_patterns` is incomplete and may cause the compiler to crash
+  --> $DIR/irrefutable-or-binding.rs:3:12
+   |
+LL | #![feature(or_patterns)]
+   |            ^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+


### PR DESCRIPTION
Or-patterns were previously not simplified at all during MIR building, which caused any irrefutable match involving or-patterns to ICE. This doesn't fix every ICE: an irrefutable match involving enum variants will still ICE (https://github.com/rust-lang/rust/issues/67514), but is a step in the right direction.