### PR TITLE
Revive delay_span_bug to prevent ICE in const_generics

### DIFF
--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -493,7 +493,8 @@ impl<'a, 'tcx> TypeFolder<'tcx> for SubstFolder<'a, 'tcx> {
                              (index={})",
                             data.name, self.root_ty, data.index
                         );
-                        span_bug!(span, "{}", msg);
+                        self.tcx.sess.delay_span_bug(span, &msg);
+                        r
                     }
                 }
             }

--- a/src/test/ui/const-generics/impl-const-generic-struct-with-str.rs
+++ b/src/test/ui/const-generics/impl-const-generic-struct-with-str.rs
@@ -1,0 +1,22 @@
+// regression test for rust-lang/rust#67883
+
+#![feature(const_generics)]
+//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+
+struct Caca<const A: &'static str> {
+    s: String
+}
+
+impl<const A: &str> Default for Caca<A> {
+    //~^ ERROR: lifetime of reference outlives
+    fn default() -> Self {
+        let a = Self::A; //~ ERROR: no associated item named `A` found
+        Self {
+            s: A.to_string()
+        }
+    }
+}
+
+fn main() {
+    println!("Hello, world!");
+}

--- a/src/test/ui/const-generics/impl-const-generic-struct-with-str.stderr
+++ b/src/test/ui/const-generics/impl-const-generic-struct-with-str.stderr
@@ -1,0 +1,34 @@
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/impl-const-generic-struct-with-str.rs:3:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0312]: lifetime of reference outlives lifetime of borrowed content...
+  --> $DIR/impl-const-generic-struct-with-str.rs:10:38
+   |
+LL | impl<const A: &str> Default for Caca<A> {
+   |                                      ^
+   |
+   = note: ...the reference is valid for the static lifetime...
+note: ...but the borrowed content is only valid for the lifetime `'_` as defined on the impl at 10:15
+  --> $DIR/impl-const-generic-struct-with-str.rs:10:15
+   |
+LL | impl<const A: &str> Default for Caca<A> {
+   |               ^
+
+error[E0599]: no associated item named `A` found for type `Caca<A>` in the current scope
+  --> $DIR/impl-const-generic-struct-with-str.rs:13:23
+   |
+LL | struct Caca<const A: &'static str> {
+   | ---------------------------------- associated item `A` not found for this
+...
+LL |         let a = Self::A;
+   |                       ^ associated item not found in `Caca<A>`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0312, E0599.
+For more information about an error, try `rustc --explain E0312`.


### PR DESCRIPTION
This `delay_span_bug` removed by cd3ead19dd37c829d22af947d510d8efa73cdb70 in #67160. But it acutually hides bugs so I think we should revive it.

Fixes #67883
