### PR TITLE
On privacy error caused by private reexport, use spans to show the `use` chain

### DIFF
--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -202,7 +202,11 @@ impl DefPath {
         let mut s = String::with_capacity(self.data.len() * 16);
 
         for component in &self.data {
-            write!(s, "::{}[{}]", component.data.as_symbol(), component.disambiguator).unwrap();
+            if component.disambiguator == 0 {
+                write!(s, "::{}", component.data.as_symbol()).unwrap();
+            } else {
+                write!(s, "::{}[{}]", component.data.as_symbol(), component.disambiguator).unwrap();
+            }
         }
 
         s

--- a/src/test/ui/extern/extern-crate-visibility.stderr
+++ b/src/test/ui/extern/extern-crate-visibility.stderr
@@ -4,7 +4,7 @@ error[E0603]: crate import `core` is private
 LL | use foo::core::cell;
    |          ^^^^ this crate import is private
    |
-note: the crate import `core` is defined here
+note: the used restricted re-export of `core`
   --> $DIR/extern-crate-visibility.rs:2:5
    |
 LL |     extern crate core;
@@ -16,7 +16,7 @@ error[E0603]: crate import `core` is private
 LL |     foo::core::cell::Cell::new(0);
    |          ^^^^ this crate import is private
    |
-note: the crate import `core` is defined here
+note: the used restricted re-export of `core`
   --> $DIR/extern-crate-visibility.rs:2:5
    |
 LL |     extern crate core;

--- a/src/test/ui/import.stderr
+++ b/src/test/ui/import.stderr
@@ -19,11 +19,12 @@ error[E0603]: unresolved item import `foo` is private
 LL |     zed::foo();
    |          ^^^ this unresolved item import is private
    |
-note: the unresolved item import `foo` is defined here
+note: the used restricted re-export of `foo`
   --> $DIR/import.rs:10:9
    |
 LL |     use foo;
    |         ^^^
+   = note: the re-exported unresolved item `foo` is defined here
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/imports/issue-55884-2.stderr
+++ b/src/test/ui/imports/issue-55884-2.stderr
@@ -4,11 +4,26 @@ error[E0603]: struct import `ParseOptions` is private
 LL | pub use parser::ParseOptions;
    |                 ^^^^^^^^^^^^ this struct import is private
    |
-note: the struct import `ParseOptions` is defined here
+note: the used restricted re-export of `ParseOptions`...
   --> $DIR/issue-55884-2.rs:9:9
    |
 LL |     use ParseOptions;
    |         ^^^^^^^^^^^^
+note: ...through this public re-export of `ParseOptions`...
+  --> $DIR/issue-55884-2.rs:12:9
+   |
+LL | pub use parser::ParseOptions;
+   |         ^^^^^^^^^^^^^^^^^^^^
+note: ...through this public re-export of `ParseOptions`
+  --> $DIR/issue-55884-2.rs:6:13
+   |
+LL |     pub use options::*;
+   |             ^^^^^^^^^^
+help: consider importing struct `::options::ParseOptions` directly
+  --> $DIR/issue-55884-2.rs:2:5
+   |
+LL |     pub struct ParseOptions {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/imports/reexports.stderr
+++ b/src/test/ui/imports/reexports.stderr
@@ -16,11 +16,16 @@ error[E0603]: module import `foo` is private
 LL |     use b::a::foo::S;
    |               ^^^ this module import is private
    |
-note: the module import `foo` is defined here
+note: the used restricted re-export of `foo`
   --> $DIR/reexports.rs:21:17
    |
 LL |         pub use super::foo; // This is OK since the value `foo` is visible enough.
    |                 ^^^^^^^^^^
+note: the re-exported module `foo` is defined here
+  --> $DIR/reexports.rs:16:5
+   |
+LL |     mod foo {
+   |     ^^^^^^^
 
 error[E0603]: module import `foo` is private
   --> $DIR/reexports.rs:34:15
@@ -28,11 +33,16 @@ error[E0603]: module import `foo` is private
 LL |     use b::b::foo::S as T;
    |               ^^^ this module import is private
    |
-note: the module import `foo` is defined here
+note: the used restricted re-export of `foo`
   --> $DIR/reexports.rs:26:17
    |
 LL |         pub use super::*; // This is also OK since the value `foo` is visible enough.
    |                 ^^^^^^^^
+note: the re-exported module `foo` is defined here
+  --> $DIR/reexports.rs:16:5
+   |
+LL |     mod foo {
+   |     ^^^^^^^
 
 warning: glob import doesn't reexport anything because no candidate is public enough
   --> $DIR/reexports.rs:9:17

--- a/src/test/ui/privacy/privacy2.stderr
+++ b/src/test/ui/privacy/privacy2.stderr
@@ -10,11 +10,16 @@ error[E0603]: function import `foo` is private
 LL |     use bar::glob::foo;
    |                    ^^^ this function import is private
    |
-note: the function import `foo` is defined here
+note: the used restricted re-export of `foo`
   --> $DIR/privacy2.rs:10:13
    |
 LL |         use foo;
    |             ^^^
+help: consider importing function `::foo` directly
+  --> $DIR/privacy2.rs:14:1
+   |
+LL | pub fn foo() {}
+   | ^^^^^^^^^^^^
 
 error: requires `sized` lang_item
 

--- a/src/test/ui/privacy/privacy5.stderr
+++ b/src/test/ui/privacy/privacy5.stderr
@@ -7,7 +7,7 @@ LL |     pub struct A(());
 LL |     let a = a::A(());
    |                ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `A` is defined here
+note: the tuple struct `A` is defined here
   --> $DIR/privacy5.rs:6:5
    |
 LL |     pub struct A(());
@@ -22,7 +22,7 @@ LL |     pub struct B(isize);
 LL |     let b = a::B(2);
    |                ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `B` is defined here
+note: the tuple struct `B` is defined here
   --> $DIR/privacy5.rs:7:5
    |
 LL |     pub struct B(isize);
@@ -37,7 +37,7 @@ LL |     pub struct C(pub isize, isize);
 LL |     let c = a::C(2, 3);
    |                ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `C` is defined here
+note: the tuple struct `C` is defined here
   --> $DIR/privacy5.rs:8:5
    |
 LL |     pub struct C(pub isize, isize);
@@ -52,7 +52,7 @@ LL |     pub struct A(());
 LL |     let a::A(()) = a;
    |            ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `A` is defined here
+note: the tuple struct `A` is defined here
   --> $DIR/privacy5.rs:6:5
    |
 LL |     pub struct A(());
@@ -67,7 +67,7 @@ LL |     pub struct A(());
 LL |     let a::A(_) = a;
    |            ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `A` is defined here
+note: the tuple struct `A` is defined here
   --> $DIR/privacy5.rs:6:5
    |
 LL |     pub struct A(());
@@ -82,7 +82,7 @@ LL |     pub struct A(());
 LL |     match a { a::A(()) => {} }
    |                  ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `A` is defined here
+note: the tuple struct `A` is defined here
   --> $DIR/privacy5.rs:6:5
    |
 LL |     pub struct A(());
@@ -97,7 +97,7 @@ LL |     pub struct A(());
 LL |     match a { a::A(_) => {} }
    |                  ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `A` is defined here
+note: the tuple struct `A` is defined here
   --> $DIR/privacy5.rs:6:5
    |
 LL |     pub struct A(());
@@ -112,7 +112,7 @@ LL |     pub struct B(isize);
 LL |     let a::B(_) = b;
    |            ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `B` is defined here
+note: the tuple struct `B` is defined here
   --> $DIR/privacy5.rs:7:5
    |
 LL |     pub struct B(isize);
@@ -127,7 +127,7 @@ LL |     pub struct B(isize);
 LL |     let a::B(_b) = b;
    |            ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `B` is defined here
+note: the tuple struct `B` is defined here
   --> $DIR/privacy5.rs:7:5
    |
 LL |     pub struct B(isize);
@@ -142,7 +142,7 @@ LL |     pub struct B(isize);
 LL |     match b { a::B(_) => {} }
    |                  ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `B` is defined here
+note: the tuple struct `B` is defined here
   --> $DIR/privacy5.rs:7:5
    |
 LL |     pub struct B(isize);
@@ -157,7 +157,7 @@ LL |     pub struct B(isize);
 LL |     match b { a::B(_b) => {} }
    |                  ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `B` is defined here
+note: the tuple struct `B` is defined here
   --> $DIR/privacy5.rs:7:5
    |
 LL |     pub struct B(isize);
@@ -172,7 +172,7 @@ LL |     pub struct B(isize);
 LL |     match b { a::B(1) => {} a::B(_) => {} }
    |                  ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `B` is defined here
+note: the tuple struct `B` is defined here
   --> $DIR/privacy5.rs:7:5
    |
 LL |     pub struct B(isize);
@@ -187,7 +187,7 @@ LL |     pub struct B(isize);
 LL |     match b { a::B(1) => {} a::B(_) => {} }
    |                                ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `B` is defined here
+note: the tuple struct `B` is defined here
   --> $DIR/privacy5.rs:7:5
    |
 LL |     pub struct B(isize);
@@ -202,7 +202,7 @@ LL |     pub struct C(pub isize, isize);
 LL |     let a::C(_, _) = c;
    |            ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `C` is defined here
+note: the tuple struct `C` is defined here
   --> $DIR/privacy5.rs:8:5
    |
 LL |     pub struct C(pub isize, isize);
@@ -217,7 +217,7 @@ LL |     pub struct C(pub isize, isize);
 LL |     let a::C(_a, _) = c;
    |            ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `C` is defined here
+note: the tuple struct `C` is defined here
   --> $DIR/privacy5.rs:8:5
    |
 LL |     pub struct C(pub isize, isize);
@@ -232,7 +232,7 @@ LL |     pub struct C(pub isize, isize);
 LL |     let a::C(_, _b) = c;
    |            ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `C` is defined here
+note: the tuple struct `C` is defined here
   --> $DIR/privacy5.rs:8:5
    |
 LL |     pub struct C(pub isize, isize);
@@ -247,7 +247,7 @@ LL |     pub struct C(pub isize, isize);
 LL |     let a::C(_a, _b) = c;
    |            ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `C` is defined here
+note: the tuple struct `C` is defined here
   --> $DIR/privacy5.rs:8:5
    |
 LL |     pub struct C(pub isize, isize);
@@ -262,7 +262,7 @@ LL |     pub struct C(pub isize, isize);
 LL |     match c { a::C(_, _) => {} }
    |                  ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `C` is defined here
+note: the tuple struct `C` is defined here
   --> $DIR/privacy5.rs:8:5
    |
 LL |     pub struct C(pub isize, isize);
@@ -277,7 +277,7 @@ LL |     pub struct C(pub isize, isize);
 LL |     match c { a::C(_a, _) => {} }
    |                  ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `C` is defined here
+note: the tuple struct `C` is defined here
   --> $DIR/privacy5.rs:8:5
    |
 LL |     pub struct C(pub isize, isize);
@@ -292,7 +292,7 @@ LL |     pub struct C(pub isize, isize);
 LL |     match c { a::C(_, _b) => {} }
    |                  ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `C` is defined here
+note: the tuple struct `C` is defined here
   --> $DIR/privacy5.rs:8:5
    |
 LL |     pub struct C(pub isize, isize);
@@ -307,7 +307,7 @@ LL |     pub struct C(pub isize, isize);
 LL |     match c { a::C(_a, _b) => {} }
    |                  ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `C` is defined here
+note: the tuple struct `C` is defined here
   --> $DIR/privacy5.rs:8:5
    |
 LL |     pub struct C(pub isize, isize);
@@ -322,7 +322,7 @@ LL |     pub struct A(());
 LL |     let a2 = a::A;
    |                 ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `A` is defined here
+note: the tuple struct `A` is defined here
   --> $DIR/privacy5.rs:6:5
    |
 LL |     pub struct A(());
@@ -337,7 +337,7 @@ LL |     pub struct B(isize);
 LL |     let b2 = a::B;
    |                 ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `B` is defined here
+note: the tuple struct `B` is defined here
   --> $DIR/privacy5.rs:7:5
    |
 LL |     pub struct B(isize);
@@ -352,7 +352,7 @@ LL |     pub struct C(pub isize, isize);
 LL |     let c2 = a::C;
    |                 ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `C` is defined here
+note: the tuple struct `C` is defined here
   --> $DIR/privacy5.rs:8:5
    |
 LL |     pub struct C(pub isize, isize);
@@ -369,7 +369,7 @@ LL |     let a = other::A(());
 LL | pub struct A(());
    |              -- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `A` is defined here
+note: the tuple struct `A` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:1:1
    |
 LL | pub struct A(());
@@ -386,7 +386,7 @@ LL |     let b = other::B(2);
 LL | pub struct B(isize);
    |              ----- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `B` is defined here
+note: the tuple struct `B` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
    |
 LL | pub struct B(isize);
@@ -403,7 +403,7 @@ LL |     let c = other::C(2, 3);
 LL | pub struct C(pub isize, isize);
    |              ---------------- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `C` is defined here
+note: the tuple struct `C` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
    |
 LL | pub struct C(pub isize, isize);
@@ -420,7 +420,7 @@ LL |     let other::A(()) = a;
 LL | pub struct A(());
    |              -- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `A` is defined here
+note: the tuple struct `A` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:1:1
    |
 LL | pub struct A(());
@@ -437,7 +437,7 @@ LL |     let other::A(_) = a;
 LL | pub struct A(());
    |              -- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `A` is defined here
+note: the tuple struct `A` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:1:1
    |
 LL | pub struct A(());
@@ -454,7 +454,7 @@ LL |     match a { other::A(()) => {} }
 LL | pub struct A(());
    |              -- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `A` is defined here
+note: the tuple struct `A` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:1:1
    |
 LL | pub struct A(());
@@ -471,7 +471,7 @@ LL |     match a { other::A(_) => {} }
 LL | pub struct A(());
    |              -- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `A` is defined here
+note: the tuple struct `A` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:1:1
    |
 LL | pub struct A(());
@@ -488,7 +488,7 @@ LL |     let other::B(_) = b;
 LL | pub struct B(isize);
    |              ----- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `B` is defined here
+note: the tuple struct `B` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
    |
 LL | pub struct B(isize);
@@ -505,7 +505,7 @@ LL |     let other::B(_b) = b;
 LL | pub struct B(isize);
    |              ----- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `B` is defined here
+note: the tuple struct `B` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
    |
 LL | pub struct B(isize);
@@ -522,7 +522,7 @@ LL |     match b { other::B(_) => {} }
 LL | pub struct B(isize);
    |              ----- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `B` is defined here
+note: the tuple struct `B` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
    |
 LL | pub struct B(isize);
@@ -539,7 +539,7 @@ LL |     match b { other::B(_b) => {} }
 LL | pub struct B(isize);
    |              ----- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `B` is defined here
+note: the tuple struct `B` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
    |
 LL | pub struct B(isize);
@@ -556,7 +556,7 @@ LL |     match b { other::B(1) => {}
 LL | pub struct B(isize);
    |              ----- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `B` is defined here
+note: the tuple struct `B` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
    |
 LL | pub struct B(isize);
@@ -573,7 +573,7 @@ LL |         other::B(_) => {} }
 LL | pub struct B(isize);
    |              ----- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `B` is defined here
+note: the tuple struct `B` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
    |
 LL | pub struct B(isize);
@@ -590,7 +590,7 @@ LL |     let other::C(_, _) = c;
 LL | pub struct C(pub isize, isize);
    |              ---------------- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `C` is defined here
+note: the tuple struct `C` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
    |
 LL | pub struct C(pub isize, isize);
@@ -607,7 +607,7 @@ LL |     let other::C(_a, _) = c;
 LL | pub struct C(pub isize, isize);
    |              ---------------- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `C` is defined here
+note: the tuple struct `C` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
    |
 LL | pub struct C(pub isize, isize);
@@ -624,7 +624,7 @@ LL |     let other::C(_, _b) = c;
 LL | pub struct C(pub isize, isize);
    |              ---------------- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `C` is defined here
+note: the tuple struct `C` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
    |
 LL | pub struct C(pub isize, isize);
@@ -641,7 +641,7 @@ LL |     let other::C(_a, _b) = c;
 LL | pub struct C(pub isize, isize);
    |              ---------------- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `C` is defined here
+note: the tuple struct `C` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
    |
 LL | pub struct C(pub isize, isize);
@@ -658,7 +658,7 @@ LL |     match c { other::C(_, _) => {} }
 LL | pub struct C(pub isize, isize);
    |              ---------------- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `C` is defined here
+note: the tuple struct `C` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
    |
 LL | pub struct C(pub isize, isize);
@@ -675,7 +675,7 @@ LL |     match c { other::C(_a, _) => {} }
 LL | pub struct C(pub isize, isize);
    |              ---------------- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `C` is defined here
+note: the tuple struct `C` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
    |
 LL | pub struct C(pub isize, isize);
@@ -692,7 +692,7 @@ LL |     match c { other::C(_, _b) => {} }
 LL | pub struct C(pub isize, isize);
    |              ---------------- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `C` is defined here
+note: the tuple struct `C` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
    |
 LL | pub struct C(pub isize, isize);
@@ -709,7 +709,7 @@ LL |     match c { other::C(_a, _b) => {} }
 LL | pub struct C(pub isize, isize);
    |              ---------------- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `C` is defined here
+note: the tuple struct `C` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
    |
 LL | pub struct C(pub isize, isize);
@@ -726,7 +726,7 @@ LL |     let a2 = other::A;
 LL | pub struct A(());
    |              -- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `A` is defined here
+note: the tuple struct `A` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:1:1
    |
 LL | pub struct A(());
@@ -743,7 +743,7 @@ LL |     let b2 = other::B;
 LL | pub struct B(isize);
    |              ----- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `B` is defined here
+note: the tuple struct `B` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:2:1
    |
 LL | pub struct B(isize);
@@ -760,7 +760,7 @@ LL |     let c2 = other::C;
 LL | pub struct C(pub isize, isize);
    |              ---------------- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `C` is defined here
+note: the tuple struct `C` is defined here
   --> $DIR/auxiliary/privacy_tuple_struct.rs:3:1
    |
 LL | pub struct C(pub isize, isize);

--- a/src/test/ui/proc-macro/disappearing-resolution.stderr
+++ b/src/test/ui/proc-macro/disappearing-resolution.stderr
@@ -10,11 +10,12 @@ error[E0603]: derive macro import `Empty` is private
 LL | use m::Empty;
    |        ^^^^^ this derive macro import is private
    |
-note: the derive macro import `Empty` is defined here
+note: the used restricted re-export of `Empty`
   --> $DIR/disappearing-resolution.rs:9:9
    |
 LL |     use test_macros::Empty;
    |         ^^^^^^^^^^^^^^^^^^
+   = help: consider importing derive macro `Empty` directly
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/resolve/privacy-struct-ctor.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor.stderr
@@ -47,7 +47,7 @@ LL |         pub(in m) struct Z(pub(in m::n) u8);
 LL |         n::Z;
    |            ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `Z` is defined here
+note: the tuple struct `Z` is defined here
   --> $DIR/privacy-struct-ctor.rs:12:9
    |
 LL |         pub(in m) struct Z(pub(in m::n) u8);
@@ -62,7 +62,7 @@ LL |     pub struct S(u8);
 LL |     m::S;
    |        ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `S` is defined here
+note: the tuple struct `S` is defined here
   --> $DIR/privacy-struct-ctor.rs:6:5
    |
 LL |     pub struct S(u8);
@@ -77,7 +77,7 @@ LL |     pub struct S(u8);
 LL |     let _: S = m::S(2);
    |                   ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `S` is defined here
+note: the tuple struct `S` is defined here
   --> $DIR/privacy-struct-ctor.rs:6:5
    |
 LL |     pub struct S(u8);
@@ -92,7 +92,7 @@ LL |         pub(in m) struct Z(pub(in m::n) u8);
 LL |     m::n::Z;
    |           ^ this tuple struct constructor is private
    |
-note: the tuple struct constructor `Z` is defined here
+note: the tuple struct `Z` is defined here
   --> $DIR/privacy-struct-ctor.rs:12:9
    |
 LL |         pub(in m) struct Z(pub(in m::n) u8);
@@ -109,7 +109,7 @@ LL |     xcrate::m::S;
 LL |     pub struct S(u8);
    |                  -- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `S` is defined here
+note: the tuple struct `S` is defined here
   --> $DIR/auxiliary/privacy-struct-ctor.rs:2:5
    |
 LL |     pub struct S(u8);
@@ -126,7 +126,7 @@ LL |     xcrate::m::n::Z;
 LL |         pub(in m) struct Z(pub(in m::n) u8);
    |                            --------------- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `Z` is defined here
+note: the tuple struct `Z` is defined here
   --> $DIR/auxiliary/privacy-struct-ctor.rs:5:9
    |
 LL |         pub(in m) struct Z(pub(in m::n) u8);

--- a/src/test/ui/rfc-2008-non-exhaustive/struct.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/struct.stderr
@@ -21,7 +21,7 @@ LL |     let ts_explicit = structs::TupleStruct(640, 480);
 LL | pub struct TupleStruct(pub u16, pub u16);
    |                        ---------------- a constructor is private if any of the fields is private
    |
-note: the tuple struct constructor `TupleStruct` is defined here
+note: the tuple struct `TupleStruct` is defined here
   --> $DIR/auxiliary/structs.rs:11:1
    |
 LL | pub struct TupleStruct(pub u16, pub u16);

--- a/src/test/ui/shadowed/shadowed-use-visibility.stderr
+++ b/src/test/ui/shadowed/shadowed-use-visibility.stderr
@@ -4,11 +4,16 @@ error[E0603]: module import `bar` is private
 LL |     use foo::bar::f as g;
    |              ^^^ this module import is private
    |
-note: the module import `bar` is defined here
+note: the used restricted re-export of `bar`
   --> $DIR/shadowed-use-visibility.rs:4:9
    |
 LL |     use foo as bar;
    |         ^^^^^^^^^^
+note: the re-exported module `bar` is defined here
+  --> $DIR/shadowed-use-visibility.rs:1:1
+   |
+LL | mod foo {
+   | ^^^^^^^
 
 error[E0603]: module import `f` is private
   --> $DIR/shadowed-use-visibility.rs:15:10
@@ -16,11 +21,16 @@ error[E0603]: module import `f` is private
 LL | use bar::f::f;
    |          ^ this module import is private
    |
-note: the module import `f` is defined here
+note: the used restricted re-export of `f`
   --> $DIR/shadowed-use-visibility.rs:11:9
    |
 LL |     use foo as f;
    |         ^^^^^^^^
+note: the re-exported module `f` is defined here
+  --> $DIR/shadowed-use-visibility.rs:1:1
+   |
+LL | mod foo {
+   | ^^^^^^^
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Fix #63942, fix #57619. Partially address #42909.