### PR TITLE
Recognise riscv64 in compiletest

### DIFF
--- a/src/tools/compiletest/src/util.rs
+++ b/src/tools/compiletest/src/util.rs
@@ -67,6 +67,7 @@ const ARCH_TABLE: &'static [(&'static str, &'static str)] = &[
     ("powerpc", "powerpc"),
     ("powerpc64", "powerpc64"),
     ("powerpc64le", "powerpc64"),
+    ("riscv64gc", "riscv64"),
     ("s390x", "s390x"),
     ("sparc", "sparc"),
     ("sparc64", "sparc64"),


### PR DESCRIPTION
Otherwise tests can't run, fails with "Cannot determine Architecture from triple"