### PR TITLE
Remove leaf bias from BTreeMap's BoxedNode and NodeRef

### DIFF
--- a/src/etc/gdb_rust_pretty_printing.py
+++ b/src/etc/gdb_rust_pretty_printing.py
@@ -336,17 +336,14 @@ def children_of_node(boxed_node, height, want_values):
     head = node_ptr.dereference()
     length = int(head['len'])
     if length > 0:
-        type_name = str(node_ptr.type.target()) # alloc::...::NodeHeader<K, V, K2>
-        assert type_name.endswith(", ()>")
-        type_name = type_name[:-5] + ">"
         if height > 0:
-            type_name = type_name.replace('NodeHeader', 'InternalNode', 1)
+            type_name = str(node_ptr.type.target()).replace('NodeHeader', 'InternalNode', 1)
             node_type = gdb.lookup_type(type_name)
             node_ptr = node_ptr.cast(node_type.pointer())
             leaf = node_ptr['data']
             edges = node_ptr['edges']
         else:
-            type_name = type_name.replace('NodeHeader', 'LeafNode', 1)
+            type_name = str(node_ptr.type.target()).replace('NodeHeader', 'LeafNode', 1)
             node_type = gdb.lookup_type(type_name)
             node_ptr = node_ptr.cast(node_type.pointer())
             leaf = node_ptr.dereference()

--- a/src/etc/gdb_rust_pretty_printing.py
+++ b/src/etc/gdb_rust_pretty_printing.py
@@ -336,13 +336,19 @@ def children_of_node(boxed_node, height, want_values):
     head = node_ptr.dereference()
     length = int(head['len'])
     if length > 0:
+        type_name = str(node_ptr.type.target()) # alloc::...::NodeHeader<K, V, K2>
+        assert type_name.endswith(", ()>")
+        type_name = type_name[:-5] + ">"
         if height > 0:
-            type_name = str(node_ptr.type.target()).replace('LeafNode', 'InternalNode', 1)
+            type_name = type_name.replace('NodeHeader', 'InternalNode', 1)
             node_type = gdb.lookup_type(type_name)
             node_ptr = node_ptr.cast(node_type.pointer())
             leaf = node_ptr['data']
             edges = node_ptr['edges']
         else:
+            type_name = type_name.replace('NodeHeader', 'LeafNode', 1)
+            node_type = gdb.lookup_type(type_name)
+            node_ptr = node_ptr.cast(node_type.pointer())
             leaf = node_ptr.dereference()
             edges = None
         keys = leaf['keys']

--- a/src/test/debuginfo/pretty-std-collections.rs
+++ b/src/test/debuginfo/pretty-std-collections.rs
@@ -24,7 +24,7 @@
 // gdb-check:$3 = BTreeMap<(), ()>(len: 0)
 
 // gdb-command: print nasty_btree_map
-// gdb-check:$4 = BTreeMap<i32, pretty_std_collections::MyLeafNode>(len: 1) = {[1] = pretty_std_collections::MyLeafNode (11)}
+// gdb-check:$4 = BTreeMap<i32, pretty_std_collections::MyNodeHeader>(len: 1) = {[1] = pretty_std_collections::MyNodeHeader (11)}
 
 // gdb-command: print vec_deque
 // gdb-check:$5 = VecDeque<i32>(len: 3, cap: 8) = {5, 3, 7}
@@ -37,7 +37,7 @@ use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::VecDeque;
 
-struct MyLeafNode(i32); // helps to ensure we don't blindly replace substring "LeafNode"
+struct MyNodeHeader(i32); // helps to ensure we don't blindly replace substring "NodeHeader"
 
 fn main() {
     // BTreeSet
@@ -52,8 +52,8 @@ fn main() {
         btree_map.insert(i, i);
     }
     let empty_btree_map: BTreeMap<(), ()> = BTreeMap::new();
-    let mut nasty_btree_map: BTreeMap<i32, MyLeafNode> = BTreeMap::new();
-    nasty_btree_map.insert(1, MyLeafNode(11));
+    let mut nasty_btree_map: BTreeMap<i32, MyNodeHeader> = BTreeMap::new();
+    nasty_btree_map.insert(1, MyNodeHeader(11));
 
     // VecDeque
     let mut vec_deque = VecDeque::new();

--- a/src/test/debuginfo/pretty-std-collections.rs
+++ b/src/test/debuginfo/pretty-std-collections.rs
@@ -20,20 +20,26 @@
 // gdb-command: print btree_map
 // gdb-check:$2 = BTreeMap<i32, i32>(len: 15) = {[0] = 0, [1] = 1, [2] = 2, [3] = 3, [4] = 4, [5] = 5, [6] = 6, [7] = 7, [8] = 8, [9] = 9, [10] = 10, [11] = 11, [12] = 12, [13] = 13, [14] = 14}
 
+// gdb-command: print empty_btree_map
+// gdb-check:$3 = BTreeMap<(), ()>(len: 0)
+
+// gdb-command: print nasty_btree_map
+// gdb-check:$4 = BTreeMap<i32, pretty_std_collections::MyLeafNode>(len: 1) = {[1] = pretty_std_collections::MyLeafNode (11)}
+
 // gdb-command: print vec_deque
-// gdb-check:$3 = VecDeque<i32>(len: 3, cap: 8) = {5, 3, 7}
+// gdb-check:$5 = VecDeque<i32>(len: 3, cap: 8) = {5, 3, 7}
 
 // gdb-command: print vec_deque2
-// gdb-check:$4 = VecDeque<i32>(len: 7, cap: 8) = {2, 3, 4, 5, 6, 7, 8}
+// gdb-check:$6 = VecDeque<i32>(len: 7, cap: 8) = {2, 3, 4, 5, 6, 7, 8}
 
 #![allow(unused_variables)]
-use std::collections::BTreeSet;
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::collections::VecDeque;
 
+struct MyLeafNode(i32); // helps to ensure we don't blindly replace substring "LeafNode"
 
 fn main() {
-
     // BTreeSet
     let mut btree_set = BTreeSet::new();
     for i in 0..15 {
@@ -45,6 +51,9 @@ fn main() {
     for i in 0..15 {
         btree_map.insert(i, i);
     }
+    let empty_btree_map: BTreeMap<(), ()> = BTreeMap::new();
+    let mut nasty_btree_map: BTreeMap<i32, MyLeafNode> = BTreeMap::new();
+    nasty_btree_map.insert(1, MyLeafNode(11));
 
     // VecDeque
     let mut vec_deque = VecDeque::new();
@@ -63,4 +72,6 @@ fn main() {
     zzz(); // #break
 }
 
-fn zzz() { () }
+fn zzz() {
+    ()
+}


### PR DESCRIPTION
Improve readability - there is no genuine problem here, after #56648.

`BoxedNode` and `NodeRef` contain a pointer to a node that is typed as `LeafNode`. In case of EMPTY_ROOT_NODE, that pointer may not be properly aligned and does not point to anything matching `LeafNode<K, V>`. Only `NodeRef`'s documentation mentions this. 

It seemed more logical to me to give these pointers as type the least common denominator, `NodeHeader<K, V>` (which only exists since  #56648). That simplifies the simplest access `as_header` and levels the playing field for leaf and internal nodes.

One could argue that most nodes are in fact leaves, and most access to nodes is to their leaf-portion, keys and values. Then I'd still like to fix the documentation of `BoxedNode`.