### PR TITLE
Micro-optimize OutputFilenames

### DIFF
--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -550,13 +550,13 @@ pub fn build_output_filenames(
                 .or_else(|| attr::find_crate_name(attrs).map(|n| n.to_string()))
                 .unwrap_or_else(|| input.filestem().to_owned());
 
-            OutputFilenames {
-                out_directory: dirpath,
-                out_filestem: stem,
-                single_output_file: None,
-                extra: sess.opts.cg.extra_filename.clone(),
-                outputs: sess.opts.output_types.clone(),
-            }
+            OutputFilenames::new(
+                dirpath,
+                stem,
+                None,
+                sess.opts.cg.extra_filename.clone(),
+                sess.opts.output_types.clone(),
+            )
         }
 
         Some(ref out_file) => {
@@ -578,18 +578,13 @@ pub fn build_output_filenames(
                 sess.warn("ignoring --out-dir flag due to -o flag");
             }
 
-            OutputFilenames {
-                out_directory: out_file.parent().unwrap_or_else(|| Path::new("")).to_path_buf(),
-                out_filestem: out_file
-                    .file_stem()
-                    .unwrap_or_default()
-                    .to_str()
-                    .unwrap()
-                    .to_string(),
-                single_output_file: ofile,
-                extra: sess.opts.cg.extra_filename.clone(),
-                outputs: sess.opts.output_types.clone(),
-            }
+            OutputFilenames::new(
+                out_file.parent().unwrap_or_else(|| Path::new("")).to_path_buf(),
+                out_file.file_stem().unwrap_or_default().to_str().unwrap().to_string(),
+                ofile,
+                sess.opts.cg.extra_filename.clone(),
+                sess.opts.output_types.clone(),
+            )
         }
     }
 }

--- a/src/librustc_session/config.rs
+++ b/src/librustc_session/config.rs
@@ -447,9 +447,9 @@ impl Input {
 #[derive(Clone, Hash)]
 pub struct OutputFilenames {
     pub out_directory: PathBuf,
-    pub out_filestem: String,
+    out_filestem: String,
     pub single_output_file: Option<PathBuf>,
-    pub extra: String,
+    extra: String,
     pub outputs: OutputTypes,
 }
 
@@ -458,6 +458,16 @@ impl_stable_hash_via_hash!(OutputFilenames);
 pub const RUST_CGU_EXT: &str = "rcgu";
 
 impl OutputFilenames {
+    pub fn new(
+        out_directory: PathBuf,
+        out_filestem: String,
+        single_output_file: Option<PathBuf>,
+        extra: String,
+        outputs: OutputTypes,
+    ) -> Self {
+        OutputFilenames { out_directory, out_filestem, single_output_file, extra, outputs }
+    }
+
     pub fn path(&self, flavor: OutputType) -> PathBuf {
         self.outputs
             .get(&flavor)

--- a/src/librustc_session/config.rs
+++ b/src/librustc_session/config.rs
@@ -447,9 +447,8 @@ impl Input {
 #[derive(Clone, Hash)]
 pub struct OutputFilenames {
     pub out_directory: PathBuf,
-    out_filestem: String,
+    filestem: String,
     pub single_output_file: Option<PathBuf>,
-    extra: String,
     pub outputs: OutputTypes,
 }
 
@@ -465,7 +464,12 @@ impl OutputFilenames {
         extra: String,
         outputs: OutputTypes,
     ) -> Self {
-        OutputFilenames { out_directory, out_filestem, single_output_file, extra, outputs }
+        OutputFilenames {
+            out_directory,
+            single_output_file,
+            outputs,
+            filestem: format!("{}{}", out_filestem, extra),
+        }
     }
 
     pub fn path(&self, flavor: OutputType) -> PathBuf {
@@ -487,7 +491,7 @@ impl OutputFilenames {
     /// Like temp_path, but also supports things where there is no corresponding
     /// OutputType, like noopt-bitcode or lto-bitcode.
     pub fn temp_path_ext(&self, ext: &str, codegen_unit_name: Option<&str>) -> PathBuf {
-        let base = self.out_directory.join(&self.filestem());
+        let base = self.out_directory.join(&self.filestem);
 
         let mut extension = String::new();
 
@@ -505,16 +509,11 @@ impl OutputFilenames {
             extension.push_str(ext);
         }
 
-        let path = base.with_extension(&extension[..]);
-        path
+        base.with_extension(extension)
     }
 
     pub fn with_extension(&self, extension: &str) -> PathBuf {
-        self.out_directory.join(&self.filestem()).with_extension(extension)
-    }
-
-    pub fn filestem(&self) -> String {
-        format!("{}{}", self.out_filestem, self.extra)
+        self.out_directory.join(&self.filestem).with_extension(extension)
     }
 }
 

--- a/src/librustc_session/config.rs
+++ b/src/librustc_session/config.rs
@@ -491,8 +491,6 @@ impl OutputFilenames {
     /// Like temp_path, but also supports things where there is no corresponding
     /// OutputType, like noopt-bitcode or lto-bitcode.
     pub fn temp_path_ext(&self, ext: &str, codegen_unit_name: Option<&str>) -> PathBuf {
-        let base = self.out_directory.join(&self.filestem);
-
         let mut extension = String::new();
 
         if let Some(codegen_unit_name) = codegen_unit_name {
@@ -509,11 +507,13 @@ impl OutputFilenames {
             extension.push_str(ext);
         }
 
-        base.with_extension(extension)
+        self.with_extension(&extension)
     }
 
     pub fn with_extension(&self, extension: &str) -> PathBuf {
-        self.out_directory.join(&self.filestem).with_extension(extension)
+        let mut path = self.out_directory.join(&self.filestem);
+        path.set_extension(extension);
+        path
     }
 }
 


### PR DESCRIPTION
For example, its methods consume 6% of time during debug-compiling a `warp` example:
![Screenshot (debug-compiling a `warp` example)](https://user-images.githubusercontent.com/7091080/72780288-d74f1580-3c61-11ea-953b-34e59ca682f9.png)

This PR optimize them a bit by using `PathBuf::set_extension` instead of `Path::with_extension`, to avoid cloning `PathBuf` excessively.