### PR TITLE
Fix some tests failing in `--pass check` mode

### DIFF
--- a/src/test/ui/consts/array-literal-index-oob.rs
+++ b/src/test/ui/consts/array-literal-index-oob.rs
@@ -1,4 +1,5 @@
 // build-pass
+// ignore-pass (emit codegen-time warnings and verify that they are indeed warnings and not errors)
 
 #![warn(const_err)]
 

--- a/src/test/ui/consts/array-literal-index-oob.stderr
+++ b/src/test/ui/consts/array-literal-index-oob.stderr
@@ -1,17 +1,17 @@
 warning: index out of bounds: the len is 3 but the index is 4
-  --> $DIR/array-literal-index-oob.rs:6:8
+  --> $DIR/array-literal-index-oob.rs:7:8
    |
 LL |     &{ [1, 2, 3][4] };
    |        ^^^^^^^^^^^^
    |
 note: lint level defined here
-  --> $DIR/array-literal-index-oob.rs:3:9
+  --> $DIR/array-literal-index-oob.rs:4:9
    |
 LL | #![warn(const_err)]
    |         ^^^^^^^^^
 
 warning: reaching this expression at runtime will panic or abort
-  --> $DIR/array-literal-index-oob.rs:6:8
+  --> $DIR/array-literal-index-oob.rs:7:8
    |
 LL |     &{ [1, 2, 3][4] };
    |     ---^^^^^^^^^^^^--
@@ -19,7 +19,7 @@ LL |     &{ [1, 2, 3][4] };
    |        indexing out of bounds: the len is 3 but the index is 4
 
 warning: erroneous constant used
-  --> $DIR/array-literal-index-oob.rs:6:5
+  --> $DIR/array-literal-index-oob.rs:7:5
    |
 LL |     &{ [1, 2, 3][4] };
    |     ^^^^^^^^^^^^^^^^^ referenced constant has errors

--- a/src/test/ui/consts/const-eval/promoted_errors.rs
+++ b/src/test/ui/consts/const-eval/promoted_errors.rs
@@ -1,4 +1,5 @@
 // build-pass
+// ignore-pass (emit codegen-time warnings and verify that they are indeed warnings and not errors)
 // compile-flags: -O
 
 #![warn(const_err)]

--- a/src/test/ui/consts/const-eval/promoted_errors.stderr
+++ b/src/test/ui/consts/const-eval/promoted_errors.stderr
@@ -1,59 +1,59 @@
 warning: this expression will panic at runtime
-  --> $DIR/promoted_errors.rs:8:14
+  --> $DIR/promoted_errors.rs:9:14
    |
 LL |     let _x = 0u32 - 1;
    |              ^^^^^^^^ attempt to subtract with overflow
    |
 note: lint level defined here
-  --> $DIR/promoted_errors.rs:4:9
+  --> $DIR/promoted_errors.rs:5:9
    |
 LL | #![warn(const_err)]
    |         ^^^^^^^^^
 
 warning: attempt to divide by zero
-  --> $DIR/promoted_errors.rs:10:20
+  --> $DIR/promoted_errors.rs:11:20
    |
 LL |     println!("{}", 1 / (1 - 1));
    |                    ^^^^^^^^^^^
 
 warning: reaching this expression at runtime will panic or abort
-  --> $DIR/promoted_errors.rs:10:20
+  --> $DIR/promoted_errors.rs:11:20
    |
 LL |     println!("{}", 1 / (1 - 1));
    |                    ^^^^^^^^^^^ dividing by zero
 
 warning: erroneous constant used
-  --> $DIR/promoted_errors.rs:10:20
+  --> $DIR/promoted_errors.rs:11:20
    |
 LL |     println!("{}", 1 / (1 - 1));
    |                    ^^^^^^^^^^^ referenced constant has errors
 
 warning: attempt to divide by zero
-  --> $DIR/promoted_errors.rs:14:14
+  --> $DIR/promoted_errors.rs:15:14
    |
 LL |     let _x = 1 / (1 - 1);
    |              ^^^^^^^^^^^
 
 warning: attempt to divide by zero
-  --> $DIR/promoted_errors.rs:16:20
+  --> $DIR/promoted_errors.rs:17:20
    |
 LL |     println!("{}", 1 / (false as u32));
    |                    ^^^^^^^^^^^^^^^^^^
 
 warning: reaching this expression at runtime will panic or abort
-  --> $DIR/promoted_errors.rs:16:20
+  --> $DIR/promoted_errors.rs:17:20
    |
 LL |     println!("{}", 1 / (false as u32));
    |                    ^^^^^^^^^^^^^^^^^^ dividing by zero
 
 warning: erroneous constant used
