### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -211,6 +211,7 @@ Peter Liniker <peter.liniker+github@gmail.com>
 Phil Dawes <phil@phildawes.net> Phil Dawes <pdawes@drw.com>
 Philipp Brüschweiler <blei42@gmail.com> <blei42@gmail.com>
 Philipp Brüschweiler <blei42@gmail.com> <bruphili@student.ethz.ch>
+Philipp Krones <hello@philkrones.com> flip1995 <hello@philkrones.com>
 Philipp Matthias Schäfer <philipp.matthias.schaefer@posteo.de>
 Przemysław Wesołek <jest@go.art.pl> Przemek Wesołek <jest@go.art.pl>
 Rafael Ávila de Espíndola <respindola@mozilla.com> Rafael Avila de Espindola <espindola@dream.(none)>

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -874,7 +874,7 @@ impl<'a> Builder<'a> {
         //
         // Only clear out the directory if we're compiling std; otherwise, we
         // should let Cargo take care of things for us (via depdep info)
-        if !self.config.dry_run && mode == Mode::ToolStd && cmd == "build" {
+        if !self.config.dry_run && mode == Mode::Std && cmd == "build" {
             self.clear_if_dirty(&out_dir, &self.rustc(compiler));
         }
 

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -659,6 +659,24 @@ fn supported_sanitizers(out_dir: &Path, target: Interned<String>) -> Vec<Sanitiz
                 });
             }
         }
+        "x86_64-fuchsia" => {
+            for s in &["asan"] {
+                result.push(SanitizerRuntime {
+                    cmake_target: format!("clang_rt.{}-x86_64", s),
+                    path: out_dir.join(&format!("build/lib/fuchsia/libclang_rt.{}-x86_64.a", s)),
+                    name: format!("librustc_rt.{}.a", s),
+                });
+            }
+        }
+        "aarch64-fuchsia" => {
+            for s in &["asan"] {
+                result.push(SanitizerRuntime {
+                    cmake_target: format!("clang_rt.{}-aarch64", s),
+                    path: out_dir.join(&format!("build/lib/fuchsia/libclang_rt.{}-aarch64.a", s)),
+                    name: format!("librustc_rt.{}.a", s),
+                });
+            }
+        }
         _ => {}
     }
     result

--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -1815,8 +1815,14 @@ where
     }
 
     #[inline]
