### PR TITLE
add a test for #60976

### DIFF
--- a/src/test/ui/use/auxiliary/extern-use-primitive-type-lib.rs
+++ b/src/test/ui/use/auxiliary/extern-use-primitive-type-lib.rs
@@ -1,0 +1,3 @@
+// compile-flags: --edition=2018
+
+pub use u32;

--- a/src/test/ui/use/issue-60976-extern-use-primitive-type.rs
+++ b/src/test/ui/use/issue-60976-extern-use-primitive-type.rs
@@ -1,0 +1,7 @@
+// Regression test for #60976: ICE (with <=1.36.0) when another file had `use <primitive_type>;`.
+// check-pass
+// aux-build:extern-use-primitive-type-lib.rs
+
+extern crate extern_use_primitive_type_lib;
+
+fn main() {}


### PR DESCRIPTION
The test fails on 1.36.0 but passes on master.

Huge thanks for @hellow554 actually digging out the minimized version of the
repro.

Fixes #60976.