### PR TITLE
Move generic arg/param validation to `create_substs_for_generic_args` to resolve various const generics issues

### DIFF
--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -941,7 +941,7 @@ impl GenericParamDefKind {
     }
 }
 
-#[derive(Clone, RustcEncodable, RustcDecodable, HashStable)]
+#[derive(Clone, Debug, RustcEncodable, RustcDecodable, HashStable)]
 pub struct GenericParamDef {
     pub name: Symbol,
     pub def_id: DefId,

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -931,6 +931,16 @@ pub enum GenericParamDefKind {
     Const,
 }
 
+impl GenericParamDefKind {
+    pub fn descr(&self) -> &'static str {
+        match self {
+            GenericParamDefKind::Lifetime => "lifetime",
+            GenericParamDefKind::Type { .. } => "type",
+            GenericParamDefKind::Const => "constant",
+        }
+    }
+}
+
 #[derive(Clone, RustcEncodable, RustcDecodable, HashStable)]
 pub struct GenericParamDef {
     pub name: Symbol,

--- a/src/librustc/ty/structural_impls.rs
+++ b/src/librustc/ty/structural_impls.rs
@@ -17,12 +17,6 @@ use std::fmt;
 use std::rc::Rc;
 use std::sync::Arc;
 
-impl fmt::Debug for ty::GenericParamDef {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}({}, {:?}, {})", self.kind.descr(), self.name, self.def_id, self.index)
-    }
-}
-
 impl fmt::Debug for ty::TraitDef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         ty::tls::with(|tcx| {

--- a/src/librustc/ty/structural_impls.rs
+++ b/src/librustc/ty/structural_impls.rs
@@ -19,12 +19,7 @@ use std::sync::Arc;
 
 impl fmt::Debug for ty::GenericParamDef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let type_name = match self.kind {
-            ty::GenericParamDefKind::Lifetime => "Lifetime",
-            ty::GenericParamDefKind::Type { .. } => "Type",
-            ty::GenericParamDefKind::Const => "Const",
-        };
-        write!(f, "{}({}, {:?}, {})", type_name, self.name, self.def_id, self.index)
+        write!(f, "{}({}, {:?}, {})", self.kind.descr(), self.name, self.def_id, self.index)
     }
 }
 

--- a/src/librustc_ast_passes/ast_validation.rs
+++ b/src/librustc_ast_passes/ast_validation.rs
@@ -8,7 +8,7 @@
 
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::fx::FxHashMap;
-use rustc_errors::{error_code, struct_span_err, Applicability, FatalError};
+use rustc_errors::{error_code, struct_span_err, Applicability};
 use rustc_parse::validate_attr;
 use rustc_session::lint::builtin::PATTERNS_IN_FNS_WITHOUT_BODY;
 use rustc_session::lint::LintBuffer;

--- a/src/librustc_error_codes/error_codes.rs
+++ b/src/librustc_error_codes/error_codes.rs
@@ -417,6 +417,7 @@ E0743: include_str!("./error_codes/E0743.md"),
 E0744: include_str!("./error_codes/E0744.md"),
 E0745: include_str!("./error_codes/E0745.md"),
 E0746: include_str!("./error_codes/E0746.md"),
+E0747: include_str!("./error_codes/E0747.md"),
 ;
 //  E0006, // merged with E0005
 //  E0008, // cannot bind by-move into a pattern guard

--- a/src/librustc_error_codes/error_codes/E0747.md
+++ b/src/librustc_error_codes/error_codes/E0747.md
@@ -9,3 +9,12 @@ struct S<'a, T>(&'a T);
 type X = S<(), 'static>; // error: the type argument is provided before the
                          // lifetime argument
 ```
+
+The argument order should be changed to match the parameter declaration
+order, as in the following.
+
+```
+struct S<'a, T>(&'a T);
+
+type X = S<'static, ()>; // ok
+```

--- a/src/librustc_error_codes/error_codes/E0747.md
+++ b/src/librustc_error_codes/error_codes/E0747.md
@@ -1,0 +1,10 @@
+Generic arguments must be provided in the same order as the corresponding generic
+parameters are declared.
+
+Erroneous code example:
+
+```compile_fail,E0747
+struct S<'a, T>(&'a T);
+
+type X = S<(), 'static>; // error: the type argument is provided before the lifetime argument
+```

--- a/src/librustc_error_codes/error_codes/E0747.md
+++ b/src/librustc_error_codes/error_codes/E0747.md
@@ -1,10 +1,11 @@
-Generic arguments must be provided in the same order as the corresponding generic
-parameters are declared.
+Generic arguments must be provided in the same order as the corresponding
+generic parameters are declared.
 
 Erroneous code example:
 
 ```compile_fail,E0747
 struct S<'a, T>(&'a T);
 
