### PR TITLE
allow rustfmt key in [build] section

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -132,6 +132,10 @@
 # specified, use this rustc binary instead as the stage0 snapshot compiler.
 #rustc = "/path/to/bin/rustc"
 
+# Instead of download the src/stage0.txt version of rustfmt specified,
+# use this rustfmt binary instead as the stage0 snapshot rustfmt.
+#rustfmt = "/path/to/bin/rustfmt"
+
 # Flag to specify whether any documentation is built. If false, rustdoc and
 # friends will still be compiled but they will not be used to generate any
 # documentation.

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -201,6 +201,7 @@ struct Build {
     target: Vec<String>,
     cargo: Option<String>,
     rustc: Option<String>,
+    rustfmt: Option<String>, /* allow bootstrap.py to use rustfmt key */
     docs: Option<bool>,
     compiler_docs: Option<bool>,
     submodules: Option<bool>,


### PR DESCRIPTION
Permit using `rustfmt` in `config.toml`. It will allow to not download `rustfmt` binary, which is not possible for at least some tiers-3 platforms.

Fixes: #67624

r? @Mark-Simulacrum 
