### PR TITLE
Enable leak sanitizer test case

### DIFF
--- a/src/test/run-make-fulldeps/sanitizer-leak/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-leak/Makefile
@@ -1,11 +1,7 @@
 -include ../tools.mk
 
 # needs-sanitizer-support
-# only-linux
-# only-x86_64
-# ignore-test
-# FIXME(#46126) ThinLTO for libstd broke this test
 
 all:
-	$(RUSTC) -C opt-level=1 -g -Z sanitizer=leak -Z print-link-args leak.rs | $(CGREP) rustc_rt.lsan
+	$(RUSTC) -O -Z sanitizer=leak -Z print-link-args leak.rs | $(CGREP) rustc_rt.lsan
 	$(TMPDIR)/leak 2>&1 | $(CGREP) 'detected memory leaks'

--- a/src/test/run-make-fulldeps/sanitizer-leak/leak.rs
+++ b/src/test/run-make-fulldeps/sanitizer-leak/leak.rs
@@ -1,6 +1,13 @@
+#![feature(test)]
+
+use std::hint::black_box;
 use std::mem;
 
 fn main() {
-    let xs = vec![1, 2, 3, 4];
-    mem::forget(xs);
+    for _ in 0..10 {
+        let xs = vec![1, 2, 3];
+        // Prevent compiler from removing the memory allocation.
+        let xs = black_box(xs);
+        mem::forget(xs);
+    }
 }


### PR DESCRIPTION
* Use `black_box` to avoid memory leak removal during optimization.
* Leak multiple objects to make test case more robust.