### PR TITLE
perf: Only search potentially changed constraints in lexical_region_resolve

### DIFF
--- a/src/librustc/infer/lexical_region_resolve/mod.rs
+++ b/src/librustc/infer/lexical_region_resolve/mod.rs
@@ -19,7 +19,6 @@ use rustc_data_structures::graph::implementation::{
     Direction, Graph, NodeIndex, INCOMING, OUTGOING,
 };
 use rustc_hir::def_id::DefId;
-use rustc_index::bit_set::BitSet;
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_span::Span;
 use std::fmt;
@@ -295,23 +294,19 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
     }
 
     fn expansion(&self, var_values: &mut LexicalRegionResolutions<'tcx>) {
-        let mut changed = false;
-        let mut constraints = Vec::new();
+        let mut constraints = IndexVec::from_elem_n(Vec::new(), var_values.values.len());
+        let mut changes = Vec::new();
         for constraint in self.data.constraints.keys() {
-            let (a_region, b_vid, b_data) = match *constraint {
+            let (a_vid, a_region, b_vid, b_data) = match *constraint {
                 Constraint::RegSubVar(a_region, b_vid) => {
                     let b_data = var_values.value_mut(b_vid);
-                    (a_region, b_vid, b_data)
+                    (None, a_region, b_vid, b_data)
                 }
                 Constraint::VarSubVar(a_vid, b_vid) => match *var_values.value(a_vid) {
                     VarValue::ErrorValue => continue,
                     VarValue::Value(a_region) => {
                         let b_data = var_values.value_mut(b_vid);
-                        match *b_data {
-                            VarValue::Value(ReStatic) | VarValue::ErrorValue => (),
-                            _ => constraints.push((a_vid, b_vid)),
-                        }
-                        (a_region, b_vid, b_data)
+                        (Some(a_vid), a_region, b_vid, b_data)
                     }
                 },
                 Constraint::RegSubReg(..) | Constraint::VarSubReg(..) => {
@@ -320,54 +315,38 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
                     continue;
                 }
             };
-            let edge_changed = self.expand_node(a_region, b_vid, b_data);
-            if edge_changed {
-                changed = true
+            if self.expand_node(a_region, b_vid, b_data) {
+                changes.push(b_vid);
+            }
+            if let Some(a_vid) = a_vid {
+                match *b_data {
+                    VarValue::Value(ReStatic) | VarValue::ErrorValue => (),
+                    _ => {
+                        constraints[a_vid].push((a_vid, b_vid));
+                        constraints[b_vid].push((a_vid, b_vid));
+                    }
+                }
             }
         }
 
-        let mut process_constraint = |a_vid, b_vid| {
-            let (a_region, b_data, retain) = match *var_values.value(a_vid) {
-                VarValue::ErrorValue => return (false, false),
-                VarValue::Value(a_region) => {
-                    let b_data = var_values.value_mut(b_vid);
-                    let retain = match *b_data {
-                        VarValue::Value(ReStatic) | VarValue::ErrorValue => false,
-                        _ => true,
-                    };
-                    (a_region, b_data, retain)
+        while let Some(vid) = changes.pop() {
+            constraints[vid].retain(|&(a_vid, b_vid)| {
+                let a_region = match *var_values.value(a_vid) {
+                    VarValue::ErrorValue => return false,
+                    VarValue::Value(a_region) => a_region,
+                };
+                let b_data = var_values.value_mut(b_vid);
+                if self.expand_node(a_region, b_vid, b_data) {
+                    changes.push(b_vid);
                 }
-            };
-            let changed = self.expand_node(a_region, b_vid, b_data);
-            (changed, retain)
-        };
-
-        // Using bitsets to track the remaining elements is faster than using a
-        // `Vec` by itself (which requires removing elements, which requires
-        // element shuffling, which is slow).
-        let mut live_indices: BitSet<usize> = BitSet::new_filled(constraints.len());
-        let mut killed_indices: BitSet<usize> = BitSet::new_empty(constraints.len());
-        while changed {
-            changed = false;
-            for index in live_indices.iter() {
-                let (a_vid, b_vid) = constraints[index];
-                let (edge_changed, retain) = process_constraint(a_vid, b_vid);
-                changed |= edge_changed;
-                if !retain {
-                    let changed = killed_indices.insert(index);
-                    debug_assert!(changed);
+                match *b_data {
+                    VarValue::Value(ReStatic) | VarValue::ErrorValue => false,
+                    _ => true,
                 }
-            }
-            live_indices.subtract(&killed_indices);
-
-            // We could clear `killed_indices` here, but we don't need to and
-            // it's cheaper not to.
+            });
         }
     }
 
-    // This function is very hot in some workloads. There's a single callsite
-    // so always inlining is ok even though it's large.
-    #[inline(always)]
     fn expand_node(
         &self,
         a_region: Region<'tcx>,


### PR DESCRIPTION
Gives a big performance increase to the unicode_normalization benchmark in my testing.