### PR TITLE
Tweak obligation error output

### DIFF
--- a/src/librustc/traits/error_reporting/mod.rs
+++ b/src/librustc/traits/error_reporting/mod.rs
@@ -1073,9 +1073,15 @@ pub fn report_object_safety_error(
                     err.span_label(span, &msg);
                 }
             }
-            if let (Some(_), Some(note)) = (trait_span, violation.solution()) {
+            match (trait_span, violation.solution()) {
+                (Some(_), Some((note, None))) => {
+                    err.help(&note);
+                }
+                (Some(_), Some((note, Some((sugg, span))))) => {
+                    err.span_suggestion(span, &note, sugg, Applicability::MachineApplicable);
+                }
                 // Only provide the help if its a local trait, otherwise it's not actionable.
-                err.help(&note);
+                _ => {}
             }
         }
     }

--- a/src/librustc/traits/error_reporting/mod.rs
+++ b/src/librustc/traits/error_reporting/mod.rs
@@ -27,7 +27,6 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::{struct_span_err, Applicability, DiagnosticBuilder};
 use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
-use rustc_span::source_map::SourceMap;
 use rustc_span::{ExpnKind, Span, DUMMY_SP};
 use std::fmt;
 use syntax::ast;
@@ -1426,75 +1425,4 @@ impl ArgKind {
             _ => ArgKind::Arg("_".to_owned(), t.to_string()),
         }
     }
-}
-
-/// Suggest restricting a type param with a new bound.
-pub fn suggest_constraining_type_param(
-    generics: &hir::Generics<'_>,
-    err: &mut DiagnosticBuilder<'_>,
-    param_name: &str,
-    constraint: &str,
-    source_map: &SourceMap,
-    span: Span,
-) -> bool {
-    let restrict_msg = "consider further restricting this bound";
-    if let Some(param) =
-        generics.params.iter().filter(|p| p.name.ident().as_str() == param_name).next()
-    {
-        if param_name.starts_with("impl ") {
-            // `impl Trait` in argument:
-            // `fn foo(x: impl Trait) {}` → `fn foo(t: impl Trait + Trait2) {}`
-            err.span_suggestion(
-                param.span,
-                restrict_msg,
-                // `impl CurrentTrait + MissingTrait`
-                format!("{} + {}", param_name, constraint),
-                Applicability::MachineApplicable,
-            );
-        } else if generics.where_clause.predicates.is_empty() && param.bounds.is_empty() {
-            // If there are no bounds whatsoever, suggest adding a constraint
-            // to the type parameter:
-            // `fn foo<T>(t: T) {}` → `fn foo<T: Trait>(t: T) {}`
-            err.span_suggestion(
-                param.span,
-                "consider restricting this bound",
-                format!("{}: {}", param_name, constraint),
-                Applicability::MachineApplicable,
-            );
-        } else if !generics.where_clause.predicates.is_empty() {
-            // There is a `where` clause, so suggest expanding it:
-            // `fn foo<T>(t: T) where T: Debug {}` →
-            // `fn foo<T>(t: T) where T: Debug, T: Trait {}`
-            err.span_suggestion(
-                generics.where_clause.span().unwrap().shrink_to_hi(),
-                &format!("consider further restricting type parameter `{}`", param_name),
-                format!(", {}: {}", param_name, constraint),
-                Applicability::MachineApplicable,
-            );
-        } else {
-            // If there is no `where` clause lean towards constraining to the
-            // type parameter:
-            // `fn foo<X: Bar, T>(t: T, x: X) {}` → `fn foo<T: Trait>(t: T) {}`
-            // `fn foo<T: Bar>(t: T) {}` → `fn foo<T: Bar + Trait>(t: T) {}`
-            let sp = param.span.with_hi(span.hi());
-            let span = source_map.span_through_char(sp, ':');
-            if sp != param.span && sp != span {
-                // Only suggest if we have high certainty that the span
-                // covers the colon in `foo<T: Trait>`.
-                err.span_suggestion(
-                    span,
-                    restrict_msg,
-                    format!("{}: {} + ", param_name, constraint),
-                    Applicability::MachineApplicable,
-                );
-            } else {
-                err.span_label(
-                    param.span,
-                    &format!("consider adding a `where {}: {}` bound", param_name, constraint),
-                );
-            }
-        }
-        return true;
-    }
-    false
 }

--- a/src/librustc/traits/error_reporting/suggestions.rs
+++ b/src/librustc/traits/error_reporting/suggestions.rs
@@ -145,12 +145,14 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                     let param_name = self_ty.to_string();
                     let constraint = trait_ref.print_only_trait_path().to_string();
                     if suggest_constraining_type_param(
+                        self.tcx,
                         generics,
                         &mut err,
                         &param_name,
                         &constraint,
                         self.tcx.sess.source_map(),
                         *span,
+                        Some(trait_ref.def_id()),
                     ) {
                         return;
                     }
@@ -1652,18 +1654,26 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
 
 /// Suggest restricting a type param with a new bound.
 pub fn suggest_constraining_type_param(
+    tcx: TyCtxt<'_>,
     generics: &hir::Generics<'_>,
     err: &mut DiagnosticBuilder<'_>,
     param_name: &str,
     constraint: &str,
     source_map: &SourceMap,
     span: Span,
+    def_id: Option<DefId>,
 ) -> bool {
     let restrict_msg = "consider further restricting this bound";
     if let Some(param) =
         generics.params.iter().filter(|p| p.name.ident().as_str() == param_name).next()
     {
-        if param_name.starts_with("impl ") {
+        if def_id == tcx.lang_items().sized_trait() {
+            // Type parameters are already `Sized` by default.
+            err.span_label(
+                param.span,
+                &format!("this type parameter needs to be `{}`", constraint),
+            );
+        } else if param_name.starts_with("impl ") {
             // `impl Trait` in argument:
             // `fn foo(x: impl Trait) {}` → `fn foo(t: impl Trait + Trait2) {}`
             err.span_suggestion(

--- a/src/librustc/traits/object_safety.rs
+++ b/src/librustc/traits/object_safety.rs
@@ -190,14 +190,7 @@ fn object_safety_violations_for_trait(
                         tcx.def_path_str(trait_def_id)
                     ),
                 );
-                let spans = violation.spans();
-                if spans.is_empty() {
-                    err.note(&violation.error_msg());
-                } else {
-                    for span in spans {
-                        err.span_label(span, violation.error_msg());
-                    }
-                }
+                err.span_label(*span, violation.error_msg());
                 err.emit();
                 false
             } else {

--- a/src/librustc/traits/object_safety.rs
+++ b/src/librustc/traits/object_safety.rs
@@ -80,12 +80,10 @@ impl ObjectSafetyViolation {
             ObjectSafetyViolation::Method(name, MethodViolationCode::UndispatchableReceiver, _) => {
                 format!("method `{}`'s `self` parameter cannot be dispatched on", name).into()
             }
-            ObjectSafetyViolation::AssocConst(_, DUMMY_SP) => {
-                "it cannot contain associated consts".into()
+            ObjectSafetyViolation::AssocConst(name, DUMMY_SP) => {
+                format!("it contains associated `const` `{}`", name).into()
             }
-            ObjectSafetyViolation::AssocConst(name, _) => {
-                format!("it cannot contain associated consts like `{}`", name).into()
-            }
+            ObjectSafetyViolation::AssocConst(..) => "it contains this associated `const`".into(),
         }
     }
 

--- a/src/librustc/traits/object_safety.rs
+++ b/src/librustc/traits/object_safety.rs
@@ -44,7 +44,7 @@ impl ObjectSafetyViolation {
     pub fn error_msg(&self) -> Cow<'static, str> {
         match *self {
             ObjectSafetyViolation::SizedSelf(_) => {
-                "the trait cannot require that `Self : Sized`".into()
+                "traits that require `Self: Sized` cannot be made into an object".into()
             }
             ObjectSafetyViolation::SupertraitSelf => {
                 "the trait cannot use `Self` as a type parameter \

--- a/src/librustc/traits/object_safety.rs
+++ b/src/librustc/traits/object_safety.rs
@@ -18,7 +18,7 @@ use rustc_hir::def_id::DefId;
 use rustc_session::lint::builtin::WHERE_CLAUSES_OBJECT_SAFETY;
 use rustc_span::symbol::Symbol;
 use rustc_span::{Span, DUMMY_SP};
-use smallvec::SmallVec;
+use smallvec::{smallvec, SmallVec};
 use syntax::ast;
 
 use std::borrow::Cow;
@@ -85,9 +85,9 @@ impl ObjectSafetyViolation {
             | ObjectSafetyViolation::Method(_, _, span)
                 if *span != DUMMY_SP =>
             {
-                vec![*span].into()
+                smallvec![*span]
             }
-            _ => vec![].into(),
+            _ => smallvec![],
         }
     }
 }

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1015,6 +1015,7 @@ impl<'tcx> GenericPredicates<'tcx> {
     ) -> InstantiatedPredicates<'tcx> {
         InstantiatedPredicates {
             predicates: self.predicates.iter().map(|(p, _)| p.subst(tcx, substs)).collect(),
+            spans: self.predicates.iter().map(|(_, sp)| *sp).collect(),
         }
     }
 
@@ -1028,6 +1029,7 @@ impl<'tcx> GenericPredicates<'tcx> {
             tcx.predicates_of(def_id).instantiate_into(tcx, instantiated, substs);
         }
         instantiated.predicates.extend(self.predicates.iter().map(|(p, _)| p.subst(tcx, substs)));
+        instantiated.spans.extend(self.predicates.iter().map(|(_, sp)| *sp));
     }
 
     pub fn instantiate_identity(&self, tcx: TyCtxt<'tcx>) -> InstantiatedPredicates<'tcx> {
@@ -1044,7 +1046,8 @@ impl<'tcx> GenericPredicates<'tcx> {
         if let Some(def_id) = self.parent {
             tcx.predicates_of(def_id).instantiate_identity_into(tcx, instantiated);
         }
-        instantiated.predicates.extend(self.predicates.iter().map(|&(p, _)| p))
+        instantiated.predicates.extend(self.predicates.iter().map(|(p, _)| p));
+        instantiated.spans.extend(self.predicates.iter().map(|(_, s)| s));
     }
 
     pub fn instantiate_supertrait(
@@ -1059,6 +1062,7 @@ impl<'tcx> GenericPredicates<'tcx> {
                 .iter()
                 .map(|(pred, _)| pred.subst_supertrait(tcx, poly_trait_ref))
                 .collect(),
+            spans: self.predicates.iter().map(|(_, sp)| *sp).collect(),
         }
     }
 }
@@ -1511,11 +1515,12 @@ impl<'tcx> Predicate<'tcx> {
 #[derive(Clone, Debug, TypeFoldable)]
 pub struct InstantiatedPredicates<'tcx> {
     pub predicates: Vec<Predicate<'tcx>>,
+    pub spans: Vec<Span>,
 }
 
 impl<'tcx> InstantiatedPredicates<'tcx> {
     pub fn empty() -> InstantiatedPredicates<'tcx> {
-        InstantiatedPredicates { predicates: vec![] }
+        InstantiatedPredicates { predicates: vec![], spans: vec![] }
     }
 
     pub fn is_empty(&self) -> bool {

--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -2631,4 +2631,25 @@ impl Node<'_> {
             _ => None,
         }
     }
+
+    pub fn fn_decl(&self) -> Option<&FnDecl<'_>> {
+        match self {
+            Node::TraitItem(TraitItem { kind: TraitItemKind::Method(fn_sig, _), .. })
+            | Node::ImplItem(ImplItem { kind: ImplItemKind::Method(fn_sig, _), .. })
+            | Node::Item(Item { kind: ItemKind::Fn(fn_sig, _, _), .. }) => Some(fn_sig.decl),
+            Node::ForeignItem(ForeignItem { kind: ForeignItemKind::Fn(fn_decl, _, _), .. }) => {
+                Some(fn_decl)
+            }
+            _ => None,
+        }
+    }
+
+    pub fn generics(&self) -> Option<&Generics<'_>> {
+        match self {
+            Node::TraitItem(TraitItem { generics, .. })
+            | Node::ImplItem(ImplItem { generics, .. })
+            | Node::Item(Item { kind: ItemKind::Fn(_, generics, _), .. }) => Some(generics),
+            _ => None,
+        }
+    }
 }

--- a/src/librustc_mir/borrow_check/diagnostics/conflict_errors.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/conflict_errors.rs
@@ -217,12 +217,14 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                         tcx.hir().get_generics(tcx.closure_base_def_id(self.mir_def_id))
                     {
                         suggest_constraining_type_param(
+                            tcx,
                             generics,
                             &mut err,
                             &param.name.as_str(),
                             "Copy",
                             tcx.sess.source_map(),
                             span,
+                            None,
                         );
                     }
                 }

--- a/src/librustc_mir/borrow_check/diagnostics/conflict_errors.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/conflict_errors.rs
@@ -3,7 +3,7 @@ use rustc::mir::{
     FakeReadCause, Local, LocalDecl, LocalInfo, LocalKind, Location, Operand, Place, PlaceRef,
     ProjectionElem, Rvalue, Statement, StatementKind, TerminatorKind, VarBindingForm,
 };
-use rustc::traits::error_reporting::suggest_constraining_type_param;
+use rustc::traits::error_reporting::suggestions::suggest_constraining_type_param;
 use rustc::ty::{self, Ty};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::{Applicability, DiagnosticBuilder};

