### PR TITLE
ci: remove 32-bit Apple targets

### DIFF
--- a/src/ci/azure-pipelines/auto.yml
+++ b/src/ci/azure-pipelines/auto.yml
@@ -85,7 +85,7 @@ jobs:
 
       dist-x86_64-apple:
         SCRIPT: ./x.py dist
-        RUST_CONFIGURE_ARGS: --target=aarch64-apple-ios,armv7-apple-ios,armv7s-apple-ios,i386-apple-ios,x86_64-apple-ios --enable-full-tools --enable-sanitizers --enable-profiler --set rust.jemalloc
+        RUST_CONFIGURE_ARGS: --target=aarch64-apple-ios,x86_64-apple-ios --enable-full-tools --enable-sanitizers --enable-profiler --set rust.jemalloc
         RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
         MACOSX_DEPLOYMENT_TARGET: 10.7
         NO_LLVM_ASSERTIONS: 1
@@ -99,25 +99,6 @@ jobs:
         MACOSX_DEPLOYMENT_TARGET: 10.7
         NO_LLVM_ASSERTIONS: 1
         NO_DEBUG_ASSERTIONS: 1
-
-      i686-apple:
-        SCRIPT: ./x.py test
-        RUST_CONFIGURE_ARGS: --build=i686-apple-darwin --set rust.jemalloc
-        RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
-        MACOSX_DEPLOYMENT_TARGET: 10.8
-        MACOSX_STD_DEPLOYMENT_TARGET: 10.7
-        NO_LLVM_ASSERTIONS: 1
-        NO_DEBUG_ASSERTIONS: 1
-
-      dist-i686-apple:
-        SCRIPT: ./x.py dist
-        RUST_CONFIGURE_ARGS: --build=i686-apple-darwin --enable-full-tools --enable-profiler --set rust.jemalloc
-        RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
-        MACOSX_DEPLOYMENT_TARGET: 10.7
-        NO_LLVM_ASSERTIONS: 1
-        NO_DEBUG_ASSERTIONS: 1
-        DIST_REQUIRE_ALL_TOOLS: 1
-
 
 
 - job: Windows


### PR DESCRIPTION
This PR drops the `i686-apple` and `dist-i686-apple` CI builders, as well as removing the `armv7-apple-ios`, `armv7s-apple-ios`  and `i386-apple-ios` targets from the `x86_64-apple` CI builder.

The change was approved in [RFC 2837](https://github.com/rust-lang/rfcs/pull/2837), and it should land in Rust 1.42 stable (so this cycle).

r? @alexcrichton 