### PR TITLE
Canonicalize inputs to const eval where needed

### DIFF
--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -502,7 +502,7 @@ rustc_queries! {
         /// returns a proper constant that is usable by the rest of the compiler.
         ///
         /// **Do not use this** directly, use one of the following wrappers: `tcx.const_eval_poly`,
-        /// `tcx.const_eval_resolve`, `tcx.const_eval_instance`, or `tcx.const_eval_promoted`.
+        /// `tcx.const_eval_resolve`, `tcx.const_eval_instance`, or `tcx.const_eval_global_id`.
         query const_eval_validated(key: ty::ParamEnvAnd<'tcx, GlobalId<'tcx>>)
             -> ConstEvalResult<'tcx> {
             no_force

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -2488,8 +2488,8 @@ impl<'tcx> Const<'tcx> {
                 // HACK(eddyb) when substs contain e.g. inference variables,
                 // attempt using identity substs instead, that will succeed
                 // when the expression doesn't depend on any parameters.
-                // FIXME(eddyb) make `const_eval` a canonical query instead,
-                // that would properly handle inference variables in `substs`.
+                // FIXME(eddyb, skinny121) pass `InferCtxt` into here when it's available, so that
+                // we can call `infcx.const_eval_resolve` which handles inference variables.
                 if substs.has_local_value() {
                     let identity_substs = InternalSubsts::identity_for_item(tcx, did);
                     // The `ParamEnv` needs to match the `identity_substs`.

--- a/src/librustc_infer/infer/mod.rs
+++ b/src/librustc_infer/infer/mod.rs
@@ -15,6 +15,8 @@ use rustc::infer::unify_key::{ConstVariableOrigin, ConstVariableOriginKind, ToTy
 use rustc::middle::free_region::RegionRelations;
 use rustc::middle::lang_items;
 use rustc::middle::region;
+use rustc::mir;
+use rustc::mir::interpret::ConstEvalResult;
 use rustc::session::config::BorrowckMode;
 use rustc::ty::error::{ExpectedFound, TypeError, UnconstrainedNumeric};
 use rustc::ty::fold::{TypeFoldable, TypeFolder};
@@ -63,6 +65,7 @@ pub mod resolve;
 mod sub;
 pub mod type_variable;
 
+use crate::infer::canonical::OriginalQueryValues;
 pub use rustc::infer::unify_key;
 
 #[must_use]
@@ -1564,6 +1567,35 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         let u = self.universe.get().next_universe();
         self.universe.set(u);
         u
+    }
+
+    /// Resolves and evaluates a constant.
+    ///
+    /// The constant can be located on a trait like `<A as B>::C`, in which case the given
+    /// substitutions and environment are used to resolve the constant. Alternatively if the
+    /// constant has generic parameters in scope the substitutions are used to evaluate the value of
+    /// the constant. For example in `fn foo<T>() { let _ = [0; bar::<T>()]; }` the repeat count
+    /// constant `bar::<T>()` requires a substitution for `T`, if the substitution for `T` is still
+    /// too generic for the constant to be evaluated then `Err(ErrorHandled::TooGeneric)` is
+    /// returned.
+    ///
+    /// This handles inferences variables within both `param_env` and `substs` by
+    /// performing the operation on their respective canonical forms.
+    pub fn const_eval_resolve(
+        &self,
+        param_env: ty::ParamEnv<'tcx>,
+        def_id: DefId,
+        substs: SubstsRef<'tcx>,
+        promoted: Option<mir::Promoted>,
+        span: Option<Span>,
+    ) -> ConstEvalResult<'tcx> {
+        let mut original_values = OriginalQueryValues::default();
+        let canonical = self.canonicalize_query(&(param_env, substs), &mut original_values);
+
+        let (param_env, substs) = canonical.value;
+        // The return value is the evaluated value which doesn't contain any reference to inference
+        // variables, thus we don't need to substitute back the original values.
+        self.tcx.const_eval_resolve(param_env, def_id, substs, promoted, span)
     }
 }
 

--- a/src/librustc_infer/traits/select.rs
+++ b/src/librustc_infer/traits/select.rs
@@ -532,20 +532,15 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             }
 
             ty::Predicate::ConstEvaluatable(def_id, substs) => {
-                if !(obligation.param_env, substs).has_local_value() {
-                    match self.tcx().const_eval_resolve(
-                        obligation.param_env,
-                        def_id,
-                        substs,
-                        None,
-                        None,
-                    ) {
-                        Ok(_) => Ok(EvaluatedToOk),
-                        Err(_) => Ok(EvaluatedToErr),
-                    }
-                } else {
-                    // Inference variables still left in param_env or substs.
-                    Ok(EvaluatedToAmbig)
+                match self.tcx().const_eval_resolve(
+                    obligation.param_env,
+                    def_id,
+                    substs,
+                    None,
+                    None,
+                ) {
+                    Ok(_) => Ok(EvaluatedToOk),
+                    Err(_) => Ok(EvaluatedToErr),
                 }
             }
         }

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -768,11 +768,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         } else {
             self.param_env
         };
-        let val = if let Some(promoted) = gid.promoted {
-            self.tcx.const_eval_promoted(param_env, gid.instance, promoted)?
-        } else {
-            self.tcx.const_eval_instance(param_env, gid.instance, Some(self.tcx.span))?
-        };
+        let val = self.tcx.const_eval_global_id(param_env, gid, Some(self.tcx.span))?;
 
         // Even though `ecx.const_eval` is called from `eval_const_to_op` we can never have a
         // recursion deeper than one level, because the `tcx.const_eval` above is guaranteed to not

--- a/src/test/incremental/const-generics/issue-68477.rs
+++ b/src/test/incremental/const-generics/issue-68477.rs
@@ -1,0 +1,23 @@
+// edition:2018
+// revisions:rpass1
+#![feature(const_generics)]
+
+const FOO: usize = 1;
+
+struct Container<T> {
+    val: std::marker::PhantomData<T>,
+    blah: [(); FOO]
+}
+
+async fn dummy() {}
+
+async fn foo() {
+    let a: Container<&'static ()>;
+    dummy().await;
+}
+
+fn is_send<T: Send>(_: T) {}
+
+fn main() {
+    is_send(foo());
+}


### PR DESCRIPTION
Canonicalize inputs to const eval, so that they can contain inference variables. Which enables invoking const eval queries even if the current param env has inference variable within it, which can occur during trait selection.

This is a reattempt of #67717, in a far less invasive way.

Fixes #68477

r? @nikomatsakis 
cc @eddyb 