### PR TITLE
Add core::ptr::slice_len

### DIFF
--- a/src/libcore/ptr/mod.rs
+++ b/src/libcore/ptr/mod.rs
@@ -281,6 +281,29 @@ pub const fn slice_from_raw_parts_mut<T>(data: *mut T, len: usize) -> *mut [T] {
     unsafe { Repr { raw: FatPtr { data, len } }.rust_mut }
 }
 
+/// Get the length of a raw pointer to a slice without manifesting a reference.
+///
+/// # Examples
+///
+/// ```rust
+/// #![feature(raw_slice_len)]
+/// use std::ptr;
+///
+/// let slice_ptr = 1_usize as *const [(); 64] as *const [()] as *const [u64];
+///
+/// // This is unsound, as slice_ptr is not a pointer to a valid slice:
+/// // assert_eq!((&*slice_ptr).len(), 64);
+///
+/// // This is sound, as it does not create a reference:
+/// assert_eq!(ptr::slice_len(slice_ptr), 64);
+/// ```
+#[inline]
+#[unstable(feature = "raw_slice_len", reason = "recently added", issue = "none")]
+#[rustc_const_unstable(feature = "const_raw_slice_len", issue = "none")]
+pub const fn slice_len<T>(data: *const [T]) -> usize {
+    unsafe { Repr { rust: data }.raw.len }
+}
+
 /// Swaps the values at two mutable locations of the same type, without
 /// deinitializing either.
 ///


### PR DESCRIPTION
Uses a placeholder tracking issue currently. I'll file a tracking issue and update the commit if this is OK'd.

If I'm reading the various issue threads about raw pointer metadata correctly, the validity invariant of pointer metadata is at max that of the metadata type. For slice pointers, the metadata is typed at usize. This means that this function should be sound over all `*const [_]` pointers.

This is doable stably for all but the null-ptr case by casting to `*const [()]` and making that a reference `&[()]`, as `[()]` has an alignment of 1 and a size of 0 no matter its length, so is valid at any location (IIUC). This just exposes a standard way of doing it without having to know to erase the type and that works for potentially-null pointers as well.

cc @rust-lang/wg-unsafe-code-guidelines @RalfJung https://github.com/rust-lang/unsafe-code-guidelines/issues/158#issuecomment-544116013