### PR TITLE
Specify units for test timeout environment variables

### DIFF
--- a/src/libtest/cli.rs
+++ b/src/libtest/cli.rs
@@ -125,6 +125,8 @@ fn optgroups() -> getopts::Options {
             `RUST_TEST_TIME_DOCTEST` environment variables.
 
             Expected format of environment variable is `VARIABLE=WARN_TIME,CRITICAL_TIME`.
+            Durations must be specified in milliseconds, e.g. `500,2000` means that the warn time
+            is 0.5 seconds, and the critical time is 2 seconds.
 
             Not available for --format=terse",
             "plain|colored",


### PR DESCRIPTION
I think it is not obvious (I got it from reading libtest sources), so it is worth mentioning in docs.