### PR TITLE
Add Games MSVC targets

### DIFF
--- a/src/librustc_target/spec/aarch64_games_windows_msvc.rs
+++ b/src/librustc_target/spec/aarch64_games_windows_msvc.rs
@@ -1,0 +1,25 @@
+use crate::spec::{LinkerFlavor, PanicStrategy, Target, TargetResult};
+
+pub fn target() -> TargetResult {
+    let mut base = super::windows_games_msvc_base::opts();
+    base.max_atomic_width = Some(64);
+    base.has_elf_tls = true;
+    base.features = "+neon,+fp-armv8".to_string();
+
+    // FIXME: this shouldn't be panic=abort, it should be panic=unwind
+    base.panic_strategy = PanicStrategy::Abort;
+
+    Ok(Target {
+        llvm_target: "aarch64-games-windows-msvc".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "64".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "e-m:w-p:64:64-i32:32-i64:64-i128:128-n32:64-S128".to_string(),
+        arch: "aarch64".to_string(),
+        target_os: "windows".to_string(),
+        target_env: "msvc".to_string(),
+        target_vendor: "games".to_string(),
+        linker_flavor: LinkerFlavor::Msvc,
+        options: base,
+    })
+}

--- a/src/librustc_target/spec/i686_games_windows_msvc.rs
+++ b/src/librustc_target/spec/i686_games_windows_msvc.rs
@@ -1,0 +1,31 @@
+use crate::spec::{LinkerFlavor, Target, TargetResult};
+
+pub fn target() -> TargetResult {
+    let mut base = super::windows_games_msvc_base::opts();
+    base.cpu = "pentium4".to_string();
+    base.max_atomic_width = Some(64);
+    base.has_elf_tls = true;
+
+    // Mark all dynamic libraries and executables as compatible with the larger 4GiB address
+    // space available to x86 Windows binaries on x86_64.
+    base.pre_link_args.get_mut(&LinkerFlavor::Msvc).unwrap().push("/LARGEADDRESSAWARE".to_string());
+
+    // Ensure the linker will only produce an image if it can also produce a table of
+    // the image's safe exception handlers.
+    // https://docs.microsoft.com/en-us/cpp/build/reference/safeseh-image-has-safe-exception-handlers
+    base.pre_link_args.get_mut(&LinkerFlavor::Msvc).unwrap().push("/SAFESEH".to_string());
+
+    Ok(Target {
+        llvm_target: "i686-games-windows-msvc".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "e-m:x-p:32:32-i64:64-f80:32-n8:16:32-a:0:32-S32".to_string(),
+        arch: "x86".to_string(),
+        target_os: "windows".to_string(),
+        target_env: "msvc".to_string(),
+        target_vendor: "games".to_string(),
+        linker_flavor: LinkerFlavor::Msvc,
+        options: base,
+    })
+}

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -70,6 +70,7 @@ mod uefi_base;
 mod vxworks_base;
 mod wasm32_base;
 mod windows_base;
+mod windows_games_msvc_base;
 mod windows_msvc_base;
 mod windows_uwp_base;
 mod windows_uwp_msvc_base;
