### PR TITLE
Rollup of 12 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,9 +570,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.22"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f083abf9bb9005a27d2da62706f661245278cb7096da37ab27410eaf60f2c1"
+checksum = "b9975aefa63997ef75ca9cf013ff1bb81487aaa0b622c21053afd3b92979a7af"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,12 +1581,11 @@ dependencies = [
 
 [[package]]
 name = "iovec"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
- "winapi 0.2.8",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,7 @@ dependencies = [
  "serde_json",
  "time",
  "toml",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -3491,6 +3492,7 @@ dependencies = [
  "serialize",
  "smallvec 1.0.0",
  "stable_deref_trait",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -3518,6 +3520,7 @@ dependencies = [
  "rustc_target",
  "serialize",
  "syntax",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -3537,6 +3540,7 @@ dependencies = [
  "term_size",
  "termcolor",
  "unicode-width",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -3647,6 +3651,7 @@ dependencies = [
  "smallvec 1.0.0",
  "syntax",
  "tempfile",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -3715,6 +3720,7 @@ dependencies = [
  "smallvec 1.0.0",
  "stable_deref_trait",
  "syntax",
+ "winapi 0.3.8",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.2.11"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126a1f4078368b163bfdee65fbab072af08a1b374a5551b21e87ade27b1fbf9d"
+checksum = "36aa6e813339d3a063292b77091dfbbb6152ff9006a459895fa5bebed7d34f10"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.38"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96210eec534fc3fbfc0452a63769424eaa80205fda6cea98e5b61cb3d97bcec8"
+checksum = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
 dependencies = [
  "cc",
 ]

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -49,5 +49,9 @@ lazy_static = "1.3.0"
 time = "0.1"
 ignore = "0.4.10"
 
+[target.'cfg(windows)'.dependencies.winapi]
+version = "0.3"
+features = ["fileapi", "ioapiset", "jobapi2", "handleapi", "winioctl"]
+
 [dev-dependencies]
 pretty_assertions = "0.5"

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -230,6 +230,8 @@ impl Step for Llvm {
                 cfg.define("CMAKE_SYSTEM_NAME", "NetBSD");
             } else if target.contains("freebsd") {
                 cfg.define("CMAKE_SYSTEM_NAME", "FreeBSD");
+            } else if target.contains("windows") {
+                cfg.define("CMAKE_SYSTEM_NAME", "Windows");
             }
 
             cfg.define("LLVM_NATIVE_BUILD", builder.llvm_out(builder.config.build).join("build"));

--- a/src/ci/docker/dist-various-2/build-wasi-toolchain.sh
+++ b/src/ci/docker/dist-various-2/build-wasi-toolchain.sh
@@ -12,7 +12,7 @@ export PATH=`pwd`/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-14.04/bin:$PATH
 git clone https://github.com/CraneStation/wasi-libc
 
 cd wasi-libc
-git reset --hard f645f498dfbbbc00a7a97874d33082d3605c3f21
+git reset --hard 1fad33890a5e299027ce0eab7b6ad5260585e347
 make -j$(nproc) INSTALL_DIR=/wasm32-wasi install
 
 cd ..

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1244,12 +1244,15 @@ impl<'a> Formatter<'a> {
             // The sign and prefix goes before the padding if the fill character
             // is zero
             Some(min) if self.sign_aware_zero_pad() => {
-                self.fill = '0';
-                self.align = rt::v1::Alignment::Right;
+                let old_fill = crate::mem::replace(&mut self.fill, '0');
+                let old_align = crate::mem::replace(&mut self.align, rt::v1::Alignment::Right);
                 write_prefix(self, sign, prefix)?;
                 let post_padding = self.padding(min - width, rt::v1::Alignment::Right)?;
                 self.buf.write_str(buf)?;
-                post_padding.write(self.buf)
+                post_padding.write(self.buf)?;
+                self.fill = old_fill;
+                self.align = old_align;
+                Ok(())
             }
             // Otherwise, the sign and prefix goes after the padding
             Some(min) => {

--- a/src/libcore/tests/fmt/mod.rs
+++ b/src/libcore/tests/fmt/mod.rs
@@ -28,3 +28,18 @@ fn test_estimated_capacity() {
     assert_eq!(format_args!("{}, hello!", "World").estimated_capacity(), 0);
     assert_eq!(format_args!("{}. 16-bytes piece", "World").estimated_capacity(), 32);
 }
+
+#[test]
+fn pad_integral_resets() {
+    struct Bar;
+
+    impl core::fmt::Display for Bar {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            "1".fmt(f)?;
+            f.pad_integral(true, "", "5")?;
+            "1".fmt(f)
+        }
+    }
+
+    assert_eq!(format!("{:<03}", Bar), "1  0051  ");
+}

--- a/src/librustc/infer/opaque_types/mod.rs
+++ b/src/librustc/infer/opaque_types/mod.rs
@@ -1219,7 +1219,7 @@ pub fn may_define_opaque_type(tcx: TyCtxt<'_>, def_id: DefId, opaque_hir_id: hir
     let res = hir_id == scope;
     trace!(
         "may_define_opaque_type(def={:?}, opaque_node={:?}) = {}",
-        tcx.hir().get(hir_id),
+        tcx.hir().find(hir_id),
         tcx.hir().get(opaque_hir_id),
         res
     );

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -34,7 +34,6 @@
 #![feature(const_transmute)]
 #![feature(core_intrinsics)]
 #![feature(drain_filter)]
-#![cfg_attr(windows, feature(libc))]
 #![feature(never_type)]
 #![feature(exhaustive_patterns)]
 #![feature(overlapping_marker_traits)]

--- a/src/librustc/mir/mono.rs
+++ b/src/librustc/mir/mono.rs
@@ -1,6 +1,7 @@
 use crate::dep_graph::{DepConstructor, DepNode, WorkProduct, WorkProductId};
 use crate::ich::{Fingerprint, NodeIdHashingMode, StableHashingContext};
 use crate::session::config::OptLevel;
+use crate::traits::TraitQueryMode;
 use crate::ty::print::obsolete::DefPathBasedNames;
 use crate::ty::{subst::InternalSubsts, Instance, InstanceDef, SymbolName, TyCtxt};
 use rustc_data_structures::base_n;
@@ -167,7 +168,9 @@ impl<'tcx> MonoItem<'tcx> {
             MonoItem::GlobalAsm(..) => return true,
         };
 
-        tcx.substitute_normalize_and_test_predicates((def_id, &substs))
+        // We shouldn't encounter any overflow here, so we use TraitQueryMode::Standard\
+        // to report an error if overflow somehow occurs.
+        tcx.substitute_normalize_and_test_predicates((def_id, &substs, TraitQueryMode::Standard))
     }
 
     pub fn to_string(&self, tcx: TyCtxt<'tcx>, debug: bool) -> String {

--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -1141,11 +1141,11 @@ rustc_queries! {
             desc { "normalizing `{:?}`", goal }
         }
 
-        query substitute_normalize_and_test_predicates(key: (DefId, SubstsRef<'tcx>)) -> bool {
+        query substitute_normalize_and_test_predicates(key: (DefId, SubstsRef<'tcx>, traits::TraitQueryMode)) -> bool {
             no_force
             desc { |tcx|
-                "testing substituted normalized predicates:`{}`",
-                tcx.def_path_str(key.0)
+                "testing substituted normalized predicates in mode {:?}:`{}`",
+                key.2, tcx.def_path_str(key.0)
             }
         }
 

--- a/src/librustc/traits/fulfill.rs
+++ b/src/librustc/traits/fulfill.rs
@@ -16,6 +16,7 @@ use super::CodeSelectionError;
 use super::{ConstEvalFailure, Unimplemented};
 use super::{FulfillmentError, FulfillmentErrorCode};
 use super::{ObligationCause, PredicateObligation};
+use crate::traits::TraitQueryMode;
 
 impl<'tcx> ForestObligation for PendingPredicateObligation<'tcx> {
     type Predicate = ty::Predicate<'tcx>;
@@ -62,6 +63,9 @@ pub struct FulfillmentContext<'tcx> {
     // a snapshot (they don't *straddle* a snapshot, so there
     // is no trouble there).
     usable_in_snapshot: bool,
+
+    // The `TraitQueryMode` used when constructing a `SelectionContext`
+    query_mode: TraitQueryMode,
 }
 
 #[derive(Clone, Debug)]
@@ -75,12 +79,26 @@ pub struct PendingPredicateObligation<'tcx> {
 static_assert_size!(PendingPredicateObligation<'_>, 136);
 
 impl<'a, 'tcx> FulfillmentContext<'tcx> {
-    /// Creates a new fulfillment context.
+    /// Creates a new fulfillment context with `TraitQueryMode::Standard`
+    /// You almost always want to use this instead of `with_query_mode`
     pub fn new() -> FulfillmentContext<'tcx> {
         FulfillmentContext {
             predicates: ObligationForest::new(),
             register_region_obligations: true,
             usable_in_snapshot: false,
+            query_mode: TraitQueryMode::Standard,
+        }
+    }
+
+    /// Creates a new fulfillment context with the specified query mode.
+    /// This should only be used when you want to ignore overflow,
+    /// rather than reporting it as an error.
+    pub fn with_query_mode(query_mode: TraitQueryMode) -> FulfillmentContext<'tcx> {
+        FulfillmentContext {
+            predicates: ObligationForest::new(),
+            register_region_obligations: true,
+            usable_in_snapshot: false,
+            query_mode,
         }
     }
 
@@ -89,6 +107,7 @@ impl<'a, 'tcx> FulfillmentContext<'tcx> {
             predicates: ObligationForest::new(),
             register_region_obligations: true,
             usable_in_snapshot: true,
+            query_mode: TraitQueryMode::Standard,
         }
     }
 
@@ -97,6 +116,7 @@ impl<'a, 'tcx> FulfillmentContext<'tcx> {
             predicates: ObligationForest::new(),
             register_region_obligations: false,
             usable_in_snapshot: false,
+            query_mode: TraitQueryMode::Standard,
         }
     }
 
@@ -217,7 +237,7 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentContext<'tcx> {
         &mut self,
         infcx: &InferCtxt<'_, 'tcx>,
     ) -> Result<(), Vec<FulfillmentError<'tcx>>> {
-        let mut selcx = SelectionContext::new(infcx);
+        let mut selcx = SelectionContext::with_query_mode(infcx, self.query_mode);
         self.select(&mut selcx)
     }
 

--- a/src/librustc/ty/query/keys.rs
+++ b/src/librustc/ty/query/keys.rs
@@ -115,6 +115,15 @@ impl<'tcx> Key for (DefId, SubstsRef<'tcx>) {
     }
 }
 
+impl<'tcx> Key for (DefId, SubstsRef<'tcx>, traits::TraitQueryMode) {
+    fn query_crate(&self) -> CrateNum {
+        self.0.krate
+    }
+    fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
+        self.0.default_span(tcx)
+    }
+}
+
 impl<'tcx> Key for (ty::ParamEnv<'tcx>, ty::PolyTraitRef<'tcx>) {
     fn query_crate(&self) -> CrateNum {
         self.1.def_id().krate

--- a/src/librustc_data_structures/Cargo.toml
+++ b/src/librustc_data_structures/Cargo.toml
@@ -31,3 +31,6 @@ measureme = "0.7.1"
 [dependencies.parking_lot]
 version = "0.9"
 features = ["nightly"]
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["fileapi", "psapi"] }

--- a/src/librustc_data_structures/flock.rs
+++ b/src/librustc_data_structures/flock.rs
@@ -87,39 +87,11 @@ cfg_if! {
     } else if #[cfg(windows)] {
         use std::mem;
         use std::os::windows::prelude::*;
-        use std::os::windows::raw::HANDLE;
         use std::fs::{File, OpenOptions};
-        use std::os::raw::{c_ulong, c_int};
 
-        type DWORD = c_ulong;
-        type BOOL = c_int;
-        type ULONG_PTR = usize;
-
-        type LPOVERLAPPED = *mut OVERLAPPED;
-        const LOCKFILE_EXCLUSIVE_LOCK: DWORD = 0x0000_0002;
-        const LOCKFILE_FAIL_IMMEDIATELY: DWORD = 0x0000_0001;
-
-        const FILE_SHARE_DELETE: DWORD = 0x4;
-        const FILE_SHARE_READ: DWORD = 0x1;
-        const FILE_SHARE_WRITE: DWORD = 0x2;
-
-        #[repr(C)]
-        struct OVERLAPPED {
-            Internal: ULONG_PTR,
-            InternalHigh: ULONG_PTR,
-            Offset: DWORD,
-            OffsetHigh: DWORD,
-            hEvent: HANDLE,
-        }
-
-        extern "system" {
-            fn LockFileEx(hFile: HANDLE,
-                          dwFlags: DWORD,
-                          dwReserved: DWORD,
-                          nNumberOfBytesToLockLow: DWORD,
-                          nNumberOfBytesToLockHigh: DWORD,
-                          lpOverlapped: LPOVERLAPPED) -> BOOL;
-        }
+        use winapi::um::minwinbase::{OVERLAPPED, LOCKFILE_FAIL_IMMEDIATELY, LOCKFILE_EXCLUSIVE_LOCK};
+        use winapi::um::fileapi::LockFileEx;
+        use winapi::um::winnt::{FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE};
 
         #[derive(Debug)]
         pub struct Lock {

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -33,9 +33,6 @@ extern crate libc;
 #[macro_use]
 extern crate cfg_if;
 
-#[cfg(windows)]
-extern crate libc;
-
 pub use rustc_serialize::hex::ToHex;
 
 #[inline(never)]

--- a/src/librustc_driver/Cargo.toml
+++ b/src/librustc_driver/Cargo.toml
@@ -32,5 +32,8 @@ rustc_serialize = { path = "../libserialize", package = "serialize" }
 syntax = { path = "../libsyntax" }
 rustc_span = { path = "../librustc_span" }
 
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["consoleapi", "debugapi", "processenv"] }
+
 [features]
 llvm = ['rustc_interface/llvm']

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -515,15 +515,10 @@ fn stdout_isatty() -> bool {
 
 #[cfg(windows)]
 fn stdout_isatty() -> bool {
-    type DWORD = u32;
-    type BOOL = i32;
-    type HANDLE = *mut u8;
-    type LPDWORD = *mut u32;
-    const STD_OUTPUT_HANDLE: DWORD = -11i32 as DWORD;
-    extern "system" {
-        fn GetStdHandle(which: DWORD) -> HANDLE;
-        fn GetConsoleMode(hConsoleHandle: HANDLE, lpMode: LPDWORD) -> BOOL;
-    }
+    use winapi::um::consoleapi::GetConsoleMode;
+    use winapi::um::processenv::GetStdHandle;
+    use winapi::um::winbase::STD_OUTPUT_HANDLE;
+
     unsafe {
         let handle = GetStdHandle(STD_OUTPUT_HANDLE);
         let mut out = 0;
@@ -1215,11 +1210,8 @@ pub fn report_ice(info: &panic::PanicInfo<'_>, bug_report_url: &str) {
     #[cfg(windows)]
     unsafe {
         if env::var("RUSTC_BREAK_ON_ICE").is_ok() {
-            extern "system" {
-                fn DebugBreak();
-            }
             // Trigger a debugger if we crashed during bootstrap
-            DebugBreak();
+            winapi::um::debugapi::DebugBreak();
         }
     }
 }

--- a/src/librustc_error_codes/error_codes/E0170.md
+++ b/src/librustc_error_codes/error_codes/E0170.md
@@ -1,3 +1,24 @@
+A pattern binding is using the same name as one of the variants a type.
+
+Erroneous code example:
+
+```compile_fail,E0170
+# #![deny(warnings)]
+enum Method {
+    GET,
+    POST,
+}
+
+fn is_empty(s: Method) -> bool {
+    match s {
+        GET => true,
+        _ => false
+    }
+}
+
+fn main() {}
+```
+
 Enum variants are qualified by default. For example, given this type:
 
 ```

--- a/src/librustc_error_codes/error_codes/E0170.md
+++ b/src/librustc_error_codes/error_codes/E0170.md
@@ -1,4 +1,4 @@
-A pattern binding is using the same name as one of the variants a type.
+A pattern binding is using the same name as one of the variants of a type.
 
 Erroneous code example:
 

--- a/src/librustc_errors/Cargo.toml
+++ b/src/librustc_errors/Cargo.toml
@@ -19,3 +19,6 @@ atty = "0.2"
 termcolor = "1.0"
 annotate-snippets = "0.6.1"
 term_size = "0.3.1"
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["handleapi", "synchapi", "winbase"] }

--- a/src/librustc_interface/Cargo.toml
+++ b/src/librustc_interface/Cargo.toml
@@ -42,6 +42,9 @@ rustc_resolve = { path = "../librustc_resolve" }
 tempfile = "3.0.5"
 once_cell = "1"
 
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["libloaderapi"] }
+
 [dev-dependencies]
 rustc_target = { path = "../librustc_target" }
 

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -340,19 +340,17 @@ fn sysroot_candidates() -> Vec<PathBuf> {
     fn current_dll_path() -> Option<PathBuf> {
         use std::ffi::OsString;
         use std::os::windows::prelude::*;
+        use std::ptr;
 
-        extern "system" {
-            fn GetModuleHandleExW(dwFlags: u32, lpModuleName: usize, phModule: *mut usize) -> i32;
-            fn GetModuleFileNameW(hModule: usize, lpFilename: *mut u16, nSize: u32) -> u32;
-        }
-
-        const GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS: u32 = 0x00000004;
+        use winapi::um::libloaderapi::{
+            GetModuleFileNameW, GetModuleHandleExW, GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+        };
 
         unsafe {
-            let mut module = 0;
+            let mut module = ptr::null_mut();
             let r = GetModuleHandleExW(
                 GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
-                current_dll_path as usize,
+                current_dll_path as usize as *mut _,
                 &mut module,
             );
             if r == 0 {

--- a/src/librustc_llvm/build.rs
+++ b/src/librustc_llvm/build.rs
@@ -215,12 +215,14 @@ fn main() {
     let mut cmd = Command::new(&llvm_config);
     cmd.arg(llvm_link_arg).arg("--ldflags");
     for lib in output(&mut cmd).split_whitespace() {
-        if lib.starts_with("-LIBPATH:") {
-            println!("cargo:rustc-link-search=native={}", &lib[9..]);
-        } else if is_crossed {
-            if lib.starts_with("-L") {
+        if is_crossed {
+            if lib.starts_with("-LIBPATH:") {
+                println!("cargo:rustc-link-search=native={}", lib[9..].replace(&host, &target));
+            } else if lib.starts_with("-L") {
                 println!("cargo:rustc-link-search=native={}", lib[2..].replace(&host, &target));
             }
+        } else if lib.starts_with("-LIBPATH:") {
+            println!("cargo:rustc-link-search=native={}", &lib[9..]);
         } else if lib.starts_with("-l") {
             println!("cargo:rustc-link-lib={}", &lib[2..]);
         } else if lib.starts_with("-L") {

--- a/src/librustc_metadata/Cargo.toml
+++ b/src/librustc_metadata/Cargo.toml
@@ -27,3 +27,6 @@ rustc_expand = { path = "../librustc_expand" }
 rustc_parse = { path = "../librustc_parse" }
 rustc_span = { path = "../librustc_span" }
 rustc_error_codes = { path = "../librustc_error_codes" }
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["errhandlingapi", "libloaderapi"] }

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -74,7 +74,7 @@ impl<'tcx> MirPass<'tcx> for ConstProp {
             return;
         }
 
-        // Check if it's even possible to satisy the 'where' clauses
+        // Check if it's even possible to satisfy the 'where' clauses
         // for this item.
         // This branch will never be taken for any normal function.
         // However, it's possible to `#!feature(trivial_bounds)]` to write

--- a/src/test/ui/consts/huge-values.rs
+++ b/src/test/ui/consts/huge-values.rs
@@ -1,6 +1,10 @@
 // build-pass
 // ignore-32bit
 
+// This test is a canary test that will essentially not compile in a reasonable time frame
+// (so it'll take hours) if any of the optimizations regress. With the optimizations, these compile
+// in milliseconds just as if the length were set to `1`.
+
 #[derive(Clone, Copy)]
 struct Foo;
 
@@ -8,4 +12,6 @@ fn main() {
     let _ = [(); 4_000_000_000];
     let _ = [0u8; 4_000_000_000];
     let _ = [Foo; 4_000_000_000];
+    let _ = [(Foo, (), Foo, ((), Foo, [0; 0])); 4_000_000_000];
+    let _ = [[0; 0]; 4_000_000_000];
 }

--- a/src/test/ui/consts/issue-67696-const-prop-ice.rs
+++ b/src/test/ui/consts/issue-67696-const-prop-ice.rs
@@ -1,0 +1,20 @@
+// check-pass
+// compile-flags: --emit=mir,link
+// Checks that we don't ICE due to attempting to run const prop
+// on a function with unsatisifable 'where' clauses
+
+#![allow(unused)]
+
+trait A {
+    fn foo(&self) -> Self where Self: Copy;
+}
+
+impl A for [fn(&())] {
+    fn foo(&self) -> Self where Self: Copy { *(&[] as &[_]) }
+}
+
+impl A for i32 {
+    fn foo(&self) -> Self { 3 }
+}
+
+fn main() {}

--- a/src/test/ui/consts/validate_never_arrays.rs
+++ b/src/test/ui/consts/validate_never_arrays.rs
@@ -1,5 +1,9 @@
 #![feature(const_raw_ptr_deref, never_type)]
 
-const FOO: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) }; //~ ERROR undefined behavior
+const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) }; //~ ERROR undefined behavior
+const _: &[!; 0] = unsafe { &*(1_usize as *const [!; 0]) }; // ok
+const _: &[!] = unsafe { &*(1_usize as *const [!; 0]) }; // ok
+const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) }; //~ ERROR undefined behavior
+const _: &[!] = unsafe { &*(1_usize as *const [!; 42]) }; //~ ERROR undefined behavior
 
 fn main() {}

