### PR TITLE
Avoid overflow in `std::iter::Skip::count`

### DIFF
--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -1815,8 +1815,14 @@ where
     }
 
     #[inline]
-    fn count(self) -> usize {
-        self.iter.count().saturating_sub(self.n)
+    fn count(mut self) -> usize {
+        if self.n > 0 {
+            // nth(n) skips n+1
+            if self.iter.nth(self.n - 1).is_none() {
+                return 0;
+            }
+        }
+        self.iter.count()
     }
 
     #[inline]

--- a/src/test/ui/iterators/skip-count-overflow.rs
+++ b/src/test/ui/iterators/skip-count-overflow.rs
@@ -1,0 +1,8 @@
+// run-pass
+// only-32bit too impatient for 2⁶⁴ items
+// compile-flags: -C overflow-checks -C opt-level=3
+
+fn main() {
+    let i = (0..usize::max_value()).chain(0..10).skip(usize::max_value());
+    assert_eq!(i.count(), 10);
+}


### PR DESCRIPTION
The call to `count` on the inner iterator can overflow even if `Skip` itself would return less that `usize::max_value()` items.

Fixes #68139