### PR TITLE
tidy: Enforce formatting rather than just check it if `--bless` is specified

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -736,7 +736,7 @@ impl Step for Tidy {
 
         if builder.config.channel == "dev" || builder.config.channel == "nightly" {
             builder.info("fmt check");
-            crate::format::format(&builder.build, true);
+            crate::format::format(&builder.build, !builder.config.cmd.bless());
         }
     }
 


### PR DESCRIPTION
Ensuring the "tidy"-ness currently requires running `rustfmt` twice:
```sh
./x.py fmt && ./x.py test tidy
```
, once to actually format code and the second time as a part of tidy to check that the code is formatted.

Running `rustfmt` is slow, so we don't want to run it twice.

With this PR tidy enforces the formatting rather than just checks it if `--bless` was passed to it:
```sh
./x.py test tidy --bless
```

r? @Mark-Simulacrum 