### PR TITLE
Add primitive module to libcore

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -262,7 +262,7 @@ mod bool;
 mod tuple;
 mod unit;
 
-#[stable(feature = "core_primitive", since = "1.42.0")]
+#[stable(feature = "core_primitive", since = "1.43.0")]
 pub mod primitive;
 
 // Pull in the `core_arch` crate directly into libcore. The contents of

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -262,6 +262,9 @@ mod bool;
 mod tuple;
 mod unit;
 
+#[stable(feature = "core_primitive", since = "1.42.0")]
+pub mod primitive;
+
 // Pull in the `core_arch` crate directly into libcore. The contents of
 // `core_arch` are in a different repository: rust-lang/stdarch.
 //

--- a/src/libcore/primitive.rs
+++ b/src/libcore/primitive.rs
@@ -31,37 +31,37 @@
 //! # trait QueryId { const SOME_PROPERTY: core::primitive::bool; }
 //! ```
 
-#[stable(feature = "core_primitive", since = "1.42.0")]
+#[stable(feature = "core_primitive", since = "1.43.0")]
 pub use bool;
-#[stable(feature = "core_primitive", since = "1.42.0")]
+#[stable(feature = "core_primitive", since = "1.43.0")]
 pub use char;
-#[stable(feature = "core_primitive", since = "1.42.0")]
+#[stable(feature = "core_primitive", since = "1.43.0")]
 pub use f32;
-#[stable(feature = "core_primitive", since = "1.42.0")]
+#[stable(feature = "core_primitive", since = "1.43.0")]
 pub use f64;
-#[stable(feature = "core_primitive", since = "1.42.0")]
+#[stable(feature = "core_primitive", since = "1.43.0")]
 pub use i128;
-#[stable(feature = "core_primitive", since = "1.42.0")]
+#[stable(feature = "core_primitive", since = "1.43.0")]
 pub use i16;
-#[stable(feature = "core_primitive", since = "1.42.0")]
+#[stable(feature = "core_primitive", since = "1.43.0")]
 pub use i32;
-#[stable(feature = "core_primitive", since = "1.42.0")]
+#[stable(feature = "core_primitive", since = "1.43.0")]
 pub use i64;
-#[stable(feature = "core_primitive", since = "1.42.0")]
+#[stable(feature = "core_primitive", since = "1.43.0")]
 pub use i8;
-#[stable(feature = "core_primitive", since = "1.42.0")]
+#[stable(feature = "core_primitive", since = "1.43.0")]
 pub use isize;
-#[stable(feature = "core_primitive", since = "1.42.0")]
+#[stable(feature = "core_primitive", since = "1.43.0")]
 pub use str;
-#[stable(feature = "core_primitive", since = "1.42.0")]
+#[stable(feature = "core_primitive", since = "1.43.0")]
 pub use u128;
-#[stable(feature = "core_primitive", since = "1.42.0")]
+#[stable(feature = "core_primitive", since = "1.43.0")]
 pub use u16;
-#[stable(feature = "core_primitive", since = "1.42.0")]
+#[stable(feature = "core_primitive", since = "1.43.0")]
 pub use u32;
-#[stable(feature = "core_primitive", since = "1.42.0")]
+#[stable(feature = "core_primitive", since = "1.43.0")]
 pub use u64;
-#[stable(feature = "core_primitive", since = "1.42.0")]
+#[stable(feature = "core_primitive", since = "1.43.0")]
 pub use u8;
-#[stable(feature = "core_primitive", since = "1.42.0")]
+#[stable(feature = "core_primitive", since = "1.43.0")]
 pub use usize;

