### PR TITLE
Minimum lint levels for C-future-compatibility issues: take two

### DIFF
--- a/src/librustc/lint.rs
+++ b/src/librustc/lint.rs
@@ -212,7 +212,6 @@ pub fn struct_lint_level<'a>(
     };
 
     // Check for future incompatibility lints and issue a stronger warning.
-    let lint_id = LintId::of(lint);
     let future_incompatible = lint.future_incompatible;
 
     // If this code originates in a foreign macro, aka something that this crate

--- a/src/librustc/lint.rs
+++ b/src/librustc/lint.rs
@@ -238,7 +238,7 @@ pub fn struct_lint_level<'a>(
     let diag_msg_id = DiagnosticMessageId::from(lint);
     let pre_warn_level = match src {
         LintSource::Default => {
-            let msg = &format!("#[{}({})] on by default", orig_level.as_str(), name);
+            let msg = &format!("`#[{}({})]` on by default", orig_level.as_str(), name);
             sess.diag_note_once(&mut err, diag_msg_id, msg);
             None
         }
@@ -265,7 +265,7 @@ pub fn struct_lint_level<'a>(
             if lint_attr_name.as_str() != name {
                 let level_str = orig_level.as_str();
                 let msg = format!(
-                    "#[{}({})] implied by #[{}({})]",
+                    "`#[{}({})]` implied by `#[{}({})]`",
                     level_str, name, level_str, lint_attr_name
                 );
                 sess.diag_note_once(&mut err, diag_msg_id, &msg);
@@ -313,19 +313,24 @@ pub fn check_future_compatibility<'a>(
                       and may become a hard error in the future",
             );
         } else {
-            let previously_msg = if let Some(n) = name {
-                format!("`{}` was previously accepted by the compiler but is being phased out", n)
-            } else {
-                format!("this was previously accepted by the compiler but is being phased out")
-            };
-            err.warn(&previously_msg);
-
             let hard_err_msg = if let Some(edition) = future_incompatible.edition {
                 format!("it will become a hard error in the {} edition!", edition)
             } else {
                 format!("it will become a hard error in a future release!")
             };
-            err.warn(&hard_err_msg);
+
+            let previously_msg = if let Some(n) = name {
+                format!(
+                    "`{}` was previously accepted by the compiler but is being phased out; {}",
+                    n, hard_err_msg
+                )
+            } else {
+                format!(
+                    "this was previously accepted by the compiler but is being phased out; {}",
+                    hard_err_msg
+                )
+            };
+            err.warn(&previously_msg);
         }
 
         err.note(&format!("for more information, see {}", future_incompatible.reference));

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1050,7 +1050,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnreachablePub {
     }
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     TYPE_ALIAS_BOUNDS,
     Warn,
     "bounds in type aliases are not enforced"

--- a/src/librustc_session/lint.rs
+++ b/src/librustc_session/lint.rs
@@ -343,6 +343,20 @@ macro_rules! declare_unsuppressable_lint {
             report_in_external_macro: false,
         };
     };
+    ($vis: vis $NAME: ident, $Level: ident, $desc: expr,
+     $(@future_incompatible = $fi:expr;)? $($v:ident),*) => (
+        $vis static $NAME: &$crate::lint::Lint = &$crate::lint::Lint {
+            name: stringify!($NAME),
+            default_level: $crate::lint::$Level,
+            min_level: $crate::lint::Warn,
+            desc: $desc,
+            edition_lint_opts: None,
+            is_plugin: false,
+            $($v: true,)*
+            $(future_incompatible: Some($fi),)*
+            ..$crate::lint::Lint::default_fields_for_macro()
+        };
+    );
 }
 
 #[macro_export]

--- a/src/librustc_session/lint.rs
+++ b/src/librustc_session/lint.rs
@@ -50,7 +50,7 @@ impl Level {
         }
     }
 
