### PR TITLE
Update some of Cargo's dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ version = "0.0.0"
 dependencies = [
  "compiler_builtins",
  "core",
- "rand 0.7.0",
+ "rand 0.7.3",
  "rand_xorshift 0.2.0",
 ]
 
@@ -32,7 +32,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e266e1f4be5ffa05309f650e2586fe1d3ae6034eb24025a7ae1dfecc330823a"
 dependencies = [
  "html5ever",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "maplit",
  "matches",
  "tendril",
@@ -115,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
+checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "backtrace"
@@ -199,7 +199,7 @@ dependencies = [
  "filetime",
  "getopts",
  "ignore",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "libc",
  "num_cpus",
  "pretty_assertions",
@@ -272,11 +272,10 @@ checksum = "716960a18f978640f25101b5cbf1c6f6b0d3192fab36a2d98ca96f0ecbe41010"
 
 [[package]]
 name = "c2-chacha"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
+checksum = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 dependencies = [
- "lazy_static 1.3.0",
  "ppv-lite86",
 ]
 
@@ -311,7 +310,7 @@ dependencies = [
  "ignore",
  "im-rc",
  "jobserver",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "lazycell",
  "libc",
  "libgit2-sys",
@@ -364,7 +363,7 @@ dependencies = [
  "flate2",
  "git2",
  "glob",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "remove_dir_all",
  "serde_json",
  "tar",
@@ -402,19 +401,18 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e450b8da92aa6f274e7c6437692f9f2ce6d701fb73bacfcf87897b3f89a4c20e"
+checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 dependencies = [
  "jobserver",
- "num_cpus",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89431bba4e6b7092fb5fcd00a6f6ca596c55cc26b2f1e6dcdd08a1f4933f66b2"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",
@@ -476,7 +474,7 @@ dependencies = [
  "compiletest_rs",
  "derive-new",
  "git2",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "regex",
  "rustc-workspace-hack",
  "rustc_tools_util 0.2.0",
@@ -497,7 +495,7 @@ dependencies = [
  "cargo_metadata 0.9.0",
  "if_chain",
  "itertools 0.8.0",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "matches",
  "pulldown-cmark 0.6.1",
  "quine-mc_cluskey",
@@ -592,7 +590,7 @@ dependencies = [
  "diff",
  "env_logger 0.7.1",
  "getopts",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "libc",
  "log",
  "miow 0.3.3",
@@ -664,7 +662,7 @@ dependencies = [
 name = "core"
 version = "0.0.0"
 dependencies = [
- "rand 0.7.0",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -750,7 +748,7 @@ dependencies = [
  "arrayvec",
  "cfg-if",
  "crossbeam-utils 0.6.5",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "memoffset",
  "scopeguard",
 ]
@@ -771,7 +769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 dependencies = [
  "cfg-if",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
 ]
 
 [[package]]
@@ -782,7 +780,7 @@ checksum = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
 dependencies = [
  "autocfg",
  "cfg-if",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
 ]
 
 [[package]]
@@ -799,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08ad3cb89d076a36b0ce5749eec2c9964f70c0c58480ab6b75a91ec4fc206d8"
+checksum = "06aa71e9208a54def20792d877bc663d6aae0732b9852e612c4a933177c31283"
 dependencies = [
  "curl-sys",
  "libc",
@@ -814,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9a9a4e417722876332136a00cacf92c2ceb331fab4b52b6a1ad16c6cd79255"
+checksum = "0c38ca47d60b86d0cc9d42caa90a0885669c2abc9791f871c81f58cdf39e979b"
 dependencies = [
  "cc",
  "libc",
@@ -979,7 +977,7 @@ version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a99a310cd1f9770e7bf8e48810c7bcbb0e078c8fb23a8c7bcf0da4c2bf61a455"
 dependencies = [
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "regex",
  "serde",
  "serde_derive",
@@ -1245,13 +1243,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
+checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.7.0",
+ "wasi",
 ]
 
 [[package]]
@@ -1329,7 +1327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df044dd42cdb7e32f28557b661406fc0f2494be75199779998810dbc35030e0d"
 dependencies = [
  "hashbrown 0.5.0",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "log",
  "pest",
  "pest_derive",
@@ -1545,7 +1543,7 @@ checksum = "0ec16832258409d571aaef8273f3c3cc5b060d784e159d1a0f3b0017308f84a7"
 dependencies = [
  "crossbeam-channel",
  "globset",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "log",
  "memchr",
  "regex",
@@ -1582,7 +1580,7 @@ dependencies = [
  "clap",
  "failure",
  "flate2",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "num_cpus",
  "rayon",
  "remove_dir_all",
@@ -1644,13 +1642,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.16"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f74e73053eaf95399bf926e48fc7a2a3ce50bd0eaaa2357d391e95b2dcdd4f10"
+checksum = "67b06c1b455f1cf4269a8cfc320ab930a810e2375a42af5075eb8a8b36405ce0"
 dependencies = [
  "libc",
- "log",
- "rand 0.7.0",
 ]
 
 [[package]]
@@ -1747,7 +1743,7 @@ dependencies = [
  "bytes",
  "globset",
  "jsonrpc-core",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "log",
  "num_cpus",
  "tokio",
@@ -1773,9 +1769,9 @@ checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 
 [[package]]
 name = "lazy_static"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lazycell"
@@ -1808,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "libnghttp2-sys"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75d7966bda4730b722d1eab8e668df445368a24394bae9fc1e8dc0ab3dbe4f4"
+checksum = "02254d44f4435dd79e695f2c2b83cd06a47919adea30216ceaf0c57ca0a72463"
 dependencies = [
  "cc",
  "libc",
@@ -1870,7 +1866,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19af41f0565d7c19b2058153ad0b42d4d5ce89ec4dbf06ed6741114a8b63e7cd"
 dependencies = [
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
 ]
 
 [[package]]
@@ -1963,7 +1959,7 @@ dependencies = [
  "error-chain",
  "handlebars",
  "itertools 0.8.0",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "log",
  "memchr",
  "open",
@@ -2157,7 +2153,7 @@ dependencies = [
  "hex 0.4.0",
  "log",
  "num-traits",
- "rand 0.7.0",
+ "rand 0.7.3",
  "rustc-workspace-hack",
  "rustc_version",
  "serde",
@@ -2171,7 +2167,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
 dependencies = [
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "libc",
  "log",
  "openssl",
@@ -2260,7 +2256,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "libc",
  "openssl-sys",
 ]
@@ -2273,18 +2269,18 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.6.0+1.1.1d"
+version = "111.6.1+1.1.1d"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9c2da1de8a7a3f860919c01540b03a6db16de042405a8a07a5e9d0b4b825d9c"
+checksum = "c91b04cb43c1a8a90e934e0cd612e2a5715d976d2d6cff4490278a0cddf35005"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.52"
+version = "0.9.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c977d08e1312e2f7e4b86f9ebaa0ed3b19d1daff75fae88bbb88108afbd801fc"
+checksum = "465d16ae7fc0e313318f7de5cecf57b2fbe7511fd213978b457e1c96ff46736f"
 dependencies = [
  "autocfg",
  "cc",
@@ -2341,7 +2337,7 @@ dependencies = [
  "log",
  "mio-named-pipes",
  "miow 0.3.3",
- "rand 0.7.0",
+ "rand 0.7.3",
  "tokio",
  "tokio-named-pipes",
  "tokio-uds",
@@ -2469,9 +2465,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.14"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
+checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
 name = "polonius-engine"
@@ -2486,9 +2482,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
+checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
 name = "precomputed-hash"
@@ -2579,7 +2575,7 @@ checksum = "9bf259a81de2b2eb9850ec990ec78e6a25319715584fd7652b9b26f96fcb1510"
 dependencies = [
  "error-chain",
  "idna 0.2.0",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "regex",
  "url 2.1.0",
 ]
@@ -2654,7 +2650,7 @@ dependencies = [
  "derive_more",
  "env_logger 0.6.2",
  "humantime 1.3.0",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "log",
  "rls-span",
  "rustc-ap-syntax",
@@ -2681,9 +2677,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
  "libc",
@@ -2831,7 +2827,7 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-queue",
  "crossbeam-utils 0.6.5",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "num_cpus",
 ]
 
@@ -2846,9 +2842,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.43"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "679da7508e9a6390aeaf7fbd02a800fdc64b73fe2204dd2c8ae66d22d9d5ad5d"
+checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "redox_termios"
@@ -2960,14 +2956,14 @@ dependencies = [
  "home",
  "itertools 0.8.0",
  "jsonrpc-core",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "log",
  "lsp-codec",
  "lsp-types",
  "num_cpus",
  "ordslice",
  "racer",
- "rand 0.7.0",
+ "rand 0.7.3",
  "rayon",
  "regex",
  "rls-analysis",
@@ -3040,7 +3036,7 @@ dependencies = [
  "failure",
  "futures",
  "log",
- "rand 0.7.0",
+ "rand 0.7.3",
  "rls-data",
  "rls-ipc",
  "serde",
@@ -3139,7 +3135,7 @@ dependencies = [
  "ena",
  "indexmap",
  "jobserver",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "log",
  "parking_lot",
  "rustc-ap-graphviz",
@@ -3232,7 +3228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61fc1c901d2cbd24cae95d7bc5a58aa7661ec3dc5320c78c32830a52a685c33c"
 dependencies = [
  "bitflags",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "log",
  "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_errors",
@@ -3309,7 +3305,7 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-queue",
  "crossbeam-utils 0.6.5",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "num_cpus",
 ]
 
@@ -3488,7 +3484,7 @@ dependencies = [
  "graphviz",
  "indexmap",
  "jobserver",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "log",
  "measureme",
  "parking_lot",
@@ -3507,7 +3503,7 @@ name = "rustc_driver"
 version = "0.0.0"
 dependencies = [
  "env_logger 0.7.1",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "log",
  "rustc",
  "rustc_codegen_utils",
@@ -3572,7 +3568,7 @@ dependencies = [
 name = "rustc_feature"
 version = "0.0.0"
 dependencies = [
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "rustc_data_structures",
  "rustc_span",
 ]
@@ -3603,7 +3599,7 @@ version = "0.0.0"
 dependencies = [
  "graphviz",
  "log",
- "rand 0.7.0",
+ "rand 0.7.3",
  "rustc",
  "rustc_data_structures",
  "rustc_fs_util",
@@ -4057,7 +4053,7 @@ dependencies = [
  "getopts",
  "ignore",
  "itertools 0.8.0",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "log",
  "regex",
  "rustc-ap-rustc_target",
@@ -4092,11 +4088,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1a231dc10abf6749cfa5d7767f25888d484201accbd919b66ab5413c502d56"
+checksum = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"
 dependencies = [
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "winapi 0.3.8",
 ]
 
@@ -4296,9 +4292,9 @@ checksum = "4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86"
 
 [[package]]
 name = "socket2"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4d11a52082057d87cb5caa31ad812f4504b97ab44732cd8359df2e9ff9f48e7"
+checksum = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4329,9 +4325,9 @@ dependencies = [
  "panic_abort",
  "panic_unwind",
  "profiler_builtins",
- "rand 0.7.0",
+ "rand 0.7.3",
  "unwind",
- "wasi 0.9.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -4349,7 +4345,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25d70109977172b127fe834e5449e5ab1740b9ba49fa18a2020f509174f25423"
 dependencies = [
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "new_debug_unreachable",
  "phf_shared",
  "precomputed-hash",
@@ -4517,7 +4513,7 @@ checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if",
  "libc",
- "rand 0.7.0",
+ "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.8",
@@ -4624,14 +4620,14 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 dependencies = [
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
 ]
 
 [[package]]
 name = "tidy"
 version = "0.1.0"
 dependencies = [
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "regex",
  "serde",
  "serde_json",
@@ -4758,7 +4754,7 @@ checksum = "afbd6ef1b8cc2bd2c2b580d882774d443ebb1c6ceefe35ba9ea4ab586c89dbe8"
 dependencies = [
  "crossbeam-queue",
  "futures",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "libc",
  "log",
  "mio",
@@ -4777,7 +4773,7 @@ checksum = "6732fe6b53c8d11178dcb77ac6d9682af27fc6d4cb87789449152e5377377146"
 dependencies = [
  "crossbeam-utils 0.6.5",
  "futures",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "log",
  "mio",
  "num_cpus",
@@ -4848,7 +4844,7 @@ dependencies = [
  "crossbeam-queue",
  "crossbeam-utils 0.6.5",
  "futures",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "log",
  "num_cpus",
  "slab",
@@ -4918,7 +4914,7 @@ dependencies = [
  "failure",
  "failure_derive",
  "is-match",
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "regex",
  "toml",
  "toml-query_derive",
@@ -4962,7 +4958,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6b52bf4da6512f0f07785a04769222e50d29639e7ecd016b7806fd2de306b4"
 dependencies = [
- "lazy_static 1.3.0",
+ "lazy_static 1.4.0",
  "regex",
 ]
 
@@ -5133,9 +5129,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
+checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 
 [[package]]
 name = "vec_map"
@@ -5196,12 +5192,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 
 [[package]]
 name = "wasi"


### PR DESCRIPTION
This is primarily updating the `curl` dependency, but also went ahead
and applied a few updates for other packages that Cargo depends on.