-type X = S<(), 'static>; // error: the type argument is provided before the lifetime argument
+type X = S<(), 'static>; // error: the type argument is provided before the
+                         // lifetime argument
 ```

--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -298,6 +298,14 @@ impl GenericArg<'_> {
             _ => false,
         }
     }
+
+    pub fn descr(&self) -> &'static str {
+        match self {
+            GenericArg::Lifetime(_) => "lifetime",
+            GenericArg::Type(_) => "type",
+            GenericArg::Const(_) => "constant",
+        }
+    }
 }
 
 #[derive(RustcEncodable, RustcDecodable, Debug, HashStable_Generic)]

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -464,15 +464,17 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
     /// Report an error that a generic argument did not match the generic parameter that was
     /// expected.
     fn generic_arg_mismatch_err(sess: &Session, arg: &GenericArg<'_>, kind: &'static str) {
-        struct_span_err!(
+        let mut err = struct_span_err!(
             sess,
             arg.span(),
             E0747,
             "{} provided when a {} was expected",
             arg.descr(),
             kind,
-        )
-        .emit();
+        );
+        // This note will be true as long as generic parameters are strictly ordered by their kind.
+        err.note(&format!("{} arguments must be provided before {} arguments", kind, arg.descr()));
+        err.emit();
     }
 
     /// Creates the relevant generic argument substitutions

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -402,10 +402,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             }
             err.emit();
 
-            (
-                provided > required, // `suppress_error`
-                potential_assoc_types,
-            )
+            (true, potential_assoc_types)
         };
 
         if reported_late_bound_region_err.is_none()

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -693,7 +693,14 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             self_ty.is_some(),
             self_ty,
             // Provide the generic args, and whether types should be inferred.
-            |_| (Some(generic_args), infer_args),
+            |did| {
+                if did == def_id {
+                    (Some(generic_args), infer_args)
+                } else {
+                    // The last component of this tuple is unimportant.
+                    (None, false)
+                }
+            },
             // Provide substitutions for parameters for which (valid) arguments have been provided.
             |param, arg| match (&param.kind, arg) {
                 (GenericParamDefKind::Lifetime, GenericArg::Lifetime(lt)) => {

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -134,8 +134,12 @@ enum GenericArgPosition {
 
 /// A marker denoting that the generic arguments that were
 /// provided did not match the respective generic parameters.
-/// The field indicates whether a fatal error was reported (`Some`), or just a lint (`None`).
-pub struct GenericArgCountMismatch(pub Option<ErrorReported>);
+pub struct GenericArgCountMismatch {
+    /// Indicates whether a fatal error was reported (`Some`), or just a lint (`None`).
+    pub reported: Option<ErrorReported>,
+    /// A list of spans of arguments provided that were not valid.
+    pub invalid_args: Vec<Span>,
+}
 
 impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
     pub fn ast_region_to_region(
@@ -279,7 +283,6 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             def.parent.is_none() && def.has_self, // `has_self`
             seg.infer_args || suppress_mismatch,  // `infer_args`
         )
-        .0
     }
 
     /// Checks that the correct number of generic arguments have been provided.
@@ -292,7 +295,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         position: GenericArgPosition,
         has_self: bool,
         infer_args: bool,
-    ) -> (Result<(), GenericArgCountMismatch>, Vec<Span>) {
+    ) -> Result<(), GenericArgCountMismatch> {
         // At this stage we are guaranteed that the generic arguments are in the correct order, e.g.
         // that lifetimes will proceed types. So it suffices to check the number of each generic
         // arguments in order to validate them with respect to the generic parameters.
@@ -328,12 +331,12 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 if position == GenericArgPosition::Value
                     && arg_counts.lifetimes != param_counts.lifetimes
                 {
-                    explicit_lifetimes = Err(GenericArgCountMismatch(Some(ErrorReported)));
+                    explicit_lifetimes = Err(true);
                     let mut err = tcx.sess.struct_span_err(span, msg);
                     err.span_note(span_late, note);
                     err.emit();
                 } else {
-                    explicit_lifetimes = Err(GenericArgCountMismatch(None));
+                    explicit_lifetimes = Err(false);
                     let mut multispan = MultiSpan::from_span(span);
                     multispan.push_span_label(span_late, note.to_string());
                     tcx.struct_span_lint_hir(
@@ -407,7 +410,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 }
                 err.emit();
 
-                Err(GenericArgCountMismatch(Some(ErrorReported)))
+                Err(true)
             };
 
         let mut arg_count_correct = explicit_lifetimes;
@@ -416,40 +419,46 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         if arg_count_correct.is_ok()
             && (!infer_lifetimes || arg_counts.lifetimes > param_counts.lifetimes)
         {
-            arg_count_correct = arg_count_correct.and(check_kind_count(
+            arg_count_correct = check_kind_count(
                 "lifetime",
                 param_counts.lifetimes,
                 param_counts.lifetimes,
                 arg_counts.lifetimes,
                 0,
                 &mut unexpected_spans,
-            ));
+            )
+            .and(arg_count_correct);
         }
         // FIXME(const_generics:defaults)
         if !infer_args || arg_counts.consts > param_counts.consts {
-            arg_count_correct = arg_count_correct.and(check_kind_count(
+            arg_count_correct = check_kind_count(
                 "const",
                 param_counts.consts,
                 param_counts.consts,
                 arg_counts.consts,
                 arg_counts.lifetimes + arg_counts.types,
                 &mut unexpected_spans,
-            ));
+            )
+            .and(arg_count_correct);
         }
         // Note that type errors are currently be emitted *after* const errors.
         if !infer_args || arg_counts.types > param_counts.types - defaults.types - has_self as usize
         {
-            arg_count_correct = arg_count_correct.and(check_kind_count(
+            arg_count_correct = check_kind_count(
                 "type",
                 param_counts.types - defaults.types - has_self as usize,
                 param_counts.types - has_self as usize,
                 arg_counts.types,
                 arg_counts.lifetimes,
                 &mut unexpected_spans,
-            ));
+            )
+            .and(arg_count_correct);
         }
 
-        (arg_count_correct, unexpected_spans)
+        arg_count_correct.map_err(|reported_err| GenericArgCountMismatch {
+            reported: if reported_err { Some(ErrorReported) } else { None },
+            invalid_args: unexpected_spans,
+        })
     }
 
     /// Report an error that a generic argument did not match the generic parameter that was
@@ -501,7 +510,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         parent_substs: &[subst::GenericArg<'tcx>],
         has_self: bool,
         self_ty: Option<Ty<'tcx>>,
-        arg_count_correct: Result<(), GenericArgCountMismatch>,
+        arg_count_correct: bool,
         args_for_def_id: impl Fn(DefId) -> (Option<&'b GenericArgs<'b>>, bool),
         provided_kind: impl Fn(&GenericParamDef, &GenericArg<'_>) -> subst::GenericArg<'tcx>,
         mut inferred_kind: impl FnMut(
@@ -595,7 +604,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                                 // another. This is an error. However, if we already know that
                                 // the arguments don't match up with the parameters, we won't issue
                                 // an additional error, as the user already knows what's wrong.
-                                if arg_count_correct.is_ok() {
+                                if arg_count_correct {
                                     Self::generic_arg_mismatch_err(tcx.sess, arg, kind.descr());
                                 }
 
@@ -621,7 +630,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                         //  2.  We've inferred some lifetimes, which have been provided later (i.e.
                         //      after a type or const). We want to throw an error in this case.
 
-                        if arg_count_correct.is_ok() {
+                        if arg_count_correct {
                             let kind = arg.descr();
                             assert_eq!(kind, "lifetime");
                             let provided =
@@ -686,7 +695,8 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         generic_args: &'a hir::GenericArgs<'_>,
         infer_args: bool,
         self_ty: Option<Ty<'tcx>>,
-    ) -> (SubstsRef<'tcx>, Vec<ConvertedBinding<'a, 'tcx>>, Vec<Span>) {
+    ) -> (SubstsRef<'tcx>, Vec<ConvertedBinding<'a, 'tcx>>, Result<(), GenericArgCountMismatch>)
+    {
         // If the type is parameterized by this region, then replace this
         // region with the current anon region binding (in other words,
         // whatever & would get replaced with).
@@ -712,7 +722,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             assert!(self_ty.is_none() && parent_substs.is_empty());
         }
 
-        let (arg_count_correct, potential_assoc_types) = Self::check_generic_arg_count(
+        let arg_count_correct = Self::check_generic_arg_count(
             tcx,
             span,
             &generic_params,
@@ -745,7 +755,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             parent_substs,
             self_ty.is_some(),
             self_ty,
-            arg_count_correct,
+            arg_count_correct.is_ok(),
             // Provide the generic args, and whether types should be inferred.
             |did| {
                 if did == def_id {
@@ -858,7 +868,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             generic_params, self_ty, substs
         );
 
-        (substs, assoc_bindings, potential_assoc_types)
+        (substs, assoc_bindings, arg_count_correct)
     }
 
     crate fn create_substs_for_associated_item(
@@ -989,7 +999,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         self_ty: Ty<'tcx>,
         bounds: &mut Bounds<'tcx>,
         speculative: bool,
-    ) -> Vec<Span> {
+    ) -> Result<(), GenericArgCountMismatch> {
         let trait_def_id = trait_ref.trait_def_id();
 
         debug!("instantiate_poly_trait_ref({:?}, def_id={:?})", trait_ref, trait_def_id);
@@ -1006,7 +1016,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         } else {
             trait_ref.path.span
         };
-        let (substs, assoc_bindings, potential_assoc_types) = self.create_substs_for_ast_trait_ref(
+        let (substs, assoc_bindings, arg_count_correct) = self.create_substs_for_ast_trait_ref(
             path_span,
             trait_def_id,
             self_ty,
@@ -1036,7 +1046,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             trait_ref, bounds, poly_trait_ref
         );
 
-        potential_assoc_types
+        arg_count_correct
     }
 
     /// Given a trait bound like `Debug`, applies that trait bound the given self-type to construct
@@ -1064,7 +1074,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         constness: Constness,
         self_ty: Ty<'tcx>,
         bounds: &mut Bounds<'tcx>,
-    ) -> Vec<Span> {
+    ) -> Result<(), GenericArgCountMismatch> {
         self.instantiate_poly_trait_ref_inner(
             &poly_trait_ref.trait_ref,
             poly_trait_ref.span,
@@ -1153,7 +1163,8 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         trait_def_id: DefId,
         self_ty: Ty<'tcx>,
         trait_segment: &'a hir::PathSegment<'a>,
-    ) -> (SubstsRef<'tcx>, Vec<ConvertedBinding<'a, 'tcx>>, Vec<Span>) {
+    ) -> (SubstsRef<'tcx>, Vec<ConvertedBinding<'a, 'tcx>>, Result<(), GenericArgCountMismatch>)
+    {
         debug!("create_substs_for_ast_trait_ref(trait_segment={:?})", trait_segment);
 
         self.complain_about_internal_fn_trait(span, trait_def_id, trait_segment);
@@ -1498,13 +1509,16 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         let mut potential_assoc_types = Vec::new();
         let dummy_self = self.tcx().types.trait_object_dummy_self;
         for trait_bound in trait_bounds.iter().rev() {
-            let cur_potential_assoc_types = self.instantiate_poly_trait_ref(
+            if let Err(GenericArgCountMismatch {
+                invalid_args: cur_potential_assoc_types, ..
+            }) = self.instantiate_poly_trait_ref(
                 trait_bound,
                 Constness::NotConst,
                 dummy_self,
                 &mut bounds,
-            );
-            potential_assoc_types.extend(cur_potential_assoc_types.into_iter());
+            ) {
+                potential_assoc_types.extend(cur_potential_assoc_types.into_iter());
+            }
         }
 
         // Expand trait aliases recursively and check that only one regular (non-auto) trait

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -313,7 +313,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
             parent_substs,
             false,
             None,
-            arg_count_correct,
+            arg_count_correct.is_ok(),
             // Provide the generic args, and whether types should be inferred.
             |def_id| {
                 // The last component of the returned tuple here is unimportant.

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -299,7 +299,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
         // If they were not explicitly supplied, just construct fresh
         // variables.
         let generics = self.tcx.generics_of(pick.item.def_id);
-        let arg_count_mismatch = AstConv::check_generic_arg_count_for_call(
+        let arg_count_correct = AstConv::check_generic_arg_count_for_call(
             self.tcx, self.span, &generics, &seg, true, // `is_method_call`
         );
 
@@ -313,7 +313,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
             parent_substs,
             false,
             None,
-            arg_count_mismatch,
+            arg_count_correct,
             // Provide the generic args, and whether types should be inferred.
             |def_id| {
                 // The last component of the returned tuple here is unimportant.

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -299,7 +299,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
         // If they were not explicitly supplied, just construct fresh
         // variables.
         let generics = self.tcx.generics_of(pick.item.def_id);
-        AstConv::check_generic_arg_count_for_call(
+        let arg_count_mismatch = AstConv::check_generic_arg_count_for_call(
             self.tcx, self.span, &generics, &seg, true, // `is_method_call`
         );
 
@@ -313,6 +313,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
             parent_substs,
             false,
             None,
+            arg_count_mismatch,
             // Provide the generic args, and whether types should be inferred.
             |def_id| {
                 // The last component of the returned tuple here is unimportant.

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -314,9 +314,14 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
             false,
             None,
             // Provide the generic args, and whether types should be inferred.
-            |_| {
-                // The last argument of the returned tuple here is unimportant.
-                if let Some(ref data) = seg.args { (Some(data), false) } else { (None, false) }
+            |def_id| {
+                // The last component of the returned tuple here is unimportant.
+                if def_id == pick.item.def_id {
+                    if let Some(ref data) = seg.args {
+                        return (Some(data), false);
+                    }
+                }
+                (None, false)
             },
             // Provide substitutions for parameters for which (valid) arguments have been provided.
             |param, arg| match (&param.kind, arg) {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -5452,7 +5452,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // parameter internally, but we don't allow users to specify the
             // parameter's value explicitly, so we have to do some error-
             // checking here.
-            if let Err(GenericArgCountMismatch(Some(ErrorReported))) =
+            if let Err(GenericArgCountMismatch { reported: Some(ErrorReported), .. }) =
                 AstConv::check_generic_arg_count_for_call(
                     tcx, span, &generics, &seg, false, // `is_method_call`
                 )
@@ -5521,11 +5521,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 &[][..],
                 has_self,
                 self_ty,
-                if infer_args_for_err.is_empty() {
-                    Ok(())
-                } else {
-                    Err(GenericArgCountMismatch(Some(ErrorReported)))
-                },
+                infer_args_for_err.is_empty(),
                 // Provide the generic args, and whether types should be inferred.
                 |def_id| {
                     if let Some(&PathSeg(_, index)) =

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -5452,11 +5452,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // parameter internally, but we don't allow users to specify the
             // parameter's value explicitly, so we have to do some error-
             // checking here.
-            let suppress_errors = AstConv::check_generic_arg_count_for_call(
-                tcx, span, &generics, &seg, false, // `is_method_call`
-            )
-            .is_err();
-            if suppress_errors {
+            if let Err(GenericArgCountMismatch(Some(ErrorReported))) =
+                AstConv::check_generic_arg_count_for_call(
+                    tcx, span, &generics, &seg, false, // `is_method_call`
+                )
+            {
                 infer_args_for_err.insert(index);
                 self.set_tainted_by_errors(); // See issue #53251.
             }
@@ -5521,7 +5521,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 &[][..],
                 has_self,
                 self_ty,
-                if infer_args_for_err.is_empty() { Ok(()) } else { Err(GenericArgCountMismatch) },
+                if infer_args_for_err.is_empty() {
+                    Ok(())
+                } else {
+                    Err(GenericArgCountMismatch(Some(ErrorReported)))
+                },
                 // Provide the generic args, and whether types should be inferred.
                 |def_id| {
                     if let Some(&PathSeg(_, index)) =

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -5520,6 +5520,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 &[][..],
                 has_self,
                 self_ty,
+                !infer_args_for_err.is_empty(),
                 // Provide the generic args, and whether types should be inferred.
                 |def_id| {
                     if let Some(&PathSeg(_, index)) =

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1269,7 +1269,7 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> &ty::Generics {
 
     let object_lifetime_defaults = tcx.object_lifetime_defaults(hir_id);
 
-    // Now create the real type parameters.
+    // Now create the real type and const parameters.
     let type_start = own_start - has_self as u32 + params.len() as u32;
     let mut i = 0;
     params.extend(ast_generics.params.iter().filter_map(|param| {

--- a/src/test/ui/const-generics/const-arg-type-arg-misordered.rs
+++ b/src/test/ui/const-generics/const-arg-type-arg-misordered.rs
@@ -1,0 +1,10 @@
+#![feature(const_generics)]
+//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+
+type Array<T, const N: usize> = [T; N];
+
+fn foo<const N: usize>() -> Array<N, ()> { //~ ERROR constant provided when a type was expected
+    unimplemented!()
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/const-arg-type-arg-misordered.stderr
+++ b/src/test/ui/const-generics/const-arg-type-arg-misordered.stderr
@@ -1,0 +1,17 @@
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/const-arg-type-arg-misordered.rs:1:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0747]: constant provided when a type was expected
+  --> $DIR/const-arg-type-arg-misordered.rs:6:35
+   |
+LL | fn foo<const N: usize>() -> Array<N, ()> {
+   |                                   ^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0747`.

