### PR TITLE
rustdoc: improve stability mark arrows

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -542,12 +542,11 @@ h4 > code, h3 > code, .invisible > code {
 }
 
 .content .stability::before {
-	content: '⤶';
-	transform:rotate(90deg);
+	content: '⬑';
 	font-size: 25px;
 	position: absolute;
 	top: -6px;
-	left: -17px;
+	left: -19px;
 }
 
 .content .impl-items .method, .content .impl-items > .type, .impl-items > .associatedconstant {

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -542,11 +542,12 @@ h4 > code, h3 > code, .invisible > code {
 }
 
 .content .stability::before {
-	content: '˪';
-	font-size: 30px;
+	content: '⤶';
+	transform:rotate(90deg);
+	font-size: 25px;
 	position: absolute;
-	top: -9px;
-	left: -13px;
+	top: -6px;
+	left: -17px;
 }
 
 .content .impl-items .method, .content .impl-items > .type, .impl-items > .associatedconstant {

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -105,6 +105,8 @@ pre {
 .content .highlighted.primitive { background-color: #00708a; }
 .content .highlighted.keyword { background-color: #884719; }
 
+.content .stability::before { color: #ccc; }
+
 .content span.enum, .content a.enum, .block a.current.enum { color: #82b089; }
 .content span.struct, .content a.struct, .block a.current.struct { color: #2dbfb8; }
 .content span.type, .content a.type, .block a.current.type { color: #ff7f00; }

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -105,6 +105,8 @@ pre {
 .content .highlighted.primitive { background-color: #9aecff; }
 .content .highlighted.keyword { background-color: #f99650; }
 
+.content .stability::before { color: #ccc; }
+
 .content span.enum, .content a.enum, .block a.current.enum { color: #508157; }
 .content span.struct, .content a.struct, .block a.current.struct { color: #ad448e; }
 .content span.type, .content a.type, .block a.current.type { color: #ba5d00; }


### PR DESCRIPTION
### current

![old-stability-arrow](https://user-images.githubusercontent.com/346530/71863520-134d8b00-3138-11ea-86f9-a98068b3cff9.png)

### new

![new-stability-arrow](https://user-images.githubusercontent.com/346530/71863539-1b0d2f80-3138-11ea-843e-d79b9e5d9eec.png)

### new dark

![dark-stability-arrow](https://user-images.githubusercontent.com/346530/71863563-26f8f180-3138-11ea-9514-050e2c779f90.png)
