### PR TITLE
Remove some unsound specializations

### DIFF
--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -385,12 +385,14 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
                 }
                 Some(Equal) => {
                     self.is_empty = Some(true);
+                    self.start = plus_n.clone();
                     return Some(plus_n);
                 }
                 _ => {}
             }
         }
 
+        self.start = self.end.clone();
         self.is_empty = Some(true);
         None
     }
@@ -477,12 +479,14 @@ impl<A: Step> DoubleEndedIterator for ops::RangeInclusive<A> {
                 }
                 Some(Equal) => {
                     self.is_empty = Some(true);
+                    self.end = minus_n.clone();
                     return Some(minus_n);
                 }
                 _ => {}
             }
         }
 
+        self.end = self.start.clone();
         self.is_empty = Some(true);
         None
     }

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -12,7 +12,7 @@ use self::pattern::{DoubleEndedSearcher, ReverseSearcher, SearchStep, Searcher};
 use crate::char;
 use crate::fmt::{self, Write};
 use crate::iter::{Chain, FlatMap, Flatten};
-use crate::iter::{Cloned, Filter, FusedIterator, Map, TrustedLen, TrustedRandomAccess};
+use crate::iter::{Copied, Filter, FusedIterator, Map, TrustedLen, TrustedRandomAccess};
 use crate::mem;
 use crate::ops::Try;
 use crate::option;
@@ -750,7 +750,7 @@ impl<'a> CharIndices<'a> {
 /// [`str`]: ../../std/primitive.str.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Clone, Debug)]
-pub struct Bytes<'a>(Cloned<slice::Iter<'a, u8>>);
+pub struct Bytes<'a>(Copied<slice::Iter<'a, u8>>);
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Iterator for Bytes<'_> {
@@ -2778,7 +2778,7 @@ impl str {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn bytes(&self) -> Bytes<'_> {
-        Bytes(self.as_bytes().iter().cloned())
+        Bytes(self.as_bytes().iter().copied())
     }
 
     /// Splits a string slice by whitespace.
