### PR TITLE
Use slash instead of backslash on windows-gnu platform.

### DIFF
--- a/src/libstd/sys/windows/path.rs
+++ b/src/libstd/sys/windows/path.rs
@@ -89,6 +89,9 @@ pub fn parse_prefix(path: &OsStr) -> Option<Prefix<'_>> {
         Some((first, second))
     }
 }
-
+#[cfg(target_env="gnu")]
+pub const MAIN_SEP_STR: &str = "/";
+pub const MAIN_SEP: char = '/';
+#[cfg(not(target_env="gnu"))]
 pub const MAIN_SEP_STR: &str = "\\";
 pub const MAIN_SEP: char = '\\';

--- a/src/libstd/sys/windows/path.rs
+++ b/src/libstd/sys/windows/path.rs
@@ -91,7 +91,9 @@ pub fn parse_prefix(path: &OsStr) -> Option<Prefix<'_>> {
 }
 #[cfg(target_env="gnu")]
 pub const MAIN_SEP_STR: &str = "/";
+#[cfg(target_env="gnu")]
 pub const MAIN_SEP: char = '/';
 #[cfg(not(target_env="gnu"))]
 pub const MAIN_SEP_STR: &str = "\\";
+#[cfg(not(target_env="gnu"))]
 pub const MAIN_SEP: char = '\\';


### PR DESCRIPTION
It's needed for working with other gnu utils. For example, now in dep-info used backslashes, and it's needed special support in Makefiles