### PR TITLE
Allow added string.insert benchmarks to compile

### DIFF
--- a/src/liballoc/benches/string.rs
+++ b/src/liballoc/benches/string.rs
@@ -1,5 +1,5 @@
 use std::iter::repeat;
-use test::Bencher;
+use test::{black_box, Bencher};
 
 #[bench]
 fn bench_with_capacity(b: &mut Bencher) {


### PR DESCRIPTION
Allow the code added by #67281 to compile.

(symptons listed [in internals forum](https://internals.rust-lang.org/t/x-py-how-to-benchmark-liballoc/11635))
r? @llogiq