### PR TITLE
Account for HR lifetimes when suggesting introduction of named lifetime

### DIFF
--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -2263,7 +2263,7 @@ pub struct PolyTraitRef<'hir> {
     /// The `'a` in `for<'a> Foo<&'a T>`.
     pub bound_generic_params: &'hir [GenericParam<'hir>],
 
-    /// The `Foo<&'a T>` in `for <'a> Foo<&'a T>`.
+    /// The `Foo<&'a T>` in `for<'a> Foo<&'a T>`.
     pub trait_ref: TraitRef<'hir>,
 
     pub span: Span,

--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -2260,10 +2260,10 @@ impl TraitRef<'_> {
 
 #[derive(RustcEncodable, RustcDecodable, Debug, HashStable_Generic)]
 pub struct PolyTraitRef<'hir> {
-    /// The `'a` in `<'a> Foo<&'a T>`.
+    /// The `'a` in `for<'a> Foo<&'a T>`.
     pub bound_generic_params: &'hir [GenericParam<'hir>],
 
-    /// The `Foo<&'a T>` in `<'a> Foo<&'a T>`.
+    /// The `Foo<&'a T>` in `for <'a> Foo<&'a T>`.
     pub trait_ref: TraitRef<'hir>,
 
     pub span: Span,

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -1498,20 +1498,20 @@ crate fn add_missing_lifetime_specifiers_label(
                         msg = "consider introducing a named lifetime parameter";
                         should_break = true;
                         match &generics.params {
-                            [] => (generics.span, "<'r>".to_string()),
-                            [param, ..] => (param.span.shrink_to_lo(), "'r, ".to_string()),
+                            [] => (generics.span, "<'a>".to_string()),
+                            [param, ..] => (param.span.shrink_to_lo(), "'a, ".to_string()),
                         }
                     }
                     MissingLifetimeSpot::HRLT { span, span_type } => {
-                        msg = "consider introducing a Higher-Ranked lifetime";
+                        msg = "consider introducing a higher-ranked lifetime";
                         should_break = false;
                         err.note(
-                            "for more information on Higher-Ranked lifetimes, visit \
+                            "for more information on higher-ranked lifetimes, visit \
                              https://doc.rust-lang.org/nomicon/hrtb.html",
                         );
                         let suggestion = match span_type {
-                            HRLTSpanType::Empty => "for<'r> ",
-                            HRLTSpanType::Tail => ", 'r",
+                            HRLTSpanType::Empty => "for<'a> ",
+                            HRLTSpanType::Tail => ", 'a",
                         };
                         (*span, suggestion.to_string())
                     }
@@ -1520,7 +1520,7 @@ crate fn add_missing_lifetime_specifiers_label(
                     if let Ok(snippet) = source_map.span_to_snippet(param.span) {
                         if snippet.starts_with("&") && !snippet.starts_with("&'") {
                             introduce_suggestion
-                                .push((param.span, format!("&'r {}", &snippet[1..])));
+                                .push((param.span, format!("&'a {}", &snippet[1..])));
                         }
                     }
                 }
@@ -1543,13 +1543,13 @@ crate fn add_missing_lifetime_specifiers_label(
                 suggest_existing(err, format!("{}<{}>", snippet, name));
             }
             (0, _, Some("&")) => {
-                suggest_new(err, "&'r ");
+                suggest_new(err, "&'a ");
             }
             (0, _, Some("'_")) => {
-                suggest_new(err, "'r");
+                suggest_new(err, "'a");
             }
             (0, _, Some(snippet)) if !snippet.ends_with(">") => {
-                suggest_new(err, &format!("{}<'r>", snippet));
+                suggest_new(err, &format!("{}<'a>", snippet));
             }
             _ => {
                 err.span_label(span, "expected lifetime parameter");

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -1498,8 +1498,8 @@ crate fn add_missing_lifetime_specifiers_label(
                         msg = "consider introducing a named lifetime parameter";
                         should_break = true;
                         match &generics.params {
-                            [] => (generics.span, "<'lifetime>".to_string()),
-                            [param, ..] => (param.span.shrink_to_lo(), "'lifetime, ".to_string()),
+                            [] => (generics.span, "<'r>".to_string()),
+                            [param, ..] => (param.span.shrink_to_lo(), "'r, ".to_string()),
                         }
                     }
                     MissingLifetimeSpot::HRLT { span, span_type } => {
@@ -1510,8 +1510,8 @@ crate fn add_missing_lifetime_specifiers_label(
                              https://doc.rust-lang.org/nomicon/hrtb.html",
                         );
                         let suggestion = match span_type {
-                            HRLTSpanType::Empty => "for<'lifetime> ",
-                            HRLTSpanType::Tail => ", 'lifetime",
+                            HRLTSpanType::Empty => "for<'r> ",
+                            HRLTSpanType::Tail => ", 'r",
                         };
                         (*span, suggestion.to_string())
                     }
@@ -1520,7 +1520,7 @@ crate fn add_missing_lifetime_specifiers_label(
                     if let Ok(snippet) = source_map.span_to_snippet(param.span) {
                         if snippet.starts_with("&") && !snippet.starts_with("&'") {
                             introduce_suggestion
-                                .push((param.span, format!("&'lifetime {}", &snippet[1..])));
+                                .push((param.span, format!("&'r {}", &snippet[1..])));
                         }
                     }
                 }
@@ -1543,13 +1543,13 @@ crate fn add_missing_lifetime_specifiers_label(
                 suggest_existing(err, format!("{}<{}>", snippet, name));
             }
             (0, _, Some("&")) => {
-                suggest_new(err, "&'lifetime ");
+                suggest_new(err, "&'r ");
             }
             (0, _, Some("'_")) => {
-                suggest_new(err, "'lifetime");
+                suggest_new(err, "'r");
             }
             (0, _, Some(snippet)) if !snippet.ends_with(">") => {
-                suggest_new(err, &format!("{}<'lifetime>", snippet));
+                suggest_new(err, &format!("{}<'r>", snippet));
             }
             _ => {
                 err.span_label(span, "expected lifetime parameter");

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -1514,7 +1514,7 @@ crate fn add_missing_lifetime_specifiers_label(
                         );
                         should_break = false;
                         err.note(
-                            "for more information on higher-ranked lifetimes, visit \
+                            "for more information on higher-ranked polymorphism, visit \
                              https://doc.rust-lang.org/nomicon/hrtb.html",
                         );
                         let suggestion = match span_type {

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -8,6 +8,7 @@ use rustc_ast_pretty::pprust;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::{pluralize, struct_span_err, Applicability, DiagnosticBuilder};
 use rustc_feature::BUILTIN_ATTRIBUTES;
+use rustc_hir as hir;
 use rustc_hir::def::Namespace::{self, *};
 use rustc_hir::def::{self, CtorKind, CtorOf, DefKind, NonMacroAttrKind};
 use rustc_hir::def_id::{DefId, CRATE_DEF_INDEX, LOCAL_CRATE};
@@ -19,7 +20,7 @@ use syntax::ast::{self, Ident, Path};
 use syntax::util::lev_distance::find_best_match_for_name;
 
 use crate::imports::{ImportDirective, ImportDirectiveSubclass, ImportResolver};
-use crate::lifetimes::{ElisionFailureInfo, MissingLifetimeSpot};
+use crate::lifetimes::{ElisionFailureInfo, LifetimeContext};
 use crate::path_names_to_string;
 use crate::{AmbiguityError, AmbiguityErrorMisc, AmbiguityKind};
 use crate::{BindingError, CrateLint, HasGenericParams, LegacyScope, Module, ModuleOrUniformRoot};
@@ -46,6 +47,40 @@ impl TypoSuggestion {
 crate struct ImportSuggestion {
     pub did: Option<DefId>,
     pub path: Path,
+}
+
+crate enum MissingLifetimeSpot<'tcx> {
+    Generics(&'tcx hir::Generics<'tcx>),
+    HigherRanked { span: Span, span_type: ForLifetimeSpanType },
+}
+
+crate enum ForLifetimeSpanType {
+    BoundEmpty,
+    BoundTail,
+    TypeEmpty,
+    TypeTail,
+}
+
+impl ForLifetimeSpanType {
+    crate fn descr(&self) -> &'static str {
+        match self {
+            Self::BoundEmpty | Self::BoundTail => "bound",
+            Self::TypeEmpty | Self::TypeTail => "type",
+        }
+    }
+
+    crate fn suggestion(&self, sugg: &str) -> String {
+        match self {
+            Self::BoundEmpty | Self::TypeEmpty => format!("for<{}> ", sugg),
+            Self::BoundTail | Self::TypeTail => format!(", {}", sugg),
+        }
+    }
+}
+
+impl<'tcx> Into<MissingLifetimeSpot<'tcx>> for &'tcx hir::Generics<'tcx> {
+    fn into(self) -> MissingLifetimeSpot<'tcx> {
+        MissingLifetimeSpot::Generics(self)
+    }
 }
 
 /// Adjust the impl span so that just the `impl` keyword is taken by removing
@@ -1457,104 +1492,185 @@ crate fn show_candidates(
     }
 }
 
-crate fn report_missing_lifetime_specifiers(
-    sess: &Session,
-    span: Span,
-    count: usize,
-) -> DiagnosticBuilder<'_> {
-    struct_span_err!(sess, span, E0106, "missing lifetime specifier{}", pluralize!(count))
-}
+impl<'tcx> LifetimeContext<'_, 'tcx> {
+    crate fn report_missing_lifetime_specifiers(
+        &self,
+        span: Span,
+        count: usize,
+    ) -> DiagnosticBuilder<'tcx> {
+        struct_span_err!(
+            self.tcx.sess,
+            span,
+            E0106,
+            "missing lifetime specifier{}",
+            pluralize!(count)
+        )
+    }
 
