### PR TITLE
Export weak symbols used by MemorySanitizer

### DIFF
--- a/src/librustc_codegen_ssa/back/symbol_export.rs
+++ b/src/librustc_codegen_ssa/back/symbol_export.rs
@@ -208,8 +208,12 @@ fn exported_symbols_provider_local(
 
     if let Some(Sanitizer::Memory) = tcx.sess.opts.debugging_opts.sanitizer {
         // Similar to profiling, preserve weak msan symbol during LTO.
-        let exported_symbol = ExportedSymbol::NoDefId(SymbolName::new("__msan_track_origins"));
-        symbols.push((exported_symbol, SymbolExportLevel::C));
+        const MSAN_WEAK_SYMBOLS: [&str; 2] = ["__msan_track_origins", "__msan_keep_going"];
+
+        symbols.extend(MSAN_WEAK_SYMBOLS.iter().map(|sym| {
+            let exported_symbol = ExportedSymbol::NoDefId(SymbolName::new(sym));
+            (exported_symbol, SymbolExportLevel::C)
+        }));
     }
 
     if tcx.sess.crate_types.borrow().contains(&config::CrateType::Dylib) {

--- a/src/test/codegen/sanitizer-memory-track-orgins.rs
+++ b/src/test/codegen/sanitizer-memory-track-orgins.rs
@@ -4,17 +4,21 @@
 // needs-sanitizer-support
 // only-linux
 // only-x86_64
-// revisions:MSAN-0 MSAN-1 MSAN-2
+// revisions:MSAN-0 MSAN-1 MSAN-2 MSAN-1-LTO MSAN-2-LTO
 //
 //[MSAN-0] compile-flags: -Zsanitizer=memory
 //[MSAN-1] compile-flags: -Zsanitizer=memory -Zsanitizer-memory-track-origins=1
 //[MSAN-2] compile-flags: -Zsanitizer=memory -Zsanitizer-memory-track-origins
+//[MSAN-1-LTO] compile-flags: -Zsanitizer=memory -Zsanitizer-memory-track-origins=1 -C lto=fat
+//[MSAN-2-LTO] compile-flags: -Zsanitizer=memory -Zsanitizer-memory-track-origins -C lto=fat
 
 #![crate_type="lib"]
 
 // MSAN-0-NOT: @__msan_track_origins
 // MSAN-1:     @__msan_track_origins = weak_odr local_unnamed_addr constant i32 1
 // MSAN-2:     @__msan_track_origins = weak_odr local_unnamed_addr constant i32 2
+// MSAN-1-LTO: @__msan_track_origins = weak_odr local_unnamed_addr constant i32 1
+// MSAN-2-LTO: @__msan_track_origins = weak_odr local_unnamed_addr constant i32 2
 //
 // MSAN-0-LABEL: define void @copy(
 // MSAN-1-LABEL: define void @copy(

--- a/src/test/codegen/sanitizer-recover.rs
+++ b/src/test/codegen/sanitizer-recover.rs
@@ -4,31 +4,47 @@
 // needs-sanitizer-support
 // only-linux
 // only-x86_64
-// revisions:ASAN ASAN-RECOVER MSAN MSAN-RECOVER
+// revisions:ASAN ASAN-RECOVER MSAN MSAN-RECOVER MSAN-RECOVER-LTO
+// no-prefer-dynamic
 //
-//[ASAN]         compile-flags: -Zsanitizer=address
-//[ASAN-RECOVER] compile-flags: -Zsanitizer=address -Zsanitizer-recover=address
-//[MSAN]         compile-flags: -Zsanitizer=memory
-//[MSAN-RECOVER] compile-flags: -Zsanitizer=memory  -Zsanitizer-recover=memory
+//[ASAN]             compile-flags: -Zsanitizer=address
+//[ASAN-RECOVER]     compile-flags: -Zsanitizer=address -Zsanitizer-recover=address
+//[MSAN]             compile-flags: -Zsanitizer=memory
+//[MSAN-RECOVER]     compile-flags: -Zsanitizer=memory  -Zsanitizer-recover=memory
+//[MSAN-RECOVER-LTO] compile-flags: -Zsanitizer=memory  -Zsanitizer-recover=memory -C lto=fat
+//
+// MSAN-NOT:         @__msan_keep_going
+// MSAN-RECOVER:     @__msan_keep_going = weak_odr {{.*}} constant i32 1
+// MSAN-RECOVER-LTO: @__msan_keep_going = weak_odr {{.*}} constant i32 1
 
-#![crate_type="lib"]
-
-// ASAN-LABEL:         define i32 @penguin(
+// ASAN-LABEL: define i32 @penguin(
+// ASAN:         call void @__asan_report_load4(i64 %0)
+// ASAN:         unreachable
+// ASAN:       }
+//
 // ASAN-RECOVER-LABEL: define i32 @penguin(
-// MSAN-LABEL:         define i32 @penguin(
+// ASAN-RECOVER:         call void @__asan_report_load4_noabort(
+// ASAN-RECOVER-NOT:     unreachable
+// ASAN:               }
+//
+// MSAN-LABEL: define i32 @penguin(
+// MSAN:         call void @__msan_warning_noreturn()
+// MSAN:         unreachable
+// MSAN:       }
+//
 // MSAN-RECOVER-LABEL: define i32 @penguin(
+// MSAN-RECOVER:         call void @__msan_warning()
+// MSAN-RECOVER-NOT:     unreachable
+// MSAN-RECOVER:       }
+//
+// MSAN-RECOVER-LTO-LABEL: define i32 @penguin(
+// MSAN-RECOVER-LTO:          call void @__msan_warning()
+// MSAN-RECOVER-LTO-NOT:      unreachable
+// MSAN-RECOVER-LTO:       }
+//
 #[no_mangle]
 pub fn penguin(p: &mut i32) -> i32 {
-    // ASAN:             call void @__asan_report_load4(i64 %0)
-    // ASAN:             unreachable
-    //
-    // ASAN-RECOVER:     call void @__asan_report_load4_noabort(
-    // ASAN-RECOVER-NOT: unreachable
-    //
-    // MSAN:             call void @__msan_warning_noreturn()
-    // MSAN:             unreachable
-    //
-    // MSAN-RECOVER:     call void @__msan_warning()
-    // MSAN-RECOVER-NOT: unreachable
     *p
 }
+
+fn main() {}


### PR DESCRIPTION
Export weak symbols defined by MemorySanitizer instrumentation, which are used
to implement `-Zsanitizer-memory-track-origins` and `-Zsanitizer-recover=memory`.
Previously, when using fat LTO, they would internalized and eliminated.

Fixes #68367.