### PR TITLE
rustc_hir: add Expr! pattern macro and try it out in a couple places.

### DIFF
--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -98,15 +98,17 @@ pub(super) fn note_and_explain_region(
             let span = scope.span(tcx, region_scope_tree);
             let tag = match tcx.hir().find(scope.hir_id(region_scope_tree)) {
                 Some(Node::Block(_)) => "block",
-                Some(Node::Expr(expr)) => match expr.kind {
-                    hir::ExprKind::Call(..) => "call",
-                    hir::ExprKind::MethodCall(..) => "method call",
-                    hir::ExprKind::Match(.., hir::MatchSource::IfLetDesugar { .. }) => "if let",
-                    hir::ExprKind::Match(.., hir::MatchSource::WhileLetDesugar) => "while let",
-                    hir::ExprKind::Match(.., hir::MatchSource::ForLoopDesugar) => "for",
-                    hir::ExprKind::Match(..) => "match",
-                    _ => "expression",
-                },
+                Some(Node::Expr(hir::Expr!(Call(..)))) => "call",
+                Some(Node::Expr(hir::Expr!(MethodCall(..)))) => "method call",
+                Some(Node::Expr(hir::Expr!(Match(.., hir::MatchSource::IfLetDesugar { .. })))) => {
+                    "if let"
+                }
+                Some(Node::Expr(hir::Expr!(Match(.., hir::MatchSource::WhileLetDesugar)))) => {
+                    "while let"
+                }
+                Some(Node::Expr(hir::Expr!(Match(.., hir::MatchSource::ForLoopDesugar)))) => "for",
+                Some(Node::Expr(hir::Expr!(Match(..)))) => "match",
+                Some(Node::Expr(_)) => "expression",
                 Some(Node::Stmt(_)) => "statement",
                 Some(Node::Item(it)) => item_scope_tag(&it),
                 Some(Node::TraitItem(it)) => trait_item_scope_tag(&it),

--- a/src/librustc/traits/error_reporting/suggestions.rs
+++ b/src/librustc/traits/error_reporting/suggestions.rs
@@ -178,7 +178,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             let parent_node = self.tcx.hir().get_parent_node(hir_id);
             if let Some(Node::Local(ref local)) = self.tcx.hir().find(parent_node) {
                 if let Some(ref expr) = local.init {
-                    if let hir::ExprKind::Index(_, _) = expr.kind {
+                    if let hir::Expr!(Index(_, _)) = expr {
                         if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(expr.span) {
                             err.span_suggestion(
                                 expr.span,
@@ -753,10 +753,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     /// `report_arg_count_mismatch`.
     pub fn get_fn_like_arguments(&self, node: Node<'_>) -> (Span, Vec<ArgKind>) {
         match node {
-            Node::Expr(&hir::Expr {
-                kind: hir::ExprKind::Closure(_, ref _decl, id, span, _),
-                ..
-            }) => (
+            Node::Expr(&hir::Expr!(Closure(_, ref _decl, id, span, _))) => (
                 self.tcx.sess.source_map().def_span(span),
                 self.tcx
                     .hir()
@@ -1699,7 +1696,7 @@ impl<'v> Visitor<'v> for ReturnsVisitor<'v> {
     }
 
     fn visit_expr(&mut self, ex: &'v hir::Expr<'v>) {
-        if let hir::ExprKind::Ret(Some(ex)) = ex.kind {
+        if let hir::Expr!(Ret(Some(ex))) = ex {
             self.0.push(ex);
         }
         hir::intravisit::walk_expr(self, ex);
@@ -1707,7 +1704,7 @@ impl<'v> Visitor<'v> for ReturnsVisitor<'v> {
 
     fn visit_body(&mut self, body: &'v hir::Body<'v>) {
         if body.generator_kind().is_none() {
-            if let hir::ExprKind::Block(block, None) = body.value.kind {
+            if let hir::Expr!(Block(block, None)) = &body.value {
                 if let Some(expr) = block.expr {
                     self.0.push(expr);
                 }

--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -1330,6 +1330,18 @@ pub struct Expr<'hir> {
     pub span: Span,
 }
 
+/// `Expr` pattern alias to facilitate pattern-matching.
+///
+/// Usage examples:
+/// * `hir::Expr!(Unary(_, hir::Expr!(Lit(_))))`
+/// * `hir::Expr! { Loop(..), hir_id: loop_id }`
+pub macro Expr($variant:ident $($rest:tt)*) {
+    $crate::hir::Expr {
+        kind: $crate::hir::ExprKind::$variant $($rest)*,
+        ..
+    }
+}
+
 // `Expr` is used a lot. Make sure it doesn't unintentionally get bigger.
 #[cfg(target_arch = "x86_64")]
 rustc_data_structures::static_assert_size!(Expr<'static>, 64);

--- a/src/librustc_hir/lib.rs
+++ b/src/librustc_hir/lib.rs
@@ -4,6 +4,7 @@
 
 #![feature(crate_visibility_modifier)]
 #![feature(const_fn)] // For the unsizing cast on `&[]`
+#![feature(decl_macro)]
 #![feature(in_band_lifetimes)]
 #![feature(specialization)]
 #![recursion_limit = "256"]

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -33,6 +33,7 @@
 #![feature(crate_visibility_modifier)]
 #![feature(never_type)]
 #![feature(nll)]
+#![feature(slice_patterns)]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/src/librustc_mir/borrow_check/diagnostics/region_name.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/region_name.rs
@@ -759,9 +759,9 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         let mir_hir_id = tcx.hir().as_local_hir_id(mbcx.mir_def_id).expect("non-local mir");
 
         let yield_span = match tcx.hir().get(mir_hir_id) {
-            hir::Node::Expr(hir::Expr {
-                kind: hir::ExprKind::Closure(_, _, _, span, _), ..
-            }) => (tcx.sess.source_map().end_point(*span)),
+            hir::Node::Expr(hir::Expr!(Closure(_, _, _, span, _))) => {
+                (tcx.sess.source_map().end_point(*span))
+            }
             _ => mbcx.body.span,
         };
 

--- a/src/librustc_mir_build/build/mod.rs
+++ b/src/librustc_mir_build/build/mod.rs
@@ -30,9 +30,7 @@ fn mir_build(tcx: TyCtxt<'_>, def_id: DefId) -> BodyAndCache<'_> {
 
     // Figure out what primary body this item has.
     let (body_id, return_ty_span) = match tcx.hir().get(id) {
-        Node::Expr(hir::Expr { kind: hir::ExprKind::Closure(_, decl, body_id, _, _), .. }) => {
-            (*body_id, decl.output.span())
-        }
+        Node::Expr(hir::Expr!(Closure(_, decl, body_id, _, _))) => (*body_id, decl.output.span()),
         Node::Item(hir::Item {
             kind: hir::ItemKind::Fn(hir::FnSig { decl, .. }, _, body_id),
             ..

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -2703,14 +2703,11 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 
         let expr = &tcx.hir().body(ast_const.body).value;
 
-        let lit_input = match expr.kind {
-            hir::ExprKind::Lit(ref lit) => Some(LitToConstInput { lit: &lit.node, ty, neg: false }),
-            hir::ExprKind::Unary(hir::UnOp::UnNeg, ref expr) => match expr.kind {
-                hir::ExprKind::Lit(ref lit) => {
-                    Some(LitToConstInput { lit: &lit.node, ty, neg: true })
-                }
-                _ => None,
-            },
+        let lit_input = match expr {
+            hir::Expr!(Lit(ref lit)) => Some(LitToConstInput { lit: &lit.node, ty, neg: false }),
+            hir::Expr!(Unary(hir::UnOp::UnNeg, hir::Expr!(Lit(ref lit)))) => {
+                Some(LitToConstInput { lit: &lit.node, ty, neg: true })
+            }
             _ => None,
         };
 

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1031,9 +1031,7 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> &ty::Generics {
                 None
             }
         }
-        Node::Expr(&hir::Expr { kind: hir::ExprKind::Closure(..), .. }) => {
-            Some(tcx.closure_base_def_id(def_id))
-        }
+        Node::Expr(hir::Expr!(Closure(..))) => Some(tcx.closure_base_def_id(def_id)),
         Node::Item(item) => match item.kind {
             ItemKind::OpaqueTy(hir::OpaqueTy { impl_trait_fn, .. }) => impl_trait_fn,
             _ => None,
@@ -1172,7 +1170,7 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> &ty::Generics {
     // provide junk type parameter defs - the only place that
     // cares about anything but the length is instantiation,
     // and we don't do that for closures.
-    if let Node::Expr(&hir::Expr { kind: hir::ExprKind::Closure(.., gen), .. }) = node {
+    if let Node::Expr(hir::Expr!(Closure(.., gen))) = node {
         let dummy_args = if gen.is_some() {
             &["<yield_ty>", "<return_ty>", "<witness>"][..]
         } else {
@@ -1433,8 +1431,8 @@ fn type_of(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
                 }
 
                 Node::Ty(&hir::Ty { kind: hir::TyKind::Path(_), .. })
-                | Node::Expr(&hir::Expr { kind: ExprKind::Struct(..), .. })
-                | Node::Expr(&hir::Expr { kind: ExprKind::Path(_), .. })
+                | Node::Expr(hir::Expr!(Struct(..)))
+                | Node::Expr(hir::Expr!(Path(_)))
                 | Node::TraitRef(..) => {
                     let path = match parent_node {
                         Node::Ty(&hir::Ty {


### PR DESCRIPTION
Came across more usecases for pattern aliases today, and realized we can use macros instead!
**EDIT**: I just checked, and pattern macros seem to be stable in 1.0? But they wouldn't have been scoped.
<details>
<summary>(click for backstory - TL;DR: pattern-matching <code>Ty</code> instead of <code>TyKind</code>)</summary>
<hr/>

I wanted to be able to write something like this, so that when the type doesn't match, it's printed (as opposed to just `assert!(ty.is_ref() || ty.is_ptr())`):
```rust
assert_matches!(ty.kind, ty::Ref(..) | ty::RawPtr(..));
```
But that would print `ty.kind`, instead of `ty`, so I'd want to match on `ty` instead:
```rust
assert_matches!(ty, ty::Ref!(..) | ty::RawPtr!(..));
```

The other example I came up with was `ty::Ref!(_, _, ty::Str!())` (for `&str`).
<hr/>
</details>

Here that idea is applied to HIR (and just `Expr` in particular), with a few patterns across the codebase replaced, to get a first impression of what can be done with it.

In the first commit I've included two examples (`rustc_lint::builtin` and `rustc_typeck::astconv`), which I found more interesting, while the second commit is more of a random set of replacements.

<hr/>

The definition of `hir::Expr!`, if we elide `$crate::hir::` paths, looks like this:
```rust
pub macro Expr($variant:ident $($rest:tt)*) {
    Expr { kind: ExprKind::$variant $($rest)*, .. }
}
```

At its most basic, this allows writing e.g. `hir::Expr!(Lit(_))` in a pattern.

But the real benefit comes from making nesting straightforward, e.g.:
```rust
hir::Expr!(Unary(hir::UnOp::UnNeg, hir::Expr!(Lit(lit))))
```

Also, you may have noticed the definition is technically more flexible than it needs to be.
This allows mentioning other fields as well, e.g. `hir::Expr! { Path(_), hir_id: path_hir_id }`.
I'm not attached to the syntax, but I think this is a neat ability.

The most complex pattern in this PR, after rustfmt, looks like this:
```rust
hir::Expr!(
    MethodCall(
        _,
        _,
        [hir::Expr!(Call(hir::Expr! { Path(ref qpath), hir_id: path_hir_id }, _)), ..],
    )
)
```

<hr/>

This probably qualifies for a @rust-lang/compiler design meeting discussion, but this is a rabbit hole I don't want to spend much time on, maybe @Centril or others are interested in taking over?