### PR TITLE
Fix ICE in const pretty printing and resolve FIXME

### DIFF
--- a/src/librustc/ty/print/obsolete.rs
+++ b/src/librustc/ty/print/obsolete.rs
@@ -165,19 +165,12 @@ impl DefPathBasedNames<'tcx> {
     }
 
     // Pushes the the name of the specified const to the provided string.
-    // If `debug` is true, usually-unprintable consts (such as `Infer`) will be printed,
-    // as well as the unprintable types of constants (see `push_type_name` for more details).
-    pub fn push_const_name(&self, c: &Const<'tcx>, output: &mut String, debug: bool) {
-        if let ty::ConstKind::Value(_) = c.val {
-            // FIXME(const_generics): we could probably do a better job here.
-            write!(output, "{:?}", c).unwrap()
-        } else if debug {
-            write!(output, "{:?}", c).unwrap()
-        } else {
-            bug!("DefPathBasedNames: trying to create const name for unexpected const: {:?}", c,);
-        }
+    // If `debug` is true, the unprintable types of constants will be printed with `fmt::Debug`
+    // (see `push_type_name` for more details).
+    pub fn push_const_name(&self, ct: &Const<'tcx>, output: &mut String, debug: bool) {
+        write!(output, "{}", ct).unwrap();
         output.push_str(": ");
-        self.push_type_name(c.ty, output, debug);
+        self.push_type_name(ct.ty, output, debug);
     }
 
     pub fn push_def_path(&self, def_id: DefId, output: &mut String) {


### PR DESCRIPTION
Consts now have a `fmt::Display` impl, so we can just use that to pretty-print.

This resolves an ICE in https://github.com/rust-lang/rust/issues/61936, though it hits more ICEs afterwards. I couldn't find a test case that was resolved by this that didn't hit errors later on.