### PR TITLE
Improve reporting errors and suggestions for trait bounds

### DIFF
--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -441,6 +441,16 @@ pub struct GenericParam<'hir> {
     pub kind: GenericParamKind<'hir>,
 }
 
+impl GenericParam<'hir> {
+    pub fn bounds_span(&self) -> Option<Span> {
+        self.bounds.iter().fold(None, |span, bound| {
+            let span = span.map(|s| s.to(bound.span())).unwrap_or_else(|| bound.span());
+
+            Some(span)
+        })
+    }
+}
+
 #[derive(Default)]
 pub struct GenericParamCount {
     pub lifetimes: usize,
@@ -513,7 +523,7 @@ pub enum SyntheticTyParamKind {
 #[derive(RustcEncodable, RustcDecodable, Debug, HashStable_Generic)]
 pub struct WhereClause<'hir> {
     pub predicates: &'hir [WherePredicate<'hir>],
-    // Only valid if predicates isn't empty.
+    // Only valid if predicates aren't empty.
     pub span: Span,
 }
 

--- a/src/librustc_mir/borrow_check/diagnostics/conflict_errors.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/conflict_errors.rs
@@ -3,7 +3,7 @@ use rustc::mir::{
     FakeReadCause, Local, LocalDecl, LocalInfo, LocalKind, Location, Operand, Place, PlaceRef,
     ProjectionElem, Rvalue, Statement, StatementKind, TerminatorKind, VarBindingForm,
 };
