### PR TITLE
Make conflicting_repr_hints a deny-by-default c-future-compat lint

### DIFF
--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -19,6 +19,16 @@ declare_lint! {
 }
 
 declare_lint! {
+    pub CONFLICTING_REPR_HINTS,
+    Deny,
+    "conflicts between `#[repr(..)]` hints that were previously accepted and used in practice",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #68585 <https://github.com/rust-lang/rust/issues/68585>",
+        edition: None,
+    };
+}
+
+declare_lint! {
     pub META_VARIABLE_MISUSE,
     Allow,
     "possible meta-variable misuse at macro definition"
@@ -520,6 +530,7 @@ declare_lint_pass! {
         MACRO_USE_EXTERN_CRATE,
         MACRO_EXPANDED_MACRO_EXPORTS_ACCESSED_BY_ABSOLUTE_PATHS,
         ILL_FORMED_ATTRIBUTE_INPUT,
+        CONFLICTING_REPR_HINTS,
         META_VARIABLE_MISUSE,
         DEPRECATED_IN_FUTURE,
         AMBIGUOUS_ASSOCIATED_ITEMS,

--- a/src/test/ui/conflicting-repr-hints.rs
+++ b/src/test/ui/conflicting-repr-hints.rs
@@ -11,11 +11,13 @@ enum B {
 }
 
 #[repr(C, u64)] //~ ERROR conflicting representation hints
+//~^ WARN this was previously accepted
 enum C {
     C,
 }
 
 #[repr(u32, u64)] //~ ERROR conflicting representation hints
+//~^ WARN this was previously accepted
 enum D {
     D,
 }

--- a/src/test/ui/conflicting-repr-hints.stderr
+++ b/src/test/ui/conflicting-repr-hints.stderr
@@ -3,45 +3,52 @@ error[E0566]: conflicting representation hints
    |
 LL | #[repr(C, u64)]
    |        ^  ^^^
+   |
+   = note: `#[deny(conflicting_repr_hints)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
 
 error[E0566]: conflicting representation hints
-  --> $DIR/conflicting-repr-hints.rs:18:8
+  --> $DIR/conflicting-repr-hints.rs:19:8
    |
 LL | #[repr(u32, u64)]
    |        ^^^  ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
 
 error[E0587]: type has conflicting packed and align representation hints
-  --> $DIR/conflicting-repr-hints.rs:27:1
+  --> $DIR/conflicting-repr-hints.rs:29:1
    |
 LL | struct F(i32);
    | ^^^^^^^^^^^^^^
 
 error[E0587]: type has conflicting packed and align representation hints
-  --> $DIR/conflicting-repr-hints.rs:31:1
+  --> $DIR/conflicting-repr-hints.rs:33:1
    |
 LL | struct G(i32);
    | ^^^^^^^^^^^^^^
 
 error[E0587]: type has conflicting packed and align representation hints
-  --> $DIR/conflicting-repr-hints.rs:35:1
+  --> $DIR/conflicting-repr-hints.rs:37:1
    |
 LL | struct H(i32);
    | ^^^^^^^^^^^^^^
 
 error[E0634]: type has conflicting packed representation hints
-  --> $DIR/conflicting-repr-hints.rs:38:1
+  --> $DIR/conflicting-repr-hints.rs:40:1
    |
 LL | struct I(i32);
    | ^^^^^^^^^^^^^^
 
 error[E0634]: type has conflicting packed representation hints
-  --> $DIR/conflicting-repr-hints.rs:42:1
+  --> $DIR/conflicting-repr-hints.rs:44:1
    |
 LL | struct J(i32);
    | ^^^^^^^^^^^^^^
 
 error[E0587]: type has conflicting packed and align representation hints
-  --> $DIR/conflicting-repr-hints.rs:48:1
+  --> $DIR/conflicting-repr-hints.rs:50:1
    |
 LL | / union X {
 LL | |
@@ -50,7 +57,7 @@ LL | | }
    | |_^
 
 error[E0587]: type has conflicting packed and align representation hints
-  --> $DIR/conflicting-repr-hints.rs:55:1
+  --> $DIR/conflicting-repr-hints.rs:57:1
    |
 LL | / union Y {
 LL | |
@@ -59,7 +66,7 @@ LL | | }
    | |_^
 
 error[E0587]: type has conflicting packed and align representation hints
-  --> $DIR/conflicting-repr-hints.rs:62:1
+  --> $DIR/conflicting-repr-hints.rs:64:1
    |
 LL | / union Z {
 LL | |

--- a/src/test/ui/feature-gates/feature-gate-repr-simd.rs
+++ b/src/test/ui/feature-gates/feature-gate-repr-simd.rs
@@ -2,6 +2,7 @@
 struct Foo(u64, u64);
 
 #[repr(C)] //~ ERROR conflicting representation hints
+//~^ WARN this was previously accepted
 #[repr(simd)] //~ error: SIMD types are experimental
 struct Bar(u64, u64);
 

--- a/src/test/ui/feature-gates/feature-gate-repr-simd.stderr
+++ b/src/test/ui/feature-gates/feature-gate-repr-simd.stderr
@@ -8,7 +8,7 @@ LL | #[repr(simd)]
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable
 
 error[E0658]: SIMD types are experimental and possibly buggy
-  --> $DIR/feature-gate-repr-simd.rs:5:1
+  --> $DIR/feature-gate-repr-simd.rs:6:1
    |
 LL | #[repr(simd)]
    | ^^^^^^^^^^^^^
@@ -21,8 +21,13 @@ error[E0566]: conflicting representation hints
    |
 LL | #[repr(C)]
    |        ^
+LL |
 LL | #[repr(simd)]
    |        ^^^^
+   |
+   = note: `#[deny(conflicting_repr_hints)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-47094.rs
+++ b/src/test/ui/issues/issue-47094.rs
@@ -1,10 +1,12 @@
 #[repr(C, u8)] //~ ERROR conflicting representation hints
+//~^ WARN this was previously accepted
 enum Foo {
     A,
     B,
 }
 
 #[repr(C)] //~ ERROR conflicting representation hints
+//~^ WARN this was previously accepted
 #[repr(u8)]
 enum Bar {
     A,

--- a/src/test/ui/issues/issue-47094.stderr
+++ b/src/test/ui/issues/issue-47094.stderr
@@ -3,14 +3,22 @@ error[E0566]: conflicting representation hints
    |
 LL | #[repr(C, u8)]
    |        ^  ^^
+   |
+   = note: `#[deny(conflicting_repr_hints)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
 
 error[E0566]: conflicting representation hints
-  --> $DIR/issue-47094.rs:7:8
+  --> $DIR/issue-47094.rs:8:8
    |
 LL | #[repr(C)]
    |        ^
+LL |
 LL | #[repr(u8)]
    |        ^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/68428.
cc https://github.com/rust-lang/rust/issues/68585.

r? @petrochenkov @pnkfelix 