### PR TITLE
Fix system call docs for time::Instant

### DIFF
--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -67,7 +67,7 @@ pub use core::time::Duration;
 /// |:---------:|:--------------------------------------------------------------------:|
 /// | Cloud ABI | [clock_time_get (Monotonic Clock)]                                   |
 /// | SGX       | [`insecure_time` usercall]. More information on [timekeeping in SGX] |
-/// | UNIX      | [clock_time_get (Monotonic Clock)]                                   |
+/// | UNIX      | [clock_gettime (Monotonic Clock)]                                    |
 /// | Darwin    | [mach_absolute_time]                                                 |
 /// | VXWorks   | [clock_gettime (Monotonic Clock)]                                    |
 /// | WASI      | [__wasi_clock_time_get (Monotonic Clock)]                            |


### PR DESCRIPTION
The link for UNIX was pointing to the Cloud ABI docs. It should have been pointing to the `clock_gettime` docs instead. A similar table is repeated in the docs for `SystemTime`, but there the UNIX entry was already correct.

`clock_gettime(CLOCK_MONOTONIC)` is the current implementation: https://github.com/rust-lang/rust/blob/3ebcfa1451cfedc13a07e6353d8ade9742dfdc2a/src/libstd/sys/unix/time.rs#L274
https://github.com/rust-lang/rust/blob/3ebcfa1451cfedc13a07e6353d8ade9742dfdc2a/src/libstd/sys/unix/time.rs#L348-L352

r? @steveklabnik 