### PR TITLE
Remove unused ignore-license directives

### DIFF
--- a/src/libstd/sys/cloudabi/abi/bitflags.rs
+++ b/src/libstd/sys/cloudabi/abi/bitflags.rs
@@ -21,9 +21,6 @@
 // OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 // SUCH DAMAGE.
 
-// Appease Rust's tidy.
-// ignore-license
-
 #[cfg(feature = "bitflags")]
 use bitflags::bitflags;
 

--- a/src/libstd/sys/cloudabi/abi/cloudabi.rs
+++ b/src/libstd/sys/cloudabi/abi/cloudabi.rs
@@ -26,7 +26,6 @@
 // Source: https://github.com/NuxiNL/cloudabi
 
 // Appease Rust's tidy.
-// ignore-license
 // ignore-tidy-linelength
 
 //! **PLEASE NOTE: This entire crate including this

--- a/src/test/pretty/top-level-doc-comments.rs
+++ b/src/test/pretty/top-level-doc-comments.rs
@@ -1,11 +1,6 @@
 /// Some doc comment.
 struct X;
 
-// ignore-license
-
-// http://rust-lang.org/COPYRIGHT.
-//
-
 // pp-exact
 
 // Test that rust can properly pretty print a doc comment if it's the first line in a file.  some

--- a/src/test/run-make-fulldeps/c-dynamic-dylib/cfoo.c
+++ b/src/test/run-make-fulldeps/c-dynamic-dylib/cfoo.c
@@ -1,4 +1,3 @@
-// ignore-license
 #ifdef _WIN32
 __declspec(dllexport)
 #endif

--- a/src/test/run-make-fulldeps/c-dynamic-rlib/cfoo.c
+++ b/src/test/run-make-fulldeps/c-dynamic-rlib/cfoo.c
@@ -1,5 +1,3 @@
-// ignore-license
-
 #ifdef _WIN32
 __declspec(dllexport)
 #endif

