### PR TITLE
Remove unused `#[link_name = "m"]` attributes

### DIFF
--- a/src/libstd/sys/unix/cmath.rs
+++ b/src/libstd/sys/unix/cmath.rs
@@ -2,7 +2,6 @@
 
 use libc::{c_double, c_float};
 
-#[link_name = "m"]
 extern "C" {
     pub fn acos(n: c_double) -> c_double;
     pub fn acosf(n: c_float) -> c_float;

--- a/src/libstd/sys/vxworks/cmath.rs
+++ b/src/libstd/sys/vxworks/cmath.rs
@@ -2,7 +2,6 @@
 
 use libc::{c_double, c_float};
 
-#[link_name = "m"]
 extern "C" {
     pub fn acos(n: c_double) -> c_double;
     pub fn acosf(n: c_float) -> c_float;

--- a/src/libstd/sys/windows/cmath.rs
+++ b/src/libstd/sys/windows/cmath.rs
@@ -2,7 +2,6 @@
 
 use libc::{c_double, c_float};
 
-#[link_name = "m"]
 extern "C" {
     pub fn acos(n: c_double) -> c_double;
     pub fn asin(n: c_double) -> c_double;


### PR DESCRIPTION
These were perhaps supposed to be `#[link(name = "m")]` but linking libm should be handled by the libc crate anyway.

They should have triggered a compile error: #47725