-crate fn add_missing_lifetime_specifiers_label(
-    err: &mut DiagnosticBuilder<'_>,
-    source_map: &SourceMap,
-    span: Span,
-    count: usize,
-    lifetime_names: &FxHashSet<ast::Ident>,
-    snippet: Option<&str>,
-    missing_named_lifetime_spots: &[MissingLifetimeSpot<'_>],
-    params: &[ElisionFailureInfo],
-) {
-    if count > 1 {
-        err.span_label(span, format!("expected {} lifetime parameters", count));
-    } else {
-        let suggest_existing = |err: &mut DiagnosticBuilder<'_>, sugg| {
-            err.span_suggestion(
-                span,
-                "consider using the named lifetime",
-                sugg,
-                Applicability::MaybeIncorrect,
-            );
-        };
-        let suggest_new = |err: &mut DiagnosticBuilder<'_>, sugg: &str| {
-            err.span_label(span, "expected named lifetime parameter");
-
-            for missing in missing_named_lifetime_spots.iter().rev() {
-                let mut introduce_suggestion = vec![];
-                let msg;
-                let should_break;
-                introduce_suggestion.push(match missing {
-                    MissingLifetimeSpot::Generics(generics) => {
-                        msg = "consider introducing a named lifetime parameter".to_string();
-                        should_break = true;
-                        match &generics.params {
-                            [] => (generics.span, "<'a>".to_string()),
-                            [param, ..] => (param.span.shrink_to_lo(), "'a, ".to_string()),
-                        }
-                    }
-                    MissingLifetimeSpot::HigherRanked { span, span_type } => {
-                        msg = format!(
-                            "consider making the {} lifetime-generic with a new `'a` lifetime",
+    crate fn emit_undeclared_lifetime_error(&self, lifetime_ref: &hir::Lifetime) {
+        let mut err = struct_span_err!(
+            self.tcx.sess,
+            lifetime_ref.span,
+            E0261,
+            "use of undeclared lifetime name `{}`",
+            lifetime_ref
+        );
+        err.span_label(lifetime_ref.span, "undeclared lifetime");
+        for missing in &self.missing_named_lifetime_spots {
+            match missing {
+                MissingLifetimeSpot::Generics(generics) => {
+                    let (span, sugg) = match &generics.params {
+                        [] => (generics.span, format!("<{}>", lifetime_ref)),
+                        [param, ..] => (param.span.shrink_to_lo(), format!("{}, ", lifetime_ref)),
+                    };
+                    err.span_suggestion(
+                        span,
+                        &format!("consider introducing lifetime `{}` here", lifetime_ref),
+                        sugg,
+                        Applicability::MaybeIncorrect,
+                    );
+                }
+                MissingLifetimeSpot::HigherRanked { span, span_type } => {
+                    err.span_suggestion(
+                        *span,
+                        &format!(
+                            "consider making the {} lifetime-generic with a new `{}` lifetime",
                             span_type.descr(),
-                        );
-                        should_break = false;
-                        err.note(
-                            "for more information on higher-ranked polymorphism, visit \
-                             https://doc.rust-lang.org/nomicon/hrtb.html",
-                        );
-                        (*span, span_type.suggestion("'a"))
-                    }
-                });
-                for param in params {
-                    if let Ok(snippet) = source_map.span_to_snippet(param.span) {
-                        if snippet.starts_with("&") && !snippet.starts_with("&'") {
-                            introduce_suggestion
-                                .push((param.span, format!("&'a {}", &snippet[1..])));
-                        } else if snippet.starts_with("&'_ ") {
-                            introduce_suggestion
-                                .push((param.span, format!("&'a {}", &snippet[4..])));
-                        }
-                    }
+                            lifetime_ref
+                        ),
+                        span_type.suggestion(&lifetime_ref.to_string()),
+                        Applicability::MaybeIncorrect,
+                    );
+                    err.note(
+                        "for more information on higher-ranked polymorphism, visit \
+                            https://doc.rust-lang.org/nomicon/hrtb.html",
+                    );
                 }
-                introduce_suggestion.push((span, sugg.to_string()));
-                err.multipart_suggestion(&msg, introduce_suggestion, Applicability::MaybeIncorrect);
-                if should_break {
-                    break;
-                }
+            }
+        }
+        err.emit();
+    }
+
+    crate fn is_trait_ref_fn_scope(&mut self, trait_ref: &'tcx hir::PolyTraitRef<'tcx>) -> bool {
+        if let def::Res::Def(_, did) = trait_ref.trait_ref.path.res {
+            if [
+                self.tcx.lang_items().fn_once_trait(),
+                self.tcx.lang_items().fn_trait(),
+                self.tcx.lang_items().fn_mut_trait(),
+            ]
+            .contains(&Some(did))
+            {
+                let (span, span_type) = match &trait_ref.bound_generic_params {
+                    [] => (trait_ref.span.shrink_to_lo(), ForLifetimeSpanType::BoundEmpty),
+                    [.., bound] => (bound.span.shrink_to_hi(), ForLifetimeSpanType::BoundTail),
+                };
+                self.missing_named_lifetime_spots
+                    .push(MissingLifetimeSpot::HigherRanked { span, span_type });
+                return true;
             }
         };
+        false
+    }
 
-        match (lifetime_names.len(), lifetime_names.iter().next(), snippet) {
-            (1, Some(name), Some("&")) => {
-                suggest_existing(err, format!("&{} ", name));
-            }
-            (1, Some(name), Some("'_")) => {
-                suggest_existing(err, name.to_string());
-            }
-            (1, Some(name), Some(snippet)) if !snippet.ends_with(">") => {
-                suggest_existing(err, format!("{}<{}>", snippet, name));
-            }
-            (0, _, Some("&")) => {
-                suggest_new(err, "&'a ");
-            }
-            (0, _, Some("'_")) => {
-                suggest_new(err, "'a");
-            }
-            (0, _, Some(snippet)) if !snippet.ends_with(">") => {
-                suggest_new(err, &format!("{}<'a>", snippet));
-            }
-            _ => {
-                err.span_label(span, "expected lifetime parameter");
+    crate fn add_missing_lifetime_specifiers_label(
+        &self,
+        err: &mut DiagnosticBuilder<'_>,
+        span: Span,
+        count: usize,
+        lifetime_names: &FxHashSet<ast::Ident>,
+        params: &[ElisionFailureInfo],
+    ) {
+        if count > 1 {
+            err.span_label(span, format!("expected {} lifetime parameters", count));
+        } else {
+            let snippet = self.tcx.sess.source_map().span_to_snippet(span).ok();
+            let suggest_existing = |err: &mut DiagnosticBuilder<'_>, sugg| {
+                err.span_suggestion(
+                    span,
+                    "consider using the named lifetime",
+                    sugg,
+                    Applicability::MaybeIncorrect,
+                );
+            };
+            let suggest_new = |err: &mut DiagnosticBuilder<'_>, sugg: &str| {
+                err.span_label(span, "expected named lifetime parameter");
+
+                for missing in self.missing_named_lifetime_spots.iter().rev() {
+                    let mut introduce_suggestion = vec![];
+                    let msg;
+                    let should_break;
+                    introduce_suggestion.push(match missing {
+                        MissingLifetimeSpot::Generics(generics) => {
+                            msg = "consider introducing a named lifetime parameter".to_string();
+                            should_break = true;
+                            match &generics.params {
+                                [] => (generics.span, "<'a>".to_string()),
+                                [param, ..] => (param.span.shrink_to_lo(), "'a, ".to_string()),
+                            }
+                        }
+                        MissingLifetimeSpot::HigherRanked { span, span_type } => {
+                            msg = format!(
+                                "consider making the {} lifetime-generic with a new `'a` lifetime",
+                                span_type.descr(),
+                            );
+                            should_break = false;
+                            err.note(
+                                "for more information on higher-ranked polymorphism, visit \
+                             https://doc.rust-lang.org/nomicon/hrtb.html",
+                            );
+                            (*span, span_type.suggestion("'a"))
+                        }
+                    });
+                    for param in params {
+                        if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(param.span)
+                        {
+                            if snippet.starts_with("&") && !snippet.starts_with("&'") {
+                                introduce_suggestion
+                                    .push((param.span, format!("&'a {}", &snippet[1..])));
+                            } else if snippet.starts_with("&'_ ") {
+                                introduce_suggestion
+                                    .push((param.span, format!("&'a {}", &snippet[4..])));
+                            }
+                        }
+                    }
+                    introduce_suggestion.push((span, sugg.to_string()));
+                    err.multipart_suggestion(
+                        &msg,
+                        introduce_suggestion,
+                        Applicability::MaybeIncorrect,
+                    );
+                    if should_break {
+                        break;
+                    }
+                }
+            };
+
+            match (
+                lifetime_names.len(),
+                lifetime_names.iter().next(),
+                snippet.as_ref().map(|s| s.as_str()),
+            ) {
+                (1, Some(name), Some("&")) => {
+                    suggest_existing(err, format!("&{} ", name));
+                }
+                (1, Some(name), Some("'_")) => {
+                    suggest_existing(err, name.to_string());
+                }
+                (1, Some(name), Some(snippet)) if !snippet.ends_with(">") => {
+                    suggest_existing(err, format!("{}<{}>", snippet, name));
+                }
+                (0, _, Some("&")) => {
+                    suggest_new(err, "&'a ");
+                }
+                (0, _, Some("'_")) => {
+                    suggest_new(err, "'a");
+                }
+                (0, _, Some(snippet)) if !snippet.ends_with(">") => {
+                    suggest_new(err, &format!("{}<'a>", snippet));
+                }
+                _ => {
+                    err.span_label(span, "expected lifetime parameter");
+                }
             }
         }
     }

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -1521,6 +1521,9 @@ crate fn add_missing_lifetime_specifiers_label(
                         if snippet.starts_with("&") && !snippet.starts_with("&'") {
                             introduce_suggestion
                                 .push((param.span, format!("&'a {}", &snippet[1..])));
+                        } else if snippet.starts_with("&'_ ") {
+                            introduce_suggestion
+                                .push((param.span, format!("&'a {}", &snippet[4..])));
                         }
                     }
                 }

--- a/src/librustc_resolve/lifetimes.rs
+++ b/src/librustc_resolve/lifetimes.rs
@@ -1913,7 +1913,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                             Applicability::MaybeIncorrect,
                         );
                         err.note(
-                            "for more information on higher-ranked lifetimes, visit \
+                            "for more information on higher-ranked polymorphism, visit \
                              https://doc.rust-lang.org/nomicon/hrtb.html",
                         );
                     }

--- a/src/librustc_resolve/lifetimes.rs
+++ b/src/librustc_resolve/lifetimes.rs
@@ -1873,7 +1873,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                         err.span_suggestion(
                             *span,
                             &format!(
-                                "consider introducing a Higher-Ranked lifetime `{}` here",
+                                "consider introducing a higher-ranked lifetime `{}` here",
                                 lifetime_ref
                             ),
                             match span_type {
@@ -1884,7 +1884,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                             Applicability::MaybeIncorrect,
                         );
                         err.note(
-                            "for more information on Higher-Ranked lifetimes, visit \
+                            "for more information on higher-ranked lifetimes, visit \
                              https://doc.rust-lang.org/nomicon/hrtb.html",
                         );
                     }

--- a/src/librustc_resolve/lifetimes.rs
+++ b/src/librustc_resolve/lifetimes.rs
@@ -280,14 +280,14 @@ enum Elide {
 }
 
 #[derive(Clone, Debug)]
-struct ElisionFailureInfo {
+crate struct ElisionFailureInfo {
     /// Where we can find the argument pattern.
     parent: Option<hir::BodyId>,
     /// The index of the argument in the original definition.
     index: usize,
     lifetime_count: usize,
     have_bound_regions: bool,
-    span: Span,
+    crate span: Span,
 }
 
 type ScopeRef<'a> = &'a Scope<'a>;
@@ -2441,11 +2441,13 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
         if add_label {
             add_missing_lifetime_specifiers_label(
                 &mut err,
+                self.tcx.sess.source_map(),
                 span,
                 lifetime_refs.len(),
                 &lifetime_names,
                 self.tcx.sess.source_map().span_to_snippet(span).ok().as_ref().map(|s| s.as_str()),
                 &self.missing_named_lifetime_spots,
+                error.map(|p| &p[..]).unwrap_or(&[]),
             );
         }
 
@@ -2488,7 +2490,8 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
         let mut spans = vec![];
 
         for (i, info) in elided_params.into_iter().enumerate() {
-            let ElisionFailureInfo { parent, index, lifetime_count: n, have_bound_regions, span } = info;
+            let ElisionFailureInfo { parent, index, lifetime_count: n, have_bound_regions, span } =
+                info;
 
             spans.push(span);
             let help_name = if let Some(ident) =

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1307,12 +1307,15 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                             );
                         }
                     };
+                    // FIXME: point at the type params that don't have appropriate lifetimes:
+                    // struct S1<F: for<'a> Fn(&i32, &i32) -> &'a i32>(F);
+                    //                         ----  ----     ^^^^^^^
                     struct_span_err!(
                         tcx.sess,
                         binding.span,
                         E0582,
                         "binding for associated type `{}` references lifetime `{}`, \
-                                     which does not appear in the trait input types",
+                         which does not appear in the trait input types",
                         binding.item_name,
                         br_name
                     )

--- a/src/test/ui/async-await/issues/issue-63388-2.nll.stderr
+++ b/src/test/ui/async-await/issues/issue-63388-2.nll.stderr
@@ -1,6 +1,8 @@
 error[E0106]: missing lifetime specifier
   --> $DIR/issue-63388-2.rs:12:10
    |
+LL |         foo: &dyn Foo, bar: &'a dyn Foo
+   |              --------       -----------
 LL |     ) -> &dyn Foo
    |          ^ help: consider using the named lifetime: `&'a`
    |

--- a/src/test/ui/async-await/issues/issue-63388-2.stderr
+++ b/src/test/ui/async-await/issues/issue-63388-2.stderr
@@ -1,14 +1,12 @@
 error[E0106]: missing lifetime specifier
   --> $DIR/issue-63388-2.rs:12:10
    |
+LL |         foo: &dyn Foo, bar: &'a dyn Foo
+   |              --------       -----------
 LL |     ) -> &dyn Foo
    |          ^ help: consider using the named lifetime: `&'a`
    |
-help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `foo` or `bar`
-  --> $DIR/issue-63388-2.rs:11:14
-   |
-LL |         foo: &dyn Foo, bar: &'a dyn Foo
-   |              ^^^^^^^^       ^^^^^^^^^^^
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `foo` or `bar`
 
 error: cannot infer an appropriate lifetime
   --> $DIR/issue-63388-2.rs:11:9

--- a/src/test/ui/async-await/issues/issue-63388-2.stderr
+++ b/src/test/ui/async-await/issues/issue-63388-2.stderr
@@ -4,7 +4,11 @@ error[E0106]: missing lifetime specifier
 LL |     ) -> &dyn Foo
    |          ^ help: consider using the named lifetime: `&'a`
    |
-   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `foo` or `bar`
+help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `foo` or `bar`
+  --> $DIR/issue-63388-2.rs:11:14
+   |
+LL |         foo: &dyn Foo, bar: &'a dyn Foo
+   |              ^^^^^^^^       ^^^^^^^^^^^
 
 error: cannot infer an appropriate lifetime
   --> $DIR/issue-63388-2.rs:11:9

--- a/src/test/ui/error-codes/E0106.stderr
+++ b/src/test/ui/error-codes/E0106.stderr
@@ -6,8 +6,8 @@ LL |     x: &bool,
    |
 help: consider introducing a named lifetime parameter
    |
-LL | struct Foo<'r> {
-LL |     x: &'r bool,
+LL | struct Foo<'a> {
+LL |     x: &'a bool,
    |
 
 error[E0106]: missing lifetime specifier
@@ -18,9 +18,9 @@ LL |     B(&bool),
    |
 help: consider introducing a named lifetime parameter
    |
-LL | enum Bar<'r> {
+LL | enum Bar<'a> {
 LL |     A(u8),
