### PR TITLE
Rebase LLVM onto 9.0.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,7 +40,7 @@
 [submodule "src/llvm-project"]
 	path = src/llvm-project
 	url = https://github.com/rust-lang/llvm-project.git
-	branch = rustc/9.0-2019-09-19
+	branch = rustc/9.0-2019-12-19
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book
 	url = https://github.com/rust-embedded/book.git


### PR DESCRIPTION
While work on LLVM 10 is in progress in #67759, in the meantime we can do a smaller rebase to pick up fixes in 9.0.1, released December 19, 2019.

r? @nikic 