--- a/src/test/run-make-fulldeps/c-link-to-rust-dylib/bar.c
+++ b/src/test/run-make-fulldeps/c-link-to-rust-dylib/bar.c
@@ -1,4 +1,3 @@
-// ignore-license
 void foo();
 
 int main() {

--- a/src/test/run-make-fulldeps/c-link-to-rust-staticlib/bar.c
+++ b/src/test/run-make-fulldeps/c-link-to-rust-staticlib/bar.c
@@ -1,4 +1,3 @@
-// ignore-license
 void foo();
 
 int main() {

--- a/src/test/run-make-fulldeps/c-static-dylib/cfoo.c
+++ b/src/test/run-make-fulldeps/c-static-dylib/cfoo.c
@@ -1,2 +1,1 @@
-// ignore-license
 int foo() { return 0; }

--- a/src/test/run-make-fulldeps/c-static-rlib/cfoo.c
+++ b/src/test/run-make-fulldeps/c-static-rlib/cfoo.c
@@ -1,2 +1,1 @@
-// ignore-license
 int foo() { return 0; }

--- a/src/test/run-make-fulldeps/compiler-rt-works-on-mingw/foo.cpp
+++ b/src/test/run-make-fulldeps/compiler-rt-works-on-mingw/foo.cpp
@@ -1,4 +1,3 @@
-// ignore-license
 extern "C" void foo() {
     int *a = new int(3);
     delete a;

--- a/src/test/run-make-fulldeps/extern-fn-generic/test.c
+++ b/src/test/run-make-fulldeps/extern-fn-generic/test.c
@@ -1,4 +1,3 @@
-// ignore-license
 #include <stdint.h>
 
 typedef struct TestStruct {

--- a/src/test/run-make-fulldeps/extern-fn-mangle/test.c
+++ b/src/test/run-make-fulldeps/extern-fn-mangle/test.c
@@ -1,4 +1,3 @@
-// ignore-license
 #include <stdint.h>
 
 uint32_t foo();

--- a/src/test/run-make-fulldeps/extern-fn-with-extern-types/ctest.c
+++ b/src/test/run-make-fulldeps/extern-fn-with-extern-types/ctest.c
@@ -1,4 +1,3 @@
-// ignore-license
 #include <stdio.h>
 #include <stdint.h>
 

--- a/src/test/run-make-fulldeps/extern-fn-with-packed-struct/test.c
+++ b/src/test/run-make-fulldeps/extern-fn-with-packed-struct/test.c
@@ -1,4 +1,3 @@
-// ignore-license
 // Pragma needed cause of gcc bug on windows: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=52991
 
 #include <assert.h>

--- a/src/test/run-make-fulldeps/extern-fn-with-union/ctest.c
+++ b/src/test/run-make-fulldeps/extern-fn-with-union/ctest.c
@@ -1,4 +1,3 @@
-// ignore-license
 #include <stdio.h>
 #include <stdint.h>
 

--- a/src/test/run-make-fulldeps/glibc-staticlib-args/program.c
+++ b/src/test/run-make-fulldeps/glibc-staticlib-args/program.c
@@ -1,4 +1,3 @@
-// ignore-license
 void args_check();
 
 int main() {

--- a/src/test/run-make-fulldeps/interdependent-c-libraries/bar.c
+++ b/src/test/run-make-fulldeps/interdependent-c-libraries/bar.c
@@ -1,4 +1,3 @@
-// ignore-license
 void foo();
 
 void bar() { foo(); }

--- a/src/test/run-make-fulldeps/interdependent-c-libraries/foo.c
+++ b/src/test/run-make-fulldeps/interdependent-c-libraries/foo.c
@@ -1,2 +1,1 @@
-// ignore-license
 void foo() {}

--- a/src/test/run-make-fulldeps/issue-25581/test.c
+++ b/src/test/run-make-fulldeps/issue-25581/test.c
@@ -1,4 +1,3 @@
-// ignore-license
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/test/run-make-fulldeps/link-path-order/correct.c
+++ b/src/test/run-make-fulldeps/link-path-order/correct.c
@@ -1,2 +1,1 @@
-// ignore-license
 int should_return_one() { return 1; }

--- a/src/test/run-make-fulldeps/link-path-order/wrong.c
+++ b/src/test/run-make-fulldeps/link-path-order/wrong.c
@@ -1,2 +1,1 @@
-// ignore-license
 int should_return_one() { return 0; }

--- a/src/test/run-make-fulldeps/linkage-attr-on-static/foo.c
+++ b/src/test/run-make-fulldeps/linkage-attr-on-static/foo.c
@@ -1,4 +1,3 @@
-// ignore-license
 #include <stdint.h>
 
 extern int32_t BAZ;

--- a/src/test/run-make-fulldeps/lto-smoke-c/bar.c
+++ b/src/test/run-make-fulldeps/lto-smoke-c/bar.c
@@ -1,4 +1,3 @@
-// ignore-license
 void foo();
 
 int main() {

--- a/src/test/run-make-fulldeps/manual-link/bar.c
+++ b/src/test/run-make-fulldeps/manual-link/bar.c
@@ -1,2 +1,1 @@
-// ignore-license
 void bar() {}

--- a/src/test/run-make-fulldeps/manual-link/foo.c
+++ b/src/test/run-make-fulldeps/manual-link/foo.c
@@ -1,2 +1,1 @@
-// ignore-license
 void bar() {}

--- a/src/test/run-make-fulldeps/sanitizer-staticlib-link/program.c
+++ b/src/test/run-make-fulldeps/sanitizer-staticlib-link/program.c
@@ -1,4 +1,3 @@
-// ignore-license
 void overflow();
 
 int main() {

--- a/src/test/ui/attr-shebang.rs
+++ b/src/test/ui/attr-shebang.rs
@@ -3,4 +3,3 @@
 #![allow(stable_features)]
 #![feature(rust1)]
 pub fn main() { }
-// ignore-license

--- a/src/test/ui/lexer-crlf-line-endings-string-literal-doc-comment.rs
+++ b/src/test/ui/lexer-crlf-line-endings-string-literal-doc-comment.rs
@@ -1,10 +1,7 @@
 // run-pass
-// ignore-tidy-cr ignore-license
+// ignore-tidy-cr
 // ignore-tidy-cr (repeated again because of tidy bug)
 // license is ignored because tidy can't handle the CRLF here properly.
-
-// http://rust-lang.org/COPYRIGHT.
-//
 
 // N.B., this file needs CRLF line endings. The .gitattributes file in
 // this directory should enforce it.


### PR DESCRIPTION
The tidy check was removed in rust-lang/rust#53617