### PR TITLE
Promoteds can contain raw pointers, but these must still only point to immutable allocations

### DIFF
--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -5,7 +5,7 @@ use rustc::ty::layout::VariantIdx;
 use rustc::ty::{self, TyCtxt};
 use rustc_span::{source_map::DUMMY_SP, symbol::Symbol};
 
-use crate::interpret::{intern_const_alloc_recursive, ConstValue, InterpCx};
+use crate::interpret::{intern_const_alloc_recursive, ConstValue, InternKind, InterpCx};
 
 mod error;
 mod eval_queries;
@@ -52,7 +52,7 @@ pub(crate) fn const_caller_location<'tcx>(
 
     let loc_ty = tcx.caller_location_ty();
     let loc_place = ecx.alloc_caller_location(file, line, col);
-    intern_const_alloc_recursive(&mut ecx, None, loc_place, false).unwrap();
+    intern_const_alloc_recursive(&mut ecx, InternKind::Constant, loc_place, false).unwrap();
     let loc_const = ty::Const {
         ty: loc_ty,
         val: ty::ConstKind::Value(ConstValue::Scalar(loc_place.ptr.into())),

--- a/src/librustc_mir/interpret/intern.rs
+++ b/src/librustc_mir/interpret/intern.rs
@@ -356,7 +356,7 @@ pub fn intern_const_alloc_recursive<M: CompileTimeMachine<'mir, 'tcx>>(
                 // It is UB to mutate through a raw pointer obtained via an immutable reference.
                 // Since all references and pointers inside a promoted must by their very definition
                 // be created from an immutable reference (and promotion also excludes interior
-                // mutability), mutating though them would be UB.
+                // mutability), mutating through them would be UB.
                 // There's no way we can check whether the user is using raw pointers correctly,
                 // so all we can do is mark this as immutable here.
                 InternKind::Promoted => {

--- a/src/librustc_mir/interpret/intern.rs
+++ b/src/librustc_mir/interpret/intern.rs
@@ -361,7 +361,8 @@ pub fn intern_const_alloc_recursive<M: CompileTimeMachine<'mir, 'tcx>>(
                 // everything as immutable.
                 // It is UB to mutate through a raw pointer obtained via an immutable reference.
                 // Since all references and pointers inside a promoted must by their very definition
-                // be created from an immutable reference, mutating though them would be UB.
+                // be created from an immutable reference (and promotion also excludes interior
+                // mutability), mutating though them would be UB.
                 // There's no way we can check whether the user is using raw pointers correctly,
                 // so all we can do is mark this as immutable here.
                 InternKind::Promoted => {

--- a/src/librustc_mir/interpret/intern.rs
+++ b/src/librustc_mir/interpret/intern.rs
@@ -358,12 +358,12 @@ pub fn intern_const_alloc_recursive<M: CompileTimeMachine<'mir, 'tcx>>(
                     alloc.mutability = Mutability::Not;
                 }
                 // Raw pointers in promoteds may only point to immutable things so we mark
-                // everything as immutable. Creating a promoted with interior mutability is UB, but
-                // there's no way we can check whether the user is using raw pointers correctly.
-                // So all we can do is mark this as immutable here.
+                // everything as immutable.
                 // It is UB to mutate through a raw pointer obtained via an immutable reference.
                 // Since all references and pointers inside a promoted must by their very definition
                 // be created from an immutable reference, mutating though them would be UB.
+                // There's no way we can check whether the user is using raw pointers correctly,
+                // so all we can do is mark this as immutable here.
                 InternKind::Promoted => {
                     alloc.mutability = Mutability::Not;
                 }
@@ -394,7 +394,7 @@ pub fn intern_const_alloc_recursive<M: CompileTimeMachine<'mir, 'tcx>>(
             // We have hit an `AllocId` that belongs to an already interned static,
             // and are thus not interning any further.
 
-            // E.g. this should be unreachable for `InternKind::Promoted` except for allocations
+            // For `InternKind::Promoted` this is only reachable for allocations
             // created for string and byte string literals, since these are interned immediately
             // at creation time.
 

--- a/src/librustc_mir/interpret/mod.rs
+++ b/src/librustc_mir/interpret/mod.rs
@@ -32,6 +32,6 @@ pub use self::visitor::{MutValueVisitor, ValueVisitor};
 
 pub use self::validity::RefTracking;
 
-pub use self::intern::intern_const_alloc_recursive;
+pub use self::intern::{intern_const_alloc_recursive, InternKind};
 
 crate use self::intrinsics::eval_nullary_intrinsic;

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -29,9 +29,9 @@ use syntax::ast::Mutability;
 
 use crate::const_eval::error_to_const_error;
 use crate::interpret::{
-    self, intern_const_alloc_recursive, AllocId, Allocation, Frame, ImmTy, Immediate, InterpCx,
-    LocalState, LocalValue, Memory, MemoryKind, OpTy, Operand as InterpOperand, PlaceTy, Pointer,
-    ScalarMaybeUndef, StackPopCleanup,
+    self, intern_const_alloc_recursive, AllocId, Allocation, Frame, ImmTy, Immediate, InternKind,
+    InterpCx, LocalState, LocalValue, Memory, MemoryKind, OpTy, Operand as InterpOperand, PlaceTy,
+    Pointer, ScalarMaybeUndef, StackPopCleanup,
 };
 use crate::transform::{MirPass, MirSource};
 
@@ -726,7 +726,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
             )) => l.is_bits() && r.is_bits(),
             interpret::Operand::Indirect(_) if mir_opt_level >= 2 => {
                 let mplace = op.assert_mem_place(&self.ecx);
-                intern_const_alloc_recursive(&mut self.ecx, None, mplace, false)
+                intern_const_alloc_recursive(&mut self.ecx, InternKind::ConstProp, mplace, false)
                     .expect("failed to intern alloc");
                 true
             }

--- a/src/test/ui/consts/raw_pointer_promoted.rs
+++ b/src/test/ui/consts/raw_pointer_promoted.rs
@@ -1,0 +1,5 @@
+// check-pass
+
+pub const FOO: &'static *const i32 = &(&0 as _);
+
+fn main() {}


### PR DESCRIPTION
fixes #67601

r? @RalfJung 

cc @wesleywiser in order to not change behaviour in this PR, const prop uses the constant rules for interning, but at least there's an explicit mode for it now that we can think about this in the future