### PR TITLE
Disallow generic type parameters from appearing within certain constants

### DIFF
--- a/src/librustc_error_codes/error_codes.rs
+++ b/src/librustc_error_codes/error_codes.rs
@@ -415,6 +415,7 @@ E0743: include_str!("./error_codes/E0743.md"),
 E0744: include_str!("./error_codes/E0744.md"),
 E0745: include_str!("./error_codes/E0745.md"),
 E0746: include_str!("./error_codes/E0746.md"),
+E0747: include_str!("./error_codes/E0747.md"),
 ;
 //  E0006, // merged with E0005
 //  E0008, // cannot bind by-move into a pattern guard

--- a/src/librustc_error_codes/error_codes/E0747.md
+++ b/src/librustc_error_codes/error_codes/E0747.md
@@ -1,5 +1,5 @@
-Any constant items, static items, array length expressions, or enum
-discriminants can't refer to type parameters.
+Any constant item, static item, array length expression, or enum
+discriminant cannot refer to type parameters.
 
 Erroneous code example:
 
@@ -23,7 +23,7 @@ fn foo<T>() {
 }
 ```
 
-Though enum discriminants can't refer to regular type parameters they can still
+While enum discriminants cannot refer to regular type parameters, they can still
 refer to the `Self` type parameter. Example:
 
 ```
@@ -34,7 +34,7 @@ enum Alpha {
 }
 ```
 
-Note, associated constants do not have this limitation and they can refer to
+Note that associated constants do not have this limitation and can refer to
 type parameters. Example:
 
 ```
