### PR TITLE
Fix panic when reexporting primitive type in rustdoc

### DIFF
--- a/src/librustc_hir/def.rs
+++ b/src/librustc_hir/def.rs
@@ -427,4 +427,11 @@ impl<Id> Res<Id> {
             Res::Err => true,
         }
     }
+
+    pub fn is_primitive(&self) -> bool {
+        match self {
+            Res::PrimTy(..) => true,
+            _ => false,
+        }
+    }
 }

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -428,12 +428,20 @@ fn build_module(cx: &DocContext<'_>, did: DefId, visited: &mut FxHashSet<DefId>)
         // two namespaces, so the target may be listed twice. Make sure we only
         // visit each node at most once.
         for &item in cx.tcx.item_children(did).iter() {
-            let def_id = item.res.def_id();
+            eprintln!("==> {:?}", item.res);
+            let def_id = match clean::utils::res_to_def_id(cx, &item.res) {
+                Some(did) => did,
+                None => continue,
+            };
+            eprintln!("TOUDOUM ==> {:?} {:?}", item.res, item.vis);
             if item.vis == ty::Visibility::Public {
                 if did == def_id || !visited.insert(def_id) {
+                    eprintln!("1");
                     continue;
                 }
+                eprintln!("2");
                 if let Some(i) = try_inline(cx, item.res, item.ident.name, None, visited) {
+                    eprintln!("3");
                     items.extend(i)
                 }
             }

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1044,6 +1044,30 @@ pub enum PrimitiveType {
     Never,
 }
 
+impl From<&hir::PrimTy> for PrimitiveType {
+    fn from(other: &hir::PrimTy) -> PrimitiveType {
+        match other {
+            hir::PrimTy::Uint(syntax::ast::UintTy::U8) => PrimitiveType::U8,
+            hir::PrimTy::Uint(syntax::ast::UintTy::U16) => PrimitiveType::U16,
+            hir::PrimTy::Uint(syntax::ast::UintTy::U32) => PrimitiveType::U32,
+            hir::PrimTy::Uint(syntax::ast::UintTy::U64) => PrimitiveType::U64,
+            hir::PrimTy::Uint(syntax::ast::UintTy::U128) => PrimitiveType::U128,
+            hir::PrimTy::Uint(syntax::ast::UintTy::Usize) => PrimitiveType::Usize,
+            hir::PrimTy::Int(syntax::ast::IntTy::I8) => PrimitiveType::I8,
+            hir::PrimTy::Int(syntax::ast::IntTy::I16) => PrimitiveType::I16,
+            hir::PrimTy::Int(syntax::ast::IntTy::I32) => PrimitiveType::I32,
+            hir::PrimTy::Int(syntax::ast::IntTy::I64) => PrimitiveType::I64,
+            hir::PrimTy::Int(syntax::ast::IntTy::I128) => PrimitiveType::I128,
+            hir::PrimTy::Int(syntax::ast::IntTy::Isize) => PrimitiveType::Isize,
+            hir::PrimTy::Float(syntax::ast::FloatTy::F32) => PrimitiveType::F32,
+            hir::PrimTy::Float(syntax::ast::FloatTy::F64) => PrimitiveType::F64,
+            hir::PrimTy::Str => PrimitiveType::Str,
+            hir::PrimTy::Bool => PrimitiveType::Bool,
+            hir::PrimTy::Char => PrimitiveType::Char,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub enum TypeKind {
     Enum,
@@ -1060,6 +1084,7 @@ pub enum TypeKind {
     Attr,
     Derive,
     TraitAlias,
+    Primitive,
 }
 
 pub trait GetDefId {

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -652,3 +652,60 @@ where
     *cx.impl_trait_bounds.borrow_mut() = old_bounds;
     r
 }
+
+pub const PRIMITIVES: &[(&str, Res)] = &[
+    ("u8", Res::PrimTy(hir::PrimTy::Uint(syntax::ast::UintTy::U8))),
+    ("u16", Res::PrimTy(hir::PrimTy::Uint(syntax::ast::UintTy::U16))),
+    ("u32", Res::PrimTy(hir::PrimTy::Uint(syntax::ast::UintTy::U32))),
+    ("u64", Res::PrimTy(hir::PrimTy::Uint(syntax::ast::UintTy::U64))),
+    ("u128", Res::PrimTy(hir::PrimTy::Uint(syntax::ast::UintTy::U128))),
+    ("usize", Res::PrimTy(hir::PrimTy::Uint(syntax::ast::UintTy::Usize))),
+    ("i8", Res::PrimTy(hir::PrimTy::Int(syntax::ast::IntTy::I8))),
+    ("i16", Res::PrimTy(hir::PrimTy::Int(syntax::ast::IntTy::I16))),
+    ("i32", Res::PrimTy(hir::PrimTy::Int(syntax::ast::IntTy::I32))),
+    ("i64", Res::PrimTy(hir::PrimTy::Int(syntax::ast::IntTy::I64))),
+    ("i128", Res::PrimTy(hir::PrimTy::Int(syntax::ast::IntTy::I128))),
+    ("isize", Res::PrimTy(hir::PrimTy::Int(syntax::ast::IntTy::Isize))),
+    ("f32", Res::PrimTy(hir::PrimTy::Float(syntax::ast::FloatTy::F32))),
+    ("f64", Res::PrimTy(hir::PrimTy::Float(syntax::ast::FloatTy::F64))),
+    ("str", Res::PrimTy(hir::PrimTy::Str)),
+    ("bool", Res::PrimTy(hir::PrimTy::Bool)),
+    ("char", Res::PrimTy(hir::PrimTy::Char)),
+];
+
+pub fn res_to_def_id(cx: &DocContext<'_>, res: &Res) -> Option<DefId> {
+    if res.is_primitive() {
+        for (path, primitive) in PRIMITIVES.iter() {
+            if primitive == res {
+                return primitive_path_impl(cx, path);
+            }
+        }
+        None
+    } else {
+        Some(res.def_id())
+    }
+}
+
+pub fn primitive_path_impl(cx: &DocContext<'_>, path_str: &str) -> Option<DefId> {
+    let tcx = cx.tcx;
+    match path_str {
+        "u8" => tcx.lang_items().u8_impl(),
+        "u16" => tcx.lang_items().u16_impl(),
+        "u32" => tcx.lang_items().u32_impl(),
+        "u64" => tcx.lang_items().u64_impl(),
+        "u128" => tcx.lang_items().u128_impl(),
+        "usize" => tcx.lang_items().usize_impl(),
+        "i8" => tcx.lang_items().i8_impl(),
+        "i16" => tcx.lang_items().i16_impl(),
+        "i32" => tcx.lang_items().i32_impl(),
+        "i64" => tcx.lang_items().i64_impl(),
+        "i128" => tcx.lang_items().i128_impl(),
+        "isize" => tcx.lang_items().isize_impl(),
+        "f32" => tcx.lang_items().f32_impl(),
+        "f64" => tcx.lang_items().f64_impl(),
+        "str" => tcx.lang_items().str_impl(),
+        "bool" => tcx.lang_items().bool_impl(),
+        "char" => tcx.lang_items().char_impl(),
+        _ => None,
+    }
+}

--- a/src/librustdoc/html/item_type.rs
+++ b/src/librustdoc/html/item_type.rs
@@ -119,6 +119,7 @@ impl From<clean::TypeKind> for ItemType {
             clean::TypeKind::Attr => ItemType::ProcAttribute,
             clean::TypeKind::Derive => ItemType::ProcDerive,
             clean::TypeKind::TraitAlias => ItemType::TraitAlias,
+            clean::TypeKind::Primitive => ItemType::Primitive,
         }
     }
 }

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -9,7 +9,6 @@ use rustc_hir::def::{
     Namespace::{self, *},
     PerNS, Res,
 };
-use rustc_hir::def_id::DefId;
 use rustc_resolve::ParentScope;
 use rustc_span::symbol::Symbol;
 use rustc_span::DUMMY_SP;

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -203,7 +203,8 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
                 .ok_or(ErrorKind::ResolutionFailure)?;
 
             if let Some(prim) = is_primitive(&path, TypeNS) {
-                let did = primitive_impl(cx, &path).ok_or(ErrorKind::ResolutionFailure)?;
+                let did =
+                    utils::primitive_path_impl(cx, &path).ok_or(ErrorKind::ResolutionFailure)?;
                 return cx
                     .tcx
                     .associated_items(did)
@@ -888,50 +889,10 @@ fn handle_variant(
     Ok((parent_def, Some(format!("{}.v", variant.ident.name))))
 }
 
-const PRIMITIVES: &[(&str, Res)] = &[
-    ("u8", Res::PrimTy(hir::PrimTy::Uint(syntax::ast::UintTy::U8))),
-    ("u16", Res::PrimTy(hir::PrimTy::Uint(syntax::ast::UintTy::U16))),
-    ("u32", Res::PrimTy(hir::PrimTy::Uint(syntax::ast::UintTy::U32))),
-    ("u64", Res::PrimTy(hir::PrimTy::Uint(syntax::ast::UintTy::U64))),
-    ("u128", Res::PrimTy(hir::PrimTy::Uint(syntax::ast::UintTy::U128))),
-    ("usize", Res::PrimTy(hir::PrimTy::Uint(syntax::ast::UintTy::Usize))),
-    ("i8", Res::PrimTy(hir::PrimTy::Int(syntax::ast::IntTy::I8))),
-    ("i16", Res::PrimTy(hir::PrimTy::Int(syntax::ast::IntTy::I16))),
-    ("i32", Res::PrimTy(hir::PrimTy::Int(syntax::ast::IntTy::I32))),
-    ("i64", Res::PrimTy(hir::PrimTy::Int(syntax::ast::IntTy::I64))),
-    ("i128", Res::PrimTy(hir::PrimTy::Int(syntax::ast::IntTy::I128))),
-    ("isize", Res::PrimTy(hir::PrimTy::Int(syntax::ast::IntTy::Isize))),
-    ("f32", Res::PrimTy(hir::PrimTy::Float(syntax::ast::FloatTy::F32))),
-    ("f64", Res::PrimTy(hir::PrimTy::Float(syntax::ast::FloatTy::F64))),
-    ("str", Res::PrimTy(hir::PrimTy::Str)),
-    ("bool", Res::PrimTy(hir::PrimTy::Bool)),
-    ("char", Res::PrimTy(hir::PrimTy::Char)),
-];
-
 fn is_primitive(path_str: &str, ns: Namespace) -> Option<Res> {
-    if ns == TypeNS { PRIMITIVES.iter().find(|x| x.0 == path_str).map(|x| x.1) } else { None }
-}
-
-fn primitive_impl(cx: &DocContext<'_>, path_str: &str) -> Option<DefId> {
-    let tcx = cx.tcx;
-    match path_str {
-        "u8" => tcx.lang_items().u8_impl(),
-        "u16" => tcx.lang_items().u16_impl(),
-        "u32" => tcx.lang_items().u32_impl(),
-        "u64" => tcx.lang_items().u64_impl(),
-        "u128" => tcx.lang_items().u128_impl(),
-        "usize" => tcx.lang_items().usize_impl(),
-        "i8" => tcx.lang_items().i8_impl(),
-        "i16" => tcx.lang_items().i16_impl(),
-        "i32" => tcx.lang_items().i32_impl(),
-        "i64" => tcx.lang_items().i64_impl(),
-        "i128" => tcx.lang_items().i128_impl(),
-        "isize" => tcx.lang_items().isize_impl(),
-        "f32" => tcx.lang_items().f32_impl(),
-        "f64" => tcx.lang_items().f64_impl(),
-        "str" => tcx.lang_items().str_impl(),
-        "bool" => tcx.lang_items().bool_impl(),
-        "char" => tcx.lang_items().char_impl(),
-        _ => None,
+    if ns == TypeNS {
+        utils::PRIMITIVES.iter().find(|x| x.0 == path_str).map(|x| x.1)
+    } else {
+        None
     }
 }

--- a/src/test/rustdoc/auxiliary/reexport-primitive.rs
+++ b/src/test/rustdoc/auxiliary/reexport-primitive.rs
@@ -1,0 +1,7 @@
+// compile-flags: --emit metadata --crate-type lib --edition 2018
+
+#![crate_name = "foo"]
+
+pub mod bar {
+    pub use bool;
+}

--- a/src/test/rustdoc/reexport-primitive.rs
+++ b/src/test/rustdoc/reexport-primitive.rs
@@ -1,6 +1,10 @@
 // aux-build: reexport-primitive.rs
 // compile-flags:--extern foo --edition 2018
 
+#![crate_name = "bar"]
+
+// @has bar/p/index.html
+// @has - 'bool'
 pub mod p {
     pub use foo::bar::*;
 }

--- a/src/test/rustdoc/reexport-primitive.rs
+++ b/src/test/rustdoc/reexport-primitive.rs
@@ -1,0 +1,6 @@
+// aux-build: reexport-primitive.rs
+// compile-flags:--extern foo --edition 2018
+
+pub mod p {
+    pub use foo::bar::*;
+}


### PR DESCRIPTION
Fixes #67646.

For info: the reexported primitive type won't appear in the documentation. It seems to me to be the expected behavior.

r? @Mark-Simulacrum 
