### PR TITLE
Export public scalar statics in wasm

### DIFF
--- a/src/librustc_codegen_ssa/back/symbol_export.rs
+++ b/src/librustc_codegen_ssa/back/symbol_export.rs
@@ -345,16 +345,11 @@ fn symbol_export_level(tcx: TyCtxt<'_>, sym_def_id: DefId) -> SymbolExportLevel 
     if is_extern && !std_internal {
         let target = &tcx.sess.target.target.llvm_target;
         // WebAssembly cannot export data symbols, so reduce their export level
-        if target.contains("wasm32") || target.contains("emscripten") {
+        if target.contains("emscripten") {
             if let Some(Node::Item(&hir::Item { kind: hir::ItemKind::Static(..), .. })) =
                 tcx.hir().get_if_local(sym_def_id)
             {
-                let export_level = if tcx.type_of(sym_def_id).is_scalar() {
-                    SymbolExportLevel::C
-                } else {
-                    SymbolExportLevel::Rust
-                };
-                return export_level;
+                return SymbolExportLevel::Rust;
             }
         }
 

--- a/src/librustc_codegen_ssa/back/symbol_export.rs
+++ b/src/librustc_codegen_ssa/back/symbol_export.rs
@@ -349,7 +349,12 @@ fn symbol_export_level(tcx: TyCtxt<'_>, sym_def_id: DefId) -> SymbolExportLevel 
             if let Some(Node::Item(&hir::Item { kind: hir::ItemKind::Static(..), .. })) =
                 tcx.hir().get_if_local(sym_def_id)
             {
-                return SymbolExportLevel::Rust;
+                let export_level = if tcx.type_of(sym_def_id).is_scalar() {
+                    SymbolExportLevel::C
+                } else {
+                    SymbolExportLevel::Rust
+                };
+                return export_level;
             }
         }
 

--- a/src/test/run-make/wasm-export-all-symbols/bar.rs
+++ b/src/test/run-make/wasm-export-all-symbols/bar.rs
@@ -2,3 +2,6 @@
 
 #[no_mangle]
 pub extern fn foo() {}
+
+#[no_mangle]
+pub static FOO: u64 = 42;

--- a/src/test/run-make/wasm-export-all-symbols/verify.js
+++ b/src/test/run-make/wasm-export-all-symbols/verify.js
@@ -8,21 +8,31 @@ let list = WebAssembly.Module.exports(m);
 console.log('exports', list);
 
 const my_exports = {};
-let nexports = 0;
+let nexports_fn = 0;
+let nexports_global = 0;
 for (const entry of list) {
-  if (entry.kind !== 'function')
-    continue;
-  my_exports[entry.name] = true;
-  nexports += 1;
+  if (entry.kind == 'function'){
+    nexports_fn += 1;
+  }
+  if (entry.kind == 'global'){
+    nexports_global += 1;
+  }
+    my_exports[entry.name] = true;
 }
 
 if (my_exports.foo === undefined)
   throw new Error("`foo` wasn't defined");
 
+if (my_exports.FOO === undefined)
+  throw new Error("`FOO` wasn't defined");
+
 if (my_exports.main === undefined) {
-  if (nexports != 1)
+  if (nexports_fn != 1)
     throw new Error("should only have one function export");
 } else {
-  if (nexports != 2)
+  if (nexports_fn != 2)
     throw new Error("should only have two function exports");
 }
+
+if (nexports_global != 1)
+  throw new Error("should only have one static export");

--- a/src/test/run-make/wasm-export-all-symbols/verify.js
+++ b/src/test/run-make/wasm-export-all-symbols/verify.js
@@ -8,14 +8,11 @@ let list = WebAssembly.Module.exports(m);
 console.log('exports', list);
 
 const my_exports = {};
-let nexports_fn = 0;
-let nexports_global = 0;
+let nexports = 0;
+
 for (const entry of list) {
   if (entry.kind == 'function'){
-    nexports_fn += 1;
-  }
-  if (entry.kind == 'global'){
-    nexports_global += 1;
+    nexports += 1;
   }
   my_exports[entry.name] = true;
 }
@@ -27,12 +24,9 @@ if (my_exports.FOO === undefined)
   throw new Error("`FOO` wasn't defined");
 
 if (my_exports.main === undefined) {
-  if (nexports_fn != 1)
+  if (nexports != 1)
     throw new Error("should only have one function export");
 } else {
-  if (nexports_fn != 2)
+  if (nexports != 2)
     throw new Error("should only have two function exports");
 }
-
-if (nexports_global != 1)
-  throw new Error("should only have one static export");

--- a/src/test/run-make/wasm-export-all-symbols/verify.js
+++ b/src/test/run-make/wasm-export-all-symbols/verify.js
@@ -14,13 +14,13 @@ for (const entry of list) {
   if (entry.kind == 'function'){
     nexports += 1;
   }
-  my_exports[entry.name] = true;
+  my_exports[entry.name] = entry.kind;
 }
 
-if (my_exports.foo === undefined)
+if (my_exports.foo != "function")
   throw new Error("`foo` wasn't defined");
 
-if (my_exports.FOO === undefined)
+if (my_exports.FOO != "global")
   throw new Error("`FOO` wasn't defined");
 
 if (my_exports.main === undefined) {

--- a/src/test/run-make/wasm-export-all-symbols/verify.js
+++ b/src/test/run-make/wasm-export-all-symbols/verify.js
@@ -17,7 +17,7 @@ for (const entry of list) {
   if (entry.kind == 'global'){
     nexports_global += 1;
   }
-    my_exports[entry.name] = true;
+  my_exports[entry.name] = true;
 }
 
 if (my_exports.foo === undefined)


### PR DESCRIPTION
Fixes #67453 

I am not sure which export level statics should get when exporting them in wasm. This small change fixes the issue that I had, but this might not be the correct way to implement this.