### PR TITLE
Avoid slices where individuals are good enough

### DIFF
--- a/src/liballoc/collections/btree/search.rs
+++ b/src/liballoc/collections/btree/search.rs
@@ -61,17 +61,15 @@ where
 {
     // This function is defined over all borrow types (immutable, mutable, owned),
     // and may be called on the shared root in each case.
-    // Using `keys()` is fine here even if BorrowType is mutable, as all we return
+    // Using `keys_at()` is fine here even if BorrowType is mutable, as all we return
     // is an index -- not a reference.
     let len = node.len();
-    if len > 0 {
-        let keys = unsafe { node.keys() }; // safe because a non-empty node cannot be the shared root
-        for (i, k) in keys.iter().enumerate() {
-            match key.cmp(k.borrow()) {
-                Ordering::Greater => {}
-                Ordering::Equal => return (i, true),
-                Ordering::Less => return (i, false),
-            }
+    for i in 0..len {
+        let key_at_i = unsafe { node.key_at(i) };
+        match key.cmp(key_at_i.borrow()) {
+            Ordering::Greater => {}
+            Ordering::Equal => return (i, true),
+            Ordering::Less => return (i, false),
         }
     }
     (len, false)


### PR DESCRIPTION
As mentioned in #67686, slices on immutable trees are almost exclusively used to `get_unchecked` a particular item or position. The only exception happens through the (locally) public `keys` function used only by `search_linear`.

A step beyond is to not make slices on immutable trees at all, but pass in an index argument. This:

- Simplifies the code because the callers no longer have to do the `get_unchecked` and such themselves.
- Avoids "leaking" the slice concept outside node.rs (for instance, a project to efficiently store a key-value pair with a 3-byte key and a 1-byte value would be a local change in node.rs) (that's really an independent point, which we could address by keeping the slice-returning function function `keys` as non-public, and tweaking `search_linear` just like is done n this PR)
- (On first sight, looks like it would speed up things because we no longer fetch length and construct slices, but benchmarks report no significant difference. Seems this was optimized out anyway.)
- But makes immutable access more different from mutable access (it's impossible to transform mutable slice access in the same way, because for insertion at least you really need to know slice length);
- Somewhat deceives readers, because the references are used as slice pointers in `ptr::copy_nonoverlapping` calls; but then again, the current implementation does the same just in time: it just assumes that the source slice and the destination slices are the same.
