### PR TITLE
Fix `Instance::resolve()` incorrectly returning specialized instances

### DIFF
--- a/src/librustc/mir/interpret/queries.rs
+++ b/src/librustc/mir/interpret/queries.rs
@@ -18,7 +18,7 @@ impl<'tcx> TyCtxt<'tcx> {
         let substs = InternalSubsts::identity_for_item(self, def_id);
         let instance = ty::Instance::new(def_id, substs);
         let cid = GlobalId { instance, promoted: None };
-        let param_env = self.param_env(def_id);
+        let param_env = self.param_env(def_id).with_reveal_all();
         self.const_eval_validated(param_env.and(cid))
     }
 

--- a/src/librustc/traits/project.rs
+++ b/src/librustc/traits/project.rs
@@ -1028,6 +1028,9 @@ fn assemble_candidates_from_impls<'cx, 'tcx>(
                 // In either case, we handle this by not adding a
                 // candidate for an impl if it contains a `default`
                 // type.
+                //
+                // NOTE: This should be kept in sync with the similar code in
+                // `rustc::ty::instance::resolve_associated_item()`.
                 let node_item =
                     assoc_ty_def(selcx, impl_data.impl_def_id, obligation.predicate.item_def_id);
 

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -742,7 +742,13 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
         let kind = match res {
             Res::Def(DefKind::Const, def_id) | Res::Def(DefKind::AssocConst, def_id) => {
                 let substs = self.tables.node_substs(id);
-                match self.tcx.const_eval_resolve(self.param_env, def_id, substs, Some(span)) {
+                // Use `Reveal::All` here because patterns are always monomorphic even if their function isn't.
+                match self.tcx.const_eval_resolve(
+                    self.param_env.with_reveal_all(),
+                    def_id,
+                    substs,
+                    Some(span),
+                ) {
                     Ok(value) => {
                         let pattern = self.const_to_pat(value, id, span);
                         if !is_associated_const {

--- a/src/test/mir-opt/inline/inline-specialization.rs
+++ b/src/test/mir-opt/inline/inline-specialization.rs
@@ -1,0 +1,48 @@
+#![feature(specialization)]
+
+fn main() {
+    let x = <Vec::<()> as Foo>::bar();
+}
+
+trait Foo {
+    fn bar() -> u32;
+}
+
+impl<T> Foo for Vec<T> {
+    #[inline(always)]
+    default fn bar() -> u32 { 123 }
+}
+
+// END RUST SOURCE
+// START rustc.main.Inline.before.mir
+// let mut _0: ();
+// let _1: u32;
+// scope 1 {
+//   debug x => _1;
+// }
+// bb0: {
+//   StorageLive(_1);
+//   _1 = const <std::vec::Vec<()> as Foo>::bar() -> bb1;
+// }
+// bb1: {
+//   _0 = ();
+//   StorageDead(_1);
+//   return;
+// }
+// END rustc.main.Inline.before.mir
+// START rustc.main.Inline.after.mir
+// let mut _0: ();
+// let _1: u32;
+// scope 1 {
+//   debug x => _1;
+// }
+// scope 2 {
+// }
+// bb0: {
+//   StorageLive(_1);
+//   _1 = const 123u32;
+//   _0 = ();
+//   StorageDead(_1);
+//   return;
+// }
+// END rustc.main.Inline.after.mir

--- a/src/test/ui/consts/trait_specialization.rs
+++ b/src/test/ui/consts/trait_specialization.rs
@@ -1,0 +1,65 @@
+// ignore-wasm32-bare which doesn't support `std::process:exit()`
+// compile-flags: -Zmir-opt-level=2
+// run-pass
+
+// Tests that specialization does not cause optimizations running on polymorphic MIR to resolve
+// to a `default` implementation.
+
+#![feature(specialization)]
+
+trait Marker {}
+
+trait SpecializedTrait {
+    const CONST_BOOL: bool;
+    const CONST_STR: &'static str;
+    fn method() -> &'static str;
+}
+impl <T> SpecializedTrait for T {
+    default const CONST_BOOL: bool = false;
+    default const CONST_STR: &'static str = "in default impl";
+    #[inline(always)]
+    default fn method() -> &'static str {
+        "in default impl"
+    }
+}
+impl <T: Marker> SpecializedTrait for T {
+    const CONST_BOOL: bool = true;
+    const CONST_STR: &'static str = "in specialized impl";
+    fn method() -> &'static str {
+        "in specialized impl"
+    }
+}
+
+fn const_bool<T>() -> &'static str {
+    if <T as SpecializedTrait>::CONST_BOOL {
+        "in specialized impl"
+    } else {
+        "in default impl"
+    }
+}
+fn const_str<T>() -> &'static str {
+    <T as SpecializedTrait>::CONST_STR
+}
+fn run_method<T>() -> &'static str {
+    <T as SpecializedTrait>::method()
+}
+
+struct TypeA;
+impl Marker for TypeA {}
+struct TypeB;
+
+#[inline(never)]
+fn exit_if_not_eq(left: &str, right: &str) {
+    if left != right {
+        std::process::exit(1);
+    }
+}
+
+pub fn main() {
+    exit_if_not_eq("in specialized impl", const_bool::<TypeA>());
+    exit_if_not_eq("in default impl", const_bool::<TypeB>());
+    exit_if_not_eq("in specialized impl", const_str::<TypeA>());
+    exit_if_not_eq("in default impl", const_str::<TypeB>());
+    exit_if_not_eq("in specialized impl", run_method::<TypeA>());
+    exit_if_not_eq("in default impl", run_method::<TypeB>());
+}

--- a/src/test/ui/type-alias-enum-variants/self-in-enum-definition.stderr
+++ b/src/test/ui/type-alias-enum-variants/self-in-enum-definition.stderr
@@ -4,6 +4,11 @@ error[E0391]: cycle detected when const-evaluating + checking `Alpha::V3::{{cons
 LL |     V3 = Self::V1 {} as u8 + 2,
    |          ^^^^^^^^
    |
+note: ...which requires const-evaluating + checking `Alpha::V3::{{constant}}#0`...
+  --> $DIR/self-in-enum-definition.rs:5:10
+   |
+LL |     V3 = Self::V1 {} as u8 + 2,
+   |          ^^^^^^^^
 note: ...which requires const-evaluating `Alpha::V3::{{constant}}#0`...
   --> $DIR/self-in-enum-definition.rs:5:10
    |


### PR DESCRIPTION
We only want to return specializations when `Reveal::All` is passed, not
when `Reveal::UserFacing` is. Resolving this fixes several issues with
the `ConstProp`, `SimplifyBranches`, and `Inline` MIR optimization
passes.

Fixes #66901

Rebased on top of #67631 

r? @oli-obk 