### PR TITLE
Don't ICE on path-collision in dep-graph

### DIFF
--- a/src/test/incremental/issue-62649-path-collisions-happen.rs
+++ b/src/test/incremental/issue-62649-path-collisions-happen.rs
@@ -1,0 +1,13 @@
+// revisions: rpass1 rpass2
+
+#[cfg(rpass1)]
+pub trait Something {
+    fn foo();
+}
+
+#[cfg(rpass2)]
+pub struct Something {
+    pub foo: u8,
+}
+
+fn main() {}


### PR DESCRIPTION
Collisions in the dep-graph due to path-reuse are rare but can occur.

So, instead of ICE'ing, just fail to mark green in such cases (for `DepKind::{Hir, HirBody, CrateMetadata}`).

Fix #62649.
