### PR TITLE
Update "unused Result" error message to clarify that using a Result is optional

### DIFF
--- a/src/doc/rustc/src/lints/listing/warn-by-default.md
+++ b/src/doc/rustc/src/lints/listing/warn-by-default.md
@@ -779,7 +779,7 @@ fn main() {
 This will produce:
 
 ```text
-warning: unused `std::result::Result` that must be used
+warning: unused `std::result::Result` that should be used
  --> src/main.rs:6:5
   |
 6 |     returns_result();

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -243,7 +243,7 @@
 //! using it. The compiler will warn us about this kind of behavior:
 //!
 //! ```text
-//! warning: unused result that must be used: iterators are lazy and
+//! warning: unused result that should be used: iterators are lazy and
 //! do nothing unless consumed
 //! ```
 //!

--- a/src/test/ui/macros/must-use-in-macro-55516.stderr
+++ b/src/test/ui/macros/must-use-in-macro-55516.stderr
@@ -1,4 +1,4 @@
-warning: unused `std::result::Result` that must be used
+warning: unused `std::result::Result` that should be used
   --> $DIR/must-use-in-macro-55516.rs:9:5
    |
 LL |     write!(&mut example, "{}", 42);


### PR DESCRIPTION
Using a Result is not required, so I think the error message should be updated to say it "should be used" rather than it "must be used".