### PR TITLE
perf: Reuse the Elaborator used in outlives/ty.rs

### DIFF
--- a/src/librustc/infer/outlives/obligations.rs
+++ b/src/librustc/infer/outlives/obligations.rs
@@ -289,7 +289,7 @@ where
         components: &[Component<'tcx>],
         region: ty::Region<'tcx>,
     ) {
-        for component in components.iter() {
+        for component in components {
             let origin = origin.clone();
             match component {
                 Component::Region(region1) => {
@@ -367,8 +367,8 @@ where
         // Compute the bounds we can derive from the environment. This
         // is an "approximate" match -- in some cases, these bounds
         // may not apply.
-        let mut approx_env_bounds =
-            self.verify_bound.projection_approx_declared_bounds_from_env(projection_ty);
+        let mut approx_env_bounds: Vec<_> =
+            self.verify_bound.projection_approx_declared_bounds_from_env(projection_ty).collect();
         debug!("projection_must_outlive: approx_env_bounds={:?}", approx_env_bounds);
 
         // Remove outlives bounds that we get from the environment but

--- a/src/librustc/infer/outlives/obligations.rs
+++ b/src/librustc/infer/outlives/obligations.rs
@@ -454,7 +454,7 @@ where
     }
 }
 
-impl<'cx, 'tcx> TypeOutlivesDelegate<'tcx> for &'cx InferCtxt<'cx, 'tcx> {
+impl<'cx, 'tcx> TypeOutlivesDelegate<'tcx> for &'_ InferCtxt<'cx, 'tcx> {
     fn push_sub_region_constraint(
         &mut self,
         origin: SubregionOrigin<'tcx>,

--- a/src/librustc/infer/outlives/obligations.rs
+++ b/src/librustc/infer/outlives/obligations.rs
@@ -62,6 +62,7 @@
 use crate::infer::outlives::env::RegionBoundPairs;
 use crate::infer::outlives::verify::VerifyBoundCx;
 use crate::infer::{self, GenericKind, InferCtxt, RegionObligation, SubregionOrigin, VerifyBound};
+use crate::traits;
 use crate::traits::ObligationCause;
 use crate::ty::outlives::Component;
 use crate::ty::subst::GenericArgKind;
@@ -154,6 +155,8 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
 
         let my_region_obligations = self.take_registered_region_obligations();
 
+        let mut elaborator = traits::Elaborator::new(self.tcx);
+
         for (body_id, RegionObligation { sup_type, sub_region, origin }) in my_region_obligations {
             debug!(
                 "process_registered_region_obligations: sup_type={:?} sub_region={:?} origin={:?}",
@@ -169,6 +172,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
                     &region_bound_pairs,
                     implicit_region_bound,
                     param_env,
+                    &mut elaborator,
                 );
                 outlives.type_must_outlive(origin, sup_type, sub_region);
             } else {
@@ -191,15 +195,16 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
         ty: Ty<'tcx>,
         region: ty::Region<'tcx>,
     ) {
-        let outlives = &mut TypeOutlives::new(
+        let ty = self.resolve_vars_if_possible(&ty);
+        TypeOutlives::new(
             self,
             self.tcx,
             region_bound_pairs,
             implicit_region_bound,
             param_env,
-        );
-        let ty = self.resolve_vars_if_possible(&ty);
-        outlives.type_must_outlive(origin, ty, region);
+            &mut traits::Elaborator::new(self.tcx),
+        )
+        .type_must_outlive(origin, ty, region);
     }
 }
 
@@ -209,7 +214,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
 /// via a "delegate" of type `D` -- this is usually the `infcx`, which
 /// accrues them into the `region_obligations` code, but for NLL we
 /// use something else.
-pub struct TypeOutlives<'cx, 'tcx, D>
+pub struct TypeOutlives<'cx, 'tcx, 'e, D>
 where
     D: TypeOutlivesDelegate<'tcx>,
 {
@@ -217,7 +222,7 @@ where
     // of these fields.
     delegate: D,
     tcx: TyCtxt<'tcx>,
-    verify_bound: VerifyBoundCx<'cx, 'tcx>,
+    verify_bound: VerifyBoundCx<'cx, 'tcx, 'e>,
 }
 
 pub trait TypeOutlivesDelegate<'tcx> {
@@ -237,7 +242,7 @@ pub trait TypeOutlivesDelegate<'tcx> {
     );
 }
 
-impl<'cx, 'tcx, D> TypeOutlives<'cx, 'tcx, D>
+impl<'cx, 'tcx, 'e, D> TypeOutlives<'cx, 'tcx, 'e, D>
 where
     D: TypeOutlivesDelegate<'tcx>,
 {
@@ -247,6 +252,7 @@ where
         region_bound_pairs: &'cx RegionBoundPairs<'tcx>,
         implicit_region_bound: Option<ty::Region<'tcx>>,
         param_env: ty::ParamEnv<'tcx>,
+        elaborator: &'e mut traits::Elaborator<'tcx>,
     ) -> Self {
         Self {
             delegate,
@@ -256,6 +262,7 @@ where
                 region_bound_pairs,
                 implicit_region_bound,
                 param_env,
+                elaborator,
             ),
         }
     }
@@ -273,7 +280,9 @@ where
         origin: infer::SubregionOrigin<'tcx>,
         ty: Ty<'tcx>,
         region: ty::Region<'tcx>,
-    ) {
+    ) where
+        'tcx: 'e,
+    {
         debug!("type_must_outlive(ty={:?}, region={:?}, origin={:?})", ty, region, origin);
 
         assert!(!ty.has_escaping_bound_vars());
@@ -288,7 +297,9 @@ where
         origin: infer::SubregionOrigin<'tcx>,
         components: &[Component<'tcx>],
         region: ty::Region<'tcx>,
-    ) {
+    ) where
+        'tcx: 'e,
+    {
         for component in components {
             let origin = origin.clone();
             match component {
@@ -338,7 +349,9 @@ where
         origin: infer::SubregionOrigin<'tcx>,
         region: ty::Region<'tcx>,
         projection_ty: ty::ProjectionTy<'tcx>,
-    ) {
+    ) where
+        'tcx: 'e,
+    {
         debug!(
             "projection_must_outlive(region={:?}, projection_ty={:?}, origin={:?})",
             region, projection_ty, origin

--- a/src/librustc/infer/outlives/verify.rs
+++ b/src/librustc/infer/outlives/verify.rs
@@ -144,11 +144,11 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
                 .map(|r| VerifyBound::OutlivedBy(r)),
         );
 
-        // see the extensive comment in projection_must_outlive
-        let ty = self.tcx.mk_projection(projection_ty.item_def_id, projection_ty.substs);
-        let recursive_bound = self.recursive_type_bound(ty);
-
-        VerifyBound::AnyBound(bounds).or(recursive_bound)
+        VerifyBound::AnyBound(bounds).or(|| {
+            // see the extensive comment in projection_must_outlive
+            let ty = self.tcx.mk_projection(projection_ty.item_def_id, projection_ty.substs);
+            self.recursive_type_bound(ty)
+        })
     }
 
     fn recursive_type_bound(&self, ty: Ty<'tcx>) -> VerifyBound<'tcx> {

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -59,7 +59,7 @@ pub use self::specialize::find_associated_item;
 pub use self::specialize::specialization_graph::FutureCompatOverlapError;
 pub use self::specialize::specialization_graph::FutureCompatOverlapErrorKind;
 pub use self::specialize::{specialization_graph, translate_substs, OverlapError};
-pub use self::util::{elaborate_predicates, elaborate_trait_ref, elaborate_trait_refs};
+pub use self::util::{elaborate_predicates, elaborate_trait_ref, elaborate_trait_refs, Elaborator};
 pub use self::util::{expand_trait_aliases, TraitAliasExpander};
 pub use self::util::{
     supertrait_def_ids, supertraits, transitive_bounds, SupertraitDefIds, Supertraits,

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -2204,7 +2204,7 @@ impl<'tcx> TyS<'tcx> {
         }
     }
 
-    /// Pushes onto `out` the regions directly referenced from this type (but not
+    /// Returns the regions directly referenced from this type (but not
     /// types reachable from this type via `walk_tys`). This ignores late-bound
     /// regions binders.
     pub fn regions(&self) -> impl Iterator<Item = ty::Region<'tcx>> {

--- a/src/librustc/util/captures.rs
+++ b/src/librustc/util/captures.rs
@@ -9,8 +9,12 @@ pub trait Captures<'a> {}
 
 impl<'a, T: ?Sized> Captures<'a> for T {}
 
-// FIXME(eddyb) false positive, the lifetime parameter is "phantom" but needed.
 #[allow(unused_lifetimes)]
 pub trait Captures2<'a, 'b> {}
 
 impl<'a, 'b, T: ?Sized> Captures2<'a, 'b> for T {}
+
+#[allow(unused_lifetimes)]
+pub trait Captures3<'a, 'b, 'c> {}
+
+impl<'a, 'b, 'c, T: ?Sized> Captures3<'a, 'b, 'c> for T {}

--- a/src/librustc/util/captures.rs
+++ b/src/librustc/util/captures.rs
@@ -8,3 +8,9 @@
 pub trait Captures<'a> {}
 
 impl<'a, T: ?Sized> Captures<'a> for T {}
+
+// FIXME(eddyb) false positive, the lifetime parameter is "phantom" but needed.
+#[allow(unused_lifetimes)]
+pub trait Captures2<'a, 'b> {}
+
+impl<'a, 'b, T: ?Sized> Captures2<'a, 'b> for T {}

--- a/src/librustc_mir/borrow_check/type_check/constraint_conversion.rs
+++ b/src/librustc_mir/borrow_check/type_check/constraint_conversion.rs
@@ -5,6 +5,7 @@ use rustc::infer::outlives::obligations::{TypeOutlives, TypeOutlivesDelegate};
 use rustc::infer::region_constraints::{GenericKind, VerifyBound};
 use rustc::infer::{self, InferCtxt, SubregionOrigin};
 use rustc::mir::ConstraintCategory;
+use rustc::traits;
 use rustc::ty::subst::GenericArgKind;
 use rustc::ty::{self, TyCtxt};
 use rustc_span::DUMMY_SP;
@@ -108,6 +109,7 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
                     region_bound_pairs,
                     implicit_region_bound,
                     param_env,
+                    &mut traits::Elaborator::new(tcx),
                 )
                 .type_must_outlive(origin, t1, r2);
             }


### PR DESCRIPTION
The first commit mostly cleans up some unnecessary allocations (I wouldn't expect it to change runtime noticeably).

The second commit should improve things a bit however.

Profiling the build of https://github.com/Marwes/combine shows that
~1.3% of the time were spent resizing and rehashing the hash set used in
`Elaborator`. By reusing the `Elaborator` between calls this should
be mostly eliminated.

It does result in some awkwardness since the `RefCell` needs to be
borrowed in the returned `Iterator` but it works fine for the current
code.
