### PR TITLE
Avoid calling tcx.hir().get() on CRATE_HIR_ID

### DIFF
--- a/src/librustc/infer/opaque_types/mod.rs
+++ b/src/librustc/infer/opaque_types/mod.rs
@@ -1219,7 +1219,7 @@ pub fn may_define_opaque_type(tcx: TyCtxt<'_>, def_id: DefId, opaque_hir_id: hir
     let res = hir_id == scope;
     trace!(
         "may_define_opaque_type(def={:?}, opaque_node={:?}) = {}",
-        tcx.hir().get(hir_id),
+        tcx.hir().find(hir_id),
         tcx.hir().get(opaque_hir_id),
         res
     );


### PR DESCRIPTION
This was causing an ICE when enabling trace logging for an unrelated
module, since the arguments to `trace!` ended up getting evaluated