### PR TITLE
Stabilize the debug_map_key_value feature

### DIFF
--- a/src/doc/unstable-book/src/library-features/debug-map-key-value.md
+++ b/src/doc/unstable-book/src/library-features/debug-map-key-value.md
@@ -1,9 +1,0 @@
-# `debug_map_key_value`
-
-The tracking issue for this feature is: [#62482]
-
-[#62482]: https://github.com/rust-lang/rust/issues/62482
-
-------------------------
-
-Add the methods `key` and `value` to `DebugMap` so that an entry can be formatted across multiple calls without additional buffering.

--- a/src/libcore/fmt/builders.rs
+++ b/src/libcore/fmt/builders.rs
@@ -778,7 +778,6 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(debug_map_key_value)]
     /// use std::fmt;
     ///
     /// struct Foo(Vec<(String, i32)>);
@@ -796,7 +795,7 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     ///     "{\"whole\": [(\"A\", 10), (\"B\", 11)]}",
     /// );
     /// ```
-    #[unstable(feature = "debug_map_key_value", reason = "recently added", issue = "62482")]
+    #[stable(feature = "debug_map_key_value", since = "1.42.0")]
     pub fn key(&mut self, key: &dyn fmt::Debug) -> &mut Self {
         self.result = self.result.and_then(|_| {
             assert!(
@@ -843,7 +842,6 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(debug_map_key_value)]
     /// use std::fmt;
     ///
     /// struct Foo(Vec<(String, i32)>);
@@ -861,7 +859,7 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     ///     "{\"whole\": [(\"A\", 10), (\"B\", 11)]}",
     /// );
     /// ```
-    #[unstable(feature = "debug_map_key_value", reason = "recently added", issue = "62482")]
+    #[stable(feature = "debug_map_key_value", since = "1.42.0")]
     pub fn value(&mut self, value: &dyn fmt::Debug) -> &mut Self {
         self.result = self.result.and_then(|_| {
             assert!(self.has_key, "attempted to format a map value before its key");

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -4,7 +4,6 @@
 #![feature(cell_update)]
 #![feature(core_private_bignum)]
 #![feature(core_private_diy_float)]
-#![feature(debug_map_key_value)]
 #![feature(debug_non_exhaustive)]
 #![feature(dec2flt)]
 #![feature(exact_size_is_empty)]


### PR DESCRIPTION
RFC: https://github.com/rust-lang/rfcs/pull/2696
Tracking issue: #62482

Stabilizes the `debug_map_key_value` feature, which covers:

```rust
impl<'a, 'b> DebugMap<'a, 'b> {
    pub fn key(&mut self, key: &dyn fmt::Debug) -> &mut DebugMap<'a, 'b> {}
    pub fn value(&mut self, value: &dyn fmt::Debug) -> &mut DebugMap<'a, 'b> {}
}
```

These methods are small and self-contained, and are used as the basis for the existing `DebugMap::entry` method, so have been used in the wild for the last 6 months or so.