### PR TITLE
Fix issue with using `self` module via indirection

### DIFF
--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -652,6 +652,9 @@ impl EmbargoVisitor<'tcx> {
             if let Some(item) = module
                 .res
                 .and_then(|res| res.mod_def_id())
+                // If the module is `self`, i.e. the current crate,
+                // there will be no corresponding item.
+                .filter(|def_id| def_id.index != CRATE_DEF_INDEX || def_id.krate != LOCAL_CRATE)
                 .and_then(|def_id| self.tcx.hir().as_local_hir_id(def_id))
                 .map(|module_hir_id| self.tcx.hir().expect_item(module_hir_id))
             {

--- a/src/test/ui/issues/issue-68103.rs
+++ b/src/test/ui/issues/issue-68103.rs
@@ -1,0 +1,6 @@
+// check-pass
+
+pub extern crate self as name;
+pub use name::name as bug;
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/68103.