### PR TITLE
Omit underscore constants from rustdoc

### DIFF
--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -9,7 +9,7 @@ use rustc::ty::TyCtxt;
 use rustc::util::nodemap::{FxHashMap, FxHashSet};
 use rustc_span::hygiene::MacroKind;
 use rustc_span::source_map::Spanned;
-use rustc_span::symbol::sym;
+use rustc_span::symbol::{kw, sym};
 use rustc_span::{self, Span};
 use syntax::ast;
 
@@ -513,16 +513,20 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                 om.statics.push(s);
             }
             hir::ItemKind::Const(type_, expr) => {
-                let s = Constant {
-                    type_,
-                    expr,
-                    id: item.hir_id,
-                    name: ident.name,
-                    attrs: &item.attrs,
-                    whence: item.span,
-                    vis: &item.vis,
-                };
-                om.constants.push(s);
+                // Underscore constants do not correspond to a nameable item and
+                // so are never useful in documentation.
+                if ident.name != kw::Underscore {
+                    let s = Constant {
+                        type_,
+                        expr,
+                        id: item.hir_id,
+                        name: ident.name,
+                        attrs: &item.attrs,
+                        whence: item.span,
+                        vis: &item.vis,
+                    };
+                    om.constants.push(s);
+                }
             }
             hir::ItemKind::Trait(is_auto, unsafety, ref generics, ref bounds, ref item_ids) => {
                 let items = item_ids.iter().map(|ti| self.cx.tcx.hir().trait_item(ti.id)).collect();

--- a/src/test/rustdoc/const-underscore.rs
+++ b/src/test/rustdoc/const-underscore.rs
@@ -1,0 +1,7 @@
+// compile-flags: --document-private-items
+
+// @!has const_underscore/constant._.html
+const _: () = {
+    #[no_mangle]
+    extern "C" fn implementation_detail() {}
+};


### PR DESCRIPTION
Underscore constants from https://github.com/rust-lang/rfcs/pull/2526 / https://github.com/rust-lang/rust/issues/54912 do not correspond to a nameable item and so are never useful in documentation.
<br>

#### Before:

> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<img src="https://user-images.githubusercontent.com/1940490/71771409-0427cc80-2eef-11ea-8b7d-d9c74a873e7e.png" width="60%">

#### After:

> Not that.