### PR TITLE
perf: Use `for_each` in `Vec::extend`

### DIFF
--- a/src/liballoc/benches/vec.rs
+++ b/src/liballoc/benches/vec.rs
@@ -194,13 +194,10 @@ fn do_bench_extend_chain(b: &mut Bencher, dst_len: usize, src_len: usize) {
         x4 = iter.next().unwrap_or(&[][..]);
         x5 = iter.next().unwrap_or(&[][..]);
     }
-    let src = x1
-        .iter()
-        .cloned()
-        .chain(x2.iter().cloned())
-        .chain(x3.iter().cloned())
-        .chain(x4.iter().cloned())
-        .chain(x5.iter().cloned());
+    let src =
+        x1.iter().cloned().chain(x2.iter().cloned().chain(x3.iter().cloned())).chain(
+            Some(()).into_iter().flat_map(|()| x4.iter().cloned().chain(x5.iter().cloned())),
+        );
     do_bench_extend_iter(b, dst_len, src_len, src)
 }
 

--- a/src/liballoc/benches/vec.rs
+++ b/src/liballoc/benches/vec.rs
@@ -173,9 +173,34 @@ fn do_bench_extend(b: &mut Bencher, dst_len: usize, src_len: usize) {
 }
 
 fn do_bench_extend_chain(b: &mut Bencher, dst_len: usize, src_len: usize) {
-    let fst = Vec::from_iter(dst_len..dst_len + src_len / 2);
-    let snd = Vec::from_iter(dst_len + src_len / 2..dst_len + src_len);
-    let src = fst.iter().cloned().chain(snd.iter().cloned());
+    let src = Vec::from_iter(dst_len..dst_len + src_len);
+    let x1;
+    let x2;
+    let x3;
+    let x4;
+    let x5;
+
+    if src.len() / 5 == 0 {
+        x1 = &[][..];
+        x2 = &[][..];
+        x3 = &[][..];
+        x4 = &[][..];
+        x5 = &[][..];
+    } else {
+        let mut iter = src.chunks_exact(src.len() / 5);
+        x1 = iter.next().unwrap_or(&[][..]);
+        x2 = iter.next().unwrap_or(&[][..]);
+        x3 = iter.next().unwrap_or(&[][..]);
+        x4 = iter.next().unwrap_or(&[][..]);
+        x5 = iter.next().unwrap_or(&[][..]);
+    }
+    let src = x1
+        .iter()
+        .cloned()
+        .chain(x2.iter().cloned())
+        .chain(x3.iter().cloned())
+        .chain(x4.iter().cloned())
+        .chain(x5.iter().cloned());
     do_bench_extend_iter(b, dst_len, src_len, src)
 }
 

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2134,7 +2134,7 @@ impl<T> Vec<T> {
         self.reserve(lower);
         loop {
             let cap = self.capacity();
-            let result = iterator.by_ref().try_fold((), |(), element| {
+            let result = iterator.try_fold((), |(), element| {
                 let len = self.len();
                 if len == cap {
                     Err(element)

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2122,7 +2122,7 @@ where
 }
 
 impl<T> Vec<T> {
-    fn extend_desugared<I: Iterator<Item = T>>(&mut self, mut iterator: I) {
+    fn extend_desugared<I: Iterator<Item = T>>(&mut self, iterator: I) {
         // This is the case for a general iterator.
         //
         // This function should be the moral equivalent of:
@@ -2130,18 +2130,10 @@ impl<T> Vec<T> {
         //      for item in iterator {
         //          self.push(item);
         //      }
-        while let Some(element) = iterator.next() {
-            let len = self.len();
-            if len == self.capacity() {
-                let (lower, _) = iterator.size_hint();
-                self.reserve(lower.saturating_add(1));
-            }
-            unsafe {
-                ptr::write(self.get_unchecked_mut(len), element);
-                // NB can't overflow since we would have had to alloc the address space
-                self.set_len(len + 1);
-            }
-        }
+        let (lower, _) = iterator.size_hint();
+        self.reserve(lower);
+
+        iterator.for_each(|element| self.push(element));
     }
 
     /// Creates a splicing iterator that replaces the specified range in the vector


### PR DESCRIPTION
`for_each` are specialized for iterators such as `chain` allowing for
faster iteration than a normal `for/while` loop.

Note that since this only checks `size_hint` once at the start it may
end up needing to call `reserve` more in the case that `size_hint`
returns a larger and more accurate lower bound during iteration.

This could maybe be alleviated with an implementation closer to the current
one but the extra complexity will likely end up harming the normal case
of an accurate or 0 (think `filter`) lower bound.

```rust
while let Some(element) = iterator.next() {
    let (lower, _) = iterator.size_hint();
    self.reserve(lower.saturating_add(1));
    unsafe {
        let len = self.len();
        ptr::write(self.get_unchecked_mut(len), element);
        // NB can't overflow since we would have had to alloc the address space
        self.set_len(len + 1);
    }

    iterator.by_ref().take(self.capacity()).for_each(|element| {
        unsafe {
            let len = self.len();
            ptr::write(self.get_unchecked_mut(len), element);
            // NB can't overflow since we would have had to alloc the address space
            self.set_len(len + 1);
        }
    });
}

// OR

let (lower, _) = iterator.size_hint();
self.reserve(lower);
loop {
    let result = iterator.by_ref().try_for_each(|element| {
        if self.len() == self.capacity() {
            return Err(element);
        }
        unsafe {
            let len = self.len();
            ptr::write(self.get_unchecked_mut(len), element);
            // NB can't overflow since we would have had to alloc the address space
            self.set_len(len + 1);
        }
        Ok(())
    });

    match result {
        Ok(()) => break,
        Err(element) => {
            let (lower, _) = iterator.size_hint();
            self.reserve(lower.saturating_add(1));
            self.push(element);
        }
    }
}
```

Closes #63340