### PR TITLE
Relax bounds on HashMap/HashSet

### DIFF
--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -110,7 +110,7 @@ pub struct HashSet<T, S = RandomState> {
     map: HashMap<T, (), S>,
 }
 
-impl<T: Hash + Eq> HashSet<T, RandomState> {
+impl<T> HashSet<T, RandomState> {
     /// Creates an empty `HashSet`.
     ///
     /// The hash set is initially created with a capacity of 0, so it will not allocate until it
@@ -261,13 +261,7 @@ impl<T, S> HashSet<T, S> {
     pub fn clear(&mut self) {
         self.map.clear()
     }
-}
 
-impl<T, S> HashSet<T, S>
-where
-    T: Eq + Hash,
-    S: BuildHasher,
-{
     /// Creates a new empty hash set which will use the given hasher to hash
     /// keys.
     ///
@@ -340,7 +334,13 @@ where
     pub fn hasher(&self) -> &S {
         self.map.hasher()
     }
+}
 
+impl<T, S> HashSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher,
+{
     /// Reserves capacity for at least `additional` more elements to be inserted
     /// in the `HashSet`. The collection may reserve more space to avoid
     /// frequent reallocations.
@@ -896,8 +896,7 @@ where
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T, S> fmt::Debug for HashSet<T, S>
 where
-    T: Eq + Hash + fmt::Debug,
-    S: BuildHasher,
+    T: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_set().entries(self.iter()).finish()
@@ -945,8 +944,7 @@ where
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T, S> Default for HashSet<T, S>
 where
-    T: Eq + Hash,
-    S: BuildHasher + Default,
+    S: Default,
 {
     /// Creates an empty `HashSet<T, S>` with the `Default` value for the hasher.
     #[inline]

--- a/src/test/ui/const-generics/array-impls/core-traits-no-impls-length-33.rs
+++ b/src/test/ui/const-generics/array-impls/core-traits-no-impls-length-33.rs
@@ -6,7 +6,6 @@ pub fn no_debug() {
 pub fn no_hash() {
     use std::collections::HashSet;
     let mut set = HashSet::new();
-    //~^ ERROR arrays only have std trait implementations for lengths 0..=32
     set.insert([0_usize; 33]);
     //~^ ERROR arrays only have std trait implementations for lengths 0..=32
 }

--- a/src/test/ui/const-generics/array-impls/core-traits-no-impls-length-33.stderr
+++ b/src/test/ui/const-generics/array-impls/core-traits-no-impls-length-33.stderr
@@ -8,24 +8,15 @@ LL |     println!("{:?}", [0_usize; 33]);
    = note: required by `std::fmt::Debug::fmt`
 
 error[E0277]: arrays only have std trait implementations for lengths 0..=32
-  --> $DIR/core-traits-no-impls-length-33.rs:10:16
+  --> $DIR/core-traits-no-impls-length-33.rs:9:16
    |
 LL |     set.insert([0_usize; 33]);
    |                ^^^^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[usize; 33]`
    |
    = note: required because of the requirements on the impl of `std::cmp::Eq` for `[usize; 33]`
 
-error[E0277]: arrays only have std trait implementations for lengths 0..=32
-  --> $DIR/core-traits-no-impls-length-33.rs:8:19
-   |
-LL |     let mut set = HashSet::new();
-   |                   ^^^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[usize; 33]`
-   |
-   = note: required because of the requirements on the impl of `std::cmp::Eq` for `[usize; 33]`
-   = note: required by `std::collections::HashSet::<T>::new`
-
 error[E0369]: binary operation `==` cannot be applied to type `[usize; 33]`
-  --> $DIR/core-traits-no-impls-length-33.rs:15:19
+  --> $DIR/core-traits-no-impls-length-33.rs:14:19
    |
 LL |     [0_usize; 33] == [1_usize; 33]
    |     ------------- ^^ ------------- [usize; 33]
@@ -35,7 +26,7 @@ LL |     [0_usize; 33] == [1_usize; 33]
    = note: an implementation of `std::cmp::PartialEq` might be missing for `[usize; 33]`
 
 error[E0369]: binary operation `<` cannot be applied to type `[usize; 33]`
-  --> $DIR/core-traits-no-impls-length-33.rs:20:19
+  --> $DIR/core-traits-no-impls-length-33.rs:19:19
    |
 LL |     [0_usize; 33] < [1_usize; 33]
    |     ------------- ^ ------------- [usize; 33]
@@ -45,7 +36,7 @@ LL |     [0_usize; 33] < [1_usize; 33]
    = note: an implementation of `std::cmp::PartialOrd` might be missing for `[usize; 33]`
 
 error[E0277]: the trait bound `&[usize; 33]: std::iter::IntoIterator` is not satisfied
-  --> $DIR/core-traits-no-impls-length-33.rs:25:14
+  --> $DIR/core-traits-no-impls-length-33.rs:24:14
    |
 LL |     for _ in &[0_usize; 33] {
    |              ^^^^^^^^^^^^^^ the trait `std::iter::IntoIterator` is not implemented for `&[usize; 33]`
@@ -57,7 +48,7 @@ LL |     for _ in &[0_usize; 33] {
              <&'a mut [T] as std::iter::IntoIterator>
    = note: required by `std::iter::IntoIterator::into_iter`
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0277, E0369.
 For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
These APIs changed from the old bound listed to the new bound (possibly empty):

K: Hash + Eq -> K
* new
* with_capacity

K: Eq + Hash, S: BuildHasher -> K, S
* with_hasher
* with_capacity_and_hasher
* hasher

K: Eq + Hash + Debug -> K: Debug
S: BuildHasher -> S
HashMap as Debug

K: Eq + Hash -> K
S: BuildHasher + Default -> S: Default
HashMap as Default

Resolves #44777.