### PR TITLE
impl TrustedLen for Cycle

### DIFF
--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -504,6 +504,9 @@ where
 #[stable(feature = "fused", since = "1.26.0")]
 impl<I> FusedIterator for Cycle<I> where I: Clone + Iterator {}
 
+#[unstable(feature = "trusted_len", issue = "37572")]
+unsafe impl<I> TrustedLen for Cycle<I> where I: Clone + TrustedLen {}
+
 /// An iterator for stepping iterators by a custom amount.
 ///
 /// This `struct` is created by the [`step_by`] method on [`Iterator`]. See


### PR DESCRIPTION
That was something I noticed in https://github.com/rust-lang/rust/pull/66531#issuecomment-575930272, so sure, why not.

`size_hint` method for `Cycle<I>` can return either `(0, Some(0))` or `(usize::MAX, None)` for `TrustedLen` implementations (`(0, None)` is impossible as `(0, x) if x != Some(0)` returned by inner iterator is impossible by `TrustedLen` invariant).