### PR TITLE
Fix const prop miscompilations of references with projections.

### DIFF
--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -643,7 +643,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
         value: Const<'tcx>,
         source_info: SourceInfo,
     ) {
-        trace!("attepting to replace {:?} with {:?}", rval, value);
+        trace!("attempting to replace {:?} with {:?}", rval, value);
         if let Err(e) = self.ecx.validate_operand(
             value,
             vec![],
@@ -654,8 +654,9 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
             return;
         }
 
-        // FIXME> figure out what tho do when try_read_immediate fails
+        // FIXME: figure out what tho do when try_read_immediate fails
         let imm = self.use_ecx(source_info, |this| this.ecx.try_read_immediate(value));
+        debug!("Read value {:?} as immediate {:?}", value, imm);
 
         if let Some(Ok(imm)) = imm {
             match *imm {
@@ -670,7 +671,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
                     ScalarMaybeUndef::Scalar(one),
                     ScalarMaybeUndef::Scalar(two),
                 ) => {
-                    // Found a value represented as a pair. For now only do cont-prop if type of
+                    // Found a value represented as a pair. For now only do const-prop if type of
                     // Rvalue is also a pair with two scalars. The more general case is more
                     // complicated to implement so we'll do it later.
                     let ty = &value.layout.ty.kind;

--- a/src/test/ui/mir/issue67529.rs
+++ b/src/test/ui/mir/issue67529.rs
@@ -1,0 +1,14 @@
+// Tests for miscompilation due to const propagation, as described in #67529. This used to result
+// in an assertion error, because d.a was replaced with a new allocation that was never
+// initialized.
+//
+// run-pass
+// compile-flags: -Zmir-opt-level=2
+struct Baz<T: ?Sized> {
+    a: T,
+}
+
+fn main() {
+    let d: Baz<[i32; 4]> = Baz { a: [1, 2, 3, 4] };
+    assert_eq!([1, 2, 3, 4], d.a);
+}


### PR DESCRIPTION
Closes #67529.

Previously, we only returned early out of const prop of uninitialised Refs to Places if they had no projection. This meant that for uninitialised Places with a projection, when we forced an allocation, we wouldn't have a value to initialise the allocation with, leading us to replace the Ref with an allocation which we would never (and could never) initialise.

This PR fixes this by early returning out of const_prop if the Place's base local is uninitialised for Refs with projections, too.

r? @oli-obk 