-use rustc::traits::error_reporting::suggestions::suggest_constraining_type_param;
+use rustc::traits::error_reporting::suggest_constraining_type_param;
 use rustc::ty::{self, Ty};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::{Applicability, DiagnosticBuilder};

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1354,7 +1354,7 @@ fn check_fn<'a, 'tcx>(
         // for simple cases like `fn foo(x: Trait)`,
         // where we would error once on the parameter as a whole, and once on the binding `x`.
         if param.pat.simple_ident().is_none() && !tcx.features().unsized_locals {
-            fcx.require_type_is_sized(param_ty, decl.output.span(), traits::SizedArgumentType);
+            fcx.require_type_is_sized(param_ty, param.pat.span, traits::SizedArgumentType);
         }
 
         fcx.write_ty(param.hir_id, param_ty);

--- a/src/test/ui/associated-const/associated-const-type-parameter-arrays-2.stderr
+++ b/src/test/ui/associated-const/associated-const-type-parameter-arrays-2.stderr
@@ -4,10 +4,14 @@ error[E0277]: the trait bound `A: Foo` is not satisfied
 LL |     const Y: usize;
    |     --------------- required by `Foo::Y`
 ...
-LL | pub fn test<A: Foo, B: Foo>() {
-   |             -- help: consider further restricting this bound: `A: Foo +`
 LL |     let _array = [4; <A as Foo>::Y];
    |                      ^^^^^^^^^^^^^ the trait `Foo` is not implemented for `A`
+   |
+help: consider further restricting this bound with `+ Foo`
+  --> $DIR/associated-const-type-parameter-arrays-2.rs:15:16
+   |
+LL | pub fn test<A: Foo, B: Foo>() {
+   |                ^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-const/associated-const-type-parameter-arrays.stderr
+++ b/src/test/ui/associated-const/associated-const-type-parameter-arrays.stderr
@@ -4,10 +4,14 @@ error[E0277]: the trait bound `A: Foo` is not satisfied
 LL |     const Y: usize;
    |     --------------- required by `Foo::Y`
 ...
-LL | pub fn test<A: Foo, B: Foo>() {
-   |             -- help: consider further restricting this bound: `A: Foo +`
 LL |     let _array: [u32; <A as Foo>::Y];
    |                       ^^^^^^^^^^^^^ the trait `Foo` is not implemented for `A`
+   |
+help: consider further restricting this bound with `+ Foo`
+  --> $DIR/associated-const-type-parameter-arrays.rs:15:16
+   |
+LL | pub fn test<A: Foo, B: Foo>() {
+   |                ^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/associated-types-invalid-trait-ref-issue-18865.stderr
+++ b/src/test/ui/associated-types/associated-types-invalid-trait-ref-issue-18865.stderr
@@ -1,10 +1,14 @@
 error[E0277]: the trait bound `T: Foo<usize>` is not satisfied
   --> $DIR/associated-types-invalid-trait-ref-issue-18865.rs:10:12
    |
-LL | fn f<T:Foo<isize>>(t: &T) {
-   |      -- help: consider further restricting this bound: `T: Foo<usize> +`
 LL |     let u: <T as Foo<usize>>::Bar = t.get_bar();
    |            ^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo<usize>` is not implemented for `T`
+   |
+help: consider further restricting this bound with `+ Foo<usize>`
+  --> $DIR/associated-types-invalid-trait-ref-issue-18865.rs:9:8
+   |
+LL | fn f<T:Foo<isize>>(t: &T) {
+   |        ^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/associated-types-no-suitable-bound.stderr
+++ b/src/test/ui/associated-types/associated-types-no-suitable-bound.stderr
@@ -2,10 +2,13 @@ error[E0277]: the trait bound `T: Get` is not satisfied
   --> $DIR/associated-types-no-suitable-bound.rs:11:5
    |
 LL |     fn uhoh<T>(foo: <T as Get>::Value) {}
-   |     ^^^^^^^^-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |       |
-   |     |       help: consider restricting this bound: `T: Get`
-   |     the trait `Get` is not implemented for `T`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Get` is not implemented for `T`
+   |
+help: consider restricting this type parameter with `T: Get`
+  --> $DIR/associated-types-no-suitable-bound.rs:11:13
+   |
+LL |     fn uhoh<T>(foo: <T as Get>::Value) {}
+   |             ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/bad/bad-method-typaram-kind.stderr
+++ b/src/test/ui/bad/bad-method-typaram-kind.stderr
@@ -1,12 +1,15 @@
 error[E0277]: `T` cannot be sent between threads safely
   --> $DIR/bad-method-typaram-kind.rs:2:7
    |
-LL | fn foo<T:'static>() {
-   |        -- help: consider further restricting this bound: `T: std::marker::Send +`
 LL |     1.bar::<T>();
    |       ^^^ `T` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `T`
+help: consider further restricting this bound with `+ std::marker::Send`
+  --> $DIR/bad-method-typaram-kind.rs:1:10
+   |
+LL | fn foo<T:'static>() {
+   |          ^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/binop/binop-consume-args.stderr
+++ b/src/test/ui/binop/binop-consume-args.stderr
@@ -2,251 +2,331 @@ error[E0382]: use of moved value: `lhs`
   --> $DIR/binop-consume-args.rs:7:10
    |
 LL | fn add<A: Add<B, Output=()>, B>(lhs: A, rhs: B) {
-   |        --                       --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
-   |        |
-   |        help: consider further restricting this bound: `A: Copy +`
+   |                                 --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
 LL |     lhs + rhs;
    |     --- value moved here
 LL |     drop(lhs);
    |          ^^^ value used here after move
+   |
+help: consider further restricting this bound with `+ Copy`
+  --> $DIR/binop-consume-args.rs:5:11
+   |
+LL | fn add<A: Add<B, Output=()>, B>(lhs: A, rhs: B) {
+   |           ^^^^^^^^^^^^^^^^^
 
 error[E0382]: use of moved value: `rhs`
   --> $DIR/binop-consume-args.rs:8:10
    |
 LL | fn add<A: Add<B, Output=()>, B>(lhs: A, rhs: B) {
-   |                              -          --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
-   |                              |
-   |                              help: consider restricting this bound: `B: Copy`
+   |                                         --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
 LL |     lhs + rhs;
    |           --- value moved here
 LL |     drop(lhs);
 LL |     drop(rhs);
    |          ^^^ value used here after move
+   |
+help: consider restricting this type parameter with `B: Copy`
+  --> $DIR/binop-consume-args.rs:5:30
+   |
+LL | fn add<A: Add<B, Output=()>, B>(lhs: A, rhs: B) {
+   |                              ^
 
 error[E0382]: use of moved value: `lhs`
   --> $DIR/binop-consume-args.rs:13:10
    |
 LL | fn sub<A: Sub<B, Output=()>, B>(lhs: A, rhs: B) {
-   |        --                       --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
-   |        |
-   |        help: consider further restricting this bound: `A: Copy +`
+   |                                 --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
 LL |     lhs - rhs;
    |     --- value moved here
 LL |     drop(lhs);
    |          ^^^ value used here after move
+   |
+help: consider further restricting this bound with `+ Copy`
+  --> $DIR/binop-consume-args.rs:11:11
+   |
+LL | fn sub<A: Sub<B, Output=()>, B>(lhs: A, rhs: B) {
+   |           ^^^^^^^^^^^^^^^^^
 
 error[E0382]: use of moved value: `rhs`
   --> $DIR/binop-consume-args.rs:14:10
    |
 LL | fn sub<A: Sub<B, Output=()>, B>(lhs: A, rhs: B) {
-   |                              -          --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
-   |                              |
-   |                              help: consider restricting this bound: `B: Copy`
+   |                                         --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
 LL |     lhs - rhs;
    |           --- value moved here
 LL |     drop(lhs);
 LL |     drop(rhs);
    |          ^^^ value used here after move
+   |
+help: consider restricting this type parameter with `B: Copy`
+  --> $DIR/binop-consume-args.rs:11:30
+   |
+LL | fn sub<A: Sub<B, Output=()>, B>(lhs: A, rhs: B) {
+   |                              ^
 
 error[E0382]: use of moved value: `lhs`
   --> $DIR/binop-consume-args.rs:19:10
    |
 LL | fn mul<A: Mul<B, Output=()>, B>(lhs: A, rhs: B) {
-   |        --                       --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
-   |        |
-   |        help: consider further restricting this bound: `A: Copy +`
+   |                                 --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
 LL |     lhs * rhs;
    |     --- value moved here
 LL |     drop(lhs);
    |          ^^^ value used here after move
+   |
+help: consider further restricting this bound with `+ Copy`
+  --> $DIR/binop-consume-args.rs:17:11
+   |
+LL | fn mul<A: Mul<B, Output=()>, B>(lhs: A, rhs: B) {
+   |           ^^^^^^^^^^^^^^^^^
 
 error[E0382]: use of moved value: `rhs`
   --> $DIR/binop-consume-args.rs:20:10
    |
 LL | fn mul<A: Mul<B, Output=()>, B>(lhs: A, rhs: B) {
-   |                              -          --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
-   |                              |
-   |                              help: consider restricting this bound: `B: Copy`
+   |                                         --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
 LL |     lhs * rhs;
    |           --- value moved here
 LL |     drop(lhs);
 LL |     drop(rhs);
    |          ^^^ value used here after move
+   |
+help: consider restricting this type parameter with `B: Copy`
+  --> $DIR/binop-consume-args.rs:17:30
+   |
+LL | fn mul<A: Mul<B, Output=()>, B>(lhs: A, rhs: B) {
+   |                              ^
 
 error[E0382]: use of moved value: `lhs`
   --> $DIR/binop-consume-args.rs:25:10
    |
 LL | fn div<A: Div<B, Output=()>, B>(lhs: A, rhs: B) {
-   |        --                       --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
-   |        |
-   |        help: consider further restricting this bound: `A: Copy +`
+   |                                 --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
 LL |     lhs / rhs;
    |     --- value moved here
 LL |     drop(lhs);
    |          ^^^ value used here after move
+   |
+help: consider further restricting this bound with `+ Copy`
+  --> $DIR/binop-consume-args.rs:23:11
+   |
+LL | fn div<A: Div<B, Output=()>, B>(lhs: A, rhs: B) {
+   |           ^^^^^^^^^^^^^^^^^
 
 error[E0382]: use of moved value: `rhs`
   --> $DIR/binop-consume-args.rs:26:10
    |
 LL | fn div<A: Div<B, Output=()>, B>(lhs: A, rhs: B) {
-   |                              -          --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
-   |                              |
-   |                              help: consider restricting this bound: `B: Copy`
+   |                                         --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
 LL |     lhs / rhs;
    |           --- value moved here
 LL |     drop(lhs);
 LL |     drop(rhs);
    |          ^^^ value used here after move
+   |
+help: consider restricting this type parameter with `B: Copy`
+  --> $DIR/binop-consume-args.rs:23:30
+   |
+LL | fn div<A: Div<B, Output=()>, B>(lhs: A, rhs: B) {
+   |                              ^
 
 error[E0382]: use of moved value: `lhs`
   --> $DIR/binop-consume-args.rs:31:10
    |
 LL | fn rem<A: Rem<B, Output=()>, B>(lhs: A, rhs: B) {
-   |        --                       --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
-   |        |
-   |        help: consider further restricting this bound: `A: Copy +`
+   |                                 --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
 LL |     lhs % rhs;
    |     --- value moved here
 LL |     drop(lhs);
    |          ^^^ value used here after move
+   |
+help: consider further restricting this bound with `+ Copy`
+  --> $DIR/binop-consume-args.rs:29:11
+   |
+LL | fn rem<A: Rem<B, Output=()>, B>(lhs: A, rhs: B) {
+   |           ^^^^^^^^^^^^^^^^^
 
 error[E0382]: use of moved value: `rhs`
   --> $DIR/binop-consume-args.rs:32:10
    |
 LL | fn rem<A: Rem<B, Output=()>, B>(lhs: A, rhs: B) {
-   |                              -          --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
-   |                              |
-   |                              help: consider restricting this bound: `B: Copy`
+   |                                         --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
 LL |     lhs % rhs;
    |           --- value moved here
 LL |     drop(lhs);
 LL |     drop(rhs);
    |          ^^^ value used here after move
+   |
+help: consider restricting this type parameter with `B: Copy`
+  --> $DIR/binop-consume-args.rs:29:30
+   |
+LL | fn rem<A: Rem<B, Output=()>, B>(lhs: A, rhs: B) {
+   |                              ^
 
 error[E0382]: use of moved value: `lhs`
   --> $DIR/binop-consume-args.rs:37:10
    |
 LL | fn bitand<A: BitAnd<B, Output=()>, B>(lhs: A, rhs: B) {
-   |           --                          --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
-   |           |
-   |           help: consider further restricting this bound: `A: Copy +`
+   |                                       --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
 LL |     lhs & rhs;
    |     --- value moved here
 LL |     drop(lhs);
    |          ^^^ value used here after move
+   |
+help: consider further restricting this bound with `+ Copy`
+  --> $DIR/binop-consume-args.rs:35:14
+   |
+LL | fn bitand<A: BitAnd<B, Output=()>, B>(lhs: A, rhs: B) {
+   |              ^^^^^^^^^^^^^^^^^^^^
 
 error[E0382]: use of moved value: `rhs`
   --> $DIR/binop-consume-args.rs:38:10
    |
 LL | fn bitand<A: BitAnd<B, Output=()>, B>(lhs: A, rhs: B) {
-   |                                    -          --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
-   |                                    |
-   |                                    help: consider restricting this bound: `B: Copy`
+   |                                               --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
 LL |     lhs & rhs;
    |           --- value moved here
 LL |     drop(lhs);
 LL |     drop(rhs);
    |          ^^^ value used here after move
+   |
+help: consider restricting this type parameter with `B: Copy`
+  --> $DIR/binop-consume-args.rs:35:36
+   |
+LL | fn bitand<A: BitAnd<B, Output=()>, B>(lhs: A, rhs: B) {
+   |                                    ^
 
 error[E0382]: use of moved value: `lhs`
   --> $DIR/binop-consume-args.rs:43:10
    |
 LL | fn bitor<A: BitOr<B, Output=()>, B>(lhs: A, rhs: B) {
-   |          --                         --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
-   |          |
-   |          help: consider further restricting this bound: `A: Copy +`
+   |                                     --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
 LL |     lhs | rhs;
    |     --- value moved here
 LL |     drop(lhs);
    |          ^^^ value used here after move
+   |
+help: consider further restricting this bound with `+ Copy`
+  --> $DIR/binop-consume-args.rs:41:13
+   |
+LL | fn bitor<A: BitOr<B, Output=()>, B>(lhs: A, rhs: B) {
+   |             ^^^^^^^^^^^^^^^^^^^
 
 error[E0382]: use of moved value: `rhs`
   --> $DIR/binop-consume-args.rs:44:10
    |
 LL | fn bitor<A: BitOr<B, Output=()>, B>(lhs: A, rhs: B) {
-   |                                  -          --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
-   |                                  |
-   |                                  help: consider restricting this bound: `B: Copy`
+   |                                             --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
 LL |     lhs | rhs;
    |           --- value moved here
 LL |     drop(lhs);
 LL |     drop(rhs);
    |          ^^^ value used here after move
+   |
+help: consider restricting this type parameter with `B: Copy`
+  --> $DIR/binop-consume-args.rs:41:34
+   |
+LL | fn bitor<A: BitOr<B, Output=()>, B>(lhs: A, rhs: B) {
+   |                                  ^
 
 error[E0382]: use of moved value: `lhs`
   --> $DIR/binop-consume-args.rs:49:10
    |
 LL | fn bitxor<A: BitXor<B, Output=()>, B>(lhs: A, rhs: B) {
-   |           --                          --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
-   |           |
-   |           help: consider further restricting this bound: `A: Copy +`
+   |                                       --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
 LL |     lhs ^ rhs;
    |     --- value moved here
 LL |     drop(lhs);
    |          ^^^ value used here after move
+   |
+help: consider further restricting this bound with `+ Copy`
+  --> $DIR/binop-consume-args.rs:47:14
+   |
+LL | fn bitxor<A: BitXor<B, Output=()>, B>(lhs: A, rhs: B) {
+   |              ^^^^^^^^^^^^^^^^^^^^
 
 error[E0382]: use of moved value: `rhs`
   --> $DIR/binop-consume-args.rs:50:10
    |
 LL | fn bitxor<A: BitXor<B, Output=()>, B>(lhs: A, rhs: B) {
-   |                                    -          --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
-   |                                    |
-   |                                    help: consider restricting this bound: `B: Copy`
+   |                                               --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
 LL |     lhs ^ rhs;
    |           --- value moved here
 LL |     drop(lhs);
 LL |     drop(rhs);
    |          ^^^ value used here after move
+   |
+help: consider restricting this type parameter with `B: Copy`
+  --> $DIR/binop-consume-args.rs:47:36
+   |
+LL | fn bitxor<A: BitXor<B, Output=()>, B>(lhs: A, rhs: B) {
+   |                                    ^
 
 error[E0382]: use of moved value: `lhs`
   --> $DIR/binop-consume-args.rs:55:10
    |
 LL | fn shl<A: Shl<B, Output=()>, B>(lhs: A, rhs: B) {
-   |        --                       --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
-   |        |
-   |        help: consider further restricting this bound: `A: Copy +`
+   |                                 --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
 LL |     lhs << rhs;
    |     --- value moved here
 LL |     drop(lhs);
    |          ^^^ value used here after move
+   |
+help: consider further restricting this bound with `+ Copy`
+  --> $DIR/binop-consume-args.rs:53:11
+   |
+LL | fn shl<A: Shl<B, Output=()>, B>(lhs: A, rhs: B) {
+   |           ^^^^^^^^^^^^^^^^^
 
 error[E0382]: use of moved value: `rhs`
   --> $DIR/binop-consume-args.rs:56:10
    |
 LL | fn shl<A: Shl<B, Output=()>, B>(lhs: A, rhs: B) {
-   |                              -          --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
-   |                              |
-   |                              help: consider restricting this bound: `B: Copy`
+   |                                         --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
 LL |     lhs << rhs;
    |            --- value moved here
 LL |     drop(lhs);
 LL |     drop(rhs);
    |          ^^^ value used here after move
+   |
+help: consider restricting this type parameter with `B: Copy`
+  --> $DIR/binop-consume-args.rs:53:30
+   |
+LL | fn shl<A: Shl<B, Output=()>, B>(lhs: A, rhs: B) {
+   |                              ^
 
 error[E0382]: use of moved value: `lhs`
   --> $DIR/binop-consume-args.rs:61:10
    |
 LL | fn shr<A: Shr<B, Output=()>, B>(lhs: A, rhs: B) {
-   |        --                       --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
-   |        |
-   |        help: consider further restricting this bound: `A: Copy +`
+   |                                 --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
 LL |     lhs >> rhs;
    |     --- value moved here
 LL |     drop(lhs);
    |          ^^^ value used here after move
+   |
+help: consider further restricting this bound with `+ Copy`
+  --> $DIR/binop-consume-args.rs:59:11
+   |
+LL | fn shr<A: Shr<B, Output=()>, B>(lhs: A, rhs: B) {
+   |           ^^^^^^^^^^^^^^^^^
 
 error[E0382]: use of moved value: `rhs`
   --> $DIR/binop-consume-args.rs:62:10
    |
 LL | fn shr<A: Shr<B, Output=()>, B>(lhs: A, rhs: B) {
-   |                              -          --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
-   |                              |
-   |                              help: consider restricting this bound: `B: Copy`
+   |                                         --- move occurs because `rhs` has type `B`, which does not implement the `Copy` trait
 LL |     lhs >> rhs;
    |            --- value moved here
 LL |     drop(lhs);
 LL |     drop(rhs);
    |          ^^^ value used here after move
+   |
+help: consider restricting this type parameter with `B: Copy`
+  --> $DIR/binop-consume-args.rs:59:30
+   |
+LL | fn shr<A: Shr<B, Output=()>, B>(lhs: A, rhs: B) {
+   |                              ^
 
 error: aborting due to 20 previous errors
 

--- a/src/test/ui/binop/binop-move-semantics.stderr
+++ b/src/test/ui/binop/binop-move-semantics.stderr
@@ -2,27 +2,35 @@ error[E0382]: use of moved value: `x`
   --> $DIR/binop-move-semantics.rs:8:5
    |
 LL | fn double_move<T: Add<Output=()>>(x: T) {
-   |                --                 - move occurs because `x` has type `T`, which does not implement the `Copy` trait
-   |                |
-   |                help: consider further restricting this bound: `T: Copy +`
+   |                                   - move occurs because `x` has type `T`, which does not implement the `Copy` trait
 LL |     x
    |     - value moved here
 LL |     +
 LL |     x;
    |     ^ value used here after move
+   |
+help: consider further restricting this bound with `+ Copy`
+  --> $DIR/binop-move-semantics.rs:5:19
+   |
+LL | fn double_move<T: Add<Output=()>>(x: T) {
+   |                   ^^^^^^^^^^^^^^
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/binop-move-semantics.rs:14:5
    |
 LL | fn move_then_borrow<T: Add<Output=()> + Clone>(x: T) {
-   |                     --                         - move occurs because `x` has type `T`, which does not implement the `Copy` trait
-   |                     |
-   |                     help: consider further restricting this bound: `T: Copy +`
+   |                                                - move occurs because `x` has type `T`, which does not implement the `Copy` trait
 LL |     x
    |     - value moved here
 LL |     +
 LL |     x.clone();
    |     ^ value borrowed here after move
+   |
+help: consider further restricting this bound with `+ Copy`
+  --> $DIR/binop-move-semantics.rs:11:24
+   |
+LL | fn move_then_borrow<T: Add<Output=()> + Clone>(x: T) {
+   |                        ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0505]: cannot move out of `x` because it is borrowed
   --> $DIR/binop-move-semantics.rs:21:5

--- a/src/test/ui/borrowck/borrowck-unboxed-closures.stderr
+++ b/src/test/ui/borrowck/borrowck-unboxed-closures.stderr
@@ -20,13 +20,17 @@ error[E0382]: use of moved value: `f`
   --> $DIR/borrowck-unboxed-closures.rs:12:5
    |
 LL | fn c<F:FnOnce(isize, isize) -> isize>(f: F) {
-   |      --                               - move occurs because `f` has type `F`, which does not implement the `Copy` trait
-   |      |
-   |      help: consider further restricting this bound: `F: Copy +`
+   |                                       - move occurs because `f` has type `F`, which does not implement the `Copy` trait
 LL |     f(1, 2);
    |     - value moved here
 LL |     f(1, 2);
    |     ^ value used here after move
+   |
+help: consider further restricting this bound with `+ Copy`
+  --> $DIR/borrowck-unboxed-closures.rs:10:8
+   |
+LL | fn c<F:FnOnce(isize, isize) -> isize>(f: F) {
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/bound-suggestions.fixed
+++ b/src/test/ui/bound-suggestions.fixed
@@ -1,0 +1,39 @@
+// run-rustfix
+
+#[allow(dead_code)]
+fn test_impl(t: impl Sized + std::fmt::Debug) {
+    println!("{:?}", t);
+    //~^ ERROR doesn't implement
+}
+
+#[allow(dead_code)]
+fn test_no_bounds<T: std::fmt::Debug>(t: T) {
+    println!("{:?}", t);
+    //~^ ERROR doesn't implement
+}
+
+#[allow(dead_code)]
+fn test_one_bound<T: std::fmt::Debug +  Sized>(t: T) {
+    println!("{:?}", t);
+    //~^ ERROR doesn't implement
+}
+
+#[allow(dead_code)]
+fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug, Y: std::fmt::Debug {
+    println!("{:?} {:?}", x, y);
+    //~^ ERROR doesn't implement
+}
+
+#[allow(dead_code)]
+fn test_one_bound_where<X>(x: X) where X: std::fmt::Debug + Sized {
+    println!("{:?}", x);
+    //~^ ERROR doesn't implement
+}
+
+#[allow(dead_code)]
+fn test_many_bounds_where<X>(x: X) where X: Sized, X: Sized, X: std::fmt::Debug {
+    println!("{:?}", x);
+    //~^ ERROR doesn't implement
+}
+
+pub fn main() { }

--- a/src/test/ui/bound-suggestions.rs
+++ b/src/test/ui/bound-suggestions.rs
@@ -1,0 +1,39 @@
+// run-rustfix
+
+#[allow(dead_code)]
+fn test_impl(t: impl Sized) {
+    println!("{:?}", t);
+    //~^ ERROR doesn't implement
+}
+
+#[allow(dead_code)]
+fn test_no_bounds<T>(t: T) {
+    println!("{:?}", t);
+    //~^ ERROR doesn't implement
+}
+
+#[allow(dead_code)]
+fn test_one_bound<T: Sized>(t: T) {
+    println!("{:?}", t);
+    //~^ ERROR doesn't implement
+}
+
+#[allow(dead_code)]
+fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug {
+    println!("{:?} {:?}", x, y);
+    //~^ ERROR doesn't implement
+}
+
+#[allow(dead_code)]
+fn test_one_bound_where<X>(x: X) where X: Sized {
+    println!("{:?}", x);
+    //~^ ERROR doesn't implement
+}
+
+#[allow(dead_code)]
+fn test_many_bounds_where<X>(x: X) where X: Sized, X: Sized {
+    println!("{:?}", x);
+    //~^ ERROR doesn't implement
+}
+
+pub fn main() { }

--- a/src/test/ui/bound-suggestions.stderr
+++ b/src/test/ui/bound-suggestions.stderr
@@ -1,0 +1,93 @@
+error[E0277]: `impl Sized` doesn't implement `std::fmt::Debug`
+  --> $DIR/bound-suggestions.rs:5:22
+   |
+LL |     println!("{:?}", t);
+   |                      ^ `impl Sized` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
+   |
+   = help: the trait `std::fmt::Debug` is not implemented for `impl Sized`
+help: consider further restricting this bound with `+ std::fmt::Debug`
+  --> $DIR/bound-suggestions.rs:4:17
+   |
+LL | fn test_impl(t: impl Sized) {
+   |                 ^^^^^^^^^^
+   = note: required by `std::fmt::Debug::fmt`
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `T` doesn't implement `std::fmt::Debug`
+  --> $DIR/bound-suggestions.rs:11:22
+   |
+LL |     println!("{:?}", t);
+   |                      ^ `T` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
+   |
+   = help: the trait `std::fmt::Debug` is not implemented for `T`
+help: consider restricting this type parameter with `T: std::fmt::Debug`
+  --> $DIR/bound-suggestions.rs:10:19
+   |
+LL | fn test_no_bounds<T>(t: T) {
+   |                   ^
+   = note: required by `std::fmt::Debug::fmt`
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `T` doesn't implement `std::fmt::Debug`
+  --> $DIR/bound-suggestions.rs:17:22
+   |
+LL |     println!("{:?}", t);
+   |                      ^ `T` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
+   |
+   = help: the trait `std::fmt::Debug` is not implemented for `T`
+help: consider further restricting this bound with `+ std::fmt::Debug`
+  --> $DIR/bound-suggestions.rs:16:22
+   |
+LL | fn test_one_bound<T: Sized>(t: T) {
+   |                      ^^^^^
+   = note: required by `std::fmt::Debug::fmt`
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `Y` doesn't implement `std::fmt::Debug`
+  --> $DIR/bound-suggestions.rs:23:30
+   |
+LL |     println!("{:?} {:?}", x, y);
+   |                              ^ `Y` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
+   |
+   = help: the trait `std::fmt::Debug` is not implemented for `Y`
+help: consider restricting this type parameter with `where Y: std::fmt::Debug`
+  --> $DIR/bound-suggestions.rs:22:28
+   |
+LL | fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug {
+   |                            ^
+   = note: required by `std::fmt::Debug::fmt`
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `X` doesn't implement `std::fmt::Debug`
+  --> $DIR/bound-suggestions.rs:29:22
+   |
+LL |     println!("{:?}", x);
+   |                      ^ `X` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
+   |
+   = help: the trait `std::fmt::Debug` is not implemented for `X`
+help: consider further restricting this bound with `+ std::fmt::Debug`
+  --> $DIR/bound-suggestions.rs:28:40
+   |
+LL | fn test_one_bound_where<X>(x: X) where X: Sized {
+   |                                        ^^^^^^^^
+   = note: required by `std::fmt::Debug::fmt`
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `X` doesn't implement `std::fmt::Debug`
+  --> $DIR/bound-suggestions.rs:35:22
+   |
+LL |     println!("{:?}", x);
+   |                      ^ `X` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
+   |
+   = help: the trait `std::fmt::Debug` is not implemented for `X`
+help: consider further restricting this type parameter with `where X: std::fmt::Debug`
+  --> $DIR/bound-suggestions.rs:34:27
+   |
+LL | fn test_many_bounds_where<X>(x: X) where X: Sized, X: Sized {
+   |                           ^
+   = note: required by `std::fmt::Debug::fmt`
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
@@ -2,22 +2,28 @@ error[E0277]: `T` cannot be sent between threads safely
   --> $DIR/builtin-superkinds-double-superkind.rs:6:24
    |
 LL | impl <T: Sync+'static> Foo for (T,) { }
-   |       --               ^^^ `T` cannot be sent between threads safely
-   |       |
-   |       help: consider further restricting this bound: `T: std::marker::Send +`
+   |                        ^^^ `T` cannot be sent between threads safely
    |
    = help: within `(T,)`, the trait `std::marker::Send` is not implemented for `T`
+help: consider further restricting this bound with `+ std::marker::Send`
+  --> $DIR/builtin-superkinds-double-superkind.rs:6:10
+   |
+LL | impl <T: Sync+'static> Foo for (T,) { }
+   |          ^^^^^^^^^^^^
    = note: required because it appears within the type `(T,)`
 
 error[E0277]: `T` cannot be shared between threads safely
   --> $DIR/builtin-superkinds-double-superkind.rs:9:16
    |
 LL | impl <T: Send> Foo for (T,T) { }
-   |       --       ^^^ `T` cannot be shared between threads safely
-   |       |
-   |       help: consider further restricting this bound: `T: std::marker::Sync +`
+   |                ^^^ `T` cannot be shared between threads safely
    |
    = help: within `(T, T)`, the trait `std::marker::Sync` is not implemented for `T`
+help: consider further restricting this bound with `+ std::marker::Sync`
+  --> $DIR/builtin-superkinds-double-superkind.rs:9:10
+   |
+LL | impl <T: Send> Foo for (T,T) { }
+   |          ^^^^
    = note: required because it appears within the type `(T, T)`
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
@@ -2,11 +2,14 @@ error[E0277]: `T` cannot be sent between threads safely
   --> $DIR/builtin-superkinds-in-metadata.rs:13:23
    |
 LL | impl <T:Sync+'static> RequiresRequiresShareAndSend for X<T> { }
-   |       --              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `T` cannot be sent between threads safely
-   |       |
-   |       help: consider further restricting this bound: `T: std::marker::Send +`
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `T` cannot be sent between threads safely
    |
    = help: within `X<T>`, the trait `std::marker::Send` is not implemented for `T`
+help: consider further restricting this bound with `+ std::marker::Send`
+  --> $DIR/builtin-superkinds-in-metadata.rs:13:9
+   |
+LL | impl <T:Sync+'static> RequiresRequiresShareAndSend for X<T> { }
+   |         ^^^^^^^^^^^^
    = note: required because it appears within the type `X<T>`
 
 error: aborting due to previous error

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
@@ -2,11 +2,14 @@ error[E0277]: `T` cannot be sent between threads safely
   --> $DIR/builtin-superkinds-typaram-not-send.rs:5:24
    |
 LL | impl <T: Sync+'static> Foo for T { }
-   |       --               ^^^ `T` cannot be sent between threads safely
-   |       |
-   |       help: consider further restricting this bound: `T: std::marker::Send +`
+   |                        ^^^ `T` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `T`
+help: consider further restricting this bound with `+ std::marker::Send`
+  --> $DIR/builtin-superkinds-typaram-not-send.rs:5:10
+   |
+LL | impl <T: Sync+'static> Foo for T { }
+   |          ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
+++ b/src/test/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
@@ -5,11 +5,14 @@ LL | struct X<F> where F: FnOnce() + 'static + Send {
    | ---------------------------------------------- required by `X`
 ...
 LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static {
-   |                      ^^^^                            - help: consider further restricting type parameter `F`: `, F: std::marker::Send`
-   |                      |
-   |                      `F` cannot be sent between threads safely
+   |                      ^^^^ `F` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `F`
+help: consider further restricting this bound with `+ std::marker::Send`
+  --> $DIR/closure-bounds-cant-promote-superkind-in-struct.rs:5:33
+   |
+LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static {
+   |                                 ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/closures/closure-bounds-subtype.stderr
+++ b/src/test/ui/closures/closure-bounds-subtype.stderr
@@ -4,13 +4,15 @@ error[E0277]: `F` cannot be shared between threads safely
 LL | fn take_const_owned<F>(_: F) where F: FnOnce() + Sync + Send {
    |    ----------------                              ---- required by this bound in `take_const_owned`
 ...
-LL | fn give_owned<F>(f: F) where F: FnOnce() + Send {
-   |                                                - help: consider further restricting type parameter `F`: `, F: std::marker::Sync`
-LL |     take_any(f);
 LL |     take_const_owned(f);
    |                      ^ `F` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `F`
+help: consider further restricting this bound with `+ std::marker::Sync`
+  --> $DIR/closure-bounds-subtype.rs:11:30
+   |
+LL | fn give_owned<F>(f: F) where F: FnOnce() + Send {
+   |                              ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/closures/issue-67123.stderr
+++ b/src/test/ui/closures/issue-67123.stderr
@@ -1,13 +1,16 @@
 error[E0382]: use of moved value: `t`
   --> $DIR/issue-67123.rs:2:13
    |
-LL | fn foo<T>(t: T) {
-   |        - help: consider restricting this bound: `T: Copy`
 LL |     || { t; t; };
    |          -  ^ value used here after move
    |          |
    |          value moved here
    |
+help: consider restricting this type parameter with `T: Copy`
+  --> $DIR/issue-67123.rs:1:8
+   |
+LL | fn foo<T>(t: T) {
+   |        ^
    = note: move occurs because `t` has type `T`, which does not implement the `Copy` trait
 
 error: aborting due to previous error

--- a/src/test/ui/generic-associated-types/impl_bounds.stderr
+++ b/src/test/ui/generic-associated-types/impl_bounds.stderr
@@ -31,12 +31,14 @@ LL |     type B<'a, 'b> where 'b: 'a = (&'a(), &'b ());
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/impl_bounds.rs:19:5
    |
-LL | impl<T> Foo for Fooy<T> {
-   |      - help: consider restricting this bound: `T: std::marker::Copy`
-...
 LL |     type C where Self: Copy = String;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
+help: consider restricting this type parameter with `T: std::marker::Copy`
+  --> $DIR/impl_bounds.rs:14:6
+   |
+LL | impl<T> Foo for Fooy<T> {
+   |      ^
    = note: required because of the requirements on the impl of `std::marker::Copy` for `Fooy<T>`
    = note: the requirement `Fooy<T>: std::marker::Copy` appears on the associated impl type but not on the corresponding associated trait type
 

--- a/src/test/ui/hrtb/hrtb-higher-ranker-supertraits-transitive.stderr
+++ b/src/test/ui/hrtb/hrtb-higher-ranker-supertraits-transitive.stderr
@@ -6,11 +6,14 @@ LL | fn want_bar_for_any_ccx<B>(b: &B)
 LL |     where B : for<'ccx> Bar<'ccx>
    |               ------------------- required by this bound in `want_bar_for_any_ccx`
 ...
-LL |     where B : Qux
-   |                  - help: consider further restricting type parameter `B`: `, B: for<'ccx> Bar<'ccx>`
-...
 LL |     want_bar_for_any_ccx(b);
    |                          ^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
+   |
+help: consider further restricting this bound with `+ for<'ccx> Bar<'ccx>`
+  --> $DIR/hrtb-higher-ranker-supertraits-transitive.rs:44:11
+   |
+LL |     where B : Qux
+   |           ^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/hrtb/hrtb-higher-ranker-supertraits.stderr
+++ b/src/test/ui/hrtb/hrtb-higher-ranker-supertraits.stderr
@@ -1,9 +1,6 @@
 error[E0277]: the trait bound `for<'tcx> F: Foo<'tcx>` is not satisfied
   --> $DIR/hrtb-higher-ranker-supertraits.rs:18:26
    |
-LL |     where F : Foo<'x>
-   |                      - help: consider further restricting type parameter `F`: `, F: for<'tcx> Foo<'tcx>`
-...
 LL |     want_foo_for_any_tcx(f);
    |                          ^ the trait `for<'tcx> Foo<'tcx>` is not implemented for `F`
 ...
@@ -11,13 +8,16 @@ LL | fn want_foo_for_any_tcx<F>(f: &F)
    |    --------------------
 LL |     where F : for<'tcx> Foo<'tcx>
    |               ------------------- required by this bound in `want_foo_for_any_tcx`
+   |
+help: consider further restricting this bound with `+ for<'tcx> Foo<'tcx>`
+  --> $DIR/hrtb-higher-ranker-supertraits.rs:15:11
+   |
+LL |     where F : Foo<'x>
+   |           ^^^^^^^^^^^
 
 error[E0277]: the trait bound `for<'ccx> B: Bar<'ccx>` is not satisfied
   --> $DIR/hrtb-higher-ranker-supertraits.rs:35:26
    |
-LL |     where B : Bar<'x>
-   |                      - help: consider further restricting type parameter `B`: `, B: for<'ccx> Bar<'ccx>`
-...
 LL |     want_bar_for_any_ccx(b);
    |                          ^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
 ...
@@ -25,6 +25,12 @@ LL | fn want_bar_for_any_ccx<B>(b: &B)
    |    --------------------
 LL |     where B : for<'ccx> Bar<'ccx>
    |               ------------------- required by this bound in `want_bar_for_any_ccx`
+   |
+help: consider further restricting this bound with `+ for<'ccx> Bar<'ccx>`
+  --> $DIR/hrtb-higher-ranker-supertraits.rs:29:11
+   |
+LL |     where B : Bar<'x>
+   |           ^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/impl-trait/issue-55872-1.stderr
+++ b/src/test/ui/impl-trait/issue-55872-1.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `S: std::marker::Copy` is not satisfied in `(S, T)`
   --> $DIR/issue-55872-1.rs:12:5
    |
-LL | impl<S: Default> Bar for S {
-   |      -- help: consider further restricting this bound: `S: std::marker::Copy +`
 LL |     type E = impl Copy;
    |     ^^^^^^^^^^^^^^^^^^^ within `(S, T)`, the trait `std::marker::Copy` is not implemented for `S`
    |
+help: consider further restricting this bound with `+ std::marker::Copy`
+  --> $DIR/issue-55872-1.rs:11:9
+   |
+LL | impl<S: Default> Bar for S {
+   |         ^^^^^^^
    = note: required because it appears within the type `(S, T)`
    = note: the return type of a function must have a statically known size
 
@@ -14,10 +17,12 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied in `(S, T)
    |
 LL |     type E = impl Copy;
    |     ^^^^^^^^^^^^^^^^^^^ within `(S, T)`, the trait `std::marker::Copy` is not implemented for `T`
-...
-LL |     fn foo<T: Default>() -> Self::E {
-   |            -- help: consider further restricting this bound: `T: std::marker::Copy +`
    |
+help: consider further restricting this bound with `+ std::marker::Copy`
+  --> $DIR/issue-55872-1.rs:16:15
+   |
+LL |     fn foo<T: Default>() -> Self::E {
+   |               ^^^^^^^
    = note: required because it appears within the type `(S, T)`
    = note: the return type of a function must have a statically known size
 

--- a/src/test/ui/issues/issue-21837.stderr
+++ b/src/test/ui/issues/issue-21837.stderr
@@ -5,9 +5,13 @@ LL | pub struct Foo<T: Bound>(T);
    | ---------------------------- required by `Foo`
 ...
 LL | impl<T> Trait2 for Foo<T> {}
-   |      -  ^^^^^^ the trait `Bound` is not implemented for `T`
-   |      |
-   |      help: consider restricting this bound: `T: Bound`
+   |         ^^^^^^ the trait `Bound` is not implemented for `T`
+   |
+help: consider restricting this type parameter with `T: Bound`
+  --> $DIR/issue-21837.rs:8:6
+   |
+LL | impl<T> Trait2 for Foo<T> {}
+   |      ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-34721.stderr
+++ b/src/test/ui/issues/issue-34721.stderr
@@ -2,9 +2,7 @@ error[E0382]: use of moved value: `x`
   --> $DIR/issue-34721.rs:27:9
    |
 LL |     pub fn baz<T: Foo>(x: T) -> T {
-   |                --      - move occurs because `x` has type `T`, which does not implement the `Copy` trait
-   |                |
-   |                help: consider further restricting this bound: `T: Copy +`
+   |                        - move occurs because `x` has type `T`, which does not implement the `Copy` trait
 LL |         if 0 == 1 {
 LL |             bar::bar(x.zero())
    |                      - value moved here
@@ -14,6 +12,12 @@ LL |             x.zero()
 LL |         };
 LL |         x.zero()
    |         ^ value used here after move
+   |
+help: consider further restricting this bound with `+ Copy`
+  --> $DIR/issue-34721.rs:21:19
+   |
+LL |     pub fn baz<T: Foo>(x: T) -> T {
+   |                   ^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-38954.stderr
+++ b/src/test/ui/issues/issue-38954.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/issue-38954.rs:1:23
+  --> $DIR/issue-38954.rs:1:10
    |
 LL | fn _test(ref _p: str) {}
-   |                       ^ doesn't have a size known at compile-time
+   |          ^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>

--- a/src/test/ui/issues/issue-41229-ref-str.stderr
+++ b/src/test/ui/issues/issue-41229-ref-str.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/issue-41229-ref-str.rs:1:28
+  --> $DIR/issue-41229-ref-str.rs:1:16
    |
 LL | pub fn example(ref s: str) {}
-   |                            ^ doesn't have a size known at compile-time
+   |                ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>

--- a/src/test/ui/issues/issue-42312.stderr
+++ b/src/test/ui/issues/issue-42312.stderr
@@ -1,10 +1,10 @@
 error[E0277]: the size for values of type `<Self as std::ops::Deref>::Target` cannot be known at compilation time
-  --> $DIR/issue-42312.rs:4:29
+  --> $DIR/issue-42312.rs:4:12
    |
 LL |     fn baz(_: Self::Target) where Self: Deref {}
-   |                             ^                - help: consider further restricting the associated type: `, <Self as std::ops::Deref>::Target: std::marker::Sized`
-   |                             |
-   |                             doesn't have a size known at compile-time
+   |            ^                                 - help: consider further restricting the associated type: `, <Self as std::ops::Deref>::Target: std::marker::Sized`
+   |            |
+   |            doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `<Self as std::ops::Deref>::Target`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
@@ -12,10 +12,10 @@ LL |     fn baz(_: Self::Target) where Self: Deref {}
    = help: unsized locals are gated as an unstable feature
 
 error[E0277]: the size for values of type `(dyn std::string::ToString + 'static)` cannot be known at compilation time
-  --> $DIR/issue-42312.rs:8:27
+  --> $DIR/issue-42312.rs:8:10
    |
 LL | pub fn f(_: dyn ToString) {}
-   |                           ^ doesn't have a size known at compile-time
+   |          ^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `(dyn std::string::ToString + 'static)`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>

--- a/src/test/ui/issues/issue-43784-associated-type.stderr
+++ b/src/test/ui/issues/issue-43784-associated-type.stderr
@@ -5,12 +5,15 @@ LL |     type Assoc: Partial<Self>;
    |          ----- associated type defined here
 ...
 LL | impl<T> Complete for T {
-   | ----------------------
-   | |    |
-   | |    help: consider restricting this bound: `T: std::marker::Copy`
-   | in this `impl` item
+   | ---------------------- in this `impl` item
 LL |     type Assoc = T;
    |     ^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
+   |
+help: consider restricting this type parameter with `T: std::marker::Copy`
+  --> $DIR/issue-43784-associated-type.rs:13:6
+   |
+LL | impl<T> Complete for T {
+   |      ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-43784-supertrait.stderr
+++ b/src/test/ui/issues/issue-43784-supertrait.stderr
@@ -2,9 +2,13 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/issue-43784-supertrait.rs:8:9
    |
 LL | impl<T> Complete for T {}
-   |      -  ^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
-   |      |
-   |      help: consider restricting this bound: `T: std::marker::Copy`
+   |         ^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
+   |
+help: consider restricting this type parameter with `T: std::marker::Copy`
+  --> $DIR/issue-43784-supertrait.rs:8:6
+   |
+LL | impl<T> Complete for T {}
+   |      ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/kindck/kindck-impl-type-params.nll.stderr
+++ b/src/test/ui/kindck/kindck-impl-type-params.nll.stderr
@@ -1,50 +1,58 @@
 error[E0277]: `T` cannot be sent between threads safely
   --> $DIR/kindck-impl-type-params.rs:18:13
    |
-LL | fn f<T>(val: T) {
-   |      - help: consider restricting this bound: `T: std::marker::Send`
-LL |     let t: S<T> = S(marker::PhantomData);
 LL |     let a = &t as &dyn Gettable<T>;
    |             ^^ `T` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `T`
+help: consider restricting this type parameter with `T: std::marker::Send`
+  --> $DIR/kindck-impl-type-params.rs:16:6
+   |
+LL | fn f<T>(val: T) {
+   |      ^
    = note: required because of the requirements on the impl of `Gettable<T>` for `S<T>`
    = note: required for the cast to the object type `dyn Gettable<T>`
 
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/kindck-impl-type-params.rs:18:13
    |
-LL | fn f<T>(val: T) {
-   |      - help: consider restricting this bound: `T: std::marker::Copy`
-LL |     let t: S<T> = S(marker::PhantomData);
 LL |     let a = &t as &dyn Gettable<T>;
    |             ^^ the trait `std::marker::Copy` is not implemented for `T`
    |
+help: consider restricting this type parameter with `T: std::marker::Copy`
+  --> $DIR/kindck-impl-type-params.rs:16:6
+   |
+LL | fn f<T>(val: T) {
+   |      ^
    = note: required because of the requirements on the impl of `Gettable<T>` for `S<T>`
    = note: required for the cast to the object type `dyn Gettable<T>`
 
 error[E0277]: `T` cannot be sent between threads safely
   --> $DIR/kindck-impl-type-params.rs:25:31
    |
-LL | fn g<T>(val: T) {
-   |      - help: consider restricting this bound: `T: std::marker::Send`
-LL |     let t: S<T> = S(marker::PhantomData);
 LL |     let a: &dyn Gettable<T> = &t;
    |                               ^^ `T` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `T`
+help: consider restricting this type parameter with `T: std::marker::Send`
+  --> $DIR/kindck-impl-type-params.rs:23:6
+   |
+LL | fn g<T>(val: T) {
+   |      ^
    = note: required because of the requirements on the impl of `Gettable<T>` for `S<T>`
    = note: required for the cast to the object type `dyn Gettable<T>`
 
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/kindck-impl-type-params.rs:25:31
    |
-LL | fn g<T>(val: T) {
-   |      - help: consider restricting this bound: `T: std::marker::Copy`
-LL |     let t: S<T> = S(marker::PhantomData);
 LL |     let a: &dyn Gettable<T> = &t;
    |                               ^^ the trait `std::marker::Copy` is not implemented for `T`
    |
+help: consider restricting this type parameter with `T: std::marker::Copy`
+  --> $DIR/kindck-impl-type-params.rs:23:6
+   |
+LL | fn g<T>(val: T) {
+   |      ^
    = note: required because of the requirements on the impl of `Gettable<T>` for `S<T>`
    = note: required for the cast to the object type `dyn Gettable<T>`
 

--- a/src/test/ui/kindck/kindck-impl-type-params.stderr
+++ b/src/test/ui/kindck/kindck-impl-type-params.stderr
@@ -1,50 +1,58 @@
 error[E0277]: `T` cannot be sent between threads safely
   --> $DIR/kindck-impl-type-params.rs:18:13
    |
-LL | fn f<T>(val: T) {
-   |      - help: consider restricting this bound: `T: std::marker::Send`
-LL |     let t: S<T> = S(marker::PhantomData);
 LL |     let a = &t as &dyn Gettable<T>;
    |             ^^ `T` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `T`
+help: consider restricting this type parameter with `T: std::marker::Send`
+  --> $DIR/kindck-impl-type-params.rs:16:6
+   |
+LL | fn f<T>(val: T) {
+   |      ^
    = note: required because of the requirements on the impl of `Gettable<T>` for `S<T>`
    = note: required for the cast to the object type `dyn Gettable<T>`
 
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/kindck-impl-type-params.rs:18:13
    |
-LL | fn f<T>(val: T) {
-   |      - help: consider restricting this bound: `T: std::marker::Copy`
-LL |     let t: S<T> = S(marker::PhantomData);
 LL |     let a = &t as &dyn Gettable<T>;
    |             ^^ the trait `std::marker::Copy` is not implemented for `T`
    |
+help: consider restricting this type parameter with `T: std::marker::Copy`
+  --> $DIR/kindck-impl-type-params.rs:16:6
+   |
+LL | fn f<T>(val: T) {
+   |      ^
    = note: required because of the requirements on the impl of `Gettable<T>` for `S<T>`
    = note: required for the cast to the object type `dyn Gettable<T>`
 
 error[E0277]: `T` cannot be sent between threads safely
   --> $DIR/kindck-impl-type-params.rs:25:31
    |
-LL | fn g<T>(val: T) {
-   |      - help: consider restricting this bound: `T: std::marker::Send`
-LL |     let t: S<T> = S(marker::PhantomData);
 LL |     let a: &dyn Gettable<T> = &t;
    |                               ^^ `T` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `T`
+help: consider restricting this type parameter with `T: std::marker::Send`
+  --> $DIR/kindck-impl-type-params.rs:23:6
+   |
+LL | fn g<T>(val: T) {
+   |      ^
    = note: required because of the requirements on the impl of `Gettable<T>` for `S<T>`
    = note: required for the cast to the object type `dyn Gettable<T>`
 
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/kindck-impl-type-params.rs:25:31
    |
-LL | fn g<T>(val: T) {
-   |      - help: consider restricting this bound: `T: std::marker::Copy`
-LL |     let t: S<T> = S(marker::PhantomData);
 LL |     let a: &dyn Gettable<T> = &t;
    |                               ^^ the trait `std::marker::Copy` is not implemented for `T`
    |
+help: consider restricting this type parameter with `T: std::marker::Copy`
+  --> $DIR/kindck-impl-type-params.rs:23:6
+   |
+LL | fn g<T>(val: T) {
+   |      ^
    = note: required because of the requirements on the impl of `Gettable<T>` for `S<T>`
    = note: required for the cast to the object type `dyn Gettable<T>`
 

--- a/src/test/ui/moves/moves-based-on-type-no-recursive-stack-closure.stderr
+++ b/src/test/ui/moves/moves-based-on-type-no-recursive-stack-closure.stderr
@@ -11,13 +11,17 @@ error[E0382]: borrow of moved value: `f`
   --> $DIR/moves-based-on-type-no-recursive-stack-closure.rs:32:5
    |
 LL | fn conspirator<F>(mut f: F) where F: FnMut(&mut R, bool) {
-   |                   -----                                 - help: consider further restricting type parameter `F`: `, F: Copy`
-   |                   |
-   |                   move occurs because `f` has type `F`, which does not implement the `Copy` trait
+   |                   ----- move occurs because `f` has type `F`, which does not implement the `Copy` trait
 LL |     let mut r = R {c: Box::new(f)};
    |                                - value moved here
 LL |     f(&mut r, false)
    |     ^ value borrowed here after move
+   |
+help: consider further restricting this bound with `+ Copy`
+  --> $DIR/moves-based-on-type-no-recursive-stack-closure.rs:30:35
+   |
+LL | fn conspirator<F>(mut f: F) where F: FnMut(&mut R, bool) {
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/once-cant-call-twice-on-heap.stderr
+++ b/src/test/ui/once-cant-call-twice-on-heap.stderr
@@ -2,13 +2,17 @@ error[E0382]: use of moved value: `blk`
   --> $DIR/once-cant-call-twice-on-heap.rs:9:5
    |
 LL | fn foo<F:FnOnce()>(blk: F) {
-   |        --          --- move occurs because `blk` has type `F`, which does not implement the `Copy` trait
-   |        |
-   |        help: consider further restricting this bound: `F: Copy +`
+   |                    --- move occurs because `blk` has type `F`, which does not implement the `Copy` trait
 LL |     blk();
    |     --- value moved here
 LL |     blk();
    |     ^^^ value used here after move
+   |
+help: consider further restricting this bound with `+ Copy`
+  --> $DIR/once-cant-call-twice-on-heap.rs:7:10
+   |
+LL | fn foo<F:FnOnce()>(blk: F) {
+   |          ^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/phantom-oibit.stderr
+++ b/src/test/ui/phantom-oibit.stderr
@@ -3,13 +3,16 @@ error[E0277]: `T` cannot be shared between threads safely
    |
 LL | fn is_zen<T: Zen>(_: T) {}
    |    ------    --- required by this bound in `is_zen`
-LL | 
-LL | fn not_sync<T>(x: Guard<T>) {
-   |             - help: consider restricting this bound: `T: std::marker::Sync`
+...
 LL |     is_zen(x)
    |            ^ `T` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `T`
+help: consider restricting this type parameter with `T: std::marker::Sync`
+  --> $DIR/phantom-oibit.rs:20:13
+   |
+LL | fn not_sync<T>(x: Guard<T>) {
+   |             ^
    = note: required because of the requirements on the impl of `Zen` for `&T`
    = note: required because it appears within the type `std::marker::PhantomData<&T>`
    = note: required because it appears within the type `Guard<'_, T>`
@@ -20,12 +23,15 @@ error[E0277]: `T` cannot be shared between threads safely
 LL | fn is_zen<T: Zen>(_: T) {}
    |    ------    --- required by this bound in `is_zen`
 ...
-LL | fn nested_not_sync<T>(x: Nested<Guard<T>>) {
-   |                    - help: consider restricting this bound: `T: std::marker::Sync`
 LL |     is_zen(x)
    |            ^ `T` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `T`
+help: consider restricting this type parameter with `T: std::marker::Sync`
+  --> $DIR/phantom-oibit.rs:25:20
+   |
+LL | fn nested_not_sync<T>(x: Nested<Guard<T>>) {
+   |                    ^
    = note: required because of the requirements on the impl of `Zen` for `&T`
    = note: required because it appears within the type `std::marker::PhantomData<&T>`
    = note: required because it appears within the type `Guard<'_, T>`

--- a/src/test/ui/specialization/defaultimpl/specialization-wfcheck.stderr
+++ b/src/test/ui/specialization/defaultimpl/specialization-wfcheck.stderr
@@ -2,9 +2,13 @@ error[E0277]: the trait bound `U: std::cmp::Eq` is not satisfied
   --> $DIR/specialization-wfcheck.rs:7:17
    |
 LL | default impl<U> Foo<'static, U> for () {}
-   |              -  ^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `U`
-   |              |
-   |              help: consider restricting this bound: `U: std::cmp::Eq`
+   |                 ^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `U`
+   |
+help: consider restricting this type parameter with `U: std::cmp::Eq`
+  --> $DIR/specialization-wfcheck.rs:7:14
+   |
+LL | default impl<U> Foo<'static, U> for () {}
+   |              ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/restrict-type-argument.stderr
+++ b/src/test/ui/suggestions/restrict-type-argument.stderr
@@ -3,13 +3,16 @@ error[E0277]: `impl Sync` cannot be sent between threads safely
    |
 LL | fn is_send<T: Send>(val: T) {}
    |    -------    ---- required by this bound in `is_send`
-LL | 
-LL | fn use_impl_sync(val: impl Sync) {
-   |                       --------- help: consider further restricting this bound: `impl Sync + std::marker::Send`
+...
 LL |     is_send(val);
    |             ^^^ `impl Sync` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `impl Sync`
+help: consider further restricting this bound with `+ std::marker::Send`
+  --> $DIR/restrict-type-argument.rs:3:23
+   |
+LL | fn use_impl_sync(val: impl Sync) {
+   |                       ^^^^^^^^^
 
 error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:8:13
@@ -17,12 +20,15 @@ error[E0277]: `S` cannot be sent between threads safely
 LL | fn is_send<T: Send>(val: T) {}
    |    -------    ---- required by this bound in `is_send`
 ...
-LL | fn use_where<S>(val: S) where S: Sync {
-   |                                      - help: consider further restricting type parameter `S`: `, S: std::marker::Send`
 LL |     is_send(val);
    |             ^^^ `S` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `S`
+help: consider further restricting this bound with `+ std::marker::Send`
+  --> $DIR/restrict-type-argument.rs:7:31
+   |
+LL | fn use_where<S>(val: S) where S: Sync {
+   |                               ^^^^^^^
 
 error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:12:13
@@ -30,27 +36,31 @@ error[E0277]: `S` cannot be sent between threads safely
 LL | fn is_send<T: Send>(val: T) {}
    |    -------    ---- required by this bound in `is_send`
 ...
-LL | fn use_bound<S: Sync>(val: S) {
-   |              -- help: consider further restricting this bound: `S: std::marker::Send +`
 LL |     is_send(val);
    |             ^^^ `S` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `S`
+help: consider further restricting this bound with `+ std::marker::Send`
+  --> $DIR/restrict-type-argument.rs:11:17
+   |
+LL | fn use_bound<S: Sync>(val: S) {
+   |                 ^^^^
 
 error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:20:13
    |
-LL |   fn is_send<T: Send>(val: T) {}
-   |      -------    ---- required by this bound in `is_send`
+LL | fn is_send<T: Send>(val: T) {}
+   |    -------    ---- required by this bound in `is_send`
 ...
-LL | /     S // Make sure we can synthezise a correct suggestion span for this case
-LL | |     :
-   | |_____- help: consider further restricting this bound: `S: std::marker::Send +`
-...
-LL |       is_send(val);
-   |               ^^^ `S` cannot be sent between threads safely
+LL |     is_send(val);
+   |             ^^^ `S` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `S`
+help: consider further restricting this bound with `+ std::marker::Send`
+  --> $DIR/restrict-type-argument.rs:18:5
+   |
+LL |     Sync
+   |     ^^^^
 
 error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:24:13
@@ -58,12 +68,15 @@ error[E0277]: `S` cannot be sent between threads safely
 LL | fn is_send<T: Send>(val: T) {}
    |    -------    ---- required by this bound in `is_send`
 ...
-LL | fn use_bound_and_where<S: Sync>(val: S) where S: std::fmt::Debug {
-   |                                                                 - help: consider further restricting type parameter `S`: `, S: std::marker::Send`
 LL |     is_send(val);
    |             ^^^ `S` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `S`
+help: consider further restricting this bound with `+ std::marker::Send`
+  --> $DIR/restrict-type-argument.rs:23:47
+   |
+LL | fn use_bound_and_where<S: Sync>(val: S) where S: std::fmt::Debug {
+   |                                               ^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:28:13
@@ -71,12 +84,15 @@ error[E0277]: `S` cannot be sent between threads safely
 LL | fn is_send<T: Send>(val: T) {}
    |    -------    ---- required by this bound in `is_send`
 ...
-LL | fn use_unbound<S>(val: S) {
-   |                - help: consider restricting this bound: `S: std::marker::Send`
 LL |     is_send(val);
    |             ^^^ `S` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `S`
+help: consider restricting this type parameter with `S: std::marker::Send`
+  --> $DIR/restrict-type-argument.rs:27:16
+   |
+LL | fn use_unbound<S>(val: S) {
+   |                ^
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/suggestions/suggest-remove-refs-1.stderr
+++ b/src/test/ui/suggestions/suggest-remove-refs-1.stderr
@@ -5,7 +5,7 @@ LL |     for (i, n) in &v.iter().enumerate() {
    |                   -^^^^^^^^^^^^^^^^^^^^
    |                   |
    |                   `&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
-   |                   help: consider removing 1 leading `&`-references
+   |                   help: consider removing the leading `&`-reference
    |
    = help: the trait `std::iter::Iterator` is not implemented for `&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>`
    = note: required by `std::iter::IntoIterator::into_iter`

--- a/src/test/ui/traits/trait-alias/trait-alias-wf.stderr
+++ b/src/test/ui/traits/trait-alias/trait-alias-wf.stderr
@@ -4,9 +4,13 @@ error[E0277]: the trait bound `T: Foo` is not satisfied
 LL | trait A<T: Foo> {}
    | --------------- required by `A`
 LL | trait B<T> = A<T>;
-   |         -    ^^^^ the trait `Foo` is not implemented for `T`
-   |         |
-   |         help: consider restricting this bound: `T: Foo`
+   |              ^^^^ the trait `Foo` is not implemented for `T`
+   |
+help: consider restricting this type parameter with `T: Foo`
+  --> $DIR/trait-alias-wf.rs:5:9
+   |
+LL | trait B<T> = A<T>;
+   |         ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums.stderr
@@ -5,9 +5,13 @@ LL | struct Foo<T:Trait> {
    | ------------------- required by `Foo`
 ...
 LL | impl<T> Foo<T> {
-   |      -  ^^^^^^ the trait `Trait` is not implemented for `T`
-   |      |
-   |      help: consider restricting this bound: `T: Trait`
+   |         ^^^^^^ the trait `Trait` is not implemented for `T`
+   |
+help: consider restricting this type parameter with `T: Trait`
+  --> $DIR/trait-bounds-on-structs-and-enums.rs:13:6
+   |
+LL | impl<T> Foo<T> {
+   |      ^
 
 error[E0277]: the trait bound `isize: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:19:5
@@ -33,10 +37,14 @@ error[E0277]: the trait bound `U: Trait` is not satisfied
 LL | struct Foo<T:Trait> {
    | ------------------- required by `Foo`
 ...
-LL | struct Badness<U> {
-   |                - help: consider restricting this bound: `U: Trait`
 LL |     b: Foo<U>,
    |     ^^^^^^^^^ the trait `Trait` is not implemented for `U`
+   |
+help: consider restricting this type parameter with `U: Trait`
+  --> $DIR/trait-bounds-on-structs-and-enums.rs:26:16
+   |
+LL | struct Badness<U> {
+   |                ^
 
 error[E0277]: the trait bound `V: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:31:21
@@ -44,10 +52,14 @@ error[E0277]: the trait bound `V: Trait` is not satisfied
 LL | enum Bar<T:Trait> {
    | ----------------- required by `Bar`
 ...
-LL | enum MoreBadness<V> {
-   |                  - help: consider restricting this bound: `V: Trait`
 LL |     EvenMoreBadness(Bar<V>),
    |                     ^^^^^^ the trait `Trait` is not implemented for `V`
+   |
+help: consider restricting this type parameter with `V: Trait`
+  --> $DIR/trait-bounds-on-structs-and-enums.rs:30:18
+   |
+LL | enum MoreBadness<V> {
+   |                  ^
 
 error[E0277]: the trait bound `i32: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:35:5

--- a/src/test/ui/traits/traits-repeated-supertrait-ambig.stderr
+++ b/src/test/ui/traits/traits-repeated-supertrait-ambig.stderr
@@ -7,10 +7,14 @@ LL |     c.same_as(22)
 error[E0277]: the trait bound `C: CompareTo<i32>` is not satisfied
   --> $DIR/traits-repeated-supertrait-ambig.rs:30:7
    |
-LL | fn with_trait<C:CompareToInts>(c: &C) -> bool {
-   |               -- help: consider further restricting this bound: `C: CompareTo<i32> +`
 LL |     c.same_as(22)
    |       ^^^^^^^ the trait `CompareTo<i32>` is not implemented for `C`
+   |
+help: consider further restricting this bound with `+ CompareTo<i32>`
+  --> $DIR/traits-repeated-supertrait-ambig.rs:29:17
+   |
+LL | fn with_trait<C:CompareToInts>(c: &C) -> bool {
+   |                 ^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `dyn CompareToInts: CompareTo<i32>` is not satisfied
   --> $DIR/traits-repeated-supertrait-ambig.rs:34:5
@@ -27,10 +31,14 @@ error[E0277]: the trait bound `C: CompareTo<i32>` is not satisfied
 LL |     fn same_as(&self, t: T) -> bool;
    |     -------------------------------- required by `CompareTo::same_as`
 ...
-LL | fn with_ufcs2<C:CompareToInts>(c: &C) -> bool {
-   |               -- help: consider further restricting this bound: `C: CompareTo<i32> +`
 LL |     CompareTo::same_as(c, 22)
    |     ^^^^^^^^^^^^^^^^^^ the trait `CompareTo<i32>` is not implemented for `C`
+   |
+help: consider further restricting this bound with `+ CompareTo<i32>`
+  --> $DIR/traits-repeated-supertrait-ambig.rs:37:17
+   |
+LL | fn with_ufcs2<C:CompareToInts>(c: &C) -> bool {
+   |                 ^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `i64: CompareTo<i32>` is not satisfied
   --> $DIR/traits-repeated-supertrait-ambig.rs:42:23

--- a/src/test/ui/type-alias-impl-trait/bound_reduction2.stderr
+++ b/src/test/ui/type-alias-impl-trait/bound_reduction2.stderr
@@ -3,9 +3,12 @@ error[E0277]: the trait bound `T: TraitWithAssoc` is not satisfied
    |
 LL | type Foo<V> = impl Trait<V>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TraitWithAssoc` is not implemented for `T`
-...
+   |
+help: consider further restricting this bound with `+ TraitWithAssoc`
+  --> $DIR/bound_reduction2.rs:18:21
+   |
 LL | fn foo_desugared<T: TraitWithAssoc>(_: T) -> Foo<T::Assoc> {
-   |                  -- help: consider further restricting this bound: `T: TraitWithAssoc +`
+   |                     ^^^^^^^^^^^^^^
 
 error: defining opaque type use does not fully define opaque type: generic parameter `V` is specified as concrete type `<T as TraitWithAssoc>::Assoc`
   --> $DIR/bound_reduction2.rs:18:1

--- a/src/test/ui/type-alias-impl-trait/generic_underconstrained.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_underconstrained.stderr
@@ -9,10 +9,12 @@ error[E0277]: the trait bound `T: Trait` is not satisfied
    |
 LL | type Underconstrained<T: Trait> = impl 'static;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `T`
-...
-LL | fn underconstrain<T>(_: T) -> Underconstrained<T> {
-   |                   - help: consider restricting this bound: `T: Trait`
    |
+help: consider restricting this type parameter with `T: Trait`
+  --> $DIR/generic_underconstrained.rs:10:19
+   |
+LL | fn underconstrain<T>(_: T) -> Underconstrained<T> {
+   |                   ^
    = note: the return type of a function must have a statically known size
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/type-alias-impl-trait/generic_underconstrained2.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_underconstrained2.stderr
@@ -16,12 +16,15 @@ error[E0277]: `U` doesn't implement `std::fmt::Debug`
 LL | type Underconstrained<T: std::fmt::Debug> = impl 'static;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `U` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
 ...
-LL | fn underconstrained<U>(_: U) -> Underconstrained<U> {
-   |                     - help: consider restricting this bound: `U: std::fmt::Debug`
 LL |     5u32
    |     ---- this returned value is of type `u32`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `U`
+help: consider restricting this type parameter with `U: std::fmt::Debug`
+  --> $DIR/generic_underconstrained2.rs:10:21
+   |
+LL | fn underconstrained<U>(_: U) -> Underconstrained<U> {
+   |                     ^
    = note: the return type of a function must have a statically known size
 
 error[E0277]: `V` doesn't implement `std::fmt::Debug`
@@ -30,12 +33,15 @@ error[E0277]: `V` doesn't implement `std::fmt::Debug`
 LL | type Underconstrained2<T: std::fmt::Debug> = impl 'static;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `V` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
 ...
-LL | fn underconstrained2<U, V>(_: U, _: V) -> Underconstrained2<V> {
-   |                         - help: consider restricting this bound: `V: std::fmt::Debug`
 LL |     5u32
    |     ---- this returned value is of type `u32`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `V`
+help: consider restricting this type parameter with `V: std::fmt::Debug`
+  --> $DIR/generic_underconstrained2.rs:19:25
+   |
+LL | fn underconstrained2<U, V>(_: U, _: V) -> Underconstrained2<V> {
+   |                         ^
    = note: the return type of a function must have a statically known size
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/type/type-check-defaults.stderr
+++ b/src/test/ui/type/type-check-defaults.stderr
@@ -52,9 +52,13 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
 LL | trait Super<T: Copy> { }
    | -------------------- required by `Super`
 LL | trait Base<T = String>: Super<T> { }
-   |            -            ^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
-   |            |
-   |            help: consider restricting this bound: `T: std::marker::Copy`
+   |                         ^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
+   |
+help: consider restricting this type parameter with `T: std::marker::Copy`
+  --> $DIR/type-check-defaults.rs:21:12
+   |
+LL | trait Base<T = String>: Super<T> { }
+   |            ^
 
 error[E0277]: cannot add `u8` to `i32`
   --> $DIR/type-check-defaults.rs:24:66

--- a/src/test/ui/typeck/typeck-default-trait-impl-send-param.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-send-param.stderr
@@ -1,8 +1,6 @@
 error[E0277]: `T` cannot be sent between threads safely
   --> $DIR/typeck-default-trait-impl-send-param.rs:5:15
    |
-LL | fn foo<T>() {
-   |        - help: consider restricting this bound: `T: std::marker::Send`
 LL |     is_send::<T>()
    |               ^ `T` cannot be sent between threads safely
 ...
@@ -10,6 +8,11 @@ LL | fn is_send<T:Send>() {
    |    -------   ---- required by this bound in `is_send`
    |
    = help: the trait `std::marker::Send` is not implemented for `T`
+help: consider restricting this type parameter with `T: std::marker::Send`
+  --> $DIR/typeck-default-trait-impl-send-param.rs:4:8
+   |
+LL | fn foo<T>() {
+   |        ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/src/test/ui/typeck/typeck_type_placeholder_item.stderr
@@ -300,10 +300,10 @@ LL |         b: (T, T),
    |
 
 error[E0282]: type annotations needed
-  --> $DIR/typeck_type_placeholder_item.rs:127:27
+  --> $DIR/typeck_type_placeholder_item.rs:127:18
    |
 LL |     fn fn_test11(_: _) -> (_, _) { panic!() }
-   |                           ^^^^^^ cannot infer type
+   |                  ^ cannot infer type
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:127:28

--- a/src/test/ui/unop-move-semantics.stderr
+++ b/src/test/ui/unop-move-semantics.stderr
@@ -2,14 +2,18 @@ error[E0382]: borrow of moved value: `x`
   --> $DIR/unop-move-semantics.rs:8:5
    |
 LL | fn move_then_borrow<T: Not<Output=T> + Clone>(x: T) {
-   |                     --                        - move occurs because `x` has type `T`, which does not implement the `Copy` trait
-   |                     |
-   |                     help: consider further restricting this bound: `T: Copy +`
+   |                                               - move occurs because `x` has type `T`, which does not implement the `Copy` trait
 LL |     !x;
    |      - value moved here
 LL | 
 LL |     x.clone();
    |     ^ value borrowed here after move
+   |
+help: consider further restricting this bound with `+ Copy`
+  --> $DIR/unop-move-semantics.rs:5:24
+   |
+LL | fn move_then_borrow<T: Not<Output=T> + Clone>(x: T) {
+   |                        ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0505]: cannot move out of `x` because it is borrowed
   --> $DIR/unop-move-semantics.rs:15:6

--- a/src/test/ui/wf/wf-enum-bound.stderr
+++ b/src/test/ui/wf/wf-enum-bound.stderr
@@ -5,9 +5,13 @@ LL | trait ExtraCopy<T:Copy> { }
    | ----------------------- required by `ExtraCopy`
 ...
 LL |     where T: ExtraCopy<U>
-   |              ^^^^^^^^^^^^- help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
-   |              |
-   |              the trait `std::marker::Copy` is not implemented for `U`
+   |              ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`
+   |
+help: consider restricting this type parameter with `where U: std::marker::Copy`
+  --> $DIR/wf-enum-bound.rs:9:17
+   |
+LL | enum SomeEnum<T,U>
+   |                 ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-enum-fields-struct-variant.stderr
+++ b/src/test/ui/wf/wf-enum-fields-struct-variant.stderr
@@ -4,11 +4,14 @@ error[E0277]: the trait bound `A: std::marker::Copy` is not satisfied
 LL | struct IsCopy<T:Copy> {
    | --------------------- required by `IsCopy`
 ...
-LL | enum AnotherEnum<A> {
-   |                  - help: consider restricting this bound: `A: std::marker::Copy`
-LL |     AnotherVariant {
 LL |         f: IsCopy<A>
    |         ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `A`
+   |
+help: consider restricting this type parameter with `A: std::marker::Copy`
+  --> $DIR/wf-enum-fields-struct-variant.rs:11:18
+   |
+LL | enum AnotherEnum<A> {
+   |                  ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-enum-fields.stderr
+++ b/src/test/ui/wf/wf-enum-fields.stderr
@@ -4,10 +4,14 @@ error[E0277]: the trait bound `A: std::marker::Copy` is not satisfied
 LL | struct IsCopy<T:Copy> {
    | --------------------- required by `IsCopy`
 ...
-LL | enum SomeEnum<A> {
-   |               - help: consider restricting this bound: `A: std::marker::Copy`
 LL |     SomeVariant(IsCopy<A>)
    |                 ^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `A`
+   |
+help: consider restricting this type parameter with `A: std::marker::Copy`
+  --> $DIR/wf-enum-fields.rs:11:15
+   |
+LL | enum SomeEnum<A> {
+   |               ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-fn-where-clause.stderr
@@ -5,9 +5,13 @@ LL | trait ExtraCopy<T:Copy> { }
    | ----------------------- required by `ExtraCopy`
 LL | 
 LL | fn foo<T,U>() where T: ExtraCopy<U>
-   |                        ^^^^^^^^^^^^- help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
-   |                        |
-   |                        the trait `std::marker::Copy` is not implemented for `U`
+   |                        ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`
+   |
+help: consider restricting this type parameter with `where U: std::marker::Copy`
+  --> $DIR/wf-fn-where-clause.rs:8:10
+   |
+LL | fn foo<T,U>() where T: ExtraCopy<U>
+   |          ^
 
 error[E0277]: the size for values of type `(dyn std::marker::Copy + 'static)` cannot be known at compilation time
   --> $DIR/wf-fn-where-clause.rs:12:16

--- a/src/test/ui/wf/wf-impl-associated-type-trait.stderr
+++ b/src/test/ui/wf/wf-impl-associated-type-trait.stderr
@@ -4,10 +4,14 @@ error[E0277]: the trait bound `T: MyHash` is not satisfied
 LL | pub struct MySet<T:MyHash> {
    | -------------------------- required by `MySet`
 ...
-LL | impl<T> Foo for T {
-   |      - help: consider restricting this bound: `T: MyHash`
 LL |     type Bar = MySet<T>;
    |     ^^^^^^^^^^^^^^^^^^^^ the trait `MyHash` is not implemented for `T`
+   |
+help: consider restricting this type parameter with `T: MyHash`
+  --> $DIR/wf-impl-associated-type-trait.rs:16:6
+   |
+LL | impl<T> Foo for T {
+   |      ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-arg.stderr
+++ b/src/test/ui/wf/wf-in-fn-arg.stderr
@@ -5,9 +5,13 @@ LL | struct MustBeCopy<T:Copy> {
    | ------------------------- required by `MustBeCopy`
 ...
 LL | fn bar<T>(_: &MustBeCopy<T>)
-   |        -     ^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
-   |        |
-   |        help: consider restricting this bound: `T: std::marker::Copy`
+   |              ^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
+   |
+help: consider restricting this type parameter with `T: std::marker::Copy`
+  --> $DIR/wf-in-fn-arg.rs:10:8
+   |
+LL | fn bar<T>(_: &MustBeCopy<T>)
+   |        ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-ret.stderr
+++ b/src/test/ui/wf/wf-in-fn-ret.stderr
@@ -5,9 +5,13 @@ LL | struct MustBeCopy<T:Copy> {
    | ------------------------- required by `MustBeCopy`
 ...
 LL | fn bar<T>() -> MustBeCopy<T>
-   |        -       ^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
-   |        |
-   |        help: consider restricting this bound: `T: std::marker::Copy`
+   |                ^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
+   |
+help: consider restricting this type parameter with `T: std::marker::Copy`
+  --> $DIR/wf-in-fn-ret.rs:10:8
+   |
+LL | fn bar<T>() -> MustBeCopy<T>
+   |        ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-type-arg.stderr
+++ b/src/test/ui/wf/wf-in-fn-type-arg.stderr
@@ -4,11 +4,14 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
 LL | struct MustBeCopy<T:Copy> {
    | ------------------------- required by `MustBeCopy`
 ...
-LL | struct Bar<T> {
-   |            - help: consider restricting this bound: `T: std::marker::Copy`
-LL |     // needs T: Copy
 LL |     x: fn(MustBeCopy<T>)
    |     ^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
+   |
+help: consider restricting this type parameter with `T: std::marker::Copy`
+  --> $DIR/wf-in-fn-type-arg.rs:7:12
+   |
+LL | struct Bar<T> {
+   |            ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-type-ret.stderr
+++ b/src/test/ui/wf/wf-in-fn-type-ret.stderr
@@ -4,11 +4,14 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
 LL | struct MustBeCopy<T:Copy> {
    | ------------------------- required by `MustBeCopy`
 ...
-LL | struct Foo<T> {
-   |            - help: consider restricting this bound: `T: std::marker::Copy`
-LL |     // needs T: 'static
 LL |     x: fn() -> MustBeCopy<T>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
+   |
+help: consider restricting this type parameter with `T: std::marker::Copy`
+  --> $DIR/wf-in-fn-type-ret.rs:7:12
+   |
+LL | struct Foo<T> {
+   |            ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-in-fn-where-clause.stderr
@@ -5,9 +5,13 @@ LL | trait MustBeCopy<T:Copy> {
    | ------------------------ required by `MustBeCopy`
 ...
 LL |     where T: MustBeCopy<U>
-   |              ^^^^^^^^^^^^^- help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
-   |              |
-   |              the trait `std::marker::Copy` is not implemented for `U`
+   |              ^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`
+   |
+help: consider restricting this type parameter with `where U: std::marker::Copy`
+  --> $DIR/wf-in-fn-where-clause.rs:9:10
+   |
+LL | fn bar<T,U>()
+   |          ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-obj-type-trait.stderr
+++ b/src/test/ui/wf/wf-in-obj-type-trait.stderr
@@ -4,11 +4,14 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
 LL | struct MustBeCopy<T:Copy> {
    | ------------------------- required by `MustBeCopy`
 ...
-LL | struct Bar<T> {
-   |            - help: consider restricting this bound: `T: std::marker::Copy`
-LL |     // needs T: Copy
 LL |     x: dyn Object<MustBeCopy<T>>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
+   |
+help: consider restricting this type parameter with `T: std::marker::Copy`
+  --> $DIR/wf-in-obj-type-trait.rs:9:12
+   |
+LL | struct Bar<T> {
+   |            ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-inherent-impl-method-where-clause.stderr
+++ b/src/test/ui/wf/wf-inherent-impl-method-where-clause.stderr
@@ -4,10 +4,14 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
 LL | trait ExtraCopy<T:Copy> { }
    | ----------------------- required by `ExtraCopy`
 ...
-LL | impl<T,U> Foo<T,U> {
-   |        - help: consider restricting this bound: `U: std::marker::Copy`
 LL |     fn foo(self) where T: ExtraCopy<U>
    |                           ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`
+   |
+help: consider restricting this type parameter with `U: std::marker::Copy`
+  --> $DIR/wf-inherent-impl-method-where-clause.rs:11:8
+   |
+LL | impl<T,U> Foo<T,U> {
+   |        ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-inherent-impl-where-clause.stderr
+++ b/src/test/ui/wf/wf-inherent-impl-where-clause.stderr
@@ -5,9 +5,13 @@ LL | trait ExtraCopy<T:Copy> { }
    | ----------------------- required by `ExtraCopy`
 ...
 LL | impl<T,U> Foo<T,U> where T: ExtraCopy<U>
-   |                             ^^^^^^^^^^^^- help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
-   |                             |
-   |                             the trait `std::marker::Copy` is not implemented for `U`
+   |                             ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`
+   |
+help: consider restricting this type parameter with `where U: std::marker::Copy`
+  --> $DIR/wf-inherent-impl-where-clause.rs:11:8
+   |
+LL | impl<T,U> Foo<T,U> where T: ExtraCopy<U>
+   |        ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-struct-bound.stderr
+++ b/src/test/ui/wf/wf-struct-bound.stderr
@@ -5,9 +5,13 @@ LL | trait ExtraCopy<T:Copy> { }
    | ----------------------- required by `ExtraCopy`
 ...
 LL |     where T: ExtraCopy<U>
-   |              ^^^^^^^^^^^^- help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
-   |              |
-   |              the trait `std::marker::Copy` is not implemented for `U`
+   |              ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`
+   |
+help: consider restricting this type parameter with `where U: std::marker::Copy`
+  --> $DIR/wf-struct-bound.rs:9:21
+   |
+LL | struct SomeStruct<T,U>
+   |                     ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-struct-field.stderr
+++ b/src/test/ui/wf/wf-struct-field.stderr
@@ -4,10 +4,14 @@ error[E0277]: the trait bound `A: std::marker::Copy` is not satisfied
 LL | struct IsCopy<T:Copy> {
    | --------------------- required by `IsCopy`
 ...
-LL | struct SomeStruct<A> {
-   |                   - help: consider restricting this bound: `A: std::marker::Copy`
 LL |     data: IsCopy<A>
    |     ^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `A`
+   |
+help: consider restricting this type parameter with `A: std::marker::Copy`
+  --> $DIR/wf-struct-field.rs:11:19
+   |
+LL | struct SomeStruct<A> {
+   |                   ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-associated-type-bound.stderr
+++ b/src/test/ui/wf/wf-trait-associated-type-bound.stderr
@@ -3,11 +3,15 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
    |
 LL | trait ExtraCopy<T:Copy> { }
    | ----------------------- required by `ExtraCopy`
-LL | 
-LL | trait SomeTrait<T> {
-   |                 - help: consider restricting this bound: `T: std::marker::Copy`
+...
 LL |     type Type1: ExtraCopy<T>;
    |                 ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
+   |
+help: consider restricting this type parameter with `T: std::marker::Copy`
+  --> $DIR/wf-trait-associated-type-bound.rs:9:17
+   |
+LL | trait SomeTrait<T> {
+   |                 ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-bound.stderr
+++ b/src/test/ui/wf/wf-trait-bound.stderr
@@ -5,9 +5,13 @@ LL | trait ExtraCopy<T:Copy> { }
    | ----------------------- required by `ExtraCopy`
 ...
 LL |     where T: ExtraCopy<U>
-   |              ^^^^^^^^^^^^- help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
-   |              |
-   |              the trait `std::marker::Copy` is not implemented for `U`
+   |              ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`
+   |
+help: consider restricting this type parameter with `where U: std::marker::Copy`
+  --> $DIR/wf-trait-bound.rs:9:19
+   |
+LL | trait SomeTrait<T,U>
+   |                   ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-superbound.stderr
+++ b/src/test/ui/wf/wf-trait-superbound.stderr
@@ -5,9 +5,13 @@ LL | trait ExtraCopy<T:Copy> { }
    | ----------------------- required by `ExtraCopy`
 LL | 
 LL | trait SomeTrait<T>: ExtraCopy<T> {
-   |                 -   ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
-   |                 |
-   |                 help: consider restricting this bound: `T: std::marker::Copy`
+   |                     ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
+   |
+help: consider restricting this type parameter with `T: std::marker::Copy`
+  --> $DIR/wf-trait-superbound.rs:9:17
+   |
+LL | trait SomeTrait<T>: ExtraCopy<T> {
+   |                 ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
+++ b/src/test/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
@@ -4,11 +4,14 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
 LL | fn require_copy<T: Copy>(x: T) {}
    |    ------------    ---- required by this bound in `require_copy`
 ...
-LL | impl<T> Foo<T> {
-   |      - help: consider restricting this bound: `T: std::marker::Copy`
-...
 LL |         require_copy(self.x);
    |                      ^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
+   |
+help: consider restricting this type parameter with `T: std::marker::Copy`
+  --> $DIR/where-clause-constraints-are-local-for-inherent-impl.rs:6:6
+   |
+LL | impl<T> Foo<T> {
+   |      ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
+++ b/src/test/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
@@ -4,11 +4,14 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
 LL | fn require_copy<T: Copy>(x: T) {}
    |    ------------    ---- required by this bound in `require_copy`
 ...
-LL | impl<T> Foo<T> for Bar<T> {
-   |      - help: consider restricting this bound: `T: std::marker::Copy`
-...
 LL |         require_copy(self.x);
    |                      ^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
+   |
+help: consider restricting this type parameter with `T: std::marker::Copy`
+  --> $DIR/where-clause-constraints-are-local-for-trait-impl.rs:11:6
+   |
+LL | impl<T> Foo<T> for Bar<T> {
+   |      ^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fix #66802

- When printing errors for unsized function parameter, properly point at the parameter instead of function's body.
- Improve `consider further restricting this bound` (and related) messages by separating human-oriented hints from the machine-oriented ones.