--- a/src/test/ui/consts/validate_never_arrays.stderr
+++ b/src/test/ui/consts/validate_never_arrays.stderr
@@ -1,11 +1,27 @@
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/validate_never_arrays.rs:3:1
    |
-LL | const FOO: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a value of an uninhabited type at .<deref>
+LL | const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a value of an uninhabited type at .<deref>
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
-error: aborting due to previous error
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/validate_never_arrays.rs:6:1
+   |
+LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a value of an uninhabited type at .<deref>[0]
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/validate_never_arrays.rs:7:1
+   |
+LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 42]) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a value of an uninhabited type at .<deref>[0]
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-associated-functions.rs
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-associated-functions.rs
@@ -1,4 +1,8 @@
 // run-pass
+// Force mir to be emitted, to ensure that const
+// propagation doesn't ICE on a function
+// with an 'impossible' body. See issue #67696
+// compile-flags: --emit=mir,link
 // Inconsistent bounds with trait implementations
 
 #![feature(trivial_bounds)]

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-associated-functions.rs
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-associated-functions.rs
@@ -1,8 +1,8 @@
-// run-pass
+// check-pass
+// compile-flags: --emit=mir
 // Force mir to be emitted, to ensure that const
 // propagation doesn't ICE on a function
 // with an 'impossible' body. See issue #67696
