### PR TITLE
perf: Don't recurse into types that do not need normalizing

### DIFF
--- a/src/librustc/traits/project.rs
+++ b/src/librustc/traits/project.rs
@@ -316,6 +316,9 @@ impl<'a, 'b, 'tcx> TypeFolder<'tcx> for AssocTypeNormalizer<'a, 'b, 'tcx> {
     }
 
     fn fold_ty(&mut self, ty: Ty<'tcx>) -> Ty<'tcx> {
+        if !ty.has_projections() {
+            return ty;
+        }
         // We don't want to normalize associated types that occur inside of region
         // binders, because they may contain bound regions, and we can't cope with that.
         //


### PR DESCRIPTION
A bit speculative at this stage but profiling shows that type folding
takes up a substantial amount of time during normalization which may
indicate that many types may be folded despite there being nothing to
normalize