### PR TITLE
Fix #[track_caller] and function pointers

### DIFF
--- a/src/librustc/ty/instance.rs
+++ b/src/librustc/ty/instance.rs
@@ -141,7 +141,12 @@ impl<'tcx> InstanceDef<'tcx> {
     }
 
     pub fn requires_caller_location(&self, tcx: TyCtxt<'_>) -> bool {
-        tcx.codegen_fn_attrs(self.def_id()).flags.contains(CodegenFnAttrFlags::TRACK_CALLER)
+        match *self {
+            InstanceDef::Item(def_id) => {
+                tcx.codegen_fn_attrs(def_id).flags.contains(CodegenFnAttrFlags::TRACK_CALLER)
+            }
+            _ => false,
+        }
     }
 }
 

--- a/src/test/ui/rfc-2091-track-caller/tracked-fn-ptr-with-arg.rs
+++ b/src/test/ui/rfc-2091-track-caller/tracked-fn-ptr-with-arg.rs
@@ -1,0 +1,16 @@
+// run-pass
+
+#![feature(track_caller)]
+
+fn pass_to_ptr_call<T>(f: fn(T), x: T) {
+    f(x);
+}
+
+#[track_caller]
+fn tracked_unit(_: ()) {
+    assert_eq!(std::panic::Location::caller().file(), file!());
+}
+
+fn main() {
+    pass_to_ptr_call(tracked_unit, ());
+}

--- a/src/test/ui/rfc-2091-track-caller/tracked-fn-ptr-with-arg.rs
+++ b/src/test/ui/rfc-2091-track-caller/tracked-fn-ptr-with-arg.rs
@@ -8,7 +8,10 @@ fn pass_to_ptr_call<T>(f: fn(T), x: T) {
 
 #[track_caller]
 fn tracked_unit(_: ()) {
-    assert_eq!(std::panic::Location::caller().file(), file!());
+    let expected_line = line!() - 1;
+    let location = std::panic::Location::caller();
+    assert_eq!(location.file(), file!());
+    assert_eq!(location.line(), expected_line, "call shims report location as fn definition");
 }
 
 fn main() {

--- a/src/test/ui/rfc-2091-track-caller/tracked-fn-ptr.rs
+++ b/src/test/ui/rfc-2091-track-caller/tracked-fn-ptr.rs
@@ -8,7 +8,10 @@ fn ptr_call(f: fn()) {
 
 #[track_caller]
 fn tracked() {
-    assert_eq!(std::panic::Location::caller().file(), file!());
+    let expected_line = line!() - 1;
+    let location = std::panic::Location::caller();
+    assert_eq!(location.file(), file!());
+    assert_eq!(location.line(), expected_line, "call shims report location as fn definition");
 }
 
 fn main() {

--- a/src/test/ui/rfc-2091-track-caller/tracked-fn-ptr.rs
+++ b/src/test/ui/rfc-2091-track-caller/tracked-fn-ptr.rs
@@ -1,0 +1,16 @@
+// run-pass
+
+#![feature(track_caller)]
+
+fn ptr_call(f: fn()) {
+    f();
+}
+
+#[track_caller]
+fn tracked() {
+    assert_eq!(std::panic::Location::caller().file(), file!());
+}
+
+fn main() {
+    ptr_call(tracked);
+}


### PR DESCRIPTION
Starting with failing tests, fix the miscompilation and ICE caused by `ReifyShim` bug.

Fixes #68178.