### PR TITLE
Add lint for never type regressions

### DIFF
--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -2286,7 +2286,8 @@ impl<'tcx> TyCtxt<'tcx> {
 
     #[inline]
     pub fn mk_diverging_default(self) -> Ty<'tcx> {
-        if self.features().never_type_fallback { self.types.never } else { self.types.unit }
+        self.types.never
+        //if self.features().never_type_fallback { self.types.never } else { self.types.unit }
     }
 
     #[inline]

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1149,8 +1149,6 @@ fn typeck_tables_of_with_fallback<'tcx>(
         // See if we can make any more progress.
         fcx.select_obligations_where_possible(fallback_has_occurred, |_| {});
 
-        never_compat.post_fallback(&fcx);
-
         // Even though coercion casts provide type hints, we check casts after fallback for
         // backwards compatibility. This makes fallback a stronger type hint than a cast coercion.
         fcx.check_casts();
@@ -1167,6 +1165,10 @@ fn typeck_tables_of_with_fallback<'tcx>(
         }
 
         fcx.select_all_obligations_or_error();
+
+        // Report other errors in preference to never-type
+        // fallback errors.
+        never_compat.post_fallback(&fcx);
 
         if fn_decl.is_some() {
             fcx.regionck_fn(id, body);

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1164,6 +1164,13 @@ fn typeck_tables_of_with_fallback<'tcx>(
 
                 if inhabited {
                     debug!("All arguments are inhabited!");
+                    fcx.tcx()
+                        .sess
+                        .struct_span_warn(
+                            path.span,
+                            "Fallback to `!` may introduce undefined behavior",
+                        )
+                        .emit();
                 }
             }
         }

--- a/src/librustc_typeck/check/never_compat.rs
+++ b/src/librustc_typeck/check/never_compat.rs
@@ -1,0 +1,215 @@
+use crate::check::{FnCtxt, InferredPath};
+use crate::rustc::ty::TypeFoldable;
+use rustc::infer::type_variable::TypeVariableOriginKind;
+use rustc::infer::InferCtxt;
+use rustc::ty;
+use rustc::ty::fold::TypeFolder;
+use rustc::ty::{Ty, TyCtxt};
+use rustc_data_structures::fx::FxHashMap;
+use rustc_hir::HirId;
+
+/// Code to detect cases where using `!` (never-type) fallback instead of `()` fallback
+/// may result in the introduction of undefined behavior
+///
+
+pub struct NeverCompatHandler<'tcx> {
+    unresolved_paths: FxHashMap<HirId, InferredPath<'tcx>>,
+    unconstrained_diverging: Vec<Ty<'tcx>>,
+}
+
+struct TyVarFinder<'a, 'tcx> {
+    infcx: &'a InferCtxt<'a, 'tcx>,
+    vars: Vec<Ty<'tcx>>,
+}
+impl<'a, 'tcx> TypeFolder<'tcx> for TyVarFinder<'a, 'tcx> {
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.infcx.tcx
+    }
+
+    fn fold_ty(&mut self, t: Ty<'tcx>) -> Ty<'tcx> {
+        if let ty::Infer(ty::InferTy::TyVar(_)) = t.kind {
+            self.vars.push(t);
+        }
+        t.super_fold_with(self)
+    }
+}
+
+impl<'tcx> NeverCompatHandler<'tcx> {
+    pub fn pre_fallback(fcx: &FnCtxt<'a, 'tcx>) -> NeverCompatHandler<'tcx> {
+        let unresolved_paths: FxHashMap<HirId, InferredPath<'tcx>> = fcx
+            .inferred_paths
+            .borrow()
+            .iter()
+            .map(|(id, path)| (*id, path.clone()))
+            .filter_map(|(hir_id, mut path)| {
+                debug!("pre_fallback: inspecting path ({:?}, {:?})", hir_id, path);
+
+                let ty_resolved = fcx.infcx.resolve_vars_if_possible(&path.ty);
+
+                let fn_substs = match ty_resolved {
+                    Some(ty::TyS { kind: ty::FnDef(_, substs), .. }) => substs,
+                    _ => {
+                        debug!("pre_fallback: non-fn ty {:?}, skipping", ty_resolved);
+                        return None;
+                    }
+                };
+
+                if fcx.infcx.unresolved_type_vars(fn_substs).is_some() {
+                    for subst in fn_substs.types() {
+                        let mut finder = TyVarFinder { infcx: &fcx.infcx, vars: vec![] };
+                        path.ty.fold_with(&mut finder);
+                        path.unresolved_vars.push(finder.vars);
+                    }
+
+                    debug!(
+                        "pre_fallback: unresolved vars in ty {:?} : {:?}",
+                        ty_resolved, path.unresolved_vars
+                    );
+
+                    Some((hir_id, path))
+                } else {
+                    debug!("pre_fallback: all vars resolved in ty: {:?}", ty_resolved);
+                    None
+                }
+            })
+            .collect();
+
+        let unconstrained_diverging: Vec<_> = fcx
+            .unsolved_variables()
+            .iter()
+            .cloned()
+            .filter(|ty| fcx.infcx.type_var_diverges(ty))
+            .collect();
+
+        NeverCompatHandler { unresolved_paths, unconstrained_diverging }
+    }
+
+    pub fn post_fallback(self, fcx: &FnCtxt<'a, 'tcx>) {
+        let tcx = fcx.tcx;
+        for (call_id, path) in self.unresolved_paths {
+            debug!(
+                "Resolved ty: {:?} at span {:?} : expr={:?} parent={:?} path={:?}",
+                path.span,
+                path.ty,
+                tcx.hir().get(call_id),
+                tcx.hir().get(tcx.hir().get_parent_node(call_id)),
+                path
+            );
+
+            let ty = fcx.infcx.resolve_vars_if_possible(&path.ty);
+            debug!("Fully resolved ty: {:?}", ty);
+
+            let ty = ty.unwrap_or_else(|| bug!("Missing ty in path: {:?}", path));
+
+            if let ty::FnDef(_, substs) = ty.kind {
+                debug!("Got substs: {:?}", substs);
+                let mut args_inhabited = true;
+                let mut uninhabited_subst = None;
+
+                for arg in &*path.args.unwrap() {
+                    let resolved_arg = fcx.infcx.resolve_vars_if_possible(arg);
+
+                    if resolved_arg.conservative_is_privately_uninhabited(tcx) {
+                        debug!("Arg is uninhabited: {:?}", resolved_arg);
+                        args_inhabited = false;
+                        break;
+                    } else {
+                        debug!("Arg is inhabited: {:?}", resolved_arg);
+                    }
+                }
+
+                for (subst_ty, vars) in substs.types().zip(path.unresolved_vars.into_iter()) {
+                    let resolved_subst = fcx.infcx.resolve_vars_if_possible(&subst_ty);
+                    if resolved_subst.conservative_is_privately_uninhabited(tcx) {
+                        debug!("Subst is uninhabited: {:?}", resolved_subst);
+                        if !vars.is_empty() {
+                            debug!("Found fallback vars: {:?}", vars);
+                            uninhabited_subst = Some((resolved_subst, vars));
+                            break;
+                        } else {
+                            debug!("No fallback vars")
+                        }
+                    } else {
+                        debug!("Subst is inhabited: {:?}", resolved_subst);
+                    }
+                }
+
+                if let (true, Some((subst, vars))) = (args_inhabited, uninhabited_subst) {
+                    debug!("All arguments are inhabited, at least one subst is not inhabited!");
+
+                    let mut best_diverging_var = None;
+                    let mut best_var = None;
+
+                    for var in vars {
+                        for diverging_var in &self.unconstrained_diverging {
+                            match (&var.kind, &diverging_var.kind) {
+                                (
+                                    ty::Infer(ty::InferTy::TyVar(vid1)),
+                                    ty::Infer(ty::InferTy::TyVar(vid2)),
+                                ) => {
+                                    if fcx
+                                        .infcx
+                                        .type_variables
+                                        .borrow_mut()
+                                        .sub_unified(*vid1, *vid2)
+                                    {
+                                        debug!(
+                                            "Type variable {:?} is equal to diverging var {:?}",
+                                            var, diverging_var
+                                        );
+
+                                        debug!(
+                                            "Var origin: {:?}",
+                                            fcx.infcx.type_variables.borrow().var_origin(*vid1)
+                                        );
+                                        best_var = Some(vid1);
+                                        best_diverging_var = Some(vid2);
+                                    }
+                                }
+                                _ => bug!(
+                                    "Unexpected types: var={:?} diverging_var={:?}",
+                                    var,
+                                    diverging_var
+                                ),
+                            }
+                        }
+                    }
+
+                    let var_origin =
+                        *fcx.infcx.type_variables.borrow().var_origin(*best_var.unwrap());
+                    let diverging_var_span = fcx
+                        .infcx
+                        .type_variables
+                        .borrow()
+                        .var_origin(*best_diverging_var.unwrap())
+                        .span;
+
+                    let mut err = tcx.sess.struct_span_warn(
+                        path.span,
+                        "Fallback to `!` may introduce undefined behavior",
+                    );
+
+                    match var_origin.kind {
+                        TypeVariableOriginKind::TypeParameterDefinition(name, did) => {
+                            err.span_note(
+                                var_origin.span,
+                                &format!("the type parameter {} here was inferred to `!`", name),
+                            );
+                            if let Some(did) = did {
+                                err.span_note(
+                                    fcx.tcx.def_span(did),
+                                    "(type parameter defined here)",
+                                );
+                            }
+                        }
+                        _ => {
+                            err.span_note(var_origin.span, "the type here was inferred to `!`");
+                        }
+                    }
+
+                    err.span_note(diverging_var_span, "... due to this expression").emit();
+                }
+            }
+        }
+    }
+}

