### PR TITLE
Fix and simplify the implementation of {f32,f64}::clamp.

### DIFF
--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -1010,14 +1010,7 @@ impl f32 {
     #[inline]
     pub fn clamp(self, min: f32, max: f32) -> f32 {
         assert!(min <= max);
-        let mut x = self;
-        if x < min {
-            x = min;
-        }
-        if x > max {
-            x = max;
-        }
-        x
+        self.min(max).max(min)
     }
 }
 

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -932,14 +932,7 @@ impl f64 {
     #[inline]
     pub fn clamp(self, min: f64, max: f64) -> f64 {
         assert!(min <= max);
-        let mut x = self;
-        if x < min {
-            x = min;
-        }
-        if x > max {
-            x = max;
-        }
-        x
+        self.min(max).max(min)
     }
 
     // Solaris/Illumos requires a wrapper around log, log2, and log10 functions


### PR DESCRIPTION
- Remove mutation. Mutation is not needed here and hence should be
  completely avoided.
- Make branching more explicit. The previous code was depending a lot on
  how the compiler would optimize away the two ifs. This code will
  always discard the second branch if the first triggers.