### PR TITLE
Rename asm! to llvm_asm!

### DIFF
--- a/src/doc/unstable-book/src/library-features/llvm-asm.md
+++ b/src/doc/unstable-book/src/library-features/llvm-asm.md
@@ -1,17 +1,17 @@
-# `asm`
+# `llvm_asm`
 
-The tracking issue for this feature is: [#29722]
+The tracking issue for this feature is: [#70173]
 
-[#29722]: https://github.com/rust-lang/rust/issues/29722
+[#70173]: https://github.com/rust-lang/rust/issues/70173
 
 ------------------------
 
 For extremely low-level manipulations and performance reasons, one
 might wish to control the CPU directly. Rust supports using inline
-assembly to do this via the `asm!` macro.
+assembly to do this via the `llvm_asm!` macro.
 
 ```rust,ignore
-asm!(assembly template
+llvm_asm!(assembly template
    : output operands
    : input operands
    : clobbers
@@ -19,7 +19,7 @@ asm!(assembly template
    );
 ```
 
-Any use of `asm` is feature gated (requires `#![feature(asm)]` on the
+Any use of `llvm_asm` is feature gated (requires `#![feature(llvm_asm)]` on the
 crate to allow) and of course requires an `unsafe` block.
 
 > **Note**: the examples here are given in x86/x86-64 assembly, but
@@ -31,12 +31,12 @@ The `assembly template` is the only required parameter and must be a
 literal string (i.e. `""`)
 
 ```rust
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn foo() {
     unsafe {
-        asm!("NOP");
+        llvm_asm!("NOP");
     }
 }
 
@@ -51,16 +51,16 @@ fn main() {
 }
 ```
 
-(The `feature(asm)` and `#[cfg]`s are omitted from now on.)
+(The `feature(llvm_asm)` and `#[cfg]`s are omitted from now on.)
 
 Output operands, input operands, clobbers and options are all optional
 but you must add the right number of `:` if you skip them:
 
 ```rust
-# #![feature(asm)]
+# #![feature(llvm_asm)]
 # #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 # fn main() { unsafe {
-asm!("xor %eax, %eax"
+llvm_asm!("xor %eax, %eax"
     :
     :
     : "eax"
@@ -73,10 +73,10 @@ asm!("xor %eax, %eax"
 Whitespace also doesn't matter:
 
 ```rust
-# #![feature(asm)]
+# #![feature(llvm_asm)]
 # #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 # fn main() { unsafe {
-asm!("xor %eax, %eax" ::: "eax");
+llvm_asm!("xor %eax, %eax" ::: "eax");
 # } }
 # #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 # fn main() {}
@@ -89,12 +89,12 @@ Input and output operands follow the same format: `:
 expressions must be mutable lvalues, or not yet assigned:
 
 ```rust
-# #![feature(asm)]
+# #![feature(llvm_asm)]
 # #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn add(a: i32, b: i32) -> i32 {
     let c: i32;
     unsafe {
-        asm!("add $2, $0"
+        llvm_asm!("add $2, $0"
              : "=r"(c)
              : "0"(a), "r"(b)
              );
@@ -116,11 +116,11 @@ operand. This is useful for very low level programming, where
 which register you use is important:
 
 ```rust
-# #![feature(asm)]
+# #![feature(llvm_asm)]
 # #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 # unsafe fn read_byte_in(port: u16) -> u8 {
 let result: u8;
-asm!("in %dx, %al" : "={al}"(result) : "{dx}"(port));
+llvm_asm!("in %dx, %al" : "={al}"(result) : "{dx}"(port));
 result
 # }
 ```
@@ -133,11 +133,11 @@ compiler not to assume any values loaded into those registers will
 stay valid.
 
 ```rust
-# #![feature(asm)]
+# #![feature(llvm_asm)]
 # #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 # fn main() { unsafe {
 // Put the value 0x200 in eax:
-asm!("mov $$0x200, %eax" : /* no outputs */ : /* no inputs */ : "eax");
+llvm_asm!("mov $$0x200, %eax" : /* no outputs */ : /* no inputs */ : "eax");
 # } }
 # #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 # fn main() {}
@@ -167,12 +167,12 @@ Current valid options are:
 3. *intel* - use intel syntax instead of the default AT&T.
 
 ```rust
-# #![feature(asm)]
+# #![feature(llvm_asm)]
 # #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 # fn main() {
 let result: i32;
 unsafe {
-   asm!("mov eax, 2" : "={eax}"(result) : : : "intel")
+   llvm_asm!("mov eax, 2" : "={eax}"(result) : : : "intel")
 }
 println!("eax is currently {}", result);
 # }
@@ -182,7 +182,7 @@ println!("eax is currently {}", result);
 
 ## More Information
 
-The current implementation of the `asm!` macro is a direct binding to [LLVM's
+The current implementation of the `llvm_asm!` macro is a direct binding to [LLVM's
 inline assembler expressions][llvm-docs], so be sure to check out [their
 documentation as well][llvm-docs] for more information about clobbers,
 constraints, etc.
@@ -190,4 +190,4 @@ constraints, etc.
 [llvm-docs]: http://llvm.org/docs/LangRef.html#inline-assembler-expressions
 
 If you need more power and don't mind losing some of the niceties of
-`asm!`, check out [global_asm](global-asm.md).
+`llvm_asm!`, check out [global_asm](global-asm.md).

--- a/src/libcore/hint.rs
+++ b/src/libcore/hint.rs
@@ -113,7 +113,7 @@ pub fn black_box<T>(dummy: T) -> T {
     // box. This isn't the greatest implementation since it probably deoptimizes
     // more than we want, but it's so far good enough.
     unsafe {
-        asm!("" : : "r"(&dummy));
+        llvm_asm!("" : : "r"(&dummy));
         dummy
     }
 }

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -98,6 +98,7 @@
 #![feature(is_sorted)]
 #![feature(lang_items)]
 #![feature(link_llvm_intrinsics)]
+#![feature(llvm_asm)]
 #![cfg_attr(not(bootstrap), feature(negative_impls))]
 #![feature(never_type)]
 #![feature(nll)]

--- a/src/libcore/macros/mod.rs
+++ b/src/libcore/macros/mod.rs
@@ -1307,12 +1307,53 @@ pub(crate) mod builtin {
     /// [unstable book]: ../unstable-book/library-features/asm.html
     #[unstable(
         feature = "asm",
-        issue = "29722",
+        issue = "70173",
         reason = "inline assembly is not stable enough for use and is subject to change"
     )]
     #[rustc_builtin_macro]
     #[macro_export]
     macro_rules! asm {
+        ("assembly template"
+                        : $("output"(operand),)*
+                        : $("input"(operand),)*
+                        : $("clobbers",)*
+                        : $("options",)*) => {
+            /* compiler built-in */
+        };
+    }
+
+    /// Inline assembly.
+    ///
+    /// Read the [unstable book] for the usage.
+    ///
+    /// [unstable book]: ../unstable-book/library-features/asm.html
+    #[cfg(bootstrap)]
+    #[unstable(
+        feature = "llvm_asm",
+        issue = "70173",
+        reason = "inline assembly is not stable enough for use and is subject to change"
+    )]
+    #[macro_export]
+    #[allow_internal_unstable(asm)]
+    macro_rules! llvm_asm {
+        // Redirect to asm! for stage0
+        ($($arg:tt)*) => { $crate::asm!($($arg)*) }
+    }
+
+    /// Inline assembly.
+    ///
+    /// Read the [unstable book] for the usage.
+    ///
+    /// [unstable book]: ../unstable-book/library-features/asm.html
+    #[cfg(not(bootstrap))]
+    #[unstable(
+        feature = "llvm_asm",
+        issue = "70173",
+        reason = "inline assembly is not stable enough for use and is subject to change"
+    )]
+    #[rustc_builtin_macro]
+    #[macro_export]
+    macro_rules! llvm_asm {
         ("assembly template"
                         : $("output"(operand),)*
                         : $("input"(operand),)*

--- a/src/libcore/num/dec2flt/algorithm.rs
+++ b/src/libcore/num/dec2flt/algorithm.rs
@@ -60,7 +60,7 @@ mod fpu_precision {
     fn set_cw(cw: u16) {
         // SAFETY: the `fldcw` instruction has been audited to be able to work correctly with
         // any `u16`
-        unsafe { asm!("fldcw $0" :: "m" (cw) :: "volatile") }
+        unsafe { llvm_asm!("fldcw $0" :: "m" (cw) :: "volatile") }
     }
 
     /// Sets the precision field of the FPU to `T` and returns a `FPUControlWord`.
@@ -78,7 +78,7 @@ mod fpu_precision {
         // `FPUControlWord` structure is dropped
         // SAFETY: the `fnstcw` instruction has been audited to be able to work correctly with
         // any `u16`
-        unsafe { asm!("fnstcw $0" : "=*m" (&cw) ::: "volatile") }
+        unsafe { llvm_asm!("fnstcw $0" : "=*m" (&cw) ::: "volatile") }
 
         // Set the control word to the desired precision. This is achieved by masking away the old
         // precision (bits 8 and 9, 0x300) and replacing it with the precision flag computed above.

--- a/src/libcore/prelude/v1.rs
+++ b/src/libcore/prelude/v1.rs
@@ -57,8 +57,8 @@ pub use crate::hash::macros::Hash;
 #[doc(no_inline)]
 pub use crate::{
     asm, assert, cfg, column, compile_error, concat, concat_idents, env, file, format_args,
-    format_args_nl, global_asm, include, include_bytes, include_str, line, log_syntax, module_path,
-    option_env, stringify, trace_macros,
+    format_args_nl, global_asm, include, include_bytes, include_str, line, llvm_asm, log_syntax,
+    module_path, option_env, stringify, trace_macros,
 };
 
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1584,7 +1584,7 @@ pub enum StatementKind<'tcx> {
 
     /// Executes a piece of inline Assembly. Stored in a Box to keep the size
     /// of `StatementKind` low.
-    InlineAsm(Box<InlineAsm<'tcx>>),
+    LlvmInlineAsm(Box<LlvmInlineAsm<'tcx>>),
 
     /// Retag references in the given place, ensuring they got fresh tags. This is
     /// part of the Stacked Borrows model. These statements are currently only interpreted
@@ -1668,8 +1668,8 @@ pub enum FakeReadCause {
 }
 
 #[derive(Clone, Debug, PartialEq, RustcEncodable, RustcDecodable, HashStable, TypeFoldable)]
-pub struct InlineAsm<'tcx> {
-    pub asm: hir::InlineAsmInner,
+pub struct LlvmInlineAsm<'tcx> {
+    pub asm: hir::LlvmInlineAsmInner,
     pub outputs: Box<[Place<'tcx>]>,
     pub inputs: Box<[(Span, Operand<'tcx>)]>,
 }
@@ -1696,8 +1696,8 @@ impl Debug for Statement<'_> {
             SetDiscriminant { ref place, variant_index } => {
                 write!(fmt, "discriminant({:?}) = {:?}", place, variant_index)
             }
-            InlineAsm(ref asm) => {
-                write!(fmt, "asm!({:?} : {:?} : {:?})", asm.asm, asm.outputs, asm.inputs)
+            LlvmInlineAsm(ref asm) => {
+                write!(fmt, "llvm_asm!({:?} : {:?} : {:?})", asm.asm, asm.outputs, asm.inputs)
             }
             AscribeUserType(box (ref place, ref c_ty), ref variance) => {
                 write!(fmt, "AscribeUserType({:?}, {:?}, {:?})", place, variance, c_ty)

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -385,7 +385,7 @@ macro_rules! make_mir_visitor {
                             location
                         );
                     }
-                    StatementKind::InlineAsm(asm) => {
+                    StatementKind::LlvmInlineAsm(asm) => {
                         for output in & $($mutability)? asm.outputs[..] {
                             self.visit_place(
                                 output,

--- a/src/librustc/ty/structural_impls.rs
+++ b/src/librustc/ty/structural_impls.rs
@@ -263,7 +263,7 @@ CloneTypeFoldableAndLiftImpls! {
     ::rustc_span::symbol::Symbol,
     ::rustc_hir::def::Res,
     ::rustc_hir::def_id::DefId,
-    ::rustc_hir::InlineAsmInner,
+    ::rustc_hir::LlvmInlineAsmInner,
     ::rustc_hir::MatchSource,
     ::rustc_hir::Mutability,
     ::rustc_hir::Unsafety,

--- a/src/librustc_ast/ast.rs
+++ b/src/librustc_ast/ast.rs
@@ -1114,7 +1114,7 @@ impl Expr {
             ExprKind::Break(..) => ExprPrecedence::Break,
             ExprKind::Continue(..) => ExprPrecedence::Continue,
             ExprKind::Ret(..) => ExprPrecedence::Ret,
-            ExprKind::InlineAsm(..) => ExprPrecedence::InlineAsm,
+            ExprKind::LlvmInlineAsm(..) => ExprPrecedence::InlineAsm,
             ExprKind::MacCall(..) => ExprPrecedence::Mac,
             ExprKind::Struct(..) => ExprPrecedence::Struct,
             ExprKind::Repeat(..) => ExprPrecedence::Repeat,
@@ -1243,8 +1243,8 @@ pub enum ExprKind {
     /// A `return`, with an optional value to be returned.
     Ret(Option<P<Expr>>),
 
-    /// Output of the `asm!()` macro.
-    InlineAsm(P<InlineAsm>),
+    /// Output of the `llvm_asm!()` macro.
+    LlvmInlineAsm(P<LlvmInlineAsm>),
 
     /// A macro invocation; pre-expansion.
     MacCall(MacCall),
@@ -1860,37 +1860,37 @@ pub enum TraitObjectSyntax {
 
 /// Inline assembly dialect.
 ///
-/// E.g., `"intel"` as in `asm!("mov eax, 2" : "={eax}"(result) : : : "intel")`.
+/// E.g., `"intel"` as in `llvm_asm!("mov eax, 2" : "={eax}"(result) : : : "intel")`.
 #[derive(Clone, PartialEq, RustcEncodable, RustcDecodable, Debug, Copy, HashStable_Generic)]
-pub enum AsmDialect {
+pub enum LlvmAsmDialect {
     Att,
     Intel,
 }
 
-/// Inline assembly.
+/// LLVM-style inline assembly.
 ///
-/// E.g., `"={eax}"(result)` as in `asm!("mov eax, 2" : "={eax}"(result) : : : "intel")`.
+/// E.g., `"={eax}"(result)` as in `llvm_asm!("mov eax, 2" : "={eax}"(result) : : : "intel")`.
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
-pub struct InlineAsmOutput {
+pub struct LlvmInlineAsmOutput {
     pub constraint: Symbol,
     pub expr: P<Expr>,
     pub is_rw: bool,
     pub is_indirect: bool,
 }
 
-/// Inline assembly.
+/// LLVM-style inline assembly.
 ///
-/// E.g., `asm!("NOP");`.
+/// E.g., `llvm_asm!("NOP");`.
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
-pub struct InlineAsm {
+pub struct LlvmInlineAsm {
     pub asm: Symbol,
     pub asm_str_style: StrStyle,
-    pub outputs: Vec<InlineAsmOutput>,
+    pub outputs: Vec<LlvmInlineAsmOutput>,
     pub inputs: Vec<(Symbol, P<Expr>)>,
     pub clobbers: Vec<Symbol>,
     pub volatile: bool,
     pub alignstack: bool,
-    pub dialect: AsmDialect,
+    pub dialect: LlvmAsmDialect,
 }
 
 /// A parameter in a function header.

--- a/src/librustc_ast/mut_visit.rs
+++ b/src/librustc_ast/mut_visit.rs
@@ -1202,8 +1202,8 @@ pub fn noop_visit_expr<T: MutVisitor>(Expr { kind, id, span, attrs }: &mut Expr,
         ExprKind::Ret(expr) => {
             visit_opt(expr, |expr| vis.visit_expr(expr));
         }
-        ExprKind::InlineAsm(asm) => {
-            let InlineAsm {
+        ExprKind::LlvmInlineAsm(asm) => {
+            let LlvmInlineAsm {
                 asm: _,
                 asm_str_style: _,
                 outputs,
@@ -1214,7 +1214,7 @@ pub fn noop_visit_expr<T: MutVisitor>(Expr { kind, id, span, attrs }: &mut Expr,
                 dialect: _,
             } = asm.deref_mut();
             for out in outputs {
-                let InlineAsmOutput { constraint: _, expr, is_rw: _, is_indirect: _ } = out;
+                let LlvmInlineAsmOutput { constraint: _, expr, is_rw: _, is_indirect: _ } = out;
                 vis.visit_expr(expr);
             }
             visit_vec(inputs, |(_c, expr)| vis.visit_expr(expr));

--- a/src/librustc_ast/visit.rs
+++ b/src/librustc_ast/visit.rs
@@ -813,7 +813,7 @@ pub fn walk_expr<'a, V: Visitor<'a>>(visitor: &mut V, expression: &'a Expr) {
         }
         ExprKind::MacCall(ref mac) => visitor.visit_mac(mac),
         ExprKind::Paren(ref subexpression) => visitor.visit_expr(subexpression),
-        ExprKind::InlineAsm(ref ia) => {
+        ExprKind::LlvmInlineAsm(ref ia) => {
             for &(_, ref input) in &ia.inputs {
                 visitor.visit_expr(input)
             }

--- a/src/librustc_ast_lowering/expr.rs
+++ b/src/librustc_ast_lowering/expr.rs
@@ -159,7 +159,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let e = e.as_ref().map(|x| self.lower_expr(x));
                 hir::ExprKind::Ret(e)
             }
-            ExprKind::InlineAsm(ref asm) => self.lower_expr_asm(asm),
+            ExprKind::LlvmInlineAsm(ref asm) => self.lower_expr_asm(asm),
             ExprKind::Struct(ref path, ref fields, ref maybe_expr) => {
                 let maybe_expr = maybe_expr.as_ref().map(|x| self.lower_expr(x));
                 hir::ExprKind::Struct(
@@ -952,13 +952,13 @@ impl<'hir> LoweringContext<'_, 'hir> {
         result
     }
 
-    fn lower_expr_asm(&mut self, asm: &InlineAsm) -> hir::ExprKind<'hir> {
-        let inner = hir::InlineAsmInner {
+    fn lower_expr_asm(&mut self, asm: &LlvmInlineAsm) -> hir::ExprKind<'hir> {
+        let inner = hir::LlvmInlineAsmInner {
             inputs: asm.inputs.iter().map(|&(c, _)| c).collect(),
             outputs: asm
                 .outputs
                 .iter()
-                .map(|out| hir::InlineAsmOutput {
+                .map(|out| hir::LlvmInlineAsmOutput {
                     constraint: out.constraint,
                     is_rw: out.is_rw,
                     is_indirect: out.is_indirect,
@@ -972,7 +972,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             alignstack: asm.alignstack,
             dialect: asm.dialect,
         };
-        let hir_asm = hir::InlineAsm {
+        let hir_asm = hir::LlvmInlineAsm {
             inner,
             inputs_exprs: self.arena.alloc_from_iter(
                 asm.inputs.iter().map(|&(_, ref input)| self.lower_expr_mut(input)),
@@ -981,7 +981,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 .arena
                 .alloc_from_iter(asm.outputs.iter().map(|out| self.lower_expr_mut(&out.expr))),
         };
-        hir::ExprKind::InlineAsm(self.arena.alloc(hir_asm))
+        hir::ExprKind::LlvmInlineAsm(self.arena.alloc(hir_asm))
     }
 
     fn lower_field(&mut self, f: &Field) -> hir::Field<'hir> {

--- a/src/librustc_ast_passes/ast_validation.rs
+++ b/src/librustc_ast_passes/ast_validation.rs
@@ -716,12 +716,12 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
 
     fn visit_expr(&mut self, expr: &'a Expr) {
         match &expr.kind {
-            ExprKind::InlineAsm(..) if !self.session.target.target.options.allow_asm => {
+            ExprKind::LlvmInlineAsm(..) if !self.session.target.target.options.allow_asm => {
                 struct_span_err!(
                     self.session,
                     expr.span,
                     E0472,
-                    "asm! is unsupported on this target"
+                    "llvm_asm! is unsupported on this target"
                 )
                 .emit();
             }

--- a/src/librustc_ast_pretty/pprust.rs
+++ b/src/librustc_ast_pretty/pprust.rs
@@ -2024,8 +2024,8 @@ impl<'a> State<'a> {
                     self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
                 }
             }
-            ast::ExprKind::InlineAsm(ref a) => {
-                self.s.word("asm!");
+            ast::ExprKind::LlvmInlineAsm(ref a) => {
+                self.s.word("llvm_asm!");
                 self.popen();
                 self.print_string(&a.asm.as_str(), a.asm_str_style);
                 self.word_space(":");
@@ -2066,7 +2066,7 @@ impl<'a> State<'a> {
                 if a.alignstack {
                     options.push("alignstack");
                 }
-                if a.dialect == ast::AsmDialect::Intel {
+                if a.dialect == ast::LlvmAsmDialect::Intel {
                     options.push("intel");
                 }
 

--- a/src/librustc_builtin_macros/lib.rs
+++ b/src/librustc_builtin_macros/lib.rs
@@ -19,7 +19,6 @@ use rustc_expand::proc_macro::BangProcMacro;
 use rustc_span::edition::Edition;
 use rustc_span::symbol::sym;
 
-mod asm;
 mod assert;
 mod cfg;
 mod cfg_accessible;
@@ -32,6 +31,7 @@ mod format;
 mod format_foreign;
 mod global_allocator;
 mod global_asm;
+mod llvm_asm;
 mod log_syntax;
 mod source_util;
 mod test;
@@ -61,7 +61,7 @@ pub fn register_builtin_macros(resolver: &mut dyn Resolver, edition: Edition) {
     }
 
     register_bang! {
-        asm: asm::expand_asm,
+        asm: llvm_asm::expand_llvm_asm,
         assert: assert::expand_assert,
         cfg: cfg::expand_cfg,
         column: source_util::expand_column,
@@ -77,6 +77,7 @@ pub fn register_builtin_macros(resolver: &mut dyn Resolver, edition: Edition) {
         include_str: source_util::expand_include_str,
         include: source_util::expand_include,
         line: source_util::expand_line,
+        llvm_asm: llvm_asm::expand_llvm_asm,
         log_syntax: log_syntax::expand_log_syntax,
         module_path: source_util::expand_mod,
         option_env: env::expand_option_env,

--- a/src/librustc_codegen_llvm/asm.rs
+++ b/src/librustc_codegen_llvm/asm.rs
@@ -14,9 +14,9 @@ use libc::{c_char, c_uint};
 use log::debug;
 
 impl AsmBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
-    fn codegen_inline_asm(
+    fn codegen_llvm_inline_asm(
         &mut self,
-        ia: &hir::InlineAsmInner,
+        ia: &hir::LlvmInlineAsmInner,
         outputs: Vec<PlaceRef<'tcx, &'ll Value>>,
         mut inputs: Vec<&'ll Value>,
         span: Span,
@@ -138,7 +138,7 @@ fn inline_asm_call(
     output: &'ll llvm::Type,
     volatile: bool,
     alignstack: bool,
-    dia: ::rustc_ast::ast::AsmDialect,
+    dia: ::rustc_ast::ast::LlvmAsmDialect,
 ) -> Option<&'ll Value> {
     let volatile = if volatile { llvm::True } else { llvm::False };
     let alignstack = if alignstack { llvm::True } else { llvm::False };

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -389,10 +389,10 @@ pub enum AsmDialect {
 }
 
 impl AsmDialect {
-    pub fn from_generic(asm: rustc_ast::ast::AsmDialect) -> Self {
+    pub fn from_generic(asm: rustc_ast::ast::LlvmAsmDialect) -> Self {
         match asm {
-            rustc_ast::ast::AsmDialect::Att => AsmDialect::Att,
-            rustc_ast::ast::AsmDialect::Intel => AsmDialect::Intel,
+            rustc_ast::ast::LlvmAsmDialect::Att => AsmDialect::Att,
+            rustc_ast::ast::LlvmAsmDialect::Intel => AsmDialect::Intel,
         }
     }
 }

--- a/src/librustc_codegen_ssa/mir/statement.rs
+++ b/src/librustc_codegen_ssa/mir/statement.rs
@@ -66,7 +66,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 }
                 bx
             }
-            mir::StatementKind::InlineAsm(ref asm) => {
+            mir::StatementKind::LlvmInlineAsm(ref asm) => {
                 let outputs = asm
                     .outputs
                     .iter()
@@ -93,7 +93,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 );
 
                 if input_vals.len() == asm.inputs.len() {
-                    let res = bx.codegen_inline_asm(
+                    let res = bx.codegen_llvm_inline_asm(
                         &asm.asm,
                         outputs,
                         input_vals,

--- a/src/librustc_codegen_ssa/traits/asm.rs
+++ b/src/librustc_codegen_ssa/traits/asm.rs
@@ -1,13 +1,13 @@
 use super::BackendTypes;
 use crate::mir::place::PlaceRef;
-use rustc_hir::{GlobalAsm, InlineAsmInner};
+use rustc_hir::{GlobalAsm, LlvmInlineAsmInner};
 use rustc_span::Span;
 
 pub trait AsmBuilderMethods<'tcx>: BackendTypes {
     /// Take an inline assembly expression and splat it out via LLVM
-    fn codegen_inline_asm(
+    fn codegen_llvm_inline_asm(
         &mut self,
-        ia: &InlineAsmInner,
+        ia: &LlvmInlineAsmInner,
         outputs: Vec<PlaceRef<'tcx, Self::Value>>,
         inputs: Vec<Self::Value>,
         span: Span,

--- a/src/librustc_error_codes/error_codes.rs
+++ b/src/librustc_error_codes/error_codes.rs
@@ -541,7 +541,7 @@ E0751: include_str!("./error_codes/E0751.md"),
 //  E0467, removed
 //  E0470, removed
 //  E0471, // constant evaluation error (in pattern)
-    E0472, // asm! is unsupported on this target
+    E0472, // llvm_asm! is unsupported on this target
     E0473, // dereference of reference outside its lifetime
     E0474, // captured variable `..` does not outlive the enclosing closure
     E0475, // index of slice outside its lifetime

--- a/src/librustc_error_codes/error_codes/E0660.md
+++ b/src/librustc_error_codes/error_codes/E0660.md
@@ -1,9 +1,9 @@
-The argument to the `asm` macro is not well-formed.
+The argument to the `llvm_asm` macro is not well-formed.
 
 Erroneous code example:
 
 ```compile_fail,E0660
-asm!("nop" "nop");
+llvm_asm!("nop" "nop");
 ```
 
 Considering that this would be a long explanation, we instead recommend you

--- a/src/librustc_error_codes/error_codes/E0661.md
+++ b/src/librustc_error_codes/error_codes/E0661.md
@@ -1,10 +1,10 @@
-An invalid syntax was passed to the second argument of an `asm` macro line.
+An invalid syntax was passed to the second argument of an `llvm_asm` macro line.
 
 Erroneous code example:
 
 ```compile_fail,E0661
 let a;
-asm!("nop" : "r"(a));
+llvm_asm!("nop" : "r"(a));
 ```
 
 Considering that this would be a long explanation, we instead recommend you

--- a/src/librustc_error_codes/error_codes/E0662.md
+++ b/src/librustc_error_codes/error_codes/E0662.md
@@ -1,12 +1,13 @@
-An invalid input operand constraint was passed to the `asm` macro (third line).
+An invalid input operand constraint was passed to the `llvm_asm` macro
+(third line).
 
 Erroneous code example:
 
 ```compile_fail,E0662
-asm!("xor %eax, %eax"
-     :
-     : "=test"("a")
-    );
+llvm_asm!("xor %eax, %eax"
+          :
+          : "=test"("a")
+         );
 ```
 
 Considering that this would be a long explanation, we instead recommend you

--- a/src/librustc_error_codes/error_codes/E0663.md
+++ b/src/librustc_error_codes/error_codes/E0663.md
@@ -1,12 +1,13 @@
-An invalid input operand constraint was passed to the `asm` macro (third line).
+An invalid input operand constraint was passed to the `llvm_asm` macro
+(third line).
 
 Erroneous code example:
 
 ```compile_fail,E0663
-asm!("xor %eax, %eax"
-     :
-     : "+test"("a")
-    );
+llvm_asm!("xor %eax, %eax"
+          :
+          : "+test"("a")
+         );
 ```
 
 Considering that this would be a long explanation, we instead recommend you

--- a/src/librustc_error_codes/error_codes/E0664.md
+++ b/src/librustc_error_codes/error_codes/E0664.md
@@ -1,13 +1,13 @@
-A clobber was surrounded by braces in the `asm` macro.
+A clobber was surrounded by braces in the `llvm_asm` macro.
 
 Erroneous code example:
 
 ```compile_fail,E0664
-asm!("mov $$0x200, %eax"
-     :
-     :
-     : "{eax}"
-    );
+llvm_asm!("mov $$0x200, %eax"
+          :
+          :
+          : "{eax}"
+         );
 ```
 
 Considering that this would be a long explanation, we instead recommend you

--- a/src/librustc_error_codes/error_codes/E0668.md
+++ b/src/librustc_error_codes/error_codes/E0668.md
@@ -7,7 +7,7 @@ assembly call.
 In particular, it can happen if you forgot the closing bracket of a register
 constraint (see issue #51430):
 ```compile_fail,E0668
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 fn main() {
     let rax: u64;

--- a/src/librustc_error_codes/error_codes/E0668.md
+++ b/src/librustc_error_codes/error_codes/E0668.md
@@ -12,7 +12,7 @@ constraint (see issue #51430):
 fn main() {
     let rax: u64;
     unsafe {
-        asm!("" :"={rax"(rax));
+        llvm_asm!("" :"={rax"(rax));
         println!("Accumulator is: {}", rax);
     }
 }

--- a/src/librustc_hir/arena.rs
+++ b/src/librustc_hir/arena.rs
@@ -28,7 +28,7 @@ macro_rules! arena_types {
             [] fn_decl: rustc_hir::FnDecl<$tcx>,
             [] foreign_item: rustc_hir::ForeignItem<$tcx>,
             [] impl_item_ref: rustc_hir::ImplItemRef<$tcx>,
-            [] inline_asm: rustc_hir::InlineAsm<$tcx>,
+            [] inline_asm: rustc_hir::LlvmInlineAsm<$tcx>,
             [] local: rustc_hir::Local<$tcx>,
             [few] macro_def: rustc_hir::MacroDef<$tcx>,
             [] param: rustc_hir::Param<$tcx>,

--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -8,7 +8,7 @@ crate use BlockCheckMode::*;
 crate use FnRetTy::*;
 crate use UnsafeSource::*;
 
-use rustc_ast::ast::{self, AsmDialect, CrateSugar, Ident, Name};
+use rustc_ast::ast::{self, CrateSugar, Ident, LlvmAsmDialect, Name};
 use rustc_ast::ast::{AttrVec, Attribute, FloatTy, IntTy, Label, LitKind, StrStyle, UintTy};
 pub use rustc_ast::ast::{BorrowKind, ImplPolarity, IsAuto};
 pub use rustc_ast::ast::{CaptureBy, Movability, Mutability};
@@ -1389,7 +1389,7 @@ impl Expr<'_> {
             ExprKind::Break(..) => ExprPrecedence::Break,
             ExprKind::Continue(..) => ExprPrecedence::Continue,
             ExprKind::Ret(..) => ExprPrecedence::Ret,
-            ExprKind::InlineAsm(..) => ExprPrecedence::InlineAsm,
+            ExprKind::LlvmInlineAsm(..) => ExprPrecedence::InlineAsm,
             ExprKind::Struct(..) => ExprPrecedence::Struct,
             ExprKind::Repeat(..) => ExprPrecedence::Repeat,
             ExprKind::Yield(..) => ExprPrecedence::Yield,
@@ -1444,7 +1444,7 @@ impl Expr<'_> {
             | ExprKind::Ret(..)
             | ExprKind::Loop(..)
             | ExprKind::Assign(..)
-            | ExprKind::InlineAsm(..)
+            | ExprKind::LlvmInlineAsm(..)
             | ExprKind::AssignOp(..)
             | ExprKind::Lit(_)
             | ExprKind::Unary(..)
@@ -1631,8 +1631,8 @@ pub enum ExprKind<'hir> {
     /// A `return`, with an optional value to be returned.
     Ret(Option<&'hir Expr<'hir>>),
 
-    /// Inline assembly (from `asm!`), with its outputs and inputs.
-    InlineAsm(&'hir InlineAsm<'hir>),
+    /// Inline assembly (from `llvm_asm!`), with its outputs and inputs.
+    LlvmInlineAsm(&'hir LlvmInlineAsm<'hir>),
 
     /// A struct or struct-like variant literal expression.
     ///
@@ -2061,7 +2061,7 @@ pub enum TyKind<'hir> {
 }
 
 #[derive(Copy, Clone, RustcEncodable, RustcDecodable, Debug, HashStable_Generic, PartialEq)]
-pub struct InlineAsmOutput {
+pub struct LlvmInlineAsmOutput {
     pub constraint: Symbol,
     pub is_rw: bool,
     pub is_indirect: bool,
@@ -2071,20 +2071,20 @@ pub struct InlineAsmOutput {
 // NOTE(eddyb) This is used within MIR as well, so unlike the rest of the HIR,
 // it needs to be `Clone` and use plain `Vec<T>` instead of arena-allocated slice.
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug, HashStable_Generic, PartialEq)]
-pub struct InlineAsmInner {
+pub struct LlvmInlineAsmInner {
     pub asm: Symbol,
     pub asm_str_style: StrStyle,
-    pub outputs: Vec<InlineAsmOutput>,
+    pub outputs: Vec<LlvmInlineAsmOutput>,
     pub inputs: Vec<Symbol>,
     pub clobbers: Vec<Symbol>,
     pub volatile: bool,
     pub alignstack: bool,
-    pub dialect: AsmDialect,
+    pub dialect: LlvmAsmDialect,
 }
 
 #[derive(RustcEncodable, RustcDecodable, Debug, HashStable_Generic)]
-pub struct InlineAsm<'hir> {
-    pub inner: InlineAsmInner,
+pub struct LlvmInlineAsm<'hir> {
+    pub inner: LlvmInlineAsmInner,
     pub outputs_exprs: &'hir [Expr<'hir>],
     pub inputs_exprs: &'hir [Expr<'hir>],
 }

--- a/src/librustc_hir/intravisit.rs
+++ b/src/librustc_hir/intravisit.rs
@@ -1151,7 +1151,7 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr<'v>) 
         ExprKind::Ret(ref optional_expression) => {
             walk_list!(visitor, visit_expr, optional_expression);
         }
-        ExprKind::InlineAsm(ref asm) => {
+        ExprKind::LlvmInlineAsm(ref asm) => {
             walk_list!(visitor, visit_expr, asm.outputs_exprs);
             walk_list!(visitor, visit_expr, asm.inputs_exprs);
         }

--- a/src/librustc_hir/print.rs
+++ b/src/librustc_hir/print.rs
@@ -1388,9 +1388,9 @@ impl<'a> State<'a> {
                     self.print_expr_maybe_paren(&expr, parser::PREC_JUMP);
                 }
             }
-            hir::ExprKind::InlineAsm(ref a) => {
+            hir::ExprKind::LlvmInlineAsm(ref a) => {
                 let i = &a.inner;
-                self.s.word("asm!");
+                self.s.word("llvm_asm!");
                 self.popen();
                 self.print_string(&i.asm.as_str(), i.asm_str_style);
                 self.word_space(":");
@@ -1435,7 +1435,7 @@ impl<'a> State<'a> {
                 if i.alignstack {
                     options.push("alignstack");
                 }
-                if i.dialect == ast::AsmDialect::Intel {
+                if i.dialect == ast::LlvmAsmDialect::Intel {
                     options.push("intel");
                 }
 

--- a/src/librustc_mir/borrow_check/invalidation.rs
+++ b/src/librustc_mir/borrow_check/invalidation.rs
@@ -68,7 +68,7 @@ impl<'cx, 'tcx> Visitor<'tcx> for InvalidationGenerator<'cx, 'tcx> {
             StatementKind::SetDiscriminant { ref place, variant_index: _ } => {
                 self.mutate_place(location, place, Shallow(None), JustWrite);
             }
-            StatementKind::InlineAsm(ref asm) => {
+            StatementKind::LlvmInlineAsm(ref asm) => {
                 for (o, output) in asm.asm.outputs.iter().zip(asm.outputs.iter()) {
                     if o.is_indirect {
                         // FIXME(eddyb) indirect inline asm outputs should

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -550,7 +550,7 @@ impl<'cx, 'tcx> dataflow::generic::ResultsVisitor<'cx, 'tcx> for MirBorrowckCtxt
             StatementKind::SetDiscriminant { ref place, variant_index: _ } => {
                 self.mutate_place(location, (place, span), Shallow(None), JustWrite, flow_state);
             }
-            StatementKind::InlineAsm(ref asm) => {
+            StatementKind::LlvmInlineAsm(ref asm) => {
                 for (o, output) in asm.asm.outputs.iter().zip(asm.outputs.iter()) {
                     if o.is_indirect {
                         // FIXME(eddyb) indirect inline asm outputs should

--- a/src/librustc_mir/borrow_check/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/type_check/mod.rs
@@ -1529,7 +1529,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             StatementKind::FakeRead(..)
             | StatementKind::StorageLive(..)
             | StatementKind::StorageDead(..)
-            | StatementKind::InlineAsm { .. }
+            | StatementKind::LlvmInlineAsm { .. }
             | StatementKind::Retag { .. }
             | StatementKind::Nop => {}
         }

--- a/src/librustc_mir/dataflow/impls/borrows.rs
+++ b/src/librustc_mir/dataflow/impls/borrows.rs
@@ -289,7 +289,7 @@ impl<'tcx> generic::GenKillAnalysis<'tcx> for Borrows<'_, 'tcx> {
                 self.kill_borrows_on_place(trans, &Place::from(local));
             }
 
-            mir::StatementKind::InlineAsm(ref asm) => {
+            mir::StatementKind::LlvmInlineAsm(ref asm) => {
                 for (output, kind) in asm.outputs.iter().zip(&asm.asm.outputs) {
                     if !kind.is_indirect && !kind.is_rw {
                         self.kill_borrows_on_place(trans, output);

--- a/src/librustc_mir/dataflow/impls/storage_liveness.rs
+++ b/src/librustc_mir/dataflow/impls/storage_liveness.rs
@@ -124,7 +124,7 @@ impl<'mir, 'tcx> dataflow::GenKillAnalysis<'tcx> for MaybeRequiresStorage<'mir, 
             | StatementKind::SetDiscriminant { box place, .. } => {
                 trans.gen(place.local);
             }
-            StatementKind::InlineAsm(asm) => {
+            StatementKind::LlvmInlineAsm(asm) => {
                 for place in &*asm.outputs {
                     trans.gen(place.local);
                 }

--- a/src/librustc_mir/dataflow/move_paths/builder.rs
+++ b/src/librustc_mir/dataflow/move_paths/builder.rs
@@ -295,7 +295,7 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
             StatementKind::FakeRead(_, ref place) => {
                 self.create_move_path(place);
             }
-            StatementKind::InlineAsm(ref asm) => {
+            StatementKind::LlvmInlineAsm(ref asm) => {
                 for (output, kind) in asm.outputs.iter().zip(&asm.asm.outputs) {
                     if !kind.is_indirect {
                         self.gather_init(output.as_ref(), InitKind::Deep);

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -124,7 +124,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             // size of MIR constantly.
             Nop => {}
 
-            InlineAsm { .. } => throw_unsup_format!("inline assembly is not supported"),
+            LlvmInlineAsm { .. } => throw_unsup_format!("inline assembly is not supported"),
         }
 
         self.stack[frame_idx].stmt += 1;

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -488,7 +488,7 @@ impl Visitor<'tcx> for Validator<'_, 'mir, 'tcx> {
             StatementKind::FakeRead(..)
             | StatementKind::StorageLive(_)
             | StatementKind::StorageDead(_)
-            | StatementKind::InlineAsm { .. }
+            | StatementKind::LlvmInlineAsm { .. }
             | StatementKind::Retag { .. }
             | StatementKind::AscribeUserType(..)
             | StatementKind::Nop => {}

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -106,7 +106,7 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
                 // safe (at least as emitted during MIR construction)
             }
 
-            StatementKind::InlineAsm { .. } => self.require_unsafe(
+            StatementKind::LlvmInlineAsm { .. } => self.require_unsafe(
                 "use of inline assembly",
                 "inline assembly is entirely unchecked and can cause undefined behavior",
                 UnsafetyViolationKind::General,

--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -230,7 +230,7 @@ fn check_statement(
         // just an assignment
         StatementKind::SetDiscriminant { place, .. } => check_place(tcx, place, span, def_id, body),
 
-        StatementKind::InlineAsm { .. } => {
+        StatementKind::LlvmInlineAsm { .. } => {
             Err((span, "cannot use inline assembly in const fn".into()))
         }
 

--- a/src/librustc_mir/transform/remove_noop_landing_pads.rs
+++ b/src/librustc_mir/transform/remove_noop_landing_pads.rs
@@ -52,7 +52,7 @@ impl RemoveNoopLandingPads {
 
                 StatementKind::Assign { .. }
                 | StatementKind::SetDiscriminant { .. }
-                | StatementKind::InlineAsm { .. }
+                | StatementKind::LlvmInlineAsm { .. }
                 | StatementKind::Retag { .. } => {
                     return false;
                 }

--- a/src/librustc_mir/transform/simplify_try.rs
+++ b/src/librustc_mir/transform/simplify_try.rs
@@ -172,7 +172,7 @@ impl<'tcx> MirPass<'tcx> for SimplifyBranchSame {
                     // so we cannot assume that the `unreachable` terminator itself is reachable.
                     // FIXME(Centril): use a normalization pass instead of a check.
                     || bb.statements.iter().any(|stmt| match stmt.kind {
-                        StatementKind::InlineAsm(..) => true,
+                        StatementKind::LlvmInlineAsm(..) => true,
                         _ => false,
                     })
                 })

--- a/src/librustc_mir/transform/unreachable_prop.rs
+++ b/src/librustc_mir/transform/unreachable_prop.rs
@@ -29,7 +29,7 @@ impl MirPass<'_> for UnreachablePropagation {
             // Accompanying testcases: mir-opt/unreachable_asm.rs and mir-opt/unreachable_asm_2.rs
             let asm_stmt_in_block = || {
                 bb_data.statements.iter().any(|stmt: &Statement<'_>| match stmt.kind {
-                    StatementKind::InlineAsm(..) => true,
+                    StatementKind::LlvmInlineAsm(..) => true,
                     _ => false,
                 })
             };

--- a/src/librustc_mir_build/build/expr/as_place.rs
+++ b/src/librustc_mir_build/build/expr/as_place.rs
@@ -255,7 +255,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             | ExprKind::Return { .. }
             | ExprKind::Literal { .. }
             | ExprKind::StaticRef { .. }
-            | ExprKind::InlineAsm { .. }
+            | ExprKind::LlvmInlineAsm { .. }
             | ExprKind::Yield { .. }
             | ExprKind::Call { .. } => {
                 // these are not places, so we need to make a temporary.

--- a/src/librustc_mir_build/build/expr/as_rvalue.rs
+++ b/src/librustc_mir_build/build/expr/as_rvalue.rs
@@ -251,7 +251,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             | ExprKind::Break { .. }
             | ExprKind::Continue { .. }
             | ExprKind::Return { .. }
-            | ExprKind::InlineAsm { .. }
+            | ExprKind::LlvmInlineAsm { .. }
             | ExprKind::PlaceTypeAscription { .. }
             | ExprKind::ValueTypeAscription { .. } => {
                 // these do not have corresponding `Rvalue` variants,

--- a/src/librustc_mir_build/build/expr/category.rs
+++ b/src/librustc_mir_build/build/expr/category.rs
@@ -64,7 +64,7 @@ impl Category {
             | ExprKind::Repeat { .. }
             | ExprKind::Assign { .. }
             | ExprKind::AssignOp { .. }
-            | ExprKind::InlineAsm { .. } => Some(Category::Rvalue(RvalueFunc::AsRvalue)),
+            | ExprKind::LlvmInlineAsm { .. } => Some(Category::Rvalue(RvalueFunc::AsRvalue)),
 
             ExprKind::Literal { .. } | ExprKind::StaticRef { .. } => Some(Category::Constant),
 

--- a/src/librustc_mir_build/build/expr/into.rs
+++ b/src/librustc_mir_build/build/expr/into.rs
@@ -328,7 +328,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             | ExprKind::AssignOp { .. }
             | ExprKind::Continue { .. }
             | ExprKind::Break { .. }
-            | ExprKind::InlineAsm { .. }
+            | ExprKind::LlvmInlineAsm { .. }
             | ExprKind::Return { .. } => {
                 unpack!(block = this.stmt_expr(block, expr, None));
                 this.cfg.push_assign_unit(block, source_info, destination);

--- a/src/librustc_mir_build/build/expr/stmt.rs
+++ b/src/librustc_mir_build/build/expr/stmt.rs
@@ -96,8 +96,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             ExprKind::Return { value } => {
                 this.break_scope(block, value, BreakableTarget::Return, source_info)
             }
-            ExprKind::InlineAsm { asm, outputs, inputs } => {
-                debug!("stmt_expr InlineAsm block_context.push(SubExpr) : {:?}", expr2);
+            ExprKind::LlvmInlineAsm { asm, outputs, inputs } => {
+                debug!("stmt_expr LlvmInlineAsm block_context.push(SubExpr) : {:?}", expr2);
                 this.block_context.push(BlockFrame::SubExpr);
                 let outputs = outputs
                     .into_iter()
@@ -115,7 +115,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     block,
                     Statement {
                         source_info,
-                        kind: StatementKind::InlineAsm(box InlineAsm {
+                        kind: StatementKind::LlvmInlineAsm(box LlvmInlineAsm {
                             asm: asm.clone(),
                             outputs,
                             inputs,

--- a/src/librustc_mir_build/hair/cx/expr.rs
+++ b/src/librustc_mir_build/hair/cx/expr.rs
@@ -398,7 +398,7 @@ fn make_mirror_unadjusted<'a, 'tcx>(
             convert_path_expr(cx, expr, res)
         }
 
-        hir::ExprKind::InlineAsm(ref asm) => ExprKind::InlineAsm {
+        hir::ExprKind::LlvmInlineAsm(ref asm) => ExprKind::LlvmInlineAsm {
             asm: &asm.inner,
             outputs: asm.outputs_exprs.to_ref(),
             inputs: asm.inputs_exprs.to_ref(),

--- a/src/librustc_mir_build/hair/mod.rs
+++ b/src/librustc_mir_build/hair/mod.rs
@@ -277,8 +277,8 @@ crate enum ExprKind<'tcx> {
         literal: &'tcx Const<'tcx>,
         def_id: DefId,
     },
-    InlineAsm {
-        asm: &'tcx hir::InlineAsmInner,
+    LlvmInlineAsm {
+        asm: &'tcx hir::LlvmInlineAsmInner,
         outputs: Vec<ExprRef<'tcx>>,
         inputs: Vec<ExprRef<'tcx>>,
     },

--- a/src/librustc_passes/liveness.rs
+++ b/src/librustc_passes/liveness.rs
@@ -532,7 +532,7 @@ fn visit_expr<'tcx>(ir: &mut IrMaps<'tcx>, expr: &'tcx Expr<'tcx>) {
         | hir::ExprKind::AssignOp(..)
         | hir::ExprKind::Struct(..)
         | hir::ExprKind::Repeat(..)
-        | hir::ExprKind::InlineAsm(..)
+        | hir::ExprKind::LlvmInlineAsm(..)
         | hir::ExprKind::Box(..)
         | hir::ExprKind::Yield(..)
         | hir::ExprKind::Type(..)
@@ -1183,7 +1183,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
             | hir::ExprKind::Yield(ref e, _)
             | hir::ExprKind::Repeat(ref e, _) => self.propagate_through_expr(&e, succ),
 
-            hir::ExprKind::InlineAsm(ref asm) => {
+            hir::ExprKind::LlvmInlineAsm(ref asm) => {
                 let ia = &asm.inner;
                 let outputs = asm.outputs_exprs;
                 let inputs = asm.inputs_exprs;
@@ -1408,7 +1408,7 @@ fn check_expr<'tcx>(this: &mut Liveness<'_, 'tcx>, expr: &'tcx Expr<'tcx>) {
             }
         }
 
-        hir::ExprKind::InlineAsm(ref asm) => {
+        hir::ExprKind::LlvmInlineAsm(ref asm) => {
             for input in asm.inputs_exprs {
                 this.visit_expr(input);
             }

--- a/src/librustc_span/symbol.rs
+++ b/src/librustc_span/symbol.rs
@@ -424,6 +424,7 @@ symbols! {
         LintPass,
         lint_reasons,
         literal,
+        llvm_asm,
         local_inner_macros,
         log_syntax,
         loop_break_value,

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -230,7 +230,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 self.check_expr_addr_of(kind, mutbl, oprnd, expected, expr)
             }
             ExprKind::Path(ref qpath) => self.check_expr_path(qpath, expr),
-            ExprKind::InlineAsm(ref asm) => {
+            ExprKind::LlvmInlineAsm(ref asm) => {
                 for expr in asm.outputs_exprs.iter().chain(asm.inputs_exprs.iter()) {
                     self.check_expr(expr);
                 }

--- a/src/librustc_typeck/expr_use_visitor.rs
+++ b/src/librustc_typeck/expr_use_visitor.rs
@@ -220,7 +220,7 @@ impl<'a, 'tcx> ExprUseVisitor<'a, 'tcx> {
                 self.borrow_expr(&base, bk);
             }
 
-            hir::ExprKind::InlineAsm(ref ia) => {
+            hir::ExprKind::LlvmInlineAsm(ref ia) => {
                 for (o, output) in ia.inner.outputs.iter().zip(ia.outputs_exprs) {
                     if o.is_indirect {
                         self.consume_expr(output);

--- a/src/librustc_typeck/mem_categorization.rs
+++ b/src/librustc_typeck/mem_categorization.rs
@@ -405,7 +405,7 @@ impl<'a, 'tcx> MemCategorizationContext<'a, 'tcx> {
             | hir::ExprKind::Continue(..)
             | hir::ExprKind::Struct(..)
             | hir::ExprKind::Repeat(..)
-            | hir::ExprKind::InlineAsm(..)
+            | hir::ExprKind::LlvmInlineAsm(..)
             | hir::ExprKind::Box(..)
             | hir::ExprKind::Err => Ok(self.cat_rvalue(expr.hir_id, expr.span, expr_ty)),
         }

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -274,6 +274,7 @@
 #![feature(libc)]
 #![feature(link_args)]
 #![feature(linkage)]
+#![feature(llvm_asm)]
 #![feature(log_syntax)]
 #![feature(maybe_uninit_ref)]
 #![feature(maybe_uninit_slice)]
@@ -533,29 +534,9 @@ pub use core::{
 // Re-export built-in macros defined through libcore.
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 pub use core::{
-    // Unstable
-    asm,
-    // Stable
-    assert,
-    cfg,
-    column,
-    compile_error,
-    concat,
-    concat_idents,
-    env,
-    file,
-    format_args,
-    format_args_nl,
-    global_asm,
-    include,
-    include_bytes,
-    include_str,
-    line,
-    log_syntax,
-    module_path,
-    option_env,
-    stringify,
-    trace_macros,
+    asm, assert, cfg, column, compile_error, concat, concat_idents, env, file, format_args,
+    format_args_nl, global_asm, include, include_bytes, include_str, line, llvm_asm, log_syntax,
+    module_path, option_env, stringify, trace_macros,
 };
 
 #[stable(feature = "core_primitive", since = "1.43.0")]

--- a/src/libstd/prelude/v1.rs
+++ b/src/libstd/prelude/v1.rs
@@ -39,8 +39,8 @@ pub use crate::result::Result::{self, Err, Ok};
 #[doc(no_inline)]
 pub use core::prelude::v1::{
     asm, assert, cfg, column, compile_error, concat, concat_idents, env, file, format_args,
-    format_args_nl, global_asm, include, include_bytes, include_str, line, log_syntax, module_path,
-    option_env, stringify, trace_macros,
+    format_args_nl, global_asm, include, include_bytes, include_str, line, llvm_asm, log_syntax,
+    module_path, option_env, stringify, trace_macros,
 };
 
 // FIXME: Attribute and derive macros are not documented because for them rustdoc generates

--- a/src/libstd/sys/sgx/abi/mem.rs
+++ b/src/libstd/sys/sgx/abi/mem.rs
@@ -22,7 +22,7 @@ extern "C" {
 #[unstable(feature = "sgx_platform", issue = "56975")]
 pub fn image_base() -> u64 {
     let base;
-    unsafe { asm!("lea IMAGE_BASE(%rip),$0":"=r"(base)) };
+    unsafe { llvm_asm!("lea IMAGE_BASE(%rip),$0":"=r"(base)) };
     base
 }
 

--- a/src/libstd/sys/sgx/ext/arch.rs
+++ b/src/libstd/sys/sgx/ext/arch.rs
@@ -31,7 +31,7 @@ pub fn egetkey(request: &Align512<[u8; 512]>) -> Result<Align16<[u8; 16]>, u32> 
         let mut out = MaybeUninit::uninit();
         let error;
 
-        asm!(
+        llvm_asm!(
             "enclu"
             : "={eax}"(error)
             : "{eax}"(ENCLU_EGETKEY),
@@ -60,7 +60,7 @@ pub fn ereport(
     unsafe {
         let mut report = MaybeUninit::uninit();
 
-        asm!(
+        llvm_asm!(
             "enclu"
             : /* no output registers */
             : "{eax}"(ENCLU_EREPORT),

--- a/src/libstd/sys/windows/mod.rs
+++ b/src/libstd/sys/windows/mod.rs
@@ -267,7 +267,7 @@ pub fn dur2timeout(dur: Duration) -> c::DWORD {
 pub unsafe fn abort_internal() -> ! {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
-        asm!("int $$0x29" :: "{ecx}"(7) ::: volatile); // 7 is FAST_FAIL_FATAL_APP_EXIT
+        llvm_asm!("int $$0x29" :: "{ecx}"(7) ::: volatile); // 7 is FAST_FAIL_FATAL_APP_EXIT
         crate::intrinsics::unreachable();
     }
     crate::intrinsics::abort();

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -20,7 +20,6 @@
 #![crate_name = "test"]
 #![unstable(feature = "test", issue = "50297")]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/", test(attr(deny(warnings))))]
-#![feature(asm)]
 #![cfg_attr(any(unix, target_os = "cloudabi"), feature(libc))]
 #![feature(rustc_private)]
 #![feature(nll)]

--- a/src/test/codegen/no-output-asm-is-volatile.rs
+++ b/src/test/codegen/no-output-asm-is-volatile.rs
@@ -1,6 +1,6 @@
 // compile-flags: -O
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![crate_type = "lib"]
 
 // Check that inline assembly expressions without any outputs
@@ -9,6 +9,6 @@
 // CHECK-LABEL: @assembly
 #[no_mangle]
 pub fn assembly() {
-    unsafe { asm!("") }
+    unsafe { llvm_asm!("") }
 // CHECK: tail call void asm sideeffect "", {{.*}}
 }

--- a/src/test/compile-fail/asm-src-loc-codegen-units.rs
+++ b/src/test/compile-fail/asm-src-loc-codegen-units.rs
@@ -3,10 +3,10 @@
 // compile-flags: -C codegen-units=2
 // ignore-emscripten
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 fn main() {
     unsafe {
-        asm!("nowayisthisavalidinstruction"); //~ ERROR instruction
+        llvm_asm!("nowayisthisavalidinstruction"); //~ ERROR instruction
     }
 }

--- a/src/test/compile-fail/asm-src-loc.rs
+++ b/src/test/compile-fail/asm-src-loc.rs
@@ -1,9 +1,9 @@
 // ignore-emscripten
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 fn main() {
     unsafe {
-        asm!("nowayisthisavalidinstruction"); //~ ERROR instruction
+        llvm_asm!("nowayisthisavalidinstruction"); //~ ERROR instruction
     }
 }

--- a/src/test/incremental/hashes/inline_asm.rs
+++ b/src/test/incremental/hashes/inline_asm.rs
@@ -11,7 +11,7 @@
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![crate_type="rlib"]
 
 
@@ -22,12 +22,12 @@
 pub fn change_template(a: i32) -> i32 {
     let c: i32;
     unsafe {
-        asm!("add 1, $0"
-             : "=r"(c)
-             : "0"(a)
-             :
-             :
-             );
+        llvm_asm!("add 1, $0"
+                  : "=r"(c)
+                  : "0"(a)
+                  :
+                  :
+                  );
     }
     c
 }
@@ -39,12 +39,12 @@ pub fn change_template(a: i32) -> i32 {
 pub fn change_template(a: i32) -> i32 {
     let c: i32;
     unsafe {
-        asm!("add 2, $0"
-             : "=r"(c)
-             : "0"(a)
-             :
-             :
-             );
+        llvm_asm!("add 2, $0"
+                  : "=r"(c)
+                  : "0"(a)
+                  :
+                  :
+                  );
     }
     c
 }
@@ -58,12 +58,12 @@ pub fn change_output(a: i32) -> i32 {
     let mut _out1: i32 = 0;
     let mut _out2: i32 = 0;
     unsafe {
-        asm!("add 1, $0"
-             : "=r"(_out1)
-             : "0"(a)
-             :
-             :
-             );
+        llvm_asm!("add 1, $0"
+                  : "=r"(_out1)
+                  : "0"(a)
+                  :
+                  :
+                  );
     }
     _out1
 }
@@ -76,12 +76,12 @@ pub fn change_output(a: i32) -> i32 {
     let mut _out1: i32 = 0;
     let mut _out2: i32 = 0;
     unsafe {
-        asm!("add 1, $0"
-             : "=r"(_out2)
-             : "0"(a)
-             :
-             :
-             );
+        llvm_asm!("add 1, $0"
+                  : "=r"(_out2)
+                  : "0"(a)
+                  :
+                  :
+                  );
     }
     _out1
 }
@@ -94,12 +94,12 @@ pub fn change_output(a: i32) -> i32 {
 pub fn change_input(_a: i32, _b: i32) -> i32 {
     let _out;
     unsafe {
-        asm!("add 1, $0"
-             : "=r"(_out)
-             : "0"(_a)
-             :
-             :
-             );
+        llvm_asm!("add 1, $0"
+                  : "=r"(_out)
+                  : "0"(_a)
+                  :
+                  :
+                  );
     }
     _out
 }
@@ -111,12 +111,12 @@ pub fn change_input(_a: i32, _b: i32) -> i32 {
 pub fn change_input(_a: i32, _b: i32) -> i32 {
     let _out;
     unsafe {
-        asm!("add 1, $0"
-             : "=r"(_out)
-             : "0"(_b)
-             :
-             :
-             );
+        llvm_asm!("add 1, $0"
+                  : "=r"(_out)
+                  : "0"(_b)
+                  :
+                  :
+                  );
     }
     _out
 }
@@ -129,12 +129,12 @@ pub fn change_input(_a: i32, _b: i32) -> i32 {
 pub fn change_input_constraint(_a: i32, _b: i32) -> i32 {
     let _out;
     unsafe {
-        asm!("add 1, $0"
-             : "=r"(_out)
-             : "0"(_a), "r"(_b)
-             :
-             :
-             );
+        llvm_asm!("add 1, $0"
+                  : "=r"(_out)
+                  : "0"(_a), "r"(_b)
+                  :
+                  :
+                  );
     }
     _out
 }
@@ -146,12 +146,12 @@ pub fn change_input_constraint(_a: i32, _b: i32) -> i32 {
 pub fn change_input_constraint(_a: i32, _b: i32) -> i32 {
     let _out;
     unsafe {
-        asm!("add 1, $0"
-             : "=r"(_out)
-             : "r"(_a), "0"(_b)
-             :
-             :
-             );
+        llvm_asm!("add 1, $0"
+                  : "=r"(_out)
+                  : "r"(_a), "0"(_b)
+                  :
+                  :
+                  );
     }
     _out
 }
@@ -164,12 +164,12 @@ pub fn change_input_constraint(_a: i32, _b: i32) -> i32 {
 pub fn change_clobber(_a: i32) -> i32 {
     let _out;
     unsafe {
-        asm!("add 1, $0"
-             : "=r"(_out)
-             : "0"(_a)
-             :
-             :
-             );
+        llvm_asm!("add 1, $0"
+                  : "=r"(_out)
+                  : "0"(_a)
+                  :
+                  :
+                  );
     }
     _out
 }
@@ -181,12 +181,12 @@ pub fn change_clobber(_a: i32) -> i32 {
 pub fn change_clobber(_a: i32) -> i32 {
     let _out;
     unsafe {
-        asm!("add 1, $0"
-             : "=r"(_out)
-             : "0"(_a)
-             : "eax"
-             :
-             );
+        llvm_asm!("add 1, $0"
+                  : "=r"(_out)
+                  : "0"(_a)
+                  : "eax"
+                  :
+                  );
     }
     _out
 }
@@ -199,12 +199,12 @@ pub fn change_clobber(_a: i32) -> i32 {
 pub fn change_options(_a: i32) -> i32 {
     let _out;
     unsafe {
-        asm!("add 1, $0"
-             : "=r"(_out)
-             : "0"(_a)
-             :
-             :
-             );
+        llvm_asm!("add 1, $0"
+                  : "=r"(_out)
+                  : "0"(_a)
+                  :
+                  :
+                  );
     }
     _out
 }
@@ -216,12 +216,12 @@ pub fn change_options(_a: i32) -> i32 {
 pub fn change_options(_a: i32) -> i32 {
     let _out;
     unsafe {
-        asm!("add 1, $0"
-             : "=r"(_out)
-             : "0"(_a)
-             :
-             : "volatile"
-             );
+        llvm_asm!("add 1, $0"
+                  : "=r"(_out)
+                  : "0"(_a)
+                  :
+                  : "volatile"
+                  );
     }
     _out
 }

--- a/src/test/mir-opt/unreachable_asm.rs
+++ b/src/test/mir-opt/unreachable_asm.rs
@@ -1,5 +1,5 @@
 // ignore-tidy-linelength
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 enum Empty {}
 
@@ -18,7 +18,7 @@ fn main() {
         }
 
         // asm instruction stops unreachable propagation to if else blocks bb4 and bb5.
-        unsafe { asm!("NOP"); }
+        unsafe { llvm_asm!("NOP"); }
         match _x { }
     }
 }
@@ -39,7 +39,7 @@ fn main() {
 //          StorageDead(_6);
 //          StorageDead(_5);
 //          StorageLive(_7);
-//          asm!(InlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []);
+//          llvm_asm!(LlvmInlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []);
 //          _7 = ();
 //          StorageDead(_7);
 //          StorageLive(_8);
@@ -62,7 +62,7 @@ fn main() {
 //          StorageDead(_6);
 //          StorageDead(_5);
 //          StorageLive(_7);
-//          asm!(InlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []);
+//          llvm_asm!(LlvmInlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []);
 //          _7 = ();
 //          StorageDead(_7);
 //          StorageLive(_8);

--- a/src/test/mir-opt/unreachable_asm_2.rs
+++ b/src/test/mir-opt/unreachable_asm_2.rs
@@ -1,5 +1,5 @@
 // ignore-tidy-linelength
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 enum Empty {}
 
@@ -13,11 +13,11 @@ fn main() {
 
         if true {
             // asm instruction stops unreachable propagation to block bb3.
-            unsafe { asm!("NOP"); }
+            unsafe { llvm_asm!("NOP"); }
             _y = 21;
         } else {
             // asm instruction stops unreachable propagation to block bb3.
-            unsafe { asm!("NOP"); }
+            unsafe { llvm_asm!("NOP"); }
             _y = 42;
         }
 
@@ -33,7 +33,7 @@ fn main() {
 //      }
 //      bb4: {
 //          StorageLive(_8);
-//          asm!(InlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []);
+//          llvm_asm!(LlvmInlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []);
 //          _8 = ();
 //          StorageDead(_8);
 //          _4 = const 42i32;
@@ -42,7 +42,7 @@ fn main() {
 //      }
 //          bb5: {
 //          StorageLive(_7);
-//          asm!(InlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []);
+//          llvm_asm!(LlvmInlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []);
 //          _7 = ();
 //          StorageDead(_7);
 //          _4 = const 21i32;
@@ -64,7 +64,7 @@ fn main() {
 //      }
 //      bb4: {
 //          StorageLive(_8);
-//          asm!(InlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []);
+//          llvm_asm!(LlvmInlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []);
 //          _8 = ();
 //          StorageDead(_8);
 //          _4 = const 42i32;
@@ -73,7 +73,7 @@ fn main() {
 //      }
 //          bb5: {
 //          StorageLive(_7);
-//          asm!(InlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []);
+//          llvm_asm!(LlvmInlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []);
 //          _7 = ();
 //          StorageDead(_7);
 //          _4 = const 21i32;

--- a/src/test/pretty/asm-clobbers.rs
+++ b/src/test/pretty/asm-clobbers.rs
@@ -1,3 +1,3 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 
-pub fn main() { unsafe { asm!("" : : : "hello", "world") }; }
+pub fn main() { unsafe { llvm_asm!("" : : : "hello", "world") }; }

--- a/src/test/pretty/asm-options.rs
+++ b/src/test/pretty/asm-options.rs
@@ -1,11 +1,11 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 // pp-exact
 
 pub fn main() {
     unsafe {
-        asm!("" : : : : "volatile");
-        asm!("" : : : : "alignstack");
-        asm!("" : : : : "intel");
+        llvm_asm!("" : : : : "volatile");
+        llvm_asm!("" : : : : "alignstack");
+        llvm_asm!("" : : : : "intel");
     }
 }

--- a/src/test/pretty/raw-str-nonexpr.rs
+++ b/src/test/pretty/raw-str-nonexpr.rs
@@ -1,8 +1,8 @@
 // pp-exact
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 #[cfg(foo = r#"just parse this"#)]
 extern crate blah as blah;
 
-fn main() { unsafe { asm!(r###"blah"###); } }
+fn main() { unsafe { llvm_asm!(r###"blah"###); } }

--- a/src/test/run-make-fulldeps/intrinsic-unreachable/exit-ret.rs
+++ b/src/test/run-make-fulldeps/intrinsic-unreachable/exit-ret.rs
@@ -1,11 +1,11 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![crate_type="lib"]
 
 #[deny(unreachable_code)]
 pub fn exit(n: usize) -> i32 {
     unsafe {
         // Pretend this asm is an exit() syscall.
-        asm!("" :: "r"(n) :: "volatile");
+        llvm_asm!("" :: "r"(n) :: "volatile");
         // Can't actually reach this point, but rustc doesn't know that.
     }
     // This return value is just here to generate some extra code for a return

--- a/src/test/run-make-fulldeps/intrinsic-unreachable/exit-unreachable.rs
+++ b/src/test/run-make-fulldeps/intrinsic-unreachable/exit-unreachable.rs
@@ -1,4 +1,4 @@
-#![feature(asm, core_intrinsics)]
+#![feature(llvm_asm, core_intrinsics)]
 #![crate_type="lib"]
 
 use std::intrinsics;
@@ -7,7 +7,7 @@ use std::intrinsics;
 pub fn exit(n: usize) -> i32 {
     unsafe {
         // Pretend this asm is an exit() syscall.
-        asm!("" :: "r"(n) :: "volatile");
+        llvm_asm!("" :: "r"(n) :: "volatile");
         intrinsics::unreachable()
     }
     // This return value is just here to generate some extra code for a return

--- a/src/test/ui/abi/abi-sysv64-register-usage.rs
+++ b/src/test/ui/abi/abi-sysv64-register-usage.rs
@@ -6,7 +6,7 @@
 // ignore-arm
 // ignore-aarch64
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 #[cfg(target_arch = "x86_64")]
 pub extern "sysv64" fn all_the_registers(rdi: i64, rsi: i64, rdx: i64,
@@ -54,34 +54,34 @@ pub extern "sysv64" fn large_struct_by_val(mut foo: LargeStruct) -> LargeStruct 
 pub fn main() {
     let result: i64;
     unsafe {
-        asm!("mov rdi, 1;
-              mov rsi, 2;
-              mov rdx, 3;
-              mov rcx, 4;
-              mov r8,  5;
-              mov r9,  6;
-              mov eax, 0x3F800000;
-              movd xmm0, eax;
-              mov eax, 0x40000000;
-              movd xmm1, eax;
-              mov eax, 0x40800000;
-              movd xmm2, eax;
-              mov eax, 0x41000000;
-              movd xmm3, eax;
-              mov eax, 0x41800000;
-              movd xmm4, eax;
-              mov eax, 0x42000000;
-              movd xmm5, eax;
-              mov eax, 0x42800000;
-              movd xmm6, eax;
-              mov eax, 0x43000000;
-              movd xmm7, eax;
-              call r10
-              "
-            : "={rax}"(result)
-            : "{r10}"(all_the_registers as usize)
-            : "rdi", "rsi", "rdx", "rcx", "r8", "r9", "r11", "cc", "memory"
-            : "intel", "alignstack"
+        llvm_asm!("mov rdi, 1;
+                   mov rsi, 2;
+                   mov rdx, 3;
+                   mov rcx, 4;
+                   mov r8,  5;
+                   mov r9,  6;
+                   mov eax, 0x3F800000;
+                   movd xmm0, eax;
+                   mov eax, 0x40000000;
+                   movd xmm1, eax;
+                   mov eax, 0x40800000;
+                   movd xmm2, eax;
+                   mov eax, 0x41000000;
+                   movd xmm3, eax;
+                   mov eax, 0x41800000;
+                   movd xmm4, eax;
+                   mov eax, 0x42000000;
+                   movd xmm5, eax;
+                   mov eax, 0x42800000;
+                   movd xmm6, eax;
+                   mov eax, 0x43000000;
+                   movd xmm7, eax;
+                   call r10
+                   "
+                 : "={rax}"(result)
+                 : "{r10}"(all_the_registers as usize)
+                 : "rdi", "rsi", "rdx", "rcx", "r8", "r9", "r11", "cc", "memory"
+                 : "intel", "alignstack"
         )
     }
     assert_eq!(result, 42);

--- a/src/test/ui/asm-concat-src.rs
+++ b/src/test/ui/asm-concat-src.rs
@@ -2,8 +2,8 @@
 // pretty-expanded FIXME #23616
 // ignore-emscripten no asm
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 pub fn main() {
-    unsafe { asm!(concat!("", "")) };
+    unsafe { llvm_asm!(concat!("", "")) };
 }

--- a/src/test/ui/asm-in-moved.rs
+++ b/src/test/ui/asm-in-moved.rs
@@ -1,6 +1,6 @@
 // run-pass
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![allow(dead_code)]
 
 use std::cell::Cell;
@@ -20,7 +20,7 @@ fn main() {
         let _y: Box<NoisyDrop>;
         let x = Box::new(NoisyDrop(&status));
         unsafe {
-            asm!("mov $1, $0" : "=r"(_y) : "r"(x));
+            llvm_asm!("mov $1, $0" : "=r"(_y) : "r"(x));
         }
         assert_eq!(status.get(), "alive");
     }

--- a/src/test/ui/asm-in-out-operand.rs
+++ b/src/test/ui/asm-in-out-operand.rs
@@ -1,21 +1,21 @@
 // run-pass
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 unsafe fn next_power_of_2(n: u32) -> u32 {
     let mut tmp = n;
-    asm!("dec $0" : "+rm"(tmp) :: "cc");
+    llvm_asm!("dec $0" : "+rm"(tmp) :: "cc");
     let mut shift = 1_u32;
     while shift <= 16 {
-        asm!(
+        llvm_asm!(
             "shr %cl, $2
             or $2, $0
             shl $$1, $1"
             : "+&rm"(tmp), "+{ecx}"(shift) : "r"(tmp) : "cc"
         );
     }
-    asm!("inc $0" : "+rm"(tmp) :: "cc");
+    llvm_asm!("inc $0" : "+rm"(tmp) :: "cc");
     return tmp;
 }
 
@@ -30,7 +30,7 @@ pub fn main() {
     let x: isize;
     unsafe {
         // Treat the output as initialization.
-        asm!(
+        llvm_asm!(
             "shl $2, $1
             add $3, $1
             mov $1, $0"
@@ -47,7 +47,7 @@ pub fn main() {
         // Assignment to mutable.
         // Early clobber "&":
         // Forbids the use of a single register by both operands.
-        asm!("shr $$2, $1; add $1, $0" : "+&r"(x) : "r"(x) : "cc");
+        llvm_asm!("shr $$2, $1; add $1, $0" : "+&r"(x) : "r"(x) : "cc");
     }
     assert_eq!(x, 60);
 }

--- a/src/test/ui/asm-indirect-memory.rs
+++ b/src/test/ui/asm-indirect-memory.rs
@@ -1,12 +1,12 @@
 // run-pass
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn read(ptr: &u32) -> u32 {
     let out: u32;
     unsafe {
-        asm!("mov $1, $0" : "=r" (out) : "*m" (ptr));
+        llvm_asm!("mov $1, $0" : "=r" (out) : "*m" (ptr));
     }
     out
 }
@@ -14,7 +14,7 @@ fn read(ptr: &u32) -> u32 {
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn write(ptr: &mut u32, val: u32) {
     unsafe {
-        asm!("mov $1, $0" : "=*m" (ptr) : "r" (val));
+        llvm_asm!("mov $1, $0" : "=*m" (ptr) : "r" (val));
     }
 }
 
@@ -22,7 +22,7 @@ fn write(ptr: &mut u32, val: u32) {
 fn replace(ptr: &mut u32, val: u32) -> u32 {
     let out: u32;
     unsafe {
-        asm!("mov $0, $1; mov $2, $0" : "+*m" (ptr), "=&r" (out) : "r" (val));
+        llvm_asm!("mov $0, $1; mov $2, $0" : "+*m" (ptr), "=&r" (out) : "r" (val));
     }
     out
 }

--- a/src/test/ui/asm-out-assign.rs
+++ b/src/test/ui/asm-out-assign.rs
@@ -1,13 +1,13 @@
 // run-pass
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn main() {
     let x: isize;
     unsafe {
         // Treat the output as initialization.
-        asm!("mov $1, $0" : "=r"(x) : "r"(5_usize));
+        llvm_asm!("mov $1, $0" : "=r"(x) : "r"(5_usize));
     }
     assert_eq!(x, 5);
 
@@ -16,7 +16,7 @@ pub fn main() {
 
     unsafe {
         // Assignment to mutable.
-        asm!("mov $1, $0" : "=r"(x) : "r"(x + 7));
+        llvm_asm!("mov $1, $0" : "=r"(x) : "r"(x + 7));
     }
     assert_eq!(x, 13);
 }

--- a/src/test/ui/asm/asm-bad-clobber.rs
+++ b/src/test/ui/asm/asm-bad-clobber.rs
@@ -11,7 +11,7 @@
 // ignore-mips
 // ignore-mips64
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 #[cfg(any(target_arch = "x86",
           target_arch = "x86_64"))]
@@ -19,7 +19,7 @@
 pub fn main() {
     unsafe {
         // clobber formatted as register input/output
-        asm!("xor %eax, %eax" : : : "{eax}");
+        llvm_asm!("xor %eax, %eax" : : : "{eax}");
         //~^ ERROR clobber should not be surrounded by braces
     }
 }

--- a/src/test/ui/asm/asm-bad-clobber.stderr
+++ b/src/test/ui/asm/asm-bad-clobber.stderr
@@ -1,8 +1,8 @@
 error[E0664]: clobber should not be surrounded by braces
-  --> $DIR/asm-bad-clobber.rs:22:37
+  --> $DIR/asm-bad-clobber.rs:22:42
    |
-LL |         asm!("xor %eax, %eax" : : : "{eax}");
-   |                                     ^^^^^^^
+LL |         llvm_asm!("xor %eax, %eax" : : : "{eax}");
+   |                                          ^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/asm/asm-in-bad-modifier.rs
+++ b/src/test/ui/asm/asm-in-bad-modifier.rs
@@ -8,7 +8,7 @@
 // ignore-mips
 // ignore-mips64
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 fn foo(x: isize) { println!("{}", x); }
 
@@ -20,8 +20,8 @@ pub fn main() {
     let x: isize;
     let y: isize;
     unsafe {
-        asm!("mov $1, $0" : "=r"(x) : "=r"(5)); //~ ERROR operand constraint contains '='
-        asm!("mov $1, $0" : "=r"(y) : "+r"(5)); //~ ERROR operand constraint contains '+'
+        llvm_asm!("mov $1, $0" : "=r"(x) : "=r"(5)); //~ ERROR operand constraint contains '='
+        llvm_asm!("mov $1, $0" : "=r"(y) : "+r"(5)); //~ ERROR operand constraint contains '+'
     }
     foo(x);
     foo(y);

--- a/src/test/ui/asm/asm-in-bad-modifier.stderr
+++ b/src/test/ui/asm/asm-in-bad-modifier.stderr
@@ -1,14 +1,14 @@
 error[E0662]: input operand constraint contains '='
-  --> $DIR/asm-in-bad-modifier.rs:23:39
+  --> $DIR/asm-in-bad-modifier.rs:23:44
    |
-LL |         asm!("mov $1, $0" : "=r"(x) : "=r"(5));
-   |                                       ^^^^
+LL |         llvm_asm!("mov $1, $0" : "=r"(x) : "=r"(5));
+   |                                            ^^^^
 
 error[E0663]: input operand constraint contains '+'
-  --> $DIR/asm-in-bad-modifier.rs:24:39
+  --> $DIR/asm-in-bad-modifier.rs:24:44
    |
-LL |         asm!("mov $1, $0" : "=r"(y) : "+r"(5));
-   |                                       ^^^^
+LL |         llvm_asm!("mov $1, $0" : "=r"(y) : "+r"(5));
+   |                                            ^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/asm/asm-literal-escaping.rs
+++ b/src/test/ui/asm/asm-literal-escaping.rs
@@ -1,12 +1,12 @@
 // build-pass
 // only-x86_64
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 fn main() {
     unsafe {
         // "nop" :: "r"(x) : "eax" : "volatile"
         let x = 10;
-        asm!("\x6Eop" :: "\x72"(x) : "\x65ax" : "\x76olatile");
+        llvm_asm!("\x6Eop" :: "\x72"(x) : "\x65ax" : "\x76olatile");
     }
 }

--- a/src/test/ui/asm/asm-misplaced-option.rs
+++ b/src/test/ui/asm/asm-misplaced-option.rs
@@ -12,7 +12,7 @@
 // ignore-mips
 // ignore-mips64
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 #[cfg(any(target_arch = "x86",
           target_arch = "x86_64"))]
@@ -21,14 +21,14 @@ fn main() {
     let mut x: isize = 0;
     unsafe {
         // extra colon
-        asm!("mov $1, $0" : "=r"(x) : "r"(5_usize), "0"(x) : : "cc");
+        llvm_asm!("mov $1, $0" : "=r"(x) : "r"(5_usize), "0"(x) : : "cc");
         //~^ WARNING unrecognized option
     }
     assert_eq!(x, 5);
 
     unsafe {
         // comma in place of a colon
-        asm!("add $2, $1; mov $1, $0" : "=r"(x) : "r"(x), "r"(8_usize) : "cc", "volatile");
+        llvm_asm!("add $2, $1; mov $1, $0" : "=r"(x) : "r"(x), "r"(8_usize) : "cc", "volatile");
         //~^ WARNING expected a clobber, found an option
     }
     assert_eq!(x, 13);

--- a/src/test/ui/asm/asm-misplaced-option.stderr
+++ b/src/test/ui/asm/asm-misplaced-option.stderr
@@ -1,12 +1,12 @@
 warning: unrecognized option
-  --> $DIR/asm-misplaced-option.rs:24:64
+  --> $DIR/asm-misplaced-option.rs:24:69
    |
-LL |         asm!("mov $1, $0" : "=r"(x) : "r"(5_usize), "0"(x) : : "cc");
-   |                                                                ^^^^
+LL |         llvm_asm!("mov $1, $0" : "=r"(x) : "r"(5_usize), "0"(x) : : "cc");
+   |                                                                     ^^^^
 
 warning: expected a clobber, found an option
-  --> $DIR/asm-misplaced-option.rs:31:80
+  --> $DIR/asm-misplaced-option.rs:31:85
    |
-LL |         asm!("add $2, $1; mov $1, $0" : "=r"(x) : "r"(x), "r"(8_usize) : "cc", "volatile");
-   |                                                                                ^^^^^^^^^^
+LL |         llvm_asm!("add $2, $1; mov $1, $0" : "=r"(x) : "r"(x), "r"(8_usize) : "cc", "volatile");
+   |                                                                                     ^^^^^^^^^^
 

--- a/src/test/ui/asm/asm-out-assign-imm.rs
+++ b/src/test/ui/asm/asm-out-assign-imm.rs
@@ -8,7 +8,7 @@
 // ignore-mips
 // ignore-mips64
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 fn foo(x: isize) { println!("{}", x); }
 
@@ -21,7 +21,7 @@ pub fn main() {
     x = 1;
     foo(x);
     unsafe {
-        asm!("mov $1, $0" : "=r"(x) : "r"(5));
+        llvm_asm!("mov $1, $0" : "=r"(x) : "r"(5));
         //~^ ERROR cannot assign twice to immutable variable `x`
     }
     foo(x);

--- a/src/test/ui/asm/asm-out-assign-imm.stderr
+++ b/src/test/ui/asm/asm-out-assign-imm.stderr
@@ -1,13 +1,13 @@
 error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/asm-out-assign-imm.rs:24:34
+  --> $DIR/asm-out-assign-imm.rs:24:39
    |
 LL |     let x: isize;
    |         - help: make this binding mutable: `mut x`
 LL |     x = 1;
    |     ----- first assignment to `x`
 ...
-LL |         asm!("mov $1, $0" : "=r"(x) : "r"(5));
-   |                                  ^ cannot assign twice to immutable variable
+LL |         llvm_asm!("mov $1, $0" : "=r"(x) : "r"(5));
+   |                                       ^ cannot assign twice to immutable variable
 
 error: aborting due to previous error
 

--- a/src/test/ui/asm/asm-out-no-modifier.rs
+++ b/src/test/ui/asm/asm-out-no-modifier.rs
@@ -8,7 +8,7 @@
 // ignore-mips
 // ignore-mips64
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 fn foo(x: isize) { println!("{}", x); }
 
@@ -19,7 +19,7 @@ fn foo(x: isize) { println!("{}", x); }
 pub fn main() {
     let x: isize;
     unsafe {
-        asm!("mov $1, $0" : "r"(x) : "r"(5)); //~ ERROR output operand constraint lacks '='
+        llvm_asm!("mov $1, $0" : "r"(x) : "r"(5)); //~ ERROR output operand constraint lacks '='
     }
     foo(x);
 }

--- a/src/test/ui/asm/asm-out-no-modifier.stderr
+++ b/src/test/ui/asm/asm-out-no-modifier.stderr
@@ -1,8 +1,8 @@
 error[E0661]: output operand constraint lacks '=' or '+'
-  --> $DIR/asm-out-no-modifier.rs:22:29
+  --> $DIR/asm-out-no-modifier.rs:22:34
    |
-LL |         asm!("mov $1, $0" : "r"(x) : "r"(5));
-   |                             ^^^
+LL |         llvm_asm!("mov $1, $0" : "r"(x) : "r"(5));
+   |                                  ^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/asm/asm-out-read-uninit.rs
+++ b/src/test/ui/asm/asm-out-read-uninit.rs
@@ -8,7 +8,7 @@
 // ignore-mips
 // ignore-mips64
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 fn foo(x: isize) { println!("{}", x); }
 
@@ -19,7 +19,7 @@ fn foo(x: isize) { println!("{}", x); }
 pub fn main() {
     let x: isize;
     unsafe {
-        asm!("mov $1, $0" : "=r"(x) : "r"(x));
+        llvm_asm!("mov $1, $0" : "=r"(x) : "r"(x));
         //~^ ERROR use of possibly-uninitialized variable: `x`
     }
     foo(x);

--- a/src/test/ui/asm/asm-out-read-uninit.stderr
+++ b/src/test/ui/asm/asm-out-read-uninit.stderr
@@ -1,8 +1,8 @@
 error[E0381]: use of possibly-uninitialized variable: `x`
-  --> $DIR/asm-out-read-uninit.rs:22:43
+  --> $DIR/asm-out-read-uninit.rs:22:48
    |
-LL |         asm!("mov $1, $0" : "=r"(x) : "r"(x));
-   |                                           ^ use of possibly-uninitialized `x`
+LL |         llvm_asm!("mov $1, $0" : "=r"(x) : "r"(x));
+   |                                                ^ use of possibly-uninitialized `x`
 
 error: aborting due to previous error
 

--- a/src/test/ui/asm/asm-parse-errors.rs
+++ b/src/test/ui/asm/asm-parse-errors.rs
@@ -1,15 +1,15 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 fn main() {
-    asm!(); //~ ERROR requires a string literal as an argument
-    asm!("nop" : struct); //~ ERROR expected string literal
-    asm!("mov %eax, $$0x2" : struct); //~ ERROR expected string literal
-    asm!("mov %eax, $$0x2" : "={eax}" struct); //~ ERROR expected `(`
-    asm!("mov %eax, $$0x2" : "={eax}"(struct)); //~ ERROR expected expression
-    asm!("in %dx, %al" : "={al}"(result) : struct); //~ ERROR expected string literal
-    asm!("in %dx, %al" : "={al}"(result) : "{dx}" struct); //~ ERROR expected `(`
-    asm!("in %dx, %al" : "={al}"(result) : "{dx}"(struct)); //~ ERROR expected expression
-    asm!("mov $$0x200, %eax" : : : struct); //~ ERROR expected string literal
-    asm!("mov eax, 2" : "={eax}"(foo) : : : struct); //~ ERROR expected string literal
-    asm!(123); //~ ERROR inline assembly must be a string literal
+    llvm_asm!(); //~ ERROR requires a string literal as an argument
+    llvm_asm!("nop" : struct); //~ ERROR expected string literal
+    llvm_asm!("mov %eax, $$0x2" : struct); //~ ERROR expected string literal
+    llvm_asm!("mov %eax, $$0x2" : "={eax}" struct); //~ ERROR expected `(`
+    llvm_asm!("mov %eax, $$0x2" : "={eax}"(struct)); //~ ERROR expected expression
+    llvm_asm!("in %dx, %al" : "={al}"(result) : struct); //~ ERROR expected string literal
+    llvm_asm!("in %dx, %al" : "={al}"(result) : "{dx}" struct); //~ ERROR expected `(`
+    llvm_asm!("in %dx, %al" : "={al}"(result) : "{dx}"(struct)); //~ ERROR expected expression
+    llvm_asm!("mov $$0x200, %eax" : : : struct); //~ ERROR expected string literal
+    llvm_asm!("mov eax, 2" : "={eax}"(foo) : : : struct); //~ ERROR expected string literal
+    llvm_asm!(123); //~ ERROR inline assembly must be a string literal
 }

--- a/src/test/ui/asm/asm-parse-errors.stderr
+++ b/src/test/ui/asm/asm-parse-errors.stderr
@@ -1,68 +1,68 @@
 error: macro requires a string literal as an argument
   --> $DIR/asm-parse-errors.rs:4:5
    |
-LL |     asm!();
-   |     ^^^^^^^ string literal required
+LL |     llvm_asm!();
+   |     ^^^^^^^^^^^^ string literal required
 
 error: expected string literal
-  --> $DIR/asm-parse-errors.rs:5:18
+  --> $DIR/asm-parse-errors.rs:5:23
    |
-LL |     asm!("nop" : struct);
-   |                  ^^^^^^ not a string literal
+LL |     llvm_asm!("nop" : struct);
+   |                       ^^^^^^ not a string literal
 
 error: expected string literal
-  --> $DIR/asm-parse-errors.rs:6:30
+  --> $DIR/asm-parse-errors.rs:6:35
    |
-LL |     asm!("mov %eax, $$0x2" : struct);
-   |                              ^^^^^^ not a string literal
+LL |     llvm_asm!("mov %eax, $$0x2" : struct);
+   |                                   ^^^^^^ not a string literal
 
 error: expected `(`, found keyword `struct`
-  --> $DIR/asm-parse-errors.rs:7:39
+  --> $DIR/asm-parse-errors.rs:7:44
    |
-LL |     asm!("mov %eax, $$0x2" : "={eax}" struct);
-   |                                       ^^^^^^ expected `(`
+LL |     llvm_asm!("mov %eax, $$0x2" : "={eax}" struct);
+   |                                            ^^^^^^ expected `(`
 
 error: expected expression, found keyword `struct`
-  --> $DIR/asm-parse-errors.rs:8:39
+  --> $DIR/asm-parse-errors.rs:8:44
    |
-LL |     asm!("mov %eax, $$0x2" : "={eax}"(struct));
-   |                                       ^^^^^^ expected expression
+LL |     llvm_asm!("mov %eax, $$0x2" : "={eax}"(struct));
+   |                                            ^^^^^^ expected expression
 
 error: expected string literal
-  --> $DIR/asm-parse-errors.rs:9:44
+  --> $DIR/asm-parse-errors.rs:9:49
    |
-LL |     asm!("in %dx, %al" : "={al}"(result) : struct);
-   |                                            ^^^^^^ not a string literal
+LL |     llvm_asm!("in %dx, %al" : "={al}"(result) : struct);
+   |                                                 ^^^^^^ not a string literal
 
 error: expected `(`, found keyword `struct`
-  --> $DIR/asm-parse-errors.rs:10:51
+  --> $DIR/asm-parse-errors.rs:10:56
    |
-LL |     asm!("in %dx, %al" : "={al}"(result) : "{dx}" struct);
-   |                                                   ^^^^^^ expected `(`
+LL |     llvm_asm!("in %dx, %al" : "={al}"(result) : "{dx}" struct);
+   |                                                        ^^^^^^ expected `(`
 
 error: expected expression, found keyword `struct`
-  --> $DIR/asm-parse-errors.rs:11:51
+  --> $DIR/asm-parse-errors.rs:11:56
    |
-LL |     asm!("in %dx, %al" : "={al}"(result) : "{dx}"(struct));
-   |                                                   ^^^^^^ expected expression
+LL |     llvm_asm!("in %dx, %al" : "={al}"(result) : "{dx}"(struct));
+   |                                                        ^^^^^^ expected expression
 
 error: expected string literal
-  --> $DIR/asm-parse-errors.rs:12:36
+  --> $DIR/asm-parse-errors.rs:12:41
    |
-LL |     asm!("mov $$0x200, %eax" : : : struct);
-   |                                    ^^^^^^ not a string literal
+LL |     llvm_asm!("mov $$0x200, %eax" : : : struct);
+   |                                         ^^^^^^ not a string literal
 
 error: expected string literal
-  --> $DIR/asm-parse-errors.rs:13:45
+  --> $DIR/asm-parse-errors.rs:13:50
    |
-LL |     asm!("mov eax, 2" : "={eax}"(foo) : : : struct);
-   |                                             ^^^^^^ not a string literal
+LL |     llvm_asm!("mov eax, 2" : "={eax}"(foo) : : : struct);
+   |                                                  ^^^^^^ not a string literal
 
 error: inline assembly must be a string literal
-  --> $DIR/asm-parse-errors.rs:14:10
+  --> $DIR/asm-parse-errors.rs:14:15
    |
-LL |     asm!(123);
-   |          ^^^
+LL |     llvm_asm!(123);
+   |               ^^^
 
 error: aborting due to 11 previous errors
 

--- a/src/test/ui/asm/issue-51431.rs
+++ b/src/test/ui/asm/issue-51431.rs
@@ -1,11 +1,11 @@
 // build-fail
-// ignore-emscripten no asm! support
+// ignore-emscripten no llvm_asm! support
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 fn main() {
     unsafe {
-        asm! {"mov $0,$1"::"0"("bx"),"1"(0x00)}
+        llvm_asm! {"mov $0,$1"::"0"("bx"),"1"(0x00)}
         //~^ ERROR: invalid value for constraint in inline assembly
     }
 }

--- a/src/test/ui/asm/issue-51431.stderr
+++ b/src/test/ui/asm/issue-51431.stderr
@@ -1,8 +1,8 @@
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/issue-51431.rs:8:32
+  --> $DIR/issue-51431.rs:8:37
    |
-LL |         asm! {"mov $0,$1"::"0"("bx"),"1"(0x00)}
-   |                                ^^^^
+LL |         llvm_asm! {"mov $0,$1"::"0"("bx"),"1"(0x00)}
+   |                                     ^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/asm/issue-62046.rs
+++ b/src/test/ui/asm/issue-62046.rs
@@ -1,11 +1,11 @@
 // build-fail
 // ignore-emscripten no asm! support
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 fn main() {
     unsafe {
-        asm!("nop" : "+r"("r15"));
+        llvm_asm!("nop" : "+r"("r15"));
         //~^ malformed inline assembly
     }
 }

--- a/src/test/ui/asm/issue-62046.stderr
+++ b/src/test/ui/asm/issue-62046.stderr
@@ -1,8 +1,8 @@
 error[E0668]: malformed inline assembly
   --> $DIR/issue-62046.rs:8:9
    |
-LL |         asm!("nop" : "+r"("r15"));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         llvm_asm!("nop" : "+r"("r15"));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/asm/issue-69092.rs
+++ b/src/test/ui/asm/issue-69092.rs
@@ -2,9 +2,9 @@
 // ignore-emscripten no asm! support
 // Regression test for #69092
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 fn main() {
-    unsafe { asm!(".ascii \"Xen\0\""); }
+    unsafe { llvm_asm!(".ascii \"Xen\0\""); }
     //~^ ERROR: <inline asm>:1:9: error: expected string in '.ascii' directive
 }

--- a/src/test/ui/asm/issue-69092.stderr
+++ b/src/test/ui/asm/issue-69092.stderr
@@ -4,8 +4,8 @@ error: <inline asm>:1:9: error: expected string in '.ascii' directive
 
   --> $DIR/issue-69092.rs:8:14
    |
-LL |     unsafe { asm!(".ascii \"Xen\0\""); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     unsafe { llvm_asm!(".ascii \"Xen\0\""); }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/ast-json/ast-json-ice.rs
+++ b/src/test/ui/ast-json/ast-json-ice.rs
@@ -8,7 +8,7 @@
 // check-pass
 // dont-check-compiler-stdout - don't check for any AST change.
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 enum V {
     A(i32),
@@ -30,7 +30,7 @@ fn main() {
         target_arch = "x86_64",
         target_arch = "arm",
         target_arch = "aarch64"))]
-    unsafe { asm!(""::::); }
+    unsafe { llvm_asm!(""::::); }
 
     let x: (i32) = 35;
     let y = x as i64<> + 5;

--- a/src/test/ui/borrowck/borrowck-asm.rs
+++ b/src/test/ui/borrowck/borrowck-asm.rs
@@ -6,7 +6,7 @@
 // ignore-sparc
 // ignore-sparc64
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 #[cfg(any(target_arch = "x86",
             target_arch = "x86_64",
@@ -19,7 +19,7 @@ mod test_cases {
         let y: &mut isize;
         let x = &mut 0isize;
         unsafe {
-            asm!("nop" : : "r"(x));
+            llvm_asm!("nop" : : "r"(x));
         }
         let z = x;  //~ ERROR use of moved value: `x`
     }
@@ -28,7 +28,7 @@ mod test_cases {
         let mut x = 3;
         let y = &mut x;
         unsafe {
-            asm!("nop" : : "r"(x)); //~ ERROR cannot use
+            llvm_asm!("nop" : : "r"(x)); //~ ERROR cannot use
         }
         let z = y;
     }
@@ -36,12 +36,12 @@ mod test_cases {
     fn out_is_assign() {
         let x = 3;
         unsafe {
-            asm!("nop" : "=r"(x));  //~ ERROR cannot assign twice
+            llvm_asm!("nop" : "=r"(x));  //~ ERROR cannot assign twice
         }
         let mut a = &mut 3;
         let b = &*a;
         unsafe {
-            asm!("nop" : "=r"(a));  // OK, Shallow write to `a`
+            llvm_asm!("nop" : "=r"(a));  // OK, Shallow write to `a`
         }
         let c = b;
         let d = *a;
@@ -50,14 +50,14 @@ mod test_cases {
     fn rw_is_assign() {
         let x = 3;
         unsafe {
-            asm!("nop" : "+r"(x));  //~ ERROR cannot assign twice
+            llvm_asm!("nop" : "+r"(x));  //~ ERROR cannot assign twice
         }
     }
 
     fn indirect_is_not_init() {
         let x: i32;
         unsafe {
-            asm!("nop" : "=*r"(x)); //~ ERROR use of possibly-uninitialized variable
+            llvm_asm!("nop" : "=*r"(x)); //~ ERROR use of possibly-uninitialized variable
         }
     }
 
@@ -65,7 +65,7 @@ mod test_cases {
         let mut x = &mut 3;
         let y = &*x;
         unsafe {
-            asm!("nop" : "+r"(x));  //~ ERROR cannot assign to `x` because it is borrowed
+            llvm_asm!("nop" : "+r"(x));  //~ ERROR cannot assign to `x` because it is borrowed
         }
         let z = y;
     }
@@ -73,7 +73,7 @@ mod test_cases {
     fn two_moves() {
         let x = &mut 2;
         unsafe {
-            asm!("nop" : : "r"(x), "r"(x) );    //~ ERROR use of moved value
+            llvm_asm!("nop" : : "r"(x), "r"(x) );    //~ ERROR use of moved value
         }
     }
 }

--- a/src/test/ui/borrowck/borrowck-asm.stderr
+++ b/src/test/ui/borrowck/borrowck-asm.stderr
@@ -4,26 +4,26 @@ error[E0382]: use of moved value: `x`
 LL |         let x = &mut 0isize;
    |             - move occurs because `x` has type `&mut isize`, which does not implement the `Copy` trait
 LL |         unsafe {
-LL |             asm!("nop" : : "r"(x));
-   |                                - value moved here
+LL |             llvm_asm!("nop" : : "r"(x));
+   |                                     - value moved here
 LL |         }
 LL |         let z = x;
    |                 ^ value used here after move
 
 error[E0503]: cannot use `x` because it was mutably borrowed
-  --> $DIR/borrowck-asm.rs:31:32
+  --> $DIR/borrowck-asm.rs:31:37
    |
 LL |         let y = &mut x;
    |                 ------ borrow of `x` occurs here
 LL |         unsafe {
-LL |             asm!("nop" : : "r"(x));
-   |                                ^ use of borrowed `x`
+LL |             llvm_asm!("nop" : : "r"(x));
+   |                                     ^ use of borrowed `x`
 LL |         }
 LL |         let z = y;
    |                 - borrow later used here
 
 error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/borrowck-asm.rs:39:31
+  --> $DIR/borrowck-asm.rs:39:36
    |
 LL |         let x = 3;
    |             -
@@ -31,11 +31,11 @@ LL |         let x = 3;
    |             first assignment to `x`
    |             help: make this binding mutable: `mut x`
 LL |         unsafe {
-LL |             asm!("nop" : "=r"(x));
-   |                               ^ cannot assign twice to immutable variable
+LL |             llvm_asm!("nop" : "=r"(x));
+   |                                    ^ cannot assign twice to immutable variable
 
 error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/borrowck-asm.rs:53:31
+  --> $DIR/borrowck-asm.rs:53:36
    |
 LL |         let x = 3;
    |             -
@@ -43,37 +43,37 @@ LL |         let x = 3;
    |             first assignment to `x`
    |             help: make this binding mutable: `mut x`
 LL |         unsafe {
-LL |             asm!("nop" : "+r"(x));
-   |                               ^ cannot assign twice to immutable variable
+LL |             llvm_asm!("nop" : "+r"(x));
+   |                                    ^ cannot assign twice to immutable variable
 
 error[E0381]: use of possibly-uninitialized variable: `x`
-  --> $DIR/borrowck-asm.rs:60:32
+  --> $DIR/borrowck-asm.rs:60:37
    |
-LL |             asm!("nop" : "=*r"(x));
-   |                                ^ use of possibly-uninitialized `x`
+LL |             llvm_asm!("nop" : "=*r"(x));
+   |                                     ^ use of possibly-uninitialized `x`
 
 error[E0506]: cannot assign to `x` because it is borrowed
-  --> $DIR/borrowck-asm.rs:68:31
+  --> $DIR/borrowck-asm.rs:68:36
    |
 LL |         let y = &*x;
    |                 --- borrow of `x` occurs here
 LL |         unsafe {
-LL |             asm!("nop" : "+r"(x));
-   |                               ^ assignment to borrowed `x` occurs here
+LL |             llvm_asm!("nop" : "+r"(x));
+   |                                    ^ assignment to borrowed `x` occurs here
 LL |         }
 LL |         let z = y;
    |                 - borrow later used here
 
 error[E0382]: use of moved value: `x`
-  --> $DIR/borrowck-asm.rs:76:40
+  --> $DIR/borrowck-asm.rs:76:45
    |
 LL |         let x = &mut 2;
    |             - move occurs because `x` has type `&mut i32`, which does not implement the `Copy` trait
 LL |         unsafe {
-LL |             asm!("nop" : : "r"(x), "r"(x) );
-   |                                -       ^ value used here after move
-   |                                |
-   |                                value moved here
+LL |             llvm_asm!("nop" : : "r"(x), "r"(x) );
+   |                                     -       ^ value used here after move
+   |                                     |
+   |                                     value moved here
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/error-codes/E0660.rs
+++ b/src/test/ui/error-codes/E0660.rs
@@ -1,9 +1,9 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 fn main() {
     let a;
-    asm!("nop" "nop");
+    llvm_asm!("nop" "nop");
     //~^ ERROR E0660
-    asm!("nop" "nop" : "=r"(a));
+    llvm_asm!("nop" "nop" : "=r"(a));
     //~^ ERROR E0660
 }

--- a/src/test/ui/error-codes/E0660.stderr
+++ b/src/test/ui/error-codes/E0660.stderr
@@ -1,14 +1,14 @@
 error[E0660]: malformed inline assembly
   --> $DIR/E0660.rs:5:5
    |
-LL |     asm!("nop" "nop");
-   |     ^^^^^^^^^^^^^^^^^^
+LL |     llvm_asm!("nop" "nop");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0660]: malformed inline assembly
   --> $DIR/E0660.rs:7:5
    |
-LL |     asm!("nop" "nop" : "=r"(a));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     llvm_asm!("nop" "nop" : "=r"(a));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/error-codes/E0661.rs
+++ b/src/test/ui/error-codes/E0661.rs
@@ -1,9 +1,9 @@
 // ignore-emscripten
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 fn main() {
     let a; //~ ERROR type annotations needed
-    asm!("nop" : "r"(a));
+    llvm_asm!("nop" : "r"(a));
     //~^ ERROR E0661
 }

--- a/src/test/ui/error-codes/E0661.stderr
+++ b/src/test/ui/error-codes/E0661.stderr
@@ -1,8 +1,8 @@
 error[E0661]: output operand constraint lacks '=' or '+'
-  --> $DIR/E0661.rs:7:18
+  --> $DIR/E0661.rs:7:23
    |
-LL |     asm!("nop" : "r"(a));
-   |                  ^^^
+LL |     llvm_asm!("nop" : "r"(a));
+   |                       ^^^
 
 error[E0282]: type annotations needed
   --> $DIR/E0661.rs:6:9

--- a/src/test/ui/error-codes/E0662.rs
+++ b/src/test/ui/error-codes/E0662.rs
@@ -1,10 +1,10 @@
 // ignore-emscripten
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 fn main() {
-    asm!("xor %eax, %eax"
-         :
-         : "=test"("a") //~ ERROR E0662
-        );
+    llvm_asm!("xor %eax, %eax"
+              :
+              : "=test"("a") //~ ERROR E0662
+             );
 }

--- a/src/test/ui/error-codes/E0662.stderr
+++ b/src/test/ui/error-codes/E0662.stderr
@@ -1,8 +1,8 @@
 error[E0662]: input operand constraint contains '='
-  --> $DIR/E0662.rs:8:12
+  --> $DIR/E0662.rs:8:17
    |
-LL |          : "=test"("a")
-   |            ^^^^^^^
+LL |               : "=test"("a")
+   |                 ^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0663.rs
+++ b/src/test/ui/error-codes/E0663.rs
@@ -1,10 +1,10 @@
 // ignore-emscripten
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 fn main() {
-    asm!("xor %eax, %eax"
-         :
-         : "+test"("a") //~ ERROR E0663
-        );
+    llvm_asm!("xor %eax, %eax"
+              :
+              : "+test"("a") //~ ERROR E0663
+             );
 }

--- a/src/test/ui/error-codes/E0663.stderr
+++ b/src/test/ui/error-codes/E0663.stderr
@@ -1,8 +1,8 @@
 error[E0663]: input operand constraint contains '+'
-  --> $DIR/E0663.rs:8:12
+  --> $DIR/E0663.rs:8:17
    |
-LL |          : "+test"("a")
-   |            ^^^^^^^
+LL |               : "+test"("a")
+   |                 ^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0664.rs
+++ b/src/test/ui/error-codes/E0664.rs
@@ -1,11 +1,11 @@
 // ignore-emscripten
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 fn main() {
-    asm!("mov $$0x200, %eax"
-         :
-         :
-         : "{eax}" //~ ERROR E0664
-        );
+    llvm_asm!("mov $$0x200, %eax"
+              :
+              :
+              : "{eax}" //~ ERROR E0664
+             );
 }

--- a/src/test/ui/error-codes/E0664.stderr
+++ b/src/test/ui/error-codes/E0664.stderr
@@ -1,8 +1,8 @@
 error[E0664]: clobber should not be surrounded by braces
-  --> $DIR/E0664.rs:9:12
+  --> $DIR/E0664.rs:9:17
    |
-LL |          : "{eax}"
-   |            ^^^^^^^
+LL |               : "{eax}"
+   |                 ^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-asm.rs
+++ b/src/test/ui/feature-gates/feature-gate-asm.rs
@@ -3,5 +3,6 @@
 fn main() {
     unsafe {
         asm!(""); //~ ERROR inline assembly is not stable enough
+        llvm_asm!(""); //~ ERROR inline assembly is not stable enough
     }
 }

--- a/src/test/ui/feature-gates/feature-gate-asm.stderr
+++ b/src/test/ui/feature-gates/feature-gate-asm.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'asm': inline assembly is not stab
 LL |         asm!("");
    |         ^^^
    |
-   = note: see issue #29722 <https://github.com/rust-lang/rust/issues/29722> for more information
+   = note: see issue #70173 <https://github.com/rust-lang/rust/issues/70173> for more information
    = help: add `#![feature(asm)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-asm.stderr
+++ b/src/test/ui/feature-gates/feature-gate-asm.stderr
@@ -7,6 +7,15 @@ LL |         asm!("");
    = note: see issue #70173 <https://github.com/rust-lang/rust/issues/70173> for more information
    = help: add `#![feature(asm)]` to the crate attributes to enable
 
-error: aborting due to previous error
+error[E0658]: use of unstable library feature 'llvm_asm': inline assembly is not stable enough for use and is subject to change
+  --> $DIR/feature-gate-asm.rs:6:9
+   |
+LL |         llvm_asm!("");
+   |         ^^^^^^^^
+   |
+   = note: see issue #70173 <https://github.com/rust-lang/rust/issues/70173> for more information
+   = help: add `#![feature(llvm_asm)]` to the crate attributes to enable
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gates/feature-gate-asm2.rs
+++ b/src/test/ui/feature-gates/feature-gate-asm2.rs
@@ -3,5 +3,6 @@
 fn main() {
     unsafe {
         println!("{:?}", asm!("")); //~ ERROR inline assembly is not stable
+        println!("{:?}", llvm_asm!("")); //~ ERROR inline assembly is not stable
     }
 }

--- a/src/test/ui/feature-gates/feature-gate-asm2.stderr
+++ b/src/test/ui/feature-gates/feature-gate-asm2.stderr
@@ -7,6 +7,15 @@ LL |         println!("{:?}", asm!(""));
    = note: see issue #70173 <https://github.com/rust-lang/rust/issues/70173> for more information
    = help: add `#![feature(asm)]` to the crate attributes to enable
 
-error: aborting due to previous error
+error[E0658]: use of unstable library feature 'llvm_asm': inline assembly is not stable enough for use and is subject to change
+  --> $DIR/feature-gate-asm2.rs:6:26
+   |
+LL |         println!("{:?}", llvm_asm!(""));
+   |                          ^^^^^^^^
+   |
+   = note: see issue #70173 <https://github.com/rust-lang/rust/issues/70173> for more information
+   = help: add `#![feature(llvm_asm)]` to the crate attributes to enable
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gates/feature-gate-asm2.stderr
+++ b/src/test/ui/feature-gates/feature-gate-asm2.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'asm': inline assembly is not stab
 LL |         println!("{:?}", asm!(""));
    |                          ^^^
    |
-   = note: see issue #29722 <https://github.com/rust-lang/rust/issues/29722> for more information
+   = note: see issue #70173 <https://github.com/rust-lang/rust/issues/70173> for more information
    = help: add `#![feature(asm)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/inline-asm-bad-constraint.rs
+++ b/src/test/ui/inline-asm-bad-constraint.rs
@@ -3,7 +3,7 @@
 // build-fail
 // ignore-emscripten
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 extern "C" {
     fn foo(a: usize);
@@ -19,7 +19,7 @@ fn main() {
 fn bad_register_constraint() {
     let rax: u64;
     unsafe {
-        asm!("" :"={rax"(rax)) //~ ERROR E0668
+        llvm_asm!("" :"={rax"(rax)) //~ ERROR E0668
     };
     println!("Accumulator is: {}", rax);
 }
@@ -27,14 +27,14 @@ fn bad_register_constraint() {
 // Issue #54376
 fn bad_input() {
     unsafe {
-        asm!("callq $0" : : "0"(foo)) //~ ERROR E0668
+        llvm_asm!("callq $0" : : "0"(foo)) //~ ERROR E0668
     };
 }
 
 fn wrong_size_output() {
     let rax: u64 = 0;
     unsafe {
-        asm!("addb $1, $0" : "={rax}"((0i32, rax))); //~ ERROR E0668
+        llvm_asm!("addb $1, $0" : "={rax}"((0i32, rax))); //~ ERROR E0668
     }
     println!("rax: {}", rax);
 }

--- a/src/test/ui/inline-asm-bad-constraint.stderr
+++ b/src/test/ui/inline-asm-bad-constraint.stderr
@@ -1,24 +1,24 @@
 error[E0668]: malformed inline assembly
   --> $DIR/inline-asm-bad-constraint.rs:22:9
    |
-LL |         asm!("" :"={rax"(rax))
-   |         ^^^^^^^^^^^^^^^^^^^^^^
+LL |         llvm_asm!("" :"={rax"(rax))
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0668]: malformed inline assembly
   --> $DIR/inline-asm-bad-constraint.rs:30:9
    |
-LL |         asm!("callq $0" : : "0"(foo))
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         llvm_asm!("callq $0" : : "0"(foo))
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0668]: malformed inline assembly
   --> $DIR/inline-asm-bad-constraint.rs:37:9
    |
-LL |         asm!("addb $1, $0" : "={rax}"((0i32, rax)));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         llvm_asm!("addb $1, $0" : "={rax}"((0i32, rax)));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/inline-asm-bad-operand.rs
+++ b/src/test/ui/inline-asm-bad-operand.rs
@@ -4,7 +4,7 @@
 // build-fail
 // ignore-emscripten
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 #[repr(C)]
 struct MyPtr(usize);
@@ -19,41 +19,41 @@ fn main() {
 
 fn issue_37433() {
     unsafe {
-        asm!("" :: "r"("")); //~ ERROR E0669
+        llvm_asm!("" :: "r"("")); //~ ERROR E0669
     }
 
     unsafe {
         let target = MyPtr(0);
-        asm!("ret" : : "{rdi}"(target)); //~ ERROR E0669
+        llvm_asm!("ret" : : "{rdi}"(target)); //~ ERROR E0669
     }
 }
 
 fn issue_37437() {
     let hello: &str = "hello";
     // this should fail...
-    unsafe { asm!("" :: "i"(hello)) }; //~ ERROR E0669
+    unsafe { llvm_asm!("" :: "i"(hello)) }; //~ ERROR E0669
     // but this should succeed.
-    unsafe { asm!("" :: "r"(hello.as_ptr())) };
+    unsafe { llvm_asm!("" :: "r"(hello.as_ptr())) };
 }
 
 fn issue_40187() {
     let arr: [u8; 1] = [0; 1];
     unsafe {
-        asm!("movups $1, %xmm0"::"m"(arr)); //~ ERROR E0669
+        llvm_asm!("movups $1, %xmm0"::"m"(arr)); //~ ERROR E0669
     }
 }
 
 fn issue_54067() {
     let addr: Option<u32> = Some(123);
     unsafe {
-        asm!("mov sp, $0"::"r"(addr)); //~ ERROR E0669
+        llvm_asm!("mov sp, $0"::"r"(addr)); //~ ERROR E0669
     }
 }
 
 fn multiple_errors() {
     let addr: (u32, u32) = (1, 2);
     unsafe {
-        asm!("mov sp, $0"::"r"(addr), //~ ERROR E0669
-                           "r"("hello e0669")); //~ ERROR E0669
+        llvm_asm!("mov sp, $0"::"r"(addr), //~ ERROR E0669
+                                "r"("hello e0669")); //~ ERROR E0669
     }
 }

--- a/src/test/ui/inline-asm-bad-operand.stderr
+++ b/src/test/ui/inline-asm-bad-operand.stderr
@@ -1,41 +1,41 @@
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:22:24
+  --> $DIR/inline-asm-bad-operand.rs:22:29
    |
-LL |         asm!("" :: "r"(""));
-   |                        ^^
+LL |         llvm_asm!("" :: "r"(""));
+   |                             ^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:27:32
+  --> $DIR/inline-asm-bad-operand.rs:27:37
    |
-LL |         asm!("ret" : : "{rdi}"(target));
-   |                                ^^^^^^
+LL |         llvm_asm!("ret" : : "{rdi}"(target));
+   |                                     ^^^^^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:34:29
+  --> $DIR/inline-asm-bad-operand.rs:34:34
    |
-LL |     unsafe { asm!("" :: "i"(hello)) };
-   |                             ^^^^^
+LL |     unsafe { llvm_asm!("" :: "i"(hello)) };
+   |                                  ^^^^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:42:38
+  --> $DIR/inline-asm-bad-operand.rs:42:43
    |
-LL |         asm!("movups $1, %xmm0"::"m"(arr));
-   |                                      ^^^
+LL |         llvm_asm!("movups $1, %xmm0"::"m"(arr));
+   |                                           ^^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:49:32
+  --> $DIR/inline-asm-bad-operand.rs:49:37
    |
-LL |         asm!("mov sp, $0"::"r"(addr));
-   |                                ^^^^
+LL |         llvm_asm!("mov sp, $0"::"r"(addr));
+   |                                     ^^^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:56:32
+  --> $DIR/inline-asm-bad-operand.rs:56:37
    |
-LL |         asm!("mov sp, $0"::"r"(addr),
-   |                                ^^^^
+LL |         llvm_asm!("mov sp, $0"::"r"(addr),
+   |                                     ^^^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:57:32
+  --> $DIR/inline-asm-bad-operand.rs:57:37
    |
 LL | ...                   "r"("hello e0669"));
    |                           ^^^^^^^^^^^^^

--- a/src/test/ui/issues/issue-14936.rs
+++ b/src/test/ui/issues/issue-14936.rs
@@ -1,7 +1,7 @@
 // build-pass
 #![allow(unused_macros)]
 #![allow(dead_code)]
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 type History = Vec<&'static str>;
 
@@ -18,10 +18,10 @@ macro_rules! demo {
 
             let mut history: History = vec![];
             unsafe {
-                asm!("mov ($1), $0"
-                     : $output_constraint (*wrap(&mut x, "out", &mut history))
-                     : "r"(&wrap(y, "in", &mut history))
-                     :: "volatile");
+                llvm_asm!("mov ($1), $0"
+                          : $output_constraint (*wrap(&mut x, "out", &mut history))
+                          : "r"(&wrap(y, "in", &mut history))
+                          :: "volatile");
             }
             assert_eq!((x,y), (1,1));
             let b: &[_] = &["out", "in"];

--- a/src/test/ui/issues/issue-23458.rs
+++ b/src/test/ui/issues/issue-23458.rs
@@ -1,11 +1,11 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 // build-fail
 // only-x86_64
 
 fn main() {
     unsafe {
-        asm!("int $3"); //~ ERROR too few operands for instruction
-                        //~| ERROR invalid operand in inline asm
+        llvm_asm!("int $3"); //~ ERROR too few operands for instruction
+                             //~| ERROR invalid operand in inline asm
     }
 }

--- a/src/test/ui/issues/issue-23458.stderr
+++ b/src/test/ui/issues/issue-23458.stderr
@@ -1,8 +1,8 @@
 error: invalid operand in inline asm: 'int $3'
   --> $DIR/issue-23458.rs:8:9
    |
-LL |         asm!("int $3");
-   |         ^^^^^^^^^^^^^^^
+LL |         llvm_asm!("int $3");
+   |         ^^^^^^^^^^^^^^^^^^^^
 
 error: <inline asm>:1:2: error: too few operands for instruction
         int 
@@ -10,8 +10,8 @@ error: <inline asm>:1:2: error: too few operands for instruction
 
   --> $DIR/issue-23458.rs:8:9
    |
-LL |         asm!("int $3");
-   |         ^^^^^^^^^^^^^^^
+LL |         llvm_asm!("int $3");
+   |         ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-33264.rs
+++ b/src/test/ui/issues/issue-33264.rs
@@ -2,7 +2,7 @@
 // only-x86_64
 
 #![allow(dead_code, non_upper_case_globals)]
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 #[repr(C)]
 pub struct D32x4(f32,f32,f32,f32);
@@ -11,16 +11,16 @@ impl D32x4 {
     fn add(&self, vec: Self) -> Self {
         unsafe {
             let ret: Self;
-            asm!("
-                 movaps $1, %xmm1
-                 movaps $2, %xmm2
-                 addps %xmm1, %xmm2
-                 movaps $xmm1, $0
-                 "
-                 : "=r"(ret)
-                 : "1"(self), "2"(vec)
-                 : "xmm1", "xmm2"
-                 );
+            llvm_asm!("
+                      movaps $1, %xmm1
+                      movaps $2, %xmm2
+                      addps %xmm1, %xmm2
+                      movaps $xmm1, $0
+                      "
+                      : "=r"(ret)
+                      : "1"(self), "2"(vec)
+                      : "xmm1", "xmm2"
+                      );
             ret
         }
     }

--- a/src/test/ui/issues/issue-37366.rs
+++ b/src/test/ui/issues/issue-37366.rs
@@ -1,12 +1,12 @@
 // check-pass
 // ignore-emscripten
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 macro_rules! interrupt_handler {
     () => {
         unsafe fn _interrupt_handler() {
-            asm!("pop  eax" :::: "intel");
+            llvm_asm!("pop  eax" :::: "intel");
         }
     }
 }

--- a/src/test/ui/issues/issue-37433.rs
+++ b/src/test/ui/issues/issue-37433.rs
@@ -1,11 +1,11 @@
 // build-fail
-// ignore-emscripten no asm! support
+// ignore-emscripten no llvm_asm! support
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 fn main() {
     unsafe {
-        asm!("" :: "r"(""));
+        llvm_asm!("" :: "r"(""));
         //~^ ERROR: invalid value for constraint in inline assembly
     }
 }

--- a/src/test/ui/issues/issue-37433.stderr
+++ b/src/test/ui/issues/issue-37433.stderr
@@ -1,8 +1,8 @@
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/issue-37433.rs:8:24
+  --> $DIR/issue-37433.rs:8:29
    |
-LL |         asm!("" :: "r"(""));
-   |                        ^^
+LL |         llvm_asm!("" :: "r"(""));
+   |                             ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-53787-inline-assembler-macro.rs
+++ b/src/test/ui/issues/issue-53787-inline-assembler-macro.rs
@@ -3,12 +3,12 @@
 // build-fail
 // ignore-emscripten
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 macro_rules! fake_jump {
     ($id:expr) => {
         unsafe {
-            asm!(
+            llvm_asm!(
             "
             jmp $0
             lea eax, [ebx]

--- a/src/test/ui/issues/issue-9129.rs
+++ b/src/test/ui/issues/issue-9129.rs
@@ -12,7 +12,7 @@ impl bomb for S { fn boom(&self, _: Ident) { } }
 
 pub struct Ident { name: usize }
 
-// macro_rules! int3 { () => ( unsafe { asm!( "int3" ); } ) }
+// macro_rules! int3 { () => ( unsafe { llvm_asm!( "int3" ); } ) }
 macro_rules! int3 { () => ( { } ) }
 
 fn Ident_new() -> Ident {

--- a/src/test/ui/macros/macro-expanded-include/foo/mod.rs
+++ b/src/test/ui/macros/macro-expanded-include/foo/mod.rs
@@ -5,5 +5,5 @@ macro_rules! m {
 }
 
 macro_rules! n {
-    () => { unsafe { asm!(include_str!("file.txt")); } }
+    () => { unsafe { llvm_asm!(include_str!("file.txt")); } }
 }

--- a/src/test/ui/macros/macro-expanded-include/test.rs
+++ b/src/test/ui/macros/macro-expanded-include/test.rs
@@ -1,6 +1,6 @@
-// ignore-emscripten no asm! support
+// ignore-emscripten no llvm_asm! support
 // build-pass (FIXME(62277): could be check-pass?)
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![allow(unused)]
 
 #[macro_use]

--- a/src/test/ui/macros/macros-nonfatal-errors.rs
+++ b/src/test/ui/macros/macros-nonfatal-errors.rs
@@ -3,14 +3,14 @@
 // test that errors in a (selection) of macros don't kill compilation
 // immediately, so that we get more errors listed at a time.
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![feature(trace_macros, concat_idents)]
 
 #[derive(Default)] //~ ERROR
 enum OrDeriveThis {}
 
 fn main() {
-    asm!(invalid); //~ ERROR
+    llvm_asm!(invalid); //~ ERROR
 
     concat_idents!("not", "idents"); //~ ERROR
 

--- a/src/test/ui/macros/macros-nonfatal-errors.stderr
+++ b/src/test/ui/macros/macros-nonfatal-errors.stderr
@@ -7,10 +7,10 @@ LL | #[derive(Default)]
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: inline assembly must be a string literal
-  --> $DIR/macros-nonfatal-errors.rs:13:10
+  --> $DIR/macros-nonfatal-errors.rs:13:15
    |
-LL |     asm!(invalid);
-   |          ^^^^^^^
+LL |     llvm_asm!(invalid);
+   |               ^^^^^^^
 
 error: concat_idents! requires ident args.
   --> $DIR/macros-nonfatal-errors.rs:15:5

--- a/src/test/ui/out-of-stack.rs
+++ b/src/test/ui/out-of-stack.rs
@@ -8,7 +8,7 @@
 // ignore-emscripten no processes
 // ignore-sgx no processes
 
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![feature(rustc_private)]
 
 #[cfg(unix)]
@@ -22,7 +22,7 @@ use std::thread;
 // Inlining to avoid llvm turning the recursive functions into tail calls,
 // which doesn't consume stack.
 #[inline(always)]
-pub fn black_box<T>(dummy: T) { unsafe { asm!("" : : "r"(&dummy)) } }
+pub fn black_box<T>(dummy: T) { unsafe { llvm_asm!("" : : "r"(&dummy)) } }
 
 fn silent_recurse() {
     let buf = [0u8; 1000];


### PR DESCRIPTION
As per https://github.com/rust-lang/rfcs/pull/2843, this PR renames `asm!` to `llvm_asm!`. It also renames the compiler's internal `InlineAsm` data structures to `LlvmInlineAsm` in preparation for the new `asm!` functionality specified in https://github.com/rust-lang/rfcs/pull/2850.

This PR doesn't actually deprecate `asm!` yet, it just makes it redirect to `llvm_asm!`. This is necessary because we first need to update the submodules (in particular stdarch) to use `llvm_asm!`.