--- a/src/librustc_parse/parser/generics.rs
+++ b/src/librustc_parse/parser/generics.rs
@@ -172,7 +172,7 @@ impl<'a> Parser<'a> {
     /// ```
     pub(super) fn parse_where_clause(&mut self) -> PResult<'a, WhereClause> {
         let mut where_clause =
-            WhereClause { predicates: Vec::new(), span: self.prev_span.to(self.prev_span) };
+            WhereClause { predicates: Vec::new(), span: self.prev_span.shrink_to_hi() };
 
         if !self.eat_keyword(kw::Where) {
             return Ok(where_clause);

--- a/src/librustc_traits/lowering/environment.rs
+++ b/src/librustc_traits/lowering/environment.rs
@@ -161,7 +161,7 @@ crate fn environment(tcx: TyCtxt<'_>, def_id: DefId) -> Environment<'_> {
     }
 
     // Compute the bounds on `Self` and the type parameters.
-    let ty::InstantiatedPredicates { predicates } =
+    let ty::InstantiatedPredicates { predicates, .. } =
         tcx.predicates_of(def_id).instantiate_identity(tcx);
 
     let clauses = predicates

--- a/src/librustc_ty/ty.rs
+++ b/src/librustc_ty/ty.rs
@@ -228,7 +228,7 @@ fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
     }
     // Compute the bounds on Self and the type parameters.
 
-    let ty::InstantiatedPredicates { predicates } =
+    let ty::InstantiatedPredicates { predicates, .. } =
         tcx.predicates_of(def_id).instantiate_identity(tcx);
 
     // Finally, we have to normalize the bounds in the environment, in

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -58,7 +58,7 @@ pub enum MethodError<'tcx> {
 
     // Found a `Self: Sized` bound where `Self` is a trait object, also the caller may have
     // forgotten to import a trait.
-    IllegalSizedBound(Vec<DefId>, bool),
+    IllegalSizedBound(Vec<DefId>, bool, Span),
 
     // Found a match, but the return type is wrong
     BadReturnType,
@@ -204,7 +204,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let result =
             self.confirm_method(span, self_expr, call_expr, self_ty, pick.clone(), segment);
 
-        if result.illegal_sized_bound {
+        if let Some(span) = result.illegal_sized_bound {
             let mut needs_mut = false;
             if let ty::Ref(region, t_type, mutability) = self_ty.kind {
                 let trait_type = self
@@ -249,7 +249,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 _ => Vec::new(),
             };
 
-            return Err(IllegalSizedBound(candidates, needs_mut));
+            return Err(IllegalSizedBound(candidates, needs_mut, span));
         }
 
         Ok(result.callee)

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -640,9 +640,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 err.emit();
             }
 
-            MethodError::IllegalSizedBound(candidates, needs_mut) => {
+            MethodError::IllegalSizedBound(candidates, needs_mut, bound_span) => {
                 let msg = format!("the `{}` method cannot be invoked on a trait object", item_name);
                 let mut err = self.sess().struct_span_err(span, &msg);
+                err.span_label(bound_span, "this has a `Sized` requirement");
                 if !candidates.is_empty() {
                     let help = format!(
                         "{an}other candidate{s} {were} found in the following trait{s}, perhaps \

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -530,7 +530,7 @@ fn check_where_clauses<'tcx, 'fcx>(
     fcx: &FnCtxt<'fcx, 'tcx>,
     span: Span,
     def_id: DefId,
-    return_ty: Option<Ty<'tcx>>,
+    return_ty: Option<(Ty<'tcx>, Span)>,
 ) {
     debug!("check_where_clauses(def_id={:?}, return_ty={:?})", def_id, return_ty);
 
@@ -664,7 +664,7 @@ fn check_where_clauses<'tcx, 'fcx>(
 
     let mut predicates = predicates.instantiate_identity(fcx.tcx);
 
-    if let Some(return_ty) = return_ty {
+    if let Some((return_ty, span)) = return_ty {
         predicates.predicates.extend(check_opaque_types(tcx, fcx, def_id, span, return_ty));
     }
 
@@ -708,7 +708,7 @@ fn check_fn_or_method<'fcx, 'tcx>(
     // FIXME(#25759) return types should not be implied bounds
     implied_bounds.push(sig.output());
 
-    check_where_clauses(tcx, fcx, span, def_id, Some(sig.output()));
+    check_where_clauses(tcx, fcx, span, def_id, Some((sig.output(), hir_sig.decl.output.span())));
 }
 
 /// Checks "defining uses" of opaque `impl Trait` types to ensure that they meet the restrictions

--- a/src/test/ui/associated-const/associated-const-in-trait.stderr
+++ b/src/test/ui/associated-const/associated-const-in-trait.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL | trait Trait {
    |       ----- this trait cannot be made into an object...
 LL |     const N: usize;
-   |           - ...because it cannot contain associated consts like `N`
+   |           - ...because it contains this associated `const`
 ...
 LL | impl dyn Trait {
    |      ^^^^^^^^^ the trait `Trait` cannot be made into an object

--- a/src/test/ui/associated-const/associated-const-in-trait.stderr
+++ b/src/test/ui/associated-const/associated-const-in-trait.stderr
@@ -1,11 +1,15 @@
 error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/associated-const-in-trait.rs:9:6
    |
+LL | trait Trait {
+   |       ----- this trait cannot be made into an object...
 LL |     const N: usize;
-   |           - the trait cannot contain associated consts like `N`
+   |           - ...because it cannot contain associated consts like `N`
 ...
 LL | impl dyn Trait {
    |      ^^^^^^^^^ the trait `Trait` cannot be made into an object
+   |
+   = help: consider moving `N` to another trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-item/issue-48027.stderr
+++ b/src/test/ui/associated-item/issue-48027.stderr
@@ -1,11 +1,15 @@
 error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/issue-48027.rs:6:6
    |
+LL | trait Bar {
+   |       --- this trait cannot be made into an object...
 LL |     const X: usize;
-   |           - the trait cannot contain associated consts like `X`
+   |           - ...because it cannot contain associated consts like `X`
 ...
 LL | impl dyn Bar {}
    |      ^^^^^^^ the trait `Bar` cannot be made into an object
+   |
+   = help: consider moving `X` to another trait
 
 error[E0283]: type annotations needed
   --> $DIR/issue-48027.rs:3:32

--- a/src/test/ui/associated-item/issue-48027.stderr
+++ b/src/test/ui/associated-item/issue-48027.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL | trait Bar {
    |       --- this trait cannot be made into an object...
 LL |     const X: usize;
-   |           - ...because it cannot contain associated consts like `X`
+   |           - ...because it contains this associated `const`
 ...
 LL | impl dyn Bar {}
    |      ^^^^^^^ the trait `Bar` cannot be made into an object

--- a/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
+++ b/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
@@ -10,9 +10,9 @@ error[E0277]: `<<T as Case1>::C as std::iter::Iterator>::Item` is not an iterato
   --> $DIR/bad-bounds-on-assoc-in-trait.rs:36:1
    |
 LL | fn assume_case1<T: Case1>() {
-   |    ^^^^^^^^^^^^            - help: consider further restricting the associated type: `where <<T as Case1>::C as std::iter::Iterator>::Item: std::iter::Iterator`
-   |    |
-   |    `<<T as Case1>::C as std::iter::Iterator>::Item` is not an iterator
+   |                    ^^^^^   - help: consider further restricting the associated type: `where <<T as Case1>::C as std::iter::Iterator>::Item: std::iter::Iterator`
+   |                    |
+   |                    `<<T as Case1>::C as std::iter::Iterator>::Item` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `<<T as Case1>::C as std::iter::Iterator>::Item`
 
@@ -23,9 +23,9 @@ LL | trait Case1 {
    | ----------- required by `Case1`
 ...
 LL | fn assume_case1<T: Case1>() {
-   |    ^^^^^^^^^^^^            - help: consider further restricting the associated type: `where <<T as Case1>::C as std::iter::Iterator>::Item: std::marker::Send`
-   |    |
-   |    `<<T as Case1>::C as std::iter::Iterator>::Item` cannot be sent between threads safely
+   |                    ^^^^^   - help: consider further restricting the associated type: `where <<T as Case1>::C as std::iter::Iterator>::Item: std::marker::Send`
+   |                    |
+   |                    `<<T as Case1>::C as std::iter::Iterator>::Item` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `<<T as Case1>::C as std::iter::Iterator>::Item`
 
@@ -36,9 +36,9 @@ LL | trait Case1 {
    | ----------- required by `Case1`
 ...
 LL | fn assume_case1<T: Case1>() {
-   |    ^^^^^^^^^^^^            - help: consider further restricting the associated type: `where <<T as Case1>::C as std::iter::Iterator>::Item: std::marker::Sync`
-   |    |
-   |    `<<T as Case1>::C as std::iter::Iterator>::Item` cannot be shared between threads safely
+   |                    ^^^^^   - help: consider further restricting the associated type: `where <<T as Case1>::C as std::iter::Iterator>::Item: std::marker::Sync`
+   |                    |
+   |                    `<<T as Case1>::C as std::iter::Iterator>::Item` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `<<T as Case1>::C as std::iter::Iterator>::Item`
 
@@ -49,7 +49,7 @@ LL | trait Case1 {
    | ----------- required by `Case1`
 ...
 LL | fn assume_case1<T: Case1>() {
-   |    ^^^^^^^^^^^^ `<_ as Lam<&'a u8>>::App` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
+   |                    ^^^^^ `<_ as Lam<&'a u8>>::App` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
    = help: the trait `for<'a> std::fmt::Debug` is not implemented for `<_ as Lam<&'a u8>>::App`
 

--- a/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
+++ b/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
@@ -9,74 +9,47 @@ LL | impl Case1 for S1 {
 error[E0277]: `<<T as Case1>::C as std::iter::Iterator>::Item` is not an iterator
   --> $DIR/bad-bounds-on-assoc-in-trait.rs:36:1
    |
-LL |   fn assume_case1<T: Case1>() {
-   |   ^                          - help: consider further restricting the associated type: `where <<T as Case1>::C as std::iter::Iterator>::Item: std::iter::Iterator`
-   |  _|
-   | |
-LL | |
-LL | |
-LL | |
-...  |
-LL | |     assert_c::<_, _, _, T::C>();
-LL | | }
-   | |_^ `<<T as Case1>::C as std::iter::Iterator>::Item` is not an iterator
+LL | fn assume_case1<T: Case1>() {
+   |    ^^^^^^^^^^^^            - help: consider further restricting the associated type: `where <<T as Case1>::C as std::iter::Iterator>::Item: std::iter::Iterator`
+   |    |
+   |    `<<T as Case1>::C as std::iter::Iterator>::Item` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `<<T as Case1>::C as std::iter::Iterator>::Item`
 
 error[E0277]: `<<T as Case1>::C as std::iter::Iterator>::Item` cannot be sent between threads safely
   --> $DIR/bad-bounds-on-assoc-in-trait.rs:36:1
    |
-LL |   trait Case1 {
-   |   ----------- required by `Case1`
+LL | trait Case1 {
+   | ----------- required by `Case1`
 ...
-LL |   fn assume_case1<T: Case1>() {
-   |   ^                          - help: consider further restricting the associated type: `where <<T as Case1>::C as std::iter::Iterator>::Item: std::marker::Send`
-   |  _|
-   | |
-LL | |
-LL | |
-LL | |
-...  |
-LL | |     assert_c::<_, _, _, T::C>();
-LL | | }
-   | |_^ `<<T as Case1>::C as std::iter::Iterator>::Item` cannot be sent between threads safely
+LL | fn assume_case1<T: Case1>() {
+   |    ^^^^^^^^^^^^            - help: consider further restricting the associated type: `where <<T as Case1>::C as std::iter::Iterator>::Item: std::marker::Send`
+   |    |
+   |    `<<T as Case1>::C as std::iter::Iterator>::Item` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `<<T as Case1>::C as std::iter::Iterator>::Item`
 
 error[E0277]: `<<T as Case1>::C as std::iter::Iterator>::Item` cannot be shared between threads safely
   --> $DIR/bad-bounds-on-assoc-in-trait.rs:36:1
    |
-LL |   trait Case1 {
-   |   ----------- required by `Case1`
+LL | trait Case1 {
+   | ----------- required by `Case1`
 ...
-LL |   fn assume_case1<T: Case1>() {
-   |   ^                          - help: consider further restricting the associated type: `where <<T as Case1>::C as std::iter::Iterator>::Item: std::marker::Sync`
-   |  _|
-   | |
-LL | |
-LL | |
-LL | |
-...  |
-LL | |     assert_c::<_, _, _, T::C>();
-LL | | }
-   | |_^ `<<T as Case1>::C as std::iter::Iterator>::Item` cannot be shared between threads safely
+LL | fn assume_case1<T: Case1>() {
+   |    ^^^^^^^^^^^^            - help: consider further restricting the associated type: `where <<T as Case1>::C as std::iter::Iterator>::Item: std::marker::Sync`
+   |    |
+   |    `<<T as Case1>::C as std::iter::Iterator>::Item` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `<<T as Case1>::C as std::iter::Iterator>::Item`
 
 error[E0277]: `<_ as Lam<&'a u8>>::App` doesn't implement `std::fmt::Debug`
   --> $DIR/bad-bounds-on-assoc-in-trait.rs:36:1
    |
-LL |   trait Case1 {
-   |   ----------- required by `Case1`
+LL | trait Case1 {
+   | ----------- required by `Case1`
 ...
-LL | / fn assume_case1<T: Case1>() {
-LL | |
-LL | |
-LL | |
-...  |
-LL | |     assert_c::<_, _, _, T::C>();
-LL | | }
-   | |_^ `<_ as Lam<&'a u8>>::App` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
+LL | fn assume_case1<T: Case1>() {
+   |    ^^^^^^^^^^^^ `<_ as Lam<&'a u8>>::App` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
    = help: the trait `for<'a> std::fmt::Debug` is not implemented for `<_ as Lam<&'a u8>>::App`
 

--- a/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
+++ b/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
@@ -7,7 +7,7 @@ LL | impl Case1 for S1 {
    = help: the trait `for<'a> std::fmt::Debug` is not implemented for `<L1 as Lam<&'a u8>>::App`
 
 error[E0277]: `<<T as Case1>::C as std::iter::Iterator>::Item` is not an iterator
-  --> $DIR/bad-bounds-on-assoc-in-trait.rs:36:1
+  --> $DIR/bad-bounds-on-assoc-in-trait.rs:36:20
    |
 LL | fn assume_case1<T: Case1>() {
    |                    ^^^^^   - help: consider further restricting the associated type: `where <<T as Case1>::C as std::iter::Iterator>::Item: std::iter::Iterator`
@@ -17,7 +17,7 @@ LL | fn assume_case1<T: Case1>() {
    = help: the trait `std::iter::Iterator` is not implemented for `<<T as Case1>::C as std::iter::Iterator>::Item`
 
 error[E0277]: `<<T as Case1>::C as std::iter::Iterator>::Item` cannot be sent between threads safely
-  --> $DIR/bad-bounds-on-assoc-in-trait.rs:36:1
+  --> $DIR/bad-bounds-on-assoc-in-trait.rs:36:20
    |
 LL | trait Case1 {
    | ----------- required by `Case1`
@@ -30,7 +30,7 @@ LL | fn assume_case1<T: Case1>() {
    = help: the trait `std::marker::Send` is not implemented for `<<T as Case1>::C as std::iter::Iterator>::Item`
 
 error[E0277]: `<<T as Case1>::C as std::iter::Iterator>::Item` cannot be shared between threads safely
-  --> $DIR/bad-bounds-on-assoc-in-trait.rs:36:1
+  --> $DIR/bad-bounds-on-assoc-in-trait.rs:36:20
    |
 LL | trait Case1 {
    | ----------- required by `Case1`
@@ -43,7 +43,7 @@ LL | fn assume_case1<T: Case1>() {
    = help: the trait `std::marker::Sync` is not implemented for `<<T as Case1>::C as std::iter::Iterator>::Item`
 
 error[E0277]: `<_ as Lam<&'a u8>>::App` doesn't implement `std::fmt::Debug`
-  --> $DIR/bad-bounds-on-assoc-in-trait.rs:36:1
+  --> $DIR/bad-bounds-on-assoc-in-trait.rs:36:20
    |
 LL | trait Case1 {
    | ----------- required by `Case1`

--- a/src/test/ui/associated-types/associated-types-overridden-binding.stderr
+++ b/src/test/ui/associated-types/associated-types-overridden-binding.stderr
@@ -1,20 +1,20 @@
 error[E0284]: type annotations needed
-  --> $DIR/associated-types-overridden-binding.rs:4:1
+  --> $DIR/associated-types-overridden-binding.rs:4:12
    |
 LL | trait Foo: Iterator<Item = i32> {}
    | ------------------------------- required by `Foo`
 LL | trait Bar: Foo<Item = u32> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `Self`
+   |            ^^^^^^^^^^^^^^^ cannot infer type for type parameter `Self`
    |
    = note: cannot resolve `<Self as std::iter::Iterator>::Item == i32`
 
 error[E0284]: type annotations needed
-  --> $DIR/associated-types-overridden-binding.rs:7:1
+  --> $DIR/associated-types-overridden-binding.rs:7:21
    |
 LL | trait I32Iterator = Iterator<Item = i32>;
    | ----------------------------------------- required by `I32Iterator`
 LL | trait U32Iterator = I32Iterator<Item = u32>;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `Self`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `Self`
    |
    = note: cannot resolve `<Self as std::iter::Iterator>::Item == i32`
 

--- a/src/test/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
+++ b/src/test/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
@@ -1,17 +1,13 @@
 error[E0277]: `F` cannot be sent between threads safely
-  --> $DIR/closure-bounds-cant-promote-superkind-in-struct.rs:5:1
+  --> $DIR/closure-bounds-cant-promote-superkind-in-struct.rs:5:22
    |
-LL |   struct X<F> where F: FnOnce() + 'static + Send {
-   |   ---------------------------------------------- required by `X`
+LL | struct X<F> where F: FnOnce() + 'static + Send {
+   | ---------------------------------------------- required by `X`
 ...
-LL |   fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static {
-   |   ^                                                    - help: consider further restricting type parameter `F`: `, F: std::marker::Send`
-   |  _|
-   | |
-LL | |
-LL | |     return X { field: blk };
-LL | | }
-   | |_^ `F` cannot be sent between threads safely
+LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static {
+   |                      ^^^^                            - help: consider further restricting type parameter `F`: `, F: std::marker::Send`
+   |                      |
+   |                      `F` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `F`
 

--- a/src/test/ui/coherence/coherence-impl-trait-for-trait-object-safe.stderr
+++ b/src/test/ui/coherence/coherence-impl-trait-for-trait-object-safe.stderr
@@ -2,7 +2,7 @@ error[E0038]: the trait `NotObjectSafe` cannot be made into an object
   --> $DIR/coherence-impl-trait-for-trait-object-safe.rs:7:6
    |
 LL | trait NotObjectSafe { fn eq(&self, other: Self); }
-   |       -------------      -- ...because method `eq` references the `Self` type in its parameters or return type
+   |       -------------                       ---- ...because method `eq` references the `Self` type in this parameter
    |       |
    |       this trait cannot be made into an object...
 LL | impl NotObjectSafe for dyn NotObjectSafe { }

--- a/src/test/ui/coherence/coherence-impl-trait-for-trait-object-safe.stderr
+++ b/src/test/ui/coherence/coherence-impl-trait-for-trait-object-safe.stderr
@@ -2,9 +2,13 @@ error[E0038]: the trait `NotObjectSafe` cannot be made into an object
   --> $DIR/coherence-impl-trait-for-trait-object-safe.rs:7:6
    |
 LL | trait NotObjectSafe { fn eq(&self, other: Self); }
-   |                          -- method `eq` references the `Self` type in its parameters or return type
+   |       -------------      -- ...because method `eq` references the `Self` type in its parameters or return type
+   |       |
+   |       this trait cannot be made into an object...
 LL | impl NotObjectSafe for dyn NotObjectSafe { }
    |      ^^^^^^^^^^^^^ the trait `NotObjectSafe` cannot be made into an object
+   |
+   = help: consider moving `eq` to another trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/too_generic_eval_ice.stderr
+++ b/src/test/ui/consts/too_generic_eval_ice.stderr
@@ -18,7 +18,7 @@ LL | pub struct Foo<A, B>(A, B);
    | --------------------------- required by `Foo`
 LL | 
 LL | impl<A, B> Foo<A, B> {
-   |      - help: consider restricting this bound: `A: std::marker::Sized`
+   |      - this type parameter needs to be `std::marker::Sized`
 ...
 LL |         [5; Self::HOST_SIZE] == [6; 0]
    |             ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -33,7 +33,7 @@ LL | pub struct Foo<A, B>(A, B);
    | --------------------------- required by `Foo`
 LL | 
 LL | impl<A, B> Foo<A, B> {
-   |         - help: consider restricting this bound: `B: std::marker::Sized`
+   |         - this type parameter needs to be `std::marker::Sized`
 ...
 LL |         [5; Self::HOST_SIZE] == [6; 0]
    |             ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/did_you_mean/trait-object-reference-without-parens-suggestion.stderr
+++ b/src/test/ui/did_you_mean/trait-object-reference-without-parens-suggestion.stderr
@@ -16,7 +16,7 @@ error[E0038]: the trait `std::marker::Copy` cannot be made into an object
 LL |     let _: &Copy + 'static;
    |            ^^^^^ the trait `std::marker::Copy` cannot be made into an object
    |
-   = note: the trait cannot require that `Self : Sized`
+   = note: traits that require `Self: Sized` cannot be made into an object
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/did_you_mean/trait-object-reference-without-parens-suggestion.stderr
+++ b/src/test/ui/did_you_mean/trait-object-reference-without-parens-suggestion.stderr
@@ -16,7 +16,7 @@ error[E0038]: the trait `std::marker::Copy` cannot be made into an object
 LL |     let _: &Copy + 'static;
    |            ^^^^^ the trait `std::marker::Copy` cannot be made into an object
    |
-   = note: traits that require `Self: Sized` cannot be made into an object
+   = note: the trait cannot be made into an object because it requires `Self: Sized`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/dst/dst-object-from-unsized-type.stderr
+++ b/src/test/ui/dst/dst-object-from-unsized-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/dst-object-from-unsized-type.rs:8:23
    |
 LL | fn test1<T: ?Sized + Foo>(t: &T) {
-   |          -- help: consider further restricting this bound: `T: std::marker::Sized +`
+   |          - this type parameter needs to be `std::marker::Sized`
 LL |     let u: &dyn Foo = t;
    |                       ^ doesn't have a size known at compile-time
    |
@@ -14,7 +14,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/dst-object-from-unsized-type.rs:13:23
    |
 LL | fn test2<T: ?Sized + Foo>(t: &T) {
-   |          -- help: consider further restricting this bound: `T: std::marker::Sized +`
+   |          - this type parameter needs to be `std::marker::Sized`
 LL |     let v: &dyn Foo = t as &dyn Foo;
    |                       ^ doesn't have a size known at compile-time
    |

--- a/src/test/ui/error-codes/E0033-teach.stderr
+++ b/src/test/ui/error-codes/E0033-teach.stderr
@@ -7,11 +7,15 @@ LL |     let trait_obj: &dyn SomeTrait = SomeTrait;
 error[E0038]: the trait `SomeTrait` cannot be made into an object
   --> $DIR/E0033-teach.rs:8:20
    |
+LL | trait SomeTrait {
+   |       --------- this trait cannot be made into an object...
 LL |     fn foo();
-   |        --- associated function `foo` has no `self` parameter
+   |        --- ...because associated function `foo` has no `self` parameter
 ...
 LL |     let trait_obj: &dyn SomeTrait = SomeTrait;
    |                    ^^^^^^^^^^^^^^ the trait `SomeTrait` cannot be made into an object
+   |
+   = help: consider turning `foo` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
 
 error[E0033]: type `&dyn SomeTrait` cannot be dereferenced
   --> $DIR/E0033-teach.rs:12:9

--- a/src/test/ui/error-codes/E0033-teach.stderr
+++ b/src/test/ui/error-codes/E0033-teach.stderr
@@ -15,7 +15,10 @@ LL |     fn foo();
 LL |     let trait_obj: &dyn SomeTrait = SomeTrait;
    |                    ^^^^^^^^^^^^^^ the trait `SomeTrait` cannot be made into an object
    |
-   = help: consider turning `foo` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
+help: consider turning `foo` into a method by giving it a `&self` argument or constraining it so it does not apply to trait objects
+   |
+LL |     fn foo() where Self: Sized;
+   |              ^^^^^^^^^^^^^^^^^
 
 error[E0033]: type `&dyn SomeTrait` cannot be dereferenced
   --> $DIR/E0033-teach.rs:12:9

--- a/src/test/ui/error-codes/E0033.stderr
+++ b/src/test/ui/error-codes/E0033.stderr
@@ -15,7 +15,10 @@ LL |     fn foo();
 LL |     let trait_obj: &dyn SomeTrait = SomeTrait;
    |                    ^^^^^^^^^^^^^^ the trait `SomeTrait` cannot be made into an object
    |
-   = help: consider turning `foo` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
+help: consider turning `foo` into a method by giving it a `&self` argument or constraining it so it does not apply to trait objects
+   |
+LL |     fn foo() where Self: Sized;
+   |              ^^^^^^^^^^^^^^^^^
 
 error[E0033]: type `&dyn SomeTrait` cannot be dereferenced
   --> $DIR/E0033.rs:10:9

--- a/src/test/ui/error-codes/E0033.stderr
+++ b/src/test/ui/error-codes/E0033.stderr
@@ -7,11 +7,15 @@ LL |     let trait_obj: &dyn SomeTrait = SomeTrait;
 error[E0038]: the trait `SomeTrait` cannot be made into an object
   --> $DIR/E0033.rs:6:20
    |
+LL | trait SomeTrait {
+   |       --------- this trait cannot be made into an object...
 LL |     fn foo();
-   |        --- associated function `foo` has no `self` parameter
+   |        --- ...because associated function `foo` has no `self` parameter
 ...
 LL |     let trait_obj: &dyn SomeTrait = SomeTrait;
    |                    ^^^^^^^^^^^^^^ the trait `SomeTrait` cannot be made into an object
+   |
+   = help: consider turning `foo` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
 
 error[E0033]: type `&dyn SomeTrait` cannot be dereferenced
   --> $DIR/E0033.rs:10:9

--- a/src/test/ui/error-codes/E0038.stderr
+++ b/src/test/ui/error-codes/E0038.stderr
@@ -1,11 +1,11 @@
 error[E0038]: the trait `Trait` cannot be made into an object
-  --> $DIR/E0038.rs:5:1
+  --> $DIR/E0038.rs:5:16
    |
 LL |     fn foo(&self) -> Self;
    |        --- method `foo` references the `Self` type in its parameters or return type
 ...
 LL | fn call_foo(x: Box<dyn Trait>) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` cannot be made into an object
+   |                ^^^^^^^^^^^^^^ the trait `Trait` cannot be made into an object
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0038.stderr
+++ b/src/test/ui/error-codes/E0038.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL | trait Trait {
    |       ----- this trait cannot be made into an object...
 LL |     fn foo(&self) -> Self;
-   |        --- ...because method `foo` references the `Self` type in its parameters or return type
+   |                      ---- ...because method `foo` references the `Self` type in its return type
 ...
 LL | fn call_foo(x: Box<dyn Trait>) {
    |                ^^^^^^^^^^^^^^ the trait `Trait` cannot be made into an object

--- a/src/test/ui/error-codes/E0038.stderr
+++ b/src/test/ui/error-codes/E0038.stderr
@@ -1,11 +1,15 @@
 error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/E0038.rs:5:16
    |
+LL | trait Trait {
+   |       ----- this trait cannot be made into an object...
 LL |     fn foo(&self) -> Self;
-   |        --- method `foo` references the `Self` type in its parameters or return type
+   |        --- ...because method `foo` references the `Self` type in its parameters or return type
 ...
 LL | fn call_foo(x: Box<dyn Trait>) {
    |                ^^^^^^^^^^^^^^ the trait `Trait` cannot be made into an object
+   |
+   = help: consider moving `foo` to another trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0275.stderr
+++ b/src/test/ui/error-codes/E0275.stderr
@@ -1,11 +1,11 @@
 error[E0275]: overflow evaluating the requirement `Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>: Foo`
-  --> $DIR/E0275.rs:5:1
+  --> $DIR/E0275.rs:5:33
    |
 LL | trait Foo {}
    | --------- required by `Foo`
 ...
 LL | impl<T> Foo for T where Bar<T>: Foo {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 ^^^
    |
    = help: consider adding a `#![recursion_limit="256"]` attribute to your crate
    = note: required because of the requirements on the impl of `Foo` for `Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>`

--- a/src/test/ui/extern/extern-types-unsized.stderr
+++ b/src/test/ui/extern/extern-types-unsized.stderr
@@ -2,7 +2,9 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
   --> $DIR/extern-types-unsized.rs:22:20
    |
 LL | fn assert_sized<T>() { }
-   |    ------------ - required by this bound in `assert_sized`
+   |    ------------ -- help: consider relaxing the implicit `Sized` restriction: `: ?Sized`
+   |                 |
+   |                 required by this bound in `assert_sized`
 ...
 LL |     assert_sized::<A>();
    |                    ^ doesn't have a size known at compile-time

--- a/src/test/ui/feature-gates/feature-gate-object_safe_for_dispatch.stderr
+++ b/src/test/ui/feature-gates/feature-gate-object_safe_for_dispatch.stderr
@@ -6,8 +6,6 @@ LL | trait NonObjectSafe1: Sized {}
 ...
 LL | fn takes_non_object_safe_ref<T>(obj: &dyn NonObjectSafe1) {
    |                                      ^^^^^^^^^^^^^^^^^^^ the trait `NonObjectSafe1` cannot be made into an object
-   |
-   = note: the trait cannot require that `Self : Sized`
 
 error[E0038]: the trait `NonObjectSafe2` cannot be made into an object
   --> $DIR/feature-gate-object_safe_for_dispatch.rs:22:36
@@ -44,8 +42,6 @@ LL | trait NonObjectSafe1: Sized {}
 ...
 LL | impl Trait for dyn NonObjectSafe1 {}
    |      ^^^^^ the trait `NonObjectSafe1` cannot be made into an object
-   |
-   = note: the trait cannot require that `Self : Sized`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-object_safe_for_dispatch.stderr
+++ b/src/test/ui/feature-gates/feature-gate-object_safe_for_dispatch.stderr
@@ -1,6 +1,9 @@
 error[E0038]: the trait `NonObjectSafe1` cannot be made into an object
   --> $DIR/feature-gate-object_safe_for_dispatch.rs:18:38
    |
+LL | trait NonObjectSafe1: Sized {}
+   |                       ----- the trait cannot require that `Self : Sized`
+...
 LL | fn takes_non_object_safe_ref<T>(obj: &dyn NonObjectSafe1) {
    |                                      ^^^^^^^^^^^^^^^^^^^ the trait `NonObjectSafe1` cannot be made into an object
    |
@@ -36,6 +39,9 @@ LL | fn return_non_object_safe_rc() -> std::rc::Rc<dyn NonObjectSafe4> {
 error[E0038]: the trait `NonObjectSafe1` cannot be made into an object
   --> $DIR/feature-gate-object_safe_for_dispatch.rs:38:6
    |
+LL | trait NonObjectSafe1: Sized {}
+   |                       ----- the trait cannot require that `Self : Sized`
+...
 LL | impl Trait for dyn NonObjectSafe1 {}
    |      ^^^^^ the trait `NonObjectSafe1` cannot be made into an object
    |

--- a/src/test/ui/feature-gates/feature-gate-object_safe_for_dispatch.stderr
+++ b/src/test/ui/feature-gates/feature-gate-object_safe_for_dispatch.stderr
@@ -1,37 +1,37 @@
 error[E0038]: the trait `NonObjectSafe1` cannot be made into an object
-  --> $DIR/feature-gate-object_safe_for_dispatch.rs:18:1
+  --> $DIR/feature-gate-object_safe_for_dispatch.rs:18:38
    |
 LL | fn takes_non_object_safe_ref<T>(obj: &dyn NonObjectSafe1) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NonObjectSafe1` cannot be made into an object
+   |                                      ^^^^^^^^^^^^^^^^^^^ the trait `NonObjectSafe1` cannot be made into an object
    |
    = note: the trait cannot require that `Self : Sized`
 
 error[E0038]: the trait `NonObjectSafe2` cannot be made into an object
-  --> $DIR/feature-gate-object_safe_for_dispatch.rs:22:1
+  --> $DIR/feature-gate-object_safe_for_dispatch.rs:22:36
    |
 LL |     fn static_fn() {}
    |        --------- associated function `static_fn` has no `self` parameter
 ...
 LL | fn return_non_object_safe_ref() -> &'static dyn NonObjectSafe2 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NonObjectSafe2` cannot be made into an object
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NonObjectSafe2` cannot be made into an object
 
 error[E0038]: the trait `NonObjectSafe3` cannot be made into an object
-  --> $DIR/feature-gate-object_safe_for_dispatch.rs:27:1
+  --> $DIR/feature-gate-object_safe_for_dispatch.rs:27:35
    |
 LL |     fn foo<T>(&self);
    |        --- method `foo` has generic type parameters
 ...
 LL | fn takes_non_object_safe_box(obj: Box<dyn NonObjectSafe3>) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NonObjectSafe3` cannot be made into an object
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^ the trait `NonObjectSafe3` cannot be made into an object
 
 error[E0038]: the trait `NonObjectSafe4` cannot be made into an object
-  --> $DIR/feature-gate-object_safe_for_dispatch.rs:31:1
+  --> $DIR/feature-gate-object_safe_for_dispatch.rs:31:35
    |
 LL |     fn foo(&self, &Self);
    |        --- method `foo` references the `Self` type in its parameters or return type
 ...
 LL | fn return_non_object_safe_rc() -> std::rc::Rc<dyn NonObjectSafe4> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NonObjectSafe4` cannot be made into an object
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NonObjectSafe4` cannot be made into an object
 
 error[E0038]: the trait `NonObjectSafe1` cannot be made into an object
   --> $DIR/feature-gate-object_safe_for_dispatch.rs:38:6

--- a/src/test/ui/feature-gates/feature-gate-object_safe_for_dispatch.stderr
+++ b/src/test/ui/feature-gates/feature-gate-object_safe_for_dispatch.stderr
@@ -20,7 +20,10 @@ LL |     fn static_fn() {}
 LL | fn return_non_object_safe_ref() -> &'static dyn NonObjectSafe2 {
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NonObjectSafe2` cannot be made into an object
    |
-   = help: consider turning `static_fn` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
+help: consider turning `static_fn` into a method by giving it a `&self` argument or constraining it so it does not apply to trait objects
+   |
+LL |     fn static_fn() where Self: Sized {}
+   |                    ^^^^^^^^^^^^^^^^^
 
 error[E0038]: the trait `NonObjectSafe3` cannot be made into an object
   --> $DIR/feature-gate-object_safe_for_dispatch.rs:27:35
@@ -41,7 +44,7 @@ error[E0038]: the trait `NonObjectSafe4` cannot be made into an object
 LL | trait NonObjectSafe4 {
    |       -------------- this trait cannot be made into an object...
 LL |     fn foo(&self, &Self);
-   |        --- ...because method `foo` references the `Self` type in its parameters or return type
+   |                   ----- ...because method `foo` references the `Self` type in this parameter
 ...
 LL | fn return_non_object_safe_rc() -> std::rc::Rc<dyn NonObjectSafe4> {
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NonObjectSafe4` cannot be made into an object

--- a/src/test/ui/feature-gates/feature-gate-object_safe_for_dispatch.stderr
+++ b/src/test/ui/feature-gates/feature-gate-object_safe_for_dispatch.stderr
@@ -2,7 +2,7 @@ error[E0038]: the trait `NonObjectSafe1` cannot be made into an object
   --> $DIR/feature-gate-object_safe_for_dispatch.rs:18:38
    |
 LL | trait NonObjectSafe1: Sized {}
-   |                       ----- the trait cannot require that `Self : Sized`
+   |                       ----- traits that require `Self: Sized` cannot be made into an object
 ...
 LL | fn takes_non_object_safe_ref<T>(obj: &dyn NonObjectSafe1) {
    |                                      ^^^^^^^^^^^^^^^^^^^ the trait `NonObjectSafe1` cannot be made into an object
@@ -38,7 +38,7 @@ error[E0038]: the trait `NonObjectSafe1` cannot be made into an object
   --> $DIR/feature-gate-object_safe_for_dispatch.rs:38:6
    |
 LL | trait NonObjectSafe1: Sized {}
-   |                       ----- the trait cannot require that `Self : Sized`
+   |                       ----- traits that require `Self: Sized` cannot be made into an object
 ...
 LL | impl Trait for dyn NonObjectSafe1 {}
    |      ^^^^^ the trait `NonObjectSafe1` cannot be made into an object

--- a/src/test/ui/feature-gates/feature-gate-object_safe_for_dispatch.stderr
+++ b/src/test/ui/feature-gates/feature-gate-object_safe_for_dispatch.stderr
@@ -2,7 +2,9 @@ error[E0038]: the trait `NonObjectSafe1` cannot be made into an object
   --> $DIR/feature-gate-object_safe_for_dispatch.rs:18:38
    |
 LL | trait NonObjectSafe1: Sized {}
-   |                       ----- traits that require `Self: Sized` cannot be made into an object
+   |       --------------  ----- ...because it requires `Self: Sized`
+   |       |
+   |       this trait cannot be made into an object...
 ...
 LL | fn takes_non_object_safe_ref<T>(obj: &dyn NonObjectSafe1) {
    |                                      ^^^^^^^^^^^^^^^^^^^ the trait `NonObjectSafe1` cannot be made into an object
@@ -10,35 +12,49 @@ LL | fn takes_non_object_safe_ref<T>(obj: &dyn NonObjectSafe1) {
 error[E0038]: the trait `NonObjectSafe2` cannot be made into an object
   --> $DIR/feature-gate-object_safe_for_dispatch.rs:22:36
    |
+LL | trait NonObjectSafe2 {
+   |       -------------- this trait cannot be made into an object...
 LL |     fn static_fn() {}
-   |        --------- associated function `static_fn` has no `self` parameter
+   |        --------- ...because associated function `static_fn` has no `self` parameter
 ...
 LL | fn return_non_object_safe_ref() -> &'static dyn NonObjectSafe2 {
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NonObjectSafe2` cannot be made into an object
+   |
+   = help: consider turning `static_fn` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
 
 error[E0038]: the trait `NonObjectSafe3` cannot be made into an object
   --> $DIR/feature-gate-object_safe_for_dispatch.rs:27:35
    |
+LL | trait NonObjectSafe3 {
+   |       -------------- this trait cannot be made into an object...
 LL |     fn foo<T>(&self);
-   |        --- method `foo` has generic type parameters
+   |        --- ...because method `foo` has generic type parameters
 ...
 LL | fn takes_non_object_safe_box(obj: Box<dyn NonObjectSafe3>) {
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^ the trait `NonObjectSafe3` cannot be made into an object
+   |
+   = help: consider moving `foo` to another trait
 
 error[E0038]: the trait `NonObjectSafe4` cannot be made into an object
   --> $DIR/feature-gate-object_safe_for_dispatch.rs:31:35
    |
+LL | trait NonObjectSafe4 {
+   |       -------------- this trait cannot be made into an object...
 LL |     fn foo(&self, &Self);
-   |        --- method `foo` references the `Self` type in its parameters or return type
+   |        --- ...because method `foo` references the `Self` type in its parameters or return type
 ...
 LL | fn return_non_object_safe_rc() -> std::rc::Rc<dyn NonObjectSafe4> {
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NonObjectSafe4` cannot be made into an object
+   |
+   = help: consider moving `foo` to another trait
 
 error[E0038]: the trait `NonObjectSafe1` cannot be made into an object
   --> $DIR/feature-gate-object_safe_for_dispatch.rs:38:6
    |
 LL | trait NonObjectSafe1: Sized {}
-   |                       ----- traits that require `Self: Sized` cannot be made into an object
+   |       --------------  ----- ...because it requires `Self: Sized`
+   |       |
+   |       this trait cannot be made into an object...
 ...
 LL | impl Trait for dyn NonObjectSafe1 {}
    |      ^^^^^ the trait `NonObjectSafe1` cannot be made into an object

--- a/src/test/ui/generic-associated-types/issue-62326-parameter-out-of-range.rs
+++ b/src/test/ui/generic-associated-types/issue-62326-parameter-out-of-range.rs
@@ -4,8 +4,8 @@
 // FIXME(generic-associated-types) Investigate why this doesn't compile.
 
 trait Iterator {
-    //~^ ERROR the requirement `for<'a> <Self as Iterator>::Item<'a>: 'a` is not satisfied
     type Item<'a>: 'a;
+    //~^ ERROR the requirement `for<'a> <Self as Iterator>::Item<'a>: 'a` is not satisfied
 }
 
 fn main() {}

--- a/src/test/ui/generic-associated-types/issue-62326-parameter-out-of-range.stderr
+++ b/src/test/ui/generic-associated-types/issue-62326-parameter-out-of-range.stderr
@@ -1,15 +1,10 @@
 error[E0280]: the requirement `for<'a> <Self as Iterator>::Item<'a>: 'a` is not satisfied
-  --> $DIR/issue-62326-parameter-out-of-range.rs:6:1
+  --> $DIR/issue-62326-parameter-out-of-range.rs:7:20
    |
-LL |   trait Iterator {
-   |   ^-------------
-   |   |
-   |  _required by `Iterator`
-   | |
-LL | |
-LL | |     type Item<'a>: 'a;
-LL | | }
-   | |_^
+LL | trait Iterator {
+   | -------------- required by `Iterator`
+LL |     type Item<'a>: 'a;
+   |                    ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/iterable.stderr
+++ b/src/test/ui/generic-associated-types/iterable.stderr
@@ -25,16 +25,13 @@ LL |     type Item<'a> where T: 'a = <std::slice::Iter<'a, T> as Iterator>::Item
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
 
 error[E0271]: type mismatch resolving `for<'a> <<std::vec::Vec<T> as Iterable>::Iter<'a> as std::iter::Iterator>::Item == <std::vec::Vec<T> as Iterable>::Item<'a>`
-  --> $DIR/iterable.rs:19:5
+  --> $DIR/iterable.rs:19:30
    |
-LL |   trait Iterable {
-   |   -------------- required by `Iterable`
+LL | trait Iterable {
+   | -------------- required by `Iterable`
 ...
-LL | /     fn iter<'a>(&'a self) -> Self::Iter<'a> {
-LL | |
-LL | |         self.iter()
-LL | |     }
-   | |_____^ expected associated type, found reference
+LL |     fn iter<'a>(&'a self) -> Self::Iter<'a> {
+   |                              ^^^^^^^^^^^^^^ expected associated type, found reference
    |
    = note: expected associated type `<std::vec::Vec<T> as Iterable>::Item<'_>`
                     found reference `&T`
@@ -42,16 +39,13 @@ LL | |     }
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
 
 error[E0271]: type mismatch resolving `for<'a> <<[T] as Iterable>::Iter<'a> as std::iter::Iterator>::Item == <[T] as Iterable>::Item<'a>`
-  --> $DIR/iterable.rs:31:5
+  --> $DIR/iterable.rs:31:30
    |
-LL |   trait Iterable {
-   |   -------------- required by `Iterable`
+LL | trait Iterable {
+   | -------------- required by `Iterable`
 ...
-LL | /     fn iter<'a>(&'a self) -> Self::Iter<'a> {
-LL | |
-LL | |         self.iter()
-LL | |     }
-   | |_____^ expected associated type, found reference
+LL |     fn iter<'a>(&'a self) -> Self::Iter<'a> {
+   |                              ^^^^^^^^^^^^^^ expected associated type, found reference
    |
    = note: expected associated type `<[T] as Iterable>::Item<'_>`
                     found reference `&T`

--- a/src/test/ui/impl-trait/object-unsafe-trait-in-return-position-dyn-trait.stderr
+++ b/src/test/ui/impl-trait/object-unsafe-trait-in-return-position-dyn-trait.stderr
@@ -1,20 +1,28 @@
 error[E0038]: the trait `NotObjectSafe` cannot be made into an object
   --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:21:13
    |
+LL | trait NotObjectSafe {
+   |       ------------- this trait cannot be made into an object...
 LL |     fn foo() -> Self;
-   |        --- associated function `foo` has no `self` parameter
+   |        --- ...because associated function `foo` has no `self` parameter
 ...
 LL | fn car() -> dyn NotObjectSafe {
    |             ^^^^^^^^^^^^^^^^^ the trait `NotObjectSafe` cannot be made into an object
+   |
+   = help: consider turning `foo` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
 
 error[E0038]: the trait `NotObjectSafe` cannot be made into an object
   --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:28:13
    |
+LL | trait NotObjectSafe {
+   |       ------------- this trait cannot be made into an object...
 LL |     fn foo() -> Self;
-   |        --- associated function `foo` has no `self` parameter
+   |        --- ...because associated function `foo` has no `self` parameter
 ...
 LL | fn cat() -> Box<dyn NotObjectSafe> {
    |             ^^^^^^^^^^^^^^^^^^^^^^ the trait `NotObjectSafe` cannot be made into an object
+   |
+   = help: consider turning `foo` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/impl-trait/object-unsafe-trait-in-return-position-dyn-trait.stderr
+++ b/src/test/ui/impl-trait/object-unsafe-trait-in-return-position-dyn-trait.stderr
@@ -9,7 +9,10 @@ LL |     fn foo() -> Self;
 LL | fn car() -> dyn NotObjectSafe {
    |             ^^^^^^^^^^^^^^^^^ the trait `NotObjectSafe` cannot be made into an object
    |
-   = help: consider turning `foo` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
+help: consider turning `foo` into a method by giving it a `&self` argument or constraining it so it does not apply to trait objects
+   |
+LL |     fn foo() -> Self where Self: Sized;
+   |                      ^^^^^^^^^^^^^^^^^
 
 error[E0038]: the trait `NotObjectSafe` cannot be made into an object
   --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:28:13
@@ -22,7 +25,10 @@ LL |     fn foo() -> Self;
 LL | fn cat() -> Box<dyn NotObjectSafe> {
    |             ^^^^^^^^^^^^^^^^^^^^^^ the trait `NotObjectSafe` cannot be made into an object
    |
-   = help: consider turning `foo` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
+help: consider turning `foo` into a method by giving it a `&self` argument or constraining it so it does not apply to trait objects
+   |
+LL |     fn foo() -> Self where Self: Sized;
+   |                      ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/impl-trait/object-unsafe-trait-in-return-position-dyn-trait.stderr
+++ b/src/test/ui/impl-trait/object-unsafe-trait-in-return-position-dyn-trait.stderr
@@ -1,20 +1,20 @@
 error[E0038]: the trait `NotObjectSafe` cannot be made into an object
-  --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:21:1
+  --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:21:13
    |
 LL |     fn foo() -> Self;
    |        --- associated function `foo` has no `self` parameter
 ...
 LL | fn car() -> dyn NotObjectSafe {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotObjectSafe` cannot be made into an object
+   |             ^^^^^^^^^^^^^^^^^ the trait `NotObjectSafe` cannot be made into an object
 
 error[E0038]: the trait `NotObjectSafe` cannot be made into an object
-  --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:28:1
+  --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:28:13
    |
 LL |     fn foo() -> Self;
    |        --- associated function `foo` has no `self` parameter
 ...
 LL | fn cat() -> Box<dyn NotObjectSafe> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotObjectSafe` cannot be made into an object
+   |             ^^^^^^^^^^^^^^^^^^^^^^ the trait `NotObjectSafe` cannot be made into an object
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-18919.stderr
+++ b/src/test/ui/issues/issue-18919.stderr
@@ -1,10 +1,8 @@
 error[E0277]: the size for values of type `dyn for<'r> std::ops::Fn(&'r isize) -> isize` cannot be known at compilation time
-  --> $DIR/issue-18919.rs:3:1
+  --> $DIR/issue-18919.rs:3:15
    |
-LL | / fn ho_func(f: Option<FuncType>) {
-LL | |
-LL | | }
-   | |_^ doesn't have a size known at compile-time
+LL | fn ho_func(f: Option<FuncType>) {
+   |               ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `dyn for<'r> std::ops::Fn(&'r isize) -> isize`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>

--- a/src/test/ui/issues/issue-18959.stderr
+++ b/src/test/ui/issues/issue-18959.stderr
@@ -2,10 +2,14 @@ error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/issue-18959.rs:11:11
    |
 LL | pub trait Foo { fn foo<T>(&self, ext_thing: &T); }
-   |                    --- method `foo` has generic type parameters
+   |                    --- ...because method `foo` has generic type parameters
+LL | pub trait Bar: Foo { }
+   |           --- this trait cannot be made into an object...
 ...
 LL | fn foo(b: &dyn Bar) {
    |           ^^^^^^^^ the trait `Bar` cannot be made into an object
+   |
+   = help: consider moving `foo` to another trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-18959.stderr
+++ b/src/test/ui/issues/issue-18959.stderr
@@ -1,11 +1,11 @@
 error[E0038]: the trait `Bar` cannot be made into an object
-  --> $DIR/issue-18959.rs:11:1
+  --> $DIR/issue-18959.rs:11:11
    |
 LL | pub trait Foo { fn foo<T>(&self, ext_thing: &T); }
    |                    --- method `foo` has generic type parameters
 ...
 LL | fn foo(b: &dyn Bar) {
-   | ^^^^^^^^^^^^^^^^^^^ the trait `Bar` cannot be made into an object
+   |           ^^^^^^^^ the trait `Bar` cannot be made into an object
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-19380.stderr
+++ b/src/test/ui/issues/issue-19380.stderr
@@ -1,11 +1,15 @@
 error[E0038]: the trait `Qiz` cannot be made into an object
   --> $DIR/issue-19380.rs:11:3
    |
+LL | trait Qiz {
+   |       --- this trait cannot be made into an object...
 LL |   fn qiz();
-   |      --- associated function `qiz` has no `self` parameter
+   |      --- ...because associated function `qiz` has no `self` parameter
 ...
 LL |   foos: &'static [&'static (dyn Qiz + 'static)]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Qiz` cannot be made into an object
+   |
+   = help: consider turning `qiz` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-19380.stderr
+++ b/src/test/ui/issues/issue-19380.stderr
@@ -9,7 +9,10 @@ LL |   fn qiz();
 LL |   foos: &'static [&'static (dyn Qiz + 'static)]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Qiz` cannot be made into an object
    |
-   = help: consider turning `qiz` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
+help: consider turning `qiz` into a method by giving it a `&self` argument or constraining it so it does not apply to trait objects
+   |
+LL |   fn qiz() where Self: Sized;
+   |            ^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-19538.stderr
+++ b/src/test/ui/issues/issue-19538.stderr
@@ -2,20 +2,29 @@ error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/issue-19538.rs:17:15
    |
 LL |     fn foo<T>(&self, val: T);
-   |        --- method `foo` has generic type parameters
+   |        --- ...because method `foo` has generic type parameters
+...
+LL | trait Bar: Foo { }
+   |       --- this trait cannot be made into an object...
 ...
 LL |     let test: &mut dyn Bar = &mut thing;
    |               ^^^^^^^^^^^^ the trait `Bar` cannot be made into an object
+   |
+   = help: consider moving `foo` to another trait
 
 error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/issue-19538.rs:17:30
    |
 LL |     fn foo<T>(&self, val: T);
-   |        --- method `foo` has generic type parameters
+   |        --- ...because method `foo` has generic type parameters
+...
+LL | trait Bar: Foo { }
+   |       --- this trait cannot be made into an object...
 ...
 LL |     let test: &mut dyn Bar = &mut thing;
    |                              ^^^^^^^^^^ the trait `Bar` cannot be made into an object
    |
+   = help: consider moving `foo` to another trait
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<&mut dyn Bar>` for `&mut Thing`
    = note: required by cast to type `&mut dyn Bar`
 

--- a/src/test/ui/issues/issue-20005.rs
+++ b/src/test/ui/issues/issue-20005.rs
@@ -5,9 +5,9 @@ trait From<Src> {
 }
 
 trait To {
-    fn to<Dst>(  //~ ERROR the size for values of type
+    fn to<Dst>(
         self
-    ) -> <Dst as From<Self>>::Result where Dst: From<Self> {
+    ) -> <Dst as From<Self>>::Result where Dst: From<Self> { //~ ERROR the size for values of type
         From::from(self)
     }
 }

--- a/src/test/ui/issues/issue-20005.stderr
+++ b/src/test/ui/issues/issue-20005.stderr
@@ -1,14 +1,13 @@
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/issue-20005.rs:8:8
+  --> $DIR/issue-20005.rs:10:49
    |
 LL | trait From<Src> {
    | --------------- required by `From`
 ...
-LL |     fn to<Dst>(
-   |        ^^ doesn't have a size known at compile-time
-LL |         self
 LL |     ) -> <Dst as From<Self>>::Result where Dst: From<Self> {
-   |                                                           - help: consider further restricting `Self`: `, Self: std::marker::Sized`
+   |                                                 ^^^^^^^^^^- help: consider further restricting `Self`: `, Self: std::marker::Sized`
+   |                                                 |
+   |                                                 doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `Self`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>

--- a/src/test/ui/issues/issue-20005.stderr
+++ b/src/test/ui/issues/issue-20005.stderr
@@ -1,16 +1,14 @@
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/issue-20005.rs:8:5
+  --> $DIR/issue-20005.rs:8:8
    |
-LL |   trait From<Src> {
-   |   --------------- required by `From`
+LL | trait From<Src> {
+   | --------------- required by `From`
 ...
-LL | /     fn to<Dst>(
-LL | |         self
-LL | |     ) -> <Dst as From<Self>>::Result where Dst: From<Self> {
-   | |                                                           - help: consider further restricting `Self`: `, Self: std::marker::Sized`
-LL | |         From::from(self)
-LL | |     }
-   | |_____^ doesn't have a size known at compile-time
+LL |     fn to<Dst>(
+   |        ^^ doesn't have a size known at compile-time
+LL |         self
+LL |     ) -> <Dst as From<Self>>::Result where Dst: From<Self> {
+   |                                                           - help: consider further restricting `Self`: `, Self: std::marker::Sized`
    |
    = help: the trait `std::marker::Sized` is not implemented for `Self`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>

--- a/src/test/ui/issues/issue-20413.rs
+++ b/src/test/ui/issues/issue-20413.rs
@@ -6,9 +6,9 @@ struct NoData<T>;
 //~^ ERROR: parameter `T` is never used
 
 impl<T> Foo for T where NoData<T>: Foo {
-//~^ ERROR: overflow evaluating the requirement
-  fn answer(self) {
   //~^ ERROR: overflow evaluating the requirement
+  //~| ERROR: overflow evaluating the requirement
+  fn answer(self) {
     let val: NoData<T> = NoData;
   }
 }

--- a/src/test/ui/issues/issue-20413.stderr
+++ b/src/test/ui/issues/issue-20413.stderr
@@ -7,19 +7,13 @@ LL | struct NoData<T>;
    = help: consider removing `T`, referring to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>: Foo`
-  --> $DIR/issue-20413.rs:8:1
+  --> $DIR/issue-20413.rs:8:36
    |
-LL |   trait Foo {
-   |   --------- required by `Foo`
+LL | trait Foo {
+   | --------- required by `Foo`
 ...
-LL | / impl<T> Foo for T where NoData<T>: Foo {
-LL | |
-LL | |   fn answer(self) {
-LL | |
-LL | |     let val: NoData<T> = NoData;
-LL | |   }
-LL | | }
-   | |_^
+LL | impl<T> Foo for T where NoData<T>: Foo {
+   |                                    ^^^
    |
    = help: consider adding a `#![recursion_limit="256"]` attribute to your crate
    = note: required because of the requirements on the impl of `Foo` for `NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>`
@@ -151,13 +145,13 @@ LL | | }
    = note: required because of the requirements on the impl of `Foo` for `NoData<T>`
 
 error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>: Foo`
-  --> $DIR/issue-20413.rs:10:6
+  --> $DIR/issue-20413.rs:8:36
    |
 LL | trait Foo {
    | --------- required by `Foo`
 ...
-LL |   fn answer(self) {
-   |      ^^^^^^
+LL | impl<T> Foo for T where NoData<T>: Foo {
+   |                                    ^^^
    |
    = help: consider adding a `#![recursion_limit="256"]` attribute to your crate
    = note: required because of the requirements on the impl of `Foo` for `NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>`

--- a/src/test/ui/issues/issue-20413.stderr
+++ b/src/test/ui/issues/issue-20413.stderr
@@ -151,16 +151,13 @@ LL | | }
    = note: required because of the requirements on the impl of `Foo` for `NoData<T>`
 
 error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>: Foo`
-  --> $DIR/issue-20413.rs:10:3
+  --> $DIR/issue-20413.rs:10:6
    |
-LL |   trait Foo {
-   |   --------- required by `Foo`
+LL | trait Foo {
+   | --------- required by `Foo`
 ...
-LL | /   fn answer(self) {
-LL | |
-LL | |     let val: NoData<T> = NoData;
-LL | |   }
-   | |___^
+LL |   fn answer(self) {
+   |      ^^^^^^
    |
    = help: consider adding a `#![recursion_limit="256"]` attribute to your crate
    = note: required because of the requirements on the impl of `Foo` for `NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>`

--- a/src/test/ui/issues/issue-20433.stderr
+++ b/src/test/ui/issues/issue-20433.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
-  --> $DIR/issue-20433.rs:6:5
+  --> $DIR/issue-20433.rs:6:18
    |
 LL |     fn iceman(c: Vec<[i32]>) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                  ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[i32]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>

--- a/src/test/ui/issues/issue-20692.rs
+++ b/src/test/ui/issues/issue-20692.rs
@@ -1,4 +1,4 @@
-trait Array: Sized {}
+trait Array: Sized + Copy {}
 
 fn f<T: Array>(x: &T) {
     let _ = x

--- a/src/test/ui/issues/issue-20692.stderr
+++ b/src/test/ui/issues/issue-20692.stderr
@@ -2,9 +2,9 @@ error[E0038]: the trait `Array` cannot be made into an object
   --> $DIR/issue-20692.rs:7:5
    |
 LL | trait Array: Sized + Copy {}
-   |              -----   ---- the trait cannot require that `Self : Sized`
+   |              -----   ---- traits that require `Self: Sized` cannot be made into an object
    |              |
-   |              the trait cannot require that `Self : Sized`
+   |              traits that require `Self: Sized` cannot be made into an object
 ...
 LL |     &dyn Array;
    |     ^^^^^^^^^^ the trait `Array` cannot be made into an object
@@ -13,9 +13,9 @@ error[E0038]: the trait `Array` cannot be made into an object
   --> $DIR/issue-20692.rs:4:13
    |
 LL | trait Array: Sized + Copy {}
-   |              -----   ---- the trait cannot require that `Self : Sized`
+   |              -----   ---- traits that require `Self: Sized` cannot be made into an object
    |              |
-   |              the trait cannot require that `Self : Sized`
+   |              traits that require `Self: Sized` cannot be made into an object
 ...
 LL |     let _ = x
    |             ^ the trait `Array` cannot be made into an object

--- a/src/test/ui/issues/issue-20692.stderr
+++ b/src/test/ui/issues/issue-20692.stderr
@@ -2,9 +2,10 @@ error[E0038]: the trait `Array` cannot be made into an object
   --> $DIR/issue-20692.rs:7:5
    |
 LL | trait Array: Sized + Copy {}
-   |              -----   ---- traits that require `Self: Sized` cannot be made into an object
-   |              |
-   |              traits that require `Self: Sized` cannot be made into an object
+   |       -----  -----   ---- ...because it requires `Self: Sized`
+   |       |      |
+   |       |      ...because it requires `Self: Sized`
+   |       this trait cannot be made into an object...
 ...
 LL |     &dyn Array;
    |     ^^^^^^^^^^ the trait `Array` cannot be made into an object
@@ -13,9 +14,10 @@ error[E0038]: the trait `Array` cannot be made into an object
   --> $DIR/issue-20692.rs:4:13
    |
 LL | trait Array: Sized + Copy {}
-   |              -----   ---- traits that require `Self: Sized` cannot be made into an object
-   |              |
-   |              traits that require `Self: Sized` cannot be made into an object
+   |       -----  -----   ---- ...because it requires `Self: Sized`
+   |       |      |
+   |       |      ...because it requires `Self: Sized`
+   |       this trait cannot be made into an object...
 ...
 LL |     let _ = x
    |             ^ the trait `Array` cannot be made into an object

--- a/src/test/ui/issues/issue-20692.stderr
+++ b/src/test/ui/issues/issue-20692.stderr
@@ -1,24 +1,25 @@
 error[E0038]: the trait `Array` cannot be made into an object
   --> $DIR/issue-20692.rs:7:5
    |
-LL | trait Array: Sized {}
-   |              ----- the trait cannot require that `Self : Sized`
+LL | trait Array: Sized + Copy {}
+   |              -----   ---- the trait cannot require that `Self : Sized`
+   |              |
+   |              the trait cannot require that `Self : Sized`
 ...
 LL |     &dyn Array;
    |     ^^^^^^^^^^ the trait `Array` cannot be made into an object
-   |
-   = note: the trait cannot require that `Self : Sized`
 
 error[E0038]: the trait `Array` cannot be made into an object
   --> $DIR/issue-20692.rs:4:13
    |
-LL | trait Array: Sized {}
-   |              ----- the trait cannot require that `Self : Sized`
+LL | trait Array: Sized + Copy {}
+   |              -----   ---- the trait cannot require that `Self : Sized`
+   |              |
+   |              the trait cannot require that `Self : Sized`
 ...
 LL |     let _ = x
    |             ^ the trait `Array` cannot be made into an object
    |
-   = note: the trait cannot require that `Self : Sized`
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<&dyn Array>` for `&T`
    = note: required by cast to type `&dyn Array`
 

--- a/src/test/ui/issues/issue-20692.stderr
+++ b/src/test/ui/issues/issue-20692.stderr
@@ -1,6 +1,9 @@
 error[E0038]: the trait `Array` cannot be made into an object
   --> $DIR/issue-20692.rs:7:5
    |
+LL | trait Array: Sized {}
+   |              ----- the trait cannot require that `Self : Sized`
+...
 LL |     &dyn Array;
    |     ^^^^^^^^^^ the trait `Array` cannot be made into an object
    |
@@ -9,6 +12,9 @@ LL |     &dyn Array;
 error[E0038]: the trait `Array` cannot be made into an object
   --> $DIR/issue-20692.rs:4:13
    |
+LL | trait Array: Sized {}
+   |              ----- the trait cannot require that `Self : Sized`
+...
 LL |     let _ = x
    |             ^ the trait `Array` cannot be made into an object
    |

--- a/src/test/ui/issues/issue-20831-debruijn.stderr
+++ b/src/test/ui/issues/issue-20831-debruijn.stderr
@@ -61,16 +61,10 @@ LL | |     }
    | |_____^
 
 error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
-  --> $DIR/issue-20831-debruijn.rs:28:5
+  --> $DIR/issue-20831-debruijn.rs:28:33
    |
-LL | /     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
-LL | |         // Not obvious, but there is an implicit lifetime here -------^
-LL | |
-LL | |
-...  |
-LL | |         self.sub = t;
-LL | |     }
-   | |_____^
+LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: first, the lifetime cannot outlive the anonymous lifetime #2 defined on the method body at 28:5...
   --> $DIR/issue-20831-debruijn.rs:28:5
@@ -89,30 +83,18 @@ note: ...but the lifetime must also be valid for the lifetime `'a` as defined on
 LL | impl<'a> Publisher<'a> for MyStruct<'a> {
    |      ^^
 note: ...so that the types are compatible
-  --> $DIR/issue-20831-debruijn.rs:28:5
+  --> $DIR/issue-20831-debruijn.rs:28:33
    |
-LL | /     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
-LL | |         // Not obvious, but there is an implicit lifetime here -------^
-LL | |
-LL | |
-...  |
-LL | |         self.sub = t;
-LL | |     }
-   | |_____^
+LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: expected  `Publisher<'_>`
               found  `Publisher<'_>`
 
 error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
-  --> $DIR/issue-20831-debruijn.rs:28:5
+  --> $DIR/issue-20831-debruijn.rs:28:33
    |
-LL | /     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
-LL | |         // Not obvious, but there is an implicit lifetime here -------^
-LL | |
-LL | |
-...  |
-LL | |         self.sub = t;
-LL | |     }
-   | |_____^
+LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: first, the lifetime cannot outlive the anonymous lifetime #2 defined on the method body at 28:5...
   --> $DIR/issue-20831-debruijn.rs:28:5
@@ -131,16 +113,10 @@ note: ...but the lifetime must also be valid for the lifetime `'a` as defined on
 LL | impl<'a> Publisher<'a> for MyStruct<'a> {
    |      ^^
 note: ...so that the types are compatible
-  --> $DIR/issue-20831-debruijn.rs:28:5
+  --> $DIR/issue-20831-debruijn.rs:28:33
    |
-LL | /     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
-LL | |         // Not obvious, but there is an implicit lifetime here -------^
-LL | |
-LL | |
-...  |
-LL | |         self.sub = t;
-LL | |     }
-   | |_____^
+LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: expected  `Publisher<'_>`
               found  `Publisher<'_>`
 

--- a/src/test/ui/issues/issue-21974.rs
+++ b/src/test/ui/issues/issue-21974.rs
@@ -7,8 +7,8 @@ trait Foo {
     fn foo(self);
 }
 
-fn foo<'a,'b,T>(x: &'a T, y: &'b T) //~ ERROR type annotations needed
-    where &'a T : Foo,
+fn foo<'a,'b,T>(x: &'a T, y: &'b T)
+    where &'a T : Foo, //~ ERROR type annotations needed
           &'b T : Foo
 {
     x.foo();

--- a/src/test/ui/issues/issue-21974.stderr
+++ b/src/test/ui/issues/issue-21974.stderr
@@ -1,17 +1,11 @@
 error[E0283]: type annotations needed
-  --> $DIR/issue-21974.rs:10:1
+  --> $DIR/issue-21974.rs:10:4
    |
-LL |   trait Foo {
-   |   --------- required by `Foo`
+LL | trait Foo {
+   | --------- required by `Foo`
 ...
-LL | / fn foo<'a,'b,T>(x: &'a T, y: &'b T)
-LL | |     where &'a T : Foo,
-LL | |           &'b T : Foo
-LL | | {
-LL | |     x.foo();
-LL | |     y.foo();
-LL | | }
-   | |_^ cannot infer type for reference `&'a T`
+LL | fn foo<'a,'b,T>(x: &'a T, y: &'b T)
+   |    ^^^ cannot infer type for reference `&'a T`
    |
    = note: cannot resolve `&'a T: Foo`
 

--- a/src/test/ui/issues/issue-21974.stderr
+++ b/src/test/ui/issues/issue-21974.stderr
@@ -1,11 +1,11 @@
 error[E0283]: type annotations needed
-  --> $DIR/issue-21974.rs:10:4
+  --> $DIR/issue-21974.rs:11:19
    |
 LL | trait Foo {
    | --------- required by `Foo`
 ...
-LL | fn foo<'a,'b,T>(x: &'a T, y: &'b T)
-   |    ^^^ cannot infer type for reference `&'a T`
+LL |     where &'a T : Foo,
+   |                   ^^^ cannot infer type for reference `&'a T`
    |
    = note: cannot resolve `&'a T: Foo`
 

--- a/src/test/ui/issues/issue-23281.stderr
+++ b/src/test/ui/issues/issue-23281.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `(dyn std::ops::Fn() + 'static)` cannot be known at compilation time
-  --> $DIR/issue-23281.rs:4:5
+  --> $DIR/issue-23281.rs:4:27
    |
 LL |     pub fn function(funs: Vec<dyn Fn() -> ()>) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                           ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `(dyn std::ops::Fn() + 'static)`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>

--- a/src/test/ui/issues/issue-24204.stderr
+++ b/src/test/ui/issues/issue-24204.stderr
@@ -1,11 +1,11 @@
 error[E0271]: type mismatch resolving `<<T as Trait>::A as MultiDispatch<i32>>::O == T`
-  --> $DIR/issue-24204.rs:14:4
+  --> $DIR/issue-24204.rs:14:12
    |
 LL | trait Trait: Sized {
    | ------------------ required by `Trait`
 ...
 LL | fn test<T: Trait<B=i32>>(b: i32) -> T where T::A: MultiDispatch<i32> { T::new(b) }
-   |    ^^^^ expected type parameter `T`, found associated type
+   |            ^^^^^^^^^^^^ expected type parameter `T`, found associated type
    |
    = note: expected type parameter `T`
              found associated type `<<T as Trait>::A as MultiDispatch<i32>>::O`

--- a/src/test/ui/issues/issue-24204.stderr
+++ b/src/test/ui/issues/issue-24204.stderr
@@ -1,11 +1,11 @@
 error[E0271]: type mismatch resolving `<<T as Trait>::A as MultiDispatch<i32>>::O == T`
-  --> $DIR/issue-24204.rs:14:1
+  --> $DIR/issue-24204.rs:14:4
    |
 LL | trait Trait: Sized {
    | ------------------ required by `Trait`
 ...
 LL | fn test<T: Trait<B=i32>>(b: i32) -> T where T::A: MultiDispatch<i32> { T::new(b) }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter `T`, found associated type
+   |    ^^^^ expected type parameter `T`, found associated type
    |
    = note: expected type parameter `T`
              found associated type `<<T as Trait>::A as MultiDispatch<i32>>::O`

--- a/src/test/ui/issues/issue-24424.stderr
+++ b/src/test/ui/issues/issue-24424.stderr
@@ -1,11 +1,11 @@
 error[E0283]: type annotations needed
-  --> $DIR/issue-24424.rs:4:1
+  --> $DIR/issue-24424.rs:4:57
    |
 LL | trait Trait0<'l0>  {}
    | ----------------- required by `Trait0`
 LL | 
 LL | impl <'l0, 'l1, T0> Trait1<'l0, T0> for bool where T0 : Trait0<'l0>, T0 : Trait0<'l1> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T0`
+   |                                                         ^^^^^^^^^^^ cannot infer type for type parameter `T0`
    |
    = note: cannot resolve `T0: Trait0<'l0>`
 

--- a/src/test/ui/issues/issue-26056.stderr
+++ b/src/test/ui/issues/issue-26056.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Map` cannot be made into an object
 LL |         as &dyn Map<Key=u32,MapValue=u32>;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Map` cannot be made into an object
    |
-   = note: the trait cannot use `Self` as a type parameter in the supertraits or where-clauses
+   = note: the trait cannot be made into an object because it cannot use `Self` as a type parameter in the supertraits or `where`-clauses
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-26056.stderr
+++ b/src/test/ui/issues/issue-26056.stderr
@@ -1,10 +1,13 @@
 error[E0038]: the trait `Map` cannot be made into an object
   --> $DIR/issue-26056.rs:20:13
    |
+LL | trait Map: MapLookup<<Self as Map>::Key> {
+   |       ---  ----------------------------- ...because it uses `Self` as a type parameter in this
+   |       |
+   |       this trait cannot be made into an object...
+...
 LL |         as &dyn Map<Key=u32,MapValue=u32>;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Map` cannot be made into an object
-   |
-   = note: the trait cannot be made into an object because it cannot use `Self` as a type parameter in the supertraits or `where`-clauses
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-27060-2.stderr
+++ b/src/test/ui/issues/issue-27060-2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/issue-27060-2.rs:3:5
    |
 LL | pub struct Bad<T: ?Sized> {
-   |                -- help: consider further restricting this bound: `T: std::marker::Sized +`
+   |                - this type parameter needs to be `std::marker::Sized`
 LL |     data: T,
    |     ^^^^^^^ doesn't have a size known at compile-time
    |

--- a/src/test/ui/issues/issue-27942.stderr
+++ b/src/test/ui/issues/issue-27942.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-27942.rs:5:5
+  --> $DIR/issue-27942.rs:5:25
    |
 LL |     fn select(&self) -> BufferViewHandle<R>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
+   |                         ^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
    = note: expected type `Resources<'_>`
               found type `Resources<'a>`
@@ -18,10 +18,10 @@ LL | pub trait Buffer<'a, R: Resources<'a>> {
    |                  ^^
 
 error[E0308]: mismatched types
-  --> $DIR/issue-27942.rs:5:5
+  --> $DIR/issue-27942.rs:5:25
    |
 LL |     fn select(&self) -> BufferViewHandle<R>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
+   |                         ^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
    = note: expected type `Resources<'_>`
               found type `Resources<'a>`

--- a/src/test/ui/issues/issue-28576.stderr
+++ b/src/test/ui/issues/issue-28576.stderr
@@ -1,11 +1,16 @@
 error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/issue-28576.rs:7:12
    |
+LL |   pub trait Bar: Foo<Assoc=()> {
+   |             ---  -------------
+   |             |    |   |
+   |             |    |   ...because it uses `Self` as a type parameter in this
+   |             |    ...because it uses `Self` as a type parameter in this
+   |             this trait cannot be made into an object...
+LL |       fn new(&self, b: &
 LL | /            dyn Bar
 LL | |               <Assoc=()>
    | |________________________^ the trait `Bar` cannot be made into an object
-   |
-   = note: the trait cannot be made into an object because it cannot use `Self` as a type parameter in the supertraits or `where`-clauses
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-28576.stderr
+++ b/src/test/ui/issues/issue-28576.stderr
@@ -5,7 +5,7 @@ LL | /            dyn Bar
 LL | |               <Assoc=()>
    | |________________________^ the trait `Bar` cannot be made into an object
    |
-   = note: the trait cannot use `Self` as a type parameter in the supertraits or where-clauses
+   = note: the trait cannot be made into an object because it cannot use `Self` as a type parameter in the supertraits or `where`-clauses
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-35976.stderr
+++ b/src/test/ui/issues/issue-35976.stderr
@@ -1,6 +1,9 @@
 error: the `wait` method cannot be invoked on a trait object
   --> $DIR/issue-35976.rs:14:9
    |
+LL |         fn wait(&self) where Self: Sized;
+   |                                    ----- this has a `Sized` requirement
+...
 LL |     arg.wait();
    |         ^^^^
    |

--- a/src/test/ui/issues/issue-38404.stderr
+++ b/src/test/ui/issues/issue-38404.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `B` cannot be made into an object
 LL | trait C<T>: A<dyn B<T, Output=usize>> {}
    |               ^^^^^^^^^^^^^^^^^^^^^^ the trait `B` cannot be made into an object
    |
-   = note: the trait cannot use `Self` as a type parameter in the supertraits or where-clauses
+   = note: the trait cannot be made into an object because it cannot use `Self` as a type parameter in the supertraits or `where`-clauses
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-38404.stderr
+++ b/src/test/ui/issues/issue-38404.stderr
@@ -1,10 +1,12 @@
 error[E0038]: the trait `B` cannot be made into an object
   --> $DIR/issue-38404.rs:3:15
    |
+LL | trait A<T>: std::ops::Add<Self> + Sized {}
+   |             ------------------- ...because it uses `Self` as a type parameter in this
+LL | trait B<T>: A<T> {}
+   |       - this trait cannot be made into an object...
 LL | trait C<T>: A<dyn B<T, Output=usize>> {}
    |               ^^^^^^^^^^^^^^^^^^^^^^ the trait `B` cannot be made into an object
-   |
-   = note: the trait cannot be made into an object because it cannot use `Self` as a type parameter in the supertraits or `where`-clauses
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-38604.stderr
+++ b/src/test/ui/issues/issue-38604.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     let _f: Box<dyn Foo> =
    |             ^^^^^^^^^^^^ the trait `Foo` cannot be made into an object
    |
-   = note: the trait cannot use `Self` as a type parameter in the supertraits or where-clauses
+   = note: the trait cannot be made into an object because it cannot use `Self` as a type parameter in the supertraits or `where`-clauses
 
 error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/issue-38604.rs:15:9
@@ -12,7 +12,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |         Box::new(());
    |         ^^^^^^^^^^^^ the trait `Foo` cannot be made into an object
    |
-   = note: the trait cannot use `Self` as a type parameter in the supertraits or where-clauses
+   = note: the trait cannot be made into an object because it cannot use `Self` as a type parameter in the supertraits or `where`-clauses
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<std::boxed::Box<dyn Foo>>` for `std::boxed::Box<()>`
    = note: required by cast to type `std::boxed::Box<dyn Foo>`
 

--- a/src/test/ui/issues/issue-38604.stderr
+++ b/src/test/ui/issues/issue-38604.stderr
@@ -1,18 +1,25 @@
 error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/issue-38604.rs:14:13
    |
+LL | trait Foo where u32: Q<Self> {
+   |       ---            ------- ...because it uses `Self` as a type parameter in this
+   |       |
+   |       this trait cannot be made into an object...
+...
 LL |     let _f: Box<dyn Foo> =
    |             ^^^^^^^^^^^^ the trait `Foo` cannot be made into an object
-   |
-   = note: the trait cannot be made into an object because it cannot use `Self` as a type parameter in the supertraits or `where`-clauses
 
 error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/issue-38604.rs:15:9
    |
+LL | trait Foo where u32: Q<Self> {
+   |       ---            ------- ...because it uses `Self` as a type parameter in this
+   |       |
+   |       this trait cannot be made into an object...
+...
 LL |         Box::new(());
    |         ^^^^^^^^^^^^ the trait `Foo` cannot be made into an object
    |
-   = note: the trait cannot be made into an object because it cannot use `Self` as a type parameter in the supertraits or `where`-clauses
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<std::boxed::Box<dyn Foo>>` for `std::boxed::Box<()>`
    = note: required by cast to type `std::boxed::Box<dyn Foo>`
 

--- a/src/test/ui/issues/issue-50781.stderr
+++ b/src/test/ui/issues/issue-50781.stderr
@@ -1,8 +1,10 @@
 error: the trait `X` cannot be made into an object
   --> $DIR/issue-50781.rs:6:8
    |
+LL | trait X {
+   |       - this trait cannot be made into an object...
 LL |     fn foo(&self) where Self: Trait;
-   |        ^^^ method `foo` references the `Self` type in where clauses
+   |        ^^^ ...because method `foo` references the `Self` type in its `where` clause
    |
 note: the lint level is defined here
   --> $DIR/issue-50781.rs:1:9
@@ -11,6 +13,7 @@ LL | #![deny(where_clauses_object_safety)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #51443 <https://github.com/rust-lang/rust/issues/51443>
+   = help: consider moving `foo` to another trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-50781.stderr
+++ b/src/test/ui/issues/issue-50781.stderr
@@ -2,7 +2,7 @@ error: the trait `X` cannot be made into an object
   --> $DIR/issue-50781.rs:6:8
    |
 LL |     fn foo(&self) where Self: Trait;
-   |        ^^^
+   |        ^^^ method `foo` references the `Self` type in where clauses
    |
 note: the lint level is defined here
   --> $DIR/issue-50781.rs:1:9
@@ -11,7 +11,6 @@ LL | #![deny(where_clauses_object_safety)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #51443 <https://github.com/rust-lang/rust/issues/51443>
-   = note: method `foo` references the `Self` type in where clauses
 
 error: aborting due to previous error
 

--- a/src/test/ui/kindck/kindck-inherited-copy-bound.curr.stderr
+++ b/src/test/ui/kindck/kindck-inherited-copy-bound.curr.stderr
@@ -13,7 +13,9 @@ error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/kindck-inherited-copy-bound.rs:28:19
    |
 LL | trait Foo : Copy {
-   |             ---- traits that require `Self: Sized` cannot be made into an object
+   |       ---   ---- ...because it requires `Self: Sized`
+   |       |
+   |       this trait cannot be made into an object...
 ...
 LL |     let z = &x as &dyn Foo;
    |                   ^^^^^^^^ the trait `Foo` cannot be made into an object
@@ -22,7 +24,9 @@ error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/kindck-inherited-copy-bound.rs:28:13
    |
 LL | trait Foo : Copy {
-   |             ---- traits that require `Self: Sized` cannot be made into an object
+   |       ---   ---- ...because it requires `Self: Sized`
+   |       |
+   |       this trait cannot be made into an object...
 ...
 LL |     let z = &x as &dyn Foo;
    |             ^^ the trait `Foo` cannot be made into an object

--- a/src/test/ui/kindck/kindck-inherited-copy-bound.curr.stderr
+++ b/src/test/ui/kindck/kindck-inherited-copy-bound.curr.stderr
@@ -12,18 +12,21 @@ LL |     take_param(&x);
 error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/kindck-inherited-copy-bound.rs:28:19
    |
+LL | trait Foo : Copy {
+   |             ---- the trait cannot require that `Self : Sized`
+...
 LL |     let z = &x as &dyn Foo;
    |                   ^^^^^^^^ the trait `Foo` cannot be made into an object
-   |
-   = note: the trait cannot require that `Self : Sized`
 
 error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/kindck-inherited-copy-bound.rs:28:13
    |
+LL | trait Foo : Copy {
+   |             ---- the trait cannot require that `Self : Sized`
+...
 LL |     let z = &x as &dyn Foo;
    |             ^^ the trait `Foo` cannot be made into an object
    |
-   = note: the trait cannot require that `Self : Sized`
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<&dyn Foo>` for `&std::boxed::Box<{integer}>`
    = note: required by cast to type `&dyn Foo`
 

--- a/src/test/ui/kindck/kindck-inherited-copy-bound.curr.stderr
+++ b/src/test/ui/kindck/kindck-inherited-copy-bound.curr.stderr
@@ -13,7 +13,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/kindck-inherited-copy-bound.rs:28:19
    |
 LL | trait Foo : Copy {
-   |             ---- the trait cannot require that `Self : Sized`
+   |             ---- traits that require `Self: Sized` cannot be made into an object
 ...
 LL |     let z = &x as &dyn Foo;
    |                   ^^^^^^^^ the trait `Foo` cannot be made into an object
@@ -22,7 +22,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/kindck-inherited-copy-bound.rs:28:13
    |
 LL | trait Foo : Copy {
-   |             ---- the trait cannot require that `Self : Sized`
+   |             ---- traits that require `Self: Sized` cannot be made into an object
 ...
 LL |     let z = &x as &dyn Foo;
    |             ^^ the trait `Foo` cannot be made into an object

--- a/src/test/ui/kindck/kindck-inherited-copy-bound.object_safe_for_dispatch.stderr
+++ b/src/test/ui/kindck/kindck-inherited-copy-bound.object_safe_for_dispatch.stderr
@@ -13,7 +13,9 @@ error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/kindck-inherited-copy-bound.rs:28:13
    |
 LL | trait Foo : Copy {
-   |             ---- traits that require `Self: Sized` cannot be made into an object
+   |       ---   ---- ...because it requires `Self: Sized`
+   |       |
+   |       this trait cannot be made into an object...
 ...
 LL |     let z = &x as &dyn Foo;
    |             ^^ the trait `Foo` cannot be made into an object

--- a/src/test/ui/kindck/kindck-inherited-copy-bound.object_safe_for_dispatch.stderr
+++ b/src/test/ui/kindck/kindck-inherited-copy-bound.object_safe_for_dispatch.stderr
@@ -13,7 +13,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/kindck-inherited-copy-bound.rs:28:13
    |
 LL | trait Foo : Copy {
-   |             ---- the trait cannot require that `Self : Sized`
+   |             ---- traits that require `Self: Sized` cannot be made into an object
 ...
 LL |     let z = &x as &dyn Foo;
    |             ^^ the trait `Foo` cannot be made into an object

--- a/src/test/ui/kindck/kindck-inherited-copy-bound.object_safe_for_dispatch.stderr
+++ b/src/test/ui/kindck/kindck-inherited-copy-bound.object_safe_for_dispatch.stderr
@@ -12,10 +12,12 @@ LL |     take_param(&x);
 error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/kindck-inherited-copy-bound.rs:28:13
    |
+LL | trait Foo : Copy {
+   |             ---- the trait cannot require that `Self : Sized`
+...
 LL |     let z = &x as &dyn Foo;
    |             ^^ the trait `Foo` cannot be made into an object
    |
-   = note: the trait cannot require that `Self : Sized`
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<&dyn Foo>` for `&std::boxed::Box<i32>`
    = note: required by cast to type `&dyn Foo`
 

--- a/src/test/ui/lifetimes/lifetime-doesnt-live-long-enough.stderr
+++ b/src/test/ui/lifetimes/lifetime-doesnt-live-long-enough.stderr
@@ -13,87 +13,69 @@ LL |     foo: &'static T
    |     ^^^^^^^^^^^^^^^
 
 error[E0309]: the parameter type `K` may not live long enough
-  --> $DIR/lifetime-doesnt-live-long-enough.rs:24:5
+  --> $DIR/lifetime-doesnt-live-long-enough.rs:24:8
    |
 LL | trait X<K>: Sized {
    |         - help: consider adding an explicit lifetime bound `K: 'a`...
 LL |     fn foo<'a, L: X<&'a Nested<K>>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^^
    |
 note: ...so that the reference type `&'a Nested<K>` does not outlive the data it points at
-  --> $DIR/lifetime-doesnt-live-long-enough.rs:24:5
+  --> $DIR/lifetime-doesnt-live-long-enough.rs:24:8
    |
 LL |     fn foo<'a, L: X<&'a Nested<K>>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^^
 
 error[E0309]: the parameter type `Self` may not live long enough
-  --> $DIR/lifetime-doesnt-live-long-enough.rs:28:5
+  --> $DIR/lifetime-doesnt-live-long-enough.rs:28:8
    |
 LL |     fn bar<'a, L: X<&'a Nested<Self>>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^^
    |
    = help: consider adding an explicit lifetime bound `Self: 'a`...
 note: ...so that the reference type `&'a Nested<Self>` does not outlive the data it points at
-  --> $DIR/lifetime-doesnt-live-long-enough.rs:28:5
+  --> $DIR/lifetime-doesnt-live-long-enough.rs:28:8
    |
 LL |     fn bar<'a, L: X<&'a Nested<Self>>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^^
 
 error[E0309]: the parameter type `L` may not live long enough
-  --> $DIR/lifetime-doesnt-live-long-enough.rs:32:5
+  --> $DIR/lifetime-doesnt-live-long-enough.rs:32:8
    |
-LL |       fn baz<'a, L, M: X<&'a Nested<L>>>() {
-   |       ^          - help: consider adding an explicit lifetime bound `L: 'a`...
-   |  _____|
-   | |
-LL | |
-LL | |     }
-   | |_____^
+LL |     fn baz<'a, L, M: X<&'a Nested<L>>>() {
+   |        ^^^     - help: consider adding an explicit lifetime bound `L: 'a`...
    |
 note: ...so that the reference type `&'a Nested<L>` does not outlive the data it points at
-  --> $DIR/lifetime-doesnt-live-long-enough.rs:32:5
+  --> $DIR/lifetime-doesnt-live-long-enough.rs:32:8
    |
-LL | /     fn baz<'a, L, M: X<&'a Nested<L>>>() {
-LL | |
-LL | |     }
-   | |_____^
+LL |     fn baz<'a, L, M: X<&'a Nested<L>>>() {
+   |        ^^^
 
 error[E0309]: the parameter type `K` may not live long enough
-  --> $DIR/lifetime-doesnt-live-long-enough.rs:41:5
+  --> $DIR/lifetime-doesnt-live-long-enough.rs:41:8
    |
-LL |   impl<K> Nested<K> {
-   |        - help: consider adding an explicit lifetime bound `K: 'a`...
-LL | /     fn generic_in_parent<'a, L: X<&'a Nested<K>>>() {
-LL | |
-LL | |     }
-   | |_____^
+LL | impl<K> Nested<K> {
+   |      - help: consider adding an explicit lifetime bound `K: 'a`...
+LL |     fn generic_in_parent<'a, L: X<&'a Nested<K>>>() {
+   |        ^^^^^^^^^^^^^^^^^
    |
 note: ...so that the reference type `&'a Nested<K>` does not outlive the data it points at
-  --> $DIR/lifetime-doesnt-live-long-enough.rs:41:5
+  --> $DIR/lifetime-doesnt-live-long-enough.rs:41:8
    |
-LL | /     fn generic_in_parent<'a, L: X<&'a Nested<K>>>() {
-LL | |
-LL | |     }
-   | |_____^
+LL |     fn generic_in_parent<'a, L: X<&'a Nested<K>>>() {
+   |        ^^^^^^^^^^^^^^^^^
 
 error[E0309]: the parameter type `M` may not live long enough
-  --> $DIR/lifetime-doesnt-live-long-enough.rs:44:5
+  --> $DIR/lifetime-doesnt-live-long-enough.rs:44:8
    |
-LL |       fn generic_in_child<'a, 'b, L: X<&'a Nested<M>>, M: 'b>() {
-   |       ^                                                -- help: consider adding an explicit lifetime bound `M: 'a`...
-   |  _____|
-   | |
-LL | |
-LL | |     }
-   | |_____^
+LL |     fn generic_in_child<'a, 'b, L: X<&'a Nested<M>>, M: 'b>() {
+   |        ^^^^^^^^^^^^^^^^                              -- help: consider adding an explicit lifetime bound `M: 'a`...
    |
 note: ...so that the reference type `&'a Nested<M>` does not outlive the data it points at
-  --> $DIR/lifetime-doesnt-live-long-enough.rs:44:5
+  --> $DIR/lifetime-doesnt-live-long-enough.rs:44:8
    |
-LL | /     fn generic_in_child<'a, 'b, L: X<&'a Nested<M>>, M: 'b>() {
-LL | |
-LL | |     }
-   | |_____^
+LL |     fn generic_in_child<'a, 'b, L: X<&'a Nested<M>>, M: 'b>() {
+   |        ^^^^^^^^^^^^^^^^
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/lifetimes/lifetime-doesnt-live-long-enough.stderr
+++ b/src/test/ui/lifetimes/lifetime-doesnt-live-long-enough.stderr
@@ -13,69 +13,71 @@ LL |     foo: &'static T
    |     ^^^^^^^^^^^^^^^
 
 error[E0309]: the parameter type `K` may not live long enough
-  --> $DIR/lifetime-doesnt-live-long-enough.rs:24:8
+  --> $DIR/lifetime-doesnt-live-long-enough.rs:24:19
    |
 LL | trait X<K>: Sized {
    |         - help: consider adding an explicit lifetime bound `K: 'a`...
 LL |     fn foo<'a, L: X<&'a Nested<K>>>();
-   |        ^^^
+   |                   ^^^^^^^^^^^^^^^^
    |
 note: ...so that the reference type `&'a Nested<K>` does not outlive the data it points at
-  --> $DIR/lifetime-doesnt-live-long-enough.rs:24:8
+  --> $DIR/lifetime-doesnt-live-long-enough.rs:24:19
    |
 LL |     fn foo<'a, L: X<&'a Nested<K>>>();
-   |        ^^^
+   |                   ^^^^^^^^^^^^^^^^
 
 error[E0309]: the parameter type `Self` may not live long enough
-  --> $DIR/lifetime-doesnt-live-long-enough.rs:28:8
+  --> $DIR/lifetime-doesnt-live-long-enough.rs:28:19
    |
 LL |     fn bar<'a, L: X<&'a Nested<Self>>>();
-   |        ^^^
+   |                   ^^^^^^^^^^^^^^^^^^^
    |
    = help: consider adding an explicit lifetime bound `Self: 'a`...
 note: ...so that the reference type `&'a Nested<Self>` does not outlive the data it points at
-  --> $DIR/lifetime-doesnt-live-long-enough.rs:28:8
+  --> $DIR/lifetime-doesnt-live-long-enough.rs:28:19
    |
 LL |     fn bar<'a, L: X<&'a Nested<Self>>>();
-   |        ^^^
+   |                   ^^^^^^^^^^^^^^^^^^^
 
 error[E0309]: the parameter type `L` may not live long enough
-  --> $DIR/lifetime-doesnt-live-long-enough.rs:32:8
+  --> $DIR/lifetime-doesnt-live-long-enough.rs:32:22
    |
 LL |     fn baz<'a, L, M: X<&'a Nested<L>>>() {
-   |        ^^^     - help: consider adding an explicit lifetime bound `L: 'a`...
+   |                -     ^^^^^^^^^^^^^^^^
+   |                |
+   |                help: consider adding an explicit lifetime bound `L: 'a`...
    |
 note: ...so that the reference type `&'a Nested<L>` does not outlive the data it points at
-  --> $DIR/lifetime-doesnt-live-long-enough.rs:32:8
+  --> $DIR/lifetime-doesnt-live-long-enough.rs:32:22
    |
 LL |     fn baz<'a, L, M: X<&'a Nested<L>>>() {
-   |        ^^^
+   |                      ^^^^^^^^^^^^^^^^
 
 error[E0309]: the parameter type `K` may not live long enough
-  --> $DIR/lifetime-doesnt-live-long-enough.rs:41:8
+  --> $DIR/lifetime-doesnt-live-long-enough.rs:41:33
    |
 LL | impl<K> Nested<K> {
    |      - help: consider adding an explicit lifetime bound `K: 'a`...
 LL |     fn generic_in_parent<'a, L: X<&'a Nested<K>>>() {
-   |        ^^^^^^^^^^^^^^^^^
+   |                                 ^^^^^^^^^^^^^^^^
    |
 note: ...so that the reference type `&'a Nested<K>` does not outlive the data it points at
-  --> $DIR/lifetime-doesnt-live-long-enough.rs:41:8
+  --> $DIR/lifetime-doesnt-live-long-enough.rs:41:33
    |
 LL |     fn generic_in_parent<'a, L: X<&'a Nested<K>>>() {
-   |        ^^^^^^^^^^^^^^^^^
+   |                                 ^^^^^^^^^^^^^^^^
 
 error[E0309]: the parameter type `M` may not live long enough
-  --> $DIR/lifetime-doesnt-live-long-enough.rs:44:8
+  --> $DIR/lifetime-doesnt-live-long-enough.rs:44:36
    |
 LL |     fn generic_in_child<'a, 'b, L: X<&'a Nested<M>>, M: 'b>() {
-   |        ^^^^^^^^^^^^^^^^                              -- help: consider adding an explicit lifetime bound `M: 'a`...
+   |                                    ^^^^^^^^^^^^^^^^  -- help: consider adding an explicit lifetime bound `M: 'a`...
    |
 note: ...so that the reference type `&'a Nested<M>` does not outlive the data it points at
-  --> $DIR/lifetime-doesnt-live-long-enough.rs:44:8
+  --> $DIR/lifetime-doesnt-live-long-enough.rs:44:36
    |
 LL |     fn generic_in_child<'a, 'b, L: X<&'a Nested<M>>, M: 'b>() {
-   |        ^^^^^^^^^^^^^^^^
+   |                                    ^^^^^^^^^^^^^^^^
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/object-safety/object-safety-associated-consts.curr.stderr
+++ b/src/test/ui/object-safety/object-safety-associated-consts.curr.stderr
@@ -1,11 +1,11 @@
 error[E0038]: the trait `Bar` cannot be made into an object
-  --> $DIR/object-safety-associated-consts.rs:12:1
+  --> $DIR/object-safety-associated-consts.rs:12:30
    |
 LL |     const X: usize;
    |           - the trait cannot contain associated consts like `X`
 ...
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar` cannot be made into an object
+   |                              ^^^^^^^^ the trait `Bar` cannot be made into an object
 
 error: aborting due to previous error
 

--- a/src/test/ui/object-safety/object-safety-associated-consts.curr.stderr
+++ b/src/test/ui/object-safety/object-safety-associated-consts.curr.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL | trait Bar {
    |       --- this trait cannot be made into an object...
 LL |     const X: usize;
-   |           - ...because it cannot contain associated consts like `X`
+   |           - ...because it contains this associated `const`
 ...
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
    |                              ^^^^^^^^ the trait `Bar` cannot be made into an object

--- a/src/test/ui/object-safety/object-safety-associated-consts.curr.stderr
+++ b/src/test/ui/object-safety/object-safety-associated-consts.curr.stderr
@@ -1,11 +1,15 @@
 error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/object-safety-associated-consts.rs:12:30
    |
+LL | trait Bar {
+   |       --- this trait cannot be made into an object...
 LL |     const X: usize;
-   |           - the trait cannot contain associated consts like `X`
+   |           - ...because it cannot contain associated consts like `X`
 ...
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
    |                              ^^^^^^^^ the trait `Bar` cannot be made into an object
+   |
+   = help: consider moving `X` to another trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/object-safety/object-safety-associated-consts.object_safe_for_dispatch.stderr
+++ b/src/test/ui/object-safety/object-safety-associated-consts.object_safe_for_dispatch.stderr
@@ -1,12 +1,15 @@
 error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/object-safety-associated-consts.rs:14:5
    |
+LL | trait Bar {
+   |       --- this trait cannot be made into an object...
 LL |     const X: usize;
-   |           - the trait cannot contain associated consts like `X`
+   |           - ...because it cannot contain associated consts like `X`
 ...
 LL |     t
    |     ^ the trait `Bar` cannot be made into an object
    |
+   = help: consider moving `X` to another trait
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<&dyn Bar>` for `&T`
    = note: required by cast to type `&dyn Bar`
 

--- a/src/test/ui/object-safety/object-safety-associated-consts.object_safe_for_dispatch.stderr
+++ b/src/test/ui/object-safety/object-safety-associated-consts.object_safe_for_dispatch.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL | trait Bar {
    |       --- this trait cannot be made into an object...
 LL |     const X: usize;
-   |           - ...because it cannot contain associated consts like `X`
+   |           - ...because it contains this associated `const`
 ...
 LL |     t
    |     ^ the trait `Bar` cannot be made into an object

--- a/src/test/ui/object-safety/object-safety-generics.curr.stderr
+++ b/src/test/ui/object-safety/object-safety-generics.curr.stderr
@@ -1,20 +1,20 @@
 error[E0038]: the trait `Bar` cannot be made into an object
-  --> $DIR/object-safety-generics.rs:18:1
+  --> $DIR/object-safety-generics.rs:18:30
    |
 LL |     fn bar<T>(&self, t: T);
    |        --- method `bar` has generic type parameters
 ...
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar` cannot be made into an object
+   |                              ^^^^^^^^ the trait `Bar` cannot be made into an object
 
 error[E0038]: the trait `Bar` cannot be made into an object
-  --> $DIR/object-safety-generics.rs:24:1
+  --> $DIR/object-safety-generics.rs:24:39
    |
 LL |     fn bar<T>(&self, t: T);
    |        --- method `bar` has generic type parameters
 ...
 LL | fn make_bar_explicit<T:Bar>(t: &T) -> &dyn Bar {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar` cannot be made into an object
+   |                                       ^^^^^^^^ the trait `Bar` cannot be made into an object
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/object-safety/object-safety-generics.curr.stderr
+++ b/src/test/ui/object-safety/object-safety-generics.curr.stderr
@@ -1,20 +1,28 @@
 error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/object-safety-generics.rs:18:30
    |
+LL | trait Bar {
+   |       --- this trait cannot be made into an object...
 LL |     fn bar<T>(&self, t: T);
-   |        --- method `bar` has generic type parameters
+   |        --- ...because method `bar` has generic type parameters
 ...
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
    |                              ^^^^^^^^ the trait `Bar` cannot be made into an object
+   |
+   = help: consider moving `bar` to another trait
 
 error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/object-safety-generics.rs:24:39
    |
+LL | trait Bar {
+   |       --- this trait cannot be made into an object...
 LL |     fn bar<T>(&self, t: T);
-   |        --- method `bar` has generic type parameters
+   |        --- ...because method `bar` has generic type parameters
 ...
 LL | fn make_bar_explicit<T:Bar>(t: &T) -> &dyn Bar {
    |                                       ^^^^^^^^ the trait `Bar` cannot be made into an object
+   |
+   = help: consider moving `bar` to another trait
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/object-safety/object-safety-generics.object_safe_for_dispatch.stderr
+++ b/src/test/ui/object-safety/object-safety-generics.object_safe_for_dispatch.stderr
@@ -1,24 +1,30 @@
 error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/object-safety-generics.rs:20:5
    |
+LL | trait Bar {
+   |       --- this trait cannot be made into an object...
 LL |     fn bar<T>(&self, t: T);
-   |        --- method `bar` has generic type parameters
+   |        --- ...because method `bar` has generic type parameters
 ...
 LL |     t
    |     ^ the trait `Bar` cannot be made into an object
    |
+   = help: consider moving `bar` to another trait
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<&dyn Bar>` for `&T`
    = note: required by cast to type `&dyn Bar`
 
 error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/object-safety-generics.rs:26:5
    |
+LL | trait Bar {
+   |       --- this trait cannot be made into an object...
 LL |     fn bar<T>(&self, t: T);
-   |        --- method `bar` has generic type parameters
+   |        --- ...because method `bar` has generic type parameters
 ...
 LL |     t as &dyn Bar
    |     ^ the trait `Bar` cannot be made into an object
    |
+   = help: consider moving `bar` to another trait
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<&dyn Bar>` for `&T`
    = note: required by cast to type `&dyn Bar`
 

--- a/src/test/ui/object-safety/object-safety-issue-22040.stderr
+++ b/src/test/ui/object-safety/object-safety-issue-22040.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Expr` cannot be made into an object
 LL |     elements: Vec<Box<dyn Expr + 'x>>,
    |                       ^^^^^^^^^^^^^ the trait `Expr` cannot be made into an object
    |
-   = note: the trait cannot use `Self` as a type parameter in the supertraits or where-clauses
+   = note: the trait cannot be made into an object because it cannot use `Self` as a type parameter in the supertraits or `where`-clauses
 
 error: aborting due to previous error
 

--- a/src/test/ui/object-safety/object-safety-issue-22040.stderr
+++ b/src/test/ui/object-safety/object-safety-issue-22040.stderr
@@ -1,10 +1,13 @@
 error[E0038]: the trait `Expr` cannot be made into an object
   --> $DIR/object-safety-issue-22040.rs:12:23
    |
+LL | trait Expr: Debug + PartialEq {
+   |       ----          --------- ...because it uses `Self` as a type parameter in this
+   |       |
+   |       this trait cannot be made into an object...
+...
 LL |     elements: Vec<Box<dyn Expr + 'x>>,
    |                       ^^^^^^^^^^^^^ the trait `Expr` cannot be made into an object
-   |
-   = note: the trait cannot be made into an object because it cannot use `Self` as a type parameter in the supertraits or `where`-clauses
 
 error: aborting due to previous error
 

--- a/src/test/ui/object-safety/object-safety-mentions-Self.curr.stderr
+++ b/src/test/ui/object-safety/object-safety-mentions-Self.curr.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL | trait Bar {
    |       --- this trait cannot be made into an object...
 LL |     fn bar(&self, x: &Self);
-   |        --- ...because method `bar` references the `Self` type in its parameters or return type
+   |                      ----- ...because method `bar` references the `Self` type in this parameter
 ...
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
    |                              ^^^^^^^^ the trait `Bar` cannot be made into an object
@@ -17,7 +17,7 @@ error[E0038]: the trait `Baz` cannot be made into an object
 LL | trait Baz {
    |       --- this trait cannot be made into an object...
 LL |     fn baz(&self) -> Self;
-   |        --- ...because method `baz` references the `Self` type in its parameters or return type
+   |                      ---- ...because method `baz` references the `Self` type in its return type
 ...
 LL | fn make_baz<T:Baz>(t: &T) -> &dyn Baz {
    |                              ^^^^^^^^ the trait `Baz` cannot be made into an object

--- a/src/test/ui/object-safety/object-safety-mentions-Self.curr.stderr
+++ b/src/test/ui/object-safety/object-safety-mentions-Self.curr.stderr
@@ -1,20 +1,28 @@
 error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/object-safety-mentions-Self.rs:22:30
    |
+LL | trait Bar {
+   |       --- this trait cannot be made into an object...
 LL |     fn bar(&self, x: &Self);
-   |        --- method `bar` references the `Self` type in its parameters or return type
+   |        --- ...because method `bar` references the `Self` type in its parameters or return type
 ...
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
    |                              ^^^^^^^^ the trait `Bar` cannot be made into an object
+   |
+   = help: consider moving `bar` to another trait
 
 error[E0038]: the trait `Baz` cannot be made into an object
   --> $DIR/object-safety-mentions-Self.rs:28:30
    |
+LL | trait Baz {
+   |       --- this trait cannot be made into an object...
 LL |     fn baz(&self) -> Self;
-   |        --- method `baz` references the `Self` type in its parameters or return type
+   |        --- ...because method `baz` references the `Self` type in its parameters or return type
 ...
 LL | fn make_baz<T:Baz>(t: &T) -> &dyn Baz {
    |                              ^^^^^^^^ the trait `Baz` cannot be made into an object
+   |
+   = help: consider moving `baz` to another trait
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/object-safety/object-safety-mentions-Self.curr.stderr
+++ b/src/test/ui/object-safety/object-safety-mentions-Self.curr.stderr
@@ -1,20 +1,20 @@
 error[E0038]: the trait `Bar` cannot be made into an object
-  --> $DIR/object-safety-mentions-Self.rs:22:1
+  --> $DIR/object-safety-mentions-Self.rs:22:30
    |
 LL |     fn bar(&self, x: &Self);
    |        --- method `bar` references the `Self` type in its parameters or return type
 ...
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar` cannot be made into an object
+   |                              ^^^^^^^^ the trait `Bar` cannot be made into an object
 
 error[E0038]: the trait `Baz` cannot be made into an object
-  --> $DIR/object-safety-mentions-Self.rs:28:1
+  --> $DIR/object-safety-mentions-Self.rs:28:30
    |
 LL |     fn baz(&self) -> Self;
    |        --- method `baz` references the `Self` type in its parameters or return type
 ...
 LL | fn make_baz<T:Baz>(t: &T) -> &dyn Baz {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Baz` cannot be made into an object
+   |                              ^^^^^^^^ the trait `Baz` cannot be made into an object
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/object-safety/object-safety-mentions-Self.object_safe_for_dispatch.stderr
+++ b/src/test/ui/object-safety/object-safety-mentions-Self.object_safe_for_dispatch.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL | trait Bar {
    |       --- this trait cannot be made into an object...
 LL |     fn bar(&self, x: &Self);
-   |        --- ...because method `bar` references the `Self` type in its parameters or return type
+   |                      ----- ...because method `bar` references the `Self` type in this parameter
 ...
 LL |     t
    |     ^ the trait `Bar` cannot be made into an object
@@ -19,7 +19,7 @@ error[E0038]: the trait `Baz` cannot be made into an object
 LL | trait Baz {
    |       --- this trait cannot be made into an object...
 LL |     fn baz(&self) -> Self;
-   |        --- ...because method `baz` references the `Self` type in its parameters or return type
+   |                      ---- ...because method `baz` references the `Self` type in its return type
 ...
 LL |     t
    |     ^ the trait `Baz` cannot be made into an object

--- a/src/test/ui/object-safety/object-safety-mentions-Self.object_safe_for_dispatch.stderr
+++ b/src/test/ui/object-safety/object-safety-mentions-Self.object_safe_for_dispatch.stderr
@@ -1,24 +1,30 @@
 error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/object-safety-mentions-Self.rs:24:5
    |
+LL | trait Bar {
+   |       --- this trait cannot be made into an object...
 LL |     fn bar(&self, x: &Self);
-   |        --- method `bar` references the `Self` type in its parameters or return type
+   |        --- ...because method `bar` references the `Self` type in its parameters or return type
 ...
 LL |     t
    |     ^ the trait `Bar` cannot be made into an object
    |
+   = help: consider moving `bar` to another trait
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<&dyn Bar>` for `&T`
    = note: required by cast to type `&dyn Bar`
 
 error[E0038]: the trait `Baz` cannot be made into an object
   --> $DIR/object-safety-mentions-Self.rs:30:5
    |
+LL | trait Baz {
+   |       --- this trait cannot be made into an object...
 LL |     fn baz(&self) -> Self;
-   |        --- method `baz` references the `Self` type in its parameters or return type
+   |        --- ...because method `baz` references the `Self` type in its parameters or return type
 ...
 LL |     t
    |     ^ the trait `Baz` cannot be made into an object
    |
+   = help: consider moving `baz` to another trait
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<&dyn Baz>` for `&T`
    = note: required by cast to type `&dyn Baz`
 

--- a/src/test/ui/object-safety/object-safety-no-static.curr.stderr
+++ b/src/test/ui/object-safety/object-safety-no-static.curr.stderr
@@ -1,11 +1,11 @@
 error[E0038]: the trait `Foo` cannot be made into an object
-  --> $DIR/object-safety-no-static.rs:12:1
+  --> $DIR/object-safety-no-static.rs:12:18
    |
 LL |     fn foo() {}
    |        --- associated function `foo` has no `self` parameter
 ...
 LL | fn diverges() -> Box<dyn Foo> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` cannot be made into an object
+   |                  ^^^^^^^^^^^^ the trait `Foo` cannot be made into an object
 
 error: aborting due to previous error
 

--- a/src/test/ui/object-safety/object-safety-no-static.curr.stderr
+++ b/src/test/ui/object-safety/object-safety-no-static.curr.stderr
@@ -9,7 +9,10 @@ LL |     fn foo() {}
 LL | fn diverges() -> Box<dyn Foo> {
    |                  ^^^^^^^^^^^^ the trait `Foo` cannot be made into an object
    |
-   = help: consider turning `foo` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
+help: consider turning `foo` into a method by giving it a `&self` argument or constraining it so it does not apply to trait objects
+   |
+LL |     fn foo() where Self: Sized {}
+   |              ^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/object-safety/object-safety-no-static.curr.stderr
+++ b/src/test/ui/object-safety/object-safety-no-static.curr.stderr
@@ -1,11 +1,15 @@
 error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/object-safety-no-static.rs:12:18
    |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
 LL |     fn foo() {}
-   |        --- associated function `foo` has no `self` parameter
+   |        --- ...because associated function `foo` has no `self` parameter
 ...
 LL | fn diverges() -> Box<dyn Foo> {
    |                  ^^^^^^^^^^^^ the trait `Foo` cannot be made into an object
+   |
+   = help: consider turning `foo` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
 
 error: aborting due to previous error
 

--- a/src/test/ui/object-safety/object-safety-no-static.object_safe_for_dispatch.stderr
+++ b/src/test/ui/object-safety/object-safety-no-static.object_safe_for_dispatch.stderr
@@ -9,9 +9,12 @@ LL |     fn foo() {}
 LL |     let b: Box<dyn Foo> = Box::new(Bar);
    |                           ^^^^^^^^^^^^^ the trait `Foo` cannot be made into an object
    |
-   = help: consider turning `foo` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<std::boxed::Box<dyn Foo>>` for `std::boxed::Box<Bar>`
    = note: required by cast to type `std::boxed::Box<dyn Foo>`
+help: consider turning `foo` into a method by giving it a `&self` argument or constraining it so it does not apply to trait objects
+   |
+LL |     fn foo() where Self: Sized {}
+   |              ^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/object-safety/object-safety-no-static.object_safe_for_dispatch.stderr
+++ b/src/test/ui/object-safety/object-safety-no-static.object_safe_for_dispatch.stderr
@@ -1,12 +1,15 @@
 error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/object-safety-no-static.rs:22:27
    |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
 LL |     fn foo() {}
-   |        --- associated function `foo` has no `self` parameter
+   |        --- ...because associated function `foo` has no `self` parameter
 ...
 LL |     let b: Box<dyn Foo> = Box::new(Bar);
    |                           ^^^^^^^^^^^^^ the trait `Foo` cannot be made into an object
    |
+   = help: consider turning `foo` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<std::boxed::Box<dyn Foo>>` for `std::boxed::Box<Bar>`
    = note: required by cast to type `std::boxed::Box<dyn Foo>`
 

--- a/src/test/ui/object-safety/object-safety-sized-2.curr.stderr
+++ b/src/test/ui/object-safety/object-safety-sized-2.curr.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Bar` cannot be made into an object
-  --> $DIR/object-safety-sized-2.rs:14:1
+  --> $DIR/object-safety-sized-2.rs:14:30
    |
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar` cannot be made into an object
+   |                              ^^^^^^^^ the trait `Bar` cannot be made into an object
    |
    = note: the trait cannot require that `Self : Sized`
 

--- a/src/test/ui/object-safety/object-safety-sized-2.curr.stderr
+++ b/src/test/ui/object-safety/object-safety-sized-2.curr.stderr
@@ -2,7 +2,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/object-safety-sized-2.rs:14:30
    |
 LL |     where Self : Sized
-   |                  ----- the trait cannot require that `Self : Sized`
+   |                  ----- traits that require `Self: Sized` cannot be made into an object
 ...
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
    |                              ^^^^^^^^ the trait `Bar` cannot be made into an object

--- a/src/test/ui/object-safety/object-safety-sized-2.curr.stderr
+++ b/src/test/ui/object-safety/object-safety-sized-2.curr.stderr
@@ -1,10 +1,11 @@
 error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/object-safety-sized-2.rs:14:30
    |
+LL |     where Self : Sized
+   |                  ----- the trait cannot require that `Self : Sized`
+...
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
    |                              ^^^^^^^^ the trait `Bar` cannot be made into an object
-   |
-   = note: the trait cannot require that `Self : Sized`
 
 error: aborting due to previous error
 

--- a/src/test/ui/object-safety/object-safety-sized-2.curr.stderr
+++ b/src/test/ui/object-safety/object-safety-sized-2.curr.stderr
@@ -1,8 +1,10 @@
 error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/object-safety-sized-2.rs:14:30
    |
+LL | trait Bar
+   |       --- this trait cannot be made into an object...
 LL |     where Self : Sized
-   |                  ----- traits that require `Self: Sized` cannot be made into an object
+   |                  ----- ...because it requires `Self: Sized`
 ...
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
    |                              ^^^^^^^^ the trait `Bar` cannot be made into an object

--- a/src/test/ui/object-safety/object-safety-sized-2.object_safe_for_dispatch.stderr
+++ b/src/test/ui/object-safety/object-safety-sized-2.object_safe_for_dispatch.stderr
@@ -2,7 +2,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/object-safety-sized-2.rs:16:5
    |
 LL |     where Self : Sized
-   |                  ----- the trait cannot require that `Self : Sized`
+   |                  ----- traits that require `Self: Sized` cannot be made into an object
 ...
 LL |     t
    |     ^ the trait `Bar` cannot be made into an object

--- a/src/test/ui/object-safety/object-safety-sized-2.object_safe_for_dispatch.stderr
+++ b/src/test/ui/object-safety/object-safety-sized-2.object_safe_for_dispatch.stderr
@@ -1,8 +1,10 @@
 error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/object-safety-sized-2.rs:16:5
    |
+LL | trait Bar
+   |       --- this trait cannot be made into an object...
 LL |     where Self : Sized
-   |                  ----- traits that require `Self: Sized` cannot be made into an object
+   |                  ----- ...because it requires `Self: Sized`
 ...
 LL |     t
    |     ^ the trait `Bar` cannot be made into an object

--- a/src/test/ui/object-safety/object-safety-sized-2.object_safe_for_dispatch.stderr
+++ b/src/test/ui/object-safety/object-safety-sized-2.object_safe_for_dispatch.stderr
@@ -1,10 +1,12 @@
 error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/object-safety-sized-2.rs:16:5
    |
+LL |     where Self : Sized
+   |                  ----- the trait cannot require that `Self : Sized`
+...
 LL |     t
    |     ^ the trait `Bar` cannot be made into an object
    |
-   = note: the trait cannot require that `Self : Sized`
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<&dyn Bar>` for `&T`
    = note: required by cast to type `&dyn Bar`
 

--- a/src/test/ui/object-safety/object-safety-sized.curr.stderr
+++ b/src/test/ui/object-safety/object-safety-sized.curr.stderr
@@ -2,7 +2,9 @@ error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/object-safety-sized.rs:12:30
    |
 LL | trait Bar : Sized {
-   |             ----- traits that require `Self: Sized` cannot be made into an object
+   |       ---   ----- ...because it requires `Self: Sized`
+   |       |
+   |       this trait cannot be made into an object...
 ...
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
    |                              ^^^^^^^^ the trait `Bar` cannot be made into an object

--- a/src/test/ui/object-safety/object-safety-sized.curr.stderr
+++ b/src/test/ui/object-safety/object-safety-sized.curr.stderr
@@ -2,7 +2,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/object-safety-sized.rs:12:30
    |
 LL | trait Bar : Sized {
-   |             ----- the trait cannot require that `Self : Sized`
+   |             ----- traits that require `Self: Sized` cannot be made into an object
 ...
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
    |                              ^^^^^^^^ the trait `Bar` cannot be made into an object

--- a/src/test/ui/object-safety/object-safety-sized.curr.stderr
+++ b/src/test/ui/object-safety/object-safety-sized.curr.stderr
@@ -1,6 +1,9 @@
 error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/object-safety-sized.rs:12:30
    |
+LL | trait Bar : Sized {
+   |             ----- the trait cannot require that `Self : Sized`
+...
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
    |                              ^^^^^^^^ the trait `Bar` cannot be made into an object
    |

--- a/src/test/ui/object-safety/object-safety-sized.curr.stderr
+++ b/src/test/ui/object-safety/object-safety-sized.curr.stderr
@@ -6,8 +6,6 @@ LL | trait Bar : Sized {
 ...
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
    |                              ^^^^^^^^ the trait `Bar` cannot be made into an object
-   |
-   = note: the trait cannot require that `Self : Sized`
 
 error: aborting due to previous error
 

--- a/src/test/ui/object-safety/object-safety-sized.curr.stderr
+++ b/src/test/ui/object-safety/object-safety-sized.curr.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Bar` cannot be made into an object
-  --> $DIR/object-safety-sized.rs:12:1
+  --> $DIR/object-safety-sized.rs:12:30
    |
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar` cannot be made into an object
+   |                              ^^^^^^^^ the trait `Bar` cannot be made into an object
    |
    = note: the trait cannot require that `Self : Sized`
 

--- a/src/test/ui/object-safety/object-safety-sized.object_safe_for_dispatch.stderr
+++ b/src/test/ui/object-safety/object-safety-sized.object_safe_for_dispatch.stderr
@@ -2,7 +2,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/object-safety-sized.rs:14:5
    |
 LL | trait Bar : Sized {
-   |             ----- the trait cannot require that `Self : Sized`
+   |             ----- traits that require `Self: Sized` cannot be made into an object
 ...
 LL |     t
    |     ^ the trait `Bar` cannot be made into an object

--- a/src/test/ui/object-safety/object-safety-sized.object_safe_for_dispatch.stderr
+++ b/src/test/ui/object-safety/object-safety-sized.object_safe_for_dispatch.stderr
@@ -7,7 +7,6 @@ LL | trait Bar : Sized {
 LL |     t
    |     ^ the trait `Bar` cannot be made into an object
    |
-   = note: the trait cannot require that `Self : Sized`
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<&dyn Bar>` for `&T`
    = note: required by cast to type `&dyn Bar`
 

--- a/src/test/ui/object-safety/object-safety-sized.object_safe_for_dispatch.stderr
+++ b/src/test/ui/object-safety/object-safety-sized.object_safe_for_dispatch.stderr
@@ -2,7 +2,9 @@ error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/object-safety-sized.rs:14:5
    |
 LL | trait Bar : Sized {
-   |             ----- traits that require `Self: Sized` cannot be made into an object
+   |       ---   ----- ...because it requires `Self: Sized`
+   |       |
+   |       this trait cannot be made into an object...
 ...
 LL |     t
    |     ^ the trait `Bar` cannot be made into an object

--- a/src/test/ui/object-safety/object-safety-sized.object_safe_for_dispatch.stderr
+++ b/src/test/ui/object-safety/object-safety-sized.object_safe_for_dispatch.stderr
@@ -1,6 +1,9 @@
 error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/object-safety-sized.rs:14:5
    |
+LL | trait Bar : Sized {
+   |             ----- the trait cannot require that `Self : Sized`
+...
 LL |     t
    |     ^ the trait `Bar` cannot be made into an object
    |

--- a/src/test/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
+++ b/src/test/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Baz` cannot be made into an object
 LL | fn make_baz<T:Baz>(t: &T) -> &dyn Baz {
    |                               ^^^^^^^ the trait `Baz` cannot be made into an object
    |
-   = note: the trait cannot use `Self` as a type parameter in the supertraits or where-clauses
+   = note: the trait cannot be made into an object because it cannot use `Self` as a type parameter in the supertraits or `where`-clauses
 
 error: aborting due to previous error
 

--- a/src/test/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
+++ b/src/test/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
@@ -1,10 +1,13 @@
 error[E0038]: the trait `Baz` cannot be made into an object
   --> $DIR/object-safety-supertrait-mentions-Self.rs:15:31
    |
+LL | trait Baz : Bar<Self> {
+   |       ---   --------- ...because it uses `Self` as a type parameter in this
+   |       |
+   |       this trait cannot be made into an object...
+...
 LL | fn make_baz<T:Baz>(t: &T) -> &dyn Baz {
    |                               ^^^^^^^ the trait `Baz` cannot be made into an object
-   |
-   = note: the trait cannot be made into an object because it cannot use `Self` as a type parameter in the supertraits or `where`-clauses
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-free-region-ordering-callee-4.stderr
+++ b/src/test/ui/regions/regions-free-region-ordering-callee-4.stderr
@@ -1,8 +1,8 @@
 error[E0491]: in type `&'a &'b usize`, reference has a longer lifetime than the data it references
-  --> $DIR/regions-free-region-ordering-callee-4.rs:5:4
+  --> $DIR/regions-free-region-ordering-callee-4.rs:5:68
    |
 LL | fn ordering4<'a, 'b, F>(a: &'a usize, b: &'b usize, x: F) where F: FnOnce(&'a &'b usize) {
-   |    ^^^^^^^^^
+   |                                                                    ^^^^^^^^^^^^^^^^^^^^^
    |
 note: the pointer is valid for the lifetime `'a` as defined on the function body at 5:14
   --> $DIR/regions-free-region-ordering-callee-4.rs:5:14

--- a/src/test/ui/regions/regions-free-region-ordering-callee-4.stderr
+++ b/src/test/ui/regions/regions-free-region-ordering-callee-4.stderr
@@ -1,12 +1,8 @@
 error[E0491]: in type `&'a &'b usize`, reference has a longer lifetime than the data it references
-  --> $DIR/regions-free-region-ordering-callee-4.rs:5:1
+  --> $DIR/regions-free-region-ordering-callee-4.rs:5:4
    |
-LL | / fn ordering4<'a, 'b, F>(a: &'a usize, b: &'b usize, x: F) where F: FnOnce(&'a &'b usize) {
-LL | |
-LL | |     // Do not infer ordering from closure argument types.
-LL | |     let z: Option<&'a &'b usize> = None;
-LL | | }
-   | |_^
+LL | fn ordering4<'a, 'b, F>(a: &'a usize, b: &'b usize, x: F) where F: FnOnce(&'a &'b usize) {
+   |    ^^^^^^^^^
    |
 note: the pointer is valid for the lifetime `'a` as defined on the function body at 5:14
   --> $DIR/regions-free-region-ordering-callee-4.rs:5:14

--- a/src/test/ui/regions/regions-implied-bounds-projection-gap-hr-1.stderr
+++ b/src/test/ui/regions/regions-implied-bounds-projection-gap-hr-1.stderr
@@ -1,11 +1,8 @@
 error[E0491]: in type `&'x (dyn for<'z> Trait1<<T as Trait2<'y, 'z>>::Foo> + 'x)`, reference has a longer lifetime than the data it references
-  --> $DIR/regions-implied-bounds-projection-gap-hr-1.rs:21:1
+  --> $DIR/regions-implied-bounds-projection-gap-hr-1.rs:21:25
    |
-LL | / fn callee<'x, 'y, T>(t: &'x dyn for<'z> Trait1< <T as Trait2<'y, 'z>>::Foo >)
-LL | |
-LL | | {
-LL | | }
-   | |_^
+LL | fn callee<'x, 'y, T>(t: &'x dyn for<'z> Trait1< <T as Trait2<'y, 'z>>::Foo >)
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the pointer is valid for the lifetime `'x` as defined on the function body at 21:11
   --> $DIR/regions-implied-bounds-projection-gap-hr-1.rs:21:11

--- a/src/test/ui/regions/regions-normalize-in-where-clause-list.stderr
+++ b/src/test/ui/regions/regions-normalize-in-where-clause-list.stderr
@@ -67,15 +67,10 @@ LL | | }
               found  `Project<'_, '_>`
 
 error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
-  --> $DIR/regions-normalize-in-where-clause-list.rs:22:1
+  --> $DIR/regions-normalize-in-where-clause-list.rs:22:4
    |
-LL | / fn bar<'a, 'b>()
-LL | |
-LL | |
-LL | |     where <() as Project<'a, 'b>>::Item : Eq
-LL | | {
-LL | | }
-   | |_^
+LL | fn bar<'a, 'b>()
+   |    ^^^
    |
 note: first, the lifetime cannot outlive the lifetime `'a` as defined on the function body at 22:8...
   --> $DIR/regions-normalize-in-where-clause-list.rs:22:8
@@ -88,15 +83,10 @@ note: ...but the lifetime must also be valid for the lifetime `'b` as defined on
 LL | fn bar<'a, 'b>()
    |            ^^
 note: ...so that the types are compatible
-  --> $DIR/regions-normalize-in-where-clause-list.rs:22:1
+  --> $DIR/regions-normalize-in-where-clause-list.rs:22:4
    |
-LL | / fn bar<'a, 'b>()
-LL | |
-LL | |
-LL | |     where <() as Project<'a, 'b>>::Item : Eq
-LL | | {
-LL | | }
-   | |_^
+LL | fn bar<'a, 'b>()
+   |    ^^^
    = note: expected  `Project<'a, 'b>`
               found  `Project<'_, '_>`
 

--- a/src/test/ui/resolve/issue-3907-2.stderr
+++ b/src/test/ui/resolve/issue-3907-2.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `issue_3907::Foo` cannot be made into an object
-  --> $DIR/issue-3907-2.rs:11:1
+  --> $DIR/issue-3907-2.rs:11:12
    |
 LL | fn bar(_x: Foo) {}
-   | ^^^^^^^^^^^^^^^ the trait `issue_3907::Foo` cannot be made into an object
+   |            ^^^ the trait `issue_3907::Foo` cannot be made into an object
    |
    = note: associated function `bar` has no `self` parameter
 

--- a/src/test/ui/resolve/issue-3907-2.stderr
+++ b/src/test/ui/resolve/issue-3907-2.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `issue_3907::Foo` cannot be made into an object
 LL | fn bar(_x: Foo) {}
    |            ^^^ the trait `issue_3907::Foo` cannot be made into an object
    |
-   = note: associated function `bar` has no `self` parameter
+   = note: the trait cannot be made into an object because associated function `bar` has no `self` parameter
 
 error: aborting due to previous error
 

--- a/src/test/ui/self/arbitrary-self-types-not-object-safe.curr.stderr
+++ b/src/test/ui/self/arbitrary-self-types-not-object-safe.curr.stderr
@@ -4,12 +4,13 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL | trait Foo {
    |       --- this trait cannot be made into an object...
 LL |     fn foo(self: &Rc<Self>) -> usize;
-   |        --- ...because method `foo`'s `self` parameter cannot be dispatched on
+   |                  ---------
+   |                  |
+   |                  ...because method `foo`'s `self` parameter cannot be dispatched on
+   |                  help: consider changing method `foo`'s `self` parameter to be `&self`: `&Self`
 ...
 LL |     let x = Rc::new(5usize) as Rc<dyn Foo>;
    |                                ^^^^^^^^^^^ the trait `Foo` cannot be made into an object
-   |
-   = help: consider changing method `foo`'s `self` parameter to be `&self`
 
 error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/arbitrary-self-types-not-object-safe.rs:33:13
@@ -17,12 +18,14 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL | trait Foo {
    |       --- this trait cannot be made into an object...
 LL |     fn foo(self: &Rc<Self>) -> usize;
-   |        --- ...because method `foo`'s `self` parameter cannot be dispatched on
+   |                  ---------
+   |                  |
+   |                  ...because method `foo`'s `self` parameter cannot be dispatched on
+   |                  help: consider changing method `foo`'s `self` parameter to be `&self`: `&Self`
 ...
 LL |     let x = Rc::new(5usize) as Rc<dyn Foo>;
    |             ^^^^^^^^^^^^^^^ the trait `Foo` cannot be made into an object
    |
-   = help: consider changing method `foo`'s `self` parameter to be `&self`
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<std::rc::Rc<dyn Foo>>` for `std::rc::Rc<usize>`
    = note: required by cast to type `std::rc::Rc<dyn Foo>`
 

--- a/src/test/ui/self/arbitrary-self-types-not-object-safe.curr.stderr
+++ b/src/test/ui/self/arbitrary-self-types-not-object-safe.curr.stderr
@@ -1,21 +1,28 @@
 error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/arbitrary-self-types-not-object-safe.rs:33:32
    |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
 LL |     fn foo(self: &Rc<Self>) -> usize;
-   |        --- method `foo`'s `self` parameter cannot be dispatched on
+   |        --- ...because method `foo`'s `self` parameter cannot be dispatched on
 ...
 LL |     let x = Rc::new(5usize) as Rc<dyn Foo>;
    |                                ^^^^^^^^^^^ the trait `Foo` cannot be made into an object
+   |
+   = help: consider changing method `foo`'s `self` parameter to be `&self`
 
 error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/arbitrary-self-types-not-object-safe.rs:33:13
    |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
 LL |     fn foo(self: &Rc<Self>) -> usize;
-   |        --- method `foo`'s `self` parameter cannot be dispatched on
+   |        --- ...because method `foo`'s `self` parameter cannot be dispatched on
 ...
 LL |     let x = Rc::new(5usize) as Rc<dyn Foo>;
    |             ^^^^^^^^^^^^^^^ the trait `Foo` cannot be made into an object
    |
+   = help: consider changing method `foo`'s `self` parameter to be `&self`
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<std::rc::Rc<dyn Foo>>` for `std::rc::Rc<usize>`
    = note: required by cast to type `std::rc::Rc<dyn Foo>`
 

--- a/src/test/ui/self/arbitrary-self-types-not-object-safe.object_safe_for_dispatch.stderr
+++ b/src/test/ui/self/arbitrary-self-types-not-object-safe.object_safe_for_dispatch.stderr
@@ -1,12 +1,15 @@
 error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/arbitrary-self-types-not-object-safe.rs:33:13
    |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
 LL |     fn foo(self: &Rc<Self>) -> usize;
-   |        --- method `foo`'s `self` parameter cannot be dispatched on
+   |        --- ...because method `foo`'s `self` parameter cannot be dispatched on
 ...
 LL |     let x = Rc::new(5usize) as Rc<dyn Foo>;
    |             ^^^^^^^^^^^^^^^ the trait `Foo` cannot be made into an object
    |
+   = help: consider changing method `foo`'s `self` parameter to be `&self`
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<std::rc::Rc<dyn Foo>>` for `std::rc::Rc<usize>`
    = note: required by cast to type `std::rc::Rc<dyn Foo>`
 

--- a/src/test/ui/self/arbitrary-self-types-not-object-safe.object_safe_for_dispatch.stderr
+++ b/src/test/ui/self/arbitrary-self-types-not-object-safe.object_safe_for_dispatch.stderr
@@ -4,12 +4,14 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL | trait Foo {
    |       --- this trait cannot be made into an object...
 LL |     fn foo(self: &Rc<Self>) -> usize;
-   |        --- ...because method `foo`'s `self` parameter cannot be dispatched on
+   |                  ---------
+   |                  |
+   |                  ...because method `foo`'s `self` parameter cannot be dispatched on
+   |                  help: consider changing method `foo`'s `self` parameter to be `&self`: `&Self`
 ...
 LL |     let x = Rc::new(5usize) as Rc<dyn Foo>;
    |             ^^^^^^^^^^^^^^^ the trait `Foo` cannot be made into an object
    |
-   = help: consider changing method `foo`'s `self` parameter to be `&self`
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<std::rc::Rc<dyn Foo>>` for `std::rc::Rc<usize>`
    = note: required by cast to type `std::rc::Rc<dyn Foo>`
 

--- a/src/test/ui/str/str-mut-idx.stderr
+++ b/src/test/ui/str/str-mut-idx.stderr
@@ -2,7 +2,9 @@ error[E0277]: the size for values of type `str` cannot be known at compilation t
   --> $DIR/str-mut-idx.rs:4:15
    |
 LL | fn bot<T>() -> T { loop {} }
-   |    --- - required by this bound in `bot`
+   |    --- -- help: consider relaxing the implicit `Sized` restriction: `: ?Sized`
+   |        |
+   |        required by this bound in `bot`
 ...
 LL |     s[1..2] = bot();
    |               ^^^ doesn't have a size known at compile-time

--- a/src/test/ui/suggestions/imm-ref-trait-object.rs
+++ b/src/test/ui/suggestions/imm-ref-trait-object.rs
@@ -1,3 +1,8 @@
+// FIXME: missing sysroot spans (#53081)
+// ignore-i586-unknown-linux-gnu
+// ignore-i586-unknown-linux-musl
+// ignore-i686-unknown-linux-musl
+
 fn test(t: &dyn Iterator<Item=&u64>) -> u64 {
      t.min().unwrap() //~ ERROR the `min` method cannot be invoked on a trait object
 }

--- a/src/test/ui/suggestions/imm-ref-trait-object.stderr
+++ b/src/test/ui/suggestions/imm-ref-trait-object.stderr
@@ -3,6 +3,11 @@ error: the `min` method cannot be invoked on a trait object
    |
 LL |      t.min().unwrap()
    |        ^^^
+   | 
+  ::: $SRC_DIR/libcore/iter/traits/iterator.rs:LL:COL
+   |
+LL |         Self: Sized,
+   |               ----- this has a `Sized` requirement
    |
    = note: you need `&mut dyn std::iter::Iterator<Item = &u64>` instead of `&dyn std::iter::Iterator<Item = &u64>`
 

--- a/src/test/ui/suggestions/imm-ref-trait-object.stderr
+++ b/src/test/ui/suggestions/imm-ref-trait-object.stderr
@@ -1,5 +1,5 @@
 error: the `min` method cannot be invoked on a trait object
-  --> $DIR/imm-ref-trait-object.rs:2:8
+  --> $DIR/imm-ref-trait-object.rs:7:8
    |
 LL |      t.min().unwrap()
    |        ^^^

--- a/src/test/ui/suggestions/missing-assoc-type-bound-restriction.stderr
+++ b/src/test/ui/suggestions/missing-assoc-type-bound-restriction.stderr
@@ -1,20 +1,13 @@
 error[E0277]: the trait bound `<T as Parent>::Assoc: Child<A>` is not satisfied
-  --> $DIR/missing-assoc-type-bound-restriction.rs:17:1
+  --> $DIR/missing-assoc-type-bound-restriction.rs:17:19
    |
-LL |   trait Parent {
-   |   ------------ required by `Parent`
+LL | trait Parent {
+   | ------------ required by `Parent`
 ...
-LL |   impl<A, T: Parent<Ty = A>> Parent for ParentWrapper<T> {
-   |   ^                                                     - help: consider further restricting the associated type: `where <T as Parent>::Assoc: Child<A>`
-   |  _|
-   | |
-LL | |
-LL | |     type Ty = A;
-LL | |     type Assoc = ChildWrapper<T::Assoc>;
-LL | |
-LL | |
-LL | | }
-   | |_^ the trait `Child<A>` is not implemented for `<T as Parent>::Assoc`
+LL | impl<A, T: Parent<Ty = A>> Parent for ParentWrapper<T> {
+   |                   ^^^^^^                              - help: consider further restricting the associated type: `where <T as Parent>::Assoc: Child<A>`
+   |                   |
+   |                   the trait `Child<A>` is not implemented for `<T as Parent>::Assoc`
 
 error[E0277]: the trait bound `<T as Parent>::Assoc: Child<A>` is not satisfied
   --> $DIR/missing-assoc-type-bound-restriction.rs:20:5

--- a/src/test/ui/suggestions/object-unsafe-trait-references-self.rs
+++ b/src/test/ui/suggestions/object-unsafe-trait-references-self.rs
@@ -1,0 +1,12 @@
+trait Trait {
+    fn baz(&self, _: Self) {}
+    fn bat(&self) -> Self {}
+}
+
+fn bar(x: &dyn Trait) {} //~ ERROR the trait `Trait` cannot be made into an object
+
+trait Other: Sized {}
+
+fn foo(x: &dyn Other) {} //~ ERROR the trait `Other` cannot be made into an object
+
+fn main() {}

--- a/src/test/ui/suggestions/object-unsafe-trait-references-self.stderr
+++ b/src/test/ui/suggestions/object-unsafe-trait-references-self.stderr
@@ -1,0 +1,30 @@
+error[E0038]: the trait `Trait` cannot be made into an object
+  --> $DIR/object-unsafe-trait-references-self.rs:6:11
+   |
+LL | trait Trait {
+   |       ----- this trait cannot be made into an object...
+LL |     fn baz(&self, _: Self) {}
+   |                      ---- ...because method `baz` references the `Self` type in this parameter
+LL |     fn bat(&self) -> Self {}
+   |                      ---- ...because method `bat` references the `Self` type in its return type
+...
+LL | fn bar(x: &dyn Trait) {}
+   |           ^^^^^^^^^^ the trait `Trait` cannot be made into an object
+   |
+   = help: consider moving `baz` to another trait
+   = help: consider moving `bat` to another trait
+
+error[E0038]: the trait `Other` cannot be made into an object
+  --> $DIR/object-unsafe-trait-references-self.rs:10:11
+   |
+LL | trait Other: Sized {}
+   |       -----  ----- ...because it requires `Self: Sized`
+   |       |
+   |       this trait cannot be made into an object...
+LL | 
+LL | fn foo(x: &dyn Other) {}
+   |           ^^^^^^^^^^ the trait `Other` cannot be made into an object
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0038`.

--- a/src/test/ui/suggestions/object-unsafe-trait-should-use-self.rs
+++ b/src/test/ui/suggestions/object-unsafe-trait-should-use-self.rs
@@ -1,0 +1,16 @@
+#![allow(bare_trait_objects)]
+trait A: Sized {
+    fn f(a: A) -> A;
+    //~^ ERROR associated item referring to unboxed trait object for its own trait
+    //~| ERROR the trait `A` cannot be made into an object
+}
+trait B {
+    fn f(a: B) -> B;
+    //~^ ERROR associated item referring to unboxed trait object for its own trait
+    //~| ERROR the trait `B` cannot be made into an object
+}
+trait C {
+    fn f(&self, a: C) -> C;
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/object-unsafe-trait-should-use-self.stderr
+++ b/src/test/ui/suggestions/object-unsafe-trait-should-use-self.stderr
@@ -6,7 +6,7 @@ LL | trait A: Sized {
 LL |     fn f(a: A) -> A;
    |             ^     ^
    |
-help: you might have meant to use `Self` to refer to the materialized type
+help: you might have meant to use `Self` to refer to the implementing type
    |
 LL |     fn f(a: Self) -> Self;
    |             ^^^^     ^^^^
@@ -29,7 +29,7 @@ LL | trait B {
 LL |     fn f(a: B) -> B;
    |             ^     ^
    |
-help: you might have meant to use `Self` to refer to the materialized type
+help: you might have meant to use `Self` to refer to the implementing type
    |
 LL |     fn f(a: Self) -> Self;
    |             ^^^^     ^^^^

--- a/src/test/ui/suggestions/object-unsafe-trait-should-use-self.stderr
+++ b/src/test/ui/suggestions/object-unsafe-trait-should-use-self.stderr
@@ -15,7 +15,9 @@ error[E0038]: the trait `A` cannot be made into an object
   --> $DIR/object-unsafe-trait-should-use-self.rs:3:13
    |
 LL | trait A: Sized {
-   |          ----- traits that require `Self: Sized` cannot be made into an object
+   |       -  ----- ...because it requires `Self: Sized`
+   |       |
+   |       this trait cannot be made into an object...
 LL |     fn f(a: A) -> A;
    |             ^ the trait `A` cannot be made into an object
 
@@ -35,10 +37,14 @@ LL |     fn f(a: Self) -> Self;
 error[E0038]: the trait `B` cannot be made into an object
   --> $DIR/object-unsafe-trait-should-use-self.rs:8:13
    |
+LL | trait B {
+   |       - this trait cannot be made into an object...
 LL |     fn f(a: B) -> B;
    |        -    ^ the trait `B` cannot be made into an object
    |        |
-   |        associated function `f` has no `self` parameter
+   |        ...because associated function `f` has no `self` parameter
+   |
+   = help: consider turning `f` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/suggestions/object-unsafe-trait-should-use-self.stderr
+++ b/src/test/ui/suggestions/object-unsafe-trait-should-use-self.stderr
@@ -15,7 +15,7 @@ error[E0038]: the trait `A` cannot be made into an object
   --> $DIR/object-unsafe-trait-should-use-self.rs:3:13
    |
 LL | trait A: Sized {
-   |          ----- the trait cannot require that `Self : Sized`
+   |          ----- traits that require `Self: Sized` cannot be made into an object
 LL |     fn f(a: A) -> A;
    |             ^ the trait `A` cannot be made into an object
 

--- a/src/test/ui/suggestions/object-unsafe-trait-should-use-self.stderr
+++ b/src/test/ui/suggestions/object-unsafe-trait-should-use-self.stderr
@@ -1,0 +1,47 @@
+error: associated item referring to unboxed trait object for its own trait
+  --> $DIR/object-unsafe-trait-should-use-self.rs:3:13
+   |
+LL | trait A: Sized {
+   |       - in this trait
+LL |     fn f(a: A) -> A;
+   |             ^     ^
+   |
+help: you might have meant to use `Self` to refer to the materialized type
+   |
+LL |     fn f(a: Self) -> Self;
+   |             ^^^^     ^^^^
+
+error[E0038]: the trait `A` cannot be made into an object
+  --> $DIR/object-unsafe-trait-should-use-self.rs:3:13
+   |
+LL | trait A: Sized {
+   |          ----- the trait cannot require that `Self : Sized`
+LL |     fn f(a: A) -> A;
+   |             ^ the trait `A` cannot be made into an object
+   |
+   = note: the trait cannot require that `Self : Sized`
+
+error: associated item referring to unboxed trait object for its own trait
+  --> $DIR/object-unsafe-trait-should-use-self.rs:8:13
+   |
+LL | trait B {
+   |       - in this trait
+LL |     fn f(a: B) -> B;
+   |             ^     ^
+   |
+help: you might have meant to use `Self` to refer to the materialized type
+   |
+LL |     fn f(a: Self) -> Self;
+   |             ^^^^     ^^^^
+
+error[E0038]: the trait `B` cannot be made into an object
+  --> $DIR/object-unsafe-trait-should-use-self.rs:8:13
+   |
+LL |     fn f(a: B) -> B;
+   |        -    ^ the trait `B` cannot be made into an object
+   |        |
+   |        associated function `f` has no `self` parameter
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0038`.

--- a/src/test/ui/suggestions/object-unsafe-trait-should-use-self.stderr
+++ b/src/test/ui/suggestions/object-unsafe-trait-should-use-self.stderr
@@ -18,8 +18,6 @@ LL | trait A: Sized {
    |          ----- the trait cannot require that `Self : Sized`
 LL |     fn f(a: A) -> A;
    |             ^ the trait `A` cannot be made into an object
-   |
-   = note: the trait cannot require that `Self : Sized`
 
 error: associated item referring to unboxed trait object for its own trait
   --> $DIR/object-unsafe-trait-should-use-self.rs:8:13

--- a/src/test/ui/suggestions/object-unsafe-trait-should-use-self.stderr
+++ b/src/test/ui/suggestions/object-unsafe-trait-should-use-self.stderr
@@ -44,7 +44,10 @@ LL |     fn f(a: B) -> B;
    |        |
    |        ...because associated function `f` has no `self` parameter
    |
-   = help: consider turning `f` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
+help: consider turning `f` into a method by giving it a `&self` argument or constraining it so it does not apply to trait objects
+   |
+LL |     fn f(a: B) -> B where Self: Sized;
+   |                     ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/suggestions/object-unsafe-trait-should-use-where-sized.fixed
+++ b/src/test/ui/suggestions/object-unsafe-trait-should-use-where-sized.fixed
@@ -1,0 +1,13 @@
+// run-rustfix
+#![allow(unused_variables, dead_code)]
+
+trait Trait {
+    fn foo() where Self: Other, Self: Sized, { }
+    fn bar(self: &Self) {} //~ ERROR invalid `self` parameter type
+}
+
+fn bar(x: &dyn Trait) {} //~ ERROR the trait `Trait` cannot be made into an object
+
+trait Other {}
+
+fn main() {}

--- a/src/test/ui/suggestions/object-unsafe-trait-should-use-where-sized.rs
+++ b/src/test/ui/suggestions/object-unsafe-trait-should-use-where-sized.rs
@@ -1,0 +1,13 @@
+// run-rustfix
+#![allow(unused_variables, dead_code)]
+
+trait Trait {
+    fn foo() where Self: Other, { }
+    fn bar(self: ()) {} //~ ERROR invalid `self` parameter type
+}
+
+fn bar(x: &dyn Trait) {} //~ ERROR the trait `Trait` cannot be made into an object
+
+trait Other {}
+
+fn main() {}

--- a/src/test/ui/suggestions/object-unsafe-trait-should-use-where-sized.stderr
+++ b/src/test/ui/suggestions/object-unsafe-trait-should-use-where-sized.stderr
@@ -1,0 +1,35 @@
+error[E0038]: the trait `Trait` cannot be made into an object
+  --> $DIR/object-unsafe-trait-should-use-where-sized.rs:9:11
+   |
+LL | trait Trait {
+   |       ----- this trait cannot be made into an object...
+LL |     fn foo() where Self: Other, { }
+   |        --- ...because associated function `foo` has no `self` parameter
+LL |     fn bar(self: ()) {}
+   |                  -- ...because method `bar`'s `self` parameter cannot be dispatched on
+...
+LL | fn bar(x: &dyn Trait) {}
+   |           ^^^^^^^^^^ the trait `Trait` cannot be made into an object
+   |
+help: consider turning `foo` into a method by giving it a `&self` argument or constraining it so it does not apply to trait objects
+   |
+LL |     fn foo() where Self: Other, Self: Sized, { }
+   |                               ^^^^^^^^^^^^^
+help: consider changing method `bar`'s `self` parameter to be `&self`
+   |
+LL |     fn bar(self: &Self) {}
+   |                  ^^^^^
+
+error[E0307]: invalid `self` parameter type: ()
+  --> $DIR/object-unsafe-trait-should-use-where-sized.rs:6:18
+   |
+LL |     fn bar(self: ()) {}
+   |                  ^^
+   |
+   = note: type of `self` must be `Self` or a type that dereferences to it
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0038, E0307.
+For more information about an error, try `rustc --explain E0038`.

--- a/src/test/ui/traits/trait-alias/trait-alias-object-fail.rs
+++ b/src/test/ui/traits/trait-alias/trait-alias-object-fail.rs
@@ -1,3 +1,8 @@
+// FIXME: missing sysroot spans (#53081)
+// ignore-i586-unknown-linux-gnu
+// ignore-i586-unknown-linux-musl
+// ignore-i686-unknown-linux-musl
+
 #![feature(trait_alias)]
 
 trait EqAlias = Eq;

--- a/src/test/ui/traits/trait-alias/trait-alias-object-fail.stderr
+++ b/src/test/ui/traits/trait-alias/trait-alias-object-fail.stderr
@@ -1,5 +1,5 @@
 error[E0038]: the trait `std::cmp::Eq` cannot be made into an object
-  --> $DIR/trait-alias-object-fail.rs:7:13
+  --> $DIR/trait-alias-object-fail.rs:12:13
    |
 LL |     let _: &dyn EqAlias = &123;
    |             ^^^^^^^^^^^ the trait `std::cmp::Eq` cannot be made into an object
@@ -10,7 +10,7 @@ LL | pub trait Eq: PartialEq<Self> {
    |               --------------- the trait cannot be made into an object because it uses `Self` as a type parameter in this
 
 error[E0191]: the value of the associated type `Item` (from trait `std::iter::Iterator`) must be specified
-  --> $DIR/trait-alias-object-fail.rs:9:17
+  --> $DIR/trait-alias-object-fail.rs:14:17
    |
 LL |     let _: &dyn IteratorAlias = &vec![123].into_iter();
    |                 ^^^^^^^^^^^^^ help: specify the associated type: `IteratorAlias<Item = Type>`

--- a/src/test/ui/traits/trait-alias/trait-alias-object-fail.stderr
+++ b/src/test/ui/traits/trait-alias/trait-alias-object-fail.stderr
@@ -3,8 +3,11 @@ error[E0038]: the trait `std::cmp::Eq` cannot be made into an object
    |
 LL |     let _: &dyn EqAlias = &123;
    |             ^^^^^^^^^^^ the trait `std::cmp::Eq` cannot be made into an object
+   | 
+  ::: $SRC_DIR/libcore/cmp.rs:LL:COL
    |
-   = note: the trait cannot be made into an object because it cannot use `Self` as a type parameter in the supertraits or `where`-clauses
+LL | pub trait Eq: PartialEq<Self> {
+   |               --------------- the trait cannot be made into an object because it uses `Self` as a type parameter in this
 
 error[E0191]: the value of the associated type `Item` (from trait `std::iter::Iterator`) must be specified
   --> $DIR/trait-alias-object-fail.rs:9:17

--- a/src/test/ui/traits/trait-alias/trait-alias-object-fail.stderr
+++ b/src/test/ui/traits/trait-alias/trait-alias-object-fail.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `std::cmp::Eq` cannot be made into an object
 LL |     let _: &dyn EqAlias = &123;
    |             ^^^^^^^^^^^ the trait `std::cmp::Eq` cannot be made into an object
    |
-   = note: the trait cannot use `Self` as a type parameter in the supertraits or where-clauses
+   = note: the trait cannot be made into an object because it cannot use `Self` as a type parameter in the supertraits or `where`-clauses
 
 error[E0191]: the value of the associated type `Item` (from trait `std::iter::Iterator`) must be specified
   --> $DIR/trait-alias-object-fail.rs:9:17

--- a/src/test/ui/traits/trait-alias/trait-alias-wf.stderr
+++ b/src/test/ui/traits/trait-alias/trait-alias-wf.stderr
@@ -1,13 +1,12 @@
 error[E0277]: the trait bound `T: Foo` is not satisfied
-  --> $DIR/trait-alias-wf.rs:5:1
+  --> $DIR/trait-alias-wf.rs:5:14
    |
 LL | trait A<T: Foo> {}
    | --------------- required by `A`
 LL | trait B<T> = A<T>;
-   | ^^^^^^^^-^^^^^^^^^
-   | |       |
-   | |       help: consider restricting this bound: `T: Foo`
-   | the trait `Foo` is not implemented for `T`
+   |         -    ^^^^ the trait `Foo` is not implemented for `T`
+   |         |
+   |         help: consider restricting this bound: `T: Foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-in-fns.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-in-fns.stderr
@@ -1,20 +1,20 @@
 error[E0277]: the trait bound `u32: Trait` is not satisfied
-  --> $DIR/trait-bounds-on-structs-and-enums-in-fns.rs:13:1
+  --> $DIR/trait-bounds-on-structs-and-enums-in-fns.rs:13:15
    |
 LL | struct Foo<T:Trait> {
    | ------------------- required by `Foo`
 ...
 LL | fn explode(x: Foo<u32>) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `u32`
+   |               ^^^^^^^^ the trait `Trait` is not implemented for `u32`
 
 error[E0277]: the trait bound `f32: Trait` is not satisfied
-  --> $DIR/trait-bounds-on-structs-and-enums-in-fns.rs:16:1
+  --> $DIR/trait-bounds-on-structs-and-enums-in-fns.rs:16:14
    |
 LL | enum Bar<T:Trait> {
    | ----------------- required by `Bar`
 ...
 LL | fn kaboom(y: Bar<f32>) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `f32`
+   |              ^^^^^^^^ the trait `Trait` is not implemented for `f32`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-xc.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-xc.stderr
@@ -1,16 +1,16 @@
 error[E0277]: the trait bound `usize: trait_bounds_on_structs_and_enums_xc::Trait` is not satisfied
-  --> $DIR/trait-bounds-on-structs-and-enums-xc.rs:7:1
+  --> $DIR/trait-bounds-on-structs-and-enums-xc.rs:7:15
    |
 LL | fn explode(x: Foo<usize>) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `trait_bounds_on_structs_and_enums_xc::Trait` is not implemented for `usize`
+   |               ^^^^^^^^^^ the trait `trait_bounds_on_structs_and_enums_xc::Trait` is not implemented for `usize`
    |
    = note: required by `trait_bounds_on_structs_and_enums_xc::Foo`
 
 error[E0277]: the trait bound `f32: trait_bounds_on_structs_and_enums_xc::Trait` is not satisfied
-  --> $DIR/trait-bounds-on-structs-and-enums-xc.rs:10:1
+  --> $DIR/trait-bounds-on-structs-and-enums-xc.rs:10:14
    |
 LL | fn kaboom(y: Bar<f32>) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `trait_bounds_on_structs_and_enums_xc::Trait` is not implemented for `f32`
+   |              ^^^^^^^^ the trait `trait_bounds_on_structs_and_enums_xc::Trait` is not implemented for `f32`
    |
    = note: required by `trait_bounds_on_structs_and_enums_xc::Bar`
 

--- a/src/test/ui/traits/trait-item-privacy.stderr
+++ b/src/test/ui/traits/trait-item-privacy.stderr
@@ -111,15 +111,15 @@ error[E0038]: the trait `assoc_const::C` cannot be made into an object
   --> $DIR/trait-item-privacy.rs:101:5
    |
 LL |         const A: u8 = 0;
-   |               - ...because it cannot contain associated consts like `A`
+   |               - ...because it contains this associated `const`
 ...
 LL |         const B: u8 = 0;
-   |               - ...because it cannot contain associated consts like `B`
+   |               - ...because it contains this associated `const`
 ...
 LL |     pub trait C: A + B {
    |               - this trait cannot be made into an object...
 LL |         const C: u8 = 0;
-   |               - ...because it cannot contain associated consts like `C`
+   |               - ...because it contains this associated `const`
 ...
 LL |     C::A;
    |     ^^^^ the trait `assoc_const::C` cannot be made into an object

--- a/src/test/ui/traits/trait-item-privacy.stderr
+++ b/src/test/ui/traits/trait-item-privacy.stderr
@@ -111,16 +111,22 @@ error[E0038]: the trait `assoc_const::C` cannot be made into an object
   --> $DIR/trait-item-privacy.rs:101:5
    |
 LL |         const A: u8 = 0;
-   |               - the trait cannot contain associated consts like `A`
+   |               - ...because it cannot contain associated consts like `A`
 ...
 LL |         const B: u8 = 0;
-   |               - the trait cannot contain associated consts like `B`
+   |               - ...because it cannot contain associated consts like `B`
 ...
+LL |     pub trait C: A + B {
+   |               - this trait cannot be made into an object...
 LL |         const C: u8 = 0;
-   |               - the trait cannot contain associated consts like `C`
+   |               - ...because it cannot contain associated consts like `C`
 ...
 LL |     C::A;
    |     ^^^^ the trait `assoc_const::C` cannot be made into an object
+   |
+   = help: consider moving `C` to another trait
+   = help: consider moving `B` to another trait
+   = help: consider moving `A` to another trait
 
 error[E0223]: ambiguous associated type
   --> $DIR/trait-item-privacy.rs:115:12

--- a/src/test/ui/traits/trait-object-macro-matcher.stderr
+++ b/src/test/ui/traits/trait-object-macro-matcher.stderr
@@ -10,7 +10,7 @@ error[E0038]: the trait `std::marker::Copy` cannot be made into an object
 LL |     m!(dyn Copy + Send + 'static);
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` cannot be made into an object
    |
-   = note: traits that require `Self: Sized` cannot be made into an object
+   = note: the trait cannot be made into an object because it requires `Self: Sized`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/trait-object-macro-matcher.stderr
+++ b/src/test/ui/traits/trait-object-macro-matcher.stderr
@@ -10,7 +10,7 @@ error[E0038]: the trait `std::marker::Copy` cannot be made into an object
 LL |     m!(dyn Copy + Send + 'static);
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` cannot be made into an object
    |
-   = note: the trait cannot require that `Self : Sized`
+   = note: traits that require `Self: Sized` cannot be made into an object
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/trait-object-safety.stderr
+++ b/src/test/ui/traits/trait-object-safety.stderr
@@ -9,9 +9,12 @@ LL |     fn foo();
 LL |     let _: &dyn Tr = &St;
    |                      ^^^ the trait `Tr` cannot be made into an object
    |
-   = help: consider turning `foo` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<&dyn Tr>` for `&St`
    = note: required by cast to type `&dyn Tr`
+help: consider turning `foo` into a method by giving it a `&self` argument or constraining it so it does not apply to trait objects
+   |
+LL |     fn foo() where Self: Sized;
+   |              ^^^^^^^^^^^^^^^^^
 
 error[E0038]: the trait `Tr` cannot be made into an object
   --> $DIR/trait-object-safety.rs:15:12
@@ -24,7 +27,10 @@ LL |     fn foo();
 LL |     let _: &dyn Tr = &St;
    |            ^^^^^^^ the trait `Tr` cannot be made into an object
    |
-   = help: consider turning `foo` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
+help: consider turning `foo` into a method by giving it a `&self` argument or constraining it so it does not apply to trait objects
+   |
+LL |     fn foo() where Self: Sized;
+   |              ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/trait-object-safety.stderr
+++ b/src/test/ui/traits/trait-object-safety.stderr
@@ -1,23 +1,30 @@
 error[E0038]: the trait `Tr` cannot be made into an object
   --> $DIR/trait-object-safety.rs:15:22
    |
+LL | trait Tr {
+   |       -- this trait cannot be made into an object...
 LL |     fn foo();
-   |        --- associated function `foo` has no `self` parameter
+   |        --- ...because associated function `foo` has no `self` parameter
 ...
 LL |     let _: &dyn Tr = &St;
    |                      ^^^ the trait `Tr` cannot be made into an object
    |
+   = help: consider turning `foo` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<&dyn Tr>` for `&St`
    = note: required by cast to type `&dyn Tr`
 
 error[E0038]: the trait `Tr` cannot be made into an object
   --> $DIR/trait-object-safety.rs:15:12
    |
+LL | trait Tr {
+   |       -- this trait cannot be made into an object...
 LL |     fn foo();
-   |        --- associated function `foo` has no `self` parameter
+   |        --- ...because associated function `foo` has no `self` parameter
 ...
 LL |     let _: &dyn Tr = &St;
    |            ^^^^^^^ the trait `Tr` cannot be made into an object
+   |
+   = help: consider turning `foo` into a method by giving it a `&self` argument or constraining it with `where Self: Sized`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/trait-suggest-where-clause.stderr
+++ b/src/test/ui/traits/trait-suggest-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `U` cannot be known at compilation tim
   --> $DIR/trait-suggest-where-clause.rs:11:20
    |
 LL | fn check<T: Iterator, U: ?Sized>() {
-   |                       -- help: consider further restricting this bound: `U: std::marker::Sized +`
+   |                       - this type parameter needs to be `std::marker::Sized`
 LL |     // suggest a where-clause, if needed
 LL |     mem::size_of::<U>();
    |                    ^ doesn't have a size known at compile-time
@@ -19,7 +19,7 @@ error[E0277]: the size for values of type `U` cannot be known at compilation tim
   --> $DIR/trait-suggest-where-clause.rs:14:5
    |
 LL | fn check<T: Iterator, U: ?Sized>() {
-   |                       -- help: consider further restricting this bound: `U: std::marker::Sized +`
+   |                       - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     mem::size_of::<Misc<U>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/traits/trait-test-2.stderr
+++ b/src/test/ui/traits/trait-test-2.stderr
@@ -14,9 +14,9 @@ error[E0038]: the trait `bar` cannot be made into an object
   --> $DIR/trait-test-2.rs:11:16
    |
 LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
-   |       ---      ---                    ---- ...because method `blah` has generic type parameters
-   |       |        |
-   |       |        ...because method `dup` references the `Self` type in its parameters or return type
+   |       ---                    ----     ---- ...because method `blah` has generic type parameters
+   |       |                      |
+   |       |                      ...because method `dup` references the `Self` type in its return type
    |       this trait cannot be made into an object...
 ...
 LL |     (box 10 as Box<dyn bar>).dup();
@@ -29,9 +29,9 @@ error[E0038]: the trait `bar` cannot be made into an object
   --> $DIR/trait-test-2.rs:11:6
    |
 LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
-   |       ---      ---                    ---- ...because method `blah` has generic type parameters
-   |       |        |
-   |       |        ...because method `dup` references the `Self` type in its parameters or return type
+   |       ---                    ----     ---- ...because method `blah` has generic type parameters
+   |       |                      |
+   |       |                      ...because method `dup` references the `Self` type in its return type
    |       this trait cannot be made into an object...
 ...
 LL |     (box 10 as Box<dyn bar>).dup();

--- a/src/test/ui/traits/trait-test-2.stderr
+++ b/src/test/ui/traits/trait-test-2.stderr
@@ -14,24 +14,31 @@ error[E0038]: the trait `bar` cannot be made into an object
   --> $DIR/trait-test-2.rs:11:16
    |
 LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
-   |                ---                    ---- method `blah` has generic type parameters
-   |                |
-   |                method `dup` references the `Self` type in its parameters or return type
+   |       ---      ---                    ---- ...because method `blah` has generic type parameters
+   |       |        |
+   |       |        ...because method `dup` references the `Self` type in its parameters or return type
+   |       this trait cannot be made into an object...
 ...
 LL |     (box 10 as Box<dyn bar>).dup();
    |                ^^^^^^^^^^^^ the trait `bar` cannot be made into an object
+   |
+   = help: consider moving `dup` to another trait
+   = help: consider moving `blah` to another trait
 
 error[E0038]: the trait `bar` cannot be made into an object
   --> $DIR/trait-test-2.rs:11:6
    |
 LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
-   |                ---                    ---- method `blah` has generic type parameters
-   |                |
-   |                method `dup` references the `Self` type in its parameters or return type
+   |       ---      ---                    ---- ...because method `blah` has generic type parameters
+   |       |        |
+   |       |        ...because method `dup` references the `Self` type in its parameters or return type
+   |       this trait cannot be made into an object...
 ...
 LL |     (box 10 as Box<dyn bar>).dup();
    |      ^^^^^^ the trait `bar` cannot be made into an object
    |
+   = help: consider moving `dup` to another trait
+   = help: consider moving `blah` to another trait
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<std::boxed::Box<dyn bar>>` for `std::boxed::Box<{integer}>`
    = note: required by cast to type `std::boxed::Box<dyn bar>`
 

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_lifetime_param.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_lifetime_param.stderr
@@ -1,8 +1,8 @@
 error: non-defining opaque type use in defining scope
-  --> $DIR/generic_duplicate_lifetime_param.rs:7:4
+  --> $DIR/generic_duplicate_lifetime_param.rs:7:26
    |
 LL | fn one<'a>(t: &'a ()) -> Two<'a, 'a> {
-   |    ^^^
+   |                          ^^^^^^^^^^^
    |
 note: lifetime used multiple times
   --> $DIR/generic_duplicate_lifetime_param.rs:5:10

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_lifetime_param.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_lifetime_param.stderr
@@ -1,10 +1,8 @@
 error: non-defining opaque type use in defining scope
-  --> $DIR/generic_duplicate_lifetime_param.rs:7:1
+  --> $DIR/generic_duplicate_lifetime_param.rs:7:4
    |
-LL | / fn one<'a>(t: &'a ()) -> Two<'a, 'a> {
-LL | |     t
-LL | | }
-   | |_^
+LL | fn one<'a>(t: &'a ()) -> Two<'a, 'a> {
+   |    ^^^
    |
 note: lifetime used multiple times
   --> $DIR/generic_duplicate_lifetime_param.rs:5:10

--- a/src/test/ui/type/type-check-defaults.stderr
+++ b/src/test/ui/type/type-check-defaults.stderr
@@ -47,15 +47,14 @@ LL | trait TraitBound<T:Copy=String> {}
    | required by `TraitBound`
 
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
-  --> $DIR/type-check-defaults.rs:21:1
+  --> $DIR/type-check-defaults.rs:21:25
    |
 LL | trait Super<T: Copy> { }
    | -------------------- required by `Super`
 LL | trait Base<T = String>: Super<T> { }
-   | ^^^^^^^^^^^-^^^^^^^^^^^^^^^^^^^^^^^^
-   | |          |
-   | |          help: consider restricting this bound: `T: std::marker::Copy`
-   | the trait `std::marker::Copy` is not implemented for `T`
+   |            -            ^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
+   |            |
+   |            help: consider restricting this bound: `T: std::marker::Copy`
 
 error[E0277]: cannot add `u8` to `i32`
   --> $DIR/type-check-defaults.rs:24:66

--- a/src/test/ui/type/type-check/issue-40294.rs
+++ b/src/test/ui/type/type-check/issue-40294.rs
@@ -2,8 +2,8 @@ trait Foo: Sized {
     fn foo(self);
 }
 
-fn foo<'a,'b,T>(x: &'a T, y: &'b T) //~ ERROR type annotations needed
-    where &'a T : Foo,
+fn foo<'a,'b,T>(x: &'a T, y: &'b T)
+    where &'a T : Foo, //~ ERROR type annotations needed
           &'b T : Foo
 {
     x.foo();

--- a/src/test/ui/type/type-check/issue-40294.stderr
+++ b/src/test/ui/type/type-check/issue-40294.stderr
@@ -1,11 +1,11 @@
 error[E0283]: type annotations needed
-  --> $DIR/issue-40294.rs:5:4
+  --> $DIR/issue-40294.rs:6:19
    |
 LL | trait Foo: Sized {
    | ---------------- required by `Foo`
 ...
-LL | fn foo<'a,'b,T>(x: &'a T, y: &'b T)
-   |    ^^^ cannot infer type for reference `&'a T`
+LL |     where &'a T : Foo,
+   |                   ^^^ cannot infer type for reference `&'a T`
    |
    = note: cannot resolve `&'a T: Foo`
 

--- a/src/test/ui/type/type-check/issue-40294.stderr
+++ b/src/test/ui/type/type-check/issue-40294.stderr
@@ -1,17 +1,11 @@
 error[E0283]: type annotations needed
-  --> $DIR/issue-40294.rs:5:1
+  --> $DIR/issue-40294.rs:5:4
    |
-LL |   trait Foo: Sized {
-   |   ---------------- required by `Foo`
+LL | trait Foo: Sized {
+   | ---------------- required by `Foo`
 ...
-LL | / fn foo<'a,'b,T>(x: &'a T, y: &'b T)
-LL | |     where &'a T : Foo,
-LL | |           &'b T : Foo
-LL | | {
-LL | |     x.foo();
-LL | |     y.foo();
-LL | | }
-   | |_^ cannot infer type for reference `&'a T`
+LL | fn foo<'a,'b,T>(x: &'a T, y: &'b T)
+   |    ^^^ cannot infer type for reference `&'a T`
    |
    = note: cannot resolve `&'a T: Foo`
 

--- a/src/test/ui/type/type-parameter-defaults-referencing-Self-ppaux.stderr
+++ b/src/test/ui/type/type-parameter-defaults-referencing-Self-ppaux.stderr
@@ -14,10 +14,14 @@ error[E0038]: the trait `MyAdd` cannot be made into an object
   --> $DIR/type-parameter-defaults-referencing-Self-ppaux.rs:14:18
    |
 LL | trait MyAdd<Rhs=Self> { fn add(&self, other: &Rhs) -> Self; }
-   |                            --- method `add` references the `Self` type in its parameters or return type
+   |       -----                --- ...because method `add` references the `Self` type in its parameters or return type
+   |       |
+   |       this trait cannot be made into an object...
 ...
 LL |     let y = x as dyn MyAdd<i32>;
    |                  ^^^^^^^^^^^^^^ the trait `MyAdd` cannot be made into an object
+   |
+   = help: consider moving `add` to another trait
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/type/type-parameter-defaults-referencing-Self-ppaux.stderr
+++ b/src/test/ui/type/type-parameter-defaults-referencing-Self-ppaux.stderr
@@ -14,7 +14,7 @@ error[E0038]: the trait `MyAdd` cannot be made into an object
   --> $DIR/type-parameter-defaults-referencing-Self-ppaux.rs:14:18
    |
 LL | trait MyAdd<Rhs=Self> { fn add(&self, other: &Rhs) -> Self; }
-   |       -----                --- ...because method `add` references the `Self` type in its parameters or return type
+   |       -----                                           ---- ...because method `add` references the `Self` type in its return type
    |       |
    |       this trait cannot be made into an object...
 ...

--- a/src/test/ui/union/union-sized-field.stderr
+++ b/src/test/ui/union/union-sized-field.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/union-sized-field.rs:4:5
    |
 LL | union Foo<T: ?Sized> {
-   |           -- help: consider further restricting this bound: `T: std::marker::Sized +`
+   |           - this type parameter needs to be `std::marker::Sized`
 LL |     value: T,
    |     ^^^^^^^^ doesn't have a size known at compile-time
    |
@@ -14,7 +14,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/union-sized-field.rs:9:5
    |
 LL | struct Foo2<T: ?Sized> {
-   |             -- help: consider further restricting this bound: `T: std::marker::Sized +`
+   |             - this type parameter needs to be `std::marker::Sized`
 LL |     value: T,
    |     ^^^^^^^^ doesn't have a size known at compile-time
    |
@@ -26,7 +26,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/union-sized-field.rs:15:11
    |
 LL | enum Foo3<T: ?Sized> {
-   |           -- help: consider further restricting this bound: `T: std::marker::Sized +`
+   |           - this type parameter needs to be `std::marker::Sized`
 LL |     Value(T),
    |           ^ doesn't have a size known at compile-time
    |

--- a/src/test/ui/unsized-locals/by-value-trait-object-safety.stderr
+++ b/src/test/ui/unsized-locals/by-value-trait-object-safety.stderr
@@ -1,6 +1,9 @@
 error: the `foo` method cannot be invoked on a trait object
   --> $DIR/by-value-trait-object-safety.rs:18:7
    |
+LL |     fn foo(self) -> String where Self: Sized;
+   |                                        ----- this has a `Sized` requirement
+...
 LL |     x.foo();
    |       ^^^
 

--- a/src/test/ui/unsized/unsized-bare-typaram.stderr
+++ b/src/test/ui/unsized/unsized-bare-typaram.stderr
@@ -4,9 +4,9 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 LL | fn bar<T: Sized>() { }
    |    --- - required by this bound in `bar`
 LL | fn foo<T: ?Sized>() { bar::<T>() }
-   |        --                   ^ doesn't have a size known at compile-time
+   |        -                    ^ doesn't have a size known at compile-time
    |        |
-   |        help: consider further restricting this bound: `T: std::marker::Sized +`
+   |        this type parameter needs to be `std::marker::Sized`
    |
    = help: the trait `std::marker::Sized` is not implemented for `T`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>

--- a/src/test/ui/unsized/unsized-enum.stderr
+++ b/src/test/ui/unsized/unsized-enum.stderr
@@ -5,9 +5,9 @@ LL | enum Foo<U> { FooSome(U), FooNone }
    | ----------- required by `Foo`
 LL | fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
 LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
-   |         --                         ^^^^^^ doesn't have a size known at compile-time
+   |         -                          ^^^^^^ doesn't have a size known at compile-time
    |         |
-   |         help: consider further restricting this bound: `T: std::marker::Sized +`
+   |         this type parameter needs to be `std::marker::Sized`
    |
    = help: the trait `std::marker::Sized` is not implemented for `T`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>

--- a/src/test/ui/unsized/unsized-enum2.stderr
+++ b/src/test/ui/unsized/unsized-enum2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `W` cannot be known at compilation tim
   --> $DIR/unsized-enum2.rs:23:8
    |
 LL | enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
-   |        -- help: consider further restricting this bound: `W: std::marker::Sized +`
+   |        - this type parameter needs to be `std::marker::Sized`
 LL |     // parameter
 LL |     VA(W),
    |        ^ doesn't have a size known at compile-time
@@ -15,7 +15,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized-enum2.rs:25:8
    |
 LL | enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
-   |                   -- help: consider further restricting this bound: `X: std::marker::Sized +`
+   |                   - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     VB{x: X},
    |        ^^^^ doesn't have a size known at compile-time
@@ -28,7 +28,7 @@ error[E0277]: the size for values of type `Y` cannot be known at compilation tim
   --> $DIR/unsized-enum2.rs:27:15
    |
 LL | enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
-   |                              -- help: consider further restricting this bound: `Y: std::marker::Sized +`
+   |                              - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     VC(isize, Y),
    |               ^ doesn't have a size known at compile-time
@@ -41,7 +41,7 @@ error[E0277]: the size for values of type `Z` cannot be known at compilation tim
   --> $DIR/unsized-enum2.rs:29:18
    |
 LL | enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
-   |                                         -- help: consider further restricting this bound: `Z: std::marker::Sized +`
+   |                                         - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     VD{u: isize, x: Z},
    |                  ^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/unsized/unsized-inherent-impl-self-type.stderr
+++ b/src/test/ui/unsized/unsized-inherent-impl-self-type.stderr
@@ -5,9 +5,9 @@ LL | struct S5<Y>(Y);
    | ---------------- required by `S5`
 LL | 
 LL | impl<X: ?Sized> S5<X> {
-   |      --         ^^^^^ doesn't have a size known at compile-time
+   |      -          ^^^^^ doesn't have a size known at compile-time
    |      |
-   |      help: consider further restricting this bound: `X: std::marker::Sized +`
+   |      this type parameter needs to be `std::marker::Sized`
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>

--- a/src/test/ui/unsized/unsized-struct.stderr
+++ b/src/test/ui/unsized/unsized-struct.stderr
@@ -5,9 +5,9 @@ LL | struct Foo<T> { data: T }
    | ------------- required by `Foo`
 LL | fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
 LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
-   |         --                         ^^^^^^ doesn't have a size known at compile-time
+   |         -                          ^^^^^^ doesn't have a size known at compile-time
    |         |
-   |         help: consider further restricting this bound: `T: std::marker::Sized +`
+   |         this type parameter needs to be `std::marker::Sized`
    |
    = help: the trait `std::marker::Sized` is not implemented for `T`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
@@ -19,9 +19,9 @@ LL | fn is_sized<T:Sized>() { }
    |    -------- - required by this bound in `is_sized`
 ...
 LL | fn bar2<T: ?Sized>() { is_sized::<Bar<T>>() }
-   |         --             ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |         -              ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |         |
-   |         help: consider further restricting this bound: `T: std::marker::Sized +`
+   |         this type parameter needs to be `std::marker::Sized`
    |
    = help: within `Bar<T>`, the trait `std::marker::Sized` is not implemented for `T`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>

--- a/src/test/ui/unsized/unsized-trait-impl-self-type.stderr
+++ b/src/test/ui/unsized/unsized-trait-impl-self-type.stderr
@@ -5,9 +5,9 @@ LL | struct S5<Y>(Y);
    | ---------------- required by `S5`
 LL | 
 LL | impl<X: ?Sized> T3<X> for S5<X> {
-   |      --         ^^^^^ doesn't have a size known at compile-time
+   |      -          ^^^^^ doesn't have a size known at compile-time
    |      |
-   |      help: consider further restricting this bound: `X: std::marker::Sized +`
+   |      this type parameter needs to be `std::marker::Sized`
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>

--- a/src/test/ui/unsized/unsized-trait-impl-trait-arg.stderr
+++ b/src/test/ui/unsized/unsized-trait-impl-trait-arg.stderr
@@ -2,9 +2,9 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized-trait-impl-trait-arg.rs:8:17
    |
 LL | impl<X: ?Sized> T2<X> for S4<X> {
-   |      --         ^^^^^ doesn't have a size known at compile-time
+   |      -          ^^^^^ doesn't have a size known at compile-time
    |      |
-   |      help: consider further restricting this bound: `X: std::marker::Sized +`
+   |      this type parameter needs to be `std::marker::Sized`
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>

--- a/src/test/ui/unsized3.stderr
+++ b/src/test/ui/unsized3.stderr
@@ -1,8 +1,6 @@
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized3.rs:7:13
    |
-LL | fn f1<X: ?Sized>(x: &X) {
-   |       -- help: consider further restricting this bound: `X: std::marker::Sized +`
 LL |     f2::<X>(x);
    |             ^ doesn't have a size known at compile-time
 ...
@@ -11,12 +9,18 @@ LL | fn f2<X>(x: &X) {
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+help: consider further restricting this bound
+   |
+LL | fn f1<X: std::marker::Sized +  ?Sized>(x: &X) {
+   |       ^^^^^^^^^^^^^^^^^^^^^^^
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | fn f2<X: ?Sized>(x: &X) {
+   |        ^^^^^^^^
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized3.rs:18:13
    |
-LL | fn f3<X: ?Sized + T>(x: &X) {
-   |       -- help: consider further restricting this bound: `X: std::marker::Sized +`
 LL |     f4::<X>(x);
    |             ^ doesn't have a size known at compile-time
 ...
@@ -25,6 +29,14 @@ LL | fn f4<X: T>(x: &X) {
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+help: consider further restricting this bound
+   |
+LL | fn f3<X: std::marker::Sized +  ?Sized + T>(x: &X) {
+   |       ^^^^^^^^^^^^^^^^^^^^^^^
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | fn f4<X: T +  ?Sized>(x: &X) {
+   |            ^^^^^^^^^
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized3.rs:33:8

--- a/src/test/ui/unsized3.stderr
+++ b/src/test/ui/unsized3.stderr
@@ -1,42 +1,34 @@
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized3.rs:7:13
    |
+LL | fn f1<X: ?Sized>(x: &X) {
+   |       - this type parameter needs to be `std::marker::Sized`
 LL |     f2::<X>(x);
    |             ^ doesn't have a size known at compile-time
 ...
 LL | fn f2<X>(x: &X) {
-   |    -- - required by this bound in `f2`
+   |    -- -- help: consider relaxing the implicit `Sized` restriction: `: ?Sized`
+   |       |
+   |       required by this bound in `f2`
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-help: consider further restricting this bound
-   |
-LL | fn f1<X: std::marker::Sized +  ?Sized>(x: &X) {
-   |       ^^^^^^^^^^^^^^^^^^^^^^^
-help: consider relaxing the implicit `Sized` restriction
-   |
-LL | fn f2<X: ?Sized>(x: &X) {
-   |        ^^^^^^^^
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized3.rs:18:13
    |
+LL | fn f3<X: ?Sized + T>(x: &X) {
+   |       - this type parameter needs to be `std::marker::Sized`
 LL |     f4::<X>(x);
    |             ^ doesn't have a size known at compile-time
 ...
 LL | fn f4<X: T>(x: &X) {
-   |    -- - required by this bound in `f4`
+   |    -- -   - help: consider relaxing the implicit `Sized` restriction: `+  ?Sized`
+   |       |
+   |       required by this bound in `f4`
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-help: consider further restricting this bound
-   |
-LL | fn f3<X: std::marker::Sized +  ?Sized + T>(x: &X) {
-   |       ^^^^^^^^^^^^^^^^^^^^^^^
-help: consider relaxing the implicit `Sized` restriction
-   |
-LL | fn f4<X: T +  ?Sized>(x: &X) {
-   |            ^^^^^^^^^
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized3.rs:33:8
@@ -45,7 +37,7 @@ LL | fn f5<Y>(x: &Y) {}
    |    -- - required by this bound in `f5`
 ...
 LL | fn f8<X: ?Sized>(x1: &S<X>, x2: &S<X>) {
-   |       -- help: consider further restricting this bound: `X: std::marker::Sized +`
+   |       - this type parameter needs to be `std::marker::Sized`
 LL |     f5(x1);
    |        ^^ doesn't have a size known at compile-time
    |
@@ -57,7 +49,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:40:8
    |
 LL | fn f9<X: ?Sized>(x1: Box<S<X>>) {
-   |       -- help: consider further restricting this bound: `X: std::marker::Sized +`
+   |       - this type parameter needs to be `std::marker::Sized`
 LL |     f5(&(*x1, 34));
    |        ^^^^^^^^^^ doesn't have a size known at compile-time
    |
@@ -70,7 +62,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:45:9
    |
 LL | fn f10<X: ?Sized>(x1: Box<S<X>>) {
-   |        -- help: consider further restricting this bound: `X: std::marker::Sized +`
+   |        - this type parameter needs to be `std::marker::Sized`
 LL |     f5(&(32, *x1));
    |         ^^^^^^^^^ doesn't have a size known at compile-time
    |
@@ -87,7 +79,7 @@ LL | fn f5<Y>(x: &Y) {}
    |    -- - required by this bound in `f5`
 ...
 LL | fn f10<X: ?Sized>(x1: Box<S<X>>) {
-   |        -- help: consider further restricting this bound: `X: std::marker::Sized +`
+   |        - this type parameter needs to be `std::marker::Sized`
 LL |     f5(&(32, *x1));
    |        ^^^^^^^^^^ doesn't have a size known at compile-time
    |

--- a/src/test/ui/unsized5.stderr
+++ b/src/test/ui/unsized5.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized5.rs:4:5
    |
 LL | struct S1<X: ?Sized> {
-   |           -- help: consider further restricting this bound: `X: std::marker::Sized +`
+   |           - this type parameter needs to be `std::marker::Sized`
 LL |     f1: X,
    |     ^^^^^ doesn't have a size known at compile-time
    |
@@ -14,7 +14,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized5.rs:10:5
    |
 LL | struct S2<X: ?Sized> {
-   |           -- help: consider further restricting this bound: `X: std::marker::Sized +`
+   |           - this type parameter needs to be `std::marker::Sized`
 LL |     f: isize,
 LL |     g: X,
    |     ^^^^ doesn't have a size known at compile-time
@@ -47,7 +47,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized5.rs:25:8
    |
 LL | enum E<X: ?Sized> {
-   |        -- help: consider further restricting this bound: `X: std::marker::Sized +`
+   |        - this type parameter needs to be `std::marker::Sized`
 LL |     V1(X, isize),
    |        ^ doesn't have a size known at compile-time
    |
@@ -59,7 +59,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized5.rs:29:8
    |
 LL | enum F<X: ?Sized> {
-   |        -- help: consider further restricting this bound: `X: std::marker::Sized +`
+   |        - this type parameter needs to be `std::marker::Sized`
 LL |     V2{f1: X, f: isize},
    |        ^^^^^ doesn't have a size known at compile-time
    |

--- a/src/test/ui/unsized6.stderr
+++ b/src/test/ui/unsized6.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `Y` cannot be known at compilation tim
   --> $DIR/unsized6.rs:9:9
    |
 LL | fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
-   |                             -- help: consider further restricting this bound: `Y: std::marker::Sized +`
+   |                             - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     let y: Y;
    |         ^ doesn't have a size known at compile-time
@@ -16,7 +16,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:7:12
    |
 LL | fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
-   |                  -- help: consider further restricting this bound: `X: std::marker::Sized +`
+   |                  - this type parameter needs to be `std::marker::Sized`
 LL |     let _: W; // <-- this is OK, no bindings created, no initializer.
 LL |     let _: (isize, (X, isize));
    |            ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -29,7 +29,7 @@ error[E0277]: the size for values of type `Z` cannot be known at compilation tim
   --> $DIR/unsized6.rs:11:12
    |
 LL | fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
-   |                                        -- help: consider further restricting this bound: `Z: std::marker::Sized +`
+   |                                        - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     let y: (isize, (Z, usize));
    |            ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -42,7 +42,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:15:9
    |
 LL | fn f2<X: ?Sized, Y: ?Sized>(x: &X) {
-   |       -- help: consider further restricting this bound: `X: std::marker::Sized +`
+   |       - this type parameter needs to be `std::marker::Sized`
 LL |     let y: X;
    |         ^ doesn't have a size known at compile-time
    |
@@ -55,7 +55,7 @@ error[E0277]: the size for values of type `Y` cannot be known at compilation tim
   --> $DIR/unsized6.rs:17:12
    |
 LL | fn f2<X: ?Sized, Y: ?Sized>(x: &X) {
-   |                  -- help: consider further restricting this bound: `Y: std::marker::Sized +`
+   |                  - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     let y: (isize, (Y, isize));
    |            ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -68,7 +68,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:22:9
    |
 LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       -- help: consider further restricting this bound: `X: std::marker::Sized +`
+   |       - this type parameter needs to be `std::marker::Sized`
 LL |     let y: X = *x1;
    |         ^ doesn't have a size known at compile-time
    |
@@ -81,7 +81,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:24:9
    |
 LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       -- help: consider further restricting this bound: `X: std::marker::Sized +`
+   |       - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     let y = *x2;
    |         ^ doesn't have a size known at compile-time
@@ -95,7 +95,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:26:10
    |
 LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       -- help: consider further restricting this bound: `X: std::marker::Sized +`
+   |       - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     let (y, z) = (*x3, 4);
    |          ^ doesn't have a size known at compile-time
@@ -109,7 +109,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:30:9
    |
 LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       -- help: consider further restricting this bound: `X: std::marker::Sized +`
+   |       - this type parameter needs to be `std::marker::Sized`
 LL |     let y: X = *x1;
    |         ^ doesn't have a size known at compile-time
    |
@@ -122,7 +122,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:32:9
    |
 LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       -- help: consider further restricting this bound: `X: std::marker::Sized +`
+   |       - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     let y = *x2;
    |         ^ doesn't have a size known at compile-time
@@ -136,7 +136,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:34:10
    |
 LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       -- help: consider further restricting this bound: `X: std::marker::Sized +`
+   |       - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     let (y, z) = (*x3, 4);
    |          ^ doesn't have a size known at compile-time
@@ -150,9 +150,9 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:38:18
    |
 LL | fn g1<X: ?Sized>(x: X) {}
-   |       --         ^ doesn't have a size known at compile-time
+   |       -          ^ doesn't have a size known at compile-time
    |       |
-   |       help: consider further restricting this bound: `X: std::marker::Sized +`
+   |       this type parameter needs to be `std::marker::Sized`
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
@@ -163,9 +163,9 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:40:22
    |
 LL | fn g2<X: ?Sized + T>(x: X) {}
-   |       --             ^ doesn't have a size known at compile-time
+   |       -              ^ doesn't have a size known at compile-time
    |       |
-   |       help: consider further restricting this bound: `X: std::marker::Sized +`
+   |       this type parameter needs to be `std::marker::Sized`
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>

--- a/src/test/ui/unsized7.stderr
+++ b/src/test/ui/unsized7.stderr
@@ -2,9 +2,9 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized7.rs:12:21
    |
 LL | impl<X: ?Sized + T> T1<X> for S3<X> {
-   |      --             ^^^^^ doesn't have a size known at compile-time
+   |      -              ^^^^^ doesn't have a size known at compile-time
    |      |
-   |      help: consider further restricting this bound: `X: std::marker::Sized +`
+   |      this type parameter needs to be `std::marker::Sized`
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>

--- a/src/test/ui/wf/wf-convert-unsafe-trait-obj-box.stderr
+++ b/src/test/ui/wf/wf-convert-unsafe-trait-obj-box.stderr
@@ -2,7 +2,9 @@ error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-convert-unsafe-trait-obj-box.rs:16:33
    |
 LL | trait Trait: Sized {}
-   |              ----- traits that require `Self: Sized` cannot be made into an object
+   |       -----  ----- ...because it requires `Self: Sized`
+   |       |
+   |       this trait cannot be made into an object...
 ...
 LL |     let t_box: Box<dyn Trait> = Box::new(S);
    |                                 ^^^^^^^^^^^ the trait `Trait` cannot be made into an object
@@ -14,7 +16,9 @@ error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-convert-unsafe-trait-obj-box.rs:17:15
    |
 LL | trait Trait: Sized {}
-   |              ----- traits that require `Self: Sized` cannot be made into an object
+   |       -----  ----- ...because it requires `Self: Sized`
+   |       |
+   |       this trait cannot be made into an object...
 ...
 LL |     takes_box(Box::new(S));
    |               ^^^^^^^^^^^ the trait `Trait` cannot be made into an object
@@ -26,7 +30,9 @@ error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-convert-unsafe-trait-obj-box.rs:15:5
    |
 LL | trait Trait: Sized {}
-   |              ----- traits that require `Self: Sized` cannot be made into an object
+   |       -----  ----- ...because it requires `Self: Sized`
+   |       |
+   |       this trait cannot be made into an object...
 ...
 LL |     Box::new(S) as Box<dyn Trait>;
    |     ^^^^^^^^^^^ the trait `Trait` cannot be made into an object

--- a/src/test/ui/wf/wf-convert-unsafe-trait-obj-box.stderr
+++ b/src/test/ui/wf/wf-convert-unsafe-trait-obj-box.stderr
@@ -2,7 +2,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-convert-unsafe-trait-obj-box.rs:16:33
    |
 LL | trait Trait: Sized {}
-   |              ----- the trait cannot require that `Self : Sized`
+   |              ----- traits that require `Self: Sized` cannot be made into an object
 ...
 LL |     let t_box: Box<dyn Trait> = Box::new(S);
    |                                 ^^^^^^^^^^^ the trait `Trait` cannot be made into an object
@@ -14,7 +14,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-convert-unsafe-trait-obj-box.rs:17:15
    |
 LL | trait Trait: Sized {}
-   |              ----- the trait cannot require that `Self : Sized`
+   |              ----- traits that require `Self: Sized` cannot be made into an object
 ...
 LL |     takes_box(Box::new(S));
    |               ^^^^^^^^^^^ the trait `Trait` cannot be made into an object
@@ -26,7 +26,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-convert-unsafe-trait-obj-box.rs:15:5
    |
 LL | trait Trait: Sized {}
-   |              ----- the trait cannot require that `Self : Sized`
+   |              ----- traits that require `Self: Sized` cannot be made into an object
 ...
 LL |     Box::new(S) as Box<dyn Trait>;
    |     ^^^^^^^^^^^ the trait `Trait` cannot be made into an object

--- a/src/test/ui/wf/wf-convert-unsafe-trait-obj-box.stderr
+++ b/src/test/ui/wf/wf-convert-unsafe-trait-obj-box.stderr
@@ -1,6 +1,9 @@
 error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-convert-unsafe-trait-obj-box.rs:16:33
    |
+LL | trait Trait: Sized {}
+   |              ----- the trait cannot require that `Self : Sized`
+...
 LL |     let t_box: Box<dyn Trait> = Box::new(S);
    |                                 ^^^^^^^^^^^ the trait `Trait` cannot be made into an object
    |
@@ -11,6 +14,9 @@ LL |     let t_box: Box<dyn Trait> = Box::new(S);
 error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-convert-unsafe-trait-obj-box.rs:17:15
    |
+LL | trait Trait: Sized {}
+   |              ----- the trait cannot require that `Self : Sized`
+...
 LL |     takes_box(Box::new(S));
    |               ^^^^^^^^^^^ the trait `Trait` cannot be made into an object
    |
@@ -21,6 +27,9 @@ LL |     takes_box(Box::new(S));
 error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-convert-unsafe-trait-obj-box.rs:15:5
    |
+LL | trait Trait: Sized {}
+   |              ----- the trait cannot require that `Self : Sized`
+...
 LL |     Box::new(S) as Box<dyn Trait>;
    |     ^^^^^^^^^^^ the trait `Trait` cannot be made into an object
    |

--- a/src/test/ui/wf/wf-convert-unsafe-trait-obj-box.stderr
+++ b/src/test/ui/wf/wf-convert-unsafe-trait-obj-box.stderr
@@ -7,7 +7,6 @@ LL | trait Trait: Sized {}
 LL |     let t_box: Box<dyn Trait> = Box::new(S);
    |                                 ^^^^^^^^^^^ the trait `Trait` cannot be made into an object
    |
-   = note: the trait cannot require that `Self : Sized`
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<std::boxed::Box<dyn Trait>>` for `std::boxed::Box<S>`
    = note: required by cast to type `std::boxed::Box<dyn Trait>`
 
@@ -20,7 +19,6 @@ LL | trait Trait: Sized {}
 LL |     takes_box(Box::new(S));
    |               ^^^^^^^^^^^ the trait `Trait` cannot be made into an object
    |
-   = note: the trait cannot require that `Self : Sized`
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<std::boxed::Box<dyn Trait>>` for `std::boxed::Box<S>`
    = note: required by cast to type `std::boxed::Box<(dyn Trait + 'static)>`
 
@@ -33,7 +31,6 @@ LL | trait Trait: Sized {}
 LL |     Box::new(S) as Box<dyn Trait>;
    |     ^^^^^^^^^^^ the trait `Trait` cannot be made into an object
    |
-   = note: the trait cannot require that `Self : Sized`
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<std::boxed::Box<dyn Trait>>` for `std::boxed::Box<S>`
    = note: required by cast to type `std::boxed::Box<dyn Trait>`
 

--- a/src/test/ui/wf/wf-convert-unsafe-trait-obj.stderr
+++ b/src/test/ui/wf/wf-convert-unsafe-trait-obj.stderr
@@ -1,6 +1,9 @@
 error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-convert-unsafe-trait-obj.rs:16:25
    |
+LL | trait Trait: Sized {}
+   |              ----- the trait cannot require that `Self : Sized`
+...
 LL |     let t: &dyn Trait = &S;
    |                         ^^ the trait `Trait` cannot be made into an object
    |
@@ -11,6 +14,9 @@ LL |     let t: &dyn Trait = &S;
 error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-convert-unsafe-trait-obj.rs:17:17
    |
+LL | trait Trait: Sized {}
+   |              ----- the trait cannot require that `Self : Sized`
+...
 LL |     takes_trait(&S);
    |                 ^^ the trait `Trait` cannot be made into an object
    |
@@ -21,6 +27,9 @@ LL |     takes_trait(&S);
 error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-convert-unsafe-trait-obj.rs:15:5
    |
+LL | trait Trait: Sized {}
+   |              ----- the trait cannot require that `Self : Sized`
+...
 LL |     &S as &dyn Trait;
    |     ^^ the trait `Trait` cannot be made into an object
    |

--- a/src/test/ui/wf/wf-convert-unsafe-trait-obj.stderr
+++ b/src/test/ui/wf/wf-convert-unsafe-trait-obj.stderr
@@ -2,7 +2,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-convert-unsafe-trait-obj.rs:16:25
    |
 LL | trait Trait: Sized {}
-   |              ----- the trait cannot require that `Self : Sized`
+   |              ----- traits that require `Self: Sized` cannot be made into an object
 ...
 LL |     let t: &dyn Trait = &S;
    |                         ^^ the trait `Trait` cannot be made into an object
@@ -14,7 +14,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-convert-unsafe-trait-obj.rs:17:17
    |
 LL | trait Trait: Sized {}
-   |              ----- the trait cannot require that `Self : Sized`
+   |              ----- traits that require `Self: Sized` cannot be made into an object
 ...
 LL |     takes_trait(&S);
    |                 ^^ the trait `Trait` cannot be made into an object
@@ -26,7 +26,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-convert-unsafe-trait-obj.rs:15:5
    |
 LL | trait Trait: Sized {}
-   |              ----- the trait cannot require that `Self : Sized`
+   |              ----- traits that require `Self: Sized` cannot be made into an object
 ...
 LL |     &S as &dyn Trait;
    |     ^^ the trait `Trait` cannot be made into an object

--- a/src/test/ui/wf/wf-convert-unsafe-trait-obj.stderr
+++ b/src/test/ui/wf/wf-convert-unsafe-trait-obj.stderr
@@ -2,7 +2,9 @@ error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-convert-unsafe-trait-obj.rs:16:25
    |
 LL | trait Trait: Sized {}
-   |              ----- traits that require `Self: Sized` cannot be made into an object
+   |       -----  ----- ...because it requires `Self: Sized`
+   |       |
+   |       this trait cannot be made into an object...
 ...
 LL |     let t: &dyn Trait = &S;
    |                         ^^ the trait `Trait` cannot be made into an object
@@ -14,7 +16,9 @@ error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-convert-unsafe-trait-obj.rs:17:17
    |
 LL | trait Trait: Sized {}
-   |              ----- traits that require `Self: Sized` cannot be made into an object
+   |       -----  ----- ...because it requires `Self: Sized`
+   |       |
+   |       this trait cannot be made into an object...
 ...
 LL |     takes_trait(&S);
    |                 ^^ the trait `Trait` cannot be made into an object
@@ -26,7 +30,9 @@ error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-convert-unsafe-trait-obj.rs:15:5
    |
 LL | trait Trait: Sized {}
-   |              ----- traits that require `Self: Sized` cannot be made into an object
+   |       -----  ----- ...because it requires `Self: Sized`
+   |       |
+   |       this trait cannot be made into an object...
 ...
 LL |     &S as &dyn Trait;
    |     ^^ the trait `Trait` cannot be made into an object

--- a/src/test/ui/wf/wf-convert-unsafe-trait-obj.stderr
+++ b/src/test/ui/wf/wf-convert-unsafe-trait-obj.stderr
@@ -7,7 +7,6 @@ LL | trait Trait: Sized {}
 LL |     let t: &dyn Trait = &S;
    |                         ^^ the trait `Trait` cannot be made into an object
    |
-   = note: the trait cannot require that `Self : Sized`
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<&dyn Trait>` for `&S`
    = note: required by cast to type `&dyn Trait`
 
@@ -20,7 +19,6 @@ LL | trait Trait: Sized {}
 LL |     takes_trait(&S);
    |                 ^^ the trait `Trait` cannot be made into an object
    |
-   = note: the trait cannot require that `Self : Sized`
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<&dyn Trait>` for `&S`
    = note: required by cast to type `&dyn Trait`
 
@@ -33,7 +31,6 @@ LL | trait Trait: Sized {}
 LL |     &S as &dyn Trait;
    |     ^^ the trait `Trait` cannot be made into an object
    |
-   = note: the trait cannot require that `Self : Sized`
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<&dyn Trait>` for `&S`
    = note: required by cast to type `&dyn Trait`
 

--- a/src/test/ui/wf/wf-enum-bound.rs
+++ b/src/test/ui/wf/wf-enum-bound.rs
@@ -6,8 +6,8 @@
 
 trait ExtraCopy<T:Copy> { }
 
-enum SomeEnum<T,U> //~ ERROR E0277
-    where T: ExtraCopy<U>
+enum SomeEnum<T,U>
+    where T: ExtraCopy<U> //~ ERROR E0277
 {
     SomeVariant(T,U)
 }

--- a/src/test/ui/wf/wf-enum-bound.stderr
+++ b/src/test/ui/wf/wf-enum-bound.stderr
@@ -1,16 +1,13 @@
 error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
-  --> $DIR/wf-enum-bound.rs:9:1
+  --> $DIR/wf-enum-bound.rs:10:14
    |
-LL |   trait ExtraCopy<T:Copy> { }
-   |   ----------------------- required by `ExtraCopy`
-LL | 
-LL | / enum SomeEnum<T,U>
-LL | |     where T: ExtraCopy<U>
-   | |                          - help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
-LL | | {
-LL | |     SomeVariant(T,U)
-LL | | }
-   | |_^ the trait `std::marker::Copy` is not implemented for `U`
+LL | trait ExtraCopy<T:Copy> { }
+   | ----------------------- required by `ExtraCopy`
+...
+LL |     where T: ExtraCopy<U>
+   |              ^^^^^^^^^^^^- help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
+   |              |
+   |              the trait `std::marker::Copy` is not implemented for `U`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-fn-where-clause.stderr
@@ -25,7 +25,7 @@ error[E0038]: the trait `std::marker::Copy` cannot be made into an object
 LL | fn bar() where Vec<dyn Copy>:, {}
    |                ^^^^^^^^^^^^^ the trait `std::marker::Copy` cannot be made into an object
    |
-   = note: the trait cannot require that `Self : Sized`
+   = note: traits that require `Self: Sized` cannot be made into an object
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/wf/wf-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-fn-where-clause.stderr
@@ -25,7 +25,7 @@ error[E0038]: the trait `std::marker::Copy` cannot be made into an object
 LL | fn bar() where Vec<dyn Copy>:, {}
    |                ^^^^^^^^^^^^^ the trait `std::marker::Copy` cannot be made into an object
    |
-   = note: traits that require `Self: Sized` cannot be made into an object
+   = note: the trait cannot be made into an object because it requires `Self: Sized`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/wf/wf-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-fn-where-clause.stderr
@@ -1,29 +1,29 @@
 error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
-  --> $DIR/wf-fn-where-clause.rs:8:4
+  --> $DIR/wf-fn-where-clause.rs:8:24
    |
 LL | trait ExtraCopy<T:Copy> { }
    | ----------------------- required by `ExtraCopy`
 LL | 
 LL | fn foo<T,U>() where T: ExtraCopy<U>
-   |    ^^^                             - help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
-   |    |
-   |    the trait `std::marker::Copy` is not implemented for `U`
+   |                        ^^^^^^^^^^^^- help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
+   |                        |
+   |                        the trait `std::marker::Copy` is not implemented for `U`
 
 error[E0277]: the size for values of type `(dyn std::marker::Copy + 'static)` cannot be known at compilation time
-  --> $DIR/wf-fn-where-clause.rs:12:4
+  --> $DIR/wf-fn-where-clause.rs:12:16
    |
 LL | fn bar() where Vec<dyn Copy>:, {}
-   |    ^^^ doesn't have a size known at compile-time
+   |                ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `(dyn std::marker::Copy + 'static)`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: required by `std::vec::Vec`
 
 error[E0038]: the trait `std::marker::Copy` cannot be made into an object
-  --> $DIR/wf-fn-where-clause.rs:12:4
+  --> $DIR/wf-fn-where-clause.rs:12:16
    |
 LL | fn bar() where Vec<dyn Copy>:, {}
-   |    ^^^ the trait `std::marker::Copy` cannot be made into an object
+   |                ^^^^^^^^^^^^^ the trait `std::marker::Copy` cannot be made into an object
    |
    = note: the trait cannot require that `Self : Sized`
 

--- a/src/test/ui/wf/wf-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-fn-where-clause.stderr
@@ -1,32 +1,29 @@
 error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
-  --> $DIR/wf-fn-where-clause.rs:8:1
+  --> $DIR/wf-fn-where-clause.rs:8:4
    |
-LL |   trait ExtraCopy<T:Copy> { }
-   |   ----------------------- required by `ExtraCopy`
+LL | trait ExtraCopy<T:Copy> { }
+   | ----------------------- required by `ExtraCopy`
 LL | 
-LL |   fn foo<T,U>() where T: ExtraCopy<U>
-   |   ^                                  - help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
-   |  _|
-   | |
-LL | | {
-LL | | }
-   | |_^ the trait `std::marker::Copy` is not implemented for `U`
+LL | fn foo<T,U>() where T: ExtraCopy<U>
+   |    ^^^                             - help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
+   |    |
+   |    the trait `std::marker::Copy` is not implemented for `U`
 
 error[E0277]: the size for values of type `(dyn std::marker::Copy + 'static)` cannot be known at compilation time
-  --> $DIR/wf-fn-where-clause.rs:12:1
+  --> $DIR/wf-fn-where-clause.rs:12:4
    |
 LL | fn bar() where Vec<dyn Copy>:, {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |    ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `(dyn std::marker::Copy + 'static)`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: required by `std::vec::Vec`
 
 error[E0038]: the trait `std::marker::Copy` cannot be made into an object
-  --> $DIR/wf-fn-where-clause.rs:12:1
+  --> $DIR/wf-fn-where-clause.rs:12:4
    |
 LL | fn bar() where Vec<dyn Copy>:, {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` cannot be made into an object
+   |    ^^^ the trait `std::marker::Copy` cannot be made into an object
    |
    = note: the trait cannot require that `Self : Sized`
 

--- a/src/test/ui/wf/wf-in-fn-arg.stderr
+++ b/src/test/ui/wf/wf-in-fn-arg.stderr
@@ -1,16 +1,13 @@
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
-  --> $DIR/wf-in-fn-arg.rs:10:1
+  --> $DIR/wf-in-fn-arg.rs:10:14
    |
-LL |   struct MustBeCopy<T:Copy> {
-   |   ------------------------- required by `MustBeCopy`
+LL | struct MustBeCopy<T:Copy> {
+   | ------------------------- required by `MustBeCopy`
 ...
-LL |   fn bar<T>(_: &MustBeCopy<T>)
-   |   ^      - help: consider restricting this bound: `T: std::marker::Copy`
-   |  _|
-   | |
-LL | | {
-LL | | }
-   | |_^ the trait `std::marker::Copy` is not implemented for `T`
+LL | fn bar<T>(_: &MustBeCopy<T>)
+   |        -     ^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
+   |        |
+   |        help: consider restricting this bound: `T: std::marker::Copy`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-ret.stderr
+++ b/src/test/ui/wf/wf-in-fn-ret.stderr
@@ -1,16 +1,13 @@
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
-  --> $DIR/wf-in-fn-ret.rs:10:1
+  --> $DIR/wf-in-fn-ret.rs:10:16
    |
-LL |   struct MustBeCopy<T:Copy> {
-   |   ------------------------- required by `MustBeCopy`
+LL | struct MustBeCopy<T:Copy> {
+   | ------------------------- required by `MustBeCopy`
 ...
-LL |   fn bar<T>() -> MustBeCopy<T>
-   |   ^      - help: consider restricting this bound: `T: std::marker::Copy`
-   |  _|
-   | |
-LL | | {
-LL | | }
-   | |_^ the trait `std::marker::Copy` is not implemented for `T`
+LL | fn bar<T>() -> MustBeCopy<T>
+   |        -       ^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
+   |        |
+   |        help: consider restricting this bound: `T: std::marker::Copy`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-where-clause.rs
+++ b/src/test/ui/wf/wf-in-fn-where-clause.rs
@@ -6,8 +6,8 @@
 trait MustBeCopy<T:Copy> {
 }
 
-fn bar<T,U>() //~ ERROR E0277
-    where T: MustBeCopy<U>
+fn bar<T,U>()
+    where T: MustBeCopy<U> //~ ERROR E0277
 {
 }
 

--- a/src/test/ui/wf/wf-in-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-in-fn-where-clause.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
-  --> $DIR/wf-in-fn-where-clause.rs:9:1
+  --> $DIR/wf-in-fn-where-clause.rs:9:4
    |
-LL |   trait MustBeCopy<T:Copy> {
-   |   ------------------------ required by `MustBeCopy`
+LL | trait MustBeCopy<T:Copy> {
+   | ------------------------ required by `MustBeCopy`
 ...
-LL | / fn bar<T,U>()
-LL | |     where T: MustBeCopy<U>
-   | |                           - help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
-LL | | {
-LL | | }
-   | |_^ the trait `std::marker::Copy` is not implemented for `U`
+LL | fn bar<T,U>()
+   |    ^^^ the trait `std::marker::Copy` is not implemented for `U`
+LL |     where T: MustBeCopy<U>
+   |                           - help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-in-fn-where-clause.stderr
@@ -1,13 +1,13 @@
 error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
-  --> $DIR/wf-in-fn-where-clause.rs:9:4
+  --> $DIR/wf-in-fn-where-clause.rs:10:14
    |
 LL | trait MustBeCopy<T:Copy> {
    | ------------------------ required by `MustBeCopy`
 ...
-LL | fn bar<T,U>()
-   |    ^^^ the trait `std::marker::Copy` is not implemented for `U`
 LL |     where T: MustBeCopy<U>
-   |                           - help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
+   |              ^^^^^^^^^^^^^- help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
+   |              |
+   |              the trait `std::marker::Copy` is not implemented for `U`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-inherent-impl-method-where-clause.stderr
+++ b/src/test/ui/wf/wf-inherent-impl-method-where-clause.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
-  --> $DIR/wf-inherent-impl-method-where-clause.rs:12:8
+  --> $DIR/wf-inherent-impl-method-where-clause.rs:12:27
    |
 LL | trait ExtraCopy<T:Copy> { }
    | ----------------------- required by `ExtraCopy`
@@ -7,7 +7,7 @@ LL | trait ExtraCopy<T:Copy> { }
 LL | impl<T,U> Foo<T,U> {
    |        - help: consider restricting this bound: `U: std::marker::Copy`
 LL |     fn foo(self) where T: ExtraCopy<U>
-   |        ^^^ the trait `std::marker::Copy` is not implemented for `U`
+   |                           ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-inherent-impl-method-where-clause.stderr
+++ b/src/test/ui/wf/wf-inherent-impl-method-where-clause.stderr
@@ -1,14 +1,13 @@
 error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
-  --> $DIR/wf-inherent-impl-method-where-clause.rs:12:5
+  --> $DIR/wf-inherent-impl-method-where-clause.rs:12:8
    |
-LL |   trait ExtraCopy<T:Copy> { }
-   |   ----------------------- required by `ExtraCopy`
+LL | trait ExtraCopy<T:Copy> { }
+   | ----------------------- required by `ExtraCopy`
 ...
-LL |   impl<T,U> Foo<T,U> {
-   |          - help: consider restricting this bound: `U: std::marker::Copy`
-LL | /     fn foo(self) where T: ExtraCopy<U>
-LL | |     {}
-   | |______^ the trait `std::marker::Copy` is not implemented for `U`
+LL | impl<T,U> Foo<T,U> {
+   |        - help: consider restricting this bound: `U: std::marker::Copy`
+LL |     fn foo(self) where T: ExtraCopy<U>
+   |        ^^^ the trait `std::marker::Copy` is not implemented for `U`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-inherent-impl-where-clause.stderr
+++ b/src/test/ui/wf/wf-inherent-impl-where-clause.stderr
@@ -1,16 +1,13 @@
 error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
-  --> $DIR/wf-inherent-impl-where-clause.rs:11:1
+  --> $DIR/wf-inherent-impl-where-clause.rs:11:29
    |
-LL |   trait ExtraCopy<T:Copy> { }
-   |   ----------------------- required by `ExtraCopy`
+LL | trait ExtraCopy<T:Copy> { }
+   | ----------------------- required by `ExtraCopy`
 ...
-LL |   impl<T,U> Foo<T,U> where T: ExtraCopy<U>
-   |   ^                                       - help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
-   |  _|
-   | |
-LL | | {
-LL | | }
-   | |_^ the trait `std::marker::Copy` is not implemented for `U`
+LL | impl<T,U> Foo<T,U> where T: ExtraCopy<U>
+   |                             ^^^^^^^^^^^^- help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
+   |                             |
+   |                             the trait `std::marker::Copy` is not implemented for `U`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-object-safe.stderr
+++ b/src/test/ui/wf/wf-object-safe.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `A` cannot be made into an object
 LL | trait A {
    |       - this trait cannot be made into an object...
 LL |     fn foo(&self, _x: &Self);
-   |        --- ...because method `foo` references the `Self` type in its parameters or return type
+   |                       ----- ...because method `foo` references the `Self` type in this parameter
 ...
 LL |     let _x: &dyn A;
    |             ^^^^^^ the trait `A` cannot be made into an object

--- a/src/test/ui/wf/wf-object-safe.stderr
+++ b/src/test/ui/wf/wf-object-safe.stderr
@@ -1,11 +1,15 @@
 error[E0038]: the trait `A` cannot be made into an object
   --> $DIR/wf-object-safe.rs:9:13
    |
+LL | trait A {
+   |       - this trait cannot be made into an object...
 LL |     fn foo(&self, _x: &Self);
-   |        --- method `foo` references the `Self` type in its parameters or return type
+   |        --- ...because method `foo` references the `Self` type in its parameters or return type
 ...
 LL |     let _x: &dyn A;
    |             ^^^^^^ the trait `A` cannot be made into an object
+   |
+   = help: consider moving `foo` to another trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-struct-bound.rs
+++ b/src/test/ui/wf/wf-struct-bound.rs
@@ -6,8 +6,8 @@
 
 trait ExtraCopy<T:Copy> { }
 
-struct SomeStruct<T,U> //~ ERROR E0277
-    where T: ExtraCopy<U>
+struct SomeStruct<T,U>
+    where T: ExtraCopy<U> //~ ERROR E0277
 {
     data: (T,U)
 }

--- a/src/test/ui/wf/wf-struct-bound.stderr
+++ b/src/test/ui/wf/wf-struct-bound.stderr
@@ -1,16 +1,13 @@
 error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
-  --> $DIR/wf-struct-bound.rs:9:1
+  --> $DIR/wf-struct-bound.rs:10:14
    |
-LL |   trait ExtraCopy<T:Copy> { }
-   |   ----------------------- required by `ExtraCopy`
-LL | 
-LL | / struct SomeStruct<T,U>
-LL | |     where T: ExtraCopy<U>
-   | |                          - help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
-LL | | {
-LL | |     data: (T,U)
-LL | | }
-   | |_^ the trait `std::marker::Copy` is not implemented for `U`
+LL | trait ExtraCopy<T:Copy> { }
+   | ----------------------- required by `ExtraCopy`
+...
+LL |     where T: ExtraCopy<U>
+   |              ^^^^^^^^^^^^- help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
+   |              |
+   |              the trait `std::marker::Copy` is not implemented for `U`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-associated-type-bound.rs
+++ b/src/test/ui/wf/wf-trait-associated-type-bound.rs
@@ -6,8 +6,8 @@
 
 trait ExtraCopy<T:Copy> { }
 
-trait SomeTrait<T> { //~ ERROR E0277
-    type Type1: ExtraCopy<T>;
+trait SomeTrait<T> {
+    type Type1: ExtraCopy<T>; //~ ERROR E0277
 }
 
 

--- a/src/test/ui/wf/wf-trait-associated-type-bound.stderr
+++ b/src/test/ui/wf/wf-trait-associated-type-bound.stderr
@@ -1,16 +1,13 @@
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
-  --> $DIR/wf-trait-associated-type-bound.rs:9:1
+  --> $DIR/wf-trait-associated-type-bound.rs:10:17
    |
-LL |   trait ExtraCopy<T:Copy> { }
-   |   ----------------------- required by `ExtraCopy`
+LL | trait ExtraCopy<T:Copy> { }
+   | ----------------------- required by `ExtraCopy`
 LL | 
-LL |   trait SomeTrait<T> {
-   |   ^               - help: consider restricting this bound: `T: std::marker::Copy`
-   |  _|
-   | |
-LL | |     type Type1: ExtraCopy<T>;
-LL | | }
-   | |_^ the trait `std::marker::Copy` is not implemented for `T`
+LL | trait SomeTrait<T> {
+   |                 - help: consider restricting this bound: `T: std::marker::Copy`
+LL |     type Type1: ExtraCopy<T>;
+   |                 ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-bound.rs
+++ b/src/test/ui/wf/wf-trait-bound.rs
@@ -6,8 +6,8 @@
 
 trait ExtraCopy<T:Copy> { }
 
-trait SomeTrait<T,U> //~ ERROR E0277
-    where T: ExtraCopy<U>
+trait SomeTrait<T,U>
+    where T: ExtraCopy<U> //~ ERROR E0277
 {
 }
 

--- a/src/test/ui/wf/wf-trait-bound.stderr
+++ b/src/test/ui/wf/wf-trait-bound.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
-  --> $DIR/wf-trait-bound.rs:9:1
+  --> $DIR/wf-trait-bound.rs:10:14
    |
-LL |   trait ExtraCopy<T:Copy> { }
-   |   ----------------------- required by `ExtraCopy`
-LL | 
-LL | / trait SomeTrait<T,U>
-LL | |     where T: ExtraCopy<U>
-   | |                          - help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
-LL | | {
-LL | | }
-   | |_^ the trait `std::marker::Copy` is not implemented for `U`
+LL | trait ExtraCopy<T:Copy> { }
+   | ----------------------- required by `ExtraCopy`
+...
+LL |     where T: ExtraCopy<U>
+   |              ^^^^^^^^^^^^- help: consider further restricting type parameter `U`: `, U: std::marker::Copy`
+   |              |
+   |              the trait `std::marker::Copy` is not implemented for `U`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-default-fn-arg.stderr
+++ b/src/test/ui/wf/wf-trait-default-fn-arg.stderr
@@ -1,18 +1,13 @@
 error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
-  --> $DIR/wf-trait-default-fn-arg.rs:11:5
+  --> $DIR/wf-trait-default-fn-arg.rs:11:22
    |
-LL |   struct Bar<T:Eq+?Sized> { value: Box<T> }
-   |   ----------------------- required by `Bar`
+LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
+   | ----------------------- required by `Bar`
 ...
-LL |       fn bar(&self, x: &Bar<Self>) {
-   |       ^                           - help: consider further restricting `Self`: `where Self: std::cmp::Eq`
-   |  _____|
-   | |
-LL | |
-LL | |         //
-LL | |         // Here, Eq ought to be implemented.
-LL | |     }
-   | |_____^ the trait `std::cmp::Eq` is not implemented for `Self`
+LL |     fn bar(&self, x: &Bar<Self>) {
+   |                      ^^^^^^^^^^ - help: consider further restricting `Self`: `where Self: std::cmp::Eq`
+   |                      |
+   |                      the trait `std::cmp::Eq` is not implemented for `Self`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-default-fn-ret.stderr
+++ b/src/test/ui/wf/wf-trait-default-fn-ret.stderr
@@ -1,19 +1,13 @@
 error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
-  --> $DIR/wf-trait-default-fn-ret.rs:11:5
+  --> $DIR/wf-trait-default-fn-ret.rs:11:22
    |
-LL |   struct Bar<T:Eq+?Sized> { value: Box<T> }
-   |   ----------------------- required by `Bar`
+LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
+   | ----------------------- required by `Bar`
 ...
-LL |       fn bar(&self) -> Bar<Self> {
-   |       ^                         - help: consider further restricting `Self`: `where Self: std::cmp::Eq`
-   |  _____|
-   | |
-LL | |
-LL | |         //
-LL | |         // Here, Eq ought to be implemented.
-LL | |         loop { }
-LL | |     }
-   | |_____^ the trait `std::cmp::Eq` is not implemented for `Self`
+LL |     fn bar(&self) -> Bar<Self> {
+   |                      ^^^^^^^^^- help: consider further restricting `Self`: `where Self: std::cmp::Eq`
+   |                      |
+   |                      the trait `std::cmp::Eq` is not implemented for `Self`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-default-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-trait-default-fn-where-clause.stderr
@@ -1,18 +1,13 @@
 error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
-  --> $DIR/wf-trait-default-fn-where-clause.rs:11:5
+  --> $DIR/wf-trait-default-fn-where-clause.rs:11:8
    |
-LL |   trait Bar<T:Eq+?Sized> { }
-   |   ---------------------- required by `Bar`
+LL | trait Bar<T:Eq+?Sized> { }
+   | ---------------------- required by `Bar`
 ...
-LL |       fn bar<A>(&self) where A: Bar<Self> {
-   |       ^                                  - help: consider further restricting `Self`: `, Self: std::cmp::Eq`
-   |  _____|
-   | |
-LL | |
-LL | |         //
-LL | |         // Here, Eq ought to be implemented.
-LL | |     }
-   | |_____^ the trait `std::cmp::Eq` is not implemented for `Self`
+LL |     fn bar<A>(&self) where A: Bar<Self> {
+   |        ^^^                             - help: consider further restricting `Self`: `, Self: std::cmp::Eq`
+   |        |
+   |        the trait `std::cmp::Eq` is not implemented for `Self`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-default-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-trait-default-fn-where-clause.stderr
@@ -1,13 +1,13 @@
 error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
-  --> $DIR/wf-trait-default-fn-where-clause.rs:11:8
+  --> $DIR/wf-trait-default-fn-where-clause.rs:11:31
    |
 LL | trait Bar<T:Eq+?Sized> { }
    | ---------------------- required by `Bar`
 ...
 LL |     fn bar<A>(&self) where A: Bar<Self> {
-   |        ^^^                             - help: consider further restricting `Self`: `, Self: std::cmp::Eq`
-   |        |
-   |        the trait `std::cmp::Eq` is not implemented for `Self`
+   |                               ^^^^^^^^^- help: consider further restricting `Self`: `, Self: std::cmp::Eq`
+   |                               |
+   |                               the trait `std::cmp::Eq` is not implemented for `Self`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-fn-arg.stderr
+++ b/src/test/ui/wf/wf-trait-fn-arg.stderr
@@ -1,14 +1,13 @@
 error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
-  --> $DIR/wf-trait-fn-arg.rs:10:5
+  --> $DIR/wf-trait-fn-arg.rs:10:22
    |
 LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
    | ----------------------- required by `Bar`
 ...
 LL |     fn bar(&self, x: &Bar<Self>);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
-   |     |                           |
-   |     |                           help: consider further restricting `Self`: `where Self: std::cmp::Eq`
-   |     the trait `std::cmp::Eq` is not implemented for `Self`
+   |                      ^^^^^^^^^^ - help: consider further restricting `Self`: `where Self: std::cmp::Eq`
+   |                      |
+   |                      the trait `std::cmp::Eq` is not implemented for `Self`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-fn-ret.stderr
+++ b/src/test/ui/wf/wf-trait-fn-ret.stderr
@@ -1,14 +1,13 @@
 error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
-  --> $DIR/wf-trait-fn-ret.rs:10:5
+  --> $DIR/wf-trait-fn-ret.rs:10:22
    |
 LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
    | ----------------------- required by `Bar`
 ...
 LL |     fn bar(&self) -> &Bar<Self>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^-
-   |     |                          |
-   |     |                          help: consider further restricting `Self`: `where Self: std::cmp::Eq`
-   |     the trait `std::cmp::Eq` is not implemented for `Self`
+   |                      ^^^^^^^^^^- help: consider further restricting `Self`: `where Self: std::cmp::Eq`
+   |                      |
+   |                      the trait `std::cmp::Eq` is not implemented for `Self`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-trait-fn-where-clause.stderr
@@ -1,13 +1,13 @@
 error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
-  --> $DIR/wf-trait-fn-where-clause.rs:10:8
+  --> $DIR/wf-trait-fn-where-clause.rs:10:49
    |
 LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
    | ----------------------- required by `Bar`
 ...
 LL |     fn bar(&self) where Self: Sized, Bar<Self>: Copy;
-   |        ^^^                                          - help: consider further restricting `Self`: `, Self: std::cmp::Eq`
-   |        |
-   |        the trait `std::cmp::Eq` is not implemented for `Self`
+   |                                                 ^^^^- help: consider further restricting `Self`: `, Self: std::cmp::Eq`
+   |                                                 |
+   |                                                 the trait `std::cmp::Eq` is not implemented for `Self`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-trait-fn-where-clause.stderr
@@ -1,14 +1,13 @@
 error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
-  --> $DIR/wf-trait-fn-where-clause.rs:10:5
+  --> $DIR/wf-trait-fn-where-clause.rs:10:8
    |
 LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
    | ----------------------- required by `Bar`
 ...
 LL |     fn bar(&self) where Self: Sized, Bar<Self>: Copy;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
-   |     |                                               |
-   |     |                                               help: consider further restricting `Self`: `, Self: std::cmp::Eq`
-   |     the trait `std::cmp::Eq` is not implemented for `Self`
+   |        ^^^                                          - help: consider further restricting `Self`: `, Self: std::cmp::Eq`
+   |        |
+   |        the trait `std::cmp::Eq` is not implemented for `Self`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-superbound.stderr
+++ b/src/test/ui/wf/wf-trait-superbound.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
-  --> $DIR/wf-trait-superbound.rs:9:1
+  --> $DIR/wf-trait-superbound.rs:9:21
    |
-LL |   trait ExtraCopy<T:Copy> { }
-   |   ----------------------- required by `ExtraCopy`
+LL | trait ExtraCopy<T:Copy> { }
+   | ----------------------- required by `ExtraCopy`
 LL | 
-LL |   trait SomeTrait<T>: ExtraCopy<T> {
-   |   ^               - help: consider restricting this bound: `T: std::marker::Copy`
-   |  _|
-   | |
-LL | | }
-   | |_^ the trait `std::marker::Copy` is not implemented for `T`
+LL | trait SomeTrait<T>: ExtraCopy<T> {
+   |                 -   ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
+   |                 |
+   |                 help: consider restricting this bound: `T: std::marker::Copy`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-unsafe-trait-obj-match.stderr
+++ b/src/test/ui/wf/wf-unsafe-trait-obj-match.stderr
@@ -16,7 +16,9 @@ error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-unsafe-trait-obj-match.rs:26:21
    |
 LL | trait Trait: Sized {}
-   |              ----- traits that require `Self: Sized` cannot be made into an object
+   |       -----  ----- ...because it requires `Self: Sized`
+   |       |
+   |       this trait cannot be made into an object...
 ...
 LL |         Some(()) => &S,
    |                     ^^ the trait `Trait` cannot be made into an object
@@ -28,7 +30,9 @@ error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-unsafe-trait-obj-match.rs:25:25
    |
 LL | trait Trait: Sized {}
-   |              ----- traits that require `Self: Sized` cannot be made into an object
+   |       -----  ----- ...because it requires `Self: Sized`
+   |       |
+   |       this trait cannot be made into an object...
 ...
 LL |     let t: &dyn Trait = match opt() {
    |                         ^^^^^^^^^^^ the trait `Trait` cannot be made into an object

--- a/src/test/ui/wf/wf-unsafe-trait-obj-match.stderr
+++ b/src/test/ui/wf/wf-unsafe-trait-obj-match.stderr
@@ -15,6 +15,9 @@ LL | |     }
 error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-unsafe-trait-obj-match.rs:26:21
    |
+LL | trait Trait: Sized {}
+   |              ----- the trait cannot require that `Self : Sized`
+...
 LL |         Some(()) => &S,
    |                     ^^ the trait `Trait` cannot be made into an object
    |
@@ -25,6 +28,9 @@ LL |         Some(()) => &S,
 error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-unsafe-trait-obj-match.rs:25:25
    |
+LL | trait Trait: Sized {}
+   |              ----- the trait cannot require that `Self : Sized`
+...
 LL |     let t: &dyn Trait = match opt() {
    |                         ^^^^^^^^^^^ the trait `Trait` cannot be made into an object
    |

--- a/src/test/ui/wf/wf-unsafe-trait-obj-match.stderr
+++ b/src/test/ui/wf/wf-unsafe-trait-obj-match.stderr
@@ -21,7 +21,6 @@ LL | trait Trait: Sized {}
 LL |         Some(()) => &S,
    |                     ^^ the trait `Trait` cannot be made into an object
    |
-   = note: the trait cannot require that `Self : Sized`
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<&dyn Trait>` for `&S`
    = note: required by cast to type `&dyn Trait`
 
@@ -34,7 +33,6 @@ LL | trait Trait: Sized {}
 LL |     let t: &dyn Trait = match opt() {
    |                         ^^^^^^^^^^^ the trait `Trait` cannot be made into an object
    |
-   = note: the trait cannot require that `Self : Sized`
    = note: required because of the requirements on the impl of `std::ops::CoerceUnsized<&dyn Trait>` for `&R`
    = note: required by cast to type `&dyn Trait`
 

--- a/src/test/ui/wf/wf-unsafe-trait-obj-match.stderr
+++ b/src/test/ui/wf/wf-unsafe-trait-obj-match.stderr
@@ -16,7 +16,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-unsafe-trait-obj-match.rs:26:21
    |
 LL | trait Trait: Sized {}
-   |              ----- the trait cannot require that `Self : Sized`
+   |              ----- traits that require `Self: Sized` cannot be made into an object
 ...
 LL |         Some(()) => &S,
    |                     ^^ the trait `Trait` cannot be made into an object
@@ -28,7 +28,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/wf-unsafe-trait-obj-match.rs:25:25
    |
 LL | trait Trait: Sized {}
-   |              ----- the trait cannot require that `Self : Sized`
+   |              ----- traits that require `Self: Sized` cannot be made into an object
 ...
 LL |     let t: &dyn Trait = match opt() {
    |                         ^^^^^^^^^^^ the trait `Trait` cannot be made into an object


### PR DESCRIPTION
- Point at arguments or output when fn obligations come from them, or ident when they don't
- Point at `Sized` bound (fix #47990)
- When object unsafe trait uses itself in associated item suggest using `Self` (fix #66424, fix #33375, partially address #38376, cc #61525)
-  Point at reason in object unsafe trait with `Self` in supertraits or `where`-clause (cc #40533, cc #68377)
- On implicit type parameter `Sized` obligations, suggest `?Sized` (fix #57744, fix #46683, fix #38936)