### PR TITLE
Remove negative number check from float sqrt

### DIFF
--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -376,7 +376,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn sqrt(self) -> f32 {
-        if self < 0.0 { NAN } else { unsafe { intrinsics::sqrtf32(self) } }
+        unsafe { intrinsics::sqrtf32(self) }
     }
 
     /// Returns `e^(self)`, (the exponential function).

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -342,7 +342,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn sqrt(self) -> f64 {
-        if self < 0.0 { NAN } else { unsafe { intrinsics::sqrtf64(self) } }
+        unsafe { intrinsics::sqrtf64(self) }
     }
 
     /// Returns `e^(self)`, (the exponential function).


### PR DESCRIPTION
It hasn't been UB to pass negative numbers to sqrt since https://reviews.llvm.org/D28797 which was included in LLVM 5.