--- a/src/libcore/primitive.rs
+++ b/src/libcore/primitive.rs
@@ -1,0 +1,67 @@
+//! This module reexports the primitive types to allow usage that is not
+//! possibly shadowed by other declared types.
+//!
+//! This is normally only useful in macro generated code.
+//!
+//! An example of this is when generating a new struct and an impl for it:
+//!
+//! ```rust,compile_fail
+//! pub struct bool;
+//!
+//! impl QueryId for bool {
+//!     const SOME_PROPERTY: bool = true;
+//! }
+//!
+//! # trait QueryId { const SOME_PROPERTY: core::primitive::bool; }
+//! ```
+//!
+//! Note that the `SOME_PROPERTY` associated constant would not compile, as its
+//! type `bool` refers to the struct, rather than to the primitive bool type.
+//!
+//! A correct implementation could look like:
+//!
+//! ```rust
+//! # #[allow(non_camel_case_types)]
+//! pub struct bool;
+//!
+//! impl QueryId for bool {
+//!     const SOME_PROPERTY: core::primitive::bool = true;
+//! }
+//!
+//! # trait QueryId { const SOME_PROPERTY: core::primitive::bool; }
+//! ```
+
+#[stable(feature = "core_primitive", since = "1.42.0")]
+pub use bool;
+#[stable(feature = "core_primitive", since = "1.42.0")]
+pub use char;
+#[stable(feature = "core_primitive", since = "1.42.0")]
+pub use f32;
+#[stable(feature = "core_primitive", since = "1.42.0")]
+pub use f64;
+#[stable(feature = "core_primitive", since = "1.42.0")]
+pub use i128;
+#[stable(feature = "core_primitive", since = "1.42.0")]
+pub use i16;
+#[stable(feature = "core_primitive", since = "1.42.0")]
+pub use i32;
+#[stable(feature = "core_primitive", since = "1.42.0")]
+pub use i64;
+#[stable(feature = "core_primitive", since = "1.42.0")]
+pub use i8;
+#[stable(feature = "core_primitive", since = "1.42.0")]
+pub use isize;
+#[stable(feature = "core_primitive", since = "1.42.0")]
+pub use str;
+#[stable(feature = "core_primitive", since = "1.42.0")]
+pub use u128;
+#[stable(feature = "core_primitive", since = "1.42.0")]
+pub use u16;
+#[stable(feature = "core_primitive", since = "1.42.0")]
+pub use u32;
+#[stable(feature = "core_primitive", since = "1.42.0")]
+pub use u64;
+#[stable(feature = "core_primitive", since = "1.42.0")]
+pub use u8;
+#[stable(feature = "core_primitive", since = "1.42.0")]
+pub use usize;

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -550,7 +550,7 @@ pub use core::{
     trace_macros,
 };
 
-#[stable(feature = "core_primitive", since = "1.42.0")]
+#[stable(feature = "core_primitive", since = "1.43.0")]
 pub use core::primitive;
 
 // Include a number of private modules that exist solely to provide

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -233,12 +233,12 @@
 #![feature(allocator_internals)]
 #![feature(allow_internal_unsafe)]
 #![feature(allow_internal_unstable)]
-#![feature(atomic_mut_ptr)]
 #![feature(arbitrary_self_types)]
 #![feature(array_error_internals)]
 #![feature(asm)]
 #![feature(assoc_int_consts)]
 #![feature(associated_type_bounds)]
+#![feature(atomic_mut_ptr)]
 #![feature(box_syntax)]
 #![feature(c_variadic)]
 #![feature(cfg_target_has_atomic)]
@@ -549,6 +549,9 @@ pub use core::{
     stringify,
     trace_macros,
 };
+
+#[stable(feature = "core_primitive", since = "1.42.0")]
+pub use core::primitive;
 
 // Include a number of private modules that exist solely to provide
 // the rustdoc documentation for primitive types. Using `include!`

--- a/src/test/ui/resolve/resolve-primitive-fallback.stderr
+++ b/src/test/ui/resolve/resolve-primitive-fallback.stderr
@@ -9,6 +9,11 @@ error[E0412]: cannot find type `u8` in the crate root
    |
 LL |     let _: ::u8;
    |              ^^ not found in the crate root
+   |
+help: possible candidate is found in another module, you can import it into scope
+   |
+LL | use std::primitive::u8;
+   |
 
 error[E0061]: this function takes 0 parameters but 1 parameter was supplied
   --> $DIR/resolve-primitive-fallback.rs:3:5

--- a/src/test/ui/shadow-bool.rs
+++ b/src/test/ui/shadow-bool.rs
@@ -1,0 +1,18 @@
+// check-pass
+
+mod bar {
+    pub trait QueryId {
+        const SOME_PROPERTY: bool;
+    }
+}
+
+use bar::QueryId;
+
+#[allow(non_camel_case_types)]
+pub struct bool;
+
+impl QueryId for bool {
+    const SOME_PROPERTY: core::primitive::bool = true;
+}
+
+fn main() {}


### PR DESCRIPTION
This re-exports the primitive types from libcore at `core::primitive` to allow
macro authors to have a reliable location to use them from.

Fixes #44865