### PR TITLE
FR: impl core::ops::* for F where F: Fn {}

### DIFF
--- a/src/libcore/ops/function.rs
+++ b/src/libcore/ops/function.rs
@@ -356,4 +356,4 @@ macro_rules! gen_fn_struct_unopt {
     };
 }
 gen_fn_struct_unopt!(impl Not, not with fn_not_impl in FnNot);
-gen_fn_struct_unopt!(impl Neg, neg with fn_neg_impl in FnNot);
+gen_fn_struct_unopt!(impl Neg, neg with fn_neg_impl in FnNeg);

--- a/src/libcore/ops/function.rs
+++ b/src/libcore/ops/function.rs
@@ -393,7 +393,8 @@ macro_rules! gen_fn_struct_biopt {
             #[$attr]
             impl<A, F1: ?Sized, F2: ?Sized> $imp<F2> for F1
             where
-                F: FnOnce<A>,
+                F1: FnOnce<A>,
+                F2: FnOnce<A>,
             {
                 type Output = $z<F1, F2>;
                 fn $method(self, that: F2) -> Self::Output {
@@ -403,7 +404,8 @@ macro_rules! gen_fn_struct_biopt {
             #[$attr]
             impl<A, F1: ?Sized, F2: ?Sized> Fn<A> for &$z<F1, F2>
             where
-                F: Fn<A>,
+                F1: Fn<A>,
+                F2: Fn<A>,
             {
                 extern "rust-call" fn call(&self, args: A) -> <F::Output as $imp>::Output {
                     $imp::$method(((**self).f1).call(args), ((**self).f2).call(args))
@@ -413,7 +415,8 @@ macro_rules! gen_fn_struct_biopt {
             #[$attr]
             impl<A, F1: ?Sized, F2: ?Sized> FnMut<A> for &$z<F1, F2>
             where
-                F: Fn<A>,
+                F1: Fn<A>,
+                F2: Fn<A>,
             {
                 extern "rust-call" fn call_mut(&mut self, args: A) -> <F::Output as $imp>::Output {
                     $imp::$method(((**self).f1).call(args), ((**self).f2).call(args))
@@ -423,7 +426,8 @@ macro_rules! gen_fn_struct_biopt {
             #[$attr]
             impl<A, F1: ?Sized, F2: ?Sized> FnOnce<A> for &$z<F1, F2>
             where
-                F: Fn<A>,
+                F1: Fn<A>,
+                F2: Fn<A>,
             {
                 type Output = F::Output;
 
@@ -435,7 +439,8 @@ macro_rules! gen_fn_struct_biopt {
             #[$attr]
             impl<A, F1: ?Sized, F2: ?Sized> FnMut<A> for &mut $z<F1, F2>
             where
-                F: FnMut<A>,
+                F1: FnMut<A>,
+                F2: FnMut<A>,
             {
                 extern "rust-call" fn call_mut(&mut self, args: A) -> <F::Output as $imp>::Output {
                     $imp::$method(((**self).f1).call_mut(args), ((**self).f2).call_mut(args))
@@ -445,7 +450,8 @@ macro_rules! gen_fn_struct_biopt {
             #[$attr]
             impl<A, F1: ?Sized, F2: ?Sized> FnOnce<A> for &mut $z<F>
             where
-                F: FnMut<A>,
+                F1: FnMut<A>,
+                F2: FnMut<A>,
             {
                 type Output = F::Output;
                 extern "rust-call" fn call_once(self, args: A) -> <F::Output as $imp>::Output {

--- a/src/libcore/ops/function.rs
+++ b/src/libcore/ops/function.rs
@@ -289,7 +289,7 @@ mod impls {
 
 macro_rules! gen_fn_struct_unopt {
     (impl $imp:ident, $method:ident with $m:ident in $z:ident) => {
-        gen_bit_fn_struct!(impl $imp, $method with $m in $z,
+        gen_fn_struct!(impl $imp, $method with $m in $z,
             #[unstable(feature = $m)]);
     };
     (impl $imp:ident, $method:ident with $m:ident in $z:ident, #[$attr:meta]) => {

--- a/src/libcore/ops/function.rs
+++ b/src/libcore/ops/function.rs
@@ -396,12 +396,12 @@ macro_rules! gen_fn_struct_biopt {
                 F: FnOnce<A>,
             {
                 type Output = $z<F1, F2>;
-                fn $method(self, rhs: F2) -> Self::Output {
-                    $z { f: self }
+                fn $method(self, that: F2) -> Self::Output {
+                    $z { f1: self, f2: that }
                 }
             }
             #[$attr]
-            impl<A, F: ?Sized> Fn<A> for &$z<F>
+            impl<A, F1: ?Sized, F2: ?Sized> Fn<A> for &$z<F1, F2>
             where
                 F: Fn<A>,
             {
@@ -411,7 +411,7 @@ macro_rules! gen_fn_struct_biopt {
             }
 
             #[$attr]
-            impl<A, F: ?Sized> FnMut<A> for &$z<F>
+            impl<A, F1: ?Sized, F2: ?Sized> FnMut<A> for &$z<F1, F2>
             where
                 F: Fn<A>,
             {
@@ -421,7 +421,7 @@ macro_rules! gen_fn_struct_biopt {
             }
 
             #[$attr]
-            impl<A, F: ?Sized> FnOnce<A> for &$z<F>
+            impl<A, F1: ?Sized, F2: ?Sized> FnOnce<A> for &$z<F1, F2>
             where
                 F: Fn<A>,
             {
@@ -433,7 +433,7 @@ macro_rules! gen_fn_struct_biopt {
             }
 
             #[$attr]
-            impl<A, F: ?Sized> FnMut<A> for &mut $z<F>
+            impl<A, F1: ?Sized, F2: ?Sized> FnMut<A> for &mut $z<F1, F2>
             where
                 F: FnMut<A>,
             {
@@ -443,7 +443,7 @@ macro_rules! gen_fn_struct_biopt {
             }
 
             #[$attr]
-            impl<A, F: ?Sized> FnOnce<A> for &mut $z<F>
+            impl<A, F1: ?Sized, F2: ?Sized> FnOnce<A> for &mut $z<F>
             where
                 F: FnMut<A>,
             {

--- a/src/libcore/ops/function.rs
+++ b/src/libcore/ops/function.rs
@@ -306,7 +306,7 @@ macro_rules! gen_fn_struct_unopt {
                 F: Fn<A>,
             {
                 extern "rust-call" fn call(&self, args: A) -> F::Output {
-                    $imp::$method((**self.f).call(args))
+                    $imp::$method(((**self).f).call(args))
                 }
             }
 
@@ -316,7 +316,7 @@ macro_rules! gen_fn_struct_unopt {
                 F: Fn<A>,
             {
                 extern "rust-call" fn call_mut(&mut self, args: A) -> F::Output {
-                    $imp::$method((**self.f).call(args))
+                    $imp::$method(((**self).f).call(args))
                 }
             }
 
@@ -328,7 +328,7 @@ macro_rules! gen_fn_struct_unopt {
                 type Output = F::Output;
 
                 extern "rust-call" fn call_once(self, args: A) -> F::Output {
-                    $imp::$method((*self.f).call(args))
+                    $imp::$method(((*self).f).call(args))
                 }
             }
 
@@ -338,7 +338,7 @@ macro_rules! gen_fn_struct_unopt {
                 F: FnMut<A>,
             {
                 extern "rust-call" fn call_mut(&mut self, args: A) -> F::Output {
-                    $imp::$method((*self.f).call_mut(args))
+                    $imp::$method(((*self).f).call_mut(args))
                 }
             }
 
@@ -349,7 +349,7 @@ macro_rules! gen_fn_struct_unopt {
             {
                 type Output = F::Output;
                 extern "rust-call" fn call_once(self, args: A) -> F::Output {
-                    $imp::$method((*self.f).call_mut(args))
+                    $imp::$method(((*self).f).call_mut(args))
                 }
             }
         }

--- a/src/libcore/ops/function.rs
+++ b/src/libcore/ops/function.rs
@@ -289,7 +289,7 @@ mod impls {
 
 macro_rules! gen_fn_struct_unopt {
     (impl $imp:ident, $method:ident with $m:ident in $z:ident) => {
-        gen_fn_struct!(impl $imp, $method with $m in $z,
+        gen_fn_struct_unopt!(impl $imp, $method with $m in $z,
             #[unstable(feature = $m)]);
     };
     (impl $imp:ident, $method:ident with $m:ident in $z:ident, #[$attr:meta]) => {

--- a/src/libcore/ops/function.rs
+++ b/src/libcore/ops/function.rs
@@ -288,11 +288,11 @@ mod impls {
 }
 
 macro_rules! gen_fn_struct_unopt {
-    (impl $imp:ident, $method:ident in $m:ty; with $z:path) => {
+    (impl $imp:ident, $method:ident in $m:path; with $z:ty) => {
         gen_fn_struct_unopt!(impl $imp, $method in $m; with $z,
             #[unstable(feature = stringify!($m))]);
     };
-    (impl $imp:ident, $method:ident in $m:ty; with $z:path, #[$attr:meta]) => {
+    (impl $imp:ident, $method:ident in $m:path; with $z:ty, #[$attr:meta]) => {
         #[$attr]
         mod $m {
             use crate::ops::$imp;

--- a/src/libcore/ops/function.rs
+++ b/src/libcore/ops/function.rs
@@ -288,11 +288,11 @@ mod impls {
 }
 
 macro_rules! gen_fn_struct_unopt {
-    (impl $imp:ident, $method:ident in $m:ty with $z:ty) => {
-        gen_fn_struct_unopt!(impl $imp, $method with $m in $z,
+    (impl $imp:ident, $method:ident in $m:ty; with $z:path) => {
+        gen_fn_struct_unopt!(impl $imp, $method in $m; with $z,
             #[unstable(feature = stringify!($m))]);
     };
-    (impl $imp:ident, $method:ident with $m:ident in $z:ident, #[$attr:meta]) => {
+    (impl $imp:ident, $method:ident in $m:ty; with $z:path, #[$attr:meta]) => {
         #[$attr]
         mod $m {
             use crate::ops::$imp;
@@ -375,5 +375,5 @@ macro_rules! gen_fn_struct_unopt {
         }
     };
 }
-gen_fn_struct_unopt!(impl Not, not in fn_not_impl with FnNot);
-gen_fn_struct_unopt!(impl Neg, neg in fn_neg_impl with FnNeg);
+gen_fn_struct_unopt!(impl Not, not in fn_not_impl; with FnNot);
+gen_fn_struct_unopt!(impl Neg, neg in fn_neg_impl; with FnNeg);

--- a/src/libcore/ops/function.rs
+++ b/src/libcore/ops/function.rs
@@ -288,9 +288,9 @@ mod impls {
 }
 
 macro_rules! gen_fn_struct_unopt {
-    (impl $imp:ident, $method:ident with $m:ident in $z:ident) => {
+    (impl $imp:ident, $method:ident in $m:ty with $z:ty) => {
         gen_fn_struct_unopt!(impl $imp, $method with $m in $z,
-            #[unstable(feature = $m)]);
+            #[unstable(feature = stringify!($m))]);
     };
     (impl $imp:ident, $method:ident with $m:ident in $z:ident, #[$attr:meta]) => {
         #[$attr]
@@ -375,5 +375,5 @@ macro_rules! gen_fn_struct_unopt {
         }
     };
 }
-gen_fn_struct_unopt!(impl Not, not with fn_not_impl in FnNot);
-gen_fn_struct_unopt!(impl Neg, neg with fn_neg_impl in FnNeg);
+gen_fn_struct_unopt!(impl Not, not in fn_not_impl with FnNot);
+gen_fn_struct_unopt!(impl Neg, neg in fn_neg_impl with FnNeg);

--- a/src/libcore/ops/function.rs
+++ b/src/libcore/ops/function.rs
@@ -328,7 +328,7 @@ macro_rules! gen_fn_struct_unopt {
                 type Output = F::Output;
 
                 extern "rust-call" fn call_once(self, args: A) -> F::Output {
-                    $imp::$method((*self).call(args))
+                    $imp::$method((*self.f).call(args))
                 }
             }
 
@@ -338,7 +338,7 @@ macro_rules! gen_fn_struct_unopt {
                 F: FnMut<A>,
             {
                 extern "rust-call" fn call_mut(&mut self, args: A) -> F::Output {
-                    $imp::$method((*self).call_mut(args))
+                    $imp::$method((*self.f).call_mut(args))
                 }
             }
 
@@ -349,7 +349,7 @@ macro_rules! gen_fn_struct_unopt {
             {
                 type Output = F::Output;
                 extern "rust-call" fn call_once(self, args: A) -> F::Output {
-                    $imp::$method((*self).call_mut(args))
+                    $imp::$method((*self.f).call_mut(args))
                 }
             }
         }

--- a/src/libcore/ops/function.rs
+++ b/src/libcore/ops/function.rs
@@ -300,18 +300,20 @@ macro_rules! gen_fn_struct_unopt {
             struct $z<F> {
                 f: F,
             }
+            #[$attr]
             impl<A, F: ?Sized> $imp for F
             where
-                F: Fn<A>,
+                F: FnOnce<A>,
             {
                 type Output = $z<F>;
                 fn $method(self) -> Self::Output {
                     $z { f: self }
                 }
             }
+            #[$attr]
             impl<A, F: ?Sized> $imp for $z<F>
             where
-                F: Fn<A>,
+                F: FnOnce<A>,
             {
                 type Output = F;
                 fn $method(self) -> Self::Output {

--- a/src/libcore/ops/function.rs
+++ b/src/libcore/ops/function.rs
@@ -300,12 +300,30 @@ macro_rules! gen_fn_struct_unopt {
             struct $z<F> {
                 f: F,
             }
+            impl<A, F: ?Sized> $imp for F
+            where
+                F: Fn<A>,
+            {
+                type Output = $z<F>;
+                fn $method(self) -> Self::Output {
+                    $z { f: self }
+                }
+            }
+            impl<A, F: ?Sized> $imp for $z<F>
+            where
+                F: Fn<A>,
+            {
+                type Output = F;
+                fn $method(self) -> Self::Output {
+                    self.f
+                }
+            }
             #[$attr]
             impl<A, F: ?Sized> Fn<A> for &$z<F>
             where
                 F: Fn<A>,
             {
-                extern "rust-call" fn call(&self, args: A) -> F::Output {
+                extern "rust-call" fn call(&self, args: A) -> <F::Output as $imp>::Output {
                     $imp::$method(((**self).f).call(args))
                 }
             }
@@ -315,7 +333,7 @@ macro_rules! gen_fn_struct_unopt {
             where
                 F: Fn<A>,
             {
-                extern "rust-call" fn call_mut(&mut self, args: A) -> F::Output {
+                extern "rust-call" fn call_mut(&mut self, args: A) -> <F::Output as $imp>::Output {
                     $imp::$method(((**self).f).call(args))
                 }
             }
@@ -327,7 +345,7 @@ macro_rules! gen_fn_struct_unopt {
             {
                 type Output = F::Output;
 
-                extern "rust-call" fn call_once(self, args: A) -> F::Output {
+                extern "rust-call" fn call_once(self, args: A) -> <F::Output as $imp>::Output {
                     $imp::$method(((*self).f).call(args))
                 }
             }
@@ -337,7 +355,7 @@ macro_rules! gen_fn_struct_unopt {
             where
                 F: FnMut<A>,
             {
-                extern "rust-call" fn call_mut(&mut self, args: A) -> F::Output {
+                extern "rust-call" fn call_mut(&mut self, args: A) -> <F::Output as $imp>::Output {
                     $imp::$method(((*self).f).call_mut(args))
                 }
             }
@@ -348,7 +366,7 @@ macro_rules! gen_fn_struct_unopt {
                 F: FnMut<A>,
             {
                 type Output = F::Output;
-                extern "rust-call" fn call_once(self, args: A) -> F::Output {
+                extern "rust-call" fn call_once(self, args: A) -> <F::Output as $imp>::Output {
                     $imp::$method(((*self).f).call_mut(args))
                 }
             }


### PR DESCRIPTION
Was looking into making closures like

```rust
|x| !x.some_boolean_function()
```

or

```rust
|x| -x.some_numeric_function()
```

into more simple manners by way of some closing structure; namely

```rust
!Structure::some_boolean_function
```

or

```rust
-Structure::some_numeric_function
```

for something like

```rust
let s: String = vec!["hi ", "there ", "friend", "", "."].into_iter().filter(!String::is_empty).collect();
```

or

```rust
let neg = ::std::iter::successors(Some(1_i128), -|x| x.checked_mul(2));
```

or similar.

Was hoping to figure it out with a simple one but... as it can be seen it takes some work and is not very nice to read through.

`Neg` may be something to reconsider in this case...