### PR TITLE
ci: another take at fixing toolstate

### DIFF
--- a/src/ci/shared.sh
+++ b/src/ci/shared.sh
@@ -80,7 +80,7 @@ function ciCommit {
 
 function ciCheckoutPath {
     if isAzurePipelines; then
-        echo "${SYSTEM_WORKFOLDER}"
+        echo "${BUILD_SOURCESDIRECTORY}"
     elif isGitHubActions; then
         echo "${GITHUB_WORKSPACE}"
     else


### PR DESCRIPTION
Seems like the variable showed by `$(ciCheckoutPath)` on Azure Pipelines was wrong, making the toolstate script fail. This commit changes that function to return the variable previously used by the toolstate script. Other uses of the function were audited, and there should be no conflict.

Failure log: https://dev.azure.com/rust-lang/rust/_build/results?buildId=17933
r? @Mark-Simulacrum 