### PR TITLE
Beta backports

### DIFF
--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -181,7 +181,7 @@ impl CodeSuggestion {
 
             // Find the bounding span.
             let lo = substitution.parts.iter().map(|part| part.span.lo()).min().unwrap();
-            let hi = substitution.parts.iter().map(|part| part.span.hi()).min().unwrap();
+            let hi = substitution.parts.iter().map(|part| part.span.hi()).max().unwrap();
             let bounding_span = Span::with_root_ctxt(lo, hi);
             let lines = cm.span_to_lines(bounding_span).unwrap();
             assert!(!lines.lines.is_empty());

--- a/src/librustc_parse/parser/diagnostics.rs
+++ b/src/librustc_parse/parser/diagnostics.rs
@@ -300,15 +300,13 @@ impl<'a> Parser<'a> {
                 expect.clone()
             };
             (format!("expected one of {}, found {}", expect, actual),
-                (self.sess.source_map().next_point(self.prev_span),
-                format!("expected one of {}", short_expect)))
+                (self.prev_span.shrink_to_hi(), format!("expected one of {}", short_expect)))
         } else if expected.is_empty() {
             (format!("unexpected token: {}", actual),
                 (self.prev_span, "unexpected token after this".to_string()))
         } else {
             (format!("expected {}, found {}", expect, actual),
-                (self.sess.source_map().next_point(self.prev_span),
-                format!("expected {}", expect)))
+                (self.prev_span.shrink_to_hi(), format!("expected {}", expect)))
         };
         self.last_unexpected_token_span = Some(self.token.span);
         let mut err = self.fatal(&msg_exp);
