### PR TITLE
When an ADT field is missing a stability attribute, look at its parent

### DIFF
--- a/src/test/ui/stability-attribute/stability-attribute-issue-43027.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-issue-43027.rs
@@ -1,8 +1,9 @@
+// check-pass
 #![feature(staged_api)]
 #![stable(feature = "test", since = "0")]
 
 #[stable(feature = "test", since = "0")]
-pub struct Reverse<T>(pub T); //~ ERROR field has missing stability attribute
+pub struct Reverse<T>(pub T); // if the field has no stability, we check its parent
 
 fn main() {
     // Make sure the field is used to fill the stability cache

--- a/src/test/ui/stability-attribute/stability-attribute-issue-43027.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-issue-43027.stderr
@@ -1,8 +1,0 @@
-error: field has missing stability attribute
-  --> $DIR/stability-attribute-issue-43027.rs:5:23
-   |
-LL | pub struct Reverse<T>(pub T);
-   |                       ^^^^^
-
-error: aborting due to previous error
-


### PR DESCRIPTION
This will allow us to remove stability attributes in fields in the stdlib which are shown in user visible output unnecessarily, obscuring the meaning of the span.

Partially address verbosity issues with the new output for #65386 introduced in #65912.

Once this is landed, we can manually modify the stdlib to no longer include `stable` attributes in tuple-like fields. This way the output can go from:

```
error[E0425]: cannot find function, tuple struct or tuple variant `OK` in this scope
   --> file.rs:2:11
    |
2   |   let _ = OK(());
    |           ^^ help: a tuple variant with a similar name exists (notice the capitalization): `Ok`
    |
   ::: src/libcore/result.rs:249:5
    |
249 |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
    |     --------------------------------------------------- similarly named tuple variant `Ok` defined here
```

to

```
error[E0425]: cannot find function, tuple struct or tuple variant `OK` in this scope
   --> file.rs:2:11
    |
2   |   let _ = OK(());
    |           ^^ help: a tuple variant with a similar name exists (notice the capitalization): `Ok`
    |
   ::: src/libcore/result.rs:249:5
    |
249 |     Ok(T),
    |     ----- similarly named tuple variant `Ok` defined here
```

r? @petrochenkov 