### PR TITLE
[WIP] [let_chains, 4/N] Introduce `hir::ExprKind::Let`

### DIFF
--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -100,8 +100,8 @@ pub(super) fn note_and_explain_region(
                 Some(Node::Expr(expr)) => match expr.kind {
                     hir::ExprKind::Call(..) => "call",
                     hir::ExprKind::MethodCall(..) => "method call",
-                    hir::ExprKind::Match(.., hir::MatchSource::IfLetDesugar { .. }) => "if let",
-                    hir::ExprKind::Match(.., hir::MatchSource::WhileLetDesugar) => "while let",
+                    hir::ExprKind::Match(.., hir::MatchSource::IfDesugar { .. }) => "if",
+                    hir::ExprKind::Match(.., hir::MatchSource::WhileDesugar) => "while",
                     hir::ExprKind::Match(.., hir::MatchSource::ForLoopDesugar) => "for",
                     hir::ExprKind::Match(..) => "match",
                     _ => "expression",
@@ -610,10 +610,6 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 scrut_hir_id,
                 ..
             }) => match source {
-                hir::MatchSource::IfLetDesugar { .. } => {
-                    let msg = "`if let` arms have incompatible types";
-                    err.span_label(cause.span, msg);
-                }
                 hir::MatchSource::TryDesugar => {
                     if let Some(ty::error::ExpectedFound { expected, .. }) = exp_found {
                         let scrut_expr = self.tcx.hir().expect_expr(scrut_hir_id);
@@ -1985,9 +1981,6 @@ impl<'tcx> ObligationCause<'tcx> {
             CompareImplTypeObligation { .. } => Error0308("type not compatible with trait"),
             MatchExpressionArm(box MatchExpressionArmCause { source, .. }) => {
                 Error0308(match source {
-                    hir::MatchSource::IfLetDesugar { .. } => {
-                        "`if let` arms have incompatible types"
-                    }
                     hir::MatchSource::TryDesugar => {
                         "try expression alternatives have incompatible types"
                     }
@@ -2023,10 +2016,7 @@ impl<'tcx> ObligationCause<'tcx> {
             CompareImplMethodObligation { .. } => "method type is compatible with trait",
             CompareImplTypeObligation { .. } => "associated type is compatible with trait",
             ExprAssignable => "expression is assignable",
-            MatchExpressionArm(box MatchExpressionArmCause { source, .. }) => match source {
-                hir::MatchSource::IfLetDesugar { .. } => "`if let` arms have compatible types",
-                _ => "`match` arms have compatible types",
-            },
+            MatchExpressionArm(_) => "`match` arms have compatible types",
             IfExpression { .. } => "`if` and `else` have incompatible types",
             IfExpressionWithNoElse => "`if` missing an `else` returns `()`",
             MainFunctionType => "`main` function has the correct type",

--- a/src/librustc_ast_passes/ast_validation.rs
+++ b/src/librustc_ast_passes/ast_validation.rs
@@ -64,6 +64,9 @@ struct AstValidator<'a> {
     /// certain positions.
     is_assoc_ty_bound_banned: bool,
 
+    /// Used to allow `let` expressions in certain syntactic locations.
+    is_let_allowed: bool,
+
     lint_buffer: &'a mut LintBuffer,
 }
 
@@ -94,6 +97,27 @@ impl<'a> AstValidator<'a> {
         let old = self.bound_context.replace(ctx);
         f(self);
         self.bound_context = old;
+    }
+
+    fn with_let_allowed(&mut self, allowed: bool, f: impl FnOnce(&mut Self, bool)) {
+        let old = mem::replace(&mut self.is_let_allowed, allowed);
+        f(self, old);
+        self.is_let_allowed = old;
+    }
+
+    /// Emits an error banning the `let` expression provided in the given location.
+    fn ban_let_expr(&self, expr: &'a Expr) {
+        let sess = &self.session;
+        if sess.opts.unstable_features.is_nightly_build() {
+            sess.struct_span_err(expr.span, "`let` expressions are not supported here")
+                .note("only supported directly in conditions of `if`- and `while`-expressions")
+                .note("as well as when nested within `&&` and parenthesis in those conditions")
+                .emit();
+        } else {
+            sess.struct_span_err(expr.span, "expected expression, found statement (`let`)")
+                .note("variable declaration using `let` is a statement")
+                .emit();
+        }
     }
 
     fn visit_assoc_ty_constraint_from_generic_args(&mut self, constraint: &'a AssocTyConstraint) {
@@ -502,23 +526,46 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
     }
 
     fn visit_expr(&mut self, expr: &'a Expr) {
-        match &expr.kind {
-            ExprKind::Closure(_, _, _, fn_decl, _, _) => {
-                self.check_fn_decl(fn_decl);
+        self.with_let_allowed(false, |this, let_allowed| {
+            match &expr.kind {
+                ExprKind::Closure(_, _, _, fn_decl, _, _) => {
+                    this.check_fn_decl(fn_decl);
+                }
+                ExprKind::InlineAsm(..) if !this.session.target.target.options.allow_asm => {
+                    struct_span_err!(
+                        this.session,
+                        expr.span,
+                        E0472,
+                        "asm! is unsupported on this target"
+                    )
+                    .emit();
+                }
+                ExprKind::Let(..) if !let_allowed => this.ban_let_expr(expr),
+                // `(e)` or `e && e` does not impose additional constraints on `e`.
+                ExprKind::Paren(_) | ExprKind::Binary(Spanned { node: BinOpKind::And, .. }, ..) => {
+                    this.with_let_allowed(let_allowed, |this, _| visit::walk_expr(this, expr));
+                    return; // We've already walked into `expr`.
+                }
+                // However, we do allow it in the condition of the `if` expression.
+                // We do not allow `let` in `then` and `opt_else` directly.
+                ExprKind::If(cond, then, opt_else) => {
+                    this.visit_block(then);
+                    walk_list!(this, visit_expr, opt_else);
+                    this.with_let_allowed(true, |this, _| this.visit_expr(cond));
+                    return; // We've already walked into `expr`.
+                }
+                // The same logic applies to `While`.
+                ExprKind::While(cond, then, opt_label) => {
+                    walk_list!(this, visit_label, opt_label);
+                    this.visit_block(then);
+                    this.with_let_allowed(true, |this, _| this.visit_expr(cond));
+                    return; // We've already walked into `expr`.
+                }
+                _ => {}
             }
-            ExprKind::InlineAsm(..) if !self.session.target.target.options.allow_asm => {
-                struct_span_err!(
-                    self.session,
-                    expr.span,
-                    E0472,
-                    "asm! is unsupported on this target"
-                )
-                .emit();
-            }
-            _ => {}
-        }
 
-        visit::walk_expr(self, expr);
+            visit::walk_expr(this, expr);
+        });
     }
 
     fn visit_ty(&mut self, ty: &'a Ty) {
@@ -1049,6 +1096,7 @@ pub fn check_crate(session: &Session, krate: &Crate, lints: &mut LintBuffer) -> 
         bound_context: None,
         is_impl_trait_banned: false,
         is_assoc_ty_bound_banned: false,
+        is_let_allowed: false,
         lint_buffer: lints,
     };
     visit::walk_crate(&mut validator, krate);

--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -1686,13 +1686,8 @@ pub enum MatchSource {
     Normal,
     /// An `if _ { .. }` (optionally with `else { .. }`).
     IfDesugar { contains_else_clause: bool },
-    /// An `if let _ = _ { .. }` (optionally with `else { .. }`).
-    IfLetDesugar { contains_else_clause: bool },
     /// A `while _ { .. }` (which was desugared to a `loop { match _ { .. } }`).
     WhileDesugar,
-    /// A `while let _ = _ { .. }` (which was desugared to a
-    /// `loop { match _ { .. } }`).
-    WhileLetDesugar,
     /// A desugared `for _ in _ { .. }` loop.
     ForLoopDesugar,
     /// A desugared `?` operator.
@@ -1706,8 +1701,8 @@ impl MatchSource {
         use MatchSource::*;
         match self {
             Normal => "match",
-            IfDesugar { .. } | IfLetDesugar { .. } => "if",
-            WhileDesugar | WhileLetDesugar => "while",
+            IfDesugar { .. } => "if",
+            WhileDesugar => "while",
             ForLoopDesugar => "for",
             TryDesugar => "?",
             AwaitDesugar => ".await",
@@ -1722,8 +1717,6 @@ pub enum LoopSource {
     Loop,
     /// A `while _ { .. }` loop.
     While,
-    /// A `while let _ = _ { .. }` loop.
-    WhileLet,
     /// A `for _ in _ { .. }` loop.
     ForLoop,
 }
@@ -1732,7 +1725,7 @@ impl LoopSource {
     pub fn name(self) -> &'static str {
         match self {
             LoopSource::Loop => "loop",
-            LoopSource::While | LoopSource::WhileLet => "while",
+            LoopSource::While => "while",
             LoopSource::ForLoop => "for",
         }
     }

--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -1348,6 +1348,7 @@ impl Expr<'_> {
             ExprKind::Lit(_) => ExprPrecedence::Lit,
             ExprKind::Type(..) | ExprKind::Cast(..) => ExprPrecedence::Cast,
             ExprKind::DropTemps(ref expr, ..) => expr.precedence(),
+            ExprKind::Let(..) => ExprPrecedence::Let,
             ExprKind::Loop(..) => ExprPrecedence::Loop,
             ExprKind::Match(..) => ExprPrecedence::Match,
             ExprKind::Closure(..) => ExprPrecedence::Closure,
@@ -1414,6 +1415,7 @@ impl Expr<'_> {
             | ExprKind::Break(..)
             | ExprKind::Continue(..)
             | ExprKind::Ret(..)
+            | ExprKind::Let(..)
             | ExprKind::Loop(..)
             | ExprKind::Assign(..)
             | ExprKind::InlineAsm(..)
@@ -1563,6 +1565,11 @@ pub enum ExprKind<'hir> {
     /// This construct only exists to tweak the drop order in HIR lowering.
     /// An example of that is the desugaring of `for` loops.
     DropTemps(&'hir Expr<'hir>),
+    /// A `let $pat = $expr` expression.
+    ///
+    /// These are not `Local` which only occur as statements.
+    /// The `let Some(x) = foo()` in `if let Some(x) = foo()` is an example of `Let(..)`.
+    Let(&'hir Pat<'hir>, &'hir Expr<'hir>),
     /// A conditionless loop (can be exited with `break`, `continue`, or `return`).
     ///
     /// I.e., `'label: loop { <block> }`.

--- a/src/librustc_hir/intravisit.rs
+++ b/src/librustc_hir/intravisit.rs
@@ -462,8 +462,7 @@ pub fn walk_body<'v, V: Visitor<'v>>(visitor: &mut V, body: &'v Body<'v>) {
 }
 
 pub fn walk_local<'v, V: Visitor<'v>>(visitor: &mut V, local: &'v Local<'v>) {
-    // Intentionally visiting the expr first - the initialization expr
-    // dominates the local's definition.
+    // Visit the expr first. The initialization expr dominates the local's definition.
     walk_list!(visitor, visit_expr, &local.init);
     walk_list!(visitor, visit_attribute, local.attrs.iter());
     visitor.visit_id(local.hir_id);
@@ -1081,6 +1080,12 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr<'v>) 
         }
         ExprKind::DropTemps(ref subexpression) => {
             visitor.visit_expr(subexpression);
+        }
+        ExprKind::Let(ref pat, ref expr) => {
+            // Visit the expr first. The initialization expr dominates the `let`'s definition.
+            // This is the same logic in `walk_local`.
+            visitor.visit_expr(expr);
+            visitor.visit_pat(pat);
         }
         ExprKind::Loop(ref block, ref opt_label, _) => {
             walk_list!(visitor, visit_label, opt_label);

--- a/src/librustc_mir_build/hair/cx/expr.rs
+++ b/src/librustc_mir_build/hair/cx/expr.rs
@@ -476,7 +476,7 @@ fn make_mirror_unadjusted<'a, 'tcx>(
         hir::ExprKind::Match(
             hir::Expr { kind: hir::ExprKind::Let(ref pat, ref scrutinee), .. },
             [ref then_arm, ref else_arm],
-            hir::MatchSource::IfLetDesugar { .. },
+            _,
         ) => {
             // HACK(let_chains, Centril): This is the desugaring for `if let`.
             // We do not yet have `hair::ExprKind::Let`.

--- a/src/librustc_mir_build/hair/pattern/_match.rs
+++ b/src/librustc_mir_build/hair/pattern/_match.rs
@@ -586,7 +586,7 @@ impl<'a, 'tcx> MatchCheckCtxt<'a, 'tcx> {
         tcx: TyCtxt<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
         module: DefId,
-        f: impl for<'b> FnOnce(MatchCheckCtxt<'b, 'tcx>) -> R,
+        f: impl FnOnce(MatchCheckCtxt<'_, 'tcx>) -> R,
     ) -> R {
         let pattern_arena = TypedArena::default();
 

--- a/src/librustc_mir_build/hair/pattern/check_match.rs
+++ b/src/librustc_mir_build/hair/pattern/check_match.rs
@@ -28,9 +28,8 @@ crate fn check_match(tcx: TyCtxt<'_>, def_id: DefId) {
         Some(id) => tcx.hir().body_owned_by(id),
     };
 
-    let mut visitor =
-        MatchVisitor { tcx, tables: tcx.body_tables(body_id), param_env: tcx.param_env(def_id) };
-    visitor.visit_body(tcx.hir().body(body_id));
+    MatchVisitor { tcx, tables: tcx.body_tables(body_id), param_env: tcx.param_env(def_id) }
+        .visit_body(tcx.hir().body(body_id));
 }
 
 fn create_e0004(sess: &Session, sp: Span, error_message: String) -> DiagnosticBuilder<'_> {
@@ -53,6 +52,7 @@ impl<'tcx> Visitor<'tcx> for MatchVisitor<'_, 'tcx> {
     fn visit_expr(&mut self, ex: &'tcx hir::Expr<'tcx>) {
         intravisit::walk_expr(self, ex);
 
+        // FIXME(let_chains): Deal with `::Let`.
         if let hir::ExprKind::Match(ref scrut, ref arms, source) = ex.kind {
             self.check_match(scrut, arms, source);
         }

--- a/src/librustc_passes/check_const.rs
+++ b/src/librustc_passes/check_const.rs
@@ -43,18 +43,13 @@ impl NonConstExpr {
         use hir::MatchSource::*;
 
         let gates: &[_] = match self {
-            Self::Match(Normal)
-            | Self::Match(IfDesugar { .. })
-            | Self::Match(IfLetDesugar { .. })
-            | Self::OrPattern => &[sym::const_if_match],
-
+            Self::Match(Normal) | Self::Match(IfDesugar { .. }) | Self::OrPattern => {
+                &[sym::const_if_match]
+            }
             Self::Loop(Loop) => &[sym::const_loop],
-
-            Self::Loop(While)
-            | Self::Loop(WhileLet)
-            | Self::Match(WhileDesugar)
-            | Self::Match(WhileLetDesugar) => &[sym::const_loop, sym::const_if_match],
-
+            Self::Loop(While) | Self::Match(WhileDesugar) => {
+                &[sym::const_loop, sym::const_if_match]
+            }
             // A `for` loop's desugaring contains a call to `IntoIterator::into_iter`,
             // so they are not yet allowed with `#![feature(const_loop)]`.
             _ => return None,
@@ -236,10 +231,7 @@ impl<'tcx> Visitor<'tcx> for CheckConstVisitor<'tcx> {
             hir::ExprKind::Match(_, _, source) => {
                 let non_const_expr = match source {
                     // These are handled by `ExprKind::Loop` above.
-                    hir::MatchSource::WhileDesugar
-                    | hir::MatchSource::WhileLetDesugar
-                    | hir::MatchSource::ForLoopDesugar => None,
-
+                    hir::MatchSource::WhileDesugar | hir::MatchSource::ForLoopDesugar => None,
                     _ => Some(NonConstExpr::Match(*source)),
                 };
 

--- a/src/librustc_passes/region.rs
+++ b/src/librustc_passes/region.rs
@@ -399,9 +399,9 @@ fn resolve_expr<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, expr: &'tcx h
         }
 
         hir::ExprKind::Match(
-            hir::Expr { kind: hir::ExprKind::Let(ref pat, ref scrutinee), .. },
+            hir::Expr { kind: hir::ExprKind::Let(ref pat, scrutinee), .. },
             [ref then_arm, ref else_arm],
-            hir::MatchSource::IfLetDesugar { .. },
+            _,
         ) => {
             // HACK(let_chains, Centril): In HAIR lowering we currently adjust this
             // to `match scrutinee { pat => then_arm.body, _ => else_arm.body }`.

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -19,11 +19,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> Ty<'tcx> {
         let tcx = self.tcx;
 
-        use hir::MatchSource::*;
         let (source_if, if_no_else, force_scrutinee_bool) = match match_src {
-            IfDesugar { contains_else_clause } => (true, !contains_else_clause, true),
-            IfLetDesugar { contains_else_clause } => (true, !contains_else_clause, false),
-            WhileDesugar => (false, false, true),
+            hir::MatchSource::IfDesugar { contains_else_clause: e } => (true, !e, true),
+            hir::MatchSource::WhileDesugar => (false, false, true),
             _ => (false, false, false),
         };
 
@@ -183,10 +181,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         arms: &'tcx [hir::Arm<'tcx>],
         source: hir::MatchSource,
     ) {
-        use hir::MatchSource::*;
         let msg = match source {
-            IfDesugar { .. } | IfLetDesugar { .. } => "block in `if` expression",
-            WhileDesugar { .. } | WhileLetDesugar { .. } => "block in `while` expression",
+            hir::MatchSource::IfDesugar { .. } => "block in `if` expression",
+            hir::MatchSource::WhileDesugar { .. } => "block in `while` expression",
             _ => "arm",
         };
         for arm in arms {

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -822,8 +822,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let coerce_to = expected.coercion_target_type(self, body.span);
                 Some(CoerceMany::new(coerce_to))
             }
-
-            hir::LoopSource::While | hir::LoopSource::WhileLet | hir::LoopSource::ForLoop => None,
+            hir::LoopSource::While | hir::LoopSource::ForLoop => None,
         };
 
         let ctxt = BreakableCtxt {

--- a/src/librustc_typeck/check/generator_interior.rs
+++ b/src/librustc_typeck/check/generator_interior.rs
@@ -250,7 +250,7 @@ impl<'a, 'tcx> Visitor<'tcx> for InteriorVisitor<'a, 'tcx> {
             ExprKind::Match(
                 Expr { kind: ExprKind::Let(pat, scrutinee), .. },
                 [then_arm, else_arm],
-                hir::MatchSource::IfLetDesugar { .. },
+                _,
             ) => {
                 // HACK(let_chains, Centril): In HAIR lowering we currently adjust this
                 // to `match scrutinee { pat => then_arm.body, _ => else_arm.body }`.

--- a/src/librustc_typeck/mem_categorization.rs
+++ b/src/librustc_typeck/mem_categorization.rs
@@ -396,6 +396,7 @@ impl<'a, 'tcx> MemCategorizationContext<'a, 'tcx> {
             | hir::ExprKind::Tup(..)
             | hir::ExprKind::Binary(..)
             | hir::ExprKind::Block(..)
+            | hir::ExprKind::Let(..)
             | hir::ExprKind::Loop(..)
             | hir::ExprKind::Match(..)
             | hir::ExprKind::Lit(..)

--- a/src/libsyntax/util/parser.rs
+++ b/src/libsyntax/util/parser.rs
@@ -367,7 +367,7 @@ pub fn prec_let_scrutinee_needs_par() -> usize {
 ///
 /// Conversely, suppose that we have `(let _ = a) OP b` and `order` is that of `OP`.
 /// Can we print this as `let _ = a OP b`?
-crate fn needs_par_as_let_scrutinee(order: i8) -> bool {
+pub fn needs_par_as_let_scrutinee(order: i8) -> bool {
     order <= prec_let_scrutinee_needs_par() as i8
 }
 

--- a/src/test/ui/if/if-let.rs
+++ b/src/test/ui/if/if-let.rs
@@ -1,33 +1,33 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 fn macros() {
     macro_rules! foo{
         ($p:pat, $e:expr, $b:block) => {{
             if let $p = $e $b
-            //~^ WARN irrefutable if-let
-            //~| WARN irrefutable if-let
         }}
     }
-    macro_rules! bar{
-        ($p:pat, $e:expr, $b:block) => {{
-            foo!($p, $e, $b)
-        }}
+    macro_rules! bar {
+        ($p:pat, $e:expr, $b:block) => {{ foo!($p, $e, $b) }};
     }
 
     foo!(a, 1, {
+        //~^ WARN irrefutable `let`
         println!("irrefutable pattern");
     });
     bar!(a, 1, {
+        //~^ WARN irrefutable `let`
         println!("irrefutable pattern");
     });
 }
 
 pub fn main() {
-    if let a = 1 { //~ WARN irrefutable if-let
+    if let a = 1 {
+        //~^ WARN irrefutable `let`
         println!("irrefutable pattern");
     }
 
-    if let a = 1 { //~ WARN irrefutable if-let
+    if let a = 1 {
+        //~^ WARN irrefutable `let`
         println!("irrefutable pattern");
     } else if true {
         println!("else-if in irrefutable if-let");
@@ -37,13 +37,15 @@ pub fn main() {
 
     if let 1 = 2 {
         println!("refutable pattern");
-    } else if let a = 1 { //~ WARN irrefutable if-let
+    } else if let a = 1 {
+        //~^ WARN irrefutable `let`
         println!("irrefutable pattern");
     }
 
     if true {
         println!("if");
-    } else if let a = 1 { //~ WARN irrefutable if-let
+    } else if let a = 1 {
+        //~^ WARN irrefutable `let`
         println!("irrefutable pattern");
     }
 }

--- a/src/test/ui/if/if-let.stderr
+++ b/src/test/ui/if/if-let.stderr
@@ -1,62 +1,38 @@
-warning: irrefutable if-let pattern
-  --> $DIR/if-let.rs:6:13
+warning: irrefutable `let` pattern
+  --> $DIR/if-let.rs:13:10
    |
-LL |               if let $p = $e $b
-   |               ^^^^^^^^^^^^^^^^^
-...
-LL | /     foo!(a, 1, {
-LL | |         println!("irrefutable pattern");
-LL | |     });
-   | |_______- in this macro invocation
+LL |     foo!(a, 1, {
+   |          ^
    |
    = note: `#[warn(irrefutable_let_patterns)]` on by default
 
-warning: irrefutable if-let pattern
-  --> $DIR/if-let.rs:6:13
+warning: irrefutable `let` pattern
+  --> $DIR/if-let.rs:17:10
    |
-LL |               if let $p = $e $b
-   |               ^^^^^^^^^^^^^^^^^
-...
-LL | /     bar!(a, 1, {
-LL | |         println!("irrefutable pattern");
-LL | |     });
-   | |_______- in this macro invocation
+LL |     bar!(a, 1, {
+   |          ^
 
-warning: irrefutable if-let pattern
-  --> $DIR/if-let.rs:26:5
+warning: irrefutable `let` pattern
+  --> $DIR/if-let.rs:24:12
    |
-LL | /     if let a = 1 {
-LL | |         println!("irrefutable pattern");
-LL | |     }
-   | |_____^
+LL |     if let a = 1 {
+   |            ^
 
-warning: irrefutable if-let pattern
-  --> $DIR/if-let.rs:30:5
+warning: irrefutable `let` pattern
+  --> $DIR/if-let.rs:29:12
    |
-LL | /     if let a = 1 {
-LL | |         println!("irrefutable pattern");
-LL | |     } else if true {
-LL | |         println!("else-if in irrefutable if-let");
-LL | |     } else {
-LL | |         println!("else in irrefutable if-let");
-LL | |     }
-   | |_____^
+LL |     if let a = 1 {
+   |            ^
 
-warning: irrefutable if-let pattern
-  --> $DIR/if-let.rs:40:12
+warning: irrefutable `let` pattern
+  --> $DIR/if-let.rs:40:19
    |
-LL |       } else if let a = 1 {
-   |  ____________^
-LL | |         println!("irrefutable pattern");
-LL | |     }
-   | |_____^
+LL |     } else if let a = 1 {
+   |                   ^
 
-warning: irrefutable if-let pattern
-  --> $DIR/if-let.rs:46:12
+warning: irrefutable `let` pattern
+  --> $DIR/if-let.rs:47:19
    |
-LL |       } else if let a = 1 {
-   |  ____________^
-LL | |         println!("irrefutable pattern");
-LL | |     }
-   | |_____^
+LL |     } else if let a = 1 {
+   |                   ^
 

--- a/src/test/ui/pattern/deny-irrefutable-let-patterns.rs
+++ b/src/test/ui/pattern/deny-irrefutable-let-patterns.rs
@@ -1,9 +1,10 @@
 #![deny(irrefutable_let_patterns)]
 
 fn main() {
-    if let _ = 5 {} //~ ERROR irrefutable if-let pattern
+    if let _ = 5 {} //~ ERROR irrefutable `let` pattern
 
-    while let _ = 5 { //~ ERROR irrefutable while-let pattern
+    while let _ = 5 {
+        //~^ ERROR irrefutable `let` pattern
         break;
     }
 }

--- a/src/test/ui/pattern/deny-irrefutable-let-patterns.stderr
+++ b/src/test/ui/pattern/deny-irrefutable-let-patterns.stderr
@@ -1,8 +1,8 @@
-error: irrefutable if-let pattern
-  --> $DIR/deny-irrefutable-let-patterns.rs:4:5
+error: irrefutable `let` pattern
+  --> $DIR/deny-irrefutable-let-patterns.rs:4:12
    |
 LL |     if let _ = 5 {}
-   |     ^^^^^^^^^^^^^^^
+   |            ^
    |
 note: lint level defined here
   --> $DIR/deny-irrefutable-let-patterns.rs:1:9
@@ -10,13 +10,11 @@ note: lint level defined here
 LL | #![deny(irrefutable_let_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: irrefutable while-let pattern
-  --> $DIR/deny-irrefutable-let-patterns.rs:6:5
+error: irrefutable `let` pattern
+  --> $DIR/deny-irrefutable-let-patterns.rs:6:15
    |
-LL | /     while let _ = 5 {
-LL | |         break;
-LL | |     }
-   | |_____^
+LL |     while let _ = 5 {
+   |               ^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.rs
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.rs
@@ -216,17 +216,14 @@ fn inside_const_generic_arguments() {
 
     if let A::<{
         true && let 1 = 1 //~ ERROR `let` expressions are not supported here
-        //~| ERROR `match` is not allowed in a `const`
     }>::O = 5 {}
 
     while let A::<{
         true && let 1 = 1 //~ ERROR `let` expressions are not supported here
-        //~| ERROR `match` is not allowed in a `const`
     }>::O = 5 {}
 
     if A::<{
         true && let 1 = 1 //~ ERROR `let` expressions are not supported here
-        //~| ERROR `match` is not allowed in a `const`
     }>::O == 5 {}
 
     // In the cases above we have `ExprKind::Block` to help us out.

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -1,5 +1,5 @@
 error: expected one of `,` or `>`, found `&&`
-  --> $DIR/disallowed-positions.rs:239:14
+  --> $DIR/disallowed-positions.rs:236:14
    |
 LL |         true && let 1 = 1
    |              ^^ expected one of `,` or `>`
@@ -482,7 +482,7 @@ LL |         true && let 1 = 1
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:223:17
+  --> $DIR/disallowed-positions.rs:222:17
    |
 LL |         true && let 1 = 1
    |                 ^^^^^^^^^
@@ -491,7 +491,7 @@ LL |         true && let 1 = 1
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:228:17
+  --> $DIR/disallowed-positions.rs:226:17
    |
 LL |         true && let 1 = 1
    |                 ^^^^^^^^^
@@ -512,33 +512,6 @@ warning: the feature `let_chains` is incomplete and may cause the compiler to cr
    |
 LL | #![feature(let_chains)] // Avoid inflating `.stderr` with overzealous gates in this test.
    |            ^^^^^^^^^^
-
-error[E0658]: `match` is not allowed in a `const`
-  --> $DIR/disallowed-positions.rs:218:17
-   |
-LL |         true && let 1 = 1
-   |                 ^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
-   = help: add `#![feature(const_if_match)]` to the crate attributes to enable
-
-error[E0658]: `match` is not allowed in a `const`
-  --> $DIR/disallowed-positions.rs:223:17
-   |
-LL |         true && let 1 = 1
-   |                 ^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
-   = help: add `#![feature(const_if_match)]` to the crate attributes to enable
-
-error[E0658]: `match` is not allowed in a `const`
-  --> $DIR/disallowed-positions.rs:228:17
-   |
-LL |         true && let 1 = 1
-   |                 ^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
-   = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:32:8
@@ -986,7 +959,7 @@ LL |         let 0 = 0?;
    = help: the trait `std::ops::Try` is not implemented for `{integer}`
    = note: required by `std::ops::Try::into_result`
 
-error: aborting due to 106 previous errors
+error: aborting due to 103 previous errors
 
-Some errors have detailed explanations: E0277, E0308, E0600, E0614, E0658.
+Some errors have detailed explanations: E0277, E0308, E0600, E0614.
 For more information about an error, try `rustc --explain E0277`.

--- a/src/test/ui/rfc-2497-if-let-chains/feature-gate.rs
+++ b/src/test/ui/rfc-2497-if-let-chains/feature-gate.rs
@@ -13,33 +13,25 @@ fn _if() {
 
     if (let 0 = 1) {}
     //~^ ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR `let` expressions are not supported here
 
     if (((let 0 = 1))) {}
     //~^ ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR `let` expressions are not supported here
 
     if true && let 0 = 1 {}
     //~^ ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR `let` expressions are not supported here
 
     if let 0 = 1 && true {}
     //~^ ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR `let` expressions are not supported here
 
     if (let 0 = 1) && true {}
     //~^ ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR `let` expressions are not supported here
 
     if true && (let 0 = 1) {}
     //~^ ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR `let` expressions are not supported here
 
     if (let 0 = 1) && (let 0 = 1) {}
     //~^ ERROR `let` expressions in this position are experimental [E0658]
     //~| ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
 
     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
     //~^ ERROR `let` expressions in this position are experimental [E0658]
@@ -47,15 +39,9 @@ fn _if() {
     //~| ERROR `let` expressions in this position are experimental [E0658]
     //~| ERROR `let` expressions in this position are experimental [E0658]
     //~| ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
 
     if let Range { start: _, end: _ } = (true..true) && false {}
     //~^ ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR `let` expressions are not supported here
 }
 
 fn _while() {
@@ -63,33 +49,25 @@ fn _while() {
 
     while (let 0 = 1) {}
     //~^ ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR `let` expressions are not supported here
 
     while (((let 0 = 1))) {}
     //~^ ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR `let` expressions are not supported here
 
     while true && let 0 = 1 {}
     //~^ ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR `let` expressions are not supported here
 
     while let 0 = 1 && true {}
     //~^ ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR `let` expressions are not supported here
 
     while (let 0 = 1) && true {}
     //~^ ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR `let` expressions are not supported here
 
     while true && (let 0 = 1) {}
     //~^ ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR `let` expressions are not supported here
 
     while (let 0 = 1) && (let 0 = 1) {}
     //~^ ERROR `let` expressions in this position are experimental [E0658]
     //~| ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
 
     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
     //~^ ERROR `let` expressions in this position are experimental [E0658]
@@ -97,19 +75,15 @@ fn _while() {
     //~| ERROR `let` expressions in this position are experimental [E0658]
     //~| ERROR `let` expressions in this position are experimental [E0658]
     //~| ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
 
     while let Range { start: _, end: _ } = (true..true) && false {}
     //~^ ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR `let` expressions are not supported here
 }
 
 fn _macros() {
-    macro_rules! noop_expr { ($e:expr) => {}; }
+    macro_rules! noop_expr {
+        ($e:expr) => {};
+    }
 
     noop_expr!((let 0 = 1));
     //~^ ERROR `let` expressions in this position are experimental [E0658]
@@ -118,16 +92,12 @@ fn _macros() {
         ($e:expr) => {
             if $e {}
             while $e {}
-        }
+        };
     }
     use_expr!((let 0 = 1 && 0 == 0));
     //~^ ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
     use_expr!((let 0 = 1));
     //~^ ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
     #[cfg(FALSE)] (let 0 = 1);
     //~^ ERROR `let` expressions in this position are experimental [E0658]
     use_expr!(let 0 = 1);

--- a/src/test/ui/rfc-2497-if-let-chains/feature-gate.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/feature-gate.stderr
@@ -1,5 +1,5 @@
 error: no rules expected the token `let`
-  --> $DIR/feature-gate.rs:133:15
+  --> $DIR/feature-gate.rs:103:15
    |
 LL |     macro_rules! use_expr {
    |     --------------------- when calling this macro
@@ -17,7 +17,7 @@ LL |     if (let 0 = 1) {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:18:11
+  --> $DIR/feature-gate.rs:17:11
    |
 LL |     if (((let 0 = 1))) {}
    |           ^^^^^^^^^
@@ -26,7 +26,7 @@ LL |     if (((let 0 = 1))) {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:22:16
+  --> $DIR/feature-gate.rs:20:16
    |
 LL |     if true && let 0 = 1 {}
    |                ^^^^^^^^^
@@ -35,7 +35,7 @@ LL |     if true && let 0 = 1 {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:26:8
+  --> $DIR/feature-gate.rs:23:8
    |
 LL |     if let 0 = 1 && true {}
    |        ^^^^^^^^^
@@ -44,7 +44,7 @@ LL |     if let 0 = 1 && true {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:30:9
+  --> $DIR/feature-gate.rs:26:9
    |
 LL |     if (let 0 = 1) && true {}
    |         ^^^^^^^^^
@@ -53,7 +53,7 @@ LL |     if (let 0 = 1) && true {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:34:17
+  --> $DIR/feature-gate.rs:29:17
    |
 LL |     if true && (let 0 = 1) {}
    |                 ^^^^^^^^^
@@ -62,7 +62,7 @@ LL |     if true && (let 0 = 1) {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:38:9
+  --> $DIR/feature-gate.rs:32:9
    |
 LL |     if (let 0 = 1) && (let 0 = 1) {}
    |         ^^^^^^^^^
@@ -71,7 +71,7 @@ LL |     if (let 0 = 1) && (let 0 = 1) {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:38:24
+  --> $DIR/feature-gate.rs:32:24
    |
 LL |     if (let 0 = 1) && (let 0 = 1) {}
    |                        ^^^^^^^^^
@@ -80,7 +80,7 @@ LL |     if (let 0 = 1) && (let 0 = 1) {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:44:8
+  --> $DIR/feature-gate.rs:36:8
    |
 LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |        ^^^^^^^^^
@@ -89,7 +89,7 @@ LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:44:21
+  --> $DIR/feature-gate.rs:36:21
    |
 LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                     ^^^^^^^^^
@@ -98,7 +98,7 @@ LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:44:35
+  --> $DIR/feature-gate.rs:36:35
    |
 LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                   ^^^^^^^^^
@@ -107,7 +107,7 @@ LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:44:48
+  --> $DIR/feature-gate.rs:36:48
    |
 LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                                ^^^^^^^^^
@@ -116,7 +116,7 @@ LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:44:61
+  --> $DIR/feature-gate.rs:36:61
    |
 LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                                             ^^^^^^^^^
@@ -125,7 +125,7 @@ LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:56:8
+  --> $DIR/feature-gate.rs:43:8
    |
 LL |     if let Range { start: _, end: _ } = (true..true) && false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -134,7 +134,7 @@ LL |     if let Range { start: _, end: _ } = (true..true) && false {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:64:12
+  --> $DIR/feature-gate.rs:50:12
    |
 LL |     while (let 0 = 1) {}
    |            ^^^^^^^^^
@@ -143,7 +143,7 @@ LL |     while (let 0 = 1) {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:68:14
+  --> $DIR/feature-gate.rs:53:14
    |
 LL |     while (((let 0 = 1))) {}
    |              ^^^^^^^^^
@@ -152,7 +152,7 @@ LL |     while (((let 0 = 1))) {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:72:19
+  --> $DIR/feature-gate.rs:56:19
    |
 LL |     while true && let 0 = 1 {}
    |                   ^^^^^^^^^
@@ -161,7 +161,7 @@ LL |     while true && let 0 = 1 {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:76:11
+  --> $DIR/feature-gate.rs:59:11
    |
 LL |     while let 0 = 1 && true {}
    |           ^^^^^^^^^
@@ -170,7 +170,7 @@ LL |     while let 0 = 1 && true {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:80:12
+  --> $DIR/feature-gate.rs:62:12
    |
 LL |     while (let 0 = 1) && true {}
    |            ^^^^^^^^^
@@ -179,7 +179,7 @@ LL |     while (let 0 = 1) && true {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:84:20
+  --> $DIR/feature-gate.rs:65:20
    |
 LL |     while true && (let 0 = 1) {}
    |                    ^^^^^^^^^
@@ -188,7 +188,7 @@ LL |     while true && (let 0 = 1) {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:88:12
+  --> $DIR/feature-gate.rs:68:12
    |
 LL |     while (let 0 = 1) && (let 0 = 1) {}
    |            ^^^^^^^^^
@@ -197,7 +197,7 @@ LL |     while (let 0 = 1) && (let 0 = 1) {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:88:27
+  --> $DIR/feature-gate.rs:68:27
    |
 LL |     while (let 0 = 1) && (let 0 = 1) {}
    |                           ^^^^^^^^^
@@ -206,7 +206,7 @@ LL |     while (let 0 = 1) && (let 0 = 1) {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:94:11
+  --> $DIR/feature-gate.rs:72:11
    |
 LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |           ^^^^^^^^^
@@ -215,7 +215,7 @@ LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:94:24
+  --> $DIR/feature-gate.rs:72:24
    |
 LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                        ^^^^^^^^^
@@ -224,7 +224,7 @@ LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:94:38
+  --> $DIR/feature-gate.rs:72:38
    |
 LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                      ^^^^^^^^^
@@ -233,7 +233,7 @@ LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:94:51
+  --> $DIR/feature-gate.rs:72:51
    |
 LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                                   ^^^^^^^^^
@@ -242,7 +242,7 @@ LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:94:64
+  --> $DIR/feature-gate.rs:72:64
    |
 LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                                                ^^^^^^^^^
@@ -251,7 +251,7 @@ LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:106:11
+  --> $DIR/feature-gate.rs:79:11
    |
 LL |     while let Range { start: _, end: _ } = (true..true) && false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -260,7 +260,7 @@ LL |     while let Range { start: _, end: _ } = (true..true) && false {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:131:20
+  --> $DIR/feature-gate.rs:101:20
    |
 LL |     #[cfg(FALSE)] (let 0 = 1);
    |                    ^^^^^^^^^
@@ -269,7 +269,7 @@ LL |     #[cfg(FALSE)] (let 0 = 1);
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:114:17
+  --> $DIR/feature-gate.rs:88:17
    |
 LL |     noop_expr!((let 0 = 1));
    |                 ^^^^^^^^^
@@ -278,7 +278,7 @@ LL |     noop_expr!((let 0 = 1));
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:123:16
+  --> $DIR/feature-gate.rs:97:16
    |
 LL |     use_expr!((let 0 = 1 && 0 == 0));
    |                ^^^^^^^^^
@@ -287,7 +287,7 @@ LL |     use_expr!((let 0 = 1 && 0 == 0));
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:127:16
+  --> $DIR/feature-gate.rs:99:16
    |
 LL |     use_expr!((let 0 = 1));
    |                ^^^^^^^^^
@@ -295,294 +295,6 @@ LL |     use_expr!((let 0 = 1));
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:14:9
-   |
-LL |     if (let 0 = 1) {}
-   |         ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:18:11
-   |
-LL |     if (((let 0 = 1))) {}
-   |           ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:22:16
-   |
-LL |     if true && let 0 = 1 {}
-   |                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:26:8
-   |
-LL |     if let 0 = 1 && true {}
-   |        ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:30:9
-   |
-LL |     if (let 0 = 1) && true {}
-   |         ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:34:17
-   |
-LL |     if true && (let 0 = 1) {}
-   |                 ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:38:9
-   |
-LL |     if (let 0 = 1) && (let 0 = 1) {}
-   |         ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:38:24
-   |
-LL |     if (let 0 = 1) && (let 0 = 1) {}
-   |                        ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:44:8
-   |
-LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |        ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:44:21
-   |
-LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                     ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:44:35
-   |
-LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                   ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:44:48
-   |
-LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:44:61
-   |
-LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                                             ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:56:8
-   |
-LL |     if let Range { start: _, end: _ } = (true..true) && false {}
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:64:12
-   |
-LL |     while (let 0 = 1) {}
-   |            ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:68:14
-   |
-LL |     while (((let 0 = 1))) {}
-   |              ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:72:19
-   |
-LL |     while true && let 0 = 1 {}
-   |                   ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:76:11
-   |
-LL |     while let 0 = 1 && true {}
-   |           ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:80:12
-   |
-LL |     while (let 0 = 1) && true {}
-   |            ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:84:20
-   |
-LL |     while true && (let 0 = 1) {}
-   |                    ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:88:12
-   |
-LL |     while (let 0 = 1) && (let 0 = 1) {}
-   |            ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:88:27
-   |
-LL |     while (let 0 = 1) && (let 0 = 1) {}
-   |                           ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:94:11
-   |
-LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |           ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:94:24
-   |
-LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                        ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:94:38
-   |
-LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                      ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:94:51
-   |
-LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                                   ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:94:64
-   |
-LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                                                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:106:11
-   |
-LL |     while let Range { start: _, end: _ } = (true..true) && false {}
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:123:16
-   |
-LL |     use_expr!((let 0 = 1 && 0 == 0));
-   |                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:123:16
-   |
-LL |     use_expr!((let 0 = 1 && 0 == 0));
-   |                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:127:16
-   |
-LL |     use_expr!((let 0 = 1));
-   |                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:127:16
-   |
-LL |     use_expr!((let 0 = 1));
-   |                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: aborting due to 65 previous errors
+error: aborting due to 33 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/rfc-2497-if-let-chains/protect-precedences.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/protect-precedences.stderr
@@ -1,10 +1,11 @@
-warning: unreachable block in `if` expression
-  --> $DIR/protect-precedences.rs:13:41
+warning: unreachable expression
+  --> $DIR/protect-precedences.rs:13:12
    |
 LL |         if let _ = return true && false {};
-   |                    -------------------- ^^ unreachable block in `if` expression
-   |                    |
-   |                    any code following this expression is unreachable
+   |            ^^^^^^^^--------------------
+   |            |       |
+   |            |       any code following this expression is unreachable
+   |            unreachable expression
    |
    = note: `#[warn(unreachable_code)]` on by default
 

--- a/src/test/ui/while-let.rs
+++ b/src/test/ui/while-let.rs
@@ -5,26 +5,25 @@ fn macros() {
     macro_rules! foo{
         ($p:pat, $e:expr, $b:block) => {{
             while let $p = $e $b
-            //~^ WARN irrefutable while-let
-            //~| WARN irrefutable while-let
         }}
     }
-    macro_rules! bar{
-        ($p:pat, $e:expr, $b:block) => {{
-            foo!($p, $e, $b)
-        }}
+    macro_rules! bar {
+        ($p:pat, $e:expr, $b:block) => {{ foo!($p, $e, $b) }};
     }
 
     foo!(_a, 1, {
+        //~^ WARN irrefutable `let`
         println!("irrefutable pattern");
     });
     bar!(_a, 1, {
+        //~^ WARN irrefutable `let`
         println!("irrefutable pattern");
     });
 }
 
 pub fn main() {
-    while let _a = 1 { //~ WARN irrefutable while-let
+    while let _a = 1 {
+        //~^ WARN irrefutable `let`
         println!("irrefutable pattern");
         break;
     }

--- a/src/test/ui/while-let.stderr
+++ b/src/test/ui/while-let.stderr
@@ -1,33 +1,20 @@
-warning: irrefutable while-let pattern
-  --> $DIR/while-let.rs:7:13
+warning: irrefutable `let` pattern
+  --> $DIR/while-let.rs:14:10
    |
-LL |               while let $p = $e $b
-   |               ^^^^^^^^^^^^^^^^^^^^
-...
-LL | /     foo!(_a, 1, {
-LL | |         println!("irrefutable pattern");
-LL | |     });
-   | |_______- in this macro invocation
+LL |     foo!(_a, 1, {
+   |          ^^
    |
    = note: `#[warn(irrefutable_let_patterns)]` on by default
 
-warning: irrefutable while-let pattern
-  --> $DIR/while-let.rs:7:13
+warning: irrefutable `let` pattern
+  --> $DIR/while-let.rs:18:10
    |
-LL |               while let $p = $e $b
-   |               ^^^^^^^^^^^^^^^^^^^^
-...
-LL | /     bar!(_a, 1, {
-LL | |         println!("irrefutable pattern");
-LL | |     });
-   | |_______- in this macro invocation
+LL |     bar!(_a, 1, {
+   |          ^^
 
-warning: irrefutable while-let pattern
-  --> $DIR/while-let.rs:27:5
+warning: irrefutable `let` pattern
+  --> $DIR/while-let.rs:25:15
    |
-LL | /     while let _a = 1 {
-LL | |         println!("irrefutable pattern");
-LL | |         break;
-LL | |     }
-   | |_____^
+LL |     while let _a = 1 {
+   |               ^^
 


### PR DESCRIPTION
Introduces `hir::ExprKind::Let(&Pat<'_>, &Expr<'_>)`. That is, this introduces `let pat = expr` expressions.

For now, this is very much WIP and probably depends on https://github.com/rust-lang/rust/pull/67668 to remove the hacks in HAIR / region / generator_interior, but I thought it would be useful to have this open for discussion purposes and so that I can check perf.

cc https://github.com/rust-lang/rust/issues/53667.

r? @matthewjasper cc @oli-obk 