### PR TITLE
slice patterns: harden match-based borrowck tests

### DIFF
--- a/src/test/ui/borrowck/borrowck-move-out-from-array-match.rs
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array-match.rs
@@ -1,0 +1,118 @@
+#![feature(slice_patterns)]
+
+fn array() -> [(String, String); 3] {
+    Default::default()
+}
+
+// Const Index + Const Index
+
+fn move_out_from_begin_and_end() {
+    let a = array();
+    match a {
+        [_, _, _x] => {}
+    }
+    match a {
+        [.., _y] => {} //~ ERROR use of moved value
+    }
+}
+
+fn move_out_from_begin_field_and_end() {
+    let a = array();
+    match a {
+        [_, _, (_x, _)] => {}
+    }
+    match a {
+        [.., _y] => {} //~ ERROR use of moved value
+    }
+}
+
+fn move_out_from_begin_field_and_end_field() {
+    let a = array();
+    match a {
+        [_, _, (_x, _)] => {}
+    }
+    match a {
+        [.., (_y, _)] => {} //~ ERROR use of moved value
+    }
+}
+
+// Const Index + Slice
+
+fn move_out_by_const_index_and_subslice() {
+    let a = array();
+    match a {
+        [_x, _, _] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [_y @ .., _, _] => {}
+    }
+}
+
+fn move_out_by_const_index_end_and_subslice() {
+    let a = array();
+    match a {
+        [.., _x] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [_, _, _y @ ..] => {}
+    }
+}
+
+fn move_out_by_const_index_field_and_subslice() {
+    let a = array();
+    match a {
+        [(_x, _), _, _] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [_y @ .., _, _] => {}
+    }
+}
+
+fn move_out_by_const_index_end_field_and_subslice() {
+    let a = array();
+    match a {
+        [.., (_x, _)] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [_, _, _y @ ..] => {}
+    }
+}
+
+fn move_out_by_subslice_and_const_index_field() {
+    let a = array();
+    match a {
+        [_y @ .., _, _] => {}
+    }
+    match a {
+        [(_x, _), _, _] => {} //~ ERROR use of moved value
+    }
+}
+
+fn move_out_by_subslice_and_const_index_end_field() {
+    let a = array();
+    match a {
+        [_, _, _y @ ..] => {}
+    }
+    match a {
+        [.., (_x, _)] => {} //~ ERROR use of moved value
+    }
+}
+
+// Slice + Slice
+
+fn move_out_by_subslice_and_subslice() {
+    let a = array();
+    match a {
+        [x @ .., _] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [_, _y @ ..] => {}
+    }
+}
+
+fn main() {}

