### PR TITLE
Improve MaybeUninit docs

### DIFF
--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -18,10 +18,7 @@ use crate::mem::ManuallyDrop;
 ///
 /// ```rust,no_run
 /// # #![allow(invalid_value)]
-/// use std::mem::{self, MaybeUninit};
-///
-/// let x: &i32 = unsafe { mem::zeroed() }; // undefined behavior!
-/// // The equivalent code with `MaybeUninit<&i32>`:
+/// use std::mem::MaybeUninit;
 /// let x: &i32 = unsafe { MaybeUninit::zeroed().assume_init() }; // undefined behavior!
 /// ```
 ///
@@ -33,10 +30,7 @@ use crate::mem::ManuallyDrop;
 ///
 /// ```rust,no_run
 /// # #![allow(invalid_value)]
-/// use std::mem::{self, MaybeUninit};
-///
-/// let b: bool = unsafe { mem::uninitialized() }; // undefined behavior!
-/// // The equivalent code with `MaybeUninit<bool>`:
+/// use std::mem::MaybeUninit;
 /// let b: bool = unsafe { MaybeUninit::uninit().assume_init() }; // undefined behavior!
 /// ```
 ///
@@ -47,10 +41,8 @@ use crate::mem::ManuallyDrop;
 ///
 /// ```rust,no_run
 /// # #![allow(invalid_value)]
-/// use std::mem::{self, MaybeUninit};
+/// use std::mem::MaybeUninit;
 ///
-/// let x: i32 = unsafe { mem::uninitialized() }; // undefined behavior!
-/// // The equivalent code with `MaybeUninit<i32>`:
 /// let x: i32 = unsafe { MaybeUninit::uninit().assume_init() }; // undefined behavior!
 /// ```
 /// (Notice that the rules around uninitialized integers are not finalized yet, but

--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -220,7 +220,7 @@ pub union MaybeUninit<T> {
     value: ManuallyDrop<T>,
 }
 
-/// `Clone` and `Copy` are implementing for `T: Copy` by copying the bytes. But remember that
+/// `Clone` and `Copy` are implemented for `T: Copy` by copying the bytes. But remember that
 /// uninitialized memory is special because the compiler knows that it doesn't have a fixed value.
 /// This example is *incorrect* because we fail to uphold the [initialization invariant][inv]:
 ///

--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -44,6 +44,9 @@ use crate::mem::ManuallyDrop;
 /// use std::mem::MaybeUninit;
 ///
 /// let x: i32 = unsafe { MaybeUninit::uninit().assume_init() }; // undefined behavior!
+///
+/// let x_copy = x;
+/// assert_eq!(x, x_copy); // may _fail_ because x doesn't have a well-defined value!
 /// ```
 /// (Notice that the rules around uninitialized integers are not finalized yet, but
 /// until they are, it is advisable to avoid them.)


### PR DESCRIPTION
Question: is the `Clone` impl the best place for the notes re: behavior? I see it as something that doesn't need to be front and center, but would be still discoverable by someone who wanted to learn what `Clone` actually did.