### PR TITLE
pprust: use as_deref

### DIFF
--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1643,7 +1643,7 @@ impl<'a> State<'a> {
                     self.print_expr_as_cond(i);
                     self.s.space();
                     self.print_block(then);
-                    self.print_else(e.as_ref().map(|e| &**e))
+                    self.print_else(e.as_deref())
                 }
                 // Final `else` block.
                 ast::ExprKind::Block(ref b, _) => {
@@ -1947,7 +1947,7 @@ impl<'a> State<'a> {
                 self.print_let(pat, scrutinee);
             }
             ast::ExprKind::If(ref test, ref blk, ref elseopt) => {
-                self.print_if(test, blk, elseopt.as_ref().map(|e| &**e));
+                self.print_if(test, blk, elseopt.as_deref())
             }
             ast::ExprKind::While(ref test, ref blk, opt_label) => {
                 if let Some(label) = opt_label {


### PR DESCRIPTION
Some drive-by cleanup.