### PR TITLE
Use function attribute "frame-pointer" instead of "no-frame-pointer-elim"

### DIFF
--- a/src/librustc_codegen_llvm/attributes.rs
+++ b/src/librustc_codegen_llvm/attributes.rs
@@ -66,12 +66,21 @@ fn naked(val: &'ll Value, is_naked: bool) {
 
 pub fn set_frame_pointer_elimination(cx: &CodegenCx<'ll, '_>, llfn: &'ll Value) {
     if cx.sess().must_not_eliminate_frame_pointers() {
-        llvm::AddFunctionAttrStringValue(
-            llfn,
-            llvm::AttributePlace::Function,
-            const_cstr!("no-frame-pointer-elim"),
-            const_cstr!("true"),
-        );
+        if llvm_util::get_major_version() >= 8 {
+            llvm::AddFunctionAttrStringValue(
+                llfn,
+                llvm::AttributePlace::Function,
+                const_cstr!("frame-pointer"),
+                const_cstr!("all"),
+            );
+        } else {
+            llvm::AddFunctionAttrStringValue(
+                llfn,
+                llvm::AttributePlace::Function,
+                const_cstr!("no-frame-pointer-elim"),
+                const_cstr!("true"),
+            );
+        }
     }
 }
 

--- a/src/test/codegen/force-frame-pointers.rs
+++ b/src/test/codegen/force-frame-pointers.rs
@@ -1,7 +1,7 @@
-//
+// min-llvm-version 8.0
 // compile-flags: -C no-prepopulate-passes -C force-frame-pointers=y
 
 #![crate_type="lib"]
 
-// CHECK: attributes #{{.*}} "no-frame-pointer-elim"="true"
+// CHECK: attributes #{{.*}} "frame-pointer"="all"
 pub fn foo() {}

--- a/src/test/codegen/instrument-mcount.rs
+++ b/src/test/codegen/instrument-mcount.rs
@@ -1,7 +1,8 @@
+// min-llvm-version 8.0
 // ignore-tidy-linelength
 // compile-flags: -Z instrument-mcount
 
 #![crate_type = "lib"]
 
-// CHECK: attributes #{{.*}} "instrument-function-entry-inlined"="{{.*}}mcount{{.*}}" "no-frame-pointer-elim"="true"
+// CHECK: attributes #{{.*}} "frame-pointer"="all" "instrument-function-entry-inlined"="{{.*}}mcount{{.*}}"
 pub fn foo() {}


### PR DESCRIPTION
LLVM 8 ([D56351](http://reviews.llvm.org/D56351)) introduced "frame-pointer". In LLVM 10 (D71863),
"no-frame-pointer-elim"/"no-frame-pointer-elim-non-leaf" will be
ignored.

-----

In the LLVM monorepo, run `git show origin/release/8.x:llvm/lib/CodeGen/TargetOptionsImpl.cpp` to see that `"frame-pointer"` is available since LLVM 8.