### PR TITLE
Enable `-pthread` flag when linking on GNU/Linux

### DIFF
--- a/src/librustc_target/spec/linux_base.rs
+++ b/src/librustc_target/spec/linux_base.rs
@@ -6,6 +6,8 @@ pub fn opts() -> TargetOptions {
     args.insert(
         LinkerFlavor::Gcc,
         vec![
+            // Enable threads support
+            "-pthread".to_string(),
             // We want to be able to strip as much executable code as possible
             // from the linker command line, and this flag indicates to the
             // linker that it can avoid linking in dynamic libraries that don't


### PR DESCRIPTION
Without this, libraries with external C/C++ dependencies may fail with atomic symbols not found on RISC-V targets: https://github.com/rust-lang/rust/issues/62117#issuecomment-573315968
r? @alexcrichton