### PR TITLE
Enable inserting sideeffect by default

### DIFF
--- a/src/librustc_codegen_llvm/intrinsic.rs
+++ b/src/librustc_codegen_llvm/intrinsic.rs
@@ -799,7 +799,7 @@ impl IntrinsicCallMethods<'tcx> for Builder<'a, 'll, 'tcx> {
     }
 
     fn sideeffect(&mut self) {
-        if self.tcx.sess.opts.debugging_opts.insert_sideeffect {
+        if self.tcx.sess.insert_sideeffect() {
             let fnname = self.get_intrinsic(&("llvm.sideeffect"));
             self.call(fnname, &[], None);
         }

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -153,7 +153,7 @@ impl<'a, 'tcx> TerminatorCodegenHelper<'tcx> {
         bx: &mut Bx,
         targets: &[mir::BasicBlock],
     ) {
-        if bx.tcx().sess.opts.debugging_opts.insert_sideeffect {
+        if bx.tcx().sess.insert_sideeffect() {
             if targets.iter().any(|&target| {
                 target <= self.bb
                     && target.start_location().is_predecessor_of(self.bb.start_location(), mir)

--- a/src/librustc_codegen_ssa/mir/mod.rs
+++ b/src/librustc_codegen_ssa/mir/mod.rs
@@ -144,8 +144,6 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         bx.set_personality_fn(cx.eh_personality());
     }
 
-    bx.sideeffect();
-
     let cleanup_kinds = analyze::cleanup_kinds(&mir);
     // Allocate a `Block` for every basic block, except
     // the start block, if nothing loops back to it.

--- a/src/librustc_session/options.rs
+++ b/src/librustc_session/options.rs
@@ -945,7 +945,7 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
         "which mangling version to use for symbol names"),
     binary_dep_depinfo: bool = (false, parse_bool, [TRACKED],
         "include artifacts (sysroot, crate dependencies) used during compilation in dep-info"),
-    insert_sideeffect: bool = (false, parse_bool, [TRACKED],
+    insert_sideeffect: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "fix undefined behavior when a thread doesn't eventually make progress \
          (such as entering an empty infinite loop) by inserting llvm.sideeffect"),
     deduplicate_diagnostics: Option<bool> = (None, parse_opt_bool, [UNTRACKED],

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -830,6 +830,10 @@ impl Session {
         // then try to skip it where possible.
         dbg_opts.plt.unwrap_or(needs_plt || !full_relro)
     }
+
+    pub fn insert_sideeffect(&self) -> bool {
+        self.opts.debugging_opts.insert_sideeffect.unwrap_or(true)
+    }
 }
 
 pub fn build_session(

--- a/src/test/codegen/non-terminate/infinite-loop-1.rs
+++ b/src/test/codegen/non-terminate/infinite-loop-1.rs
@@ -1,4 +1,4 @@
-// compile-flags: -C opt-level=3 -Z insert-sideeffect
+// compile-flags: -C opt-level=3
 
 #![crate_type = "lib"]
 

--- a/src/test/codegen/non-terminate/infinite-loop-2.rs
+++ b/src/test/codegen/non-terminate/infinite-loop-2.rs
@@ -1,4 +1,4 @@
-// compile-flags: -C opt-level=3 -Z insert-sideeffect
+// compile-flags: -C opt-level=3
 
 #![crate_type = "lib"]
 

--- a/src/test/codegen/non-terminate/infinite-recursion.rs
+++ b/src/test/codegen/non-terminate/infinite-recursion.rs
@@ -1,7 +1,6 @@
-// compile-flags: -C opt-level=3 -Z insert-sideeffect
+// compile-flags: -C opt-level=3
 
 #![crate_type = "lib"]
-
 #![allow(unconditional_recursion)]
 
 // CHECK-LABEL: @infinite_recursion


### PR DESCRIPTION
This makes the -Zinsert-sideeffect be enabled by default, and can be disabled
with -Zinsert-sideeffect=no.