-LL |     B(&'r bool),
+LL |     B(&'a bool),
    |
 
 error[E0106]: missing lifetime specifier
@@ -31,7 +31,7 @@ LL | type MyStr = &str;
    |
 help: consider introducing a named lifetime parameter
    |
-LL | type MyStr<'r> = &'r str;
+LL | type MyStr<'a> = &'a str;
    |           ^^^^   ^^^
 
 error[E0106]: missing lifetime specifier
@@ -42,8 +42,8 @@ LL |     baz: Baz,
    |
 help: consider introducing a named lifetime parameter
    |
-LL | struct Quux<'r> {
-LL |     baz: Baz<'r>,
+LL | struct Quux<'a> {
+LL |     baz: Baz<'a>,
    |
 
 error[E0106]: missing lifetime specifiers

--- a/src/test/ui/error-codes/E0106.stderr
+++ b/src/test/ui/error-codes/E0106.stderr
@@ -6,8 +6,8 @@ LL |     x: &bool,
    |
 help: consider introducing a named lifetime parameter
    |
-LL | struct Foo<'lifetime> {
-LL |     x: &'lifetime bool,
+LL | struct Foo<'r> {
+LL |     x: &'r bool,
    |
 
 error[E0106]: missing lifetime specifier
@@ -18,9 +18,9 @@ LL |     B(&bool),
    |
 help: consider introducing a named lifetime parameter
    |
-LL | enum Bar<'lifetime> {
+LL | enum Bar<'r> {
 LL |     A(u8),
-LL |     B(&'lifetime bool),
+LL |     B(&'r bool),
    |
 
 error[E0106]: missing lifetime specifier
@@ -31,8 +31,8 @@ LL | type MyStr = &str;
    |
 help: consider introducing a named lifetime parameter
    |
-LL | type MyStr<'lifetime> = &'lifetime str;
-   |           ^^^^^^^^^^^   ^^^^^^^^^^
+LL | type MyStr<'r> = &'r str;
+   |           ^^^^   ^^^
 
 error[E0106]: missing lifetime specifier
   --> $DIR/E0106.rs:17:10
@@ -42,8 +42,8 @@ LL |     baz: Baz,
    |
 help: consider introducing a named lifetime parameter
    |
-LL | struct Quux<'lifetime> {
-LL |     baz: Baz<'lifetime>,
+LL | struct Quux<'r> {
+LL |     baz: Baz<'r>,
    |
 
 error[E0106]: missing lifetime specifiers

--- a/src/test/ui/generic/generic-extern-lifetime.stderr
+++ b/src/test/ui/generic/generic-extern-lifetime.stderr
@@ -10,7 +10,7 @@ error[E0261]: use of undeclared lifetime name `'a`
 LL |    pub fn life4<'b>(x: for<'c> fn(&'a i32));
    |                                    ^^ undeclared lifetime
    |
-   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider making the type lifetime-generic with a new `'a` lifetime
    |
 LL |    pub fn life4<'b>(x: for<'c, 'a> fn(&'a i32));
@@ -22,7 +22,7 @@ error[E0261]: use of undeclared lifetime name `'a`
 LL |    pub fn life7<'b>() -> for<'c> fn(&'a i32);
    |                                      ^^ undeclared lifetime
    |
-   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider making the type lifetime-generic with a new `'a` lifetime
    |
 LL |    pub fn life7<'b>() -> for<'c, 'a> fn(&'a i32);

--- a/src/test/ui/generic/generic-extern-lifetime.stderr
+++ b/src/test/ui/generic/generic-extern-lifetime.stderr
@@ -9,12 +9,24 @@ error[E0261]: use of undeclared lifetime name `'a`
    |
 LL |    pub fn life4<'b>(x: for<'c> fn(&'a i32));
    |                                    ^^ undeclared lifetime
+   |
+   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the type lifetime-generic with a new `'a` lifetime
+   |
+LL |    pub fn life4<'b>(x: for<'c, 'a> fn(&'a i32));
+   |                              ^^^^
 
 error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/generic-extern-lifetime.rs:11:38
    |
 LL |    pub fn life7<'b>() -> for<'c> fn(&'a i32);
    |                                      ^^ undeclared lifetime
+   |
+   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the type lifetime-generic with a new `'a` lifetime
+   |
+LL |    pub fn life7<'b>() -> for<'c, 'a> fn(&'a i32);
+   |                                ^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/impl-header-lifetime-elision/assoc-type.stderr
+++ b/src/test/ui/impl-header-lifetime-elision/assoc-type.stderr
@@ -6,7 +6,7 @@ LL |     type Output = &i32;
    |
 help: consider introducing a named lifetime parameter
    |
-LL |     type Output<'r> = &'r i32;
+LL |     type Output<'a> = &'a i32;
    |                ^^^^   ^^^
 
 error[E0106]: missing lifetime specifier
@@ -17,7 +17,7 @@ LL |     type Output = &'_ i32;
    |
 help: consider introducing a named lifetime parameter
    |
-LL |     type Output<'r> = &'r i32;
+LL |     type Output<'a> = &'a i32;
    |                ^^^^    ^^
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/impl-header-lifetime-elision/assoc-type.stderr
+++ b/src/test/ui/impl-header-lifetime-elision/assoc-type.stderr
@@ -6,8 +6,8 @@ LL |     type Output = &i32;
    |
 help: consider introducing a named lifetime parameter
    |
-LL |     type Output<'lifetime> = &'lifetime i32;
-   |                ^^^^^^^^^^^   ^^^^^^^^^^
+LL |     type Output<'r> = &'r i32;
+   |                ^^^^   ^^^
 
 error[E0106]: missing lifetime specifier
   --> $DIR/assoc-type.rs:16:20
@@ -17,8 +17,8 @@ LL |     type Output = &'_ i32;
    |
 help: consider introducing a named lifetime parameter
    |
-LL |     type Output<'lifetime> = &'lifetime i32;
-   |                ^^^^^^^^^^^    ^^^^^^^^^
+LL |     type Output<'r> = &'r i32;
+   |                ^^^^    ^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/in-band-lifetimes/issue-61124-anon-lifetime-in-struct-declaration.stderr
+++ b/src/test/ui/in-band-lifetimes/issue-61124-anon-lifetime-in-struct-declaration.stderr
@@ -6,8 +6,8 @@ LL | struct Heartbreak(Betrayal);
    |
 help: consider introducing a named lifetime parameter
    |
-LL | struct Heartbreak<'lifetime>(Betrayal<'lifetime>);
-   |                  ^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^
+LL | struct Heartbreak<'r>(Betrayal<'r>);
+   |                  ^^^^ ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/in-band-lifetimes/issue-61124-anon-lifetime-in-struct-declaration.stderr
+++ b/src/test/ui/in-band-lifetimes/issue-61124-anon-lifetime-in-struct-declaration.stderr
@@ -6,7 +6,7 @@ LL | struct Heartbreak(Betrayal);
    |
 help: consider introducing a named lifetime parameter
    |
-LL | struct Heartbreak<'r>(Betrayal<'r>);
+LL | struct Heartbreak<'a>(Betrayal<'a>);
    |                  ^^^^ ^^^^^^^^^^^^
 
 error: aborting due to previous error

--- a/src/test/ui/in-band-lifetimes/no_introducing_in_band_in_locals.stderr
+++ b/src/test/ui/in-band-lifetimes/no_introducing_in_band_in_locals.stderr
@@ -9,10 +9,18 @@ LL |     let y: &'test u32 = x;
 error[E0261]: use of undeclared lifetime name `'test`
   --> $DIR/no_introducing_in_band_in_locals.rs:10:16
    |
