### PR TITLE
tidy: change msdn links to newer locations

### DIFF
--- a/src/etc/installer/msi/rust.wxs
+++ b/src/etc/installer/msi/rust.wxs
@@ -85,7 +85,7 @@
         <Property Id="ARPPRODUCTICON" Value="rust.ico" />
         <Property Id="ARPURLINFOABOUT" Value="https://www.rust-lang.org/" />
         <Property Id="ARPCOMMENTS" Value="$(env.CFG_RELEASE_INFO)" />
-        <!-- This is a dual-mode package. http://msdn.microsoft.com/en-us/library/windows/desktop/dd408068.aspx -->
+        <!-- This is a dual-mode package. https://docs.microsoft.com/en-us/windows/win32/msi/single-package-authoring -->
         <Property Id="ALLUSERS" Value="2" Secure="yes" />
         <Property Id="MSIINSTALLPERUSER" Secure="yes" />
         <!-- The actual install location (initialized below) -->

--- a/src/libpanic_unwind/seh.rs
+++ b/src/libpanic_unwind/seh.rs
@@ -41,7 +41,7 @@
 //!   are then recovered in the filter function to be written to the stack frame
 //!   of the `try` intrinsic.
 //!
-//! [win64]: http://msdn.microsoft.com/en-us/library/1eyas8tf.aspx
+//! [win64]: https://docs.microsoft.com/en-us/cpp/build/exception-handling-x64
 //! [llvm]: http://llvm.org/docs/ExceptionHandling.html#background-on-windows-exceptions
 
 #![allow(nonstandard_style)]

--- a/src/librustc_codegen_llvm/metadata.rs
+++ b/src/librustc_codegen_llvm/metadata.rs
@@ -97,7 +97,7 @@ pub fn metadata_section_name(target: &Target) -> &'static str {
     // > Executable images do not use a string table and do not support
     // > section names longer than 8 characters
     //
-    // https://msdn.microsoft.com/en-us/library/windows/hardware/gg463119.aspx
+    // https://docs.microsoft.com/en-us/windows/win32/debug/pe-format
     //
     // As a result, we choose a slightly shorter name! As to why
     // `.note.rustc` works on MinGW, that's another good question...

