### PR TITLE
Also share drop-glue when compiling with -Zshare-generics (i.e. at opt-level=0)

### DIFF
--- a/src/librustc/mir/mono.rs
+++ b/src/librustc/mir/mono.rs
@@ -79,7 +79,7 @@ impl<'tcx> MonoItem<'tcx> {
     }
 
     pub fn instantiation_mode(&self, tcx: TyCtxt<'tcx>) -> InstantiationMode {
-        let inline_in_all_cgus = tcx
+        let generate_cgu_internal_copies = tcx
             .sess
             .opts
             .debugging_opts
@@ -93,7 +93,7 @@ impl<'tcx> MonoItem<'tcx> {
                 // If this function isn't inlined or otherwise has explicit
                 // linkage, then we'll be creating a globally shared version.
                 if self.explicit_linkage(tcx).is_some()
-                    || !instance.def.requires_local(tcx)
+                    || !instance.def.generates_cgu_internal_copy(tcx)
                     || Some(instance.def_id()) == entry_def_id
                 {
                     return InstantiationMode::GloballyShared { may_conflict: false };
@@ -102,7 +102,7 @@ impl<'tcx> MonoItem<'tcx> {
                 // At this point we don't have explicit linkage and we're an
                 // inlined function. If we're inlining into all CGUs then we'll
                 // be creating a local copy per CGU
-                if inline_in_all_cgus {
+                if generate_cgu_internal_copies {
                     return InstantiationMode::LocalCopy;
                 }
 

--- a/src/librustc/ty/query/keys.rs
+++ b/src/librustc/ty/query/keys.rs
@@ -116,6 +116,15 @@ impl Key for (DefId, SimplifiedType) {
     }
 }
 
+impl<'tcx> Key for SubstsRef<'tcx> {
+    fn query_crate(&self) -> CrateNum {
+        LOCAL_CRATE
+    }
+    fn default_span(&self, _: TyCtxt<'_>) -> Span {
+        DUMMY_SP
+    }
+}
+
 impl<'tcx> Key for (DefId, SubstsRef<'tcx>) {
     fn query_crate(&self) -> CrateNum {
         self.0.krate

--- a/src/librustc_codegen_llvm/attributes.rs
+++ b/src/librustc_codegen_llvm/attributes.rs
@@ -246,7 +246,7 @@ pub fn from_fn_attrs(
     }
 
     // FIXME(eddyb) consolidate these two `inline` calls (and avoid overwrites).
-    if instance.def.is_inline(cx.tcx) {
+    if instance.def.requires_inline(cx.tcx) {
         inline(cx, llfn, attributes::InlineAttr::Hint);
     }
 

--- a/src/librustc_codegen_llvm/callee.rs
+++ b/src/librustc_codegen_llvm/callee.rs
@@ -130,12 +130,7 @@ pub fn get_fn(cx: &CodegenCx<'ll, 'tcx>, instance: Instance<'tcx>) -> &'ll Value
                     } else {
                         // This is a monomorphization of a generic function
                         // defined in an upstream crate.
-                        if cx
-                            .tcx
-                            .upstream_monomorphizations_for(instance_def_id)
-                            .map(|set| set.contains_key(instance.substs))
-                            .unwrap_or(false)
-                        {
+                        if instance.upstream_monomorphization(tcx).is_some() {
                             // This is instantiated in another crate. It cannot
                             // be `hidden`.
                         } else {

--- a/src/librustc_codegen_ssa/back/symbol_export.rs
+++ b/src/librustc_codegen_ssa/back/symbol_export.rs
@@ -17,8 +17,6 @@ use rustc_hir::Node;
 use rustc_index::vec::IndexVec;
 use syntax::expand::allocator::ALLOCATOR_METHODS;
 
-pub type ExportedSymbols = FxHashMap<CrateNum, Arc<Vec<(String, SymbolExportLevel)>>>;
-
 pub fn threshold(tcx: TyCtxt<'_>) -> SymbolExportLevel {
     crates_export_threshold(&tcx.sess.crate_types.borrow())
 }
@@ -96,7 +94,7 @@ fn reachable_non_generics_provider(
                     if !generics.requires_monomorphization(tcx) &&
                         // Functions marked with #[inline] are only ever codegened
                         // with "internal" linkage and are never exported.
-                        !Instance::mono(tcx, def_id).def.requires_local(tcx)
+                        !Instance::mono(tcx, def_id).def.generates_cgu_internal_copy(tcx)
                     {
                         Some(def_id)
                     } else {

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -2,7 +2,8 @@ use super::command::Command;
 use super::link::{self, get_linker, remove};
 use super::linker::LinkerInfo;
 use super::lto::{self, SerializedModule};
-use super::symbol_export::{symbol_name_for_instance_in_crate, ExportedSymbols};
+use super::symbol_export::symbol_name_for_instance_in_crate;
+
 use crate::{
     CachedModuleCodegen, CodegenResults, CompiledModule, CrateInfo, ModuleCodegen, ModuleKind,
     RLIB_BYTECODE_EXTENSION,
@@ -12,6 +13,7 @@ use crate::traits::*;
 use jobserver::{Acquired, Client};
 use rustc::dep_graph::{WorkProduct, WorkProductFileKind, WorkProductId};
 use rustc::middle::cstore::EncodedMetadata;
+use rustc::middle::exported_symbols::SymbolExportLevel;
 use rustc::session::config::{
     self, Lto, OutputFilenames, OutputType, Passes, Sanitizer, SwitchWithOptPath,
 };
@@ -204,6 +206,8 @@ impl<B: WriteBackendMethods> Clone for TargetMachineFactory<B> {
         TargetMachineFactory(self.0.clone())
     }
 }
+
+pub type ExportedSymbols = FxHashMap<CrateNum, Arc<Vec<(String, SymbolExportLevel)>>>;
 
 /// Additional resources used by optimize_and_codegen (not module specific)
 #[derive(Clone)]

--- a/src/librustc_mir/monomorphize/partitioning.rs
+++ b/src/librustc_mir/monomorphize/partitioning.rs
@@ -324,7 +324,7 @@ fn mono_item_visibility(
     };
 
     let def_id = match instance.def {
-        InstanceDef::Item(def_id) => def_id,
+        InstanceDef::Item(def_id) | InstanceDef::DropGlue(def_id, Some(_)) => def_id,
 
         // These are all compiler glue and such, never exported, always hidden.
         InstanceDef::VtableShim(..)

--- a/src/test/codegen-units/partitioning/auxiliary/shared_generics_aux.rs
+++ b/src/test/codegen-units/partitioning/auxiliary/shared_generics_aux.rs
@@ -1,4 +1,6 @@
-// compile-flags:-Zshare-generics=yes
+// NOTE: We always compile this test with -Copt-level=0 because higher opt-levels
+//       prevent drop-glue from participating in share-generics.
+// compile-flags:-Zshare-generics=yes -Copt-level=0
 // no-prefer-dynamic
 
 #![crate_type="rlib"]
@@ -8,5 +10,17 @@ pub fn generic_fn<T>(x: T, y: T) -> (T, T) {
 }
 
 pub fn use_generic_fn_f32() -> (f32, f32) {
+    // This line causes drop glue for Foo to be instantiated. We want to make
+    // sure that this crate exports an instance to be re-used by share-generics.
+    let _ = Foo(0);
+
     generic_fn(0.0f32, 1.0f32)
+}
+
+pub struct Foo(pub u32);
+
+impl Drop for Foo {
+    fn drop(&mut self) {
+        println!("foo");
+    }
 }

--- a/src/test/codegen-units/partitioning/shared-generics.rs
+++ b/src/test/codegen-units/partitioning/shared-generics.rs
@@ -1,6 +1,8 @@
 // ignore-tidy-linelength
 // no-prefer-dynamic
-// compile-flags:-Zprint-mono-items=eager -Zshare-generics=yes -Zincremental=tmp/partitioning-tests/shared-generics-exe
+// NOTE: We always compile this test with -Copt-level=0 because higher opt-levels
+//       prevent drop-glue from participating in share-generics.
+// compile-flags:-Zprint-mono-items=eager -Zshare-generics=yes -Zincremental=tmp/partitioning-tests/shared-generics-exe -Copt-level=0
 
 #![crate_type="rlib"]
 
@@ -16,6 +18,10 @@ pub fn foo() {
     // This should not generate a monomorphization because it's already
     // available in `shared_generics_aux`.
     let _ = shared_generics_aux::generic_fn(0.0f32, 3.0f32);
-}
 
-// MONO_ITEM drop-glue i8
+    // The following line will drop an instance of `Foo`, generating a call to
+    // Foo's drop-glue function. However, share-generics should take care of
+    // reusing the drop-glue from the upstream crate, so we do not expect a
+    // mono item for the drop-glue
+    let _ = shared_generics_aux::Foo(1);
+}


### PR DESCRIPTION
This PR adds drop-glue to the set of monomorphizations that can be shared across crates via `-Zshare-generics`.

This version of the PR might have detrimental effects on performance as it makes lots of stuff dependent on a single query results (`upstream_monomorphizations_for(def_id_of_drop_in_place)`). That should be fixable but let's do a perf run first.

Potentially fixes issue https://github.com/rust-lang/rust/issues/64140. (cc @alexcrichton)
The changes here are related to @matthewjasper's https://github.com/rust-lang/rust/pull/67332 but should be mostly orthogonal. 

r? @ghost