### PR TITLE
Improve nop-match simplification

### DIFF
--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -317,6 +317,7 @@ fn run_optimization_passes<'tcx>(
             &simplify::SimplifyCfg::new("after-remove-noop-landing-pads"),
             &simplify_try::SimplifyArmIdentity,
             &simplify_try::SimplifyBranchSame,
+            &simplify_try::SinkCommonCodeFromPredecessors,
             &simplify::SimplifyCfg::new("final"),
             &simplify::SimplifyLocals,
             &add_call_guards::CriticalCallEdges,

--- a/src/librustc_mir/transform/simplify_try.rs
+++ b/src/librustc_mir/transform/simplify_try.rs
@@ -155,7 +155,7 @@ fn match_arm<'tcx>(
     };
 
     if idx + 8 != stmts.len() {
-        // There should be other 8 statements than the one assigining to drop flag.
+        // There should be 8 statements other than the one assigning to the drop flag.
         return;
     }
 

--- a/src/librustc_mir/transform/simplify_try.rs
+++ b/src/librustc_mir/transform/simplify_try.rs
@@ -153,6 +153,11 @@ fn match_arm<'tcx>(
         _ => (0, None),
     };
 
+    if idx + 8 != stmts.len() {
+        // There should be other 8 statements than the one assigining to drop flag.
+        return;
+    }
+
     // _LOCAL_TMP = ((_LOCAL_1 as Variant ).FIELD: TY );
     let (local_tmp, local_1, vf_1) = match match_get_variant_field(&stmts[idx + 1]) {
         None => return,

--- a/src/test/mir-opt/simplify_try_opt_1.rs
+++ b/src/test/mir-opt/simplify_try_opt_1.rs
@@ -1,0 +1,118 @@
+// ignore-tidy-linelength
+// compile-flags: -Zmir-opt-level=1
+
+// Note: Applying the optimization to `?` requires MIR inlining,
+// which is not run in `mir-opt-level=1`.
+
+fn try_identity(x: Result<u64, i32>) -> Result<u64, i32> {
+    match x {
+        Ok(x) => Ok(x),
+        Err(x) => Err(x),
+    }
+}
+
+fn main() {
+    let _ = try_identity(Ok(0));
+}
+
+// END RUST SOURCE
+// START rustc.try_identity.SimplifyArmIdentity.before.mir
+// fn  try_identity(_1: std::result::Result<u64, i32>) -> std::result::Result<u64, i32> {
+//     ...
+//     bb0: {
+//         _2 = discriminant(_1);
+//         switchInt(move _2) -> [0isize: bb2, 1isize: bb3, otherwise: bb1];
+//     }
+//     bb1: {
+//         unreachable;
+//     }
+//     bb2: {
+//         StorageLive(_3);
+//         _3 = ((_1 as Ok).0: u64);
+//         StorageLive(_4);
+//         _4 = _3;
+//         ((_0 as Ok).0: u64) = move _4;
+//         discriminant(_0) = 0;
+//         StorageDead(_4);
+//         StorageDead(_3);
+//         goto -> bb4;
+//     }
+//     bb3: {
+//         StorageLive(_5);
+//         _5 = ((_1 as Err).0: i32);
+//         StorageLive(_6);
+//         _6 = _5;
+//         ((_0 as Err).0: i32) = move _6;
+//         discriminant(_0) = 1;
+//         StorageDead(_6);
+//         StorageDead(_5);
+//         goto -> bb4;
+//     }
+//     bb4: {
+//         return;
+//     }
+// }
+// END rustc.try_identity.SimplifyArmIdentity.before.mir
+
+
+// START rustc.try_identity.SimplifyArmIdentity.after.mir
+// fn  try_identity(_1: std::result::Result<u64, i32>) -> std::result::Result<u64, i32> {
+//     ...
+//     bb0: {
+//         _2 = discriminant(_1);
+//         switchInt(move _2) -> [0isize: bb2, 1isize: bb3, otherwise: bb1];
+//     }
+//     bb1: {
+//         unreachable;
+//     }
+//     bb2: {
+//         _0 = move _1;
+//         nop;
+//         nop;
+//         nop;
+//         nop;
+//         nop;
+//         nop;
+//         nop;
+//         goto -> bb4;
+//     }
+//     bb3: {
+//         _0 = move _1;
+//         nop;
+//         nop;
+//         nop;
+//         nop;
+//         nop;
+//         nop;
+//         nop;
+//         goto -> bb4;
+//     }
+//     bb4: {
+//         return;
+//     }
+// }
+// END rustc.try_identity.SimplifyArmIdentity.after.mir
+
+// START rustc.try_identity.SimplifyBranchSame.after.mir
+// fn  try_identity(_1: std::result::Result<u64, i32>) -> std::result::Result<u64, i32> {
+//     ...
+//     bb0: {
+//         _2 = discriminant(_1);
+//         goto -> bb1;
+//     }
+//     bb1: {
+//         _0 = move _1;
+//         nop;
+//         nop;
+//         nop;
+//         nop;
+//         nop;
+//         nop;
+//         nop;
+//         goto -> bb2;
+//     }
+//     bb2: {
+//         return;
+//     }
+// }
+// END rustc.try_identity.SimplifyBranchSame.after.mir

--- a/src/test/mir-opt/simplify_try_opt_1.rs
+++ b/src/test/mir-opt/simplify_try_opt_1.rs
@@ -11,8 +11,16 @@ fn try_identity(x: Result<u64, i32>) -> Result<u64, i32> {
     }
 }
 