--- a/src/test/ui/borrowck/borrowck-move-out-from-array-match.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array-match.stderr
@@ -1,0 +1,113 @@
+error[E0382]: use of moved value: `a[..]`
+  --> $DIR/borrowck-move-out-from-array-match.rs:15:14
+   |
+LL |         [_, _, _x] => {}
+   |                -- value moved here
+...
+LL |         [.., _y] => {}
+   |              ^^ value used here after move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a[..]`
+  --> $DIR/borrowck-move-out-from-array-match.rs:25:14
+   |
+LL |         [_, _, (_x, _)] => {}
+   |                 -- value moved here
+...
+LL |         [.., _y] => {}
+   |              ^^ value used here after partial move
+   |
+   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a[..].0`
+  --> $DIR/borrowck-move-out-from-array-match.rs:35:15
+   |
+LL |         [_, _, (_x, _)] => {}
+   |                 -- value moved here
+...
+LL |         [.., (_y, _)] => {}
+   |               ^^ value used here after move
+   |
+   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-match.rs:46:11
+   |
+LL |         [_x, _, _] => {}
+   |          -- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-match.rs:57:11
+   |
+LL |         [.., _x] => {}
+   |              -- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-match.rs:68:11
+   |
+LL |         [(_x, _), _, _] => {}
+   |           -- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-match.rs:79:11
+   |
+LL |         [.., (_x, _)] => {}
+   |               -- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a[..].0`
+  --> $DIR/borrowck-move-out-from-array-match.rs:91:11
+   |
+LL |         [_y @ .., _, _] => {}
+   |          ------- value moved here
+...
+LL |         [(_x, _), _, _] => {}
+   |           ^^ value used here after move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a[..].0`
+  --> $DIR/borrowck-move-out-from-array-match.rs:101:15
+   |
+LL |         [_, _, _y @ ..] => {}
+   |                ------- value moved here
+...
+LL |         [.., (_x, _)] => {}
+   |               ^^ value used here after move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-match.rs:112:11
+   |
+LL |         [x @ .., _] => {}
+   |          ------ value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error: aborting due to 10 previous errors
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/borrowck/borrowck-move-out-from-array-no-overlap-match.rs
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array-no-overlap-match.rs
@@ -1,0 +1,117 @@
+// Due to #53114, which causes a "read" of the `_` patterns,
+// the borrow-checker refuses this code, while it should probably be allowed.
+// Once the bug is fixed, the test, which is derived from a
+// passing test for `let` statements, should become check-pass.
+
+#![feature(slice_patterns)]
+
+fn array() -> [(String, String); 3] {
+    Default::default()
+}
+
+// Const Index + Const Index
+
+fn move_out_from_begin_and_one_from_end() {
+    let a = array();
+    match a {
+        [_, _, _x] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [.., _y, _] => {}
+    }
+}
+
+fn move_out_from_begin_field_and_end_field() {
+    let a = array();
+    match a {
+        [_, _, (_x, _)] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [.., (_, _y)] => {}
+    }
+}
+
+// Const Index + Slice
+
+fn move_out_by_const_index_and_subslice() {
+    let a = array();
+    match a {
+        [_x, _, _] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [_, _y @ ..] => {}
+    }
+}
+
+fn move_out_by_const_index_end_and_subslice() {
+    let a = array();
+    match a {
+        [.., _x] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [_y @ .., _] => {}
+    }
+}
+
+fn move_out_by_const_index_field_and_subslice() {
+    let a = array();
+    match a {
+        [(_x, _), _, _] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [_, _y @ ..] => {}
+    }
+}
+
+fn move_out_by_const_index_end_field_and_subslice() {
+    let a = array();
+    match a {
+        [.., (_x, _)] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [_y @ .., _] => {}
+    }
+}
+
+fn move_out_by_const_subslice_and_index_field() {
+    let a = array();
+    match a {
+        [_, _y @ ..] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [(_x, _), _, _] => {}
+    }
+}
+
+fn move_out_by_const_subslice_and_end_index_field() {
+    let a = array();
+    match a {
+        [_y @ .., _] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [.., (_x, _)] => {}
+    }
+}
+
+// Slice + Slice
+
+fn move_out_by_subslice_and_subslice() {
+    let a = array();
+    match a {
+        [x @ .., _, _] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [_, _y @ ..] => {}
+    }
+}
+
+fn main() {}

