### PR TITLE
Fix issue #68008

### DIFF
--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -330,7 +330,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     Some("std::ops::Add"),
                                 ),
                                 hir::BinOpKind::Sub => (
-                                    format!("cannot substract `{}` from `{}`", rhs_ty, lhs_ty),
+                                    format!("cannot subtract `{}` from `{}`", rhs_ty, lhs_ty),
                                     Some("std::ops::Sub"),
                                 ),
                                 hir::BinOpKind::Mul => (

--- a/src/test/ui/issues/issue-28837.rs
+++ b/src/test/ui/issues/issue-28837.rs
@@ -5,7 +5,7 @@ fn main() {
 
     a + a; //~ ERROR cannot add `A` to `A`
 
-    a - a; //~ ERROR cannot substract `A` from `A`
+    a - a; //~ ERROR cannot subtract `A` from `A`
 
     a * a; //~ ERROR cannot multiply `A` to `A`
 

--- a/src/test/ui/issues/issue-28837.stderr
+++ b/src/test/ui/issues/issue-28837.stderr
@@ -8,7 +8,7 @@ LL |     a + a;
    |
    = note: an implementation of `std::ops::Add` might be missing for `A`
 
-error[E0369]: cannot substract `A` from `A`
+error[E0369]: cannot subtract `A` from `A`
   --> $DIR/issue-28837.rs:8:7
    |
 LL |     a - a;


### PR DESCRIPTION
Correcting Typo on error message. From "substract" to "subtract".

Fixes #68008.