### PR TITLE
[beta] backports

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -1477,7 +1477,11 @@ impl EmitterWriter {
             Some(ref sm) => sm,
             None => return Ok(()),
         };
-        if !suggestion.has_valid_spans(&**sm) {
+
+        // Render the replacements for each suggestion
+        let suggestions = suggestion.splice_lines(&**sm);
+
+        if suggestions.is_empty() {
             // Suggestions coming from macros can have malformed spans. This is a heavy handed
             // approach to avoid ICEs by ignoring the suggestion outright.
             return Ok(());
@@ -1498,9 +1502,6 @@ impl EmitterWriter {
             "suggestion",
             Some(Style::HeaderMsg),
         );
-
-        // Render the replacements for each suggestion
-        let suggestions = suggestion.splice_lines(&**sm);
 
         let mut row_num = 2;
         let mut notice_capitalization = false;

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -9,26 +9,25 @@
 
 use Destination::*;
 
-use syntax_pos::{SourceFile, Span, MultiSpan};
 use syntax_pos::source_map::SourceMap;
+use syntax_pos::{MultiSpan, SourceFile, Span};
 
-use crate::{
-    Level, CodeSuggestion, Diagnostic, SubDiagnostic, pluralize,
-    SuggestionStyle, DiagnosticId,
-};
-use crate::Level::Error;
-use crate::snippet::{Annotation, AnnotationType, Line, MultilineAnnotation, StyledString, Style};
+use crate::snippet::{Annotation, AnnotationType, Line, MultilineAnnotation, Style, StyledString};
 use crate::styled_buffer::StyledBuffer;
+use crate::Level::Error;
+use crate::{
+    pluralize, CodeSuggestion, Diagnostic, DiagnosticId, Level, SubDiagnostic, SuggestionStyle,
+};
 
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync::Lrc;
 use std::borrow::Cow;
-use std::io::prelude::*;
+use std::cmp::{max, min, Reverse};
 use std::io;
-use std::cmp::{min, max, Reverse};
+use std::io::prelude::*;
 use std::path::Path;
-use termcolor::{StandardStream, ColorChoice, ColorSpec, BufferWriter, Ansi};
-use termcolor::{WriteColor, Color, Buffer};
+use termcolor::{Ansi, BufferWriter, ColorChoice, ColorSpec, StandardStream};
+use termcolor::{Buffer, Color, WriteColor};
 
 /// Describes the way the content of the `rendered` field of the json output is generated
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -57,8 +56,15 @@ impl HumanReadableErrorType {
     ) -> EmitterWriter {
         let (short, color_config) = self.unzip();
         let color = color_config.suggests_using_colors();
-        EmitterWriter::new(dst, source_map, short, teach, color, terminal_width,
-            external_macro_backtrace)
+        EmitterWriter::new(
+            dst,
+            source_map,
+            short,
+            teach,
+            color,
+            terminal_width,
+            external_macro_backtrace,
+        )
     }
 }
 
@@ -117,15 +123,15 @@ impl Margin {
     }
 
     fn was_cut_right(&self, line_len: usize) -> bool {
-        let right = if self.computed_right == self.span_right ||
-            self.computed_right == self.label_right
-        {
-            // Account for the "..." padding given above. Otherwise we end up with code lines that
-            // do fit but end in "..." as if they were trimmed.
-            self.computed_right - 6
-        } else {
-            self.computed_right
-        };
+        let right =
+            if self.computed_right == self.span_right || self.computed_right == self.label_right {
+                // Account for the "..." padding given above. Otherwise we end
+                // up with code lines that do fit but end in "..." as if they
+                // were trimmed.
+                self.computed_right - 6
+            } else {
+                self.computed_right
+            };
         right < line_len && self.computed_left + self.column_width < line_len
     }
 
@@ -156,7 +162,8 @@ impl Margin {
                 let padding_left = (self.column_width - (self.span_right - self.span_left)) / 5 * 2;
                 self.computed_left = self.span_left.saturating_sub(padding_left);
                 self.computed_right = self.computed_left + self.column_width;
-            } else { // Mostly give up but still don't show the full line.
+            } else {
+                // Mostly give up but still don't show the full line.
                 self.computed_left = self.span_left;
                 self.computed_right = self.span_right;
             }
@@ -240,11 +247,15 @@ pub trait Emitter {
                     format!(
                         "help: {}{}: `{}`",
                         sugg.msg,
-                        if self.source_map().map(|sm| is_case_difference(
-                            &**sm,
-                            substitution,
-                            sugg.substitutions[0].parts[0].span,
-                        )).unwrap_or(false) {
+                        if self
+                            .source_map()
+                            .map(|sm| is_case_difference(
+                                &**sm,
+                                substitution,
+                                sugg.substitutions[0].parts[0].span,
+                            ))
+                            .unwrap_or(false)
+                        {
                             " (notice the capitalization)"
                         } else {
                             ""
@@ -271,37 +282,35 @@ pub trait Emitter {
     // This does a small "fix" for multispans by looking to see if it can find any that
     // point directly at <*macros>. Since these are often difficult to read, this
     // will change the span to point at the use site.
-    fn fix_multispans_in_std_macros(&self,
-                                    source_map: &Option<Lrc<SourceMap>>,
-                                    span: &mut MultiSpan,
-                                    children: &mut Vec<SubDiagnostic>,
-                                    level: &Level,
-                                    backtrace: bool) {
+    fn fix_multispans_in_std_macros(
+        &self,
+        source_map: &Option<Lrc<SourceMap>>,
+        span: &mut MultiSpan,
+        children: &mut Vec<SubDiagnostic>,
+        level: &Level,
+        backtrace: bool,
+    ) {
         let mut spans_updated = self.fix_multispan_in_std_macros(source_map, span, backtrace);
         for child in children.iter_mut() {
-            spans_updated |= self.fix_multispan_in_std_macros(
-                                 source_map,
-                                 &mut child.span,
-                                 backtrace
-                             );
+            spans_updated |=
+                self.fix_multispan_in_std_macros(source_map, &mut child.span, backtrace);
         }
         let msg = if level == &Error {
             "this error originates in a macro outside of the current crate \
              (in Nightly builds, run with -Z external-macro-backtrace \
-              for more info)".to_string()
+              for more info)"
+                .to_string()
         } else {
             "this warning originates in a macro outside of the current crate \
              (in Nightly builds, run with -Z external-macro-backtrace \
-              for more info)".to_string()
+              for more info)"
+                .to_string()
         };
 
         if spans_updated {
             children.push(SubDiagnostic {
                 level: Level::Note,
-                message: vec![
-                    (msg,
-                     Style::NoStyle),
-                ],
+                message: vec![(msg, Style::NoStyle)],
                 span: MultiSpan::new(),
                 render_span: None,
             });
@@ -311,10 +320,12 @@ pub trait Emitter {
     // This "fixes" MultiSpans that contain Spans that are pointing to locations inside of
     // <*macros>. Since these locations are often difficult to read, we move these Spans from
     // <*macros> to their corresponding use site.
-    fn fix_multispan_in_std_macros(&self,
-                                   source_map: &Option<Lrc<SourceMap>>,
-                                   span: &mut MultiSpan,
-                                   always_backtrace: bool) -> bool {
+    fn fix_multispan_in_std_macros(
+        &self,
+        source_map: &Option<Lrc<SourceMap>>,
+        span: &mut MultiSpan,
+        always_backtrace: bool,
+    ) -> bool {
         let sm = match source_map {
             Some(ref sm) => sm,
             None => return false,
@@ -340,31 +351,40 @@ pub trait Emitter {
                     continue;
                 }
                 if always_backtrace {
-                    new_labels.push((trace.def_site_span,
-                                        format!("in this expansion of `{}`{}",
-                                                trace.macro_decl_name,
-                                                if backtrace_len > 2 {
-                                                    // if backtrace_len == 1 it'll be pointed
-                                                    // at by "in this macro invocation"
-                                                    format!(" (#{})", i + 1)
-                                                } else {
-                                                    String::new()
-                                                })));
+                    new_labels.push((
+                        trace.def_site_span,
+                        format!(
+                            "in this expansion of `{}`{}",
+                            trace.macro_decl_name,
+                            if backtrace_len > 2 {
+                                // if backtrace_len == 1 it'll be pointed
+                                // at by "in this macro invocation"
+                                format!(" (#{})", i + 1)
+                            } else {
+                                String::new()
+                            }
+                        ),
+                    ));
                 }
                 // Check to make sure we're not in any <*macros>
-                if !sm.span_to_filename(trace.def_site_span).is_macros() &&
-                    !trace.macro_decl_name.starts_with("desugaring of ") &&
-                    !trace.macro_decl_name.starts_with("#[") ||
-                    always_backtrace {
-                    new_labels.push((trace.call_site,
-                                        format!("in this macro invocation{}",
-                                                if backtrace_len > 2 && always_backtrace {
-                                                    // only specify order when the macro
-                                                    // backtrace is multiple levels deep
-                                                    format!(" (#{})", i + 1)
-                                                } else {
-                                                    String::new()
-                                                })));
+                if !sm.span_to_filename(trace.def_site_span).is_macros()
+                    && !trace.macro_decl_name.starts_with("desugaring of ")
+                    && !trace.macro_decl_name.starts_with("#[")
+                    || always_backtrace
+                {
+                    new_labels.push((
+                        trace.call_site,
+                        format!(
+                            "in this macro invocation{}",
+                            if backtrace_len > 2 && always_backtrace {
+                                // only specify order when the macro
+                                // backtrace is multiple levels deep
+                                format!(" (#{})", i + 1)
+                            } else {
+                                String::new()
+                            }
+                        ),
+                    ));
                     if !always_backtrace {
                         break;
                     }
@@ -378,9 +398,7 @@ pub trait Emitter {
             if sp_label.span.is_dummy() {
                 continue;
             }
-            if sm.span_to_filename(sp_label.span.clone()).is_macros() &&
-                !always_backtrace
-            {
+            if sm.span_to_filename(sp_label.span.clone()).is_macros() && !always_backtrace {
                 let v = sp_label.span.macro_backtrace();
                 if let Some(use_site) = v.last() {
                     before_after.push((sp_label.span.clone(), use_site.call_site.clone()));
@@ -406,18 +424,22 @@ impl Emitter for EmitterWriter {
         let mut children = diag.children.clone();
         let (mut primary_span, suggestions) = self.primary_span_formatted(&diag);
 
-        self.fix_multispans_in_std_macros(&self.sm,
-                                          &mut primary_span,
-                                          &mut children,
-                                          &diag.level,
-                                          self.external_macro_backtrace);
+        self.fix_multispans_in_std_macros(
+            &self.sm,
+            &mut primary_span,
+            &mut children,
+            &diag.level,
+            self.external_macro_backtrace,
+        );
 
-        self.emit_messages_default(&diag.level,
-                                   &diag.styled_message(),
-                                   &diag.code,
-                                   &primary_span,
-                                   &children,
-                                   &suggestions);
+        self.emit_messages_default(
+            &diag.level,
+            &diag.styled_message(),
+            &diag.code,
+            &primary_span,
+            &children,
+            &suggestions,
+        );
     }
 
     fn should_show_explain(&self) -> bool {
@@ -429,7 +451,9 @@ impl Emitter for EmitterWriter {
 pub struct SilentEmitter;
 
 impl Emitter for SilentEmitter {
-    fn source_map(&self) -> Option<&Lrc<SourceMap>> { None }
+    fn source_map(&self) -> Option<&Lrc<SourceMap>> {
+        None
+    }
     fn emit_diagnostic(&mut self, _: &Diagnostic) {}
 }
 
@@ -458,17 +482,13 @@ impl ColorConfig {
                 }
             }
             ColorConfig::Never => ColorChoice::Never,
-            ColorConfig::Auto if atty::is(atty::Stream::Stderr) => {
-                ColorChoice::Auto
-            }
+            ColorConfig::Auto if atty::is(atty::Stream::Stderr) => ColorChoice::Auto,
             ColorConfig::Auto => ColorChoice::Never,
         }
     }
     fn suggests_using_colors(self) -> bool {
         match self {
-            | ColorConfig::Always
-            | ColorConfig::Auto
-            => true,
+            ColorConfig::Always | ColorConfig::Auto => true,
             ColorConfig::Never => false,
         }
     }
@@ -540,11 +560,7 @@ impl EmitterWriter {
     }
 
     fn maybe_anonymized(&self, line_num: usize) -> String {
-        if self.ui_testing {
-            ANONYMIZED_LINE_NUM.to_string()
-        } else {
-            line_num.to_string()
-        }
+        if self.ui_testing { ANONYMIZED_LINE_NUM.to_string() } else { line_num.to_string() }
     }
 
     fn draw_line(
@@ -563,17 +579,22 @@ impl EmitterWriter {
         let right = margin.right(line_len);
         // On long lines, we strip the source line, accounting for unicode.
         let mut taken = 0;
-        let code: String = source_string.chars().skip(left).take_while(|ch| {
-            // Make sure that the trimming on the right will fall within the terminal width.
-            // FIXME: `unicode_width` sometimes disagrees with terminals on how wide a `char` is.
-            // For now, just accept that sometimes the code line will be longer than desired.
-            let next = unicode_width::UnicodeWidthChar::width(*ch).unwrap_or(1);
-            if taken + next > right - left {
-                return false;
-            }
-            taken += next;
-            true
-        }).collect();
+        let code: String = source_string
+            .chars()
+            .skip(left)
+            .take_while(|ch| {
+                // Make sure that the trimming on the right will fall within the
+                // terminal width.  FIXME: `unicode_width` sometimes disagrees
+                // with terminals on how wide a `char` is.  For now, just accept
+                // that sometimes the code line will be longer than desired.
+                let next = unicode_width::UnicodeWidthChar::width(*ch).unwrap_or(1);
+                if taken + next > right - left {
+                    return false;
+                }
+                taken += next;
+                true
+            })
+            .collect();
         buffer.puts(line_offset, code_offset, &code, Style::Quotation);
         if margin.was_cut_left() {
             // We have stripped some code/whitespace from the beginning, make it clear.
@@ -624,7 +645,9 @@ impl EmitterWriter {
 
         let left = margin.left(source_string.len()); // Left trim
         // Account for unicode characters of width !=0 that were removed.
-        let left = source_string.chars().take(left)
+        let left = source_string
+            .chars()
+            .take(left)
             .map(|ch| unicode_width::UnicodeWidthChar::width(ch).unwrap_or(1))
             .sum();
 
@@ -773,13 +796,14 @@ impl EmitterWriter {
                 if overlaps(next, annotation, 0)  // This label overlaps with another one and both
                     && annotation.has_label()     // take space (they have text and are not
                     && j > i                      // multiline lines).
-                    && p == 0  // We're currently on the first line, move the label one line down
+                    && p == 0
+                // We're currently on the first line, move the label one line down
                 {
                     // If we're overlapping with an un-labelled annotation with the same span
                     // we can just merge them in the output
                     if next.start_col == annotation.start_col
-                    && next.end_col == annotation.end_col
-                    && !next.has_label()
+                        && next.end_col == annotation.end_col
+                        && !next.has_label()
                     {
                         continue;
                     }
@@ -791,7 +815,7 @@ impl EmitterWriter {
             }
             annotations_position.push((p, annotation));
             for (j, next) in annotations.iter().enumerate() {
-                if j > i  {
+                if j > i {
                     let l = next.label.as_ref().map_or(0, |label| label.len() + 2);
                     if (overlaps(next, annotation, l) // Do not allow two labels to be in the same
                                                      // line if they overlap including padding, to
@@ -814,7 +838,8 @@ impl EmitterWriter {
                         || (overlaps(next, annotation, l)
                             && next.end_col <= annotation.end_col
                             && next.has_label()
-                            && p == 0)  // Avoid #42595.
+                            && p == 0)
+                    // Avoid #42595.
                     {
                         // This annotation needs a new line in the output.
                         p += 1;
@@ -848,10 +873,7 @@ impl EmitterWriter {
         //   |
         for pos in 0..=line_len {
             draw_col_separator(buffer, line_offset + pos + 1, width_offset - 2);
-            buffer.putc(line_offset + pos + 1,
-                        width_offset - 2,
-                        '|',
-                        Style::LineNumber);
+            buffer.putc(line_offset + pos + 1, width_offset - 2, '|', Style::LineNumber);
         }
 
         // Write the horizontal lines for multiline annotations
@@ -874,8 +896,7 @@ impl EmitterWriter {
             };
             let pos = pos + 1;
             match annotation.annotation_type {
-                AnnotationType::MultilineStart(depth) |
-                AnnotationType::MultilineEnd(depth) => {
+                AnnotationType::MultilineStart(depth) | AnnotationType::MultilineEnd(depth) => {
                     draw_range(
                         buffer,
                         '_',
@@ -919,27 +940,23 @@ impl EmitterWriter {
 
             if pos > 1 && (annotation.has_label() || annotation.takes_space()) {
                 for p in line_offset + 1..=line_offset + pos {
-                    buffer.putc(p,
-                                (code_offset + annotation.start_col).saturating_sub(left),
-                                '|',
-                                style);
+                    buffer.putc(
+                        p,
+                        (code_offset + annotation.start_col).saturating_sub(left),
+                        '|',
+                        style,
+                    );
                 }
             }
             match annotation.annotation_type {
                 AnnotationType::MultilineStart(depth) => {
                     for p in line_offset + pos + 1..line_offset + line_len + 2 {
-                        buffer.putc(p,
-                                    width_offset + depth - 1,
-                                    '|',
-                                    style);
+                        buffer.putc(p, width_offset + depth - 1, '|', style);
                     }
                 }
                 AnnotationType::MultilineEnd(depth) => {
                     for p in line_offset..=line_offset + pos {
-                        buffer.putc(p,
-                                    width_offset + depth - 1,
-                                    '|',
-                                    style);
+                        buffer.putc(p, width_offset + depth - 1, '|', style);
                     }
                 }
                 _ => (),
@@ -958,11 +975,8 @@ impl EmitterWriter {
         // 4 |   }
         //   |  _  test
         for &(pos, annotation) in &annotations_position {
-            let style = if annotation.is_primary {
-                Style::LabelPrimary
-            } else {
-                Style::LabelSecondary
-            };
+            let style =
+                if annotation.is_primary { Style::LabelPrimary } else { Style::LabelSecondary };
             let (pos, col) = if pos == 0 {
                 (pos + 1, (annotation.end_col + 1).saturating_sub(left))
             } else {
@@ -1012,8 +1026,9 @@ impl EmitterWriter {
                 );
             }
         }
-        annotations_position.iter().filter_map(|&(_, annotation)| {
-            match annotation.annotation_type {
+        annotations_position
+            .iter()
+            .filter_map(|&(_, annotation)| match annotation.annotation_type {
                 AnnotationType::MultilineStart(p) | AnnotationType::MultilineEnd(p) => {
                     let style = if annotation.is_primary {
                         Style::LabelPrimary
@@ -1022,10 +1037,9 @@ impl EmitterWriter {
                     };
                     Some((p, style))
                 }
-                _ => None
-            }
-
-        }).collect::<Vec<_>>()
+                _ => None,
+            })
+            .collect::<Vec<_>>()
     }
 
     fn get_multispan_max_line_num(&mut self, msp: &MultiSpan) -> usize {
@@ -1055,7 +1069,8 @@ impl EmitterWriter {
 
     fn get_max_line_num(&mut self, span: &MultiSpan, children: &[SubDiagnostic]) -> usize {
         let primary = self.get_multispan_max_line_num(span);
-        children.iter()
+        children
+            .iter()
             .map(|sub| self.get_multispan_max_line_num(&sub.span))
             .max()
             .unwrap_or(0)
@@ -1064,13 +1079,14 @@ impl EmitterWriter {
 
     /// Adds a left margin to every line but the first, given a padding length and the label being
     /// displayed, keeping the provided highlighting.
-    fn msg_to_buffer(&self,
-                     buffer: &mut StyledBuffer,
-                     msg: &[(String, Style)],
-                     padding: usize,
-                     label: &str,
-                     override_style: Option<Style>) {
-
+    fn msg_to_buffer(
+        &self,
+        buffer: &mut StyledBuffer,
+        msg: &[(String, Style)],
+        padding: usize,
+        label: &str,
+        override_style: Option<Style>,
+    ) {
         // The extra 5 ` ` is padding that's always needed to align to the `note: `:
         //
         //   error: message
@@ -1144,14 +1160,10 @@ impl EmitterWriter {
         is_secondary: bool,
     ) -> io::Result<()> {
         let mut buffer = StyledBuffer::new();
-        let header_style = if is_secondary {
-            Style::HeaderMsg
-        } else {
-            Style::MainHeaderMsg
-        };
+        let header_style = if is_secondary { Style::HeaderMsg } else { Style::MainHeaderMsg };
 
-        if !msp.has_primary_spans() && !msp.has_span_labels() && is_secondary
-           && !self.short_message {
+        if !msp.has_primary_spans() && !msp.has_span_labels() && is_secondary && !self.short_message
+        {
             // This is a secondary message with no span info
             for _ in 0..max_line_num_len {
                 buffer.prepend(0, " ", Style::NoStyle);
@@ -1189,7 +1201,8 @@ impl EmitterWriter {
 
         // Make sure our primary file comes first
         let (primary_lo, sm) = if let (Some(sm), Some(ref primary_span)) =
-            (self.sm.as_ref(), msp.primary_span().as_ref()) {
+            (self.sm.as_ref(), msp.primary_span().as_ref())
+        {
             if !primary_span.is_dummy() {
                 (sm.lookup_char_pos(primary_span.lo()), sm)
             } else {
@@ -1202,7 +1215,8 @@ impl EmitterWriter {
             return Ok(());
         };
         if let Ok(pos) =
-            annotated_files.binary_search_by(|x| x.file.name.cmp(&primary_lo.file.name)) {
+            annotated_files.binary_search_by(|x| x.file.name.cmp(&primary_lo.file.name))
+        {
             annotated_files.swap(0, pos);
         }
 
@@ -1263,17 +1277,16 @@ impl EmitterWriter {
                     } else {
                         String::new()
                     };
-                    format!("{}:{}{}",
-                            annotated_file.file.name,
-                            sm.doctest_offset_line(
-                                &annotated_file.file.name, first_line.line_index),
-                            col)
+                    format!(
+                        "{}:{}{}",
+                        annotated_file.file.name,
+                        sm.doctest_offset_line(&annotated_file.file.name, first_line.line_index),
+                        col
+                    )
                 } else {
                     annotated_file.file.name.to_string()
                 };
-                buffer.append(buffer_msg_line_offset + 1,
-                              &loc,
-                              Style::LineAndColumn);
+                buffer.append(buffer_msg_line_offset + 1, &loc, Style::LineAndColumn);
                 for _ in 0..max_line_num_len {
                     buffer.prepend(buffer_msg_line_offset + 1, " ", Style::NoStyle);
                 }
@@ -1282,9 +1295,11 @@ impl EmitterWriter {
             if !self.short_message {
                 // Put in the spacer between the location and annotated source
                 let buffer_msg_line_offset = buffer.num_lines();
-                draw_col_separator_no_space(&mut buffer,
-                                            buffer_msg_line_offset,
-                                            max_line_num_len + 1);
+                draw_col_separator_no_space(
+                    &mut buffer,
+                    buffer_msg_line_offset,
+                    max_line_num_len + 1,
+                );
 
                 // Contains the vertical lines' positions for active multiline annotations
                 let mut multilines = FxHashMap::default();
@@ -1295,15 +1310,10 @@ impl EmitterWriter {
                     let file = annotated_file.file.clone();
                     let line = &annotated_file.lines[line_idx];
                     if let Some(source_string) = file.get_line(line.line_index - 1) {
-                        let leading_whitespace = source_string
-                            .chars()
-                            .take_while(|c| c.is_whitespace())
-                            .count();
+                        let leading_whitespace =
+                            source_string.chars().take_while(|c| c.is_whitespace()).count();
                         if source_string.chars().any(|c| !c.is_whitespace()) {
-                            whitespace_margin = min(
-                                whitespace_margin,
-                                leading_whitespace,
-                            );
+                            whitespace_margin = min(whitespace_margin, leading_whitespace);
                         }
                     }
                 }
@@ -1328,9 +1338,10 @@ impl EmitterWriter {
                 let mut label_right_margin = 0;
                 let mut max_line_len = 0;
                 for line in &annotated_file.lines {
-                    max_line_len = max(max_line_len, annotated_file.file
-                        .get_line(line.line_index - 1)
-                        .map_or(0, |s| s.len()));
+                    max_line_len = max(
+                        max_line_len,
+                        annotated_file.file.get_line(line.line_index - 1).map_or(0, |s| s.len()),
+                    );
                     for ann in &line.annotations {
                         span_right_margin = max(span_right_margin, ann.start_col);
                         span_right_margin = max(span_right_margin, ann.end_col);
@@ -1393,32 +1404,31 @@ impl EmitterWriter {
                     // the code in this line.
                     for (depth, style) in &multilines {
                         for line in previous_buffer_line..buffer.num_lines() {
-                            draw_multiline_line(&mut buffer,
-                                                line,
-                                                width_offset,
-                                                *depth,
-                                                *style);
+                            draw_multiline_line(&mut buffer, line, width_offset, *depth, *style);
                         }
                     }
                     // check to see if we need to print out or elide lines that come between
                     // this annotated line and the next one.
                     if line_idx < (annotated_file.lines.len() - 1) {
-                        let line_idx_delta = annotated_file.lines[line_idx + 1].line_index -
-                                             annotated_file.lines[line_idx].line_index;
+                        let line_idx_delta = annotated_file.lines[line_idx + 1].line_index
+                            - annotated_file.lines[line_idx].line_index;
                         if line_idx_delta > 2 {
                             let last_buffer_line_num = buffer.num_lines();
                             buffer.puts(last_buffer_line_num, 0, "...", Style::LineNumber);
 
                             // Set the multiline annotation vertical lines on `...` bridging line.
                             for (depth, style) in &multilines {
-                                draw_multiline_line(&mut buffer,
-                                                    last_buffer_line_num,
-                                                    width_offset,
-                                                    *depth,
-                                                    *style);
+                                draw_multiline_line(
+                                    &mut buffer,
+                                    last_buffer_line_num,
+                                    width_offset,
+                                    *depth,
+                                    *style,
+                                );
                             }
                         } else if line_idx_delta == 2 {
-                            let unannotated_line = annotated_file.file
+                            let unannotated_line = annotated_file
+                                .file
                                 .get_line(annotated_file.lines[line_idx].line_index)
                                 .unwrap_or_else(|| Cow::from(""));
 
@@ -1455,7 +1465,6 @@ impl EmitterWriter {
         emit_to_destination(&buffer.render(), level, &mut self.dst, self.short_message)?;
 
         Ok(())
-
     }
 
     fn emit_suggestion_default(
@@ -1466,7 +1475,7 @@ impl EmitterWriter {
     ) -> io::Result<()> {
         let sm = match self.sm {
             Some(ref sm) => sm,
-            None => return Ok(())
+            None => return Ok(()),
         };
 
         let mut buffer = StyledBuffer::new();
@@ -1495,8 +1504,7 @@ impl EmitterWriter {
             // Only show underline if the suggestion spans a single line and doesn't cover the
             // entirety of the code output. If you have multiple replacements in the same line
             // of code, show the underline.
-            let show_underline = !(parts.len() == 1
-                && parts[0].snippet.trim() == complete.trim())
+            let show_underline = !(parts.len() == 1 && parts[0].snippet.trim() == complete.trim())
                 && complete.lines().count() == 1;
 
             let lines = sm.span_to_lines(parts[0].span).unwrap();
@@ -1509,10 +1517,12 @@ impl EmitterWriter {
             let mut lines = complete.lines();
             for line in lines.by_ref().take(MAX_HIGHLIGHT_LINES) {
                 // Print the span column to avoid confusion
-                buffer.puts(row_num,
-                            0,
-                            &self.maybe_anonymized(line_start + line_pos),
-                            Style::LineNumber);
+                buffer.puts(
+                    row_num,
+                    0,
+                    &self.maybe_anonymized(line_start + line_pos),
+                    Style::LineNumber,
+                );
                 // print the suggestion
                 draw_col_separator(&mut buffer, row_num, max_line_num_len + 1);
                 buffer.append(row_num, line, Style::NoStyle);
@@ -1532,34 +1542,42 @@ impl EmitterWriter {
                     let span_end_pos = sm.lookup_char_pos(part.span.hi()).col_display;
 
                     // Do not underline the leading...
-                    let start = part.snippet.len()
-                        .saturating_sub(part.snippet.trim_start().len());
+                    let start = part.snippet.len().saturating_sub(part.snippet.trim_start().len());
                     // ...or trailing spaces. Account for substitutions containing unicode
                     // characters.
-                    let sub_len: usize = part.snippet.trim().chars()
+                    let sub_len: usize = part
+                        .snippet
+                        .trim()
+                        .chars()
                         .map(|ch| unicode_width::UnicodeWidthChar::width(ch).unwrap_or(1))
                         .sum();
 
                     let underline_start = (span_start_pos + start) as isize + offset;
                     let underline_end = (span_start_pos + start + sub_len) as isize + offset;
                     for p in underline_start..underline_end {
-                        buffer.putc(row_num,
-                                    max_line_num_len + 3 + p as usize,
-                                    '^',
-                                    Style::UnderlinePrimary);
+                        buffer.putc(
+                            row_num,
+                            max_line_num_len + 3 + p as usize,
+                            '^',
+                            Style::UnderlinePrimary,
+                        );
                     }
                     // underline removals too
                     if underline_start == underline_end {
-                        for p in underline_start-1..underline_start+1 {
-                            buffer.putc(row_num,
-                                        max_line_num_len + 3 + p as usize,
-                                        '-',
-                                        Style::UnderlineSecondary);
+                        for p in underline_start - 1..underline_start + 1 {
+                            buffer.putc(
+                                row_num,
+                                max_line_num_len + 3 + p as usize,
+                                '-',
+                                Style::UnderlineSecondary,
+                            );
                         }
                     }
 
                     // length of the code after substitution
-                    let full_sub_len = part.snippet.chars()
+                    let full_sub_len = part
+                        .snippet
+                        .chars()
                         .map(|ch| unicode_width::UnicodeWidthChar::width(ch).unwrap_or(1))
                         .sum::<usize>() as isize;
 
@@ -1609,17 +1627,21 @@ impl EmitterWriter {
 
         match self.emit_message_default(span, message, code, level, max_line_num_len, false) {
             Ok(()) => {
-                if !children.is_empty() || suggestions.iter().any(|s| {
-                    s.style != SuggestionStyle::CompletelyHidden
-                }) {
+                if !children.is_empty()
+                    || suggestions.iter().any(|s| s.style != SuggestionStyle::CompletelyHidden)
+                {
                     let mut buffer = StyledBuffer::new();
                     if !self.short_message {
                         draw_col_separator_no_space(&mut buffer, 0, max_line_num_len + 1);
                     }
-                    match emit_to_destination(&buffer.render(), level, &mut self.dst,
-                                              self.short_message) {
+                    match emit_to_destination(
+                        &buffer.render(),
+                        level,
+                        &mut self.dst,
+                        self.short_message,
+                    ) {
                         Ok(()) => (),
-                        Err(e) => panic!("failed to emit error: {}", e)
+                        Err(e) => panic!("failed to emit error: {}", e),
                     }
                 }
                 if !self.short_message {
@@ -1634,7 +1656,7 @@ impl EmitterWriter {
                             true,
                         ) {
                             Err(e) => panic!("failed to emit error: {}", e),
-                            _ => ()
+                            _ => (),
                         }
                     }
                     for sugg in suggestions {
@@ -1650,16 +1672,13 @@ impl EmitterWriter {
                                 true,
                             ) {
                                 Err(e) => panic!("failed to emit error: {}", e),
-                                _ => ()
+                                _ => (),
                             }
                         } else {
-                            match self.emit_suggestion_default(
-                                sugg,
-                                &Level::Help,
-                                max_line_num_len,
-                            ) {
+                            match self.emit_suggestion_default(sugg, &Level::Help, max_line_num_len)
+                            {
                                 Err(e) => panic!("failed to emit error: {}", e),
-                                _ => ()
+                                _ => (),
                             }
                         }
                     }
@@ -1671,12 +1690,10 @@ impl EmitterWriter {
         let mut dst = self.dst.writable();
         match writeln!(dst) {
             Err(e) => panic!("failed to emit error: {}", e),
-            _ => {
-                match dst.flush() {
-                    Err(e) => panic!("failed to emit error: {}", e),
-                    _ => (),
-                }
-            }
+            _ => match dst.flush() {
+                Err(e) => panic!("failed to emit error: {}", e),
+                _ => (),
+            },
         }
     }
 }
@@ -1686,13 +1703,14 @@ impl FileWithAnnotatedLines {
     /// This helps us quickly iterate over the whole message (including secondary file spans)
     pub fn collect_annotations(
         msp: &MultiSpan,
-        source_map: &Option<Lrc<SourceMap>>
+        source_map: &Option<Lrc<SourceMap>>,
     ) -> Vec<FileWithAnnotatedLines> {
-        fn add_annotation_to_file(file_vec: &mut Vec<FileWithAnnotatedLines>,
-                                  file: Lrc<SourceFile>,
-                                  line_index: usize,
-                                  ann: Annotation) {
-
+        fn add_annotation_to_file(
+            file_vec: &mut Vec<FileWithAnnotatedLines>,
+            file: Lrc<SourceFile>,
+            line_index: usize,
+            ann: Annotation,
+        ) {
             for slot in file_vec.iter_mut() {
                 // Look through each of our files for the one we're adding to
                 if slot.file.name == file.name {
@@ -1704,10 +1722,7 @@ impl FileWithAnnotatedLines {
                         }
                     }
                     // We don't have a line yet, create one
-                    slot.lines.push(Line {
-                        line_index,
-                        annotations: vec![ann],
-                    });
+                    slot.lines.push(Line { line_index, annotations: vec![ann] });
                     slot.lines.sort();
                     return;
                 }
@@ -1715,10 +1730,7 @@ impl FileWithAnnotatedLines {
             // This is the first time we're seeing the file
             file_vec.push(FileWithAnnotatedLines {
                 file,
-                lines: vec![Line {
-                                line_index,
-                                annotations: vec![ann],
-                            }],
+                lines: vec![Line { line_index, annotations: vec![ann] }],
                 multiline_depth: 0,
             });
         }
@@ -1776,8 +1788,8 @@ impl FileWithAnnotatedLines {
             for (_, a) in multiline_annotations.iter_mut() {
                 // Move all other multiline annotations overlapping with this one
                 // one level to the right.
-                if !(ann.same_span(a)) &&
-                    num_overlap(ann.line_start, ann.line_end, a.line_start, a.line_end, true)
+                if !(ann.same_span(a))
+                    && num_overlap(ann.line_start, ann.line_end, a.line_start, a.line_end, true)
                 {
                     a.increase_depth();
                 } else if ann.same_span(a) && &ann != a {
@@ -1788,7 +1800,7 @@ impl FileWithAnnotatedLines {
             }
         }
 
-        let mut max_depth = 0;  // max overlapping multiline spans
+        let mut max_depth = 0; // max overlapping multiline spans
         for (file, ann) in multiline_annotations {
             max_depth = max(max_depth, ann.depth);
             let mut end_ann = ann.as_end();
@@ -1849,15 +1861,23 @@ fn draw_col_separator_no_space(buffer: &mut StyledBuffer, line: usize, col: usiz
     draw_col_separator_no_space_with_style(buffer, line, col, Style::LineNumber);
 }
 
-fn draw_col_separator_no_space_with_style(buffer: &mut StyledBuffer,
-                                          line: usize,
-                                          col: usize,
-                                          style: Style) {
+fn draw_col_separator_no_space_with_style(
+    buffer: &mut StyledBuffer,
+    line: usize,
+    col: usize,
+    style: Style,
+) {
     buffer.putc(line, col, '|', style);
 }
 
-fn draw_range(buffer: &mut StyledBuffer, symbol: char, line: usize,
-              col_from: usize, col_to: usize, style: Style) {
+fn draw_range(
+    buffer: &mut StyledBuffer,
+    symbol: char,
+    line: usize,
+    col_from: usize,
+    col_to: usize,
+    style: Style,
+) {
     for col in col_from..col_to {
         buffer.putc(line, col, symbol, style);
     }
@@ -1867,33 +1887,36 @@ fn draw_note_separator(buffer: &mut StyledBuffer, line: usize, col: usize) {
     buffer.puts(line, col, "= ", Style::LineNumber);
 }
 
-fn draw_multiline_line(buffer: &mut StyledBuffer,
-                       line: usize,
-                       offset: usize,
-                       depth: usize,
-                       style: Style)
-{
+fn draw_multiline_line(
+    buffer: &mut StyledBuffer,
+    line: usize,
+    offset: usize,
+    depth: usize,
+    style: Style,
+) {
     buffer.putc(line, offset + depth - 1, '|', style);
 }
 
-fn num_overlap(a_start: usize, a_end: usize, b_start: usize, b_end:usize, inclusive: bool) -> bool {
-    let extra = if inclusive {
-        1
-    } else {
-        0
-    };
-    (b_start..b_end + extra).contains(&a_start) ||
-    (a_start..a_end + extra).contains(&b_start)
+fn num_overlap(
+    a_start: usize,
+    a_end: usize,
+    b_start: usize,
+    b_end: usize,
+    inclusive: bool,
+) -> bool {
+    let extra = if inclusive { 1 } else { 0 };
+    (b_start..b_end + extra).contains(&a_start) || (a_start..a_end + extra).contains(&b_start)
 }
 fn overlaps(a1: &Annotation, a2: &Annotation, padding: usize) -> bool {
     num_overlap(a1.start_col, a1.end_col + padding, a2.start_col, a2.end_col, false)
 }
 
-fn emit_to_destination(rendered_buffer: &[Vec<StyledString>],
-                       lvl: &Level,
-                       dst: &mut Destination,
-                       short_message: bool)
-                       -> io::Result<()> {
+fn emit_to_destination(
+    rendered_buffer: &[Vec<StyledString>],
+    lvl: &Level,
+    dst: &mut Destination,
+    short_message: bool,
+) -> io::Result<()> {
     use crate::lock;
 
     let mut dst = dst.writable();
@@ -1986,26 +2009,22 @@ impl<'a> WritableDst<'a> {
             Style::MainHeaderMsg => {
                 spec.set_bold(true);
                 if cfg!(windows) {
-                    spec.set_intense(true)
-                        .set_fg(Some(Color::White));
+                    spec.set_intense(true).set_fg(Some(Color::White));
                 }
             }
             Style::UnderlinePrimary | Style::LabelPrimary => {
                 spec = lvl.color();
                 spec.set_bold(true);
             }
-            Style::UnderlineSecondary |
-            Style::LabelSecondary => {
-                spec.set_bold(true)
-                    .set_intense(true);
+            Style::UnderlineSecondary | Style::LabelSecondary => {
+                spec.set_bold(true).set_intense(true);
                 if cfg!(windows) {
                     spec.set_fg(Some(Color::Cyan));
                 } else {
                     spec.set_fg(Some(Color::Blue));
                 }
             }
-            Style::HeaderMsg |
-            Style::NoStyle => {}
+            Style::HeaderMsg | Style::NoStyle => {}
             Style::Level(lvl) => {
                 spec = lvl.color();
                 spec.set_bold(true);
@@ -2022,7 +2041,7 @@ impl<'a> WritableDst<'a> {
             WritableDst::Terminal(ref mut t) => t.set_color(color),
             WritableDst::Buffered(_, ref mut t) => t.set_color(color),
             WritableDst::ColoredRaw(ref mut t) => t.set_color(color),
-            WritableDst::Raw(_) => Ok(())
+            WritableDst::Raw(_) => Ok(()),
         }
     }
 
@@ -2073,9 +2092,11 @@ pub fn is_case_difference(sm: &SourceMap, suggested: &str, sp: Span) -> bool {
     let found = sm.span_to_snippet(sp).unwrap();
     let ascii_confusables = &['c', 'f', 'i', 'k', 'o', 's', 'u', 'v', 'w', 'x', 'y', 'z'];
     // All the chars that differ in capitalization are confusable (above):
-    let confusable = found.chars().zip(suggested.chars()).filter(|(f, s)| f != s).all(|(f, s)| {
-        (ascii_confusables.contains(&f) || ascii_confusables.contains(&s))
-    });
+    let confusable = found
+        .chars()
+        .zip(suggested.chars())
+        .filter(|(f, s)| f != s)
+        .all(|(f, s)| (ascii_confusables.contains(&f) || ascii_confusables.contains(&s)));
     confusable && found.to_lowercase() == suggested.to_lowercase()
             // FIXME: We sometimes suggest the same thing we already have, which is a
             //        bug, but be defensive against that here.

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -1477,6 +1477,11 @@ impl EmitterWriter {
             Some(ref sm) => sm,
             None => return Ok(()),
         };
+        if !suggestion.has_valid_spans(&**sm) {
+            // Suggestions coming from macros can have malformed spans. This is a heavy handed
+            // approach to avoid ICEs by ignoring the suggestion outright.
+            return Ok(());
+        }
 
         let mut buffer = StyledBuffer::new();
 
@@ -1507,7 +1512,9 @@ impl EmitterWriter {
             let show_underline = !(parts.len() == 1 && parts[0].snippet.trim() == complete.trim())
                 && complete.lines().count() == 1;
 
-            let lines = sm.span_to_lines(parts[0].span).unwrap();
+            let lines = sm
+                .span_to_lines(parts[0].span)
+                .expect("span_to_lines failed when emitting suggestion");
 
             assert!(!lines.lines.is_empty());
 

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -3,7 +3,6 @@
 //! This module contains the code for creating and emitting diagnostics.
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
-
 #![feature(crate_visibility_modifier)]
 #![cfg_attr(unix, feature(libc))]
 #![feature(nll)]
@@ -13,31 +12,31 @@ pub use emitter::ColorConfig;
 
 use Level::*;
 
-use emitter::{Emitter, EmitterWriter, is_case_difference};
+use emitter::{is_case_difference, Emitter, EmitterWriter};
 use registry::Registry;
-use rustc_data_structures::sync::{self, Lrc, Lock};
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap};
 use rustc_data_structures::stable_hasher::StableHasher;
+use rustc_data_structures::sync::{self, Lock, Lrc};
 use syntax_pos::source_map::SourceMap;
-use syntax_pos::{Loc, Span, MultiSpan};
+use syntax_pos::{Loc, MultiSpan, Span};
 
 use std::borrow::Cow;
 use std::cell::Cell;
-use std::{error, fmt};
 use std::panic;
 use std::path::Path;
+use std::{error, fmt};
 
-use termcolor::{ColorSpec, Color};
+use termcolor::{Color, ColorSpec};
 
+pub mod annotate_snippet_emitter_writer;
 mod diagnostic;
 mod diagnostic_builder;
 pub mod emitter;
-pub mod annotate_snippet_emitter_writer;
-mod snippet;
-pub mod registry;
-mod styled_buffer;
-mod lock;
 pub mod json;
+mod lock;
+pub mod registry;
+mod snippet;
+mod styled_buffer;
 pub use snippet::Style;
 
 pub type PResult<'a, T> = Result<T, DiagnosticBuilder<'a>>;
@@ -146,16 +145,15 @@ pub struct SubstitutionPart {
 impl CodeSuggestion {
     /// Returns the assembled code suggestions, whether they should be shown with an underline
     /// and whether the substitution only differs in capitalization.
-    pub fn splice_lines(
-        &self,
-        cm: &SourceMap,
-    ) -> Vec<(String, Vec<SubstitutionPart>, bool)> {
+    pub fn splice_lines(&self, cm: &SourceMap) -> Vec<(String, Vec<SubstitutionPart>, bool)> {
         use syntax_pos::{CharPos, Pos};
 
-        fn push_trailing(buf: &mut String,
-                         line_opt: Option<&Cow<'_, str>>,
-                         lo: &Loc,
-                         hi_opt: Option<&Loc>) {
+        fn push_trailing(
+            buf: &mut String,
+            line_opt: Option<&Cow<'_, str>>,
+            lo: &Loc,
+            hi_opt: Option<&Loc>,
+        ) {
             let (lo, hi_opt) = (lo.col.to_usize(), hi_opt.map(|hi| hi.col.to_usize()));
             if let Some(line) = line_opt {
                 if let Some(lo) = line.char_indices().map(|(i, _)| i).nth(lo) {
@@ -174,67 +172,71 @@ impl CodeSuggestion {
 
         assert!(!self.substitutions.is_empty());
 
-        self.substitutions.iter().cloned().map(|mut substitution| {
-            // Assumption: all spans are in the same file, and all spans
-            // are disjoint. Sort in ascending order.
-            substitution.parts.sort_by_key(|part| part.span.lo());
+        self.substitutions
+            .iter()
+            .cloned()
+            .map(|mut substitution| {
+                // Assumption: all spans are in the same file, and all spans
+                // are disjoint. Sort in ascending order.
+                substitution.parts.sort_by_key(|part| part.span.lo());
 
-            // Find the bounding span.
-            let lo = substitution.parts.iter().map(|part| part.span.lo()).min().unwrap();
-            let hi = substitution.parts.iter().map(|part| part.span.hi()).max().unwrap();
-            let bounding_span = Span::with_root_ctxt(lo, hi);
-            let lines = cm.span_to_lines(bounding_span).unwrap();
-            assert!(!lines.lines.is_empty());
+                // Find the bounding span.
+                let lo = substitution.parts.iter().map(|part| part.span.lo()).min().unwrap();
+                let hi = substitution.parts.iter().map(|part| part.span.hi()).max().unwrap();
+                let bounding_span = Span::with_root_ctxt(lo, hi);
+                let lines = cm.span_to_lines(bounding_span).unwrap();
+                assert!(!lines.lines.is_empty());
 
-            // To build up the result, we do this for each span:
-            // - push the line segment trailing the previous span
-            //   (at the beginning a "phantom" span pointing at the start of the line)
-            // - push lines between the previous and current span (if any)
-            // - if the previous and current span are not on the same line
-            //   push the line segment leading up to the current span
-            // - splice in the span substitution
-            //
-            // Finally push the trailing line segment of the last span
-            let fm = &lines.file;
-            let mut prev_hi = cm.lookup_char_pos(bounding_span.lo());
-            prev_hi.col = CharPos::from_usize(0);
+                // To build up the result, we do this for each span:
+                // - push the line segment trailing the previous span
+                //   (at the beginning a "phantom" span pointing at the start of the line)
+                // - push lines between the previous and current span (if any)
+                // - if the previous and current span are not on the same line
+                //   push the line segment leading up to the current span
+                // - splice in the span substitution
+                //
+                // Finally push the trailing line segment of the last span
+                let fm = &lines.file;
+                let mut prev_hi = cm.lookup_char_pos(bounding_span.lo());
+                prev_hi.col = CharPos::from_usize(0);
 
-            let mut prev_line = fm.get_line(lines.lines[0].line_index);
-            let mut buf = String::new();
+                let mut prev_line = fm.get_line(lines.lines[0].line_index);
+                let mut buf = String::new();
 
-            for part in &substitution.parts {
-                let cur_lo = cm.lookup_char_pos(part.span.lo());
-                if prev_hi.line == cur_lo.line {
-                    push_trailing(&mut buf, prev_line.as_ref(), &prev_hi, Some(&cur_lo));
-                } else {
-                    push_trailing(&mut buf, prev_line.as_ref(), &prev_hi, None);
-                    // push lines between the previous and current span (if any)
-                    for idx in prev_hi.line..(cur_lo.line - 1) {
-                        if let Some(line) = fm.get_line(idx) {
-                            buf.push_str(line.as_ref());
-                            buf.push('\n');
+                for part in &substitution.parts {
+                    let cur_lo = cm.lookup_char_pos(part.span.lo());
+                    if prev_hi.line == cur_lo.line {
+                        push_trailing(&mut buf, prev_line.as_ref(), &prev_hi, Some(&cur_lo));
+                    } else {
+                        push_trailing(&mut buf, prev_line.as_ref(), &prev_hi, None);
+                        // push lines between the previous and current span (if any)
+                        for idx in prev_hi.line..(cur_lo.line - 1) {
+                            if let Some(line) = fm.get_line(idx) {
+                                buf.push_str(line.as_ref());
+                                buf.push('\n');
+                            }
+                        }
+                        if let Some(cur_line) = fm.get_line(cur_lo.line - 1) {
+                            let end = std::cmp::min(cur_line.len(), cur_lo.col.to_usize());
+                            buf.push_str(&cur_line[..end]);
                         }
                     }
-                    if let Some(cur_line) = fm.get_line(cur_lo.line - 1) {
-                        let end = std::cmp::min(cur_line.len(), cur_lo.col.to_usize());
-                        buf.push_str(&cur_line[..end]);
-                    }
+                    buf.push_str(&part.snippet);
+                    prev_hi = cm.lookup_char_pos(part.span.hi());
+                    prev_line = fm.get_line(prev_hi.line - 1);
                 }
-                buf.push_str(&part.snippet);
-                prev_hi = cm.lookup_char_pos(part.span.hi());
-                prev_line = fm.get_line(prev_hi.line - 1);
-            }
-            let only_capitalization = is_case_difference(cm, &buf, bounding_span);
-            // if the replacement already ends with a newline, don't print the next line
-            if !buf.ends_with('\n') {
-                push_trailing(&mut buf, prev_line.as_ref(), &prev_hi, None);
-            }
-            // remove trailing newlines
-            while buf.ends_with('\n') {
-                buf.pop();
-            }
-            (buf, substitution.parts, only_capitalization)
-        }).collect()
+                let only_capitalization = is_case_difference(cm, &buf, bounding_span);
+                // if the replacement already ends with a newline, don't print the next line
+                if !buf.ends_with('\n') {
+                    push_trailing(&mut buf, prev_line.as_ref(), &prev_hi, None);
+                }
+                // remove trailing newlines
+                while buf.ends_with('\n') {
+                    buf.pop();
+                }
+                (buf, substitution.parts, only_capitalization)
+            })
+            .collect()
     }
 }
 
@@ -257,7 +259,7 @@ impl error::Error for ExplicitBug {
     }
 }
 
-pub use diagnostic::{Diagnostic, SubDiagnostic, DiagnosticStyledString, DiagnosticId};
+pub use diagnostic::{Diagnostic, DiagnosticId, DiagnosticStyledString, SubDiagnostic};
 pub use diagnostic_builder::DiagnosticBuilder;
 
 /// A handler deals with errors and other compiler output.
@@ -360,11 +362,7 @@ impl Handler {
         Self::with_tty_emitter_and_flags(
             color_config,
             cm,
-            HandlerFlags {
-                can_emit_warnings,
-                treat_err_as_bug,
-                .. Default::default()
-            },
+            HandlerFlags { can_emit_warnings, treat_err_as_bug, ..Default::default() },
         )
     }
 
@@ -391,17 +389,13 @@ impl Handler {
     ) -> Self {
         Handler::with_emitter_and_flags(
             emitter,
-            HandlerFlags {
-                can_emit_warnings,
-                treat_err_as_bug,
-                .. Default::default()
-            },
+            HandlerFlags { can_emit_warnings, treat_err_as_bug, ..Default::default() },
         )
     }
 
     pub fn with_emitter_and_flags(
         emitter: Box<dyn Emitter + sync::Send>,
-        flags: HandlerFlags
+        flags: HandlerFlags,
     ) -> Self {
         Self {
             flags,
@@ -457,7 +451,10 @@ impl Handler {
             old_diag.level = Bug;
             old_diag.note(&format!(
                 "{}:{}: already existing stashed diagnostic with (span = {:?}, key = {:?})",
-                file!(), line!(), span, key
+                file!(),
+                line!(),
+                span,
+                key
             ));
             inner.emit_diag_at_span(old_diag, span);
             panic!(ExplicitBug);
@@ -779,7 +776,7 @@ impl HandlerInner {
         let s = match self.deduplicated_err_count {
             0 => return,
             1 => "aborting due to previous error".to_string(),
-            count => format!("aborting due to {} previous errors", count)
+            count => format!("aborting due to {} previous errors", count),
         };
         if self.treat_err_as_bug() {
             return;
@@ -804,16 +801,22 @@ impl HandlerInner {
                 error_codes.sort();
                 if error_codes.len() > 1 {
                     let limit = if error_codes.len() > 9 { 9 } else { error_codes.len() };
-                    self.failure(&format!("Some errors have detailed explanations: {}{}",
-                                          error_codes[..limit].join(", "),
-                                          if error_codes.len() > 9 { "..." } else { "." }));
-                    self.failure(&format!("For more information about an error, try \
+                    self.failure(&format!(
+                        "Some errors have detailed explanations: {}{}",
+                        error_codes[..limit].join(", "),
+                        if error_codes.len() > 9 { "..." } else { "." }
+                    ));
+                    self.failure(&format!(
+                        "For more information about an error, try \
                                            `rustc --explain {}`.",
-                                          &error_codes[0]));
+                        &error_codes[0]
+                    ));
                 } else {
-                    self.failure(&format!("For more information about this error, try \
+                    self.failure(&format!(
+                        "For more information about this error, try \
                                            `rustc --explain {}`.",
-                                          &error_codes[0]));
+                        &error_codes[0]
+                    ));
                 }
             }
         }
@@ -880,7 +883,7 @@ impl HandlerInner {
     }
 
     /// Emit an error; level should be `Error` or `Fatal`.
-    fn emit_error(&mut self, level: Level, msg: &str,) {
+    fn emit_error(&mut self, level: Level, msg: &str) {
         if self.treat_err_as_bug() {
             self.bug(msg);
         }
@@ -910,13 +913,10 @@ impl HandlerInner {
                 (0, _) => return,
                 (1, 1) => "aborting due to `-Z treat-err-as-bug=1`".to_string(),
                 (1, _) => return,
-                (count, as_bug) => {
-                    format!(
-                        "aborting after {} errors due to `-Z treat-err-as-bug={}`",
-                        count,
-                        as_bug,
-                    )
-                }
+                (count, as_bug) => format!(
+                    "aborting after {} errors due to `-Z treat-err-as-bug={}`",
+                    count, as_bug,
+                ),
             };
             panic!(s);
         }
@@ -946,20 +946,16 @@ impl Level {
         let mut spec = ColorSpec::new();
         match self {
             Bug | Fatal | Error => {
-                spec.set_fg(Some(Color::Red))
-                    .set_intense(true);
+                spec.set_fg(Some(Color::Red)).set_intense(true);
             }
             Warning => {
-                spec.set_fg(Some(Color::Yellow))
-                    .set_intense(cfg!(windows));
+                spec.set_fg(Some(Color::Yellow)).set_intense(cfg!(windows));
             }
             Note => {
-                spec.set_fg(Some(Color::Green))
-                    .set_intense(true);
+                spec.set_fg(Some(Color::Green)).set_intense(true);
             }
             Help => {
-                spec.set_fg(Some(Color::Cyan))
-                    .set_intense(true);
+                spec.set_fg(Some(Color::Cyan)).set_intense(true);
             }
             FailureNote => {}
             Cancelled => unreachable!(),

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -7,10 +7,12 @@ use errors;
 use getopts;
 use rustc::lint::Level;
 use rustc::session;
-use rustc::session::config::{CrateType, parse_crate_types_from_list, parse_externs};
+use rustc::session::config::{
+    build_codegen_options, build_debugging_options, get_cmd_lint_options, host_triple,
+    nightly_options,
+};
+use rustc::session::config::{parse_crate_types_from_list, parse_externs, CrateType};
 use rustc::session::config::{CodegenOptions, DebuggingOptions, ErrorOutputType, Externs};
-use rustc::session::config::{nightly_options, build_codegen_options, build_debugging_options,
-                             get_cmd_lint_options, host_triple};
 use rustc::session::search_paths::SearchPath;
 use rustc_driver;
 use rustc_target::spec::TargetTriple;
@@ -19,8 +21,8 @@ use syntax::edition::{Edition, DEFAULT_EDITION};
 use crate::core::new_handler;
 use crate::externalfiles::ExternalHtml;
 use crate::html;
-use crate::html::{static_files};
-use crate::html::markdown::{IdMap};
+use crate::html::markdown::IdMap;
+use crate::html::static_files;
 use crate::opts;
 use crate::passes::{self, DefaultPassOption};
 use crate::theme;
@@ -29,7 +31,6 @@ use crate::theme;
 #[derive(Clone)]
 pub struct Options {
     // Basic options / Options passed directly to rustc
-
     /// The crate root or Markdown file to load.
     pub input: PathBuf,
     /// The name of the crate being documented.
@@ -72,7 +73,6 @@ pub struct Options {
     pub lint_cap: Option<Level>,
 
     // Options specific to running doctests
-
     /// Whether we should run doctests instead of generating docs.
     pub should_test: bool,
     /// List of arguments to pass to the test harness, if running tests.
@@ -94,7 +94,6 @@ pub struct Options {
     pub test_builder: Option<PathBuf>,
 
     // Options that affect the documentation process
-
     /// The selected default set of passes to use.
     ///
     /// Be aware: This option can come both from the CLI and from crate attributes!
@@ -111,7 +110,6 @@ pub struct Options {
     pub show_coverage: bool,
 
     // Options that alter generated documentation pages
-
     /// Crate version to note on the sidebar of generated docs.
     pub crate_version: Option<String>,
     /// Collected options specific to outputting final pages.
@@ -124,9 +122,7 @@ impl fmt::Debug for Options {
 
         impl<'a> fmt::Debug for FmtExterns<'a> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                f.debug_map()
-                    .entries(self.0.iter())
-                    .finish()
+                f.debug_map().entries(self.0.iter()).finish()
             }
         }
 
@@ -208,7 +204,6 @@ pub struct RenderOptions {
     pub static_root_path: Option<String>,
 
     // Options specific to reading standalone Markdown files
-
     /// Whether to generate a table of contents on the output file when reading a standalone
     /// Markdown file.
     pub markdown_no_toc: bool,
@@ -274,10 +269,12 @@ impl Options {
         let codegen_options = build_codegen_options(matches, error_format);
         let debugging_options = build_debugging_options(matches, error_format);
 
-        let diag = new_handler(error_format,
-                               None,
-                               debugging_options.treat_err_as_bug,
-                               debugging_options.ui_testing);
+        let diag = new_handler(
+            error_format,
+            None,
+            debugging_options.treat_err_as_bug,
+            debugging_options.ui_testing,
+        );
 
         // check for deprecated options
         check_deprecated_options(&matches, &diag);
@@ -317,7 +314,9 @@ impl Options {
         }
         let input = PathBuf::from(&matches.free[0]);
 
-        let libs = matches.opt_strs("L").iter()
+        let libs = matches
+            .opt_strs("L")
+            .iter()
             .map(|s| SearchPath::from_cli_opt(s, error_format))
             .collect();
         let externs = parse_externs(&matches, &debugging_options, error_format);
@@ -330,16 +329,13 @@ impl Options {
         };
 
         let test_args = matches.opt_strs("test-args");
-        let test_args: Vec<String> = test_args.iter()
-                                              .flat_map(|s| s.split_whitespace())
-                                              .map(|s| s.to_string())
-                                              .collect();
+        let test_args: Vec<String> =
+            test_args.iter().flat_map(|s| s.split_whitespace()).map(|s| s.to_string()).collect();
 
         let should_test = matches.opt_present("test");
 
-        let output = matches.opt_str("o")
-                            .map(|s| PathBuf::from(&s))
-                            .unwrap_or_else(|| PathBuf::from("doc"));
+        let output =
+            matches.opt_str("o").map(|s| PathBuf::from(&s)).unwrap_or_else(|| PathBuf::from("doc"));
         let cfgs = matches.opt_strs("cfg");
 
         let extension_css = matches.opt_str("e").map(|s| PathBuf::from(&s));
@@ -355,9 +351,9 @@ impl Options {
         if matches.opt_present("theme") {
             let paths = theme::load_css_paths(static_files::themes::LIGHT.as_bytes());
 
-            for (theme_file, theme_s) in matches.opt_strs("theme")
-                                                .iter()
-                                                .map(|s| (PathBuf::from(&s), s.to_owned())) {
+            for (theme_file, theme_s) in
+                matches.opt_strs("theme").iter().map(|s| (PathBuf::from(&s), s.to_owned()))
+            {
                 if !theme_file.is_file() {
                     diag.struct_err(&format!("invalid argument: \"{}\"", theme_s))
                         .help("arguments to --theme must be files")
@@ -365,8 +361,7 @@ impl Options {
                     return Err(1);
                 }
                 if theme_file.extension() != Some(OsStr::new("css")) {
-                    diag.struct_err(&format!("invalid argument: \"{}\"", theme_s))
-                        .emit();
+                    diag.struct_err(&format!("invalid argument: \"{}\"", theme_s)).emit();
                     return Err(1);
                 }
                 let (success, ret) = theme::test_theme_against(&theme_file, &paths, &diag);
@@ -374,12 +369,18 @@ impl Options {
                     diag.struct_err(&format!("error loading theme file: \"{}\"", theme_s)).emit();
                     return Err(1);
                 } else if !ret.is_empty() {
-                    diag.struct_warn(&format!("theme file \"{}\" is missing CSS rules from the \
-                                               default theme", theme_s))
-                        .warn("the theme may appear incorrect when loaded")
-                        .help(&format!("to see what rules are missing, call `rustdoc \
-                                        --check-theme \"{}\"`", theme_s))
-                        .emit();
+                    diag.struct_warn(&format!(
+                        "theme file \"{}\" is missing CSS rules from the \
+                                               default theme",
+                        theme_s
+                    ))
+                    .warn("the theme may appear incorrect when loaded")
+                    .help(&format!(
+                        "to see what rules are missing, call `rustdoc \
+                                        --check-theme \"{}\"`",
+                        theme_s
+                    ))
+                    .emit();
                 }
                 themes.push(theme_file);
             }
@@ -400,12 +401,16 @@ impl Options {
         let mut id_map = html::markdown::IdMap::new();
         id_map.populate(html::render::initial_ids());
         let external_html = match ExternalHtml::load(
-                &matches.opt_strs("html-in-header"),
-                &matches.opt_strs("html-before-content"),
-                &matches.opt_strs("html-after-content"),
-                &matches.opt_strs("markdown-before-content"),
-                &matches.opt_strs("markdown-after-content"),
-                &diag, &mut id_map, edition, &None) {
+            &matches.opt_strs("html-in-header"),
+            &matches.opt_strs("html-before-content"),
+            &matches.opt_strs("html-after-content"),
+            &matches.opt_strs("markdown-before-content"),
+            &matches.opt_strs("markdown-after-content"),
+            &diag,
+            &mut id_map,
+            edition,
+            &None,
+        ) {
             Some(eh) => eh,
             None => return Err(3),
         };
@@ -434,15 +439,14 @@ impl Options {
             }
         }
 
-        let target = matches.opt_str("target").map_or(
-            TargetTriple::from_triple(host_triple()),
-            |target| {
-            if target.ends_with(".json") {
-                TargetTriple::TargetPath(PathBuf::from(target))
-            } else {
-                TargetTriple::TargetTriple(target)
-            }
-        });
+        let target =
+            matches.opt_str("target").map_or(TargetTriple::from_triple(host_triple()), |target| {
+                if target.ends_with(".json") {
+                    TargetTriple::TargetPath(PathBuf::from(target))
+                } else {
+                    TargetTriple::TargetTriple(target)
+                }
+            });
 
         let show_coverage = matches.opt_present("show-coverage");
         let document_private = matches.opt_present("document-private-items");
@@ -462,7 +466,7 @@ impl Options {
 
         let crate_types = match parse_crate_types_from_list(matches.opt_strs("crate-type")) {
             Ok(types) => types,
-            Err(e) =>{
+            Err(e) => {
                 diag.struct_err(&format!("unknown crate type: {}", e)).emit();
                 return Err(1);
             }
@@ -547,30 +551,24 @@ impl Options {
                 markdown_playground_url,
                 generate_search_filter,
                 generate_redirect_pages,
-            }
+            },
         })
     }
 
     /// Returns `true` if the file given as `self.input` is a Markdown file.
     pub fn markdown_input(&self) -> bool {
-        self.input.extension()
-            .map_or(false, |e| e == "md" || e == "markdown")
+        self.input.extension().map_or(false, |e| e == "md" || e == "markdown")
     }
 }
 
 /// Prints deprecation warnings for deprecated options
 fn check_deprecated_options(matches: &getopts::Matches, diag: &errors::Handler) {
-    let deprecated_flags = [
-       "input-format",
-       "output-format",
-       "no-defaults",
-       "passes",
-    ];
+    let deprecated_flags = ["input-format", "output-format", "no-defaults", "passes"];
 
     for flag in deprecated_flags.iter() {
         if matches.opt_present(flag) {
-            let mut err = diag.struct_warn(&format!("the '{}' flag is considered deprecated",
-                                                    flag));
+            let mut err =
+                diag.struct_warn(&format!("the '{}' flag is considered deprecated", flag));
             err.warn("please see https://github.com/rust-lang/rust/issues/44136");
 
             if *flag == "no-defaults" {
@@ -581,10 +579,7 @@ fn check_deprecated_options(matches: &getopts::Matches, diag: &errors::Handler) 
         }
     }
 
-    let removed_flags = [
-        "plugins",
-        "plugin-path",
-    ];
+    let removed_flags = ["plugins", "plugin-path"];
 
     for &flag in removed_flags.iter() {
         if matches.opt_present(flag) {

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -24,7 +24,7 @@ use crate::html;
 use crate::html::markdown::IdMap;
 use crate::html::static_files;
 use crate::opts;
-use crate::passes::{self, DefaultPassOption};
+use crate::passes::{self, Condition, DefaultPassOption};
 use crate::theme;
 
 /// Configuration options for rustdoc.
@@ -98,6 +98,10 @@ pub struct Options {
     ///
     /// Be aware: This option can come both from the CLI and from crate attributes!
     pub default_passes: DefaultPassOption,
+    /// Document items that have lower than `pub` visibility.
+    pub document_private: bool,
+    /// Document items that have `doc(hidden)`.
+    pub document_hidden: bool,
     /// Any passes manually selected by the user.
     ///
     /// Be aware: This option can come both from the CLI and from crate attributes!
@@ -146,6 +150,8 @@ impl fmt::Debug for Options {
             .field("test_args", &self.test_args)
             .field("persist_doctests", &self.persist_doctests)
             .field("default_passes", &self.default_passes)
+            .field("document_private", &self.document_private)
+            .field("document_hidden", &self.document_hidden)
             .field("manual_passes", &self.manual_passes)
             .field("display_warnings", &self.display_warnings)
             .field("show_coverage", &self.show_coverage)
@@ -240,22 +246,26 @@ impl Options {
                 println!("{:>20} - {}", pass.name, pass.description);
             }
             println!("\nDefault passes for rustdoc:");
-            for pass in passes::DEFAULT_PASSES {
-                println!("{:>20}", pass.name);
-            }
-            println!("\nPasses run with `--document-private-items`:");
-            for pass in passes::DEFAULT_PRIVATE_PASSES {
-                println!("{:>20}", pass.name);
+            for p in passes::DEFAULT_PASSES {
+                print!("{:>20}", p.pass.name);
+                println_condition(p.condition);
             }
 
             if nightly_options::is_nightly_build() {
                 println!("\nPasses run with `--show-coverage`:");
-                for pass in passes::DEFAULT_COVERAGE_PASSES {
-                    println!("{:>20}", pass.name);
+                for p in passes::COVERAGE_PASSES {
+                    print!("{:>20}", p.pass.name);
+                    println_condition(p.condition);
                 }
-                println!("\nPasses run with `--show-coverage --document-private-items`:");
-                for pass in passes::PRIVATE_COVERAGE_PASSES {
-                    println!("{:>20}", pass.name);
+            }
+
+            fn println_condition(condition: Condition) {
+                use Condition::*;
+                match condition {
+                    Always => println!(),
+                    WhenDocumentPrivate => println!("  (when --document-private-items)"),
+                    WhenNotDocumentPrivate => println!("  (when not --document-private-items)"),
+                    WhenNotDocumentHidden => println!("  (when not --document-hidden-items)"),
                 }
             }
 
@@ -449,16 +459,11 @@ impl Options {
             });
 
         let show_coverage = matches.opt_present("show-coverage");
-        let document_private = matches.opt_present("document-private-items");
 
         let default_passes = if matches.opt_present("no-defaults") {
             passes::DefaultPassOption::None
-        } else if show_coverage && document_private {
-            passes::DefaultPassOption::PrivateCoverage
         } else if show_coverage {
             passes::DefaultPassOption::Coverage
-        } else if document_private {
-            passes::DefaultPassOption::Private
         } else {
             passes::DefaultPassOption::Default
         };
@@ -497,6 +502,8 @@ impl Options {
         let runtool = matches.opt_str("runtool");
         let runtool_args = matches.opt_strs("runtool-arg");
         let enable_per_target_ignores = matches.opt_present("enable-per-target-ignores");
+        let document_private = matches.opt_present("document-private-items");
+        let document_hidden = matches.opt_present("document-hidden-items");
 
         let (lint_opts, describe_lints, lint_cap) = get_cmd_lint_options(matches, error_format);
 
@@ -523,6 +530,8 @@ impl Options {
             should_test,
             test_args,
             default_passes,
+            document_private,
+            document_hidden,
             manual_passes,
             display_warnings,
             show_coverage,

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -33,7 +33,7 @@ use crate::clean::{AttributesExt, MAX_DEF_ID};
 use crate::config::{Options as RustdocOptions, RenderOptions};
 use crate::html::render::RenderInfo;
 
-use crate::passes;
+use crate::passes::{self, Condition::*, ConditionalPass};
 
 pub use rustc::session::config::{CodegenOptions, Input, Options};
 pub use rustc::session::search_paths::SearchPath;
@@ -234,6 +234,8 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
         describe_lints,
         lint_cap,
         mut default_passes,
+        mut document_private,
+        document_hidden,
         mut manual_passes,
         display_warnings,
         render_options,
@@ -469,16 +471,14 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
                     }
 
                     if attr.is_word() && name == sym::document_private_items {
-                        if default_passes == passes::DefaultPassOption::Default {
-                            default_passes = passes::DefaultPassOption::Private;
-                        }
+                        document_private = true;
                     }
                 }
 
-                let passes = passes::defaults(default_passes).iter().chain(
+                let passes = passes::defaults(default_passes).iter().copied().chain(
                     manual_passes.into_iter().flat_map(|name| {
                         if let Some(pass) = passes::find_pass(&name) {
-                            Some(pass)
+                            Some(ConditionalPass::always(pass))
                         } else {
                             error!("unknown pass {}, skipping", name);
                             None
@@ -488,9 +488,17 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
 
                 info!("Executing passes");
 
-                for pass in passes {
-                    debug!("running pass {}", pass.name);
-                    krate = (pass.pass)(krate, &ctxt);
+                for p in passes {
+                    let run = match p.condition {
+                        Always => true,
+                        WhenDocumentPrivate => document_private,
+                        WhenNotDocumentPrivate => !document_private,
+                        WhenNotDocumentHidden => !document_hidden,
+                    };
+                    if run {
+                        debug!("running pass {}", p.pass.name);
+                        krate = (p.pass.run)(krate, &ctxt);
+                    }
                 }
 
                 ctxt.sess().abort_if_errors();

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -1,47 +1,46 @@
-use rustc_lint;
-use rustc::session::{self, config};
 use rustc::hir::def::Namespace::TypeNS;
-use rustc::hir::def_id::{DefId, DefIndex, CrateNum, LOCAL_CRATE};
+use rustc::hir::def_id::{CrateNum, DefId, DefIndex, LOCAL_CRATE};
 use rustc::hir::HirId;
+use rustc::lint;
 use rustc::middle::cstore::CrateStore;
 use rustc::middle::privacy::AccessLevels;
-use rustc::ty::{Ty, TyCtxt};
-use rustc::lint;
 use rustc::session::config::ErrorOutputType;
 use rustc::session::DiagnosticOutput;
+use rustc::session::{self, config};
+use rustc::ty::{Ty, TyCtxt};
 use rustc::util::nodemap::{FxHashMap, FxHashSet};
-use rustc_interface::interface;
 use rustc_driver::abort_on_err;
 use rustc_feature::UnstableFeatures;
+use rustc_interface::interface;
+use rustc_lint;
 use rustc_resolve as resolve;
 
-use syntax::ast::CRATE_NODE_ID;
-use syntax::source_map;
-use syntax::attr;
+use errors::emitter::{Emitter, EmitterWriter};
 use errors::json::JsonEmitter;
+use syntax::ast::CRATE_NODE_ID;
+use syntax::attr;
+use syntax::source_map;
 use syntax::symbol::sym;
 use syntax_pos::DUMMY_SP;
-use errors::emitter::{Emitter, EmitterWriter};
 
+use rustc_data_structures::sync::{self, Lrc};
 use std::cell::RefCell;
 use std::mem;
-use rustc_data_structures::sync::{self, Lrc};
 use std::rc::Rc;
 
-use crate::config::{Options as RustdocOptions, RenderOptions};
 use crate::clean;
-use crate::clean::{MAX_DEF_ID, AttributesExt};
+use crate::clean::{AttributesExt, MAX_DEF_ID};
+use crate::config::{Options as RustdocOptions, RenderOptions};
 use crate::html::render::RenderInfo;
 
 use crate::passes;
 
-pub use rustc::session::config::{Input, Options, CodegenOptions};
+pub use rustc::session::config::{CodegenOptions, Input, Options};
 pub use rustc::session::search_paths::SearchPath;
 
 pub type ExternalPaths = FxHashMap<DefId, (Vec<String>, clean::TypeKind)>;
 
 pub struct DocContext<'tcx> {
-
     pub tcx: TyCtxt<'tcx>,
     pub resolver: Rc<RefCell<interface::BoxedResolver>>,
     /// Later on moved into `html::render::CACHE_KEY`
@@ -53,7 +52,6 @@ pub struct DocContext<'tcx> {
     pub active_extern_traits: RefCell<FxHashSet<DefId>>,
     // The current set of type and lifetime substitutions,
     // for expanding type aliases at the HIR level:
-
     /// Table `DefId` of type parameter -> substituted type
     pub ty_substs: RefCell<FxHashMap<DefId, clean::Type>>,
     /// Table `DefId` of lifetime parameter -> substituted lifetime
@@ -76,18 +74,24 @@ impl<'tcx> DocContext<'tcx> {
     }
 
     pub fn enter_resolver<F, R>(&self, f: F) -> R
-    where F: FnOnce(&mut resolve::Resolver<'_>) -> R {
+    where
+        F: FnOnce(&mut resolve::Resolver<'_>) -> R,
+    {
         self.resolver.borrow_mut().access(f)
     }
 
     /// Call the closure with the given parameters set as
     /// the substitutions for a type alias' RHS.
-    pub fn enter_alias<F, R>(&self,
-                             ty_substs: FxHashMap<DefId, clean::Type>,
-                             lt_substs: FxHashMap<DefId, clean::Lifetime>,
-                             ct_substs: FxHashMap<DefId, clean::Constant>,
-                             f: F) -> R
-    where F: FnOnce() -> R {
+    pub fn enter_alias<F, R>(
+        &self,
+        ty_substs: FxHashMap<DefId, clean::Type>,
+        lt_substs: FxHashMap<DefId, clean::Lifetime>,
+        ct_substs: FxHashMap<DefId, clean::Constant>,
+        f: F,
+    ) -> R
+    where
+        F: FnOnce() -> R,
+    {
         let (old_tys, old_lts, old_cts) = (
             mem::replace(&mut *self.ty_substs.borrow_mut(), ty_substs),
             mem::replace(&mut *self.lt_substs.borrow_mut(), lt_substs),
@@ -111,19 +115,12 @@ impl<'tcx> DocContext<'tcx> {
     pub fn next_def_id(&self, crate_num: CrateNum) -> DefId {
         let start_def_id = {
             let next_id = if crate_num == LOCAL_CRATE {
-                self.tcx
-                    .hir()
-                    .definitions()
-                    .def_path_table()
-                    .next_id()
+                self.tcx.hir().definitions().def_path_table().next_id()
             } else {
                 self.enter_resolver(|r| r.cstore().def_path_table(crate_num).next_id())
             };
 
-            DefId {
-                krate: crate_num,
-                index: next_id,
-            }
+            DefId { krate: crate_num, index: next_id }
         };
 
         let mut fake_ids = self.fake_def_ids.borrow_mut();
@@ -131,16 +128,11 @@ impl<'tcx> DocContext<'tcx> {
         let def_id = fake_ids.entry(crate_num).or_insert(start_def_id).clone();
         fake_ids.insert(
             crate_num,
-            DefId {
-                krate: crate_num,
-                index: DefIndex::from(def_id.index.index() + 1),
-            },
+            DefId { krate: crate_num, index: DefIndex::from(def_id.index.index() + 1) },
         );
 
         MAX_DEF_ID.with(|m| {
-            m.borrow_mut()
-                .entry(def_id.krate.clone())
-                .or_insert(start_def_id);
+            m.borrow_mut().entry(def_id.krate.clone()).or_insert(start_def_id);
         });
 
         self.all_fake_def_ids.borrow_mut().insert(def_id);
@@ -159,13 +151,15 @@ impl<'tcx> DocContext<'tcx> {
     }
 
     pub fn stability(&self, id: HirId) -> Option<attr::Stability> {
-        self.tcx.hir().opt_local_def_id(id)
-            .and_then(|def_id| self.tcx.lookup_stability(def_id)).cloned()
+        self.tcx
+            .hir()
+            .opt_local_def_id(id)
+            .and_then(|def_id| self.tcx.lookup_stability(def_id))
+            .cloned()
     }
 
     pub fn deprecation(&self, id: HirId) -> Option<attr::Deprecation> {
-        self.tcx.hir().opt_local_def_id(id)
-            .and_then(|def_id| self.tcx.lookup_deprecation(def_id))
+        self.tcx.hir().opt_local_def_id(id).and_then(|def_id| self.tcx.lookup_deprecation(def_id))
     }
 }
 
@@ -173,10 +167,11 @@ impl<'tcx> DocContext<'tcx> {
 ///
 /// If the given `error_format` is `ErrorOutputType::Json` and no `SourceMap` is given, a new one
 /// will be created for the handler.
-pub fn new_handler(error_format: ErrorOutputType,
-                   source_map: Option<Lrc<source_map::SourceMap>>,
-                   treat_err_as_bug: Option<usize>,
-                   ui_testing: bool,
+pub fn new_handler(
+    error_format: ErrorOutputType,
+    source_map: Option<Lrc<source_map::SourceMap>>,
+    treat_err_as_bug: Option<usize>,
+    ui_testing: bool,
 ) -> errors::Handler {
     // rustdoc doesn't override (or allow to override) anything from this that is relevant here, so
     // stick to the defaults
@@ -192,22 +187,19 @@ pub fn new_handler(error_format: ErrorOutputType,
                     sessopts.debugging_opts.teach,
                     sessopts.debugging_opts.terminal_width,
                     false,
-                ).ui_testing(ui_testing)
+                )
+                .ui_testing(ui_testing),
             )
-        },
+        }
         ErrorOutputType::Json { pretty, json_rendered } => {
-            let source_map = source_map.unwrap_or_else(
-                || Lrc::new(source_map::SourceMap::new(sessopts.file_path_mapping())));
+            let source_map = source_map.unwrap_or_else(|| {
+                Lrc::new(source_map::SourceMap::new(sessopts.file_path_mapping()))
+            });
             Box::new(
-                JsonEmitter::stderr(
-                    None,
-                    source_map,
-                    pretty,
-                    json_rendered,
-                    false,
-                ).ui_testing(ui_testing)
+                JsonEmitter::stderr(None, source_map, pretty, json_rendered, false)
+                    .ui_testing(ui_testing),
             )
-        },
+        }
     };
 
     errors::Handler::with_emitter_and_flags(
@@ -248,9 +240,12 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
         ..
     } = options;
 
-    let extern_names: Vec<String> = externs.iter()
+    let extern_names: Vec<String> = externs
+        .iter()
         .filter(|(_, entry)| entry.add_prelude)
-        .map(|(name, _)| name).cloned().collect();
+        .map(|(name, _)| name)
+        .cloned()
+        .collect();
 
     // Add the doc cfg into the doc build.
     cfgs.push("doc".to_string());
@@ -266,11 +261,13 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
 
     // In addition to those specific lints, we also need to whitelist those given through
     // command line, otherwise they'll get ignored and we don't want that.
-    let mut whitelisted_lints = vec![warnings_lint_name.to_owned(),
-                                     intra_link_resolution_failure_name.to_owned(),
-                                     missing_docs.to_owned(),
-                                     missing_doc_example.to_owned(),
-                                     private_doc_tests.to_owned()];
+    let mut whitelisted_lints = vec![
+        warnings_lint_name.to_owned(),
+        intra_link_resolution_failure_name.to_owned(),
+        missing_docs.to_owned(),
+        missing_doc_example.to_owned(),
+        private_doc_tests.to_owned(),
+    ];
 
     whitelisted_lints.extend(lint_opts.iter().map(|(lint, _)| lint).cloned());
 
@@ -280,24 +277,28 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
             .chain(rustc_lint::SoftLints::get_lints().into_iter())
     };
 
-    let lint_opts = lints().filter_map(|lint| {
-        if lint.name == warnings_lint_name ||
-            lint.name == intra_link_resolution_failure_name {
-            None
-        } else {
-            Some((lint.name_lower(), lint::Allow))
-        }
-    }).chain(lint_opts.into_iter()).collect::<Vec<_>>();
+    let lint_opts = lints()
+        .filter_map(|lint| {
+            if lint.name == warnings_lint_name || lint.name == intra_link_resolution_failure_name {
+                None
+            } else {
+                Some((lint.name_lower(), lint::Allow))
+            }
+        })
+        .chain(lint_opts.into_iter())
+        .collect::<Vec<_>>();
 
-    let lint_caps = lints().filter_map(|lint| {
-        // We don't want to whitelist *all* lints so let's
-        // ignore those ones.
-        if whitelisted_lints.iter().any(|l| &lint.name == l) {
-            None
-        } else {
-            Some((lint::LintId::of(lint), lint::Allow))
-        }
-    }).collect();
+    let lint_caps = lints()
+        .filter_map(|lint| {
+            // We don't want to whitelist *all* lints so let's
+            // ignore those ones.
+            if whitelisted_lints.iter().any(|l| &lint.name == l) {
+                None
+            } else {
+                Some((lint::LintId::of(lint), lint::Allow))
+            }
+        })
+        .collect();
 
     let crate_types = if proc_macro_crate {
         vec![config::CrateType::ProcMacro]
@@ -309,11 +310,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
         maybe_sysroot,
         search_paths: libs,
         crate_types,
-        lint_opts: if !display_warnings {
-            lint_opts
-        } else {
-            vec![]
-        },
+        lint_opts: if !display_warnings { lint_opts } else { vec![] },
         lint_cap: Some(lint_cap.unwrap_or_else(|| lint::Forbid)),
         cg: codegen_options,
         externs,
@@ -344,151 +341,164 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
         registry: rustc_driver::diagnostics_registry(),
     };
 
-    interface::run_compiler_in_existing_thread_pool(config, |compiler| compiler.enter(|queries| {
-        let sess = compiler.session();
+    interface::run_compiler_in_existing_thread_pool(config, |compiler| {
+        compiler.enter(|queries| {
+            let sess = compiler.session();
 
-        // We need to hold on to the complete resolver, so we cause everything to be
-        // cloned for the analysis passes to use. Suboptimal, but necessary in the
-        // current architecture.
-        let resolver = {
-            let parts = abort_on_err(queries.expansion(), sess).peek();
-            let resolver = parts.1.borrow();
+            // We need to hold on to the complete resolver, so we cause everything to be
+            // cloned for the analysis passes to use. Suboptimal, but necessary in the
+            // current architecture.
+            let resolver = {
+                let parts = abort_on_err(queries.expansion(), sess).peek();
+                let resolver = parts.1.borrow();
 
-            // Before we actually clone it, let's force all the extern'd crates to
-            // actually be loaded, just in case they're only referred to inside
-            // intra-doc-links
-            resolver.borrow_mut().access(|resolver| {
-                for extern_name in &extern_names {
-                    resolver.resolve_str_path_error(
-                        DUMMY_SP, extern_name, TypeNS, CRATE_NODE_ID
-                    ).unwrap_or_else(
-                        |()| panic!("Unable to resolve external crate {}", extern_name)
-                    );
-                }
-            });
+                // Before we actually clone it, let's force all the extern'd crates to
+                // actually be loaded, just in case they're only referred to inside
+                // intra-doc-links
+                resolver.borrow_mut().access(|resolver| {
+                    for extern_name in &extern_names {
+                        resolver
+                            .resolve_str_path_error(DUMMY_SP, extern_name, TypeNS, CRATE_NODE_ID)
+                            .unwrap_or_else(|()| {
+                                panic!("Unable to resolve external crate {}", extern_name)
+                            });
+                    }
+                });
 
-            // Now we're good to clone the resolver because everything should be loaded
-            resolver.clone()
-        };
-
-        if sess.has_errors() {
-            sess.fatal("Compilation failed, aborting rustdoc");
-        }
-
-        let mut global_ctxt = abort_on_err(queries.global_ctxt(), sess).take();
-
-        global_ctxt.enter(|tcx| {
-            tcx.analysis(LOCAL_CRATE).ok();
-
-            // Abort if there were any errors so far
-            sess.abort_if_errors();
-
-            let access_levels = tcx.privacy_access_levels(LOCAL_CRATE);
-            // Convert from a HirId set to a DefId set since we don't always have easy access
-            // to the map from defid -> hirid
-            let access_levels = AccessLevels {
-                map: access_levels.map.iter()
-                                    .map(|(&k, &v)| (tcx.hir().local_def_id(k), v))
-                                    .collect()
+                // Now we're good to clone the resolver because everything should be loaded
+                resolver.clone()
             };
 
-            let mut renderinfo = RenderInfo::default();
-            renderinfo.access_levels = access_levels;
-
-            let mut ctxt = DocContext {
-                tcx,
-                resolver,
-                external_traits: Default::default(),
-                active_extern_traits: Default::default(),
-                renderinfo: RefCell::new(renderinfo),
-                ty_substs: Default::default(),
-                lt_substs: Default::default(),
-                ct_substs: Default::default(),
-                impl_trait_bounds: Default::default(),
-                fake_def_ids: Default::default(),
-                all_fake_def_ids: Default::default(),
-                generated_synthetics: Default::default(),
-                auto_traits: tcx.all_traits(LOCAL_CRATE).iter().cloned().filter(|trait_def_id| {
-                    tcx.trait_is_auto(*trait_def_id)
-                }).collect(),
-            };
-            debug!("crate: {:?}", tcx.hir().krate());
-
-            let mut krate = clean::krate(&mut ctxt);
-
-            fn report_deprecated_attr(name: &str, diag: &errors::Handler) {
-                let mut msg = diag.struct_warn(&format!("the `#![doc({})]` attribute is \
-                                                         considered deprecated", name));
-                msg.warn("please see https://github.com/rust-lang/rust/issues/44136");
-
-                if name == "no_default_passes" {
-                    msg.help("you may want to use `#![doc(document_private_items)]`");
-                }
-
-                msg.emit();
+            if sess.has_errors() {
+                sess.fatal("Compilation failed, aborting rustdoc");
             }
 
-            // Process all of the crate attributes, extracting plugin metadata along
-            // with the passes which we are supposed to run.
-            for attr in krate.module.as_ref().unwrap().attrs.lists(sym::doc) {
-                let diag = ctxt.sess().diagnostic();
+            let mut global_ctxt = abort_on_err(queries.global_ctxt(), sess).take();
 
-                let name = attr.name_or_empty();
-                if attr.is_word() {
-                    if name == sym::no_default_passes {
-                        report_deprecated_attr("no_default_passes", diag);
-                        if default_passes == passes::DefaultPassOption::Default {
-                            default_passes = passes::DefaultPassOption::None;
+            global_ctxt.enter(|tcx| {
+                tcx.analysis(LOCAL_CRATE).ok();
+
+                // Abort if there were any errors so far
+                sess.abort_if_errors();
+
+                let access_levels = tcx.privacy_access_levels(LOCAL_CRATE);
+                // Convert from a HirId set to a DefId set since we don't always have easy access
+                // to the map from defid -> hirid
+                let access_levels = AccessLevels {
+                    map: access_levels
+                        .map
+                        .iter()
+                        .map(|(&k, &v)| (tcx.hir().local_def_id(k), v))
+                        .collect(),
+                };
+
+                let mut renderinfo = RenderInfo::default();
+                renderinfo.access_levels = access_levels;
+
+                let mut ctxt = DocContext {
+                    tcx,
+                    resolver,
+                    external_traits: Default::default(),
+                    active_extern_traits: Default::default(),
+                    renderinfo: RefCell::new(renderinfo),
+                    ty_substs: Default::default(),
+                    lt_substs: Default::default(),
+                    ct_substs: Default::default(),
+                    impl_trait_bounds: Default::default(),
+                    fake_def_ids: Default::default(),
+                    all_fake_def_ids: Default::default(),
+                    generated_synthetics: Default::default(),
+                    auto_traits: tcx
+                        .all_traits(LOCAL_CRATE)
+                        .iter()
+                        .cloned()
+                        .filter(|trait_def_id| tcx.trait_is_auto(*trait_def_id))
+                        .collect(),
+                };
+                debug!("crate: {:?}", tcx.hir().krate());
+
+                let mut krate = clean::krate(&mut ctxt);
+
+                fn report_deprecated_attr(name: &str, diag: &errors::Handler) {
+                    let mut msg = diag.struct_warn(&format!(
+                        "the `#![doc({})]` attribute is \
+                                                         considered deprecated",
+                        name
+                    ));
+                    msg.warn("please see https://github.com/rust-lang/rust/issues/44136");
+
+                    if name == "no_default_passes" {
+                        msg.help("you may want to use `#![doc(document_private_items)]`");
+                    }
+
+                    msg.emit();
+                }
+
+                // Process all of the crate attributes, extracting plugin metadata along
+                // with the passes which we are supposed to run.
+                for attr in krate.module.as_ref().unwrap().attrs.lists(sym::doc) {
+                    let diag = ctxt.sess().diagnostic();
+
+                    let name = attr.name_or_empty();
+                    if attr.is_word() {
+                        if name == sym::no_default_passes {
+                            report_deprecated_attr("no_default_passes", diag);
+                            if default_passes == passes::DefaultPassOption::Default {
+                                default_passes = passes::DefaultPassOption::None;
+                            }
+                        }
+                    } else if let Some(value) = attr.value_str() {
+                        let sink = match name {
+                            sym::passes => {
+                                report_deprecated_attr("passes = \"...\"", diag);
+                                &mut manual_passes
+                            }
+                            sym::plugins => {
+                                report_deprecated_attr("plugins = \"...\"", diag);
+                                eprintln!(
+                                    "WARNING: `#![doc(plugins = \"...\")]` \
+                                      no longer functions; see CVE-2018-1000622"
+                                );
+                                continue;
+                            }
+                            _ => continue,
+                        };
+                        for name in value.as_str().split_whitespace() {
+                            sink.push(name.to_string());
                         }
                     }
-                } else if let Some(value) = attr.value_str() {
-                    let sink = match name {
-                        sym::passes => {
-                            report_deprecated_attr("passes = \"...\"", diag);
-                            &mut manual_passes
-                        },
-                        sym::plugins => {
-                            report_deprecated_attr("plugins = \"...\"", diag);
-                            eprintln!("WARNING: `#![doc(plugins = \"...\")]` \
-                                      no longer functions; see CVE-2018-1000622");
-                            continue
-                        },
-                        _ => continue,
-                    };
-                    for name in value.as_str().split_whitespace() {
-                        sink.push(name.to_string());
+
+                    if attr.is_word() && name == sym::document_private_items {
+                        if default_passes == passes::DefaultPassOption::Default {
+                            default_passes = passes::DefaultPassOption::Private;
+                        }
                     }
                 }
 
-                if attr.is_word() && name == sym::document_private_items {
-                    if default_passes == passes::DefaultPassOption::Default {
-                        default_passes = passes::DefaultPassOption::Private;
-                    }
+                let passes = passes::defaults(default_passes).iter().chain(
+                    manual_passes.into_iter().flat_map(|name| {
+                        if let Some(pass) = passes::find_pass(&name) {
+                            Some(pass)
+                        } else {
+                            error!("unknown pass {}, skipping", name);
+                            None
+                        }
+                    }),
+                );
+
+                info!("Executing passes");
+
+                for pass in passes {
+                    debug!("running pass {}", pass.name);
+                    krate = (pass.pass)(krate, &ctxt);
                 }
-            }
 
-            let passes = passes::defaults(default_passes).iter().chain(manual_passes.into_iter()
-                .flat_map(|name| {
-                    if let Some(pass) = passes::find_pass(&name) {
-                        Some(pass)
-                    } else {
-                        error!("unknown pass {}, skipping", name);
-                        None
-                    }
-                }));
+                ctxt.sess().abort_if_errors();
 
-            info!("Executing passes");
-
-            for pass in passes {
-                debug!("running pass {}", pass.name);
-                krate = (pass.pass)(krate, &ctxt);
-            }
-
-            ctxt.sess().abort_if_errors();
-
-            (krate, ctxt.renderinfo.into_inner(), render_options)
+                (krate, ctxt.renderinfo.into_inner(), render_options)
+            })
         })
-    }))
+    })
 }
 
 /// `DefId` or parameter index (`ty::ParamTy.index`) of a synthetic type parameter

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -1,6 +1,7 @@
-#![doc(html_root_url = "https://doc.rust-lang.org/nightly/",
-       html_playground_url = "https://play.rust-lang.org/")]
-
+#![doc(
+    html_root_url = "https://doc.rust-lang.org/nightly/",
+    html_playground_url = "https://play.rust-lang.org/"
+)]
 #![feature(rustc_private)]
 #![feature(arbitrary_self_types)]
 #![feature(box_patterns)]
@@ -16,30 +17,30 @@
 #![feature(drain_filter)]
 #![feature(never_type)]
 #![feature(unicode_internals)]
+#![recursion_limit = "256"]
 
-#![recursion_limit="256"]
-
-extern crate getopts;
 extern crate env_logger;
+extern crate getopts;
 extern crate rustc;
 extern crate rustc_data_structures;
 extern crate rustc_driver;
-extern crate rustc_feature;
 extern crate rustc_error_codes;
+extern crate rustc_feature;
 extern crate rustc_index;
-extern crate rustc_resolve;
-extern crate rustc_lint;
 extern crate rustc_interface;
+extern crate rustc_lexer;
+extern crate rustc_lint;
 extern crate rustc_metadata;
 extern crate rustc_parse;
+extern crate rustc_resolve;
 extern crate rustc_target;
 extern crate rustc_typeck;
-extern crate rustc_lexer;
 extern crate syntax;
 extern crate syntax_expand;
 extern crate syntax_pos;
 extern crate test as testing;
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 extern crate rustc_errors as errors;
 
 use std::default::Default;
@@ -47,8 +48,8 @@ use std::env;
 use std::panic;
 use std::process;
 
-use rustc::session::{early_warn, early_error};
-use rustc::session::config::{ErrorOutputType, RustcOptGroup, make_crate_type_option};
+use rustc::session::config::{make_crate_type_option, ErrorOutputType, RustcOptGroup};
+use rustc::session::{early_error, early_warn};
 
 #[macro_use]
 mod externalfiles;
@@ -60,23 +61,23 @@ mod docfs;
 mod doctree;
 mod fold;
 pub mod html {
-    crate mod highlight;
     crate mod escape;
-    crate mod item_type;
     crate mod format;
+    crate mod highlight;
+    crate mod item_type;
     crate mod layout;
     pub mod markdown;
     crate mod render;
+    crate mod sources;
     crate mod static_files;
     crate mod toc;
-    crate mod sources;
 }
 mod markdown;
 mod passes;
-mod visit_ast;
-mod visit_lib;
 mod test;
 mod theme;
+mod visit_ast;
+mod visit_lib;
 
 struct Output {
     krate: clean::Crate,
@@ -92,29 +93,41 @@ pub fn main() {
     };
     rustc_driver::set_sigpipe_handler();
     env_logger::init_from_env("RUSTDOC_LOG");
-    let res = std::thread::Builder::new().stack_size(thread_stack_size).spawn(move || {
-        get_args().map(|args| main_args(&args)).unwrap_or(1)
-    }).unwrap().join().unwrap_or(rustc_driver::EXIT_FAILURE);
+    let res = std::thread::Builder::new()
+        .stack_size(thread_stack_size)
+        .spawn(move || get_args().map(|args| main_args(&args)).unwrap_or(1))
+        .unwrap()
+        .join()
+        .unwrap_or(rustc_driver::EXIT_FAILURE);
     process::exit(res);
 }
 
 fn get_args() -> Option<Vec<String>> {
-    env::args_os().enumerate()
-        .map(|(i, arg)| arg.into_string().map_err(|arg| {
-             early_warn(ErrorOutputType::default(),
-                        &format!("Argument {} is not valid Unicode: {:?}", i, arg));
-        }).ok())
+    env::args_os()
+        .enumerate()
+        .map(|(i, arg)| {
+            arg.into_string()
+                .map_err(|arg| {
+                    early_warn(
+                        ErrorOutputType::default(),
+                        &format!("Argument {} is not valid Unicode: {:?}", i, arg),
+                    );
+                })
+                .ok()
+        })
         .collect()
 }
 
 fn stable<F>(name: &'static str, f: F) -> RustcOptGroup
-    where F: Fn(&mut getopts::Options) -> &mut getopts::Options + 'static
+where
+    F: Fn(&mut getopts::Options) -> &mut getopts::Options + 'static,
 {
     RustcOptGroup::stable(name, f)
 }
 
 fn unstable<F>(name: &'static str, f: F) -> RustcOptGroup
-    where F: Fn(&mut getopts::Options) -> &mut getopts::Options + 'static
+where
+    F: Fn(&mut getopts::Options) -> &mut getopts::Options + 'static,
 {
     RustcOptGroup::unstable(name, f)
 }
@@ -125,118 +138,127 @@ fn opts() -> Vec<RustcOptGroup> {
         stable("V", |o| o.optflag("V", "version", "print rustdoc's version")),
         stable("v", |o| o.optflag("v", "verbose", "use verbose output")),
         stable("r", |o| {
-            o.optopt("r", "input-format", "the input type of the specified file",
-                     "[rust]")
+            o.optopt("r", "input-format", "the input type of the specified file", "[rust]")
         }),
-        stable("w", |o| {
-            o.optopt("w", "output-format", "the output type to write", "[html]")
-        }),
+        stable("w", |o| o.optopt("w", "output-format", "the output type to write", "[html]")),
         stable("o", |o| o.optopt("o", "output", "where to place the output", "PATH")),
         stable("crate-name", |o| {
             o.optopt("", "crate-name", "specify the name of this crate", "NAME")
         }),
         make_crate_type_option(),
         stable("L", |o| {
-            o.optmulti("L", "library-path", "directory to add to crate search path",
-                       "DIR")
+            o.optmulti("L", "library-path", "directory to add to crate search path", "DIR")
         }),
         stable("cfg", |o| o.optmulti("", "cfg", "pass a --cfg to rustc", "")),
-        stable("extern", |o| {
-            o.optmulti("", "extern", "pass an --extern to rustc", "NAME[=PATH]")
-        }),
+        stable("extern", |o| o.optmulti("", "extern", "pass an --extern to rustc", "NAME[=PATH]")),
         unstable("extern-html-root-url", |o| {
-            o.optmulti("", "extern-html-root-url",
-                       "base URL to use for dependencies", "NAME=URL")
+            o.optmulti("", "extern-html-root-url", "base URL to use for dependencies", "NAME=URL")
         }),
-        stable("plugin-path", |o| {
-            o.optmulti("", "plugin-path", "removed", "DIR")
-        }),
+        stable("plugin-path", |o| o.optmulti("", "plugin-path", "removed", "DIR")),
         stable("C", |o| {
             o.optmulti("C", "codegen", "pass a codegen option to rustc", "OPT[=VALUE]")
         }),
         stable("passes", |o| {
-            o.optmulti("", "passes",
-                       "list of passes to also run, you might want \
+            o.optmulti(
+                "",
+                "passes",
+                "list of passes to also run, you might want \
                         to pass it multiple times; a value of `list` \
                         will print available passes",
-                       "PASSES")
+                "PASSES",
+            )
         }),
-        stable("plugins", |o| {
-            o.optmulti("", "plugins", "removed",
-                       "PLUGINS")
-        }),
-        stable("no-default", |o| {
-            o.optflag("", "no-defaults", "don't run the default passes")
-        }),
+        stable("plugins", |o| o.optmulti("", "plugins", "removed", "PLUGINS")),
+        stable("no-default", |o| o.optflag("", "no-defaults", "don't run the default passes")),
         stable("document-private-items", |o| {
             o.optflag("", "document-private-items", "document private items")
         }),
         stable("test", |o| o.optflag("", "test", "run code examples as tests")),
         stable("test-args", |o| {
-            o.optmulti("", "test-args", "arguments to pass to the test runner",
-                       "ARGS")
+            o.optmulti("", "test-args", "arguments to pass to the test runner", "ARGS")
         }),
         stable("target", |o| o.optopt("", "target", "target triple to document", "TRIPLE")),
         stable("markdown-css", |o| {
-            o.optmulti("", "markdown-css",
-                       "CSS files to include via <link> in a rendered Markdown file",
-                       "FILES")
+            o.optmulti(
+                "",
+                "markdown-css",
+                "CSS files to include via <link> in a rendered Markdown file",
+                "FILES",
+            )
         }),
-        stable("html-in-header", |o|  {
-            o.optmulti("", "html-in-header",
-                       "files to include inline in the <head> section of a rendered Markdown file \
+        stable("html-in-header", |o| {
+            o.optmulti(
+                "",
+                "html-in-header",
+                "files to include inline in the <head> section of a rendered Markdown file \
                         or generated documentation",
-                       "FILES")
+                "FILES",
+            )
         }),
         stable("html-before-content", |o| {
-            o.optmulti("", "html-before-content",
-                       "files to include inline between <body> and the content of a rendered \
+            o.optmulti(
+                "",
+                "html-before-content",
+                "files to include inline between <body> and the content of a rendered \
                         Markdown file or generated documentation",
-                       "FILES")
+                "FILES",
+            )
         }),
         stable("html-after-content", |o| {
-            o.optmulti("", "html-after-content",
-                       "files to include inline between the content and </body> of a rendered \
+            o.optmulti(
+                "",
+                "html-after-content",
+                "files to include inline between the content and </body> of a rendered \
                         Markdown file or generated documentation",
-                       "FILES")
+                "FILES",
+            )
         }),
         unstable("markdown-before-content", |o| {
-            o.optmulti("", "markdown-before-content",
-                       "files to include inline between <body> and the content of a rendered \
+            o.optmulti(
+                "",
+                "markdown-before-content",
+                "files to include inline between <body> and the content of a rendered \
                         Markdown file or generated documentation",
-                       "FILES")
+                "FILES",
+            )
         }),
         unstable("markdown-after-content", |o| {
-            o.optmulti("", "markdown-after-content",
-                       "files to include inline between the content and </body> of a rendered \
+            o.optmulti(
+                "",
+                "markdown-after-content",
+                "files to include inline between the content and </body> of a rendered \
                         Markdown file or generated documentation",
-                       "FILES")
+                "FILES",
+            )
         }),
         stable("markdown-playground-url", |o| {
-            o.optopt("", "markdown-playground-url",
-                     "URL to send code snippets to", "URL")
+            o.optopt("", "markdown-playground-url", "URL to send code snippets to", "URL")
         }),
         stable("markdown-no-toc", |o| {
             o.optflag("", "markdown-no-toc", "don't include table of contents")
         }),
         stable("e", |o| {
-            o.optopt("e", "extend-css",
-                     "To add some CSS rules with a given file to generate doc with your \
+            o.optopt(
+                "e",
+                "extend-css",
+                "To add some CSS rules with a given file to generate doc with your \
                       own theme. However, your theme might break if the rustdoc's generated HTML \
-                      changes, so be careful!", "PATH")
+                      changes, so be careful!",
+                "PATH",
+            )
         }),
         unstable("Z", |o| {
-            o.optmulti("Z", "",
-                       "internal and debugging options (only on nightly build)", "FLAG")
+            o.optmulti("Z", "", "internal and debugging options (only on nightly build)", "FLAG")
         }),
-        stable("sysroot", |o| {
-            o.optopt("", "sysroot", "Override the system root", "PATH")
-        }),
+        stable("sysroot", |o| o.optopt("", "sysroot", "Override the system root", "PATH")),
         unstable("playground-url", |o| {
-            o.optopt("", "playground-url",
-                     "URL to send code snippets to, may be reset by --markdown-playground-url \
+            o.optopt(
+                "",
+                "playground-url",
+                "URL to send code snippets to, may be reset by --markdown-playground-url \
                       or `#![doc(html_playground_url=...)]`",
-                     "URL")
+                "URL",
+            )
         }),
         unstable("display-warnings", |o| {
             o.optflag("", "display-warnings", "to print code warnings when testing doc")
@@ -245,69 +267,70 @@ fn opts() -> Vec<RustcOptGroup> {
             o.optopt("", "crate-version", "crate version to print into documentation", "VERSION")
         }),
         unstable("sort-modules-by-appearance", |o| {
-            o.optflag("", "sort-modules-by-appearance", "sort modules by where they appear in the \
-                                                         program, rather than alphabetically")
+            o.optflag(
+                "",
+                "sort-modules-by-appearance",
+                "sort modules by where they appear in the \
+                                                         program, rather than alphabetically",
+            )
         }),
         stable("theme", |o| {
-            o.optmulti("", "theme",
-                       "additional themes which will be added to the generated docs",
-                       "FILES")
+            o.optmulti(
+                "",
+                "theme",
+                "additional themes which will be added to the generated docs",
+                "FILES",
+            )
         }),
         stable("check-theme", |o| {
-            o.optmulti("", "check-theme",
-                       "check if given theme is valid",
-                       "FILES")
+            o.optmulti("", "check-theme", "check if given theme is valid", "FILES")
         }),
         unstable("resource-suffix", |o| {
-            o.optopt("",
-                     "resource-suffix",
-                     "suffix to add to CSS and JavaScript files, e.g., \"light.css\" will become \
+            o.optopt(
+                "",
+                "resource-suffix",
+                "suffix to add to CSS and JavaScript files, e.g., \"light.css\" will become \
                       \"light-suffix.css\"",
-                     "PATH")
+                "PATH",
+            )
         }),
         stable("edition", |o| {
-            o.optopt("", "edition",
-                     "edition to use when compiling rust code (default: 2015)",
-                     "EDITION")
+            o.optopt(
+                "",
+                "edition",
+                "edition to use when compiling rust code (default: 2015)",
+                "EDITION",
+            )
         }),
         stable("color", |o| {
-            o.optopt("",
-                     "color",
-                     "Configure coloring of output:
+            o.optopt(
+                "",
+                "color",
+                "Configure coloring of output:
                                           auto   = colorize, if output goes to a tty (default);
                                           always = always colorize output;
                                           never  = never colorize output",
-                     "auto|always|never")
+                "auto|always|never",
+            )
         }),
         stable("error-format", |o| {
-            o.optopt("",
-                     "error-format",
-                     "How errors and other messages are produced",
-                     "human|json|short")
+            o.optopt(
+                "",
+                "error-format",
+                "How errors and other messages are produced",
+                "human|json|short",
+            )
         }),
         stable("json", |o| {
-            o.optopt("",
-                     "json",
-                     "Configure the structure of JSON diagnostics",
-                     "CONFIG")
+            o.optopt("", "json", "Configure the structure of JSON diagnostics", "CONFIG")
         }),
         unstable("disable-minification", |o| {
-             o.optflag("",
-                       "disable-minification",
-                       "Disable minification applied on JS files")
+            o.optflag("", "disable-minification", "Disable minification applied on JS files")
         }),
-        stable("warn", |o| {
-            o.optmulti("W", "warn", "Set lint warnings", "OPT")
-        }),
-        stable("allow", |o| {
-            o.optmulti("A", "allow", "Set lint allowed", "OPT")
-        }),
-        stable("deny", |o| {
-            o.optmulti("D", "deny", "Set lint denied", "OPT")
-        }),
-        stable("forbid", |o| {
-            o.optmulti("F", "forbid", "Set lint forbidden", "OPT")
-        }),
+        stable("warn", |o| o.optmulti("W", "warn", "Set lint warnings", "OPT")),
+        stable("allow", |o| o.optmulti("A", "allow", "Set lint allowed", "OPT")),
+        stable("deny", |o| o.optmulti("D", "deny", "Set lint denied", "OPT")),
+        stable("forbid", |o| o.optmulti("F", "forbid", "Set lint forbidden", "OPT")),
         stable("cap-lints", |o| {
             o.optmulti(
                 "",
@@ -319,65 +342,78 @@ fn opts() -> Vec<RustcOptGroup> {
             )
         }),
         unstable("index-page", |o| {
-             o.optopt("",
-                      "index-page",
-                      "Markdown file to be used as index page",
-                      "PATH")
+            o.optopt("", "index-page", "Markdown file to be used as index page", "PATH")
         }),
         unstable("enable-index-page", |o| {
-             o.optflag("",
-                       "enable-index-page",
-                       "To enable generation of the index page")
+            o.optflag("", "enable-index-page", "To enable generation of the index page")
         }),
         unstable("static-root-path", |o| {
-            o.optopt("",
-                     "static-root-path",
-                     "Path string to force loading static files from in output pages. \
+            o.optopt(
+                "",
+                "static-root-path",
+                "Path string to force loading static files from in output pages. \
                       If not set, uses combinations of '../' to reach the documentation root.",
-                     "PATH")
+                "PATH",
+            )
         }),
         unstable("disable-per-crate-search", |o| {
-            o.optflag("",
-                      "disable-per-crate-search",
-                      "disables generating the crate selector on the search box")
+            o.optflag(
+                "",
+                "disable-per-crate-search",
+                "disables generating the crate selector on the search box",
+            )
         }),
         unstable("persist-doctests", |o| {
-             o.optopt("",
-                       "persist-doctests",
-                       "Directory to persist doctest executables into",
-                       "PATH")
+            o.optopt(
+                "",
+                "persist-doctests",
+                "Directory to persist doctest executables into",
+                "PATH",
+            )
         }),
         unstable("generate-redirect-pages", |o| {
-            o.optflag("",
-                      "generate-redirect-pages",
-                      "Generate extra pages to support legacy URLs and tool links")
+            o.optflag(
+                "",
+                "generate-redirect-pages",
+                "Generate extra pages to support legacy URLs and tool links",
+            )
         }),
         unstable("show-coverage", |o| {
-            o.optflag("",
-                      "show-coverage",
-                      "calculate percentage of public items with documentation")
+            o.optflag(
+                "",
+                "show-coverage",
+                "calculate percentage of public items with documentation",
+            )
         }),
         unstable("enable-per-target-ignores", |o| {
-            o.optflag("",
-                      "enable-per-target-ignores",
-                      "parse ignore-foo for ignoring doctests on a per-target basis")
+            o.optflag(
+                "",
+                "enable-per-target-ignores",
+                "parse ignore-foo for ignoring doctests on a per-target basis",
+            )
         }),
         unstable("runtool", |o| {
-            o.optopt("",
-                     "runtool",
-                     "",
-                     "The tool to run tests with when building for a different target than host")
+            o.optopt(
+                "",
+                "runtool",
+                "",
+                "The tool to run tests with when building for a different target than host",
+            )
         }),
         unstable("runtool-arg", |o| {
-            o.optmulti("",
-                       "runtool-arg",
-                       "",
-                       "One (of possibly many) arguments to pass to the runtool")
+            o.optmulti(
+                "",
+                "runtool-arg",
+                "",
+                "One (of possibly many) arguments to pass to the runtool",
+            )
         }),
         unstable("test-builder", |o| {
-            o.optflag("",
-                      "test-builder",
-                      "specified the rustc-like binary to use as the test builder")
+            o.optflag(
+                "",
+                "test-builder",
+                "specified the rustc-like binary to use as the test builder",
+            )
         }),
     ]
 }
@@ -405,33 +441,34 @@ fn main_args(args: &[String]) -> i32 {
         Ok(opts) => opts,
         Err(code) => return code,
     };
-    rustc_interface::interface::default_thread_pool(options.edition, move || {
-        main_options(options)
-    })
+    rustc_interface::interface::default_thread_pool(options.edition, move || main_options(options))
 }
 
 fn main_options(options: config::Options) -> i32 {
-    let diag = core::new_handler(options.error_format,
-                                 None,
-                                 options.debugging_options.treat_err_as_bug,
-                                 options.debugging_options.ui_testing);
+    let diag = core::new_handler(
+        options.error_format,
+        None,
+        options.debugging_options.treat_err_as_bug,
+        options.debugging_options.ui_testing,
+    );
 
     match (options.should_test, options.markdown_input()) {
         (true, true) => return markdown::test(options, &diag),
         (true, false) => return test::run(options),
-        (false, true) => return markdown::render(options.input,
-                                                 options.render_options,
-                                                 &diag,
-                                                 options.edition),
+        (false, true) => {
+            return markdown::render(options.input, options.render_options, &diag, options.edition);
+        }
         (false, false) => {}
     }
 
     // need to move these items separately because we lose them by the time the closure is called,
     // but we can't crates the Handler ahead of time because it's not Send
-    let diag_opts = (options.error_format,
-                     options.debugging_options.treat_err_as_bug,
-                     options.debugging_options.ui_testing,
-                     options.edition);
+    let diag_opts = (
+        options.error_format,
+        options.debugging_options.treat_err_as_bug,
+        options.debugging_options.ui_testing,
+        options.edition,
+    );
     let show_coverage = options.show_coverage;
     rust_input(options, move |out| {
         if show_coverage {
@@ -444,13 +481,7 @@ fn main_options(options: config::Options) -> i32 {
         info!("going to format");
         let (error_format, treat_err_as_bug, ui_testing, edition) = diag_opts;
         let diag = core::new_handler(error_format, None, treat_err_as_bug, ui_testing);
-        match html::render::run(
-            krate,
-            renderopts,
-            renderinfo,
-            &diag,
-            edition,
-        ) {
+        match html::render::run(krate, renderopts, renderinfo, &diag, edition) {
             Ok(_) => rustc_driver::EXIT_SUCCESS,
             Err(e) => {
                 diag.struct_err(&format!("couldn't generate documentation: {}", e.error))
@@ -468,8 +499,9 @@ fn main_options(options: config::Options) -> i32 {
 ///
 /// This form of input will run all of the plug/cleaning passes
 fn rust_input<R, F>(options: config::Options, f: F) -> R
-where R: 'static + Send,
-      F: 'static + Send + FnOnce(Output) -> R
+where
+    R: 'static + Send,
+    F: 'static + Send + FnOnce(Output) -> R,
 {
     // First, parse the crate and extract all relevant information.
     info!("starting to run rustc");
@@ -487,11 +519,7 @@ where R: 'static + Send,
 
         krate.version = crate_version;
 
-        f(Output {
-            krate,
-            renderinfo,
-            renderopts,
-        })
+        f(Output { krate, renderinfo, renderopts })
     });
 
     match result {

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -173,6 +173,9 @@ fn opts() -> Vec<RustcOptGroup> {
         stable("document-private-items", |o| {
             o.optflag("", "document-private-items", "document private items")
         }),
+        unstable("document-hidden-items", |o| {
+            o.optflag("", "document-hidden-items", "document items that have doc(hidden)")
+        }),
         stable("test", |o| o.optflag("", "test", "run code examples as tests")),
         stable("test-args", |o| {
             o.optmulti("", "test-args", "arguments to pass to the test runner", "ARGS")

--- a/src/librustdoc/passes/calculate_doc_coverage.rs
+++ b/src/librustdoc/passes/calculate_doc_coverage.rs
@@ -4,8 +4,8 @@ use crate::fold::{self, DocFolder};
 use crate::passes::Pass;
 
 use syntax::attr;
-use syntax_pos::FileName;
 use syntax::symbol::sym;
+use syntax_pos::FileName;
 
 use std::collections::BTreeMap;
 use std::ops;
@@ -53,10 +53,7 @@ impl ops::Sub for ItemCount {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
-        ItemCount {
-            total: self.total - rhs.total,
-            with_docs: self.with_docs - rhs.with_docs,
-        }
+        ItemCount { total: self.total - rhs.total, with_docs: self.with_docs - rhs.with_docs }
     }
 }
 
@@ -81,13 +78,17 @@ impl CoverageCalculator {
         }
 
         fn print_table_record(name: &str, count: ItemCount, percentage: f64) {
-            println!("| {:<35} | {:>10} | {:>10} | {:>9.1}% |",
-                     name, count.with_docs, count.total, percentage);
+            println!(
+                "| {:<35} | {:>10} | {:>10} | {:>9.1}% |",
+                name, count.with_docs, count.total, percentage
+            );
         }
 
         print_table_line();
-        println!("| {:<35} | {:>10} | {:>10} | {:>10} |",
-                 "File", "Documented", "Total", "Percentage");
+        println!(
+            "| {:<35} | {:>10} | {:>10} | {:>10} |",
+            "File", "Documented", "Total", "Percentage"
+        );
         print_table_line();
 
         for (file, &count) in &self.items {
@@ -97,7 +98,7 @@ impl CoverageCalculator {
                 // FIXME(misdreavus): this needs to count graphemes, and probably also track
                 // double-wide characters...
                 if name.len() > 35 {
-                    name = "...".to_string() + &name[name.len()-32..];
+                    name = "...".to_string() + &name[name.len() - 32..];
                 }
 
                 print_table_record(&name, count, percentage);
@@ -133,7 +134,8 @@ impl fold::DocFolder for CoverageCalculator {
             }
             clean::ImplItem(ref impl_)
                 if attr::contains_name(&i.attrs.other_attrs, sym::automatically_derived)
-                    || impl_.synthetic || impl_.blanket_impl.is_some() =>
+                    || impl_.synthetic
+                    || impl_.blanket_impl.is_some() =>
             {
                 // built-in derives get the `#[automatically_derived]` attribute, and
                 // synthetic/blanket impls are made up by rustdoc and can't be documented
@@ -142,8 +144,12 @@ impl fold::DocFolder for CoverageCalculator {
             }
             clean::ImplItem(ref impl_) => {
                 if let Some(ref tr) = impl_.trait_ {
-                    debug!("impl {:#} for {:#} in {}",
-                        tr.print(), impl_.for_.print(), i.source.filename);
+                    debug!(
+                        "impl {:#} for {:#} in {}",
+                        tr.print(),
+                        impl_.for_.print(),
+                        i.source.filename
+                    );
 
                     // don't count trait impls, the missing-docs lint doesn't so we shouldn't
                     // either
@@ -157,9 +163,7 @@ impl fold::DocFolder for CoverageCalculator {
             }
             _ => {
                 debug!("counting {:?} {:?} in {}", i.type_(), i.name, i.source.filename);
-                self.items.entry(i.source.filename.clone())
-                          .or_default()
-                          .count_item(has_docs);
+                self.items.entry(i.source.filename.clone()).or_default().count_item(has_docs);
             }
         }
 

--- a/src/librustdoc/passes/calculate_doc_coverage.rs
+++ b/src/librustdoc/passes/calculate_doc_coverage.rs
@@ -12,7 +12,7 @@ use std::ops;
 
 pub const CALCULATE_DOC_COVERAGE: Pass = Pass {
     name: "calculate-doc-coverage",
-    pass: calculate_doc_coverage,
+    run: calculate_doc_coverage,
     description: "counts the number of items with and without documentation",
 };
 

--- a/src/librustdoc/passes/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/check_code_block_syntax.rs
@@ -1,9 +1,9 @@
 use errors::Applicability;
-use rustc_parse::lexer::{StringReader as Lexer};
-use syntax::token;
+use rustc_parse::lexer::StringReader as Lexer;
 use syntax::sess::ParseSess;
 use syntax::source_map::FilePathMapping;
-use syntax_pos::{InnerSpan, FileName};
+use syntax::token;
+use syntax_pos::{FileName, InnerSpan};
 
 use crate::clean;
 use crate::core::DocContext;
@@ -38,7 +38,7 @@ impl<'a, 'tcx> SyntaxChecker<'a, 'tcx> {
             let mut only_whitespace = true;
             // even if there is a syntax error, we need to run the lexer over the whole file
             let mut lexer = Lexer::new(&sess, source_file, None);
-            loop  {
+            loop {
                 match lexer.next_token().kind {
                     token::Eof => break,
                     token::Whitespace => (),

--- a/src/librustdoc/passes/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/check_code_block_syntax.rs
@@ -13,7 +13,7 @@ use crate::passes::Pass;
 
 pub const CHECK_CODE_BLOCK_SYNTAX: Pass = Pass {
     name: "check-code-block-syntax",
-    pass: check_code_block_syntax,
+    run: check_code_block_syntax,
     description: "validates syntax inside Rust code blocks",
 };
 

--- a/src/librustdoc/passes/collapse_docs.rs
+++ b/src/librustdoc/passes/collapse_docs.rs
@@ -1,7 +1,7 @@
 use crate::clean::{self, DocFragment, Item};
 use crate::core::DocContext;
 use crate::fold;
-use crate::fold::{DocFolder};
+use crate::fold::DocFolder;
 use crate::passes::Pass;
 
 use std::mem::take;
@@ -56,10 +56,10 @@ fn collapse(doc_strings: &mut Vec<DocFragment>) {
             if curr_kind == DocFragmentKind::Include || curr_kind != new_kind {
                 match curr_frag {
                     DocFragment::SugaredDoc(_, _, ref mut doc_string)
-                        | DocFragment::RawDoc(_, _, ref mut doc_string) => {
-                            // add a newline for extra padding between segments
-                            doc_string.push('\n');
-                        }
+                    | DocFragment::RawDoc(_, _, ref mut doc_string) => {
+                        // add a newline for extra padding between segments
+                        doc_string.push('\n');
+                    }
                     _ => {}
                 }
                 docs.push(curr_frag);
@@ -67,11 +67,11 @@ fn collapse(doc_strings: &mut Vec<DocFragment>) {
             } else {
                 match curr_frag {
                     DocFragment::SugaredDoc(_, ref mut span, ref mut doc_string)
-                        | DocFragment::RawDoc(_, ref mut span, ref mut doc_string) => {
-                            doc_string.push('\n');
-                            doc_string.push_str(frag.as_str());
-                            *span = span.to(frag.span());
-                        }
+                    | DocFragment::RawDoc(_, ref mut span, ref mut doc_string) => {
+                        doc_string.push('\n');
+                        doc_string.push_str(frag.as_str());
+                        *span = span.to(frag.span());
+                    }
                     _ => unreachable!(),
                 }
                 last_frag = Some(curr_frag);

--- a/src/librustdoc/passes/collapse_docs.rs
+++ b/src/librustdoc/passes/collapse_docs.rs
@@ -8,7 +8,7 @@ use std::mem::take;
 
 pub const COLLAPSE_DOCS: Pass = Pass {
     name: "collapse-docs",
-    pass: collapse_docs,
+    run: collapse_docs,
     description: "concatenates all document attributes into one document attribute",
 };
 

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -28,7 +28,7 @@ use super::span_of_attrs;
 
 pub const COLLECT_INTRA_DOC_LINKS: Pass = Pass {
     name: "collect-intra-doc-links",
-    pass: collect_intra_doc_links,
+    run: collect_intra_doc_links,
     description: "reads a crate's documentation to resolve intra-doc-links",
 };
 

--- a/src/librustdoc/passes/collect_trait_impls.rs
+++ b/src/librustdoc/passes/collect_trait_impls.rs
@@ -9,7 +9,7 @@ use syntax::symbol::sym;
 
 pub const COLLECT_TRAIT_IMPLS: Pass = Pass {
     name: "collect-trait-impls",
-    pass: collect_trait_impls,
+    run: collect_trait_impls,
     description: "retrieves trait impls for items in the crate",
 };
 

--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -2,12 +2,12 @@
 //! process.
 
 use rustc::hir::def_id::DefId;
-use rustc::lint as lint;
+use rustc::lint;
 use rustc::middle::privacy::AccessLevels;
 use rustc::util::nodemap::DefIdSet;
 use std::mem;
-use syntax_pos::{DUMMY_SP, InnerSpan, Span};
 use std::ops::Range;
+use syntax_pos::{InnerSpan, Span, DUMMY_SP};
 
 use crate::clean::{self, GetDefId, Item};
 use crate::core::DocContext;
@@ -57,7 +57,6 @@ pub struct Pass {
     pub description: &'static str,
 }
 
-
 /// The full list of passes.
 pub const PASSES: &[Pass] = &[
     CHECK_PRIVATE_ITEMS_DOC_TESTS,
@@ -99,19 +98,12 @@ pub const DEFAULT_PRIVATE_PASSES: &[Pass] = &[
 ];
 
 /// The list of default passes run when `--doc-coverage` is passed to rustdoc.
-pub const DEFAULT_COVERAGE_PASSES: &[Pass] = &[
-    COLLECT_TRAIT_IMPLS,
-    STRIP_HIDDEN,
-    STRIP_PRIVATE,
-    CALCULATE_DOC_COVERAGE,
-];
+pub const DEFAULT_COVERAGE_PASSES: &[Pass] =
+    &[COLLECT_TRAIT_IMPLS, STRIP_HIDDEN, STRIP_PRIVATE, CALCULATE_DOC_COVERAGE];
 
 /// The list of default passes run when `--doc-coverage --document-private-items` is passed to
 /// rustdoc.
-pub const PRIVATE_COVERAGE_PASSES: &[Pass] = &[
-    COLLECT_TRAIT_IMPLS,
-    CALCULATE_DOC_COVERAGE,
-];
+pub const PRIVATE_COVERAGE_PASSES: &[Pass] = &[COLLECT_TRAIT_IMPLS, CALCULATE_DOC_COVERAGE];
 
 /// A shorthand way to refer to which set of passes to use, based on the presence of
 /// `--no-defaults` or `--document-private-items`.
@@ -229,9 +221,7 @@ impl<'a> DocFolder for Stripper<'a> {
             // implementations of traits are always public.
             clean::ImplItem(ref imp) if imp.trait_.is_some() => true,
             // Struct variant fields have inherited visibility
-            clean::VariantItem(clean::Variant {
-                kind: clean::VariantKind::Struct(..),
-            }) => true,
+            clean::VariantItem(clean::Variant { kind: clean::VariantKind::Struct(..) }) => true,
             _ => false,
         };
 
@@ -281,8 +271,10 @@ impl<'a> DocFolder for ImplStripper<'a> {
                 for typaram in generics {
                     if let Some(did) = typaram.def_id() {
                         if did.is_local() && !self.retained.contains(&did) {
-                            debug!("ImplStripper: stripped item in trait's generics; \
-                                    removing impl");
+                            debug!(
+                                "ImplStripper: stripped item in trait's generics; \
+                                    removing impl"
+                            );
                             return None;
                         }
                     }
@@ -298,9 +290,7 @@ struct ImportStripper;
 impl DocFolder for ImportStripper {
     fn fold_item(&mut self, i: Item) -> Option<Item> {
         match i.inner {
-            clean::ExternCrateItem(..) | clean::ImportItem(..)
-                if i.visibility != clean::Public =>
-            {
+            clean::ExternCrateItem(..) | clean::ImportItem(..) if i.visibility != clean::Public => {
                 None
             }
             _ => self.fold_item_recur(i),
@@ -332,9 +322,7 @@ pub fn look_for_tests<'tcx>(
         }
     }
 
-    let mut tests = Tests {
-        found_tests: 0,
-    };
+    let mut tests = Tests { found_tests: 0 };
 
     find_testable_code(&dox, &mut tests, ErrorCodes::No, false);
 
@@ -344,16 +332,19 @@ pub fn look_for_tests<'tcx>(
             lint::builtin::MISSING_DOC_CODE_EXAMPLES,
             hir_id,
             sp,
-            "missing code example in this documentation");
+            "missing code example in this documentation",
+        );
         diag.emit();
-    } else if check_missing_code == false &&
-              tests.found_tests > 0 &&
-              !cx.renderinfo.borrow().access_levels.is_public(item.def_id) {
+    } else if check_missing_code == false
+        && tests.found_tests > 0
+        && !cx.renderinfo.borrow().access_levels.is_public(item.def_id)
+    {
         let mut diag = cx.tcx.struct_span_lint_hir(
             lint::builtin::PRIVATE_DOC_TESTS,
             hir_id,
             span_of_attrs(&item.attrs).unwrap_or(item.source.span()),
-            "documentation test in private item");
+            "documentation test in private item",
+        );
         diag.emit();
     }
 }
@@ -391,11 +382,7 @@ crate fn source_span_for_markdown_range(
         return None;
     }
 
-    let snippet = cx
-        .sess()
-        .source_map()
-        .span_to_snippet(span_of_attrs(attrs)?)
-        .ok()?;
+    let snippet = cx.sess().source_map().span_to_snippet(span_of_attrs(attrs)?).ok()?;
 
     let starting_line = markdown[..md_range.start].matches('\n').count();
     let ending_line = starting_line + markdown[md_range.start..md_range.end].matches('\n').count();

--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -9,6 +9,7 @@ use std::mem;
 use std::ops::Range;
 use syntax_pos::{InnerSpan, Span, DUMMY_SP};
 
+use self::Condition::*;
 use crate::clean::{self, GetDefId, Item};
 use crate::core::DocContext;
 use crate::fold::{DocFolder, StripItem};
@@ -53,8 +54,27 @@ pub use self::calculate_doc_coverage::CALCULATE_DOC_COVERAGE;
 #[derive(Copy, Clone)]
 pub struct Pass {
     pub name: &'static str,
-    pub pass: fn(clean::Crate, &DocContext<'_>) -> clean::Crate,
+    pub run: fn(clean::Crate, &DocContext<'_>) -> clean::Crate,
     pub description: &'static str,
+}
+
+/// In a list of passes, a pass that may or may not need to be run depending on options.
+#[derive(Copy, Clone)]
+pub struct ConditionalPass {
+    pub pass: Pass,
+    pub condition: Condition,
+}
+
+/// How to decide whether to run a conditional pass.
+#[derive(Copy, Clone)]
+pub enum Condition {
+    Always,
+    /// When `--document-private-items` is passed.
+    WhenDocumentPrivate,
+    /// When `--document-private-items` is not passed.
+    WhenNotDocumentPrivate,
+    /// When `--document-hidden-items` is not passed.
+    WhenNotDocumentHidden,
 }
 
 /// The full list of passes.
@@ -73,63 +93,58 @@ pub const PASSES: &[Pass] = &[
 ];
 
 /// The list of passes run by default.
-pub const DEFAULT_PASSES: &[Pass] = &[
-    COLLECT_TRAIT_IMPLS,
-    COLLAPSE_DOCS,
-    UNINDENT_COMMENTS,
-    CHECK_PRIVATE_ITEMS_DOC_TESTS,
-    STRIP_HIDDEN,
-    STRIP_PRIVATE,
-    COLLECT_INTRA_DOC_LINKS,
-    CHECK_CODE_BLOCK_SYNTAX,
-    PROPAGATE_DOC_CFG,
-];
-
-/// The list of default passes run with `--document-private-items` is passed to rustdoc.
-pub const DEFAULT_PRIVATE_PASSES: &[Pass] = &[
-    COLLECT_TRAIT_IMPLS,
-    COLLAPSE_DOCS,
-    UNINDENT_COMMENTS,
-    CHECK_PRIVATE_ITEMS_DOC_TESTS,
-    STRIP_PRIV_IMPORTS,
-    COLLECT_INTRA_DOC_LINKS,
-    CHECK_CODE_BLOCK_SYNTAX,
-    PROPAGATE_DOC_CFG,
+pub const DEFAULT_PASSES: &[ConditionalPass] = &[
+    ConditionalPass::always(COLLECT_TRAIT_IMPLS),
+    ConditionalPass::always(COLLAPSE_DOCS),
+    ConditionalPass::always(UNINDENT_COMMENTS),
+    ConditionalPass::always(CHECK_PRIVATE_ITEMS_DOC_TESTS),
+    ConditionalPass::new(STRIP_HIDDEN, WhenNotDocumentHidden),
+    ConditionalPass::new(STRIP_PRIVATE, WhenNotDocumentPrivate),
+    ConditionalPass::new(STRIP_PRIV_IMPORTS, WhenDocumentPrivate),
+    ConditionalPass::always(COLLECT_INTRA_DOC_LINKS),
+    ConditionalPass::always(CHECK_CODE_BLOCK_SYNTAX),
+    ConditionalPass::always(PROPAGATE_DOC_CFG),
 ];
 
 /// The list of default passes run when `--doc-coverage` is passed to rustdoc.
-pub const DEFAULT_COVERAGE_PASSES: &[Pass] =
-    &[COLLECT_TRAIT_IMPLS, STRIP_HIDDEN, STRIP_PRIVATE, CALCULATE_DOC_COVERAGE];
+pub const COVERAGE_PASSES: &[ConditionalPass] = &[
+    ConditionalPass::always(COLLECT_TRAIT_IMPLS),
+    ConditionalPass::new(STRIP_HIDDEN, WhenNotDocumentHidden),
+    ConditionalPass::new(STRIP_PRIVATE, WhenNotDocumentPrivate),
+    ConditionalPass::always(CALCULATE_DOC_COVERAGE),
+];
 
-/// The list of default passes run when `--doc-coverage --document-private-items` is passed to
-/// rustdoc.
-pub const PRIVATE_COVERAGE_PASSES: &[Pass] = &[COLLECT_TRAIT_IMPLS, CALCULATE_DOC_COVERAGE];
+impl ConditionalPass {
+    pub const fn always(pass: Pass) -> Self {
+        Self::new(pass, Always)
+    }
+
+    pub const fn new(pass: Pass, condition: Condition) -> Self {
+        ConditionalPass { pass, condition }
+    }
+}
 
 /// A shorthand way to refer to which set of passes to use, based on the presence of
-/// `--no-defaults` or `--document-private-items`.
+/// `--no-defaults` and `--show-coverage`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum DefaultPassOption {
     Default,
-    Private,
     Coverage,
-    PrivateCoverage,
     None,
 }
 
 /// Returns the given default set of passes.
-pub fn defaults(default_set: DefaultPassOption) -> &'static [Pass] {
+pub fn defaults(default_set: DefaultPassOption) -> &'static [ConditionalPass] {
     match default_set {
         DefaultPassOption::Default => DEFAULT_PASSES,
-        DefaultPassOption::Private => DEFAULT_PRIVATE_PASSES,
-        DefaultPassOption::Coverage => DEFAULT_COVERAGE_PASSES,
-        DefaultPassOption::PrivateCoverage => PRIVATE_COVERAGE_PASSES,
+        DefaultPassOption::Coverage => COVERAGE_PASSES,
         DefaultPassOption::None => &[],
     }
 }
 
 /// If the given name matches a known pass, returns its information.
-pub fn find_pass(pass_name: &str) -> Option<&'static Pass> {
-    PASSES.iter().find(|p| p.name == pass_name)
+pub fn find_pass(pass_name: &str) -> Option<Pass> {
+    PASSES.iter().find(|p| p.name == pass_name).copied()
 }
 
 struct Stripper<'a> {

--- a/src/librustdoc/passes/private_items_doc_tests.rs
+++ b/src/librustdoc/passes/private_items_doc_tests.rs
@@ -5,7 +5,7 @@ use crate::passes::{look_for_tests, Pass};
 
 pub const CHECK_PRIVATE_ITEMS_DOC_TESTS: Pass = Pass {
     name: "check-private-items-doc-tests",
-    pass: check_private_items_doc_tests,
+    run: check_private_items_doc_tests,
     description: "check private items doc tests",
 };
 

--- a/src/librustdoc/passes/private_items_doc_tests.rs
+++ b/src/librustdoc/passes/private_items_doc_tests.rs
@@ -15,9 +15,7 @@ struct PrivateItemDocTestLinter<'a, 'tcx> {
 
 impl<'a, 'tcx> PrivateItemDocTestLinter<'a, 'tcx> {
     fn new(cx: &'a DocContext<'tcx>) -> Self {
-        PrivateItemDocTestLinter {
-            cx,
-        }
+        PrivateItemDocTestLinter { cx }
     }
 }
 

--- a/src/librustdoc/passes/propagate_doc_cfg.rs
+++ b/src/librustdoc/passes/propagate_doc_cfg.rs
@@ -8,7 +8,7 @@ use crate::passes::Pass;
 
 pub const PROPAGATE_DOC_CFG: Pass = Pass {
     name: "propagate-doc-cfg",
-    pass: propagate_doc_cfg,
+    run: propagate_doc_cfg,
     description: "propagates `#[doc(cfg(...))]` to child items",
 };
 

--- a/src/librustdoc/passes/propagate_doc_cfg.rs
+++ b/src/librustdoc/passes/propagate_doc_cfg.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use crate::clean::{Crate, Item};
 use crate::clean::cfg::Cfg;
+use crate::clean::{Crate, Item};
 use crate::core::DocContext;
 use crate::fold::DocFolder;
 use crate::passes::Pass;

--- a/src/librustdoc/passes/strip_hidden.rs
+++ b/src/librustdoc/passes/strip_hidden.rs
@@ -2,8 +2,8 @@ use rustc::util::nodemap::DefIdSet;
 use std::mem;
 use syntax::symbol::sym;
 
-use crate::clean::{self, AttributesExt, NestedAttributesExt};
 use crate::clean::Item;
+use crate::clean::{self, AttributesExt, NestedAttributesExt};
 use crate::core::DocContext;
 use crate::fold::{DocFolder, StripItem};
 use crate::passes::{ImplStripper, Pass};
@@ -20,7 +20,7 @@ pub fn strip_hidden(krate: clean::Crate, _: &DocContext<'_>) -> clean::Crate {
 
     // strip all #[doc(hidden)] items
     let krate = {
-        let mut stripper = Stripper{ retained: &mut retained, update_retained: true };
+        let mut stripper = Stripper { retained: &mut retained, update_retained: true };
         stripper.fold_crate(krate)
     };
 

--- a/src/librustdoc/passes/strip_hidden.rs
+++ b/src/librustdoc/passes/strip_hidden.rs
@@ -10,7 +10,7 @@ use crate::passes::{ImplStripper, Pass};
 
 pub const STRIP_HIDDEN: Pass = Pass {
     name: "strip-hidden",
-    pass: strip_hidden,
+    run: strip_hidden,
     description: "strips all doc(hidden) items from the output",
 };
 

--- a/src/librustdoc/passes/strip_priv_imports.rs
+++ b/src/librustdoc/passes/strip_priv_imports.rs
@@ -1,6 +1,6 @@
 use crate::clean;
-use crate::fold::{DocFolder};
 use crate::core::DocContext;
+use crate::fold::DocFolder;
 use crate::passes::{ImportStripper, Pass};
 
 pub const STRIP_PRIV_IMPORTS: Pass = Pass {
@@ -9,6 +9,6 @@ pub const STRIP_PRIV_IMPORTS: Pass = Pass {
     description: "strips all private import statements (`use`, `extern crate`) from a crate",
 };
 
-pub fn strip_priv_imports(krate: clean::Crate, _: &DocContext<'_>)  -> clean::Crate {
+pub fn strip_priv_imports(krate: clean::Crate, _: &DocContext<'_>) -> clean::Crate {
     ImportStripper.fold_crate(krate)
 }

--- a/src/librustdoc/passes/strip_priv_imports.rs
+++ b/src/librustdoc/passes/strip_priv_imports.rs
@@ -5,7 +5,7 @@ use crate::passes::{ImportStripper, Pass};
 
 pub const STRIP_PRIV_IMPORTS: Pass = Pass {
     name: "strip-priv-imports",
-    pass: strip_priv_imports,
+    run: strip_priv_imports,
     description: "strips all private import statements (`use`, `extern crate`) from a crate",
 };
 

--- a/src/librustdoc/passes/strip_private.rs
+++ b/src/librustdoc/passes/strip_private.rs
@@ -1,9 +1,9 @@
 use rustc::util::nodemap::DefIdSet;
 
 use crate::clean;
-use crate::fold::{DocFolder};
 use crate::core::DocContext;
-use crate::passes::{ImplStripper, ImportStripper, Stripper, Pass};
+use crate::fold::DocFolder;
+use crate::passes::{ImplStripper, ImportStripper, Pass, Stripper};
 
 pub const STRIP_PRIVATE: Pass = Pass {
     name: "strip-private",

--- a/src/librustdoc/passes/strip_private.rs
+++ b/src/librustdoc/passes/strip_private.rs
@@ -7,7 +7,7 @@ use crate::passes::{ImplStripper, ImportStripper, Pass, Stripper};
 
 pub const STRIP_PRIVATE: Pass = Pass {
     name: "strip-private",
-    pass: strip_private,
+    run: strip_private,
     description: "strips all private items from a crate which cannot be seen externally, \
         implies strip-priv-imports",
 };

--- a/src/librustdoc/passes/unindent_comments.rs
+++ b/src/librustdoc/passes/unindent_comments.rs
@@ -38,34 +38,28 @@ impl clean::Attributes {
 fn unindent_fragments(docs: &mut Vec<DocFragment>) {
     for fragment in docs {
         match *fragment {
-            DocFragment::SugaredDoc(_, _, ref mut doc_string) |
-            DocFragment::RawDoc(_, _, ref mut doc_string) |
-            DocFragment::Include(_, _, _, ref mut doc_string) =>
-                *doc_string = unindent(doc_string),
+            DocFragment::SugaredDoc(_, _, ref mut doc_string)
+            | DocFragment::RawDoc(_, _, ref mut doc_string)
+            | DocFragment::Include(_, _, _, ref mut doc_string) => {
+                *doc_string = unindent(doc_string)
+            }
         }
     }
 }
 
 fn unindent(s: &str) -> String {
-    let lines = s.lines().collect::<Vec<&str> >();
+    let lines = s.lines().collect::<Vec<&str>>();
     let mut saw_first_line = false;
     let mut saw_second_line = false;
     let min_indent = lines.iter().fold(usize::MAX, |min_indent, line| {
-
         // After we see the first non-whitespace line, look at
         // the line we have. If it is not whitespace, and therefore
         // part of the first paragraph, then ignore the indentation
         // level of the first line
         let ignore_previous_indents =
-            saw_first_line &&
-            !saw_second_line &&
-            !line.chars().all(|c| c.is_whitespace());
+            saw_first_line && !saw_second_line && !line.chars().all(|c| c.is_whitespace());
 
-        let min_indent = if ignore_previous_indents {
-            usize::MAX
-        } else {
-            min_indent
-        };
+        let min_indent = if ignore_previous_indents { usize::MAX } else { min_indent };
 
         if saw_first_line {
             saw_second_line = true;
@@ -91,15 +85,20 @@ fn unindent(s: &str) -> String {
     });
 
     if !lines.is_empty() {
-        let mut unindented = vec![ lines[0].trim_start().to_string() ];
-        unindented.extend_from_slice(&lines[1..].iter().map(|&line| {
-            if line.chars().all(|c| c.is_whitespace()) {
-                line.to_string()
-            } else {
-                assert!(line.len() >= min_indent);
-                line[min_indent..].to_string()
-            }
-        }).collect::<Vec<_>>());
+        let mut unindented = vec![lines[0].trim_start().to_string()];
+        unindented.extend_from_slice(
+            &lines[1..]
+                .iter()
+                .map(|&line| {
+                    if line.chars().all(|c| c.is_whitespace()) {
+                        line.to_string()
+                    } else {
+                        assert!(line.len() >= min_indent);
+                        line[min_indent..].to_string()
+                    }
+                })
+                .collect::<Vec<_>>(),
+        );
         unindented.join("\n")
     } else {
         s.to_string()

--- a/src/librustdoc/passes/unindent_comments.rs
+++ b/src/librustdoc/passes/unindent_comments.rs
@@ -12,7 +12,7 @@ mod tests;
 
 pub const UNINDENT_COMMENTS: Pass = Pass {
     name: "unindent-comments",
-    pass: unindent_comments,
+    run: unindent_comments,
     description: "removes excess indentation on comments in order for markdown to like it",
 };
 

--- a/src/libsyntax_pos/source_map.rs
+++ b/src/libsyntax_pos/source_map.rs
@@ -493,20 +493,23 @@ impl SourceMap {
         lo.line != hi.line
     }
 
-    pub fn span_to_lines(&self, sp: Span) -> FileLinesResult {
-        debug!("span_to_lines(sp={:?})", sp);
-
+    pub fn is_valid_span(&self, sp: Span) -> Result<(Loc, Loc), SpanLinesError> {
         let lo = self.lookup_char_pos(sp.lo());
         debug!("span_to_lines: lo={:?}", lo);
         let hi = self.lookup_char_pos(sp.hi());
         debug!("span_to_lines: hi={:?}", hi);
-
         if lo.file.start_pos != hi.file.start_pos {
             return Err(SpanLinesError::DistinctSources(DistinctSources {
                 begin: (lo.file.name.clone(), lo.file.start_pos),
                 end: (hi.file.name.clone(), hi.file.start_pos),
             }));
         }
+        Ok((lo, hi))
+    }
+
+    pub fn span_to_lines(&self, sp: Span) -> FileLinesResult {
+        debug!("span_to_lines(sp={:?})", sp);
+        let (lo, hi) = self.is_valid_span(sp)?;
         assert!(hi.line >= lo.line);
 
         let mut lines = Vec::with_capacity(hi.line - lo.line + 1);

--- a/src/test/rustdoc/issue-46380.rs
+++ b/src/test/rustdoc/issue-46380.rs
@@ -1,5 +1,0 @@
-// compile-flags: --document-private-items
-
-// @has issue_46380/struct.Hidden.html
-#[doc(hidden)]
-pub struct Hidden;

--- a/src/test/rustdoc/issue-67851-both.rs
+++ b/src/test/rustdoc/issue-67851-both.rs
@@ -1,0 +1,8 @@
+// compile-flags: -Zunstable-options --document-private-items --document-hidden-items
+
+// @has issue_67851_both/struct.Hidden.html
+#[doc(hidden)]
+pub struct Hidden;
+
+// @has issue_67851_both/struct.Private.html
+struct Private;

--- a/src/test/rustdoc/issue-67851-hidden.rs
+++ b/src/test/rustdoc/issue-67851-hidden.rs
@@ -1,0 +1,8 @@
+// compile-flags: -Zunstable-options --document-hidden-items
+
+// @has issue_67851_hidden/struct.Hidden.html
+#[doc(hidden)]
+pub struct Hidden;
+
+// @!has issue_67851_hidden/struct.Private.html
+struct Private;

--- a/src/test/rustdoc/issue-67851-neither.rs
+++ b/src/test/rustdoc/issue-67851-neither.rs
@@ -1,0 +1,6 @@
+// @!has issue_67851_neither/struct.Hidden.html
+#[doc(hidden)]
+pub struct Hidden;
+
+// @!has issue_67851_neither/struct.Private.html
+struct Private;

--- a/src/test/rustdoc/issue-67851-private.rs
+++ b/src/test/rustdoc/issue-67851-private.rs
@@ -1,0 +1,8 @@
+// compile-flags: --document-private-items
+
+// @!has issue_67851_private/struct.Hidden.html
+#[doc(hidden)]
+pub struct Hidden;
+
+// @has issue_67851_private/struct.Private.html
+struct Private;


### PR DESCRIPTION
This backports:
 * Do not ICE on malformed suggestion spans #68256 
 * Distinguish between private items and hidden items in rustdoc #67875 
 *  Revert parts of #66405. #67471 

It also includes a few formatting commits to permit the backports to proceed cleanly (those are scoped to the relevant files, but still generate noise, of course). This was deemed easier than attempting to manually deal with the formatting.

r? @ghost