--- a/src/test/ui/borrowck/borrowck-move-out-from-array-no-overlap-match.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array-no-overlap-match.stderr
@@ -1,0 +1,102 @@
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-no-overlap-match.rs:19:11
+   |
+LL |         [_, _, _x] => {}
+   |                -- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-no-overlap-match.rs:30:11
+   |
+LL |         [_, _, (_x, _)] => {}
+   |                 -- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-no-overlap-match.rs:43:11
+   |
+LL |         [_x, _, _] => {}
+   |          -- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-no-overlap-match.rs:54:11
+   |
+LL |         [.., _x] => {}
+   |              -- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-no-overlap-match.rs:65:11
+   |
+LL |         [(_x, _), _, _] => {}
+   |           -- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-no-overlap-match.rs:76:11
+   |
+LL |         [.., (_x, _)] => {}
+   |               -- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-no-overlap-match.rs:87:11
+   |
+LL |         [_, _y @ ..] => {}
+   |             ------- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-no-overlap-match.rs:98:11
+   |
+LL |         [_y @ .., _] => {}
+   |          ------- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-no-overlap-match.rs:111:11
+   |
+LL |         [x @ .., _, _] => {}
+   |          ------ value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error: aborting due to 9 previous errors
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/borrowck/borrowck-move-out-from-array-use-match.rs
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array-use-match.rs
@@ -1,0 +1,152 @@
+#![feature(slice_patterns)]
+
+fn array() -> [(String, String); 3] {
+    Default::default()
+}
+
+// Const Index + Const Index
+
+fn move_out_from_begin_and_end() {
+    let a = array();
+    match a {
+        [_, _, _x] => {}
+    }
+    match a {
+        [.., ref _y] => {} //~ ERROR [E0382]
+    }
+}
+
+fn move_out_from_begin_field_and_end() {
+    let a = array();
+    match a {
+        [_, _, (_x, _)] => {}
+    }
+    match a {
+        [.., ref _y] => {} //~ ERROR [E0382]
+    }
+}
+
+fn move_out_from_begin_field_and_end_field() {
+    let a = array();
+    match a {
+        [_, _, (_x, _)] => {}
+    }
+    match a {
+        [.., (ref _y, _)] => {} //~ ERROR [E0382]
+    }
+}
+
+// Const Index + Slice
+
+fn move_out_by_const_index_and_subslice() {
+    let a = array();
+    match a {
+        [_x, _, _] => {}
+    }
+    match a {
+        //~^ ERROR [E0382]
+        [ref _y @ .., _, _] => {}
+    }
+}
+
+fn move_out_by_const_index_end_and_subslice() {
+    let a = array();
+    match a {
+        [.., _x] => {}
+    }
+    match a {
+        //~^ ERROR [E0382]
+        [_, _, ref _y @ ..] => {}
+    }
+}
+
+fn move_out_by_const_index_field_and_subslice() {
+    let a = array();
+    match a {
+        [(_x, _), _, _] => {}
+    }
+    match a {
+        //~^ ERROR [E0382]
+        [ref _y @ .., _, _] => {}
+    }
+}
+
+fn move_out_by_const_index_end_field_and_subslice() {
+    let a = array();
+    match a {
+        [.., (_x, _)] => {}
+    }
+    match a {
+        //~^ ERROR [E0382]
+        [_, _, ref _y @ ..] => {}
+    }
+}
+
+fn move_out_by_subslice_and_const_index_field() {
+    let a = array();
+    match a {
+        [_y @ .., _, _] => {}
+    }
+    match a {
+        [(ref _x, _), _, _] => {} //~ ERROR [E0382]
+    }
+}
+
+fn move_out_by_subslice_and_const_index_end_field() {
+    let a = array();
+    match a {
+        [_, _, _y @ ..] => {}
+    }
+    match a {
+        [.., (ref _x, _)] => {} //~ ERROR [E0382]
+    }
+}
+
+// Slice + Slice
+
+fn move_out_by_subslice_and_subslice() {
+    let a = array();
+    match a {
+        [x @ .., _] => {}
+    }
+    match a {
+        //~^ ERROR [E0382]
+        [_, ref _y @ ..] => {}
+    }
+}
+
+// Move + Assign
+
+fn move_out_and_assign_end() {
+    let mut a = array();
+    match a {
+        [_, _, _x] => {}
+    }
+    a[2] = Default::default(); //~ ERROR [E0382]
+}
+
+fn move_out_and_assign_end_field() {
+    let mut a = array();
+    match a {
+        [_, _, (_x, _)] => {}
+    }
+    a[2].1 = Default::default(); //~ ERROR [E0382]
+}
+
+fn move_out_slice_and_assign_end() {
+    let mut a = array();
+    match a {
+        [_, _, _x @ ..] => {}
+    }
+    a[0] = Default::default(); //~ ERROR [E0382]
+}
+
+fn move_out_slice_and_assign_end_field() {
+    let mut a = array();
+    match a {
+        [_, _, _x @ ..] => {}
+    }
+    a[0].1 = Default::default(); //~ ERROR [E0382]
+}
+
+fn main() {}

