### PR TITLE
Treat extern statics just like statics in the "const pointer to static" representation

### DIFF
--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -665,8 +665,6 @@ impl<'tcx> TyCtxt<'tcx> {
 
         if self.is_mutable_static(def_id) {
             self.mk_mut_ptr(static_ty)
-        } else if self.is_foreign_item(def_id) {
-            self.mk_imm_ptr(static_ty)
         } else {
             self.mk_imm_ref(self.lifetimes.re_erased, static_ty)
         }

--- a/src/test/mir-opt/const-promotion-extern-static.rs
+++ b/src/test/mir-opt/const-promotion-extern-static.rs
@@ -1,0 +1,71 @@
+extern "C" {
+    static X: i32;
+}
+
+static Y: i32 = 42;
+
+static mut BAR: *const &'static i32 = [&Y].as_ptr();
+
+static mut FOO: *const &'static i32 = [unsafe { &X }].as_ptr();
+
+fn main() {}
+
+// END RUST SOURCE
+// START rustc.FOO.PromoteTemps.before.mir
+// bb0: {
+// ...
+//     _5 = const Scalar(AllocId(1).0x0) : &i32;
+//     _4 = &(*_5);
+//     _3 = [move _4];
+//     _2 = &_3;
+//     _1 = move _2 as &[&'static i32] (Pointer(Unsize));
+//     _0 = const core::slice::<impl [&'static i32]>::as_ptr(move _1) -> [return: bb2, unwind: bb1];
+// }
+// ...
+// bb2: {
+//     StorageDead(_5);
+//     StorageDead(_3);
+//     return;
+// }
+// END rustc.FOO.PromoteTemps.before.mir
+// START rustc.BAR.PromoteTemps.before.mir
+// bb0: {
+// ...
+//     _5 = const Scalar(AllocId(0).0x0) : &i32;
+//     _4 = &(*_5);
+//     _3 = [move _4];
+//     _2 = &_3;
+//     _1 = move _2 as &[&'static i32] (Pointer(Unsize));
+//     _0 = const core::slice::<impl [&'static i32]>::as_ptr(move _1) -> [return: bb2, unwind: bb1];
+// }
+// ...
+// bb2: {
+//     StorageDead(_5);
+//     StorageDead(_3);
+//     return;
+// }
+// END rustc.BAR.PromoteTemps.before.mir
+// START rustc.BAR.PromoteTemps.after.mir
+// bb0: {
+// ...
+//     _2 = &(promoted[0]: [&'static i32; 1]);
+//     _1 = move _2 as &[&'static i32] (Pointer(Unsize));
+//     _0 = const core::slice::<impl [&'static i32]>::as_ptr(move _1) -> [return: bb2, unwind: bb1];
+// }
+// ...
+// bb2: {
+//     return;
+// }
+// END rustc.BAR.PromoteTemps.after.mir
+// START rustc.FOO.PromoteTemps.after.mir
+// bb0: {
+// ...
+//     _2 = &(promoted[0]: [&'static i32; 1]);
+//     _1 = move _2 as &[&'static i32] (Pointer(Unsize));
+//     _0 = const core::slice::<impl [&'static i32]>::as_ptr(move _1) -> [return: bb2, unwind: bb1];
+// }
+// ...
+// bb2: {
+//     return;
+// }
+// END rustc.FOO.PromoteTemps.after.mir


### PR DESCRIPTION
fixes #67612

r? @spastorino 

cc @RalfJung this does not affect runtime promotion at all. This is just about promotion within static item bodies.