### PR TITLE
Add `riscv64gc-unknown-linux-gnu` into target list in build-manifest

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -110,6 +110,7 @@ static TARGETS: &[&str] = &[
     "riscv32imac-unknown-none-elf",
     "riscv64imac-unknown-none-elf",
     "riscv64gc-unknown-none-elf",
+    "riscv64gc-unknown-linux-gnu",
     "s390x-unknown-linux-gnu",
     "sparc64-unknown-linux-gnu",
     "sparcv9-sun-solaris",


### PR DESCRIPTION
Missed in #68037 

r? @alexcrichton