### PR TITLE
perf: Reuse a Vec in mir simplification

### DIFF
--- a/src/librustc_mir/transform/simplify.rs
+++ b/src/librustc_mir/transform/simplify.rs
@@ -128,12 +128,12 @@ impl<'a, 'tcx> CfgSimplifier<'a, 'tcx> {
                     changed |= inner_changed;
                 }
 
-                let merged_block_count =
+                let statements_to_merge =
                     merged_blocks.iter().map(|&i| self.basic_blocks[i].statements.len()).sum();
 
-                if merged_block_count > 0 {
+                if statements_to_merge > 0 {
                     let mut statements = std::mem::take(&mut self.basic_blocks[bb].statements);
-                    statements.reserve(merged_block_count);
+                    statements.reserve(statements_to_merge);
                     for &from in &merged_blocks {
                         statements.append(&mut self.basic_blocks[from].statements);
                     }

--- a/src/librustc_mir/transform/simplify.rs
+++ b/src/librustc_mir/transform/simplify.rs
@@ -94,6 +94,7 @@ impl<'a, 'tcx> CfgSimplifier<'a, 'tcx> {
         self.strip_nops();
 
         let mut start = START_BLOCK;
+        let mut new_stmts = vec![];
 
         loop {
             let mut changed = false;
@@ -114,7 +115,6 @@ impl<'a, 'tcx> CfgSimplifier<'a, 'tcx> {
                     self.collapse_goto_chain(successor, &mut changed);
                 }
 
-                let mut new_stmts = vec![];
                 let mut inner_changed = true;
                 while inner_changed {
                     inner_changed = false;
@@ -124,7 +124,7 @@ impl<'a, 'tcx> CfgSimplifier<'a, 'tcx> {
                 }
 
                 let data = &mut self.basic_blocks[bb];
-                data.statements.extend(new_stmts);
+                data.statements.extend(new_stmts.drain(..));
                 data.terminator = Some(terminator);
 
                 changed |= inner_changed;

--- a/src/librustc_mir/transform/simplify.rs
+++ b/src/librustc_mir/transform/simplify.rs
@@ -124,7 +124,7 @@ impl<'a, 'tcx> CfgSimplifier<'a, 'tcx> {
                 }
 
                 let data = &mut self.basic_blocks[bb];
-                data.statements.extend(new_stmts.drain(..));
+                data.statements.append(&mut new_stmts);
                 data.terminator = Some(terminator);
 
                 changed |= inner_changed;

--- a/src/librustc_mir/transform/simplify.rs
+++ b/src/librustc_mir/transform/simplify.rs
@@ -95,6 +95,10 @@ impl<'a, 'tcx> CfgSimplifier<'a, 'tcx> {
 
         let mut start = START_BLOCK;
 
+        // Vec of the blocks that should be merged. We store the indices here, instead of the
+        // statements itself to avoid moving the (relatively) large statements twice.
+        // We do not push the statements directly into the target block (`bb`) as that is slower
+        // due to additional reallocations
         let mut merged_blocks = Vec::new();
         loop {
             let mut changed = false;
@@ -116,6 +120,7 @@ impl<'a, 'tcx> CfgSimplifier<'a, 'tcx> {
                 }
 
                 let mut inner_changed = true;
+                merged_blocks.clear();
                 while inner_changed {
                     inner_changed = false;
                     inner_changed |= self.simplify_branch(&mut terminator);
@@ -134,7 +139,6 @@ impl<'a, 'tcx> CfgSimplifier<'a, 'tcx> {
                     }
                     self.basic_blocks[bb].statements = statements;
                 }
-                merged_blocks.clear();
 
                 self.basic_blocks[bb].terminator = Some(terminator);
 


### PR DESCRIPTION
Just moves the vec out of the outer loop so it is reused every iteration