### PR TITLE
Don't propagate __RUST_TEST_INVOKE to subprocess

### DIFF
--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -153,12 +153,13 @@ pub fn test_main_static_abort(tests: &[&TestDescAndFn]) {
     // If we're being run in SpawnedSecondary mode, run the test here. run_test
     // will then exit the process.
     if let Ok(name) = env::var(SECONDARY_TEST_INVOKER_VAR) {
+        env::remove_var(SECONDARY_TEST_INVOKER_VAR);
         let test = tests
             .iter()
             .filter(|test| test.desc.name.as_slice() == name)
             .map(make_owned_test)
             .next()
-            .expect("couldn't find a test with the provided name");
+            .expect(&format!("couldn't find a test with the provided name '{}'", name));
         let TestDescAndFn { desc, testfn } = test;
         let testfn = match testfn {
             StaticTestFn(f) => f,

--- a/src/test/ui/test-panic-abort.rs
+++ b/src/test/ui/test-panic-abort.rs
@@ -11,6 +11,7 @@
 #![cfg(test)]
 
 use std::io::Write;
+use std::env;
 
 #[test]
 fn it_works() {
@@ -34,4 +35,14 @@ fn it_fails() {
 #[test]
 fn it_exits() {
     std::process::exit(123);
+}
+
+#[test]
+fn no_residual_environment() {
+    for (key, _) in env::vars() {
+        // Look for keys like __RUST_TEST_INVOKE.
+        if key.contains("TEST_INVOKE") {
+            panic!("shouldn't have '{}' in environment", key);
+        }
+    }
 }

--- a/src/test/ui/test-panic-abort.run.stdout
+++ b/src/test/ui/test-panic-abort.run.stdout
@@ -1,9 +1,10 @@
 
-running 4 tests
+running 5 tests
 test it_exits ... FAILED
 test it_fails ... FAILED
 test it_panics ... ok
 test it_works ... ok
+test no_residual_environment ... ok
 
 failures:
 
@@ -17,7 +18,7 @@ testing123
 testing321
 thread 'main' panicked at 'assertion failed: `(left == right)`
   left: `2`,
- right: `5`', $DIR/test-panic-abort.rs:31:5
+ right: `5`', $DIR/test-panic-abort.rs:32:5
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 
@@ -25,5 +26,5 @@ failures:
     it_exits
     it_fails
 
-test result: FAILED. 2 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
+test result: FAILED. 3 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
 


### PR DESCRIPTION
When -Z panic_abort_tests is enabled, we use an environment variable to
tell the subprocess which test to invoke. If that subprocess then
invokes another Rust test binary, chaos ensues.

r? @alexcrichton 