### PR TITLE
Handle multiple error fix suggestions carefuly

### DIFF
--- a/src/test/ui/type/issue-67690-type-alias-bound-diagnostic-crash.rs
+++ b/src/test/ui/type/issue-67690-type-alias-bound-diagnostic-crash.rs
@@ -1,0 +1,8 @@
+// Regression test for issue #67690
+// Rustc endless loop out-of-memory and consequent SIGKILL in generic new type
+
+// check-pass
+pub type T<P: Send + Send + Send> = P;
+//~^ WARN bounds on generic parameters are not enforced in type aliases
+
+fn main() {}

--- a/src/test/ui/type/issue-67690-type-alias-bound-diagnostic-crash.stderr
+++ b/src/test/ui/type/issue-67690-type-alias-bound-diagnostic-crash.stderr
@@ -1,0 +1,12 @@
+warning: bounds on generic parameters are not enforced in type aliases
+  --> $DIR/issue-67690-type-alias-bound-diagnostic-crash.rs:5:15
+   |
+LL | pub type T<P: Send + Send + Send> = P;
+   |               ^^^^   ^^^^   ^^^^
+   |
+   = note: `#[warn(type_alias_bounds)]` on by default
+help: the bound will not be checked when the type alias is used, and should be removed
+   |
+LL | pub type T<P> = P;
+   |            --
+

--- a/src/test/ui/type/type-alias-bounds.rs
+++ b/src/test/ui/type/type-alias-bounds.rs
@@ -1,6 +1,6 @@
 // Test `ignored_generic_bounds` lint warning about bounds in type aliases.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![allow(dead_code)]
 
 use std::rc::Rc;

--- a/src/test/ui/type/type-alias-bounds.stderr
+++ b/src/test/ui/type/type-alias-bounds.stderr
@@ -8,7 +8,7 @@ LL | type SVec<T: Send + Send> = Vec<T>;
 help: the bound will not be checked when the type alias is used, and should be removed
    |
 LL | type SVec<T> = Vec<T>;
-   |     --    --
+   |           --
 
 warning: where clauses are not enforced in type aliases
   --> $DIR/type-alias-bounds.rs:10:21
@@ -30,7 +30,7 @@ LL | type VVec<'b, 'a: 'b + 'b> = (&'b u32, Vec<&'a i32>);
 help: the bound will not be checked when the type alias is used, and should be removed
    |
 LL | type VVec<'b, 'a> = (&'b u32, Vec<&'a i32>);
-   |            --  --
+   |                --
 
 warning: bounds on generic parameters are not enforced in type aliases
   --> $DIR/type-alias-bounds.rs:14:18
@@ -41,7 +41,7 @@ LL | type WVec<'b, T: 'b + 'b> = (&'b u32, Vec<T>);
 help: the bound will not be checked when the type alias is used, and should be removed
    |
 LL | type WVec<'b, T> = (&'b u32, Vec<T>);
-   |           --  --
+   |               --
 
 warning: where clauses are not enforced in type aliases
   --> $DIR/type-alias-bounds.rs:16:25


### PR DESCRIPTION
The existing code seems to assume that substitutions spans are disjoint,
which is not always the case.

In the example:

    pub trait AAAA {}
    pub trait B {}
    pub trait C {}
    pub type T<P: AAAA + B + C> = P;

, we get three substituions starting from ':' and ending respectively at
the end of each trait token.

With the former offset calculation, this would cause `underline_start` to
eventually become negative before being converted to `usize`...

The new version may report erroneous results for non perfectly overlapping
substitutions but I don't know if such examples exist. Alternatively, we
could detect these cases and trim out overlapping substitutions.

Fixes #67690