### PR TITLE
Update LLVM to fix crash on Emscripten targets

### DIFF
--- a/src/test/ui/issues/issue-66308.rs
+++ b/src/test/ui/issues/issue-66308.rs
@@ -1,0 +1,8 @@
+// build-pass
+// compile-flags: --crate-type lib
+
+// Regression test for LLVM crash affecting Emscripten targets
+
+pub fn foo() {
+    (0..0).rev().next();
+}


### PR DESCRIPTION
Pulls in a bug fix from upstream to resolve #66308. Also adds a small
Rust regression test.

r? @alexcrichton