### PR TITLE
Make iter::Empty<T> Send and Sync for any T

### DIFF
--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -208,6 +208,11 @@ pub fn repeat_with<A, F: FnMut() -> A>(repeater: F) -> RepeatWith<F> {
 #[stable(feature = "iter_empty", since = "1.2.0")]
 pub struct Empty<T>(marker::PhantomData<T>);
 
+#[stable(feature = "iter_empty_send_sync", since = "1.42.0")]
+unsafe impl<T> Send for Empty<T> {}
+#[stable(feature = "iter_empty_send_sync", since = "1.42.0")]
+unsafe impl<T> Sync for Empty<T> {}
+
 #[stable(feature = "core_impl_debug", since = "1.9.0")]
 impl<T> fmt::Debug for Empty<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/test/ui/threads-sendsync/sync-send-iterators-in-libcore.rs
+++ b/src/test/ui/threads-sendsync/sync-send-iterators-in-libcore.rs
@@ -88,6 +88,7 @@ fn main() {
     is_sync_send!((1..));
     is_sync_send!(repeat(1));
     is_sync_send!(empty::<usize>());
+    is_sync_send!(empty::<*mut i32>());
     is_sync_send!(once(1));
 
     // for option.rs


### PR DESCRIPTION
Continuing from #57682

It's quite funny, when I initially submitted this pull request, I said "Likely nobody will be using that property of `iter::empty`", but then a year later I got a compilation error because it wasn't `Send` and `Sync`.

Unfortunately, `PhantomData<fn() -> T>` still errors out. Oh well. I proposed `
struct PhantomFnWorkaround<T>(fn() -> T);`, but dtolnay did not like it, so using explicit implementations.