### PR TITLE
perf: Avoid re-interning types in outlives checking

### DIFF
--- a/src/librustc/infer/lexical_region_resolve/mod.rs
+++ b/src/librustc/infer/lexical_region_resolve/mod.rs
@@ -602,7 +602,7 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
                 continue;
             }
 
-            let verify_kind_ty = verify.kind.to_ty(self.tcx());
+            let verify_kind_ty = verify.kind.as_ty();
             if self.bound_is_met(&verify.bound, var_data, verify_kind_ty, sub) {
                 continue;
             }

--- a/src/librustc/infer/outlives/obligations.rs
+++ b/src/librustc/infer/outlives/obligations.rs
@@ -337,7 +337,7 @@ where
         &mut self,
         origin: infer::SubregionOrigin<'tcx>,
         region: ty::Region<'tcx>,
-        projection_ty: ty::ProjectionTy<'tcx>,
+        projection_ty: ty::View<'tcx, ty::ProjectionTy<'tcx>>,
     ) {
         debug!(
             "projection_must_outlive(region={:?}, projection_ty={:?}, origin={:?})",
@@ -376,8 +376,8 @@ where
         // #55756) in cases where you have e.g., `<T as Foo<'a>>::Item:
         // 'a` in the environment but `trait Foo<'b> { type Item: 'b
         // }` in the trait definition.
-        approx_env_bounds.retain(|bound| match bound.0.kind {
-            ty::Projection(projection_ty) => self
+        approx_env_bounds.retain(|bound| match bound.0.into() {
+            ty::view::Projection(projection_ty) => self
                 .verify_bound
                 .projection_declared_bounds_from_trait(projection_ty)
                 .all(|r| r != bound.1),

--- a/src/librustc/infer/outlives/obligations.rs
+++ b/src/librustc/infer/outlives/obligations.rs
@@ -321,7 +321,7 @@ where
         &mut self,
         origin: infer::SubregionOrigin<'tcx>,
         region: ty::Region<'tcx>,
-        param_ty: ty::ParamTy,
+        param_ty: ty::View<'tcx, ty::ParamTy>,
     ) {
         debug!(
             "param_ty_must_outlive(region={:?}, param_ty={:?}, origin={:?})",

--- a/src/librustc/infer/region_constraints/mod.rs
+++ b/src/librustc/infer/region_constraints/mod.rs
@@ -184,7 +184,7 @@ pub struct Verify<'tcx> {
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, TypeFoldable)]
 pub enum GenericKind<'tcx> {
-    Param(ty::ParamTy),
+    Param(ty::View<'tcx, ty::ParamTy>),
     Projection(ty::ProjectionTy<'tcx>),
 }
 

--- a/src/librustc/infer/region_constraints/mod.rs
+++ b/src/librustc/infer/region_constraints/mod.rs
@@ -904,18 +904,13 @@ impl<'tcx> VerifyBound<'tcx> {
         }
     }
 
-    pub fn or(self, vb: impl FnOnce() -> VerifyBound<'tcx>) -> VerifyBound<'tcx> {
-        if self.must_hold() {
+    pub fn or(self, vb: VerifyBound<'tcx>) -> VerifyBound<'tcx> {
+        if self.must_hold() || vb.cannot_hold() {
             self
+        } else if self.cannot_hold() || vb.must_hold() {
+            vb
         } else {
-            let vb = vb();
-            if vb.cannot_hold() {
-                self
-            } else if self.cannot_hold() || vb.must_hold() {
-                vb
-            } else {
-                VerifyBound::AnyBound(vec![self, vb])
-            }
+            VerifyBound::AnyBound(vec![self, vb])
         }
     }
 

--- a/src/librustc/infer/region_constraints/mod.rs
+++ b/src/librustc/infer/region_constraints/mod.rs
@@ -185,7 +185,7 @@ pub struct Verify<'tcx> {
 #[derive(Copy, Clone, PartialEq, Eq, Hash, TypeFoldable)]
 pub enum GenericKind<'tcx> {
     Param(ty::View<'tcx, ty::ParamTy>),
-    Projection(ty::ProjectionTy<'tcx>),
+    Projection(ty::View<'tcx, ty::ProjectionTy<'tcx>>),
 }
 
 /// Describes the things that some `GenericKind` value `G` is known to
@@ -875,10 +875,10 @@ impl<'tcx> fmt::Display for GenericKind<'tcx> {
 }
 
 impl<'tcx> GenericKind<'tcx> {
-    pub fn to_ty(&self, tcx: TyCtxt<'tcx>) -> Ty<'tcx> {
+    pub fn as_ty(&self) -> Ty<'tcx> {
         match *self {
-            GenericKind::Param(ref p) => p.to_ty(tcx),
-            GenericKind::Projection(ref p) => tcx.mk_projection(p.item_def_id, p.substs),
+            GenericKind::Param(ref p) => p.as_ty(),
+            GenericKind::Projection(ref p) => p.as_ty(),
         }
     }
 }
@@ -904,13 +904,18 @@ impl<'tcx> VerifyBound<'tcx> {
         }
     }
 
-    pub fn or(self, vb: VerifyBound<'tcx>) -> VerifyBound<'tcx> {
-        if self.must_hold() || vb.cannot_hold() {
+    pub fn or(self, vb: impl FnOnce() -> VerifyBound<'tcx>) -> VerifyBound<'tcx> {
+        if self.must_hold() {
             self
-        } else if self.cannot_hold() || vb.must_hold() {
-            vb
         } else {
-            VerifyBound::AnyBound(vec![self, vb])
+            let vb = vb();
+            if vb.cannot_hold() {
+                self
+            } else if self.cannot_hold() || vb.must_hold() {
+                vb
+            } else {
+                VerifyBound::AnyBound(vec![self, vb])
+            }
         }
     }
 

--- a/src/librustc/traits/query/outlives_bounds.rs
+++ b/src/librustc/traits/query/outlives_bounds.rs
@@ -20,7 +20,7 @@ use std::mem;
 #[derive(Clone, Debug, TypeFoldable, Lift)]
 pub enum OutlivesBound<'tcx> {
     RegionSubRegion(ty::Region<'tcx>, ty::Region<'tcx>),
-    RegionSubParam(ty::Region<'tcx>, ty::ParamTy),
+    RegionSubParam(ty::Region<'tcx>, ty::View<'tcx, ty::ParamTy>),
     RegionSubProjection(ty::Region<'tcx>, ty::ProjectionTy<'tcx>),
 }
 

--- a/src/librustc/traits/query/outlives_bounds.rs
+++ b/src/librustc/traits/query/outlives_bounds.rs
@@ -21,7 +21,7 @@ use std::mem;
 pub enum OutlivesBound<'tcx> {
     RegionSubRegion(ty::Region<'tcx>, ty::Region<'tcx>),
     RegionSubParam(ty::Region<'tcx>, ty::View<'tcx, ty::ParamTy>),
-    RegionSubProjection(ty::Region<'tcx>, ty::ProjectionTy<'tcx>),
+    RegionSubProjection(ty::Region<'tcx>, ty::View<'tcx, ty::ProjectionTy<'tcx>>),
 }
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for OutlivesBound<'tcx> {

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -89,6 +89,8 @@ pub use self::trait_def::TraitDef;
 
 pub use self::query::queries;
 
+pub use self::view::View;
+
 pub mod adjustment;
 pub mod binding;
 pub mod cast;
@@ -112,6 +114,7 @@ pub mod steal;
 pub mod subst;
 pub mod trait_def;
 pub mod util;
+pub mod view;
 pub mod walk;
 
 mod context;

--- a/src/librustc/ty/outlives.rs
+++ b/src/librustc/ty/outlives.rs
@@ -8,7 +8,7 @@ use smallvec::SmallVec;
 #[derive(Debug)]
 pub enum Component<'tcx> {
     Region(ty::Region<'tcx>),
-    Param(ty::ParamTy),
+    Param(ty::View<'tcx, ty::ParamTy>),
     UnresolvedInferenceVariable(ty::InferTy),
 
     // Projections like `T::Foo` are tricky because a constraint like
@@ -82,8 +82,8 @@ fn compute_components(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, out: &mut SmallVec<[Compo
 
             // OutlivesTypeParameterEnv -- the actual checking that `X:'a`
             // is implied by the environment is done in regionck.
-            ty::Param(p) => {
-                out.push(Component::Param(p));
+            ty::Param(_) => {
+                out.push(Component::Param(ty::View::new(ty).unwrap()));
             }
 
             // For projections, we prefer to generate an obligation like

--- a/src/librustc/ty/structural_impls.rs
+++ b/src/librustc/ty/structural_impls.rs
@@ -13,6 +13,7 @@ use rustc_index::vec::{Idx, IndexVec};
 
 use smallvec::SmallVec;
 use std::fmt;
+use std::marker::PhantomData;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -386,6 +387,13 @@ impl<'tcx, I: Idx, T: Lift<'tcx>> Lift<'tcx> for IndexVec<I, T> {
     type Lifted = IndexVec<I, T::Lifted>;
     fn lift_to_tcx(&self, tcx: TyCtxt<'tcx>) -> Option<Self::Lifted> {
         self.iter().map(|e| tcx.lift(e)).collect()
+    }
+}
+
+impl<'tcx, T: Lift<'tcx>> Lift<'tcx> for PhantomData<T> {
+    type Lifted = PhantomData<T::Lifted>;
+    fn lift_to_tcx(&self, _tcx: TyCtxt<'tcx>) -> Option<Self::Lifted> {
+        Some(PhantomData)
     }
 }
 
@@ -1059,6 +1067,16 @@ impl<'tcx> TypeFoldable<'tcx> for ty::ConstKind<'tcx> {
 }
 
 impl<'tcx> TypeFoldable<'tcx> for InferConst<'tcx> {
+    fn super_fold_with<F: TypeFolder<'tcx>>(&self, _folder: &mut F) -> Self {
+        *self
+    }
+
+    fn super_visit_with<V: TypeVisitor<'tcx>>(&self, _visitor: &mut V) -> bool {
+        false
+    }
+}
+
+impl<'tcx, T> TypeFoldable<'tcx> for PhantomData<T> {
     fn super_fold_with<F: TypeFolder<'tcx>>(&self, _folder: &mut F) -> Self {
         *self
     }

--- a/src/librustc/ty/view.rs
+++ b/src/librustc/ty/view.rs
@@ -1,0 +1,182 @@
+use std::{fmt, marker::PhantomData};
+
+use syntax::ast;
+
+use crate::{
+    hir::{self, def_id::DefId},
+    ty::{
+        self, AdtDef, Binder, BoundTy, ExistentialPredicate, InferTy, List, ParamTy, PolyFnSig,
+        ProjectionTy, Region, SubstsRef, Ty, TypeAndMut,
+    },
+};
+
+pub use self::ViewKind::*;
+
+// TODO Forward eq/hash?
+#[derive(Eq, PartialEq, Hash, TypeFoldable, Lift)]
+pub struct View<'tcx, T> {
+    ty: Ty<'tcx>,
+    _marker: PhantomData<T>,
+}
+
+impl<T> Copy for View<'_, T> {}
+impl<T> Clone for View<'_, T> {
+    fn clone(&self) -> Self {
+        View { ty: self.ty, _marker: PhantomData }
+    }
+}
+
+impl<'tcx, T> fmt::Debug for View<'tcx, T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.ty.fmt(f)
+    }
+}
+
+impl<'tcx, T> fmt::Display for View<'tcx, T>
+where
+    T: fmt::Display + TyDeref<'tcx> + 'tcx,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
+impl<'tcx, T> std::ops::Deref for View<'tcx, T>
+where
+    T: TyDeref<'tcx> + 'tcx,
+{
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        match T::ty_deref(self.ty) {
+            Some(t) => t,
+            // SAFETY verified by `View::new`
+            None => unsafe { std::hint::unreachable_unchecked() },
+        }
+    }
+}
+
+impl<'tcx, T> View<'tcx, T>
+where
+    T: TyDeref<'tcx> + 'tcx,
+{
+    pub fn new(ty: Ty<'tcx>) -> Option<Self> {
+        T::ty_deref(ty)?;
+        Some(View { ty, _marker: PhantomData })
+    }
+}
+
+impl<'tcx, T> View<'tcx, T> {
+    pub fn as_ty(&self) -> Ty<'tcx> {
+        self.ty
+    }
+}
+
+/// SAFETY If `Some` is returned for `ty` then `Some` must always be returned for any subsequent
+/// call with the same `Ty` value
+pub unsafe trait TyDeref<'tcx>: Sized {
+    fn ty_deref(ty: Ty<'tcx>) -> Option<&'tcx Self>;
+}
+
+unsafe impl<'tcx> TyDeref<'tcx> for ty::ParamTy {
+    fn ty_deref(ty: Ty<'tcx>) -> Option<&'tcx Self> {
+        match &ty.kind {
+            ty::Param(p) => Some(p),
+            _ => None,
+        }
+    }
+}
+
+pub enum ViewKind<'tcx> {
+    Bool,
+
+    Char,
+
+    Int(ast::IntTy),
+
+    Uint(ast::UintTy),
+
+    Float(ast::FloatTy),
+
+    Adt(&'tcx AdtDef, SubstsRef<'tcx>),
+
+    Foreign(DefId),
+
+    Str,
+
+    Array(Ty<'tcx>, &'tcx ty::Const<'tcx>),
+
+    Slice(Ty<'tcx>),
+
+    RawPtr(TypeAndMut<'tcx>),
+
+    Ref(Region<'tcx>, Ty<'tcx>, hir::Mutability),
+
+    FnDef(DefId, SubstsRef<'tcx>),
+
+    FnPtr(PolyFnSig<'tcx>),
+
+    Dynamic(Binder<&'tcx List<ExistentialPredicate<'tcx>>>, ty::Region<'tcx>),
+
+    Closure(DefId, SubstsRef<'tcx>),
+
+    Generator(DefId, SubstsRef<'tcx>, hir::Movability),
+
+    GeneratorWitness(Binder<&'tcx List<Ty<'tcx>>>),
+
+    Never,
+
+    Tuple(SubstsRef<'tcx>),
+
+    Projection(ProjectionTy<'tcx>),
+
+    UnnormalizedProjection(ProjectionTy<'tcx>),
+
+    Opaque(DefId, SubstsRef<'tcx>),
+
+    Param(View<'tcx, ParamTy>),
+
+    Bound(ty::DebruijnIndex, BoundTy),
+
+    Placeholder(ty::PlaceholderType),
+
+    Infer(InferTy),
+
+    Error,
+}
+
+impl<'tcx> From<Ty<'tcx>> for ViewKind<'tcx> {
+    fn from(ty: Ty<'tcx>) -> Self {
+        match ty.kind {
+            ty::RawPtr(tm) => Self::RawPtr(tm),
+            ty::Array(typ, sz) => Self::Array(typ, sz),
+            ty::Slice(typ) => Self::Slice(typ),
+            ty::Adt(tid, substs) => Self::Adt(tid, substs),
+            ty::Dynamic(trait_ty, region) => Self::Dynamic(trait_ty, region),
+            ty::Tuple(ts) => Self::Tuple(ts),
+            ty::FnDef(def_id, substs) => Self::FnDef(def_id, substs),
+            ty::FnPtr(f) => Self::FnPtr(f),
+            ty::Ref(r, ty, mutbl) => Self::Ref(r, ty, mutbl),
+            ty::Generator(did, substs, movability) => Self::Generator(did, substs, movability),
+            ty::GeneratorWitness(types) => Self::GeneratorWitness(types),
+            ty::Closure(did, substs) => Self::Closure(did, substs),
+            ty::Projection(data) => Self::Projection(data),
+            ty::UnnormalizedProjection(data) => Self::UnnormalizedProjection(data),
+            ty::Opaque(did, substs) => Self::Opaque(did, substs),
+            ty::Bool => Self::Bool,
+            ty::Char => Self::Char,
+            ty::Str => Self::Str,
+            ty::Int(i) => Self::Int(i),
+            ty::Uint(i) => Self::Uint(i),
+            ty::Float(f) => Self::Float(f),
+            ty::Error => Self::Error,
+            ty::Infer(i) => Self::Infer(i),
+            ty::Param(_) => Self::Param(View::new(ty).unwrap()),
+            ty::Bound(b, c) => Self::Bound(b, c),
+            ty::Placeholder(p) => Self::Placeholder(p),
+            ty::Never => Self::Never,
+            ty::Foreign(f) => Self::Foreign(f),
+        }
+    }
+}

--- a/src/librustc/ty/view.rs
+++ b/src/librustc/ty/view.rs
@@ -1,4 +1,8 @@
-use std::{fmt, marker::PhantomData};
+use std::{
+    fmt,
+    hash::{Hash, Hasher},
+    marker::PhantomData,
+};
 
 use syntax::ast;
 
@@ -10,14 +14,37 @@ use rustc_hir::{self as hir, def_id::DefId};
 
 pub use self::ViewKind::*;
 
-// TODO Forward eq/hash?
-#[derive(Eq, PartialEq, Hash, TypeFoldable, Lift)]
+#[derive(TypeFoldable, Lift)]
 pub struct View<'tcx, T> {
     ty: Ty<'tcx>,
     _marker: PhantomData<T>,
 }
 
+impl<'tcx, T> PartialEq for View<'tcx, T>
+where
+    T: PartialEq + TyDeref<'tcx>,
+{
+    fn eq(&self, other: &Self) -> bool {
+        **self == **other
+    }
+}
+
+impl<'tcx, T> Eq for View<'tcx, T> where T: Eq + TyDeref<'tcx> {}
+
+impl<'tcx, T> Hash for View<'tcx, T>
+where
+    T: Hash + TyDeref<'tcx>,
+{
+    fn hash<H>(&self, hasher: &mut H)
+    where
+        H: Hasher,
+    {
+        (**self).hash(hasher)
+    }
+}
+
 impl<T> Copy for View<'_, T> {}
+
 impl<T> Clone for View<'_, T> {
     fn clone(&self) -> Self {
         View { ty: self.ty, _marker: PhantomData }
@@ -35,7 +62,7 @@ where
 
 impl<'tcx, T> fmt::Display for View<'tcx, T>
 where
-    T: fmt::Display + TyDeref<'tcx> + 'tcx,
+    T: fmt::Display + TyDeref<'tcx>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (**self).fmt(f)
@@ -43,7 +70,7 @@ where
 }
 impl<'tcx, T> std::ops::Deref for View<'tcx, T>
 where
-    T: TyDeref<'tcx> + 'tcx,
+    T: TyDeref<'tcx>,
 {
     type Target = T;
     fn deref(&self) -> &Self::Target {
@@ -57,7 +84,7 @@ where
 
 impl<'tcx, T> View<'tcx, T>
 where
-    T: TyDeref<'tcx> + 'tcx,
+    T: TyDeref<'tcx>,
 {
     pub fn new(ty: Ty<'tcx>) -> Option<Self> {
         T::ty_deref(ty)?;
@@ -73,7 +100,7 @@ impl<'tcx, T> View<'tcx, T> {
 
 /// SAFETY If `Some` is returned for `ty` then `Some` must always be returned for any subsequent
 /// call with the same `Ty` value
-pub unsafe trait TyDeref<'tcx>: Sized {
+pub unsafe trait TyDeref<'tcx>: Sized + 'tcx {
     fn ty_deref(ty: Ty<'tcx>) -> Option<&'tcx Self>;
 }
 

--- a/src/librustc/ty/view.rs
+++ b/src/librustc/ty/view.rs
@@ -14,6 +14,9 @@ use rustc_hir::{self as hir, def_id::DefId};
 
 pub use self::ViewKind::*;
 
+/// `View<'tcx, T>` contains a value of `T` but stores the `Ty<'tcx>` ptr that contains the `T`
+/// This allows for cheap access to the `Ty<'tcx>` without needing to ask the type interner or
+/// losing the `T` type.
 #[derive(TypeFoldable, Lift)]
 pub struct View<'tcx, T> {
     ty: Ty<'tcx>,

--- a/src/librustc/ty/view.rs
+++ b/src/librustc/ty/view.rs
@@ -1,8 +1,4 @@
-use std::{
-    fmt,
-    hash::{Hash, Hasher},
-    marker::PhantomData,
-};
+use std::{fmt, marker::PhantomData};
 
 use syntax::ast;
 
@@ -17,33 +13,10 @@ pub use self::ViewKind::*;
 /// `View<'tcx, T>` contains a value of `T` but stores the `Ty<'tcx>` ptr that contains the `T`
 /// This allows for cheap access to the `Ty<'tcx>` without needing to ask the type interner or
 /// losing the `T` type.
-#[derive(TypeFoldable, Lift)]
+#[derive(TypeFoldable, Eq, PartialEq, Hash, Lift)]
 pub struct View<'tcx, T> {
     ty: Ty<'tcx>,
     _marker: PhantomData<T>,
-}
-
-impl<'tcx, T> PartialEq for View<'tcx, T>
-where
-    T: PartialEq + TyDeref<'tcx>,
-{
-    fn eq(&self, other: &Self) -> bool {
-        **self == **other
-    }
-}
-
-impl<'tcx, T> Eq for View<'tcx, T> where T: Eq + TyDeref<'tcx> {}
-
-impl<'tcx, T> Hash for View<'tcx, T>
-where
-    T: Hash + TyDeref<'tcx>,
-{
-    fn hash<H>(&self, hasher: &mut H)
-    where
-        H: Hasher,
-    {
-        (**self).hash(hasher)
-    }
 }
 
 impl<T> Copy for View<'_, T> {}

--- a/src/librustc/ty/view.rs
+++ b/src/librustc/ty/view.rs
@@ -22,6 +22,7 @@ pub struct View<'tcx, T> {
 impl<T> Copy for View<'_, T> {}
 
 impl<T> Clone for View<'_, T> {
+    #[inline]
     fn clone(&self) -> Self {
         View { ty: self.ty, _marker: PhantomData }
     }
@@ -49,6 +50,8 @@ where
     T: TyDeref<'tcx>,
 {
     type Target = T;
+
+    #[inline]
     fn deref(&self) -> &Self::Target {
         match T::ty_deref(self.ty) {
             Some(t) => t,
@@ -62,6 +65,7 @@ impl<'tcx, T> View<'tcx, T>
 where
     T: TyDeref<'tcx>,
 {
+    #[inline]
     pub fn new(ty: Ty<'tcx>) -> Option<Self> {
         T::ty_deref(ty)?;
         Some(View { ty, _marker: PhantomData })
@@ -69,6 +73,7 @@ where
 }
 
 impl<'tcx, T> View<'tcx, T> {
+    #[inline]
     pub fn as_ty(&self) -> Ty<'tcx> {
         self.ty
     }
@@ -83,6 +88,7 @@ pub unsafe trait TyDeref<'tcx>: Sized + 'tcx {
 macro_rules! impl_ty_deref {
     ($ty: ty, $variant: ident) => {
         unsafe impl<'tcx> TyDeref<'tcx> for $ty {
+            #[inline]
             fn ty_deref(ty: Ty<'tcx>) -> Option<&'tcx Self> {
                 match &ty.kind {
                     ty::$variant(p) => Some(p),
@@ -129,6 +135,7 @@ pub enum ViewKind<'tcx> {
 }
 
 impl<'tcx> From<Ty<'tcx>> for ViewKind<'tcx> {
+    #[inline]
     fn from(ty: Ty<'tcx>) -> Self {
         match ty.kind {
             ty::RawPtr(tm) => Self::RawPtr(tm),

--- a/src/librustc_data_structures/captures.rs
+++ b/src/librustc_data_structures/captures.rs
@@ -8,8 +8,3 @@
 pub trait Captures<'a> {}
 
 impl<T: ?Sized> Captures<'_> for T {}
-
-#[allow(unused_lifetimes)]
-pub trait Captures2<'a, 'b> {}
-
-impl<T: ?Sized> Captures2<'_, '_> for T {}

--- a/src/librustc_data_structures/captures.rs
+++ b/src/librustc_data_structures/captures.rs
@@ -7,4 +7,9 @@
 #[allow(unused_lifetimes)]
 pub trait Captures<'a> {}
 
-impl<'a, T: ?Sized> Captures<'a> for T {}
+impl<T: ?Sized> Captures<'_> for T {}
+
+#[allow(unused_lifetimes)]
+pub trait Captures2<'a, 'b> {}
+
+impl<T: ?Sized> Captures2<'_, '_> for T {}

--- a/src/librustc_mir/borrow_check/region_infer/mod.rs
+++ b/src/librustc_mir/borrow_check/region_infer/mod.rs
@@ -815,7 +815,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         for type_test in &self.type_tests {
             debug!("check_type_test: {:?}", type_test);
 
-            let generic_ty = type_test.generic_kind.to_ty(tcx);
+            let generic_ty = type_test.generic_kind.as_ty();
             if self.eval_verify_bound(
                 tcx,
                 body,
@@ -910,7 +910,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
 
         let TypeTest { generic_kind, lower_bound, locations, verify_bound: _ } = type_test;
 
-        let generic_ty = generic_kind.to_ty(tcx);
+        let generic_ty = generic_kind.as_ty();
         let subject = match self.try_promote_type_test_subject(infcx, generic_ty) {
             Some(s) => s,
             None => return false,


### PR DESCRIPTION
In profiling `intern_ty` is a very hot function (9% in the test I used). While there does not seem to be a way to reduce the cost of calling we can avoid the call in some cases.

In outlives checking `ParamTy` and `ProjectionTy` are extracted from the `Ty` value that contains them only to later be passed as an argument to `intern_ty` again later. This seems to be happening a lot in my test with `intern_ty` called from outlives is at ~6%.

Since all `ParamTy` and `ProjectionTy` are already stored in a `Ty` I had an idea to pass around a `View` type which provides direct access to the specific, inner type without losing the original `Ty` pointer. While the current implementation does so with some unsafe to let the branch be elided on `Deref`, it could be done entirely in safe code as well, either by accepting the (predictable) branch in `Deref` or by storing the inner type in `View` as well as the `Ty`. But considering that the unsafe is trivial to prove and the call sites seem quite hot I opted to show the unsafe approach first.

Based on #67840 (since it touches the same file/lines)

Commits without #67840 https://github.com/rust-lang/rust/pull/67899/files/77ddc3540e52be4b5bd75cf082c621392acaf81b..b55bab206096c27533120921f6b0c273f115e34a