### PR TITLE
Add regression test for old NLL ICE

### DIFF
--- a/src/test/ui/issues/issue-51770.rs
+++ b/src/test/ui/issues/issue-51770.rs
@@ -1,0 +1,20 @@
+// check-pass
+
+#![crate_type = "lib"]
+
+// In an older version, when NLL was still a feature, the following previously did not compile
+// #![feature(nll)]
+
+use std::ops::Index;
+
+pub struct Test<T> {
+    a: T,
+}
+
+impl<T> Index<usize> for Test<T> {
+    type Output = T;
+
+    fn index(&self, _index: usize) -> &Self::Output {
+        &self.a
+    }
+}


### PR DESCRIPTION
This fails on nightly-2018-06-24.

Resolves #51770