### PR TITLE
Attempt to fix intermittent failures of pgo-branch-weights test.

### DIFF
--- a/src/test/run-make-fulldeps/pgo-branch-weights/Makefile
+++ b/src/test/run-make-fulldeps/pgo-branch-weights/Makefile
@@ -15,21 +15,29 @@ ifdef IS_MSVC
 COMMON_FLAGS=-Cpanic=abort
 endif
 
+# For some very small programs GNU ld seems to not properly handle
+# instrumentation sections correctly. Neither Gold nor LLD have that problem.
+ifeq ($(UNAME),Linux)
+ifneq (,$(findstring x86,$(TARGET)))
+COMMON_FLAGS=-Clink-args=-fuse-ld=gold
+endif
+endif
+
+
 all:
 	# We don't compile `opaque` with either optimizations or instrumentation.
-	# We don't compile `opaque` with either optimizations or instrumentation.
-	$(RUSTC) $(COMMON_FLAGS) opaque.rs
+	$(RUSTC) $(COMMON_FLAGS) opaque.rs || exit 1
 	# Compile the test program with instrumentation
-	mkdir -p "$(TMPDIR)"/prof_data_dir
+	mkdir -p "$(TMPDIR)/prof_data_dir" || exit 1
 	$(RUSTC) $(COMMON_FLAGS) interesting.rs \
-		-Cprofile-generate="$(TMPDIR)"/prof_data_dir -O -Ccodegen-units=1
-	$(RUSTC) $(COMMON_FLAGS) main.rs -Cprofile-generate="$(TMPDIR)"/prof_data_dir -O
+		-Cprofile-generate="$(TMPDIR)/prof_data_dir" -O -Ccodegen-units=1 || exit 1
+	$(RUSTC) $(COMMON_FLAGS) main.rs -Cprofile-generate="$(TMPDIR)/prof_data_dir" -O || exit 1
 	# The argument below generates to the expected branch weights
 	$(call RUN,main aaaaaaaaaaaa2bbbbbbbbbbbb2bbbbbbbbbbbbbbbbcc) || exit 1
-	"$(LLVM_BIN_DIR)"/llvm-profdata merge \
-		-o "$(TMPDIR)"/prof_data_dir/merged.profdata \
-		"$(TMPDIR)"/prof_data_dir
+	"$(LLVM_BIN_DIR)/llvm-profdata" merge \
+		-o "$(TMPDIR)/prof_data_dir/merged.profdata" \
+		"$(TMPDIR)/prof_data_dir" || exit 1
 	$(RUSTC) $(COMMON_FLAGS) interesting.rs \
-		-Cprofile-use="$(TMPDIR)"/prof_data_dir/merged.profdata -O \
-		-Ccodegen-units=1 --emit=llvm-ir
-	cat "$(TMPDIR)"/interesting.ll | "$(LLVM_FILECHECK)" filecheck-patterns.txt
+		-Cprofile-use="$(TMPDIR)/prof_data_dir/merged.profdata" -O \
+		-Ccodegen-units=1 --emit=llvm-ir || exit 1
+	cat "$(TMPDIR)/interesting.ll" | "$(LLVM_FILECHECK)" filecheck-patterns.txt


### PR DESCRIPTION
This PR tries to fix the intermittent failures of the pgo-branch-weights test (https://github.com/rust-lang/rust/issues/67746). The failing instances show no `!prof` annotations in LLVM IR. One possible cause is that the instrumented binary did not record anything. This is something I've occasionally seen happen for similarly small programs when using GNU ld as linker. The linker would not properly append the instruction counter sections, leading to most counters being dropped. This PR makes the test use the Gold linker instead. 

It also makes each command exit immediately on failure so we can pinpoint the failure source better, should there still be a problem.

r? @Mark-Simulacrum 