### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -44,7 +44,7 @@
 // Here we explicitly #[cfg]-out this whole crate when testing. If we don't do
 // this, both the generated test artifact and the linked libtest (which
 // transitively includes libcore) will both define the same set of lang items,
-// and this will cause the E0152 "duplicate lang item found" error. See
+// and this will cause the E0152 "found duplicate lang item" error. See
 // discussion in #50466 for details.
 //
 // This cfg won't affect doc tests.

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -184,7 +184,7 @@ impl LanguageItemCollector<'tcx> {
                         self.tcx.sess,
                         span,
                         E0152,
-                        "duplicate lang item found: `{}`.",
+                        "found duplicate lang item `{}`",
                         name
                     ),
                     None => {
@@ -206,12 +206,12 @@ impl LanguageItemCollector<'tcx> {
                     },
                 };
                 if let Some(span) = self.tcx.hir().span_if_local(original_def_id) {
-                    err.span_note(span, "first defined here.");
+                    err.span_note(span, "first defined here");
                 } else {
                     match self.tcx.extern_crate(original_def_id) {
                         Some(ExternCrate {dependency_of, ..}) => {
                             err.note(&format!(
-                            "first defined in crate `{}` (which `{}` depends on).",
+                            "first defined in crate `{}` (which `{}` depends on)",
                                       self.tcx.crate_name(original_def_id.krate),
                                       self.tcx.crate_name(*dependency_of)));
                         },

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -1156,7 +1156,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 err.span_help(impl_span, "trait impl with same name found");
                 let trait_crate = self.tcx.crate_name(trait_with_same_path.krate);
                 let crate_msg = format!(
-                    "Perhaps two different versions of crate `{}` are being used?",
+                    "perhaps two different versions of crate `{}` are being used?",
                     trait_crate
                 );
                 err.note(&crate_msg);

--- a/src/librustc_ast_passes/feature_gate.rs
+++ b/src/librustc_ast_passes/feature_gate.rs
@@ -440,7 +440,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 self.check_extern(bare_fn_ty.ext);
             }
             ast::TyKind::Never => {
-                gate_feature_post!(&self, never_type, ty.span, "The `!` type is experimental");
+                gate_feature_post!(&self, never_type, ty.span, "the `!` type is experimental");
             }
             _ => {}
         }