@@ -51,7 +51,7 @@ impl<T> Foo for Bar<T> {
 }
 ```
 
-This is currently a limitation with the compiler and these restrictions may be
+This is currently a limitation with the compiler. These restrictions may be
 relaxed in the future, see [issue 43408] for more information.
 
 [`vec!`]: https://doc.rust-lang.org/std/vec/struct.Vec.html

--- a/src/librustc_error_codes/error_codes/E0747.md
+++ b/src/librustc_error_codes/error_codes/E0747.md
@@ -1,0 +1,58 @@
+Any constant items, static items, array length expressions, or enum
+discriminants can't refer to type parameters.
+
+Erroneous code example:
+
+```compile_fail,E0747
+use std::mem::size_of;
+
+fn foo<T>() {
+    let _ = [0; size_of::<T>()];
+}
+```
+
+A workaround for array length expressions is to use [`vec!`] instead, which
+does support type parameters in it's length expression, though this does
+perform dynamic memory allocation. Example:
+
+```
+use std::mem::size_of;
+
+fn foo<T>() {
+    let _ = vec![0; size_of::<T>()];
+}
+```
+
+Though enum discriminants can't refer to regular type parameters they can still
+refer to the `Self` type parameter. Example:
+
+```
+#[repr(u8)]
+enum Alpha {
+    V1 = 41,
+    V2 = Self::V1 as u8 + 1,
+}
+```
+
+Note, associated constants do not have this limitation and they can refer to
+type parameters. Example:
+
+```
+use std::mem::size_of;
+
+trait Foo {
+    const X: i32;
+}
+
+struct Bar<T>(T);
+
+impl<T> Foo for Bar<T> {
+    const X: i32 = size_of::<T>();
+}
+```
+
+This is currently a limitation with the compiler and these restrictions may be
+relaxed in the future, see [issue 43408] for more information.
+
+[`vec!`]: https://doc.rust-lang.org/std/vec/struct.Vec.html
+[issue 43408]: https://github.com/rust-lang/rust/issues/43408

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -364,8 +364,8 @@ impl<'a> Resolver<'a> {
                 let mut err = struct_span_err!(
                     self.session,
                     span,
-                    E0447,
-                    "type parameters can't appear within {}",
+                    E0747,
+                    "type parameters cannot appear within {}",
                     source.descr()
                 );
                 err.span_label(span, "type parameter");

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -360,6 +360,17 @@ impl<'a> Resolver<'a> {
                 err.span_label(span, "non-constant value");
                 err
             }
+            ResolutionError::GenericParamsInConst(source) => {
+                let mut err = struct_span_err!(
+                    self.session,
+                    span,
+                    E0447,
+                    "type parameters can't appear within {}",
+                    source.descr()
+                );
+                err.span_label(span, "type parameter");
+                err
+            }
             ResolutionError::BindingShadowsSomethingUnacceptable(what_binding, name, binding) => {
                 let res = binding.res();
                 let shadows_what = res.descr();

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -204,7 +204,7 @@ enum ResolutionError<'a> {
     CannotCaptureDynamicEnvironmentInFnItem,
     /// Error E0435: attempt to use a non-constant value in a constant.
     AttemptToUseNonConstantValueInConstant,
-    /// Error E0747: type parameters can't appear within `{}`.
+    /// Error E0747: type parameters cannot appear within `{}`.
     GenericParamsInConst(AnonConstUsage),
     /// Error E0530: `X` bindings cannot shadow `Y`s.
     BindingShadowsSomethingUnacceptable(&'a str, Name, &'a NameBinding<'a>),
@@ -2367,7 +2367,9 @@ impl<'a> Resolver<'a> {
                                 continue;
                             };
                             match usage {
-                                AnonConstUsage::AssocConstant | AnonConstUsage::GenericArg => {
+                                AnonConstUsage::AssocConstant
+                                | AnonConstUsage::GenericArg
+                                | AnonConstUsage::Typeof => {
                                     // Allowed to use any type parameters.
                                     continue
                                 },

--- a/src/test/ui/associated-const/associated-const-type-parameter-arrays-2.rs
+++ b/src/test/ui/associated-const/associated-const-type-parameter-arrays-2.rs
@@ -14,7 +14,7 @@ impl Foo for Def {
 
 pub fn test<A: Foo, B: Foo>() {
     let _array = [4; <A as Foo>::Y];
-    //~^ ERROR type parameters can't appear within an array length expression [E0447]
+    //~^ ERROR type parameters cannot appear within an array length expression [E0747]
 }
 
 fn main() {

--- a/src/test/ui/associated-const/associated-const-type-parameter-arrays-2.rs
+++ b/src/test/ui/associated-const/associated-const-type-parameter-arrays-2.rs
@@ -14,7 +14,7 @@ impl Foo for Def {
 
 pub fn test<A: Foo, B: Foo>() {
     let _array = [4; <A as Foo>::Y];
-    //~^ ERROR the trait bound `A: Foo` is not satisfied [E0277]
+    //~^ ERROR type parameters can't appear within an array length expression [E0447]
 }
 
 fn main() {

--- a/src/test/ui/associated-const/associated-const-type-parameter-arrays-2.stderr
+++ b/src/test/ui/associated-const/associated-const-type-parameter-arrays-2.stderr
@@ -1,4 +1,4 @@
-error[E0447]: type parameters can't appear within an array length expression
+error[E0747]: type parameters cannot appear within an array length expression
   --> $DIR/associated-const-type-parameter-arrays-2.rs:16:23
    |
 LL |     let _array = [4; <A as Foo>::Y];
@@ -6,4 +6,4 @@ LL |     let _array = [4; <A as Foo>::Y];
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0447`.
+For more information about this error, try `rustc --explain E0747`.

--- a/src/test/ui/associated-const/associated-const-type-parameter-arrays-2.stderr
+++ b/src/test/ui/associated-const/associated-const-type-parameter-arrays-2.stderr
@@ -1,14 +1,9 @@
-error[E0277]: the trait bound `A: Foo` is not satisfied
-  --> $DIR/associated-const-type-parameter-arrays-2.rs:16:22
+error[E0447]: type parameters can't appear within an array length expression
+  --> $DIR/associated-const-type-parameter-arrays-2.rs:16:23
    |