--- a/src/test/ui/borrowck/borrowck-move-out-from-array-use-match.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array-use-match.stderr
@@ -1,0 +1,157 @@
+error[E0382]: borrow of moved value: `a[..]`
+  --> $DIR/borrowck-move-out-from-array-use-match.rs:15:14
+   |
+LL |         [_, _, _x] => {}
+   |                -- value moved here
+...
+LL |         [.., ref _y] => {}
+   |              ^^^^^^ value borrowed here after move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: borrow of moved value: `a[..]`
+  --> $DIR/borrowck-move-out-from-array-use-match.rs:25:14
+   |
+LL |         [_, _, (_x, _)] => {}
+   |                 -- value moved here
+...
+LL |         [.., ref _y] => {}
+   |              ^^^^^^ value borrowed here after partial move
+   |
+   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+
+error[E0382]: borrow of moved value: `a[..].0`
+  --> $DIR/borrowck-move-out-from-array-use-match.rs:35:15
+   |
+LL |         [_, _, (_x, _)] => {}
+   |                 -- value moved here
+...
+LL |         [.., (ref _y, _)] => {}
+   |               ^^^^^^ value borrowed here after move
+   |
+   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-use-match.rs:46:11
+   |
+LL |         [_x, _, _] => {}
+   |          -- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-use-match.rs:57:11
+   |
+LL |         [.., _x] => {}
+   |              -- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-use-match.rs:68:11
+   |
+LL |         [(_x, _), _, _] => {}
+   |           -- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-use-match.rs:79:11
+   |
+LL |         [.., (_x, _)] => {}
+   |               -- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+
+error[E0382]: borrow of moved value: `a[..]`
+  --> $DIR/borrowck-move-out-from-array-use-match.rs:91:11
+   |
+LL |         [_y @ .., _, _] => {}
+   |          ------- value moved here
+...
+LL |         [(ref _x, _), _, _] => {}
+   |           ^^^^^^ value borrowed here after move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: borrow of moved value: `a[..]`
+  --> $DIR/borrowck-move-out-from-array-use-match.rs:101:15
+   |
+LL |         [_, _, _y @ ..] => {}
+   |                ------- value moved here
+...
+LL |         [.., (ref _x, _)] => {}
+   |               ^^^^^^ value borrowed here after move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-use-match.rs:112:11
+   |
+LL |         [x @ .., _] => {}
+   |          ------ value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-use-match.rs:125:5
+   |
+LL |         [_, _, _x] => {}
+   |                -- value moved here
+LL |     }
+LL |     a[2] = Default::default();
+   |     ^^^^ value used here after partial move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-use-match.rs:133:5
+   |
+LL |         [_, _, (_x, _)] => {}
+   |                 -- value moved here
+LL |     }
+LL |     a[2].1 = Default::default();
+   |     ^^^^ value used here after partial move
+   |
+   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-use-match.rs:141:5
+   |
+LL |         [_, _, _x @ ..] => {}
+   |                ------- value moved here
+LL |     }
+LL |     a[0] = Default::default();
+   |     ^^^^ value used here after partial move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-use-match.rs:149:5
+   |
+LL |         [_, _, _x @ ..] => {}
+   |                ------- value moved here
+LL |     }
+LL |     a[0].1 = Default::default();
+   |     ^^^^ value used here after partial move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error: aborting due to 14 previous errors
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/borrowck/borrowck-move-out-from-array-use-no-overlap-match.rs
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array-use-no-overlap-match.rs
@@ -1,0 +1,117 @@
+// Due to #53114, which causes a "read" of the `_` patterns,
+// the borrow-checker refuses this code, while it should probably be allowed.
+// Once the bug is fixed, the test, which is derived from a
+// passing test for `let` statements, should become check-pass.
+
+#![feature(slice_patterns)]
+
+fn array() -> [(String, String); 3] {
+    Default::default()
+}
+
+// Const Index + Const Index
+
+fn move_out_from_begin_and_one_from_end() {
+    let a = array();
+    match a {
+        [_, _, _x] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [.., ref _y, _] => {}
+    }
+}
+
+fn move_out_from_begin_field_and_end_field() {
+    let a = array();
+    match a {
+        [_, _, (_x, _)] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [.., (_, ref _y)] => {}
+    }
+}
+
+// Const Index + Slice
+
+fn move_out_by_const_index_and_subslice() {
+    let a = array();
+    match a {
+        [_x, _, _] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [_, ref _y @ ..] => {}
+    }
+}
+
+fn move_out_by_const_index_end_and_subslice() {
+    let a = array();
+    match a {
+        [.., _x] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [ref _y @ .., _] => {}
+    }
+}
+
+fn move_out_by_const_index_field_and_subslice() {
+    let a = array();
+    match a {
+        [(_x, _), _, _] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [_, ref _y @ ..] => {}
+    }
+}
+
+fn move_out_by_const_index_end_field_and_subslice() {
+    let a = array();
+    match a {
+        [.., (_x, _)] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [ref _y @ .., _] => {}
+    }
+}
+
+fn move_out_by_const_subslice_and_index_field() {
+    let a = array();
+    match a {
+        [_, _y @ ..] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [(ref _x, _), _, _] => {}
+    }
+}
+
+fn move_out_by_const_subslice_and_end_index_field() {
+    let a = array();
+    match a {
+        [_y @ .., _] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [.., (ref _x, _)] => {}
+    }
+}
+
+// Slice + Slice
+
+fn move_out_by_subslice_and_subslice() {
+    let a = array();
+    match a {
+        [x @ .., _, _] => {}
+    }
+    match a {
+        //~^ ERROR use of moved value
+        [_, ref _y @ ..] => {}
+    }
+}
+
+fn main() {}