-LL | fn bar() {
-   |       - help: consider introducing lifetime `'test` here: `<'test>`
 LL |     let y: fn(&'test u32) = foo2;
    |                ^^^^^ undeclared lifetime
+   |
+   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider introducing lifetime `'test` here
+   |
+LL | fn bar<'test>() {
+   |       ^^^^^^^
+help: consider making the type lifetime-generic with a new `'test` lifetime
+   |
+LL |     let y: for<'test> fn(&'test u32) = foo2;
+   |            ^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/in-band-lifetimes/no_introducing_in_band_in_locals.stderr
+++ b/src/test/ui/in-band-lifetimes/no_introducing_in_band_in_locals.stderr
@@ -9,6 +9,8 @@ LL |     let y: &'test u32 = x;
 error[E0261]: use of undeclared lifetime name `'test`
   --> $DIR/no_introducing_in_band_in_locals.rs:10:16
    |
+LL | fn bar() {
+   |       - help: consider introducing lifetime `'test` here: `<'test>`
 LL |     let y: fn(&'test u32) = foo2;
    |                ^^^^^ undeclared lifetime
 

--- a/src/test/ui/in-band-lifetimes/no_introducing_in_band_in_locals.stderr
+++ b/src/test/ui/in-band-lifetimes/no_introducing_in_band_in_locals.stderr
@@ -12,7 +12,7 @@ error[E0261]: use of undeclared lifetime name `'test`
 LL |     let y: fn(&'test u32) = foo2;
    |                ^^^^^ undeclared lifetime
    |
-   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider introducing lifetime `'test` here
    |
 LL | fn bar<'test>() {

--- a/src/test/ui/issues/issue-19707.stderr
+++ b/src/test/ui/issues/issue-19707.stderr
@@ -17,6 +17,11 @@ LL | fn bar<F: Fn(&u8, &u8) -> &u8>(f: &F) {}
    |                           ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
+   = note: for more information on Higher-Ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider introducing a Higher-Ranked lifetime
+   |
+LL | fn bar<F: for<'lifetime> Fn(&u8, &u8) -> &'lifetime u8>(f: &F) {}
+   |           ^^^^^^^^^^^^^^                 ^^^^^^^^^^
 help: consider introducing a named lifetime parameter
    |
 LL | fn bar<'lifetime, F: Fn(&u8, &u8) -> &'lifetime u8>(f: &F) {}

--- a/src/test/ui/issues/issue-19707.stderr
+++ b/src/test/ui/issues/issue-19707.stderr
@@ -11,7 +11,7 @@ LL | type Foo = fn(&u8, &u8) -> &u8;
    |               ^^^  ^^^
 help: consider introducing a named lifetime parameter
    |
-LL | type Foo<'r> = fn(&'r u8, &'r u8) -> &'r u8;
+LL | type Foo<'a> = fn(&'a u8, &'a u8) -> &'a u8;
    |         ^^^^      ^^^^^^  ^^^^^^     ^^^
 
 error[E0106]: missing lifetime specifier
@@ -25,14 +25,14 @@ help: this function's return type contains a borrowed value, but the signature d
    |
 LL | fn bar<F: Fn(&u8, &u8) -> &u8>(f: &F) {}
    |              ^^^  ^^^
-   = note: for more information on Higher-Ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
-help: consider introducing a Higher-Ranked lifetime
+   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider introducing a higher-ranked lifetime
    |
-LL | fn bar<F: for<'r> Fn(&'r u8, &'r u8) -> &'r u8>(f: &F) {}
+LL | fn bar<F: for<'a> Fn(&'a u8, &'a u8) -> &'a u8>(f: &F) {}
    |           ^^^^^^^    ^^^^^^  ^^^^^^     ^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn bar<'r, F: Fn(&'r u8, &'r u8) -> &'r u8>(f: &F) {}
+LL | fn bar<'a, F: Fn(&'a u8, &'a u8) -> &'a u8>(f: &F) {}
    |        ^^^       ^^^^^^  ^^^^^^     ^^^
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/issues/issue-19707.stderr
+++ b/src/test/ui/issues/issue-19707.stderr
@@ -11,8 +11,8 @@ LL | type Foo = fn(&u8, &u8) -> &u8;
    |               ^^^  ^^^
 help: consider introducing a named lifetime parameter
    |
-LL | type Foo<'lifetime> = fn(&'lifetime u8, &'lifetime u8) -> &'lifetime u8;
-   |         ^^^^^^^^^^^      ^^^^^^^^^^^^^  ^^^^^^^^^^^^^     ^^^^^^^^^^
+LL | type Foo<'r> = fn(&'r u8, &'r u8) -> &'r u8;
+   |         ^^^^      ^^^^^^  ^^^^^^     ^^^
 
 error[E0106]: missing lifetime specifier
   --> $DIR/issue-19707.rs:5:27
@@ -28,12 +28,12 @@ LL | fn bar<F: Fn(&u8, &u8) -> &u8>(f: &F) {}
    = note: for more information on Higher-Ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider introducing a Higher-Ranked lifetime
    |
-LL | fn bar<F: for<'lifetime> Fn(&'lifetime u8, &'lifetime u8) -> &'lifetime u8>(f: &F) {}
-   |           ^^^^^^^^^^^^^^    ^^^^^^^^^^^^^  ^^^^^^^^^^^^^     ^^^^^^^^^^
+LL | fn bar<F: for<'r> Fn(&'r u8, &'r u8) -> &'r u8>(f: &F) {}
+   |           ^^^^^^^    ^^^^^^  ^^^^^^     ^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn bar<'lifetime, F: Fn(&'lifetime u8, &'lifetime u8) -> &'lifetime u8>(f: &F) {}
-   |        ^^^^^^^^^^       ^^^^^^^^^^^^^  ^^^^^^^^^^^^^     ^^^^^^^^^^
+LL | fn bar<'r, F: Fn(&'r u8, &'r u8) -> &'r u8>(f: &F) {}
+   |        ^^^       ^^^^^^  ^^^^^^     ^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-19707.stderr
+++ b/src/test/ui/issues/issue-19707.stderr
@@ -4,7 +4,11 @@ error[E0106]: missing lifetime specifier
 LL | type Foo = fn(&u8, &u8) -> &u8;
    |                            ^ expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
+help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
+  --> $DIR/issue-19707.rs:3:15
+   |
+LL | type Foo = fn(&u8, &u8) -> &u8;
+   |               ^^^  ^^^
 help: consider introducing a named lifetime parameter
    |
 LL | type Foo<'lifetime> = fn(&u8, &u8) -> &'lifetime u8;
@@ -16,7 +20,11 @@ error[E0106]: missing lifetime specifier
 LL | fn bar<F: Fn(&u8, &u8) -> &u8>(f: &F) {}
    |                           ^ expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
+help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
+  --> $DIR/issue-19707.rs:5:14
+   |
+LL | fn bar<F: Fn(&u8, &u8) -> &u8>(f: &F) {}
+   |              ^^^  ^^^
    = note: for more information on Higher-Ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider introducing a Higher-Ranked lifetime
    |

--- a/src/test/ui/issues/issue-19707.stderr
+++ b/src/test/ui/issues/issue-19707.stderr
@@ -2,13 +2,14 @@ error[E0106]: missing lifetime specifier
   --> $DIR/issue-19707.rs:3:28
    |
 LL | type Foo = fn(&u8, &u8) -> &u8;
-   |                            ^ expected named lifetime parameter
+   |               ---  ---     ^ expected named lifetime parameter
    |
-help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
-  --> $DIR/issue-19707.rs:3:15
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
+   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the type lifetime-generic with a new `'a` lifetime
    |
-LL | type Foo = fn(&u8, &u8) -> &u8;
-   |               ^^^  ^^^
+LL | type Foo = for<'a> fn(&'a u8, &'a u8) -> &'a u8;
+   |            ^^^^^^^    ^^^^^^  ^^^^^^     ^^^
 help: consider introducing a named lifetime parameter
    |
 LL | type Foo<'a> = fn(&'a u8, &'a u8) -> &'a u8;
@@ -18,15 +19,11 @@ error[E0106]: missing lifetime specifier
   --> $DIR/issue-19707.rs:5:27
    |
 LL | fn bar<F: Fn(&u8, &u8) -> &u8>(f: &F) {}
-   |                           ^ expected named lifetime parameter
+   |              ---  ---     ^ expected named lifetime parameter
    |
-help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
-  --> $DIR/issue-19707.rs:5:14
-   |
-LL | fn bar<F: Fn(&u8, &u8) -> &u8>(f: &F) {}
-   |              ^^^  ^^^
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
    = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
-help: consider introducing a higher-ranked lifetime
+help: consider making the bound lifetime-generic with a new `'a` lifetime
    |
 LL | fn bar<F: for<'a> Fn(&'a u8, &'a u8) -> &'a u8>(f: &F) {}
    |           ^^^^^^^    ^^^^^^  ^^^^^^     ^^^

--- a/src/test/ui/issues/issue-19707.stderr
+++ b/src/test/ui/issues/issue-19707.stderr
@@ -11,8 +11,8 @@ LL | type Foo = fn(&u8, &u8) -> &u8;
    |               ^^^  ^^^
 help: consider introducing a named lifetime parameter
    |
-LL | type Foo<'lifetime> = fn(&u8, &u8) -> &'lifetime u8;
-   |         ^^^^^^^^^^^                   ^^^^^^^^^^
+LL | type Foo<'lifetime> = fn(&'lifetime u8, &'lifetime u8) -> &'lifetime u8;
+   |         ^^^^^^^^^^^      ^^^^^^^^^^^^^  ^^^^^^^^^^^^^     ^^^^^^^^^^
 
 error[E0106]: missing lifetime specifier
   --> $DIR/issue-19707.rs:5:27
@@ -28,12 +28,12 @@ LL | fn bar<F: Fn(&u8, &u8) -> &u8>(f: &F) {}
    = note: for more information on Higher-Ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider introducing a Higher-Ranked lifetime
    |
-LL | fn bar<F: for<'lifetime> Fn(&u8, &u8) -> &'lifetime u8>(f: &F) {}
-   |           ^^^^^^^^^^^^^^                 ^^^^^^^^^^
+LL | fn bar<F: for<'lifetime> Fn(&'lifetime u8, &'lifetime u8) -> &'lifetime u8>(f: &F) {}
+   |           ^^^^^^^^^^^^^^    ^^^^^^^^^^^^^  ^^^^^^^^^^^^^     ^^^^^^^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn bar<'lifetime, F: Fn(&u8, &u8) -> &'lifetime u8>(f: &F) {}
-   |        ^^^^^^^^^^                    ^^^^^^^^^^
+LL | fn bar<'lifetime, F: Fn(&'lifetime u8, &'lifetime u8) -> &'lifetime u8>(f: &F) {}
+   |        ^^^^^^^^^^       ^^^^^^^^^^^^^  ^^^^^^^^^^^^^     ^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-19707.stderr
+++ b/src/test/ui/issues/issue-19707.stderr
@@ -5,7 +5,7 @@ LL | type Foo = fn(&u8, &u8) -> &u8;
    |               ---  ---     ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
-   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider making the type lifetime-generic with a new `'a` lifetime
    |
 LL | type Foo = for<'a> fn(&'a u8, &'a u8) -> &'a u8;
@@ -22,7 +22,7 @@ LL | fn bar<F: Fn(&u8, &u8) -> &u8>(f: &F) {}
    |              ---  ---     ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
-   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider making the bound lifetime-generic with a new `'a` lifetime
    |
 LL | fn bar<F: for<'a> Fn(&'a u8, &'a u8) -> &'a u8>(f: &F) {}

--- a/src/test/ui/issues/issue-26638.stderr
+++ b/src/test/ui/issues/issue-26638.stderr
@@ -11,8 +11,8 @@ LL | fn parse_type(iter: Box<dyn Iterator<Item=&str>+'static>) -> &str { iter.ne
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn parse_type<'lifetime>(iter: Box<dyn Iterator<Item=&str>+'static>) -> &'lifetime str { iter.next() }
-   |              ^^^^^^^^^^^                                                ^^^^^^^^^^
+LL | fn parse_type<'r>(iter: Box<dyn Iterator<Item=&str>+'static>) -> &'r str { iter.next() }
+   |              ^^^^                                                ^^^
 
 error[E0106]: missing lifetime specifier
   --> $DIR/issue-26638.rs:4:40

--- a/src/test/ui/issues/issue-26638.stderr
+++ b/src/test/ui/issues/issue-26638.stderr
@@ -2,13 +2,9 @@ error[E0106]: missing lifetime specifier
   --> $DIR/issue-26638.rs:1:62
    |
 LL | fn parse_type(iter: Box<dyn Iterator<Item=&str>+'static>) -> &str { iter.next() }
-   |                                                              ^ expected named lifetime parameter
+   |                     ------------------------------------     ^ expected named lifetime parameter
    |
-help: this function's return type contains a borrowed value, but the signature does not say which one of `iter`'s 2 lifetimes it is borrowed from
-  --> $DIR/issue-26638.rs:1:21
-   |
-LL | fn parse_type(iter: Box<dyn Iterator<Item=&str>+'static>) -> &str { iter.next() }
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: this function's return type contains a borrowed value, but the signature does not say which one of `iter`'s 2 lifetimes it is borrowed from
 help: consider introducing a named lifetime parameter
    |
 LL | fn parse_type<'a>(iter: Box<dyn Iterator<Item=&str>+'static>) -> &'a str { iter.next() }

--- a/src/test/ui/issues/issue-26638.stderr
+++ b/src/test/ui/issues/issue-26638.stderr
@@ -11,7 +11,7 @@ LL | fn parse_type(iter: Box<dyn Iterator<Item=&str>+'static>) -> &str { iter.ne
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn parse_type<'r>(iter: Box<dyn Iterator<Item=&str>+'static>) -> &'r str { iter.next() }
+LL | fn parse_type<'a>(iter: Box<dyn Iterator<Item=&str>+'static>) -> &'a str { iter.next() }
    |              ^^^^                                                ^^^
 
 error[E0106]: missing lifetime specifier

--- a/src/test/ui/issues/issue-26638.stderr
+++ b/src/test/ui/issues/issue-26638.stderr
@@ -4,7 +4,11 @@ error[E0106]: missing lifetime specifier
 LL | fn parse_type(iter: Box<dyn Iterator<Item=&str>+'static>) -> &str { iter.next() }
    |                                                              ^ expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value, but the signature does not say which one of `iter`'s 2 lifetimes it is borrowed from
+help: this function's return type contains a borrowed value, but the signature does not say which one of `iter`'s 2 lifetimes it is borrowed from
+  --> $DIR/issue-26638.rs:1:21
+   |
+LL | fn parse_type(iter: Box<dyn Iterator<Item=&str>+'static>) -> &str { iter.next() }
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider introducing a named lifetime parameter
    |
 LL | fn parse_type<'lifetime>(iter: Box<dyn Iterator<Item=&str>+'static>) -> &'lifetime str { iter.next() }

--- a/src/test/ui/issues/issue-30255.stderr
+++ b/src/test/ui/issues/issue-30255.stderr
@@ -2,13 +2,9 @@ error[E0106]: missing lifetime specifier
   --> $DIR/issue-30255.rs:9:24
    |
 LL | fn f(a: &S, b: i32) -> &i32 {
-   |                        ^ expected named lifetime parameter
+   |         --             ^ expected named lifetime parameter
    |
-help: this function's return type contains a borrowed value, but the signature does not say which one of `a`'s 2 lifetimes it is borrowed from
-  --> $DIR/issue-30255.rs:9:9
-   |
-LL | fn f(a: &S, b: i32) -> &i32 {
-   |         ^^
+   = help: this function's return type contains a borrowed value, but the signature does not say which one of `a`'s 2 lifetimes it is borrowed from
 help: consider introducing a named lifetime parameter
    |
 LL | fn f<'a>(a: &'a S, b: i32) -> &'a i32 {
@@ -18,13 +14,9 @@ error[E0106]: missing lifetime specifier
   --> $DIR/issue-30255.rs:14:34
    |
 LL | fn g(a: &S, b: bool, c: &i32) -> &i32 {
-   |                                  ^ expected named lifetime parameter
+   |         --              ----     ^ expected named lifetime parameter
    |
-help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from one of `a`'s 2 lifetimes or `c`
-  --> $DIR/issue-30255.rs:14:9
-   |
-LL | fn g(a: &S, b: bool, c: &i32) -> &i32 {
-   |         ^^              ^^^^
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from one of `a`'s 2 lifetimes or `c`
 help: consider introducing a named lifetime parameter
    |
 LL | fn g<'a>(a: &'a S, b: bool, c: &'a i32) -> &'a i32 {
@@ -34,13 +26,9 @@ error[E0106]: missing lifetime specifier
   --> $DIR/issue-30255.rs:19:44
    |
 LL | fn h(a: &bool, b: bool, c: &S, d: &i32) -> &i32 {
-   |                                            ^ expected named lifetime parameter
+   |         -----              --     ----     ^ expected named lifetime parameter
    |
-help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `a`, one of `c`'s 2 lifetimes, or `d`
-  --> $DIR/issue-30255.rs:19:9
-   |
-LL | fn h(a: &bool, b: bool, c: &S, d: &i32) -> &i32 {
-   |         ^^^^^              ^^     ^^^^
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `a`, one of `c`'s 2 lifetimes, or `d`
 help: consider introducing a named lifetime parameter
    |
 LL | fn h<'a>(a: &'a bool, b: bool, c: &'a S, d: &'a i32) -> &'a i32 {

--- a/src/test/ui/issues/issue-30255.stderr
+++ b/src/test/ui/issues/issue-30255.stderr
@@ -11,8 +11,8 @@ LL | fn f(a: &S, b: i32) -> &i32 {
    |         ^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn f<'lifetime>(a: &'lifetime S, b: i32) -> &'lifetime i32 {
-   |     ^^^^^^^^^^^    ^^^^^^^^^^^^             ^^^^^^^^^^
+LL | fn f<'r>(a: &'r S, b: i32) -> &'r i32 {
+   |     ^^^^    ^^^^^             ^^^
 
 error[E0106]: missing lifetime specifier
   --> $DIR/issue-30255.rs:14:34
@@ -27,8 +27,8 @@ LL | fn g(a: &S, b: bool, c: &i32) -> &i32 {
    |         ^^              ^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn g<'lifetime>(a: &'lifetime S, b: bool, c: &'lifetime i32) -> &'lifetime i32 {
-   |     ^^^^^^^^^^^    ^^^^^^^^^^^^              ^^^^^^^^^^^^^^     ^^^^^^^^^^
+LL | fn g<'r>(a: &'r S, b: bool, c: &'r i32) -> &'r i32 {
+   |     ^^^^    ^^^^^              ^^^^^^^     ^^^
 
 error[E0106]: missing lifetime specifier
   --> $DIR/issue-30255.rs:19:44
@@ -43,8 +43,8 @@ LL | fn h(a: &bool, b: bool, c: &S, d: &i32) -> &i32 {
    |         ^^^^^              ^^     ^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn h<'lifetime>(a: &'lifetime bool, b: bool, c: &'lifetime S, d: &'lifetime i32) -> &'lifetime i32 {
-   |     ^^^^^^^^^^^    ^^^^^^^^^^^^^^^              ^^^^^^^^^^^^     ^^^^^^^^^^^^^^     ^^^^^^^^^^
+LL | fn h<'r>(a: &'r bool, b: bool, c: &'r S, d: &'r i32) -> &'r i32 {
+   |     ^^^^    ^^^^^^^^              ^^^^^     ^^^^^^^     ^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-30255.stderr
+++ b/src/test/ui/issues/issue-30255.stderr
@@ -11,7 +11,7 @@ LL | fn f(a: &S, b: i32) -> &i32 {
    |         ^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn f<'r>(a: &'r S, b: i32) -> &'r i32 {
+LL | fn f<'a>(a: &'a S, b: i32) -> &'a i32 {
    |     ^^^^    ^^^^^             ^^^
 
 error[E0106]: missing lifetime specifier
@@ -27,7 +27,7 @@ LL | fn g(a: &S, b: bool, c: &i32) -> &i32 {
    |         ^^              ^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn g<'r>(a: &'r S, b: bool, c: &'r i32) -> &'r i32 {
+LL | fn g<'a>(a: &'a S, b: bool, c: &'a i32) -> &'a i32 {
    |     ^^^^    ^^^^^              ^^^^^^^     ^^^
 
 error[E0106]: missing lifetime specifier
@@ -43,7 +43,7 @@ LL | fn h(a: &bool, b: bool, c: &S, d: &i32) -> &i32 {
    |         ^^^^^              ^^     ^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn h<'r>(a: &'r bool, b: bool, c: &'r S, d: &'r i32) -> &'r i32 {
+LL | fn h<'a>(a: &'a bool, b: bool, c: &'a S, d: &'a i32) -> &'a i32 {
    |     ^^^^    ^^^^^^^^              ^^^^^     ^^^^^^^     ^^^
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/issues/issue-30255.stderr
+++ b/src/test/ui/issues/issue-30255.stderr
@@ -11,8 +11,8 @@ LL | fn f(a: &S, b: i32) -> &i32 {
    |         ^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn f<'lifetime>(a: &S, b: i32) -> &'lifetime i32 {
-   |     ^^^^^^^^^^^                   ^^^^^^^^^^
+LL | fn f<'lifetime>(a: &'lifetime S, b: i32) -> &'lifetime i32 {
+   |     ^^^^^^^^^^^    ^^^^^^^^^^^^             ^^^^^^^^^^
 
 error[E0106]: missing lifetime specifier
   --> $DIR/issue-30255.rs:14:34
@@ -27,8 +27,8 @@ LL | fn g(a: &S, b: bool, c: &i32) -> &i32 {
    |         ^^              ^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn g<'lifetime>(a: &S, b: bool, c: &i32) -> &'lifetime i32 {
-   |     ^^^^^^^^^^^                             ^^^^^^^^^^
+LL | fn g<'lifetime>(a: &'lifetime S, b: bool, c: &'lifetime i32) -> &'lifetime i32 {
+   |     ^^^^^^^^^^^    ^^^^^^^^^^^^              ^^^^^^^^^^^^^^     ^^^^^^^^^^
 
 error[E0106]: missing lifetime specifier
   --> $DIR/issue-30255.rs:19:44
@@ -43,8 +43,8 @@ LL | fn h(a: &bool, b: bool, c: &S, d: &i32) -> &i32 {
    |         ^^^^^              ^^     ^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn h<'lifetime>(a: &bool, b: bool, c: &S, d: &i32) -> &'lifetime i32 {
-   |     ^^^^^^^^^^^                                       ^^^^^^^^^^
+LL | fn h<'lifetime>(a: &'lifetime bool, b: bool, c: &'lifetime S, d: &'lifetime i32) -> &'lifetime i32 {
+   |     ^^^^^^^^^^^    ^^^^^^^^^^^^^^^              ^^^^^^^^^^^^     ^^^^^^^^^^^^^^     ^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-30255.stderr
+++ b/src/test/ui/issues/issue-30255.stderr
@@ -4,7 +4,11 @@ error[E0106]: missing lifetime specifier
 LL | fn f(a: &S, b: i32) -> &i32 {
    |                        ^ expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value, but the signature does not say which one of `a`'s 2 lifetimes it is borrowed from
+help: this function's return type contains a borrowed value, but the signature does not say which one of `a`'s 2 lifetimes it is borrowed from
+  --> $DIR/issue-30255.rs:9:9
+   |
+LL | fn f(a: &S, b: i32) -> &i32 {
+   |         ^^
 help: consider introducing a named lifetime parameter
    |
 LL | fn f<'lifetime>(a: &S, b: i32) -> &'lifetime i32 {
@@ -16,7 +20,11 @@ error[E0106]: missing lifetime specifier
 LL | fn g(a: &S, b: bool, c: &i32) -> &i32 {
    |                                  ^ expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from one of `a`'s 2 lifetimes or `c`
+help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from one of `a`'s 2 lifetimes or `c`
+  --> $DIR/issue-30255.rs:14:9
+   |
+LL | fn g(a: &S, b: bool, c: &i32) -> &i32 {
+   |         ^^              ^^^^
 help: consider introducing a named lifetime parameter
    |
 LL | fn g<'lifetime>(a: &S, b: bool, c: &i32) -> &'lifetime i32 {
@@ -28,7 +36,11 @@ error[E0106]: missing lifetime specifier
 LL | fn h(a: &bool, b: bool, c: &S, d: &i32) -> &i32 {
    |                                            ^ expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `a`, one of `c`'s 2 lifetimes, or `d`
+help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `a`, one of `c`'s 2 lifetimes, or `d`
+  --> $DIR/issue-30255.rs:19:9
+   |
+LL | fn h(a: &bool, b: bool, c: &S, d: &i32) -> &i32 {
+   |         ^^^^^              ^^     ^^^^
 help: consider introducing a named lifetime parameter
    |
 LL | fn h<'lifetime>(a: &bool, b: bool, c: &S, d: &i32) -> &'lifetime i32 {

--- a/src/test/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
+++ b/src/test/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
@@ -19,8 +19,8 @@ LL | fn g(_x: &isize, _y: &isize) -> &isize {
    |          ^^^^^^      ^^^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn g<'lifetime>(_x: &'lifetime isize, _y: &'lifetime isize) -> &'lifetime isize {
-   |     ^^^^^^^^^^^     ^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^     ^^^^^^^^^^
+LL | fn g<'r>(_x: &'r isize, _y: &'r isize) -> &'r isize {
+   |     ^^^^     ^^^^^^^^^      ^^^^^^^^^     ^^^
 
 error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:17:19
@@ -35,8 +35,8 @@ LL | fn h(_x: &Foo) -> &isize {
    |          ^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn h<'lifetime>(_x: &'lifetime Foo) -> &'lifetime isize {
-   |     ^^^^^^^^^^^     ^^^^^^^^^^^^^^     ^^^^^^^^^^
+LL | fn h<'r>(_x: &'r Foo) -> &'r isize {
+   |     ^^^^     ^^^^^^^     ^^^
 
 error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:21:20

--- a/src/test/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
+++ b/src/test/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
@@ -19,8 +19,8 @@ LL | fn g(_x: &isize, _y: &isize) -> &isize {
    |          ^^^^^^      ^^^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn g<'lifetime>(_x: &isize, _y: &isize) -> &'lifetime isize {
-   |     ^^^^^^^^^^^                            ^^^^^^^^^^
+LL | fn g<'lifetime>(_x: &'lifetime isize, _y: &'lifetime isize) -> &'lifetime isize {
+   |     ^^^^^^^^^^^     ^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^     ^^^^^^^^^^
 
 error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:17:19
@@ -35,8 +35,8 @@ LL | fn h(_x: &Foo) -> &isize {
    |          ^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn h<'lifetime>(_x: &Foo) -> &'lifetime isize {
-   |     ^^^^^^^^^^^              ^^^^^^^^^^
+LL | fn h<'lifetime>(_x: &'lifetime Foo) -> &'lifetime isize {
+   |     ^^^^^^^^^^^     ^^^^^^^^^^^^^^     ^^^^^^^^^^
 
 error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:21:20

--- a/src/test/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
+++ b/src/test/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
@@ -12,7 +12,11 @@ error[E0106]: missing lifetime specifier
 LL | fn g(_x: &isize, _y: &isize) -> &isize {
    |                                 ^ expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `_x` or `_y`
+help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `_x` or `_y`
+  --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:7:10
+   |
+LL | fn g(_x: &isize, _y: &isize) -> &isize {
+   |          ^^^^^^      ^^^^^^
 help: consider introducing a named lifetime parameter
    |
 LL | fn g<'lifetime>(_x: &isize, _y: &isize) -> &'lifetime isize {
@@ -24,7 +28,11 @@ error[E0106]: missing lifetime specifier
 LL | fn h(_x: &Foo) -> &isize {
    |                   ^ expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value, but the signature does not say which one of `_x`'s 2 lifetimes it is borrowed from
+help: this function's return type contains a borrowed value, but the signature does not say which one of `_x`'s 2 lifetimes it is borrowed from
+  --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:17:10
+   |
+LL | fn h(_x: &Foo) -> &isize {
+   |          ^^^^
 help: consider introducing a named lifetime parameter
    |
 LL | fn h<'lifetime>(_x: &Foo) -> &'lifetime isize {

--- a/src/test/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
+++ b/src/test/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
@@ -10,13 +10,9 @@ error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:7:33
    |
 LL | fn g(_x: &isize, _y: &isize) -> &isize {
-   |                                 ^ expected named lifetime parameter
+   |          ------      ------     ^ expected named lifetime parameter
    |
-help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `_x` or `_y`
-  --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:7:10
-   |
-LL | fn g(_x: &isize, _y: &isize) -> &isize {
-   |          ^^^^^^      ^^^^^^
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `_x` or `_y`
 help: consider introducing a named lifetime parameter
    |
 LL | fn g<'a>(_x: &'a isize, _y: &'a isize) -> &'a isize {
@@ -26,13 +22,9 @@ error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:17:19
    |
 LL | fn h(_x: &Foo) -> &isize {
-   |                   ^ expected named lifetime parameter
+   |          ----     ^ expected named lifetime parameter
    |
-help: this function's return type contains a borrowed value, but the signature does not say which one of `_x`'s 2 lifetimes it is borrowed from
-  --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:17:10
-   |
-LL | fn h(_x: &Foo) -> &isize {
-   |          ^^^^
+   = help: this function's return type contains a borrowed value, but the signature does not say which one of `_x`'s 2 lifetimes it is borrowed from
 help: consider introducing a named lifetime parameter
    |
 LL | fn h<'a>(_x: &'a Foo) -> &'a isize {

--- a/src/test/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
+++ b/src/test/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
@@ -19,7 +19,7 @@ LL | fn g(_x: &isize, _y: &isize) -> &isize {
    |          ^^^^^^      ^^^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn g<'r>(_x: &'r isize, _y: &'r isize) -> &'r isize {
+LL | fn g<'a>(_x: &'a isize, _y: &'a isize) -> &'a isize {
    |     ^^^^     ^^^^^^^^^      ^^^^^^^^^     ^^^
 
 error[E0106]: missing lifetime specifier
@@ -35,7 +35,7 @@ LL | fn h(_x: &Foo) -> &isize {
    |          ^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn h<'r>(_x: &'r Foo) -> &'r isize {
+LL | fn h<'a>(_x: &'a Foo) -> &'a isize {
    |     ^^^^     ^^^^^^^     ^^^
 
 error[E0106]: missing lifetime specifier

--- a/src/test/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.stderr
@@ -4,7 +4,11 @@ error[E0106]: missing lifetime specifier
 LL | fn foo(x: &i32, y: &i32) -> &i32 {
    |                             ^ expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `x` or `y`
+help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `x` or `y`
+  --> $DIR/ex1b-return-no-names-if-else.rs:1:11
+   |
+LL | fn foo(x: &i32, y: &i32) -> &i32 {
+   |           ^^^^     ^^^^
 help: consider introducing a named lifetime parameter
    |
 LL | fn foo<'lifetime>(x: &i32, y: &i32) -> &'lifetime i32 {

--- a/src/test/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.stderr
@@ -2,13 +2,9 @@ error[E0106]: missing lifetime specifier
   --> $DIR/ex1b-return-no-names-if-else.rs:1:29
    |
 LL | fn foo(x: &i32, y: &i32) -> &i32 {
-   |                             ^ expected named lifetime parameter
+   |           ----     ----     ^ expected named lifetime parameter
    |
-help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `x` or `y`
-  --> $DIR/ex1b-return-no-names-if-else.rs:1:11
-   |
-LL | fn foo(x: &i32, y: &i32) -> &i32 {
-   |           ^^^^     ^^^^
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `x` or `y`
 help: consider introducing a named lifetime parameter
    |
 LL | fn foo<'a>(x: &'a i32, y: &'a i32) -> &'a i32 {

--- a/src/test/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.stderr
@@ -11,7 +11,7 @@ LL | fn foo(x: &i32, y: &i32) -> &i32 {
    |           ^^^^     ^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn foo<'r>(x: &'r i32, y: &'r i32) -> &'r i32 {
+LL | fn foo<'a>(x: &'a i32, y: &'a i32) -> &'a i32 {
    |       ^^^^    ^^^^^^^     ^^^^^^^     ^^^
 
 error: aborting due to previous error

--- a/src/test/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.stderr
@@ -11,8 +11,8 @@ LL | fn foo(x: &i32, y: &i32) -> &i32 {
    |           ^^^^     ^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn foo<'lifetime>(x: &i32, y: &i32) -> &'lifetime i32 {
-   |       ^^^^^^^^^^^                      ^^^^^^^^^^
+LL | fn foo<'lifetime>(x: &'lifetime i32, y: &'lifetime i32) -> &'lifetime i32 {
+   |       ^^^^^^^^^^^    ^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^     ^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.stderr
@@ -11,8 +11,8 @@ LL | fn foo(x: &i32, y: &i32) -> &i32 {
    |           ^^^^     ^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn foo<'lifetime>(x: &'lifetime i32, y: &'lifetime i32) -> &'lifetime i32 {
-   |       ^^^^^^^^^^^    ^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^     ^^^^^^^^^^
+LL | fn foo<'r>(x: &'r i32, y: &'r i32) -> &'r i32 {
+   |       ^^^^    ^^^^^^^     ^^^^^^^     ^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/proc-macro/item-error.stderr
+++ b/src/test/ui/proc-macro/item-error.stderr
@@ -6,8 +6,8 @@ LL |     a: &u64
    |
 help: consider introducing a named lifetime parameter
    |
-LL | struct A<'r> {
-LL |     a: &'r u64
+LL | struct A<'a> {
+LL |     a: &'a u64
    |
 
 error: aborting due to previous error

--- a/src/test/ui/proc-macro/item-error.stderr
+++ b/src/test/ui/proc-macro/item-error.stderr
@@ -6,8 +6,8 @@ LL |     a: &u64
    |
 help: consider introducing a named lifetime parameter
    |
-LL | struct A<'lifetime> {
-LL |     a: &'lifetime u64
+LL | struct A<'r> {
+LL |     a: &'r u64
    |
 
 error: aborting due to previous error

--- a/src/test/ui/regions/regions-in-enums-anon.stderr
+++ b/src/test/ui/regions/regions-in-enums-anon.stderr
@@ -6,8 +6,8 @@ LL |     Bar(&isize)
    |
 help: consider introducing a named lifetime parameter
    |
-LL | enum Foo<'lifetime> {
-LL |     Bar(&'lifetime isize)
+LL | enum Foo<'r> {
+LL |     Bar(&'r isize)
    |
 
 error: aborting due to previous error

--- a/src/test/ui/regions/regions-in-enums-anon.stderr
+++ b/src/test/ui/regions/regions-in-enums-anon.stderr
@@ -6,8 +6,8 @@ LL |     Bar(&isize)
    |
 help: consider introducing a named lifetime parameter
    |
-LL | enum Foo<'r> {
-LL |     Bar(&'r isize)
+LL | enum Foo<'a> {
+LL |     Bar(&'a isize)
    |
 
 error: aborting due to previous error

--- a/src/test/ui/regions/regions-in-structs-anon.stderr
+++ b/src/test/ui/regions/regions-in-structs-anon.stderr
@@ -6,8 +6,8 @@ LL |     x: &isize
    |
 help: consider introducing a named lifetime parameter
    |
-LL | struct Foo<'r> {
-LL |     x: &'r isize
+LL | struct Foo<'a> {
+LL |     x: &'a isize
    |
 
 error: aborting due to previous error

--- a/src/test/ui/regions/regions-in-structs-anon.stderr
+++ b/src/test/ui/regions/regions-in-structs-anon.stderr
@@ -6,8 +6,8 @@ LL |     x: &isize
    |
 help: consider introducing a named lifetime parameter
    |
-LL | struct Foo<'lifetime> {
-LL |     x: &'lifetime isize
+LL | struct Foo<'r> {
+LL |     x: &'r isize
    |
 
 error: aborting due to previous error

--- a/src/test/ui/regions/regions-name-undeclared.stderr
+++ b/src/test/ui/regions/regions-name-undeclared.stderr
@@ -89,7 +89,7 @@ error[E0261]: use of undeclared lifetime name `'b`
 LL | ...                   &'b isize,
    |                        ^^ undeclared lifetime
    |
-   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider introducing lifetime `'b` here
    |
 LL | fn fn_types<'b>(a: &'a isize,
@@ -105,7 +105,7 @@ error[E0261]: use of undeclared lifetime name `'b`
 LL | ...                   &'b isize)>,
    |                        ^^ undeclared lifetime
    |
-   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider introducing lifetime `'b` here
    |
 LL | fn fn_types<'b>(a: &'a isize,

--- a/src/test/ui/regions/regions-name-undeclared.stderr
+++ b/src/test/ui/regions/regions-name-undeclared.stderr
@@ -88,12 +88,32 @@ error[E0261]: use of undeclared lifetime name `'b`
    |
 LL | ...                   &'b isize,
    |                        ^^ undeclared lifetime
+   |
+   = note: for more information on Higher-Ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider introducing lifetime `'b` here
+   |
+LL | fn fn_types<'b>(a: &'a isize,
+   |            ^^^^
+help: consider introducing a Higher-Ranked lifetime `'b` here
+   |
+LL |             b: Box<dyn for<'a, 'b> FnOnce(&'a isize,
+   |                              ^^^^
 
 error[E0261]: use of undeclared lifetime name `'b`
   --> $DIR/regions-name-undeclared.rs:45:36
    |
 LL | ...                   &'b isize)>,
    |                        ^^ undeclared lifetime
+   |
+   = note: for more information on Higher-Ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider introducing lifetime `'b` here
+   |
+LL | fn fn_types<'b>(a: &'a isize,
+   |            ^^^^
+help: consider introducing a Higher-Ranked lifetime `'b` here
+   |
+LL |             b: Box<dyn for<'a, 'b> FnOnce(&'a isize,
+   |                              ^^^^
 
 error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/regions-name-undeclared.rs:46:17

--- a/src/test/ui/regions/regions-name-undeclared.stderr
+++ b/src/test/ui/regions/regions-name-undeclared.stderr
@@ -94,7 +94,7 @@ help: consider introducing lifetime `'b` here
    |
 LL | fn fn_types<'b>(a: &'a isize,
    |            ^^^^
-help: consider introducing a higher-ranked lifetime `'b` here
+help: consider making the bound lifetime-generic with a new `'b` lifetime
    |
 LL |             b: Box<dyn for<'a, 'b> FnOnce(&'a isize,
    |                              ^^^^
@@ -110,7 +110,7 @@ help: consider introducing lifetime `'b` here
    |
 LL | fn fn_types<'b>(a: &'a isize,
    |            ^^^^
-help: consider introducing a higher-ranked lifetime `'b` here
+help: consider making the bound lifetime-generic with a new `'b` lifetime
    |
 LL |             b: Box<dyn for<'a, 'b> FnOnce(&'a isize,
    |                              ^^^^

--- a/src/test/ui/regions/regions-name-undeclared.stderr
+++ b/src/test/ui/regions/regions-name-undeclared.stderr
@@ -89,12 +89,12 @@ error[E0261]: use of undeclared lifetime name `'b`
 LL | ...                   &'b isize,
    |                        ^^ undeclared lifetime
    |
-   = note: for more information on Higher-Ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider introducing lifetime `'b` here
    |
 LL | fn fn_types<'b>(a: &'a isize,
    |            ^^^^
-help: consider introducing a Higher-Ranked lifetime `'b` here
+help: consider introducing a higher-ranked lifetime `'b` here
    |
 LL |             b: Box<dyn for<'a, 'b> FnOnce(&'a isize,
    |                              ^^^^
@@ -105,12 +105,12 @@ error[E0261]: use of undeclared lifetime name `'b`
 LL | ...                   &'b isize)>,
    |                        ^^ undeclared lifetime
    |
-   = note: for more information on Higher-Ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider introducing lifetime `'b` here
    |
 LL | fn fn_types<'b>(a: &'a isize,
    |            ^^^^
-help: consider introducing a Higher-Ranked lifetime `'b` here
+help: consider introducing a higher-ranked lifetime `'b` here
    |
 LL |             b: Box<dyn for<'a, 'b> FnOnce(&'a isize,
    |                              ^^^^

--- a/src/test/ui/rfc1623-2.rs
+++ b/src/test/ui/rfc1623-2.rs
@@ -1,0 +1,13 @@
+#![allow(dead_code)]
+
+fn non_elidable<'a, 'b>(a: &'a u8, b: &'b u8) -> &'a u8 {
+    a
+}
+
+// the boundaries of elision
+static NON_ELIDABLE_FN: &fn(&u8, &u8) -> &u8 =
+//~^ ERROR missing lifetime specifier [E0106]
+    &(non_elidable as fn(&u8, &u8) -> &u8);
+    //~^ ERROR missing lifetime specifier [E0106]
+
+fn main() {}

--- a/src/test/ui/rfc1623-2.stderr
+++ b/src/test/ui/rfc1623-2.stderr
@@ -1,0 +1,29 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/rfc1623-2.rs:8:42
+   |
+LL | static NON_ELIDABLE_FN: &fn(&u8, &u8) -> &u8 =
+   |                             ---  ---     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
+   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the type lifetime-generic with a new `'a` lifetime
+   |
+LL | static NON_ELIDABLE_FN: &for<'a> fn(&'a u8, &'a u8) -> &'a u8 =
+   |                          ^^^^^^^    ^^^^^^  ^^^^^^     ^^^
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/rfc1623-2.rs:10:39
+   |
+LL |     &(non_elidable as fn(&u8, &u8) -> &u8);
+   |                          ---  ---     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
+   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the type lifetime-generic with a new `'a` lifetime
+   |
+LL |     &(non_elidable as for<'a> fn(&'a u8, &'a u8) -> &'a u8);
+   |                       ^^^^^^^    ^^^^^^  ^^^^^^     ^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/rfc1623-2.stderr
+++ b/src/test/ui/rfc1623-2.stderr
@@ -5,7 +5,7 @@ LL | static NON_ELIDABLE_FN: &fn(&u8, &u8) -> &u8 =
    |                             ---  ---     ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
-   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider making the type lifetime-generic with a new `'a` lifetime
    |
 LL | static NON_ELIDABLE_FN: &for<'a> fn(&'a u8, &'a u8) -> &'a u8 =
@@ -18,7 +18,7 @@ LL |     &(non_elidable as fn(&u8, &u8) -> &u8);
    |                          ---  ---     ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
-   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider making the type lifetime-generic with a new `'a` lifetime
    |
 LL |     &(non_elidable as for<'a> fn(&'a u8, &'a u8) -> &'a u8);

--- a/src/test/ui/rfc1623.rs
+++ b/src/test/ui/rfc1623.rs
@@ -4,11 +4,10 @@ fn non_elidable<'a, 'b>(a: &'a u8, b: &'b u8) -> &'a u8 {
     a
 }
 
-// the boundaries of elision
-static NON_ELIDABLE_FN: &fn(&u8, &u8) -> &u8 =
-//~^ ERROR missing lifetime specifier [E0106]
-    &(non_elidable as fn(&u8, &u8) -> &u8);
-    //~^ ERROR missing lifetime specifier [E0106]
+// The incorrect case without `for<'a>` is tested for in `rfc1623-2.rs`
+static NON_ELIDABLE_FN: &for<'a> fn(&'a u8, &'a u8) -> &'a u8 =
+    &(non_elidable as for<'a> fn(&'a u8, &'a u8) -> &'a u8);
+
 
 struct SomeStruct<'x, 'y, 'z: 'x> {
     foo: &'x Foo<'z>,
@@ -20,10 +19,12 @@ fn id<T>(t: T) -> T {
     t
 }
 
-static SOME_STRUCT: &SomeStruct = SomeStruct {
+static SOME_STRUCT: &SomeStruct = SomeStruct { //~ ERROR mismatched types
     foo: &Foo { bools: &[false, true] },
     bar: &Bar { bools: &[true, true] },
     f: &id,
+    //~^ ERROR type mismatch in function arguments
+    //~| ERROR type mismatch resolving
 };
 
 // very simple test for a 'static static with default lifetime

--- a/src/test/ui/rfc1623.stderr
+++ b/src/test/ui/rfc1623.stderr
@@ -1,27 +1,46 @@
-error[E0106]: missing lifetime specifier
-  --> $DIR/rfc1623.rs:8:42
+error[E0308]: mismatched types
+  --> $DIR/rfc1623.rs:22:35
    |
-LL | static NON_ELIDABLE_FN: &fn(&u8, &u8) -> &u8 =
-   |                                          ^ expected named lifetime parameter
+LL |   static SOME_STRUCT: &SomeStruct = SomeStruct {
+   |  ___________________________________^
+LL | |     foo: &Foo { bools: &[false, true] },
+LL | |     bar: &Bar { bools: &[true, true] },
+LL | |     f: &id,
+LL | |
+LL | |
+LL | | };
+   | |_^ expected `&SomeStruct<'static, 'static, 'static>`, found struct `SomeStruct`
    |
-help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
-  --> $DIR/rfc1623.rs:8:29
+help: consider borrowing here
    |
-LL | static NON_ELIDABLE_FN: &fn(&u8, &u8) -> &u8 =
-   |                             ^^^  ^^^
+LL | static SOME_STRUCT: &SomeStruct = &SomeStruct {
+LL |     foo: &Foo { bools: &[false, true] },
+LL |     bar: &Bar { bools: &[true, true] },
+LL |     f: &id,
+LL |
+LL |
+ ...
 
-error[E0106]: missing lifetime specifier
-  --> $DIR/rfc1623.rs:10:39
+error[E0631]: type mismatch in function arguments
+  --> $DIR/rfc1623.rs:25:8
    |
-LL |     &(non_elidable as fn(&u8, &u8) -> &u8);
-   |                                       ^ expected named lifetime parameter
+LL | fn id<T>(t: T) -> T {
+   | ------------------- found signature of `fn(_) -> _`
+...
+LL |     f: &id,
+   |        ^^^ expected signature of `for<'a, 'b> fn(&'a Foo<'b>) -> _`
    |
-help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
-  --> $DIR/rfc1623.rs:10:26
-   |
-LL |     &(non_elidable as fn(&u8, &u8) -> &u8);
-   |                          ^^^  ^^^
+   = note: required for the cast to the object type `dyn for<'a, 'b> std::ops::Fn(&'a Foo<'b>) -> &'a Foo<'b>`
 
-error: aborting due to 2 previous errors
+error[E0271]: type mismatch resolving `for<'a, 'b> <fn(_) -> _ {id::<_>} as std::ops::FnOnce<(&'a Foo<'b>,)>>::Output == &'a Foo<'b>`
+  --> $DIR/rfc1623.rs:25:8
+   |
+LL |     f: &id,
+   |        ^^^ expected bound lifetime parameter 'a, found concrete lifetime
+   |
+   = note: required for the cast to the object type `dyn for<'a, 'b> std::ops::Fn(&'a Foo<'b>) -> &'a Foo<'b>`
 
-For more information about this error, try `rustc --explain E0106`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0271, E0308, E0631.
+For more information about an error, try `rustc --explain E0271`.

--- a/src/test/ui/rfc1623.stderr
+++ b/src/test/ui/rfc1623.stderr
@@ -4,7 +4,11 @@ error[E0106]: missing lifetime specifier
 LL | static NON_ELIDABLE_FN: &fn(&u8, &u8) -> &u8 =
    |                                          ^ expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
+help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
+  --> $DIR/rfc1623.rs:8:29
+   |
+LL | static NON_ELIDABLE_FN: &fn(&u8, &u8) -> &u8 =
+   |                             ^^^  ^^^
 
 error[E0106]: missing lifetime specifier
   --> $DIR/rfc1623.rs:10:39
@@ -12,7 +16,11 @@ error[E0106]: missing lifetime specifier
 LL |     &(non_elidable as fn(&u8, &u8) -> &u8);
    |                                       ^ expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
+help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
+  --> $DIR/rfc1623.rs:10:26
+   |
+LL |     &(non_elidable as fn(&u8, &u8) -> &u8);
+   |                          ^^^  ^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/suggestions/fn-missing-lifetime-in-item.rs
+++ b/src/test/ui/suggestions/fn-missing-lifetime-in-item.rs
@@ -1,0 +1,8 @@
+struct S1<F: Fn(&i32, &i32) -> &'a i32>(F); //~ ERROR use of undeclared lifetime name `'a`
+struct S2<F: Fn(&i32, &i32) -> &i32>(F); //~ ERROR missing lifetime specifier
+struct S3<F: for<'a> Fn(&i32, &i32) -> &'a i32>(F);
+//~^ ERROR binding for associated type `Output` references lifetime `'a`, which does not appear
+struct S4<F: for<'x> Fn(&'x i32, &'x i32) -> &'x i32>(F);
+const C: Option<Box<dyn for<'a> Fn(&usize, &usize) -> &'a usize>> = None;
+//~^ ERROR binding for associated type `Output` references lifetime `'a`, which does not appear
+fn main() {}

--- a/src/test/ui/suggestions/fn-missing-lifetime-in-item.stderr
+++ b/src/test/ui/suggestions/fn-missing-lifetime-in-item.stderr
@@ -4,7 +4,7 @@ error[E0261]: use of undeclared lifetime name `'a`
 LL | struct S1<F: Fn(&i32, &i32) -> &'a i32>(F);
    |                                 ^^ undeclared lifetime
    |
-   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider introducing lifetime `'a` here
    |
 LL | struct S1<'a, F: Fn(&i32, &i32) -> &'a i32>(F);
@@ -21,7 +21,7 @@ LL | struct S2<F: Fn(&i32, &i32) -> &i32>(F);
    |                 ----  ----     ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
-   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider making the bound lifetime-generic with a new `'a` lifetime
    |
 LL | struct S2<F: for<'a> Fn(&'a i32, &'a i32) -> &'a i32>(F);

--- a/src/test/ui/suggestions/fn-missing-lifetime-in-item.stderr
+++ b/src/test/ui/suggestions/fn-missing-lifetime-in-item.stderr
@@ -9,7 +9,7 @@ help: consider introducing lifetime `'a` here
    |
 LL | struct S1<'a, F: Fn(&i32, &i32) -> &'a i32>(F);
    |           ^^^
-help: consider introducing a higher-ranked lifetime `'a` here
+help: consider making the bound lifetime-generic with a new `'a` lifetime
    |
 LL | struct S1<F: for<'a> Fn(&i32, &i32) -> &'a i32>(F);
    |              ^^^^^^^
@@ -18,15 +18,11 @@ error[E0106]: missing lifetime specifier
   --> $DIR/fn-missing-lifetime-in-item.rs:2:32
    |
 LL | struct S2<F: Fn(&i32, &i32) -> &i32>(F);
-   |                                ^ expected named lifetime parameter
+   |                 ----  ----     ^ expected named lifetime parameter
    |
-help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
-  --> $DIR/fn-missing-lifetime-in-item.rs:2:17
-   |
-LL | struct S2<F: Fn(&i32, &i32) -> &i32>(F);
-   |                 ^^^^  ^^^^
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
    = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
-help: consider introducing a higher-ranked lifetime
+help: consider making the bound lifetime-generic with a new `'a` lifetime
    |
 LL | struct S2<F: for<'a> Fn(&'a i32, &'a i32) -> &'a i32>(F);
    |              ^^^^^^^    ^^^^^^^  ^^^^^^^     ^^^

--- a/src/test/ui/suggestions/fn-missing-lifetime-in-item.stderr
+++ b/src/test/ui/suggestions/fn-missing-lifetime-in-item.stderr
@@ -1,0 +1,53 @@
+error[E0261]: use of undeclared lifetime name `'a`
+  --> $DIR/fn-missing-lifetime-in-item.rs:1:33
+   |
+LL | struct S1<F: Fn(&i32, &i32) -> &'a i32>(F);
+   |                                 ^^ undeclared lifetime
+   |
+   = note: for more information on Higher-Ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider introducing lifetime `'a` here
+   |
+LL | struct S1<'a, F: Fn(&i32, &i32) -> &'a i32>(F);
+   |           ^^^
+help: consider introducing a Higher-Ranked lifetime `'a` here
+   |
+LL | struct S1<F: for<'a> Fn(&i32, &i32) -> &'a i32>(F);
+   |              ^^^^^^^
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/fn-missing-lifetime-in-item.rs:2:32
+   |
+LL | struct S2<F: Fn(&i32, &i32) -> &i32>(F);
+   |                                ^ expected named lifetime parameter
+   |
+help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
+  --> $DIR/fn-missing-lifetime-in-item.rs:2:17
+   |
+LL | struct S2<F: Fn(&i32, &i32) -> &i32>(F);
+   |                 ^^^^  ^^^^
+   = note: for more information on Higher-Ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider introducing a Higher-Ranked lifetime
+   |
+LL | struct S2<F: for<'r> Fn(&'r i32, &'r i32) -> &'r i32>(F);
+   |              ^^^^^^^    ^^^^^^^  ^^^^^^^     ^^^
+help: consider introducing a named lifetime parameter
+   |
+LL | struct S2<'r, F: Fn(&'r i32, &'r i32) -> &'r i32>(F);
+   |           ^^^       ^^^^^^^  ^^^^^^^     ^^^
+
+error[E0582]: binding for associated type `Output` references lifetime `'a`, which does not appear in the trait input types
+  --> $DIR/fn-missing-lifetime-in-item.rs:3:40
+   |
+LL | struct S3<F: for<'a> Fn(&i32, &i32) -> &'a i32>(F);
+   |                                        ^^^^^^^
+
+error[E0582]: binding for associated type `Output` references lifetime `'a`, which does not appear in the trait input types
+  --> $DIR/fn-missing-lifetime-in-item.rs:6:55
+   |
+LL | const C: Option<Box<dyn for<'a> Fn(&usize, &usize) -> &'a usize>> = None;
+   |                                                       ^^^^^^^^^
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0106, E0261, E0582.
+For more information about an error, try `rustc --explain E0106`.

--- a/src/test/ui/suggestions/fn-missing-lifetime-in-item.stderr
+++ b/src/test/ui/suggestions/fn-missing-lifetime-in-item.stderr
@@ -4,12 +4,12 @@ error[E0261]: use of undeclared lifetime name `'a`
 LL | struct S1<F: Fn(&i32, &i32) -> &'a i32>(F);
    |                                 ^^ undeclared lifetime
    |
-   = note: for more information on Higher-Ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider introducing lifetime `'a` here
    |
 LL | struct S1<'a, F: Fn(&i32, &i32) -> &'a i32>(F);
    |           ^^^
-help: consider introducing a Higher-Ranked lifetime `'a` here
+help: consider introducing a higher-ranked lifetime `'a` here
    |
 LL | struct S1<F: for<'a> Fn(&i32, &i32) -> &'a i32>(F);
    |              ^^^^^^^
@@ -25,14 +25,14 @@ help: this function's return type contains a borrowed value, but the signature d
    |
 LL | struct S2<F: Fn(&i32, &i32) -> &i32>(F);
    |                 ^^^^  ^^^^
-   = note: for more information on Higher-Ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
-help: consider introducing a Higher-Ranked lifetime
+   = note: for more information on higher-ranked lifetimes, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider introducing a higher-ranked lifetime
    |
-LL | struct S2<F: for<'r> Fn(&'r i32, &'r i32) -> &'r i32>(F);
+LL | struct S2<F: for<'a> Fn(&'a i32, &'a i32) -> &'a i32>(F);
    |              ^^^^^^^    ^^^^^^^  ^^^^^^^     ^^^
 help: consider introducing a named lifetime parameter
    |
-LL | struct S2<'r, F: Fn(&'r i32, &'r i32) -> &'r i32>(F);
+LL | struct S2<'a, F: Fn(&'a i32, &'a i32) -> &'a i32>(F);
    |           ^^^       ^^^^^^^  ^^^^^^^     ^^^
 
 error[E0582]: binding for associated type `Output` references lifetime `'a`, which does not appear in the trait input types

--- a/src/test/ui/suggestions/impl-trait-missing-lifetime.rs
+++ b/src/test/ui/suggestions/impl-trait-missing-lifetime.rs
@@ -1,0 +1,2 @@
+fn f(_: impl Iterator<Item = &'_ ()>) {} //~ ERROR missing lifetime specifier
+fn main() {}

--- a/src/test/ui/suggestions/impl-trait-missing-lifetime.stderr
+++ b/src/test/ui/suggestions/impl-trait-missing-lifetime.stderr
@@ -1,0 +1,14 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/impl-trait-missing-lifetime.rs:1:31
+   |
+LL | fn f(_: impl Iterator<Item = &'_ ()>) {}
+   |                               ^^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | fn f<'a>(_: impl Iterator<Item = &'a ()>) {}
+   |     ^^^^                          ^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/suggestions/return-without-lifetime.stderr
+++ b/src/test/ui/suggestions/return-without-lifetime.stderr
@@ -8,25 +8,17 @@ error[E0106]: missing lifetime specifier
   --> $DIR/return-without-lifetime.rs:5:34
    |
 LL | fn func1<'a>(_arg: &'a Thing) -> &() { unimplemented!() }
-   |                                  ^ help: consider using the named lifetime: `&'a`
+   |                    ---------     ^ help: consider using the named lifetime: `&'a`
    |
-help: this function's return type contains a borrowed value, but the signature does not say which one of `_arg`'s 2 lifetimes it is borrowed from
-  --> $DIR/return-without-lifetime.rs:5:20
-   |
-LL | fn func1<'a>(_arg: &'a Thing) -> &() { unimplemented!() }
-   |                    ^^^^^^^^^
+   = help: this function's return type contains a borrowed value, but the signature does not say which one of `_arg`'s 2 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifier
   --> $DIR/return-without-lifetime.rs:7:35
    |
 LL | fn func2<'a>(_arg: &Thing<'a>) -> &() { unimplemented!() }
-   |                                   ^ help: consider using the named lifetime: `&'a`
+   |                    ----------     ^ help: consider using the named lifetime: `&'a`
    |
-help: this function's return type contains a borrowed value, but the signature does not say which one of `_arg`'s 2 lifetimes it is borrowed from
-  --> $DIR/return-without-lifetime.rs:7:20
-   |
-LL | fn func2<'a>(_arg: &Thing<'a>) -> &() { unimplemented!() }
-   |                    ^^^^^^^^^^
+   = help: this function's return type contains a borrowed value, but the signature does not say which one of `_arg`'s 2 lifetimes it is borrowed from
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/suggestions/return-without-lifetime.stderr
+++ b/src/test/ui/suggestions/return-without-lifetime.stderr
@@ -10,7 +10,11 @@ error[E0106]: missing lifetime specifier
 LL | fn func1<'a>(_arg: &'a Thing) -> &() { unimplemented!() }
    |                                  ^ help: consider using the named lifetime: `&'a`
    |
-   = help: this function's return type contains a borrowed value, but the signature does not say which one of `_arg`'s 2 lifetimes it is borrowed from
+help: this function's return type contains a borrowed value, but the signature does not say which one of `_arg`'s 2 lifetimes it is borrowed from
+  --> $DIR/return-without-lifetime.rs:5:20
+   |
+LL | fn func1<'a>(_arg: &'a Thing) -> &() { unimplemented!() }
+   |                    ^^^^^^^^^
 
 error[E0106]: missing lifetime specifier
   --> $DIR/return-without-lifetime.rs:7:35
@@ -18,7 +22,11 @@ error[E0106]: missing lifetime specifier
 LL | fn func2<'a>(_arg: &Thing<'a>) -> &() { unimplemented!() }
    |                                   ^ help: consider using the named lifetime: `&'a`
    |
-   = help: this function's return type contains a borrowed value, but the signature does not say which one of `_arg`'s 2 lifetimes it is borrowed from
+help: this function's return type contains a borrowed value, but the signature does not say which one of `_arg`'s 2 lifetimes it is borrowed from
+  --> $DIR/return-without-lifetime.rs:7:20
+   |
+LL | fn func2<'a>(_arg: &Thing<'a>) -> &() { unimplemented!() }
+   |                    ^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-lifetime-elision.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-lifetime-elision.stderr
@@ -4,7 +4,11 @@ error[E0106]: missing lifetime specifier
 LL |     let _: dyn Foo(&isize, &usize) -> &usize;
    |                                       ^ expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
+help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
+  --> $DIR/unboxed-closure-sugar-lifetime-elision.rs:26:20
+   |
+LL |     let _: dyn Foo(&isize, &usize) -> &usize;
+   |                    ^^^^^^  ^^^^^^
 help: consider introducing a named lifetime parameter
    |
 LL | fn main<'lifetime>() {

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-lifetime-elision.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-lifetime-elision.stderr
@@ -2,13 +2,9 @@ error[E0106]: missing lifetime specifier
   --> $DIR/unboxed-closure-sugar-lifetime-elision.rs:26:39
    |
 LL |     let _: dyn Foo(&isize, &usize) -> &usize;
-   |                                       ^ expected named lifetime parameter
+   |                    ------  ------     ^ expected named lifetime parameter
    |
-help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
-  --> $DIR/unboxed-closure-sugar-lifetime-elision.rs:26:20
-   |
-LL |     let _: dyn Foo(&isize, &usize) -> &usize;
-   |                    ^^^^^^  ^^^^^^
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
 help: consider introducing a named lifetime parameter
    |
 LL | fn main<'a>() {

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-lifetime-elision.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-lifetime-elision.stderr
@@ -11,7 +11,7 @@ LL |     let _: dyn Foo(&isize, &usize) -> &usize;
    |                    ^^^^^^  ^^^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn main<'r>() {
+LL | fn main<'a>() {
 LL |     eq::< dyn for<'a> Foo<(&'a isize,), Output=&'a isize>,
 LL |           dyn Foo(&isize) -> &isize                                   >();
 LL |     eq::< dyn for<'a> Foo<(&'a isize,), Output=(&'a isize, &'a isize)>,

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-lifetime-elision.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-lifetime-elision.stderr
@@ -11,7 +11,7 @@ LL |     let _: dyn Foo(&isize, &usize) -> &usize;
    |                    ^^^^^^  ^^^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn main<'lifetime>() {
+LL | fn main<'r>() {
 LL |     eq::< dyn for<'a> Foo<(&'a isize,), Output=&'a isize>,
 LL |           dyn Foo(&isize) -> &isize                                   >();
 LL |     eq::< dyn for<'a> Foo<(&'a isize,), Output=(&'a isize, &'a isize)>,

--- a/src/test/ui/underscore-lifetime/dyn-trait-underscore-in-struct.stderr
+++ b/src/test/ui/underscore-lifetime/dyn-trait-underscore-in-struct.stderr
@@ -6,8 +6,8 @@ LL |     x: Box<dyn Debug + '_>,
    |
 help: consider introducing a named lifetime parameter
    |
-LL | struct Foo<'lifetime> {
-LL |     x: Box<dyn Debug + 'lifetime>,
+LL | struct Foo<'r> {
+LL |     x: Box<dyn Debug + 'r>,
    |
 
 error[E0228]: the lifetime bound for this object type cannot be deduced from context; please supply an explicit bound

--- a/src/test/ui/underscore-lifetime/dyn-trait-underscore-in-struct.stderr
+++ b/src/test/ui/underscore-lifetime/dyn-trait-underscore-in-struct.stderr
@@ -6,8 +6,8 @@ LL |     x: Box<dyn Debug + '_>,
    |
 help: consider introducing a named lifetime parameter
    |
-LL | struct Foo<'r> {
-LL |     x: Box<dyn Debug + 'r>,
+LL | struct Foo<'a> {
+LL |     x: Box<dyn Debug + 'a>,
    |
 
 error[E0228]: the lifetime bound for this object type cannot be deduced from context; please supply an explicit bound

--- a/src/test/ui/underscore-lifetime/in-fn-return-illegal.stderr
+++ b/src/test/ui/underscore-lifetime/in-fn-return-illegal.stderr
@@ -11,7 +11,7 @@ LL | fn foo(x: &u32, y: &u32) -> &'_ u32 { loop { } }
    |           ^^^^     ^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn foo<'r>(x: &'r u32, y: &'r u32) -> &'r u32 { loop { } }
+LL | fn foo<'a>(x: &'a u32, y: &'a u32) -> &'a u32 { loop { } }
    |       ^^^^    ^^^^^^^     ^^^^^^^      ^^
 
 error: aborting due to previous error

--- a/src/test/ui/underscore-lifetime/in-fn-return-illegal.stderr
+++ b/src/test/ui/underscore-lifetime/in-fn-return-illegal.stderr
@@ -11,8 +11,8 @@ LL | fn foo(x: &u32, y: &u32) -> &'_ u32 { loop { } }
    |           ^^^^     ^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn foo<'lifetime>(x: &u32, y: &u32) -> &'lifetime u32 { loop { } }
-   |       ^^^^^^^^^^^                       ^^^^^^^^^
+LL | fn foo<'lifetime>(x: &'lifetime u32, y: &'lifetime u32) -> &'lifetime u32 { loop { } }
+   |       ^^^^^^^^^^^    ^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^      ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/underscore-lifetime/in-fn-return-illegal.stderr
+++ b/src/test/ui/underscore-lifetime/in-fn-return-illegal.stderr
@@ -4,7 +4,11 @@ error[E0106]: missing lifetime specifier
 LL | fn foo(x: &u32, y: &u32) -> &'_ u32 { loop { } }
    |                              ^^ expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `x` or `y`
+help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `x` or `y`
+  --> $DIR/in-fn-return-illegal.rs:5:11
+   |
+LL | fn foo(x: &u32, y: &u32) -> &'_ u32 { loop { } }
+   |           ^^^^     ^^^^
 help: consider introducing a named lifetime parameter
    |
 LL | fn foo<'lifetime>(x: &u32, y: &u32) -> &'lifetime u32 { loop { } }

--- a/src/test/ui/underscore-lifetime/in-fn-return-illegal.stderr
+++ b/src/test/ui/underscore-lifetime/in-fn-return-illegal.stderr
@@ -11,8 +11,8 @@ LL | fn foo(x: &u32, y: &u32) -> &'_ u32 { loop { } }
    |           ^^^^     ^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn foo<'lifetime>(x: &'lifetime u32, y: &'lifetime u32) -> &'lifetime u32 { loop { } }
-   |       ^^^^^^^^^^^    ^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^      ^^^^^^^^^
+LL | fn foo<'r>(x: &'r u32, y: &'r u32) -> &'r u32 { loop { } }
+   |       ^^^^    ^^^^^^^     ^^^^^^^      ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/underscore-lifetime/in-fn-return-illegal.stderr
+++ b/src/test/ui/underscore-lifetime/in-fn-return-illegal.stderr
@@ -2,13 +2,9 @@ error[E0106]: missing lifetime specifier
   --> $DIR/in-fn-return-illegal.rs:5:30
    |
 LL | fn foo(x: &u32, y: &u32) -> &'_ u32 { loop { } }
-   |                              ^^ expected named lifetime parameter
+   |           ----     ----      ^^ expected named lifetime parameter
    |
-help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `x` or `y`
-  --> $DIR/in-fn-return-illegal.rs:5:11
-   |
-LL | fn foo(x: &u32, y: &u32) -> &'_ u32 { loop { } }
-   |           ^^^^     ^^^^
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `x` or `y`
 help: consider introducing a named lifetime parameter
    |
 LL | fn foo<'a>(x: &'a u32, y: &'a u32) -> &'a u32 { loop { } }

--- a/src/test/ui/underscore-lifetime/in-struct.stderr
+++ b/src/test/ui/underscore-lifetime/in-struct.stderr
@@ -6,8 +6,8 @@ LL |     x: &'_ u32,
    |
 help: consider introducing a named lifetime parameter
    |
-LL | struct Foo<'lifetime> {
-LL |     x: &'lifetime u32,
+LL | struct Foo<'r> {
+LL |     x: &'r u32,
    |
 
 error[E0106]: missing lifetime specifier
@@ -18,8 +18,8 @@ LL |     Variant(&'_ u32),
    |
 help: consider introducing a named lifetime parameter
    |
-LL | enum Bar<'lifetime> {
-LL |     Variant(&'lifetime u32),
+LL | enum Bar<'r> {
+LL |     Variant(&'r u32),
    |
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/underscore-lifetime/in-struct.stderr
+++ b/src/test/ui/underscore-lifetime/in-struct.stderr
@@ -6,8 +6,8 @@ LL |     x: &'_ u32,
    |
 help: consider introducing a named lifetime parameter
    |
-LL | struct Foo<'r> {
-LL |     x: &'r u32,
+LL | struct Foo<'a> {
+LL |     x: &'a u32,
    |
 
 error[E0106]: missing lifetime specifier
@@ -18,8 +18,8 @@ LL |     Variant(&'_ u32),
    |
 help: consider introducing a named lifetime parameter
    |
-LL | enum Bar<'r> {
-LL |     Variant(&'r u32),
+LL | enum Bar<'a> {
+LL |     Variant(&'a u32),
    |
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/underscore-lifetime/underscore-lifetime-binders.stderr
+++ b/src/test/ui/underscore-lifetime/underscore-lifetime-binders.stderr
@@ -37,8 +37,8 @@ LL | fn foo2(_: &'_ u8, y: &'_ u8) -> &'_ u8 { y }
    |            ^^^^^^     ^^^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn foo2<'lifetime>(_: &'_ u8, y: &'_ u8) -> &'lifetime u8 { y }
-   |        ^^^^^^^^^^^                           ^^^^^^^^^
+LL | fn foo2<'r>(_: &'_ u8, y: &'_ u8) -> &'r u8 { y }
+   |        ^^^^                           ^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/underscore-lifetime/underscore-lifetime-binders.stderr
+++ b/src/test/ui/underscore-lifetime/underscore-lifetime-binders.stderr
@@ -37,7 +37,7 @@ LL | fn foo2(_: &'_ u8, y: &'_ u8) -> &'_ u8 { y }
    |            ^^^^^^     ^^^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn foo2<'r>(_: &'_ u8, y: &'_ u8) -> &'r u8 { y }
+LL | fn foo2<'a>(_: &'_ u8, y: &'_ u8) -> &'a u8 { y }
    |        ^^^^                           ^^
 
 error: aborting due to 5 previous errors

--- a/src/test/ui/underscore-lifetime/underscore-lifetime-binders.stderr
+++ b/src/test/ui/underscore-lifetime/underscore-lifetime-binders.stderr
@@ -28,13 +28,9 @@ error[E0106]: missing lifetime specifier
   --> $DIR/underscore-lifetime-binders.rs:16:35
    |
 LL | fn foo2(_: &'_ u8, y: &'_ u8) -> &'_ u8 { y }
-   |                                   ^^ expected named lifetime parameter
+   |            ------     ------      ^^ expected named lifetime parameter
    |
-help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or `y`
-  --> $DIR/underscore-lifetime-binders.rs:16:12
-   |
-LL | fn foo2(_: &'_ u8, y: &'_ u8) -> &'_ u8 { y }
-   |            ^^^^^^     ^^^^^^
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or `y`
 help: consider introducing a named lifetime parameter
    |
 LL | fn foo2<'a>(_: &'a u8, y: &'a u8) -> &'a u8 { y }

--- a/src/test/ui/underscore-lifetime/underscore-lifetime-binders.stderr
+++ b/src/test/ui/underscore-lifetime/underscore-lifetime-binders.stderr
@@ -30,7 +30,11 @@ error[E0106]: missing lifetime specifier
 LL | fn foo2(_: &'_ u8, y: &'_ u8) -> &'_ u8 { y }
    |                                   ^^ expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or `y`
+help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or `y`
+  --> $DIR/underscore-lifetime-binders.rs:16:12
+   |
+LL | fn foo2(_: &'_ u8, y: &'_ u8) -> &'_ u8 { y }
+   |            ^^^^^^     ^^^^^^
 help: consider introducing a named lifetime parameter
    |
 LL | fn foo2<'lifetime>(_: &'_ u8, y: &'_ u8) -> &'lifetime u8 { y }

--- a/src/test/ui/underscore-lifetime/underscore-lifetime-binders.stderr
+++ b/src/test/ui/underscore-lifetime/underscore-lifetime-binders.stderr
@@ -37,8 +37,8 @@ LL | fn foo2(_: &'_ u8, y: &'_ u8) -> &'_ u8 { y }
    |            ^^^^^^     ^^^^^^
 help: consider introducing a named lifetime parameter
    |
-LL | fn foo2<'a>(_: &'_ u8, y: &'_ u8) -> &'a u8 { y }
-   |        ^^^^                           ^^
+LL | fn foo2<'a>(_: &'a u8, y: &'a u8) -> &'a u8 { y }
+   |        ^^^^    ^^^^^^     ^^^^^^      ^^
 
 error: aborting due to 5 previous errors
 


### PR DESCRIPTION
```
error[E0106]: missing lifetime specifier
 --> src/test/ui/suggestions/fn-missing-lifetime-in-item.rs:2:32
  |
2 | struct S2<F: Fn(&i32, &i32) -> &i32>(F);
  |                 ----  ----     ^ expected named lifetime parameter
  |
  = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
  = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
help: consider making the bound lifetime-generic with a new `'a` lifetime
  |
2 | struct S2<F: for<'a> Fn(&'a i32, &'a i32) -> &'a i32>(F);
  |              ^^^^^^^    ^^^^^^^  ^^^^^^^     ^^^
help: consider introducing a named lifetime parameter
  |
2 | struct S2<'a, F: Fn(&'a i32, &'a i32) -> &'a i32>(F);=
  |           ^^^       ^^^^^^^  ^^^^^^^     ^^^
```

Follow up to #68267. Addresses the diagnostics part of #49287.