+fn try_identity_drop(x: Result<String, i32>) -> Result<String, i32> {
+    match x {
+        Ok(x) => Ok(x),
+        Err(x) => Err(x),
+    }
+}
+
 fn main() {
     let _ = try_identity(Ok(0));
+    let _ = try_identity_drop(Err(0));
 }
 
 // END RUST SOURCE
@@ -93,14 +101,86 @@ fn main() {
 // }
 // END rustc.try_identity.SimplifyArmIdentity.after.mir
 
-// START rustc.try_identity.SimplifyBranchSame.after.mir
+// START rustc.try_identity.SimplifyCfg-final.after.mir
 // fn  try_identity(_1: std::result::Result<u64, i32>) -> std::result::Result<u64, i32> {
 //     ...
 //     bb0: {
 //         _2 = discriminant(_1);
-//         goto -> bb1;
+//         _0 = move _1;
+//         return;
+//     }
+// }
+// END rustc.try_identity.SimplifyCfg-final.after.mir
+
+// START rustc.try_identity_drop.SimplifyArmIdentity.before.mir
+// fn  try_identity_drop(_1: std::result::Result<std::string::String, i32>) -> std::result::Result<std::string::String, i32> {
+//     ...
+//     bb0: {
+//         _7 = const false;
+//         _7 = const true;
+//         _2 = discriminant(_1);
+//         switchInt(move _2) -> [0isize: bb2, 1isize: bb3, otherwise: bb1];
 //     }
 //     bb1: {
+//         unreachable;
+//     }
+//     bb2: {
+//         StorageLive(_3);
+//         _7 = const false;
+//         _3 = move ((_1 as Ok).0: std::string::String);
+//         StorageLive(_4);
+//         _4 = move _3;
+//         ((_0 as Ok).0: std::string::String) = move _4;
+//         discriminant(_0) = 0;
+//         StorageDead(_4);
+//         StorageDead(_3);
+//         goto -> bb8;
+//     }
+//     bb3: {
+//         StorageLive(_5);
+//         _5 = ((_1 as Err).0: i32);
+//         StorageLive(_6);
+//         _6 = _5;
+//         ((_0 as Err).0: i32) = move _6;
+//         discriminant(_0) = 1;
+//         StorageDead(_6);
+//         StorageDead(_5);
+//         goto -> bb8;
+//     }
+//     bb4: {
+//         return;
+//     }
+//     bb5: {
+//         switchInt(_7) -> [false: bb4, otherwise: bb6];
+//     }
+//     bb6: {
+//         _7 = const false;
+//         drop(((_1 as Ok).0: std::string::String)) -> bb4;
+//     }
+//     bb7: {
+//         drop(_1) -> bb4;
+//     }
+//     bb8: {
+//         _8 = discriminant(_1);
+//         switchInt(move _8) -> [0isize: bb5, otherwise: bb7];
+//     }
+// }
+// END rustc.try_identity_drop.SimplifyArmIdentity.before.mir
+
+// START rustc.try_identity_drop.SimplifyArmIdentity.after.mir
+// fn  try_identity_drop(_1: std::result::Result<std::string::String, i32>) -> std::result::Result<std::string::String, i32> {
+//     ...
+//     bb0: {
+//         _7 = const false;
+//         _7 = const true;
+//         _2 = discriminant(_1);
+//         switchInt(move _2) -> [0isize: bb2, 1isize: bb3, otherwise: bb1];
+//     }
+//     bb1: {
+//         unreachable;
+//     }
+//     bb2: {
+//         _7 = const false;
 //         _0 = move _1;
 //         nop;
 //         nop;
@@ -109,10 +189,72 @@ fn main() {
 //         nop;
 //         nop;
 //         nop;
-//         goto -> bb2;
+//         goto -> bb8;
 //     }
-//     bb2: {
+//     bb3: {
+//         _0 = move _1;
+//         nop;
+//         nop;
+//         nop;
+//         nop;
+//         nop;
+//         nop;
+//         nop;
+//         goto -> bb8;
+//     }
+//     bb4: {
 //         return;
 //     }
+//     bb5: {
+//         switchInt(_7) -> [false: bb4, otherwise: bb6];
+//     }
+//     bb6: {
+//         _7 = const false;
+//         drop(((_1 as Ok).0: std::string::String)) -> bb4;
+//     }
+//     bb7: {
+//         drop(_1) -> bb4;
+//     }
+//     bb8: {
+//         _8 = discriminant(_1);
+//         switchInt(move _8) -> [0isize: bb5, otherwise: bb7];
+//     }
 // }
-// END rustc.try_identity.SimplifyBranchSame.after.mir
+// END rustc.try_identity_drop.SimplifyArmIdentity.after.mir
+
+// START rustc.try_identity_drop.SimplifyCfg-final.after.mir
+// fn  try_identity_drop(_1: std::result::Result<std::string::String, i32>) -> std::result::Result<std::string::String, i32> {
+//     ...
+//     bb0: {
+//         _7 = const false;
+//         _7 = const true;
+//         _2 = discriminant(_1);
+//         switchInt(move _2) -> [0isize: bb2, 1isize: bb7, otherwise: bb1];
+//     }
+//     bb1: {
+//         unreachable;
+//     }
+//     bb2: {
+//         _7 = const false;
+//         goto -> bb7;
+//     }
+//     bb3: {
+//         return;
+//     }
+//     bb4: {
+//         switchInt(_7) -> [false: bb3, otherwise: bb5];
+//     }
+//     bb5: {
+//         _7 = const false;
+//         drop(((_1 as Ok).0: std::string::String)) -> bb3;
+//     }
+//     bb6: {
+//         drop(_1) -> bb3;
+//     }
+//     bb7: {
+//         _0 = move _1;
+//         _8 = discriminant(_1);
+//         switchInt(move _8) -> [0isize: bb4, otherwise: bb6];
+//     }
+// }
+// END rustc.try_identity_drop.SimplifyCfg-final.after.mir

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1872,11 +1872,11 @@ impl<'test> TestCx<'test> {
                 rustc.arg("-Zdeduplicate-diagnostics=no");
             }
             MirOpt => {
-                rustc.args(&[
-                    "-Zdump-mir=all",
-                    "-Zmir-opt-level=3",
-                    "-Zdump-mir-exclude-pass-number",
-                ]);
+                if !self.props.compile_flags.iter().any(|s| s.starts_with("-Zmir-opt-level")) {
+                    rustc.arg("-Zmir-opt-level=3");
+                }
+
+                rustc.args(&["-Zdump-mir=all", "-Zdump-mir-exclude-pass-number"]);
 
                 let mir_dump_dir = self.get_mir_dump_dir();
                 let _ = fs::remove_dir_all(&mir_dump_dir);


### PR DESCRIPTION
* The first commit fixes `SimplifyArmIdentity` not working in presence of temporaries and storage markes, which are not eliminated in `mir-opt-level=1`. This does *not* fix the issue of `?` not being eliminated in `mir-opt-level < 2`.
* The third commit adds `SinkCommonCodeFromPredecessors` pass. This allows optimizing identical matches on types that have destructors.

<details>

This code ...

```rust
// `String` has destructor
pub fn foo(x: Result<String, u32>) -> Result<String, u32> {
    match x {
        Ok(x) => Ok(x),
        Err(x) => Err(x),
    }
}
```

... gives you MIR with drop flag manipulation:

```rust
    bb2: {
        StorageLive(_3);
        _7 = const false;             // <--- This is drop flag for `String`
        _3 = move ((_1 as Ok).0: std::string::String);
        StorageLive(_4);
        _4 = move _3;
        ((_0 as Ok).0: std::string::String) = move _4;
        discriminant(_0) = 0;
        StorageDead(_4);
        StorageDead(_3);
        goto -> bb8;
    }
    bb3: {
        StorageLive(_5);
        _5 = ((_1 as Err).0: u32);
        StorageLive(_6);
        _6 = _5;
        ((_0 as Err).0: u32) = move _6;
        discriminant(_0) = 1;
        StorageDead(_6);
        StorageDead(_5);
        goto -> bb8;
    }
```

In this case `SimplifyBranchSame` does not work because `bb2` and `bb3` is still unequal after `SimplifyArmIdentity` pass. It seems that LLVM is able to optimize the `match` into `memcpy` from this state, though.

```rust
    bb2: {
        _7 = const false;             // <---
        _0 = move _1;
        goto -> bb8;
    }
    bb3: {
        _0 = move _1;
        goto -> bb8;
    }
```

`SinkCommonCodeFromPredecessors` is able to sink the common statement, `_0 = move _1`, to `bb8`.

I stole the idea from [LLVM](https://github.com/llvm-mirror/llvm/blob/2c4ca6832fa6b306ee6a7010bfb80a3f2596f824/lib/Transforms/Utils/SimplifyCFG.cpp#L1704), but this PR implements only (1) in the comment there.
</details>

#66234