### PR TITLE
[experiment] Make incremental compilation respect the -Ccodegen-units flag.

### DIFF
--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -741,6 +741,13 @@ impl Session {
             return n as usize;
         }
 
+        // If incremental compilation is turned on, we default to a high number
+        // codegen units in order to reduce the "collatoral damage" small
+        // changes cause.
+        if self.opts.incremental.is_some() {
+            return 256;
+        }
+
         // Why is 16 codegen units the default all the time?
         //
         // The main reason for enabling multiple codegen units by default is to


### PR DESCRIPTION
Some local testing I did last year showed that limiting the number of CGUs for incremental compilation can improve performance quite a bit for big crates. Let's look into that some more.