### PR TITLE
Render const pointers in MIR more compactly

### DIFF
--- a/src/librustc/mir/interpret/mod.rs
+++ b/src/librustc/mir/interpret/mod.rs
@@ -166,8 +166,14 @@ pub enum LitToConstError {
     Reported,
 }
 
-#[derive(Copy, Clone, Eq, Hash, Ord, PartialEq, PartialOrd, Debug)]
+#[derive(Copy, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct AllocId(pub u64);
+
+impl fmt::Debug for AllocId {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "alloc{}", self.0)
+    }
+}
 
 impl rustc_serialize::UseSpecializedEncodable for AllocId {}
 impl rustc_serialize::UseSpecializedDecodable for AllocId {}

--- a/src/librustc/mir/interpret/pointer.rs
+++ b/src/librustc/mir/interpret/pointer.rs
@@ -133,13 +133,13 @@ static_assert_size!(Pointer, 16);
 
 impl<Tag: fmt::Debug, Id: fmt::Debug> fmt::Debug for Pointer<Tag, Id> {
     default fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}.{:#x}[{:?}]", self.alloc_id, self.offset.bytes(), self.tag)
+        write!(f, "{:?}+{:x}[{:?}]", self.alloc_id, self.offset.bytes(), self.tag)
     }
 }
 // Specialization for no tag
 impl<Id: fmt::Debug> fmt::Debug for Pointer<(), Id> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}.{:#x}", self.alloc_id, self.offset.bytes())
+        write!(f, "{:?}+{:x}", self.alloc_id, self.offset.bytes())
     }
 }
 

--- a/src/test/mir-opt/const-promotion-extern-static.rs
+++ b/src/test/mir-opt/const-promotion-extern-static.rs
@@ -14,7 +14,7 @@ fn main() {}
 // START rustc.FOO.PromoteTemps.before.mir
 // bb0: {
 // ...
-//     _5 = const Scalar(AllocId(1).0x0) : &i32;
+//     _5 = const Scalar(alloc1+0) : &i32;
 //     _4 = &(*_5);
 //     _3 = [move _4];
 //     _2 = &_3;
@@ -31,7 +31,7 @@ fn main() {}
 // START rustc.BAR.PromoteTemps.before.mir
 // bb0: {
 // ...
-//     _5 = const Scalar(AllocId(0).0x0) : &i32;
+//     _5 = const Scalar(alloc0+0) : &i32;
 //     _4 = &(*_5);
 //     _3 = [move _4];
 //     _2 = &_3;

--- a/src/test/mir-opt/const_prop/read_immutable_static.rs
+++ b/src/test/mir-opt/const_prop/read_immutable_static.rs
@@ -10,10 +10,10 @@ fn main() {
 // START rustc.main.ConstProp.before.mir
 //  bb0: {
 //      ...
-//      _3 = const Scalar(AllocId(0).0x0) : &u8;
+//      _3 = const Scalar(alloc0+0) : &u8;
 //      _2 = (*_3);
 //      ...
-//      _5 = const Scalar(AllocId(0).0x0) : &u8;
+//      _5 = const Scalar(alloc0+0) : &u8;
 //      _4 = (*_5);
 //      _1 = Add(move _2, move _4);
 //      ...


### PR DESCRIPTION
Split out from #67133 to make that PR simpler

cc @RalfJung 

r? @eddyb 