### PR TITLE
Deduplicate crate types

### DIFF
--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -173,7 +173,11 @@ pub fn register_plugins<'a>(
     // these need to be set "early" so that expansion sees `quote` if enabled.
     sess.init_features(features);
 
-    let crate_types = util::collect_crate_types(sess, &krate.attrs);
+    let mut crate_types = util::collect_crate_types(sess, &krate.attrs);
+    // This makes sure that `--crate-type rlib --crate-type rlib` doesn't end up
+    // causing us issues down the line.
+    crate_types.sort();
+    crate_types.dedup();
     sess.crate_types.set(crate_types);
 
     let disambiguator = util::compute_crate_disambiguator(sess);


### PR DESCRIPTION
Noted in the review of PR 68298, it turns out that this was previously allowed,
which could lead us to some odd (if not necessarily incorrect) behavior when
checking for the presence of crate types in the list. Deduplicating doesn't
entirely eliminate the problem -- a full fix is likely to only provide APIs
which check for "set intersection" loosely -- but this more minimal fix is
likely enough given current code, if not a 100% solution.