### PR TITLE
Add a ?Sized bound for box_error conversion

### DIFF
--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -496,7 +496,7 @@ impl Error for char::DecodeUtf16Error {
 }
 
 #[stable(feature = "box_error", since = "1.8.0")]
-impl<T: Error> Error for Box<T> {
+impl<T: Error + ?Sized> Error for Box<T> {
     #[allow(deprecated, deprecated_in_future)]
     fn description(&self) -> &str {
         Error::description(&**self)
@@ -801,5 +801,12 @@ mod tests {
             Ok(..) => panic!("expected error"),
             Err(e) => assert_eq!(*e.downcast::<A>().unwrap(), A),
         }
+    }
+
+    #[test]
+    fn box_dyn_error_is_error() {
+        let x: Box<dyn Error + Send + Sync + 'static> = "hello".into();
+        fn use_error<E: std::error::Error>(x: E) {}
+        use_error(x);
     }
 }


### PR DESCRIPTION
`Box<dyn Error + …>` has lately been gaining in popularity as the error
type in the Rust ecosystem (esp. between people who don’t need anything
more than just type erasure). This type, however is not as full-featured
as some alternatives in the crates ecosystem. Namely, it does not itself
implement `std::error::Error` because the relevant implementation is
lacking the `T: ?Sized` bound relaxation.

Remembering that for trait to be object safe (and thus making it
possible to make a trait object of), its methods must be able to accept
a `Self: ?Sized`. `Self = T` in this instance, and therefore this
relaxation of bounds should not have any stability implications.

TL;DR: This allows code like the following to work:

```rust
fn main() {
    let x: Box<dyn std::error::Error> = std::io::Error::last_os_error().into();
    fn use_error<E: std::error::Error>(x: E) {}
    use_error(x);
}
```