@@ -871,7 +869,7 @@ impl<'a> Parser<'a> {
             _ if self.prev_span == DUMMY_SP => (self.token.span, self.token.span),
             // EOF, don't want to point at the following char, but rather the last token.
             (token::Eof, None) => (self.prev_span, self.token.span),
-            _ => (self.sess.source_map().next_point(self.prev_span), self.token.span),
+            _ => (self.prev_span.shrink_to_hi(), self.token.span),
         };
         let msg = format!(
             "expected `{}`, found {}",
@@ -1179,7 +1177,7 @@ impl<'a> Parser<'a> {
                     err.span_label(sp, "unclosed delimiter");
                 }
                 err.span_suggestion_short(
-                    self.sess.source_map().next_point(self.prev_span),
+                    self.prev_span.shrink_to_hi(),
                     &format!("{} may belong here", delim.to_string()),
                     delim.to_string(),
                     Applicability::MaybeIncorrect,

--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -1647,7 +1647,7 @@ impl<'a> Parser<'a> {
                             //   |      |
                             //   |      parsed until here as `"y" & X`
                             err.span_suggestion_short(
-                                cm.next_point(arm_start_span),
+                                arm_start_span.shrink_to_hi(),
                                 "missing a comma here to end this `match` arm",
                                 ",".to_owned(),
                                 Applicability::MachineApplicable

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -1706,7 +1706,7 @@ impl<'a> Parser<'a> {
             // it's safe to peel off one character only when it has the close delim
             self.prev_span.with_lo(self.prev_span.hi() - BytePos(1))
         } else {
-            self.sess.source_map().next_point(self.prev_span)
+            self.prev_span.shrink_to_hi()
         };
 
         self.struct_span_err(
@@ -1720,7 +1720,7 @@ impl<'a> Parser<'a> {
             ],
             Applicability::MaybeIncorrect,
         ).span_suggestion(
-            self.sess.source_map().next_point(self.prev_span),
+            self.prev_span.shrink_to_hi(),
             "add a semicolon",
             ';'.to_string(),
             Applicability::MaybeIncorrect,

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -144,7 +144,7 @@ impl<'a> Parser<'a> {
                     self.sess.gated_spans.gate(sym::const_extern_fn, lo.to(self.token.span));
                 }
                 let ext = self.parse_extern()?;
-                self.bump(); // `fn`
+                self.expect_keyword(kw::Fn)?;
 
                 let header = FnHeader {
                     unsafety,

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -1572,7 +1572,7 @@ impl<'a> Parser<'a> {
                 }
             }
             _ => {
-                let sp = self.sess.source_map().next_point(self.prev_span);
+                let sp = self.prev_span.shrink_to_hi();
                 let mut err = self.struct_span_err(sp, &format!("expected `,`, or `}}`, found {}",
                                                                 self.this_token_descr()));
                 if self.token.is_ident() {

--- a/src/librustc_parse/parser/mod.rs
+++ b/src/librustc_parse/parser/mod.rs
@@ -803,7 +803,7 @@ impl<'a> Parser<'a> {
                             break;
                         }
                         Err(mut expect_err) => {
-                            let sp = self.sess.source_map().next_point(self.prev_span);
+                            let sp = self.prev_span.shrink_to_hi();
                             let token_str = pprust::token_kind_to_string(t);
 
                             // Attempt to keep parsing if it was a similar separator.

--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -254,7 +254,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             hir::ExprKind::Block(..),
         ) = (parent_node, callee_node) {
             let start = sp.shrink_to_lo();
-            let end = self.tcx.sess.source_map().next_point(callee_span);
+            let end = callee_span.shrink_to_hi();
             err.multipart_suggestion(
                 "if you meant to create this closure and immediately call it, surround the \
                 closure with parenthesis",
@@ -332,9 +332,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             let call_is_multiline =
                                 self.tcx.sess.source_map().is_multiline(call_expr.span);
                             if call_is_multiline {
-                                let span = self.tcx.sess.source_map().next_point(callee.span);
                                 err.span_suggestion(
-                                    span,
+                                    callee.span.shrink_to_hi(),
                                     "try adding a semicolon",
                                     ";".to_owned(),
                                     Applicability::MaybeIncorrect,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4834,9 +4834,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 ExprKind::Loop(..) |
                 ExprKind::Match(..) |
                 ExprKind::Block(..) => {
-                    let sp = self.tcx.sess.source_map().next_point(cause_span);
                     err.span_suggestion(
-                        sp,
+                        cause_span.shrink_to_hi(),
                         "try adding a semicolon",
                         ";".to_string(),
                         Applicability::MachineApplicable);

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -318,8 +318,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
         cg: codegen_options,
         externs,
         target_triple: target,
-        // Ensure that rustdoc works even if rustc is feature-staged
-        unstable_features: UnstableFeatures::Allow,
+        unstable_features: UnstableFeatures::from_environment(),
         actually_rustdoc: true,
         debugging_opts: debugging_options,
         error_format,

--- a/src/libsyntax_expand/mbe/macro_parser.rs
+++ b/src/libsyntax_expand/mbe/macro_parser.rs
@@ -708,7 +708,7 @@ pub(super) fn parse(
                     Token::new(token::Eof, if parser.token.span.is_dummy() {
                         parser.token.span
                     } else {
-                        sess.source_map().next_point(parser.token.span)
+                        parser.token.span.shrink_to_hi()
                     }),
                     "missing tokens in macro arguments",
                 );

--- a/src/libsyntax_ext/assert.rs
+++ b/src/libsyntax_ext/assert.rs
@@ -105,7 +105,7 @@ fn parse_assert<'a>(
     let custom_message = if let token::Literal(token::Lit { kind: token::Str, .. })
                                 = parser.token.kind {
         let mut err = cx.struct_span_warn(parser.token.span, "unexpected string literal");
-        let comma_span = cx.source_map().next_point(parser.prev_span);
+        let comma_span = parser.prev_span.shrink_to_hi();
         err.span_suggestion_short(
             comma_span,
             "try adding a comma",

--- a/src/libsyntax_pos/source_map.rs
+++ b/src/libsyntax_pos/source_map.rs
@@ -739,7 +739,7 @@ impl SourceMap {
     pub fn next_point(&self, sp: Span) -> Span {
         let start_of_next_point = sp.hi().0;
 
-        let width = self.find_width_of_character_at_span(sp, true);
+        let width = self.find_width_of_character_at_span(sp.shrink_to_hi(), true);
         // If the width is 1, then the next span should point to the same `lo` and `hi`. However,
         // in the case of a multibyte character, where the width != 1, the next span should
         // span multiple bytes to include the whole character.

--- a/src/test/ui/consts/const-extern-fn/issue-68062-const-extern-fns-dont-need-fn-specifier-2.rs
+++ b/src/test/ui/consts/const-extern-fn/issue-68062-const-extern-fns-dont-need-fn-specifier-2.rs
@@ -1,0 +1,7 @@
+fn main() {}
+
+#[cfg(FALSE)]
+fn container() {
+    const unsafe WhereIsFerris Now() {}
+    //~^ ERROR expected one of `extern` or `fn`
+}

--- a/src/test/ui/consts/const-extern-fn/issue-68062-const-extern-fns-dont-need-fn-specifier-2.stderr
+++ b/src/test/ui/consts/const-extern-fn/issue-68062-const-extern-fns-dont-need-fn-specifier-2.stderr
@@ -1,0 +1,8 @@
+error: expected one of `extern` or `fn`, found `WhereIsFerris`
+  --> $DIR/issue-68062-const-extern-fns-dont-need-fn-specifier-2.rs:5:18
+   |
+LL |     const unsafe WhereIsFerris Now() {}
+   |                  ^^^^^^^^^^^^^ expected one of `extern` or `fn`
+
+error: aborting due to previous error
+

--- a/src/test/ui/consts/const-extern-fn/issue-68062-const-extern-fns-dont-need-fn-specifier.rs
+++ b/src/test/ui/consts/const-extern-fn/issue-68062-const-extern-fns-dont-need-fn-specifier.rs
@@ -1,0 +1,8 @@
+fn main() {}
+
+#[cfg(FALSE)]
+fn container() {
+    const extern "Rust" PUT_ANYTHING_YOU_WANT_HERE bug() -> usize { 1 }
+    //~^ ERROR expected `fn`
+    //~| ERROR `const extern fn` definitions are unstable
+}

--- a/src/test/ui/consts/const-extern-fn/issue-68062-const-extern-fns-dont-need-fn-specifier.stderr
+++ b/src/test/ui/consts/const-extern-fn/issue-68062-const-extern-fns-dont-need-fn-specifier.stderr
@@ -1,0 +1,18 @@
+error: expected `fn`, found `PUT_ANYTHING_YOU_WANT_HERE`
+  --> $DIR/issue-68062-const-extern-fns-dont-need-fn-specifier.rs:5:25
+   |
+LL |     const extern "Rust" PUT_ANYTHING_YOU_WANT_HERE bug() -> usize { 1 }
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `fn`
+
+error[E0658]: `const extern fn` definitions are unstable
+  --> $DIR/issue-68062-const-extern-fns-dont-need-fn-specifier.rs:5:5
+   |
+LL |     const extern "Rust" PUT_ANYTHING_YOU_WANT_HERE bug() -> usize { 1 }
+   |     ^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/64926
+   = help: add `#![feature(const_extern_fn)]` to the crate attributes to enable
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/issues/issue-68000-unicode-ident-after-missing-comma.rs
+++ b/src/test/ui/issues/issue-68000-unicode-ident-after-missing-comma.rs
@@ -1,0 +1,6 @@
+pub struct Foo {
+    pub bar: Vec<i32>ö
+    //~^ ERROR expected `,`, or `}`, found `ö`
+} //~ ERROR expected `:`, found `}`
+
+fn main() {}

--- a/src/test/ui/issues/issue-68000-unicode-ident-after-missing-comma.stderr
+++ b/src/test/ui/issues/issue-68000-unicode-ident-after-missing-comma.stderr
@@ -1,0 +1,17 @@
+error: expected `,`, or `}`, found `ö`
+  --> $DIR/issue-68000-unicode-ident-after-missing-comma.rs:2:22
+   |
+LL |     pub bar: Vec<i32>ö
+   |                      ^ help: try adding a comma: `,`
+
+error: expected `:`, found `}`
+  --> $DIR/issue-68000-unicode-ident-after-missing-comma.rs:4:1
+   |
+LL |     pub bar: Vec<i32>ö
+   |                       - expected `:`
+LL |
+LL | }
+   | ^ unexpected token
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/issues/issue-68091-unicode-ident-after-if.rs
+++ b/src/test/ui/issues/issue-68091-unicode-ident-after-if.rs
@@ -1,0 +1,9 @@
+macro_rules! x {
+    ($($c:tt)*) => {
+        $($c)ö* {} //~ ERROR missing condition for `if` expression
+    };
+}
+
+fn main() {
+    x!(if);
+}

--- a/src/test/ui/issues/issue-68091-unicode-ident-after-if.stderr
+++ b/src/test/ui/issues/issue-68091-unicode-ident-after-if.stderr
@@ -1,0 +1,8 @@
+error: missing condition for `if` expression
+  --> $DIR/issue-68091-unicode-ident-after-if.rs:3:14
+   |
+LL |         $($c)ö* {}
+   |              ^ expected if condition here
+
+error: aborting due to previous error
+

--- a/src/test/ui/issues/issue-68092-unicode-ident-after-incomplete-expr.rs
+++ b/src/test/ui/issues/issue-68092-unicode-ident-after-incomplete-expr.rs
@@ -1,0 +1,9 @@
+macro_rules! x {
+    ($($c:tt)*) => {
+        $($c)ö* //~ ERROR macro expansion ends with an incomplete expression: expected expression
+    };
+}
+
+fn main() {
+    x!(!);
+}

--- a/src/test/ui/issues/issue-68092-unicode-ident-after-incomplete-expr.stderr
+++ b/src/test/ui/issues/issue-68092-unicode-ident-after-incomplete-expr.stderr
@@ -1,0 +1,8 @@
+error: macro expansion ends with an incomplete expression: expected expression
+  --> $DIR/issue-68092-unicode-ident-after-incomplete-expr.rs:3:14
+   |
+LL |         $($c)ö*
+   |              ^ expected expression
+
+error: aborting due to previous error
+


### PR DESCRIPTION
- expect `fn` after `const unsafe` / `const extern` #68073
- Do not ICE on unicode next point #68084
- rustdoc: Don't allow `#![feature(...)]` on stable or beta #67989

r? @Mark-Simulacrum 