### PR TITLE
rustdoc: Fix handling of compile errors when running `rustdoc --test`

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -43,7 +43,7 @@ pub fn run(options: Options) -> i32 {
     let crate_types = if options.proc_macro_crate {
         vec![config::CrateType::ProcMacro]
     } else {
-        vec![config::CrateType::Dylib]
+        vec![config::CrateType::Rlib]
     };
 
     let sessopts = config::Options {
@@ -117,12 +117,16 @@ pub fn run(options: Options) -> i32 {
                     intravisit::walk_crate(this, krate);
                 });
             });
+            compiler.session().abort_if_errors();
 
             let ret: Result<_, ErrorReported> = Ok(collector.tests);
             ret
         })
-    })
-    .expect("compiler aborted in rustdoc!");
+    });
+    let tests = match tests {
+        Ok(tests) => tests,
+        Err(ErrorReported) => return 1,
+    };
 
     test_args.insert(0, "rustdoctest".to_string());
 

--- a/src/test/rustdoc-ui/test-compile-fail1.rs
+++ b/src/test/rustdoc-ui/test-compile-fail1.rs
@@ -1,0 +1,8 @@
+// compile-flags:--test
+
+/// ```
+/// assert!(true)
+/// ```
+pub fn f() {}
+
+pub fn f() {}

--- a/src/test/rustdoc-ui/test-compile-fail1.stderr
+++ b/src/test/rustdoc-ui/test-compile-fail1.stderr
@@ -1,0 +1,14 @@
+error[E0428]: the name `f` is defined multiple times
+ --> $DIR/test-compile-fail1.rs:8:1
+  |
+6 | pub fn f() {}
+  | ---------- previous definition of the value `f` here
+7 | 
+8 | pub fn f() {}
+  | ^^^^^^^^^^ `f` redefined here
+  |
+  = note: `f` must be defined only once in the value namespace of this module
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0428`.

--- a/src/test/rustdoc-ui/test-compile-fail2.rs
+++ b/src/test/rustdoc-ui/test-compile-fail2.rs
@@ -1,0 +1,3 @@
+// compile-flags:--test
+
+fail

--- a/src/test/rustdoc-ui/test-compile-fail2.stderr
+++ b/src/test/rustdoc-ui/test-compile-fail2.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!` or `::`, found `<eof>`
+ --> $DIR/test-compile-fail2.rs:3:1
+  |
+3 | fail
+  | ^^^^ expected one of `!` or `::`
+
+error: aborting due to previous error
+

--- a/src/test/rustdoc-ui/test-compile-fail3.rs
+++ b/src/test/rustdoc-ui/test-compile-fail3.rs
@@ -1,0 +1,3 @@
+// compile-flags:--test
+
+"fail

--- a/src/test/rustdoc-ui/test-compile-fail3.stderr
+++ b/src/test/rustdoc-ui/test-compile-fail3.stderr
@@ -1,0 +1,8 @@
+error: unterminated double quote string
+ --> $DIR/test-compile-fail3.rs:3:1
+  |
+3 | "fail
+  | ^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/rustdoc-ui/test-no_std.rs
+++ b/src/test/rustdoc-ui/test-no_std.rs
@@ -1,0 +1,12 @@
+// compile-flags:--test
+// normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// build-pass
+
+#![no_std]
+
+extern crate alloc;
+
+/// ```
+/// assert!(true)
+/// ```
+pub fn f() {}

--- a/src/test/rustdoc-ui/test-no_std.stdout
+++ b/src/test/rustdoc-ui/test-no_std.stdout
@@ -1,0 +1,6 @@
+
+running 1 test
+test $DIR/test-no_std.rs - f (line 9) ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+


### PR DESCRIPTION
 * Call `abort_if_errors` so all errors actually stop rustdoc.
* Don't panic with "compiler aborted in rustdoc!", instead just exit to avoid the ugly panic message.
* Use rlib as the crate type when searching for doctests matching what is used for doc generation so `#[no_std]` crates don't create "no global memory allocator" errors.

Fixes #52243
Fixes #54010

r? @GuillaumeGomez