--- a/src/librustc_builtin_macros/test.rs
+++ b/src/librustc_builtin_macros/test.rs
@@ -325,7 +325,7 @@ fn should_panic(cx: &ExtCtxt<'_>, i: &ast::Item) -> ShouldPanic {
                              `expected = \"error message\"`",
                         )
                         .note(
-                            "Errors in this attribute were erroneously \
+                            "errors in this attribute were erroneously \
                                 allowed and will become a hard error in a \
                                 future release.",
                         )

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1959,13 +1959,16 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidValue {
                         // return `Bound::Excluded`.  (And we have tests checking that we
                         // handle the attribute correctly.)
                         (Bound::Included(lo), _) if lo > 0 => {
-                            return Some((format!("{} must be non-null", ty), None));
+                            return Some((format!("`{}` must be non-null", ty), None));
                         }
                         (Bound::Included(_), _) | (_, Bound::Included(_))
                             if init == InitKind::Uninit =>
                         {
                             return Some((
-                                format!("{} must be initialized inside its custom valid range", ty),
+                                format!(
+                                    "`{}` must be initialized inside its custom valid range",
+                                    ty,
+                                ),
                                 None,
                             ));
                         }
@@ -1973,7 +1976,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidValue {
                     }
                     // Now, recurse.
                     match adt_def.variants.len() {
-                        0 => Some((format!("0-variant enums have no valid value"), None)),
+                        0 => Some((format!("enums with no variants have no valid value"), None)),
                         1 => {
                             // Struct, or enum with exactly one variant.
                             // Proceed recursively, check all fields.

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -657,7 +657,7 @@ impl EarlyLintPass for AnonymousParameters {
                                 )
                                 .span_suggestion(
                                     arg.pat.span,
-                                    "Try naming the parameter or explicitly \
+                                    "try naming the parameter or explicitly \
                                     ignoring it",
                                     format!("_: {}", ty_snip),
                                     appl,
@@ -1934,21 +1934,21 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidValue {
             use rustc::ty::TyKind::*;
             match ty.kind {
                 // Primitive types that don't like 0 as a value.
-                Ref(..) => Some((format!("References must be non-null"), None)),
+                Ref(..) => Some((format!("references must be non-null"), None)),
                 Adt(..) if ty.is_box() => Some((format!("`Box` must be non-null"), None)),
-                FnPtr(..) => Some((format!("Function pointers must be non-null"), None)),
-                Never => Some((format!("The never type (`!`) has no valid value"), None)),
+                FnPtr(..) => Some((format!("function pointers must be non-null"), None)),
+                Never => Some((format!("the `!` type has no valid value"), None)),
                 RawPtr(tm) if matches!(tm.ty.kind, Dynamic(..)) =>
                 // raw ptr to dyn Trait
                 {
-                    Some((format!("The vtable of a wide raw pointer must be non-null"), None))
+                    Some((format!("the vtable of a wide raw pointer must be non-null"), None))
                 }
                 // Primitive types with other constraints.
                 Bool if init == InitKind::Uninit => {
-                    Some((format!("Booleans must be `true` or `false`"), None))
+                    Some((format!("booleans must be either `true` or `false`"), None))
                 }
                 Char if init == InitKind::Uninit => {
-                    Some((format!("Characters must be a valid unicode codepoint"), None))
+                    Some((format!("characters must be a valid Unicode codepoint"), None))
                 }
                 // Recurse and checks for some compound types.
                 Adt(adt_def, substs) if !adt_def.is_union() => {

--- a/src/librustc_mir/borrow_check/nll.rs
+++ b/src/librustc_mir/borrow_check/nll.rs
@@ -368,7 +368,7 @@ pub(super) fn dump_annotation<'a, 'tcx>(
     // better.
 
     if let Some(closure_region_requirements) = closure_region_requirements {
-        let mut err = tcx.sess.diagnostic().span_note_diag(body.span, "External requirements");
+        let mut err = tcx.sess.diagnostic().span_note_diag(body.span, "external requirements");
 
         regioncx.annotate(tcx, &mut err);
 
@@ -387,7 +387,7 @@ pub(super) fn dump_annotation<'a, 'tcx>(
 
         err.buffer(errors_buffer);
     } else {
-        let mut err = tcx.sess.diagnostic().span_note_diag(body.span, "No external requirements");
+        let mut err = tcx.sess.diagnostic().span_note_diag(body.span, "no external requirements");
         regioncx.annotate(tcx, &mut err);
 
         err.buffer(errors_buffer);

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -651,16 +651,22 @@ pub trait BottomValue {
 
     /// Merges `in_set` into `inout_set`, returning `true` if `inout_set` changed.
     ///
-    /// You usually don't need to override this, since it automatically applies
+    /// It is almost certainly wrong to override this, since it automatically applies
     /// * `inout_set & in_set` if `BOTTOM_VALUE == true`
     /// * `inout_set | in_set` if `BOTTOM_VALUE == false`
     ///
     /// This means that if a bit is not `BOTTOM_VALUE`, it is propagated into all target blocks.
     /// For clarity, the above statement again from a different perspective:
-    /// A block's initial bit value is `!BOTTOM_VALUE` if *any* predecessor block's bit value is
+    /// A bit in the block's entry set is `!BOTTOM_VALUE` if *any* predecessor block's bit value is
     /// `!BOTTOM_VALUE`.
+    ///
     /// There are situations where you want the opposite behaviour: propagate only if *all*
-    /// predecessor blocks's value is `!BOTTOM_VALUE`. In that case you need to
+    /// predecessor blocks's value is `!BOTTOM_VALUE`.
+    /// E.g. if you want to know whether a bit is *definitely* set at a specific location. This
+    /// means that all code paths leading to the location must have set the bit, instead of any
+    /// code path leading there.
+    ///
+    /// If you want this kind of "definitely set" analysis, you need to
     /// 1. Invert `BOTTOM_VALUE`
     /// 2. Reset the `entry_set` in `start_block_effect` to `!BOTTOM_VALUE`
     /// 3. Override `join` to do the opposite from what it's doing now.

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -75,7 +75,7 @@ impl<'tcx> MirPass<'tcx> for ConstProp {
             return;
         }
 
-        // Check if it's even possible to satisy the 'where' clauses
+        // Check if it's even possible to satisfy the 'where' clauses
         // for this item.
         // This branch will never be taken for any normal function.
         // However, it's possible to `#!feature(trivial_bounds)]` to write

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -75,6 +75,31 @@ impl<'tcx> MirPass<'tcx> for ConstProp {
             return;
         }
 
+        // Check if it's even possible to satisy the 'where' clauses
+        // for this item.
+        // This branch will never be taken for any normal function.
+        // However, it's possible to `#!feature(trivial_bounds)]` to write
+        // a function with impossible to satisfy clauses, e.g.:
+        // `fn foo() where String: Copy {}`
+        //
+        // We don't usually need to worry about this kind of case,
+        // since we would get a compilation error if the user tried
+        // to call it. However, since we can do const propagation
+        // even without any calls to the function, we need to make
+        // sure that it even makes sense to try to evaluate the body.
+        // If there are unsatisfiable where clauses, then all bets are
+        // off, and we just give up.
+        if !tcx.substitute_normalize_and_test_predicates((
+            source.def_id(),
+            InternalSubsts::identity_for_item(tcx, source.def_id()),
+        )) {
+            trace!(
+                "ConstProp skipped for item with unsatisfiable predicates: {:?}",
+                source.def_id()
+            );
+            return;
+        }
+
         trace!("ConstProp starting for {:?}", source.def_id());
 
         let dummy_body = &Body::new(

--- a/src/librustc_parse/parser/attr.rs
+++ b/src/librustc_parse/parser/attr.rs
@@ -236,8 +236,8 @@ impl<'a> Parser<'a> {
             self.struct_span_err(lit.span, msg)
                 .help(
                     "instead of using a suffixed literal \
-                                    (1u8, 1.0f32, etc.), use an unsuffixed version \
-                                    (1, 1.0, etc.).",
+                                    (`1u8`, `1.0f32`, etc.), use an unsuffixed version \
+                                    (`1`, `1.0`, etc.)",
                 )
                 .emit()
         }

--- a/src/librustc_parse/parser/mod.rs
+++ b/src/librustc_parse/parser/mod.rs
@@ -2,6 +2,7 @@ pub mod attr;
 mod expr;
 mod item;
 mod module;
+pub use module::{ModulePath, ModulePathSuccess};
 mod pat;
 mod path;
 mod ty;
@@ -117,7 +118,8 @@ pub struct Parser<'a> {
     /// Used to determine the path to externally loaded source files.
     pub(super) directory: Directory<'a>,
     /// `true` to parse sub-modules in other files.
-    pub(super) recurse_into_file_modules: bool,
+    // Public for rustfmt usage.
+    pub recurse_into_file_modules: bool,
     /// Name of the root module this parser originated from. If `None`, then the
     /// name is not known. This does not change while the parser is descending
     /// into modules, and sub-parsers have new values for this name.
@@ -126,7 +128,8 @@ pub struct Parser<'a> {
     token_cursor: TokenCursor,
     desugar_doc_comments: bool,
     /// `true` we should configure out of line modules as we parse.
-    cfg_mods: bool,
+    // Public for rustfmt usage.
+    pub cfg_mods: bool,
     /// This field is used to keep track of how many left angle brackets we have seen. This is
     /// required in order to detect extra leading left angle brackets (`<` characters) and error
     /// appropriately.
@@ -483,7 +486,8 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_ident(&mut self) -> PResult<'a, ast::Ident> {
+    // Public for rustfmt usage.
+    pub fn parse_ident(&mut self) -> PResult<'a, ast::Ident> {
         self.parse_ident_common(true)
     }
 
@@ -540,7 +544,8 @@ impl<'a> Parser<'a> {
 
     /// If the next token is the given keyword, eats it and returns `true`.
     /// Otherwise, returns `false`. An expectation is also added for diagnostics purposes.
-    fn eat_keyword(&mut self, kw: Symbol) -> bool {
+    // Public for rustfmt usage.
+    pub fn eat_keyword(&mut self, kw: Symbol) -> bool {
         if self.check_keyword(kw) {
             self.bump();
             true

--- a/src/librustc_parse/parser/module.rs
+++ b/src/librustc_parse/parser/module.rs
@@ -14,13 +14,15 @@ use syntax::token::{self, TokenKind};
 use std::path::{self, Path, PathBuf};
 
 /// Information about the path to a module.
-pub(super) struct ModulePath {
+// Public for rustfmt usage.
+pub struct ModulePath {
     name: String,
     path_exists: bool,
     pub result: Result<ModulePathSuccess, Error>,
 }
 
-pub(super) struct ModulePathSuccess {
+// Public for rustfmt usage.
+pub struct ModulePathSuccess {
     pub path: PathBuf,
     pub directory_ownership: DirectoryOwnership,
 }
@@ -177,7 +179,8 @@ impl<'a> Parser<'a> {
         }
     }
 
-    pub(super) fn submod_path_from_attr(attrs: &[Attribute], dir_path: &Path) -> Option<PathBuf> {
+    // Public for rustfmt usage.
+    pub fn submod_path_from_attr(attrs: &[Attribute], dir_path: &Path) -> Option<PathBuf> {
         if let Some(s) = attr::first_attr_value_str_by_name(attrs, sym::path) {
             let s = s.as_str();
 
@@ -194,7 +197,8 @@ impl<'a> Parser<'a> {
     }
 
     /// Returns a path to a module.
-    pub(super) fn default_submod_path(
+    // Public for rustfmt usage.
+    pub fn default_submod_path(
         id: ast::Ident,
         relative: Option<ast::Ident>,
         dir_path: &Path,

--- a/src/librustc_parse/parser/pat.rs
+++ b/src/librustc_parse/parser/pat.rs
@@ -209,13 +209,13 @@ impl<'a> Parser<'a> {
         if let Ok(seq_snippet) = self.span_to_snippet(seq_span) {
             err.span_suggestion(
                 seq_span,
-                "try adding parentheses to match on a tuple..",
+                "try adding parentheses to match on a tuple...",
                 format!("({})", seq_snippet),
                 Applicability::MachineApplicable,
             )
             .span_suggestion(
                 seq_span,
-                "..or a vertical bar to match on multiple alternatives",
+                "...or a vertical bar to match on multiple alternatives",
                 format!("{}", seq_snippet.replace(",", " |")),
                 Applicability::MachineApplicable,
             );

--- a/src/librustc_passes/diagnostic_items.rs
+++ b/src/librustc_passes/diagnostic_items.rs
@@ -73,7 +73,7 @@ fn collect_item(
                 )),
             };
             if let Some(span) = tcx.hir().span_if_local(original_def_id) {
-                err.span_note(span, "first defined here.");
+                err.span_note(span, "first defined here");
             } else {
                 err.note(&format!(
                     "first defined in crate `{}`.",

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -963,7 +963,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
                             .session
                             .struct_span_err(
                                 attr.span,
-                                "`macro_use` is not supported on `extern crate self`",
+                                "`#[macro_use]` is not supported on `extern crate self`",
                             )
                             .emit();
                     }
@@ -1054,7 +1054,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
     fn contains_macro_use(&mut self, attrs: &[ast::Attribute]) -> bool {
         for attr in attrs {
             if attr.check_name(sym::macro_escape) {
-                let msg = "macro_escape is a deprecated synonym for macro_use";
+                let msg = "`#[macro_escape]` is a deprecated synonym for `#[macro_use]`";
                 let mut err = self.r.session.struct_span_warn(attr.span, msg);
                 if let ast::AttrStyle::Inner = attr.style {
                     err.help("consider an outer attribute, `#[macro_use]` mod ...").emit();
@@ -1066,7 +1066,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
             }
 
             if !attr.is_word() {
-                self.r.session.span_err(attr.span, "arguments to macro_use are not allowed here");
+                self.r.session.span_err(attr.span, "arguments to `macro_use` are not allowed here");
             }
             return true;
         }

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -1057,7 +1057,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
                 let msg = "`#[macro_escape]` is a deprecated synonym for `#[macro_use]`";
                 let mut err = self.r.session.struct_span_warn(attr.span, msg);
                 if let ast::AttrStyle::Inner = attr.style {
-                    err.help("consider an outer attribute, `#[macro_use]` mod ...").emit();
+                    err.help("try an outer attribute: `#[macro_use]`").emit();
                 } else {
                     err.emit();
                 }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2006,7 +2006,7 @@ impl<'a> Resolver<'a> {
                             continue;
                         }
                     }
-                    let msg = "there are too many initial `super`s.".to_string();
+                    let msg = "there are too many leading `super` keywords".to_string();
                     return PathResult::Failed {
                         span: ident.span,
                         label: msg,

--- a/src/librustc_typeck/check/cast.rs
+++ b/src/librustc_typeck/check/cast.rs
@@ -381,7 +381,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                     if unknown_cast_to { "to" } else { "from" }
                 );
                 err.note(
-                    "The type information given here is insufficient to check whether \
+                    "the type information given here is insufficient to check whether \
                           the pointer cast is valid",
                 );
                 if unknown_cast_to {

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -479,7 +479,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     macro_rules! report_function {
                         ($span:expr, $name:expr) => {
                             err.note(&format!(
-                                "{} is a function, perhaps you wish to call it",
+                                "`{}` is a function, perhaps you wish to call it",
                                 $name
                             ));
                         };

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1664,7 +1664,7 @@ fn check_opaque_for_cycles<'tcx>(
         if let hir::OpaqueTyOrigin::AsyncFn = origin {
             struct_span_err!(tcx.sess, span, E0733, "recursion in an `async fn` requires boxing",)
                 .span_label(span, "recursive `async fn`")
-                .note("a recursive `async fn` must be rewritten to return a boxed `dyn Future`.")
+                .note("a recursive `async fn` must be rewritten to return a boxed `dyn Future`")
                 .emit();
         } else {
             let mut err =

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -542,12 +542,11 @@ h4 > code, h3 > code, .invisible > code {
 }
 
 .content .stability::before {
-	content: '⤶';
-	transform:rotate(90deg);
+	content: '⬑';
 	font-size: 25px;
 	position: absolute;
 	top: -6px;
-	left: -17px;
+	left: -19px;
 }
 
 .content .impl-items .method, .content .impl-items > .type, .impl-items > .associatedconstant {

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -542,11 +542,12 @@ h4 > code, h3 > code, .invisible > code {
 }
 
 .content .stability::before {
-	content: '˪';
-	font-size: 30px;
+	content: '⤶';
+	transform:rotate(90deg);
+	font-size: 25px;
 	position: absolute;
-	top: -9px;
-	left: -13px;
+	top: -6px;
+	left: -17px;
 }
 
 .content .impl-items .method, .content .impl-items > .type, .impl-items > .associatedconstant {

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -105,6 +105,8 @@ pre {
 .content .highlighted.primitive { background-color: #00708a; }
 .content .highlighted.keyword { background-color: #884719; }
 
+.content .stability::before { color: #ccc; }
+
 .content span.enum, .content a.enum, .block a.current.enum { color: #82b089; }
 .content span.struct, .content a.struct, .block a.current.struct { color: #2dbfb8; }
 .content span.type, .content a.type, .block a.current.type { color: #ff7f00; }

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -105,6 +105,8 @@ pre {
 .content .highlighted.primitive { background-color: #9aecff; }
 .content .highlighted.keyword { background-color: #f99650; }
 
+.content .stability::before { color: #ccc; }
+
 .content span.enum, .content a.enum, .block a.current.enum { color: #508157; }
 .content span.struct, .content a.struct, .block a.current.struct { color: #ad448e; }
 .content span.type, .content a.type, .block a.current.type { color: #ba5d00; }

--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -199,7 +199,7 @@ fn default_hook(info: &PanicInfo<'_>) {
                     let _ = writeln!(
                         err,
                         "note: run with `RUST_BACKTRACE=1` \
-                                           environment variable to display a backtrace."
+                                           environment variable to display a backtrace"
                     );
                 }
             }

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -91,7 +91,7 @@ pub fn stderr() -> Option<Box<StderrTerminal>> {
 #[allow(missing_docs)]
 pub mod color {
     /// Number for a terminal color
-    pub type Color = u16;
+    pub type Color = u32;
 
     pub const BLACK: Color = 0;
     pub const RED: Color = 1;

--- a/src/libterm/terminfo/mod.rs
+++ b/src/libterm/terminfo/mod.rs
@@ -24,7 +24,7 @@ pub struct TermInfo {
     /// Map of capability name to boolean value
     pub bools: HashMap<String, bool>,
     /// Map of capability name to numeric value
-    pub numbers: HashMap<String, u16>,
+    pub numbers: HashMap<String, u32>,
     /// Map of capability name to raw (unexpanded) string
     pub strings: HashMap<String, Vec<u8>>,
 }
@@ -129,7 +129,7 @@ fn cap_for_attr(attr: Attr) -> &'static str {
 /// A Terminal that knows how many colors it supports, with a reference to its
 /// parsed Terminfo database record.
 pub struct TerminfoTerminal<T> {
-    num_colors: u16,
+    num_colors: u32,
     out: T,
     ti: TermInfo,
 }

--- a/src/libterm/win.rs
+++ b/src/libterm/win.rs
@@ -89,7 +89,7 @@ fn bits_to_color(bits: u16) -> color::Color {
         _ => unreachable!(),
     };
 
-    color | (bits & 0x8) // copy the hi-intensity bit
+    color | (u32::from(bits) & 0x8) // copy the hi-intensity bit
 }
 
 impl<T: Write + Send + 'static> WinConsole<T> {

--- a/src/test/compile-fail/panic-handler-twice.rs
+++ b/src/test/compile-fail/panic-handler-twice.rs
@@ -10,7 +10,7 @@ use core::panic::PanicInfo;
 
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
-    //~^ error duplicate lang item found: `panic_impl`
+    //~^ ERROR found duplicate lang item `panic_impl`
     loop {}
 }
 

--- a/src/test/run-make-fulldeps/libtest-json/output-default.json
+++ b/src/test/run-make-fulldeps/libtest-json/output-default.json
@@ -2,7 +2,7 @@
 { "type": "test", "event": "started", "name": "a" }
 { "type": "test", "name": "a", "event": "ok" }
 { "type": "test", "event": "started", "name": "b" }
-{ "type": "test", "name": "b", "event": "failed", "stdout": "thread 'main' panicked at 'assertion failed: false', f.rs:9:5\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.\n" }
+{ "type": "test", "name": "b", "event": "failed", "stdout": "thread 'main' panicked at 'assertion failed: false', f.rs:9:5\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\n" }
 { "type": "test", "event": "started", "name": "c" }
 { "type": "test", "name": "c", "event": "ok" }
 { "type": "test", "event": "started", "name": "d" }

--- a/src/test/run-make-fulldeps/libtest-json/output-stdout-success.json
+++ b/src/test/run-make-fulldeps/libtest-json/output-stdout-success.json
@@ -2,7 +2,7 @@
 { "type": "test", "event": "started", "name": "a" }
 { "type": "test", "name": "a", "event": "ok", "stdout": "print from successful test\n" }
 { "type": "test", "event": "started", "name": "b" }
-{ "type": "test", "name": "b", "event": "failed", "stdout": "thread 'main' panicked at 'assertion failed: false', f.rs:9:5\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.\n" }
+{ "type": "test", "name": "b", "event": "failed", "stdout": "thread 'main' panicked at 'assertion failed: false', f.rs:9:5\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\n" }
 { "type": "test", "event": "started", "name": "c" }
 { "type": "test", "name": "c", "event": "ok", "stdout": "thread 'main' panicked at 'assertion failed: false', f.rs:15:5\n" }
 { "type": "test", "event": "started", "name": "d" }

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -27,7 +27,7 @@ stderr:
 stderr 1
 stderr 2
 thread 'main' panicked at 'oh no', $DIR/failed-doctest-output.rs:7:1
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 
 

--- a/src/test/ui/anon-params-deprecated.stderr
+++ b/src/test/ui/anon-params-deprecated.stderr
@@ -2,7 +2,7 @@ warning: anonymous parameters are deprecated and will be removed in the next edi
   --> $DIR/anon-params-deprecated.rs:9:12
    |
 LL |     fn foo(i32);
-   |            ^^^ help: Try naming the parameter or explicitly ignoring it: `_: i32`
+   |            ^^^ help: try naming the parameter or explicitly ignoring it: `_: i32`
    |
 note: lint level defined here
   --> $DIR/anon-params-deprecated.rs:1:9
@@ -16,7 +16,7 @@ warning: anonymous parameters are deprecated and will be removed in the next edi
   --> $DIR/anon-params-deprecated.rs:12:30
    |
 LL |     fn bar_with_default_impl(String, String) {}
-   |                              ^^^^^^ help: Try naming the parameter or explicitly ignoring it: `_: String`
+   |                              ^^^^^^ help: try naming the parameter or explicitly ignoring it: `_: String`
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue #41686 <https://github.com/rust-lang/rust/issues/41686>
@@ -25,7 +25,7 @@ warning: anonymous parameters are deprecated and will be removed in the next edi
   --> $DIR/anon-params-deprecated.rs:12:38
    |
 LL |     fn bar_with_default_impl(String, String) {}
-   |                                      ^^^^^^ help: Try naming the parameter or explicitly ignoring it: `_: String`
+   |                                      ^^^^^^ help: try naming the parameter or explicitly ignoring it: `_: String`
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue #41686 <https://github.com/rust-lang/rust/issues/41686>

--- a/src/test/ui/async-await/mutually-recursive-async-impl-trait-type.stderr
+++ b/src/test/ui/async-await/mutually-recursive-async-impl-trait-type.stderr
@@ -4,7 +4,7 @@ error[E0733]: recursion in an `async fn` requires boxing
 LL | async fn rec_1() {
    |                  ^ recursive `async fn`
    |
-   = note: a recursive `async fn` must be rewritten to return a boxed `dyn Future`.
+   = note: a recursive `async fn` must be rewritten to return a boxed `dyn Future`
 
 error[E0733]: recursion in an `async fn` requires boxing
   --> $DIR/mutually-recursive-async-impl-trait-type.rs:9:18
@@ -12,7 +12,7 @@ error[E0733]: recursion in an `async fn` requires boxing
 LL | async fn rec_2() {
    |                  ^ recursive `async fn`
    |
-   = note: a recursive `async fn` must be rewritten to return a boxed `dyn Future`.
+   = note: a recursive `async fn` must be rewritten to return a boxed `dyn Future`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/async-await/recursive-async-impl-trait-type.stderr
+++ b/src/test/ui/async-await/recursive-async-impl-trait-type.stderr
@@ -4,7 +4,7 @@ error[E0733]: recursion in an `async fn` requires boxing
 LL | async fn recursive_async_function() -> () {
    |                                        ^^ recursive `async fn`
    |
-   = note: a recursive `async fn` must be rewritten to return a boxed `dyn Future`.
+   = note: a recursive `async fn` must be rewritten to return a boxed `dyn Future`
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/validate_uninhabited_zsts.stderr
+++ b/src/test/ui/consts/const-eval/validate_uninhabited_zsts.stderr
@@ -34,7 +34,7 @@ LL |     unsafe { std::mem::transmute(()) }
    |              help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
    = note: `#[warn(invalid_value)]` on by default
-   = note: The never type (`!`) has no valid value
+   = note: the `!` type has no valid value
 
 warning: the type `Empty` does not permit zero-initialization
   --> $DIR/validate_uninhabited_zsts.rs:17:35

--- a/src/test/ui/consts/const-eval/validate_uninhabited_zsts.stderr
+++ b/src/test/ui/consts/const-eval/validate_uninhabited_zsts.stderr
@@ -45,7 +45,7 @@ LL | const BAR: [Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
    |                                   this code causes undefined behavior when executed
    |                                   help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: 0-variant enums have no valid value
+   = note: enums with no variants have no valid value
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/issue-67696-const-prop-ice.rs
+++ b/src/test/ui/consts/issue-67696-const-prop-ice.rs
@@ -1,0 +1,20 @@
+// check-pass
+// compile-flags: --emit=mir,link
+// Checks that we don't ICE due to attempting to run const prop
+// on a function with unsatisifable 'where' clauses
+
+#![allow(unused)]
+
+trait A {
+    fn foo(&self) -> Self where Self: Copy;
+}
+
+impl A for [fn(&())] {
+    fn foo(&self) -> Self where Self: Copy { *(&[] as &[_]) }
+}
+
+impl A for i32 {
+    fn foo(&self) -> Self { 3 }
+}
+
+fn main() {}

--- a/src/test/ui/consts/miri_unleashed/mutable_const2.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_const2.stderr
@@ -11,7 +11,7 @@ LL | const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *m
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 thread 'rustc' panicked at 'no errors encountered even though `delay_span_bug` issued', src/librustc_errors/lib.rs:346:17
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 error: internal compiler error: unexpected panic
 

--- a/src/test/ui/consts/miri_unleashed/mutable_references_ice.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_references_ice.stderr
@@ -7,7 +7,7 @@ LL |     x: &UnsafeCell::new(42),
 thread 'rustc' panicked at 'assertion failed: `(left != right)`
   left: `Const`,
  right: `Const`: UnsafeCells are not allowed behind references in constants. This should have been prevented statically by const qualification. If this were allowed one would be able to change a constant at one use site and other use sites could observe that mutation.', src/librustc_mir/interpret/intern.rs:LL:CC
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 error: internal compiler error: unexpected panic
 

--- a/src/test/ui/deprecation/deprecated-macro_escape-inner.rs
+++ b/src/test/ui/deprecation/deprecated-macro_escape-inner.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 mod foo {
-    #![macro_escape] //~ WARNING macro_escape is a deprecated synonym for macro_use
+    #![macro_escape] //~ WARN `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
 }
 
 fn main() {

--- a/src/test/ui/deprecation/deprecated-macro_escape-inner.stderr
+++ b/src/test/ui/deprecation/deprecated-macro_escape-inner.stderr
@@ -1,4 +1,4 @@
-warning: macro_escape is a deprecated synonym for macro_use
+warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
   --> $DIR/deprecated-macro_escape-inner.rs:4:5
    |
 LL |     #![macro_escape]

--- a/src/test/ui/deprecation/deprecated-macro_escape-inner.stderr
+++ b/src/test/ui/deprecation/deprecated-macro_escape-inner.stderr
@@ -4,5 +4,5 @@ warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
 LL |     #![macro_escape]
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: consider an outer attribute, `#[macro_use]` mod ...
+   = help: try an outer attribute: `#[macro_use]`
 

--- a/src/test/ui/deprecation/deprecated-macro_escape.rs
+++ b/src/test/ui/deprecation/deprecated-macro_escape.rs
@@ -1,8 +1,6 @@
 // run-pass
 
-#[macro_escape] //~ WARNING macro_escape is a deprecated synonym for macro_use
-mod foo {
-}
+#[macro_escape] //~ WARNING `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
+mod foo {}
 
-fn main() {
-}
+fn main() {}

--- a/src/test/ui/deprecation/deprecated-macro_escape.stderr
+++ b/src/test/ui/deprecation/deprecated-macro_escape.stderr
@@ -1,4 +1,4 @@
-warning: macro_escape is a deprecated synonym for macro_use
+warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
   --> $DIR/deprecated-macro_escape.rs:3:1
    |
 LL | #[macro_escape]

--- a/src/test/ui/did_you_mean/issue-48492-tuple-destructure-missing-parens.stderr
+++ b/src/test/ui/did_you_mean/issue-48492-tuple-destructure-missing-parens.stderr
@@ -4,11 +4,11 @@ error: unexpected `,` in pattern
 LL |     while let b1, b2, b3 = reading_frame.next().expect("there should be a start codon") {
    |                 ^
    |
-help: try adding parentheses to match on a tuple..
+help: try adding parentheses to match on a tuple...
    |
 LL |     while let (b1, b2, b3) = reading_frame.next().expect("there should be a start codon") {
    |               ^^^^^^^^^^^^
-help: ..or a vertical bar to match on multiple alternatives
+help: ...or a vertical bar to match on multiple alternatives
    |
 LL |     while let b1 | b2 | b3 = reading_frame.next().expect("there should be a start codon") {
    |               ^^^^^^^^^^^^
@@ -19,11 +19,11 @@ error: unexpected `,` in pattern
 LL |     if let b1, b2, b3 = reading_frame.next().unwrap() {
    |              ^
    |
-help: try adding parentheses to match on a tuple..
+help: try adding parentheses to match on a tuple...
    |
 LL |     if let (b1, b2, b3) = reading_frame.next().unwrap() {
    |            ^^^^^^^^^^^^
-help: ..or a vertical bar to match on multiple alternatives
+help: ...or a vertical bar to match on multiple alternatives
    |
 LL |     if let b1 | b2 | b3 = reading_frame.next().unwrap() {
    |            ^^^^^^^^^^^^
@@ -34,11 +34,11 @@ error: unexpected `,` in pattern
 LL |         Nucleotide::Adenine, Nucleotide::Cytosine, _ => true
    |                            ^
    |
-help: try adding parentheses to match on a tuple..
+help: try adding parentheses to match on a tuple...
    |
 LL |         (Nucleotide::Adenine, Nucleotide::Cytosine, _) => true
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: ..or a vertical bar to match on multiple alternatives
+help: ...or a vertical bar to match on multiple alternatives
    |
 LL |         Nucleotide::Adenine | Nucleotide::Cytosine | _ => true
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -49,11 +49,11 @@ error: unexpected `,` in pattern
 LL |     for x, _barr_body in women.iter().map(|woman| woman.allosomes.clone()) {
    |          ^
    |
-help: try adding parentheses to match on a tuple..
+help: try adding parentheses to match on a tuple...
    |
 LL |     for (x, _barr_body) in women.iter().map(|woman| woman.allosomes.clone()) {
    |         ^^^^^^^^^^^^^^^
-help: ..or a vertical bar to match on multiple alternatives
+help: ...or a vertical bar to match on multiple alternatives
    |
 LL |     for x | _barr_body in women.iter().map(|woman| woman.allosomes.clone()) {
    |         ^^^^^^^^^^^^^^
@@ -64,11 +64,11 @@ error: unexpected `,` in pattern
 LL |     for x, y @ Allosome::Y(_) in men.iter().map(|man| man.allosomes.clone()) {
    |          ^
    |
-help: try adding parentheses to match on a tuple..
+help: try adding parentheses to match on a tuple...
    |
 LL |     for (x, y @ Allosome::Y(_)) in men.iter().map(|man| man.allosomes.clone()) {
    |         ^^^^^^^^^^^^^^^^^^^^^^^
-help: ..or a vertical bar to match on multiple alternatives
+help: ...or a vertical bar to match on multiple alternatives
    |
 LL |     for x | y @ Allosome::Y(_) in men.iter().map(|man| man.allosomes.clone()) {
    |         ^^^^^^^^^^^^^^^^^^^^^^
@@ -79,11 +79,11 @@ error: unexpected `,` in pattern
 LL |     let women, men: (Vec<Genome>, Vec<Genome>) = genomes.iter().cloned()
    |              ^
    |
-help: try adding parentheses to match on a tuple..
+help: try adding parentheses to match on a tuple...
    |
 LL |     let (women, men): (Vec<Genome>, Vec<Genome>) = genomes.iter().cloned()
    |         ^^^^^^^^^^^^
-help: ..or a vertical bar to match on multiple alternatives
+help: ...or a vertical bar to match on multiple alternatives
    |
 LL |     let women | men: (Vec<Genome>, Vec<Genome>) = genomes.iter().cloned()
    |         ^^^^^^^^^^^

--- a/src/test/ui/duplicate_entry_error.rs
+++ b/src/test/ui/duplicate_entry_error.rs
@@ -8,7 +8,7 @@ use std::panic::PanicInfo;
 
 #[lang = "panic_impl"]
 fn panic_impl(info: &PanicInfo) -> ! {
-//~^ ERROR: duplicate lang item found: `panic_impl`.
+//~^ ERROR: found duplicate lang item `panic_impl`
     loop {}
 }
 

--- a/src/test/ui/duplicate_entry_error.stderr
+++ b/src/test/ui/duplicate_entry_error.stderr
@@ -1,4 +1,4 @@
-error[E0152]: duplicate lang item found: `panic_impl`.
+error[E0152]: found duplicate lang item `panic_impl`
   --> $DIR/duplicate_entry_error.rs:10:1
    |
 LL | / fn panic_impl(info: &PanicInfo) -> ! {
@@ -7,7 +7,7 @@ LL | |     loop {}
 LL | | }
    | |_^
    |
-   = note: first defined in crate `std` (which `duplicate_entry_error` depends on).
+   = note: first defined in crate `std` (which `duplicate_entry_error` depends on)
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0152.stderr
+++ b/src/test/ui/error-codes/E0152.stderr
@@ -1,10 +1,10 @@
-error[E0152]: duplicate lang item found: `arc`.
+error[E0152]: found duplicate lang item `arc`
   --> $DIR/E0152.rs:4:1
    |
 LL | struct Foo;
    | ^^^^^^^^^^^
    |
-   = note: first defined in crate `alloc` (which `std` depends on).
+   = note: first defined in crate `alloc` (which `std` depends on)
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.rs
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.rs
@@ -464,10 +464,10 @@ mod reexport_test_harness_main {
 
 // Cannot feed "2700" to `#[macro_escape]` without signaling an error.
 #[macro_escape]
-//~^ WARN macro_escape is a deprecated synonym for macro_use
+//~^ WARN `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
 mod macro_escape {
     mod inner { #![macro_escape] }
-    //~^ WARN macro_escape is a deprecated synonym for macro_use
+    //~^ WARN `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
 
     #[macro_escape] fn f() { }
     //~^ WARN unused attribute

--- a/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.stderr
@@ -172,13 +172,13 @@ warning: unknown lint: `x5100`
 LL |     #[deny(x5100)] impl S { }
    |            ^^^^^
 
-warning: macro_escape is a deprecated synonym for macro_use
+warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:466:1
    |
 LL | #[macro_escape]
    | ^^^^^^^^^^^^^^^
 
-warning: macro_escape is a deprecated synonym for macro_use
+warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:469:17
    |
 LL |     mod inner { #![macro_escape] }

--- a/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.stderr
@@ -184,7 +184,7 @@ warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
 LL |     mod inner { #![macro_escape] }
    |                 ^^^^^^^^^^^^^^^^
    |
-   = help: consider an outer attribute, `#[macro_use]` mod ...
+   = help: try an outer attribute: `#[macro_use]`
 
 warning: use of deprecated attribute `plugin_registrar`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:221:17

--- a/src/test/ui/feature-gate/issue-43106-gating-of-macro_escape.rs
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-macro_escape.rs
@@ -6,6 +6,6 @@
 // check-pass
 
 #![macro_escape]
-//~^ WARN macro_escape is a deprecated synonym for macro_use
+//~^ WARN `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
 
 fn main() {}

--- a/src/test/ui/feature-gate/issue-43106-gating-of-macro_escape.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-macro_escape.stderr
@@ -4,5 +4,5 @@ warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
 LL | #![macro_escape]
    | ^^^^^^^^^^^^^^^^
    |
-   = help: consider an outer attribute, `#[macro_use]` mod ...
+   = help: try an outer attribute: `#[macro_use]`
 

--- a/src/test/ui/feature-gate/issue-43106-gating-of-macro_escape.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-macro_escape.stderr
@@ -1,4 +1,4 @@
-warning: macro_escape is a deprecated synonym for macro_use
+warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
   --> $DIR/issue-43106-gating-of-macro_escape.rs:8:1
    |
 LL | #![macro_escape]

--- a/src/test/ui/feature-gate/issue-43106-gating-of-macro_use.rs
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-macro_use.rs
@@ -4,13 +4,13 @@
 // get that warning; see issue-43106-gating-of-builtin-attrs.rs
 
 #![macro_use(my_macro)]
-//~^ ERROR arguments to macro_use are not allowed here
+//~^ ERROR arguments to `macro_use` are not allowed here
 
 #[macro_use(my_macro)]
-//~^ ERROR arguments to macro_use are not allowed here
+//~^ ERROR arguments to `macro_use` are not allowed here
 mod macro_escape {
     mod inner { #![macro_use(my_macro)] }
-    //~^ ERROR arguments to macro_use are not allowed here
+    //~^ ERROR arguments to `macro_use` are not allowed here
 
     #[macro_use = "2700"] struct S;
     //~^ ERROR malformed `macro_use` attribute

--- a/src/test/ui/feature-gate/issue-43106-gating-of-macro_use.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-macro_use.stderr
@@ -1,16 +1,16 @@
-error: arguments to macro_use are not allowed here
+error: arguments to `macro_use` are not allowed here
   --> $DIR/issue-43106-gating-of-macro_use.rs:6:1
    |
 LL | #![macro_use(my_macro)]
    | ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: arguments to macro_use are not allowed here
+error: arguments to `macro_use` are not allowed here
   --> $DIR/issue-43106-gating-of-macro_use.rs:9:1
    |
 LL | #[macro_use(my_macro)]
    | ^^^^^^^^^^^^^^^^^^^^^^
 
-error: arguments to macro_use are not allowed here
+error: arguments to `macro_use` are not allowed here
   --> $DIR/issue-43106-gating-of-macro_use.rs:12:17
    |
 LL |     mod inner { #![macro_use(my_macro)] }

--- a/src/test/ui/feature-gates/feature-gate-never_type.stderr
+++ b/src/test/ui/feature-gates/feature-gate-never_type.stderr
@@ -1,4 +1,4 @@
-error[E0658]: The `!` type is experimental
+error[E0658]: the `!` type is experimental
   --> $DIR/feature-gate-never_type.rs:7:17
    |
 LL | type Ma = (u32, !, i32);
@@ -7,7 +7,7 @@ LL | type Ma = (u32, !, i32);
    = note: for more information, see https://github.com/rust-lang/rust/issues/35121
    = help: add `#![feature(never_type)]` to the crate attributes to enable
 
-error[E0658]: The `!` type is experimental
+error[E0658]: the `!` type is experimental
   --> $DIR/feature-gate-never_type.rs:8:20
    |
 LL | type Meeshka = Vec<!>;
@@ -16,7 +16,7 @@ LL | type Meeshka = Vec<!>;
    = note: for more information, see https://github.com/rust-lang/rust/issues/35121
    = help: add `#![feature(never_type)]` to the crate attributes to enable
 
-error[E0658]: The `!` type is experimental
+error[E0658]: the `!` type is experimental
   --> $DIR/feature-gate-never_type.rs:9:24
    |
 LL | type Mow = &'static fn(!) -> !;
@@ -25,7 +25,7 @@ LL | type Mow = &'static fn(!) -> !;
    = note: for more information, see https://github.com/rust-lang/rust/issues/35121
    = help: add `#![feature(never_type)]` to the crate attributes to enable
 
-error[E0658]: The `!` type is experimental
+error[E0658]: the `!` type is experimental
   --> $DIR/feature-gate-never_type.rs:10:27
    |
 LL | type Skwoz = &'static mut !;
@@ -34,7 +34,7 @@ LL | type Skwoz = &'static mut !;
    = note: for more information, see https://github.com/rust-lang/rust/issues/35121
    = help: add `#![feature(never_type)]` to the crate attributes to enable
 
-error[E0658]: The `!` type is experimental
+error[E0658]: the `!` type is experimental
   --> $DIR/feature-gate-never_type.rs:13:16
    |
 LL |     type Wub = !;

--- a/src/test/ui/future-incompatible-lint-group.stderr
+++ b/src/test/ui/future-incompatible-lint-group.stderr
@@ -2,7 +2,7 @@ error: anonymous parameters are deprecated and will be removed in the next editi
   --> $DIR/future-incompatible-lint-group.rs:4:10
    |
 LL |     fn f(u8) {}
-   |          ^^ help: Try naming the parameter or explicitly ignoring it: `_: u8`
+   |          ^^ help: try naming the parameter or explicitly ignoring it: `_: u8`
    |
 note: lint level defined here
   --> $DIR/future-incompatible-lint-group.rs:1:9

--- a/src/test/ui/imports/extern-crate-self/extern-crate-self-fail.rs
+++ b/src/test/ui/imports/extern-crate-self/extern-crate-self-fail.rs
@@ -1,6 +1,6 @@
 extern crate self; //~ ERROR `extern crate self;` requires renaming
 
-#[macro_use] //~ ERROR `macro_use` is not supported on `extern crate self`
+#[macro_use] //~ ERROR `#[macro_use]` is not supported on `extern crate self`
 extern crate self as foo;
 
 fn main() {}

--- a/src/test/ui/imports/extern-crate-self/extern-crate-self-fail.stderr
+++ b/src/test/ui/imports/extern-crate-self/extern-crate-self-fail.stderr
@@ -4,7 +4,7 @@ error: `extern crate self;` requires renaming
 LL | extern crate self;
    | ^^^^^^^^^^^^^^^^^^ help: try: `extern crate self as name;`
 
-error: `macro_use` is not supported on `extern crate self`
+error: `#[macro_use]` is not supported on `extern crate self`
   --> $DIR/extern-crate-self-fail.rs:3:1
    |
 LL | #[macro_use]

--- a/src/test/ui/issues/issue-29124.stderr
+++ b/src/test/ui/issues/issue-29124.stderr
@@ -4,7 +4,7 @@ error[E0599]: no method named `x` found for fn item `fn() -> Ret {Obj::func}` in
 LL |     Obj::func.x();
    |               ^ method not found in `fn() -> Ret {Obj::func}`
    |
-   = note: Obj::func is a function, perhaps you wish to call it
+   = note: `Obj::func` is a function, perhaps you wish to call it
 
 error[E0599]: no method named `x` found for fn item `fn() -> Ret {func}` in the current scope
   --> $DIR/issue-29124.rs:17:10
@@ -12,7 +12,7 @@ error[E0599]: no method named `x` found for fn item `fn() -> Ret {func}` in the 
 LL |     func.x();
    |          ^ method not found in `fn() -> Ret {func}`
    |
-   = note: func is a function, perhaps you wish to call it
+   = note: `func` is a function, perhaps you wish to call it
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-45730.stderr
+++ b/src/test/ui/issues/issue-45730.stderr
@@ -6,7 +6,7 @@ LL |     let x: *const _ = 0 as _;
    |                            |
    |                            help: consider giving more type information
    |
-   = note: The type information given here is insufficient to check whether the pointer cast is valid
+   = note: the type information given here is insufficient to check whether the pointer cast is valid
 
 error[E0641]: cannot cast to a pointer of an unknown kind
   --> $DIR/issue-45730.rs:5:23
@@ -16,7 +16,7 @@ LL |     let x: *const _ = 0 as *const _;
    |                            |
    |                            help: consider giving more type information
    |
-   = note: The type information given here is insufficient to check whether the pointer cast is valid
+   = note: the type information given here is insufficient to check whether the pointer cast is valid
 
 error[E0641]: cannot cast to a pointer of an unknown kind
   --> $DIR/issue-45730.rs:8:13
@@ -26,7 +26,7 @@ LL |     let x = 0 as *const i32 as *const _ as *mut _;
    |                                            |
    |                                            help: consider giving more type information
    |
-   = note: The type information given here is insufficient to check whether the pointer cast is valid
+   = note: the type information given here is insufficient to check whether the pointer cast is valid
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-57362-1.stderr
+++ b/src/test/ui/issues/issue-57362-1.stderr
@@ -4,7 +4,7 @@ error[E0599]: no method named `f` found for fn pointer `fn(&u8)` in the current 
 LL |     a.f();
    |       ^ method not found in `fn(&u8)`
    |
-   = note: a is a function, perhaps you wish to call it
+   = note: `a` is a function, perhaps you wish to call it
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `f`, perhaps you need to implement it:
            candidate #1: `Trait`

--- a/src/test/ui/keyword/keyword-super-as-identifier.rs
+++ b/src/test/ui/keyword/keyword-super-as-identifier.rs
@@ -1,3 +1,3 @@
 fn main() {
-    let super = 22; //~ ERROR failed to resolve: there are too many initial `super`s
+    let super = 22; //~ ERROR failed to resolve: there are too many leading `super` keywords
 }

--- a/src/test/ui/keyword/keyword-super-as-identifier.stderr
+++ b/src/test/ui/keyword/keyword-super-as-identifier.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: there are too many initial `super`s.
+error[E0433]: failed to resolve: there are too many leading `super` keywords
   --> $DIR/keyword-super-as-identifier.rs:2:9
    |
 LL |     let super = 22;
-   |         ^^^^^ there are too many initial `super`s.
+   |         ^^^^^ there are too many leading `super` keywords
 
 error: aborting due to previous error
 

--- a/src/test/ui/keyword/keyword-super.rs
+++ b/src/test/ui/keyword/keyword-super.rs
@@ -1,3 +1,3 @@
 fn main() {
-    let super: isize; //~ ERROR failed to resolve: there are too many initial `super`s
+    let super: isize; //~ ERROR failed to resolve: there are too many leading `super` keywords
 }

--- a/src/test/ui/keyword/keyword-super.stderr
+++ b/src/test/ui/keyword/keyword-super.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: there are too many initial `super`s.
+error[E0433]: failed to resolve: there are too many leading `super` keywords
   --> $DIR/keyword-super.rs:2:9
    |
 LL |     let super: isize;
-   |         ^^^^^ there are too many initial `super`s.
+   |         ^^^^^ there are too many leading `super` keywords
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/uninitialized-zeroed.stderr
+++ b/src/test/ui/lint/uninitialized-zeroed.stderr
@@ -12,7 +12,7 @@ note: lint level defined here
    |
 LL | #![deny(invalid_value)]
    |         ^^^^^^^^^^^^^
-   = note: References must be non-null
+   = note: references must be non-null
 
 error: the type `&'static T` does not permit being left uninitialized
   --> $DIR/uninitialized-zeroed.rs:30:32
@@ -23,7 +23,7 @@ LL |         let _val: &'static T = mem::uninitialized();
    |                                this code causes undefined behavior when executed
    |                                help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: References must be non-null
+   = note: references must be non-null
 
 error: the type `Wrap<&'static T>` does not permit zero-initialization
   --> $DIR/uninitialized-zeroed.rs:32:38
@@ -34,7 +34,7 @@ LL |         let _val: Wrap<&'static T> = mem::zeroed();
    |                                      this code causes undefined behavior when executed
    |                                      help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-note: References must be non-null (in this struct field)
+note: references must be non-null (in this struct field)
   --> $DIR/uninitialized-zeroed.rs:18:18
    |
 LL | struct Wrap<T> { wrapped: T }
@@ -49,7 +49,7 @@ LL |         let _val: Wrap<&'static T> = mem::uninitialized();
    |                                      this code causes undefined behavior when executed
    |                                      help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-note: References must be non-null (in this struct field)
+note: references must be non-null (in this struct field)
   --> $DIR/uninitialized-zeroed.rs:18:18
    |
 LL | struct Wrap<T> { wrapped: T }
@@ -64,7 +64,7 @@ LL |         let _val: ! = mem::zeroed();
    |                       this code causes undefined behavior when executed
    |                       help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: The never type (`!`) has no valid value
+   = note: the `!` type has no valid value
 
 error: the type `!` does not permit being left uninitialized
   --> $DIR/uninitialized-zeroed.rs:41:23
@@ -75,7 +75,7 @@ LL |         let _val: ! = mem::uninitialized();
    |                       this code causes undefined behavior when executed
    |                       help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: The never type (`!`) has no valid value
+   = note: the `!` type has no valid value
 
 error: the type `(i32, !)` does not permit zero-initialization
   --> $DIR/uninitialized-zeroed.rs:43:30
@@ -86,7 +86,7 @@ LL |         let _val: (i32, !) = mem::zeroed();
    |                              this code causes undefined behavior when executed
    |                              help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: The never type (`!`) has no valid value
+   = note: the `!` type has no valid value
 
 error: the type `(i32, !)` does not permit being left uninitialized
   --> $DIR/uninitialized-zeroed.rs:44:30
@@ -97,7 +97,7 @@ LL |         let _val: (i32, !) = mem::uninitialized();
    |                              this code causes undefined behavior when executed
    |                              help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: The never type (`!`) has no valid value
+   = note: the `!` type has no valid value
 
 error: the type `Void` does not permit zero-initialization
   --> $DIR/uninitialized-zeroed.rs:46:26
@@ -130,7 +130,7 @@ LL |         let _val: &'static i32 = mem::zeroed();
    |                                  this code causes undefined behavior when executed
    |                                  help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: References must be non-null
+   = note: references must be non-null
 
 error: the type `&'static i32` does not permit being left uninitialized
   --> $DIR/uninitialized-zeroed.rs:50:34
@@ -141,7 +141,7 @@ LL |         let _val: &'static i32 = mem::uninitialized();
    |                                  this code causes undefined behavior when executed
    |                                  help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: References must be non-null
+   = note: references must be non-null
 
 error: the type `Ref` does not permit zero-initialization
   --> $DIR/uninitialized-zeroed.rs:52:25
@@ -152,7 +152,7 @@ LL |         let _val: Ref = mem::zeroed();
    |                         this code causes undefined behavior when executed
    |                         help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-note: References must be non-null (in this struct field)
+note: references must be non-null (in this struct field)
   --> $DIR/uninitialized-zeroed.rs:15:12
    |
 LL | struct Ref(&'static i32);
@@ -167,7 +167,7 @@ LL |         let _val: Ref = mem::uninitialized();
    |                         this code causes undefined behavior when executed
    |                         help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-note: References must be non-null (in this struct field)
+note: references must be non-null (in this struct field)
   --> $DIR/uninitialized-zeroed.rs:15:12
    |
 LL | struct Ref(&'static i32);
@@ -182,7 +182,7 @@ LL |         let _val: fn() = mem::zeroed();
    |                          this code causes undefined behavior when executed
    |                          help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: Function pointers must be non-null
+   = note: function pointers must be non-null
 
 error: the type `fn()` does not permit being left uninitialized
   --> $DIR/uninitialized-zeroed.rs:56:26
@@ -193,7 +193,7 @@ LL |         let _val: fn() = mem::uninitialized();
    |                          this code causes undefined behavior when executed
    |                          help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: Function pointers must be non-null
+   = note: function pointers must be non-null
 
 error: the type `Wrap<fn()>` does not permit zero-initialization
   --> $DIR/uninitialized-zeroed.rs:58:32
@@ -204,7 +204,7 @@ LL |         let _val: Wrap<fn()> = mem::zeroed();
    |                                this code causes undefined behavior when executed
    |                                help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-note: Function pointers must be non-null (in this struct field)
+note: function pointers must be non-null (in this struct field)
   --> $DIR/uninitialized-zeroed.rs:18:18
    |
 LL | struct Wrap<T> { wrapped: T }
@@ -219,7 +219,7 @@ LL |         let _val: Wrap<fn()> = mem::uninitialized();
    |                                this code causes undefined behavior when executed
    |                                help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-note: Function pointers must be non-null (in this struct field)
+note: function pointers must be non-null (in this struct field)
   --> $DIR/uninitialized-zeroed.rs:18:18
    |
 LL | struct Wrap<T> { wrapped: T }
@@ -234,7 +234,7 @@ LL |         let _val: WrapEnum<fn()> = mem::zeroed();
    |                                    this code causes undefined behavior when executed
    |                                    help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-note: Function pointers must be non-null (in this enum field)
+note: function pointers must be non-null (in this enum field)
   --> $DIR/uninitialized-zeroed.rs:19:28
    |
 LL | enum WrapEnum<T> { Wrapped(T) }
@@ -249,7 +249,7 @@ LL |         let _val: WrapEnum<fn()> = mem::uninitialized();
    |                                    this code causes undefined behavior when executed
    |                                    help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-note: Function pointers must be non-null (in this enum field)
+note: function pointers must be non-null (in this enum field)
   --> $DIR/uninitialized-zeroed.rs:19:28
    |
 LL | enum WrapEnum<T> { Wrapped(T) }
@@ -264,7 +264,7 @@ LL |         let _val: Wrap<(RefPair, i32)> = mem::zeroed();
    |                                          this code causes undefined behavior when executed
    |                                          help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-note: References must be non-null (in this struct field)
+note: references must be non-null (in this struct field)
   --> $DIR/uninitialized-zeroed.rs:16:16
    |
 LL | struct RefPair((&'static i32, i32));
@@ -279,7 +279,7 @@ LL |         let _val: Wrap<(RefPair, i32)> = mem::uninitialized();
    |                                          this code causes undefined behavior when executed
    |                                          help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-note: References must be non-null (in this struct field)
+note: references must be non-null (in this struct field)
   --> $DIR/uninitialized-zeroed.rs:16:16
    |
 LL | struct RefPair((&'static i32, i32));
@@ -316,7 +316,7 @@ LL |         let _val: *const dyn Send = mem::zeroed();
    |                                     this code causes undefined behavior when executed
    |                                     help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: The vtable of a wide raw pointer must be non-null
+   = note: the vtable of a wide raw pointer must be non-null
 
 error: the type `*const dyn std::marker::Send` does not permit being left uninitialized
   --> $DIR/uninitialized-zeroed.rs:71:37
@@ -327,7 +327,7 @@ LL |         let _val: *const dyn Send = mem::uninitialized();
    |                                     this code causes undefined behavior when executed
    |                                     help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: The vtable of a wide raw pointer must be non-null
+   = note: the vtable of a wide raw pointer must be non-null
 
 error: the type `bool` does not permit being left uninitialized
   --> $DIR/uninitialized-zeroed.rs:75:26
@@ -338,7 +338,7 @@ LL |         let _val: bool = mem::uninitialized();
    |                          this code causes undefined behavior when executed
    |                          help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: Booleans must be `true` or `false`
+   = note: booleans must be either `true` or `false`
 
 error: the type `Wrap<char>` does not permit being left uninitialized
   --> $DIR/uninitialized-zeroed.rs:78:32
@@ -349,7 +349,7 @@ LL |         let _val: Wrap<char> = mem::uninitialized();
    |                                this code causes undefined behavior when executed
    |                                help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-note: Characters must be a valid unicode codepoint (in this struct field)
+note: characters must be a valid Unicode codepoint (in this struct field)
   --> $DIR/uninitialized-zeroed.rs:18:18
    |
 LL | struct Wrap<T> { wrapped: T }
@@ -375,7 +375,7 @@ LL |         let _val: &'static i32 = mem::transmute(0usize);
    |                                  this code causes undefined behavior when executed
    |                                  help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: References must be non-null
+   = note: references must be non-null
 
 error: the type `&'static [i32]` does not permit zero-initialization
   --> $DIR/uninitialized-zeroed.rs:85:36
@@ -386,7 +386,7 @@ LL |         let _val: &'static [i32] = mem::transmute((0usize, 0usize));
    |                                    this code causes undefined behavior when executed
    |                                    help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: References must be non-null
+   = note: references must be non-null
 
 error: the type `std::num::NonZeroU32` does not permit zero-initialization
   --> $DIR/uninitialized-zeroed.rs:86:32
@@ -430,7 +430,7 @@ LL |         let _val: bool = MaybeUninit::uninit().assume_init();
    |                          this code causes undefined behavior when executed
    |                          help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: Booleans must be `true` or `false`
+   = note: booleans must be either `true` or `false`
 
 error: aborting due to 35 previous errors
 

--- a/src/test/ui/lint/uninitialized-zeroed.stderr
+++ b/src/test/ui/lint/uninitialized-zeroed.stderr
@@ -108,7 +108,7 @@ LL |         let _val: Void = mem::zeroed();
    |                          this code causes undefined behavior when executed
    |                          help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: 0-variant enums have no valid value
+   = note: enums with no variants have no valid value
 
 error: the type `Void` does not permit being left uninitialized
   --> $DIR/uninitialized-zeroed.rs:47:26
@@ -119,7 +119,7 @@ LL |         let _val: Void = mem::uninitialized();
    |                          this code causes undefined behavior when executed
    |                          help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: 0-variant enums have no valid value
+   = note: enums with no variants have no valid value
 
 error: the type `&'static i32` does not permit zero-initialization
   --> $DIR/uninitialized-zeroed.rs:49:34
@@ -294,7 +294,7 @@ LL |         let _val: NonNull<i32> = mem::zeroed();
    |                                  this code causes undefined behavior when executed
    |                                  help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: std::ptr::NonNull<i32> must be non-null
+   = note: `std::ptr::NonNull<i32>` must be non-null
 
 error: the type `std::ptr::NonNull<i32>` does not permit being left uninitialized
   --> $DIR/uninitialized-zeroed.rs:68:34
@@ -305,7 +305,7 @@ LL |         let _val: NonNull<i32> = mem::uninitialized();
    |                                  this code causes undefined behavior when executed
    |                                  help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: std::ptr::NonNull<i32> must be non-null
+   = note: `std::ptr::NonNull<i32>` must be non-null
 
 error: the type `*const dyn std::marker::Send` does not permit zero-initialization
   --> $DIR/uninitialized-zeroed.rs:70:37
@@ -364,7 +364,7 @@ LL |         let _val: NonBig = mem::uninitialized();
    |                            this code causes undefined behavior when executed
    |                            help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: NonBig must be initialized inside its custom valid range
+   = note: `NonBig` must be initialized inside its custom valid range
 
 error: the type `&'static i32` does not permit zero-initialization
   --> $DIR/uninitialized-zeroed.rs:84:34
@@ -397,7 +397,7 @@ LL |         let _val: NonZeroU32 = mem::transmute(0);
    |                                this code causes undefined behavior when executed
    |                                help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: std::num::NonZeroU32 must be non-null
+   = note: `std::num::NonZeroU32` must be non-null
 
 error: the type `std::ptr::NonNull<i32>` does not permit zero-initialization
   --> $DIR/uninitialized-zeroed.rs:89:34
@@ -408,7 +408,7 @@ LL |         let _val: NonNull<i32> = MaybeUninit::zeroed().assume_init();
    |                                  this code causes undefined behavior when executed
    |                                  help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: std::ptr::NonNull<i32> must be non-null
+   = note: `std::ptr::NonNull<i32>` must be non-null
 
 error: the type `std::ptr::NonNull<i32>` does not permit being left uninitialized
   --> $DIR/uninitialized-zeroed.rs:90:34
@@ -419,7 +419,7 @@ LL |         let _val: NonNull<i32> = MaybeUninit::uninit().assume_init();
    |                                  this code causes undefined behavior when executed
    |                                  help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: std::ptr::NonNull<i32> must be non-null
+   = note: `std::ptr::NonNull<i32>` must be non-null
 
 error: the type `bool` does not permit being left uninitialized
   --> $DIR/uninitialized-zeroed.rs:91:26

--- a/src/test/ui/malformed/malformed-interpolated.stderr
+++ b/src/test/ui/malformed/malformed-interpolated.stderr
@@ -4,7 +4,7 @@ error: suffixed literals are not allowed in attributes
 LL | check!(0u8);
    |        ^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: unexpected token: `-0`
   --> $DIR/malformed-interpolated.rs:5:25

--- a/src/test/ui/module-macro_use-arguments.rs
+++ b/src/test/ui/module-macro_use-arguments.rs
@@ -1,4 +1,4 @@
-#[macro_use(foo, bar)] //~ ERROR arguments to macro_use are not allowed here
+#[macro_use(foo, bar)] //~ ERROR arguments to `macro_use` are not allowed here
 mod foo {
 }
 

--- a/src/test/ui/module-macro_use-arguments.stderr
+++ b/src/test/ui/module-macro_use-arguments.stderr
@@ -1,4 +1,4 @@
-error: arguments to macro_use are not allowed here
+error: arguments to `macro_use` are not allowed here
   --> $DIR/module-macro_use-arguments.rs:1:1
    |
 LL | #[macro_use(foo, bar)]

--- a/src/test/ui/multi-panic.rs
+++ b/src/test/ui/multi-panic.rs
@@ -10,7 +10,7 @@ fn check_for_no_backtrace(test: std::process::Output) {
 
     assert_eq!(it.next().map(|l| l.starts_with("thread '<unnamed>' panicked at")), Some(true));
     assert_eq!(it.next(), Some("note: run with `RUST_BACKTRACE=1` \
-                                environment variable to display a backtrace."));
+                                environment variable to display a backtrace"));
     assert_eq!(it.next().map(|l| l.starts_with("thread 'main' panicked at")), Some(true));
     assert_eq!(it.next(), None);
 }

--- a/src/test/ui/nll/closure-requirements/escape-argument-callee.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-argument-callee.stderr
@@ -1,4 +1,4 @@
-note: No external requirements
+note: no external requirements
   --> $DIR/escape-argument-callee.rs:26:38
    |
 LL |         let mut closure = expect_sig(|p, y| *p = y);
@@ -18,7 +18,7 @@ LL |         let mut closure = expect_sig(|p, y| *p = y);
    |                                       |  has type `&'1 i32`
    |                                       has type `&'_#2r mut &'2 i32`
 
-note: No external requirements
+note: no external requirements
   --> $DIR/escape-argument-callee.rs:20:1
    |
 LL | / fn test() {

--- a/src/test/ui/nll/closure-requirements/escape-argument.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-argument.stderr
@@ -1,4 +1,4 @@
-note: No external requirements
+note: no external requirements
   --> $DIR/escape-argument.rs:26:38
    |
 LL |         let mut closure = expect_sig(|p, y| *p = y);
@@ -9,7 +9,7 @@ LL |         let mut closure = expect_sig(|p, y| *p = y);
                for<'r, 's> extern "rust-call" fn((&ReLateBound(DebruijnIndex(0), BrNamed('r)) mut &ReLateBound(DebruijnIndex(0), BrNamed('s)) i32, &ReLateBound(DebruijnIndex(0), BrNamed('s)) i32)),
            ]
 
-note: No external requirements
+note: no external requirements
   --> $DIR/escape-argument.rs:20:1
    |
 LL | / fn test() {

--- a/src/test/ui/nll/closure-requirements/escape-upvar-nested.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-upvar-nested.stderr
@@ -1,4 +1,4 @@
-note: External requirements
+note: external requirements
   --> $DIR/escape-upvar-nested.rs:21:32
    |
 LL |             let mut closure1 = || p = &y;
@@ -13,7 +13,7 @@ LL |             let mut closure1 = || p = &y;
    = note: number of external vids: 4
    = note: where '_#1r: '_#3r
 
-note: External requirements
+note: external requirements
   --> $DIR/escape-upvar-nested.rs:20:27
    |
 LL |           let mut closure = || {
@@ -32,7 +32,7 @@ LL | |         };
    = note: number of external vids: 4
    = note: where '_#1r: '_#3r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/escape-upvar-nested.rs:13:1
    |
 LL | / fn test() {

--- a/src/test/ui/nll/closure-requirements/escape-upvar-ref.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-upvar-ref.stderr
@@ -1,4 +1,4 @@
-note: External requirements
+note: external requirements
   --> $DIR/escape-upvar-ref.rs:23:27
    |
 LL |         let mut closure = || p = &y;
@@ -13,7 +13,7 @@ LL |         let mut closure = || p = &y;
    = note: number of external vids: 4
    = note: where '_#1r: '_#3r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/escape-upvar-ref.rs:17:1
    |
 LL | / fn test() {

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-fail-no-postdom.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-fail-no-postdom.stderr
@@ -1,4 +1,4 @@
-note: No external requirements
+note: no external requirements
   --> $DIR/propagate-approximated-fail-no-postdom.rs:43:9
    |
 LL | /         |_outlives1, _outlives2, _outlives3, x, y| {
@@ -27,7 +27,7 @@ LL |         |_outlives1, _outlives2, _outlives3, x, y| {
 LL |             demand_y(x, y, p)
    |             ^^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
 
-note: No external requirements
+note: no external requirements
   --> $DIR/propagate-approximated-fail-no-postdom.rs:38:1
    |
 LL | / fn supply<'a, 'b, 'c>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>, cell_c: Cell<&'c u32>) {

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-ref.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-ref.stderr
@@ -1,4 +1,4 @@
-note: External requirements
+note: external requirements
   --> $DIR/propagate-approximated-ref.rs:43:47
    |
 LL |       establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
@@ -18,7 +18,7 @@ LL | |     });
    = note: number of external vids: 5
    = note: where '_#1r: '_#2r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/propagate-approximated-ref.rs:42:1
    |
 LL | / fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -1,4 +1,4 @@
-note: No external requirements
+note: no external requirements
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:21:15
    |
 LL |       foo(cell, |cell_a, cell_x| {
@@ -23,7 +23,7 @@ LL |     foo(cell, |cell_a, cell_x| {
 LL |         cell_a.set(cell_x.get()); // forces 'x: 'a, error in closure
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ `cell_x` escapes the closure body here
 
-note: No external requirements
+note: no external requirements
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:18:1
    |
 LL | / fn case1() {
@@ -37,7 +37,7 @@ LL | | }
    |
    = note: defining type: case1
 
-note: External requirements
+note: external requirements
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:35:15
    |
 LL |       foo(cell, |cell_a, cell_x| {
@@ -53,7 +53,7 @@ LL | |     })
    = note: number of external vids: 2
    = note: where '_#1r: '_#0r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:28:1
    |
 LL | / fn case2() {

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
@@ -1,4 +1,4 @@
-note: External requirements
+note: external requirements
   --> $DIR/propagate-approximated-shorter-to-static-no-bound.rs:32:47
    |
 LL |       establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
@@ -19,7 +19,7 @@ LL | |     });
    = note: number of external vids: 4
    = note: where '_#1r: '_#0r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/propagate-approximated-shorter-to-static-no-bound.rs:31:1
    |
 LL | / fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
@@ -1,4 +1,4 @@
-note: External requirements
+note: external requirements
   --> $DIR/propagate-approximated-shorter-to-static-wrong-bound.rs:35:47
    |
 LL |       establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
@@ -19,7 +19,7 @@ LL | |     });
    = note: number of external vids: 5
    = note: where '_#1r: '_#0r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/propagate-approximated-shorter-to-static-wrong-bound.rs:34:1
    |
 LL | / fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-val.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-val.stderr
@@ -1,4 +1,4 @@
-note: External requirements
+note: external requirements
   --> $DIR/propagate-approximated-val.rs:36:45
    |
 LL |       establish_relationships(cell_a, cell_b, |outlives1, outlives2, x, y| {
@@ -18,7 +18,7 @@ LL | |     });
    = note: number of external vids: 5
    = note: where '_#1r: '_#2r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/propagate-approximated-val.rs:35:1
    |
 LL | / fn test<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {

--- a/src/test/ui/nll/closure-requirements/propagate-despite-same-free-region.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-despite-same-free-region.stderr
@@ -1,4 +1,4 @@
-note: External requirements
+note: external requirements
   --> $DIR/propagate-despite-same-free-region.rs:42:9
    |
 LL | /         |_outlives1, _outlives2, x, y| {
@@ -16,7 +16,7 @@ LL | |         },
    = note: number of external vids: 4
    = note: where '_#1r: '_#2r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/propagate-despite-same-free-region.rs:39:1
    |
 LL | / fn supply<'a>(cell_a: Cell<&'a u32>) {

--- a/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
@@ -1,4 +1,4 @@
-note: No external requirements
+note: no external requirements
   --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:35:47
    |
 LL |       establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
@@ -27,7 +27,7 @@ LL |         // Only works if 'x: 'y:
 LL |         demand_y(x, y, x.get())
    |         ^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
 
-note: No external requirements
+note: no external requirements
   --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:34:1
    |
 LL | / fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {

--- a/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
@@ -1,4 +1,4 @@
-note: No external requirements
+note: no external requirements
   --> $DIR/propagate-fail-to-approximate-longer-wrong-bounds.rs:39:47
    |
 LL |       establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
@@ -27,7 +27,7 @@ LL |         // Only works if 'x: 'y:
 LL |         demand_y(x, y, x.get())
    |         ^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
 
-note: No external requirements
+note: no external requirements
   --> $DIR/propagate-fail-to-approximate-longer-wrong-bounds.rs:38:1
    |
 LL | / fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {

--- a/src/test/ui/nll/closure-requirements/propagate-from-trait-match.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-from-trait-match.stderr
@@ -1,4 +1,4 @@
-note: External requirements
+note: external requirements
   --> $DIR/propagate-from-trait-match.rs:32:36
    |
 LL |       establish_relationships(value, |value| {
@@ -18,7 +18,7 @@ LL | |     });
    = note: number of external vids: 2
    = note: where T: '_#1r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/propagate-from-trait-match.rs:28:1
    |
 LL | / fn supply<'a, T>(value: T)

--- a/src/test/ui/nll/closure-requirements/return-wrong-bound-region.stderr
+++ b/src/test/ui/nll/closure-requirements/return-wrong-bound-region.stderr
@@ -1,4 +1,4 @@
-note: No external requirements
+note: no external requirements
   --> $DIR/return-wrong-bound-region.rs:11:16
    |
 LL |     expect_sig(|a, b| b); // ought to return `a`
@@ -18,7 +18,7 @@ LL |     expect_sig(|a, b| b); // ought to return `a`
    |                 |  has type `&'1 i32`
    |                 has type `&'2 i32`
 
-note: No external requirements
+note: no external requirements
   --> $DIR/return-wrong-bound-region.rs:10:1
    |
 LL | / fn test() {

--- a/src/test/ui/nll/ty-outlives/projection-no-regions-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-no-regions-closure.stderr
@@ -1,4 +1,4 @@
-note: External requirements
+note: external requirements
   --> $DIR/projection-no-regions-closure.rs:25:23
    |
 LL |     with_signature(x, |mut y| Box::new(y.next()))
@@ -11,7 +11,7 @@ LL |     with_signature(x, |mut y| Box::new(y.next()))
    = note: number of external vids: 3
    = note: where <T as std::iter::Iterator>::Item: '_#2r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-no-regions-closure.rs:21:1
    |
 LL | / fn no_region<'a, T>(x: Box<T>) -> Box<dyn Anything + 'a>
@@ -33,7 +33,7 @@ LL |     with_signature(x, |mut y| Box::new(y.next()))
    |
    = help: consider adding an explicit lifetime bound `<T as std::iter::Iterator>::Item: ReEarlyBound(0, 'a)`...
 
-note: External requirements
+note: external requirements
   --> $DIR/projection-no-regions-closure.rs:34:23
    |
 LL |     with_signature(x, |mut y| Box::new(y.next()))
@@ -46,7 +46,7 @@ LL |     with_signature(x, |mut y| Box::new(y.next()))
    = note: number of external vids: 3
    = note: where <T as std::iter::Iterator>::Item: '_#2r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-no-regions-closure.rs:30:1
    |
 LL | / fn correct_region<'a, T>(x: Box<T>) -> Box<dyn Anything + 'a>
@@ -59,7 +59,7 @@ LL | | }
    |
    = note: defining type: correct_region::<'_#1r, T>
 
-note: External requirements
+note: external requirements
   --> $DIR/projection-no-regions-closure.rs:42:23
    |
 LL |     with_signature(x, |mut y| Box::new(y.next()))
@@ -72,7 +72,7 @@ LL |     with_signature(x, |mut y| Box::new(y.next()))
    = note: number of external vids: 4
    = note: where <T as std::iter::Iterator>::Item: '_#3r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-no-regions-closure.rs:38:1
    |
 LL | / fn wrong_region<'a, 'b, T>(x: Box<T>) -> Box<dyn Anything + 'a>
@@ -94,7 +94,7 @@ LL |     with_signature(x, |mut y| Box::new(y.next()))
    |
    = help: consider adding an explicit lifetime bound `<T as std::iter::Iterator>::Item: ReEarlyBound(0, 'a)`...
 
-note: External requirements
+note: external requirements
   --> $DIR/projection-no-regions-closure.rs:52:23
    |
 LL |     with_signature(x, |mut y| Box::new(y.next()))
@@ -107,7 +107,7 @@ LL |     with_signature(x, |mut y| Box::new(y.next()))
    = note: number of external vids: 4
    = note: where <T as std::iter::Iterator>::Item: '_#3r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-no-regions-closure.rs:47:1
    |
 LL | / fn outlives_region<'a, 'b, T>(x: Box<T>) -> Box<dyn Anything + 'a>

--- a/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
@@ -1,4 +1,4 @@
-note: External requirements
+note: external requirements
   --> $DIR/projection-one-region-closure.rs:45:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -13,7 +13,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: where T: '_#2r
    = note: where '_#1r: '_#2r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-one-region-closure.rs:41:1
    |
 LL | / fn no_relationships_late<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
@@ -48,7 +48,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |
    = help: consider adding the following bound: `'b: 'a`
 
-note: External requirements
+note: external requirements
   --> $DIR/projection-one-region-closure.rs:56:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -62,7 +62,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: where T: '_#3r
    = note: where '_#2r: '_#3r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-one-region-closure.rs:51:1
    |
 LL | / fn no_relationships_early<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
@@ -97,7 +97,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |
    = help: consider adding the following bound: `'b: 'a`
 
-note: External requirements
+note: external requirements
   --> $DIR/projection-one-region-closure.rs:70:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -110,7 +110,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 4
    = note: where <T as Anything<ReClosureBound('_#2r)>>::AssocType: '_#3r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-one-region-closure.rs:62:1
    |
 LL | / fn projection_outlives<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
@@ -124,7 +124,7 @@ LL | | }
    |
    = note: defining type: projection_outlives::<'_#1r, '_#2r, T>
 
-note: External requirements
+note: external requirements
   --> $DIR/projection-one-region-closure.rs:80:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -138,7 +138,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: where T: '_#3r
    = note: where '_#2r: '_#3r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-one-region-closure.rs:74:1
    |
 LL | / fn elements_outlive<'a, 'b, T>(cell: Cell<&'a ()>, t: T)

--- a/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
@@ -1,4 +1,4 @@
-note: External requirements
+note: external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:37:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -12,7 +12,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 4
    = note: where '_#1r: '_#2r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:33:1
    |
 LL | / fn no_relationships_late<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
@@ -39,7 +39,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |
    = help: consider adding the following bound: `'b: 'a`
 
-note: External requirements
+note: external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:47:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -52,7 +52,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 4
    = note: where '_#2r: '_#3r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:42:1
    |
 LL | / fn no_relationships_early<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
@@ -79,7 +79,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |
    = help: consider adding the following bound: `'b: 'a`
 
-note: External requirements
+note: external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:60:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -92,7 +92,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 4
    = note: where <T as Anything<ReClosureBound('_#2r)>>::AssocType: '_#3r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:52:1
    |
 LL | / fn projection_outlives<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
@@ -106,7 +106,7 @@ LL | | }
    |
    = note: defining type: projection_outlives::<'_#1r, '_#2r, T>
 
-note: External requirements
+note: external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:69:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -119,7 +119,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 4
    = note: where '_#2r: '_#3r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:64:1
    |
 LL | / fn elements_outlive<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
@@ -133,7 +133,7 @@ LL | | }
    |
    = note: defining type: elements_outlive::<'_#1r, '_#2r, T>
 
-note: External requirements
+note: external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:81:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -146,7 +146,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 3
    = note: where '_#1r: '_#2r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:73:1
    |
 LL | / fn one_region<'a, T>(cell: Cell<&'a ()>, t: T)

--- a/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.stderr
@@ -1,4 +1,4 @@
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:36:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -10,7 +10,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
            ]
    = note: late-bound region is '_#3r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:32:1
    |
 LL | / fn no_relationships_late<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
@@ -23,7 +23,7 @@ LL | | }
    |
    = note: defining type: no_relationships_late::<'_#1r, T>
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:45:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -34,7 +34,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
            ]
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:40:1
    |
 LL | / fn no_relationships_early<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
@@ -48,7 +48,7 @@ LL | | }
    |
    = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:64:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -59,7 +59,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
            ]
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:49:1
    |
 LL | / fn projection_outlives<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
@@ -73,7 +73,7 @@ LL | | }
    |
    = note: defining type: projection_outlives::<'_#1r, '_#2r, T>
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:73:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -84,7 +84,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
            ]
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:68:1
    |
 LL | / fn elements_outlive<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
@@ -98,7 +98,7 @@ LL | | }
    |
    = note: defining type: elements_outlive::<'_#1r, '_#2r, T>
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:85:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -109,7 +109,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
                extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T)),
            ]
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-one-region-trait-bound-static-closure.rs:77:1
    |
 LL | / fn one_region<'a, T>(cell: Cell<&'a ()>, t: T)

--- a/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
@@ -1,4 +1,4 @@
-note: External requirements
+note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:38:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -12,7 +12,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 5
    = note: where <T as Anything<ReClosureBound('_#1r), ReClosureBound('_#2r)>>::AssocType: '_#3r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:34:1
    |
 LL | / fn no_relationships_late<'a, 'b, 'c, T>(cell: Cell<&'a ()>, t: T)
@@ -34,7 +34,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |
    = help: consider adding an explicit lifetime bound `<T as Anything<'_#5r, '_#6r>>::AssocType: ReFree(DefId(0:17 ~ projection_two_region_trait_bound_closure[317d]::no_relationships_late[0]), BrNamed(DefId(0:18 ~ projection_two_region_trait_bound_closure[317d]::no_relationships_late[0]::'a[0]), 'a))`...
 
-note: External requirements
+note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:48:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -47,7 +47,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 5
    = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#3r)>>::AssocType: '_#4r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:43:1
    |
 LL | / fn no_relationships_early<'a, 'b, 'c, T>(cell: Cell<&'a ()>, t: T)
@@ -69,7 +69,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |
    = help: consider adding an explicit lifetime bound `<T as Anything<'_#6r, '_#7r>>::AssocType: ReEarlyBound(0, 'a)`...
 
-note: External requirements
+note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:61:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -82,7 +82,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 5
    = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#3r)>>::AssocType: '_#4r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:53:1
    |
 LL | / fn projection_outlives<'a, 'b, 'c, T>(cell: Cell<&'a ()>, t: T)
@@ -96,7 +96,7 @@ LL | | }
    |
    = note: defining type: projection_outlives::<'_#1r, '_#2r, '_#3r, T>
 
-note: External requirements
+note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:70:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -109,7 +109,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 5
    = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#3r)>>::AssocType: '_#4r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:65:1
    |
 LL | / fn elements_outlive1<'a, 'b, 'c, T>(cell: Cell<&'a ()>, t: T)
@@ -123,7 +123,7 @@ LL | | }
    |
    = note: defining type: elements_outlive1::<'_#1r, '_#2r, '_#3r, T>
 
-note: External requirements
+note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:79:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -136,7 +136,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 5
    = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#3r)>>::AssocType: '_#4r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:74:1
    |
 LL | / fn elements_outlive2<'a, 'b, 'c, T>(cell: Cell<&'a ()>, t: T)
@@ -150,7 +150,7 @@ LL | | }
    |
    = note: defining type: elements_outlive2::<'_#1r, '_#2r, '_#3r, T>
 
-note: External requirements
+note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:87:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -164,7 +164,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 4
    = note: where <T as Anything<ReClosureBound('_#1r), ReClosureBound('_#1r)>>::AssocType: '_#2r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:83:1
    |
 LL | / fn two_regions<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
@@ -191,7 +191,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |
    = help: consider adding the following bound: `'b: 'a`
 
-note: External requirements
+note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:97:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -204,7 +204,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 4
    = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#2r)>>::AssocType: '_#3r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:92:1
    |
 LL | / fn two_regions_outlive<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
@@ -218,7 +218,7 @@ LL | | }
    |
    = note: defining type: two_regions_outlive::<'_#1r, '_#2r, T>
 
-note: External requirements
+note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:109:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
@@ -231,7 +231,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    = note: number of external vids: 3
    = note: where <T as Anything<ReClosureBound('_#1r), ReClosureBound('_#1r)>>::AssocType: '_#2r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:101:1
    |
 LL | / fn one_region<'a, T>(cell: Cell<&'a ()>, t: T)

--- a/src/test/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
@@ -1,4 +1,4 @@
-note: External requirements
+note: external requirements
   --> $DIR/ty-param-closure-approximate-lower-bound.rs:24:24
    |
 LL |     twice(cell, value, |a, b| invoke(a, b));
@@ -11,7 +11,7 @@ LL |     twice(cell, value, |a, b| invoke(a, b));
    = note: number of external vids: 2
    = note: where T: '_#1r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/ty-param-closure-approximate-lower-bound.rs:22:1
    |
 LL | / fn generic<T>(value: T) {
@@ -22,7 +22,7 @@ LL | | }
    |
    = note: defining type: generic::<T>
 
-note: External requirements
+note: external requirements
   --> $DIR/ty-param-closure-approximate-lower-bound.rs:29:24
    |
 LL |     twice(cell, value, |a, b| invoke(a, b));
@@ -36,7 +36,7 @@ LL |     twice(cell, value, |a, b| invoke(a, b));
    = note: number of external vids: 3
    = note: where T: '_#1r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/ty-param-closure-approximate-lower-bound.rs:28:1
    |
 LL | / fn generic_fail<'a, T>(cell: Cell<&'a ()>, value: T) {

--- a/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
@@ -1,4 +1,4 @@
-note: External requirements
+note: external requirements
   --> $DIR/ty-param-closure-outlives-from-return-type.rs:26:23
    |
 LL |     with_signature(x, |y| y)
@@ -11,7 +11,7 @@ LL |     with_signature(x, |y| y)
    = note: number of external vids: 3
    = note: where T: '_#2r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/ty-param-closure-outlives-from-return-type.rs:15:1
    |
 LL | / fn no_region<'a, T>(x: Box<T>) -> Box<dyn Debug + 'a>

--- a/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
+++ b/src/test/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
@@ -1,4 +1,4 @@
-note: External requirements
+note: external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:27:26
    |
 LL |       with_signature(a, b, |x, y| {
@@ -19,7 +19,7 @@ LL | |     })
    = note: number of external vids: 3
    = note: where T: '_#1r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:26:1
    |
 LL | / fn no_region<'a, T>(a: Cell<&'a ()>, b: T) {
@@ -48,7 +48,7 @@ LL | |     })
    |
    = help: consider adding an explicit lifetime bound `T: ReFree(DefId(0:11 ~ ty_param_closure_outlives_from_where_clause[317d]::no_region[0]), BrNamed(DefId(0:12 ~ ty_param_closure_outlives_from_where_clause[317d]::no_region[0]::'a[0]), 'a))`...
 
-note: External requirements
+note: external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:43:26
    |
 LL |       with_signature(a, b, |x, y| {
@@ -68,7 +68,7 @@ LL | |     })
    = note: number of external vids: 3
    = note: where T: '_#2r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:39:1
    |
 LL | / fn correct_region<'a, T>(a: Cell<&'a ()>, b: T)
@@ -82,7 +82,7 @@ LL | | }
    |
    = note: defining type: correct_region::<'_#1r, T>
 
-note: External requirements
+note: external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:64:26
    |
 LL |       with_signature(a, b, |x, y| {
@@ -101,7 +101,7 @@ LL | |     })
    = note: number of external vids: 4
    = note: where T: '_#2r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:60:1
    |
 LL | / fn wrong_region<'a, 'b, T>(a: Cell<&'a ()>, b: T)
@@ -128,7 +128,7 @@ LL | |     })
    |
    = help: consider adding an explicit lifetime bound `T: ReFree(DefId(0:19 ~ ty_param_closure_outlives_from_where_clause[317d]::wrong_region[0]), BrNamed(DefId(0:20 ~ ty_param_closure_outlives_from_where_clause[317d]::wrong_region[0]::'a[0]), 'a))`...
 
-note: External requirements
+note: external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:77:26
    |
 LL |       with_signature(a, b, |x, y| {
@@ -145,7 +145,7 @@ LL | |     })
    = note: number of external vids: 4
    = note: where T: '_#3r
 
-note: No external requirements
+note: no external requirements
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:72:1
    |
 LL | / fn outlives_region<'a, 'b, T>(a: Cell<&'a ()>, b: T)

--- a/src/test/ui/order-dependent-cast-inference.stderr
+++ b/src/test/ui/order-dependent-cast-inference.stderr
@@ -6,7 +6,7 @@ LL |     let mut y = 0 as *const _;
    |                      |
    |                      help: consider giving more type information
    |
-   = note: The type information given here is insufficient to check whether the pointer cast is valid
+   = note: the type information given here is insufficient to check whether the pointer cast is valid
 
 error: aborting due to previous error
 

--- a/src/test/ui/panic-handler/panic-handler-duplicate.rs
+++ b/src/test/ui/panic-handler/panic-handler-duplicate.rs
@@ -12,6 +12,6 @@ fn panic(info: &PanicInfo) -> ! {
 }
 
 #[lang = "panic_impl"]
-fn panic2(info: &PanicInfo) -> ! { //~ ERROR duplicate lang item found: `panic_impl`.
+fn panic2(info: &PanicInfo) -> ! { //~ ERROR found duplicate lang item `panic_impl`
     loop {}
 }

--- a/src/test/ui/panic-handler/panic-handler-duplicate.stderr
+++ b/src/test/ui/panic-handler/panic-handler-duplicate.stderr
@@ -1,4 +1,4 @@
-error[E0152]: duplicate lang item found: `panic_impl`.
+error[E0152]: found duplicate lang item `panic_impl`
   --> $DIR/panic-handler-duplicate.rs:15:1
    |
 LL | / fn panic2(info: &PanicInfo) -> ! {
@@ -6,7 +6,7 @@ LL | |     loop {}
 LL | | }
    | |_^
    |
-note: first defined here.
+note: first defined here
   --> $DIR/panic-handler-duplicate.rs:10:1
    |
 LL | / fn panic(info: &PanicInfo) -> ! {

--- a/src/test/ui/panic-handler/panic-handler-std.rs
+++ b/src/test/ui/panic-handler/panic-handler-std.rs
@@ -1,4 +1,4 @@
-// error-pattern: duplicate lang item found: `panic_impl`.
+// error-pattern: found duplicate lang item `panic_impl`
 
 
 use std::panic::PanicInfo;

--- a/src/test/ui/panic-handler/panic-handler-std.stderr
+++ b/src/test/ui/panic-handler/panic-handler-std.stderr
@@ -1,4 +1,4 @@
-error[E0152]: duplicate lang item found: `panic_impl`.
+error[E0152]: found duplicate lang item `panic_impl`
   --> $DIR/panic-handler-std.rs:7:1
    |
 LL | / fn panic(info: PanicInfo) -> ! {
@@ -6,7 +6,7 @@ LL | |     loop {}
 LL | | }
    | |_^
    |
-   = note: first defined in crate `std` (which `panic_handler_std` depends on).
+   = note: first defined in crate `std` (which `panic_handler_std` depends on)
 
 error: argument should be `&PanicInfo`
   --> $DIR/panic-handler-std.rs:7:16

--- a/src/test/ui/pattern/const-pat-ice.stderr
+++ b/src/test/ui/pattern/const-pat-ice.stderr
@@ -1,5 +1,5 @@
 thread 'rustc' panicked at 'assertion failed: rows.iter().all(|r| r.len() == v.len())', src/librustc_mir/hair/pattern/_match.rs:LL:CC
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 error: internal compiler error: unexpected panic
 

--- a/src/test/ui/resolve/impl-items-vis-unresolved.rs
+++ b/src/test/ui/resolve/impl-items-vis-unresolved.rs
@@ -18,7 +18,8 @@ mod state {
 pub struct RawFloatState;
 impl RawFloatState {
     perftools_inline! {
-        pub(super) fn new() {} //~ ERROR failed to resolve: there are too many leading `super` keywords
+        pub(super) fn new() {}
+        //~^ ERROR failed to resolve: there are too many leading `super` keywords
     }
 }
 

--- a/src/test/ui/resolve/impl-items-vis-unresolved.rs
+++ b/src/test/ui/resolve/impl-items-vis-unresolved.rs
@@ -18,7 +18,7 @@ mod state {
 pub struct RawFloatState;
 impl RawFloatState {
     perftools_inline! {
-        pub(super) fn new() {} //~ ERROR failed to resolve: there are too many initial `super`s
+        pub(super) fn new() {} //~ ERROR failed to resolve: there are too many leading `super` keywords
     }
 }
 

--- a/src/test/ui/resolve/impl-items-vis-unresolved.stderr
+++ b/src/test/ui/resolve/impl-items-vis-unresolved.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: there are too many initial `super`s.
+error[E0433]: failed to resolve: there are too many leading `super` keywords
   --> $DIR/impl-items-vis-unresolved.rs:21:13
    |
 LL |         pub(super) fn new() {}
-   |             ^^^^^ there are too many initial `super`s.
+   |             ^^^^^ there are too many leading `super` keywords.
 
 error: aborting due to previous error
 

--- a/src/test/ui/resolve/impl-items-vis-unresolved.stderr
+++ b/src/test/ui/resolve/impl-items-vis-unresolved.stderr
@@ -2,7 +2,7 @@ error[E0433]: failed to resolve: there are too many leading `super` keywords
   --> $DIR/impl-items-vis-unresolved.rs:21:13
    |
 LL |         pub(super) fn new() {}
-   |             ^^^^^ there are too many leading `super` keywords.
+   |             ^^^^^ there are too many leading `super` keywords
 
 error: aborting due to previous error
 

--- a/src/test/ui/suffixed-literal-meta.stderr
+++ b/src/test/ui/suffixed-literal-meta.stderr
@@ -4,7 +4,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1usize]
    |                 ^^^^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:5:17
@@ -12,7 +12,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1u8]
    |                 ^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:7:17
@@ -20,7 +20,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1u16]
    |                 ^^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:9:17
@@ -28,7 +28,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1u32]
    |                 ^^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:11:17
@@ -36,7 +36,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1u64]
    |                 ^^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:13:17
@@ -44,7 +44,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1isize]
    |                 ^^^^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:15:17
@@ -52,7 +52,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1i8]
    |                 ^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:17:17
@@ -60,7 +60,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1i16]
    |                 ^^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:19:17
@@ -68,7 +68,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1i32]
    |                 ^^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:21:17
@@ -76,7 +76,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1i64]
    |                 ^^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:23:17
@@ -84,7 +84,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1.0f32]
    |                 ^^^^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:25:17
@@ -92,7 +92,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1.0f64]
    |                 ^^^^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:3:17
@@ -100,7 +100,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1usize]
    |                 ^^^^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:5:17
@@ -108,7 +108,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1u8]
    |                 ^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:7:17
@@ -116,7 +116,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1u16]
    |                 ^^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:9:17
@@ -124,7 +124,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1u32]
    |                 ^^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:11:17
@@ -132,7 +132,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1u64]
    |                 ^^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:13:17
@@ -140,7 +140,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1isize]
    |                 ^^^^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:15:17
@@ -148,7 +148,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1i8]
    |                 ^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:17:17
@@ -156,7 +156,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1i16]
    |                 ^^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:19:17
@@ -164,7 +164,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1i32]
    |                 ^^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:21:17
@@ -172,7 +172,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1i64]
    |                 ^^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:23:17
@@ -180,7 +180,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1.0f32]
    |                 ^^^^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/suffixed-literal-meta.rs:25:17
@@ -188,7 +188,7 @@ error: suffixed literals are not allowed in attributes
 LL | #[rustc_dummy = 1.0f64]
    |                 ^^^^^^
    |
-   = help: instead of using a suffixed literal (1u8, 1.0f32, etc.), use an unsuffixed version (1, 1.0, etc.).
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error: aborting due to 24 previous errors
 

--- a/src/test/ui/super-at-top-level.rs
+++ b/src/test/ui/super-at-top-level.rs
@@ -1,4 +1,4 @@
-use super::f; //~ ERROR there are too many initial `super`s
+use super::f; //~ ERROR there are too many leading `super` keywords
 
 fn main() {
 }

--- a/src/test/ui/super-at-top-level.stderr
+++ b/src/test/ui/super-at-top-level.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: there are too many initial `super`s.
+error[E0433]: failed to resolve: there are too many leading `super` keywords
   --> $DIR/super-at-top-level.rs:1:5
    |
 LL | use super::f;
-   |     ^^^^^ there are too many initial `super`s.
+   |     ^^^^^ there are too many leading `super` keywords
 
 error: aborting due to previous error
 

--- a/src/test/ui/test-attrs/test-should-panic-attr.stderr
+++ b/src/test/ui/test-attrs/test-should-panic-attr.stderr
@@ -4,7 +4,7 @@ warning: argument must be of the form: `expected = "error message"`
 LL | #[should_panic(expected)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: Errors in this attribute were erroneously allowed and will become a hard error in a future release.
+   = note: errors in this attribute were erroneously allowed and will become a hard error in a future release.
 
 warning: argument must be of the form: `expected = "error message"`
   --> $DIR/test-should-panic-attr.rs:18:1
@@ -12,7 +12,7 @@ warning: argument must be of the form: `expected = "error message"`
 LL | #[should_panic(expect)]
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: Errors in this attribute were erroneously allowed and will become a hard error in a future release.
+   = note: errors in this attribute were erroneously allowed and will become a hard error in a future release.
 
 warning: argument must be of the form: `expected = "error message"`
   --> $DIR/test-should-panic-attr.rs:25:1
@@ -20,7 +20,7 @@ warning: argument must be of the form: `expected = "error message"`
 LL | #[should_panic(expected(foo, bar))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: Errors in this attribute were erroneously allowed and will become a hard error in a future release.
+   = note: errors in this attribute were erroneously allowed and will become a hard error in a future release.
 
 warning: argument must be of the form: `expected = "error message"`
   --> $DIR/test-should-panic-attr.rs:32:1
@@ -28,5 +28,5 @@ warning: argument must be of the form: `expected = "error message"`
 LL | #[should_panic(expected = "foo", bar)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: Errors in this attribute were erroneously allowed and will become a hard error in a future release.
+   = note: errors in this attribute were erroneously allowed and will become a hard error in a future release.
 

--- a/src/test/ui/test-panic-abort.run.stdout
+++ b/src/test/ui/test-panic-abort.run.stdout
@@ -18,7 +18,7 @@ testing321
 thread 'main' panicked at 'assertion failed: `(left == right)`
   left: `2`,
  right: `5`', $DIR/test-panic-abort.rs:31:5
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 
 failures:

--- a/src/test/ui/traits/trait-bounds-same-crate-name.rs
+++ b/src/test/ui/traits/trait-bounds-same-crate-name.rs
@@ -31,7 +31,7 @@ fn main() {
         a::try_foo(foo);
         //~^ ERROR E0277
         //~| trait impl with same name found
-        //~| Perhaps two different versions of crate `crate_a2`
+        //~| perhaps two different versions of crate `crate_a2`
 
         // We don't want to see the "version mismatch" help message here
         // because `implements_no_traits` has no impl for `Foo`

--- a/src/test/ui/traits/trait-bounds-same-crate-name.stderr
+++ b/src/test/ui/traits/trait-bounds-same-crate-name.stderr
@@ -14,7 +14,7 @@ help: trait impl with same name found
    |
 LL | impl Bar for Foo {}
    | ^^^^^^^^^^^^^^^^^^^
-   = note: Perhaps two different versions of crate `crate_a2` are being used?
+   = note: perhaps two different versions of crate `crate_a2` are being used?
 
 error[E0277]: the trait bound `main::a::DoesNotImplementTrait: main::a::Bar` is not satisfied
   --> $DIR/trait-bounds-same-crate-name.rs:38:20
@@ -43,7 +43,7 @@ help: trait impl with same name found
    |
 LL | impl Bar for ImplementsWrongTraitConditionally<isize> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: Perhaps two different versions of crate `crate_a2` are being used?
+   = note: perhaps two different versions of crate `crate_a2` are being used?
 
 error[E0277]: the trait bound `main::a::ImplementsTraitForUsize<isize>: main::a::Bar` is not satisfied
   --> $DIR/trait-bounds-same-crate-name.rs:51:20

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-associated-functions.rs
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-associated-functions.rs
@@ -1,4 +1,8 @@
 // run-pass
+// Force mir to be emitted, to ensure that const
+// propagation doesn't ICE on a function
+// with an 'impossible' body. See issue #67696
+// compile-flags: --emit=mir,link
 // Inconsistent bounds with trait implementations
 
 #![feature(trivial_bounds)]

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-associated-functions.rs
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-associated-functions.rs
@@ -1,8 +1,8 @@
-// run-pass
+// check-pass
+// compile-flags: --emit=mir
 // Force mir to be emitted, to ensure that const
 // propagation doesn't ICE on a function
 // with an 'impossible' body. See issue #67696
-// compile-flags: --emit=mir,link
 // Inconsistent bounds with trait implementations
 
 #![feature(trivial_bounds)]

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-associated-functions.rs
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-associated-functions.rs
@@ -1,5 +1,5 @@
 // check-pass
-// compile-flags: --emit=mir
+// compile-flags: --emit=mir,link
 // Force mir to be emitted, to ensure that const
 // propagation doesn't ICE on a function
 // with an 'impossible' body. See issue #67696

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-associated-functions.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-associated-functions.stderr
@@ -1,0 +1,2 @@
+warning: due to multiple output types requested, the explicitly specified output file name will be adapted for each output type
+

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-associated-functions.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-associated-functions.stderr
@@ -1,2 +1,0 @@
-warning: due to multiple output types requested, the explicitly specified output file name will be adapted for each output type
-

--- a/src/test/ui/unboxed-closures/unboxed-closures-static-call-wrong-trait.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-static-call-wrong-trait.stderr
@@ -4,7 +4,7 @@ error[E0599]: no method named `call` found for closure `[closure@$DIR/unboxed-cl
 LL |     mut_.call((0, ));
    |          ^^^^ method not found in `[closure@$DIR/unboxed-closures-static-call-wrong-trait.rs:6:26: 6:31]`
    |
-   = note: mut_ is a function, perhaps you wish to call it
+   = note: `mut_` is a function, perhaps you wish to call it
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #67313 (Document more use cases of dataflow)
 - #67914 (Don't run const propagation on items with inconsistent bounds)
 - #67959 (rustdoc: improve stability mark arrows)
 - #68036 (libterm: parse extended terminfo format)
 - #68096 (Clean up some diagnostics by making them more consistent)
 - #68135 (restore some rustc_parse visibilities for rustfmt)

Failed merges:


r? @ghost