### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/src/libpanic_unwind/gcc.rs
+++ b/src/libpanic_unwind/gcc.rs
@@ -4,7 +4,7 @@
 //! "Exception Handling in LLVM" (llvm.org/docs/ExceptionHandling.html) and
 //! documents linked from it.
 //! These are also good reads:
-//!     http://mentorembedded.github.io/cxx-abi/abi-eh.html
+//!     https://itanium-cxx-abi.github.io/cxx-abi/abi-eh.html
 //!     http://monoinfinito.wordpress.com/series/exception-handling-in-c/
 //!     http://www.airs.com/blog/index.php?s=exception+frames
 //!

--- a/src/librustc_codegen_utils/symbol_names/legacy.rs
+++ b/src/librustc_codegen_utils/symbol_names/legacy.rs
@@ -237,7 +237,7 @@ impl Printer<'tcx> for SymbolPrinter<'tcx> {
         // only print integers
         if let ty::ConstKind::Value(ConstValue::Scalar(Scalar::Raw { .. })) = ct.val {
             if ct.ty.is_integral() {
-                return self.pretty_print_const(ct);
+                return self.pretty_print_const(ct, true);
             }
         }
         self.write_str("_")?;

--- a/src/librustc_error_codes/error_codes/E0223.md
+++ b/src/librustc_error_codes/error_codes/E0223.md
@@ -1,5 +1,6 @@
 An attempt was made to retrieve an associated type, but the type was ambiguous.
-For example:
+
+Erroneous code example:
 
 ```compile_fail,E0223
 trait MyTrait {type X; }

--- a/src/librustc_error_codes/error_codes/E0225.md
+++ b/src/librustc_error_codes/error_codes/E0225.md
@@ -1,11 +1,14 @@
-You attempted to use multiple types as bounds for a closure or trait object.
-Rust does not currently support this. A simple example that causes this error:
+Multiple types were used as bounds for a closure or trait object.
+
+Erroneous code example:
 
 ```compile_fail,E0225
 fn main() {
     let _: Box<dyn std::io::Read + std::io::Write>;
 }
 ```
+
+Rust does not currently support this.
 
 Auto traits such as Send and Sync are an exception to this rule:
 It's possible to have bounds of one non-builtin trait, plus any number of

--- a/src/librustc_mir/interpret/intrinsics/type_name.rs
+++ b/src/librustc_mir/interpret/intrinsics/type_name.rs
@@ -69,9 +69,8 @@ impl<'tcx> Printer<'tcx> for AbsolutePathPrinter<'tcx> {
         }
     }
 
-    fn print_const(self, _: &'tcx ty::Const<'tcx>) -> Result<Self::Const, Self::Error> {
-        // don't print constants to the user
-        Ok(self)
+    fn print_const(self, ct: &'tcx ty::Const<'tcx>) -> Result<Self::Const, Self::Error> {
+        self.pretty_print_const(ct, false)
     }
 
     fn print_dyn_existential(

--- a/src/libstd/sys/cloudabi/abi/bitflags.rs
+++ b/src/libstd/sys/cloudabi/abi/bitflags.rs
@@ -21,9 +21,6 @@
 // OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 // SUCH DAMAGE.
 
-// Appease Rust's tidy.
-// ignore-license
-
 #[cfg(feature = "bitflags")]
 use bitflags::bitflags;
 

--- a/src/libstd/sys/cloudabi/abi/cloudabi.rs
+++ b/src/libstd/sys/cloudabi/abi/cloudabi.rs
@@ -26,7 +26,6 @@
 // Source: https://github.com/NuxiNL/cloudabi
 
 // Appease Rust's tidy.
-// ignore-license
 // ignore-tidy-linelength
 
 //! **PLEASE NOTE: This entire crate including this

--- a/src/libstd/sys/vxworks/ext/process.rs
+++ b/src/libstd/sys/vxworks/ext/process.rs
@@ -2,6 +2,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+use crate::ffi::OsStr;
 use crate::io;
 use crate::process;
 use crate::sys;
@@ -105,6 +106,15 @@ pub trait CommandExt {
     /// cross-platform `spawn` instead.
     #[stable(feature = "process_exec2", since = "1.9.0")]
     fn exec(&mut self) -> io::Error;
+
+    /// Set executable argument
+    ///
+    /// Set the first process argument, `argv[0]`, to something other than the
+    /// default executable path.
+    #[unstable(feature = "process_set_argv0", issue = "66510")]
+    fn arg0<S>(&mut self, arg: S) -> &mut process::Command
+    where
+        S: AsRef<OsStr>;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -129,6 +139,14 @@ impl CommandExt for process::Command {
 
     fn exec(&mut self) -> io::Error {
         self.as_inner_mut().exec(sys::process::Stdio::Inherit)
+    }
+
+    fn arg0<S>(&mut self, arg: S) -> &mut process::Command
+    where
+        S: AsRef<OsStr>,
+    {
+        self.as_inner_mut().set_arg_0(arg.as_ref());
+        self
     }
 }
 

--- a/src/libstd/sys/vxworks/process/process_vxworks.rs
+++ b/src/libstd/sys/vxworks/process/process_vxworks.rs
@@ -67,7 +67,7 @@ impl Command {
             let _lock = sys::os::env_lock();
 
             let ret = libc::rtpSpawn(
-                self.get_argv()[0],                             // executing program
+                self.get_program().as_ptr(),
                 self.get_argv().as_ptr() as *mut *const c_char, // argv
                 c_envp as *mut *const c_char,
                 100 as c_int, // initial priority

--- a/src/test/pretty/top-level-doc-comments.rs
+++ b/src/test/pretty/top-level-doc-comments.rs
@@ -1,11 +1,6 @@
 /// Some doc comment.
 struct X;
 
-// ignore-license
-
-// http://rust-lang.org/COPYRIGHT.
-//
-
 // pp-exact
 
 // Test that rust can properly pretty print a doc comment if it's the first line in a file.  some

--- a/src/test/run-make-fulldeps/c-dynamic-dylib/cfoo.c
+++ b/src/test/run-make-fulldeps/c-dynamic-dylib/cfoo.c
@@ -1,4 +1,3 @@
-// ignore-license
 #ifdef _WIN32
 __declspec(dllexport)
 #endif

--- a/src/test/run-make-fulldeps/c-dynamic-rlib/cfoo.c
+++ b/src/test/run-make-fulldeps/c-dynamic-rlib/cfoo.c
@@ -1,5 +1,3 @@
-// ignore-license
-
 #ifdef _WIN32
 __declspec(dllexport)
 #endif

--- a/src/test/run-make-fulldeps/c-link-to-rust-dylib/bar.c
+++ b/src/test/run-make-fulldeps/c-link-to-rust-dylib/bar.c
@@ -1,4 +1,3 @@
-// ignore-license
 void foo();
 
 int main() {

--- a/src/test/run-make-fulldeps/c-link-to-rust-staticlib/bar.c
+++ b/src/test/run-make-fulldeps/c-link-to-rust-staticlib/bar.c
@@ -1,4 +1,3 @@
-// ignore-license
 void foo();
 
 int main() {

--- a/src/test/run-make-fulldeps/c-static-dylib/cfoo.c
+++ b/src/test/run-make-fulldeps/c-static-dylib/cfoo.c
@@ -1,2 +1,1 @@
-// ignore-license
 int foo() { return 0; }

--- a/src/test/run-make-fulldeps/c-static-rlib/cfoo.c
+++ b/src/test/run-make-fulldeps/c-static-rlib/cfoo.c
@@ -1,2 +1,1 @@
-// ignore-license
 int foo() { return 0; }

--- a/src/test/run-make-fulldeps/compiler-rt-works-on-mingw/foo.cpp
+++ b/src/test/run-make-fulldeps/compiler-rt-works-on-mingw/foo.cpp
@@ -1,4 +1,3 @@
-// ignore-license
 extern "C" void foo() {
     int *a = new int(3);
     delete a;

--- a/src/test/run-make-fulldeps/extern-fn-generic/test.c
+++ b/src/test/run-make-fulldeps/extern-fn-generic/test.c
@@ -1,4 +1,3 @@
-// ignore-license
 #include <stdint.h>
 
 typedef struct TestStruct {

--- a/src/test/run-make-fulldeps/extern-fn-mangle/test.c
+++ b/src/test/run-make-fulldeps/extern-fn-mangle/test.c
@@ -1,4 +1,3 @@
-// ignore-license
 #include <stdint.h>
 
 uint32_t foo();

--- a/src/test/run-make-fulldeps/extern-fn-with-extern-types/ctest.c
+++ b/src/test/run-make-fulldeps/extern-fn-with-extern-types/ctest.c
@@ -1,4 +1,3 @@
-// ignore-license
 #include <stdio.h>
 #include <stdint.h>
 

--- a/src/test/run-make-fulldeps/extern-fn-with-packed-struct/test.c
+++ b/src/test/run-make-fulldeps/extern-fn-with-packed-struct/test.c
@@ -1,4 +1,3 @@
-// ignore-license
 // Pragma needed cause of gcc bug on windows: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=52991
 
 #include <assert.h>

--- a/src/test/run-make-fulldeps/extern-fn-with-union/ctest.c
+++ b/src/test/run-make-fulldeps/extern-fn-with-union/ctest.c
@@ -1,4 +1,3 @@
-// ignore-license
 #include <stdio.h>
 #include <stdint.h>
 

--- a/src/test/run-make-fulldeps/glibc-staticlib-args/program.c
+++ b/src/test/run-make-fulldeps/glibc-staticlib-args/program.c
@@ -1,4 +1,3 @@
-// ignore-license
 void args_check();
 
 int main() {

--- a/src/test/run-make-fulldeps/interdependent-c-libraries/bar.c
+++ b/src/test/run-make-fulldeps/interdependent-c-libraries/bar.c
@@ -1,4 +1,3 @@
-// ignore-license
 void foo();
 
 void bar() { foo(); }

--- a/src/test/run-make-fulldeps/interdependent-c-libraries/foo.c
+++ b/src/test/run-make-fulldeps/interdependent-c-libraries/foo.c
@@ -1,2 +1,1 @@
-// ignore-license
 void foo() {}

--- a/src/test/run-make-fulldeps/issue-25581/test.c
+++ b/src/test/run-make-fulldeps/issue-25581/test.c
@@ -1,4 +1,3 @@
-// ignore-license
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/test/run-make-fulldeps/link-path-order/correct.c
+++ b/src/test/run-make-fulldeps/link-path-order/correct.c
@@ -1,2 +1,1 @@
-// ignore-license
 int should_return_one() { return 1; }

--- a/src/test/run-make-fulldeps/link-path-order/wrong.c
+++ b/src/test/run-make-fulldeps/link-path-order/wrong.c
@@ -1,2 +1,1 @@
-// ignore-license
 int should_return_one() { return 0; }

--- a/src/test/run-make-fulldeps/linkage-attr-on-static/foo.c
+++ b/src/test/run-make-fulldeps/linkage-attr-on-static/foo.c
@@ -1,4 +1,3 @@
-// ignore-license
 #include <stdint.h>
 
 extern int32_t BAZ;

--- a/src/test/run-make-fulldeps/lto-smoke-c/bar.c
+++ b/src/test/run-make-fulldeps/lto-smoke-c/bar.c
@@ -1,4 +1,3 @@
-// ignore-license
 void foo();
 
 int main() {

--- a/src/test/run-make-fulldeps/manual-link/bar.c
+++ b/src/test/run-make-fulldeps/manual-link/bar.c
@@ -1,2 +1,1 @@
-// ignore-license
 void bar() {}

--- a/src/test/run-make-fulldeps/manual-link/foo.c
+++ b/src/test/run-make-fulldeps/manual-link/foo.c
@@ -1,2 +1,1 @@
-// ignore-license
 void bar() {}

--- a/src/test/run-make-fulldeps/sanitizer-staticlib-link/program.c
+++ b/src/test/run-make-fulldeps/sanitizer-staticlib-link/program.c
@@ -1,4 +1,3 @@
-// ignore-license
 void overflow();
 
 int main() {

--- a/src/test/ui/attr-shebang.rs
+++ b/src/test/ui/attr-shebang.rs
@@ -3,4 +3,3 @@
 #![allow(stable_features)]
 #![feature(rust1)]
 pub fn main() { }
-// ignore-license

--- a/src/test/ui/const-generics/const-generic-type_name.rs
+++ b/src/test/ui/const-generics/const-generic-type_name.rs
@@ -1,0 +1,11 @@
+// run-pass
+
+#![feature(const_generics)]
+//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+
+#[derive(Debug)]
+struct S<const N: usize>;
+
+fn main() {
+    assert_eq!(std::any::type_name::<S<3>>(), "const_generic_type_name::S<3usize>");
+}

--- a/src/test/ui/const-generics/const-generic-type_name.stderr
+++ b/src/test/ui/const-generics/const-generic-type_name.stderr
@@ -1,0 +1,8 @@
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/const-generic-type_name.rs:3:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+

--- a/src/test/ui/lexer-crlf-line-endings-string-literal-doc-comment.rs
+++ b/src/test/ui/lexer-crlf-line-endings-string-literal-doc-comment.rs
@@ -1,10 +1,7 @@
 // run-pass
-// ignore-tidy-cr ignore-license
+// ignore-tidy-cr
 // ignore-tidy-cr (repeated again because of tidy bug)
 // license is ignored because tidy can't handle the CRLF here properly.
-
-// http://rust-lang.org/COPYRIGHT.
-//
 
 // N.B., this file needs CRLF line endings. The .gitattributes file in
 // this directory should enforce it.

--- a/src/test/ui/lint/command-line-lint-group-allow.rs
+++ b/src/test/ui/lint/command-line-lint-group-allow.rs
@@ -1,5 +1,5 @@
 // compile-flags: -A bad-style
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 fn main() {
     let _InappropriateCamelCasing = true;

--- a/src/test/ui/lint/dead-code/tuple-struct-field.rs
+++ b/src/test/ui/lint/dead-code/tuple-struct-field.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![deny(dead_code)]
 

--- a/src/test/ui/lint/inclusive-range-pattern-syntax.fixed
+++ b/src/test/ui/lint/inclusive-range-pattern-syntax.fixed
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // run-rustfix
 
 #![warn(ellipsis_inclusive_range_patterns)]

--- a/src/test/ui/lint/inclusive-range-pattern-syntax.rs
+++ b/src/test/ui/lint/inclusive-range-pattern-syntax.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // run-rustfix
 
 #![warn(ellipsis_inclusive_range_patterns)]

--- a/src/test/ui/lint/lint-lowercase-static-const-pattern-rename.rs
+++ b/src/test/ui/lint/lint-lowercase-static-const-pattern-rename.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // Issue #7526: lowercase static constants in patterns look like bindings
 
 // This is similar to lint-lowercase-static-const-pattern.rs, except it

--- a/src/test/ui/lint/lint-non-camel-case-variant.rs
+++ b/src/test/ui/lint/lint-non-camel-case-variant.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![deny(non_camel_case_types)]
 

--- a/src/test/ui/lint/lint-non-camel-case-with-trailing-underscores.rs
+++ b/src/test/ui/lint/lint-non-camel-case-with-trailing-underscores.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![allow(dead_code)]
 // This is ok because we often use the trailing underscore to mean 'prime'

--- a/src/test/ui/lint/lint-non-snake-case-no-lowercase-equivalent.rs
+++ b/src/test/ui/lint/lint-non-snake-case-no-lowercase-equivalent.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![allow(dead_code)]
 // pretty-expanded FIXME #23616

--- a/src/test/ui/lint/lint-nonstandard-style-unicode.rs
+++ b/src/test/ui/lint/lint-nonstandard-style-unicode.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![allow(dead_code)]
 

--- a/src/test/ui/lint/lint-output-format-2.rs
+++ b/src/test/ui/lint/lint-output-format-2.rs
@@ -1,7 +1,7 @@
 // aux-build:lint_output_format.rs
 
 #![feature(unstable_test_feature)]
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 extern crate lint_output_format;
 use lint_output_format::{foo, bar};

--- a/src/test/ui/lint/lint-stability-deprecated.rs
+++ b/src/test/ui/lint/lint-stability-deprecated.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // aux-build:lint_stability.rs
 // aux-build:inherited_stability.rs
 // aux-build:stability_cfg1.rs

--- a/src/test/ui/lint/lints-in-foreign-macros.rs
+++ b/src/test/ui/lint/lints-in-foreign-macros.rs
@@ -1,5 +1,5 @@
 // aux-build:lints-in-foreign-macros.rs
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![warn(unused_imports)] //~ missing documentation for crate [missing_docs]
 #![warn(missing_docs)]

--- a/src/test/ui/lint/reasons.rs
+++ b/src/test/ui/lint/reasons.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(lint_reasons)]
 

--- a/src/test/ui/lint/type-overflow.rs
+++ b/src/test/ui/lint/type-overflow.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![warn(overflowing_literals)]
 
 fn main() {

--- a/src/test/ui/lint/unused_labels.rs
+++ b/src/test/ui/lint/unused_labels.rs
@@ -2,7 +2,7 @@
 // should also deal with the edge cases where a label is shadowed,
 // within nested loops
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(label_break_value)]
 #![warn(unused_labels)]

--- a/src/test/ui/lint/use-redundant.rs
+++ b/src/test/ui/lint/use-redundant.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![warn(unused_imports)]
 
 use crate::foo::Bar;

--- a/src/test/ui/nll/closure-requirements/propagate-despite-same-free-region.rs
+++ b/src/test/ui/nll/closure-requirements/propagate-despite-same-free-region.rs
@@ -4,7 +4,7 @@
 // regions is erased.
 
 // compile-flags:-Zborrowck=mir -Zverbose
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rustc_attrs)]
 

--- a/src/test/ui/nll/constant.rs
+++ b/src/test/ui/nll/constant.rs
@@ -2,7 +2,7 @@
 // arbitrary types without ICEs.
 
 // compile-flags:-Zborrowck=mir
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 const HI: &str = "hi";
 

--- a/src/test/ui/nll/drop-may-dangle.rs
+++ b/src/test/ui/nll/drop-may-dangle.rs
@@ -3,7 +3,7 @@
 // including) the call to `use_x`. The `else` branch is not included.
 
 // compile-flags:-Zborrowck=mir
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![allow(warnings)]
 #![feature(dropck_eyepatch)]

--- a/src/test/ui/nll/extra-unused-mut.rs
+++ b/src/test/ui/nll/extra-unused-mut.rs
@@ -1,6 +1,6 @@
 // extra unused mut lint tests for #51918
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(generators, nll)]
 #![deny(unused_mut)]

--- a/src/test/ui/nll/generator-distinct-lifetime.rs
+++ b/src/test/ui/nll/generator-distinct-lifetime.rs
@@ -6,7 +6,7 @@
 // over a yield -- because the data that is borrowed (`*x`) is not
 // stored on the stack.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 fn foo(x: &mut u32) {
     move || {

--- a/src/test/ui/nll/maybe-initialized-drop-uninitialized.rs
+++ b/src/test/ui/nll/maybe-initialized-drop-uninitialized.rs
@@ -1,5 +1,5 @@
 // compile-flags: -Zborrowck=mir
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![allow(warnings)]
 

--- a/src/test/ui/nll/projection-return.rs
+++ b/src/test/ui/nll/projection-return.rs
@@ -1,5 +1,5 @@
 // compile-flags:-Zborrowck=mir
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rustc_attrs)]
 

--- a/src/test/ui/nll/relate_tys/hr-fn-aau-eq-abu.rs
+++ b/src/test/ui/nll/relate_tys/hr-fn-aau-eq-abu.rs
@@ -6,7 +6,7 @@
 // another -- effectively, the single lifetime `'a` is just inferred
 // to be the intersection of the two distinct lifetimes.
 //
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // compile-flags:-Zno-leak-check
 
 #![feature(nll)]

--- a/src/test/ui/nll/relate_tys/hr-fn-aba-as-aaa.rs
+++ b/src/test/ui/nll/relate_tys/hr-fn-aba-as-aaa.rs
@@ -2,7 +2,7 @@
 // function returning always its first argument can be upcast to one
 // that returns either first or second argument.
 //
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // compile-flags:-Zno-leak-check
 
 #![feature(nll)]

--- a/src/test/ui/nll/ty-outlives/projection-body.rs
+++ b/src/test/ui/nll/ty-outlives/projection-body.rs
@@ -1,7 +1,7 @@
 // Test that when we infer the lifetime to a subset of the fn body, it
 // works out.
 //
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 trait MyTrait<'a> {
     type Output;

--- a/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.rs
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.rs
@@ -3,7 +3,7 @@
 // we don't even propagate constraints from the closures to the callers.
 
 // compile-flags:-Zborrowck=mir -Zverbose
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]

