### PR TITLE
Ensure that we error when calling "const extern fn" with wrong convention

### DIFF
--- a/src/test/ui/consts/miri_unleashed/abi-mismatch.rs
+++ b/src/test/ui/consts/miri_unleashed/abi-mismatch.rs
@@ -1,0 +1,16 @@
+// Checks that we report ABI mismatches for "const extern fn"
+// compile-flags: -Z unleash-the-miri-inside-of-you
+
+#![feature(const_extern_fn)]
+
+const extern "C" fn c_fn() {}
+
+const fn call_rust_fn(my_fn: extern "Rust" fn()) {
+    my_fn(); //~ ERROR any use of this value will cause an error
+    //~^ WARN skipping const checks
+}
+
+const VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
+//~^ WARN skipping const checks
+
+fn main() {}

--- a/src/test/ui/consts/miri_unleashed/abi-mismatch.stderr
+++ b/src/test/ui/consts/miri_unleashed/abi-mismatch.stderr
@@ -1,0 +1,28 @@
+warning: skipping const checks
+  --> $DIR/abi-mismatch.rs:9:5
+   |
+LL |     my_fn();
+   |     ^^^^^^^
+
+warning: skipping const checks
+  --> $DIR/abi-mismatch.rs:13:39
+   |
+LL | const VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: any use of this value will cause an error
+  --> $DIR/abi-mismatch.rs:9:5
+   |
+LL |     my_fn();
+   |     ^^^^^^^
+   |     |
+   |     tried to call a function with ABI C using caller ABI Rust
+   |     inside call to `call_rust_fn` at $DIR/abi-mismatch.rs:13:17
+...
+LL | const VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
+   | --------------------------------------------------------------------------------------
+   |
+   = note: `#[deny(const_err)]` on by default
+
+error: aborting due to previous error
+


### PR DESCRIPTION
See #64926