-// compile-flags: --emit=mir,link
 // Inconsistent bounds with trait implementations
 
 #![feature(trivial_bounds)]

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-associated-functions.rs
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-associated-functions.rs
@@ -1,5 +1,5 @@
 // check-pass
-// compile-flags: --emit=mir
+// compile-flags: --emit=mir,link
 // Force mir to be emitted, to ensure that const
 // propagation doesn't ICE on a function
 // with an 'impossible' body. See issue #67696

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-associated-functions.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-associated-functions.stderr
@@ -1,0 +1,2 @@
+warning: due to multiple output types requested, the explicitly specified output file name will be adapted for each output type
+

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-associated-functions.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-associated-functions.stderr
@@ -1,2 +1,0 @@
-warning: due to multiple output types requested, the explicitly specified output file name will be adapted for each output type
-

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -42,10 +42,8 @@ mod tests;
 #[cfg(windows)]
 fn disable_error_reporting<F: FnOnce() -> R, R>(f: F) -> R {
     use std::sync::Mutex;
-    const SEM_NOGPFAULTERRORBOX: u32 = 0x0002;
-    extern "system" {
-        fn SetErrorMode(mode: u32) -> u32;
-    }
+    use winapi::um::errhandlingapi::SetErrorMode;
+    use winapi::um::winbase::SEM_NOGPFAULTERRORBOX;
 
     lazy_static! {
         static ref LOCK: Mutex<()> = { Mutex::new(()) };


### PR DESCRIPTION
Successful merges:

 - #67784 (Reset Formatter flags on exit from pad_integral)
 - #67914 (Don't run const propagation on items with inconsistent bounds)
 - #68141 (use winapi for non-stdlib Windows bindings)
 - #68211 (Add failing example for E0170 explanation)
 - #68219 (Untangle ZST validation from integer validation and generalize it to all zsts)
 - #68222 (Update the wasi-libc bundled with libstd)
 - #68226 (Avoid calling tcx.hir().get() on CRATE_HIR_ID)
 - #68227 (Update to a version of cmake with windows arm64 support)
 - #68229 (Update iovec to a version with no winapi dependency)
 - #68230 (Update libssh2-sys to a version that can build for aarch64-pc-windows…)
 - #68231 (Better support for cross compilation on Windows.)
 - #68233 (Update compiler_builtins with changes to fix 128 bit integer remainder for aarch64 windows.)

Failed merges:


r? @ghost