### PR TITLE
Clean up const-hack PRs now that const if / match exist.

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -71,6 +71,8 @@
 #![feature(cfg_target_has_atomic)]
 #![feature(concat_idents)]
 #![feature(const_fn)]
+#![feature(const_if_match)]
+#![feature(const_panic)]
 #![feature(const_fn_union)]
 #![feature(const_generics)]
 #![feature(const_ptr_offset_from)]

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1709,8 +1709,13 @@ assert_eq!(", stringify!($SelfT), "::MIN.overflowing_neg(), (", stringify!($Self
             #[inline]
             #[stable(feature = "wrapping", since = "1.7.0")]
             #[rustc_const_stable(feature = "const_int_methods", since = "1.32.0")]
+            #[allow_internal_unstable(const_if_match)]
             pub const fn overflowing_neg(self) -> (Self, bool) {
-                ((!self).wrapping_add(1), self == Self::min_value())
+                if self == Self::min_value() {
+                    (Self::min_value(), true)
+                } else {
+                    (-self, false)
+                }
             }
         }
 

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1416,18 +1416,14 @@ $EndFeature, "
 ```"),
             #[stable(feature = "no_panic_abs", since = "1.13.0")]
             #[rustc_const_stable(feature = "const_int_methods", since = "1.32.0")]
+            #[allow_internal_unstable(const_if_match)]
             #[inline]
             pub const fn wrapping_abs(self) -> Self {
-                // sign is -1 (all ones) for negative numbers, 0 otherwise.
-                let sign = self >> ($BITS - 1);
-                // For positive self, sign == 0 so the expression is simply
-                // (self ^ 0).wrapping_sub(0) == self == abs(self).
-                //
-                // For negative self, self ^ sign == self ^ all_ones.
-                // But all_ones ^ self == all_ones - self == -1 - self.
-                // So for negative numbers, (self ^ sign).wrapping_sub(sign) is
-                // (-1 - self).wrapping_sub(-1) == -self == abs(self).
-                (self ^ sign).wrapping_sub(sign)
+                 if self.is_negative() {
+                     self.wrapping_neg()
+                 } else {
+                     self
+                 }
             }
         }
 

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -2037,7 +2037,11 @@ $EndFeature, "
             #[rustc_const_unstable(feature = "const_int_sign", issue = "53718")]
             #[inline]
             pub const fn signum(self) -> Self {
-                (self > 0) as Self - (self < 0) as Self
+                match self {
+                    n if n > 0 =>  1,
+                    0          =>  0,
+                    _          => -1,
+                }
             }
         }
 

--- a/src/libcore/ptr/const_ptr.rs
+++ b/src/libcore/ptr/const_ptr.rs
@@ -288,10 +288,7 @@ impl<T: ?Sized> *const T {
         T: Sized,
     {
         let pointee_size = mem::size_of::<T>();
-        let ok = 0 < pointee_size && pointee_size <= isize::max_value() as usize;
-        // assert that the pointee size is valid in a const eval compatible way
-        // FIXME: do this with a real assert at some point
-        [()][(!ok) as usize];
+        assert!(0 < pointee_size && pointee_size <= isize::max_value() as usize);
         intrinsics::ptr_offset_from(self, origin)
     }
 


### PR DESCRIPTION
Closes #67627.

Cleans up these merged PRs tagged with `const-hack`:

- #63810
- #63786
- #61635
- #58044

reverting their contents to have the match or if expressions they originally contained.

r? @oli-obk 

There's one more PR in those tagged with `const-hack` that originally wasn't merged (#65107). Reading the thread, it looks like it was originally closed because the `const-hack` for the checked arithmetic non-negligibly hurt performance, and because there was no way to manipulate the returned Option at compile time anyway (with neither const if nor const match). Would you like me to add these changes to the changes from this PR here too, now that we have the necessary features?