### PR TITLE
Stabilize the `matches!` macro

### DIFF
--- a/src/libcore/macros/mod.rs
+++ b/src/libcore/macros/mod.rs
@@ -252,8 +252,6 @@ macro_rules! debug_assert_ne {
 /// # Examples
 ///
 /// ```
-/// #![feature(matches_macro)]
-///
 /// let foo = 'f';
 /// assert!(matches!(foo, 'A'..='Z' | 'a'..='z'));
 ///
@@ -261,7 +259,7 @@ macro_rules! debug_assert_ne {
 /// assert!(matches!(bar, Some(x) if x > 2));
 /// ```
 #[macro_export]
-#[unstable(feature = "matches_macro", issue = "65721")]
+#[stable(feature = "matches_macro", since = "1.42.0")]
 macro_rules! matches {
     ($expression:expr, $( $pattern:pat )|+ $( if $guard: expr )?) => {
         match $expression {

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -15,7 +15,6 @@
 #![feature(box_patterns)]
 #![feature(box_syntax)]
 #![feature(nll)]
-#![feature(matches_macro)]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -29,7 +29,6 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 #![feature(range_is_empty)]
 #![feature(stmt_expr_attributes)]
 #![feature(trait_alias)]
-#![feature(matches_macro)]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -276,7 +276,6 @@
 #![feature(linkage)]
 #![feature(log_syntax)]
 #![feature(manually_drop_take)]
-#![feature(matches_macro)]
 #![feature(maybe_uninit_ref)]
 #![feature(maybe_uninit_slice)]
 #![feature(needs_panic_runtime)]

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -11,7 +11,6 @@
 #![feature(const_transmute)]
 #![feature(crate_visibility_modifier)]
 #![feature(label_break_value)]
-#![feature(matches_macro)]
 #![feature(nll)]
 #![feature(try_trait)]
 #![feature(slice_patterns)]


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/65721

FCP: https://github.com/rust-lang/rust/issues/65721#issuecomment-569118119