@@ -3895,7 +3895,7 @@ impl str {
             debug_assert_eq!(
                 start, 0,
                 "The first search step from Searcher \
-                must include the first character"
+                 must include the first character"
             );
             // SAFETY: `Searcher` is known to return valid indices.
             unsafe { Some(self.get_unchecked(len..)) }
@@ -3934,7 +3934,7 @@ impl str {
                 end,
                 self.len(),
                 "The first search step from ReverseSearcher \
-                must include the last character"
+                 must include the last character"
             );
             // SAFETY: `Searcher` is known to return valid indices.
             unsafe { Some(self.get_unchecked(..start)) }

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1954,10 +1954,18 @@ fn test_range_inclusive_exhaustion() {
     assert_eq!(r.next(), None);
     assert_eq!(r.next(), None);
 
+    assert_eq!(*r.start(), 10);
+    assert_eq!(*r.end(), 10);
+    assert_ne!(r, 10..=10);
+
     let mut r = 10..=10;
     assert_eq!(r.next_back(), Some(10));
     assert!(r.is_empty());
     assert_eq!(r.next_back(), None);
+
+    assert_eq!(*r.start(), 10);
+    assert_eq!(*r.end(), 10);
+    assert_ne!(r, 10..=10);
 
     let mut r = 10..=12;
     assert_eq!(r.next(), Some(10));
@@ -2076,6 +2084,9 @@ fn test_range_inclusive_nth() {
     assert_eq!((10..=15).nth(5), Some(15));
     assert_eq!((10..=15).nth(6), None);
 
+    let mut exhausted_via_next = 10_u8..=20;
+    while exhausted_via_next.next().is_some() {}
+
     let mut r = 10_u8..=20;
     assert_eq!(r.nth(2), Some(12));
     assert_eq!(r, 13..=20);
@@ -2085,6 +2096,7 @@ fn test_range_inclusive_nth() {
     assert_eq!(ExactSizeIterator::is_empty(&r), false);
     assert_eq!(r.nth(10), None);
     assert_eq!(r.is_empty(), true);
+    assert_eq!(r, exhausted_via_next);
     assert_eq!(ExactSizeIterator::is_empty(&r), true);
 }
 
@@ -2096,6 +2108,9 @@ fn test_range_inclusive_nth_back() {
     assert_eq!((10..=15).nth_back(6), None);
     assert_eq!((-120..=80_i8).nth_back(200), Some(-120));
 
+    let mut exhausted_via_next_back = 10_u8..=20;
+    while exhausted_via_next_back.next_back().is_some() {}
+
     let mut r = 10_u8..=20;
     assert_eq!(r.nth_back(2), Some(18));
     assert_eq!(r, 10..=17);
@@ -2105,6 +2120,7 @@ fn test_range_inclusive_nth_back() {
     assert_eq!(ExactSizeIterator::is_empty(&r), false);
     assert_eq!(r.nth_back(10), None);
     assert_eq!(r.is_empty(), true);
+    assert_eq!(r, exhausted_via_next_back);
     assert_eq!(ExactSizeIterator::is_empty(&r), true);
 }
 

--- a/src/test/ui/specialization/soundness/partial_eq_range_inclusive.rs
+++ b/src/test/ui/specialization/soundness/partial_eq_range_inclusive.rs
@@ -1,0 +1,35 @@
+// run-pass
+
+use std::cell::RefCell;
+use std::cmp::Ordering;
+
+struct Evil<'a, 'b> {
+    values: RefCell<Vec<&'a str>>,
+    to_insert: &'b String,
+}
+
+impl<'a, 'b> PartialEq for Evil<'a, 'b> {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl<'a> PartialOrd for Evil<'a, 'a> {
+    fn partial_cmp(&self, _other: &Self) -> Option<Ordering> {
+        self.values.borrow_mut().push(self.to_insert);
+        None
+    }
+}
+
+fn main() {
+    let e;
+    let values;
+    {
+        let to_insert = String::from("Hello, world!");
+        e = Evil { values: RefCell::new(Vec::new()), to_insert: &to_insert };
+        let range = &e..=&e;
+        let _ = range == range;
+        values = e.values;
+    }
+    assert_eq!(*values.borrow(), Vec::<&str>::new());
+}

--- a/src/test/ui/specialization/soundness/partial_ord_slice.rs
+++ b/src/test/ui/specialization/soundness/partial_ord_slice.rs
@@ -1,0 +1,42 @@
+// Check that we aren't using unsound specialization in slice comparisons.
+
+// run-pass
+
+use std::cell::Cell;
+use std::cmp::Ordering;
+
+struct Evil<'a, 'b>(Cell<(&'a [i32], &'b [i32])>);
+
+impl PartialEq for Evil<'_, '_> {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for Evil<'_, '_> {}
+
+impl PartialOrd for Evil<'_, '_> {
+    fn partial_cmp(&self, _other: &Self) -> Option<Ordering> {
+        Some(Ordering::Equal)
+    }
+}
+
+impl<'a> Ord for Evil<'a, 'a> {
+    fn cmp(&self, _other: &Self) -> Ordering {
+        let (a, b) = self.0.get();
+        self.0.set((b, a));
+        Ordering::Equal
+    }
+}
+
+fn main() {
+    let x = &[1, 2, 3, 4];
+    let u = {
+        let a = Box::new([7, 8, 9, 10]);
+        let y = [Evil(Cell::new((x, &*a)))];
+        let _ = &y[..] <= &y[..];
+        let [Evil(c)] = y;
+        c.get().0
+    };
+    assert_eq!(u, &[1, 2, 3, 4]);
+}


### PR DESCRIPTION
This removes the unsound and exploitable specializations in the standard library

* The `PartialEq` and `Hash` implementations for  `RangeInclusive` are changed to avoid specialization.
* The `PartialOrd` specialization for slices now specializes on a limited set of concrete types.
* Added some tests for the soundness problems.