-    fn level_to_flag(self) -> &'static str {
+    pub fn level_to_flag(self) -> &'static str {
         match self {
             Level::Warn => "-W",
             Level::Deny => "-D",
@@ -115,6 +115,7 @@ impl Lint {
         Lint {
             name: "",
             default_level: Level::Forbid,
+            min_level: Level::Allow,
             desc: "",
             edition_lint_opts: None,
             is_plugin: false,

--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -5,7 +5,7 @@
 //! lints are all available in `rustc_lint::builtin`.
 
 use crate::lint::FutureIncompatibleInfo;
-use crate::{declare_lint, declare_lint_pass};
+use crate::{declare_lint, declare_lint_pass, declare_unsuppressable_lint};
 use rustc_span::edition::Edition;
 
 declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
@@ -320,7 +320,7 @@ declare_lint! {
      };
 }
 
-declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
+declare_unsuppressable_lint! {
     pub ILLEGAL_FLOATING_POINT_LITERAL_PATTERN,
     Warn,
     "floating-point literals cannot be used in patterns",

--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -80,6 +80,7 @@ declare_lint! {
 }
 
 declare_lint! {
+    pub DEAD_CODE,
     Warn,
     "detect unused, unexported items"
 }

--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -8,7 +8,7 @@ use crate::lint::FutureIncompatibleInfo;
 use crate::{declare_lint, declare_lint_pass};
 use rustc_span::edition::Edition;
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub ILL_FORMED_ATTRIBUTE_INPUT,
     Deny,
     "ill-formed attribute inputs that were previously accepted and used in practice",
@@ -78,14 +78,15 @@ declare_lint! {
     Warn,
     "detect assignments that will never be read"
 }
+hings have progressed,
+    //   consider using `declare_unsuppressable_lint!` instead.
 
-declare_lint! {
-    pub DEAD_CODE,
+declare_lint! {his will t
     Warn,
     "detect unused, unexported items"
 }
 
-declare_lint! {
+declare_lint! {    k// - By default, `udeclare_linbt!` is recommended for use to declare the
     pub UNUSED_ATTRIBUTES,
     Warn,
     "detects attributes that were not used by the compiler"
@@ -158,7 +159,7 @@ declare_lint! {
     "detects trivial casts of numeric types which could be removed"
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub PRIVATE_IN_PUBLIC,
     Warn,
     "detect private items in public interfaces not caught by the old implementation",
@@ -184,7 +185,7 @@ declare_lint! {
     };
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub INVALID_TYPE_PARAM_DEFAULT,
     Deny,
     "type parameter default erroneously allowed in invalid location",
@@ -200,7 +201,7 @@ declare_lint! {
     "lints that have been renamed or removed"
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub SAFE_PACKED_BORROWS,
     Warn,
     "safe borrows of fields of packed structs were was erroneously allowed",
@@ -210,7 +211,7 @@ declare_lint! {
     };
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub PATTERNS_IN_FNS_WITHOUT_BODY,
     Deny,
     "patterns in functions without body were erroneously allowed",
@@ -220,7 +221,7 @@ declare_lint! {
     };
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub MISSING_FRAGMENT_SPECIFIER,
     Deny,
     "detects missing fragment specifiers in unused `macro_rules!` patterns",
@@ -230,7 +231,7 @@ declare_lint! {
     };
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub LATE_BOUND_LIFETIME_ARGUMENTS,
     Warn,
     "detects generic lifetime arguments in path segments with late bound lifetime parameters",
@@ -240,7 +241,7 @@ declare_lint! {
     };
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub ORDER_DEPENDENT_TRAIT_OBJECTS,
     Deny,
     "trait-object types were treated as different depending on marker-trait order",
@@ -287,7 +288,7 @@ declare_lint! {
     "detects lifetime parameters that are never used"
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub TYVAR_BEHIND_RAW_POINTER,
     Warn,
     "raw pointer to an inference variable",
@@ -320,7 +321,7 @@ declare_lint! {
      };
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub ILLEGAL_FLOATING_POINT_LITERAL_PATTERN,
     Warn,
     "floating-point literals cannot be used in patterns",
@@ -372,7 +373,7 @@ declare_lint! {
     "detects code samples in docs of private items not documented by rustdoc"
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub WHERE_CLAUSES_OBJECT_SAFETY,
     Warn,
     "checks the object safety of where clauses",
@@ -434,7 +435,7 @@ declare_lint! {
     report_in_external_macro
 }
 
-declare_lint! {
+declare_lint! { // FIXME(centril): consider using `declare_unsuppressable_lint`
     pub AMBIGUOUS_ASSOCIATED_ITEMS,
     Deny,
     "ambiguous associated items",

--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -78,15 +78,13 @@ declare_lint! {
     Warn,
     "detect assignments that will never be read"
 }
-hings have progressed,
-    //   consider using `declare_unsuppressable_lint!` instead.
 
-declare_lint! {his will t
+declare_lint! {
     Warn,
     "detect unused, unexported items"
 }
 
-declare_lint! {    k// - By default, `udeclare_linbt!` is recommended for use to declare the
+declare_lint! {
     pub UNUSED_ATTRIBUTES,
     Warn,
     "detects attributes that were not used by the compiler"

--- a/src/test/ui/half-open-range-patterns/half-open-range-pats-exhaustive-fail.stderr
+++ b/src/test/ui/half-open-range-patterns/half-open-range-pats-exhaustive-fail.stderr
@@ -1,3 +1,19 @@
+warning: floating-point types cannot be used in patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:16:14
+   |
+LL |     m!(0f32, core::f32::NEG_INFINITY..);
+   |              ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:5:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: #[warn(illegal_floating_point_literal_pattern)] is the minimum lint level
+   = note: the lint level cannot be reduced to `allow`
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:16:8
    |
@@ -5,6 +21,15 @@ LL |     m!(0f32, core::f32::NEG_INFINITY..);
    |        ^^^^ pattern `_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:17:16
+   |
+LL |     m!(0f32, ..core::f32::INFINITY);
+   |                ^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:17:8
@@ -541,6 +566,24 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43i128` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:16:14
+   |
+LL |     m!(0f32, core::f32::NEG_INFINITY..);
+   |              ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:17:16
+   |
+LL |     m!(0f32, ..core::f32::INFINITY);
+   |                ^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: aborting due to 68 previous errors
 

--- a/src/test/ui/half-open-range-patterns/half-open-range-pats-hair-lower-empty.stderr
+++ b/src/test/ui/half-open-range-patterns/half-open-range-pats-hair-lower-empty.stderr
@@ -58,11 +58,36 @@ error[E0579]: lower range bound must be less than upper
 LL |     m!(0, ..core::i128::MIN);
    |           ^^^^^^^^^^^^^^^^^
 
+warning: floating-point types cannot be used in patterns
+  --> $DIR/half-open-range-pats-hair-lower-empty.rs:44:16
+   |
+LL |     m!(0f32, ..core::f32::NEG_INFINITY);
+   |                ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/half-open-range-pats-hair-lower-empty.rs:3:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: #[warn(illegal_floating_point_literal_pattern)] is the minimum lint level
+   = note: the lint level cannot be reduced to `allow`
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-hair-lower-empty.rs:44:14
    |
 LL |     m!(0f32, ..core::f32::NEG_INFINITY);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/half-open-range-pats-hair-lower-empty.rs:47:16
+   |
+LL |     m!(0f64, ..core::f64::NEG_INFINITY);
+   |                ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-hair-lower-empty.rs:47:14
@@ -136,11 +161,29 @@ error[E0579]: lower range bound must be less than upper
 LL |     m!(0, ..core::i128::MIN);
    |           ^^^^^^^^^^^^^^^^^
 
+warning: floating-point types cannot be used in patterns
+  --> $DIR/half-open-range-pats-hair-lower-empty.rs:44:16
+   |
+LL |     m!(0f32, ..core::f32::NEG_INFINITY);
+   |                ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-hair-lower-empty.rs:44:14
    |
 LL |     m!(0f32, ..core::f32::NEG_INFINITY);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/half-open-range-pats-hair-lower-empty.rs:47:16
+   |
+LL |     m!(0f64, ..core::f64::NEG_INFINITY);
+   |                ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-hair-lower-empty.rs:47:14

--- a/src/test/ui/pattern/usefulness/non-exhaustive-float-range-match.stderr
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-float-range-match.stderr
@@ -1,3 +1,46 @@
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-float-range-match.rs:6:7
+   |
+LL |       0.0..=1.0 => {}
+   |       ^^^
+   |
+note: lint level defined here
+  --> $DIR/non-exhaustive-float-range-match.rs:1:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: #[warn(illegal_floating_point_literal_pattern)] is the minimum lint level
+   = note: the lint level cannot be reduced to `allow`
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-float-range-match.rs:6:13
+   |
+LL |       0.0..=1.0 => {}
+   |             ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-float-range-match.rs:11:7
+   |
+LL |       0.0..=1.0 => {}
+   |       ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-float-range-match.rs:11:13
+   |
+LL |       0.0..=1.0 => {}
+   |             ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/non-exhaustive-float-range-match.rs:10:11
    |
@@ -5,6 +48,42 @@ LL |     match 0.0 {
    |           ^^^ pattern `_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-float-range-match.rs:6:7
+   |
+LL |       0.0..=1.0 => {}
+   |       ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-float-range-match.rs:6:13
+   |
+LL |       0.0..=1.0 => {}
+   |             ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-float-range-match.rs:11:7
+   |
+LL |       0.0..=1.0 => {}
+   |       ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-float-range-match.rs:11:13
+   |
+LL |       0.0..=1.0 => {}
+   |             ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: aborting due to previous error
 

--- a/src/test/ui/pattern/usefulness/non-exhaustive-match.stderr
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-match.stderr
@@ -66,6 +66,67 @@ LL |     match *vec {
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-match.rs:47:10
+   |
+LL |         [0.1, 0.2, 0.3] => (),
+   |          ^^^
+   |
+note: lint level defined here
+  --> $DIR/non-exhaustive-match.rs:1:10
+   |
+LL | #![allow(illegal_floating_point_literal_pattern)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: #[warn(illegal_floating_point_literal_pattern)] is the minimum lint level
+   = note: the lint level cannot be reduced to `allow`
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-match.rs:47:15
+   |
+LL |         [0.1, 0.2, 0.3] => (),
+   |               ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-match.rs:47:20
+   |
+LL |         [0.1, 0.2, 0.3] => (),
+   |                    ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-match.rs:48:10
+   |
+LL |         [0.1, 0.2] => (),
+   |          ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-match.rs:48:15
+   |
+LL |         [0.1, 0.2] => (),
+   |               ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-match.rs:49:10
+   |
+LL |         [0.1] => (),
+   |          ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
 error[E0004]: non-exhaustive patterns: `[_, _, _, _, ..]` not covered
   --> $DIR/non-exhaustive-match.rs:46:11
    |
@@ -73,6 +134,60 @@ LL |     match *vec {
    |           ^^^^ pattern `[_, _, _, _, ..]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-match.rs:47:10
+   |
+LL |         [0.1, 0.2, 0.3] => (),
+   |          ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-match.rs:47:15
+   |
+LL |         [0.1, 0.2, 0.3] => (),
+   |               ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-match.rs:47:20
+   |
+LL |         [0.1, 0.2, 0.3] => (),
+   |                    ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-match.rs:48:10
+   |
+LL |         [0.1, 0.2] => (),
+   |          ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-match.rs:48:15
+   |
+LL |         [0.1, 0.2] => (),
+   |               ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+warning: floating-point types cannot be used in patterns
+  --> $DIR/non-exhaustive-match.rs:49:10
+   |
+LL |         [0.1] => (),
+   |          ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: aborting due to 8 previous errors
 


### PR DESCRIPTION
This is a revival of https://github.com/rust-lang/rust/pull/59658.

For now, I've just rebased against `master`, and tweaked the output (e.g. added in backticks) to remove unnecessary churn.

It doesn't look like the discussion in https://github.com/rust-lang/rust/pull/59658 arrived at a consensus as to what the exact behavior of this should be. The main options seem to be:

1. For all crates (ignoring `cap-lint`): do not suppress any warning messages, and additional emit a warning whenever `#[allow]` is applied to the future-compat lint. This is the most verbose option, and seems quite spammy.
2. For all crates (ignoring `cap-lint`): emit a single message per lint type, possibly pointing to the span where it occurs.
3. Don't make this change at all.

I'm interested in getting this infrastructure merged in order to support https://github.com/rust-lang/rust/pull/68350 (never-type fallback lint)., I'd like the never-type fallback lint to be deny-by-default while piercing `cap-lints`.