### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/src/liballoc/tests/lib.rs
+++ b/src/liballoc/tests/lib.rs
@@ -11,7 +11,6 @@
 #![feature(associated_type_bounds)]
 #![feature(binary_heap_into_iter_sorted)]
 #![feature(binary_heap_drain_sorted)]
-#![feature(vec_remove_item)]
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1054,7 +1054,7 @@ impl<T> Vec<T> {
     ///
     /// ```
     /// let mut vec = vec![1, 2, 3, 4];
-    /// vec.retain(|&x| x%2 == 0);
+    /// vec.retain(|&x| x % 2 == 0);
     /// assert_eq!(vec, [2, 4]);
     /// ```
     ///

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1702,7 +1702,7 @@ impl<T> Vec<T> {
     ///
     /// assert_eq!(vec, vec![2, 3, 1]);
     /// ```
-    #[unstable(feature = "vec_remove_item", reason = "recently added", issue = "40062")]
+    #[stable(feature = "vec_remove_item", since = "1.42.0")]
     pub fn remove_item<V>(&mut self, item: &V) -> Option<T>
     where
         T: PartialEq<V>,

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1696,7 +1696,6 @@ impl<T> Vec<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vec_remove_item)]
     /// let mut vec = vec![1, 2, 3, 1];
     ///
     /// vec.remove_item(&1);

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -50,7 +50,6 @@
 #![feature(thread_local)]
 #![feature(trace_macros)]
 #![feature(trusted_len)]
-#![feature(vec_remove_item)]
 #![feature(stmt_expr_attributes)]
 #![feature(integer_atomics)]
 #![feature(test)]

--- a/src/librustc_error_codes/error_codes/E0178.md
+++ b/src/librustc_error_codes/error_codes/E0178.md
@@ -1,16 +1,27 @@
-In types, the `+` type operator has low precedence, so it is often necessary
-to use parentheses.
+The `+` type operator was used in an ambiguous context.
 
-For example:
+Erroneous code example:
 
 ```compile_fail,E0178
 trait Foo {}
 
 struct Bar<'a> {
-    w: &'a Foo + Copy,   // error, use &'a (Foo + Copy)
-    x: &'a Foo + 'a,     // error, use &'a (Foo + 'a)
-    y: &'a mut Foo + 'a, // error, use &'a mut (Foo + 'a)
-    z: fn() -> Foo + 'a, // error, use fn() -> (Foo + 'a)
+    x: &'a Foo + 'a,     // error!
+    y: &'a mut Foo + 'a, // error!
+    z: fn() -> Foo + 'a, // error!
+}
+```
+
+In types, the `+` type operator has low precedence, so it is often necessary
+to use parentheses:
+
+```
+trait Foo {}
+
+struct Bar<'a> {
+    x: &'a (Foo + 'a),     // ok!
+    y: &'a mut (Foo + 'a), // ok!
+    z: fn() -> (Foo + 'a), // ok!
 }
 ```
 

--- a/src/librustc_lint/nonstandard_style.rs
+++ b/src/librustc_lint/nonstandard_style.rs
@@ -142,6 +142,12 @@ impl EarlyLintPass for NonCamelCaseTypes {
         }
     }
 
+    fn check_trait_item(&mut self, cx: &EarlyContext<'_>, it: &ast::AssocItem) {
+        if let ast::AssocItemKind::TyAlias(..) = it.kind {
+            self.check_case(cx, "associated type", &it.ident);
+        }
+    }
+
     fn check_variant(&mut self, cx: &EarlyContext<'_>, v: &ast::Variant) {
         self.check_case(cx, "variant", &v.ident);
     }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -15,6 +15,7 @@ use rustc::util::nodemap::FxHashSet;
 use rustc_target::spec::abi::Abi;
 
 use crate::clean::{self, PrimitiveType};
+use crate::html::escape::Escape;
 use crate::html::item_type::ItemType;
 use crate::html::render::{self, cache, CURRENT_DEPTH};
 
@@ -314,8 +315,14 @@ impl clean::Lifetime {
 }
 
 impl clean::Constant {
-    crate fn print(&self) -> &str {
-        &self.expr
+    crate fn print(&self) -> impl fmt::Display + '_ {
+        display_fn(move |f| {
+            if f.alternate() {
+                f.write_str(&self.expr)
+            } else {
+                write!(f, "{}", Escape(&self.expr))
+            }
+        })
     }
 }
 
