### PR TITLE
GitHub Actions: preparations, part 2

### DIFF
--- a/src/ci/publish_toolstate.sh
+++ b/src/ci/publish_toolstate.sh
@@ -1,6 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 
-set -eu
+set -euo pipefail
+IFS=$'\n\t'
+
+source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 
 # The following lines are also found in src/bootstrap/toolstate.rs,
 # so if updating here, please also update that file.
@@ -21,7 +24,7 @@ cd rust-toolstate
 FAILURE=1
 for RETRY_COUNT in 1 2 3 4 5; do
     #  The purpose is to publish the new "current" toolstate in the toolstate repo.
-    "$BUILD_SOURCESDIRECTORY/src/tools/publish_toolstate.py" "$GIT_COMMIT" \
+    "$(ciCheckoutPath)/src/tools/publish_toolstate.py" "$GIT_COMMIT" \
         "$GIT_COMMIT_MSG" \
         "$MESSAGE_FILE" \
         "$TOOLSTATE_REPO_ACCESS_TOKEN"

--- a/src/ci/scripts/install-clang.sh
+++ b/src/ci/scripts/install-clang.sh
@@ -14,6 +14,15 @@ if isMacOS; then
     ciCommandSetEnv CC "$(pwd)/clang+llvm-9.0.0-x86_64-darwin-apple/bin/clang"
     ciCommandSetEnv CXX "$(pwd)/clang+llvm-9.0.0-x86_64-darwin-apple/bin/clang++"
 
+    # macOS 10.15 onwards doesn't have libraries in /usr/include anymore: those
+    # are now located deep into the filesystem, under Xcode's own files. The
+    # native clang is configured to use the correct path, but our custom one
+    # doesn't. This sets the SDKROOT environment variable to the SDK so that
+    # our own clang can figure out the correct include path on its own.
+    if ! [[ -d "/usr/include" ]]; then
+        ciCommandSetEnv SDKROOT "$(xcrun --sdk macosx --show-sdk-path)"
+    fi
+
     # Configure `AR` specifically so rustbuild doesn't try to infer it as
     # `clang-ar` by accident.
     ciCommandSetEnv AR "ar"

--- a/src/ci/scripts/install-msys2-packages.sh
+++ b/src/ci/scripts/install-msys2-packages.sh
@@ -6,7 +6,8 @@ IFS=$'\n\t'
 source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 
 if isWindows; then
-    pacman -S --noconfirm --needed base-devel ca-certificates make diffutils tar
+    pacman -S --noconfirm --needed base-devel ca-certificates make diffutils tar \
+        binutils
 
     # Make sure we use the native python interpreter instead of some msys equivalent
     # one way or another. The msys interpreters seem to have weird path conversions

--- a/src/ci/shared.sh
+++ b/src/ci/shared.sh
@@ -99,7 +99,7 @@ function ciCommandAddPath {
     if isAzurePipelines; then
         echo "##vso[task.prependpath]${path}"
     elif isGitHubActions; then
-        echo "::add-path::${value}"
+        echo "::add-path::${path}"
     else
         echo "ciCommandAddPath only works inside CI!"
         exit 1


### PR DESCRIPTION
This PR adds the second batch of commits in preparation for GitHub Actions:

* Removed hardcoded Azure Pipelines variables from `publish_toolstate.sh`
* Fixed a bug in `shared.sh`'s GitHub Actions support
* Fixed binutils missing from MSYS2 on Windows 2019 (GitHub Actions-specific)
* Fixed wrong sysroot in macOS 10.15 onwards (GitHub Actions-specific)

This PR does **not** yet add any builders on GitHub Actions.

r? @alexcrichton