### PR TITLE
When encountering an Item in a pat context, point at the item def

### DIFF
--- a/src/test/ui/blind/blind-item-block-middle.stderr
+++ b/src/test/ui/blind/blind-item-block-middle.stderr
@@ -1,8 +1,15 @@
 error[E0308]: mismatched types
   --> $DIR/blind-item-block-middle.rs:6:9
    |
+LL | mod foo { pub struct bar; }
+   |           --------------- unit struct defined here
+...
 LL |     let bar = 5;
-   |         ^^^ expected integer, found struct `foo::bar`
+   |         ^^^
+   |         |
+   |         expected integer, found struct `foo::bar`
+   |         `bar` is interpreted as a unit struct, not a new binding
+   |         help: introduce a new binding instead: `other_bar`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-33504.stderr
+++ b/src/test/ui/issues/issue-33504.stderr
@@ -1,8 +1,15 @@
 error[E0308]: mismatched types
   --> $DIR/issue-33504.rs:7:13
    |
+LL | struct Test;
+   | ------------ unit struct defined here
+...
 LL |         let Test = 1;
-   |             ^^^^ expected integer, found struct `Test`
+   |             ^^^^
+   |             |
+   |             expected integer, found struct `Test`
+   |             `Test` is interpreted as a unit struct, not a new binding
+   |             help: introduce a new binding instead: `other_test`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-4968.stderr
+++ b/src/test/ui/issues/issue-4968.stderr
@@ -1,8 +1,15 @@
 error[E0308]: mismatched types
   --> $DIR/issue-4968.rs:5:16
    |
+LL | const A: (isize,isize) = (4,2);
+   | ------------------------------- constant defined here
+LL | fn main() {
 LL |     match 42 { A => () }
-   |                ^ expected integer, found tuple
+   |                ^
+   |                |
+   |                expected integer, found tuple
+   |                `A` is interpreted as a constant, not a new binding
+   |                help: introduce a new binding instead: `other_a`
    |
    = note: expected type `{integer}`
              found tuple `(isize, isize)`

--- a/src/test/ui/issues/issue-5100.stderr
+++ b/src/test/ui/issues/issue-5100.stderr
@@ -1,6 +1,9 @@
 error[E0308]: mismatched types
   --> $DIR/issue-5100.rs:8:9
    |
+LL | enum A { B, C }
+   |          - unit variant defined here
+...
 LL |     match (true, false) {
    |           ------------- this expression has type `(bool, bool)`
 LL |         A::B => (),

--- a/src/test/ui/issues/issue-7867.stderr
+++ b/src/test/ui/issues/issue-7867.stderr
@@ -1,6 +1,9 @@
 error[E0308]: mismatched types
   --> $DIR/issue-7867.rs:7:9
    |
+LL | enum A { B, C }
+   |          - unit variant defined here
+...
 LL |     match (true, false) {
    |           ------------- this expression has type `(bool, bool)`
 LL |         A::B => (),

--- a/src/test/ui/match/match-tag-nullary.stderr
+++ b/src/test/ui/match/match-tag-nullary.stderr
@@ -1,6 +1,9 @@
 error[E0308]: mismatched types
   --> $DIR/match-tag-nullary.rs:4:40
    |
+LL | enum B { B }
+   |          - unit variant defined here
+LL | 
 LL | fn main() { let x: A = A::A; match x { B::B => { } } }
    |                                    -   ^^^^ expected enum `A`, found enum `B`
    |                                    |

--- a/src/test/ui/rfc-2005-default-binding-mode/const.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/const.stderr
@@ -1,10 +1,17 @@
 error[E0308]: mismatched types
   --> $DIR/const.rs:14:9
    |
+LL | const FOO: Foo = Foo{bar: 5};
+   | ----------------------------- constant defined here
+...
 LL |     match &f {
    |           -- this expression has type `&Foo`
 LL |         FOO => {},
-   |         ^^^ expected `&Foo`, found struct `Foo`
+   |         ^^^
+   |         |
+   |         expected `&Foo`, found struct `Foo`
+   |         `FOO` is interpreted as a constant, not a new binding
+   |         help: introduce a new binding instead: `other_foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/const-in-struct-pat.rs
+++ b/src/test/ui/suggestions/const-in-struct-pat.rs
@@ -1,0 +1,11 @@
+#[allow(non_camel_case_types)]
+struct foo;
+struct Thing {
+    foo: String,
+}
+
+fn example(t: Thing) {
+    let Thing { foo } = t; //~ ERROR mismatched types
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/const-in-struct-pat.stderr
+++ b/src/test/ui/suggestions/const-in-struct-pat.stderr
@@ -1,0 +1,16 @@
+error[E0308]: mismatched types
+  --> $DIR/const-in-struct-pat.rs:8:17
+   |
+LL | struct foo;
+   | ----------- unit struct defined here
+...
+LL |     let Thing { foo } = t;
+   |                 ^^^     - this expression has type `Thing`
+   |                 |
+   |                 expected struct `std::string::String`, found struct `foo`
+   |                 `foo` is interpreted as a unit struct, not a new binding
+   |                 help: bind the struct field to a different name instead: `foo: other_foo`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
```
error[E0308]: mismatched types
  --> $DIR/const-in-struct-pat.rs:8:17
   |
LL | struct foo;
   | ----------- `foo` defined here
...
LL |     let Thing { foo } = t;
   |                 ^^^ expected struct `std::string::String`, found struct `foo`
   |
   = note: `foo` is interpreted as a unit struct, not a new binding
help: you can bind the struct field to a different name
   |
LL |     let Thing { foo: other_foo } = t;
   |                 ^^^^^^^^^^^^^^
```
```
error[E0308]: mismatched types
  --> $DIR/const.rs:14:9
   |
LL | const FOO: Foo = Foo{bar: 5};
   | ----------------------------- constant defined here
...
LL |         FOO => {},
   |         ^^^
   |         |
   |         expected `&Foo`, found struct `Foo`
   |         `FOO` is interpreted as a constant, not a new binding
   |         help: use different name to introduce a new binding: `other_foo`
```

Fix #55631, fix #48062, cc #42876.