### PR TITLE
Add a test for #37333

### DIFF
--- a/src/test/incremental/change_implementation_cross_crate/auxiliary/a.rs
+++ b/src/test/incremental/change_implementation_cross_crate/auxiliary/a.rs
@@ -1,0 +1,31 @@
+#![allow(warnings)]
+#![crate_name = "a"]
+#![crate_type = "rlib"]
+
+#[cfg(rpass1)]
+#[inline(never)]
+pub fn foo(b: u8) -> u32 {
+    b as u32
+}
+
+#[cfg(rpass2)]
+#[inline(never)]
+pub fn foo(b: u8) -> u32 {
+    (b + 42) as u32
+}
+
+pub fn bar(b: u8) -> u32 {
+    bar_impl(b) as u32
+}
+
+#[cfg(rpass1)]
+#[inline(never)]
+fn bar_impl(b: u8) -> u16 {
+    b as u16
+}
+
+#[cfg(rpass2)]
+#[inline(never)]
+fn bar_impl(b: u8) -> u32 {
+    (b + 42) as u32
+}

--- a/src/test/incremental/change_implementation_cross_crate/main.rs
+++ b/src/test/incremental/change_implementation_cross_crate/main.rs
@@ -1,0 +1,20 @@
+// Test that we are able to reuse `main` despite the changes in the implementation of `foo` and
+// `bar`.
+
+// revisions: rpass1 rpass2
+// aux-build: a.rs
+// compile-flags: -Zquery-dep-graph
+
+#![feature(rustc_attrs)]
+#![crate_type = "bin"]
+#![rustc_partition_reused(module = "main", cfg = "rpass2")]
+
+extern crate a;
+
+pub fn main() {
+    let vec: Vec<u8> = vec![0, 1, 2, 3];
+    for b in vec {
+        println!("{}", a::foo(b));
+        println!("{}", a::bar(b));
+    }
+}


### PR DESCRIPTION
The test checks that we reuse the CGU of a crate when the implementation
details of an `extern crate` have changed.

Signed-off-by: Michal Terepeta <michal.terepeta@gmail.com>