--- a/src/librustc_typeck/check/never_compat.rs
+++ b/src/librustc_typeck/check/never_compat.rs
@@ -207,7 +207,11 @@ impl<'tcx> NeverCompatHandler<'tcx> {
                         }
                     }
 
-                    err.span_note(diverging_var_span, "... due to this expression").emit();
+                    err.span_note(
+                        diverging_var_span,
+                        "... due to this expression evaluating to `!`",
+                    )
+                    .emit();
                 }
             }
         }

--- a/src/librustc_typeck/check/never_compat.rs
+++ b/src/librustc_typeck/check/never_compat.rs
@@ -9,14 +9,162 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::HirId;
 
 /// Code to detect cases where using `!` (never-type) fallback instead of `()` fallback
-/// may result in the introduction of undefined behavior
+/// may result in the introduction of undefined behavior;
 ///
+/// TL;DR: We look for method calls whose arguments are all inhabited, but
+/// that have a generic parameter (e.g. `T` in `fn foo<T>() { ... } `)
+/// that's uninhabited due to fallback. We emit an error, forcing
+/// users to add explicit type annotations indicating whether they
+/// actually want the `!` type, or something else.
+///
+/// Background: When we first tried to enable never-type fallback, it was found to
+/// cause code in the 'obj' crate to segfault. The root cause was a piece
+/// of code that looked like this:
+///
+/// ```rust
+///fn unconstrained_return<T>() -> Result<T, String> {
+///     let ffi: fn() -> T = transmute(some_pointer);
+///     Ok(ffi())
+/// }
+///fn foo() {
+///     match unconstrained_return::<_>() {
+///         Ok(x) => x,  // `x` has type `_`, which is unconstrained
+///         Err(s) => panic!(s),  // … except for unifying with the type of `panic!()`
+///         // so that both `match` arms have the same type.
+///         // Therefore `_` resolves to `!` and we "return" an `Ok(!)` value.
+///     };
+///}
+/// ```
+///
+/// Previously, the return type of `panic!()` would end up as `()` due to fallback
+/// (even though `panic()` is declared as returning `!`). This meant that
+/// the function pointer would get transmuted to `fn() -> ()`.
+///
+/// With never-type fallback enabled, the function pointer was transmuted
+/// to `fn() -> !`, despite the fact that it actually returned. This lead
+/// to undefined behavior, since we actually "produced" an instance of `!`
+/// at runtime.
+///
+/// We want to prevent this code from compiling, unless the user provides
+/// explicit type annotations indicating that they want the `!` type to be used.
+///
+/// However, we want code like this to continue working:
+///
+/// ```rust
+/// fn foo(e: !) -> Box<dyn std::error::Error> {
+///    Box::<_>::new(e)
+/// }```
+///
+/// From the perspective of fallback, these two snippets of code are very
+/// similar. We have some expression that starts out with type `!`, which
+/// we replace with a divergent inference variable. When fallback runs,
+/// we unify the inference variable with `!`, which leads to other
+/// expressions getting a type of `!` as well (`Box<!>` in this case),
+/// becoming uninhabited as well.
+///
+/// Our task is to distinguish things that are "legitimately" uninhabited,
+/// (such as `Box<!>` in the second example), from things that are
+/// "suspiciously" uninhabited and may lead to undefined behavior
+/// (the `Result<!, !>` in the first example).
+///
+/// The key difference between these two snippets of code turns out
+/// to be the *arguments* used in a function call. In the first example,
+/// we call `unconstrained_return` with no arguments, and an inferred
+/// type parameter of `!` (a.k.a `unconstrained_return::<!>()`).
+///
+/// In the second example, we call `Box::new(!)`, again inferring
+/// the type parameter to `!`. Since at least one argument to `Box::new`,
+/// is uninhabited, we know that this call is *statically unreachable* -
+/// if it were ever executed, we would have instantaited an uninhabited
+/// type for a parameter, which is impossible. This means that while
+/// the fallback to `!` has affected the type-checking of this call,
+/// it won't actually affect the runtime behavior of the call, since
+/// the call can never be executed.
+///
+/// In the first example, the call to `unconstrained_return::<!>()` is
+/// still (potentially) live, since it trivially has no uninhabited arguments
+/// (it has no arguments at all). This means that our fallback to `!` may
+/// have changed the runtime behavior of `unconstrained_return` (in this case,
+/// it did) - we may actually execute the call at runtime, but with an uninhabited
+/// type parameter that the user did not intend to provide.
+///
+/// This distinction forms the basis for our lint. We look for
+/// any function/method calls that meet the following requirements:
+///
+/// * Unresolved inference variables are present in the generic substs prior to fallback
+/// * All arguments are inhabited
+/// * After fallback, at least one generic subsst is uninhabited.
+///
+/// Let's break down each of these requirements:
+///
+/// 1. We only look at method calls, not other expressions.
+/// This is because the issue boils down to a generic subst being
+/// uninhabited due to fallback. Generic parameters can only be used
+/// in two places - as arguments to types, and arguments to methods.
+/// We don't care about types - the only relevant expression would be
+/// a constructor (e.g. `MyStruct { a: true, b: 25 }`). In and of itself,
+/// constructing a type this way (after all field values are evaluated)
+/// can never cause undefined behavior.
+///
+/// Methods calls, on the other hand, might cause undefined behavior
+/// due to how they use their generic paramters. Note that this
+/// still true if the undefineed behavior occurs in the same function
+/// where fallback occurs - there still must be a call `transmute`
+/// or some other intrinsic that allows 'instantating' an `!` instance
+/// somehow.
+///
+/// 2. Only function calls with inference variables in their generic
+/// substs can possibly be affected by fallback - if all types are resolved,
+/// then fallback cannot possibly have any effect.
+///
+/// 3. If any arguments are uninhabited, then the function call cannot ever
+/// cause undefined behavior, since it can never be executed. This check
+/// ensures that we don't lint on `Box::<_>::new(!)` - even though
+/// we're inferring a generic subst (`_`) to `!`, it has no runtime
+/// effect.
+///
+/// 4. If a generic substs is uninhabited after fallback, then we have
+/// the potential for undefined behavior. Note that this check can
+/// have false positives - if a generic argument was already uninhabited
+/// prior to fallback, we might end up triggering the lint even if fallback
+/// didn't cause any generic substs to become uninhabited. However, this isn't
+/// a big deal for a few reasons:
+///
+/// * This lint should be incredibly rare (as of the time of writing, only
+/// `obj` has run into the relevant issue).
+/// * Even if fallback didn't cause anything to become uninhabited
+/// (e.g. a `*const _` being inferred to `*const !`), it's still influencing
+/// the generic substs of a potentially live (all arguments inhabited) function
+/// call. This is arguably something worth linting against, since the user
+/// might not be aware that a live call is being affected by a seemingly
+/// unrelated expression.
+///
+/// * It should always be possible to resolve this lint while keeping the
+/// existing behavior, simply by adding explicit type annotations. This
+/// ensures that fallback never runs (since the type variable will
+/// actually be constrained to `!` or something else). At worst,
+/// we will force users to write some arguably unecessary type annotation,
+/// but we will not permanently break any code.
 
+/// The main interface to this module.
+/// It exposes two hooks: `pre_fallback` and `post_fallback`,
+/// which are invoked by `typeck_tables_of_with_fallback` respectively before
+/// and after fallback is run.
 pub struct NeverCompatHandler<'tcx> {
+    /// A map from method call `HirId`'s to `InferredPaths`.
+    /// This is computed from `FnCtxt.inferred_paths`, which
+    /// is in turn populated during typecheck.
     unresolved_paths: FxHashMap<HirId, InferredPath<'tcx>>,
