### PR TITLE
Stabilize ptr::slice_from_raw_parts[_mut]

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -104,7 +104,6 @@
 #![feature(ptr_offset_from)]
 #![feature(rustc_attrs)]
 #![feature(receiver_trait)]
-#![feature(slice_from_raw_parts)]
 #![feature(specialization)]
 #![feature(staged_api)]
 #![feature(std_internals)]

--- a/src/libcore/ptr/mod.rs
+++ b/src/libcore/ptr/mod.rs
@@ -252,7 +252,7 @@ pub(crate) struct FatPtr<T> {
 ///
 /// // create a slice pointer when starting out with a pointer to the first element
 /// let x = [5, 6, 7];
-/// let ptr = &x[0] as *const _;
+/// let ptr = x.as_ptr();
 /// let slice = ptr::slice_from_raw_parts(ptr, 3);
 /// assert_eq!(unsafe { &*slice }[2], 7);
 /// ```

--- a/src/libcore/ptr/mod.rs
+++ b/src/libcore/ptr/mod.rs
@@ -248,17 +248,16 @@ pub(crate) struct FatPtr<T> {
 /// # Examples
 ///
 /// ```rust
-/// #![feature(slice_from_raw_parts)]
 /// use std::ptr;
 ///
 /// // create a slice pointer when starting out with a pointer to the first element
-/// let mut x = [5, 6, 7];
-/// let ptr = &mut x[0] as *mut _;
-/// let slice = ptr::slice_from_raw_parts_mut(ptr, 3);
+/// let x = [5, 6, 7];
+/// let ptr = &x[0] as *const _;
+/// let slice = ptr::slice_from_raw_parts(ptr, 3);
 /// assert_eq!(unsafe { &*slice }[2], 7);
 /// ```
 #[inline]
-#[unstable(feature = "slice_from_raw_parts", reason = "recently added", issue = "36925")]
+#[stable(feature = "slice_from_raw_parts", since = "1.42.0")]
 #[rustc_const_unstable(feature = "const_slice_from_raw_parts", issue = "67456")]
 pub const fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {
     unsafe { Repr { raw: FatPtr { data, len } }.rust }
@@ -275,7 +274,7 @@ pub const fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {
 /// [`slice_from_raw_parts`]: fn.slice_from_raw_parts.html
 /// [`from_raw_parts_mut`]: ../../std/slice/fn.from_raw_parts_mut.html
 #[inline]
-#[unstable(feature = "slice_from_raw_parts", reason = "recently added", issue = "36925")]
+#[stable(feature = "slice_from_raw_parts", since = "1.42.0")]
 #[rustc_const_unstable(feature = "const_slice_from_raw_parts", issue = "67456")]
 pub const fn slice_from_raw_parts_mut<T>(data: *mut T, len: usize) -> *mut [T] {
     unsafe { Repr { raw: FatPtr { data, len } }.rust_mut }

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -37,7 +37,6 @@
 #![feature(iter_is_partitioned)]
 #![feature(iter_order_by)]
 #![feature(cmp_min_max_by)]
-#![feature(slice_from_raw_parts)]
 #![feature(const_slice_from_raw_parts)]
 #![feature(const_raw_ptr_deref)]
 


### PR DESCRIPTION
Closes #36925, the tracking issue.
Initial impl: #60667

r? @rust-lang/libs 

In addition to stabilizing, I've adjusted the example of `ptr::slice_from_raw_parts` to use `slice_from_raw_parts` instead of `slice_from_raw_parts_mut`, which was unnecessary for the example as written.