### PR TITLE
Fix ICE / miscompilation when inlining simd shuffle intrinsic in MIR.

### DIFF
--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -625,7 +625,10 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                                     projection: &[],
                                 } = place.as_ref()
                                 {
-                                    let c = bx.tcx().const_eval_promoted(Instance::new(def_id, self.monomorphize(&substs)), promoted);
+                                    let c = bx.tcx().const_eval_promoted(
+                                        Instance::new(def_id, self.monomorphize(&substs)),
+                                        promoted,
+                                    );
                                     let (llval, ty) = self.simd_shuffle_indices(
                                         &bx,
                                         terminator.source_info.span,

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -618,14 +618,14 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                                 if let mir::PlaceRef {
                                     base:
                                         &PlaceBase::Static(box Static {
-                                            kind: StaticKind::Promoted(promoted, _),
+                                            kind: StaticKind::Promoted(promoted, substs),
                                             ty,
-                                            def_id: _,
+                                            def_id,
                                         }),
                                     projection: &[],
                                 } = place.as_ref()
                                 {
-                                    let c = bx.tcx().const_eval_promoted(self.instance, promoted);
+                                    let c = bx.tcx().const_eval_promoted(Instance::new(def_id, self.monomorphize(&substs)), promoted);
                                     let (llval, ty) = self.simd_shuffle_indices(
                                         &bx,
                                         terminator.source_info.span,

--- a/src/test/ui/simd-intrinsic/simd-intrinsic-inlining-issue67557-ice.rs
+++ b/src/test/ui/simd-intrinsic/simd-intrinsic-inlining-issue67557-ice.rs
@@ -1,0 +1,25 @@
+// This used to cause an ICE for an internal index out of range due to simd_shuffle_indices being
+// passed the wrong Instance, causing issues with inlining. See #67557.
+//
+// run-pass
+// compile-flags: -Zmir-opt-level=3
+#![feature(platform_intrinsics, repr_simd)]
+
+extern "platform-intrinsic" {
+    fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
+}
+
+#[repr(simd)]
+#[derive(Debug, PartialEq)]
+struct Simd2(u8, u8);
+
+fn main() {
+    unsafe {
+        let _: Simd2 = inline_me();
+    }
+}
+
+#[inline(always)]
+unsafe fn inline_me() -> Simd2 {
+    simd_shuffle2(Simd2(10, 11), Simd2(12, 13), [0, 3])
+}

--- a/src/test/ui/simd-intrinsic/simd-intrinsic-inlining-issue67557.rs
+++ b/src/test/ui/simd-intrinsic/simd-intrinsic-inlining-issue67557.rs
@@ -1,0 +1,40 @@
+// This used to cause assert_10_13 to unexpectingly fail, due to simd_shuffle_indices being passed
+// the wrong Instance, causing issues with inlining. See #67557.
+//
+// run-pass
+// compile-flags: -Zmir-opt-level=3
+#![feature(platform_intrinsics, repr_simd)]
+
+extern "platform-intrinsic" {
+    fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
+}
+
+#[repr(simd)]
+#[derive(Debug, PartialEq)]
+struct Simd2(u8, u8);
+
+fn main() {
+    unsafe {
+        let p_res: Simd2 = simd_shuffle2(Simd2(10, 11), Simd2(12, 13), [0, 1]);
+        let a_res: Simd2 = inline_me();
+
+        assert_10_11(p_res);
+        assert_10_13(a_res);
+    }
+}
+
+#[inline(never)]
+fn assert_10_11(x: Simd2) {
+    assert_eq!(x, Simd2(10, 11));
+}
+
+#[inline(never)]
+fn assert_10_13(x: Simd2) {
+    assert_eq!(x, Simd2(10, 13));
+}
+
+
+#[inline(always)]
+unsafe fn inline_me() -> Simd2 {
+    simd_shuffle2(Simd2(10, 11), Simd2(12, 13), [0, 3])
+}


### PR DESCRIPTION
Closes #67557.

r? @oli-obk 