### PR TITLE
Use 3.6 instead of 3.5 in float fract() documentation

### DIFF
--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -131,10 +131,10 @@ impl f32 {
     /// ```
     /// use std::f32;
     ///
-    /// let x = 3.5_f32;
-    /// let y = -3.5_f32;
-    /// let abs_difference_x = (x.fract() - 0.5).abs();
-    /// let abs_difference_y = (y.fract() - (-0.5)).abs();
+    /// let x = 3.6_f32;
+    /// let y = -3.6_f32;
+    /// let abs_difference_x = (x.fract() - 0.6).abs();
+    /// let abs_difference_y = (y.fract() - (-0.6)).abs();
     ///
     /// assert!(abs_difference_x <= f32::EPSILON);
     /// assert!(abs_difference_y <= f32::EPSILON);

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -109,10 +109,10 @@ impl f64 {
     /// # Examples
     ///
     /// ```
-    /// let x = 3.5_f64;
-    /// let y = -3.5_f64;
-    /// let abs_difference_x = (x.fract() - 0.5).abs();
-    /// let abs_difference_y = (y.fract() - (-0.5)).abs();
+    /// let x = 3.6_f64;
+    /// let y = -3.6_f64;
+    /// let abs_difference_x = (x.fract() - 0.6).abs();
+    /// let abs_difference_y = (y.fract() - (-0.6)).abs();
     ///
     /// assert!(abs_difference_x < 1e-10);
     /// assert!(abs_difference_y < 1e-10);


### PR DESCRIPTION
It is not self-explanatory whether the fract() function inverts the fractional part of negative numbers. This change clarifies this possible question (so that it is `.6` not `.4`)