### PR TITLE
resolve: Minor cleanup of duplicate macro reexports

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -528,31 +528,7 @@ impl<'a> Resolver<'a> {
                         resolution.shadowed_glob = Some(glob_binding);
                     }
                     (false, false) => {
-                        if let (&NameBindingKind::Res(_, true), &NameBindingKind::Res(_, true)) =
-                            (&old_binding.kind, &binding.kind)
-                        {
-                            this.session
-                                .struct_span_err(
-                                    binding.span,
-                                    &format!(
-                                        "a macro named `{}` has already been exported",
-                                        key.ident
-                                    ),
-                                )
-                                .span_label(
-                                    binding.span,
-                                    format!("`{}` already exported", key.ident),
-                                )
-                                .span_note(
-                                    old_binding.span,
-                                    "previous macro export is now shadowed",
-                                )
-                                .emit();
-
-                            resolution.binding = Some(binding);
-                        } else {
-                            return Err(old_binding);
-                        }
+                        return Err(old_binding);
                     }
                 }
             } else {

--- a/src/test/ui/issues/issue-38715.rs
+++ b/src/test/ui/issues/issue-38715.rs
@@ -2,6 +2,6 @@
 macro_rules! foo { ($i:ident) => {} }
 
 #[macro_export]
-macro_rules! foo { () => {} } //~ ERROR a macro named `foo` has already been exported
+macro_rules! foo { () => {} } //~ ERROR the name `foo` is defined multiple times
 
 fn main() {}

--- a/src/test/ui/issues/issue-38715.stderr
+++ b/src/test/ui/issues/issue-38715.stderr
@@ -1,14 +1,14 @@
-error: a macro named `foo` has already been exported
+error[E0428]: the name `foo` is defined multiple times
   --> $DIR/issue-38715.rs:5:1
    |
-LL | macro_rules! foo { () => {} }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `foo` already exported
-   |
-note: previous macro export is now shadowed
-  --> $DIR/issue-38715.rs:2:1
-   |
 LL | macro_rules! foo { ($i:ident) => {} }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ---------------- previous definition of the macro `foo` here
+...
+LL | macro_rules! foo { () => {} }
+   | ^^^^^^^^^^^^^^^^ `foo` redefined here
+   |
+   = note: `foo` must be defined only once in the macro namespace of this module
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0428`.


### PR DESCRIPTION
Enabled by https://github.com/rust-lang/rust/pull/65785 which changed `duplicate_macro_exports` from a lint to a hard error.