@@ -689,7 +696,11 @@ fn fmt_type(t: &clean::Type, f: &mut fmt::Formatter<'_>, use_absolute: bool) -> 
         clean::Array(ref t, ref n) => {
             primitive_link(f, PrimitiveType::Array, "[")?;
             fmt::Display::fmt(&t.print(), f)?;
-            primitive_link(f, PrimitiveType::Array, &format!("; {}]", n))
+            if f.alternate() {
+                primitive_link(f, PrimitiveType::Array, &format!("; {}]", n))
+            } else {
+                primitive_link(f, PrimitiveType::Array, &format!("; {}]", Escape(n)))
+            }
         }
         clean::Never => primitive_link(f, PrimitiveType::Never, "!"),
         clean::RawPointer(m, ref t) => {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2279,7 +2279,7 @@ fn item_constant(w: &mut Buffer, cx: &Context, it: &clean::Item, c: &clean::Cons
     );
 
     if c.value.is_some() || c.is_literal {
-        write!(w, " = {expr};", expr = c.expr);
+        write!(w, " = {expr};", expr = Escape(&c.expr));
     } else {
         write!(w, ";");
     }
@@ -2292,7 +2292,7 @@ fn item_constant(w: &mut Buffer, cx: &Context, it: &clean::Item, c: &clean::Cons
             if value_lowercase != expr_lowercase
                 && value_lowercase.trim_end_matches("i32") != expr_lowercase
             {
-                write!(w, " // {value}", value = value);
+                write!(w, " // {value}", value = Escape(value));
             }
         }
     }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -10,7 +10,6 @@
 #![feature(nll)]
 #![feature(set_stdio)]
 #![feature(test)]
-#![feature(vec_remove_item)]
 #![feature(ptr_offset_from)]
 #![feature(crate_visibility_modifier)]
 #![feature(const_fn)]

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -9,7 +9,7 @@ use rustc::ty::TyCtxt;
 use rustc::util::nodemap::{FxHashMap, FxHashSet};
 use rustc_span::hygiene::MacroKind;
 use rustc_span::source_map::Spanned;
-use rustc_span::symbol::sym;
+use rustc_span::symbol::{kw, sym};
 use rustc_span::{self, Span};
 use syntax::ast;
 
@@ -513,16 +513,20 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                 om.statics.push(s);
             }
             hir::ItemKind::Const(type_, expr) => {
-                let s = Constant {
-                    type_,
-                    expr,
-                    id: item.hir_id,
-                    name: ident.name,
-                    attrs: &item.attrs,
-                    whence: item.span,
-                    vis: &item.vis,
-                };
-                om.constants.push(s);
+                // Underscore constants do not correspond to a nameable item and
+                // so are never useful in documentation.
+                if ident.name != kw::Underscore {
+                    let s = Constant {
+                        type_,
+                        expr,
+                        id: item.hir_id,
+                        name: ident.name,
+                        attrs: &item.attrs,
+                        whence: item.span,
+                        vis: &item.vis,
+                    };
+                    om.constants.push(s);
+                }
             }
             hir::ItemKind::Trait(is_auto, unsafety, ref generics, ref bounds, ref item_ids) => {
                 let items = item_ids.iter().map(|ti| self.cx.tcx.hir().trait_item(ti.id)).collect();

--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -63,7 +63,6 @@ pub struct TcpStream(net_imp::TcpStream);
 /// # Examples
 ///
 /// ```no_run
-/// # use std::io;
 /// use std::net::{TcpListener, TcpStream};
 ///
 /// fn handle_client(stream: TcpStream) {

--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -70,7 +70,7 @@ pub struct TcpStream(net_imp::TcpStream);
 ///     // ...
 /// }
 ///
-/// fn main() -> io::Result<()> {
+/// fn main() -> std::io::Result<()> {
 ///     let listener = TcpListener::bind("127.0.0.1:80")?;
 ///
 ///     // accept connections and process them serially

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -1072,6 +1072,19 @@ impl ThreadId {
             ThreadId(NonZeroU64::new(id).unwrap())
         }
     }
+
+    /// This returns a numeric identifier for the thread identified by this
+    /// `ThreadId`.
+    ///
+    /// As noted in the documentation for the type itself, it is essentially an
+    /// opaque ID, but is guaranteed to be unique for each thread. The returned
+    /// value is entirely opaque -- only equality testing is stable. Note that
+    /// it is not guaranteed which values new threads will return, and this may
+    /// change across Rust versions.
+    #[unstable(feature = "thread_id_value", issue = "67939")]
+    pub fn as_u64(&self) -> u64 {
+        self.0.get()
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/test/rustdoc/const-generics/const-impl.rs
+++ b/src/test/rustdoc/const-generics/const-impl.rs
@@ -30,3 +30,10 @@ impl <T> VSet<T, {Order::Unsorted}> {
         Self { inner: Vec::new() }
     }
 }
