### PR TITLE
rustdoc: Fix re-exporting primitive types

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1290,6 +1290,19 @@ impl From<ast::FloatTy> for PrimitiveType {
     }
 }
 
+impl From<hir::PrimTy> for PrimitiveType {
+    fn from(prim_ty: hir::PrimTy) -> PrimitiveType {
+        match prim_ty {
+            hir::PrimTy::Int(int_ty) => int_ty.into(),
+            hir::PrimTy::Uint(uint_ty) => uint_ty.into(),
+            hir::PrimTy::Float(float_ty) => float_ty.into(),
+            hir::PrimTy::Str => PrimitiveType::Str,
+            hir::PrimTy::Bool => PrimitiveType::Bool,
+            hir::PrimTy::Char => PrimitiveType::Char,
+        }
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Visibility {
     Public,

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -570,14 +570,7 @@ pub fn resolve_type(cx: &DocContext<'_>, path: Path, id: hir::HirId) -> Type {
     }
 
     let is_generic = match path.res {
-        Res::PrimTy(p) => match p {
-            hir::PrimTy::Str => return Primitive(PrimitiveType::Str),
-            hir::PrimTy::Bool => return Primitive(PrimitiveType::Bool),
-            hir::PrimTy::Char => return Primitive(PrimitiveType::Char),
-            hir::PrimTy::Int(int_ty) => return Primitive(int_ty.into()),
-            hir::PrimTy::Uint(uint_ty) => return Primitive(uint_ty.into()),
-            hir::PrimTy::Float(float_ty) => return Primitive(float_ty.into()),
-        },
+        Res::PrimTy(p) => return Primitive(PrimitiveType::from(p)),
         Res::SelfTy(..) if path.segments.len() == 1 => {
             return Generic(kw::SelfUpper.to_string());
         }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1171,11 +1171,14 @@ impl clean::ImportSource {
         display_fn(move |f| match self.did {
             Some(did) => resolved_path(f, did, &self.path, true, false),
             _ => {
-                for (i, seg) in self.path.segments.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, "::")?
-                    }
-                    write!(f, "{}", seg.name)?;
+                for seg in &self.path.segments[..self.path.segments.len() - 1] {
+                    write!(f, "{}::", seg.name)?;
+                }
+                let name = self.path.last_name();
+                if let hir::def::Res::PrimTy(p) = self.path.res {
+                    primitive_link(f, PrimitiveType::from(p), name)?;
+                } else {
+                    write!(f, "{}", name)?;
                 }
                 Ok(())
             }

--- a/src/test/rustdoc/auxiliary/primitive-reexport.rs
+++ b/src/test/rustdoc/auxiliary/primitive-reexport.rs
@@ -1,0 +1,8 @@
+// compile-flags: --emit metadata --crate-type lib --edition 2018
+
+#![crate_name = "foo"]
+
+pub mod bar {
+    pub use bool;
+    pub use char as my_char;
+}

--- a/src/test/rustdoc/primitive-reexport.rs
+++ b/src/test/rustdoc/primitive-reexport.rs
@@ -1,0 +1,28 @@
+// aux-build: primitive-reexport.rs
+// compile-flags:--extern foo --edition 2018
+
+#![crate_name = "bar"]
+
+// @has bar/p/index.html
+// @has - '//code' 'pub use bool;'
+// @has - '//code/a[@href="https://doc.rust-lang.org/nightly/std/primitive.bool.html"]' 'bool'
+// @has - '//code' 'pub use char as my_char;'
+// @has - '//code/a[@href="https://doc.rust-lang.org/nightly/std/primitive.char.html"]' 'char'
+pub mod p {
+    pub use foo::bar::*;
+}
+
+// @has bar/baz/index.html
+// @has - '//code' 'pub use bool;'
+// @has - '//code/a[@href="https://doc.rust-lang.org/nightly/std/primitive.bool.html"]' 'bool'
+// @has - '//code' 'pub use char as my_char;'
+// @has - '//code/a[@href="https://doc.rust-lang.org/nightly/std/primitive.char.html"]' 'char'
+pub use foo::bar as baz;
+
+// @has bar/index.html
+// @has - '//code' 'pub use str;'
+// @has - '//code/a[@href="https://doc.rust-lang.org/nightly/std/primitive.str.html"]' 'str'
+// @has - '//code' 'pub use i32 as my_i32;'
+// @has - '//code/a[@href="https://doc.rust-lang.org/nightly/std/primitive.i32.html"]' 'i32'
+pub use str;
+pub use i32 as my_i32;


### PR DESCRIPTION
* Generate links to the primitive type docs for re-exports.
* Don't ICE on cross crate primitive type re-exports.
* Make primitive type re-exports show up cross crate.

Fixes #67646
Closes #67972

r? @GuillaumeGomez