### PR TITLE
Fix emoji size to be congruent

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -796,10 +796,6 @@ body.blur > :not(#help) {
 	display: list-item;
 }
 
-.stab .emoji {
-	font-size: 1.5em;
-}
-
 .module-item .stab {
 	border-radius: 3px;
 	display: inline-block;


### PR DESCRIPTION
Original emoji looks exceptionally huge

![2020-01-04-225119_824x120_scrot](https://user-images.githubusercontent.com/4687791/71767666-61506c00-2f49-11ea-9369-ffa228898f4b.png)

Which looks weird compared to those without emoji

![2020-01-04-225204_822x212_scrot](https://user-images.githubusercontent.com/4687791/71767672-72997880-2f49-11ea-9f34-7bd4d649316a.png)

Updated to match font size and box

![2020-01-04-225143_826x100_scrot](https://user-images.githubusercontent.com/4687791/71767660-585f9a80-2f49-11ea-973a-e16b69c444e9.png)

By the way, I think we should have an emoji for deprecation. I suggest coffin so far, later in another pull request.