### PR TITLE
Use `as_millis()` in `connect_timeout()`

### DIFF
--- a/src/libstd/sys/unix/net.rs
+++ b/src/libstd/sys/unix/net.rs
@@ -140,10 +140,7 @@ impl Socket {
             }
 
             let timeout = timeout - elapsed;
-            let mut timeout = timeout
-                .as_secs()
-                .saturating_mul(1_000)
-                .saturating_add(timeout.subsec_nanos() as u64 / 1_000_000);
+            let mut timeout = timeout.as_millis() as u64;
             if timeout == 0 {
                 timeout = 1;
             }

--- a/src/libstd/sys/vxworks/net.rs
+++ b/src/libstd/sys/vxworks/net.rs
@@ -99,10 +99,7 @@ impl Socket {
             }
 
             let timeout = timeout - elapsed;
-            let mut timeout = timeout
-                .as_secs()
-                .saturating_mul(1_000)
-                .saturating_add(timeout.subsec_nanos() as u64 / 1_000_000);
+            let mut timeout = timeout.as_millis() as u64;
             if timeout == 0 {
                 timeout = 1;
             }


### PR DESCRIPTION
Fixes #68168