+    /// All divering type variables that were unconstrained
+    /// prior to fallback. We use this to help generate
+    /// better diagnostics by determining which
+    /// inference variables were equated with a diverging
+    /// fallback variable.
     unconstrained_diverging: Vec<Ty<'tcx>>,
 }
 
+/// A simpler helper to collect all `InferTy::TyVar`s found
+/// in a `TypeFoldable`.
 struct TyVarFinder<'a, 'tcx> {
     infcx: &'a InferCtxt<'a, 'tcx>,
     vars: Vec<Ty<'tcx>>,
@@ -34,64 +182,104 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TyVarFinder<'a, 'tcx> {
     }
 }
 
+/// The core logic of this check. Given
+/// an `InferredPath`, we determine
+/// if this method call is "questionable" using the criteria
+/// described at the top of the module.
+///
+/// If the method call is "questionable", and should
+/// be linted, we return Ok(tys), where `tys`
+/// is a list of all inference variables involved
+/// with the generic paramter affected by fallback.
+///
+/// Otherwise, we return None
 fn find_questionable_call<'a, 'tcx>(
     path: &'a InferredPath<'tcx>,
     fcx: &FnCtxt<'a, 'tcx>,
 ) -> Option<&'a [Ty<'tcx>]> {
     let tcx = fcx.tcx;
     let ty = fcx.infcx.resolve_vars_if_possible(&path.ty);
-    debug!("post_fallback: Fully resolved ty: {:?}", ty);
+    debug!("find_questionable_call: Fully resolved ty: {:?}", ty);
 
     let ty = ty.unwrap_or_else(|| bug!("Missing ty in path: {:?}", path));
 
+    /// Check that this InferredPath actually corresponds to a method
+    /// invocation. Currently, type-checking resolves generic paths
+    /// (e.g. `Box::<_>::new` separately from determining that a method call
+    /// is occuring). We use this check to skip over `InferredPaths` for
+    /// non-method-calls (e.g. struct constructors).
     if let ty::FnDef(_, substs) = ty.kind {
-        debug!("Got substs: {:?}", substs);
+        debug!("find_questionable_call: Got substs: {:?}", substs);
         let mut args_inhabited = true;
 
+        // See if we can find any arguments that are definitely uninhabited.
+        // If we can, we're done - the method call is dead, so fallback
+        // cannot affect its runtime behavior.
         for arg in &**path.args.as_ref().unwrap() {
             let resolved_arg = fcx.infcx.resolve_vars_if_possible(arg);
 
+            // We use `conservative_is_privately_uninhabited` so that we only
+            // bail out if we're certain that a type is uninhabited.
             if resolved_arg.conservative_is_privately_uninhabited(tcx) {
-                debug!("post_fallback: Arg is uninhabited: {:?}", resolved_arg);
-                args_inhabited = false;
-                break;
+                debug!("find_questionable_call: bailing out due to uninhabited arg: {:?}", resolved_arg);
+                return None;
             } else {
-                debug!("post_fallback: Arg is inhabited: {:?}", resolved_arg);
+                debug!("find_questionable_call: Arg is inhabited: {:?}", resolved_arg);
             }
         }
 
-        if !args_inhabited {
-            debug!("post_fallback: Not all arguments are inhabited");
-            return None;
-        }
-
+        // Now, check the generic substs for the method (e.g. `T` and `V` in `foo::<T, V>()`.
+        // If we find an uninhabited subst,
         for (subst_ty, vars) in substs.types().zip(path.unresolved_vars.iter()) {
             let resolved_subst = fcx.infcx.resolve_vars_if_possible(&subst_ty);
-            if resolved_subst.conservative_is_privately_uninhabited(tcx) {
-                debug!("post_fallback: Subst is uninhabited: {:?}", resolved_subst);
+            // We use `is_ty_uninhabited_from_any_module` instead of `conservative_is_privately_uninhabited`.
+            // Using a broader check for uninhabitedness ensures that we lint
+            // whenever the subst is uninhabted, regardless of whether or not
+            // the user code could know this.
+            if tcx.is_ty_uninhabited_from_any_module(resolved_subst){
+                debug!("find_questionable_call: Subst is uninhabited: {:?}", resolved_subst);
                 if !vars.is_empty() {
-                    debug!("Found fallback vars: {:?}", vars);
+                    debug!("find_questionable_call: Found fallback vars: {:?}", vars);
                     debug!(
-                        "post_fallback: All arguments are inhabited, at least one subst is not inhabited!"
+                        "find_questionable_call: All arguments are inhabited, at least one subst is not inhabited!"
                     );
+                    // These variables were recorded prior to fallback runntime.
+                    // When generating a diagnostic message, we will use these
+                    // to determine which spans will we show to the user.
                     return Some(vars);
                 } else {
-                    debug!("No fallback vars")
+                    debug!("find_questionable_call: No fallback vars")
                 }
             } else {
-                debug!("post_fallback: Subst is inhabited: {:?}", resolved_subst);
+                debug!("find_questionable_call: Subst is inhabited: {:?}", resolved_subst);
             }
         }
     }
     return None;
 }
 
+/// Holds the "best" type variables that we want
+/// to use to generate a message for the user.
+///
+/// Note that these two variables are unified with each other,
+/// and therefore represent the same type. However, they have different
+/// origin information, which we can use to generate a nice error message.
 struct VarData {
+    /// A type variable that was actually used in an uninhabited
+    /// generic subst (e.g. `foo::<_#0t>()` where `_#0t = !`)
+    /// This is used to point at the span where the U.B potentially
+    /// occurs
     best_var: TyVid,
+    /// The diverging type variable that is ultimately responsible
+    /// for the U.B. occuring. In the `obj` example, this would
+    /// be the type variable corresponding the `panic!()` expression.
     best_diverging_var: TyVid,
 }
 
 impl<'tcx> NeverCompatHandler<'tcx> {
+    /// The pre-fallback hook invoked by typecheck. We collect
+    /// all unconstrained inference variables used in method call substs,
+    /// so that we can check if any changes occur due to fallback.
     pub fn pre_fallback(fcx: &FnCtxt<'a, 'tcx>) -> NeverCompatHandler<'tcx> {
         let unresolved_paths: FxHashMap<HirId, InferredPath<'tcx>> = fcx
             .inferred_paths
@@ -103,6 +291,7 @@ impl<'tcx> NeverCompatHandler<'tcx> {
 
                 let ty_resolved = fcx.infcx.resolve_vars_if_possible(&path.ty);
 
+                // We only care about method calls, not other uses of generic paths.
                 let fn_substs = match ty_resolved {
                     Some(ty::TyS { kind: ty::FnDef(_, substs), .. }) => substs,
                     _ => {
@@ -111,6 +300,8 @@ impl<'tcx> NeverCompatHandler<'tcx> {
                     }
                 };
 
+                // Any method call with inference variables in its substs
+                // could potentially be affected by fallback.
                 if fcx.infcx.unresolved_type_vars(fn_substs).is_some() {
                     for subst in fn_substs.types() {
                         let mut finder = TyVarFinder { infcx: &fcx.infcx, vars: vec![] };
@@ -131,6 +322,8 @@ impl<'tcx> NeverCompatHandler<'tcx> {
             })
             .collect();
 
+        // Collect all divering inference variables, so that we
+        // can later compare them against other inference variables.
         let unconstrained_diverging: Vec<_> = fcx
             .unsolved_variables()
             .iter()
@@ -141,6 +334,18 @@ impl<'tcx> NeverCompatHandler<'tcx> {
         NeverCompatHandler { unresolved_paths, unconstrained_diverging }
     }
 
+    /// Finds the 'best' type variables to use for display to the user,
+    /// given a list of the type variables originally used in the
+    /// generic substs for a method.
+    ///
+    /// We look for a type variable that ended up unified with a diverging
+    /// inference variable. This represents a place where fallback to a never
+    /// type ended up affecting a live method call. We then return the
+    /// inference variable, along with the corresponding divering inference
+    /// variable that was unified with it
+    ///
+    /// Note that their be multiple such pairs of inference variables - howver,
+    /// we only display one to the user, to avoid overwhelming them with information.
     fn find_best_vars(&self, fcx: &FnCtxt<'a, 'tcx>, vars: &[Ty<'tcx>]) -> VarData {
         for var in vars {
             for diverging_var in &self.unconstrained_diverging {
@@ -163,9 +368,12 @@ impl<'tcx> NeverCompatHandler<'tcx> {
                 }
             }
         }
-        bug!("No vars were equated to divering vars: {:?}", vars)
+        bug!("No vars were equated to diverging vars: {:?}", vars)
     }
 
+    /// The hook used by typecheck after fallback has been run.
+    /// We look for any "questionable" calls, generating diagnostic
+    /// message for them.
     pub fn post_fallback(self, fcx: &FnCtxt<'a, 'tcx>) {
         let tcx = fcx.tcx;
         for (call_id, path) in &self.unresolved_paths {
@@ -190,7 +398,13 @@ impl<'tcx> NeverCompatHandler<'tcx> {
                     .sess
                     .struct_span_warn(span, "Fallback to `!` may introduce undefined behavior");
 
+                // There are two possible cases here:
                 match var_origin.kind {
+                    // 1. This inference variable was automatically generated due to the user
+                    // not using the turbofish syntax. For example, `foo()` where foo is deinfed
+                    // as `fn foo<T>() { ... }`.
+                    // In this case, we point at the definition of the type variable (e.g. the `T`
+                    // in `foo<T>`), to better explain to the user what's going on.
                     TypeVariableOriginKind::TypeParameterDefinition(name, did) => {
                         err.span_note(
                             var_origin.span,
@@ -200,6 +414,9 @@ impl<'tcx> NeverCompatHandler<'tcx> {
                             err.span_note(fcx.tcx.def_span(did), "(type parameter defined here)");
                         }
                     }
+                    // The user wrote an explicit inference variable: e.g. `foo::<_>()`. We point
+                    // directly at its span, since this is sufficient to explain to the user
+                    // what's going on.
                     _ => {
                         err.span_note(var_origin.span, "the type here was inferred to `!`");
                     }

--- a/src/librustc_typeck/check/never_compat.rs
+++ b/src/librustc_typeck/check/never_compat.rs
@@ -399,6 +399,11 @@ impl<'tcx> NeverCompatHandler<'tcx> {
     /// We look for any "questionable" calls, generating diagnostic
     /// message for them.
     pub fn post_fallback(self, fcx: &FnCtxt<'a, 'tcx>) {
+        if fcx.tcx.sess.has_errors() {
+            debug!("post_fallback: sess has errors, bailing out");
+            return;
+        }
+
         let tcx = fcx.tcx;
         for (call_id, path) in &self.unresolved_paths {
             debug!(

--- a/src/librustc_typeck/check/never_compat.rs
+++ b/src/librustc_typeck/check/never_compat.rs
@@ -34,6 +34,58 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TyVarFinder<'a, 'tcx> {
     }
 }
 
+fn find_questionable_call(
+    path: InferredPath<'tcx>,
+    fcx: &FnCtxt<'a, 'tcx>,
+) -> Option<Vec<Ty<'tcx>>> {
+    let tcx = fcx.tcx;
+    let ty = fcx.infcx.resolve_vars_if_possible(&path.ty);
+    debug!("post_fallback: Fully resolved ty: {:?}", ty);
+
+    let ty = ty.unwrap_or_else(|| bug!("Missing ty in path: {:?}", path));
+
+    if let ty::FnDef(_, substs) = ty.kind {
+        debug!("Got substs: {:?}", substs);
+        let mut args_inhabited = true;
+
+        for arg in &*path.args.unwrap() {
+            let resolved_arg = fcx.infcx.resolve_vars_if_possible(arg);
+
+            if resolved_arg.conservative_is_privately_uninhabited(tcx) {
+                debug!("post_fallback: Arg is uninhabited: {:?}", resolved_arg);
+                args_inhabited = false;
+                break;
+            } else {
+                debug!("post_fallback: Arg is inhabited: {:?}", resolved_arg);
+            }
+        }
+
+        if !args_inhabited {
+            debug!("post_fallback: Not all arguments are inhabited");
+            return None;
+        }
+
+        for (subst_ty, vars) in substs.types().zip(path.unresolved_vars.into_iter()) {
+            let resolved_subst = fcx.infcx.resolve_vars_if_possible(&subst_ty);
+            if resolved_subst.conservative_is_privately_uninhabited(tcx) {
+                debug!("post_fallback: Subst is uninhabited: {:?}", resolved_subst);
+                if !vars.is_empty() {
+                    debug!("Found fallback vars: {:?}", vars);
+                    debug!(
+                        "post_fallback: All arguments are inhabited, at least one subst is not inhabited!"
+                    );
+                    return Some(vars);
+                } else {
+                    debug!("No fallback vars")
+                }
+            } else {
+                debug!("post_fallback: Subst is inhabited: {:?}", resolved_subst);
+            }
+        }
+    }
+    return None;
+}
+
 impl<'tcx> NeverCompatHandler<'tcx> {
     pub fn pre_fallback(fcx: &FnCtxt<'a, 'tcx>) -> NeverCompatHandler<'tcx> {
         let unresolved_paths: FxHashMap<HirId, InferredPath<'tcx>> = fcx
@@ -88,7 +140,7 @@ impl<'tcx> NeverCompatHandler<'tcx> {
         let tcx = fcx.tcx;
         for (call_id, path) in self.unresolved_paths {
             debug!(
-                "Resolved ty: {:?} at span {:?} : expr={:?} parent={:?} path={:?}",
+                "post_fallback: resolved ty: {:?} at span {:?} : expr={:?} parent={:?} path={:?}",
                 path.span,
                 path.ty,
                 tcx.hir().get(call_id),
@@ -96,124 +148,67 @@ impl<'tcx> NeverCompatHandler<'tcx> {
                 path
             );
 
-            let ty = fcx.infcx.resolve_vars_if_possible(&path.ty);
-            debug!("Fully resolved ty: {:?}", ty);
+            let span = path.span;
+            if let Some(vars) = find_questionable_call(path, fcx) {
+                let mut best_diverging_var = None;
+                let mut best_var = None;
 
-            let ty = ty.unwrap_or_else(|| bug!("Missing ty in path: {:?}", path));
+                for var in vars {
+                    for diverging_var in &self.unconstrained_diverging {
+                        match (&var.kind, &diverging_var.kind) {
+                            (
+                                ty::Infer(ty::InferTy::TyVar(vid1)),
+                                ty::Infer(ty::InferTy::TyVar(vid2)),
+                            ) => {
+                                if fcx.infcx.type_variables.borrow_mut().sub_unified(*vid1, *vid2) {
+                                    debug!(
+                                        "Type variable {:?} is equal to diverging var {:?}",
+                                        var, diverging_var
+                                    );
 
-            if let ty::FnDef(_, substs) = ty.kind {
-                debug!("Got substs: {:?}", substs);
-                let mut args_inhabited = true;
-                let mut uninhabited_subst = None;
-
-                for arg in &*path.args.unwrap() {
-                    let resolved_arg = fcx.infcx.resolve_vars_if_possible(arg);
-
-                    if resolved_arg.conservative_is_privately_uninhabited(tcx) {
-                        debug!("Arg is uninhabited: {:?}", resolved_arg);
-                        args_inhabited = false;
-                        break;
-                    } else {
-                        debug!("Arg is inhabited: {:?}", resolved_arg);
-                    }
-                }
-
-                for (subst_ty, vars) in substs.types().zip(path.unresolved_vars.into_iter()) {
-                    let resolved_subst = fcx.infcx.resolve_vars_if_possible(&subst_ty);
-                    if resolved_subst.conservative_is_privately_uninhabited(tcx) {
-                        debug!("Subst is uninhabited: {:?}", resolved_subst);
-                        if !vars.is_empty() {
-                            debug!("Found fallback vars: {:?}", vars);
-                            uninhabited_subst = Some(vars);
-                            break;
-                        } else {
-                            debug!("No fallback vars")
-                        }
-                    } else {
-                        debug!("Subst is inhabited: {:?}", resolved_subst);
-                    }
-                }
-
-                if let (true, Some(vars)) = (args_inhabited, uninhabited_subst) {
-                    debug!("All arguments are inhabited, at least one subst is not inhabited!");
-
-                    let mut best_diverging_var = None;
-                    let mut best_var = None;
-
-                    for var in vars {
-                        for diverging_var in &self.unconstrained_diverging {
-                            match (&var.kind, &diverging_var.kind) {
-                                (
-                                    ty::Infer(ty::InferTy::TyVar(vid1)),
-                                    ty::Infer(ty::InferTy::TyVar(vid2)),
-                                ) => {
-                                    if fcx
-                                        .infcx
-                                        .type_variables
-                                        .borrow_mut()
-                                        .sub_unified(*vid1, *vid2)
-                                    {
-                                        debug!(
-                                            "Type variable {:?} is equal to diverging var {:?}",
-                                            var, diverging_var
-                                        );
-
-                                        debug!(
-                                            "Var origin: {:?}",
-                                            fcx.infcx.type_variables.borrow().var_origin(*vid1)
-                                        );
-                                        best_var = Some(vid1);
-                                        best_diverging_var = Some(vid2);
-                                    }
+                                    debug!(
+                                        "Var origin: {:?}",
+                                        fcx.infcx.type_variables.borrow().var_origin(*vid1)
+                                    );
+                                    best_var = Some(vid1);
+                                    best_diverging_var = Some(vid2);
                                 }
-                                _ => bug!(
-                                    "Unexpected types: var={:?} diverging_var={:?}",
-                                    var,
-                                    diverging_var
-                                ),
                             }
+                            _ => bug!(
+                                "Unexpected types: var={:?} diverging_var={:?}",
+                                var,
+                                diverging_var
+                            ),
                         }
                     }
+                }
 
-                    let var_origin =
-                        *fcx.infcx.type_variables.borrow().var_origin(*best_var.unwrap());
-                    let diverging_var_span = fcx
-                        .infcx
-                        .type_variables
-                        .borrow()
-                        .var_origin(*best_diverging_var.unwrap())
-                        .span;
+                let var_origin = *fcx.infcx.type_variables.borrow().var_origin(*best_var.unwrap());
+                let diverging_var_span =
+                    fcx.infcx.type_variables.borrow().var_origin(*best_diverging_var.unwrap()).span;
 
-                    let mut err = tcx.sess.struct_span_warn(
-                        path.span,
-                        "Fallback to `!` may introduce undefined behavior",
-                    );
+                let mut err = tcx
+                    .sess
+                    .struct_span_warn(span, "Fallback to `!` may introduce undefined behavior");
 
-                    match var_origin.kind {
-                        TypeVariableOriginKind::TypeParameterDefinition(name, did) => {
-                            err.span_note(
-                                var_origin.span,
-                                &format!("the type parameter {} here was inferred to `!`", name),
-                            );
-                            if let Some(did) = did {
-                                err.span_note(
-                                    fcx.tcx.def_span(did),
-                                    "(type parameter defined here)",
-                                );
-                            }
-                        }
-                        _ => {
-                            err.span_note(var_origin.span, "the type here was inferred to `!`");
+                match var_origin.kind {
+                    TypeVariableOriginKind::TypeParameterDefinition(name, did) => {
+                        err.span_note(
+                            var_origin.span,
+                            &format!("the type parameter {} here was inferred to `!`", name),
+                        );
+                        if let Some(did) = did {
+                            err.span_note(fcx.tcx.def_span(did), "(type parameter defined here)");
                         }
                     }
+                    _ => {
+                        err.span_note(var_origin.span, "the type here was inferred to `!`");
+                    }
+                }
 
-                    err.span_note(
-                        diverging_var_span,
-                        "... due to this expression evaluating to `!`",
-                    )
+                err.span_note(diverging_var_span, "... due to this expression evaluating to `!`")
                     .note("If you want the `!` type to be used here, add explicit type annotations")
                     .emit();
-                }
             }
         }
     }

--- a/src/librustc_typeck/check/never_compat.rs
+++ b/src/librustc_typeck/check/never_compat.rs
@@ -209,8 +209,13 @@ fn find_questionable_call<'a, 'tcx>(
     // (e.g. `Box::<_>::new` separately from determining that a method call
     // is occurring). We use this check to skip over `InferredPaths` for
     // non-method-calls (e.g. struct constructors).
-    if let ty::FnDef(_, substs) = ty.kind {
+    if let ty::FnDef(did, substs) = ty.kind {
         debug!("find_questionable_call: Got substs: {:?}", substs);
+
+        if tcx.is_constructor(did) {
+            debug!("find_questionable_call: found constructor {:?}, bailing out", did);
+            return None;
+        }
 
         // See if we can find any arguments that are definitely uninhabited.
         // If we can, we're done - the method call is dead, so fallback

--- a/src/librustc_typeck/check/never_compat.rs
+++ b/src/librustc_typeck/check/never_compat.rs
@@ -57,7 +57,7 @@ impl<'tcx> NeverCompatHandler<'tcx> {
                 if fcx.infcx.unresolved_type_vars(fn_substs).is_some() {
                     for subst in fn_substs.types() {
                         let mut finder = TyVarFinder { infcx: &fcx.infcx, vars: vec![] };
-                        path.ty.fold_with(&mut finder);
+                        subst.fold_with(&mut finder);
                         path.unresolved_vars.push(finder.vars);
                     }
 
@@ -124,7 +124,7 @@ impl<'tcx> NeverCompatHandler<'tcx> {
                         debug!("Subst is uninhabited: {:?}", resolved_subst);
                         if !vars.is_empty() {
                             debug!("Found fallback vars: {:?}", vars);
-                            uninhabited_subst = Some((resolved_subst, vars));
+                            uninhabited_subst = Some(vars);
                             break;
                         } else {
                             debug!("No fallback vars")
@@ -134,7 +134,7 @@ impl<'tcx> NeverCompatHandler<'tcx> {
                     }
                 }
 
-                if let (true, Some((subst, vars))) = (args_inhabited, uninhabited_subst) {
+                if let (true, Some(vars)) = (args_inhabited, uninhabited_subst) {
                     debug!("All arguments are inhabited, at least one subst is not inhabited!");
 
                     let mut best_diverging_var = None;
@@ -211,6 +211,7 @@ impl<'tcx> NeverCompatHandler<'tcx> {
                         diverging_var_span,
                         "... due to this expression evaluating to `!`",
                     )
+                    .note("If you want the `!` type to be used here, add explicit type annotations")
                     .emit();
                 }
             }

--- a/src/librustc_typeck/check/never_compat.rs
+++ b/src/librustc_typeck/check/never_compat.rs
@@ -203,14 +203,13 @@ fn find_questionable_call<'a, 'tcx>(
 
     let ty = ty.unwrap_or_else(|| bug!("Missing ty in path: {:?}", path));
 
-    /// Check that this InferredPath actually corresponds to a method
-    /// invocation. Currently, type-checking resolves generic paths
-    /// (e.g. `Box::<_>::new` separately from determining that a method call
-    /// is occuring). We use this check to skip over `InferredPaths` for
-    /// non-method-calls (e.g. struct constructors).
+    // Check that this InferredPath actually corresponds to a method
+    // invocation. Currently, type-checking resolves generic paths
+    // (e.g. `Box::<_>::new` separately from determining that a method call
+    // is occurring). We use this check to skip over `InferredPaths` for
+    // non-method-calls (e.g. struct constructors).
     if let ty::FnDef(_, substs) = ty.kind {
         debug!("find_questionable_call: Got substs: {:?}", substs);
-        let mut args_inhabited = true;
 
         // See if we can find any arguments that are definitely uninhabited.
         // If we can, we're done - the method call is dead, so fallback
@@ -221,7 +220,10 @@ fn find_questionable_call<'a, 'tcx>(
             // We use `conservative_is_privately_uninhabited` so that we only
             // bail out if we're certain that a type is uninhabited.
             if resolved_arg.conservative_is_privately_uninhabited(tcx) {
-                debug!("find_questionable_call: bailing out due to uninhabited arg: {:?}", resolved_arg);
+                debug!(
+                    "find_questionable_call: bailing out due to uninhabited arg: {:?}",
+                    resolved_arg
+                );
                 return None;
             } else {
                 debug!("find_questionable_call: Arg is inhabited: {:?}", resolved_arg);
@@ -236,7 +238,7 @@ fn find_questionable_call<'a, 'tcx>(
             // Using a broader check for uninhabitedness ensures that we lint
             // whenever the subst is uninhabted, regardless of whether or not
             // the user code could know this.
-            if tcx.is_ty_uninhabited_from_any_module(resolved_subst){
+            if tcx.is_ty_uninhabited_from_any_module(resolved_subst) {
                 debug!("find_questionable_call: Subst is uninhabited: {:?}", resolved_subst);
                 if !vars.is_empty() {
                     debug!("find_questionable_call: Found fallback vars: {:?}", vars);

--- a/src/librustc_typeck/check/never_compat.rs
+++ b/src/librustc_typeck/check/never_compat.rs
@@ -398,7 +398,7 @@ impl<'tcx> NeverCompatHandler<'tcx> {
 
                 let mut err = tcx
                     .sess
-                    .struct_span_warn(span, "Fallback to `!` may introduce undefined behavior");
+                    .struct_span_err(span, "Fallback to `!` may introduce undefined behavior");
 
                 // There are two possible cases here:
                 match var_origin.kind {

--- a/src/librustc_typeck/check/never_compat.rs
+++ b/src/librustc_typeck/check/never_compat.rs
@@ -404,11 +404,6 @@ impl<'tcx> NeverCompatHandler<'tcx> {
     /// We look for any "questionable" calls, generating diagnostic
     /// message for them.
     pub fn post_fallback(self, fcx: &FnCtxt<'a, 'tcx>) {
-        if fcx.tcx.sess.has_errors() {
-            debug!("post_fallback: sess has errors, bailing out");
-            return;
-        }
-
         let tcx = fcx.tcx;
         for (call_id, path) in &self.unresolved_paths {
             debug!(

--- a/src/test/ui/associated-types/associated-types-ICE-when-projecting-out-of-err.rs
+++ b/src/test/ui/associated-types/associated-types-ICE-when-projecting-out-of-err.rs
@@ -21,5 +21,5 @@ trait Add<RHS=Self> {
 fn ice<A>(a: A) {
     let r = loop {};
     r = r + a;
-    //~^ ERROR the trait bound `(): Add<A>` is not satisfied
+    //~^ ERROR the trait bound `!: Add<A>` is not satisfied
 }

--- a/src/test/ui/associated-types/associated-types-ICE-when-projecting-out-of-err.stderr
+++ b/src/test/ui/associated-types/associated-types-ICE-when-projecting-out-of-err.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `(): Add<A>` is not satisfied
+error[E0277]: the trait bound `!: Add<A>` is not satisfied
   --> $DIR/associated-types-ICE-when-projecting-out-of-err.rs:23:11
    |
 LL |     r = r + a;
-   |           ^ the trait `Add<A>` is not implemented for `()`
+   |           ^ the trait `Add<A>` is not implemented for `!`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-51345.rs
+++ b/src/test/ui/issues/issue-51345.rs
@@ -2,7 +2,7 @@
 #![allow(unreachable_code)]
 
 fn main() {
-    let mut v = Vec::new();
+    let mut v: Vec<()> = Vec::new();
 
     loop { v.push(break) }
 }

--- a/src/test/ui/never-fallback/box_it.rs
+++ b/src/test/ui/never-fallback/box_it.rs
@@ -1,0 +1,11 @@
+// check-pass
+// Verifies that our fallback-UB check doesn't trigger
+// on correct code
+#![feature(never_type)]
+#![feature(never_type_fallback)]
+
+fn foo(e: !) -> Box<dyn std::error::Error> {
+    Box::<_>::new(e)
+}
+
+fn main() {}

--- a/src/test/ui/never-fallback/from.rs
+++ b/src/test/ui/never-fallback/from.rs
@@ -1,0 +1,14 @@
+// check-pass
+// Tests that we correctly infer types to !
+#![feature(never_type)]
+#![feature(never_type_fallback)]
+
+struct E;
+impl From<!> for E {
+    fn from(x: !) -> E { x }
+}
+fn foo(never: !) {
+    <E as From<_>>::from(never);
+}
+
+fn main() {}

--- a/src/test/ui/never-fallback/from_try.rs
+++ b/src/test/ui/never-fallback/from_try.rs
@@ -1,0 +1,17 @@
+// check-pass
+use std::convert::{TryFrom, Infallible};
+
+struct E;
+
+impl From<Infallible> for E {
+    fn from(_: Infallible) -> E {
+        E
+    }
+}
+
+fn foo() -> Result<(), E> {
+    u32::try_from(1u32)?;
+    Ok(())
+}
+
+fn main() {}

--- a/src/test/ui/never-fallback/obj.rs
+++ b/src/test/ui/never-fallback/obj.rs
@@ -10,15 +10,15 @@ fn unconstrained_return<T>() -> Result<T, String> {
 }
 
 fn foo() {
-    let a = || { 
-        match unconstrained_return::<_>() { //~ ERROR Fallback to `!` may introduce undefined behavior
+    let a = || {
+        match unconstrained_return::<_>() { //~ ERROR Fallback to `!` may introduce undefined
             Ok(x) => x,  // `x` has type `_`, which is unconstrained
             Err(s) => panic!(s),  // … except for unifying with the type of `panic!()`
             // so that both `match` arms have the same type.
             // Therefore `_` resolves to `!` and we "return" an `Ok(!)` value.
         }
     };
-    
+
     let cast: &dyn FnOnce() -> _ = &a;
     println!("Return type: {:?}", get_type(cast));
 }

--- a/src/test/ui/never-fallback/obj.rs
+++ b/src/test/ui/never-fallback/obj.rs
@@ -1,0 +1,28 @@
+#![feature(never_type)]
+#![feature(never_type_fallback)]
+
+fn get_type<T>(_: T) -> &'static str {
+    std::any::type_name::<T>()
+}
+
+fn unconstrained_return<T>() -> Result<T, String> {
+    Err("Hi".to_string())
+}
+
+fn foo() {
+    let a = || { 
+        match unconstrained_return::<_>() { //~ ERROR Fallback to `!` may introduce undefined behavior
+            Ok(x) => x,  // `x` has type `_`, which is unconstrained
+            Err(s) => panic!(s),  // … except for unifying with the type of `panic!()`
+            // so that both `match` arms have the same type.
+            // Therefore `_` resolves to `!` and we "return" an `Ok(!)` value.
+        }
+    };
+    
+    let cast: &dyn FnOnce() -> _ = &a;
+    println!("Return type: {:?}", get_type(cast));
+}
+
+fn main() {
+    foo()
+}

--- a/src/test/ui/never-fallback/obj.stderr
+++ b/src/test/ui/never-fallback/obj.stderr
@@ -1,0 +1,21 @@
+error: Fallback to `!` may introduce undefined behavior
+  --> $DIR/obj.rs:14:15
+   |
+LL |         match unconstrained_return::<_>() {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the type here was inferred to `!`
+  --> $DIR/obj.rs:14:38
+   |
+LL |         match unconstrained_return::<_>() {
+   |                                      ^
+note: ... due to this expression evaluating to `!`
+  --> $DIR/obj.rs:16:23
+   |
+LL |             Err(s) => panic!(s),  // … except for unifying with the type of `panic!()`
+   |                       ^^^^^^^^^
+   = note: If you want the `!` type to be used here, add explicit type annotations
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+

--- a/src/test/ui/never-fallback/obj_implicit.rs
+++ b/src/test/ui/never-fallback/obj_implicit.rs
@@ -1,0 +1,28 @@
+#![feature(never_type)]
+#![feature(never_type_fallback)]
+
+fn get_type<T>(_: T) -> &'static str {
+    std::any::type_name::<T>()
+}
+
+fn unconstrained_return<T>() -> Result<T, String> {
+    Err("Hi".to_string())
+}
+
+fn foo() {
+    let a = || { 
+        match unconstrained_return() { //~ ERROR Fallback to `!` may introduce undefined behavior
+            Ok(x) => x,  // `x` has type `_`, which is unconstrained
+            Err(s) => panic!(s),  // … except for unifying with the type of `panic!()`
+            // so that both `match` arms have the same type.
+            // Therefore `_` resolves to `!` and we "return" an `Ok(!)` value.
+        }
+    };
+    
+    let cast: &dyn FnOnce() -> _ = &a;
+    println!("Return type: {:?}", get_type(cast));
+}
+
+fn main() {
+    foo()
+}

--- a/src/test/ui/never-fallback/obj_implicit.rs
+++ b/src/test/ui/never-fallback/obj_implicit.rs
@@ -10,7 +10,7 @@ fn unconstrained_return<T>() -> Result<T, String> {
 }
 
 fn foo() {
-    let a = || { 
+    let a = || {
         match unconstrained_return() { //~ ERROR Fallback to `!` may introduce undefined behavior
             Ok(x) => x,  // `x` has type `_`, which is unconstrained
             Err(s) => panic!(s),  // … except for unifying with the type of `panic!()`
@@ -18,7 +18,7 @@ fn foo() {
             // Therefore `_` resolves to `!` and we "return" an `Ok(!)` value.
         }
     };
-    
+
     let cast: &dyn FnOnce() -> _ = &a;
     println!("Return type: {:?}", get_type(cast));
 }

--- a/src/test/ui/never-fallback/obj_implicit.stderr
+++ b/src/test/ui/never-fallback/obj_implicit.stderr
@@ -1,0 +1,26 @@
+error: Fallback to `!` may introduce undefined behavior
+  --> $DIR/obj_implicit.rs:14:15
+   |
+LL |         match unconstrained_return() {
+   |               ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the type parameter T here was inferred to `!`
+  --> $DIR/obj_implicit.rs:14:15
+   |
+LL |         match unconstrained_return() {
+   |               ^^^^^^^^^^^^^^^^^^^^
+note: (type parameter defined here)
+  --> $DIR/obj_implicit.rs:8:25
+   |
+LL | fn unconstrained_return<T>() -> Result<T, String> {
+   |                         ^
+note: ... due to this expression evaluating to `!`
+  --> $DIR/obj_implicit.rs:16:23
+   |
+LL |             Err(s) => panic!(s),  // … except for unifying with the type of `panic!()`
+   |                       ^^^^^^^^^
+   = note: If you want the `!` type to be used here, add explicit type annotations
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+

--- a/src/test/ui/never_type/diverging-fallback-control-flow.rs
+++ b/src/test/ui/never_type/diverging-fallback-control-flow.rs
@@ -1,5 +1,3 @@
-// run-pass
-
 #![allow(dead_code)]
 #![allow(unused_assignments)]
 #![allow(unused_variables)]
@@ -33,7 +31,7 @@ fn assignment() {
     let x;
 
     if true {
-        x = BadDefault::default();
+        x = BadDefault::default(); //~ ERROR Fallback to `!`
     } else {
         x = return;
     }
@@ -45,13 +43,13 @@ fn assignment_rev() {
     if true {
         x = return;
     } else {
-        x = BadDefault::default();
+        x = BadDefault::default(); //~ ERROR Fallback to `!`
     }
 }
 
 fn if_then_else() {
     let _x = if true {
-        BadDefault::default()
+        BadDefault::default() //~ ERROR Fallback to `!`
     } else {
         return;
     };
@@ -61,19 +59,19 @@ fn if_then_else_rev() {
     let _x = if true {
         return;
     } else {
-        BadDefault::default()
+        BadDefault::default() //~ ERROR Fallback to `!`
     };
 }
 
 fn match_arm() {
-    let _x = match Ok(BadDefault::default()) {
+    let _x = match Ok(BadDefault::default()) { //~ ERROR Fallback to `!`
         Ok(v) => v,
         Err(()) => return,
     };
 }
 
 fn match_arm_rev() {
-    let _x = match Ok(BadDefault::default()) {
+    let _x = match Ok(BadDefault::default()) { //~ ERROR Fallback to `!`
         Err(()) => return,
         Ok(v) => v,
     };
@@ -84,7 +82,7 @@ fn loop_break() {
         if false {
             break return;
         } else {
-            break BadDefault::default();
+            break BadDefault::default(); //~ ERROR Fallback to `!`
         }
     };
 }
@@ -94,7 +92,7 @@ fn loop_break_rev() {
         if false {
             break return;
         } else {
-            break BadDefault::default();
+            break BadDefault::default(); //~ ERROR Fallback to `!`
         }
     };
 }

--- a/src/test/ui/never_type/diverging-fallback-control-flow.stderr
+++ b/src/test/ui/never_type/diverging-fallback-control-flow.stderr
@@ -1,0 +1,209 @@
+error: Fallback to `!` may introduce undefined behavior
+  --> $DIR/diverging-fallback-control-flow.rs:34:13
+   |
+LL |         x = BadDefault::default();
+   |             ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the type parameter Self here was inferred to `!`
+  --> $DIR/diverging-fallback-control-flow.rs:34:13
+   |
+LL |         x = BadDefault::default();
+   |             ^^^^^^^^^^^^^^^^^^^
+note: (type parameter defined here)
+  --> $DIR/diverging-fallback-control-flow.rs:14:1
+   |
+LL | / trait BadDefault {
+LL | |     fn default() -> Self;
+LL | | }
+   | |_^
+note: ... due to this expression evaluating to `!`
+  --> $DIR/diverging-fallback-control-flow.rs:36:13
+   |
+LL |         x = return;
+   |             ^^^^^^
+   = note: If you want the `!` type to be used here, add explicit type annotations
+
+error: Fallback to `!` may introduce undefined behavior
+  --> $DIR/diverging-fallback-control-flow.rs:46:13
+   |
+LL |         x = BadDefault::default();
+   |             ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the type parameter Self here was inferred to `!`
+  --> $DIR/diverging-fallback-control-flow.rs:46:13
+   |
+LL |         x = BadDefault::default();
+   |             ^^^^^^^^^^^^^^^^^^^
+note: (type parameter defined here)
+  --> $DIR/diverging-fallback-control-flow.rs:14:1
+   |
+LL | / trait BadDefault {
+LL | |     fn default() -> Self;
+LL | | }
+   | |_^
+note: ... due to this expression evaluating to `!`
+  --> $DIR/diverging-fallback-control-flow.rs:44:13
+   |
+LL |         x = return;
+   |             ^^^^^^
+   = note: If you want the `!` type to be used here, add explicit type annotations
+
+error: Fallback to `!` may introduce undefined behavior
+  --> $DIR/diverging-fallback-control-flow.rs:52:9
+   |
+LL |         BadDefault::default()
+   |         ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the type parameter Self here was inferred to `!`
+  --> $DIR/diverging-fallback-control-flow.rs:52:9
+   |
+LL |         BadDefault::default()
+   |         ^^^^^^^^^^^^^^^^^^^
+note: (type parameter defined here)
+  --> $DIR/diverging-fallback-control-flow.rs:14:1
+   |
+LL | / trait BadDefault {
+LL | |     fn default() -> Self;
+LL | | }
+   | |_^
+note: ... due to this expression evaluating to `!`
+  --> $DIR/diverging-fallback-control-flow.rs:54:9
+   |
+LL |         return;
+   |         ^^^^^^^
+   = note: If you want the `!` type to be used here, add explicit type annotations
+
+error: Fallback to `!` may introduce undefined behavior
+  --> $DIR/diverging-fallback-control-flow.rs:62:9
+   |
+LL |         BadDefault::default()
+   |         ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the type parameter Self here was inferred to `!`
+  --> $DIR/diverging-fallback-control-flow.rs:62:9
+   |
+LL |         BadDefault::default()
+   |         ^^^^^^^^^^^^^^^^^^^
+note: (type parameter defined here)
+  --> $DIR/diverging-fallback-control-flow.rs:14:1
+   |
+LL | / trait BadDefault {
+LL | |     fn default() -> Self;
+LL | | }
+   | |_^
+note: ... due to this expression evaluating to `!`
+  --> $DIR/diverging-fallback-control-flow.rs:59:22
+   |
+LL |       let _x = if true {
+   |  ______________________^
+LL | |         return;
+LL | |     } else {
+   | |_____^
+   = note: If you want the `!` type to be used here, add explicit type annotations
+
+error: Fallback to `!` may introduce undefined behavior
+  --> $DIR/diverging-fallback-control-flow.rs:67:23
+   |
+LL |     let _x = match Ok(BadDefault::default()) {
+   |                       ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the type parameter Self here was inferred to `!`
+  --> $DIR/diverging-fallback-control-flow.rs:67:23
+   |
+LL |     let _x = match Ok(BadDefault::default()) {
+   |                       ^^^^^^^^^^^^^^^^^^^
+note: (type parameter defined here)
+  --> $DIR/diverging-fallback-control-flow.rs:14:1
+   |
+LL | / trait BadDefault {
+LL | |     fn default() -> Self;
+LL | | }
+   | |_^
+note: ... due to this expression evaluating to `!`
+  --> $DIR/diverging-fallback-control-flow.rs:67:14
+   |
+LL |       let _x = match Ok(BadDefault::default()) {
+   |  ______________^
+LL | |         Ok(v) => v,
+LL | |         Err(()) => return,
+LL | |     };
+   | |_____^
+   = note: If you want the `!` type to be used here, add explicit type annotations
+
+error: Fallback to `!` may introduce undefined behavior
+  --> $DIR/diverging-fallback-control-flow.rs:74:23
+   |
+LL |     let _x = match Ok(BadDefault::default()) {
+   |                       ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the type parameter Self here was inferred to `!`
+  --> $DIR/diverging-fallback-control-flow.rs:74:23
+   |
+LL |     let _x = match Ok(BadDefault::default()) {
+   |                       ^^^^^^^^^^^^^^^^^^^
+note: (type parameter defined here)
+  --> $DIR/diverging-fallback-control-flow.rs:14:1
+   |
+LL | / trait BadDefault {
+LL | |     fn default() -> Self;
+LL | | }
+   | |_^
+note: ... due to this expression evaluating to `!`
+  --> $DIR/diverging-fallback-control-flow.rs:75:20
+   |
+LL |         Err(()) => return,
+   |                    ^^^^^^
+   = note: If you want the `!` type to be used here, add explicit type annotations
+
+error: Fallback to `!` may introduce undefined behavior
+  --> $DIR/diverging-fallback-control-flow.rs:85:19
+   |
+LL |             break BadDefault::default();
+   |                   ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the type parameter Self here was inferred to `!`
+  --> $DIR/diverging-fallback-control-flow.rs:85:19
+   |
+LL |             break BadDefault::default();
+   |                   ^^^^^^^^^^^^^^^^^^^
+note: (type parameter defined here)
+  --> $DIR/diverging-fallback-control-flow.rs:14:1
+   |
+LL | / trait BadDefault {
+LL | |     fn default() -> Self;
+LL | | }
+   | |_^
+note: ... due to this expression evaluating to `!`
+  --> $DIR/diverging-fallback-control-flow.rs:83:19
+   |
+LL |             break return;
+   |                   ^^^^^^
+   = note: If you want the `!` type to be used here, add explicit type annotations
+
+error: Fallback to `!` may introduce undefined behavior
+  --> $DIR/diverging-fallback-control-flow.rs:95:19
+   |
+LL |             break BadDefault::default();
+   |                   ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the type parameter Self here was inferred to `!`
+  --> $DIR/diverging-fallback-control-flow.rs:95:19
+   |
+LL |             break BadDefault::default();
+   |                   ^^^^^^^^^^^^^^^^^^^
+note: (type parameter defined here)
+  --> $DIR/diverging-fallback-control-flow.rs:14:1
+   |
+LL | / trait BadDefault {
+LL | |     fn default() -> Self;
+LL | | }
+   | |_^
+note: ... due to this expression evaluating to `!`
+  --> $DIR/diverging-fallback-control-flow.rs:93:19
+   |
+LL |             break return;
+   |                   ^^^^^^
+   = note: If you want the `!` type to be used here, add explicit type annotations
+
+error: aborting due to 8 previous errors
+

--- a/src/test/ui/never_type/feature-gate-never_type_fallback.rs
+++ b/src/test/ui/never_type/feature-gate-never_type_fallback.rs
@@ -7,6 +7,6 @@ fn main() {}
 trait T {}
 
 fn should_ret_unit() -> impl T {
-    //~^ ERROR the trait bound `(): T` is not satisfied
+    //~^ ERROR the trait bound `!: T` is not satisfied
     panic!()
 }

--- a/src/test/ui/never_type/feature-gate-never_type_fallback.stderr
+++ b/src/test/ui/never_type/feature-gate-never_type_fallback.stderr
@@ -1,11 +1,11 @@
-error[E0277]: the trait bound `(): T` is not satisfied
+error[E0277]: the trait bound `!: T` is not satisfied
   --> $DIR/feature-gate-never_type_fallback.rs:9:25
    |
 LL | fn should_ret_unit() -> impl T {
-   |                         ^^^^^^ the trait `T` is not implemented for `()`
+   |                         ^^^^^^ the trait `T` is not implemented for `!`
 LL |
 LL |     panic!()
-   |     -------- this returned value is of type `()`
+   |     -------- this returned value is of type `!`
    |
    = note: the return type of a function must have a statically known size
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)

--- a/src/test/ui/never_type/issue-13352.stderr
+++ b/src/test/ui/never_type/issue-13352.stderr
@@ -1,10 +1,10 @@
-error[E0277]: cannot add `()` to `usize`
+error[E0277]: cannot add `!` to `usize`
   --> $DIR/issue-13352.rs:9:13
    |
 LL |     2_usize + (loop {});
-   |             ^ no implementation for `usize + ()`
+   |             ^ no implementation for `usize + !`
    |
-   = help: the trait `std::ops::Add<()>` is not implemented for `usize`
+   = help: the trait `std::ops::Add<!>` is not implemented for `usize`
 
 error: aborting due to previous error
 

--- a/src/test/ui/never_type/issue-2149.stderr
+++ b/src/test/ui/never_type/issue-2149.stderr
@@ -1,10 +1,10 @@
-error[E0277]: cannot add `std::vec::Vec<B>` to `()`
+error[E0277]: cannot add `std::vec::Vec<B>` to `!`
   --> $DIR/issue-2149.rs:8:33
    |
 LL |         for elt in self { r = r + f(*elt); }
-   |                                 ^ no implementation for `() + std::vec::Vec<B>`
+   |                                 ^ no implementation for `! + std::vec::Vec<B>`
    |
-   = help: the trait `std::ops::Add<std::vec::Vec<B>>` is not implemented for `()`
+   = help: the trait `std::ops::Add<std::vec::Vec<B>>` is not implemented for `!`
 
 error[E0599]: no method named `bind` found for array `[&str; 1]` in the current scope
   --> $DIR/issue-2149.rs:13:12

--- a/src/test/ui/type-alias-impl-trait/different_defining_uses_never_type.stderr
+++ b/src/test/ui/type-alias-impl-trait/different_defining_uses_never_type.stderr
@@ -4,7 +4,7 @@ error: concrete type differs from previous defining opaque type use
 LL | / fn bar() -> Foo {
 LL | |     panic!()
 LL | | }
-   | |_^ expected `&'static str`, got `()`
+   | |_^ expected `&'static str`, got `!`
    |
 note: previous use here
   --> $DIR/different_defining_uses_never_type.rs:8:1
@@ -20,7 +20,7 @@ error: concrete type differs from previous defining opaque type use
 LL | / fn boo() -> Foo {
 LL | |     loop {}
 LL | | }
-   | |_^ expected `&'static str`, got `()`
+   | |_^ expected `&'static str`, got `!`
    |
 note: previous use here
   --> $DIR/different_defining_uses_never_type.rs:8:1


### PR DESCRIPTION
Fixes #67225
Fixes #66173

Tl;DR: This PR introduces a lint that detects the 'bad' never-type fallback in `objc` (which results in U.B.), while allowing safe fallback to occur without a warning.

See https://hackmd.io/@FohtAO04T92wF-8_TVATYQ/SJ0vcjyWL for some background on never-type fallback.

### The problem

We want to reject "bad" code like this:

```rust
fn unconstrained_return<T>() -> Result<T, String> {
    let ffi: fn() -> T = transmute(some_pointer);
    Ok(ffi())
}
fn foo() {
    match unconstrained_return::<_>() {
        Ok(x) => x,  // `x` has type `_`, which is unconstrained
        Err(s) => panic!(s),  // … except for unifying with the type of `panic!()`
        // so that both `match` arms have the same type.
        // Therefore `_` resolves to `!` and we "return" an `Ok(!)` value.
    };
}
```

in which enabling never-type fallback can cause undefined behavior.

However, we want to allow "good" code like this:

```rust
struct E;
impl From<!> for E {
    fn from(x: !) -> E { x }
}
fn foo(never: !) {
    <E as From<_>>::from(never);
}

fn main() {}
```

which relies on never-type fallback being enabled, but is perfectly safe.

### The solution

The key difference between these two examples lies in how the result of never-type fallback is used. In the first example, we end up inferring the generic parameter of `unconstrained_return` to be `!`. In the second example, we still infer a generic parameter to be `!` (`Box::<!>::new(!)`), but we also pass an uninhabited parameter to the function.

Another way of looking at this is that the call to `unconstrained_return` is **potentially live* - none of its arguments are uninhabited, so we might (and in fact, do) end up actually executing the call at runtime.

In the second example, `Box::new()` has an uninhabited argument (the `!` type). This means that this call is **definitely dead** - since the `!` type can never be instantiated, it's impossible for the call to every be executed.

This forms the basis for the check. For each method call, we check the following:

1. Did the generic arguments have unconstrained type variables prior to fallback?
2. Did any of the generic arguments become uninhabited after fallback?
3. Are all of the method arguments inhabited?

If the answer to all of these is *yes*, we emit an error. I've left extensive comments in the code describing how this is accomplished.

These conditions ensure that we don't error on the `Box` and `From<!>` examples, while still erroring on the bad `objc` code.

### Further notes

You can test out this branch with the original bad `objc` code as follows:

1. Clone `https://github.com/Aaron1011/rust-objc`
2. Checkout the `bad-fallback` branch.
3. With a local rustc toolchain built from this branch, run `cargo build --example example`
4. Note that you get an error due to an unconstrained return type

### Unresolved questions

1. This lint only checks method calls. I believe this is sufficient to catch any undefined behavior caused by fallback changes. Since the introduced undefined behavior relies on actually 'producing' a `!` type instance, the user must be doing something 'weird' (calling `transmute` or some other intrinsic). I don't think it's possible to trigger this without *some* kind of intrinsic call - however, I'm not 100% certain.

2. This lint requires us to perform extra work during the type-checking of every single method. This is not ideal - however, changing this would have required significant refactoring to method type-checking. It would be a good idea to due to a perf run to see what kind of impact this has, and it another approach will be required.

3. This 'lint' is currently a hard error. I believe it should always be possible to fix this error by adding explicit type annotations *somewhere* (though in the `obj` case, this may be in the caller of a macro). Unfortunately, I think actually emitting any kind of suggestion to the user will be extremely difficult. Hopefully, this error is so rare that the lack of suggestion isn't a problem. If users are running into this with any frequency, I think we'll need a different approach.

4. If this PR is accepted, I see two ways of rolling this out:

1. If the bad `objc` crate is the only crate known to be affected, we could potentially go from no warning/lint to a hard error in a single release (coupled enabling never-type fallback0.
2. If we're worried that this could break a lot of crates, we could make this into a future compatibility lint. At some point in the future, we could enable never-type fallback while simultaneously making this a hard error.

What we should **not** do is make the never-type fallback changes without making this lint (or whatever lint ends up getting accepted) into a hard error. A lint, even a deny-by-default one, would be insufficient, as we would run a serious risk introducing undefined behavior without any kind of explicit acknowledgment from the user.
