### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/src/librustc_error_codes/error_codes/E0198.md
+++ b/src/librustc_error_codes/error_codes/E0198.md
@@ -1,16 +1,17 @@
+A negative implementation was marked as unsafe.
+
+Erroneous code example:
+
+```compile_fail
+struct Foo;
+
+unsafe impl !Clone for Foo { } // error!
+```
+
 A negative implementation is one that excludes a type from implementing a
 particular trait. Not being able to use a trait is always a safe operation,
 so negative implementations are always safe and never need to be marked as
 unsafe.
-
-```compile_fail
-#![feature(optin_builtin_traits)]
-
-struct Foo;
-
-// unsafe is unnecessary
-unsafe impl !Clone for Foo { }
-```
 
 This will compile:
 

--- a/src/librustc_error_codes/error_codes/E0199.md
+++ b/src/librustc_error_codes/error_codes/E0199.md
@@ -1,14 +1,23 @@
-Safe traits should not have unsafe implementations, therefore marking an
-implementation for a safe trait unsafe will cause a compiler error. Removing
-the unsafe marker on the trait noted in the error will resolve this problem.
+A trait implementation was marked as unsafe while the trait is safe.
+
+Erroneous code example:
 
 ```compile_fail,E0199
 struct Foo;
 
 trait Bar { }
 
-// this won't compile because Bar is safe
-unsafe impl Bar for Foo { }
-// this will compile
-impl Bar for Foo { }
+unsafe impl Bar for Foo { } // error!
+```
+
+Safe traits should not have unsafe implementations, therefore marking an
+implementation for a safe trait unsafe will cause a compiler error. Removing
+the unsafe marker on the trait noted in the error will resolve this problem:
+
+```
+struct Foo;
+
+trait Bar { }
+
+impl Bar for Foo { } // ok!
 ```

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -284,11 +284,9 @@ fn build_type_alias_type(cx: &DocContext<'_>, did: DefId) -> Option<clean::Type>
 
 pub fn build_ty(cx: &DocContext, did: DefId) -> Option<clean::Type> {
     match cx.tcx.def_kind(did)? {
-        DefKind::Struct |
-        DefKind::Union |
-        DefKind::Enum |
-        DefKind::Const |
-        DefKind::Static => Some(cx.tcx.type_of(did).clean(cx)),
+        DefKind::Struct | DefKind::Union | DefKind::Enum | DefKind::Const | DefKind::Static => {
+            Some(cx.tcx.type_of(did).clean(cx))
+        }
         DefKind::TyAlias => build_type_alias_type(cx, did),
         _ => None,
     }

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -273,6 +273,24 @@ fn build_type_alias(cx: &DocContext<'_>, did: DefId) -> clean::Typedef {
     clean::Typedef {
         type_: cx.tcx.type_of(did).clean(cx),
         generics: (cx.tcx.generics_of(did), predicates).clean(cx),
+        item_type: build_type_alias_type(cx, did),
+    }
+}
+
+fn build_type_alias_type(cx: &DocContext<'_>, did: DefId) -> Option<clean::Type> {
+    let type_ = cx.tcx.type_of(did).clean(cx);
+    type_.def_id().and_then(|did| build_ty(cx, did))
+}
+
+pub fn build_ty(cx: &DocContext, did: DefId) -> Option<clean::Type> {
+    match cx.tcx.def_kind(did)? {
+        DefKind::Struct |
+        DefKind::Union |
+        DefKind::Enum |
+        DefKind::Const |
+        DefKind::Static => Some(cx.tcx.type_of(did).clean(cx)),
+        DefKind::TyAlias => build_type_alias_type(cx, did),
+        _ => None,
     }
 }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1124,14 +1124,7 @@ impl Clean<Item> for hir::ImplItem<'_> {
             hir::ImplItemKind::TyAlias(ref ty) => {
                 let type_ = ty.clean(cx);
                 let item_type = type_.def_id().and_then(|did| inline::build_ty(cx, did));
-                TypedefItem(
-                    Typedef {
-                        type_,
-                        generics: Generics::default(),
-                        item_type,
-                    },
-                    true,
-                )
+                TypedefItem(Typedef { type_, generics: Generics::default(), item_type }, true)
             }
             hir::ImplItemKind::OpaqueTy(ref bounds) => OpaqueTyItem(
                 OpaqueTy { bounds: bounds.clean(cx), generics: Generics::default() },
@@ -2011,14 +2004,7 @@ impl Clean<Item> for doctree::Typedef<'_> {
             visibility: self.vis.clean(cx),
             stability: cx.stability(self.id).clean(cx),
             deprecation: cx.deprecation(self.id).clean(cx),
-            inner: TypedefItem(
-                Typedef {
-                    type_,
-                    generics: self.gen.clean(cx),
-                    item_type,
-                },
-                false,
-            ),
+            inner: TypedefItem(Typedef { type_, generics: self.gen.clean(cx), item_type }, false),
         }
     }
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2121,8 +2121,8 @@ impl Clean<Vec<Item>> for doctree::Impl<'_> {
             Some(DefKind::TyAlias) => Some(cx.tcx.type_of(did).clean(cx)),
             _ => None,
         });
