### PR TITLE
Print constants in `type_name` for const generics

### DIFF
--- a/src/librustc_codegen_utils/symbol_names/legacy.rs
+++ b/src/librustc_codegen_utils/symbol_names/legacy.rs
@@ -237,7 +237,7 @@ impl Printer<'tcx> for SymbolPrinter<'tcx> {
         // only print integers
         if let ty::ConstKind::Value(ConstValue::Scalar(Scalar::Raw { .. })) = ct.val {
             if ct.ty.is_integral() {
-                return self.pretty_print_const(ct);
+                return self.pretty_print_const(ct, true);
             }
         }
         self.write_str("_")?;

--- a/src/librustc_mir/interpret/intrinsics/type_name.rs
+++ b/src/librustc_mir/interpret/intrinsics/type_name.rs
@@ -69,9 +69,8 @@ impl<'tcx> Printer<'tcx> for AbsolutePathPrinter<'tcx> {
         }
     }
 
-    fn print_const(self, _: &'tcx ty::Const<'tcx>) -> Result<Self::Const, Self::Error> {
-        // don't print constants to the user
-        Ok(self)
+    fn print_const(self, ct: &'tcx ty::Const<'tcx>) -> Result<Self::Const, Self::Error> {
+        self.pretty_print_const(ct, false)
     }
 
     fn print_dyn_existential(

--- a/src/test/ui/const-generics/const-generic-type_name.rs
+++ b/src/test/ui/const-generics/const-generic-type_name.rs
@@ -1,0 +1,11 @@
+// run-pass
+
+#![feature(const_generics)]
+//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+
+#[derive(Debug)]
+struct S<const N: usize>;
+
+fn main() {
+    assert_eq!(std::any::type_name::<S<3>>(), "const_generic_type_name::S<3usize>");
+}

--- a/src/test/ui/const-generics/const-generic-type_name.stderr
+++ b/src/test/ui/const-generics/const-generic-type_name.stderr
@@ -1,0 +1,8 @@
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/const-generic-type_name.rs:3:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/65372.

r? @oli-obk as there may have been a deliberate decision not to in https://github.com/rust-lang/rust/commit/5b9848912a85e28d000602fc2e81bad9c2f2a981#diff-4ed1a72c0bfdf17be769ed520932cd02R80.