### PR TITLE
Test gdb pretty printing more and fix overzealous type substitution

### DIFF
--- a/src/etc/gdb_rust_pretty_printing.py
+++ b/src/etc/gdb_rust_pretty_printing.py
@@ -335,7 +335,7 @@ class RustStdVecDequePrinter(object):
 def children_of_node(boxed_node, height, want_values):
     node_ptr = boxed_node['ptr']['pointer']
     if height > 0:
-        type_name = str(node_ptr.type.target()).replace('LeafNode', 'InternalNode')
+        type_name = str(node_ptr.type.target()).replace('LeafNode', 'InternalNode', 1)
         node_type = gdb.lookup_type(type_name)
         node_ptr = node_ptr.cast(node_type.pointer())
         leaf = node_ptr['data']

--- a/src/test/debuginfo/pretty-std-collections.rs
+++ b/src/test/debuginfo/pretty-std-collections.rs
@@ -26,16 +26,21 @@
 // gdb-command: print empty_btree_map
 // gdb-check:$4 = BTreeMap<i32, u32>(len: 0)
 
+// gdb-command: print nasty_btree_map
+// gdb-check:$5 = BTreeMap<i32, pretty_std_collections::MyLeafNode>(len: 1) = {[1] = pretty_std_collections::MyLeafNode (11)}
+
 // gdb-command: print vec_deque
-// gdb-check:$5 = VecDeque<i32>(len: 3, cap: 8) = {5, 3, 7}
+// gdb-check:$6 = VecDeque<i32>(len: 3, cap: 8) = {5, 3, 7}
 
 // gdb-command: print vec_deque2
-// gdb-check:$6 = VecDeque<i32>(len: 7, cap: 8) = {2, 3, 4, 5, 6, 7, 8}
+// gdb-check:$7 = VecDeque<i32>(len: 7, cap: 8) = {2, 3, 4, 5, 6, 7, 8}
 
 #![allow(unused_variables)]
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::VecDeque;
+
+struct MyLeafNode(i32); // helps to ensure we don't blindly replace substring "LeafNode"
 
 fn main() {
     // BTreeSet
@@ -53,6 +58,9 @@ fn main() {
     }
 
     let mut empty_btree_map: BTreeMap<i32, u32> = BTreeMap::new();
+
+    let mut nasty_btree_map: BTreeMap<i32, MyLeafNode> = BTreeMap::new();
+    nasty_btree_map.insert(1, MyLeafNode(11));
 
     // VecDeque
     let mut vec_deque = VecDeque::new();


### PR DESCRIPTION
Adresses a problem concerning printing BTreeMap / BTreeSet data in gdb: when the key or value type name contains substring "LeafNode", and the map has multiple nodes (e.g. more than 11 elements), printing causes an exception. E.g.

```
rustc -g - <<EOF
    use std::collections::BTreeMap;

    struct MyLeafNode(i8);

    fn main() {
        let m: BTreeMap<i8, MyLeafNode> = (0..12).map(|i| (i, MyLeafNode(i))).collect();
        assert!(!m.is_empty());
    }
EOF
```

```
$ rust-gdb rust_out
(gdb) b 7
(gdb) r
(gdb) p m
$1 = BTreeMap<i8, rust_out::MyLeafNode>(len: 12)Python Exception <class 'gdb.error'> No type named alloc::collections::btree::node::InternalNode<i8, rust_out::MyInternalNode>.:
use std::collections::BTreeMap;
```

The code was written in #56144 by @tromey (and later touched upon by @RalfJung in #57045, but I think that had nothing to do with the issues in this PR).