### PR TITLE
tweak wording of mismatched delimiter errors

### DIFF
--- a/src/librustc_parse/lexer/tokentrees.rs
+++ b/src/librustc_parse/lexer/tokentrees.rs
@@ -78,11 +78,11 @@ impl<'a> TokenTreesReader<'a> {
         let sm = self.string_reader.sess.source_map();
         match self.token.kind {
             token::Eof => {
-                let msg = "this file contains an un-closed delimiter";
+                let msg = "this file contains an unclosed delimiter";
                 let mut err =
                     self.string_reader.sess.span_diagnostic.struct_span_err(self.token.span, msg);
                 for &(_, sp) in &self.open_braces {
-                    err.span_label(sp, "un-closed delimiter");
+                    err.span_label(sp, "unclosed delimiter");
                     self.unmatched_braces.push(UnmatchedBrace {
                         expected_delim: token::DelimToken::Brace,
                         found_delim: None,
@@ -155,7 +155,7 @@ impl<'a> TokenTreesReader<'a> {
                                 close_brace_span,
                             ));
                         }
-                        // Parse the close delimiter.
+                        // Parse the closing delimiter.
                         self.real_token();
                     }
                     // Incorrect delimiter.
@@ -218,7 +218,7 @@ impl<'a> TokenTreesReader<'a> {
                 // An unexpected closing delimiter (i.e., there is no
                 // matching opening delimiter).
                 let token_str = token_to_string(&self.token);
-                let msg = format!("unexpected close delimiter: `{}`", token_str);
+                let msg = format!("unexpected closing delimiter: `{}`", token_str);
                 let mut err =
                     self.string_reader.sess.span_diagnostic.struct_span_err(self.token.span, &msg);
 
@@ -228,7 +228,7 @@ impl<'a> TokenTreesReader<'a> {
                         "this block is empty, you might have not meant to close it",
                     );
                 }
-                err.span_label(self.token.span, "unexpected close delimiter");
+                err.span_label(self.token.span, "unexpected closing delimiter");
                 Err(err)
             }
             _ => {

--- a/src/librustc_parse/parser/mod.rs
+++ b/src/librustc_parse/parser/mod.rs
@@ -1354,16 +1354,16 @@ crate fn make_unclosed_delims_error(
     let mut err = sess.span_diagnostic.struct_span_err(
         unmatched.found_span,
         &format!(
-            "incorrect close delimiter: `{}`",
+            "mismatched closing delimiter: `{}`",
             pprust::token_kind_to_string(&token::CloseDelim(found_delim)),
         ),
     );
-    err.span_label(unmatched.found_span, "incorrect close delimiter");
+    err.span_label(unmatched.found_span, "mismatched closing delimiter");
     if let Some(sp) = unmatched.candidate_span {
-        err.span_label(sp, "close delimiter possibly meant for this");
+        err.span_label(sp, "closing delimiter possibly meant for this");
     }
     if let Some(sp) = unmatched.unclosed_span {
-        err.span_label(sp, "un-closed delimiter");
+        err.span_label(sp, "unclosed delimiter");
     }
     Some(err)
 }

--- a/src/test/ui/issues/issue-62554.rs
+++ b/src/test/ui/issues/issue-62554.rs
@@ -2,4 +2,4 @@ fn main() {}
 
 fn foo(u: u8) { if u8 macro_rules! u8 { (u6) => { fn uuuuuuuuuuu() { use s loo mod u8 {
 //~^ ERROR expected `{`, found `macro_rules`
-//~ ERROR this file contains an un-closed delimiter
+//~ ERROR this file contains an unclosed delimiter

--- a/src/test/ui/issues/issue-62554.stderr
+++ b/src/test/ui/issues/issue-62554.stderr
@@ -1,15 +1,15 @@
-error: this file contains an un-closed delimiter
-  --> $DIR/issue-62554.rs:5:53
+error: this file contains an unclosed delimiter
+  --> $DIR/issue-62554.rs:5:52
    |
 LL | fn foo(u: u8) { if u8 macro_rules! u8 { (u6) => { fn uuuuuuuuuuu() { use s loo mod u8 {
-   |               -                       -         -                  -                  - un-closed delimiter
+   |               -                       -         -                  -                  - unclosed delimiter
    |               |                       |         |                  |
-   |               |                       |         |                  un-closed delimiter
-   |               |                       |         un-closed delimiter
-   |               un-closed delimiter     un-closed delimiter
+   |               |                       |         |                  unclosed delimiter
+   |               |                       |         unclosed delimiter
+   |               unclosed delimiter      unclosed delimiter
 LL |
 LL |
-   |                                                     ^
+   |                                                    ^
 
 error: expected `{`, found `macro_rules`
   --> $DIR/issue-62554.rs:3:23

--- a/src/test/ui/parser-recovery-1.rs
+++ b/src/test/ui/parser-recovery-1.rs
@@ -12,4 +12,4 @@ fn main() {
     let x = y.;
     //~^ ERROR unexpected token
     //~| ERROR cannot find value `y` in this scope
-} //~ ERROR this file contains an un-closed delimiter
+} //~ ERROR this file contains an unclosed delimiter

--- a/src/test/ui/parser-recovery-1.stderr
+++ b/src/test/ui/parser-recovery-1.stderr
@@ -1,8 +1,8 @@
-error: this file contains an un-closed delimiter
-  --> $DIR/parser-recovery-1.rs:15:55
+error: this file contains an unclosed delimiter
+  --> $DIR/parser-recovery-1.rs:15:54
    |
 LL | trait Foo {
-   |           - un-closed delimiter
+   |           - unclosed delimiter
 LL |     fn bar() {
    |              - this delimiter might not be properly closed...
 ...
@@ -10,7 +10,7 @@ LL | }
    | - ...as it matches this but it has different indentation
 ...
 LL | }
-   |                                                       ^
+   |                                                      ^
 
 error: unexpected token: `;`
   --> $DIR/parser-recovery-1.rs:12:15

--- a/src/test/ui/parser-recovery-2.rs
+++ b/src/test/ui/parser-recovery-2.rs
@@ -5,7 +5,7 @@
 trait Foo {
     fn bar() {
         let x = foo(); //~ ERROR cannot find function `foo` in this scope
-    ) //~ ERROR incorrect close delimiter: `)`
+    ) //~ ERROR mismatched closing delimiter: `)`
 }
 
 fn main() {

--- a/src/test/ui/parser-recovery-2.stderr
+++ b/src/test/ui/parser-recovery-2.stderr
@@ -4,14 +4,14 @@ error: unexpected token: `;`
 LL |     let x = y.;
    |               ^
 
-error: incorrect close delimiter: `)`
+error: mismatched closing delimiter: `)`
   --> $DIR/parser-recovery-2.rs:8:5
    |
 LL |     fn bar() {
-   |              - un-closed delimiter
+   |              - unclosed delimiter
 LL |         let x = foo();
 LL |     )
-   |     ^ incorrect close delimiter
+   |     ^ mismatched closing delimiter
 
 error[E0425]: cannot find function `foo` in this scope
   --> $DIR/parser-recovery-2.rs:7:17

--- a/src/test/ui/parser/issue-10636-1.rs
+++ b/src/test/ui/parser/issue-10636-1.rs
@@ -1,8 +1,8 @@
 struct Obj {
-    //~^ NOTE: un-closed delimiter
+    //~^ NOTE: unclosed delimiter
     member: usize
 )
-//~^ ERROR incorrect close delimiter
-//~| NOTE incorrect close delimiter
+//~^ ERROR mismatched closing delimiter
+//~| NOTE mismatched closing delimiter
 
 fn main() {}

--- a/src/test/ui/parser/issue-10636-1.stderr
+++ b/src/test/ui/parser/issue-10636-1.stderr
@@ -1,11 +1,11 @@
-error: incorrect close delimiter: `)`
+error: mismatched closing delimiter: `)`
   --> $DIR/issue-10636-1.rs:4:1
    |
 LL | struct Obj {
-   |            - un-closed delimiter
+   |            - unclosed delimiter
 ...
 LL | )
-   | ^ incorrect close delimiter
+   | ^ mismatched closing delimiter
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issue-2354-1.rs
+++ b/src/test/ui/parser/issue-2354-1.rs
@@ -1,1 +1,1 @@
-static foo: isize = 2; } //~ ERROR unexpected close delimiter:
+static foo: isize = 2; } //~ ERROR unexpected closing delimiter:

--- a/src/test/ui/parser/issue-2354-1.stderr
+++ b/src/test/ui/parser/issue-2354-1.stderr
@@ -1,8 +1,8 @@
-error: unexpected close delimiter: `}`
+error: unexpected closing delimiter: `}`
   --> $DIR/issue-2354-1.rs:1:24
    |
 LL | static foo: isize = 2; }
-   |                        ^ unexpected close delimiter
+   |                        ^ unexpected closing delimiter
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issue-2354.rs
+++ b/src/test/ui/parser/issue-2354.rs
@@ -1,4 +1,4 @@
-fn foo() { //~ NOTE un-closed delimiter
+fn foo() { //~ NOTE unclosed delimiter
   match Some(10) {
   //~^ NOTE this delimiter might not be properly closed...
       Some(y) => { panic!(); }
@@ -12,4 +12,4 @@ fn bar() {
 }
 
 fn main() {}
-//~ ERROR this file contains an un-closed delimiter
+//~ ERROR this file contains an unclosed delimiter

--- a/src/test/ui/parser/issue-2354.stderr
+++ b/src/test/ui/parser/issue-2354.stderr
@@ -1,8 +1,8 @@
-error: this file contains an un-closed delimiter
-  --> $DIR/issue-2354.rs:15:53
+error: this file contains an unclosed delimiter
+  --> $DIR/issue-2354.rs:15:52
    |
 LL | fn foo() {
-   |          - un-closed delimiter
+   |          - unclosed delimiter
 LL |   match Some(10) {
    |                  - this delimiter might not be properly closed...
 ...
@@ -10,7 +10,7 @@ LL | }
    | - ...as it matches this but it has different indentation
 ...
 LL |
-   |                                                     ^
+   |                                                    ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issue-58094-missing-right-square-bracket.stderr
+++ b/src/test/ui/parser/issue-58094-missing-right-square-bracket.stderr
@@ -1,10 +1,10 @@
-error: this file contains an un-closed delimiter
+error: this file contains an unclosed delimiter
   --> $DIR/issue-58094-missing-right-square-bracket.rs:4:4
    |
 LL | #[Ѕ
    |  - ^
    |  |
-   |  un-closed delimiter
+   |  unclosed delimiter
 
 error: expected item after attributes
   --> $DIR/issue-58094-missing-right-square-bracket.rs:4:4

--- a/src/test/ui/parser/issue-62524.stderr
+++ b/src/test/ui/parser/issue-62524.stderr
@@ -1,8 +1,8 @@
-error: this file contains an un-closed delimiter
+error: this file contains an unclosed delimiter
   --> $DIR/issue-62524.rs:4:3
    |
 LL | y![
-   |   - un-closed delimiter
+   |   - unclosed delimiter
 LL | Ϥ,
    |   ^
 

--- a/src/test/ui/parser/issue-62546.rs
+++ b/src/test/ui/parser/issue-62546.rs
@@ -1,3 +1,3 @@
 pub t(#
 //~^ ERROR missing `fn` or `struct` for function or struct definition
-//~ ERROR this file contains an un-closed delimiter
+//~ ERROR this file contains an unclosed delimiter

--- a/src/test/ui/parser/issue-62546.stderr
+++ b/src/test/ui/parser/issue-62546.stderr
@@ -1,11 +1,11 @@
-error: this file contains an un-closed delimiter
-  --> $DIR/issue-62546.rs:3:53
+error: this file contains an unclosed delimiter
+  --> $DIR/issue-62546.rs:3:52
    |
 LL | pub t(#
-   |      - un-closed delimiter
+   |      - unclosed delimiter
 LL |
 LL |
-   |                                                     ^
+   |                                                    ^
 
 error: missing `fn` or `struct` for function or struct definition
   --> $DIR/issue-62546.rs:1:4

--- a/src/test/ui/parser/issue-62881.rs
+++ b/src/test/ui/parser/issue-62881.rs
@@ -3,4 +3,4 @@ fn main() {}
 fn f() -> isize { fn f() -> isize {} pub f<
 //~^ ERROR missing `fn` or `struct` for function or struct definition
 //~| ERROR mismatched types
-//~ ERROR this file contains an un-closed delimiter
+//~ ERROR this file contains an unclosed delimiter

--- a/src/test/ui/parser/issue-62881.stderr
+++ b/src/test/ui/parser/issue-62881.stderr
@@ -1,11 +1,11 @@
-error: this file contains an un-closed delimiter
-  --> $DIR/issue-62881.rs:6:53
+error: this file contains an unclosed delimiter
+  --> $DIR/issue-62881.rs:6:52
    |
 LL | fn f() -> isize { fn f() -> isize {} pub f<
-   |                 - un-closed delimiter
+   |                 - unclosed delimiter
 ...
 LL |
-   |                                                     ^
+   |                                                    ^
 
 error: missing `fn` or `struct` for function or struct definition
   --> $DIR/issue-62881.rs:3:41

--- a/src/test/ui/parser/issue-62973.stderr
+++ b/src/test/ui/parser/issue-62973.stderr
@@ -1,10 +1,10 @@
-error: this file contains an un-closed delimiter
+error: this file contains an unclosed delimiter
   --> $DIR/issue-62973.rs:8:2
    |
 LL | fn p() { match s { v, E { [) {) }
-   |        -         - un-closed delimiter
+   |        -         - unclosed delimiter
    |        |
-   |        un-closed delimiter
+   |        unclosed delimiter
 LL | 
 LL | 
    |  ^
@@ -44,21 +44,21 @@ LL |
 LL | 
    |  ^ expected one of `.`, `?`, `{`, or an operator
 
-error: incorrect close delimiter: `)`
+error: mismatched closing delimiter: `)`
   --> $DIR/issue-62973.rs:6:28
    |
 LL | fn p() { match s { v, E { [) {) }
-   |                           -^ incorrect close delimiter
+   |                           -^ mismatched closing delimiter
    |                           |
-   |                           un-closed delimiter
+   |                           unclosed delimiter
 
-error: incorrect close delimiter: `)`
+error: mismatched closing delimiter: `)`
   --> $DIR/issue-62973.rs:6:31
    |
 LL | fn p() { match s { v, E { [) {) }
-   |                              -^ incorrect close delimiter
+   |                              -^ mismatched closing delimiter
    |                              |
-   |                              un-closed delimiter
+   |                              unclosed delimiter
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/parser/issue-63116.stderr
+++ b/src/test/ui/parser/issue-63116.stderr
@@ -1,10 +1,10 @@
-error: this file contains an un-closed delimiter
+error: this file contains an unclosed delimiter
   --> $DIR/issue-63116.rs:3:18
    |
 LL | impl W <s(f;Y(;]
    |          -       ^
    |          |
-   |          un-closed delimiter
+   |          unclosed delimiter
 
 error: expected one of `!`, `(`, `)`, `+`, `,`, `::`, or `<`, found `;`
   --> $DIR/issue-63116.rs:3:12

--- a/src/test/ui/parser/issue-63135.stderr
+++ b/src/test/ui/parser/issue-63135.stderr
@@ -1,11 +1,11 @@
-error: this file contains an un-closed delimiter
+error: this file contains an unclosed delimiter
   --> $DIR/issue-63135.rs:3:16
    |
 LL | fn i(n{...,f #
    |     - -        ^
    |     | |
-   |     | un-closed delimiter
-   |     un-closed delimiter
+   |     | unclosed delimiter
+   |     unclosed delimiter
 
 error: expected field pattern, found `...`
   --> $DIR/issue-63135.rs:3:8

--- a/src/test/ui/parser/macro-mismatched-delim-brace-paren.rs
+++ b/src/test/ui/parser/macro-mismatched-delim-brace-paren.rs
@@ -3,5 +3,5 @@ macro_rules! foo { ($($tt:tt)*) => () }
 fn main() {
     foo! {
         bar, "baz", 1, 2.0
-    ) //~ ERROR incorrect close delimiter
+    ) //~ ERROR mismatched closing delimiter
 }

--- a/src/test/ui/parser/macro-mismatched-delim-brace-paren.stderr
+++ b/src/test/ui/parser/macro-mismatched-delim-brace-paren.stderr
@@ -1,11 +1,11 @@
-error: incorrect close delimiter: `)`
+error: mismatched closing delimiter: `)`
   --> $DIR/macro-mismatched-delim-brace-paren.rs:6:5
    |
 LL |     foo! {
-   |          - un-closed delimiter
+   |          - unclosed delimiter
 LL |         bar, "baz", 1, 2.0
 LL |     )
-   |     ^ incorrect close delimiter
+   |     ^ mismatched closing delimiter
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/macro-mismatched-delim-paren-brace.rs
+++ b/src/test/ui/parser/macro-mismatched-delim-paren-brace.rs
@@ -1,5 +1,5 @@
 fn main() {
     foo! (
         bar, "baz", 1, 2.0
-    } //~ ERROR incorrect close delimiter
-} //~ ERROR unexpected close delimiter: `}`
+    } //~ ERROR mismatched closing delimiter
+} //~ ERROR unexpected closing delimiter: `}`

--- a/src/test/ui/parser/macro-mismatched-delim-paren-brace.stderr
+++ b/src/test/ui/parser/macro-mismatched-delim-paren-brace.stderr
@@ -1,17 +1,17 @@
-error: unexpected close delimiter: `}`
+error: unexpected closing delimiter: `}`
   --> $DIR/macro-mismatched-delim-paren-brace.rs:5:1
    |
 LL | }
-   | ^ unexpected close delimiter
+   | ^ unexpected closing delimiter
 
-error: incorrect close delimiter: `}`
+error: mismatched closing delimiter: `}`
   --> $DIR/macro-mismatched-delim-paren-brace.rs:4:5
    |
 LL |     foo! (
-   |          - un-closed delimiter
+   |          - unclosed delimiter
 LL |         bar, "baz", 1, 2.0
 LL |     }
-   |     ^ incorrect close delimiter
+   |     ^ mismatched closing delimiter
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/mbe_missing_right_paren.stderr
+++ b/src/test/ui/parser/mbe_missing_right_paren.stderr
@@ -1,10 +1,10 @@
-error: this file contains an un-closed delimiter
+error: this file contains an unclosed delimiter
   --> $DIR/mbe_missing_right_paren.rs:3:19
    |
 LL | macro_rules! abc(ؼ
    |                 - ^
    |                 |
-   |                 un-closed delimiter
+   |                 unclosed delimiter
 
 error: macros that expand to items must be delimited with braces or followed by a semicolon
   --> $DIR/mbe_missing_right_paren.rs:3:17

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-impl-trait.rs
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-impl-trait.rs
@@ -9,4 +9,4 @@ trait T { //~ ERROR expected one of
 pub(crate) struct Bar<T>();
 
 fn main() {}
-//~ ERROR this file contains an un-closed delimiter
+//~ ERROR this file contains an unclosed delimiter

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-impl-trait.stderr
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-impl-trait.stderr
@@ -1,11 +1,11 @@
-error: this file contains an un-closed delimiter
-  --> $DIR/missing-close-brace-in-impl-trait.rs:12:53
+error: this file contains an unclosed delimiter
+  --> $DIR/missing-close-brace-in-impl-trait.rs:12:52
    |
 LL | impl T for () {
-   |               - un-closed delimiter
+   |               - unclosed delimiter
 ...
 LL |
-   |                                                     ^
+   |                                                    ^
 
 error: expected one of `async`, `const`, `crate`, `default`, `extern`, `fn`, `pub`, `type`, `unsafe`, or `}`, found keyword `trait`
   --> $DIR/missing-close-brace-in-impl-trait.rs:5:1

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-struct.rs
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-struct.rs
@@ -11,4 +11,4 @@ impl T for Bar<usize> {
 fn foo(&self) {}
 }
 
-fn main() {} //~ ERROR this file contains an un-closed delimiter
+fn main() {} //~ ERROR this file contains an unclosed delimiter

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-struct.stderr
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-struct.stderr
@@ -1,11 +1,11 @@
-error: this file contains an un-closed delimiter
-  --> $DIR/missing-close-brace-in-struct.rs:14:66
+error: this file contains an unclosed delimiter
+  --> $DIR/missing-close-brace-in-struct.rs:14:65
    |
 LL | pub(crate) struct Bar<T> {
-   |                          - un-closed delimiter
+   |                          - unclosed delimiter
 ...
 LL | fn main() {}
-   |                                                                  ^
+   |                                                                 ^
 
 error: expected identifier, found keyword `trait`
   --> $DIR/missing-close-brace-in-struct.rs:4:1

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-trait.rs
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-trait.rs
@@ -9,4 +9,4 @@ impl T for Bar<usize> {
 fn foo(&self) {}
 }
 
-fn main() {} //~ ERROR this file contains an un-closed delimiter
+fn main() {} //~ ERROR this file contains an unclosed delimiter

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-trait.stderr
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-trait.stderr
@@ -1,11 +1,11 @@
-error: this file contains an un-closed delimiter
-  --> $DIR/missing-close-brace-in-trait.rs:12:66
+error: this file contains an unclosed delimiter
+  --> $DIR/missing-close-brace-in-trait.rs:12:65
    |
 LL | trait T {
-   |         - un-closed delimiter
+   |         - unclosed delimiter
 ...
 LL | fn main() {}
-   |                                                                  ^
+   |                                                                 ^
 
 error: expected one of `async`, `const`, `default`, `extern`, `fn`, `type`, or `unsafe`, found keyword `struct`
   --> $DIR/missing-close-brace-in-trait.rs:5:12
@@ -23,7 +23,7 @@ LL | |
 ...  |
 LL | |
 LL | | fn main() {}
-   | |_________________________________________________________________^ consider adding a `main` function to `$DIR/missing-close-brace-in-trait.rs`
+   | |________________________________________________________________^ consider adding a `main` function to `$DIR/missing-close-brace-in-trait.rs`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/parser/mismatched-delim-brace-empty-block.rs
+++ b/src/test/ui/parser/mismatched-delim-brace-empty-block.rs
@@ -2,4 +2,4 @@ fn main() {
 
 }
     let _ = ();
-} //~ ERROR unexpected close delimiter
+} //~ ERROR unexpected closing delimiter

--- a/src/test/ui/parser/mismatched-delim-brace-empty-block.stderr
+++ b/src/test/ui/parser/mismatched-delim-brace-empty-block.stderr
@@ -1,4 +1,4 @@
-error: unexpected close delimiter: `}`
+error: unexpected closing delimiter: `}`
   --> $DIR/mismatched-delim-brace-empty-block.rs:5:1
    |
 LL |   fn main() {
@@ -8,7 +8,7 @@ LL | | }
    | |_- this block is empty, you might have not meant to close it
 LL |       let _ = ();
 LL |   }
-   |   ^ unexpected close delimiter
+   |   ^ unexpected closing delimiter
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/missing_right_paren.stderr
+++ b/src/test/ui/parser/missing_right_paren.stderr
@@ -1,11 +1,11 @@
-error: this file contains an un-closed delimiter
+error: this file contains an unclosed delimiter
   --> $DIR/missing_right_paren.rs:3:11
    |
 LL | fn main((ؼ
    |        -- ^
    |        ||
-   |        |un-closed delimiter
-   |        un-closed delimiter
+   |        |unclosed delimiter
+   |        unclosed delimiter
 
 error: expected one of `:` or `|`, found `)`
   --> $DIR/missing_right_paren.rs:3:11

--- a/src/test/ui/parser/unclosed-braces.rs
+++ b/src/test/ui/parser/unclosed-braces.rs
@@ -11,7 +11,7 @@ fn foo() {
 }
 
 fn main() {
-//~^ NOTE un-closed delimiter
+//~^ NOTE unclosed delimiter
     {
         {
         //~^ NOTE this delimiter might not be properly closed...
@@ -19,4 +19,4 @@ fn main() {
     }
     //~^ NOTE ...as it matches this but it has different indentation
 }
-//~ ERROR this file contains an un-closed delimiter
+//~ ERROR this file contains an unclosed delimiter

--- a/src/test/ui/parser/unclosed-braces.stderr
+++ b/src/test/ui/parser/unclosed-braces.stderr
@@ -1,8 +1,8 @@
-error: this file contains an un-closed delimiter
-  --> $DIR/unclosed-braces.rs:22:53
+error: this file contains an unclosed delimiter
+  --> $DIR/unclosed-braces.rs:22:52
    |
 LL | fn main() {
-   |           - un-closed delimiter
+   |           - unclosed delimiter
 ...
 LL |         {
    |         - this delimiter might not be properly closed...
@@ -11,7 +11,7 @@ LL |     }
    |     - ...as it matches this but it has different indentation
 ...
 LL |
-   |                                                     ^
+   |                                                    ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/unclosed-delimiter-in-dep.stderr
+++ b/src/test/ui/parser/unclosed-delimiter-in-dep.stderr
@@ -1,13 +1,13 @@
-error: incorrect close delimiter: `}`
+error: mismatched closing delimiter: `}`
   --> $DIR/unclosed_delim_mod.rs:7:1
    |
 LL | pub fn new() -> Result<Value, ()> {
-   |                                   - close delimiter possibly meant for this
+   |                                   - closing delimiter possibly meant for this
 LL |     Ok(Value {
-   |       - un-closed delimiter
+   |       - unclosed delimiter
 LL |     }
 LL | }
-   | ^ incorrect close delimiter
+   | ^ mismatched closing delimiter
 
 error[E0308]: mismatched types
   --> $DIR/unclosed-delimiter-in-dep.rs:4:20

--- a/src/test/ui/parser/unclosed_delim_mod.rs
+++ b/src/test/ui/parser/unclosed_delim_mod.rs
@@ -5,4 +5,4 @@ pub fn new() -> Result<Value, ()> {
     Ok(Value {
     }
 }
-//~^ ERROR incorrect close delimiter
+//~^ ERROR mismatched closing delimiter

--- a/src/test/ui/parser/unclosed_delim_mod.stderr
+++ b/src/test/ui/parser/unclosed_delim_mod.stderr
@@ -1,13 +1,13 @@
-error: incorrect close delimiter: `}`
+error: mismatched closing delimiter: `}`
   --> $DIR/unclosed_delim_mod.rs:7:1
    |
 LL | pub fn new() -> Result<Value, ()> {
-   |                                   - close delimiter possibly meant for this
+   |                                   - closing delimiter possibly meant for this
 LL |     Ok(Value {
-   |       - un-closed delimiter
+   |       - unclosed delimiter
 LL |     }
 LL | }
-   | ^ incorrect close delimiter
+   | ^ mismatched closing delimiter
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/unmatched-delimiter-at-end-of-file.rs
+++ b/src/test/ui/parser/unmatched-delimiter-at-end-of-file.rs
@@ -8,4 +8,4 @@ fn main() {
         y: 5 };
 }
 
-fn foo() { //~ ERROR this file contains an un-closed delimiter
+fn foo() { //~ ERROR this file contains an unclosed delimiter

--- a/src/test/ui/parser/unmatched-delimiter-at-end-of-file.stderr
+++ b/src/test/ui/parser/unmatched-delimiter-at-end-of-file.stderr
@@ -1,8 +1,8 @@
-error: this file contains an un-closed delimiter
-  --> $DIR/unmatched-delimiter-at-end-of-file.rs:11:64
+error: this file contains an unclosed delimiter
+  --> $DIR/unmatched-delimiter-at-end-of-file.rs:11:63
    |
 LL | fn foo() {
-   |          - un-closed delimiter                                 ^
+   |          - unclosed delimiter                                 ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/proc-macro/invalid-punct-ident-4.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-4.rs
@@ -4,4 +4,4 @@
 extern crate invalid_punct_ident;
 
 lexer_failure!(); //~ ERROR proc macro panicked
-                  //~| ERROR unexpected close delimiter: `)`
+                  //~| ERROR unexpected closing delimiter: `)`

--- a/src/test/ui/proc-macro/invalid-punct-ident-4.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-4.stderr
@@ -1,10 +1,10 @@
-error: unexpected close delimiter: `)`
+error: unexpected closing delimiter: `)`
   --> $DIR/invalid-punct-ident-4.rs:6:1
    |
 LL | lexer_failure!();
    | ^^^^^^^^^^^^^^^^^
    | |
-   | unexpected close delimiter
+   | unexpected closing delimiter
    | in this macro invocation
 
 error: proc macro panicked

--- a/src/test/ui/resolve/token-error-correct-2.rs
+++ b/src/test/ui/resolve/token-error-correct-2.rs
@@ -3,5 +3,5 @@
 fn main() {
     if foo {
     //~^ ERROR: cannot find value `foo`
-    ) //~ ERROR: incorrect close delimiter: `)`
+    ) //~ ERROR: mismatched closing delimiter: `)`
 }

--- a/src/test/ui/resolve/token-error-correct-2.stderr
+++ b/src/test/ui/resolve/token-error-correct-2.stderr
@@ -1,11 +1,11 @@
-error: incorrect close delimiter: `)`
+error: mismatched closing delimiter: `)`
   --> $DIR/token-error-correct-2.rs:6:5
    |
 LL |     if foo {
-   |            - un-closed delimiter
+   |            - unclosed delimiter
 LL |
 LL |     )
-   |     ^ incorrect close delimiter
+   |     ^ mismatched closing delimiter
 
 error[E0425]: cannot find value `foo` in this scope
   --> $DIR/token-error-correct-2.rs:4:8

--- a/src/test/ui/resolve/token-error-correct.rs
+++ b/src/test/ui/resolve/token-error-correct.rs
@@ -4,6 +4,6 @@ fn main() {
     foo(bar(;
     //~^ ERROR cannot find function `bar` in this scope
 }
-//~^ ERROR: incorrect close delimiter: `}`
+//~^ ERROR: mismatched closing delimiter: `}`
 
 fn foo(_: usize) {}

--- a/src/test/ui/resolve/token-error-correct.stderr
+++ b/src/test/ui/resolve/token-error-correct.stderr
@@ -1,13 +1,13 @@
-error: incorrect close delimiter: `}`
+error: mismatched closing delimiter: `}`
   --> $DIR/token-error-correct.rs:6:1
    |
 LL | fn main() {
-   |           - close delimiter possibly meant for this
+   |           - closing delimiter possibly meant for this
 LL |     foo(bar(;
-   |            - un-closed delimiter
+   |            - unclosed delimiter
 LL |
 LL | }
-   | ^ incorrect close delimiter
+   | ^ mismatched closing delimiter
 
 error[E0425]: cannot find function `bar` in this scope
   --> $DIR/token-error-correct.rs:4:9


### PR DESCRIPTION
This PR improves the wording of the "incorrect delimiter" error messages. Here's a quick rationale:

- *"un-closed" -> "unclosed"*: "unclosed" is valid English, so there's no need to hyphenate the prefix. This should be pretty uncontroversial, I think.
- *"close delimiter" -> "closing delimiter"*: In my anecdotal experience, I've always heard "closing delimiter" or "closing parenthesis". In addition, the codebase already uses this terminology in comments and function names more than "close delimiter", which could indicate that it's more intuitive.
- "incorrect delimiter" -> "mismatched delimiter": "Incorrect delimiter" is vague; why is it incorrect? "mismatched" clearly indicates why the delimiter is causing the error.

r? @estebank 