--- a/src/test/ui/const-generics/const-arg-type-arg-misordered.stderr
+++ b/src/test/ui/const-generics/const-arg-type-arg-misordered.stderr
@@ -11,6 +11,8 @@ error[E0747]: constant provided when a type was expected
    |
 LL | fn foo<const N: usize>() -> Array<N, ()> {
    |                                   ^
+   |
+   = note: type arguments must be provided before constant arguments
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/const-param-after-const-literal-arg.rs
+++ b/src/test/ui/const-generics/const-param-after-const-literal-arg.rs
@@ -1,7 +1,7 @@
 // check-pass
 
+#![allow(incomplete_features)]
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
 
 struct Foo<const A: usize, const B: usize>;
 

--- a/src/test/ui/const-generics/const-param-after-const-literal-arg.rs
+++ b/src/test/ui/const-generics/const-param-after-const-literal-arg.rs
@@ -1,0 +1,10 @@
+// check-pass
+
+#![feature(const_generics)]
+//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+
+struct Foo<const A: usize, const B: usize>;
+
+impl<const A: usize> Foo<1, A> {} // ok
+
+fn main() {}

--- a/src/test/ui/const-generics/const-param-after-const-literal-arg.stderr
+++ b/src/test/ui/const-generics/const-param-after-const-literal-arg.stderr
@@ -1,0 +1,8 @@
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/const-param-after-const-literal-arg.rs:3:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+

--- a/src/test/ui/const-generics/const-param-after-const-literal-arg.stderr
+++ b/src/test/ui/const-generics/const-param-after-const-literal-arg.stderr
@@ -1,8 +1,0 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
-  --> $DIR/const-param-after-const-literal-arg.rs:3:12
-   |
-LL | #![feature(const_generics)]
-   |            ^^^^^^^^^^^^^^
-   |
-   = note: `#[warn(incomplete_features)]` on by default
-

--- a/src/test/ui/const-generics/const-param-before-other-params.rs
+++ b/src/test/ui/const-generics/const-param-before-other-params.rs
@@ -1,5 +1,5 @@
+#![allow(incomplete_features)]
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
 
 fn bar<const X: (), 'a>(_: &'a ()) {
     //~^ ERROR lifetime parameters must be declared prior to const parameters

--- a/src/test/ui/const-generics/const-param-before-other-params.rs
+++ b/src/test/ui/const-generics/const-param-before-other-params.rs
@@ -1,4 +1,5 @@
 #![feature(const_generics)]
+//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
 
 fn bar<const X: (), 'a>(_: &'a ()) {
     //~^ ERROR lifetime parameters must be declared prior to const parameters

--- a/src/test/ui/const-generics/const-param-before-other-params.stderr
+++ b/src/test/ui/const-generics/const-param-before-other-params.stderr
@@ -10,13 +10,5 @@ error: type parameters must be declared prior to const parameters
 LL | fn foo<const X: (), T>(_: &T) {
    |       --------------^- help: reorder the parameters: lifetimes, then types, then consts: `<T, const X: ()>`
 
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
-  --> $DIR/const-param-before-other-params.rs:1:12
-   |
-LL | #![feature(const_generics)]
-   |            ^^^^^^^^^^^^^^
-   |
-   = note: `#[warn(incomplete_features)]` on by default
-
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/const-param-before-other-params.stderr
+++ b/src/test/ui/const-generics/const-param-before-other-params.stderr
@@ -1,14 +1,22 @@
 error: lifetime parameters must be declared prior to const parameters
-  --> $DIR/const-param-before-other-params.rs:3:21
+  --> $DIR/const-param-before-other-params.rs:4:21
    |
 LL | fn bar<const X: (), 'a>(_: &'a ()) {
    |       --------------^^- help: reorder the parameters: lifetimes, then types, then consts: `<'a, const X: ()>`
 
 error: type parameters must be declared prior to const parameters
-  --> $DIR/const-param-before-other-params.rs:7:21
+  --> $DIR/const-param-before-other-params.rs:8:21
    |
 LL | fn foo<const X: (), T>(_: &T) {
    |       --------------^- help: reorder the parameters: lifetimes, then types, then consts: `<T, const X: ()>`
+
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/const-param-before-other-params.rs:1:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generic/generic-arg-mismatch-recover.rs
+++ b/src/test/ui/generic/generic-arg-mismatch-recover.rs
@@ -4,7 +4,6 @@ struct Bar<'a>(&'a ());
 
 fn main() {
     Foo::<'static, 'static, ()>(&0); //~ ERROR wrong number of lifetime arguments
-    //~^ ERROR mismatched types
 
     Bar::<'static, 'static, ()>(&()); //~ ERROR wrong number of lifetime arguments
     //~^ ERROR wrong number of type arguments

--- a/src/test/ui/generic/generic-arg-mismatch-recover.stderr
+++ b/src/test/ui/generic/generic-arg-mismatch-recover.stderr
@@ -4,28 +4,18 @@ error[E0107]: wrong number of lifetime arguments: expected 1, found 2
 LL |     Foo::<'static, 'static, ()>(&0);
    |                    ^^^^^^^ unexpected lifetime argument
 
-error[E0308]: mismatched types
-  --> $DIR/generic-arg-mismatch-recover.rs:6:33
-   |
-LL |     Foo::<'static, 'static, ()>(&0);
-   |                                 ^^ expected `()`, found integer
-   |
-   = note: expected reference `&'static ()`
-              found reference `&{integer}`
-
 error[E0107]: wrong number of lifetime arguments: expected 1, found 2
-  --> $DIR/generic-arg-mismatch-recover.rs:9:20
+  --> $DIR/generic-arg-mismatch-recover.rs:8:20
    |
 LL |     Bar::<'static, 'static, ()>(&());
    |                    ^^^^^^^ unexpected lifetime argument
 
 error[E0107]: wrong number of type arguments: expected 0, found 1
-  --> $DIR/generic-arg-mismatch-recover.rs:9:29
+  --> $DIR/generic-arg-mismatch-recover.rs:8:29
    |
 LL |     Bar::<'static, 'static, ()>(&());
    |                             ^^ unexpected type argument
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0107, E0308.
-For more information about an error, try `rustc --explain E0107`.
+For more information about this error, try `rustc --explain E0107`.

--- a/src/test/ui/parser/issue-14303-fncall.rs
+++ b/src/test/ui/parser/issue-14303-fncall.rs
@@ -11,7 +11,7 @@ fn foo<'a, 'b>(start: &'a usize, end: &'a usize) {
     let _x = (*start..*end)
         .map(|x| S { a: start, b: end })
         .collect::<Vec<S<_, 'a>>>();
-        //~^ ERROR lifetime arguments must be declared prior to type arguments
+        //~^ ERROR type provided when a lifetime was expected
 }
 
 fn main() {}

--- a/src/test/ui/parser/issue-14303-fncall.stderr
+++ b/src/test/ui/parser/issue-14303-fncall.stderr
@@ -1,8 +1,9 @@
-error: lifetime arguments must be declared prior to type arguments
-  --> $DIR/issue-14303-fncall.rs:13:29
+error[E0747]: type provided when a lifetime was expected
+  --> $DIR/issue-14303-fncall.rs:13:26
    |
 LL |         .collect::<Vec<S<_, 'a>>>();
-   |                             ^^
+   |                          ^
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0747`.

--- a/src/test/ui/parser/issue-14303-fncall.stderr
+++ b/src/test/ui/parser/issue-14303-fncall.stderr
@@ -3,6 +3,8 @@ error[E0747]: type provided when a lifetime was expected
    |
 LL |         .collect::<Vec<S<_, 'a>>>();
    |                          ^
+   |
+   = note: lifetime arguments must be provided before type arguments
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issue-14303-path.rs
+++ b/src/test/ui/parser/issue-14303-path.rs
@@ -8,6 +8,6 @@ mod foo {
 }
 
 fn bar<'a, 'b, 'c, T>(x: foo::X<'a, T, 'b, 'c>) {}
-//~^ ERROR lifetime arguments must be declared prior to type arguments
+//~^ ERROR type provided when a lifetime was expected
 
 fn main() {}

--- a/src/test/ui/parser/issue-14303-path.stderr
+++ b/src/test/ui/parser/issue-14303-path.stderr
@@ -1,8 +1,9 @@
-error: lifetime arguments must be declared prior to type arguments
-  --> $DIR/issue-14303-path.rs:10:40
+error[E0747]: type provided when a lifetime was expected
+  --> $DIR/issue-14303-path.rs:10:37
    |
 LL | fn bar<'a, 'b, 'c, T>(x: foo::X<'a, T, 'b, 'c>) {}
-   |                                        ^^  ^^
+   |                                     ^
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0747`.

--- a/src/test/ui/parser/issue-14303-path.stderr
+++ b/src/test/ui/parser/issue-14303-path.stderr
@@ -3,6 +3,8 @@ error[E0747]: type provided when a lifetime was expected
    |
 LL | fn bar<'a, 'b, 'c, T>(x: foo::X<'a, T, 'b, 'c>) {}
    |                                     ^
+   |
+   = note: lifetime arguments must be provided before type arguments
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/suggest-move-types.rs
+++ b/src/test/ui/suggestions/suggest-move-types.rs
@@ -33,7 +33,7 @@ struct A<T, M: One<A=(), T>> { //~ ERROR associated type bindings must be declar
 
 struct Al<'a, T, M: OneWithLifetime<A=(), T, 'a>> {
 //~^ ERROR associated type bindings must be declared after generic parameters
-//~^^ ERROR lifetime arguments must be declared prior to type arguments
+//~^^ ERROR type provided when a lifetime was expected
     m: M,
     t: &'a T,
 }
@@ -47,7 +47,7 @@ struct B<T, U, V, M: Three<A=(), B=(), C=(), T, U, V>> { //~ ERROR associated ty
 
 struct Bl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<A=(), B=(), C=(), T, U, V, 'a, 'b, 'c>> {
 //~^ ERROR associated type bindings must be declared after generic parameters
-//~^^ ERROR lifetime arguments must be declared prior to type arguments
+//~^^ ERROR type provided when a lifetime was expected
     m: M,
     t: &'a T,
     u: &'b U,
@@ -63,7 +63,7 @@ struct C<T, U, V, M: Three<T, A=(), B=(), C=(), U, V>> { //~ ERROR associated ty
 
 struct Cl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), C=(), U, 'b, V, 'c>> {
 //~^ ERROR associated type bindings must be declared after generic parameters
-//~^^ ERROR lifetime arguments must be declared prior to type arguments
+//~^^ ERROR lifetime provided when a type was expected
     m: M,
     t: &'a T,
     u: &'b U,
@@ -79,7 +79,7 @@ struct D<T, U, V, M: Three<T, A=(), B=(), U, C=(), V>> { //~ ERROR associated ty
 
 struct Dl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), U, 'b, C=(), V, 'c>> {
 //~^ ERROR associated type bindings must be declared after generic parameters
-//~^^ ERROR lifetime arguments must be declared prior to type arguments
+//~^^ ERROR lifetime provided when a type was expected
     m: M,
     t: &'a T,
     u: &'b U,

--- a/src/test/ui/suggestions/suggest-move-types.stderr
+++ b/src/test/ui/suggestions/suggest-move-types.stderr
@@ -74,29 +74,30 @@ LL | struct Dl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), U, '
    |                                                            |     this associated type binding should be moved after the generic parameters
    |                                                            this associated type binding should be moved after the generic parameters
 
-error: lifetime arguments must be declared prior to type arguments
-  --> $DIR/suggest-move-types.rs:34:46
+error[E0747]: type provided when a lifetime was expected
+  --> $DIR/suggest-move-types.rs:34:43
    |
 LL | struct Al<'a, T, M: OneWithLifetime<A=(), T, 'a>> {
-   |                                              ^^
+   |                                           ^
 
-error: lifetime arguments must be declared prior to type arguments
-  --> $DIR/suggest-move-types.rs:48:80
+error[E0747]: type provided when a lifetime was expected
+  --> $DIR/suggest-move-types.rs:48:71
    |
 LL | struct Bl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<A=(), B=(), C=(), T, U, V, 'a, 'b, 'c>> {
-   |                                                                                ^^  ^^  ^^
+   |                                                                       ^
 
-error: lifetime arguments must be declared prior to type arguments
+error[E0747]: lifetime provided when a type was expected
   --> $DIR/suggest-move-types.rs:64:56
    |
 LL | struct Cl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), C=(), U, 'b, V, 'c>> {
-   |                                                        ^^                       ^^     ^^
+   |                                                        ^^
 
-error: lifetime arguments must be declared prior to type arguments
+error[E0747]: lifetime provided when a type was expected
   --> $DIR/suggest-move-types.rs:80:56
    |
 LL | struct Dl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), U, 'b, C=(), V, 'c>> {
-   |                                                        ^^                 ^^           ^^
+   |                                                        ^^
 
 error: aborting due to 12 previous errors
 
+For more information about this error, try `rustc --explain E0747`.

--- a/src/test/ui/suggestions/suggest-move-types.stderr
+++ b/src/test/ui/suggestions/suggest-move-types.stderr
@@ -79,24 +79,32 @@ error[E0747]: type provided when a lifetime was expected
    |
 LL | struct Al<'a, T, M: OneWithLifetime<A=(), T, 'a>> {
    |                                           ^
+   |
+   = note: lifetime arguments must be provided before type arguments
 
 error[E0747]: type provided when a lifetime was expected
   --> $DIR/suggest-move-types.rs:48:71
    |
 LL | struct Bl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<A=(), B=(), C=(), T, U, V, 'a, 'b, 'c>> {
    |                                                                       ^
+   |
+   = note: lifetime arguments must be provided before type arguments
 
 error[E0747]: lifetime provided when a type was expected
   --> $DIR/suggest-move-types.rs:64:56
    |
 LL | struct Cl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), C=(), U, 'b, V, 'c>> {
    |                                                        ^^
+   |
+   = note: type arguments must be provided before lifetime arguments
 
 error[E0747]: lifetime provided when a type was expected
   --> $DIR/suggest-move-types.rs:80:56
    |
 LL | struct Dl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), U, 'b, C=(), V, 'c>> {
    |                                                        ^^
+   |
+   = note: type arguments must be provided before lifetime arguments
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/traits/trait-object-vs-lifetime.rs
+++ b/src/test/ui/traits/trait-object-vs-lifetime.rs
@@ -12,6 +12,6 @@ fn main() {
     //~^ ERROR wrong number of lifetime arguments: expected 1, found 2
     //~| ERROR wrong number of type arguments: expected 1, found 0
     let _: S<dyn 'static +, 'static>;
-    //~^ ERROR lifetime arguments must be declared prior to type arguments
+    //~^ ERROR type provided when a lifetime was expected
     //~| ERROR at least one trait is required for an object type
 }

--- a/src/test/ui/traits/trait-object-vs-lifetime.stderr
+++ b/src/test/ui/traits/trait-object-vs-lifetime.stderr
@@ -27,6 +27,8 @@ error[E0747]: type provided when a lifetime was expected
    |
 LL |     let _: S<dyn 'static +, 'static>;
    |              ^^^^^^^^^^^^^
+   |
+   = note: lifetime arguments must be provided before type arguments
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/traits/trait-object-vs-lifetime.stderr
+++ b/src/test/ui/traits/trait-object-vs-lifetime.stderr
@@ -1,9 +1,3 @@
-error: lifetime arguments must be declared prior to type arguments
-  --> $DIR/trait-object-vs-lifetime.rs:14:29
-   |
-LL |     let _: S<dyn 'static +, 'static>;
-   |                             ^^^^^^^
-
 error[E0224]: at least one trait is required for an object type
   --> $DIR/trait-object-vs-lifetime.rs:9:23
    |
@@ -28,6 +22,13 @@ error[E0224]: at least one trait is required for an object type
 LL |     let _: S<dyn 'static +, 'static>;
    |              ^^^^^^^^^^^^^
 
+error[E0747]: type provided when a lifetime was expected
+  --> $DIR/trait-object-vs-lifetime.rs:14:14
+   |
+LL |     let _: S<dyn 'static +, 'static>;
+   |              ^^^^^^^^^^^^^
+
 error: aborting due to 5 previous errors
 
-For more information about this error, try `rustc --explain E0107`.
+Some errors have detailed explanations: E0107, E0747.
+For more information about an error, try `rustc --explain E0107`.


### PR DESCRIPTION
This changes some diagnostics, but I think they're around as helpful as the previous ones, and occur infrequently regardless.

Fixes https://github.com/rust-lang/rust/issues/68257.
Fixes https://github.com/rust-lang/rust/issues/68398.

r? @eddyb 
