### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -1,0 +1,4 @@
+---
+name: Blank Issue
+about: Create a blank issue.
+---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug Report
+about: Create a bug report for Rust.
+labels: C-bug
+---
+<!--
+Thank you for filing a bug report! 🐛 Please provide a short summary of the bug,
+along with any information you feel relevant to replicating the bug.
+-->
+
+I tried this code:
+
+```rust
+<code>
+```
+
+I expected to see this happen: *explanation*
+
+Instead, this happened: *explanation*
+
+### Meta
+<!--
+If you're using the stable version of the compiler, you should also check if the
+bug also exists in the beta or nightly versions.
+-->
+
+`rustc --version --verbose`:
+```
+<version>
+```
+
+<!--
+Include a backtrace in the code block by setting `RUST_BACKTRACE=1` in your
+environment. E.g. `RUST_BACKTRACE=1 cargo build`.
+-->
+<details><summary>Backtrace</summary>
+<p>
+
+```
+<backtrace>
+```
+
+</p>
+</details>

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Rust Programming Language Forum
+    url: https://users.rust-lang.org
+    about: Please ask and answer questions about Rust here.

--- a/.github/ISSUE_TEMPLATE/ice.md
+++ b/.github/ISSUE_TEMPLATE/ice.md
@@ -1,0 +1,52 @@
+---
+name: Internal Compiler Error
+about: Create a report for an internal compiler error in rustc.
+labels: C-bug, I-ICE, T-compiler
+---
+<!--
+Thank you for finding an Internal Compiler Error! 🧊  If possible, try to provide
+a minimal verifiable example. You can read "Rust Bug Minimization Patterns" for
+how to create smaller examples.
+
+http://blog.pnkfx.org/blog/2019/11/18/rust-bug-minimization-patterns/
+
+-->
+
+### Code
+
+```
+<code>
+```
+
+
+### Meta
+<!--
+If you're using the stable version of the compiler, you should also check if the
+bug also exists in the beta or nightly versions.
+-->
+
+`rustc --version --verbose`:
+```
+<version>
+```
+
+### Error output
+
+```
+<output>
+```
+
+<!--
+Include a backtrace in the code block by setting `RUST_BACKTRACE=1` in your
+environment. E.g. `RUST_BACKTRACE=1 cargo build`.
+-->
+<details><summary><strong>Backtrace</strong></summary>
+<p>
+
+```
+<backtrace>
+```
+
+</p>
+</details>
+

--- a/.github/ISSUE_TEMPLATE/tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue.md
@@ -1,0 +1,58 @@
+---
+name: Tracking Issue
+about: A tracking issue for a feature in Rust.
+title: Tracking Issue for XXX
+labels: C-tracking-issue
+---
+<!--
+Thank you for creating a tracking issue! 📜 Tracking issues are for tracking a
+feature from implementation to stabilisation. Make sure to include the relevant
+RFC for the feature if it has one. Otherwise provide a short summary of the
+feature and link any relevant PRs or issues, and remove any sections that are
+not relevant to the feature.
+
+Remember to add team labels to the tracking issue.
+For a language team feature, this would e.g., be `T-lang`.
+Such a feature should also be labeled with e.g., `F-my_feature`.
+This label is used to associate issues (e.g., bugs and design questions) to the feature.
+-->
+
+This is a tracking issue for the RFC "XXX" (rust-lang/rfcs#NNN).
+The feature gate for the issue is `#![feature(FFF)]`.
+
+### About tracking issues
+
+Tracking issues are used to record the overall progress of implementation.
+They are also uses as hubs connecting to other relevant issues, e.g., bugs or open design questions.
+A tracking issue is however *not* meant for large scale discussion, questions, or bug reports about a feature.
+Instead, open a dedicated issue for the specific matter and add the relevant feature gate label.
+
+### Steps
+<!--
+Include each step required to complete the feature. Typically this is a PR
+implementing a feature, followed by a PR that stabilises the feature. However
+for larger features an implementation could be broken up into multiple PRs.
+-->
+
+- [ ] Implement the RFC (cc @rust-lang/XXX -- can anyone write up mentoring
+      instructions?)
+- [ ] Adjust documentation ([see instructions on rustc-guide][doc-guide])
+- [ ] Stabilization PR ([see instructions on rustc-guide][stabilization-guide])
+
+[stabilization-guide]: https://rust-lang.github.io/rustc-guide/stabilization_guide.html#stabilization-pr
+[doc-guide]: https://rust-lang.github.io/rustc-guide/stabilization_guide.html#documentation-prs
+
+### Unresolved Questions
+<!--
+Include any open questions that need to be answered before the feature can be
+stabilised.
+-->
+
+XXX --- list all the "unresolved questions" found in the RFC to ensure they are
+not forgotten
+
+### Implementation history
+
+<!--
+Include a list of all the PRs that were involved in implementing the feature.
+-->


### PR DESCRIPTION
This PR adds GitHub's issue templates to the repository. Adding templates for two of the most common issues we create on the repository. We could add more specific templates (e.g. ICEs) depending on the response to initial templates. I've included a screenshot of what it looks like, and people can also try out the UI and specific templates, by going to [`XAMPPRocky/rust`](https://github.com/XAMPPRocky/rust/issues/new/choose).

<img width="1115" alt="Screenshot 2020-01-21 at 13 57 46" src="https://user-images.githubusercontent.com/4464295/72807027-c51baa00-3c56-11ea-8a4c-98238489b345.png">