@@ -452,10 +453,13 @@ supported_targets! {
 
     ("aarch64-pc-windows-msvc", aarch64_pc_windows_msvc),
     ("aarch64-uwp-windows-msvc", aarch64_uwp_windows_msvc),
+    ("aarch64-games-windows-msvc", aarch64_games_windows_msvc),
     ("x86_64-pc-windows-msvc", x86_64_pc_windows_msvc),
     ("x86_64-uwp-windows-msvc", x86_64_uwp_windows_msvc),
+    ("x86_64-games-windows-msvc", x86_64_games_windows_msvc),
     ("i686-pc-windows-msvc", i686_pc_windows_msvc),
     ("i686-uwp-windows-msvc", i686_uwp_windows_msvc),
+    ("i686-games-windows-msvc", i686_games_windows_msvc),
     ("i586-pc-windows-msvc", i586_pc_windows_msvc),
     ("thumbv7a-pc-windows-msvc", thumbv7a_pc_windows_msvc),
 

--- a/src/librustc_target/spec/windows_games_msvc_base.rs
+++ b/src/librustc_target/spec/windows_games_msvc_base.rs
@@ -1,0 +1,36 @@
+use crate::spec::{LinkArgs, LinkerFlavor, TargetOptions};
+use std::default::Default;
+
+pub fn opts() -> TargetOptions {
+    let mut args = LinkArgs::new();
+    args.insert(
+        LinkerFlavor::Msvc,
+        vec!["/NOLOGO".to_string(), "/NXCOMPAT".to_string(), "onecore.lib".to_string()],
+    );
+
+    TargetOptions {
+        function_sections: true,
+        dynamic_linking: true,
+        executables: true,
+        dll_prefix: String::new(),
+        dll_suffix: ".dll".to_string(),
+        exe_suffix: ".exe".to_string(),
+        staticlib_prefix: String::new(),
+        staticlib_suffix: ".lib".to_string(),
+        target_family: Some("windows".to_string()),
+        is_like_windows: true,
+        is_like_msvc: true,
+        // set VSLANG to 1033 can prevent link.exe from using
+        // language packs, and avoid generating Non-UTF-8 error
+        // messages if a link error occurred.
+        link_env: vec![("VSLANG".to_string(), "1033".to_string())],
+        pre_link_args: args,
+        crt_static_allows_dylibs: true,
+        crt_static_respected: true,
+        abi_return_struct_as_int: true,
+        emit_debug_gdb_scripts: false,
+        requires_uwtable: true,
+
+        ..Default::default()
+    }
+}

--- a/src/librustc_target/spec/x86_64_games_windows_msvc.rs
+++ b/src/librustc_target/spec/x86_64_games_windows_msvc.rs
@@ -1,0 +1,22 @@
+use crate::spec::{LinkerFlavor, Target, TargetResult};
+
+pub fn target() -> TargetResult {
+    let mut base = super::windows_games_msvc_base::opts();
+    base.cpu = "x86-64".to_string();
+    base.max_atomic_width = Some(64);
+    base.has_elf_tls = true;
+
+    Ok(Target {
+        llvm_target: "x86_64-games-windows-msvc".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "64".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "e-m:w-i64:64-f80:128-n8:16:32:64-S128".to_string(),
+        arch: "x86_64".to_string(),
+        target_os: "windows".to_string(),
+        target_env: "msvc".to_string(),
+        target_vendor: "games".to_string(),
+        linker_flavor: LinkerFlavor::Msvc,
+        options: base,
+    })
+}

--- a/src/libstd/sys/windows/fs.rs
+++ b/src/libstd/sys/windows/fs.rs
@@ -322,7 +322,7 @@ impl File {
         Ok(())
     }
 
-    #[cfg(not(target_vendor = "uwp"))]
+    #[cfg(not(any(target_vendor = "uwp", target_vendor = "games")))]
     pub fn file_attr(&self) -> io::Result<FileAttr> {
         unsafe {
             let mut info: c::BY_HANDLE_FILE_INFORMATION = mem::zeroed();
@@ -350,7 +350,7 @@ impl File {
         }
     }
 
-    #[cfg(target_vendor = "uwp")]
+    #[cfg(any(target_vendor = "uwp", target_vendor = "games"))]
     pub fn file_attr(&self) -> io::Result<FileAttr> {
         unsafe {
             let mut info: c::FILE_BASIC_INFO = mem::zeroed();
@@ -753,6 +753,7 @@ pub fn symlink(src: &Path, dst: &Path) -> io::Result<()> {
     symlink_inner(src, dst, false)
 }
 
+#[cfg(not(target_vendor = "games"))]
 pub fn symlink_inner(src: &Path, dst: &Path, dir: bool) -> io::Result<()> {
     let src = to_u16s(src)?;
     let dst = to_u16s(dst)?;
@@ -778,6 +779,14 @@ pub fn symlink_inner(src: &Path, dst: &Path, dir: bool) -> io::Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(target_vendor = "games")]
+pub fn symlink_inner(_: &Path, _: &Path, _: bool) -> io::Result<()> {
+    return Err(io::Error::new(
+        io::ErrorKind::Other,
+        "symbolic links are not supported on the Games API partition",
+    ));
 }
 
 #[cfg(not(target_vendor = "uwp"))]

--- a/src/libstd/sys/windows/mod.rs
+++ b/src/libstd/sys/windows/mod.rs
@@ -38,14 +38,18 @@ pub mod thread;
 pub mod thread_local;
 pub mod time;
 cfg_if::cfg_if! {
-    if #[cfg(not(target_vendor = "uwp"))] {
-        pub mod stdio;
-        pub mod stack_overflow;
-    } else {
+    if #[cfg(target_vendor = "uwp")] {
         pub mod stdio_uwp;
         pub mod stack_overflow_uwp;
         pub use self::stdio_uwp as stdio;
         pub use self::stack_overflow_uwp as stack_overflow;
+    } else if #[cfg(target_vendor = "games")] {
+        pub mod stdio_uwp;
+        pub mod stack_overflow;
+        pub use self::stdio_uwp as stdio;
+    } else {
+        pub mod stdio;
+        pub mod stack_overflow;
     }
 }
 

--- a/src/libstd/sys/windows/os.rs
+++ b/src/libstd/sys/windows/os.rs
@@ -284,7 +284,7 @@ pub fn temp_dir() -> PathBuf {
     super::fill_utf16_buf(|buf, sz| unsafe { c::GetTempPathW(sz, buf) }, super::os2path).unwrap()
 }
 
-#[cfg(not(target_vendor = "uwp"))]
+#[cfg(not(any(target_vendor = "uwp", target_vendor = "games")))]
 fn home_dir_crt() -> Option<PathBuf> {
     unsafe {
         use crate::sys::handle::Handle;
@@ -309,7 +309,7 @@ fn home_dir_crt() -> Option<PathBuf> {
     }
 }
 
-#[cfg(target_vendor = "uwp")]
+#[cfg(any(target_vendor = "uwp", target_vendor = "games"))]
 fn home_dir_crt() -> Option<PathBuf> {
     None
 }

--- a/src/libstd/sys/windows/rand.rs
+++ b/src/libstd/sys/windows/rand.rs
@@ -2,7 +2,7 @@ use crate::io;
 use crate::mem;
 use crate::sys::c;
 
-#[cfg(not(target_vendor = "uwp"))]
+#[cfg(not(any(target_vendor = "uwp", target_vendor = "games")))]
 pub fn hashmap_random_keys() -> (u64, u64) {
     let mut v = (0, 0);
     let ret =
@@ -13,7 +13,7 @@ pub fn hashmap_random_keys() -> (u64, u64) {
     v
 }
 
-#[cfg(target_vendor = "uwp")]
+#[cfg(any(target_vendor = "uwp", target_vendor = "games"))]
 pub fn hashmap_random_keys() -> (u64, u64) {
     use crate::ptr;
 


### PR DESCRIPTION
This PR adds the following new targets to Rust:

```
x86_64-games-windows-msvc
i686-games-windows-msvc
aarch64-games-windows-msvc
```

Starting around Windows SDK 1903 (10.0.18362.0) a new Windows API family called `WINAPI_FAMILY_GAMES` and a new partition called `WINAPI_PARTITION_GAMES` were added. Here's the documentation from the `winapifamily.h` header in the SDK:

```
/*
 * When compiling C and C++ code using SDK header files, the development
 * environment can specify a target platform by #define-ing the
 * pre-processor symbol WINAPI_FAMILY to one of the following values.
 * Each FAMILY value denotes an application family for which a different
 * subset of the total set of header-file-defined APIs are available.
 * Setting the WINAPI_FAMILY value will effectively hide from the
 * editing and compilation environments the existence of APIs that
 * are not applicable to the family of applications targeting a
 * specific platform.
 */

/* In Windows 10, WINAPI_PARTITIONs will be used to add additional  
 * device specific APIs to a particular WINAPI_FAMILY.  
 * For example, when writing Windows Universal apps, specifying 
 * WINAPI_FAMILY_APP will hide phone APIs from compilation.  
 * However, specifying WINAPI_PARTITION_PHONE_APP=1 additionally, will         
 * unhide any API hidden behind the partition, to the compiler.

 * The following partitions are currently defined:
 * WINAPI_PARTITION_DESKTOP            // usable for Desktop Win32 apps (but not store apps)
 * WINAPI_PARTITION_APP                // usable for Windows Universal store apps
 * WINAPI_PARTITION_PC_APP             // specific to Desktop-only store apps
 * WINAPI_PARTITION_PHONE_APP          // specific to Phone-only store apps
 * WINAPI_PARTITION_SYSTEM             // specific to System applications
 * WINAPI_PARTITION_GAMES              // specific to games and apps
*/

/*
 * The WINAPI_FAMILY values of 0 and 1 are reserved to ensure that
 * an error will occur if WINAPI_FAMILY is set to any
 * WINAPI_PARTITION value (which must be 0 or 1, see below).
 */
#define WINAPI_FAMILY_PC_APP               2   /* Windows Store Applications */
#define WINAPI_FAMILY_PHONE_APP            3   /* Windows Phone Applications */
#define WINAPI_FAMILY_SYSTEM               4   /* Windows Drivers and Tools */
#define WINAPI_FAMILY_SERVER               5   /* Windows Server Applications */
#define WINAPI_FAMILY_GAMES                6   /* Windows Games and Applications */
#define WINAPI_FAMILY_DESKTOP_APP          100   /* Windows Desktop Applications */
```

See this [three](https://walbourn.github.io/dual-use-coding-techniques-for-games-part-1/) [part](https://walbourn.github.io/dual-use-coding-techniques-for-games-part-2/) [article](https://walbourn.github.io/dual-use-coding-techniques-for-games-part-3/) series for some background on API families. Currently, the `*-pc-windows-*` targets correspond to the `WINAPI_PARTITION_DESKTOP` partition, and the `*-uwp-windows-*` targets correspond to the `WINAPI_PARTITION_[PC|PHONE]_APP` partitions. The only other partitions are games (which this PR adds support for) and drivers (I assume these are [user-mode drivers](https://docs.microsoft.com/en-us/windows-hardware/drivers/gettingstarted/writing-a-umdf-driver-based-on-a-template)).

This new API family appears to include more Win32 API surface area than UWP but less than the full desktop environment. Here are some examples of APIs that are available in the games partition but not on UWP:

```
#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM | WINAPI_PARTITION_GAMES)

WINBASEAPI
_Ret_maybenull_
PVOID
WINAPI
AddVectoredExceptionHandler(
    _In_ ULONG First,
    _In_ PVECTORED_EXCEPTION_HANDLER Handler
    );


WINBASEAPI
ULONG
WINAPI
RemoveVectoredExceptionHandler(
    _In_ PVOID Handle
    );


WINBASEAPI
_Ret_maybenull_
PVOID
WINAPI
AddVectoredContinueHandler(
    _In_ ULONG First,
    _In_ PVECTORED_EXCEPTION_HANDLER Handler
    );


WINBASEAPI
ULONG
WINAPI
RemoveVectoredContinueHandler(
    _In_ PVOID Handle
    );

...
```

```
#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_GAMES)

BOOL
WINAPI
MiniDumpWriteDump(
    _In_ HANDLE hProcess,
    _In_ DWORD ProcessId,
    _In_ HANDLE hFile,
    _In_ MINIDUMP_TYPE DumpType,
    _In_opt_ PMINIDUMP_EXCEPTION_INFORMATION ExceptionParam,
    _In_opt_ PMINIDUMP_USER_STREAM_INFORMATION UserStreamParam,
    _In_opt_ PMINIDUMP_CALLBACK_INFORMATION CallbackParam
    );

#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_GAMES) */
```

While UWP can be used to [write games too](https://docs.microsoft.com/en-us/windows/uwp/gaming/e2e), it's generally a limited API with a lot of restrictions. The new games partition provides access to a larger set of Win32 APIs than what UWP provides.

With these changes it would now be possible to build apps that target this new API family while avoiding the use of APIs that are not available there.

See #60260 and #63155 for similar past PRs where the UWP targets were added.

Tested these changes by building a hello_world executable for the following targets:

```
x86_64-pc-windows-msvc
x86_64-uwp-windows-msvc
x86_64-games-windows-msvc
i686-pc-windows-msvc
i686-uwp-windows-msvc
i686-games-windows-msvc
aarch64-pc-windows-msvc
aarch64-uwp-windows-msvc
aarch64-games-windows-msvc
```