### PR TITLE
Add Read/Write::can_read/write_vectored

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -660,8 +660,8 @@ impl Read for File {
     }
 
     #[inline]
-    fn can_read_vectored(&self) -> bool {
-        self.inner.can_read_vectored()
+    fn is_read_vectored(&self) -> bool {
+        self.inner.is_read_vectored()
     }
 
     #[inline]
@@ -680,8 +680,8 @@ impl Write for File {
     }
 
     #[inline]
-    fn can_write_vectored(&self) -> bool {
-        self.inner.can_write_vectored()
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -705,8 +705,8 @@ impl Read for &File {
     }
 
     #[inline]
-    fn can_read_vectored(&self) -> bool {
-        self.inner.can_read_vectored()
+    fn is_read_vectored(&self) -> bool {
+        self.inner.is_read_vectored()
     }
 
     #[inline]
@@ -725,8 +725,8 @@ impl Write for &File {
     }
 
     #[inline]
-    fn can_write_vectored(&self) -> bool {
-        self.inner.can_write_vectored()
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -660,6 +660,11 @@ impl Read for File {
     }
 
     #[inline]
+    fn can_read_vectored(&self) -> bool {
+        self.inner.can_read_vectored()
+    }
+
+    #[inline]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
@@ -672,6 +677,11 @@ impl Write for File {
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.inner.write_vectored(bufs)
+    }
+
+    #[inline]
+    fn can_write_vectored(&self) -> bool {
+        self.inner.can_write_vectored()
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -695,6 +705,11 @@ impl Read for &File {
     }
 
     #[inline]
+    fn can_read_vectored(&self) -> bool {
+        self.inner.can_read_vectored()
+    }
+
+    #[inline]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
@@ -707,6 +722,11 @@ impl Write for &File {
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.inner.write_vectored(bufs)
+    }
+
+    #[inline]
+    fn can_write_vectored(&self) -> bool {
+        self.inner.can_write_vectored()
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -292,6 +292,10 @@ impl<R: Read> Read for BufReader<R> {
         Ok(nread)
     }
 
+    fn can_read_vectored(&self) -> bool {
+        self.inner.can_read_vectored()
+    }
+
     // we can't skip unconditionally because of the large buffer case in read.
     unsafe fn initializer(&self) -> Initializer {
         self.inner.initializer()
@@ -678,6 +682,10 @@ impl<W: Write> Write for BufWriter<W> {
         } else {
             self.buf.write_vectored(bufs)
         }
+    }
+
+    fn can_write_vectored(&self) -> bool {
+        self.get_ref().can_write_vectored()
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -292,8 +292,8 @@ impl<R: Read> Read for BufReader<R> {
         Ok(nread)
     }
 
-    fn can_read_vectored(&self) -> bool {
-        self.inner.can_read_vectored()
+    fn is_read_vectored(&self) -> bool {
+        self.inner.is_read_vectored()
     }
 
     // we can't skip unconditionally because of the large buffer case in read.
@@ -684,8 +684,8 @@ impl<W: Write> Write for BufWriter<W> {
         }
     }
 
-    fn can_write_vectored(&self) -> bool {
-        self.get_ref().can_write_vectored()
+    fn is_write_vectored(&self) -> bool {
+        self.get_ref().is_write_vectored()
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -266,6 +266,10 @@ where
         Ok(nread)
     }
 
+    fn can_read_vectored(&self) -> bool {
+        true
+    }
+
     fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
         let n = buf.len();
         Read::read_exact(&mut self.fill_buf()?, buf)?;
@@ -373,6 +377,11 @@ impl Write for Cursor<&mut [u8]> {
     }
 
     #[inline]
+    fn can_write_vectored(&self) -> bool {
+        true
+    }
+
+    #[inline]
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
     }
@@ -386,6 +395,11 @@ impl Write for Cursor<&mut Vec<u8>> {
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         vec_write_vectored(&mut self.pos, self.inner, bufs)
+    }
+
+    #[inline]
+    fn can_write_vectored(&self) -> bool {
+        true
     }
 
     #[inline]
@@ -405,6 +419,11 @@ impl Write for Cursor<Vec<u8>> {
     }
 
     #[inline]
+    fn can_write_vectored(&self) -> bool {
+        true
+    }
+
+    #[inline]
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
     }
@@ -420,6 +439,11 @@ impl Write for Cursor<Box<[u8]>> {
     #[inline]
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         slice_write_vectored(&mut self.pos, &mut self.inner, bufs)
+    }
+
+    #[inline]
+    fn can_write_vectored(&self) -> bool {
+        true
     }
 
     #[inline]

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -266,7 +266,7 @@ where
         Ok(nread)
     }
 
-    fn can_read_vectored(&self) -> bool {
+    fn is_read_vectored(&self) -> bool {
         true
     }
 
@@ -377,7 +377,7 @@ impl Write for Cursor<&mut [u8]> {
     }
 
     #[inline]
-    fn can_write_vectored(&self) -> bool {
+    fn is_write_vectored(&self) -> bool {
         true
     }
 
@@ -398,7 +398,7 @@ impl Write for Cursor<&mut Vec<u8>> {
     }
 
     #[inline]
-    fn can_write_vectored(&self) -> bool {
+    fn is_write_vectored(&self) -> bool {
         true
     }
 
@@ -419,7 +419,7 @@ impl Write for Cursor<Vec<u8>> {
     }
 
     #[inline]
-    fn can_write_vectored(&self) -> bool {
+    fn is_write_vectored(&self) -> bool {
         true
     }
 
@@ -442,7 +442,7 @@ impl Write for Cursor<Box<[u8]>> {
     }
 
     #[inline]
-    fn can_write_vectored(&self) -> bool {
+    fn is_write_vectored(&self) -> bool {
         true
     }
 

--- a/src/libstd/io/impls.rs
+++ b/src/libstd/io/impls.rs
@@ -21,8 +21,8 @@ impl<R: Read + ?Sized> Read for &mut R {
     }
 
     #[inline]
-    fn can_read_vectored(&self) -> bool {
-        (**self).can_read_vectored()
+    fn is_read_vectored(&self) -> bool {
+        (**self).is_read_vectored()
     }
 
     #[inline]
@@ -58,8 +58,8 @@ impl<W: Write + ?Sized> Write for &mut W {
     }
 
     #[inline]
-    fn can_write_vectored(&self) -> bool {
-        (**self).can_write_vectored()
+    fn is_write_vectored(&self) -> bool {
+        (**self).is_write_vectored()
     }
 
     #[inline]
@@ -120,8 +120,8 @@ impl<R: Read + ?Sized> Read for Box<R> {
     }
 
     #[inline]
-    fn can_read_vectored(&self) -> bool {
-        (**self).can_read_vectored()
+    fn is_read_vectored(&self) -> bool {
+        (**self).is_read_vectored()
     }
 
     #[inline]
@@ -157,8 +157,8 @@ impl<W: Write + ?Sized> Write for Box<W> {
     }
 
     #[inline]
-    fn can_write_vectored(&self) -> bool {
-        (**self).can_write_vectored()
+    fn is_write_vectored(&self) -> bool {
+        (**self).is_write_vectored()
     }
 
     #[inline]
@@ -261,7 +261,7 @@ impl Read for &[u8] {
     }
 
     #[inline]
-    fn can_read_vectored(&self) -> bool {
+    fn is_read_vectored(&self) -> bool {
         true
     }
 
@@ -342,7 +342,7 @@ impl Write for &mut [u8] {
     }
 
     #[inline]
-    fn can_write_vectored(&self) -> bool {
+    fn is_write_vectored(&self) -> bool {
         true
     }
 
@@ -382,7 +382,7 @@ impl Write for Vec<u8> {
     }
 
     #[inline]
-    fn can_write_vectored(&self) -> bool {
+    fn is_write_vectored(&self) -> bool {
         true
     }
 

--- a/src/libstd/io/impls.rs
+++ b/src/libstd/io/impls.rs
@@ -21,6 +21,11 @@ impl<R: Read + ?Sized> Read for &mut R {
     }
 
     #[inline]
+    fn can_read_vectored(&self) -> bool {
+        (**self).can_read_vectored()
+    }
+
+    #[inline]
     unsafe fn initializer(&self) -> Initializer {
         (**self).initializer()
     }
@@ -50,6 +55,11 @@ impl<W: Write + ?Sized> Write for &mut W {
     #[inline]
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         (**self).write_vectored(bufs)
+    }
+
+    #[inline]
+    fn can_write_vectored(&self) -> bool {
+        (**self).can_write_vectored()
     }
 
     #[inline]
@@ -110,6 +120,11 @@ impl<R: Read + ?Sized> Read for Box<R> {
     }
 
     #[inline]
+    fn can_read_vectored(&self) -> bool {
+        (**self).can_read_vectored()
+    }
+
+    #[inline]
     unsafe fn initializer(&self) -> Initializer {
         (**self).initializer()
     }
@@ -139,6 +154,11 @@ impl<W: Write + ?Sized> Write for Box<W> {
     #[inline]
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         (**self).write_vectored(bufs)
+    }
+
+    #[inline]
+    fn can_write_vectored(&self) -> bool {
+        (**self).can_write_vectored()
     }
 
     #[inline]
@@ -241,6 +261,11 @@ impl Read for &[u8] {
     }
 
     #[inline]
+    fn can_read_vectored(&self) -> bool {
+        true
+    }
+
+    #[inline]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
@@ -317,6 +342,11 @@ impl Write for &mut [u8] {
     }
 
     #[inline]
+    fn can_write_vectored(&self) -> bool {
+        true
+    }
+
+    #[inline]
     fn write_all(&mut self, data: &[u8]) -> io::Result<()> {
         if self.write(data)? == data.len() {
             Ok(())
@@ -349,6 +379,11 @@ impl Write for Vec<u8> {
             self.extend_from_slice(buf);
         }
         Ok(len)
+    }
+
+    #[inline]
+    fn can_write_vectored(&self) -> bool {
+        true
     }
 
     #[inline]

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -256,6 +256,7 @@
 //! [`Read::read`]: trait.Read.html#tymethod.read
 //! [`Result`]: ../result/enum.Result.html
 //! [`.unwrap()`]: ../result/enum.Result.html#method.unwrap
+// ignore-tidy-filelength
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -580,6 +580,19 @@ pub trait Read {
         default_read_vectored(|b| self.read(b), bufs)
     }
 
+    /// Determines if this `Read`er has an efficient `read_vectored`
+    /// implementation.
+    ///
+    /// If a `Read`er does not override the default `read_vectored`
+    /// implementation, code using it may want to avoid the method all together
+    /// and coalesce writes into a single buffer for higher performance.
+    ///
+    /// The default implementation returns `false`.
+    #[unstable(feature = "can_vector", issue = "none")]
+    fn can_read_vectored(&self) -> bool {
+        false
+    }
+
     /// Determines if this `Read`er can work with buffers of uninitialized
     /// memory.
     ///
@@ -1302,6 +1315,19 @@ pub trait Write {
     #[stable(feature = "iovec", since = "1.36.0")]
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize> {
         default_write_vectored(|b| self.write(b), bufs)
+    }
+
+    /// Determines if this `Write`er has an efficient `write_vectored`
+    /// implementation.
+    ///
+    /// If a `Write`er does not override the default `write_vectored`
+    /// implementation, code using it may want to avoid the method all together
+    /// and coalesce writes into a single buffer for higher performance.
+    ///
+    /// The default implementation returns `false`.
+    #[unstable(feature = "can_vector", issue = "none")]
+    fn can_write_vectored(&self) -> bool {
+        false
     }
 
     /// Flush this output stream, ensuring that all intermediately buffered

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -588,8 +588,8 @@ pub trait Read {
     /// and coalesce writes into a single buffer for higher performance.
     ///
     /// The default implementation returns `false`.
-    #[unstable(feature = "can_vector", issue = "none")]
-    fn can_read_vectored(&self) -> bool {
+    #[unstable(feature = "can_vector", issue = "69941")]
+    fn is_read_vectored(&self) -> bool {
         false
     }
 
@@ -1325,8 +1325,8 @@ pub trait Write {
     /// and coalesce writes into a single buffer for higher performance.
     ///
     /// The default implementation returns `false`.
-    #[unstable(feature = "can_vector", issue = "none")]
-    fn can_write_vectored(&self) -> bool {
+    #[unstable(feature = "can_vector", issue = "69941")]
+    fn is_write_vectored(&self) -> bool {
         false
     }
 

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -88,6 +88,11 @@ impl Read for StdinRaw {
     }
 
     #[inline]
+    fn can_read_vectored(&self) -> bool {
+        self.0.can_read_vectored()
+    }
+
+    #[inline]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
@@ -101,6 +106,11 @@ impl Write for StdoutRaw {
         self.0.write_vectored(bufs)
     }
 
+    #[inline]
+    fn can_write_vectored(&self) -> bool {
+        self.0.can_write_vectored()
+    }
+
     fn flush(&mut self) -> io::Result<()> {
         self.0.flush()
     }
@@ -112,6 +122,11 @@ impl Write for StderrRaw {
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.0.write_vectored(bufs)
+    }
+
+    #[inline]
+    fn can_write_vectored(&self) -> bool {
+        self.0.can_write_vectored()
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -140,6 +155,14 @@ impl<W: io::Write> io::Write for Maybe<W> {
         }
     }
 
+    #[inline]
+    fn can_write_vectored(&self) -> bool {
+        match self {
+            Maybe::Real(w) => w.can_write_vectored(),
+            Maybe::Fake => true,
+        }
+    }
+
     fn flush(&mut self) -> io::Result<()> {
         match *self {
             Maybe::Real(ref mut w) => handle_ebadf(w.flush(), ()),
@@ -160,6 +183,14 @@ impl<R: io::Read> io::Read for Maybe<R> {
         match self {
             Maybe::Real(r) => handle_ebadf(r.read_vectored(bufs), 0),
             Maybe::Fake => Ok(0),
+        }
+    }
+
+    #[inline]
+    fn can_read_vectored(&self) -> bool {
+        match self {
+            Maybe::Real(w) => w.can_read_vectored(),
+            Maybe::Fake => true,
         }
     }
 }
@@ -352,6 +383,10 @@ impl Read for Stdin {
         self.lock().read_vectored(bufs)
     }
     #[inline]
+    fn can_read_vectored(&self) -> bool {
+        self.lock().can_read_vectored()
+    }
+    #[inline]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
@@ -374,6 +409,11 @@ impl Read for StdinLock<'_> {
 
     fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         self.inner.read_vectored(bufs)
+    }
+
+    #[inline]
+    fn can_read_vectored(&self) -> bool {
+        self.inner.can_read_vectored()
     }
 
     #[inline]
@@ -543,6 +583,10 @@ impl Write for Stdout {
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.lock().write_vectored(bufs)
     }
+    #[inline]
+    fn can_write_vectored(&self) -> bool {
+        self.lock().can_write_vectored()
+    }
     fn flush(&mut self) -> io::Result<()> {
         self.lock().flush()
     }
@@ -560,6 +604,10 @@ impl Write for StdoutLock<'_> {
     }
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.inner.borrow_mut().write_vectored(bufs)
+    }
+    #[inline]
+    fn can_write_vectored(&self) -> bool {
+        self.inner.borrow_mut().can_write_vectored()
     }
     fn flush(&mut self) -> io::Result<()> {
         self.inner.borrow_mut().flush()
@@ -709,6 +757,10 @@ impl Write for Stderr {
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.lock().write_vectored(bufs)
     }
+    #[inline]
+    fn can_write_vectored(&self) -> bool {
+        self.lock().can_write_vectored()
+    }
     fn flush(&mut self) -> io::Result<()> {
         self.lock().flush()
     }
@@ -726,6 +778,10 @@ impl Write for StderrLock<'_> {
     }
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.inner.borrow_mut().write_vectored(bufs)
+    }
+    #[inline]
+    fn can_write_vectored(&self) -> bool {
+        self.inner.borrow_mut().can_write_vectored()
     }
     fn flush(&mut self) -> io::Result<()> {
         self.inner.borrow_mut().flush()

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -88,8 +88,8 @@ impl Read for StdinRaw {
     }
 
     #[inline]
-    fn can_read_vectored(&self) -> bool {
-        self.0.can_read_vectored()
+    fn is_read_vectored(&self) -> bool {
+        self.0.is_read_vectored()
     }
 
     #[inline]
@@ -107,8 +107,8 @@ impl Write for StdoutRaw {
     }
 
     #[inline]
-    fn can_write_vectored(&self) -> bool {
-        self.0.can_write_vectored()
+    fn is_write_vectored(&self) -> bool {
+        self.0.is_write_vectored()
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -125,8 +125,8 @@ impl Write for StderrRaw {
     }
 
     #[inline]
-    fn can_write_vectored(&self) -> bool {
-        self.0.can_write_vectored()
+    fn is_write_vectored(&self) -> bool {
+        self.0.is_write_vectored()
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -156,9 +156,9 @@ impl<W: io::Write> io::Write for Maybe<W> {
     }
 
     #[inline]
-    fn can_write_vectored(&self) -> bool {
+    fn is_write_vectored(&self) -> bool {
         match self {
-            Maybe::Real(w) => w.can_write_vectored(),
+            Maybe::Real(w) => w.is_write_vectored(),
             Maybe::Fake => true,
         }
     }
@@ -187,9 +187,9 @@ impl<R: io::Read> io::Read for Maybe<R> {
     }
 
     #[inline]
-    fn can_read_vectored(&self) -> bool {
+    fn is_read_vectored(&self) -> bool {
         match self {
-            Maybe::Real(w) => w.can_read_vectored(),
+            Maybe::Real(w) => w.is_read_vectored(),
             Maybe::Fake => true,
         }
     }
@@ -383,8 +383,8 @@ impl Read for Stdin {
         self.lock().read_vectored(bufs)
     }
     #[inline]
-    fn can_read_vectored(&self) -> bool {
-        self.lock().can_read_vectored()
+    fn is_read_vectored(&self) -> bool {
+        self.lock().is_read_vectored()
     }
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
@@ -412,8 +412,8 @@ impl Read for StdinLock<'_> {
     }
 
     #[inline]
-    fn can_read_vectored(&self) -> bool {
-        self.inner.can_read_vectored()
+    fn is_read_vectored(&self) -> bool {
+        self.inner.is_read_vectored()
     }
 
     #[inline]
@@ -584,8 +584,8 @@ impl Write for Stdout {
         self.lock().write_vectored(bufs)
     }
     #[inline]
-    fn can_write_vectored(&self) -> bool {
-        self.lock().can_write_vectored()
+    fn is_write_vectored(&self) -> bool {
+        self.lock().is_write_vectored()
     }
     fn flush(&mut self) -> io::Result<()> {
         self.lock().flush()
@@ -606,8 +606,8 @@ impl Write for StdoutLock<'_> {
         self.inner.borrow_mut().write_vectored(bufs)
     }
     #[inline]
-    fn can_write_vectored(&self) -> bool {
-        self.inner.borrow_mut().can_write_vectored()
+    fn is_write_vectored(&self) -> bool {
+        self.inner.borrow_mut().is_write_vectored()
     }
     fn flush(&mut self) -> io::Result<()> {
         self.inner.borrow_mut().flush()
@@ -758,8 +758,8 @@ impl Write for Stderr {
         self.lock().write_vectored(bufs)
     }
     #[inline]
-    fn can_write_vectored(&self) -> bool {
-        self.lock().can_write_vectored()
+    fn is_write_vectored(&self) -> bool {
+        self.lock().is_write_vectored()
     }
     fn flush(&mut self) -> io::Result<()> {
         self.lock().flush()
@@ -780,8 +780,8 @@ impl Write for StderrLock<'_> {
         self.inner.borrow_mut().write_vectored(bufs)
     }
     #[inline]
-    fn can_write_vectored(&self) -> bool {
-        self.inner.borrow_mut().can_write_vectored()
+    fn is_write_vectored(&self) -> bool {
+        self.inner.borrow_mut().is_write_vectored()
     }
     fn flush(&mut self) -> io::Result<()> {
         self.inner.borrow_mut().flush()

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -180,6 +180,11 @@ impl Read for Repeat {
     }
 
     #[inline]
+    fn can_read_vectored(&self) -> bool {
+        true
+    }
+
+    #[inline]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
@@ -233,6 +238,11 @@ impl Write for Sink {
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         let total_len = bufs.iter().map(|b| b.len()).sum();
         Ok(total_len)
+    }
+
+    #[inline]
+    fn can_write_vectored(&self) -> bool {
+        true
     }
 
     #[inline]

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -180,7 +180,7 @@ impl Read for Repeat {
     }
 
     #[inline]
-    fn can_read_vectored(&self) -> bool {
+    fn is_read_vectored(&self) -> bool {
         true
     }
 
@@ -241,7 +241,7 @@ impl Write for Sink {
     }
 
     #[inline]
-    fn can_write_vectored(&self) -> bool {
+    fn is_write_vectored(&self) -> bool {
         true
     }
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -243,6 +243,7 @@
 #![feature(box_syntax)]
 #![feature(c_variadic)]
 #![feature(cfg_accessible)]
+#![feature(can_vector)]
 #![feature(cfg_target_has_atomic)]
 #![feature(cfg_target_thread_local)]
 #![feature(char_error_internals)]

--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -577,8 +577,8 @@ impl Read for TcpStream {
     }
 
     #[inline]
-    fn can_read_vectored(&self) -> bool {
-        self.0.can_read_vectored()
+    fn is_read_vectored(&self) -> bool {
+        self.0.is_read_vectored()
     }
 
     #[inline]
@@ -597,8 +597,8 @@ impl Write for TcpStream {
     }
 
     #[inline]
-    fn can_write_vectored(&self) -> bool {
-        self.0.can_write_vectored()
+    fn is_write_vectored(&self) -> bool {
+        self.0.is_write_vectored()
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -616,8 +616,8 @@ impl Read for &TcpStream {
     }
 
     #[inline]
-    fn can_read_vectored(&self) -> bool {
-        self.0.can_read_vectored()
+    fn is_read_vectored(&self) -> bool {
+        self.0.is_read_vectored()
     }
 
     #[inline]
@@ -636,8 +636,8 @@ impl Write for &TcpStream {
     }
 
     #[inline]
-    fn can_write_vectored(&self) -> bool {
-        self.0.can_write_vectored()
+    fn is_write_vectored(&self) -> bool {
+        self.0.is_write_vectored()
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -577,6 +577,11 @@ impl Read for TcpStream {
     }
 
     #[inline]
+    fn can_read_vectored(&self) -> bool {
+        self.0.can_read_vectored()
+    }
+
+    #[inline]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
@@ -589,6 +594,11 @@ impl Write for TcpStream {
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.0.write_vectored(bufs)
+    }
+
+    #[inline]
+    fn can_write_vectored(&self) -> bool {
+        self.0.can_write_vectored()
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -606,6 +616,11 @@ impl Read for &TcpStream {
     }
 
     #[inline]
+    fn can_read_vectored(&self) -> bool {
+        self.0.can_read_vectored()
+    }
+
+    #[inline]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
@@ -618,6 +633,11 @@ impl Write for &TcpStream {
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.0.write_vectored(bufs)
+    }
+
+    #[inline]
+    fn can_write_vectored(&self) -> bool {
+        self.0.can_write_vectored()
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -245,6 +245,10 @@ impl Write for ChildStdin {
         self.inner.write_vectored(bufs)
     }
 
+    fn can_write_vectored(&self) -> bool {
+        self.inner.can_write_vectored()
+    }
+
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
     }
@@ -301,6 +305,11 @@ impl Read for ChildStdout {
     }
 
     #[inline]
+    fn can_read_vectored(&self) -> bool {
+        self.inner.can_read_vectored()
+    }
+
+    #[inline]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
@@ -354,6 +363,11 @@ impl Read for ChildStderr {
 
     fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         self.inner.read_vectored(bufs)
+    }
+
+    #[inline]
+    fn can_read_vectored(&self) -> bool {
+        self.inner.can_read_vectored()
     }
 
     #[inline]

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -245,8 +245,8 @@ impl Write for ChildStdin {
         self.inner.write_vectored(bufs)
     }
 
-    fn can_write_vectored(&self) -> bool {
-        self.inner.can_write_vectored()
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -305,8 +305,8 @@ impl Read for ChildStdout {
     }
 
     #[inline]
-    fn can_read_vectored(&self) -> bool {
-        self.inner.can_read_vectored()
+    fn is_read_vectored(&self) -> bool {
+        self.inner.is_read_vectored()
     }
 
     #[inline]
@@ -366,8 +366,8 @@ impl Read for ChildStderr {
     }
 
     #[inline]
-    fn can_read_vectored(&self) -> bool {
-        self.inner.can_read_vectored()
+    fn is_read_vectored(&self) -> bool {
+        self.inner.is_read_vectored()
     }
 
     #[inline]

--- a/src/libstd/sys/cloudabi/shims/fs.rs
+++ b/src/libstd/sys/cloudabi/shims/fs.rs
@@ -214,7 +214,7 @@ impl File {
         match self.0 {}
     }
 
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/cloudabi/shims/fs.rs
+++ b/src/libstd/sys/cloudabi/shims/fs.rs
@@ -202,11 +202,19 @@ impl File {
         match self.0 {}
     }
 
+    pub fn can_read_vectored(&self) -> bool {
+        match self.0 {}
+    }
+
     pub fn write(&self, _buf: &[u8]) -> io::Result<usize> {
         match self.0 {}
     }
 
     pub fn write_vectored(&self, _bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        match self.0 {}
+    }
+
+    pub fn can_write_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/cloudabi/shims/fs.rs
+++ b/src/libstd/sys/cloudabi/shims/fs.rs
@@ -202,7 +202,7 @@ impl File {
         match self.0 {}
     }
 
-    pub fn can_read_vectored(&self) -> bool {
+    pub fn is_read_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/cloudabi/shims/net.rs
+++ b/src/libstd/sys/cloudabi/shims/net.rs
@@ -47,11 +47,19 @@ impl TcpStream {
         match self.0 {}
     }
 
+    pub fn can_read_vectored(&self) -> bool {
+        match self.0 {}
+    }
+
     pub fn write(&self, _: &[u8]) -> io::Result<usize> {
         match self.0 {}
     }
 
     pub fn write_vectored(&self, _: &[IoSlice<'_>]) -> io::Result<usize> {
+        match self.0 {}
+    }
+
+    pub fn can_write_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/cloudabi/shims/net.rs
+++ b/src/libstd/sys/cloudabi/shims/net.rs
@@ -59,7 +59,7 @@ impl TcpStream {
         match self.0 {}
     }
 
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/cloudabi/shims/net.rs
+++ b/src/libstd/sys/cloudabi/shims/net.rs
@@ -47,7 +47,7 @@ impl TcpStream {
         match self.0 {}
     }
 
-    pub fn can_read_vectored(&self) -> bool {
+    pub fn is_read_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/cloudabi/shims/pipe.rs
+++ b/src/libstd/sys/cloudabi/shims/pipe.rs
@@ -12,11 +12,19 @@ impl AnonPipe {
         match self.0 {}
     }
 
+    pub fn can_read_vectored(&self) -> bool {
+        match self.0 {}
+    }
+
     pub fn write(&self, _buf: &[u8]) -> io::Result<usize> {
         match self.0 {}
     }
 
     pub fn write_vectored(&self, _bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        match self.0 {}
+    }
+
+    pub fn can_write_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/cloudabi/shims/pipe.rs
+++ b/src/libstd/sys/cloudabi/shims/pipe.rs
@@ -12,7 +12,7 @@ impl AnonPipe {
         match self.0 {}
     }
 
-    pub fn can_read_vectored(&self) -> bool {
+    pub fn is_read_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/cloudabi/shims/pipe.rs
+++ b/src/libstd/sys/cloudabi/shims/pipe.rs
@@ -24,7 +24,7 @@ impl AnonPipe {
         match self.0 {}
     }
 
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/hermit/fs.rs
+++ b/src/libstd/sys/hermit/fs.rs
@@ -301,12 +301,22 @@ impl File {
         crate::io::default_read_vectored(|buf| self.read(buf), bufs)
     }
 
+    #[inline]
+    pub fn can_read_vectored(&self) -> bool {
+        false
+    }
+
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
         self.0.write(buf)
     }
 
     pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         crate::io::default_write_vectored(|buf| self.write(buf), bufs)
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        false
     }
 
     pub fn flush(&self) -> io::Result<()> {

--- a/src/libstd/sys/hermit/fs.rs
+++ b/src/libstd/sys/hermit/fs.rs
@@ -302,7 +302,7 @@ impl File {
     }
 
     #[inline]
-    pub fn can_read_vectored(&self) -> bool {
+    pub fn is_read_vectored(&self) -> bool {
         false
     }
 
@@ -315,7 +315,7 @@ impl File {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         false
     }
 

--- a/src/libstd/sys/hermit/net.rs
+++ b/src/libstd/sys/hermit/net.rs
@@ -99,6 +99,11 @@ impl TcpStream {
         Ok(size)
     }
 
+    #[inline]
+    pub fn can_read_vectored(&self) -> bool {
+        true
+    }
+
     pub fn write(&self, buffer: &[u8]) -> io::Result<usize> {
         self.write_vectored(&[IoSlice::new(buffer)])
     }
@@ -112,6 +117,11 @@ impl TcpStream {
         }
 
         Ok(size)
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        true
     }
 
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {

--- a/src/libstd/sys/hermit/net.rs
+++ b/src/libstd/sys/hermit/net.rs
@@ -100,7 +100,7 @@ impl TcpStream {
     }
 
     #[inline]
-    pub fn can_read_vectored(&self) -> bool {
+    pub fn is_read_vectored(&self) -> bool {
         true
     }
 
@@ -120,7 +120,7 @@ impl TcpStream {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         true
     }
 

--- a/src/libstd/sys/hermit/pipe.rs
+++ b/src/libstd/sys/hermit/pipe.rs
@@ -12,11 +12,19 @@ impl AnonPipe {
         match self.0 {}
     }
 
+    pub fn can_read_vectored(&self) -> bool {
+        match self.0 {}
+    }
+
     pub fn write(&self, _buf: &[u8]) -> io::Result<usize> {
         match self.0 {}
     }
 
     pub fn write_vectored(&self, _bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        match self.0 {}
+    }
+
+    pub fn can_write_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/hermit/pipe.rs
+++ b/src/libstd/sys/hermit/pipe.rs
@@ -12,7 +12,7 @@ impl AnonPipe {
         match self.0 {}
     }
 
-    pub fn can_read_vectored(&self) -> bool {
+    pub fn is_read_vectored(&self) -> bool {
         match self.0 {}
     }
 
@@ -24,7 +24,7 @@ impl AnonPipe {
         match self.0 {}
     }
 
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/hermit/stdio.rs
+++ b/src/libstd/sys/hermit/stdio.rs
@@ -22,7 +22,7 @@ impl Stdin {
     }
 
     #[inline]
-    pub fn can_read_vectored(&self) -> bool {
+    pub fn is_read_vectored(&self) -> bool {
         true
     }
 }
@@ -57,7 +57,7 @@ impl Stdout {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         true
     }
 
@@ -96,7 +96,7 @@ impl Stderr {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         true
     }
 

--- a/src/libstd/sys/hermit/stdio.rs
+++ b/src/libstd/sys/hermit/stdio.rs
@@ -20,6 +20,11 @@ impl Stdin {
         //    .read(data)
         Ok(0)
     }
+
+    #[inline]
+    pub fn can_read_vectored(&self) -> bool {
+        true
+    }
 }
 
 impl Stdout {
@@ -49,6 +54,11 @@ impl Stdout {
         } else {
             Ok(len as usize)
         }
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        true
     }
 
     pub fn flush(&self) -> io::Result<()> {
@@ -83,6 +93,11 @@ impl Stderr {
         } else {
             Ok(len as usize)
         }
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        true
     }
 
     pub fn flush(&self) -> io::Result<()> {

--- a/src/libstd/sys/sgx/fd.rs
+++ b/src/libstd/sys/sgx/fd.rs
@@ -34,12 +34,22 @@ impl FileDesc {
         usercalls::read(self.fd, bufs)
     }
 
+    #[inline]
+    pub fn can_read_vectored(&self) -> bool {
+        true
+    }
+
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
         usercalls::write(self.fd, &[IoSlice::new(buf)])
     }
 
     pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         usercalls::write(self.fd, bufs)
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        true
     }
 
     pub fn flush(&self) -> io::Result<()> {

--- a/src/libstd/sys/sgx/fd.rs
+++ b/src/libstd/sys/sgx/fd.rs
@@ -35,7 +35,7 @@ impl FileDesc {
     }
 
     #[inline]
-    pub fn can_read_vectored(&self) -> bool {
+    pub fn is_read_vectored(&self) -> bool {
         true
     }
 
@@ -48,7 +48,7 @@ impl FileDesc {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         true
     }
 

--- a/src/libstd/sys/sgx/fs.rs
+++ b/src/libstd/sys/sgx/fs.rs
@@ -202,11 +202,19 @@ impl File {
         match self.0 {}
     }
 
+    pub fn can_read_vectored(&self) -> bool {
+        match self.0 {}
+    }
+
     pub fn write(&self, _buf: &[u8]) -> io::Result<usize> {
         match self.0 {}
     }
 
     pub fn write_vectored(&self, _bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        match self.0 {}
+    }
+
+    pub fn can_write_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/sgx/fs.rs
+++ b/src/libstd/sys/sgx/fs.rs
@@ -202,7 +202,7 @@ impl File {
         match self.0 {}
     }
 
-    pub fn can_read_vectored(&self) -> bool {
+    pub fn is_read_vectored(&self) -> bool {
         match self.0 {}
     }
 
@@ -214,7 +214,7 @@ impl File {
         match self.0 {}
     }
 
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/sgx/net.rs
+++ b/src/libstd/sys/sgx/net.rs
@@ -149,12 +149,22 @@ impl TcpStream {
         self.inner.inner.read_vectored(bufs)
     }
 
+    #[inline]
+    pub fn can_read_vectored(&self) -> bool {
+        self.inner.inner.can_read_vectored()
+    }
+
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
         self.inner.inner.write(buf)
     }
 
     pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.inner.inner.write_vectored(bufs)
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        self.inner.inner.can_write_vectored()
     }
 
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {

--- a/src/libstd/sys/sgx/net.rs
+++ b/src/libstd/sys/sgx/net.rs
@@ -151,7 +151,7 @@ impl TcpStream {
 
     #[inline]
     pub fn is_read_vectored(&self) -> bool {
-        self.inner.inner.can_read_vectored()
+        self.inner.inner.is_read_vectored()
     }
 
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {

--- a/src/libstd/sys/sgx/net.rs
+++ b/src/libstd/sys/sgx/net.rs
@@ -150,7 +150,7 @@ impl TcpStream {
     }
 
     #[inline]
-    pub fn can_read_vectored(&self) -> bool {
+    pub fn is_read_vectored(&self) -> bool {
         self.inner.inner.can_read_vectored()
     }
 
@@ -163,8 +163,8 @@ impl TcpStream {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
-        self.inner.inner.can_write_vectored()
+    pub fn is_write_vectored(&self) -> bool {
+        self.inner.inner.is_write_vectored()
     }
 
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {

--- a/src/libstd/sys/sgx/pipe.rs
+++ b/src/libstd/sys/sgx/pipe.rs
@@ -12,11 +12,19 @@ impl AnonPipe {
         match self.0 {}
     }
 
+    pub fn can_read_vectored(&self) -> bool {
+        match self.0 {}
+    }
+
     pub fn write(&self, _buf: &[u8]) -> io::Result<usize> {
         match self.0 {}
     }
 
     pub fn write_vectored(&self, _bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        match self.0 {}
+    }
+
+    pub fn can_write_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/sgx/pipe.rs
+++ b/src/libstd/sys/sgx/pipe.rs
@@ -12,7 +12,7 @@ impl AnonPipe {
         match self.0 {}
     }
 
-    pub fn can_read_vectored(&self) -> bool {
+    pub fn is_read_vectored(&self) -> bool {
         match self.0 {}
     }
 
@@ -24,7 +24,7 @@ impl AnonPipe {
         match self.0 {}
     }
 
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/unix/ext/net.rs
+++ b/src/libstd/sys/unix/ext/net.rs
@@ -614,6 +614,11 @@ impl io::Read for UnixStream {
     }
 
     #[inline]
+    fn can_read_vectored(&self) -> bool {
+        io::Read::can_read_vectored(&&*self)
+    }
+
+    #[inline]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
@@ -627,6 +632,11 @@ impl<'a> io::Read for &'a UnixStream {
 
     fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         self.0.read_vectored(bufs)
+    }
+
+    #[inline]
+    fn can_read_vectored(&self) -> bool {
+        self.0.can_read_vectored()
     }
 
     #[inline]
@@ -645,6 +655,11 @@ impl io::Write for UnixStream {
         io::Write::write_vectored(&mut &*self, bufs)
     }
 
+    #[inline]
+    fn can_write_vectored(&self) -> bool {
+        io::Write::can_write_vectored(&&*self)
+    }
+
     fn flush(&mut self) -> io::Result<()> {
         io::Write::flush(&mut &*self)
     }
@@ -658,6 +673,11 @@ impl<'a> io::Write for &'a UnixStream {
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.0.write_vectored(bufs)
+    }
+
+    #[inline]
+    fn can_write_vectored(&self) -> bool {
+        self.0.can_write_vectored()
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/libstd/sys/unix/ext/net.rs
+++ b/src/libstd/sys/unix/ext/net.rs
@@ -614,8 +614,8 @@ impl io::Read for UnixStream {
     }
 
     #[inline]
-    fn can_read_vectored(&self) -> bool {
-        io::Read::can_read_vectored(&&*self)
+    fn is_read_vectored(&self) -> bool {
+        io::Read::is_read_vectored(&&*self)
     }
 
     #[inline]
@@ -635,8 +635,8 @@ impl<'a> io::Read for &'a UnixStream {
     }
 
     #[inline]
-    fn can_read_vectored(&self) -> bool {
-        self.0.can_read_vectored()
+    fn is_read_vectored(&self) -> bool {
+        self.0.is_read_vectored()
     }
 
     #[inline]
@@ -677,7 +677,7 @@ impl<'a> io::Write for &'a UnixStream {
 
     #[inline]
     fn is_write_vectored(&self) -> bool {
-        self.0.can_write_vectored()
+        self.0.is_write_vectored()
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/libstd/sys/unix/ext/net.rs
+++ b/src/libstd/sys/unix/ext/net.rs
@@ -656,8 +656,8 @@ impl io::Write for UnixStream {
     }
 
     #[inline]
-    fn can_write_vectored(&self) -> bool {
-        io::Write::can_write_vectored(&&*self)
+    fn is_write_vectored(&self) -> bool {
+        io::Write::is_write_vectored(&&*self)
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -676,7 +676,7 @@ impl<'a> io::Write for &'a UnixStream {
     }
 
     #[inline]
-    fn can_write_vectored(&self) -> bool {
+    fn is_write_vectored(&self) -> bool {
         self.0.can_write_vectored()
     }
 

--- a/src/libstd/sys/unix/fd.rs
+++ b/src/libstd/sys/unix/fd.rs
@@ -65,7 +65,7 @@ impl FileDesc {
     }
 
     #[inline]
-    pub fn can_read_vectored(&self) -> bool {
+    pub fn is_read_vectored(&self) -> bool {
         true
     }
 
@@ -122,7 +122,7 @@ impl FileDesc {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         true
     }
 

--- a/src/libstd/sys/unix/fd.rs
+++ b/src/libstd/sys/unix/fd.rs
@@ -64,6 +64,11 @@ impl FileDesc {
         Ok(ret as usize)
     }
 
+    #[inline]
+    pub fn can_read_vectored(&self) -> bool {
+        true
+    }
+
     pub fn read_to_end(&self, buf: &mut Vec<u8>) -> io::Result<usize> {
         let mut me = self;
         (&mut me).read_to_end(buf)
@@ -114,6 +119,11 @@ impl FileDesc {
             )
         })?;
         Ok(ret as usize)
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        true
     }
 
     pub fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -828,6 +828,11 @@ impl File {
         self.0.read_vectored(bufs)
     }
 
+    #[inline]
+    pub fn can_read_vectored(&self) -> bool {
+        self.0.can_read_vectored()
+    }
+
     pub fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
         self.0.read_at(buf, offset)
     }
@@ -838,6 +843,11 @@ impl File {
 
     pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.0.write_vectored(bufs)
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        self.0.can_write_vectored()
     }
 
     pub fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -829,8 +829,8 @@ impl File {
     }
 
     #[inline]
-    pub fn can_read_vectored(&self) -> bool {
-        self.0.can_read_vectored()
+    pub fn is_read_vectored(&self) -> bool {
+        self.0.is_read_vectored()
     }
 
     pub fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
@@ -846,8 +846,8 @@ impl File {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
-        self.0.can_write_vectored()
+    pub fn is_write_vectored(&self) -> bool {
+        self.0.is_write_vectored()
     }
 
     pub fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {

--- a/src/libstd/sys/unix/l4re.rs
+++ b/src/libstd/sys/unix/l4re.rs
@@ -55,7 +55,7 @@ pub mod net {
             unimpl!();
         }
 
-        pub fn can_read_vectored(&self) -> bool {
+        pub fn is_read_vectored(&self) -> bool {
             unimpl!();
         }
 
@@ -79,7 +79,7 @@ pub mod net {
             unimpl!();
         }
 
-        pub fn can_write_vectored(&self) -> bool {
+        pub fn is_write_vectored(&self) -> bool {
             unimpl!();
         }
 
@@ -179,7 +179,7 @@ pub mod net {
             unimpl!();
         }
 
-        pub fn can_read_vectored(&self) -> bool {
+        pub fn is_read_vectored(&self) -> bool {
             unimpl!();
         }
 
@@ -191,7 +191,7 @@ pub mod net {
             unimpl!();
         }
 
-        pub fn can_write_vectored(&self) -> bool {
+        pub fn is_write_vectored(&self) -> bool {
             unimpl!();
         }
 

--- a/src/libstd/sys/unix/l4re.rs
+++ b/src/libstd/sys/unix/l4re.rs
@@ -55,6 +55,10 @@ pub mod net {
             unimpl!();
         }
 
+        pub fn can_read_vectored(&self) -> bool {
+            unimpl!();
+        }
+
         pub fn peek(&self, _: &mut [u8]) -> io::Result<usize> {
             unimpl!();
         }
@@ -72,6 +76,10 @@ pub mod net {
         }
 
         pub fn write_vectored(&self, _: &[IoSlice<'_>]) -> io::Result<usize> {
+            unimpl!();
+        }
+
+        pub fn can_write_vectored(&self) -> bool {
             unimpl!();
         }
 
@@ -171,11 +179,19 @@ pub mod net {
             unimpl!();
         }
 
+        pub fn can_read_vectored(&self) -> bool {
+            unimpl!();
+        }
+
         pub fn write(&self, _: &[u8]) -> io::Result<usize> {
             unimpl!();
         }
 
         pub fn write_vectored(&self, _: &[IoSlice<'_>]) -> io::Result<usize> {
+            unimpl!();
+        }
+
+        pub fn can_write_vectored(&self) -> bool {
             unimpl!();
         }
 

--- a/src/libstd/sys/unix/net.rs
+++ b/src/libstd/sys/unix/net.rs
@@ -227,8 +227,8 @@ impl Socket {
     }
 
     #[inline]
-    pub fn can_read_vectored(&self) -> bool {
-        self.0.can_read_vectored()
+    pub fn is_read_vectored(&self) -> bool {
+        self.0.is_read_vectored()
     }
 
     fn recv_from_with_flags(
@@ -269,8 +269,8 @@ impl Socket {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
-        self.0.can_write_vectored()
+    pub fn is_write_vectored(&self) -> bool {
+        self.0.is_write_vectored()
     }
 
     pub fn set_timeout(&self, dur: Option<Duration>, kind: libc::c_int) -> io::Result<()> {

--- a/src/libstd/sys/unix/net.rs
+++ b/src/libstd/sys/unix/net.rs
@@ -226,6 +226,11 @@ impl Socket {
         self.0.read_vectored(bufs)
     }
 
+    #[inline]
+    pub fn can_read_vectored(&self) -> bool {
+        self.0.can_read_vectored()
+    }
+
     fn recv_from_with_flags(
         &self,
         buf: &mut [u8],
@@ -261,6 +266,11 @@ impl Socket {
 
     pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.0.write_vectored(bufs)
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        self.0.can_write_vectored()
     }
 
     pub fn set_timeout(&self, dur: Option<Duration>, kind: libc::c_int) -> io::Result<()> {

--- a/src/libstd/sys/unix/pipe.rs
+++ b/src/libstd/sys/unix/pipe.rs
@@ -65,8 +65,8 @@ impl AnonPipe {
     }
 
     #[inline]
-    pub fn can_read_vectored(&self) -> bool {
-        self.0.can_read_vectored()
+    pub fn is_read_vectored(&self) -> bool {
+        self.0.is_read_vectored()
     }
 
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
@@ -78,8 +78,8 @@ impl AnonPipe {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
-        self.0.can_write_vectored()
+    pub fn is_write_vectored(&self) -> bool {
+        self.0.is_write_vectored()
     }
 
     pub fn fd(&self) -> &FileDesc {

--- a/src/libstd/sys/unix/pipe.rs
+++ b/src/libstd/sys/unix/pipe.rs
@@ -64,12 +64,22 @@ impl AnonPipe {
         self.0.read_vectored(bufs)
     }
 
+    #[inline]
+    pub fn can_read_vectored(&self) -> bool {
+        self.0.can_read_vectored()
+    }
+
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
         self.0.write(buf)
     }
 
     pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.0.write_vectored(bufs)
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        self.0.can_write_vectored()
     }
 
     pub fn fd(&self) -> &FileDesc {

--- a/src/libstd/sys/unix/stdio.rs
+++ b/src/libstd/sys/unix/stdio.rs
@@ -22,7 +22,7 @@ impl io::Read for Stdin {
     }
 
     #[inline]
-    fn can_read_vectored(&self) -> bool {
+    fn is_read_vectored(&self) -> bool {
         true
     }
 }
@@ -43,7 +43,7 @@ impl io::Write for Stdout {
     }
 
     #[inline]
-    fn can_write_vectored(&self) -> bool {
+    fn is_write_vectored(&self) -> bool {
         true
     }
 
@@ -68,7 +68,7 @@ impl io::Write for Stderr {
     }
 
     #[inline]
-    fn can_write_vectored(&self) -> bool {
+    fn is_write_vectored(&self) -> bool {
         true
     }
 

--- a/src/libstd/sys/unix/stdio.rs
+++ b/src/libstd/sys/unix/stdio.rs
@@ -20,6 +20,11 @@ impl io::Read for Stdin {
     fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         ManuallyDrop::new(FileDesc::new(libc::STDIN_FILENO)).read_vectored(bufs)
     }
+
+    #[inline]
+    fn can_read_vectored(&self) -> bool {
+        true
+    }
 }
 
 impl Stdout {
@@ -35,6 +40,11 @@ impl io::Write for Stdout {
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         ManuallyDrop::new(FileDesc::new(libc::STDOUT_FILENO)).write_vectored(bufs)
+    }
+
+    #[inline]
+    fn can_write_vectored(&self) -> bool {
+        true
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -55,6 +65,11 @@ impl io::Write for Stderr {
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         ManuallyDrop::new(FileDesc::new(libc::STDERR_FILENO)).write_vectored(bufs)
+    }
+
+    #[inline]
+    fn can_write_vectored(&self) -> bool {
+        true
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/libstd/sys/vxworks/fd.rs
+++ b/src/libstd/sys/vxworks/fd.rs
@@ -55,7 +55,7 @@ impl FileDesc {
     }
 
     #[inline]
-    fn can_read_vectored(&self) -> bool {
+    fn is_read_vectored(&self) -> bool {
         true
     }
 
@@ -105,7 +105,7 @@ impl FileDesc {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         true
     }
 

--- a/src/libstd/sys/vxworks/fd.rs
+++ b/src/libstd/sys/vxworks/fd.rs
@@ -54,6 +54,11 @@ impl FileDesc {
         Ok(ret as usize)
     }
 
+    #[inline]
+    fn can_read_vectored(&self) -> bool {
+        true
+    }
+
     pub fn read_to_end(&self, buf: &mut Vec<u8>) -> io::Result<usize> {
         let mut me = self;
         (&mut me).read_to_end(buf)
@@ -97,6 +102,11 @@ impl FileDesc {
             )
         })?;
         Ok(ret as usize)
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        true
     }
 
     pub fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {

--- a/src/libstd/sys/vxworks/fs.rs
+++ b/src/libstd/sys/vxworks/fs.rs
@@ -351,6 +351,11 @@ impl File {
         self.0.read_vectored(bufs)
     }
 
+    #[inline]
+    pub fn can_read_vectored(&self) -> bool {
+        self.0.can_read_vectored()
+    }
+
     pub fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
         self.0.read_at(buf, offset)
     }
@@ -361,6 +366,11 @@ impl File {
 
     pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.0.write_vectored(bufs)
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        self.0.can_write_vectored()
     }
 
     pub fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {

--- a/src/libstd/sys/vxworks/fs.rs
+++ b/src/libstd/sys/vxworks/fs.rs
@@ -352,8 +352,8 @@ impl File {
     }
 
     #[inline]
-    pub fn can_read_vectored(&self) -> bool {
-        self.0.can_read_vectored()
+    pub fn is_read_vectored(&self) -> bool {
+        self.0.is_read_vectored()
     }
 
     pub fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
@@ -369,8 +369,8 @@ impl File {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
-        self.0.can_write_vectored()
+    pub fn is_write_vectored(&self) -> bool {
+        self.0.is_write_vectored()
     }
 
     pub fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {

--- a/src/libstd/sys/vxworks/net.rs
+++ b/src/libstd/sys/vxworks/net.rs
@@ -163,6 +163,11 @@ impl Socket {
         self.0.read_vectored(bufs)
     }
 
+    #[inline]
+    pub fn can_read_vectored(&self) -> bool {
+        self.0.can_read_vectored()
+    }
+
     fn recv_from_with_flags(
         &self,
         buf: &mut [u8],
@@ -198,6 +203,11 @@ impl Socket {
 
     pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.0.write_vectored(bufs)
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        self.0.can_write_vectored()
     }
 
     pub fn set_timeout(&self, dur: Option<Duration>, kind: libc::c_int) -> io::Result<()> {

--- a/src/libstd/sys/vxworks/net.rs
+++ b/src/libstd/sys/vxworks/net.rs
@@ -164,8 +164,8 @@ impl Socket {
     }
 
     #[inline]
-    pub fn can_read_vectored(&self) -> bool {
-        self.0.can_read_vectored()
+    pub fn is_read_vectored(&self) -> bool {
+        self.0.is_read_vectored()
     }
 
     fn recv_from_with_flags(
@@ -206,8 +206,8 @@ impl Socket {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
-        self.0.can_write_vectored()
+    pub fn is_write_vectored(&self) -> bool {
+        self.0.is_write_vectored()
     }
 
     pub fn set_timeout(&self, dur: Option<Duration>, kind: libc::c_int) -> io::Result<()> {

--- a/src/libstd/sys/vxworks/pipe.rs
+++ b/src/libstd/sys/vxworks/pipe.rs
@@ -30,8 +30,8 @@ impl AnonPipe {
     }
 
     #[inline]
-    pub fn can_read_vectored(&self) -> bool {
-        self.0.can_read_vectored()
+    pub fn is_read_vectored(&self) -> bool {
+        self.0.is_read_vectored()
     }
 
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
@@ -43,8 +43,8 @@ impl AnonPipe {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
-        self.0.can_write_vectored()
+    pub fn is_write_vectored(&self) -> bool {
+        self.0.is_write_vectored()
     }
 
     pub fn fd(&self) -> &FileDesc {

--- a/src/libstd/sys/vxworks/pipe.rs
+++ b/src/libstd/sys/vxworks/pipe.rs
@@ -24,8 +24,14 @@ impl AnonPipe {
     pub fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.0.read(buf)
     }
+
     pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         self.0.read_vectored(bufs)
+    }
+
+    #[inline]
+    pub fn can_read_vectored(&self) -> bool {
+        self.0.can_read_vectored()
     }
 
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
@@ -34,6 +40,11 @@ impl AnonPipe {
 
     pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.0.write_vectored(bufs)
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        self.0.can_write_vectored()
     }
 
     pub fn fd(&self) -> &FileDesc {

--- a/src/libstd/sys/wasi/fs.rs
+++ b/src/libstd/sys/wasi/fs.rs
@@ -400,7 +400,7 @@ impl File {
     }
 
     #[inline]
-    pub fn can_read_vectored(&self) -> bool {
+    pub fn is_read_vectored(&self) -> bool {
         true
     }
 
@@ -413,7 +413,7 @@ impl File {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         true
     }
 

--- a/src/libstd/sys/wasi/fs.rs
+++ b/src/libstd/sys/wasi/fs.rs
@@ -399,12 +399,22 @@ impl File {
         self.fd.read(bufs)
     }
 
+    #[inline]
+    pub fn can_read_vectored(&self) -> bool {
+        true
+    }
+
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
         self.write_vectored(&[IoSlice::new(buf)])
     }
 
     pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.fd.write(bufs)
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        true
     }
 
     pub fn flush(&self) -> io::Result<()> {

--- a/src/libstd/sys/wasi/net.rs
+++ b/src/libstd/sys/wasi/net.rs
@@ -48,7 +48,7 @@ impl TcpStream {
         unsupported()
     }
 
-    pub fn can_read_vectored(&self) -> bool {
+    pub fn is_read_vectored(&self) -> bool {
         unsupported()
     }
 
@@ -60,7 +60,7 @@ impl TcpStream {
         unsupported()
     }
 
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         unsupported()
     }
 

--- a/src/libstd/sys/wasi/net.rs
+++ b/src/libstd/sys/wasi/net.rs
@@ -49,7 +49,7 @@ impl TcpStream {
     }
 
     pub fn is_read_vectored(&self) -> bool {
-        unsupported()
+        true
     }
 
     pub fn write(&self, _: &[u8]) -> io::Result<usize> {
@@ -61,7 +61,7 @@ impl TcpStream {
     }
 
     pub fn is_write_vectored(&self) -> bool {
-        unsupported()
+        true
     }
 
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {

--- a/src/libstd/sys/wasi/net.rs
+++ b/src/libstd/sys/wasi/net.rs
@@ -48,11 +48,19 @@ impl TcpStream {
         unsupported()
     }
 
+    pub fn can_read_vectored(&self) -> bool {
+        unsupported()
+    }
+
     pub fn write(&self, _: &[u8]) -> io::Result<usize> {
         unsupported()
     }
 
     pub fn write_vectored(&self, _: &[IoSlice<'_>]) -> io::Result<usize> {
+        unsupported()
+    }
+
+    pub fn can_write_vectored(&self) -> bool {
         unsupported()
     }
 

--- a/src/libstd/sys/wasi/pipe.rs
+++ b/src/libstd/sys/wasi/pipe.rs
@@ -12,11 +12,19 @@ impl AnonPipe {
         match self.0 {}
     }
 
+    pub fn can_read_vectored(&self) -> bool {
+        match self.0 {}
+    }
+
     pub fn write(&self, _buf: &[u8]) -> io::Result<usize> {
         match self.0 {}
     }
 
     pub fn write_vectored(&self, _bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        match self.0 {}
+    }
+
+    pub fn can_write_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/wasi/pipe.rs
+++ b/src/libstd/sys/wasi/pipe.rs
@@ -12,7 +12,7 @@ impl AnonPipe {
         match self.0 {}
     }
 
-    pub fn can_read_vectored(&self) -> bool {
+    pub fn is_read_vectored(&self) -> bool {
         match self.0 {}
     }
 
@@ -24,7 +24,7 @@ impl AnonPipe {
         match self.0 {}
     }
 
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/wasi/stdio.rs
+++ b/src/libstd/sys/wasi/stdio.rs
@@ -20,7 +20,7 @@ impl Stdin {
     }
 
     #[inline]
-    pub fn can_read_vectored(&self) -> bool {
+    pub fn is_read_vectored(&self) -> bool {
         true
     }
 
@@ -43,7 +43,7 @@ impl Stdout {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         true
     }
 
@@ -70,7 +70,7 @@ impl Stderr {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         true
     }
 

--- a/src/libstd/sys/wasi/stdio.rs
+++ b/src/libstd/sys/wasi/stdio.rs
@@ -19,6 +19,11 @@ impl Stdin {
         ManuallyDrop::new(unsafe { WasiFd::from_raw(self.as_raw_fd()) }).read(data)
     }
 
+    #[inline]
+    pub fn can_read_vectored(&self) -> bool {
+        true
+    }
+
     pub fn as_raw_fd(&self) -> u32 {
         0
     }
@@ -35,6 +40,11 @@ impl Stdout {
 
     pub fn write_vectored(&self, data: &[IoSlice<'_>]) -> io::Result<usize> {
         ManuallyDrop::new(unsafe { WasiFd::from_raw(self.as_raw_fd()) }).write(data)
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        true
     }
 
     pub fn flush(&self) -> io::Result<()> {
@@ -57,6 +67,11 @@ impl Stderr {
 
     pub fn write_vectored(&self, data: &[IoSlice<'_>]) -> io::Result<usize> {
         ManuallyDrop::new(unsafe { WasiFd::from_raw(self.as_raw_fd()) }).write(data)
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        true
     }
 
     pub fn flush(&self) -> io::Result<()> {

--- a/src/libstd/sys/wasm/fs.rs
+++ b/src/libstd/sys/wasm/fs.rs
@@ -202,11 +202,19 @@ impl File {
         match self.0 {}
     }
 
+    pub fn can_read_vectored(&self) -> bool {
+        match self.0 {}
+    }
+
     pub fn write(&self, _buf: &[u8]) -> io::Result<usize> {
         match self.0 {}
     }
 
     pub fn write_vectored(&self, _bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        match self.0 {}
+    }
+
+    pub fn can_write_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/wasm/fs.rs
+++ b/src/libstd/sys/wasm/fs.rs
@@ -202,7 +202,7 @@ impl File {
         match self.0 {}
     }
 
-    pub fn can_read_vectored(&self) -> bool {
+    pub fn is_read_vectored(&self) -> bool {
         match self.0 {}
     }
 
@@ -214,7 +214,7 @@ impl File {
         match self.0 {}
     }
 
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/wasm/net.rs
+++ b/src/libstd/sys/wasm/net.rs
@@ -44,7 +44,7 @@ impl TcpStream {
         match self.0 {}
     }
 
-    pub fn can_read_vectored(&self) -> bool {
+    pub fn is_read_vectored(&self) -> bool {
         match self.0 {}
     }
 
@@ -56,7 +56,7 @@ impl TcpStream {
         match self.0 {}
     }
 
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/wasm/net.rs
+++ b/src/libstd/sys/wasm/net.rs
@@ -44,11 +44,19 @@ impl TcpStream {
         match self.0 {}
     }
 
+    pub fn can_read_vectored(&self) -> bool {
+        match self.0 {}
+    }
+
     pub fn write(&self, _: &[u8]) -> io::Result<usize> {
         match self.0 {}
     }
 
     pub fn write_vectored(&self, _: &[IoSlice<'_>]) -> io::Result<usize> {
+        match self.0 {}
+    }
+
+    pub fn can_write_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/wasm/pipe.rs
+++ b/src/libstd/sys/wasm/pipe.rs
@@ -12,11 +12,19 @@ impl AnonPipe {
         match self.0 {}
     }
 
+    pub fn is_read_vectored(&self) -> bool {
+        match self.0 {}
+    }
+
     pub fn write(&self, _buf: &[u8]) -> io::Result<usize> {
         match self.0 {}
     }
 
     pub fn write_vectored(&self, _bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        match self.0 {}
+    }
+
+    pub fn is_write_vectored(&self) -> bool {
         match self.0 {}
     }
 

--- a/src/libstd/sys/windows/fs.rs
+++ b/src/libstd/sys/windows/fs.rs
@@ -409,6 +409,11 @@ impl File {
         self.handle.read_vectored(bufs)
     }
 
+    #[inline]
+    pub fn can_read_vectored(&self) -> bool {
+        self.handle.can_read_vectored()
+    }
+
     pub fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
         self.handle.read_at(buf, offset)
     }
@@ -419,6 +424,11 @@ impl File {
 
     pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.handle.write_vectored(bufs)
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        self.handle.can_write_vectored()
     }
 
     pub fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {

--- a/src/libstd/sys/windows/fs.rs
+++ b/src/libstd/sys/windows/fs.rs
@@ -410,8 +410,8 @@ impl File {
     }
 
     #[inline]
-    pub fn can_read_vectored(&self) -> bool {
-        self.handle.can_read_vectored()
+    pub fn is_read_vectored(&self) -> bool {
+        self.handle.is_read_vectored()
     }
 
     pub fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
@@ -427,8 +427,8 @@ impl File {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
-        self.handle.can_write_vectored()
+    pub fn is_write_vectored(&self) -> bool {
+        self.handle.is_write_vectored()
     }
 
     pub fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {

--- a/src/libstd/sys/windows/handle.rs
+++ b/src/libstd/sys/windows/handle.rs
@@ -92,6 +92,11 @@ impl RawHandle {
         crate::io::default_read_vectored(|buf| self.read(buf), bufs)
     }
 
+    #[inline]
+    pub fn can_read_vectored(&self) -> bool {
+        false
+    }
+
     pub fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
         let mut read = 0;
         let len = cmp::min(buf.len(), <c::DWORD>::max_value() as usize) as c::DWORD;
@@ -169,6 +174,11 @@ impl RawHandle {
 
     pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         crate::io::default_write_vectored(|buf| self.write(buf), bufs)
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        false
     }
 
     pub fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {

--- a/src/libstd/sys/windows/handle.rs
+++ b/src/libstd/sys/windows/handle.rs
@@ -93,7 +93,7 @@ impl RawHandle {
     }
 
     #[inline]
-    pub fn can_read_vectored(&self) -> bool {
+    pub fn is_read_vectored(&self) -> bool {
         false
     }
 
@@ -177,7 +177,7 @@ impl RawHandle {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         false
     }
 

--- a/src/libstd/sys/windows/net.rs
+++ b/src/libstd/sys/windows/net.rs
@@ -267,7 +267,7 @@ impl Socket {
     }
 
     #[inline]
-    pub fn can_read_vectored(&self) -> bool {
+    pub fn is_read_vectored(&self) -> bool {
         true
     }
 
@@ -330,7 +330,7 @@ impl Socket {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
+    pub fn is_write_vectored(&self) -> bool {
         true
     }
 

--- a/src/libstd/sys/windows/net.rs
+++ b/src/libstd/sys/windows/net.rs
@@ -266,6 +266,11 @@ impl Socket {
         }
     }
 
+    #[inline]
+    pub fn can_read_vectored(&self) -> bool {
+        true
+    }
+
     pub fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.recv_with_flags(buf, c::MSG_PEEK)
     }
@@ -322,6 +327,11 @@ impl Socket {
             ))?;
         }
         Ok(nwritten as usize)
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        true
     }
 
     pub fn set_timeout(&self, dur: Option<Duration>, kind: c_int) -> io::Result<()> {

--- a/src/libstd/sys/windows/pipe.rs
+++ b/src/libstd/sys/windows/pipe.rs
@@ -183,8 +183,8 @@ impl AnonPipe {
     }
 
     #[inline]
-    pub fn can_read_vectored(&self) -> bool {
-        self.inner.can_read_vectored()
+    pub fn is_read_vectored(&self) -> bool {
+        self.inner.is_read_vectored()
     }
 
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
@@ -196,8 +196,8 @@ impl AnonPipe {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
-        self.inner.can_write_vectored()
+    pub fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
     }
 }
 

--- a/src/libstd/sys/windows/pipe.rs
+++ b/src/libstd/sys/windows/pipe.rs
@@ -182,12 +182,22 @@ impl AnonPipe {
         self.inner.read_vectored(bufs)
     }
 
+    #[inline]
+    pub fn can_read_vectored(&self) -> bool {
+        self.inner.can_read_vectored()
+    }
+
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
         self.inner.write(buf)
     }
 
     pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.inner.write_vectored(bufs)
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        self.inner.can_write_vectored()
     }
 }
 

--- a/src/libstd/sys_common/net.rs
+++ b/src/libstd/sys_common/net.rs
@@ -266,8 +266,8 @@ impl TcpStream {
     }
 
     #[inline]
-    pub fn can_read_vectored(&self) -> bool {
-        self.inner.can_read_vectored()
+    pub fn is_read_vectored(&self) -> bool {
+        self.inner.is_read_vectored()
     }
 
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
@@ -283,8 +283,8 @@ impl TcpStream {
     }
 
     #[inline]
-    pub fn can_write_vectored(&self) -> bool {
-        self.inner.can_write_vectored()
+    pub fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
     }
 
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {

--- a/src/libstd/sys_common/net.rs
+++ b/src/libstd/sys_common/net.rs
@@ -265,6 +265,11 @@ impl TcpStream {
         self.inner.read_vectored(bufs)
     }
 
+    #[inline]
+    pub fn can_read_vectored(&self) -> bool {
+        self.inner.can_read_vectored()
+    }
+
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
         let len = cmp::min(buf.len(), <wrlen_t>::max_value() as usize) as wrlen_t;
         let ret = cvt(unsafe {
@@ -275,6 +280,11 @@ impl TcpStream {
 
     pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.inner.write_vectored(bufs)
+    }
+
+    #[inline]
+    pub fn can_write_vectored(&self) -> bool {
+        self.inner.can_write_vectored()
     }
 
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {


### PR DESCRIPTION
When working with an arbitrary reader or writer, code that uses vectored
operations may end up being slower than code that copies into a single
buffer when the underlying reader or writer doesn't actually support
vectored operations. These new methods allow you to ask the reader or
witer up front if vectored operations are efficiently supported.

Currently, you have to use some heuristics to guess by e.g. checking if
the read or write only accessed the first buffer. Hyper is one concrete
example of a library that has to do this dynamically:
https://github.com/hyperium/hyper/blob/0eaf304644a396895a4ce1f0146e596640bb666a/src/proto/h1/io.rs#L582-L594