### PR TITLE
[WIP] Don't drop an enum after all its fields have been moved from

### DIFF
--- a/src/librustc_mir/util/elaborate_drops.rs
+++ b/src/librustc_mir/util/elaborate_drops.rs
@@ -472,7 +472,7 @@ where
                 }
                 let (normal, _) = self.drop_ladder(fields, succ, unwind);
                 normal_blocks.push(normal);
-            } else {
+            } else if !adt.variants[variant_index].fields.is_empty() {
                 have_otherwise = true;
             }
         }


### PR DESCRIPTION
Drop elaboration is smart enough to realize when all fields of a struct or tuple are moved out of along a given code path and will remove drop terminators on that code path. However, if all fields of an *enum* with multiple variants are moved out of, drop terminators are still emitted. After this PR, drop elaboration will eliminate drops of an `Option` after the value in the `Some` variant is moved out of. `Option::unwrap` is an example of code whose MIR should be a bit better optimized as a result.

```rust
fn unwrap<T>(opt: Option<T>) -> T {
    match opt {
        Some(inner) => inner,
        None => panic!("unwrap"),
    }
}
```

When I say all fields of an enum, I mean all fields across all variants, so this optimization does not apply when, e.g., the value in `Result::Ok` is moved out of. To improve this case, we would need to incorporate information about the [variant that is currently live](https://github.com/rust-lang/rust/issues/66753#issuecomment-575386659) into the `{Un,}InitializedPlaces` dataflow analyses. This is more involved, but I plan to give it a try.

This is a WIP pending perf results and the addition of a test.