### PR TITLE
Address inconsistency in using "is" with "declared here"

### DIFF
--- a/src/librustc/lint.rs
+++ b/src/librustc/lint.rs
@@ -259,7 +259,7 @@ pub fn struct_lint_level<'a>(
                 &mut err,
                 DiagnosticMessageId::from(lint),
                 src,
-                "lint level defined here",
+                "the lint level is defined here",
             );
             if lint_attr_name.as_str() != name {
                 let level_str = level.as_str();

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -204,17 +204,17 @@ impl LanguageItemCollector<'tcx> {
                     },
                 };
                 if let Some(span) = self.tcx.hir().span_if_local(original_def_id) {
-                    err.span_note(span, "first defined here");
+                    err.span_note(span, "the lang item is first defined here");
                 } else {
                     match self.tcx.extern_crate(original_def_id) {
                         Some(ExternCrate {dependency_of, ..}) => {
                             err.note(&format!(
-                            "first defined in crate `{}` (which `{}` depends on)",
+                            "the lang item is first defined in crate `{}` (which `{}` depends on)",
                                       self.tcx.crate_name(original_def_id.krate),
                                       self.tcx.crate_name(*dependency_of)));
                         },
                         _ => {
-                            err.note(&format!("first defined in crate `{}`.",
+                            err.note(&format!("the lang item is first defined in crate `{}`.",
                                       self.tcx.crate_name(original_def_id.krate)));
                         }
                     }

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -894,7 +894,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
         diag.note(note);
         if let ty::Adt(def, _) = ty.kind {
             if let Some(sp) = self.cx.tcx.hir().span_if_local(def.did) {
-                diag.span_note(sp, "type defined here");
+                diag.span_note(sp, "the type is defined here");
             }
         }
         diag.emit();

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -694,7 +694,7 @@ impl<'a> CrateLoader<'a> {
                 self.sess
                     .struct_span_err(*span2, "cannot define multiple global allocators")
                     .span_label(*span2, "cannot define a new global allocator")
-                    .span_label(*span1, "previous global allocator is defined here")
+                    .span_label(*span1, "previous global allocator defined here")
                     .emit();
                 true
             }

--- a/src/librustc_mir/borrow_check/diagnostics/conflict_errors.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/conflict_errors.rs
@@ -1259,7 +1259,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
 
         err.span_label(
             upvar_span,
-            format!("`{}` is declared here, outside of the {} body", upvar_name, escapes_from),
+            format!("`{}` declared here, outside of the {} body", upvar_name, escapes_from),
         );
 
         err.span_label(borrow_span, format!("borrow is only valid in the {} body", escapes_from));

--- a/src/librustc_mir/borrow_check/diagnostics/region_errors.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/region_errors.rs
@@ -457,7 +457,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
             diag.span_label(
                 outlived_fr_span,
                 format!(
-                    "`{}` is declared here, outside of the {} body",
+                    "`{}` declared here, outside of the {} body",
                     outlived_fr_name, escapes_from
                 ),
             );

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -625,7 +625,7 @@ fn check_short_circuiting_in_const_local(item: &Item<'_, 'tcx>) {
         }
         for local in locals {
             let span = body.local_decls[local].source_info.span;
-            error.span_note(span, "more locals defined here");
+            error.span_note(span, "more locals are defined here");
         }
         error.emit();
     }

--- a/src/librustc_passes/diagnostic_items.rs
+++ b/src/librustc_passes/diagnostic_items.rs
@@ -73,10 +73,10 @@ fn collect_item(
                 )),
             };
             if let Some(span) = tcx.hir().span_if_local(original_def_id) {
-                err.span_note(span, "first defined here");
+                err.span_note(span, "the diagnostic item is first defined here");
             } else {
                 err.note(&format!(
-                    "first defined in crate `{}`.",
+                    "the diagnostic item is first defined in crate `{}`.",
                     tcx.crate_name(original_def_id.krate)
                 ));
             }

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -2220,7 +2220,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 
             let mut could_refer_to = |kind: DefKind, def_id, also| {
                 let note_msg = format!(
-                    "`{}` could{} refer to {} defined here",
+                    "`{}` could{} refer to the {} defined here",
                     assoc_ident,
                     also,
                     kind.descr(def_id)

--- a/src/test/rustdoc-ui/deny-intra-link-resolution-failure.stderr
+++ b/src/test/rustdoc-ui/deny-intra-link-resolution-failure.stderr
@@ -4,7 +4,7 @@ error: `[v2]` cannot be resolved, ignoring it.
 LL | /// [v2]
    |      ^^ cannot be resolved, ignoring
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/deny-intra-link-resolution-failure.rs:1:9
    |
 LL | #![deny(intra_doc_link_resolution_failure)]

--- a/src/test/rustdoc-ui/deny-missing-docs-crate.stderr
+++ b/src/test/rustdoc-ui/deny-missing-docs-crate.stderr
@@ -6,7 +6,7 @@ LL | |
 LL | | pub struct Foo;
    | |_______________^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/deny-missing-docs-crate.rs:1:9
    |
 LL | #![deny(missing_docs)]

--- a/src/test/rustdoc-ui/deny-missing-docs-macro.stderr
+++ b/src/test/rustdoc-ui/deny-missing-docs-macro.stderr
@@ -4,7 +4,7 @@ error: missing documentation for macro
 LL | macro_rules! foo {
    | ^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/deny-missing-docs-macro.rs:3:9
    |
 LL | #![deny(missing_docs)]

--- a/src/test/rustdoc-ui/doc-without-codeblock.stderr
+++ b/src/test/rustdoc-ui/doc-without-codeblock.stderr
@@ -10,7 +10,7 @@ LL | |     pub fn bar() {}
 LL | | }
    | |_^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/doc-without-codeblock.rs:1:9
    |
 LL | #![deny(missing_doc_code_examples)]

--- a/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
+++ b/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
@@ -4,7 +4,7 @@ error: `[TypeAlias::hoge]` cannot be resolved, ignoring it.
 LL | /// [broken cross-reference](TypeAlias::hoge)
    |                              ^^^^^^^^^^^^^^^ cannot be resolved, ignoring
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/intra-doc-alias-ice.rs:1:9
    |
 LL | #![deny(intra_doc_link_resolution_failure)]

--- a/src/test/rustdoc-ui/intra-link-span-ice-55723.stderr
+++ b/src/test/rustdoc-ui/intra-link-span-ice-55723.stderr
@@ -4,7 +4,7 @@ error: `[i]` cannot be resolved, ignoring it.
 LL | /// （arr[i]）
    |           ^ cannot be resolved, ignoring
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/intra-link-span-ice-55723.rs:1:9
    |
 LL | #![deny(intra_doc_link_resolution_failure)]

--- a/src/test/rustdoc-ui/intra-links-ambiguity.stderr
+++ b/src/test/rustdoc-ui/intra-links-ambiguity.stderr
@@ -4,7 +4,7 @@ error: `ambiguous` is both a struct and a function
 LL | /// [`ambiguous`] is ambiguous.
    |      ^^^^^^^^^^^ ambiguous link
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/intra-links-ambiguity.rs:1:9
    |
 LL | #![deny(intra_doc_link_resolution_failure)]

--- a/src/test/rustdoc-ui/intra-links-anchors.stderr
+++ b/src/test/rustdoc-ui/intra-links-anchors.stderr
@@ -4,7 +4,7 @@ error: `[Foo::f#hola]` has an issue with the link anchor.
 LL | /// Or maybe [Foo::f#hola].
    |               ^^^^^^^^^^^ struct fields cannot be followed by anchors
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/intra-links-anchors.rs:1:9
    |
 LL | #![deny(intra_doc_link_resolution_failure)]

--- a/src/test/rustdoc-ui/lint-group.stderr
+++ b/src/test/rustdoc-ui/lint-group.stderr
@@ -8,7 +8,7 @@ LL | | /// println!("sup");
 LL | | /// ```
    | |_______^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-group.rs:7:9
    |
 LL | #![deny(rustdoc)]
@@ -21,7 +21,7 @@ error: `[error]` cannot be resolved, ignoring it.
 LL | /// what up, let's make an [error]
    |                             ^^^^^ cannot be resolved, ignoring
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-group.rs:7:9
    |
 LL | #![deny(rustdoc)]
@@ -35,7 +35,7 @@ error: missing code example in this documentation
 LL | /// wait, this doesn't have a doctest?
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-group.rs:7:9
    |
 LL | #![deny(rustdoc)]

--- a/src/test/rustdoc-ui/lint-missing-doc-code-example.stderr
+++ b/src/test/rustdoc-ui/lint-missing-doc-code-example.stderr
@@ -5,7 +5,7 @@ LL | / mod module1 {
 LL | | }
    | |_^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-missing-doc-code-example.rs:2:9
    |
 LL | #![deny(missing_doc_code_examples)]

--- a/src/test/rustdoc-ui/private-item-doc-test.stderr
+++ b/src/test/rustdoc-ui/private-item-doc-test.stderr
@@ -8,7 +8,7 @@ LL | |     /// assert!(false);
 LL | |     /// ```
    | |___________^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/private-item-doc-test.rs:1:9
    |
 LL | #![deny(private_doc_tests)]

--- a/src/test/ui-fulldeps/internal-lints/default_hash_types.stderr
+++ b/src/test/ui-fulldeps/internal-lints/default_hash_types.stderr
@@ -4,7 +4,7 @@ error: Prefer FxHashMap over HashMap, it has better performance
 LL |     let _map: HashMap<String, String> = HashMap::default();
    |               ^^^^^^^ help: use: `FxHashMap`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/default_hash_types.rs:10:8
    |
 LL | #[deny(rustc::default_hash_types)]

--- a/src/test/ui-fulldeps/internal-lints/lint_pass_impl_without_macro.stderr
+++ b/src/test/ui-fulldeps/internal-lints/lint_pass_impl_without_macro.stderr
@@ -4,7 +4,7 @@ error: implementing `LintPass` by hand
 LL | impl LintPass for Foo {
    |      ^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint_pass_impl_without_macro.rs:4:9
    |
 LL | #![deny(rustc::lint_pass_impl_without_macro)]

--- a/src/test/ui-fulldeps/internal-lints/pass_ty_by_ref.stderr
+++ b/src/test/ui-fulldeps/internal-lints/pass_ty_by_ref.stderr
@@ -4,7 +4,7 @@ error: passing `Ty<'_>` by reference
 LL |     ty_ref: &Ty<'_>,
    |             ^^^^^^^ help: try passing by value: `Ty<'_>`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/pass_ty_by_ref.rs:4:9
    |
 LL | #![deny(rustc::ty_pass_by_reference)]

--- a/src/test/ui-fulldeps/internal-lints/qualified_ty_ty_ctxt.stderr
+++ b/src/test/ui-fulldeps/internal-lints/qualified_ty_ty_ctxt.stderr
@@ -4,7 +4,7 @@ error: usage of qualified `ty::Ty<'_>`
 LL |     ty_q: ty::Ty<'_>,
    |           ^^^^^^^^^^ help: try using it unqualified: `Ty<'_>`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/qualified_ty_ty_ctxt.rs:4:9
    |
 LL | #![deny(rustc::usage_of_qualified_ty)]

--- a/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.stderr
+++ b/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.stderr
@@ -4,7 +4,7 @@ error: usage of `ty::TyKind::<kind>`
 LL |     let kind = TyKind::Bool;
    |                ^^^^^^ help: try using ty::<kind> directly: `ty`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/ty_tykind_usage.rs:9:8
    |
 LL | #[deny(rustc::usage_of_ty_tykind)]

--- a/src/test/ui-fulldeps/lint-plugin-deny-attr.stderr
+++ b/src/test/ui-fulldeps/lint-plugin-deny-attr.stderr
@@ -12,7 +12,7 @@ error: item is named 'lintme'
 LL | fn lintme() { }
    | ^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-plugin-deny-attr.rs:7:9
    |
 LL | #![deny(test_lint)]

--- a/src/test/ui-fulldeps/lint-plugin-forbid-attrs.stderr
+++ b/src/test/ui-fulldeps/lint-plugin-forbid-attrs.stderr
@@ -30,7 +30,7 @@ error: item is named 'lintme'
 LL | fn lintme() { }
    | ^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-plugin-forbid-attrs.rs:7:11
    |
 LL | #![forbid(test_lint)]

--- a/src/test/ui-fulldeps/lint-tool-test.stderr
+++ b/src/test/ui-fulldeps/lint-tool-test.stderr
@@ -70,7 +70,7 @@ error: item is named 'lintme'
 LL | fn lintme() { }
    | ^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-tool-test.rs:13:9
    |
 LL | #![deny(clippy_group)]
@@ -83,7 +83,7 @@ error: item is named 'lintmetoo'
 LL |     fn lintmetoo() { }
    |     ^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-tool-test.rs:13:9
    |
 LL | #![deny(clippy_group)]

--- a/src/test/ui/allocator/two-allocators.stderr
+++ b/src/test/ui/allocator/two-allocators.stderr
@@ -2,7 +2,7 @@ error: cannot define multiple global allocators
   --> $DIR/two-allocators.rs:6:1
    |
 LL | static A: System = System;
-   | -------------------------- previous global allocator is defined here
+   | -------------------------- previous global allocator defined here
 LL | #[global_allocator]
 LL | static B: System = System;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot define a new global allocator

--- a/src/test/ui/anon-params-deprecated.stderr
+++ b/src/test/ui/anon-params-deprecated.stderr
@@ -4,7 +4,7 @@ warning: anonymous parameters are deprecated and will be removed in the next edi
 LL |     fn foo(i32);
    |            ^^^ help: try naming the parameter or explicitly ignoring it: `_: i32`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/anon-params-deprecated.rs:1:9
    |
 LL | #![warn(anonymous_parameters)]

--- a/src/test/ui/associated-const/associated-const-dead-code.stderr
+++ b/src/test/ui/associated-const/associated-const-dead-code.stderr
@@ -4,7 +4,7 @@ error: associated const is never used: `BAR`
 LL |     const BAR: u32 = 1;
    |     ^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/associated-const-dead-code.rs:1:9
    |
 LL | #![deny(dead_code)]

--- a/src/test/ui/async-await/await-keyword/2015-edition-error-various-positions.stderr
+++ b/src/test/ui/async-await/await-keyword/2015-edition-error-various-positions.stderr
@@ -4,7 +4,7 @@ error: `await` is a keyword in the 2018 edition
 LL |     pub mod await {
    |             ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/2015-edition-error-various-positions.rs:2:9
    |
 LL | #![deny(keyword_idents)]

--- a/src/test/ui/async-await/await-keyword/2015-edition-warning.stderr
+++ b/src/test/ui/async-await/await-keyword/2015-edition-warning.stderr
@@ -4,7 +4,7 @@ error: `await` is a keyword in the 2018 edition
 LL |     pub mod await {
    |             ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/2015-edition-warning.rs:4:9
    |
 LL | #![deny(keyword_idents)]

--- a/src/test/ui/async-await/unreachable-lint-1.stderr
+++ b/src/test/ui/async-await/unreachable-lint-1.stderr
@@ -6,7 +6,7 @@ LL |     return; bar().await;
    |     |
    |     any code following this expression is unreachable
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unreachable-lint-1.rs:2:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/async-await/unused-lifetime.stderr
+++ b/src/test/ui/async-await/unused-lifetime.stderr
@@ -4,7 +4,7 @@ error: lifetime parameter `'a` never used
 LL | pub async fn func_with_unused_lifetime<'a>(s: &'a str) {
    |                                        ^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused-lifetime.rs:7:9
    |
 LL | #![deny(unused_lifetimes)]

--- a/src/test/ui/attributes/register-attr-tool-unused.stderr
+++ b/src/test/ui/attributes/register-attr-tool-unused.stderr
@@ -4,7 +4,7 @@ error: unused attribute
 LL | #[register_attr(attr)]
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/register-attr-tool-unused.rs:1:9
    |
 LL | #![deny(unused)]

--- a/src/test/ui/bad/bad-lint-cap2.stderr
+++ b/src/test/ui/bad/bad-lint-cap2.stderr
@@ -4,7 +4,7 @@ error: unused import: `std::option`
 LL | use std::option;
    |     ^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/bad-lint-cap2.rs:4:9
    |
 LL | #![deny(warnings)]

--- a/src/test/ui/bad/bad-lint-cap3.stderr
+++ b/src/test/ui/bad/bad-lint-cap3.stderr
@@ -4,7 +4,7 @@ warning: unused import: `std::option`
 LL | use std::option;
    |     ^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/bad-lint-cap3.rs:5:9
    |
 LL | #![deny(warnings)]

--- a/src/test/ui/borrowck/issue-45983.nll.stderr
+++ b/src/test/ui/borrowck/issue-45983.nll.stderr
@@ -2,7 +2,7 @@ error[E0521]: borrowed data escapes outside of closure
   --> $DIR/issue-45983.rs:20:18
    |
 LL |     let x = None;
-   |         - `x` is declared here, outside of the closure body
+   |         - `x` declared here, outside of the closure body
 LL |     give_any(|y| x = Some(y));
    |               -  ^^^^^^^^^^^ `y` escapes the closure body here
    |               |

--- a/src/test/ui/borrowck/issue-7573.nll.stderr
+++ b/src/test/ui/borrowck/issue-7573.nll.stderr
@@ -2,7 +2,7 @@ error[E0521]: borrowed data escapes outside of closure
   --> $DIR/issue-7573.rs:21:9
    |
 LL |     let mut lines_to_use: Vec<&CrateId> = Vec::new();
-   |         ---------------- `lines_to_use` is declared here, outside of the closure body
+   |         ---------------- `lines_to_use` declared here, outside of the closure body
 LL |
 LL |     let push_id = |installed_id: &CrateId| {
    |                    ------------ `installed_id` is a reference that is only valid in the closure body

--- a/src/test/ui/borrowck/regions-escape-bound-fn-2.nll.stderr
+++ b/src/test/ui/borrowck/regions-escape-bound-fn-2.nll.stderr
@@ -2,7 +2,7 @@ error[E0521]: borrowed data escapes outside of closure
   --> $DIR/regions-escape-bound-fn-2.rs:8:18
    |
 LL |     let mut x = None;
-   |         ----- `x` is declared here, outside of the closure body
+   |         ----- `x` declared here, outside of the closure body
 LL |     with_int(|y| x = Some(y));
    |               -  ^^^^^^^^^^^ `y` escapes the closure body here
    |               |

--- a/src/test/ui/borrowck/regions-escape-bound-fn.nll.stderr
+++ b/src/test/ui/borrowck/regions-escape-bound-fn.nll.stderr
@@ -2,7 +2,7 @@ error[E0521]: borrowed data escapes outside of closure
   --> $DIR/regions-escape-bound-fn.rs:8:18
    |
 LL |     let mut x: Option<&isize> = None;
-   |         ----- `x` is declared here, outside of the closure body
+   |         ----- `x` declared here, outside of the closure body
 LL |     with_int(|y| x = Some(y));
    |               -  ^^^^^^^^^^^ `y` escapes the closure body here
    |               |

--- a/src/test/ui/borrowck/regions-escape-unboxed-closure.nll.stderr
+++ b/src/test/ui/borrowck/regions-escape-unboxed-closure.nll.stderr
@@ -2,7 +2,7 @@ error[E0521]: borrowed data escapes outside of closure
   --> $DIR/regions-escape-unboxed-closure.rs:6:23
    |
 LL |     let mut x: Option<&isize> = None;
-   |         ----- `x` is declared here, outside of the closure body
+   |         ----- `x` declared here, outside of the closure body
 LL |     with_int(&mut |y| x = Some(y));
    |                    -  ^^^^^^^^^^^ `y` escapes the closure body here
    |                    |

--- a/src/test/ui/borrowck/two-phase-reservation-sharing-interference-future-compat-lint.stderr
+++ b/src/test/ui/borrowck/two-phase-reservation-sharing-interference-future-compat-lint.stderr
@@ -9,7 +9,7 @@ LL |         v.push(shared.len());
    |         |
    |         mutable borrow occurs here
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/two-phase-reservation-sharing-interference-future-compat-lint.rs:18:13
    |
 LL |     #![warn(mutable_borrow_reservation_conflict)]
@@ -28,7 +28,7 @@ LL |         v.push(shared.len());
    |         |
    |         mutable borrow occurs here
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/two-phase-reservation-sharing-interference-future-compat-lint.rs:31:13
    |
 LL |     #![deny(mutable_borrow_reservation_conflict)]

--- a/src/test/ui/cast-char.stderr
+++ b/src/test/ui/cast-char.stderr
@@ -4,7 +4,7 @@ error: only `u8` can be cast into `char`
 LL |     const XYZ: char = 0x1F888 as char;
    |                       ^^^^^^^^^^^^^^^ help: use a `char` literal instead: `'\u{1F888}'`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/cast-char.rs:1:9
    |
 LL | #![deny(overflowing_literals)]

--- a/src/test/ui/closures/closure-expected-type/expect-region-supply-region.nll.stderr
+++ b/src/test/ui/closures/closure-expected-type/expect-region-supply-region.nll.stderr
@@ -2,7 +2,7 @@ error[E0521]: borrowed data escapes outside of closure
   --> $DIR/expect-region-supply-region.rs:18:9
    |
 LL |     let mut f: Option<&u32> = None;
-   |         ----- `f` is declared here, outside of the closure body
+   |         ----- `f` declared here, outside of the closure body
 LL |     closure_expecting_bound(|x| {
    |                              - `x` is a reference that is only valid in the closure body
 LL |         f = Some(x);
@@ -12,7 +12,7 @@ error[E0521]: borrowed data escapes outside of closure
   --> $DIR/expect-region-supply-region.rs:28:9
    |
 LL |     let mut f: Option<&u32> = None;
-   |         ----- `f` is declared here, outside of the closure body
+   |         ----- `f` declared here, outside of the closure body
 LL |     closure_expecting_bound(|x: &u32| {
    |                              - `x` is a reference that is only valid in the closure body
 LL |         f = Some(x);

--- a/src/test/ui/conditional-compilation/cfg-attr-empty-is-unused.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-empty-is-unused.stderr
@@ -4,7 +4,7 @@ error: unused attribute
 LL | #[cfg_attr(FALSE,)]
    | ^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/cfg-attr-empty-is-unused.rs:5:9
    |
 LL | #![deny(unused)]

--- a/src/test/ui/conditional-compilation/cfg-attr-multi-true.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-multi-true.stderr
@@ -30,7 +30,7 @@ warning: unused `MustUseDeprecated` that must be used
 LL |     MustUseDeprecated::new();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/cfg-attr-multi-true.rs:7:9
    |
 LL | #![warn(unused_must_use)]

--- a/src/test/ui/const-generics/const-parameter-uppercase-lint.stderr
+++ b/src/test/ui/const-generics/const-parameter-uppercase-lint.stderr
@@ -12,7 +12,7 @@ error: const parameter `x` should have an upper case name
 LL | fn noop<const x: u32>() {
    |               ^ help: convert the identifier to upper case (notice the capitalization): `X`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/const-parameter-uppercase-lint.rs:4:9
    |
 LL | #![deny(non_upper_case_globals)]

--- a/src/test/ui/consts/array-literal-index-oob.stderr
+++ b/src/test/ui/consts/array-literal-index-oob.stderr
@@ -4,7 +4,7 @@ warning: index out of bounds: the len is 3 but the index is 4
 LL |     &{ [1, 2, 3][4] };
    |        ^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/array-literal-index-oob.rs:4:9
    |
 LL | #![warn(const_err)]

--- a/src/test/ui/consts/assoc_const_generic_impl.stderr
+++ b/src/test/ui/consts/assoc_const_generic_impl.stderr
@@ -6,7 +6,7 @@ LL |     const I_AM_ZERO_SIZED: ()  = [()][std::mem::size_of::<Self>()];
    |                                  |
    |                                  index out of bounds: the len is 1 but the index is 4
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/assoc_const_generic_impl.rs:3:9
    |
 LL | #![warn(const_err)]

--- a/src/test/ui/consts/const-err-early.stderr
+++ b/src/test/ui/consts/const-err-early.stderr
@@ -6,7 +6,7 @@ LL | pub const A: i8 = -std::i8::MIN;
    |                   |
    |                   attempt to negate with overflow
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/const-err-early.rs:1:9
    |
 LL | #![deny(const_err)]

--- a/src/test/ui/consts/const-err-multi.stderr
+++ b/src/test/ui/consts/const-err-multi.stderr
@@ -6,7 +6,7 @@ LL | pub const A: i8 = -std::i8::MIN;
    |                   |
    |                   attempt to negate with overflow
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/const-err-multi.rs:1:9
    |
 LL | #![deny(const_err)]

--- a/src/test/ui/consts/const-err.stderr
+++ b/src/test/ui/consts/const-err.stderr
@@ -6,7 +6,7 @@ LL | const FOO: u8 = [5u8][1];
    |                 |
    |                 index out of bounds: the len is 1 but the index is 1
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/const-err.rs:5:9
    |
 LL | #![warn(const_err)]

--- a/src/test/ui/consts/const-err2.stderr
+++ b/src/test/ui/consts/const-err2.stderr
@@ -4,7 +4,7 @@ error: this expression will panic at runtime
 LL |     let a = -std::i8::MIN;
    |             ^^^^^^^^^^^^^ attempt to negate with overflow
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/const-err2.rs:11:9
    |
 LL | #![deny(const_err)]

--- a/src/test/ui/consts/const-err3.stderr
+++ b/src/test/ui/consts/const-err3.stderr
@@ -4,7 +4,7 @@ error: attempt to negate with overflow
 LL |     let a = -std::i8::MIN;
    |             ^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/const-err3.rs:11:9
    |
 LL | #![deny(const_err)]

--- a/src/test/ui/consts/const-eval/conditional_array_execution.stderr
+++ b/src/test/ui/consts/const-eval/conditional_array_execution.stderr
@@ -6,7 +6,7 @@ LL | const FOO: u32 = [X - Y, Y - X][(X < Y) as usize];
    |                   |
    |                   attempt to subtract with overflow
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/conditional_array_execution.rs:3:9
    |
 LL | #![warn(const_err)]

--- a/src/test/ui/consts/const-eval/const-eval-overflow2.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2.stderr
@@ -8,7 +8,7 @@ LL | |      i8::MIN - 1,
 LL | |      );
    | |_______-
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/const-eval-overflow2.rs:8:9
    |
 LL | #![deny(const_err)]

--- a/src/test/ui/consts/const-eval/const-eval-overflow2b.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2b.stderr
@@ -8,7 +8,7 @@ LL | |      i8::MAX + 1,
 LL | |      );
    | |_______-
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/const-eval-overflow2b.rs:8:9
    |
 LL | #![deny(const_err)]

--- a/src/test/ui/consts/const-eval/const-eval-overflow2c.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2c.stderr
@@ -8,7 +8,7 @@ LL | |      i8::MIN * 2,
 LL | |      );
    | |_______-
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/const-eval-overflow2c.rs:8:9
    |
 LL | #![deny(const_err)]

--- a/src/test/ui/consts/const-eval/index-out-of-bounds-never-type.stderr
+++ b/src/test/ui/consts/const-eval/index-out-of-bounds-never-type.stderr
@@ -6,7 +6,7 @@ LL |     const VOID: ! = { let x = 0 * std::mem::size_of::<T>(); [][x] };
    |                                                             |
    |                                                             index out of bounds: the len is 0 but the index is 0
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/index-out-of-bounds-never-type.rs:4:9
    |
 LL | #![warn(const_err)]

--- a/src/test/ui/consts/const-eval/issue-43197.stderr
+++ b/src/test/ui/consts/const-eval/issue-43197.stderr
@@ -6,7 +6,7 @@ LL |     const X: u32 = 0 - 1;
    |                    |
    |                    attempt to subtract with overflow
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-43197.rs:3:9
    |
 LL | #![warn(const_err)]

--- a/src/test/ui/consts/const-eval/panic-assoc-never-type.stderr
+++ b/src/test/ui/consts/const-eval/panic-assoc-never-type.stderr
@@ -6,7 +6,7 @@ LL |     const VOID: ! = panic!();
    |                     |
    |                     the evaluated program panicked at 'explicit panic', $DIR/panic-assoc-never-type.rs:11:21
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/panic-assoc-never-type.rs:4:9
    |
 LL | #![warn(const_err)]

--- a/src/test/ui/consts/const-eval/panic-never-type.stderr
+++ b/src/test/ui/consts/const-eval/panic-never-type.stderr
@@ -6,7 +6,7 @@ LL | const VOID: ! = panic!();
    |                 |
    |                 the evaluated program panicked at 'explicit panic', $DIR/panic-never-type.rs:8:17
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/panic-never-type.rs:4:9
    |
 LL | #![warn(const_err)]

--- a/src/test/ui/consts/const-eval/promoted_errors.stderr
+++ b/src/test/ui/consts/const-eval/promoted_errors.stderr
@@ -4,7 +4,7 @@ warning: this expression will panic at runtime
 LL |     let _x = 0u32 - 1;
    |              ^^^^^^^^ attempt to subtract with overflow
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/promoted_errors.rs:5:9
    |
 LL | #![warn(const_err)]

--- a/src/test/ui/consts/const-eval/promoted_errors2.stderr
+++ b/src/test/ui/consts/const-eval/promoted_errors2.stderr
@@ -4,7 +4,7 @@ warning: attempt to subtract with overflow
 LL |     println!("{}", 0u32 - 1);
    |                    ^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/promoted_errors2.rs:5:9
    |
 LL | #![warn(const_err)]

--- a/src/test/ui/consts/const-eval/pub_const_err.stderr
+++ b/src/test/ui/consts/const-eval/pub_const_err.stderr
@@ -6,7 +6,7 @@ LL | pub const Z: u32 = 0 - 1;
    |                    |
    |                    attempt to subtract with overflow
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/pub_const_err.rs:2:9
    |
 LL | #![warn(const_err)]

--- a/src/test/ui/consts/const-eval/pub_const_err_bin.stderr
+++ b/src/test/ui/consts/const-eval/pub_const_err_bin.stderr
@@ -6,7 +6,7 @@ LL | pub const Z: u32 = 0 - 1;
    |                    |
    |                    attempt to subtract with overflow
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/pub_const_err_bin.rs:2:9
    |
 LL | #![warn(const_err)]

--- a/src/test/ui/consts/const-eval/ub-nonnull.stderr
+++ b/src/test/ui/consts/const-eval/ub-nonnull.stderr
@@ -18,7 +18,7 @@ LL | |     mem::transmute(out_of_bounds_ptr)
 LL | | } };
    | |____-
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/ub-nonnull.rs:14:8
    |
 LL | #[deny(const_err)] // this triggers a `const_err` so validation does not even happen

--- a/src/test/ui/consts/const-eval/validate_uninhabited_zsts.stderr
+++ b/src/test/ui/consts/const-eval/validate_uninhabited_zsts.stderr
@@ -10,7 +10,7 @@ LL |     unsafe { std::mem::transmute(()) }
 LL | const FOO: [Empty; 3] = [foo(); 3];
    | -----------------------------------
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/validate_uninhabited_zsts.rs:13:8
    |
 LL | #[warn(const_err)]

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
@@ -64,7 +64,7 @@ LL | |
 LL | | };
    | |__-
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/const_refers_to_static.rs:2:9
    |
 LL | #![warn(const_err)]

--- a/src/test/ui/consts/miri_unleashed/mutable_const.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_const.stderr
@@ -16,7 +16,7 @@ LL | |     }
 LL | | };
    | |__-
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/mutable_const.rs:5:9
    |
 LL | #![deny(const_err)]

--- a/src/test/ui/consts/miri_unleashed/non_const_fn.stderr
+++ b/src/test/ui/consts/miri_unleashed/non_const_fn.stderr
@@ -12,7 +12,7 @@ LL | const C: () = foo();
    |               |
    |               calling non-const function `foo`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/non_const_fn.rs:4:9
    |
 LL | #![warn(const_err)]

--- a/src/test/ui/deprecation/deprecation-lint-2.stderr
+++ b/src/test/ui/deprecation/deprecation-lint-2.stderr
@@ -4,7 +4,7 @@ error: use of deprecated item 'deprecation_lint::deprecated': text
 LL |     macro_test!();
    |     ^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/deprecation-lint-2.rs:4:9
    |
 LL | #![deny(deprecated)]

--- a/src/test/ui/deprecation/deprecation-lint-3.stderr
+++ b/src/test/ui/deprecation/deprecation-lint-3.stderr
@@ -4,7 +4,7 @@ error: use of deprecated item 'deprecation_lint::deprecated_text': text
 LL |     macro_test_arg_nested!(deprecated_text);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/deprecation-lint-3.rs:4:9
    |
 LL | #![deny(deprecated)]

--- a/src/test/ui/deprecation/deprecation-lint-nested.stderr
+++ b/src/test/ui/deprecation/deprecation-lint-nested.stderr
@@ -4,7 +4,7 @@ error: use of deprecated item 'loud::DeprecatedType'
 LL |     struct Foo(DeprecatedType);
    |                ^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/deprecation-lint-nested.rs:1:9
    |
 LL | #![deny(deprecated)]

--- a/src/test/ui/deprecation/deprecation-lint.stderr
+++ b/src/test/ui/deprecation/deprecation-lint.stderr
@@ -4,7 +4,7 @@ error: use of deprecated item 'deprecation_lint::deprecated': text
 LL |         deprecated();
    |         ^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/deprecation-lint.rs:4:9
    |
 LL | #![deny(deprecated)]

--- a/src/test/ui/deprecation/rustc_deprecation-in-future.stderr
+++ b/src/test/ui/deprecation/rustc_deprecation-in-future.stderr
@@ -4,7 +4,7 @@ error: use of item 'S' that will be deprecated in future version 99.99.99: effec
 LL |     let _ = S;
    |             ^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/rustc_deprecation-in-future.rs:3:9
    |
 LL | #![deny(deprecated_in_future)]

--- a/src/test/ui/deprecation/suggestion.stderr
+++ b/src/test/ui/deprecation/suggestion.stderr
@@ -4,7 +4,7 @@ error: use of deprecated item 'Foo::deprecated': replaced by `replacement`
 LL |     foo.deprecated();
    |         ^^^^^^^^^^ help: replace the use of the deprecated item: `replacement`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/suggestion.rs:7:9
    |
 LL | #![deny(deprecated)]

--- a/src/test/ui/derives/deriving-meta-empty-trait-list.stderr
+++ b/src/test/ui/derives/deriving-meta-empty-trait-list.stderr
@@ -4,7 +4,7 @@ error: unused attribute
 LL | #[derive()]
    | ^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/deriving-meta-empty-trait-list.rs:1:9
    |
 LL | #![deny(unused)]

--- a/src/test/ui/derives/deriving-with-repr-packed.stderr
+++ b/src/test/ui/derives/deriving-with-repr-packed.stderr
@@ -4,7 +4,7 @@ error: `#[derive]` can't be used on a `#[repr(packed)]` struct with type or cons
 LL | #[derive(Copy, Clone, PartialEq, Eq)]
    |                ^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/deriving-with-repr-packed.rs:1:9
    |
 LL | #![deny(safe_packed_borrows)]

--- a/src/test/ui/duplicate_entry_error.stderr
+++ b/src/test/ui/duplicate_entry_error.stderr
@@ -7,7 +7,7 @@ LL | |     loop {}
 LL | | }
    | |_^
    |
-   = note: first defined in crate `std` (which `duplicate_entry_error` depends on)
+   = note: the lang item is first defined in crate `std` (which `duplicate_entry_error` depends on)
 
 error: aborting due to previous error
 

--- a/src/test/ui/dyn-keyword/dyn-2015-edition-keyword-ident-lint.stderr
+++ b/src/test/ui/dyn-keyword/dyn-2015-edition-keyword-ident-lint.stderr
@@ -4,7 +4,7 @@ error: `dyn` is a keyword in the 2018 edition
 LL |     pub mod dyn {
    |             ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:10:9
    |
 LL | #![deny(keyword_idents)]

--- a/src/test/ui/editions/edition-extern-crate-allowed.stderr
+++ b/src/test/ui/editions/edition-extern-crate-allowed.stderr
@@ -4,7 +4,7 @@ warning: unused extern crate
 LL | extern crate edition_extern_crate_allowed;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/edition-extern-crate-allowed.rs:5:9
    |
 LL | #![warn(rust_2018_idioms)]

--- a/src/test/ui/editions/edition-raw-pointer-method-2015.stderr
+++ b/src/test/ui/editions/edition-raw-pointer-method-2015.stderr
@@ -4,7 +4,7 @@ error: type annotations needed
 LL |     let _ = y.is_null();
    |               ^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/edition-raw-pointer-method-2015.rs:5:8
    |
 LL | #[deny(warnings)]

--- a/src/test/ui/enable-unstable-lib-feature.stderr
+++ b/src/test/ui/enable-unstable-lib-feature.stderr
@@ -4,7 +4,7 @@ error: function `BOGUS` should have a snake case name
 LL | pub fn BOGUS() { }
    |        ^^^^^ help: convert the identifier to snake case: `bogus`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/enable-unstable-lib-feature.rs:6:9
    |
 LL | #![deny(non_snake_case)] // To trigger a hard error

--- a/src/test/ui/enum/enum-discrim-too-small2.stderr
+++ b/src/test/ui/enum/enum-discrim-too-small2.stderr
@@ -4,7 +4,7 @@ error: literal out of range for `i8`
 LL |     Ci8 = 223,
    |           ^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/enum-discrim-too-small2.rs:1:9
    |
 LL | #![deny(overflowing_literals)]

--- a/src/test/ui/enum/enum-size-variance.stderr
+++ b/src/test/ui/enum/enum-size-variance.stderr
@@ -4,7 +4,7 @@ warning: enum variant is more than three times larger (32 bytes) than the next l
 LL |     L(i64, i64, i64, i64),
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/enum-size-variance.rs:3:9
    |
 LL | #![warn(variant_size_differences)]

--- a/src/test/ui/error-codes/E0001.stderr
+++ b/src/test/ui/error-codes/E0001.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         _ => {/* ... */}
    |         ^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/E0001.rs:1:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/error-codes/E0152.stderr
+++ b/src/test/ui/error-codes/E0152.stderr
@@ -4,7 +4,7 @@ error[E0152]: found duplicate lang item `arc`
 LL | struct Foo;
    | ^^^^^^^^^^^
    |
-   = note: first defined in crate `alloc` (which `std` depends on)
+   = note: the lang item is first defined in crate `alloc` (which `std` depends on)
 
 error: aborting due to previous error
 

--- a/src/test/ui/expr_attr_paren_order.stderr
+++ b/src/test/ui/expr_attr_paren_order.stderr
@@ -4,7 +4,7 @@ error: variable `X` should have a snake case name
 LL |             let X = 0;
    |                 ^ help: convert the identifier to snake case (notice the capitalization): `x`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/expr_attr_paren_order.rs:17:17
    |
 LL |         #![deny(non_snake_case)]

--- a/src/test/ui/extern-flag/public-and-private.stderr
+++ b/src/test/ui/extern-flag/public-and-private.stderr
@@ -4,7 +4,7 @@ error: type `somedep::S` from private dependency 'somedep' in public interface
 LL |     pub field: somedep::S,
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/public-and-private.rs:5:9
    |
 LL | #![deny(exported_private_dependencies)]

--- a/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.stderr
@@ -4,7 +4,7 @@ warning: unknown lint: `x5400`
 LL | #![warn(x5400)]
    |         ^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:36:28
    |
 LL | #![warn(unused_attributes, unknown_lints)]
@@ -250,7 +250,7 @@ warning: unused attribute
 LL |     #[macro_use] fn f() { }
    |     ^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:36:9
    |
 LL | #![warn(unused_attributes, unknown_lints)]

--- a/src/test/ui/feature-gates/feature-gate-feature-gate.stderr
+++ b/src/test/ui/feature-gates/feature-gate-feature-gate.stderr
@@ -4,7 +4,7 @@ error: unstable feature
 LL | #![feature(intrinsics)]
    |            ^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/feature-gate-feature-gate.rs:1:11
    |
 LL | #![forbid(unstable_features)]

--- a/src/test/ui/feature-gates/feature-gate-no-debug-2.stderr
+++ b/src/test/ui/feature-gates/feature-gate-no-debug-2.stderr
@@ -4,7 +4,7 @@ error: use of deprecated attribute `no_debug`: the `#[no_debug]` attribute was a
 LL | #[no_debug]
    | ^^^^^^^^^^^ help: remove this attribute
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/feature-gate-no-debug-2.rs:1:9
    |
 LL | #![deny(deprecated)]

--- a/src/test/ui/fn_must_use.stderr
+++ b/src/test/ui/fn_must_use.stderr
@@ -4,7 +4,7 @@ warning: unused return value of `need_to_use_this_value` that must be used
 LL |     need_to_use_this_value();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/fn_must_use.rs:3:9
    |
 LL | #![warn(unused_must_use)]

--- a/src/test/ui/future-incompatible-lint-group.stderr
+++ b/src/test/ui/future-incompatible-lint-group.stderr
@@ -4,7 +4,7 @@ error: anonymous parameters are deprecated and will be removed in the next editi
 LL |     fn f(u8) {}
    |          ^^ help: try naming the parameter or explicitly ignoring it: `_: u8`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/future-incompatible-lint-group.rs:1:9
    |
 LL | #![deny(future_incompatible)]

--- a/src/test/ui/generator/ref-escapes-but-not-over-yield.stderr
+++ b/src/test/ui/generator/ref-escapes-but-not-over-yield.stderr
@@ -2,7 +2,7 @@ error[E0521]: borrowed data escapes outside of generator
   --> $DIR/ref-escapes-but-not-over-yield.rs:11:9
    |
 LL |     let mut a = &3;
-   |         ----- `a` is declared here, outside of the generator body
+   |         ----- `a` declared here, outside of the generator body
 ...
 LL |         a = &b;
    |         ^^^^--

--- a/src/test/ui/generic/generic-no-mangle.stderr
+++ b/src/test/ui/generic/generic-no-mangle.stderr
@@ -6,7 +6,7 @@ LL | #[no_mangle]
 LL | pub fn foo<T>() {}
    | ^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/generic-no-mangle.rs:1:9
    |
 LL | #![deny(no_mangle_generic_items)]

--- a/src/test/ui/imports/extern-crate-used.stderr
+++ b/src/test/ui/imports/extern-crate-used.stderr
@@ -4,7 +4,7 @@ error: unused extern crate
 LL | extern crate core;
    | ^^^^^^^^^^^^^^^^^^ help: remove it
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/extern-crate-used.rs:6:9
    |
 LL | #![deny(unused_extern_crates)]

--- a/src/test/ui/imports/reexports.stderr
+++ b/src/test/ui/imports/reexports.stderr
@@ -40,7 +40,7 @@ warning: glob import doesn't reexport anything because no candidate is public en
 LL |         pub use super::*;
    |                 ^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/reexports.rs:1:9
    |
 LL | #![warn(unused_imports)]

--- a/src/test/ui/imports/unresolved-imports-used.stderr
+++ b/src/test/ui/imports/unresolved-imports-used.stderr
@@ -52,7 +52,7 @@ error: unused import: `qux::quy`
 LL | use qux::quy;
    |     ^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unresolved-imports-used.rs:2:9
    |
 LL | #![deny(unused_imports)]

--- a/src/test/ui/imports/unused-macro-use.stderr
+++ b/src/test/ui/imports/unused-macro-use.stderr
@@ -4,7 +4,7 @@ error: unused `#[macro_use]` import
 LL | #[macro_use]
    | ^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused-macro-use.rs:1:9
    |
 LL | #![deny(unused)]

--- a/src/test/ui/imports/unused.stderr
+++ b/src/test/ui/imports/unused.stderr
@@ -4,7 +4,7 @@ error: unused import: `super::f`
 LL |         pub(super) use super::f;
    |                        ^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused.rs:1:9
    |
 LL | #![deny(unused)]

--- a/src/test/ui/in-band-lifetimes/elided-lifetimes.fixed
+++ b/src/test/ui/in-band-lifetimes/elided-lifetimes.fixed
@@ -3,7 +3,7 @@
 
 #![allow(unused)]
 #![deny(elided_lifetimes_in_paths)]
-//~^ NOTE lint level defined here
+//~^ NOTE the lint level is defined here
 
 use std::cell::{RefCell, Ref};
 

--- a/src/test/ui/in-band-lifetimes/elided-lifetimes.rs
+++ b/src/test/ui/in-band-lifetimes/elided-lifetimes.rs
@@ -3,7 +3,7 @@
 
 #![allow(unused)]
 #![deny(elided_lifetimes_in_paths)]
-//~^ NOTE lint level defined here
+//~^ NOTE the lint level is defined here
 
 use std::cell::{RefCell, Ref};
 

--- a/src/test/ui/in-band-lifetimes/elided-lifetimes.stderr
+++ b/src/test/ui/in-band-lifetimes/elided-lifetimes.stderr
@@ -4,7 +4,7 @@ error: hidden lifetime parameters in types are deprecated
 LL | fn foo(x: &Foo) {
    |            ^^^- help: indicate the anonymous lifetime: `<'_>`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/elided-lifetimes.rs:5:9
    |
 LL | #![deny(elided_lifetimes_in_paths)]

--- a/src/test/ui/invalid/invalid-plugin-attr.stderr
+++ b/src/test/ui/invalid/invalid-plugin-attr.stderr
@@ -12,7 +12,7 @@ error: unused attribute
 LL | #[plugin(bla)]
    | ^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/invalid-plugin-attr.rs:1:9
    |
 LL | #![deny(unused_attributes)]

--- a/src/test/ui/issues/issue-10656.stderr
+++ b/src/test/ui/issues/issue-10656.stderr
@@ -5,7 +5,7 @@ LL | / #![deny(missing_docs)]
 LL | | #![crate_type="lib"]
    | |____________________^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-10656.rs:1:9
    |
 LL | #![deny(missing_docs)]

--- a/src/test/ui/issues/issue-12116.stderr
+++ b/src/test/ui/issues/issue-12116.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         &IntList::Cons(val, box IntList::Nil)  => IntList::Cons(val, box IntList::Nil),
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-12116.rs:5:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/issues/issue-12369.stderr
+++ b/src/test/ui/issues/issue-12369.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         &[10,a, ref rest @ ..] => 10
    |         ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-12369.rs:1:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/issues/issue-13727.stderr
+++ b/src/test/ui/issues/issue-13727.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |     512 => print!("0b1111\n"),
    |     ^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-13727.rs:2:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/issues/issue-14221.stderr
+++ b/src/test/ui/issues/issue-14221.stderr
@@ -21,7 +21,7 @@ LL |
 LL |             B => "B",
    |             ^ unreachable pattern
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-14221.rs:1:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/issues/issue-14309.stderr
+++ b/src/test/ui/issues/issue-14309.stderr
@@ -4,14 +4,14 @@ error: `extern` block uses type `A`, which is not FFI-safe
 LL |     fn foo(x: A);
    |               ^ not FFI-safe
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-14309.rs:1:9
    |
 LL | #![deny(improper_ctypes)]
    |         ^^^^^^^^^^^^^^^
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
-note: type defined here
+note: the type is defined here
   --> $DIR/issue-14309.rs:4:1
    |
 LL | / struct A {
@@ -27,7 +27,7 @@ LL |     fn bar(x: B);
    |
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
-note: type defined here
+note: the type is defined here
   --> $DIR/issue-14309.rs:4:1
    |
 LL | / struct A {
@@ -43,7 +43,7 @@ LL |     fn qux(x: A2);
    |
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
-note: type defined here
+note: the type is defined here
   --> $DIR/issue-14309.rs:4:1
    |
 LL | / struct A {
@@ -59,7 +59,7 @@ LL |     fn quux(x: B2);
    |
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
-note: type defined here
+note: the type is defined here
   --> $DIR/issue-14309.rs:4:1
    |
 LL | / struct A {
@@ -75,7 +75,7 @@ LL |     fn fred(x: D);
    |
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
-note: type defined here
+note: the type is defined here
   --> $DIR/issue-14309.rs:4:1
    |
 LL | / struct A {

--- a/src/test/ui/issues/issue-16250.stderr
+++ b/src/test/ui/issues/issue-16250.stderr
@@ -4,7 +4,7 @@ error: `extern` block uses type `Foo`, which is not FFI-safe
 LL |     pub fn foo(x: (Foo));
    |                    ^^^ not FFI-safe
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-16250.rs:1:9
    |
 LL | #![deny(warnings)]
@@ -12,7 +12,7 @@ LL | #![deny(warnings)]
    = note: `#[deny(improper_ctypes)]` implied by `#[deny(warnings)]`
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
-note: type defined here
+note: the type is defined here
   --> $DIR/issue-16250.rs:3:1
    |
 LL | pub struct Foo;

--- a/src/test/ui/issues/issue-17337.stderr
+++ b/src/test/ui/issues/issue-17337.stderr
@@ -4,7 +4,7 @@ error: use of deprecated item 'Foo::foo': text
 LL |     .foo();
    |      ^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-17337.rs:2:9
    |
 LL | #![deny(deprecated)]

--- a/src/test/ui/issues/issue-17718-const-naming.stderr
+++ b/src/test/ui/issues/issue-17718-const-naming.stderr
@@ -4,7 +4,7 @@ error: constant item is never used: `foo`
 LL | const foo: isize = 3;
    | ^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-17718-const-naming.rs:2:9
    |
 LL | #![deny(warnings)]
@@ -17,7 +17,7 @@ error: constant `foo` should have an upper case name
 LL | const foo: isize = 3;
    |       ^^^ help: convert the identifier to upper case (notice the capitalization): `FOO`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-17718-const-naming.rs:2:9
    |
 LL | #![deny(warnings)]

--- a/src/test/ui/issues/issue-17999.stderr
+++ b/src/test/ui/issues/issue-17999.stderr
@@ -4,7 +4,7 @@ error: unused variable: `x`
 LL |         let x = ();
    |             ^ help: consider prefixing with an underscore: `_x`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-17999.rs:1:9
    |
 LL | #![deny(unused_variables)]

--- a/src/test/ui/issues/issue-2150.stderr
+++ b/src/test/ui/issues/issue-2150.stderr
@@ -6,7 +6,7 @@ LL |     panic!();
 LL |     for x in &v { i += 1; }
    |     ^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-2150.rs:1:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/issues/issue-22599.stderr
+++ b/src/test/ui/issues/issue-22599.stderr
@@ -4,7 +4,7 @@ error: unused variable: `a`
 LL |     v = match 0 { a => 0 };
    |                   ^ help: consider prefixing with an underscore: `_a`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-22599.rs:1:9
    |
 LL | #![deny(unused_variables)]

--- a/src/test/ui/issues/issue-27060.stderr
+++ b/src/test/ui/issues/issue-27060.stderr
@@ -4,7 +4,7 @@ error: borrow of packed field is unsafe and requires unsafe function or block (e
 LL |     let _ = &good.data;
    |             ^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-27060.rs:13:8
    |
 LL | #[deny(safe_packed_borrows)]

--- a/src/test/ui/issues/issue-30240-b.stderr
+++ b/src/test/ui/issues/issue-30240-b.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         "hello" => {}
    |         ^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-30240-b.rs:1:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/issues/issue-30302.stderr
+++ b/src/test/ui/issues/issue-30302.stderr
@@ -15,7 +15,7 @@ LL |
 LL |         _ => false
    |         ^ unreachable pattern
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-30302.rs:4:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/issues/issue-30730.stderr
+++ b/src/test/ui/issues/issue-30730.stderr
@@ -4,7 +4,7 @@ error: unused import: `std::thread`
 LL | use std::thread;
    |     ^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-30730.rs:2:9
    |
 LL | #![deny(warnings)]

--- a/src/test/ui/issues/issue-31221.stderr
+++ b/src/test/ui/issues/issue-31221.stderr
@@ -6,7 +6,7 @@ LL |         Var3 => (),
 LL |         Var2 => (),
    |         ^^^^ unreachable pattern
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-31221.rs:4:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/issues/issue-33140-traitobject-crate.stderr
+++ b/src/test/ui/issues/issue-33140-traitobject-crate.stderr
@@ -6,7 +6,7 @@ LL | unsafe impl Trait for dyn (::std::marker::Send) + Sync { }
 LL | unsafe impl Trait for dyn (::std::marker::Send) + Send + Sync { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn std::marker::Send + std::marker::Sync + 'static)`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-33140-traitobject-crate.rs:3:9
    |
 LL | #![warn(order_dependent_trait_objects)]

--- a/src/test/ui/issues/issue-37515.stderr
+++ b/src/test/ui/issues/issue-37515.stderr
@@ -4,7 +4,7 @@ warning: type alias is never used: `Z`
 LL | type Z = dyn for<'x> Send;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-37515.rs:3:9
    |
 LL | #![warn(unused)]

--- a/src/test/ui/issues/issue-41255.stderr
+++ b/src/test/ui/issues/issue-41255.stderr
@@ -4,7 +4,7 @@ error: floating-point types cannot be used in patterns
 LL |         5.0 => {},
    |         ^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-41255.rs:6:11
    |
 LL | #![forbid(illegal_floating_point_literal_pattern)]

--- a/src/test/ui/issues/issue-45107-unnecessary-unsafe-in-closure.stderr
+++ b/src/test/ui/issues/issue-45107-unnecessary-unsafe-in-closure.stderr
@@ -7,7 +7,7 @@ LL |         let f = |v: &mut Vec<_>| {
 LL |             unsafe {
    |             ^^^^^^ unnecessary `unsafe` block
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-45107-unnecessary-unsafe-in-closure.rs:1:8
    |
 LL | #[deny(unused_unsafe)]

--- a/src/test/ui/issues/issue-46576.stderr
+++ b/src/test/ui/issues/issue-46576.stderr
@@ -4,7 +4,7 @@ error: unused import: `BufRead`
 LL | use std::io::{BufRead, BufReader, Read};
    |               ^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-46576.rs:4:9
    |
 LL | #![deny(unused_imports)]

--- a/src/test/ui/issues/issue-48131.stderr
+++ b/src/test/ui/issues/issue-48131.stderr
@@ -4,7 +4,7 @@ error: unnecessary `unsafe` block
 LL |         unsafe { /* unnecessary */ }
    |         ^^^^^^ unnecessary `unsafe` block
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-48131.rs:3:9
    |
 LL | #![deny(unused_unsafe)]

--- a/src/test/ui/issues/issue-49934.rs
+++ b/src/test/ui/issues/issue-49934.rs
@@ -1,7 +1,7 @@
 // check-pass
 
 #![feature(stmt_expr_attributes)]
-#![warn(unused_attributes)] //~ NOTE lint level defined here
+#![warn(unused_attributes)] //~ NOTE the lint level is defined here
 
 fn main() {
     // fold_stmt (Item)

--- a/src/test/ui/issues/issue-49934.stderr
+++ b/src/test/ui/issues/issue-49934.stderr
@@ -12,7 +12,7 @@ warning: unused attribute
 LL |     #[derive(Debug)]
    |     ^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-49934.rs:4:9
    |
 LL | #![warn(unused_attributes)]

--- a/src/test/ui/issues/issue-50781.stderr
+++ b/src/test/ui/issues/issue-50781.stderr
@@ -4,7 +4,7 @@ error: the trait `X` cannot be made into an object
 LL |     fn foo(&self) where Self: Trait;
    |        ^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-50781.rs:1:9
    |
 LL | #![deny(where_clauses_object_safety)]

--- a/src/test/ui/issues/issue-55511.stderr
+++ b/src/test/ui/issues/issue-55511.stderr
@@ -4,7 +4,7 @@ warning: to use a constant of type `std::cell::Cell` in a pattern, `std::cell::C
 LL |         <() as Foo<'static>>::C => { }
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-55511.rs:1:9
    |
 LL | #![warn(indirect_structural_match)]

--- a/src/test/ui/issues/issue-56685.stderr
+++ b/src/test/ui/issues/issue-56685.stderr
@@ -4,7 +4,7 @@ error: unused variable: `x`
 LL |         E::A(x) | E::B(x) => {}
    |              ^         ^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-56685.rs:2:9
    |
 LL | #![deny(unused_variables)]

--- a/src/test/ui/issues/issue-57472.stderr
+++ b/src/test/ui/issues/issue-57472.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |             Punned { bar: [_], .. } => println!("bar"),
    |             ^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-57472.rs:2:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/issues/issue-59896.stderr
+++ b/src/test/ui/issues/issue-59896.stderr
@@ -7,7 +7,7 @@ LL | struct S;
 LL |     use S;
    |         ^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-59896.rs:1:9
    |
 LL | #![deny(unused_imports)]

--- a/src/test/ui/issues/issue-60622.stderr
+++ b/src/test/ui/issues/issue-60622.stderr
@@ -7,7 +7,7 @@ LL |     fn a(&self) {}
 LL |     b.a::<'_, T>();
    |           ^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-60622.rs:3:9
    |
 LL | #![deny(warnings)]

--- a/src/test/ui/issues/issue-6804.stderr
+++ b/src/test/ui/issues/issue-6804.stderr
@@ -4,7 +4,7 @@ error: floating-point types cannot be used in patterns
 LL |         NAN => {},
    |         ^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-6804.rs:4:9
    |
 LL | #![deny(illegal_floating_point_literal_pattern)]

--- a/src/test/ui/issues/issue-7246.stderr
+++ b/src/test/ui/issues/issue-7246.stderr
@@ -6,7 +6,7 @@ LL |     return;
 LL |     if *ptr::null() {};
    |     ^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-7246.rs:1:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/issues/issue-8460-const.stderr
+++ b/src/test/ui/issues/issue-8460-const.stderr
@@ -4,7 +4,7 @@ error: attempt to divide with overflow
 LL |     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-8460-const.rs:4:9
    |
 LL | #![deny(const_err)]

--- a/src/test/ui/issues/issue-8460-const2.stderr
+++ b/src/test/ui/issues/issue-8460-const2.stderr
@@ -4,7 +4,7 @@ error: attempt to divide with overflow
 LL |     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-8460-const2.rs:4:9
    |
 LL | #![deny(const_err)]

--- a/src/test/ui/lint/dead-code/basic.stderr
+++ b/src/test/ui/lint/dead-code/basic.stderr
@@ -4,7 +4,7 @@ error: function is never used: `foo`
 LL | fn foo() {
    |    ^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/basic.rs:1:9
    |
 LL | #![deny(dead_code)]

--- a/src/test/ui/lint/dead-code/empty-unused-enum.stderr
+++ b/src/test/ui/lint/dead-code/empty-unused-enum.stderr
@@ -4,7 +4,7 @@ error: enum is never used: `E`
 LL | enum E {}
    |      ^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/empty-unused-enum.rs:1:9
    |
 LL | #![deny(unused)]

--- a/src/test/ui/lint/dead-code/impl-trait.stderr
+++ b/src/test/ui/lint/dead-code/impl-trait.stderr
@@ -4,7 +4,7 @@ error: type alias is never used: `Unused`
 LL | type Unused = ();
    | ^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/impl-trait.rs:1:9
    |
 LL | #![deny(dead_code)]

--- a/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
@@ -4,7 +4,7 @@ error: struct is never constructed: `Bar`
 LL |     pub struct Bar;
    |                ^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-dead-code-1.rs:5:9
    |
 LL | #![deny(dead_code)]

--- a/src/test/ui/lint/dead-code/lint-dead-code-2.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-2.stderr
@@ -4,7 +4,7 @@ error: function is never used: `dead_fn`
 LL | fn dead_fn() {}
    |    ^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-dead-code-2.rs:2:9
    |
 LL | #![deny(dead_code)]

--- a/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
@@ -4,7 +4,7 @@ error: struct is never constructed: `Foo`
 LL | struct Foo;
    |        ^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-dead-code-3.rs:3:9
    |
 LL | #![deny(dead_code)]

--- a/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
@@ -4,7 +4,7 @@ error: field is never read: `b`
 LL |     b: bool,
    |     ^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-dead-code-4.rs:3:9
    |
 LL | #![deny(dead_code)]

--- a/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
@@ -4,7 +4,7 @@ error: variant is never constructed: `Variant2`
 LL |     Variant2
    |     ^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-dead-code-5.rs:2:9
    |
 LL | #![deny(dead_code)]

--- a/src/test/ui/lint/dead-code/newline-span.stderr
+++ b/src/test/ui/lint/dead-code/newline-span.stderr
@@ -4,7 +4,7 @@ error: function is never used: `unused`
 LL | fn unused() {
    |    ^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/newline-span.rs:1:9
    |
 LL | #![deny(dead_code)]

--- a/src/test/ui/lint/dead-code/type-alias.stderr
+++ b/src/test/ui/lint/dead-code/type-alias.stderr
@@ -4,7 +4,7 @@ error: type alias is never used: `Unused`
 LL | type Unused = u8;
    | ^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/type-alias.rs:1:9
    |
 LL | #![deny(dead_code)]

--- a/src/test/ui/lint/dead-code/unused-enum.stderr
+++ b/src/test/ui/lint/dead-code/unused-enum.stderr
@@ -4,7 +4,7 @@ error: struct is never constructed: `F`
 LL | struct F;
    |        ^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused-enum.rs:1:9
    |
 LL | #![deny(unused)]

--- a/src/test/ui/lint/dead-code/unused-struct-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-struct-variant.stderr
@@ -4,7 +4,7 @@ error: variant is never constructed: `Bar`
 LL |     Bar(B),
    |     ^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused-struct-variant.rs:1:9
    |
 LL | #![deny(unused)]

--- a/src/test/ui/lint/dead-code/unused-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-variant.stderr
@@ -4,7 +4,7 @@ error: variant is never constructed: `Variant1`
 LL |     Variant1,
    |     ^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused-variant.rs:1:9
    |
 LL | #![deny(dead_code)]

--- a/src/test/ui/lint/dead-code/with-core-crate.stderr
+++ b/src/test/ui/lint/dead-code/with-core-crate.stderr
@@ -4,7 +4,7 @@ error: function is never used: `foo`
 LL | fn foo() {
    |    ^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/with-core-crate.rs:1:9
    |
 LL | #![deny(dead_code)]

--- a/src/test/ui/lint/inclusive-range-pattern-syntax.stderr
+++ b/src/test/ui/lint/inclusive-range-pattern-syntax.stderr
@@ -4,7 +4,7 @@ warning: `...` range patterns are deprecated
 LL |         1...2 => {}
    |          ^^^ help: use `..=` for an inclusive range
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/inclusive-range-pattern-syntax.rs:4:9
    |
 LL | #![warn(ellipsis_inclusive_range_patterns)]

--- a/src/test/ui/lint/inline-trait-and-foreign-items.stderr
+++ b/src/test/ui/lint/inline-trait-and-foreign-items.stderr
@@ -20,7 +20,7 @@ warning: `#[inline]` is ignored on constants
 LL |     #[inline]
    |     ^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/inline-trait-and-foreign-items.rs:4:9
    |
 LL | #![warn(unused_attributes)]

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
@@ -4,7 +4,7 @@ warning: unused variable: `i_think_continually`
 LL |     let i_think_continually = 2;
    |         ^^^^^^^^^^^^^^^^^^^ help: consider prefixing with an underscore: `_i_think_continually`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:5:9
    |
 LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)
@@ -49,7 +49,7 @@ warning: value assigned to `hours_are_suns` is never read
 LL |         hours_are_suns = false;
    |         ^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:5:9
    |
 LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)
@@ -107,7 +107,7 @@ LL |     let mut mut_unused_var = 1;
    |         |
    |         help: remove this `mut`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:5:9
    |
 LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)

--- a/src/test/ui/lint/issue-54180-unused-ref-field.stderr
+++ b/src/test/ui/lint/issue-54180-unused-ref-field.stderr
@@ -6,7 +6,7 @@ LL |         E::Variant { ref field } => (),
    |                      |
    |                      help: try ignoring the field: `field: _`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-54180-unused-ref-field.rs:3:9
    |
 LL | #![deny(unused)]

--- a/src/test/ui/lint/issue-54538-unused-parens-lint.stderr
+++ b/src/test/ui/lint/issue-54538-unused-parens-lint.stderr
@@ -12,7 +12,7 @@ error: unnecessary parentheses around pattern
 LL |     let (a) = 0;
    |         ^^^ help: remove these parentheses
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-54538-unused-parens-lint.rs:9:9
    |
 LL | #![deny(unused_parens)]

--- a/src/test/ui/lint/issue-66362-no-snake-case-warning-for-field-puns.stderr
+++ b/src/test/ui/lint/issue-66362-no-snake-case-warning-for-field-puns.stderr
@@ -4,7 +4,7 @@ error: structure field `lowerCamelCaseName` should have a snake case name
 LL |         lowerCamelCaseName: bool,
    |         ^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `lower_camel_case_name`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-66362-no-snake-case-warning-for-field-puns.rs:1:9
    |
 LL | #![deny(non_snake_case)]

--- a/src/test/ui/lint/lint-attr-non-item-node.stderr
+++ b/src/test/ui/lint/lint-attr-non-item-node.stderr
@@ -6,7 +6,7 @@ LL |         break;
 LL |         "unreachable";
    |         ^^^^^^^^^^^^^^ unreachable statement
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-attr-non-item-node.rs:4:12
    |
 LL |     #[deny(unreachable_code)]

--- a/src/test/ui/lint/lint-change-warnings.stderr
+++ b/src/test/ui/lint/lint-change-warnings.stderr
@@ -4,7 +4,7 @@ error: denote infinite loops with `loop { ... }`
 LL |     while true {}
    |     ^^^^^^^^^^ help: use `loop`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-change-warnings.rs:1:9
    |
 LL | #![deny(warnings)]
@@ -25,7 +25,7 @@ error: denote infinite loops with `loop { ... }`
 LL |     while true {}
    |     ^^^^^^^^^^ help: use `loop`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-change-warnings.rs:18:10
    |
 LL | #[forbid(warnings)]

--- a/src/test/ui/lint/lint-ctypes-enum.stderr
+++ b/src/test/ui/lint/lint-ctypes-enum.stderr
@@ -4,14 +4,14 @@ error: `extern` block uses type `U`, which is not FFI-safe
 LL |    fn uf(x: U);
    |             ^ not FFI-safe
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-ctypes-enum.rs:3:9
    |
 LL | #![deny(improper_ctypes)]
    |         ^^^^^^^^^^^^^^^
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
-note: type defined here
+note: the type is defined here
   --> $DIR/lint-ctypes-enum.rs:9:1
    |
 LL | enum U { A }
@@ -25,7 +25,7 @@ LL |    fn bf(x: B);
    |
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
-note: type defined here
+note: the type is defined here
   --> $DIR/lint-ctypes-enum.rs:10:1
    |
 LL | enum B { C, D }
@@ -39,7 +39,7 @@ LL |    fn tf(x: T);
    |
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
-note: type defined here
+note: the type is defined here
   --> $DIR/lint-ctypes-enum.rs:11:1
    |
 LL | enum T { E, F, G }

--- a/src/test/ui/lint/lint-ctypes.stderr
+++ b/src/test/ui/lint/lint-ctypes.stderr
@@ -4,14 +4,14 @@ error: `extern` block uses type `Foo`, which is not FFI-safe
 LL |     pub fn ptr_type1(size: *const Foo);
    |                            ^^^^^^^^^^ not FFI-safe
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-ctypes.rs:4:9
    |
 LL | #![deny(improper_ctypes)]
    |         ^^^^^^^^^^^^^^^
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
-note: type defined here
+note: the type is defined here
   --> $DIR/lint-ctypes.rs:24:1
    |
 LL | pub struct Foo;
@@ -25,7 +25,7 @@ LL |     pub fn ptr_type2(size: *const Foo);
    |
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
-note: type defined here
+note: the type is defined here
   --> $DIR/lint-ctypes.rs:24:1
    |
 LL | pub struct Foo;
@@ -117,7 +117,7 @@ LL |     pub fn zero_size(p: ZeroSize);
    |
    = help: consider adding a member to this struct
    = note: this struct has no fields
-note: type defined here
+note: the type is defined here
   --> $DIR/lint-ctypes.rs:20:1
    |
 LL | pub struct ZeroSize;
@@ -130,7 +130,7 @@ LL |     pub fn zero_size_phantom(p: ZeroSizeWithPhantomData);
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: composed only of `PhantomData`
-note: type defined here
+note: the type is defined here
   --> $DIR/lint-ctypes.rs:43:1
    |
 LL | pub struct ZeroSizeWithPhantomData(::std::marker::PhantomData<i32>);

--- a/src/test/ui/lint/lint-directives-on-use-items-issue-10534.stderr
+++ b/src/test/ui/lint/lint-directives-on-use-items-issue-10534.stderr
@@ -4,7 +4,7 @@ error: unused import: `a::x`
 LL |     use a::x;
    |         ^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-directives-on-use-items-issue-10534.rs:1:9
    |
 LL | #![deny(unused_imports)]
@@ -16,7 +16,7 @@ error: unused import: `a::y`
 LL |     use a::y;
    |         ^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-directives-on-use-items-issue-10534.rs:20:12
    |
 LL |     #[deny(unused_imports)]

--- a/src/test/ui/lint/lint-exceeding-bitshifts.stderr
+++ b/src/test/ui/lint/lint-exceeding-bitshifts.stderr
@@ -4,7 +4,7 @@ error: attempt to shift left with overflow
 LL |       let n = 1u8 << 8;
    |               ^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-exceeding-bitshifts.rs:4:9
    |
 LL | #![deny(exceeding_bitshifts, const_err)]

--- a/src/test/ui/lint/lint-exceeding-bitshifts2.stderr
+++ b/src/test/ui/lint/lint-exceeding-bitshifts2.stderr
@@ -4,7 +4,7 @@ error: attempt to shift left with overflow
 LL |       let n = 1u8 << (4+4);
    |               ^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-exceeding-bitshifts2.rs:4:9
    |
 LL | #![deny(exceeding_bitshifts, const_err)]

--- a/src/test/ui/lint/lint-forbid-internal-unsafe.stderr
+++ b/src/test/ui/lint/lint-forbid-internal-unsafe.stderr
@@ -4,7 +4,7 @@ error: `allow_internal_unsafe` allows defining macros using unsafe without trigg
 LL | #[allow_internal_unsafe]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-forbid-internal-unsafe.rs:1:11
    |
 LL | #![forbid(unsafe_code)]

--- a/src/test/ui/lint/lint-group-nonstandard-style.stderr
+++ b/src/test/ui/lint/lint-group-nonstandard-style.stderr
@@ -4,7 +4,7 @@ warning: type `snake_case` should have an upper camel case name
 LL |         struct snake_case;
    |                ^^^^^^^^^^ help: convert the identifier to upper camel case: `SnakeCase`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-group-nonstandard-style.rs:18:17
    |
 LL |         #![warn(nonstandard_style)]
@@ -17,7 +17,7 @@ error: function `CamelCase` should have a snake case name
 LL | fn CamelCase() {}
    |    ^^^^^^^^^ help: convert the identifier to snake case: `camel_case`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-group-nonstandard-style.rs:1:9
    |
 LL | #![deny(nonstandard_style)]
@@ -30,7 +30,7 @@ error: function `CamelCase` should have a snake case name
 LL |         fn CamelCase() {}
    |            ^^^^^^^^^ help: convert the identifier to snake case: `camel_case`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-group-nonstandard-style.rs:10:14
    |
 LL |     #[forbid(nonstandard_style)]
@@ -43,7 +43,7 @@ error: static variable `bad` should have an upper case name
 LL |         static bad: isize = 1;
    |                ^^^ help: convert the identifier to upper case: `BAD`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-group-nonstandard-style.rs:10:14
    |
 LL |     #[forbid(nonstandard_style)]
@@ -56,7 +56,7 @@ warning: function `CamelCase` should have a snake case name
 LL |         fn CamelCase() {}
    |            ^^^^^^^^^ help: convert the identifier to snake case: `camel_case`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-group-nonstandard-style.rs:18:17
    |
 LL |         #![warn(nonstandard_style)]

--- a/src/test/ui/lint/lint-impl-fn.stderr
+++ b/src/test/ui/lint/lint-impl-fn.stderr
@@ -4,7 +4,7 @@ error: denote infinite loops with `loop { ... }`
 LL |     fn bar(&self) { while true {} }
    |                     ^^^^^^^^^^ help: use `loop`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-impl-fn.rs:9:12
    |
 LL |     #[deny(while_true)]
@@ -16,7 +16,7 @@ error: denote infinite loops with `loop { ... }`
 LL |         fn foo(&self) { while true {} }
    |                         ^^^^^^^^^^ help: use `loop`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-impl-fn.rs:13:8
    |
 LL | #[deny(while_true)]
@@ -28,7 +28,7 @@ error: denote infinite loops with `loop { ... }`
 LL |     while true {}
    |     ^^^^^^^^^^ help: use `loop`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-impl-fn.rs:25:8
    |
 LL | #[deny(while_true)]

--- a/src/test/ui/lint/lint-lowercase-static-const-pattern.stderr
+++ b/src/test/ui/lint/lint-lowercase-static-const-pattern.stderr
@@ -4,7 +4,7 @@ error: constant in pattern `a` should have an upper case name
 LL |         (0, a) => 0,
    |             ^ help: convert the identifier to upper case: `A`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-lowercase-static-const-pattern.rs:4:9
    |
 LL | #![deny(non_upper_case_globals)]

--- a/src/test/ui/lint/lint-match-arms.rs
+++ b/src/test/ui/lint/lint-match-arms.rs
@@ -1,7 +1,7 @@
 fn deny_on_arm() {
     match 0 {
         #[deny(unused_variables)]
-        //~^ NOTE lint level defined here
+        //~^ NOTE the lint level is defined here
         y => (),
         //~^ ERROR unused variable
     }

--- a/src/test/ui/lint/lint-match-arms.stderr
+++ b/src/test/ui/lint/lint-match-arms.stderr
@@ -4,7 +4,7 @@ error: unused variable: `y`
 LL |         y => (),
    |         ^ help: consider prefixing with an underscore: `_y`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-match-arms.rs:3:16
    |
 LL |         #[deny(unused_variables)]

--- a/src/test/ui/lint/lint-misplaced-attr.stderr
+++ b/src/test/ui/lint/lint-misplaced-attr.stderr
@@ -4,7 +4,7 @@ error: unused attribute
 LL |     #![crate_type = "bin"]
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-misplaced-attr.rs:4:9
    |
 LL | #![deny(unused_attributes)]

--- a/src/test/ui/lint/lint-missing-copy-implementations.stderr
+++ b/src/test/ui/lint/lint-missing-copy-implementations.stderr
@@ -6,7 +6,7 @@ LL | |         pub field: i32
 LL | |     }
    | |_____^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-missing-copy-implementations.rs:3:9
    |
 LL | #![deny(missing_copy_implementations)]

--- a/src/test/ui/lint/lint-missing-doc.stderr
+++ b/src/test/ui/lint/lint-missing-doc.stderr
@@ -4,7 +4,7 @@ error: missing documentation for a type alias
 LL | pub type PubTypedef = String;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-missing-doc.rs:3:9
    |
 LL | #![deny(missing_docs)]

--- a/src/test/ui/lint/lint-non-camel-case-types.stderr
+++ b/src/test/ui/lint/lint-non-camel-case-types.stderr
@@ -4,7 +4,7 @@ error: type `ONE_TWO_THREE` should have an upper camel case name
 LL | struct ONE_TWO_THREE;
    |        ^^^^^^^^^^^^^ help: convert the identifier to upper camel case: `OneTwoThree`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-non-camel-case-types.rs:1:11
    |
 LL | #![forbid(non_camel_case_types)]

--- a/src/test/ui/lint/lint-non-snake-case-crate-2.stderr
+++ b/src/test/ui/lint/lint-non-snake-case-crate-2.stderr
@@ -1,6 +1,6 @@
 error: crate `NonSnakeCase` should have a snake case name
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-non-snake-case-crate-2.rs:4:9
    |
 LL | #![deny(non_snake_case)]

--- a/src/test/ui/lint/lint-non-snake-case-crate.stderr
+++ b/src/test/ui/lint/lint-non-snake-case-crate.stderr
@@ -4,7 +4,7 @@ error: crate `NonSnakeCase` should have a snake case name
 LL | #![crate_name = "NonSnakeCase"]
    |                  ^^^^^^^^^^^^ help: convert the identifier to snake case: `non_snake_case`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-non-snake-case-crate.rs:3:9
    |
 LL | #![deny(non_snake_case)]

--- a/src/test/ui/lint/lint-non-snake-case-functions.stderr
+++ b/src/test/ui/lint/lint-non-snake-case-functions.stderr
@@ -4,7 +4,7 @@ error: method `Foo_Method` should have a snake case name
 LL |     fn Foo_Method() {}
    |        ^^^^^^^^^^ help: convert the identifier to snake case: `foo_method`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-non-snake-case-functions.rs:1:9
    |
 LL | #![deny(non_snake_case)]

--- a/src/test/ui/lint/lint-non-snake-case-lifetimes.stderr
+++ b/src/test/ui/lint/lint-non-snake-case-lifetimes.stderr
@@ -4,7 +4,7 @@ error: lifetime `'FooBar` should have a snake case name
 LL | fn f<'FooBar>(
    |      ^^^^^^^ help: convert the identifier to snake case: `'foo_bar`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-non-snake-case-lifetimes.rs:1:9
    |
 LL | #![deny(non_snake_case)]

--- a/src/test/ui/lint/lint-non-snake-case-modules.stderr
+++ b/src/test/ui/lint/lint-non-snake-case-modules.stderr
@@ -4,7 +4,7 @@ error: module `FooBar` should have a snake case name
 LL | mod FooBar {
    |     ^^^^^^ help: convert the identifier to snake case: `foo_bar`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-non-snake-case-modules.rs:1:9
    |
 LL | #![deny(non_snake_case)]

--- a/src/test/ui/lint/lint-non-uppercase-associated-const.stderr
+++ b/src/test/ui/lint/lint-non-uppercase-associated-const.stderr
@@ -4,7 +4,7 @@ error: associated constant `not_upper` should have an upper case name
 LL |     const not_upper: bool = true;
    |           ^^^^^^^^^ help: convert the identifier to upper case: `NOT_UPPER`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-non-uppercase-associated-const.rs:1:9
    |
 LL | #![deny(non_upper_case_globals)]

--- a/src/test/ui/lint/lint-non-uppercase-statics.stderr
+++ b/src/test/ui/lint/lint-non-uppercase-statics.stderr
@@ -4,7 +4,7 @@ error: static variable `foo` should have an upper case name
 LL | static foo: isize = 1;
    |        ^^^ help: convert the identifier to upper case (notice the capitalization): `FOO`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-non-uppercase-statics.rs:1:11
    |
 LL | #![forbid(non_upper_case_globals)]

--- a/src/test/ui/lint/lint-owned-heap-memory.stderr
+++ b/src/test/ui/lint/lint-owned-heap-memory.stderr
@@ -4,7 +4,7 @@ error: type uses owned (Box type) pointers: std::boxed::Box<isize>
 LL |     x: Box<isize>
    |     ^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-owned-heap-memory.rs:2:11
    |
 LL | #![forbid(box_pointers)]

--- a/src/test/ui/lint/lint-qualification.stderr
+++ b/src/test/ui/lint/lint-qualification.stderr
@@ -4,7 +4,7 @@ error: unnecessary qualification
 LL |     foo::bar();
    |     ^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-qualification.rs:1:9
    |
 LL | #![deny(unused_qualifications)]

--- a/src/test/ui/lint/lint-range-endpoint-overflow.stderr
+++ b/src/test/ui/lint/lint-range-endpoint-overflow.stderr
@@ -4,7 +4,7 @@ error: range endpoint is out of range for `u8`
 LL |     let range_a = 0..256;
    |                   ^^^^^^ help: use an inclusive range instead: `0..=255`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-range-endpoint-overflow.rs:1:9
    |
 LL | #![deny(overflowing_literals)]

--- a/src/test/ui/lint/lint-removed-allow.stderr
+++ b/src/test/ui/lint/lint-removed-allow.stderr
@@ -4,7 +4,7 @@ error: unused variable: `unused`
 LL | fn main() { let unused = (); }
    |                 ^^^^^^ help: consider prefixing with an underscore: `_unused`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-removed-allow.rs:7:8
    |
 LL | #[deny(unused_variables)]

--- a/src/test/ui/lint/lint-removed-cmdline.stderr
+++ b/src/test/ui/lint/lint-removed-cmdline.stderr
@@ -20,7 +20,7 @@ error: unused variable: `unused`
 LL | fn main() { let unused = (); }
    |                 ^^^^^^ help: consider prefixing with an underscore: `_unused`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-removed-cmdline.rs:11:8
    |
 LL | #[deny(warnings)]

--- a/src/test/ui/lint/lint-removed.stderr
+++ b/src/test/ui/lint/lint-removed.stderr
@@ -12,7 +12,7 @@ error: unused variable: `unused`
 LL | fn main() { let unused = (); }
    |                 ^^^^^^ help: consider prefixing with an underscore: `_unused`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-removed.rs:7:8
    |
 LL | #[deny(unused_variables)]

--- a/src/test/ui/lint/lint-renamed-allow.stderr
+++ b/src/test/ui/lint/lint-renamed-allow.stderr
@@ -4,7 +4,7 @@ error: unused variable: `unused`
 LL | fn main() { let unused = (); }
    |                 ^^^^^^ help: consider prefixing with an underscore: `_unused`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-renamed-allow.rs:7:8
    |
 LL | #[deny(unused)]

--- a/src/test/ui/lint/lint-renamed-cmdline.stderr
+++ b/src/test/ui/lint/lint-renamed-cmdline.stderr
@@ -20,7 +20,7 @@ error: unused variable: `unused`
 LL | fn main() { let unused = (); }
    |                 ^^^^^^ help: consider prefixing with an underscore: `_unused`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-renamed-cmdline.rs:7:8
    |
 LL | #[deny(unused)]

--- a/src/test/ui/lint/lint-renamed.stderr
+++ b/src/test/ui/lint/lint-renamed.stderr
@@ -12,7 +12,7 @@ error: unused variable: `unused`
 LL | fn main() { let unused = (); }
    |                 ^^^^^^ help: consider prefixing with an underscore: `_unused`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-renamed.rs:3:8
    |
 LL | #[deny(unused)]

--- a/src/test/ui/lint/lint-shorthand-field.stderr
+++ b/src/test/ui/lint/lint-shorthand-field.stderr
@@ -4,7 +4,7 @@ error: the `x:` in this pattern is redundant
 LL |             x: x,
    |             ^^^^ help: use shorthand field pattern: `x`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-shorthand-field.rs:4:9
    |
 LL | #![deny(non_shorthand_field_patterns)]

--- a/src/test/ui/lint/lint-stability-deprecated.stderr
+++ b/src/test/ui/lint/lint-stability-deprecated.stderr
@@ -4,7 +4,7 @@ warning: use of deprecated item 'lint_stability::deprecated': text
 LL |         deprecated();
    |         ^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-stability-deprecated.rs:7:9
    |
 LL | #![warn(deprecated)]

--- a/src/test/ui/lint/lint-stability-fields-deprecated.stderr
+++ b/src/test/ui/lint/lint-stability-fields-deprecated.stderr
@@ -4,7 +4,7 @@ error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated': 
 LL |         let x = Deprecated {
    |                 ^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-stability-fields-deprecated.rs:3:9
    |
 LL | #![deny(deprecated)]

--- a/src/test/ui/lint/lint-stability2.stderr
+++ b/src/test/ui/lint/lint-stability2.stderr
@@ -4,7 +4,7 @@ error: use of deprecated item 'lint_stability::deprecated': text
 LL |     macro_test!();
    |     ^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-stability2.rs:4:9
    |
 LL | #![deny(deprecated)]

--- a/src/test/ui/lint/lint-stability3.stderr
+++ b/src/test/ui/lint/lint-stability3.stderr
@@ -4,7 +4,7 @@ error: use of deprecated item 'lint_stability::deprecated_text': text
 LL |     macro_test_arg_nested!(deprecated_text);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-stability3.rs:4:9
    |
 LL | #![deny(deprecated)]

--- a/src/test/ui/lint/lint-type-limits2.stderr
+++ b/src/test/ui/lint/lint-type-limits2.stderr
@@ -12,7 +12,7 @@ warning: literal out of range for `i8`
 LL |     128 > bar()
    |     ^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-type-limits2.rs:2:9
    |
 LL | #![warn(overflowing_literals)]

--- a/src/test/ui/lint/lint-type-limits3.stderr
+++ b/src/test/ui/lint/lint-type-limits3.stderr
@@ -12,7 +12,7 @@ warning: literal out of range for `i8`
 LL |     while 200 != i {
    |           ^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-type-limits3.rs:2:9
    |
 LL | #![warn(overflowing_literals)]

--- a/src/test/ui/lint/lint-type-overflow.stderr
+++ b/src/test/ui/lint/lint-type-overflow.stderr
@@ -4,7 +4,7 @@ error: literal out of range for `u8`
 LL |     let x1: u8 = 256;
    |                  ^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-type-overflow.rs:1:9
    |
 LL | #![deny(overflowing_literals)]

--- a/src/test/ui/lint/lint-type-overflow2.stderr
+++ b/src/test/ui/lint/lint-type-overflow2.stderr
@@ -4,7 +4,7 @@ error: literal out of range for `i8`
 LL |     let x2: i8 = --128;
    |                    ^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-type-overflow2.rs:3:9
    |
 LL | #![deny(overflowing_literals)]

--- a/src/test/ui/lint/lint-unconditional-recursion.stderr
+++ b/src/test/ui/lint/lint-unconditional-recursion.stderr
@@ -6,7 +6,7 @@ LL | fn foo() {
 LL |     foo();
    |     ----- recursive call site
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-unconditional-recursion.rs:1:9
    |
 LL | #![deny(unconditional_recursion)]

--- a/src/test/ui/lint/lint-unknown-lint.stderr
+++ b/src/test/ui/lint/lint-unknown-lint.stderr
@@ -4,7 +4,7 @@ error: unknown lint: `not_a_real_lint`
 LL | #![allow(not_a_real_lint)]
    |          ^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-unknown-lint.rs:1:9
    |
 LL | #![deny(unknown_lints)]

--- a/src/test/ui/lint/lint-unnecessary-import-braces.stderr
+++ b/src/test/ui/lint/lint-unnecessary-import-braces.stderr
@@ -4,7 +4,7 @@ error: braces around A is unnecessary
 LL | use test::{A};
    | ^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-unnecessary-import-braces.rs:1:9
    |
 LL | #![deny(unused_import_braces)]

--- a/src/test/ui/lint/lint-unnecessary-parens.stderr
+++ b/src/test/ui/lint/lint-unnecessary-parens.stderr
@@ -4,7 +4,7 @@ error: unnecessary parentheses around `return` value
 LL |     return (1);
    |            ^^^ help: remove these parentheses
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-unnecessary-parens.rs:1:9
    |
 LL | #![deny(unused_parens)]

--- a/src/test/ui/lint/lint-unsafe-code.stderr
+++ b/src/test/ui/lint/lint-unsafe-code.stderr
@@ -4,7 +4,7 @@ error: declaration of an `unsafe` function
 LL | unsafe fn baz() {}
    | ^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-unsafe-code.rs:3:9
    |
 LL | #![deny(unsafe_code)]

--- a/src/test/ui/lint/lint-unused-extern-crate.stderr
+++ b/src/test/ui/lint/lint-unused-extern-crate.stderr
@@ -4,7 +4,7 @@ error: unused extern crate
 LL | extern crate lint_unused_extern_crate5;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-unused-extern-crate.rs:7:9
    |
 LL | #![deny(unused_extern_crates)]

--- a/src/test/ui/lint/lint-unused-imports.stderr
+++ b/src/test/ui/lint/lint-unused-imports.stderr
@@ -4,7 +4,7 @@ error: unused import: `std::fmt::{}`
 LL | use std::fmt::{};
    |     ^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-unused-imports.rs:1:9
    |
 LL | #![deny(unused_imports)]

--- a/src/test/ui/lint/lint-unused-mut-self.stderr
+++ b/src/test/ui/lint/lint-unused-mut-self.stderr
@@ -6,7 +6,7 @@ LL |     fn foo(mut self) {}
    |            |
    |            help: remove this `mut`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-unused-mut-self.rs:4:9
    |
 LL | #![deny(unused_mut)]

--- a/src/test/ui/lint/lint-unused-mut-variables.stderr
+++ b/src/test/ui/lint/lint-unused-mut-variables.stderr
@@ -6,7 +6,7 @@ LL |     mut a: i32,
    |     |
    |     help: remove this `mut`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-unused-mut-variables.rs:5:9
    |
 LL | #![deny(unused_mut)]
@@ -212,7 +212,7 @@ LL |     let mut b = vec![2];
    |         |
    |         help: remove this `mut`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-unused-mut-variables.rs:198:8
    |
 LL | #[deny(unused_mut)]

--- a/src/test/ui/lint/lint-unused-variables.stderr
+++ b/src/test/ui/lint/lint-unused-variables.stderr
@@ -4,7 +4,7 @@ error: unused variable: `a`
 LL |     a: i32,
    |     ^ help: consider prefixing with an underscore: `_a`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-unused-variables.rs:5:9
    |
 LL | #![deny(unused_variables)]

--- a/src/test/ui/lint/lint-uppercase-variables.stderr
+++ b/src/test/ui/lint/lint-uppercase-variables.stderr
@@ -24,7 +24,7 @@ warning: unused variable: `Foo`
 LL |         Foo => {}
    |         ^^^ help: consider prefixing with an underscore: `_Foo`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-uppercase-variables.rs:1:9
    |
 LL | #![warn(unused)]
@@ -49,7 +49,7 @@ error: structure field `X` should have a snake case name
 LL |     X: usize
    |     ^ help: convert the identifier to snake case (notice the capitalization): `x`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-uppercase-variables.rs:3:9
    |
 LL | #![deny(non_snake_case)]

--- a/src/test/ui/lint/lints-in-foreign-macros.stderr
+++ b/src/test/ui/lint/lints-in-foreign-macros.stderr
@@ -7,7 +7,7 @@ LL |     () => {use std::string::ToString;}
 LL | mod a { foo!(); }
    |         ------- in this macro invocation
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lints-in-foreign-macros.rs:4:9
    |
 LL | #![warn(unused_imports)]
@@ -37,7 +37,7 @@ LL | |
 LL | | fn main() {}
    | |____________^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lints-in-foreign-macros.rs:5:9
    |
 LL | #![warn(missing_docs)]

--- a/src/test/ui/lint/must-use-ops.stderr
+++ b/src/test/ui/lint/must-use-ops.stderr
@@ -4,7 +4,7 @@ warning: unused comparison that must be used
 LL |     val == 1;
    |     ^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/must-use-ops.rs:5:9
    |
 LL | #![warn(unused_must_use)]

--- a/src/test/ui/lint/must_use-array.stderr
+++ b/src/test/ui/lint/must_use-array.stderr
@@ -4,7 +4,7 @@ error: unused array of `S` that must be used
 LL |     singleton();
    |     ^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/must_use-array.rs:1:9
    |
 LL | #![deny(unused_must_use)]

--- a/src/test/ui/lint/must_use-trait.stderr
+++ b/src/test/ui/lint/must_use-trait.stderr
@@ -4,7 +4,7 @@ error: unused implementer of `Critical` that must be used
 LL |     get_critical();
    |     ^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/must_use-trait.rs:1:9
    |
 LL | #![deny(unused_must_use)]

--- a/src/test/ui/lint/must_use-tuple.stderr
+++ b/src/test/ui/lint/must_use-tuple.stderr
@@ -4,7 +4,7 @@ error: unused `std::result::Result` in tuple element 0 that must be used
 LL |     (Ok::<(), ()>(()),);
    |      ^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/must_use-tuple.rs:1:9
    |
 LL | #![deny(unused_must_use)]

--- a/src/test/ui/lint/must_use-unit.stderr
+++ b/src/test/ui/lint/must_use-unit.stderr
@@ -4,7 +4,7 @@ error: unused return value of `foo` that must be used
 LL |     foo();
    |     ^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/must_use-unit.rs:2:9
    |
 LL | #![deny(unused_must_use)]

--- a/src/test/ui/lint/opaque-ty-ffi-unsafe.stderr
+++ b/src/test/ui/lint/opaque-ty-ffi-unsafe.stderr
@@ -4,7 +4,7 @@ error: `extern` block uses type `A`, which is not FFI-safe
 LL |     pub fn a(_: A);
    |                 ^ not FFI-safe
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/opaque-ty-ffi-unsafe.rs:3:9
    |
 LL | #![deny(improper_ctypes)]

--- a/src/test/ui/lint/reasons.rs
+++ b/src/test/ui/lint/reasons.rs
@@ -3,11 +3,11 @@
 #![feature(lint_reasons)]
 
 #![warn(elided_lifetimes_in_paths,
-        //~^ NOTE lint level defined here
+        //~^ NOTE the lint level is defined here
         reason = "explicit anonymous lifetimes aid reasoning about ownership")]
 #![warn(
     nonstandard_style,
-    //~^ NOTE lint level defined here
+    //~^ NOTE the lint level is defined here
     reason = r#"people shouldn't have to change their usual style habits
 to contribute to our project"#
 )]

--- a/src/test/ui/lint/reasons.stderr
+++ b/src/test/ui/lint/reasons.stderr
@@ -5,7 +5,7 @@ LL |     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
    |                             ^^^^^^^^^^^^^^- help: indicate the anonymous lifetime: `<'_>`
    |
    = note: explicit anonymous lifetimes aid reasoning about ownership
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/reasons.rs:5:9
    |
 LL | #![warn(elided_lifetimes_in_paths,
@@ -19,7 +19,7 @@ LL |     let Social_exchange_psychology = CheaterDetectionMechanism {};
    |
    = note: people shouldn't have to change their usual style habits
            to contribute to our project
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/reasons.rs:9:5
    |
 LL |     nonstandard_style,

--- a/src/test/ui/lint/redundant-semicolon/redundant-semi-proc-macro.stderr
+++ b/src/test/ui/lint/redundant-semicolon/redundant-semi-proc-macro.stderr
@@ -5,7 +5,7 @@ error: unnecessary trailing semicolon
 LL |     let tst = 123;;
    |                   ^ help: remove this semicolon
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/redundant-semi-proc-macro.rs:3:9
    |
 LL | #![deny(redundant_semicolon)]

--- a/src/test/ui/lint/rfc-2457-non-ascii-idents/lint-non-ascii-idents.stderr
+++ b/src/test/ui/lint/rfc-2457-non-ascii-idents/lint-non-ascii-idents.stderr
@@ -4,7 +4,7 @@ error: identifier contains non-ASCII characters
 LL | const חלודה: usize = 2;
    |       ^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-non-ascii-idents.rs:2:9
    |
 LL | #![deny(non_ascii_idents)]

--- a/src/test/ui/lint/rfc-2457-non-ascii-idents/lint-uncommon-codepoints.stderr
+++ b/src/test/ui/lint/rfc-2457-non-ascii-idents/lint-uncommon-codepoints.stderr
@@ -4,7 +4,7 @@ error: identifier contains uncommon Unicode codepoints
 LL | const µ: f64 = 0.000001;
    |       ^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-uncommon-codepoints.rs:2:9
    |
 LL | #![deny(uncommon_codepoints)]

--- a/src/test/ui/lint/suggestions.stderr
+++ b/src/test/ui/lint/suggestions.stderr
@@ -12,7 +12,7 @@ warning: unnecessary parentheses around assigned value
 LL |         let mut registry_no = (format!("NX-{}", 74205));
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/suggestions.rs:3:21
    |
 LL | #![warn(unused_mut, unused_parens)] // UI tests pass `-A unused`—see Issue #43896
@@ -34,7 +34,7 @@ LL |         let mut registry_no = (format!("NX-{}", 74205));
    |             |
    |             help: remove this `mut`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/suggestions.rs:3:9
    |
 LL | #![warn(unused_mut, unused_parens)] // UI tests pass `-A unused`—see Issue #43896

--- a/src/test/ui/lint/trivial-casts-featuring-type-ascription.stderr
+++ b/src/test/ui/lint/trivial-casts-featuring-type-ascription.stderr
@@ -4,7 +4,7 @@ error: trivial numeric cast: `i32` as `i32`
 LL |     let lugubrious = 12i32 as i32;
    |                      ^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/trivial-casts-featuring-type-ascription.rs:1:24
    |
 LL | #![deny(trivial_casts, trivial_numeric_casts)]
@@ -17,7 +17,7 @@ error: trivial cast: `&u32` as `*const u32`
 LL |     let _ = haunted as *const u32;
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/trivial-casts-featuring-type-ascription.rs:1:9
    |
 LL | #![deny(trivial_casts, trivial_numeric_casts)]

--- a/src/test/ui/lint/trivial-casts.stderr
+++ b/src/test/ui/lint/trivial-casts.stderr
@@ -4,7 +4,7 @@ error: trivial numeric cast: `i32` as `i32`
 LL |     let lugubrious = 12i32 as i32;
    |                      ^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/trivial-casts.rs:1:24
    |
 LL | #![deny(trivial_casts, trivial_numeric_casts)]
@@ -17,7 +17,7 @@ error: trivial cast: `&u32` as `*const u32`
 LL |     let _ = haunted as *const u32;
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/trivial-casts.rs:1:9
    |
 LL | #![deny(trivial_casts, trivial_numeric_casts)]

--- a/src/test/ui/lint/type-overflow.stderr
+++ b/src/test/ui/lint/type-overflow.stderr
@@ -4,7 +4,7 @@ warning: literal out of range for `i8`
 LL |     let error = 255i8;
    |                 ^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/type-overflow.rs:2:9
    |
 LL | #![warn(overflowing_literals)]

--- a/src/test/ui/lint/uninitialized-zeroed.stderr
+++ b/src/test/ui/lint/uninitialized-zeroed.stderr
@@ -7,7 +7,7 @@ LL |         let _val: &'static T = mem::zeroed();
    |                                this code causes undefined behavior when executed
    |                                help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/uninitialized-zeroed.rs:7:9
    |
 LL | #![deny(invalid_value)]

--- a/src/test/ui/lint/unreachable_pub-pub_crate.stderr
+++ b/src/test/ui/lint/unreachable_pub-pub_crate.stderr
@@ -6,7 +6,7 @@ LL |     pub use std::fmt;
    |     |
    |     help: consider restricting its visibility: `pub(crate)`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unreachable_pub-pub_crate.rs:10:9
    |
 LL | #![warn(unreachable_pub)]

--- a/src/test/ui/lint/unreachable_pub.stderr
+++ b/src/test/ui/lint/unreachable_pub.stderr
@@ -6,7 +6,7 @@ LL |     pub use std::fmt;
    |     |
    |     help: consider restricting its visibility: `crate`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unreachable_pub.rs:6:9
    |
 LL | #![warn(unreachable_pub)]

--- a/src/test/ui/lint/unused_import_warning_issue_45268.stderr
+++ b/src/test/ui/lint/unused_import_warning_issue_45268.stderr
@@ -4,7 +4,7 @@ warning: unused import: `test::Unused`
 LL | use test::Unused;   // This is really unused, so warning is OK
    |     ^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused_import_warning_issue_45268.rs:3:9
    |
 LL | #![warn(unused_imports)] // Warning explanation here, it's OK

--- a/src/test/ui/lint/unused_labels.stderr
+++ b/src/test/ui/lint/unused_labels.stderr
@@ -4,7 +4,7 @@ warning: unused label
 LL |     'unused_while_label: while 0 == 0 {
    |     ^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused_labels.rs:8:9
    |
 LL | #![warn(unused_labels)]

--- a/src/test/ui/lint/unused_parens_json_suggestion.stderr
+++ b/src/test/ui/lint/unused_parens_json_suggestion.stderr
@@ -4,7 +4,7 @@
 LL |     let _a = (1 / (2 + 3));
    |              ^^^^^^^^^^^^^ help: remove these parentheses
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused_parens_json_suggestion.rs:10:9
    |
 LL | #![deny(unused_parens)]

--- a/src/test/ui/lint/unused_parens_remove_json_suggestion.stderr
+++ b/src/test/ui/lint/unused_parens_remove_json_suggestion.stderr
@@ -4,7 +4,7 @@
 LL |     if (_b) {
    |        ^^^^ help: remove these parentheses
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused_parens_remove_json_suggestion.rs:10:9
    |
 LL | #![deny(unused_parens)]

--- a/src/test/ui/lint/use-redundant.stderr
+++ b/src/test/ui/lint/use-redundant.stderr
@@ -4,7 +4,7 @@ warning: unused import: `m1::*`
 LL | use m1::*;
    |     ^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/use-redundant.rs:2:9
    |
 LL | #![warn(unused_imports)]

--- a/src/test/ui/lint/warn-unused-inline-on-fn-prototypes.stderr
+++ b/src/test/ui/lint/warn-unused-inline-on-fn-prototypes.stderr
@@ -4,7 +4,7 @@ error: `#[inline]` is ignored on function prototypes
 LL |     #[inline]
    |     ^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/warn-unused-inline-on-fn-prototypes.rs:1:9
    |
 LL | #![deny(unused_attributes)]

--- a/src/test/ui/liveness/liveness-dead.stderr
+++ b/src/test/ui/liveness/liveness-dead.stderr
@@ -4,7 +4,7 @@ error: value assigned to `x` is never read
 LL |     let mut x: isize = 3;
    |             ^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/liveness-dead.rs:2:9
    |
 LL | #![deny(unused_assignments)]

--- a/src/test/ui/liveness/liveness-unused.stderr
+++ b/src/test/ui/liveness/liveness-unused.stderr
@@ -6,7 +6,7 @@ LL |         continue;
 LL |         drop(*x as i32);
    |         ^^^^^^^^^^^^^^^^ unreachable statement
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/liveness-unused.rs:1:9
    |
 LL | #![warn(unused)]
@@ -19,7 +19,7 @@ error: unused variable: `x`
 LL | fn f1(x: isize) {
    |       ^ help: consider prefixing with an underscore: `_x`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/liveness-unused.rs:2:9
    |
 LL | #![deny(unused_variables)]
@@ -57,7 +57,7 @@ error: value assigned to `x` is never read
 LL |     x += 4;
    |     ^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/liveness-unused.rs:3:9
    |
 LL | #![deny(unused_assignments)]

--- a/src/test/ui/macros/issue-61053-different-kleene.stderr
+++ b/src/test/ui/macros/issue-61053-different-kleene.stderr
@@ -4,7 +4,7 @@ error: meta-variable repeats with different Kleene operator
 LL |     ( $( $i:ident = $($j:ident),+ );* ) => { $( $( $i = $j; )* )* };
    |                                 - expected repetition   ^^   - conflicting repetition
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-61053-different-kleene.rs:1:9
    |
 LL | #![deny(meta_variable_misuse)]

--- a/src/test/ui/macros/issue-61053-duplicate-binder.stderr
+++ b/src/test/ui/macros/issue-61053-duplicate-binder.stderr
@@ -6,7 +6,7 @@ LL |             ($x:tt $x:tt) => { $x };
    |              |
    |              previous declaration
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-61053-duplicate-binder.rs:1:9
    |
 LL | #![deny(meta_variable_misuse)]

--- a/src/test/ui/macros/issue-61053-missing-repetition.stderr
+++ b/src/test/ui/macros/issue-61053-missing-repetition.stderr
@@ -6,7 +6,7 @@ LL |     ($( $i:ident = $($j:ident),+ );*) => { $( $i = $j; )* };
    |                                |
    |                                expected repetition
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-61053-missing-repetition.rs:1:9
    |
 LL | #![deny(meta_variable_misuse)]

--- a/src/test/ui/macros/issue-61053-unbound.stderr
+++ b/src/test/ui/macros/issue-61053-unbound.stderr
@@ -4,7 +4,7 @@ error: unknown macro variable `k`
 LL |     ($( $i:ident = $($j:ident),+ );*) => { $( $( $i = $k; )+ )* };
    |                                                       ^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-61053-unbound.rs:1:9
    |
 LL | #![deny(meta_variable_misuse)]

--- a/src/test/ui/macros/macro-use-all-and-none.stderr
+++ b/src/test/ui/macros/macro-use-all-and-none.stderr
@@ -4,7 +4,7 @@ warning: unused attribute
 LL | #[macro_use()]
    | ^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/macro-use-all-and-none.rs:4:9
    |
 LL | #![warn(unused_attributes)]

--- a/src/test/ui/match/match-no-arms-unreachable-after.stderr
+++ b/src/test/ui/match/match-no-arms-unreachable-after.stderr
@@ -6,7 +6,7 @@ LL |     match v { }
 LL |     let x = 2;
    |     ^^^^^^^^^^ unreachable statement
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/match-no-arms-unreachable-after.rs:2:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/methods/method-call-lifetime-args-lint-fail.stderr
+++ b/src/test/ui/methods/method-call-lifetime-args-lint-fail.stderr
@@ -7,7 +7,7 @@ LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
 LL |     S.late::<'static>(&0, &0);
    |              ^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/method-call-lifetime-args-lint-fail.rs:1:9
    |
 LL | #![deny(late_bound_lifetime_arguments)]

--- a/src/test/ui/methods/method-call-lifetime-args-lint.stderr
+++ b/src/test/ui/methods/method-call-lifetime-args-lint.stderr
@@ -7,7 +7,7 @@ LL |     fn late<'a, 'b>(self, _: &'a u8, _: &'b u8) {}
 LL |     S.late::<'static>(&0, &0);
    |              ^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/method-call-lifetime-args-lint.rs:1:9
    |
 LL | #![deny(late_bound_lifetime_arguments)]

--- a/src/test/ui/missing_debug_impls.stderr
+++ b/src/test/ui/missing_debug_impls.stderr
@@ -4,7 +4,7 @@ error: type does not implement `fmt::Debug`; consider adding `#[derive(Debug)]` 
 LL | pub enum A {}
    | ^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/missing_debug_impls.rs:2:9
    |
 LL | #![deny(missing_debug_implementations)]

--- a/src/test/ui/never_type/never-assign-dead-code.stderr
+++ b/src/test/ui/never_type/never-assign-dead-code.stderr
@@ -6,7 +6,7 @@ LL |     let x: ! = panic!("aah");
 LL |     drop(x);
    |     ^^^^^^^^ unreachable statement
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/never-assign-dead-code.rs:6:9
    |
 LL | #![warn(unused)]
@@ -28,7 +28,7 @@ warning: unused variable: `x`
 LL |     let x: ! = panic!("aah");
    |         ^ help: consider prefixing with an underscore: `_x`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/never-assign-dead-code.rs:6:9
    |
 LL | #![warn(unused)]

--- a/src/test/ui/nll/capture-mut-ref.stderr
+++ b/src/test/ui/nll/capture-mut-ref.stderr
@@ -6,7 +6,7 @@ LL |     let mut x = &mut 0;
    |         |
    |         help: remove this `mut`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/capture-mut-ref.rs:4:9
    |
 LL | #![deny(unused_mut)]

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -19,7 +19,7 @@ error[E0521]: borrowed data escapes outside of closure
 LL |     foo(cell, |cell_a, cell_x| {
    |                ------  ------ `cell_x` is a reference that is only valid in the closure body
    |                |
-   |                `cell_a` is declared here, outside of the closure body
+   |                `cell_a` declared here, outside of the closure body
 LL |         cell_a.set(cell_x.get()); // forces 'x: 'a, error in closure
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ `cell_x` escapes the closure body here
 

--- a/src/test/ui/nll/issue-61424.stderr
+++ b/src/test/ui/nll/issue-61424.stderr
@@ -6,7 +6,7 @@ LL |     let mut x;
    |         |
    |         help: remove this `mut`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-61424.rs:1:9
    |
 LL | #![deny(unused_mut)]

--- a/src/test/ui/nll/outlives-suggestion-simple.stderr
+++ b/src/test/ui/nll/outlives-suggestion-simple.stderr
@@ -99,7 +99,7 @@ error[E0521]: borrowed data escapes outside of function
 LL |     fn get_bar(&self) -> Bar2 {
    |                -----
    |                |
-   |                `self` is declared here, outside of the function body
+   |                `self` declared here, outside of the function body
    |                `self` is a reference that is only valid in the function body
 LL |         Bar2::new(&self)
    |         ^^^^^^^^^^^^^^^^ `self` escapes the function body here

--- a/src/test/ui/nll/unused-mut-issue-50343.stderr
+++ b/src/test/ui/nll/unused-mut-issue-50343.stderr
@@ -6,7 +6,7 @@ LL |     vec![(42, 22)].iter().map(|(mut x, _y)| ()).count();
    |                                 |
    |                                 help: remove this `mut`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused-mut-issue-50343.rs:1:9
    |
 LL | #![deny(unused_mut)]

--- a/src/test/ui/no-patterns-in-args-2.stderr
+++ b/src/test/ui/no-patterns-in-args-2.stderr
@@ -10,7 +10,7 @@ error: patterns aren't allowed in methods without bodies
 LL |     fn f1(mut arg: u8);
    |           ^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/no-patterns-in-args-2.rs:1:9
    |
 LL | #![deny(patterns_in_fns_without_body)]

--- a/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
+++ b/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         (1,) => {}
    |         ^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/exhaustiveness-unreachable-pattern.rs:4:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/panic-handler/panic-handler-duplicate.stderr
+++ b/src/test/ui/panic-handler/panic-handler-duplicate.stderr
@@ -6,7 +6,7 @@ LL | |     loop {}
 LL | | }
    | |_^
    |
-note: first defined here
+note: the lang item is first defined here
   --> $DIR/panic-handler-duplicate.rs:10:1
    |
 LL | / fn panic(info: &PanicInfo) -> ! {

--- a/src/test/ui/panic-handler/panic-handler-std.stderr
+++ b/src/test/ui/panic-handler/panic-handler-std.stderr
@@ -6,7 +6,7 @@ LL | |     loop {}
 LL | | }
    | |_^
    |
-   = note: first defined in crate `std` (which `panic_handler_std` depends on)
+   = note: the lang item is first defined in crate `std` (which `panic_handler_std` depends on)
 
 error: argument should be `&PanicInfo`
   --> $DIR/panic-handler-std.rs:7:16

--- a/src/test/ui/parser/recover-range-pats.stderr
+++ b/src/test/ui/parser/recover-range-pats.stderr
@@ -195,7 +195,7 @@ error: `...` range patterns are deprecated
 LL |     if let 0...3 = 0 {}
    |             ^^^ help: use `..=` for an inclusive range
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/recover-range-pats.rs:8:9
    |
 LL | #![deny(ellipsis_inclusive_range_patterns)]

--- a/src/test/ui/path-lookahead.stderr
+++ b/src/test/ui/path-lookahead.stderr
@@ -4,7 +4,7 @@ warning: unnecessary parentheses around `return` value
 LL |   return (<T as ToString>::to_string(&arg));
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/path-lookahead.rs:3:9
    |
 LL | #![warn(unused_parens)]

--- a/src/test/ui/pattern/deny-irrefutable-let-patterns.stderr
+++ b/src/test/ui/pattern/deny-irrefutable-let-patterns.stderr
@@ -4,7 +4,7 @@ error: irrefutable if-let pattern
 LL |     if let _ = 5 {}
    |     ^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/deny-irrefutable-let-patterns.rs:1:9
    |
 LL | #![deny(irrefutable_let_patterns)]

--- a/src/test/ui/pattern/usefulness/exhaustive_integer_patterns.stderr
+++ b/src/test/ui/pattern/usefulness/exhaustive_integer_patterns.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         200 => {}
    |         ^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/exhaustive_integer_patterns.rs:3:9
    |
 LL | #![deny(unreachable_patterns)]
@@ -88,7 +88,7 @@ LL |         0 .. 2 => {}
 LL |         1 ..= 2 => {}
    |         ^^^^^^^ overlapping patterns
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/exhaustive_integer_patterns.rs:4:9
    |
 LL | #![deny(overlapping_patterns)]

--- a/src/test/ui/pattern/usefulness/issue-43253.stderr
+++ b/src/test/ui/pattern/usefulness/issue-43253.stderr
@@ -6,7 +6,7 @@ LL |         1..10 => {},
 LL |         9..=10 => {},
    |         ^^^^^^ overlapping patterns
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-43253.rs:4:9
    |
 LL | #![warn(overlapping_patterns)]
@@ -18,7 +18,7 @@ warning: unreachable pattern
 LL |         9 => {},
    |         ^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-43253.rs:3:9
    |
 LL | #![warn(unreachable_patterns)]

--- a/src/test/ui/pattern/usefulness/match-arm-statics.stderr
+++ b/src/test/ui/pattern/usefulness/match-arm-statics.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         (true, true) => ()
    |         ^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/match-arm-statics.rs:2:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/pattern/usefulness/match-byte-array-patterns.stderr
+++ b/src/test/ui/pattern/usefulness/match-byte-array-patterns.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         &[0x41, 0x41, 0x41, 0x41] => {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/match-byte-array-patterns.rs:1:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/pattern/usefulness/match-empty-exhaustive_patterns.stderr
+++ b/src/test/ui/pattern/usefulness/match-empty-exhaustive_patterns.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         _ => {},
    |         ^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/match-empty-exhaustive_patterns.rs:3:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/pattern/usefulness/match-range-fail-dominate.stderr
+++ b/src/test/ui/pattern/usefulness/match-range-fail-dominate.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |       5 ..= 6 => { }
    |       ^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/match-range-fail-dominate.rs:1:9
    |
 LL | #![deny(unreachable_patterns, overlapping_patterns)]

--- a/src/test/ui/pattern/usefulness/match-ref-ice.stderr
+++ b/src/test/ui/pattern/usefulness/match-ref-ice.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         [1, 2, 3] => (),
    |         ^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/match-ref-ice.rs:1:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/pattern/usefulness/match-vec-fixed.stderr
+++ b/src/test/ui/pattern/usefulness/match-vec-fixed.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         [_, _, _] => {}
    |         ^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/match-vec-fixed.rs:1:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/pattern/usefulness/match-vec-unreachable.stderr
+++ b/src/test/ui/pattern/usefulness/match-vec-unreachable.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         [(1, 2), (2, 3), b] => (),
    |         ^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/match-vec-unreachable.rs:1:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/pattern/usefulness/slice-pattern-const-2.stderr
+++ b/src/test/ui/pattern/usefulness/slice-pattern-const-2.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         FOO => (),
    |         ^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/slice-pattern-const-2.rs:1:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/pattern/usefulness/slice-pattern-const-3.stderr
+++ b/src/test/ui/pattern/usefulness/slice-pattern-const-3.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         FOO => (),
    |         ^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/slice-pattern-const-3.rs:1:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/pattern/usefulness/slice-pattern-const.stderr
+++ b/src/test/ui/pattern/usefulness/slice-pattern-const.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         [84, 69, 83, 84] => (),
    |         ^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/slice-pattern-const.rs:1:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/pattern/usefulness/slice-patterns-reachability.stderr
+++ b/src/test/ui/pattern/usefulness/slice-patterns-reachability.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         [true, ..] => {}
    |         ^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/slice-patterns-reachability.rs:1:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/pattern/usefulness/struct-pattern-match-useless.stderr
+++ b/src/test/ui/pattern/usefulness/struct-pattern-match-useless.stderr
@@ -6,7 +6,7 @@ LL |         Foo { x: _x, y: _y } => (),
 LL |         Foo { .. } => ()
    |         ^^^^^^^^^^ unreachable pattern
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/struct-pattern-match-useless.rs:1:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/pattern/usefulness/top-level-alternation.stderr
+++ b/src/test/ui/pattern/usefulness/top-level-alternation.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |     while let 0..=2 | 1 = 0 {}
    |                       ^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/top-level-alternation.rs:1:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/privacy/private-in-public-non-principal.stderr
+++ b/src/test/ui/privacy/private-in-public-non-principal.stderr
@@ -14,7 +14,7 @@ error: missing documentation for a method
 LL |         pub fn check_doc_lint() {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/private-in-public-non-principal.rs:10:8
    |
 LL | #[deny(missing_docs)]

--- a/src/test/ui/privacy/private-in-public-warn.stderr
+++ b/src/test/ui/privacy/private-in-public-warn.stderr
@@ -4,7 +4,7 @@ error: private type `types::Priv` in public interface (error E0446)
 LL |     pub type Alias = Priv;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/private-in-public-warn.rs:5:9
    |
 LL | #![deny(private_in_public)]

--- a/src/test/ui/privacy/pub-priv-dep/pub-priv1.stderr
+++ b/src/test/ui/privacy/pub-priv-dep/pub-priv1.stderr
@@ -4,7 +4,7 @@ error: type `priv_dep::OtherType` from private dependency 'priv_dep' in public i
 LL |     pub field: OtherType,
    |     ^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/pub-priv1.rs:3:9
    |
 LL | #![deny(exported_private_dependencies)]

--- a/src/test/ui/proc-macro/attributes-included.stderr
+++ b/src/test/ui/proc-macro/attributes-included.stderr
@@ -4,7 +4,7 @@ warning: unused variable: `a`
 LL |     let a: i32 = "foo";
    |         ^ help: consider prefixing with an underscore: `_a`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/attributes-included.rs:4:9
    |
 LL | #![warn(unused)]

--- a/src/test/ui/proc-macro/no-macro-use-attr.stderr
+++ b/src/test/ui/proc-macro/no-macro-use-attr.stderr
@@ -4,7 +4,7 @@ warning: unused extern crate
 LL | extern crate test_macros;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/no-macro-use-attr.rs:4:9
    |
 LL | #![warn(unused_extern_crates)]

--- a/src/test/ui/range/range-inclusive-pattern-precedence.stderr
+++ b/src/test/ui/range/range-inclusive-pattern-precedence.stderr
@@ -16,7 +16,7 @@ warning: `...` range patterns are deprecated
 LL |         &0...9 => {}
    |         ^^^^^^ help: use `..=` for an inclusive range: `&(0..=9)`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/range-inclusive-pattern-precedence.rs:9:9
    |
 LL | #![warn(ellipsis_inclusive_range_patterns)]

--- a/src/test/ui/reachable/expr_add.stderr
+++ b/src/test/ui/reachable/expr_add.stderr
@@ -7,7 +7,7 @@ LL |     let x = Foo + return;
    |             |     any code following this expression is unreachable
    |             unreachable expression
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/expr_add.rs:3:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/expr_again.stderr
+++ b/src/test/ui/reachable/expr_again.stderr
@@ -6,7 +6,7 @@ LL |         continue;
 LL |         println!("hi");
    |         ^^^^^^^^^^^^^^^ unreachable statement
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/expr_again.rs:3:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/expr_array.stderr
+++ b/src/test/ui/reachable/expr_array.stderr
@@ -6,7 +6,7 @@ LL |     let x: [usize; 2] = [return, 22];
    |                          |
    |                          any code following this expression is unreachable
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/expr_array.rs:4:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/expr_assign.stderr
+++ b/src/test/ui/reachable/expr_assign.stderr
@@ -7,7 +7,7 @@ LL |     x = return;
    |     |   any code following this expression is unreachable
    |     unreachable expression
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/expr_assign.rs:5:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/expr_block.stderr
+++ b/src/test/ui/reachable/expr_block.stderr
@@ -6,7 +6,7 @@ LL |         return;
 LL |         22
    |         ^^ unreachable expression
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/expr_block.rs:4:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/expr_box.stderr
+++ b/src/test/ui/reachable/expr_box.stderr
@@ -7,7 +7,7 @@ LL |     let x = box return;
    |             |   any code following this expression is unreachable
    |             unreachable expression
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/expr_box.rs:3:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/expr_call.stderr
+++ b/src/test/ui/reachable/expr_call.stderr
@@ -6,7 +6,7 @@ LL |     foo(return, 22);
    |         |
    |         any code following this expression is unreachable
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/expr_call.rs:5:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/expr_cast.stderr
+++ b/src/test/ui/reachable/expr_cast.stderr
@@ -7,7 +7,7 @@ LL |     let x = {return} as !;
    |             |any code following this expression is unreachable
    |             unreachable expression
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/expr_cast.rs:4:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/expr_if.stderr
+++ b/src/test/ui/reachable/expr_if.stderr
@@ -9,7 +9,7 @@ LL | |         println!("Hello, world!");
 LL | |     }
    | |_____^ unreachable block in `if` expression
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/expr_if.rs:4:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/expr_loop.stderr
+++ b/src/test/ui/reachable/expr_loop.stderr
@@ -6,7 +6,7 @@ LL |     loop { return; }
 LL |     println!("I am dead.");
    |     ^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/expr_loop.rs:4:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/expr_match.stderr
+++ b/src/test/ui/reachable/expr_match.stderr
@@ -6,7 +6,7 @@ LL |     match () { () => return }
 LL |     println!("I am dead");
    |     ^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/expr_match.rs:4:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/expr_method.stderr
+++ b/src/test/ui/reachable/expr_method.stderr
@@ -6,7 +6,7 @@ LL |     Foo.foo(return, 22);
    |             |
    |             any code following this expression is unreachable
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/expr_method.rs:5:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/expr_repeat.stderr
+++ b/src/test/ui/reachable/expr_repeat.stderr
@@ -7,7 +7,7 @@ LL |     let x: [usize; 2] = [return; 2];
    |                         |any code following this expression is unreachable
    |                         unreachable expression
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/expr_repeat.rs:4:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/expr_return.stderr
+++ b/src/test/ui/reachable/expr_return.stderr
@@ -7,7 +7,7 @@ LL |     let x = {return {return {return;}}};
    |                      |       any code following this expression is unreachable
    |                      unreachable expression
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/expr_return.rs:4:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/expr_return_in_macro.stderr
+++ b/src/test/ui/reachable/expr_return_in_macro.stderr
@@ -7,7 +7,7 @@ LL |         return ()
 LL |     return early_return!();
    |     ^^^^^^^^^^^^^^^^^^^^^^ unreachable expression
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/expr_return_in_macro.rs:4:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/expr_struct.stderr
+++ b/src/test/ui/reachable/expr_struct.stderr
@@ -7,7 +7,7 @@ LL |     let x = Foo { a: 22, b: 33, ..return };
    |             |                     any code following this expression is unreachable
    |             unreachable expression
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/expr_struct.rs:4:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/expr_tup.stderr
+++ b/src/test/ui/reachable/expr_tup.stderr
@@ -6,7 +6,7 @@ LL |     let x: (usize, usize) = (return, 2);
    |                              |
    |                              any code following this expression is unreachable
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/expr_tup.rs:4:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/expr_type.stderr
+++ b/src/test/ui/reachable/expr_type.stderr
@@ -7,7 +7,7 @@ LL |     let x = {return}: !;
    |             |any code following this expression is unreachable
    |             unreachable expression
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/expr_type.rs:4:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/expr_unary.stderr
+++ b/src/test/ui/reachable/expr_unary.stderr
@@ -13,7 +13,7 @@ LL |     let x: ! = ! { return; };
    |                |   any code following this expression is unreachable
    |                unreachable expression
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/expr_unary.rs:5:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/expr_while.stderr
+++ b/src/test/ui/reachable/expr_while.stderr
@@ -10,7 +10,7 @@ LL | |         println!("Hello, world!");
 LL | |     }
    | |_____^ unreachable block in `while` expression
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/expr_while.rs:4:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/unreachable-arm.stderr
+++ b/src/test/ui/reachable/unreachable-arm.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         Foo::A(_, 1) => { }
    |         ^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unreachable-arm.rs:4:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/reachable/unreachable-code.stderr
+++ b/src/test/ui/reachable/unreachable-code.stderr
@@ -7,7 +7,7 @@ LL |
 LL |   let a = 3;
    |   ^^^^^^^^^^ unreachable statement
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unreachable-code.rs:1:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/unreachable-in-call.stderr
+++ b/src/test/ui/reachable/unreachable-in-call.stderr
@@ -6,7 +6,7 @@ LL |     call(diverge(),
 LL |          get_u8());
    |          ^^^^^^^^ unreachable expression
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unreachable-in-call.rs:2:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/reachable/unreachable-loop-patterns.stderr
+++ b/src/test/ui/reachable/unreachable-loop-patterns.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |     for _ in unimplemented!() as Void {}
    |         ^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unreachable-loop-patterns.rs:5:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/reachable/unreachable-try-pattern.stderr
+++ b/src/test/ui/reachable/unreachable-try-pattern.stderr
@@ -7,7 +7,7 @@ LL |     let y = (match x { Ok(n) => Ok(n as u32), Err(e) => Err(e) })?;
    |                                    unreachable expression
    |                                    any code following this expression is unreachable
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unreachable-try-pattern.rs:3:9
    |
 LL | #![warn(unreachable_code)]
@@ -19,7 +19,7 @@ warning: unreachable pattern
 LL |     let y = (match x { Ok(n) => Ok(n as u32), Err(e) => Err(e) })?;
    |                        ^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unreachable-try-pattern.rs:4:9
    |
 LL | #![warn(unreachable_patterns)]

--- a/src/test/ui/reachable/unwarned-match-on-never.stderr
+++ b/src/test/ui/reachable/unwarned-match-on-never.stderr
@@ -7,7 +7,7 @@ LL |     // But matches in unreachable code are warned.
 LL |     match x {}
    |     ^^^^^^^^^^ unreachable expression
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unwarned-match-on-never.rs:1:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/regions/regions-bounded-method-type-parameters-trait-bound.nll.stderr
+++ b/src/test/ui/regions/regions-bounded-method-type-parameters-trait-bound.nll.stderr
@@ -4,7 +4,7 @@ error[E0521]: borrowed data escapes outside of function
 LL | fn caller2<'a,'b,F:Foo<'a>>(a: Inv<'a>, b: Inv<'b>, f: F) {
    |                             -           - `b` is a reference that is only valid in the function body
    |                             |
-   |                             `a` is declared here, outside of the function body
+   |                             `a` declared here, outside of the function body
 LL |     // Here the value provided for 'y is 'b, and hence 'b:'a does not hold.
 LL |     f.method(b);
    |     ^^^^^^^^^^^ `b` escapes the function body here

--- a/src/test/ui/regions/regions-nested-fns.nll.stderr
+++ b/src/test/ui/regions/regions-nested-fns.nll.stderr
@@ -2,7 +2,7 @@ error[E0521]: borrowed data escapes outside of closure
   --> $DIR/regions-nested-fns.rs:10:9
    |
 LL |     let mut ay = &y;
-   |         ------ `ay` is declared here, outside of the closure body
+   |         ------ `ay` declared here, outside of the closure body
 LL | 
 LL |     ignore::<Box<dyn for<'z> FnMut(&'z isize)>>(Box::new(|z| {
    |                                                           - `z` is a reference that is only valid in the closure body

--- a/src/test/ui/removing-extern-crate.stderr
+++ b/src/test/ui/removing-extern-crate.stderr
@@ -4,7 +4,7 @@ warning: unused extern crate
 LL | extern crate removing_extern_crate as foo;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/removing-extern-crate.rs:6:9
    |
 LL | #![warn(rust_2018_idioms)]

--- a/src/test/ui/rfc-2008-non-exhaustive/improper_ctypes/extern_crate_improper.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/improper_ctypes/extern_crate_improper.stderr
@@ -4,7 +4,7 @@ error: `extern` block uses type `types::NonExhaustiveEnum`, which is not FFI-saf
 LL |     pub fn non_exhaustive_enum(_: NonExhaustiveEnum);
    |                                   ^^^^^^^^^^^^^^^^^ not FFI-safe
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/extern_crate_improper.rs:2:9
    |
 LL | #![deny(improper_ctypes)]

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/issue-65157-repeated-match-arm.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/issue-65157-repeated-match-arm.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         PartiallyInhabitedVariants::Struct { .. } => {},
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-65157-repeated-match-arm.rs:2:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/patterns_same_crate.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/patterns_same_crate.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         Some(_x) => (),
    |         ^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/patterns_same_crate.rs:1:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/rfc-2565-param-attrs/param-attrs-cfg.stderr
+++ b/src/test/ui/rfc-2565-param-attrs/param-attrs-cfg.stderr
@@ -4,7 +4,7 @@ error: unused variable: `a`
 LL |     #[cfg(something)] a: i32,
    |                       ^ help: consider prefixing with an underscore: `_a`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/param-attrs-cfg.rs:5:9
    |
 LL | #![deny(unused_variables)]

--- a/src/test/ui/rfc1445/cant-hide-behind-doubly-indirect-embedded.stderr
+++ b/src/test/ui/rfc1445/cant-hide-behind-doubly-indirect-embedded.stderr
@@ -4,7 +4,7 @@ warning: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be a
 LL |         WRAP_DOUBLY_INDIRECT_INLINE => { panic!("WRAP_DOUBLY_INDIRECT_INLINE matched itself"); }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/cant-hide-behind-doubly-indirect-embedded.rs:7:9
    |
 LL | #![warn(indirect_structural_match)]

--- a/src/test/ui/rfc1445/cant-hide-behind-doubly-indirect-param.stderr
+++ b/src/test/ui/rfc1445/cant-hide-behind-doubly-indirect-param.stderr
@@ -4,7 +4,7 @@ warning: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be a
 LL |         WRAP_DOUBLY_INDIRECT_PARAM => { panic!("WRAP_DOUBLY_INDIRECT_PARAM matched itself"); }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/cant-hide-behind-doubly-indirect-param.rs:7:9
    |
 LL | #![warn(indirect_structural_match)]

--- a/src/test/ui/rfc1445/cant-hide-behind-indirect-struct-embedded.stderr
+++ b/src/test/ui/rfc1445/cant-hide-behind-indirect-struct-embedded.stderr
@@ -4,7 +4,7 @@ warning: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be a
 LL |         WRAP_INDIRECT_INLINE => { panic!("WRAP_INDIRECT_INLINE matched itself"); }
    |         ^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/cant-hide-behind-indirect-struct-embedded.rs:7:9
    |
 LL | #![warn(indirect_structural_match)]

--- a/src/test/ui/rfc1445/cant-hide-behind-indirect-struct-param.stderr
+++ b/src/test/ui/rfc1445/cant-hide-behind-indirect-struct-param.stderr
@@ -4,7 +4,7 @@ warning: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be a
 LL |         WRAP_INDIRECT_PARAM => { panic!("WRAP_INDIRECT_PARAM matched itself"); }
    |         ^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/cant-hide-behind-indirect-struct-param.rs:7:9
    |
 LL | #![warn(indirect_structural_match)]

--- a/src/test/ui/rfc1445/issue-62307-match-ref-ref-forbidden-without-eq.stderr
+++ b/src/test/ui/rfc1445/issue-62307-match-ref-ref-forbidden-without-eq.stderr
@@ -4,7 +4,7 @@ warning: to use a constant of type `B` in a pattern, `B` must be annotated with 
 LL |         RR_B1 => { println!("CLAIM RR0: {:?} matches {:?}", RR_B1, RR_B0); }
    |         ^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-62307-match-ref-ref-forbidden-without-eq.rs:13:9
    |
 LL | #![warn(indirect_structural_match)]

--- a/src/test/ui/rust-2018/async-ident-allowed.stderr
+++ b/src/test/ui/rust-2018/async-ident-allowed.stderr
@@ -4,7 +4,7 @@ error: `async` is a keyword in the 2018 edition
 LL |     let async = 3;
    |         ^^^^^ help: you can use a raw identifier to stay compatible: `r#async`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/async-ident-allowed.rs:3:9
    |
 LL | #![deny(rust_2018_compatibility)]

--- a/src/test/ui/rust-2018/async-ident.stderr
+++ b/src/test/ui/rust-2018/async-ident.stderr
@@ -4,7 +4,7 @@ error: `async` is a keyword in the 2018 edition
 LL | fn async() {}
    |    ^^^^^ help: you can use a raw identifier to stay compatible: `r#async`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/async-ident.rs:2:9
    |
 LL | #![deny(keyword_idents)]

--- a/src/test/ui/rust-2018/dyn-keyword.stderr
+++ b/src/test/ui/rust-2018/dyn-keyword.stderr
@@ -4,7 +4,7 @@ error: `dyn` is a keyword in the 2018 edition
 LL |     let dyn = ();
    |         ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/dyn-keyword.rs:5:9
    |
 LL | #![deny(keyword_idents)]

--- a/src/test/ui/rust-2018/edition-lint-fully-qualified-paths.stderr
+++ b/src/test/ui/rust-2018/edition-lint-fully-qualified-paths.stderr
@@ -4,7 +4,7 @@ error: absolute paths must start with `self`, `super`, `crate`, or an external c
 LL |     let _: <foo::Baz as ::foo::Foo>::Bar = ();
    |                         ^^^^^^^^^^ help: use `crate`: `crate::foo::Foo`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/edition-lint-fully-qualified-paths.rs:4:9
    |
 LL | #![deny(absolute_paths_not_starting_with_crate)]

--- a/src/test/ui/rust-2018/edition-lint-infer-outlives-multispan.stderr
+++ b/src/test/ui/rust-2018/edition-lint-infer-outlives-multispan.stderr
@@ -4,7 +4,7 @@ error: outlives requirements can be inferred
 LL |     struct TeeOutlivesAyIsDebugBee<'a, 'b, T: 'a + Debug + 'b> {
    |                                               ^^^^^     ^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/edition-lint-infer-outlives-multispan.rs:2:9
    |
 LL | #![deny(explicit_outlives_requirements)]

--- a/src/test/ui/rust-2018/edition-lint-infer-outlives.stderr
+++ b/src/test/ui/rust-2018/edition-lint-infer-outlives.stderr
@@ -4,7 +4,7 @@ error: outlives requirements can be inferred
 LL |     struct TeeOutlivesAy<'a, T: 'a> {
    |                               ^^^^ help: remove this bound
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/edition-lint-infer-outlives.rs:4:9
    |
 LL | #![deny(explicit_outlives_requirements)]

--- a/src/test/ui/rust-2018/edition-lint-nested-empty-paths.stderr
+++ b/src/test/ui/rust-2018/edition-lint-nested-empty-paths.stderr
@@ -4,7 +4,7 @@ error: absolute paths must start with `self`, `super`, `crate`, or an external c
 LL | use foo::{bar::{baz::{}}};
    |     ^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{bar::{baz::{}}}`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/edition-lint-nested-empty-paths.rs:4:9
    |
 LL | #![deny(absolute_paths_not_starting_with_crate)]

--- a/src/test/ui/rust-2018/edition-lint-nested-paths.stderr
+++ b/src/test/ui/rust-2018/edition-lint-nested-paths.stderr
@@ -4,7 +4,7 @@ error: absolute paths must start with `self`, `super`, `crate`, or an external c
 LL | use foo::{a, b};
    |     ^^^^^^^^^^^ help: use `crate`: `crate::foo::{a, b}`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/edition-lint-nested-paths.rs:4:9
    |
 LL | #![deny(absolute_paths_not_starting_with_crate)]

--- a/src/test/ui/rust-2018/edition-lint-paths.stderr
+++ b/src/test/ui/rust-2018/edition-lint-paths.stderr
@@ -4,7 +4,7 @@ error: absolute paths must start with `self`, `super`, `crate`, or an external c
 LL |     use ::bar::Bar;
    |         ^^^^^^^^^^ help: use `crate`: `crate::bar::Bar`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/edition-lint-paths.rs:5:9
    |
 LL | #![deny(absolute_paths_not_starting_with_crate)]

--- a/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.stderr
+++ b/src/test/ui/rust-2018/extern-crate-idiomatic-in-2018.stderr
@@ -4,7 +4,7 @@ error: unused extern crate
 LL | extern crate edition_lint_paths;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/extern-crate-idiomatic-in-2018.rs:9:9
    |
 LL | #![deny(rust_2018_idioms)]

--- a/src/test/ui/rust-2018/extern-crate-rename.stderr
+++ b/src/test/ui/rust-2018/extern-crate-rename.stderr
@@ -4,7 +4,7 @@ error: absolute paths must start with `self`, `super`, `crate`, or an external c
 LL | use my_crate::foo;
    |     ^^^^^^^^^^^^^ help: use `crate`: `crate::my_crate::foo`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/extern-crate-rename.rs:8:9
    |
 LL | #![deny(absolute_paths_not_starting_with_crate)]

--- a/src/test/ui/rust-2018/extern-crate-submod.stderr
+++ b/src/test/ui/rust-2018/extern-crate-submod.stderr
@@ -4,7 +4,7 @@ error: absolute paths must start with `self`, `super`, `crate`, or an external c
 LL | use m::edition_lint_paths::foo;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::m::edition_lint_paths::foo`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/extern-crate-submod.rs:9:9
    |
 LL | #![deny(absolute_paths_not_starting_with_crate)]

--- a/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.stderr
+++ b/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.stderr
@@ -7,7 +7,7 @@ LL | | extern crate edition_lint_paths;
    | |________________________________|
    |                                  help: remove it
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-54400-unused-extern-crate-attr-span.rs:6:9
    |
 LL | #![deny(rust_2018_idioms)]

--- a/src/test/ui/rust-2018/macro-use-warned-against.stderr
+++ b/src/test/ui/rust-2018/macro-use-warned-against.stderr
@@ -4,7 +4,7 @@ warning: deprecated `#[macro_use]` directive used to import macros should be rep
 LL | #[macro_use]
    | ^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/macro-use-warned-against.rs:5:9
    |
 LL | #![warn(macro_use_extern_crate, unused)]
@@ -16,7 +16,7 @@ warning: unused `#[macro_use]` import
 LL | #[macro_use]
    | ^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/macro-use-warned-against.rs:5:33
    |
 LL | #![warn(macro_use_extern_crate, unused)]

--- a/src/test/ui/rust-2018/remove-extern-crate.stderr
+++ b/src/test/ui/rust-2018/remove-extern-crate.stderr
@@ -4,7 +4,7 @@ warning: unused extern crate
 LL | extern crate core;
    | ^^^^^^^^^^^^^^^^^^ help: remove it
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/remove-extern-crate.rs:7:9
    |
 LL | #![warn(rust_2018_idioms)]

--- a/src/test/ui/rust-2018/suggestions-not-always-applicable.stderr
+++ b/src/test/ui/rust-2018/suggestions-not-always-applicable.stderr
@@ -4,7 +4,7 @@ warning: absolute paths must start with `self`, `super`, `crate`, or an external
 LL |     #[foo]
    |     ^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/suggestions-not-always-applicable.rs:8:9
    |
 LL | #![warn(rust_2018_compatibility)]

--- a/src/test/ui/rust-2018/try-ident.stderr
+++ b/src/test/ui/rust-2018/try-ident.stderr
@@ -4,7 +4,7 @@ warning: `try` is a keyword in the 2018 edition
 LL |     try();
    |     ^^^ help: you can use a raw identifier to stay compatible: `r#try`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/try-ident.rs:4:9
    |
 LL | #![warn(rust_2018_compatibility)]

--- a/src/test/ui/rust-2018/try-macro.stderr
+++ b/src/test/ui/rust-2018/try-macro.stderr
@@ -4,7 +4,7 @@ warning: `try` is a keyword in the 2018 edition
 LL |     try!(x);
    |     ^^^ help: you can use a raw identifier to stay compatible: `r#try`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/try-macro.rs:6:9
    |
 LL | #![warn(rust_2018_compatibility)]

--- a/src/test/ui/single-use-lifetime/fn-types.stderr
+++ b/src/test/ui/single-use-lifetime/fn-types.stderr
@@ -6,7 +6,7 @@ LL |   a: for<'a> fn(&'a u32),
    |          |
    |          this lifetime...
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/fn-types.rs:1:9
    |
 LL | #![deny(single_use_lifetimes)]

--- a/src/test/ui/single-use-lifetime/one-use-in-fn-argument-in-band.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-fn-argument-in-band.stderr
@@ -7,7 +7,7 @@ LL | fn a(x: &'a u32, y: &'b u32) {
    |          this lifetime is only used here
    |          help: elide the single-use lifetime
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/one-use-in-fn-argument-in-band.rs:4:9
    |
 LL | #![deny(single_use_lifetimes)]

--- a/src/test/ui/single-use-lifetime/one-use-in-fn-argument.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-fn-argument.stderr
@@ -6,7 +6,7 @@ LL | fn a<'a>(x: &'a u32) {
    |      |
    |      this lifetime...
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/one-use-in-fn-argument.rs:1:9
    |
 LL | #![deny(single_use_lifetimes)]

--- a/src/test/ui/single-use-lifetime/one-use-in-inherent-impl-header.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-inherent-impl-header.stderr
@@ -6,7 +6,7 @@ LL | impl<'f> Foo<'f> {
    |      |
    |      this lifetime...
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/one-use-in-inherent-impl-header.rs:1:9
    |
 LL | #![deny(single_use_lifetimes)]

--- a/src/test/ui/single-use-lifetime/one-use-in-inherent-method-argument.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-inherent-method-argument.stderr
@@ -6,7 +6,7 @@ LL |     fn inherent_a<'a>(&self, data: &'a u32) {
    |                   |
    |                   this lifetime...
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/one-use-in-inherent-method-argument.rs:1:9
    |
 LL | #![deny(single_use_lifetimes)]

--- a/src/test/ui/single-use-lifetime/one-use-in-inherent-method-return.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-inherent-method-return.stderr
@@ -6,7 +6,7 @@ LL | impl<'f> Foo<'f> {
    |      |
    |      this lifetime...
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/one-use-in-inherent-method-return.rs:1:9
    |
 LL | #![deny(single_use_lifetimes)]

--- a/src/test/ui/single-use-lifetime/one-use-in-trait-method-argument.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-trait-method-argument.stderr
@@ -6,7 +6,7 @@ LL |     fn next<'g>(&'g mut self) -> Option<Self::Item> {
    |             |
    |             this lifetime...
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/one-use-in-trait-method-argument.rs:4:9
    |
 LL | #![deny(single_use_lifetimes)]

--- a/src/test/ui/single-use-lifetime/two-uses-in-inherent-method-argument-and-return.stderr
+++ b/src/test/ui/single-use-lifetime/two-uses-in-inherent-method-argument-and-return.stderr
@@ -6,7 +6,7 @@ LL | impl<'f> Foo<'f> {
    |      |
    |      this lifetime...
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/two-uses-in-inherent-method-argument-and-return.rs:4:9
    |
 LL | #![deny(single_use_lifetimes)]

--- a/src/test/ui/single-use-lifetime/zero-uses-in-fn.stderr
+++ b/src/test/ui/single-use-lifetime/zero-uses-in-fn.stderr
@@ -4,7 +4,7 @@ error: lifetime parameter `'a` never used
 LL | fn september<'a>() {}
    |             -^^- help: elide the unused lifetime
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/zero-uses-in-fn.rs:5:9
    |
 LL | #![deny(unused_lifetimes)]

--- a/src/test/ui/single-use-lifetime/zero-uses-in-impl.stderr
+++ b/src/test/ui/single-use-lifetime/zero-uses-in-impl.stderr
@@ -4,7 +4,7 @@ error: lifetime parameter `'a` never used
 LL | impl<'a> Foo {}
    |     -^^- help: elide the unused lifetime
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/zero-uses-in-impl.rs:3:9
    |
 LL | #![deny(unused_lifetimes)]

--- a/src/test/ui/span/issue-24690.stderr
+++ b/src/test/ui/span/issue-24690.stderr
@@ -4,7 +4,7 @@ warning: unused variable: `theOtherTwo`
 LL |     let theOtherTwo = 2;
    |         ^^^^^^^^^^^ help: consider prefixing with an underscore: `_theOtherTwo`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-24690.rs:8:9
    |
 LL | #![warn(unused)]

--- a/src/test/ui/span/lint-unused-unsafe.stderr
+++ b/src/test/ui/span/lint-unused-unsafe.stderr
@@ -4,7 +4,7 @@ error: unnecessary `unsafe` block
 LL | fn bad1() { unsafe {} }
    |             ^^^^^^ unnecessary `unsafe` block
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/lint-unused-unsafe.rs:4:9
    |
 LL | #![deny(unused_unsafe)]

--- a/src/test/ui/span/macro-span-replacement.stderr
+++ b/src/test/ui/span/macro-span-replacement.stderr
@@ -7,7 +7,7 @@ LL |         $b $a;
 LL |     m!(S struct);
    |     ------------- in this macro invocation
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/macro-span-replacement.rs:3:9
    |
 LL | #![warn(unused)]

--- a/src/test/ui/span/multispan-import-lint.stderr
+++ b/src/test/ui/span/multispan-import-lint.stderr
@@ -4,7 +4,7 @@ warning: unused imports: `Eq`, `Ord`, `PartialEq`, `PartialOrd`
 LL | use std::cmp::{Eq, Ord, min, PartialEq, PartialOrd};
    |                ^^  ^^^       ^^^^^^^^^  ^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/multispan-import-lint.rs:3:9
    |
 LL | #![warn(unused)]

--- a/src/test/ui/span/unused-warning-point-at-identifier.stderr
+++ b/src/test/ui/span/unused-warning-point-at-identifier.stderr
@@ -4,7 +4,7 @@ warning: enum is never used: `Enum`
 LL | enum Enum {
    |      ^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused-warning-point-at-identifier.rs:3:9
    |
 LL | #![warn(unused)]

--- a/src/test/ui/stable-features.stderr
+++ b/src/test/ui/stable-features.stderr
@@ -4,7 +4,7 @@ error: the feature `test_accepted_feature` has been stable since 1.0.0 and no lo
 LL | #![feature(test_accepted_feature)]
    |            ^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/stable-features.rs:4:9
    |
 LL | #![deny(stable_features)]

--- a/src/test/ui/suggestions/issue-61963.stderr
+++ b/src/test/ui/suggestions/issue-61963.stderr
@@ -4,7 +4,7 @@ error: trait objects without an explicit `dyn` are deprecated
 LL |     bar: Box<Bar>,
    |              ^^^ help: use `dyn`: `dyn Bar`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/issue-61963.rs:3:9
    |
 LL | #![deny(bare_trait_objects)]

--- a/src/test/ui/suggestions/unused-closure-argument.stderr
+++ b/src/test/ui/suggestions/unused-closure-argument.stderr
@@ -4,7 +4,7 @@ error: unused variable: `x`
 LL |         .map(|Point { x, y }| y)
    |                       ^ help: try ignoring the field: `x: _`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused-closure-argument.rs:1:9
    |
 LL | #![deny(unused_variables)]

--- a/src/test/ui/test-attrs/test-warns-dead-code.stderr
+++ b/src/test/ui/test-attrs/test-warns-dead-code.stderr
@@ -4,7 +4,7 @@ error: function is never used: `dead`
 LL | fn dead() {}
    |    ^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/test-warns-dead-code.rs:3:9
    |
 LL | #![deny(dead_code)]

--- a/src/test/ui/tool_lints-fail.stderr
+++ b/src/test/ui/tool_lints-fail.stderr
@@ -4,7 +4,7 @@ error: unknown lint: `clippy`
 LL | #![deny(clippy)]
    |         ^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/tool_lints-fail.rs:4:9
    |
 LL | #![deny(unknown_lints)]

--- a/src/test/ui/trivial-bounds/trivial-bounds-lint.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-lint.stderr
@@ -4,7 +4,7 @@ error: Trait bound i32: std::marker::Copy does not depend on any type or lifetim
 LL | struct A where i32: Copy;
    |                     ^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/trivial-bounds-lint.rs:3:9
    |
 LL | #![deny(trivial_bounds)]

--- a/src/test/ui/trivial_casts.stderr
+++ b/src/test/ui/trivial_casts.stderr
@@ -4,7 +4,7 @@ error: trivial numeric cast: `i32` as `i32`
 LL |     let _ = 42_i32 as i32;
    |             ^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/trivial_casts.rs:4:24
    |
 LL | #![deny(trivial_casts, trivial_numeric_casts)]
@@ -25,7 +25,7 @@ error: trivial cast: `&u32` as `*const u32`
 LL |     let _ = x as *const u32;
    |             ^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/trivial_casts.rs:4:9
    |
 LL | #![deny(trivial_casts, trivial_numeric_casts)]

--- a/src/test/ui/try-block/try-block-unreachable-code-lint.stderr
+++ b/src/test/ui/try-block/try-block-unreachable-code-lint.stderr
@@ -11,7 +11,7 @@ LL | |             }
 LL | |         }
    | |_________^ unreachable expression
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/try-block-unreachable-code-lint.rs:6:9
    |
 LL | #![warn(unreachable_code)]

--- a/src/test/ui/type-alias-enum-variants/enum-variant-priority-lint-ambiguous_associated_items.stderr
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-priority-lint-ambiguous_associated_items.stderr
@@ -7,12 +7,12 @@ LL |     fn f() -> Self::V { 0 }
    = note: `#[deny(ambiguous_associated_items)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57644 <https://github.com/rust-lang/rust/issues/57644>
-note: `V` could refer to variant defined here
+note: `V` could refer to the variant defined here
   --> $DIR/enum-variant-priority-lint-ambiguous_associated_items.rs:22:5
    |
 LL |     V
    |     ^
-note: `V` could also refer to associated type defined here
+note: `V` could also refer to the associated type defined here
   --> $DIR/enum-variant-priority-lint-ambiguous_associated_items.rs:26:5
    |
 LL |     type V;

--- a/src/test/ui/underscore-imports/basic.stderr
+++ b/src/test/ui/underscore-imports/basic.stderr
@@ -4,7 +4,7 @@ warning: unused import: `m::Tr1 as _`
 LL |     use m::Tr1 as _;
    |         ^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/basic.rs:4:9
    |
 LL | #![warn(unused_imports, unused_extern_crates)]

--- a/src/test/ui/underscore-imports/unused-2018.stderr
+++ b/src/test/ui/underscore-imports/unused-2018.stderr
@@ -4,7 +4,7 @@ error: unused import: `core::any`
 LL |     use core::any;
    |         ^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused-2018.rs:3:9
    |
 LL | #![deny(unused_imports)]

--- a/src/test/ui/uninhabited/uninhabited-patterns.stderr
+++ b/src/test/ui/uninhabited/uninhabited-patterns.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         &[..] => (),
    |         ^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/uninhabited-patterns.rs:6:9
    |
 LL | #![deny(unreachable_patterns)]

--- a/src/test/ui/union/union-fields-1.stderr
+++ b/src/test/ui/union/union-fields-1.stderr
@@ -4,7 +4,7 @@ error: field is never read: `c`
 LL |     c: u8,
    |     ^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/union-fields-1.rs:1:9
    |
 LL | #![deny(dead_code)]

--- a/src/test/ui/union/union-lint-dead-code.stderr
+++ b/src/test/ui/union/union-lint-dead-code.stderr
@@ -4,7 +4,7 @@ error: field is never read: `b`
 LL |     b: bool,
    |     ^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/union-lint-dead-code.rs:1:9
    |
 LL | #![deny(dead_code)]

--- a/src/test/ui/union/union-repr-c.stderr
+++ b/src/test/ui/union/union-repr-c.stderr
@@ -4,14 +4,14 @@ error: `extern` block uses type `W`, which is not FFI-safe
 LL |     static FOREIGN2: W;
    |                      ^ not FFI-safe
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/union-repr-c.rs:2:9
    |
 LL | #![deny(improper_ctypes)]
    |         ^^^^^^^^^^^^^^^
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this union
    = note: this union has unspecified layout
-note: type defined here
+note: the type is defined here
   --> $DIR/union-repr-c.rs:9:1
    |
 LL | / union W {

--- a/src/test/ui/unnecessary-extern-crate.stderr
+++ b/src/test/ui/unnecessary-extern-crate.stderr
@@ -4,7 +4,7 @@ error: unused extern crate
 LL | extern crate libc;
    | ^^^^^^^^^^^^^^^^^^ help: remove it
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unnecessary-extern-crate.rs:3:9
    |
 LL | #![deny(unused_extern_crates)]

--- a/src/test/ui/unreachable-code-ret.stderr
+++ b/src/test/ui/unreachable-code-ret.stderr
@@ -6,7 +6,7 @@ LL |     return;
 LL |     println!("Paul is dead");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unreachable-code-ret.rs:3:9
    |
 LL | #![deny(unreachable_code)]

--- a/src/test/ui/unsafe/unsafe-around-compiler-generated-unsafe.stderr
+++ b/src/test/ui/unsafe/unsafe-around-compiler-generated-unsafe.stderr
@@ -4,7 +4,7 @@ error: unnecessary `unsafe` block
 LL |     unsafe { println!("foo"); }
    |     ^^^^^^ unnecessary `unsafe` block
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unsafe-around-compiler-generated-unsafe.rs:3:9
    |
 LL | #![deny(unused_unsafe)]

--- a/src/test/ui/unused/unused-attr.stderr
+++ b/src/test/ui/unused/unused-attr.stderr
@@ -4,7 +4,7 @@ error: unused attribute
 LL | #[rustc_dummy]
    | ^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused-attr.rs:1:9
    |
 LL | #![deny(unused_attributes)]

--- a/src/test/ui/unused/unused-macro-rules.stderr
+++ b/src/test/ui/unused/unused-macro-rules.stderr
@@ -6,7 +6,7 @@ LL | |     () => {};
 LL | | }
    | |_^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused-macro-rules.rs:1:9
    |
 LL | #![deny(unused_macros)]
@@ -31,7 +31,7 @@ LL | |         () => {};
 LL | |     }
    | |_____^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused-macro-rules.rs:23:12
    |
 LL |     #[deny(unused_macros)]

--- a/src/test/ui/unused/unused-macro.stderr
+++ b/src/test/ui/unused/unused-macro.stderr
@@ -6,7 +6,7 @@ LL | |     () => {}
 LL | | }
    | |_^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused-macro.rs:2:9
    |
 LL | #![deny(unused_macros)]
@@ -20,7 +20,7 @@ LL | |         () => {}
 LL | |     }
    | |_____^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused-macro.rs:14:12
    |
 LL |     #[deny(unused_macros)]

--- a/src/test/ui/unused/unused-mut-warning-captured-var.stderr
+++ b/src/test/ui/unused/unused-mut-warning-captured-var.stderr
@@ -6,7 +6,7 @@ LL |     let mut x = 1;
    |         |
    |         help: remove this `mut`
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused-mut-warning-captured-var.rs:1:11
    |
 LL | #![forbid(unused_mut)]

--- a/src/test/ui/unused/unused-result.rs
+++ b/src/test/ui/unused/unused-result.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 #![deny(unused_results, unused_must_use)]
-//~^ NOTE: lint level defined here
-//~| NOTE: lint level defined here
+//~^ NOTE: the lint level is defined here
+//~| NOTE: the lint level is defined here
 
 #[must_use]
 enum MustUse { Test }

--- a/src/test/ui/unused/unused-result.stderr
+++ b/src/test/ui/unused/unused-result.stderr
@@ -4,7 +4,7 @@ error: unused `MustUse` that must be used
 LL |     foo::<MustUse>();
    |     ^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused-result.rs:2:25
    |
 LL | #![deny(unused_results, unused_must_use)]
@@ -24,7 +24,7 @@ error: unused result
 LL |     foo::<isize>();
    |     ^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/unused-result.rs:2:9
    |
 LL | #![deny(unused_results, unused_must_use)]

--- a/src/test/ui/use/use-nested-groups-unused-imports.stderr
+++ b/src/test/ui/use/use-nested-groups-unused-imports.stderr
@@ -4,7 +4,7 @@ error: unused imports: `*`, `Foo`, `baz::{}`, `foobar::*`
 LL | use foo::{Foo, bar::{baz::{}, foobar::*}, *};
    |           ^^^        ^^^^^^^  ^^^^^^^^^   ^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/use-nested-groups-unused-imports.rs:3:9
    |
 LL | #![deny(unused_imports)]

--- a/src/test/ui/useless-comment.stderr
+++ b/src/test/ui/useless-comment.stderr
@@ -6,7 +6,7 @@ LL | /// foo
 LL | mac!();
    | ------- rustdoc does not generate documentation for macro expansions
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/useless-comment.rs:3:9
    |
 LL | #![deny(unused_doc_comments)]

--- a/src/test/ui/variants/variant-size-differences.stderr
+++ b/src/test/ui/variants/variant-size-differences.stderr
@@ -4,7 +4,7 @@ error: enum variant is more than three times larger (1024 bytes) than the next l
 LL |     VBig([u8; 1024]),
    |     ^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> $DIR/variant-size-differences.rs:1:9
    |
 LL | #![deny(variant_size_differences)]


### PR DESCRIPTION
"is" was generally used for NLL diagnostics, but not other diagnostics. Using "is" makes the diagnostics sound more natural and readable, so it seems sensible to commit to them throughout.

r? @Centril