### PR TITLE
[stable] Rust 1.41.0 stable release

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -75,8 +75,7 @@ Misc
   should be compiled the 2018 edition of Rust.
 - [You can now provide custom themes to rustdoc with `--theme`, and check the
   current theme with `--check-theme`.][54733]
-- [You can use `#[doc(cfg(item))]` to document that a item is only available with
-  certain features.][61351]
+- [You can use `#[cfg(doc)]` to compile an item when building documentation.][61351]
 
 Compatibility Notes
 -------------------

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,119 @@
+Version 1.41.0 (2020-01-30)
+===========================
+
+Language
+--------
+
+- [You can now pass type parameters to foreign items when implementing
+  traits.][65879] E.g. You can now write `impl<T> From<Foo> for Vec<T> {}`.
+- [You can now arbitrarily nest receiver types in the `self` position.][64325] E.g. you can
+  now write `fn foo(self: Box<Box<Self>>) {}`. Previously only `Self`, `&Self`,
+  `&mut Self`, `Arc<Self>`, `Rc<Self>`, and `Box<Self>` were allowed.
+- [You can now use any valid identifier in a `format_args` macro.][66847]
+  Previously identifiers starting with an underscore were not allowed.
+- [Visibility modifiers (e.g. `pub`) are now syntactically allowed on trait items and
+  enum variants.][66183] These are still rejected semantically, but
+  can be seen and parsed by procedural macros and conditional compilation.
+
+Compiler
+--------
+
+- [Rustc will now warn if you have unused loop `'label`s.][66325]
+- [Removed support for the `i686-unknown-dragonfly` target.][67255]
+- [Added tier 3 support\* for the `riscv64gc-unknown-linux-gnu` target.][66661]
+- [You can now pass an arguments file passing the `@path` syntax
+  to rustc.][66172] Note that the format differs somewhat from what is
+  found in other tooling; please see [the documentation][argfile-docs] for
+  more information.
+- [You can now provide `--extern` flag without a path, indicating that it is
+  available from the search path or specified with an `-L` flag.][64882]
+
+\* Refer to Rust's [platform support page][forge-platform-support] for more
+information on Rust's tiered platform support.
+
+[argfile-docs]: https://doc.rust-lang.org/nightly/rustc/command-line-arguments.html#path-load-command-line-flags-from-a-path
+
+Libraries
+---------
+
+- [The `core::panic` module is now stable.][66771] It was already stable
+  through `std`.
+- [`NonZero*` numerics now implement `From<NonZero*>` if it's a smaller integer
+  width.][66277] E.g. `NonZeroU16` now implements `From<NonZeroU8>`.
+- [`MaybeUninit<T>` now implements `fmt::Debug`.][65013]
+
+Stabilized APIs
+---------------
+
+- [`Result::map_or`]
+- [`Result::map_or_else`]
+- [`std::rc::Weak::weak_count`]
+- [`std::rc::Weak::strong_count`]
+- [`std::sync::Weak::weak_count`]
+- [`std::sync::Weak::strong_count`]
+
+Cargo
+-----
+
+- [Cargo will now document all the private items for binary crates
+  by default.][cargo/7593]
+- [`cargo-install` will now reinstall the package if it detects that it is out
+  of date.][cargo/7560]
+- [Cargo.lock now uses a more git friendly format that should help to reduce
+  merge conflicts.][cargo/7579]
+- [You can now override specific dependencies's build settings][cargo/7591] E.g.
+  `[profile.dev.overrides.image] opt-level = 2` sets the `image` crate's
+  optimisation level to `2` for debug builds. You can also use
+  `[profile.<profile>.build_overrides]` to override build scripts and
+  their dependencies.
+
+Misc
+----
+
+- [You can now specify `edition` in documentation code blocks to compile the block
+  for that edition.][66238] E.g. `edition2018` tells rustdoc that the code sample
+  should be compiled the 2018 edition of Rust.
+- [You can now provide custom themes to rustdoc with `--theme`, and check the
+  current theme with `--check-theme`.][54733]
+- [You can use `#[doc(cfg(item))]` to document that a item is only available with
+  certain features.][61351]
+
+Compatibility Notes
+-------------------
+
+- [As previously announced 1.41.0 will be the last tier 1 release for 32-bit
+  Apple targets.][apple-32bit-drop] This means that the source code is still
+  available to build, but the targets are no longer being tested and release
+  binaries for those platforms will no longer be distributed by the Rust project.
+  Please refer to the linked blog post for more information.
+
+[54733]: https://github.com/rust-lang/rust/pull/54733/
+[61351]: https://github.com/rust-lang/rust/pull/61351/
+[67255]: https://github.com/rust-lang/rust/pull/67255/
+[66661]: https://github.com/rust-lang/rust/pull/66661/
+[66771]: https://github.com/rust-lang/rust/pull/66771/
+[66847]: https://github.com/rust-lang/rust/pull/66847/
+[66238]: https://github.com/rust-lang/rust/pull/66238/
+[66277]: https://github.com/rust-lang/rust/pull/66277/
+[66325]: https://github.com/rust-lang/rust/pull/66325/
+[66172]: https://github.com/rust-lang/rust/pull/66172/
+[66183]: https://github.com/rust-lang/rust/pull/66183/
+[65879]: https://github.com/rust-lang/rust/pull/65879/
+[65013]: https://github.com/rust-lang/rust/pull/65013/
+[64882]: https://github.com/rust-lang/rust/pull/64882/
+[64325]: https://github.com/rust-lang/rust/pull/64325/
+[cargo/7560]: https://github.com/rust-lang/cargo/pull/7560/
+[cargo/7579]: https://github.com/rust-lang/cargo/pull/7579/
+[cargo/7591]: https://github.com/rust-lang/cargo/pull/7591/
+[cargo/7593]: https://github.com/rust-lang/cargo/pull/7593/
+[`Result::map_or_else`]: https://doc.rust-lang.org/std/result/enum.Result.html#method.map_or_else
+[`Result::map_or`]: https://doc.rust-lang.org/std/result/enum.Result.html#method.map_or
+[`std::rc::Weak::weak_count`]: https://doc.rust-lang.org/std/rc/struct.Weak.html#method.weak_count
+[`std::rc::Weak::strong_count`]: https://doc.rust-lang.org/std/rc/struct.Weak.html#method.strong_count
+[`std::sync::Weak::weak_count`]: https://doc.rust-lang.org/std/sync/struct.Weak.html#method.weak_count
+[`std::sync::Weak::strong_count`]: https://doc.rust-lang.org/std/sync/struct.Weak.html#method.strong_count
+[apple-32bit-drop]: https://blog.rust-lang.org/2020/01/03/reducing-support-for-32-bit-apple-targets.html
+
 Version 1.40.0 (2019-12-19)
 ===========================
 

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -43,7 +43,7 @@ fi
 #
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
-export RUST_RELEASE_CHANNEL=beta
+export RUST_RELEASE_CHANNEL=stable
 if [ "$DEPLOY$DEPLOY_ALT" = "1" ]; then
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=$RUST_RELEASE_CHANNEL"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"

--- a/src/librustc_mir/build/expr/as_temp.rs
+++ b/src/librustc_mir/build/expr/as_temp.rs
@@ -66,6 +66,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
             if let ExprKind::StaticRef { def_id, .. } = expr.kind {
                 let is_thread_local = this.hir.tcx().has_attr(def_id, sym::thread_local);
+                local_decl.internal = true;
                 local_decl.local_info = LocalInfo::StaticRef {def_id, is_thread_local };
             }
             this.local_decls.push(local_decl)

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -249,28 +249,30 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
             if let (PlaceBase::Local(local), []) = (&place.base, proj_base) {
                 let decl = &self.body.local_decls[*local];
                 if decl.internal {
-                    // Internal locals are used in the `move_val_init` desugaring.
-                    // We want to check unsafety against the source info of the
-                    // desugaring, rather than the source info of the RHS.
-                    self.source_info = self.body.local_decls[*local].source_info;
-                } else if let LocalInfo::StaticRef { def_id, .. } = decl.local_info {
-                    if self.tcx.is_mutable_static(def_id) {
-                        self.require_unsafe(
-                            "use of mutable static",
-                            "mutable statics can be mutated by multiple threads: aliasing \
-                        violations or data races will cause undefined behavior",
-                            UnsafetyViolationKind::General,
-                        );
-                        return;
-                    } else if self.tcx.is_foreign_item(def_id) {
-                        self.require_unsafe(
-                            "use of extern static",
-                            "extern statics are not controlled by the Rust type system: \
-                        invalid data, aliasing violations or data races will cause \
-                        undefined behavior",
-                            UnsafetyViolationKind::General,
-                        );
-                        return;
+                    if let LocalInfo::StaticRef { def_id, .. } = decl.local_info {
+                        if self.tcx.is_mutable_static(def_id) {
+                            self.require_unsafe(
+                                "use of mutable static",
+                                "mutable statics can be mutated by multiple threads: aliasing \
+                            violations or data races will cause undefined behavior",
+                                UnsafetyViolationKind::General,
+                            );
+                            return;
+                        } else if self.tcx.is_foreign_item(def_id) {
+                            self.require_unsafe(
+                                "use of extern static",
+                                "extern statics are not controlled by the Rust type system: \
+                            invalid data, aliasing violations or data races will cause \
+                            undefined behavior",
+                                UnsafetyViolationKind::General,
+                            );
+                            return;
+                        }
+                    } else {
+                        // Internal locals are used in the `move_val_init` desugaring.
+                        // We want to check unsafety against the source info of the
+                        // desugaring, rather than the source info of the RHS.
+                        self.source_info = self.body.local_decls[*local].source_info;
                     }
                 }
             }

--- a/src/librustc_typeck/check/generator_interior.rs
+++ b/src/librustc_typeck/check/generator_interior.rs
@@ -185,8 +185,6 @@ impl<'a, 'tcx> Visitor<'tcx> for InteriorVisitor<'a, 'tcx> {
     }
 
     fn visit_expr(&mut self, expr: &'tcx Expr) {
-        let scope = self.region_scope_tree.temporary_scope(expr.hir_id.local_id);
-
         match &expr.kind {
             ExprKind::Call(callee, args) => match &callee.kind {
                 ExprKind::Path(qpath) => {
@@ -212,19 +210,12 @@ impl<'a, 'tcx> Visitor<'tcx> for InteriorVisitor<'a, 'tcx> {
                 }
                 _ => intravisit::walk_expr(self, expr),
             }
-            ExprKind::Path(qpath) => {
-                let res = self.fcx.tables.borrow().qpath_res(qpath, expr.hir_id);
-                if let Res::Def(DefKind::Static, def_id) = res {
-                    // Statics are lowered to temporary references or
-                    // pointers in MIR, so record that type.
-                    let ptr_ty = self.fcx.tcx.static_ptr_ty(def_id);
-                    self.record(ptr_ty, scope, Some(expr), expr.span);
-                }
-            }
             _ => intravisit::walk_expr(self, expr),
         }
 
         self.expr_count += 1;
+
+        let scope = self.region_scope_tree.temporary_scope(expr.hir_id.local_id);
 
         // If there are adjustments, then record the final type --
         // this is the actual value that is being produced.

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,7 +12,7 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.x.0` for Cargo where they were released on `date`.
 
-date: 2019-12-16
+date: 2019-12-19
 rustc: 1.40.0
 cargo: 0.41.0
 
@@ -34,4 +34,4 @@ cargo: 0.41.0
 # looking at a beta source tarball and it's uncommented we'll shortly comment it
 # out.
 
-dev: 1
+#dev: 1

--- a/src/test/ui/async-await/issues/issue-67611-static-mut-refs.rs
+++ b/src/test/ui/async-await/issues/issue-67611-static-mut-refs.rs
@@ -1,0 +1,33 @@
+// build-pass
+// edition:2018
+
+static mut A: [i32; 5] = [1, 2, 3, 4, 5];
+
+fn is_send_sync<T: Send + Sync>(_: T) {}
+
+async fn fun() {
+    let u = unsafe { A[async { 1 }.await] };
+    unsafe {
+        match A {
+            i if async { true }.await => (),
+            _ => (),
+        }
+    }
+}
+
+fn main() {
+    let index_block = async {
+        let u = unsafe { A[async { 1 }.await] };
+    };
+    let match_block = async {
+        unsafe {
+            match A {
+                i if async { true }.await => (),
+                _ => (),
+            }
+        }
+    };
+    is_send_sync(index_block);
+    is_send_sync(match_block);
+    is_send_sync(fun());
+}

--- a/src/test/ui/generator/static-mut-reference-across-yield.rs
+++ b/src/test/ui/generator/static-mut-reference-across-yield.rs
@@ -1,0 +1,29 @@
+// build-pass
+#![feature(generators)]
+
+static mut A: [i32; 5] = [1, 2, 3, 4, 5];
+
+fn is_send_sync<T: Send + Sync>(_: T) {}
+
+fn main() {
+    unsafe {
+        let gen_index = static || {
+            let u = A[{
+                yield;
+                1
+            }];
+        };
+        let gen_match = static || match A {
+            i if {
+                yield;
+                true
+            } =>
+            {
+                ()
+            }
+            _ => (),
+        };
+        is_send_sync(gen_index);
+        is_send_sync(gen_match);
+    }
+}


### PR DESCRIPTION
This PR produces the 1.41.0 stable release, backporting the following PRs as well:

* #68494: Make pointers to statics internal 
* #67928: Update RELEASES.md for 1.41.0 

r? @ghost