### PR TITLE
Change opt-level from 2 back to 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,6 @@ exclude = [
   "obj",
 ]
 
-# Curiously, LLVM 7.0 will segfault if compiled with opt-level=3
-# See issue https://github.com/rust-lang/rust/issues/52378
-[profile.release]
-opt-level = 2
-[profile.bench]
-opt-level = 2
-
 # These options are controlled from our rustc wrapper script, so turn them off
 # here and have them controlled elsewhere.
 [profile.dev]

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -38,6 +38,9 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
     /// Returns `true` as long as there are more things to do.
     ///
     /// This is used by [priroda](https://github.com/oli-obk/priroda)
+    ///
+    /// This is marked `#inline(always)` to work around adverserial codegen when `opt-level = 3`
+    #[inline(always)]
     pub fn step(&mut self) -> InterpResult<'tcx, bool> {
         if self.stack.is_empty() {
             return Ok(false);

--- a/src/test/run-make/wasm-stringify-ints-small/Makefile
+++ b/src/test/run-make/wasm-stringify-ints-small/Makefile
@@ -4,7 +4,7 @@ ifeq ($(TARGET),wasm32-unknown-unknown)
 all:
 	$(RUSTC) foo.rs -C lto -O --target wasm32-unknown-unknown
 	wc -c < $(TMPDIR)/foo.wasm
-	[ "`wc -c < $(TMPDIR)/foo.wasm`" -lt "20500" ]
+	[ "`wc -c < $(TMPDIR)/foo.wasm`" -lt "25000" ]
 else
 all:
 endif


### PR DESCRIPTION
In Cargo.toml, the opt-level for `release` and `bench` was overridden to be 2. This was to work around a problem with LLVM 7. However, rust no longer uses LLVM 7, so this is hopefully no longer needed?

I tried a little bit to replicate the original problem, and could not. I think running this through CI is the best way to smoke test this :) Even if things break dramatically, the comment should be updated to reflect that things are still broken with LLVM 9. 

I'm just getting started playing with the compiler, so apologies if I've missed an obvious problem here.

fixes #52378

(possibly relevant is the [current update to LLVM 10](https://github.com/rust-lang/rust/pull/67759))