### PR TITLE
Use self profile infrastructure for -Z time and -Z time-passes

### DIFF
--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -11,8 +11,6 @@ use crate::hir::print::Nested;
 use crate::hir::*;
 use crate::middle::cstore::CrateStoreDyn;
 use crate::ty::query::Providers;
-use crate::util::common::time;
-
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::svh::Svh;
 use rustc_index::vec::IndexVec;
@@ -1245,7 +1243,7 @@ pub fn map_crate<'hir>(
         definitions,
     };
 
-    time(sess, "validate HIR map", || {
+    sess.time("validate HIR map", || {
         hir_id_validator::check_crate(&map);
     });
 

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -66,8 +66,6 @@
 extern crate bitflags;
 #[macro_use]
 extern crate scoped_tls;
-#[cfg(windows)]
-extern crate libc;
 #[macro_use]
 extern crate rustc_macros;
 #[macro_use]

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -2,11 +2,9 @@
 
 use rustc_data_structures::sync::Lock;
 
-use std::cell::Cell;
 use std::fmt::Debug;
 use std::time::{Duration, Instant};
 
-use crate::session::Session;
 use rustc_span::symbol::{sym, Symbol};
 
 #[cfg(test)]
@@ -16,85 +14,6 @@ mod tests;
 pub const FN_OUTPUT_NAME: Symbol = sym::Output;
 
 pub use errors::ErrorReported;
-
-thread_local!(static TIME_DEPTH: Cell<usize> = Cell::new(0));
-
-#[allow(nonstandard_style)]
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct QueryMsg {
-    pub query: &'static str,
-    pub msg: Option<String>,
-}
-
-/// Read the current depth of `time()` calls. This is used to
-/// encourage indentation across threads.
-pub fn time_depth() -> usize {
-    TIME_DEPTH.with(|slot| slot.get())
-}
-
-/// Sets the current depth of `time()` calls. The idea is to call
-/// `set_time_depth()` with the result from `time_depth()` in the
-/// parent thread.
-pub fn set_time_depth(depth: usize) {
-    TIME_DEPTH.with(|slot| slot.set(depth));
-}
-
-pub fn time<T, F>(sess: &Session, what: &str, f: F) -> T
-where
-    F: FnOnce() -> T,
-{
-    time_ext(sess.time_passes(), what, f)
-}
-
-pub fn time_ext<T, F>(do_it: bool, what: &str, f: F) -> T
-where
-    F: FnOnce() -> T,
-{
-    if !do_it {
-        return f();
-    }
-
-    let old = TIME_DEPTH.with(|slot| {
-        let r = slot.get();
-        slot.set(r + 1);
-        r
-    });
-
-    let start = Instant::now();
-    let rv = f();
-    let dur = start.elapsed();
-
-    print_time_passes_entry(true, what, dur);
-
-    TIME_DEPTH.with(|slot| slot.set(old));
-
-    rv
-}
-
-pub fn print_time_passes_entry(do_it: bool, what: &str, dur: Duration) {
-    if !do_it {
-        return;
-    }
-
-    let indentation = TIME_DEPTH.with(|slot| slot.get());
-
-    let mem_string = match get_resident() {
-        Some(n) => {
-            let mb = n as f64 / 1_000_000.0;
-            format!("; rss: {}MB", mb.round() as usize)
-        }
-        None => String::new(),
-    };
-    println!(
-        "{}time: {}{}\t{}",
-        "  ".repeat(indentation),
-        duration_to_secs_str(dur),
-        mem_string,
-        what
-    );
-}
-
-pub use rustc_session::utils::duration_to_secs_str;
 
 pub fn to_readable_str(mut val: usize) -> String {
     let mut groups = vec![];
@@ -126,58 +45,6 @@ where
     let mut accu = accu.lock();
     *accu = *accu + duration;
     rv
-}
-
-// Memory reporting
-#[cfg(unix)]
-fn get_resident() -> Option<usize> {
-    use std::fs;
-
-    let field = 1;
-    let contents = fs::read("/proc/self/statm").ok()?;
-    let contents = String::from_utf8(contents).ok()?;
-    let s = contents.split_whitespace().nth(field)?;
-    let npages = s.parse::<usize>().ok()?;
-    Some(npages * 4096)
-}
-
-#[cfg(windows)]
-fn get_resident() -> Option<usize> {
-    type BOOL = i32;
-    type DWORD = u32;
-    type HANDLE = *mut u8;
-    use libc::size_t;
-    use std::mem;
-    #[repr(C)]
-    #[allow(non_snake_case)]
-    struct PROCESS_MEMORY_COUNTERS {
-        cb: DWORD,
-        PageFaultCount: DWORD,
-        PeakWorkingSetSize: size_t,
-        WorkingSetSize: size_t,
-        QuotaPeakPagedPoolUsage: size_t,
-        QuotaPagedPoolUsage: size_t,
-        QuotaPeakNonPagedPoolUsage: size_t,
-        QuotaNonPagedPoolUsage: size_t,
-        PagefileUsage: size_t,
-        PeakPagefileUsage: size_t,
-    }
-    type PPROCESS_MEMORY_COUNTERS = *mut PROCESS_MEMORY_COUNTERS;
-    #[link(name = "psapi")]
-    extern "system" {
-        fn GetCurrentProcess() -> HANDLE;
-        fn GetProcessMemoryInfo(
-            Process: HANDLE,
-            ppsmemCounters: PPROCESS_MEMORY_COUNTERS,
-            cb: DWORD,
-        ) -> BOOL;
-    }
-    let mut pmc: PROCESS_MEMORY_COUNTERS = unsafe { mem::zeroed() };
-    pmc.cb = mem::size_of_val(&pmc) as DWORD;
-    match unsafe { GetProcessMemoryInfo(GetCurrentProcess(), &mut pmc, pmc.cb) } {
-        0 => None,
-        _ => Some(pmc.WorkingSetSize as usize),
-    }
 }
 
 pub fn indent<R, F>(op: F) -> R

--- a/src/librustc_codegen_llvm/lib.rs
+++ b/src/librustc_codegen_llvm/lib.rs
@@ -275,7 +275,6 @@ impl CodegenBackend for LlvmCodegenBackend {
         dep_graph: &DepGraph,
         outputs: &OutputFilenames,
     ) -> Result<(), ErrorReported> {
-        use rustc::util::common::time;
         let (codegen_results, work_products) = ongoing_codegen
             .downcast::<rustc_codegen_ssa::back::write::OngoingCodegen<LlvmCodegenBackend>>()
             .expect("Expected LlvmCodegenBackend's OngoingCodegen, found Box<Any>")
@@ -284,7 +283,7 @@ impl CodegenBackend for LlvmCodegenBackend {
             rustc_codegen_ssa::back::write::dump_incremental_data(&codegen_results);
         }
 
-        time(sess, "serialize work products", move || {
+        sess.time("serialize work products", move || {
             rustc_incremental::save_work_product_index(sess, &dep_graph, work_products)
         });
 
@@ -301,9 +300,7 @@ impl CodegenBackend for LlvmCodegenBackend {
 
         // Run the linker on any artifacts that resulted from the LLVM run.
         // This should produce either a finished executable or library.
-        time(sess, "linking", || {
-            let _prof_timer = sess.prof.generic_activity("link_crate");
-
+        sess.time("linking", || {
             use crate::back::archive::LlvmArchiveBuilder;
             use rustc_codegen_ssa::back::link::link_binary;
 

--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -8,7 +8,6 @@ use rustc::session::search_paths::PathKind;
 /// For all the linkers we support, and information they might
 /// need out of the shared crate context before we get rid of it.
 use rustc::session::{filesearch, Session};
-use rustc::util::common::{time, time_ext};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_fs_util::fix_windows_verbatim_for_gcc;
 use rustc_span::symbol::Symbol;
@@ -578,7 +577,7 @@ fn link_natively<'a, B: ArchiveBuilder<'a>>(
     let mut i = 0;
     loop {
         i += 1;
-        prog = time(sess, "running linker", || exec_linker(sess, &mut cmd, out_filename, tmpdir));
+        prog = sess.time("running linker", || exec_linker(sess, &mut cmd, out_filename, tmpdir));
         let output = match prog {
             Ok(ref output) => output,
             Err(_) => break,
@@ -1563,7 +1562,7 @@ fn add_upstream_rust_crates<'a, B: ArchiveBuilder<'a>>(
         let name = cratepath.file_name().unwrap().to_str().unwrap();
         let name = &name[3..name.len() - 5]; // chop off lib/.rlib
 
-        time_ext(sess.time_extended(), &format!("altering {}.rlib", name), || {
+        sess.prof.generic_pass(&format!("altering {}.rlib", name)).run(|| {
             let mut archive = <B as ArchiveBuilder>::new(sess, &dst, Some(cratepath));
             archive.update_symbols();
 

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -33,6 +33,9 @@ extern crate libc;
 #[macro_use]
 extern crate cfg_if;
 
+#[cfg(windows)]
+extern crate libc;
+
 pub use rustc_serialize::hex::ToHex;
 
 #[inline(never)]

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -34,8 +34,9 @@ use rustc::session::config::{ErrorOutputType, Input, OutputType, PrintRequest};
 use rustc::session::{config, DiagnosticOutput, Session};
 use rustc::session::{early_error, early_warn};
 use rustc::ty::TyCtxt;
-use rustc::util::common::{print_time_passes_entry, set_time_depth, time, ErrorReported};
+use rustc::util::common::ErrorReported;
 use rustc_codegen_utils::codegen_backend::CodegenBackend;
+use rustc_data_structures::profiling::print_time_passes_entry;
 use rustc_data_structures::sync::SeqCst;
 use rustc_feature::{find_gated_cfg, UnstableFeatures};
 use rustc_interface::util::get_builtin_codegen_backend;
@@ -368,7 +369,7 @@ pub fn run_compiler(
                 queries.global_ctxt()?.peek_mut().enter(|tcx| {
                     let result = tcx.analysis(LOCAL_CRATE);
 
-                    time(sess, "save analysis", || {
+                    sess.time("save analysis", || {
                         save::process_crate(
                             tcx,
                             &expanded_crate,
@@ -1260,7 +1261,6 @@ pub fn main() {
         Err(_) => EXIT_FAILURE,
     };
     // The extra `\t` is necessary to align this label with the others.
-    set_time_depth(0);
     print_time_passes_entry(callbacks.time_passes, "\ttotal", start.elapsed());
     process::exit(exit_code);
 }

--- a/src/librustc_interface/queries.rs
+++ b/src/librustc_interface/queries.rs
@@ -11,7 +11,7 @@ use rustc::session::config::{OutputFilenames, OutputType};
 use rustc::session::Session;
 use rustc::ty::steal::Steal;
 use rustc::ty::{AllArenas, GlobalCtxt, ResolverOutputs};
-use rustc::util::common::{time, ErrorReported};
+use rustc::util::common::ErrorReported;
 use rustc_codegen_utils::codegen_backend::CodegenBackend;
 use rustc_data_structures::sync::{Lrc, Once, WorkerLocal};
 use rustc_incremental::DepGraphFuture;
@@ -195,7 +195,7 @@ impl<'tcx> Queries<'tcx> {
                 None => DepGraph::new_disabled(),
                 Some(future) => {
                     let (prev_graph, prev_work_products) =
-                        time(self.session(), "blocked while dep-graph loading finishes", || {
+                        self.session().time("blocked while dep-graph loading finishes", || {
                             future
                                 .open()
                                 .unwrap_or_else(|e| rustc_incremental::LoadResult::Error {

--- a/src/librustc_lint/early.rs
+++ b/src/librustc_lint/early.rs
@@ -18,7 +18,6 @@ use rustc::lint::{EarlyContext, LintStore};
 use rustc::lint::{EarlyLintPass, EarlyLintPassObject};
 use rustc::lint::{LintBuffer, LintContext, LintPass};
 use rustc::session::Session;
-use rustc::util::common::time;
 
 use rustc_span::Span;
 use std::slice;
@@ -351,7 +350,7 @@ pub fn check_ast_crate<T: EarlyLintPass>(
         }
     } else {
         for pass in &mut passes {
-            buffered = time(sess, &format!("running lint: {}", pass.name()), || {
+            buffered = sess.time(&format!("running lint: {}", pass.name()), || {
                 early_lint_crate(
                     sess,
                     lint_store,

--- a/src/librustc_lint/late.rs
+++ b/src/librustc_lint/late.rs
@@ -22,7 +22,6 @@ use rustc::lint::LateContext;
 use rustc::lint::LintPass;
 use rustc::lint::{LateLintPass, LateLintPassObject};
 use rustc::ty::{self, TyCtxt};
-use rustc::util::common::time;
 
 use rustc_data_structures::sync::{join, par_iter, ParallelIterator};
 use rustc_span::Span;
@@ -433,7 +432,7 @@ fn late_lint_crate<'tcx, T: for<'a> LateLintPass<'a, 'tcx>>(tcx: TyCtxt<'tcx>, b
         late_lint_pass_crate(tcx, builtin_lints);
     } else {
         for pass in &mut passes {
-            time(tcx.sess, &format!("running late lint: {}", pass.name()), || {
+            tcx.sess.time(&format!("running late lint: {}", pass.name()), || {
                 late_lint_pass_crate(tcx, LateLintPassObjects { lints: slice::from_mut(pass) });
             });
         }
@@ -442,7 +441,7 @@ fn late_lint_crate<'tcx, T: for<'a> LateLintPass<'a, 'tcx>>(tcx: TyCtxt<'tcx>, b
             tcx.lint_store.late_module_passes.iter().map(|pass| (pass)()).collect();
 
         for pass in &mut passes {
-            time(tcx.sess, &format!("running late module lint: {}", pass.name()), || {
+            tcx.sess.time(&format!("running late module lint: {}", pass.name()), || {
                 late_lint_pass_crate(tcx, LateLintPassObjects { lints: slice::from_mut(pass) });
             });
         }
@@ -456,13 +455,13 @@ pub fn check_crate<'tcx, T: for<'a> LateLintPass<'a, 'tcx>>(
 ) {
     join(
         || {
-            time(tcx.sess, "crate lints", || {
+            tcx.sess.time("crate lints", || {
                 // Run whole crate non-incremental lints
                 late_lint_crate(tcx, builtin_lints());
             });
         },
         || {
-            time(tcx.sess, "module lints", || {
+            tcx.sess.time("module lints", || {
                 // Run per-module lints
                 par_iter(&tcx.hir().krate().modules).for_each(|(&module, _)| {
                     tcx.ensure().lint_mod(tcx.hir().local_def_id(module));

--- a/src/librustc_mir/monomorphize/partitioning.rs
+++ b/src/librustc_mir/monomorphize/partitioning.rs
@@ -105,7 +105,6 @@ use rustc::mir::mono::{InstantiationMode, MonoItem};
 use rustc::ty::print::characteristic_def_id_of_type;
 use rustc::ty::query::Providers;
 use rustc::ty::{self, DefIdTree, InstanceDef, TyCtxt};
-use rustc::util::common::time;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_span::symbol::Symbol;
 
@@ -866,7 +865,7 @@ fn collect_and_partition_mono_items(
         }
     };
 
-    let (items, inlining_map) = time(tcx.sess, "monomorphization collection", || {
+    let (items, inlining_map) = tcx.sess.time("monomorphization collection", || {
         collector::collect_crate_mono_items(tcx, collection_mode)
     });
 
@@ -880,7 +879,7 @@ fn collect_and_partition_mono_items(
         PartitioningStrategy::FixedUnitCount(tcx.sess.codegen_units())
     };
 
-    let codegen_units = time(tcx.sess, "codegen unit partitioning", || {
+    let codegen_units = tcx.sess.time("codegen unit partitioning", || {
         partition(tcx, items.iter().cloned(), strategy, &inlining_map)
             .into_iter()
             .map(Arc::new)

--- a/src/librustc_session/utils.rs
+++ b/src/librustc_session/utils.rs
@@ -1,10 +1,13 @@
-// Hack up our own formatting for the duration to make it easier for scripts
-// to parse (always use the same number of decimal places and the same unit).
-pub fn duration_to_secs_str(dur: std::time::Duration) -> String {
-    const NANOS_PER_SEC: f64 = 1_000_000_000.0;
-    let secs = dur.as_secs() as f64 + dur.subsec_nanos() as f64 / NANOS_PER_SEC;
+use crate::session::Session;
+use rustc_data_structures::profiling::VerboseTimingGuard;
 
-    format!("{:.3}", secs)
+impl Session {
+    pub fn timer<'a>(&'a self, what: &'a str) -> VerboseTimingGuard<'a> {
+        self.prof.sparse_pass(what)
+    }
+    pub fn time<R>(&self, what: &str, f: impl FnOnce() -> R) -> R {
+        self.prof.sparse_pass(what).run(f)
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, RustcEncodable, RustcDecodable)]

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -10,7 +10,6 @@ use crate::hir::HirId;
 use rustc::traits;
 use rustc::ty::query::Providers;
 use rustc::ty::{self, TyCtxt, TypeFoldable};
-use rustc::util::common::time;
 
 use rustc_error_codes::*;
 
@@ -146,8 +145,8 @@ pub fn check_coherence(tcx: TyCtxt<'_>) {
         tcx.ensure().coherent_trait(trait_def_id);
     }
 
-    time(tcx.sess, "unsafety checking", || unsafety::check(tcx));
-    time(tcx.sess, "orphan checking", || orphan::check(tcx));
+    tcx.sess.time("unsafety checking", || unsafety::check(tcx));
+    tcx.sess.time("orphan checking", || orphan::check(tcx));
 
     // these queries are executed for side-effects (error reporting):
     tcx.ensure().crate_inherent_impls(LOCAL_CRATE);


### PR DESCRIPTION
There's no longer indentation for -Z time and -Z time-passes and duplicate timers between self profiling and -Z time-passes have been removed.

r? @wesleywiser 