### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -208,6 +208,11 @@ pub fn repeat_with<A, F: FnMut() -> A>(repeater: F) -> RepeatWith<F> {
 #[stable(feature = "iter_empty", since = "1.2.0")]
 pub struct Empty<T>(marker::PhantomData<T>);
 
+#[stable(feature = "iter_empty_send_sync", since = "1.42.0")]
+unsafe impl<T> Send for Empty<T> {}
+#[stable(feature = "iter_empty_send_sync", since = "1.42.0")]
+unsafe impl<T> Sync for Empty<T> {}
+
 #[stable(feature = "core_impl_debug", since = "1.9.0")]
 impl<T> fmt::Debug for Empty<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/librustc_error_codes/error_codes/E0195.md
+++ b/src/librustc_error_codes/error_codes/E0195.md
@@ -1,4 +1,5 @@
-Your method's lifetime parameters do not match the trait declaration.
+The lifetime parameters of the method do not match the trait declaration.
+
 Erroneous code example:
 
 ```compile_fail,E0195
@@ -16,7 +17,7 @@ impl Trait for Foo {
 }
 ```
 
-The lifetime constraint `'b` for bar() implementation does not match the
+The lifetime constraint `'b` for `bar()` implementation does not match the
 trait declaration. Ensure lifetime declarations match exactly in both trait
 declaration and implementation. Example:
 

--- a/src/librustc_error_codes/error_codes/E0197.md
+++ b/src/librustc_error_codes/error_codes/E0197.md
@@ -1,13 +1,20 @@
+An inherent implementation was marked unsafe.
+
+Erroneous code example:
+
+```compile_fail,E0197
+struct Foo;
+
+unsafe impl Foo { } // error!
+```
+
 Inherent implementations (one that do not implement a trait but provide
 methods associated with a type) are always safe because they are not
 implementing an unsafe trait. Removing the `unsafe` keyword from the inherent
 implementation will resolve this error.
 
-```compile_fail,E0197
+```
 struct Foo;
 
-// this will cause this error
-unsafe impl Foo { }
-// converting it to this will fix it
-impl Foo { }
+impl Foo { } // ok!
 ```

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -464,11 +464,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
         r
     }
 
-    fn eval_constant(
-        &mut self,
-        c: &Constant<'tcx>,
-        source_info: SourceInfo,
-    ) -> Option<OpTy<'tcx>> {
+    fn eval_constant(&mut self, c: &Constant<'tcx>, source_info: SourceInfo) -> Option<OpTy<'tcx>> {
         self.ecx.tcx.span = c.span;
 
         // FIXME we need to revisit this for #67176

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -288,8 +288,6 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for ConstPropMachine {
     }
 }
 
-type Const<'tcx> = OpTy<'tcx>;
-
 /// Finds optimization opportunities on the MIR.
 struct ConstPropagator<'mir, 'tcx> {
     ecx: InterpCx<'mir, 'tcx, ConstPropMachine>,
@@ -387,7 +385,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
         }
     }
 
-    fn get_const(&self, local: Local) -> Option<Const<'tcx>> {
+    fn get_const(&self, local: Local) -> Option<OpTy<'tcx>> {
         if local == RETURN_PLACE {
             // Try to read the return place as an immediate so that if it is representable as a
             // scalar, we can handle it as such, but otherwise, just return the value as is.
@@ -470,7 +468,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
         &mut self,
         c: &Constant<'tcx>,
         source_info: SourceInfo,
-    ) -> Option<Const<'tcx>> {
+    ) -> Option<OpTy<'tcx>> {
         self.ecx.tcx.span = c.span;
 
         // FIXME we need to revisit this for #67176
@@ -510,12 +508,12 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
         }
     }
 
-    fn eval_place(&mut self, place: &Place<'tcx>, source_info: SourceInfo) -> Option<Const<'tcx>> {
+    fn eval_place(&mut self, place: &Place<'tcx>, source_info: SourceInfo) -> Option<OpTy<'tcx>> {
         trace!("eval_place(place={:?})", place);
         self.use_ecx(source_info, |this| this.ecx.eval_place_to_op(place, None))
     }
 
-    fn eval_operand(&mut self, op: &Operand<'tcx>, source_info: SourceInfo) -> Option<Const<'tcx>> {
+    fn eval_operand(&mut self, op: &Operand<'tcx>, source_info: SourceInfo) -> Option<OpTy<'tcx>> {
         match *op {
             Operand::Constant(ref c) => self.eval_constant(c, source_info),
             Operand::Move(ref place) | Operand::Copy(ref place) => {
@@ -664,7 +662,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
     fn replace_with_const(
         &mut self,
         rval: &mut Rvalue<'tcx>,
-        value: Const<'tcx>,
+        value: OpTy<'tcx>,
         source_info: SourceInfo,
     ) {
         trace!("attepting to replace {:?} with {:?}", rval, value);

--- a/src/test/ui/threads-sendsync/sync-send-iterators-in-libcore.rs
+++ b/src/test/ui/threads-sendsync/sync-send-iterators-in-libcore.rs
@@ -88,6 +88,7 @@ fn main() {
     is_sync_send!((1..));
     is_sync_send!(repeat(1));
     is_sync_send!(empty::<usize>());
+    is_sync_send!(empty::<*mut i32>());
     is_sync_send!(once(1));
 
     // for option.rs


### PR DESCRIPTION
Successful merges:

 - #67682 ([const-prop] Remove useless typedef)
 - #68247 (Clean up err codes)
 - #68348 (Make iter::Empty<T> Send and Sync for any T)

Failed merges:


r? @ghost