+
+pub struct Escape<const S: &'static str>;
+
+// @has foo/struct.Escape.html '//h3[@id="impl"]/code' 'impl Escape<{ r#"<script>alert("Escape");</script>"# }>'
+impl Escape<{ r#"<script>alert("Escape");</script>"# }> {
+    pub fn f() {}
+}

--- a/src/test/rustdoc/const-underscore.rs
+++ b/src/test/rustdoc/const-underscore.rs
@@ -1,0 +1,7 @@
+// compile-flags: --document-private-items
+
+// @!has const_underscore/constant._.html
+const _: () = {
+    #[no_mangle]
+    extern "C" fn implementation_detail() {}
+};

--- a/src/test/rustdoc/show-const-contents.rs
+++ b/src/test/rustdoc/show-const-contents.rs
@@ -62,3 +62,6 @@ macro_rules! int_module {
 
 // @has show_const_contents/constant.MIN.html '= i16::min_value(); // -32_768i16'
 int_module!(i16);
+
+// @has show_const_contents/constant.ESCAPE.html //pre '= r#"<script>alert("ESCAPE");</script>"#;'
+pub const ESCAPE: &str = r#"<script>alert("ESCAPE");</script>"#;

--- a/src/test/ui/issues/issue-17732.rs
+++ b/src/test/ui/issues/issue-17732.rs
@@ -1,5 +1,6 @@
 // check-pass
 #![allow(dead_code)]
+#![allow(non_camel_case_types)]
 // pretty-expanded FIXME #23616
 
 trait Person {

--- a/src/test/ui/issues/issue-35600.rs
+++ b/src/test/ui/issues/issue-35600.rs
@@ -1,5 +1,7 @@
 // run-pass
+#![allow(non_camel_case_types)]
 #![allow(unused_variables)]
+
 trait Foo {
     type bar;
     fn bar();

--- a/src/test/ui/lint/lint-non-camel-case-types.rs
+++ b/src/test/ui/lint/lint-non-camel-case-types.rs
@@ -23,6 +23,7 @@ enum Foo5 {
 }
 
 trait foo6 { //~ ERROR trait `foo6` should have an upper camel case name
+    type foo7; //~ ERROR associated type `foo7` should have an upper camel case name
     fn dummy(&self) { }
 }
 

--- a/src/test/ui/lint/lint-non-camel-case-types.stderr
+++ b/src/test/ui/lint/lint-non-camel-case-types.stderr
@@ -46,11 +46,17 @@ error: trait `foo6` should have an upper camel case name
 LL | trait foo6 {
    |       ^^^^ help: convert the identifier to upper camel case (notice the capitalization): `Foo6`
 
+error: associated type `foo7` should have an upper camel case name
+  --> $DIR/lint-non-camel-case-types.rs:26:10
+   |
+LL |     type foo7;
+   |          ^^^^ help: convert the identifier to upper camel case (notice the capitalization): `Foo7`
+
 error: type parameter `ty` should have an upper camel case name
-  --> $DIR/lint-non-camel-case-types.rs:29:6
+  --> $DIR/lint-non-camel-case-types.rs:30:6
    |
 LL | fn f<ty>(_: ty) {}
    |      ^^ help: convert the identifier to upper camel case: `Ty`
 
-error: aborting due to 8 previous errors
+error: aborting due to 9 previous errors
 

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -1,6 +1,5 @@
 #![crate_name = "compiletest"]
 #![feature(test)]
-#![feature(vec_remove_item)]
 #![deny(warnings)]
 
 extern crate test;


### PR DESCRIPTION
Successful merges:

 - #67566 (Add an unstable conversion from thread ID to u64)
 - #67727 (Stabilise vec::remove_item)
 - #67877 (Omit underscore constants from rustdoc)
 - #67908 (rustdoc: HTML escape const values)
 - #67929 (Formatting an example for method Vec.retain)
 - #67934 (Clean up E0178 explanation)
 - #67936 (fire "non_camel_case_types" for associated types)
 - #67943 (Missing module std in example.)

Failed merges:


r? @ghost