--- a/src/test/ui/nll/ty-outlives/projection-where-clause-env.rs
+++ b/src/test/ui/nll/ty-outlives/projection-where-clause-env.rs
@@ -4,7 +4,7 @@
 //
 // Regression test for #53121.
 //
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 trait MyTrait<'a> {
     type Output;

--- a/src/test/ui/nll/ty-outlives/projection-where-clause-trait.rs
+++ b/src/test/ui/nll/ty-outlives/projection-where-clause-trait.rs
@@ -4,7 +4,7 @@
 // MyTrait<'a>>::Output: 'a` outlives `'a` (because the trait says
 // so).
 //
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 trait MyTrait<'a> {
     type Output: 'a;

--- a/src/test/ui/nll/ty-outlives/ty-param-implied-bounds.rs
+++ b/src/test/ui/nll/ty-outlives/ty-param-implied-bounds.rs
@@ -1,5 +1,5 @@
 // compile-flags:-Zborrowck=mir -Zverbose
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 // Test that we assume that universal types like `T` outlive the
 // function body.

--- a/src/test/ui/nll/user-annotations/downcast-infer.rs
+++ b/src/test/ui/nll/user-annotations/downcast-infer.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 // Check that we don't try to downcast `_` when type-checking the annotation.
 fn main() {


### PR DESCRIPTION
Successful merges:

 - #68111 (Print constants in `type_name` for const generics)
 - #68374 (Fix invalid link to the C++ Exception Handling ABI documentation)
 - #68504 (Use check-pass mode for lint tests and nll tests)
 - #68509 (Clean up error codes E0223 and E0225 explanations)
 - #68511 (Remove unused ignore-license directives)
 - #68515 (Support feature process_set_argv0 for VxWorks)

Failed merges:


r? @ghost