### PR TITLE
Ensure all iterations in Rayon iterators run in the presence of panics

### DIFF
--- a/src/librustc/hir/map/hir_id_validator.rs
+++ b/src/librustc/hir/map/hir_id_validator.rs
@@ -1,6 +1,6 @@
 use crate::hir::map::Map;
 use rustc_data_structures::fx::FxHashSet;
-use rustc_data_structures::sync::{par_iter, Lock, ParallelIterator};
+use rustc_data_structures::sync::{par_for_each, Lock};
 use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, DefIndex, CRATE_DEF_INDEX};
 use rustc_hir::intravisit;
@@ -12,7 +12,7 @@ pub fn check_crate(hir_map: &Map<'_>) {
 
     let errors = Lock::new(Vec::new());
 
-    par_iter(&hir_map.krate().modules).for_each(|(module_id, _)| {
+    par_for_each(&hir_map.krate().modules, |(module_id, _)| {
         let local_def_id = hir_map.local_def_id(*module_id);
         hir_map.visit_item_likes_in_module(
             local_def_id,

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -30,7 +30,7 @@ use rustc_data_structures::captures::Captures;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
-use rustc_data_structures::sync::{self, par_iter, Lrc, ParallelIterator};
+use rustc_data_structures::sync::{self, par_for_each, Lrc};
 use rustc_hir as hir;
 use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, LocalDefId, CRATE_DEF_INDEX, LOCAL_CRATE};
@@ -2642,8 +2642,9 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     pub fn par_body_owners<F: Fn(DefId) + sync::Sync + sync::Send>(self, f: F) {
-        par_iter(&self.hir().krate().body_ids)
-            .for_each(|&body_id| f(self.hir().body_owner_def_id(body_id)));
+        par_for_each(&self.hir().krate().body_ids, |&body_id| {
+            f(self.hir().body_owner_def_id(body_id))
+        });
     }
 
     pub fn provided_trait_methods(self, id: DefId) -> Vec<AssocItem> {

--- a/src/librustc_data_structures/sync.rs
+++ b/src/librustc_data_structures/sync.rs
@@ -199,11 +199,11 @@ cfg_if! {
             ($($blocks:tt),*) => {
                 // We catch panics here ensuring that all the blocks execute.
                 // This makes behavior consistent with the parallel compiler.
-                let panic = ::rustc_data_structures::sync::Lock::new(None);
+                let panic = $crate::sync::Lock::new(None);
                 $(
-                    ::rustc_data_structures::sync::catch(&panic, || $blocks);
+                    $crate::sync::catch(&panic, || $blocks);
                 )*
-                ::rustc_data_structures::sync::resume(panic);
+                $crate::sync::resume(panic);
             }
         }
 
@@ -383,7 +383,7 @@ cfg_if! {
                 parallel!(impl $fblock [$block, $($c,)*] [$($rest),*])
             };
             (impl $fblock:tt [$($blocks:tt,)*] []) => {
-                ::rustc_data_structures::sync::scope(|s| {
+                $crate::sync::scope(|s| {
                     $(
                         s.spawn(|_| $blocks);
                     )*
@@ -445,7 +445,7 @@ cfg_if! {
         macro_rules! rustc_erase_owner {
             ($v:expr) => {{
                 let v = $v;
-                ::rustc_data_structures::sync::assert_send_val(&v);
+                $crate::sync::assert_send_val(&v);
                 v.erase_send_sync_owner()
             }}
         }

--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -9,7 +9,7 @@ crate use FunctionRetTy::*;
 crate use UnsafeSource::*;
 
 use rustc_data_structures::fx::FxHashSet;
-use rustc_data_structures::sync::{par_for_each_in, Send, Sync};
+use rustc_data_structures::sync::{par_for_each, Send, Sync};
 use rustc_errors::FatalError;
 use rustc_macros::HashStable_Generic;
 use rustc_session::node_id::NodeMap;
@@ -669,17 +669,17 @@ impl Crate<'_> {
     {
         parallel!(
             {
-                par_for_each_in(&self.items, |(_, item)| {
+                par_for_each(&self.items, |(_, item)| {
                     visitor.visit_item(item);
                 });
             },
             {
-                par_for_each_in(&self.trait_items, |(_, trait_item)| {
+                par_for_each(&self.trait_items, |(_, trait_item)| {
                     visitor.visit_trait_item(trait_item);
                 });
             },
             {
-                par_for_each_in(&self.impl_items, |(_, impl_item)| {
+                par_for_each(&self.impl_items, |(_, impl_item)| {
                     visitor.visit_impl_item(impl_item);
                 });
             }

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -21,7 +21,7 @@ use rustc_builtin_macros;
 use rustc_codegen_ssa::back::link::emit_metadata;
 use rustc_codegen_utils::codegen_backend::CodegenBackend;
 use rustc_codegen_utils::link::filename_for_metadata;
-use rustc_data_structures::sync::{par_iter, Lrc, Once, ParallelIterator, WorkerLocal};
+use rustc_data_structures::sync::{par_for_each, Lrc, Once, WorkerLocal};
 use rustc_data_structures::{box_region_allow_access, declare_box_region_type, parallel};
 use rustc_errors::PResult;
 use rustc_expand::base::ExtCtxt;
@@ -786,7 +786,7 @@ fn analysis(tcx: TyCtxt<'_>, cnum: CrateNum) -> Result<()> {
                 sess.time("looking_for_derive_registrar", || proc_macro_decls::find(tcx));
             },
             {
-                par_iter(&tcx.hir().krate().modules).for_each(|(&module, _)| {
+                par_for_each(&tcx.hir().krate().modules, |(&module, _)| {
                     let local_def_id = tcx.hir().local_def_id(module);
                     tcx.ensure().check_mod_loops(local_def_id);
                     tcx.ensure().check_mod_attrs(local_def_id);
@@ -811,7 +811,7 @@ fn analysis(tcx: TyCtxt<'_>, cnum: CrateNum) -> Result<()> {
             },
             {
                 sess.time("liveness_and_intrinsic_checking", || {
-                    par_iter(&tcx.hir().krate().modules).for_each(|(&module, _)| {
+                    par_for_each(&tcx.hir().krate().modules, |(&module, _)| {
                         // this must run before MIR dump, because
                         // "not all control paths return a value" is reported here.
                         //
@@ -879,7 +879,7 @@ fn analysis(tcx: TyCtxt<'_>, cnum: CrateNum) -> Result<()> {
             },
             {
                 sess.time("privacy_checking_modules", || {
-                    par_iter(&tcx.hir().krate().modules).for_each(|(&module, _)| {
+                    par_for_each(&tcx.hir().krate().modules, |(&module, _)| {
                         tcx.ensure().check_mod_privacy(tcx.hir().local_def_id(module));
                     });
                 });

--- a/src/librustc_lint/late.rs
+++ b/src/librustc_lint/late.rs
@@ -17,7 +17,7 @@
 use crate::{passes::LateLintPassObject, LateContext, LateLintPass, LintStore};
 use rustc::hir::map::Map;
 use rustc::ty::{self, TyCtxt};
-use rustc_data_structures::sync::{join, par_iter, ParallelIterator};
+use rustc_data_structures::sync::{join, par_for_each};
 use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_hir::intravisit as hir_visit;
@@ -481,7 +481,7 @@ pub fn check_crate<'tcx, T: for<'a> LateLintPass<'a, 'tcx>>(
         || {
             tcx.sess.time("module_lints", || {
                 // Run per-module lints
-                par_iter(&tcx.hir().krate().modules).for_each(|(&module, _)| {
+                par_for_each(&tcx.hir().krate().modules, |(&module, _)| {
                     tcx.ensure().lint_mod(tcx.hir().local_def_id(module));
                 });
             });

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -189,7 +189,7 @@ use rustc::ty::print::obsolete::DefPathBasedNames;
 use rustc::ty::subst::{InternalSubsts, SubstsRef};
 use rustc::ty::{self, GenericParamDefKind, Instance, Ty, TyCtxt, TypeFoldable};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
-use rustc_data_structures::sync::{par_iter, MTLock, MTRef, ParallelIterator};
+use rustc_data_structures::sync::{par_for_each, MTLock, MTRef};
 use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, DefIdMap, LOCAL_CRATE};
 use rustc_hir::itemlikevisit::ItemLikeVisitor;
@@ -291,7 +291,7 @@ pub fn collect_crate_mono_items(
         let inlining_map: MTRef<'_, _> = &mut inlining_map;
 
         tcx.sess.time("monomorphization_collector_graph_walk", || {
-            par_iter(roots).for_each(|root| {
+            par_for_each(roots, |root| {
                 let mut recursion_depths = DefIdMap::default();
                 collect_items_rec(tcx, root, visited, &mut recursion_depths, inlining_map);
             });

--- a/src/test/ui/privacy/privacy2.stderr
+++ b/src/test/ui/privacy/privacy2.stderr
@@ -12,7 +12,13 @@ LL |     use bar::glob::foo;
 
 error: requires `sized` lang_item
 
-error: aborting due to 3 previous errors
+error: requires `sized` lang_item
+
+error: requires `sized` lang_item
+
+error: requires `sized` lang_item
+
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0432, E0603.
 For more information about an error, try `rustc --explain E0432`.

--- a/src/test/ui/privacy/privacy3.stderr
+++ b/src/test/ui/privacy/privacy3.stderr
@@ -6,6 +6,12 @@ LL |     use bar::gpriv;
 
 error: requires `sized` lang_item
 
-error: aborting due to 2 previous errors
+error: requires `sized` lang_item
+
+error: requires `sized` lang_item
+
+error: requires `sized` lang_item
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0432`.


### PR DESCRIPTION
This ensures that fatal errors cannot non-deterministically hide errors that occur later.

r? @Mark-Simulacrum