-LL |     const Y: usize;
-   |     --------------- required by `Foo::Y`
-...
-LL | pub fn test<A: Foo, B: Foo>() {
-   |             -- help: consider further restricting this bound: `A: Foo +`
 LL |     let _array = [4; <A as Foo>::Y];
-   |                      ^^^^^^^^^^^^^ the trait `Foo` is not implemented for `A`
+   |                       ^ type parameter
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0447`.

--- a/src/test/ui/associated-const/associated-const-type-parameter-arrays.rs
+++ b/src/test/ui/associated-const/associated-const-type-parameter-arrays.rs
@@ -14,7 +14,7 @@ impl Foo for Def {
 
 pub fn test<A: Foo, B: Foo>() {
     let _array: [u32; <A as Foo>::Y];
-    //~^ ERROR type parameters can't appear within an array length expression [E0447]
+    //~^ ERROR type parameters cannot appear within an array length expression [E0747]
 }
 
 fn main() {

--- a/src/test/ui/associated-const/associated-const-type-parameter-arrays.rs
+++ b/src/test/ui/associated-const/associated-const-type-parameter-arrays.rs
@@ -14,7 +14,7 @@ impl Foo for Def {
 
 pub fn test<A: Foo, B: Foo>() {
     let _array: [u32; <A as Foo>::Y];
-    //~^ ERROR the trait bound `A: Foo` is not satisfied [E0277]
+    //~^ ERROR type parameters can't appear within an array length expression [E0447]
 }
 
 fn main() {

--- a/src/test/ui/associated-const/associated-const-type-parameter-arrays.stderr
+++ b/src/test/ui/associated-const/associated-const-type-parameter-arrays.stderr
@@ -1,14 +1,9 @@
-error[E0277]: the trait bound `A: Foo` is not satisfied
-  --> $DIR/associated-const-type-parameter-arrays.rs:16:23
+error[E0447]: type parameters can't appear within an array length expression
+  --> $DIR/associated-const-type-parameter-arrays.rs:16:24
    |
-LL |     const Y: usize;
-   |     --------------- required by `Foo::Y`
-...
-LL | pub fn test<A: Foo, B: Foo>() {
-   |             -- help: consider further restricting this bound: `A: Foo +`
 LL |     let _array: [u32; <A as Foo>::Y];
-   |                       ^^^^^^^^^^^^^ the trait `Foo` is not implemented for `A`
+   |                        ^ type parameter
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0447`.

--- a/src/test/ui/associated-const/associated-const-type-parameter-arrays.stderr
+++ b/src/test/ui/associated-const/associated-const-type-parameter-arrays.stderr
@@ -1,4 +1,4 @@
-error[E0447]: type parameters can't appear within an array length expression
+error[E0747]: type parameters cannot appear within an array length expression
   --> $DIR/associated-const-type-parameter-arrays.rs:16:24
    |
 LL |     let _array: [u32; <A as Foo>::Y];
@@ -6,4 +6,4 @@ LL |     let _array: [u32; <A as Foo>::Y];
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0447`.
+For more information about this error, try `rustc --explain E0747`.

--- a/src/test/ui/consts/const-type-parameter-self.rs
+++ b/src/test/ui/consts/const-type-parameter-self.rs
@@ -1,0 +1,15 @@
+// check-pass
+
+struct Foo;
+
+impl Foo {
+    const A: usize = 37;
+
+    fn bar() -> [u8; Self::A]{
+        [0; Self::A]
+    }
+}
+
+fn main() {
+    let _: [u8; 37] = Foo::bar();
+}

--- a/src/test/ui/consts/const-type-parameter.rs
+++ b/src/test/ui/consts/const-type-parameter.rs
@@ -1,0 +1,32 @@
+use std::mem::size_of;
+
+trait Bar {
+    const A: usize;
+}
+
+fn foo<T: Bar>() {
+    const A: usize = size_of::<T>();
+    //~^ can't use generic parameters from outer function [E0401]
+    const B: usize = T::A;
+    //~^ can't use generic parameters from outer function [E0401]
+    static C: usize = size_of::<T>();
+    //~^ can't use generic parameters from outer function [E0401]
+    static D: usize = T::A;
+    //~^ can't use generic parameters from outer function [E0401]
+
+    let _ = [0; size_of::<T>()];
+    //~^ ERROR type parameters can't appear within an array length expression [E0447]
+    let _ = [0; T::A];
+    //~^ ERROR type parameters can't appear within an array length expression [E0447]
+}
+
+#[repr(usize)]
+enum Enum<T: Bar> {
+    //~^ ERROR parameter `T` is never used [E0392]
+    V1 = size_of::<T>(),
+    //~^ ERROR type parameters can't appear within an enum discriminant [E0447]
+    V2 = T::A,
+    //~^ ERROR type parameters can't appear within an enum discriminant [E0447]
+}
+
+fn main() {}

--- a/src/test/ui/consts/const-type-parameter.rs
+++ b/src/test/ui/consts/const-type-parameter.rs
@@ -15,18 +15,18 @@ fn foo<T: Bar>() {
     //~^ can't use generic parameters from outer function [E0401]
 
     let _ = [0; size_of::<T>()];
-    //~^ ERROR type parameters can't appear within an array length expression [E0447]
+    //~^ ERROR type parameters cannot appear within an array length expression [E0747]
     let _ = [0; T::A];
-    //~^ ERROR type parameters can't appear within an array length expression [E0447]
+    //~^ ERROR type parameters cannot appear within an array length expression [E0747]
 }
 
 #[repr(usize)]
 enum Enum<T: Bar> {
     //~^ ERROR parameter `T` is never used [E0392]
     V1 = size_of::<T>(),
-    //~^ ERROR type parameters can't appear within an enum discriminant [E0447]
+    //~^ ERROR type parameters cannot appear within an enum discriminant [E0747]
     V2 = T::A,
-    //~^ ERROR type parameters can't appear within an enum discriminant [E0447]
+    //~^ ERROR type parameters cannot appear within an enum discriminant [E0747]
 }
 
 fn main() {}

--- a/src/test/ui/consts/const-type-parameter.stderr
+++ b/src/test/ui/consts/const-type-parameter.stderr
@@ -33,25 +33,25 @@ LL | fn foo<T: Bar>() {
 LL |     static D: usize = T::A;
    |                       ^^^^ use of generic parameter from outer function
 
-error[E0447]: type parameters can't appear within an array length expression
+error[E0747]: type parameters cannot appear within an array length expression
   --> $DIR/const-type-parameter.rs:17:27
    |
 LL |     let _ = [0; size_of::<T>()];
    |                           ^ type parameter
 
-error[E0447]: type parameters can't appear within an array length expression
+error[E0747]: type parameters cannot appear within an array length expression
   --> $DIR/const-type-parameter.rs:19:17
    |
 LL |     let _ = [0; T::A];
    |                 ^^^^ type parameter
 
-error[E0447]: type parameters can't appear within an enum discriminant
+error[E0747]: type parameters cannot appear within an enum discriminant
   --> $DIR/const-type-parameter.rs:26:20
    |
 LL |     V1 = size_of::<T>(),
    |                    ^ type parameter
 
-error[E0447]: type parameters can't appear within an enum discriminant
+error[E0747]: type parameters cannot appear within an enum discriminant
   --> $DIR/const-type-parameter.rs:28:10
    |
 LL |     V2 = T::A,
@@ -67,5 +67,5 @@ LL | enum Enum<T: Bar> {
 
 error: aborting due to 9 previous errors
 
-Some errors have detailed explanations: E0392, E0401, E0447.
+Some errors have detailed explanations: E0392, E0401, E0747.
 For more information about an error, try `rustc --explain E0392`.

--- a/src/test/ui/consts/const-type-parameter.stderr
+++ b/src/test/ui/consts/const-type-parameter.stderr
@@ -1,0 +1,71 @@
+error[E0401]: can't use generic parameters from outer function
+  --> $DIR/const-type-parameter.rs:8:32
+   |
+LL | fn foo<T: Bar>() {
+   |        - type parameter from outer function
+LL |     const A: usize = size_of::<T>();
+   |                                ^ use of generic parameter from outer function
+
+error[E0401]: can't use generic parameters from outer function
+  --> $DIR/const-type-parameter.rs:10:22
+   |
+LL | fn foo<T: Bar>() {
+   |        - type parameter from outer function
+...
+LL |     const B: usize = T::A;
+   |                      ^^^^ use of generic parameter from outer function
+
+error[E0401]: can't use generic parameters from outer function
+  --> $DIR/const-type-parameter.rs:12:33
+   |
+LL | fn foo<T: Bar>() {
+   |        - type parameter from outer function
+...
+LL |     static C: usize = size_of::<T>();
+   |                                 ^ use of generic parameter from outer function
+
+error[E0401]: can't use generic parameters from outer function
+  --> $DIR/const-type-parameter.rs:14:23
+   |
+LL | fn foo<T: Bar>() {
+   |        - type parameter from outer function
+...
+LL |     static D: usize = T::A;
+   |                       ^^^^ use of generic parameter from outer function
+
+error[E0447]: type parameters can't appear within an array length expression
+  --> $DIR/const-type-parameter.rs:17:27
+   |
+LL |     let _ = [0; size_of::<T>()];
+   |                           ^ type parameter
+
+error[E0447]: type parameters can't appear within an array length expression
+  --> $DIR/const-type-parameter.rs:19:17
+   |
+LL |     let _ = [0; T::A];
+   |                 ^^^^ type parameter
+
+error[E0447]: type parameters can't appear within an enum discriminant
+  --> $DIR/const-type-parameter.rs:26:20
+   |
+LL |     V1 = size_of::<T>(),
+   |                    ^ type parameter
+
+error[E0447]: type parameters can't appear within an enum discriminant
+  --> $DIR/const-type-parameter.rs:28:10
+   |
+LL |     V2 = T::A,
+   |          ^^^^ type parameter
+
+error[E0392]: parameter `T` is never used
+  --> $DIR/const-type-parameter.rs:24:11
+   |
+LL | enum Enum<T: Bar> {
+   |           ^ unused parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `std::marker::PhantomData`
+
+error: aborting due to 9 previous errors
+
+Some errors have detailed explanations: E0392, E0401, E0447.
+For more information about an error, try `rustc --explain E0392`.

--- a/src/test/ui/consts/issue-67945.rs
+++ b/src/test/ui/consts/issue-67945.rs
@@ -1,0 +1,50 @@
+#![feature(type_ascription)]
+
+use std::marker::PhantomData;
+use std::mem::{self, MaybeUninit};
+
+struct Bug1<S> {
+    //~^ ERROR parameter `S` is never used [E0392]
+    A: [(); {
+        let x: S = MaybeUninit::uninit();
+        //~^ ERROR type parameters can't appear within an array length expression [E0447]
+        let b = &*(&x as *const _ as *const S);
+        //~^ ERROR type parameters can't appear within an array length expression [E0447]
+        0
+    }],
+}
+
+struct Bug2<S> {
+    //~^ ERROR parameter `S` is never used [E0392]
+    A: [(); {
+        let x: Option<S> = None;
+        //~^ ERROR type parameters can't appear within an array length expression [E0447]
+        0
+    }],
+}
+
+struct Bug3<S> {
+    //~^ ERROR parameter `S` is never used [E0392]
+    A: [(); {
+        let x: Option<Box<S>> = None;
+        //~^ ERROR type parameters can't appear within an array length expression [E0447]
+        0
+    }],
+}
+
+enum Bug4<S> {
+    //~^ ERROR parameter `S` is never used [E0392]
+    Var = {
+        let x: S = 0;
+        //~^ ERROR type parameters can't appear within an enum discriminant [E0447]
+        0
+    },
+}
+
+enum Bug5<S> {
+    //~^ ERROR parameter `S` is never used [E0392]
+    Var = 0: S,
+    //~^ ERROR type parameters can't appear within an enum discriminant [E0447]
+}
+
+fn main() {}

--- a/src/test/ui/consts/issue-67945.rs
+++ b/src/test/ui/consts/issue-67945.rs
@@ -7,9 +7,9 @@ struct Bug1<S> {
     //~^ ERROR parameter `S` is never used [E0392]
     A: [(); {
         let x: S = MaybeUninit::uninit();
-        //~^ ERROR type parameters can't appear within an array length expression [E0447]
+        //~^ ERROR type parameters cannot appear within an array length expression [E0747]
         let b = &*(&x as *const _ as *const S);
-        //~^ ERROR type parameters can't appear within an array length expression [E0447]
+        //~^ ERROR type parameters cannot appear within an array length expression [E0747]
         0
     }],
 }
@@ -18,7 +18,7 @@ struct Bug2<S> {
     //~^ ERROR parameter `S` is never used [E0392]
     A: [(); {
         let x: Option<S> = None;
-        //~^ ERROR type parameters can't appear within an array length expression [E0447]
+        //~^ ERROR type parameters cannot appear within an array length expression [E0747]
         0
     }],
 }
@@ -27,7 +27,7 @@ struct Bug3<S> {
     //~^ ERROR parameter `S` is never used [E0392]
     A: [(); {
         let x: Option<Box<S>> = None;
-        //~^ ERROR type parameters can't appear within an array length expression [E0447]
+        //~^ ERROR type parameters cannot appear within an array length expression [E0747]
         0
     }],
 }
@@ -36,7 +36,7 @@ enum Bug4<S> {
     //~^ ERROR parameter `S` is never used [E0392]
     Var = {
         let x: S = 0;
-        //~^ ERROR type parameters can't appear within an enum discriminant [E0447]
+        //~^ ERROR type parameters cannot appear within an enum discriminant [E0747]
         0
     },
 }
@@ -44,7 +44,7 @@ enum Bug4<S> {
 enum Bug5<S> {
     //~^ ERROR parameter `S` is never used [E0392]
     Var = 0: S,
-    //~^ ERROR type parameters can't appear within an enum discriminant [E0447]
+    //~^ ERROR type parameters cannot appear within an enum discriminant [E0747]
 }
 
 fn main() {}

--- a/src/test/ui/consts/issue-67945.stderr
+++ b/src/test/ui/consts/issue-67945.stderr
@@ -1,0 +1,80 @@
+error[E0447]: type parameters can't appear within an array length expression
+  --> $DIR/issue-67945.rs:9:16
+   |
+LL |         let x: S = MaybeUninit::uninit();
+   |                ^ type parameter
+
+error[E0447]: type parameters can't appear within an array length expression
+  --> $DIR/issue-67945.rs:11:45
+   |
+LL |         let b = &*(&x as *const _ as *const S);
+   |                                             ^ type parameter
+
+error[E0447]: type parameters can't appear within an array length expression
+  --> $DIR/issue-67945.rs:20:23
+   |
+LL |         let x: Option<S> = None;
+   |                       ^ type parameter
+
+error[E0447]: type parameters can't appear within an array length expression
+  --> $DIR/issue-67945.rs:29:27
+   |
+LL |         let x: Option<Box<S>> = None;
+   |                           ^ type parameter
+
+error[E0447]: type parameters can't appear within an enum discriminant
+  --> $DIR/issue-67945.rs:38:16
+   |
+LL |         let x: S = 0;
+   |                ^ type parameter
+
+error[E0447]: type parameters can't appear within an enum discriminant
+  --> $DIR/issue-67945.rs:46:14
+   |
+LL |     Var = 0: S,
+   |              ^ type parameter
+
+error[E0392]: parameter `S` is never used
+  --> $DIR/issue-67945.rs:6:13
+   |
+LL | struct Bug1<S> {
+   |             ^ unused parameter
+   |
+   = help: consider removing `S`, referring to it in a field, or using a marker such as `std::marker::PhantomData`
+
+error[E0392]: parameter `S` is never used
+  --> $DIR/issue-67945.rs:17:13
+   |
+LL | struct Bug2<S> {
+   |             ^ unused parameter
+   |
+   = help: consider removing `S`, referring to it in a field, or using a marker such as `std::marker::PhantomData`
+
+error[E0392]: parameter `S` is never used
+  --> $DIR/issue-67945.rs:26:13
+   |
+LL | struct Bug3<S> {
+   |             ^ unused parameter
+   |
+   = help: consider removing `S`, referring to it in a field, or using a marker such as `std::marker::PhantomData`
+
+error[E0392]: parameter `S` is never used
+  --> $DIR/issue-67945.rs:35:11
+   |
+LL | enum Bug4<S> {
+   |           ^ unused parameter
+   |
+   = help: consider removing `S`, referring to it in a field, or using a marker such as `std::marker::PhantomData`
+
+error[E0392]: parameter `S` is never used
+  --> $DIR/issue-67945.rs:44:11
+   |
+LL | enum Bug5<S> {
+   |           ^ unused parameter
+   |
+   = help: consider removing `S`, referring to it in a field, or using a marker such as `std::marker::PhantomData`
+
+error: aborting due to 11 previous errors
+
+Some errors have detailed explanations: E0392, E0447.
+For more information about an error, try `rustc --explain E0392`.

--- a/src/test/ui/consts/issue-67945.stderr
+++ b/src/test/ui/consts/issue-67945.stderr
@@ -1,34 +1,34 @@
-error[E0447]: type parameters can't appear within an array length expression
+error[E0747]: type parameters cannot appear within an array length expression
   --> $DIR/issue-67945.rs:9:16
    |
 LL |         let x: S = MaybeUninit::uninit();
    |                ^ type parameter
 
-error[E0447]: type parameters can't appear within an array length expression
+error[E0747]: type parameters cannot appear within an array length expression
   --> $DIR/issue-67945.rs:11:45
    |
 LL |         let b = &*(&x as *const _ as *const S);
    |                                             ^ type parameter
 
-error[E0447]: type parameters can't appear within an array length expression
+error[E0747]: type parameters cannot appear within an array length expression
   --> $DIR/issue-67945.rs:20:23
    |
 LL |         let x: Option<S> = None;
    |                       ^ type parameter
 
-error[E0447]: type parameters can't appear within an array length expression
+error[E0747]: type parameters cannot appear within an array length expression
   --> $DIR/issue-67945.rs:29:27
    |
 LL |         let x: Option<Box<S>> = None;
    |                           ^ type parameter
 
-error[E0447]: type parameters can't appear within an enum discriminant
+error[E0747]: type parameters cannot appear within an enum discriminant
   --> $DIR/issue-67945.rs:38:16
    |
 LL |         let x: S = 0;
    |                ^ type parameter
 
-error[E0447]: type parameters can't appear within an enum discriminant
+error[E0747]: type parameters cannot appear within an enum discriminant
   --> $DIR/issue-67945.rs:46:14
    |
 LL |     Var = 0: S,
@@ -76,5 +76,5 @@ LL | enum Bug5<S> {
 
 error: aborting due to 11 previous errors
 
-Some errors have detailed explanations: E0392, E0447.
+Some errors have detailed explanations: E0392, E0747.
 For more information about an error, try `rustc --explain E0392`.

--- a/src/test/ui/issues/issue-39211.rs
+++ b/src/test/ui/issues/issue-39211.rs
@@ -9,7 +9,7 @@ trait Mat {
 
 fn m<M: Mat>() {
     let a = [3; M::Row::DIM];
-    //~^ ERROR type parameters can't appear within an array length expression [E0447]
+    //~^ ERROR type parameters cannot appear within an array length expression [E0747]
 }
 fn main() {
 }

--- a/src/test/ui/issues/issue-39211.rs
+++ b/src/test/ui/issues/issue-39211.rs
@@ -8,7 +8,8 @@ trait Mat {
 }
 
 fn m<M: Mat>() {
-    let a = [3; M::Row::DIM]; //~ ERROR associated type `Row` not found for `M`
+    let a = [3; M::Row::DIM];
+    //~^ ERROR type parameters can't appear within an array length expression [E0447]
 }
 fn main() {
 }

--- a/src/test/ui/issues/issue-39211.stderr
+++ b/src/test/ui/issues/issue-39211.stderr
@@ -1,9 +1,9 @@
-error[E0220]: associated type `Row` not found for `M`
-  --> $DIR/issue-39211.rs:11:20
+error[E0447]: type parameters can't appear within an array length expression
+  --> $DIR/issue-39211.rs:11:17
    |
 LL |     let a = [3; M::Row::DIM];
-   |                    ^^^ associated type `Row` not found
+   |                 ^^^^^^^^^^^ type parameter
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0220`.
+For more information about this error, try `rustc --explain E0447`.

--- a/src/test/ui/issues/issue-39211.stderr
+++ b/src/test/ui/issues/issue-39211.stderr
@@ -1,4 +1,4 @@
-error[E0447]: type parameters can't appear within an array length expression
+error[E0747]: type parameters cannot appear within an array length expression
   --> $DIR/issue-39211.rs:11:17
    |
 LL |     let a = [3; M::Row::DIM];
@@ -6,4 +6,4 @@ LL |     let a = [3; M::Row::DIM];
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0447`.
+For more information about this error, try `rustc --explain E0747`.

--- a/src/test/ui/issues/issue-39559.rs
+++ b/src/test/ui/issues/issue-39559.rs
@@ -12,7 +12,7 @@ impl Dim for Dim3 {
 
 pub struct Vector<T, D: Dim> {
     entries: [T; D::dim()],
-    //~^ ERROR type parameters can't appear within an array length expression [E0447]
+    //~^ ERROR type parameters cannot appear within an array length expression [E0747]
     _dummy: D,
 }
 

--- a/src/test/ui/issues/issue-39559.rs
+++ b/src/test/ui/issues/issue-39559.rs
@@ -12,7 +12,7 @@ impl Dim for Dim3 {
 
 pub struct Vector<T, D: Dim> {
     entries: [T; D::dim()],
-    //~^ ERROR no function or associated item named `dim` found
+    //~^ ERROR type parameters can't appear within an array length expression [E0447]
     _dummy: D,
 }
 

--- a/src/test/ui/issues/issue-39559.stderr
+++ b/src/test/ui/issues/issue-39559.stderr
@@ -1,4 +1,4 @@
-error[E0447]: type parameters can't appear within an array length expression
+error[E0747]: type parameters cannot appear within an array length expression
   --> $DIR/issue-39559.rs:14:18
    |
 LL |     entries: [T; D::dim()],
@@ -6,4 +6,4 @@ LL |     entries: [T; D::dim()],
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0447`.
+For more information about this error, try `rustc --explain E0747`.

--- a/src/test/ui/issues/issue-39559.stderr
+++ b/src/test/ui/issues/issue-39559.stderr
@@ -1,15 +1,9 @@
-error[E0599]: no function or associated item named `dim` found for type parameter `D` in the current scope
-  --> $DIR/issue-39559.rs:14:21
+error[E0447]: type parameters can't appear within an array length expression
+  --> $DIR/issue-39559.rs:14:18
    |
 LL |     entries: [T; D::dim()],
-   |                     ^^^ function or associated item not found in `D`
-   |
-   = help: items from traits can only be used if the type parameter is bounded by the trait
-help: the following trait defines an item `dim`, perhaps you need to restrict type parameter `D` with it:
-   |
-LL | pub struct Vector<T, D: Dim + Dim> {
-   |                      ^^^^^^^^
+   |                  ^^^^^^ type parameter
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0599`.
+For more information about this error, try `rustc --explain E0447`.


### PR DESCRIPTION
This improves the diagonistics/fixes ICEs when generic parameters appear within some constants. For example of the new errors:
```rust
use std::mem::size_of;

fn foo<T>() {
    let _ = [0; size_of::<T>()]; // now errors with: type parameters can't appear within an array length expression
}

#[repr(usize)]
enum Enum<T> {
    V1 = size_of::<T>(), // now errors with: type parameters can't appear within an enum discriminant
}
``` 

Previously emitted confusing errors like:
```
error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> src/main.rs:45:27
    |
35  | fn foo<T>() {
    |        - help: consider restricting this bound: `T: std::marker::Sized`
...
45  |     let _ = [0; size_of::<T>()];
    |                           ^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `T`
```
Note doesn't disallow referring to `Self` in either enum discriminants or array length expressions as there are cases where it can currently be sucessfully used, i.e.:
```rust
struct Foo;

impl Foo {
    const A: usize = 37;

    fn bar() -> [u8; Self::A]{
        [0; Self::A]
    }
}
```
I don't think that this disallows any more code that didn't either produce a compiler error before or caused an ICE.

cc #43408 
cc #67945 (doesn't actually fully fix it see: https://github.com/rust-lang/rust/issues/67945#issuecomment-575946966)