### PR TITLE
Amend Rc/Arc::from_raw() docs regarding unsafety

### DIFF
--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -573,10 +573,11 @@ impl<T: ?Sized> Rc<T> {
     /// Constructs an `Rc` from a raw pointer.
     ///
     /// The raw pointer must have been previously returned by a call to a
-    /// [`Rc::into_raw`][into_raw].
+    /// [`Rc::into_raw`][into_raw] using the same `T`.
     ///
-    /// This function is unsafe because improper use may lead to memory problems. For example, a
-    /// double-free may occur if the function is called twice on the same raw pointer.
+    /// This function is unsafe because improper use may lead to memory unsafety,
+    /// even if `T` is never accessed. For example, a double-free may occur if the function is
+    /// called twice on the same raw pointer.
     ///
     /// [into_raw]: struct.Rc.html#method.into_raw
     ///

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -259,6 +259,10 @@ use crate::vec::Vec;
 #[cfg(test)]
 mod tests;
 
+// This is repr(C) to future-proof against possible field-reordering, which
+// would interfere with otherwise safe [into|from]_raw() of transmutable
+// inner types.
+#[repr(C)]
 struct RcBox<T: ?Sized> {
     strong: Cell<usize>,
     weak: Cell<usize>,

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -570,16 +570,24 @@ impl<T: ?Sized> Rc<T> {
         ptr
     }
 
-    /// Constructs an `Rc` from a raw pointer.
+    /// Constructs an `Rc<T>` from a raw pointer.
     ///
-    /// The raw pointer must have been previously returned by a call to a
-    /// [`Rc::into_raw`][into_raw] using the same `T`.
+    /// The raw pointer must have been previously returned by a call to
+    /// [`Rc<U>::into_raw`][into_raw] where `U` must have the same size
+    /// and alignment as `T`. This is trivially true if `U` is `T`.
+    /// Note that if `U` is not `T` but has the same size and alignment, this is
+    /// basically like transmuting references of different types. See
+    /// [`mem::transmute`][transmute] for more information on what
+    /// restrictions apply in this case.
+    ///
+    /// The user of `from_raw` has to make sure a specific value of `T` is only
+    /// dropped once.
     ///
     /// This function is unsafe because improper use may lead to memory unsafety,
-    /// even if `T` is never accessed. For example, a double-free may occur if the function is
-    /// called twice on the same raw pointer.
+    /// even if the returned `Rc<T>` is never accessed.
     ///
     /// [into_raw]: struct.Rc.html#method.into_raw
+    /// [transmute]: ../../std/mem/fn.transmute.html
     ///
     /// # Examples
     ///

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -553,10 +553,11 @@ impl<T: ?Sized> Arc<T> {
     /// Constructs an `Arc` from a raw pointer.
     ///
     /// The raw pointer must have been previously returned by a call to a
-    /// [`Arc::into_raw`][into_raw].
+    /// [`Arc::into_raw`][into_raw], using the same `T`.
     ///
-    /// This function is unsafe because improper use may lead to memory problems. For example, a
-    /// double-free may occur if the function is called twice on the same raw pointer.
+    /// This function is unsafe because improper use may lead to memory unsafety,
+    /// even if `T` is never accessed. For example, a double-free may occur if the function is
+    /// called twice on the same raw pointer.
     ///
     /// [into_raw]: struct.Arc.html#method.into_raw
     ///

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -550,16 +550,24 @@ impl<T: ?Sized> Arc<T> {
         ptr
     }
 
-    /// Constructs an `Arc` from a raw pointer.
+    /// Constructs an `Arc<T>` from a raw pointer.
     ///
-    /// The raw pointer must have been previously returned by a call to a
-    /// [`Arc::into_raw`][into_raw], using the same `T`.
+    /// The raw pointer must have been previously returned by a call to
+    /// [`Arc<U>::into_raw`][into_raw] where `U` must have the same size and
+    /// alignment as `T`. This is trivially true if `U` is `T`.
+    /// Note that if `U` is not `T` but has the same size and alignment, this is
+    /// basically like transmuting references of different types. See
+    /// [`mem::transmute`][transmute] for more information on what
+    /// restrictions apply in this case.
+    ///
+    /// The user of `from_raw` has to make sure a specific value of `T` is only
+    /// dropped once.
     ///
     /// This function is unsafe because improper use may lead to memory unsafety,
-    /// even if `T` is never accessed. For example, a double-free may occur if the function is
-    /// called twice on the same raw pointer.
+    /// even if the returned `Arc<T>` is never accessed.
     ///
     /// [into_raw]: struct.Arc.html#method.into_raw
+    /// [transmute]: ../../std/mem/fn.transmute.html
     ///
     /// # Examples
     ///

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -270,6 +270,10 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for Weak<T> {
     }
 }
 
+// This is repr(C) to future-proof against possible field-reordering, which
+// would interfere with otherwise safe [into|from]_raw() of transmutable
+// inner types.
+#[repr(C)]
 struct ArcInner<T: ?Sized> {
     strong: atomic::AtomicUsize,
 


### PR DESCRIPTION
[This](https://stackoverflow.com/questions/59671647/is-it-safe-to-clone-a-type-erased-arc-via-raw-pointer) question on SO boils down to "is it safe to `::from_raw()` a `Rc<T>`/`Arc<T>` using a dummy `T` even if `T` is never dereferenced via the new `Rc`/`Arc`?". It almost never is.

This PR amends the docs of `from_raw()` regarding this point.