-    fn count(self) -> usize {
-        self.iter.count().saturating_sub(self.n)
+    fn count(mut self) -> usize {
+        if self.n > 0 {
+            // nth(n) skips n+1
+            if self.iter.nth(self.n - 1).is_none() {
+                return 0;
+            }
+        }
+        self.iter.count()
     }
 
     #[inline]

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -151,6 +151,7 @@ use crate::{
 
 /// The `Option` type. See [the module level documentation](index.html) for more.
 #[derive(Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
+#[rustc_diagnostic_item = "option_type"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub enum Option<T> {
     /// No value

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -242,6 +242,7 @@ use crate::ops::{self, Deref, DerefMut};
 /// [`Err`]: enum.Result.html#variant.Err
 #[derive(Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
 #[must_use = "this `Result` may be an `Err` variant, which should be handled"]
+#[rustc_diagnostic_item = "result_type"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub enum Result<T, E> {
     /// Contains the success value

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2410,7 +2410,7 @@ impl<'tcx> AdtDef {
 
     #[inline]
     pub fn variant_range(&self) -> Range<VariantIdx> {
-        (VariantIdx::new(0)..VariantIdx::new(self.variants.len()))
+        VariantIdx::new(0)..VariantIdx::new(self.variants.len())
     }
 
     /// Computes the discriminant value used by a specific variant.

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -529,7 +529,7 @@ impl<'tcx> GeneratorSubsts<'tcx> {
     pub fn variant_range(&self, def_id: DefId, tcx: TyCtxt<'tcx>) -> Range<VariantIdx> {
         // FIXME requires optimized MIR
         let num_variants = tcx.generator_layout(def_id).variant_fields.len();
-        (VariantIdx::new(0)..VariantIdx::new(num_variants))
+        VariantIdx::new(0)..VariantIdx::new(num_variants)
     }
 
     /// The discriminant for the given variant. Panics if the `variant_index` is

--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -777,7 +777,7 @@ fn link_sanitizer_runtime(sess: &Session, crate_type: config::CrateType, linker:
             linker.args(&["-Wl,-rpath".into(), "-Xlinker".into(), rpath.into()]);
             linker.link_dylib(Symbol::intern(&libname));
         }
-        "x86_64-unknown-linux-gnu" => {
+        "x86_64-unknown-linux-gnu" | "x86_64-fuchsia" | "aarch64-fuchsia" => {
             let filename = format!("librustc_rt.{}.a", name);
             let path = default_tlib.join(&filename);
             linker.link_whole_rlib(&path);

--- a/src/librustc_data_structures/sorted_map.rs
+++ b/src/librustc_data_structures/sorted_map.rs
@@ -132,7 +132,7 @@ impl<K: Ord, V> SortedMap<K, V> {
         R: RangeBounds<K>,
     {
         let (start, end) = self.range_slice_indices(range);
-        (&self.data[start..end])
+        &self.data[start..end]
     }
 
     #[inline]

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -544,12 +544,20 @@ impl EarlyLintPass for UnusedParens {
     }
 
     fn check_stmt(&mut self, cx: &EarlyContext<'_>, s: &ast::Stmt) {
-        if let ast::StmtKind::Local(ref local) = s.kind {
-            self.check_unused_parens_pat(cx, &local.pat, false, false);
+        use ast::StmtKind::*;
 
-            if let Some(ref value) = local.init {
-                self.check_unused_parens_expr(cx, &value, "assigned value", false, None, None);
+        match s.kind {
+            Local(ref local) => {
+                self.check_unused_parens_pat(cx, &local.pat, false, false);
+
+                if let Some(ref value) = local.init {
+                    self.check_unused_parens_expr(cx, &value, "assigned value", false, None, None);
+                }
             }
+            Expr(ref expr) => {
+                self.check_unused_parens_expr(cx, &expr, "block return value", false, None, None);
+            }
+            _ => {}
         }
     }
 

--- a/src/librustc_mir/borrow_check/diagnostics/move_errors.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/move_errors.rs
@@ -2,7 +2,7 @@ use rustc::mir::*;
 use rustc::ty;
 use rustc_errors::{Applicability, DiagnosticBuilder};
 use rustc_span::source_map::DesugaringKind;
-use rustc_span::Span;
+use rustc_span::{Span, Symbol};
 
 use crate::borrow_check::diagnostics::UseSpans;
 use crate::borrow_check::prefixes::PrefixSet;
@@ -384,10 +384,20 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                 }
             }
         };
-        let move_ty = format!("{:?}", move_place.ty(*self.body, self.infcx.tcx).ty,);
         if let Ok(snippet) = self.infcx.tcx.sess.source_map().span_to_snippet(span) {
-            let is_option = move_ty.starts_with("std::option::Option");
-            let is_result = move_ty.starts_with("std::result::Result");
+            let def_id = match move_place.ty(*self.body, self.infcx.tcx).ty.kind {
+                ty::Adt(self_def, _) => self_def.did,
+                ty::Foreign(def_id)
+                | ty::FnDef(def_id, _)
+                | ty::Closure(def_id, _)
+                | ty::Generator(def_id, ..)
+                | ty::Opaque(def_id, _) => def_id,
+                _ => return err,
+            };
+            let is_option =
+                self.infcx.tcx.is_diagnostic_item(Symbol::intern("option_type"), def_id);
+            let is_result =
+                self.infcx.tcx.is_diagnostic_item(Symbol::intern("result_type"), def_id);
             if (is_option || is_result) && use_spans.map_or(true, |v| !v.for_closure()) {
                 err.span_suggestion(
                     span,
@@ -399,12 +409,12 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                     Applicability::MaybeIncorrect,
                 );
             } else if span.is_desugaring(DesugaringKind::ForLoop)
-                && move_ty.starts_with("std::vec::Vec")
+                && self.infcx.tcx.is_diagnostic_item(Symbol::intern("vec_type"), def_id)
             {
                 // FIXME: suggest for anything that implements `IntoIterator`.
                 err.span_suggestion(
                     span,
-                    "consider iterating over a slice of the `Vec`'s content",
+                    "consider iterating over a slice of the `Vec<_>`'s content",
                     format!("&{}", snippet),
                     Applicability::MaybeIncorrect,
                 );

--- a/src/librustc_mir_build/hair/pattern/_match.rs
+++ b/src/librustc_mir_build/hair/pattern/_match.rs
@@ -1530,7 +1530,7 @@ impl<'tcx> IntRange<'tcx> {
         // 2       --------   // 2 -------
         let (lo, hi) = self.boundaries();
         let (other_lo, other_hi) = other.boundaries();
-        (lo == other_hi || hi == other_lo)
+        lo == other_hi || hi == other_lo
     }
 
     fn to_pat(&self, tcx: TyCtxt<'tcx>) -> Pat<'tcx> {

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -1127,8 +1127,12 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
 
     // Sanitizers can only be used on some tested platforms.
     if let Some(ref sanitizer) = sess.opts.debugging_opts.sanitizer {
-        const ASAN_SUPPORTED_TARGETS: &[&str] =
-            &["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-fuchsia", "aarch64-fuchsia" ];
+        const ASAN_SUPPORTED_TARGETS: &[&str] = &[
+            "x86_64-unknown-linux-gnu",
+            "x86_64-apple-darwin",
+            "x86_64-fuchsia",
+            "aarch64-fuchsia",
+        ];
         const TSAN_SUPPORTED_TARGETS: &[&str] =
             &["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"];
         const LSAN_SUPPORTED_TARGETS: &[&str] =

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -1128,7 +1128,7 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
     // Sanitizers can only be used on some tested platforms.
     if let Some(ref sanitizer) = sess.opts.debugging_opts.sanitizer {
         const ASAN_SUPPORTED_TARGETS: &[&str] =
-            &["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"];
+            &["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-fuchsia", "aarch64-fuchsia" ];
         const TSAN_SUPPORTED_TARGETS: &[&str] =
             &["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"];
         const LSAN_SUPPORTED_TARGETS: &[&str] =

--- a/src/librustc_span/source_map.rs
+++ b/src/librustc_span/source_map.rs
@@ -774,10 +774,10 @@ impl SourceMap {
         // searching forwards for boundaries we've got somewhere to search.
         let snippet = if let Some(ref src) = local_begin.sf.src {
             let len = src.len();
-            (&src[start_index..len])
+            &src[start_index..len]
         } else if let Some(src) = src.get_source() {
             let len = src.len();
-            (&src[start_index..len])
+            &src[start_index..len]
         } else {
             return 1;
         };

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1673,8 +1673,15 @@ fn find_opaque_ty_constraints(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
                     ty::Param(_) => true,
                     _ => false,
                 };
-                let bad_substs: Vec<_> =
-                    substs.types().enumerate().filter(|(_, ty)| !is_param(ty)).collect();
+                let bad_substs: Vec<_> = substs
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, k)| {
+                        if let GenericArgKind::Type(ty) = k.unpack() { Some((i, ty)) } else { None }
+                    })
+                    .filter(|(_, ty)| !is_param(ty))
+                    .collect();
+
                 if !bad_substs.is_empty() {
                     let identity_substs = InternalSubsts::identity_for_item(self.tcx, self.def_id);
                     for (i, bad_subst) in bad_substs {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -548,11 +548,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
         let st = match style {
             ast::StrStyle::Cooked => (format!("\"{}\"", st.escape_debug())),
             ast::StrStyle::Raw(n) => {
-                (format!(
-                    "r{delim}\"{string}\"{delim}",
-                    delim = "#".repeat(n as usize),
-                    string = st
-                ))
+                format!("r{delim}\"{string}\"{delim}", delim = "#".repeat(n as usize), string = st)
             }
         };
         self.word(st)

--- a/src/test/ui/iterators/skip-count-overflow.rs
+++ b/src/test/ui/iterators/skip-count-overflow.rs
@@ -1,0 +1,8 @@
+// run-pass
+// only-32bit too impatient for 2⁶⁴ items
+// compile-flags: -C overflow-checks -C opt-level=3
+
+fn main() {
+    let i = (0..usize::max_value()).chain(0..10).skip(usize::max_value());
+    assert_eq!(i.count(), 10);
+}

--- a/src/test/ui/lint/lint-unnecessary-parens.rs
+++ b/src/test/ui/lint/lint-unnecessary-parens.rs
@@ -17,6 +17,13 @@ fn unused_parens_around_return_type() -> (u32) { //~ ERROR unnecessary parenthes
     panic!()
 }
 
+fn unused_parens_around_block_return() -> u32 {
+    let foo = {
+        (5) //~ ERROR unnecessary parentheses around block return value
+    };
+    (5) //~ ERROR unnecessary parentheses around block return value
+}
+
 trait Trait {
     fn test(&self);
 }

--- a/src/test/ui/lint/lint-unnecessary-parens.stderr
+++ b/src/test/ui/lint/lint-unnecessary-parens.stderr
@@ -22,26 +22,38 @@ error: unnecessary parentheses around type
 LL | fn unused_parens_around_return_type() -> (u32) {
    |                                          ^^^^^ help: remove these parentheses
 
+error: unnecessary parentheses around block return value
+  --> $DIR/lint-unnecessary-parens.rs:22:9
+   |
+LL |         (5)
+   |         ^^^ help: remove these parentheses
+
+error: unnecessary parentheses around block return value
+  --> $DIR/lint-unnecessary-parens.rs:24:5
+   |
+LL |     (5)
+   |     ^^^ help: remove these parentheses
+
 error: unnecessary parentheses around function argument
-  --> $DIR/lint-unnecessary-parens.rs:36:9
+  --> $DIR/lint-unnecessary-parens.rs:43:9
    |
 LL |     bar((true));
    |         ^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around `if` condition
-  --> $DIR/lint-unnecessary-parens.rs:38:8
+  --> $DIR/lint-unnecessary-parens.rs:45:8
    |
 LL |     if (true) {}
    |        ^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around `while` condition
-  --> $DIR/lint-unnecessary-parens.rs:39:11
+  --> $DIR/lint-unnecessary-parens.rs:46:11
    |
 LL |     while (true) {}
    |           ^^^^^^ help: remove these parentheses
 
 warning: denote infinite loops with `loop { ... }`
-  --> $DIR/lint-unnecessary-parens.rs:39:5
+  --> $DIR/lint-unnecessary-parens.rs:46:5
    |
 LL |     while (true) {}
    |     ^^^^^^^^^^^^ help: use `loop`
@@ -49,46 +61,46 @@ LL |     while (true) {}
    = note: `#[warn(while_true)]` on by default
 
 error: unnecessary parentheses around `match` head expression
-  --> $DIR/lint-unnecessary-parens.rs:41:11
+  --> $DIR/lint-unnecessary-parens.rs:48:11
    |
 LL |     match (true) {
    |           ^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around `let` head expression
-  --> $DIR/lint-unnecessary-parens.rs:44:16
+  --> $DIR/lint-unnecessary-parens.rs:51:16
    |
 LL |     if let 1 = (1) {}
    |                ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around `let` head expression
-  --> $DIR/lint-unnecessary-parens.rs:45:19
+  --> $DIR/lint-unnecessary-parens.rs:52:19
    |
 LL |     while let 1 = (2) {}
    |                   ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around method argument
-  --> $DIR/lint-unnecessary-parens.rs:59:24
+  --> $DIR/lint-unnecessary-parens.rs:66:24
    |
 LL |     X { y: false }.foo((true));
    |                        ^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around assigned value
-  --> $DIR/lint-unnecessary-parens.rs:61:18
+  --> $DIR/lint-unnecessary-parens.rs:68:18
    |
 LL |     let mut _a = (0);
    |                  ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around assigned value
-  --> $DIR/lint-unnecessary-parens.rs:62:10
+  --> $DIR/lint-unnecessary-parens.rs:69:10
    |
 LL |     _a = (0);
    |          ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around assigned value
-  --> $DIR/lint-unnecessary-parens.rs:63:11
+  --> $DIR/lint-unnecessary-parens.rs:70:11
    |
 LL |     _a += (1);
    |           ^^^ help: remove these parentheses
 
-error: aborting due to 13 previous errors
+error: aborting due to 15 previous errors
 

--- a/src/test/ui/suggestions/for-i-in-vec.fixed
+++ b/src/test/ui/suggestions/for-i-in-vec.fixed
@@ -1,0 +1,15 @@
+// run-rustfix
+#![allow(dead_code)]
+
+struct Foo {
+    v: Vec<u32>,
+}
+
+impl Foo {
+    fn bar(&self) {
+        for _ in &self.v { //~ ERROR cannot move out of `self.v` which is behind a shared reference
+        }
+    }
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/for-i-in-vec.rs
+++ b/src/test/ui/suggestions/for-i-in-vec.rs
@@ -1,0 +1,15 @@
+// run-rustfix
+#![allow(dead_code)]
+
+struct Foo {
+    v: Vec<u32>,
+}
+
+impl Foo {
+    fn bar(&self) {
+        for _ in self.v { //~ ERROR cannot move out of `self.v` which is behind a shared reference
+        }
+    }
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/for-i-in-vec.stderr
+++ b/src/test/ui/suggestions/for-i-in-vec.stderr
@@ -1,0 +1,12 @@
+error[E0507]: cannot move out of `self.v` which is behind a shared reference
+  --> $DIR/for-i-in-vec.rs:10:18
+   |
+LL |         for _ in self.v {
+   |                  ^^^^^^
+   |                  |
+   |                  move occurs because `self.v` has type `std::vec::Vec<u32>`, which does not implement the `Copy` trait
+   |                  help: consider iterating over a slice of the `Vec`'s content: `&self.v`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0507`.

--- a/src/test/ui/suggestions/for-i-in-vec.stderr
+++ b/src/test/ui/suggestions/for-i-in-vec.stderr
@@ -5,7 +5,7 @@ LL |         for _ in self.v {
    |                  ^^^^^^
    |                  |
    |                  move occurs because `self.v` has type `std::vec::Vec<u32>`, which does not implement the `Copy` trait
-   |                  help: consider iterating over a slice of the `Vec`'s content: `&self.v`
+   |                  help: consider iterating over a slice of the `Vec<_>`'s content: `&self.v`
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/issue-68368-non-defining-use.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-68368-non-defining-use.rs
@@ -1,0 +1,13 @@
+// Regression test for issue #68368
+// Ensures that we don't ICE when emitting an error
+// for a non-defining use when lifetimes are involved
+
+#![feature(type_alias_impl_trait)]
+trait Trait<T> {}
+type Alias<'a, U> = impl Trait<U>; //~ ERROR could not find defining uses
+fn f<'a>() -> Alias<'a, ()> {}
+//~^ ERROR defining opaque type use does not fully define opaque type: generic parameter `U`
+
+fn main() {}
+
+impl Trait<()> for () {}

--- a/src/test/ui/type-alias-impl-trait/issue-68368-non-defining-use.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-68368-non-defining-use.stderr
@@ -1,0 +1,14 @@
+error: defining opaque type use does not fully define opaque type: generic parameter `U` is specified as concrete type `()`
+  --> $DIR/issue-68368-non-defining-use.rs:8:1
+   |
+LL | fn f<'a>() -> Alias<'a, ()> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: could not find defining uses
+  --> $DIR/issue-68368-non-defining-use.rs:7:1
+   |
+LL | type Alias<'a, U> = impl Trait<U>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Successful merges:

 - #68424 (Suggest borrowing `Vec<NonCopy>` in for loop)
 - #68438 (Account for non-types in substs for opaque type error messages)
 - #68469 (Avoid overflow in `std::iter::Skip::count`)
 - #68473 (Enable ASan on Fuchsia)
 - #68479 (Implement `unused_parens` for block return values)
 - #68483 (Add my (@flip1995) name to .mailmap)
 - #68500 (Clear out std, not std tools)

Failed merges:


r? @ghost