### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -14,6 +14,12 @@
 # =============================================================================
 [llvm]
 
+# Indicates whether LLVM rebuild should be skipped when running bootstrap. If
+# this is `false` then the compiler's LLVM will be rebuilt whenever the built
+# version doesn't have the correct hash. If it is `true` then LLVM will never
+# be rebuilt. The default value is `false`.
+#skip-rebuild = false
+
 # Indicates whether the LLVM build is a Release or Debug build
 #optimize = true
 

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -66,6 +66,7 @@ pub struct Config {
     pub backtrace_on_ice: bool,
 
     // llvm codegen options
+    pub llvm_skip_rebuild: bool,
     pub llvm_assertions: bool,
     pub llvm_optimize: bool,
     pub llvm_thin_lto: bool,
@@ -242,6 +243,7 @@ struct Install {
 #[derive(Deserialize, Default)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 struct Llvm {
+    skip_rebuild: Option<bool>,
     optimize: Option<bool>,
     thin_lto: Option<bool>,
     release_debuginfo: Option<bool>,
@@ -487,6 +489,7 @@ impl Config {
 
         // Store off these values as options because if they're not provided
         // we'll infer default values for them later
+        let mut llvm_skip_rebuild = None;
         let mut llvm_assertions = None;
         let mut debug = None;
         let mut debug_assertions = None;
@@ -510,6 +513,7 @@ impl Config {
             }
             set(&mut config.ninja, llvm.ninja);
             llvm_assertions = llvm.assertions;
+            llvm_skip_rebuild = llvm.skip_rebuild;
             set(&mut config.llvm_optimize, llvm.optimize);
             set(&mut config.llvm_thin_lto, llvm.thin_lto);
             set(&mut config.llvm_release_debuginfo, llvm.release_debuginfo);
@@ -616,6 +620,8 @@ impl Config {
 
         set(&mut config.initial_rustc, build.rustc.map(PathBuf::from));
         set(&mut config.initial_cargo, build.cargo.map(PathBuf::from));
+
+        config.llvm_skip_rebuild = llvm_skip_rebuild.unwrap_or(false);
 
         let default = false;
         config.llvm_assertions = llvm_assertions.unwrap_or(default);

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -74,6 +74,13 @@ impl Step for Llvm {
         let done_stamp = out_dir.join("llvm-finished-building");
 
         if done_stamp.exists() {
+            if builder.config.llvm_skip_rebuild {
+                builder.info("Warning: \
+                              Using a potentially stale build of LLVM; \
+                              This may not behave well.");
+                return build_llvm_config;
+            }
+
             if let Some(llvm_commit) = llvm_info.sha() {
                 let done_contents = t!(fs::read(&done_stamp));
 

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -384,9 +384,6 @@ impl Step for Miri {
             );
             cargo.arg("--bin").arg("cargo-miri").arg("--").arg("miri").arg("setup");
 
-            // Tell `cargo miri` not to worry about the sysroot mismatch (we built with
-            // stage1 but run with stage2).
-            cargo.env("MIRI_SKIP_SYSROOT_CHECK", "1");
             // Tell `cargo miri setup` where to find the sources.
             cargo.env("XARGO_RUST_SRC", builder.src.join("src"));
             // Debug things.

--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -450,7 +450,8 @@ impl<T> [T] {
         // and `rem` is the remaining part of `n`.
 
         // Using `Vec` to access `set_len()`.
-        let mut buf = Vec::with_capacity(self.len().checked_mul(n).expect("capacity overflow"));
+        let capacity = self.len().checked_mul(n).expect("capacity overflow");
+        let mut buf = Vec::with_capacity(capacity);
 
         // `2^expn` repetition is done by doubling `buf` `expn`-times.
         buf.extend(self);
@@ -476,7 +477,7 @@ impl<T> [T] {
 
         // `rem` (`= n - 2^expn`) repetition is done by copying
         // first `rem` repetitions from `buf` itself.
-        let rem_len = self.len() * n - buf.len(); // `self.len() * rem`
+        let rem_len = capacity - buf.len(); // `self.len() * rem`
         if rem_len > 0 {
             // `buf.extend(buf[0 .. rem_len])`:
             unsafe {
@@ -487,8 +488,7 @@ impl<T> [T] {
                     rem_len,
                 );
                 // `buf.len() + rem_len` equals to `buf.capacity()` (`= self.len() * n`).
-                let buf_cap = buf.capacity();
-                buf.set_len(buf_cap);
+                buf.set_len(capacity);
             }
         }
         buf


### PR DESCRIPTION
Successful merges:

 - #67437 (Add LLVM `skip-rebuild` option to `x.py`)
 - #67576 (reuse `capacity` variable in slice::repeat)
 - #67579 (update miri)

Failed merges:


r? @ghost