### PR TITLE
Don't call `tcx.fn_sig` on closures

### DIFF
--- a/src/librustc_mir/const_eval/fn_queries.rs
+++ b/src/librustc_mir/const_eval/fn_queries.rs
@@ -86,6 +86,10 @@ pub fn provide(providers: &mut Providers<'_>) {
     /// Const evaluability whitelist is here to check evaluability at the
     /// top level beforehand.
     fn is_const_intrinsic(tcx: TyCtxt<'_>, def_id: DefId) -> Option<bool> {
+        if tcx.is_closure(def_id) {
+            return None;
+        }
+
         match tcx.fn_sig(def_id).abi() {
             Abi::RustIntrinsic | Abi::PlatformIntrinsic => {
                 Some(tcx.lookup_const_stability(def_id).is_some())

--- a/src/test/ui/consts/issue-68542-closure-in-array-len.rs
+++ b/src/test/ui/consts/issue-68542-closure-in-array-len.rs
@@ -1,0 +1,10 @@
+// Regression test for issue #68542
+// Tests that we don't ICE when a closure appears
+// in the length part of an array.
+
+struct Bug {
+    a: [(); (|| { 0 })()] //~ ERROR calls in constants are limited to
+    //~^ ERROR evaluation of constant value failed
+}
+
+fn main() {}

--- a/src/test/ui/consts/issue-68542-closure-in-array-len.stderr
+++ b/src/test/ui/consts/issue-68542-closure-in-array-len.stderr
@@ -1,0 +1,16 @@
+error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+  --> $DIR/issue-68542-closure-in-array-len.rs:6:13
+   |
+LL |     a: [(); (|| { 0 })()]
+   |             ^^^^^^^^^^^^
+
+error[E0080]: evaluation of constant value failed
+  --> $DIR/issue-68542-closure-in-array-len.rs:6:13
+   |
+LL |     a: [(); (|| { 0 })()]
+   |             ^^^^^^^^^^^^ calling non-const function `Bug::a::{{constant}}#0::{{closure}}#0`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0015, E0080.
+For more information about an error, try `rustc --explain E0015`.


### PR DESCRIPTION
Fixes #68542