-        if let Some(type_alias) = type_alias {
-            ret.push(Item {
+        let make_item = |trait_: Option<Type>, for_: Type, items: Vec<Item>| {
+            Item {
                 name: None,
                 attrs: self.attrs.clean(cx),
                 source: self.whence.clean(cx),
@@ -2134,35 +2134,19 @@ impl Clean<Vec<Item>> for doctree::Impl<'_> {
                     unsafety: self.unsafety,
                     generics: self.generics.clean(cx),
                     provided_trait_methods: provided.clone(),
-                    trait_: trait_.clone(),
-                    for_: type_alias,
-                    items: items.clone(),
+                    trait_,
+                    for_,
+                    items,
                     polarity: Some(cx.tcx.impl_polarity(def_id).clean(cx)),
                     synthetic: false,
                     blanket_impl: None,
                 }),
-            });
+            }
+        };
+        if let Some(type_alias) = type_alias {
+            ret.push(make_item(trait_.clone(), type_alias, items.clone()));
         }
-        ret.push(Item {
-            name: None,
-            attrs: self.attrs.clean(cx),
-            source: self.whence.clean(cx),
-            def_id,
-            visibility: self.vis.clean(cx),
-            stability: cx.stability(self.id).clean(cx),
-            deprecation: cx.deprecation(self.id).clean(cx),
-            inner: ImplItem(Impl {
-                unsafety: self.unsafety,
-                generics: self.generics.clean(cx),
-                provided_trait_methods: provided,
-                trait_,
-                for_,
-                items,
-                polarity: Some(cx.tcx.impl_polarity(def_id).clean(cx)),
-                synthetic: false,
-                blanket_impl: None,
-            }),
-        });
+        ret.push(make_item(trait_, for_, items));
         ret
     }
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1122,7 +1122,16 @@ impl Clean<Item> for hir::ImplItem<'_> {
                 MethodItem((sig, &self.generics, body, Some(self.defaultness)).clean(cx))
             }
             hir::ImplItemKind::TyAlias(ref ty) => {
-                TypedefItem(Typedef { type_: ty.clean(cx), generics: Generics::default() }, true)
+                let type_ = ty.clean(cx);
+                let item_type = type_.def_id().and_then(|did| inline::build_ty(cx, did));
+                TypedefItem(
+                    Typedef {
+                        type_,
+                        generics: Generics::default(),
+                        item_type,
+                    },
+                    true,
+                )
             }
             hir::ImplItemKind::OpaqueTy(ref bounds) => OpaqueTyItem(
                 OpaqueTy { bounds: bounds.clean(cx), generics: Generics::default() },
@@ -1282,10 +1291,13 @@ impl Clean<Item> for ty::AssocItem {
 
                     AssocTypeItem(bounds, ty.clean(cx))
                 } else {
+                    let type_ = cx.tcx.type_of(self.def_id).clean(cx);
+                    let item_type = type_.def_id().and_then(|did| inline::build_ty(cx, did));
                     TypedefItem(
                         Typedef {
-                            type_: cx.tcx.type_of(self.def_id).clean(cx),
+                            type_,
                             generics: Generics { params: Vec::new(), where_predicates: Vec::new() },
+                            item_type,
                         },
                         true,
                     )
@@ -1989,6 +2001,8 @@ impl Clean<String> for ast::Name {
 
 impl Clean<Item> for doctree::Typedef<'_> {
     fn clean(&self, cx: &DocContext<'_>) -> Item {
+        let type_ = self.ty.clean(cx);
+        let item_type = type_.def_id().and_then(|did| inline::build_ty(cx, did));
         Item {
             name: Some(self.name.clean(cx)),
             attrs: self.attrs.clean(cx),
@@ -1998,7 +2012,11 @@ impl Clean<Item> for doctree::Typedef<'_> {
             stability: cx.stability(self.id).clean(cx),
             deprecation: cx.deprecation(self.id).clean(cx),
             inner: TypedefItem(
-                Typedef { type_: self.ty.clean(cx), generics: self.gen.clean(cx) },
+                Typedef {
+                    type_,
+                    generics: self.gen.clean(cx),
+                    item_type,
+                },
                 false,
             ),
         }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2121,27 +2121,25 @@ impl Clean<Vec<Item>> for doctree::Impl<'_> {
             Some(DefKind::TyAlias) => Some(cx.tcx.type_of(did).clean(cx)),
             _ => None,
         });
-        let make_item = |trait_: Option<Type>, for_: Type, items: Vec<Item>| {
-            Item {
-                name: None,
-                attrs: self.attrs.clean(cx),
-                source: self.whence.clean(cx),
-                def_id,
-                visibility: self.vis.clean(cx),
-                stability: cx.stability(self.id).clean(cx),
-                deprecation: cx.deprecation(self.id).clean(cx),
-                inner: ImplItem(Impl {
-                    unsafety: self.unsafety,
-                    generics: self.generics.clean(cx),
-                    provided_trait_methods: provided.clone(),
-                    trait_,
-                    for_,
-                    items,
-                    polarity: Some(cx.tcx.impl_polarity(def_id).clean(cx)),
-                    synthetic: false,
-                    blanket_impl: None,
-                }),
-            }
+        let make_item = |trait_: Option<Type>, for_: Type, items: Vec<Item>| Item {
+            name: None,
+            attrs: self.attrs.clean(cx),
+            source: self.whence.clean(cx),
+            def_id,
+            visibility: self.vis.clean(cx),
+            stability: cx.stability(self.id).clean(cx),
+            deprecation: cx.deprecation(self.id).clean(cx),
+            inner: ImplItem(Impl {
+                unsafety: self.unsafety,
+                generics: self.generics.clean(cx),
+                provided_trait_methods: provided.clone(),
+                trait_,
+                for_,
+                items,
+                polarity: Some(cx.tcx.impl_polarity(def_id).clean(cx)),
+                synthetic: false,
+                blanket_impl: None,
+            }),
         };
         if let Some(type_alias) = type_alias {
             ret.push(make_item(trait_.clone(), type_alias, items.clone()));

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1406,6 +1406,14 @@ pub struct PathSegment {
 pub struct Typedef {
     pub type_: Type,
     pub generics: Generics,
+    // Type of target item.
+    pub item_type: Option<Type>,
+}
+
+impl GetDefId for Typedef {
+    fn def_id(&self) -> Option<DefId> {
+        self.type_.def_id()
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -4126,14 +4126,14 @@ fn sidebar_assoc_items(it: &clean::Item) -> String {
                 .filter(|i| i.inner_impl().trait_.is_some())
                 .find(|i| i.inner_impl().trait_.def_id() == c.deref_trait_did)
             {
-                if let Some(target) = impl_
+                if let Some((target, real_target)) = impl_
                     .inner_impl()
                     .items
                     .iter()
                     .filter_map(|item| match item.inner {
                         clean::TypedefItem(ref t, true) => Some(match *t {
-                            clean::Typedef { item_type: Some(ref type_), .. } => type_,
-                            _ => &t.type_,
+                            clean::Typedef { item_type: Some(ref type_), .. } => (type_, &t.type_),
+                            _ => (&t.type_, &t.type_),
                         }),
                         _ => None,
                     })
@@ -4153,7 +4153,7 @@ fn sidebar_assoc_items(it: &clean::Item) -> String {
                                 "{:#}",
                                 impl_.inner_impl().trait_.as_ref().unwrap().print()
                             )),
-                            Escape(&format!("{:#}", target.print()))
+                            Escape(&format!("{:#}", real_target.print()))
                         ));
                         out.push_str("</a>");
                         let mut ret = impls

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2595,7 +2595,7 @@ fn item_trait(w: &mut Buffer, cx: &Context, it: &clean::Item, t: &clean::Trait) 
     }
 
     // If there are methods directly on this trait object, render them here.
-    render_assoc_items(w, cx, it, it.def_id, AssocItemRender::All);
+    render_assoc_items(w, cx, it, it.def_id, &AssocItemRender::All);
 
     let mut synthetic_types = Vec::new();
 
@@ -2942,7 +2942,7 @@ fn item_struct(w: &mut Buffer, cx: &Context, it: &clean::Item, s: &clean::Struct
             }
         }
     }
-    render_assoc_items(w, cx, it, it.def_id, AssocItemRender::All)
+    render_assoc_items(w, cx, it, it.def_id, &AssocItemRender::All)
 }
 
 fn item_union(w: &mut Buffer, cx: &Context, it: &clean::Item, s: &clean::Union) {
@@ -2988,7 +2988,7 @@ fn item_union(w: &mut Buffer, cx: &Context, it: &clean::Item, s: &clean::Union) 
             document(w, cx, field);
         }
     }
-    render_assoc_items(w, cx, it, it.def_id, AssocItemRender::All)
+    render_assoc_items(w, cx, it, it.def_id, &AssocItemRender::All)
 }
 
 fn item_enum(w: &mut Buffer, cx: &Context, it: &clean::Item, e: &clean::Enum) {
@@ -3130,7 +3130,7 @@ fn item_enum(w: &mut Buffer, cx: &Context, it: &clean::Item, e: &clean::Enum) {
             render_stability_since(w, variant, it);
         }
     }