--- a/src/librustc_codegen_ssa/back/command.rs
+++ b/src/librustc_codegen_ssa/back/command.rs
@@ -168,8 +168,8 @@ impl Command {
         // error code if we fail to spawn and automatically re-spawning the
         // linker with smaller arguments.
         //
-        // [1]: https://msdn.microsoft.com/en-us/library/windows/desktop/ms682425(v=vs.85).aspx
-        // [2]: https://blogs.msdn.microsoft.com/oldnewthing/20031210-00/?p=41553
+        // [1]: https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa
+        // [2]: https://devblogs.microsoft.com/oldnewthing/?p=41553
 
         let estimated_command_line_len = self.args.iter().map(|a| a.len()).sum::<usize>();
         estimated_command_line_len > 1024 * 6

--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -1044,7 +1044,7 @@ pub fn exec_linker(
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             if self.is_like_msvc {
                 // This is "documented" at
-                // https://msdn.microsoft.com/en-us/library/4xdcbak7.aspx
+                // https://docs.microsoft.com/en-us/cpp/build/reference/at-specify-a-linker-response-file
                 //
                 // Unfortunately there's not a great specification of the
                 // syntax I could find online (at least) but some local

--- a/src/librustc_target/abi/call/x86_win64.rs
+++ b/src/librustc_target/abi/call/x86_win64.rs
@@ -1,7 +1,7 @@
 use crate::abi::call::{ArgAbi, FnAbi, Reg};
 use crate::abi::Abi;
 
-// Win64 ABI: http://msdn.microsoft.com/en-us/library/zthk2dkh.aspx
+// Win64 ABI: https://docs.microsoft.com/en-us/cpp/build/parameter-passing
 
 pub fn compute_abi_info<Ty>(fn_abi: &mut FnAbi<'_, Ty>) {
     let fixup = |a: &mut ArgAbi<'_, Ty>| {

--- a/src/librustc_target/spec/i686_pc_windows_msvc.rs
+++ b/src/librustc_target/spec/i686_pc_windows_msvc.rs
@@ -11,7 +11,7 @@ pub fn target() -> TargetResult {
 
     // Ensure the linker will only produce an image if it can also produce a table of
     // the image's safe exception handlers.
-    // https://msdn.microsoft.com/en-us/library/9a89h429.aspx
+    // https://docs.microsoft.com/en-us/cpp/build/reference/safeseh-image-has-safe-exception-handlers
     base.pre_link_args.get_mut(&LinkerFlavor::Msvc).unwrap().push("/SAFESEH".to_string());
 
     Ok(Target {

--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -550,7 +550,7 @@ impl Error for JoinPathsError {
 ///   (including to an empty string).
 /// - If both do not exist, [`GetUserProfileDirectory`][msdn] is used to return the path.
 ///
-/// [msdn]: https://msdn.microsoft.com/en-us/library/windows/desktop/bb762280(v=vs.85).aspx
+/// [msdn]: https://docs.microsoft.com/en-us/windows/win32/api/userenv/nf-userenv-getuserprofiledirectorya
 ///
 /// # Examples
 ///
@@ -589,7 +589,7 @@ pub fn home_dir() -> Option<PathBuf> {
 /// This behavior is identical to that of [`GetTempPath`][msdn], which this
 /// function uses internally.
 ///
-/// [msdn]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa364992(v=vs.85).aspx
+/// [msdn]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppatha
 ///
 /// ```no_run
 /// use std::env;

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1841,7 +1841,7 @@ pub fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
 /// or written to a file another application may read).
 ///
 /// [changes]: ../io/index.html#platform-specific-behavior
-/// [path]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx#maxpath
+/// [path]: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
 ///
 /// # Errors
 ///

--- a/src/libstd/sys/windows/ext/fs.rs
+++ b/src/libstd/sys/windows/ext/fs.rs
@@ -117,7 +117,7 @@ pub trait OpenOptionsExt {
     /// let file = OpenOptions::new().access_mode(0).open("foo.txt");
     /// ```
     ///
-    /// [`CreateFile`]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa363858.aspx
+    /// [`CreateFile`]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea
     #[stable(feature = "open_options_ext", since = "1.10.0")]
     fn access_mode(&mut self, access: u32) -> &mut Self;
 
@@ -145,7 +145,7 @@ pub trait OpenOptionsExt {
     ///     .open("foo.txt");
     /// ```
     ///
-    /// [`CreateFile`]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa363858.aspx
+    /// [`CreateFile`]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea
     #[stable(feature = "open_options_ext", since = "1.10.0")]
     fn share_mode(&mut self, val: u32) -> &mut Self;
 
@@ -174,8 +174,8 @@ pub trait OpenOptionsExt {
     ///     .open("foo.txt");
     /// ```
     ///
-    /// [`CreateFile`]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa363858.aspx
-    /// [`CreateFile2`]: https://msdn.microsoft.com/en-us/library/windows/desktop/hh449422.aspx
+    /// [`CreateFile`]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea
+    /// [`CreateFile2`]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfile2
     #[stable(feature = "open_options_ext", since = "1.10.0")]
     fn custom_flags(&mut self, flags: u32) -> &mut Self;
 
@@ -211,8 +211,8 @@ pub trait OpenOptionsExt {
     ///     .open("foo.txt");
     /// ```
     ///
-    /// [`CreateFile`]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa363858.aspx
-    /// [`CreateFile2`]: https://msdn.microsoft.com/en-us/library/windows/desktop/hh449422.aspx
+    /// [`CreateFile`]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea
+    /// [`CreateFile2`]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfile2
     #[stable(feature = "open_options_ext", since = "1.10.0")]
     fn attributes(&mut self, val: u32) -> &mut Self;
 
@@ -254,10 +254,10 @@ pub trait OpenOptionsExt {
     ///     .open(r"\\.\pipe\MyPipe");
     /// ```
     ///
-    /// [`CreateFile`]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa363858.aspx
-    /// [`CreateFile2`]: https://msdn.microsoft.com/en-us/library/windows/desktop/hh449422.aspx
+    /// [`CreateFile`]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea
+    /// [`CreateFile2`]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfile2
     /// [Impersonation Levels]:
-    ///     https://msdn.microsoft.com/en-us/library/windows/desktop/aa379572.aspx
+    ///     https://docs.microsoft.com/en-us/windows/win32/api/winnt/ne-winnt-security_impersonation_level
     #[stable(feature = "open_options_ext", since = "1.10.0")]
     fn security_qos_flags(&mut self, flags: u32) -> &mut OpenOptions;
 }
@@ -297,7 +297,7 @@ impl OpenOptionsExt for OpenOptions {
 ///
 /// [`fs::Metadata`]: ../../../../std/fs/struct.Metadata.html
 /// [`BY_HANDLE_FILE_INFORMATION`]:
-///     https://msdn.microsoft.com/en-us/library/windows/desktop/aa363788.aspx
+///     https://docs.microsoft.com/en-us/windows/win32/api/fileapi/ns-fileapi-by_handle_file_information
 #[stable(feature = "metadata_ext", since = "1.1.0")]
 pub trait MetadataExt {
     /// Returns the value of the `dwFileAttributes` field of this metadata.
@@ -321,7 +321,7 @@ pub trait MetadataExt {
     /// ```
     ///
     /// [File Attribute Constants]:
-    ///     https://msdn.microsoft.com/en-us/library/windows/desktop/gg258117.aspx
+    ///     https://docs.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants
     #[stable(feature = "metadata_ext", since = "1.1.0")]
     fn file_attributes(&self) -> u32;
 
@@ -350,7 +350,7 @@ pub trait MetadataExt {
     /// }
     /// ```
     ///
-    /// [`FILETIME`]: https://msdn.microsoft.com/en-us/library/windows/desktop/ms724284.aspx
+    /// [`FILETIME`]: https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime
     #[stable(feature = "metadata_ext", since = "1.1.0")]
     fn creation_time(&self) -> u64;
 
@@ -385,7 +385,7 @@ pub trait MetadataExt {
     /// }
     /// ```
     ///
-    /// [`FILETIME`]: https://msdn.microsoft.com/en-us/library/windows/desktop/ms724284.aspx
+    /// [`FILETIME`]: https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime
     #[stable(feature = "metadata_ext", since = "1.1.0")]
     fn last_access_time(&self) -> u64;
 
@@ -418,7 +418,7 @@ pub trait MetadataExt {
     /// }
     /// ```
     ///
-    /// [`FILETIME`]: https://msdn.microsoft.com/en-us/library/windows/desktop/ms724284.aspx
+    /// [`FILETIME`]: https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime
     #[stable(feature = "metadata_ext", since = "1.1.0")]
     fn last_write_time(&self) -> u64;
 

--- a/src/libstd/sys/windows/ext/process.rs
+++ b/src/libstd/sys/windows/ext/process.rs
@@ -99,7 +99,7 @@ pub trait CommandExt {
     ///
     /// These will always be ORed with `CREATE_UNICODE_ENVIRONMENT`.
     ///
-    /// [1]: https://msdn.microsoft.com/en-us/library/windows/desktop/ms684863(v=vs.85).aspx
+    /// [1]: https://docs.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
     #[stable(feature = "windows_process_extensions", since = "1.16.0")]
     fn creation_flags(&mut self, flags: u32) -> &mut process::Command;
 }

--- a/src/libstd/sys/windows/mod.rs
+++ b/src/libstd/sys/windows/mod.rs
@@ -262,7 +262,7 @@ pub fn dur2timeout(dur: Duration) -> c::DWORD {
 // terminating the process but without necessarily bypassing all exception
 // handlers.
 //
-// https://msdn.microsoft.com/en-us/library/dn774154.aspx
+// https://docs.microsoft.com/en-us/cpp/intrinsics/fastfail
 #[allow(unreachable_code)]
 pub unsafe fn abort_internal() -> ! {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]

--- a/src/libstd/sys/windows/os.rs
+++ b/src/libstd/sys/windows/os.rs
@@ -34,7 +34,7 @@ pub fn error_string(mut errnum: i32) -> String {
 
         // NTSTATUS errors may be encoded as HRESULT, which may returned from
         // GetLastError. For more information about Windows error codes, see
-        // `[MS-ERREF]`: https://msdn.microsoft.com/en-us/library/cc231198.aspx
+        // `[MS-ERREF]`: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/0642cb2f-2075-4469-918c-4441e69c548a
         if (errnum & c::FACILITY_NT_BIT as i32) != 0 {
             // format according to https://support.microsoft.com/en-us/help/259693
             const NTDLL_DLL: &[u16] = &[

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -27,7 +27,7 @@
 //! ```
 //!
 //! [ansi]: https://en.wikipedia.org/wiki/ANSI_escape_code
-//! [win]: http://msdn.microsoft.com/en-us/library/windows/desktop/ms682010%28v=vs.85%29.aspx
+//! [win]: https://docs.microsoft.com/en-us/windows/console/character-mode-applications
 //! [ti]: https://en.wikipedia.org/wiki/Terminfo
 
 #![doc(

--- a/src/libterm/win.rs
+++ b/src/libterm/win.rs
@@ -101,7 +101,7 @@ impl<T: Write + Send + 'static> WinConsole<T> {
 
         unsafe {
             // Magic -11 means stdout, from
-            // http://msdn.microsoft.com/en-us/library/windows/desktop/ms683231%28v=vs.85%29.aspx
+            // https://docs.microsoft.com/en-us/windows/console/getstdhandle
             //
             // You may be wondering, "but what about stderr?", and the answer
             // to that is that setting terminal attributes on the stdout


### PR DESCRIPTION
see accouncement at https://docs.microsoft.com/welcome-to-docs
The script that I used: https://gist.github.com/lzutao/1449c9210ad91899841d62e0058d2caa