-  --> $DIR/promoted_errors.rs:16:20
+  --> $DIR/promoted_errors.rs:17:20
    |
 LL |     println!("{}", 1 / (false as u32));
    |                    ^^^^^^^^^^^^^^^^^^ referenced constant has errors
 
 warning: attempt to divide by zero
-  --> $DIR/promoted_errors.rs:20:14
+  --> $DIR/promoted_errors.rs:21:14
    |
 LL |     let _x = 1 / (false as u32);
    |              ^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/consts/const-eval/promoted_errors2.rs
+++ b/src/test/ui/consts/const-eval/promoted_errors2.rs
@@ -1,4 +1,5 @@
 // build-pass
+// ignore-pass (emit codegen-time warnings and verify that they are indeed warnings and not errors)
 // compile-flags: -C overflow-checks=on -O
 
 #![warn(const_err)]

--- a/src/test/ui/consts/const-eval/promoted_errors2.stderr
+++ b/src/test/ui/consts/const-eval/promoted_errors2.stderr
@@ -1,65 +1,65 @@
 warning: attempt to subtract with overflow
-  --> $DIR/promoted_errors2.rs:7:20
+  --> $DIR/promoted_errors2.rs:8:20
    |
 LL |     println!("{}", 0u32 - 1);
    |                    ^^^^^^^^
    |
 note: lint level defined here
-  --> $DIR/promoted_errors2.rs:4:9
+  --> $DIR/promoted_errors2.rs:5:9
    |
 LL | #![warn(const_err)]
    |         ^^^^^^^^^
 
 warning: attempt to subtract with overflow
-  --> $DIR/promoted_errors2.rs:9:14
+  --> $DIR/promoted_errors2.rs:10:14
    |
 LL |     let _x = 0u32 - 1;
    |              ^^^^^^^^
 
 warning: attempt to divide by zero
-  --> $DIR/promoted_errors2.rs:11:20
+  --> $DIR/promoted_errors2.rs:12:20
    |
 LL |     println!("{}", 1 / (1 - 1));
    |                    ^^^^^^^^^^^
 
 warning: reaching this expression at runtime will panic or abort
-  --> $DIR/promoted_errors2.rs:11:20
+  --> $DIR/promoted_errors2.rs:12:20
    |
 LL |     println!("{}", 1 / (1 - 1));
    |                    ^^^^^^^^^^^ dividing by zero
 
 warning: erroneous constant used
-  --> $DIR/promoted_errors2.rs:11:20
+  --> $DIR/promoted_errors2.rs:12:20
    |
 LL |     println!("{}", 1 / (1 - 1));
    |                    ^^^^^^^^^^^ referenced constant has errors
 
 warning: attempt to divide by zero
-  --> $DIR/promoted_errors2.rs:15:14
+  --> $DIR/promoted_errors2.rs:16:14
    |
 LL |     let _x = 1 / (1 - 1);
    |              ^^^^^^^^^^^
 
 warning: attempt to divide by zero
-  --> $DIR/promoted_errors2.rs:17:20
+  --> $DIR/promoted_errors2.rs:18:20
    |
 LL |     println!("{}", 1 / (false as u32));
    |                    ^^^^^^^^^^^^^^^^^^
 
 warning: reaching this expression at runtime will panic or abort
-  --> $DIR/promoted_errors2.rs:17:20
+  --> $DIR/promoted_errors2.rs:18:20
    |
 LL |     println!("{}", 1 / (false as u32));
    |                    ^^^^^^^^^^^^^^^^^^ dividing by zero
 
 warning: erroneous constant used
-  --> $DIR/promoted_errors2.rs:17:20
+  --> $DIR/promoted_errors2.rs:18:20
    |
 LL |     println!("{}", 1 / (false as u32));
    |                    ^^^^^^^^^^^^^^^^^^ referenced constant has errors
 
 warning: attempt to divide by zero
-  --> $DIR/promoted_errors2.rs:21:14
+  --> $DIR/promoted_errors2.rs:22:14
    |
 LL |     let _x = 1 / (false as u32);
    |              ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Warnings reported at codegen or linking time either have to be converted to errors (preferable), or the tests for them need to be marked with `// ignore-pass` (as a last resort).

https://github.com/rust-lang/rust/commit/ecd5852194f43511443f134aebf0462b58c8e197 turned them from errors to warnings, but that shouldn't be necessary because it's still clear from the `.stderr` output that the errors are lints and not hard-coded.