-    render_assoc_items(w, cx, it, it.def_id, AssocItemRender::All)
+    render_assoc_items(w, cx, it, it.def_id, &AssocItemRender::All)
 }
 
 fn render_attribute(attr: &ast::MetaItem) -> Option<String> {
@@ -3344,7 +3344,7 @@ fn render_assoc_items(
     cx: &Context,
     containing_item: &clean::Item,
     it: DefId,
-    what: AssocItemRender<'_>,
+    what: &AssocItemRender<'_>,
 ) {
     let c = &cx.cache;
     let v = match c.impls.get(&it) {
@@ -3377,7 +3377,7 @@ fn render_assoc_items(
                     trait_.print(),
                     type_.print()
                 );
-                RenderMode::ForDeref { mut_: deref_mut_ }
+                RenderMode::ForDeref { mut_: *deref_mut_ }
             }
         };
         for i in &non_trait {
@@ -3461,6 +3461,19 @@ fn render_assoc_items(
     }
 }
 
+fn get_def_id(real_target: &clean::Type, cx: &Context) -> Option<DefId> {
+    if let Some(did) = real_target.def_id() {
+        return Some(did);
+    } else {
+        if let Some(prim) = real_target.primitive_type() {
+            if let Some(&did) = cx.cache.primitive_locations.get(&prim) {
+                return Some(did);
+            }
+        }
+    }
+    None
+}
+
 fn render_deref_methods(
     w: &mut Buffer,
     cx: &Context,
@@ -3475,23 +3488,21 @@ fn render_deref_methods(
         .iter()
         .filter_map(|item| match item.inner {
             clean::TypedefItem(ref t, true) => Some(match *t {
-                clean::Typedef { item_type: Some(ref type_), .. } => (&t.type_, type_),
-                _ => (&t.type_, &t.type_),
+                clean::Typedef { item_type: Some(ref type_), .. } => (&t.type_, Some(type_)),
+                _ => (&t.type_, None),
             }),
             _ => None,
         })
         .next()
         .expect("Expected associated type binding");
+    let did = get_def_id(&target, cx);
     let what =
         AssocItemRender::DerefFor { trait_: deref_type, type_: target, deref_mut_: deref_mut };
-    if let Some(did) = real_target.def_id() {
-        render_assoc_items(w, cx, container_item, did, what)
-    } else {
-        if let Some(prim) = real_target.primitive_type() {
-            if let Some(&did) = cx.cache.primitive_locations.get(&prim) {
-                render_assoc_items(w, cx, container_item, did, what);
-            }
-        }
+    if let Some(did) = did {
+        render_assoc_items(w, cx, container_item, did, &what);
+    }
+    if let Some(did) = real_target.and_then(|x| get_def_id(x, cx)) {
+        render_assoc_items(w, cx, container_item, did, &what);
     }
 }
 
@@ -3873,7 +3884,7 @@ fn item_opaque_ty(w: &mut Buffer, cx: &Context, it: &clean::Item, t: &clean::Opa
     // won't be visible anywhere in the docs. It would be nice to also show
     // associated items from the aliased type (see discussion in #32077), but
     // we need #14072 to make sense of the generics.
-    render_assoc_items(w, cx, it, it.def_id, AssocItemRender::All)
+    render_assoc_items(w, cx, it, it.def_id, &AssocItemRender::All)
 }
 
 fn item_trait_alias(w: &mut Buffer, cx: &Context, it: &clean::Item, t: &clean::TraitAlias) {
@@ -3894,7 +3905,7 @@ fn item_trait_alias(w: &mut Buffer, cx: &Context, it: &clean::Item, t: &clean::T
     // won't be visible anywhere in the docs. It would be nice to also show
     // associated items from the aliased type (see discussion in #32077), but
     // we need #14072 to make sense of the generics.
-    render_assoc_items(w, cx, it, it.def_id, AssocItemRender::All)
+    render_assoc_items(w, cx, it, it.def_id, &AssocItemRender::All)
 }
 
 fn item_typedef(w: &mut Buffer, cx: &Context, it: &clean::Item, t: &clean::Typedef) {
@@ -3915,7 +3926,7 @@ fn item_typedef(w: &mut Buffer, cx: &Context, it: &clean::Item, t: &clean::Typed
     // won't be visible anywhere in the docs. It would be nice to also show
     // associated items from the aliased type (see discussion in #32077), but
     // we need #14072 to make sense of the generics.
-    render_assoc_items(w, cx, it, it.def_id, AssocItemRender::All)
+    render_assoc_items(w, cx, it, it.def_id, &AssocItemRender::All)
 }
 
 fn item_foreign_type(w: &mut Buffer, cx: &Context, it: &clean::Item) {
@@ -3930,7 +3941,7 @@ fn item_foreign_type(w: &mut Buffer, cx: &Context, it: &clean::Item) {
 
     document(w, cx, it);
 
-    render_assoc_items(w, cx, it, it.def_id, AssocItemRender::All)
+    render_assoc_items(w, cx, it, it.def_id, &AssocItemRender::All)
 }
 
 fn print_sidebar(cx: &Context, it: &clean::Item, buffer: &mut Buffer) {
@@ -4602,7 +4613,7 @@ fn item_proc_macro(w: &mut Buffer, cx: &Context, it: &clean::Item, m: &clean::Pr
 
 fn item_primitive(w: &mut Buffer, cx: &Context, it: &clean::Item) {
     document(w, cx, it);
-    render_assoc_items(w, cx, it, it.def_id, AssocItemRender::All)
+    render_assoc_items(w, cx, it, it.def_id, &AssocItemRender::All)
 }
 
 fn item_keyword(w: &mut Buffer, cx: &Context, it: &clean::Item) {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -3474,12 +3474,10 @@ fn render_deref_methods(
         .items
         .iter()
         .filter_map(|item| match item.inner {
-            clean::TypedefItem(ref t, true) => {
-                Some(match *t {
-                    clean::Typedef { item_type: Some(ref type_), .. } => (&t.type_, type_),
-                    _ => (&t.type_, &t.type_),
-                })
-            }
+            clean::TypedefItem(ref t, true) => Some(match *t {
+                clean::Typedef { item_type: Some(ref type_), .. } => (&t.type_, type_),
+                _ => (&t.type_, &t.type_),
+            }),
             _ => None,
         })
         .next()
@@ -4133,12 +4131,10 @@ fn sidebar_assoc_items(it: &clean::Item) -> String {
                     .items
                     .iter()
                     .filter_map(|item| match item.inner {
-                        clean::TypedefItem(ref t, true) => {
-                            Some(match *t {
-                                clean::Typedef { item_type: Some(ref type_), .. } => (&t.type_, type_),
-                                _ => (&t.type_, &t.type_),
-                            })
-                        }
+                        clean::TypedefItem(ref t, true) => Some(match *t {
+                            clean::Typedef { item_type: Some(ref type_), .. } => (&t.type_, type_),
+                            _ => (&t.type_, &t.type_),
+                        }),
                         _ => None,
                     })
                     .next()

--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -574,10 +574,6 @@ fn build_index(krate: &clean::Crate, cache: &mut Cache) -> String {
     // has since been learned.
     for &(did, ref item) in orphan_impl_items {
         if let Some(&(ref fqp, _)) = paths.get(&did) {
-            if item.name.is_none() {
-                // this is most likely from a typedef
-                continue;
-            }
             search_index.push(IndexItem {
                 ty: item.type_(),
                 name: item.name.clone().unwrap(),
@@ -596,23 +592,19 @@ fn build_index(krate: &clean::Crate, cache: &mut Cache) -> String {
     let mut lastpathid = 0usize;
 
     for item in search_index {
-        item.parent_idx = match item.parent {
-            Some(nodeid) => Some(if nodeid_to_pathid.contains_key(&nodeid) {
+        item.parent_idx = item.parent.map(|nodeid| {
+            if nodeid_to_pathid.contains_key(&nodeid) {
                 *nodeid_to_pathid.get(&nodeid).expect("no pathid")
             } else {
                 let pathid = lastpathid;
                 nodeid_to_pathid.insert(nodeid, pathid);
                 lastpathid += 1;
 
-                if let Some(&(ref fqp, short)) = paths.get(&nodeid) {
-                    crate_paths.push((short, fqp.last().expect("no fqp").clone()));
-                } else {
-                    continue;
-                }
+                let &(ref fqp, short) = paths.get(&nodeid).unwrap();
+                crate_paths.push((short, fqp.last().unwrap().clone()));
                 pathid
-            }),
-            None => None,
-        };
+            }
+        });
 
         // Omit the parent path if it is same to that of the prior item.
         if lastpath == item.path {

--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -574,7 +574,8 @@ fn build_index(krate: &clean::Crate, cache: &mut Cache) -> String {
     // has since been learned.
     for &(did, ref item) in orphan_impl_items {
         if let Some(&(ref fqp, _)) = paths.get(&did) {
-            if item.name.is_none() { // this is most likely from a typedef
+            if item.name.is_none() {
+                // this is most likely from a typedef
                 continue;
             }
             search_index.push(IndexItem {
@@ -596,22 +597,20 @@ fn build_index(krate: &clean::Crate, cache: &mut Cache) -> String {
 
     for item in search_index {
         item.parent_idx = match item.parent {
-            Some(nodeid) => {
-                Some(if nodeid_to_pathid.contains_key(&nodeid) {
-                    *nodeid_to_pathid.get(&nodeid).expect("no pathid")
-                } else {
-                    let pathid = lastpathid;
-                    nodeid_to_pathid.insert(nodeid, pathid);
-                    lastpathid += 1;
+            Some(nodeid) => Some(if nodeid_to_pathid.contains_key(&nodeid) {
+                *nodeid_to_pathid.get(&nodeid).expect("no pathid")
+            } else {
+                let pathid = lastpathid;
+                nodeid_to_pathid.insert(nodeid, pathid);
+                lastpathid += 1;
 
-                    if let Some(&(ref fqp, short)) = paths.get(&nodeid) {
-                        crate_paths.push((short, fqp.last().expect("no fqp").clone()));
-                    } else {
-                        continue
-                    }
-                    pathid
-                })
-            }
+                if let Some(&(ref fqp, short)) = paths.get(&nodeid) {
+                    crate_paths.push((short, fqp.last().expect("no fqp").clone()));
+                } else {
+                    continue;
+                }
+                pathid
+            }),
             None => None,
         };
 

--- a/src/test/rustdoc/deref-typedef.rs
+++ b/src/test/rustdoc/deref-typedef.rs
@@ -1,0 +1,19 @@
+#![crate_name = "foo"]
+
+// @has 'foo/struct.Bar.html'
+// @has '-' '//*[@id="deref-methods"]' 'Methods from Deref<Target = FooB>'
+// @has '-' '//*[@class="impl-items"]//*[@id="method.happy"]' 'pub fn happy(&self)'
+// @has '-' '//*[@class="sidebar-title"]' 'Methods from Deref<Target=FooB>'
+// @has '-' '//*[@class="sidebar-links"]/a[@href="#method.happy"]' 'happy'
+pub struct FooA;
+pub type FooB = FooA;
+
+impl FooA {
+    pub fn happy(&self) {}
+}
+
+pub struct Bar;
+impl std::ops::Deref for Bar {
+    type Target = FooB;
+    fn deref(&self) -> &FooB { unimplemented!() }
+}

--- a/src/test/rustdoc/deref-typedef.rs
+++ b/src/test/rustdoc/deref-typedef.rs
@@ -1,19 +1,33 @@
 #![crate_name = "foo"]
 
 // @has 'foo/struct.Bar.html'
-// @has '-' '//*[@id="deref-methods"]' 'Methods from Deref<Target = FooB>'
-// @has '-' '//*[@class="impl-items"]//*[@id="method.happy"]' 'pub fn happy(&self)'
-// @has '-' '//*[@class="sidebar-title"]' 'Methods from Deref<Target=FooB>'
-// @has '-' '//*[@class="sidebar-links"]/a[@href="#method.happy"]' 'happy'
+// @has '-' '//*[@id="deref-methods"]' 'Methods from Deref<Target = FooC>'
+// @has '-' '//*[@class="impl-items"]//*[@id="method.foo_a"]' 'pub fn foo_a(&self)'
+// @has '-' '//*[@class="impl-items"]//*[@id="method.foo_b"]' 'pub fn foo_b(&self)'
+// @has '-' '//*[@class="impl-items"]//*[@id="method.foo_c"]' 'pub fn foo_c(&self)'
+// @has '-' '//*[@class="sidebar-title"]' 'Methods from Deref<Target=FooC>'
+// @has '-' '//*[@class="sidebar-links"]/a[@href="#method.foo_a"]' 'foo_a'
+// @has '-' '//*[@class="sidebar-links"]/a[@href="#method.foo_b"]' 'foo_b'
+// @has '-' '//*[@class="sidebar-links"]/a[@href="#method.foo_c"]' 'foo_c'
+
 pub struct FooA;
 pub type FooB = FooA;
+pub type FooC = FooB;
 
 impl FooA {
-    pub fn happy(&self) {}
+    pub fn foo_a(&self) {}
+}
+
+impl FooB {
+    pub fn foo_b(&self) {}
+}
+
+impl FooC {
+    pub fn foo_c(&self) {}
 }
 
 pub struct Bar;
 impl std::ops::Deref for Bar {
-    type Target = FooB;
-    fn deref(&self) -> &FooB { unimplemented!() }
+    type Target = FooC;
+    fn deref(&self) -> &Self::Target { unimplemented!() }
 }

--- a/src/test/ui/const-generics/integer-literal-generic-arg-in-where-clause.rs
+++ b/src/test/ui/const-generics/integer-literal-generic-arg-in-where-clause.rs
@@ -1,0 +1,18 @@
+// check-pass
+
+#![feature(const_generics)]
+//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+
+fn takes_closure_of_array_3<F>(f: F) where F: Fn([i32; 3]) {
+    f([1, 2, 3]);
+}
+
+fn takes_closure_of_array_3_apit(f: impl Fn([i32; 3])) {
+    f([1, 2, 3]);
+}
+
+fn returns_closure_of_array_3() -> impl Fn([i32; 3]) {
+    |_| {}
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/integer-literal-generic-arg-in-where-clause.stderr
+++ b/src/test/ui/const-generics/integer-literal-generic-arg-in-where-clause.stderr
@@ -1,0 +1,8 @@
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/integer-literal-generic-arg-in-where-clause.rs:3:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+

--- a/src/test/ui/lint/issue-66362-no-snake-case-warning-for-field-puns.rs
+++ b/src/test/ui/lint/issue-66362-no-snake-case-warning-for-field-puns.rs
@@ -1,0 +1,29 @@
+#![deny(non_snake_case)]
+#![allow(unused_variables)]
+#![allow(dead_code)]
+
+enum Foo {
+    Bad {
+        lowerCamelCaseName: bool,
+        //~^ ERROR structure field `lowerCamelCaseName` should have a snake case name
+    },
+    Good {
+        snake_case_name: bool,
+    },
+}
+
+fn main() {
+    let b = Foo::Bad { lowerCamelCaseName: true };
+
+    match b {
+        Foo::Bad { lowerCamelCaseName } => {}
+        Foo::Good { snake_case_name: lowerCamelCaseBinding } => { }
+        //~^ ERROR variable `lowerCamelCaseBinding` should have a snake case name
+    }
+
+    if let Foo::Good { snake_case_name: anotherLowerCamelCaseBinding } = b { }
+    //~^ ERROR variable `anotherLowerCamelCaseBinding` should have a snake case name
+
+    if let Foo::Bad { lowerCamelCaseName: yetAnotherLowerCamelCaseBinding } = b { }
+    //~^ ERROR variable `yetAnotherLowerCamelCaseBinding` should have a snake case name
+}

--- a/src/test/ui/lint/issue-66362-no-snake-case-warning-for-field-puns.stderr
+++ b/src/test/ui/lint/issue-66362-no-snake-case-warning-for-field-puns.stderr
@@ -1,0 +1,32 @@
+error: structure field `lowerCamelCaseName` should have a snake case name
+  --> $DIR/issue-66362-no-snake-case-warning-for-field-puns.rs:7:9
+   |
+LL |         lowerCamelCaseName: bool,
+   |         ^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `lower_camel_case_name`
+   |
+note: lint level defined here
+  --> $DIR/issue-66362-no-snake-case-warning-for-field-puns.rs:1:9
+   |
+LL | #![deny(non_snake_case)]
+   |         ^^^^^^^^^^^^^^
+
+error: variable `lowerCamelCaseBinding` should have a snake case name
+  --> $DIR/issue-66362-no-snake-case-warning-for-field-puns.rs:20:38
+   |
+LL |         Foo::Good { snake_case_name: lowerCamelCaseBinding } => { }
+   |                                      ^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `lower_camel_case_binding`
+
+error: variable `anotherLowerCamelCaseBinding` should have a snake case name
+  --> $DIR/issue-66362-no-snake-case-warning-for-field-puns.rs:24:41
+   |
+LL |     if let Foo::Good { snake_case_name: anotherLowerCamelCaseBinding } = b { }
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `another_lower_camel_case_binding`
+
+error: variable `yetAnotherLowerCamelCaseBinding` should have a snake case name
+  --> $DIR/issue-66362-no-snake-case-warning-for-field-puns.rs:27:43
+   |
+LL |     if let Foo::Bad { lowerCamelCaseName: yetAnotherLowerCamelCaseBinding } = b { }
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `yet_another_lower_camel_case_binding`
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Successful merges:

 - #66660 (Don't warn about snake case for field puns.)
 - #67940 (Update rustc-guide)
 - #68093 (Fix deref impl typedef)
 - #68279 (Clean up E0198 explanation)
 - #68312 (Add regression test for integer literals in generic arguments in where clauses)
 - #68314 (Stop treating `FalseEdges` and `FalseUnwind` as having semantic value for const eval)
 - #68317 (Clean up E0199 explanation)

Failed merges:


r? @ghost