--- a/src/test/ui/borrowck/borrowck-move-out-from-array-use-no-overlap-match.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array-use-no-overlap-match.stderr
@@ -1,0 +1,102 @@
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-use-no-overlap-match.rs:19:11
+   |
+LL |         [_, _, _x] => {}
+   |                -- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-use-no-overlap-match.rs:30:11
+   |
+LL |         [_, _, (_x, _)] => {}
+   |                 -- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-use-no-overlap-match.rs:43:11
+   |
+LL |         [_x, _, _] => {}
+   |          -- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-use-no-overlap-match.rs:54:11
+   |
+LL |         [.., _x] => {}
+   |              -- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-use-no-overlap-match.rs:65:11
+   |
+LL |         [(_x, _), _, _] => {}
+   |           -- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-use-no-overlap-match.rs:76:11
+   |
+LL |         [.., (_x, _)] => {}
+   |               -- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-use-no-overlap-match.rs:87:11
+   |
+LL |         [_, _y @ ..] => {}
+   |             ------- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-use-no-overlap-match.rs:98:11
+   |
+LL |         [_y @ .., _] => {}
+   |          ------- value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/borrowck-move-out-from-array-use-no-overlap-match.rs:111:11
+   |
+LL |         [x @ .., _, _] => {}
+   |          ------ value moved here
+LL |     }
+LL |     match a {
+   |           ^ value used here after partial move
+   |
+   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+
+error: aborting due to 9 previous errors
+
+For more information about this error, try `rustc --explain E0382`.


### PR DESCRIPTION
This hardens some move-checking tests wrt. slice patterns and `match` expressions.

r? @matthewjasper
cc @pnkfelix 
cc https://github.com/rust-lang/rust/pull/67712
cc https://github.com/rust-lang/rust/issues/53114