### PR TITLE
Silence `TooGeneric` error

### DIFF
--- a/src/librustc_typeck/impl_wf_check.rs
+++ b/src/librustc_typeck/impl_wf_check.rs
@@ -98,7 +98,10 @@ fn enforce_impl_params_are_constrained(
         // (#36836)
         tcx.sess.delay_span_bug(
             tcx.def_span(impl_def_id),
-            "potentially unconstrained type parameters weren't evaluated",
+            &format!(
+                "potentially unconstrained type parameters weren't evaluated: {:?}",
+                impl_self_ty,
+            ),
         );
         return;
     }

--- a/src/test/ui/const-generics/array-size-in-generic-struct-param.rs
+++ b/src/test/ui/const-generics/array-size-in-generic-struct-param.rs
@@ -1,0 +1,23 @@
+// run-pass
+
+#![feature(const_generics)]
+//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+
+#[allow(dead_code)]
+struct ArithArrayLen<const N: usize>([u32; 0 + N]); // ok
+
+#[derive(PartialEq, Eq)]
+struct Config {
+    arr_size: usize,
+}
+
+struct B<const CFG: Config> {
+    arr: [u8; CFG.arr_size], // ok
+}
+
+const C: Config = Config { arr_size: 5 };
+
+fn main() {
+    let b = B::<C> { arr: [1, 2, 3, 4, 5] };
+    assert_eq!(b.arr.len(), 5);
+}

--- a/src/test/ui/const-generics/array-size-in-generic-struct-param.stderr
+++ b/src/test/ui/const-generics/array-size-in-generic-struct-param.stderr
@@ -1,0 +1,8 @@
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/array-size-in-generic-struct-param.rs:3:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+


### PR DESCRIPTION
This error may be produced during intermediate failed attempts at evaluation of a generic const, which may nevertheless succeed later.

Fixes https://github.com/rust-lang/rust/issues/66962.

r? @eddyb 