### PR TITLE
Enable ASan on Fuchsia

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -659,6 +659,24 @@ fn supported_sanitizers(out_dir: &Path, target: Interned<String>) -> Vec<Sanitiz
                 });
             }
         }
+        "x86_64-fuchsia" => {
+            for s in &["asan"] {
+                result.push(SanitizerRuntime {
+                    cmake_target: format!("clang_rt.{}-x86_64", s),
+                    path: out_dir.join(&format!("build/lib/fuchsia/libclang_rt.{}-x86_64.a", s)),
+                    name: format!("librustc_rt.{}.a", s),
+                });
+            }
+        }
+        "aarch64-fuchsia" => {
+            for s in &["asan"] {
+                result.push(SanitizerRuntime {
+                    cmake_target: format!("clang_rt.{}-aarch64", s),
+                    path: out_dir.join(&format!("build/lib/fuchsia/libclang_rt.{}-aarch64.a", s)),
+                    name: format!("librustc_rt.{}.a", s),
+                });
+            }
+        }
         _ => {}
     }
     result

--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -777,7 +777,7 @@ fn link_sanitizer_runtime(sess: &Session, crate_type: config::CrateType, linker:
             linker.args(&["-Wl,-rpath".into(), "-Xlinker".into(), rpath.into()]);
             linker.link_dylib(Symbol::intern(&libname));
         }
-        "x86_64-unknown-linux-gnu" => {
+        "x86_64-unknown-linux-gnu" | "x86_64-fuchsia" | "aarch64-fuchsia" => {
             let filename = format!("librustc_rt.{}.a", name);
             let path = default_tlib.join(&filename);
             linker.link_whole_rlib(&path);

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -1127,8 +1127,12 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
 
     // Sanitizers can only be used on some tested platforms.
     if let Some(ref sanitizer) = sess.opts.debugging_opts.sanitizer {
-        const ASAN_SUPPORTED_TARGETS: &[&str] =
-            &["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-fuchsia", "aarch64-fuchsia" ];
+        const ASAN_SUPPORTED_TARGETS: &[&str] = &[
+            "x86_64-unknown-linux-gnu",
+            "x86_64-apple-darwin",
+            "x86_64-fuchsia",
+            "aarch64-fuchsia",
+        ];
         const TSAN_SUPPORTED_TARGETS: &[&str] =
             &["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"];
         const LSAN_SUPPORTED_TARGETS: &[&str] =

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -1128,7 +1128,7 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
     // Sanitizers can only be used on some tested platforms.
     if let Some(ref sanitizer) = sess.opts.debugging_opts.sanitizer {
         const ASAN_SUPPORTED_TARGETS: &[&str] =
-            &["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"];
+            &["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-fuchsia", "aarch64-fuchsia" ];
         const TSAN_SUPPORTED_TARGETS: &[&str] =
             &["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"];
         const LSAN_SUPPORTED_TARGETS: &[&str] =


### PR DESCRIPTION
This change adds the x86_64-fuchsia and aarch64-fuchsia LLVM targets to
those allowed to invoke -Zsanitizer. Currently, the only overlap between
compiler_rt sanitizers supported by both rustc and Fuchsia is ASan.