### PR TITLE
Resolve long compile times when evaluating always valid constants

### DIFF
--- a/src/test/ui/consts/const-eval/validate_uninhabited_zsts.rs
+++ b/src/test/ui/consts/const-eval/validate_uninhabited_zsts.rs
@@ -1,0 +1,24 @@
+#![feature(const_fn)]
+#![feature(const_transmute)]
+
+const fn foo() -> ! {
+    unsafe { std::mem::transmute(()) }
+    //~^ WARN any use of this value will cause an error [const_err]
+    //~| WARN the type `!` does not permit zero-initialization [invalid_value]
+}
+
+#[derive(Clone, Copy)]
+enum Empty { }
+
+#[warn(const_err)]
+const FOO: [Empty; 3] = [foo(); 3];
+
+#[warn(const_err)]
+const BAR: [Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
+//~^ ERROR it is undefined behavior to use this value
+//~| WARN the type `Empty` does not permit zero-initialization
+
+fn main() {
+    FOO;
+    BAR;
+}

--- a/src/test/ui/consts/const-eval/validate_uninhabited_zsts.stderr
+++ b/src/test/ui/consts/const-eval/validate_uninhabited_zsts.stderr
@@ -1,0 +1,52 @@
+warning: any use of this value will cause an error
+  --> $DIR/validate_uninhabited_zsts.rs:5:14
+   |
+LL |     unsafe { std::mem::transmute(()) }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^
+   |              |
+   |              entering unreachable code
+   |              inside call to `foo` at $DIR/validate_uninhabited_zsts.rs:14:26
+...
+LL | const FOO: [Empty; 3] = [foo(); 3];
+   | -----------------------------------
+   |
+note: lint level defined here
+  --> $DIR/validate_uninhabited_zsts.rs:13:8
+   |
+LL | #[warn(const_err)]
+   |        ^^^^^^^^^
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/validate_uninhabited_zsts.rs:17:1
+   |
+LL | const BAR: [Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a value of an uninhabited type
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+
+warning: the type `!` does not permit zero-initialization
+  --> $DIR/validate_uninhabited_zsts.rs:5:14
+   |
+LL |     unsafe { std::mem::transmute(()) }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^
+   |              |
+   |              this code causes undefined behavior when executed
+   |              help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
+   |
+   = note: `#[warn(invalid_value)]` on by default
+   = note: The never type (`!`) has no valid value
+
+warning: the type `Empty` does not permit zero-initialization
+  --> $DIR/validate_uninhabited_zsts.rs:17:35
+   |
+LL | const BAR: [Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   |
+   |                                   this code causes undefined behavior when executed
+   |                                   help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
+   |
+   = note: 0-variant enums have no valid value
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/huge-values.rs
+++ b/src/test/ui/consts/huge-values.rs
@@ -1,0 +1,11 @@
+// build-pass
+// ignore-32bit
+
+#[derive(Clone, Copy)]
+struct Foo;
+
+fn main() {
+    let _ = [(); 4_000_000_000];
+    let _ = [0u8; 4_000_000_000];
+    let _ = [Foo; 4_000_000_000];
+}


### PR DESCRIPTION
This extends the existing logic which skips validating every integer or
floating point number type to also skip validating empty structs because
they are also trivially valid.

Fixes #67539

r? @oli-obk 
cc @RalfJung @spastorino 