### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/src/doc/unstable-book/src/library-features/debug-map-key-value.md
+++ b/src/doc/unstable-book/src/library-features/debug-map-key-value.md
@@ -1,9 +1,0 @@
-# `debug_map_key_value`
-
-The tracking issue for this feature is: [#62482]
-
-[#62482]: https://github.com/rust-lang/rust/issues/62482
-
-------------------------
-
-Add the methods `key` and `value` to `DebugMap` so that an entry can be formatted across multiple calls without additional buffering.

--- a/src/libcore/fmt/builders.rs
+++ b/src/libcore/fmt/builders.rs
@@ -778,7 +778,6 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(debug_map_key_value)]
     /// use std::fmt;
     ///
     /// struct Foo(Vec<(String, i32)>);
@@ -796,7 +795,7 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     ///     "{\"whole\": [(\"A\", 10), (\"B\", 11)]}",
     /// );
     /// ```
-    #[unstable(feature = "debug_map_key_value", reason = "recently added", issue = "62482")]
+    #[stable(feature = "debug_map_key_value", since = "1.42.0")]
     pub fn key(&mut self, key: &dyn fmt::Debug) -> &mut Self {
         self.result = self.result.and_then(|_| {
             assert!(
@@ -843,7 +842,6 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(debug_map_key_value)]
     /// use std::fmt;
     ///
     /// struct Foo(Vec<(String, i32)>);
@@ -861,7 +859,7 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     ///     "{\"whole\": [(\"A\", 10), (\"B\", 11)]}",
     /// );
     /// ```
-    #[unstable(feature = "debug_map_key_value", reason = "recently added", issue = "62482")]
+    #[stable(feature = "debug_map_key_value", since = "1.42.0")]
     pub fn value(&mut self, value: &dyn fmt::Debug) -> &mut Self {
         self.result = self.result.and_then(|_| {
             assert!(self.has_key, "attempted to format a map value before its key");

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -4,7 +4,6 @@
 #![feature(cell_update)]
 #![feature(core_private_bignum)]
 #![feature(core_private_diy_float)]
-#![feature(debug_map_key_value)]
 #![feature(debug_non_exhaustive)]
 #![feature(dec2flt)]
 #![feature(exact_size_is_empty)]

--- a/src/librustc_error_codes/error_codes/E0206.md
+++ b/src/librustc_error_codes/error_codes/E0206.md
@@ -1,12 +1,18 @@
-You can only implement `Copy` for a struct or enum. Both of the following
-examples will fail, because neither `[u8; 256]` nor `&'static mut Bar`
-(mutable reference to `Bar`) is a struct or enum:
+The `Copy` trait was implemented on a type which is neither a struct nor an
+enum.
+
+Erroneous code example:
 
 ```compile_fail,E0206
 type Foo = [u8; 256];
-impl Copy for Foo { } // error
+impl Copy for Foo { } // error!
 
 #[derive(Copy, Clone)]
 struct Bar;
-impl Copy for &'static mut Bar { } // error
+
+impl Copy for &'static mut Bar { } // error!
 ```
+
+You can only implement `Copy` for a struct or an enum. Both of the previous
+examples will fail, because neither `[u8; 256]` nor `&'static mut Bar`
+(mutable reference to `Bar`) is a struct or enum.

--- a/src/librustc_error_codes/error_codes/E0207.md
+++ b/src/librustc_error_codes/error_codes/E0207.md
@@ -1,3 +1,19 @@
+A type or lifetime parameter that is specified for `impl` is not constrained.
+
+Erroneous code example:
+
+```compile_fail,E0207
+struct Foo;
+
+impl<T: Default> Foo {
+    // error: the type parameter `T` is not constrained by the impl trait, self
+    // type, or predicates [E0207]
+    fn get(&self) -> T {
+        <T as Default>::default()
+    }
+}
+```
+
 Any type parameter or lifetime parameter of an `impl` must meet at least one of
 the following criteria:
 
@@ -10,19 +26,7 @@ the following criteria:
 ### Error example 1
 
 Suppose we have a struct `Foo` and we would like to define some methods for it.
-The following definition leads to a compiler error:
-
-```compile_fail,E0207
-struct Foo;
-
-impl<T: Default> Foo {
-// error: the type parameter `T` is not constrained by the impl trait, self
-// type, or predicates [E0207]
-    fn get(&self) -> T {
-        <T as Default>::default()
-    }
-}
-```
+The previous code example has a definition which leads to a compiler error:
 
 The problem is that the parameter `T` does not appear in the implementing type
 (`Foo`) of the impl. In this case, we can fix the error by moving the type

--- a/src/librustc_error_codes/error_codes/E0214.md
+++ b/src/librustc_error_codes/error_codes/E0214.md
@@ -1,12 +1,17 @@
 A generic type was described using parentheses rather than angle brackets.
-For example:
+
+Erroneous code example:
 
 ```compile_fail,E0214
-fn main() {
-    let v: Vec(&str) = vec!["foo"];
-}
+let v: Vec(&str) = vec!["foo"];
 ```
 
 This is not currently supported: `v` should be defined as `Vec<&str>`.
 Parentheses are currently only used with generic types when defining parameters
 for `Fn`-family traits.
+
+The previous code example fixed:
+
+```
+let v: Vec<&str> = vec!["foo"];
+```

--- a/src/librustc_error_codes/error_codes/E0220.md
+++ b/src/librustc_error_codes/error_codes/E0220.md
@@ -1,4 +1,5 @@
-You used an associated type which isn't defined in the trait.
+A used associated type wasn't defined in the trait.
+
 Erroneous code example:
 
 ```compile_fail,E0220

--- a/src/librustc_error_codes/error_codes/E0220.md
+++ b/src/librustc_error_codes/error_codes/E0220.md
@@ -1,4 +1,4 @@
-A used associated type wasn't defined in the trait.
+The associated type used was not defined in the trait.
 
 Erroneous code example:
 

--- a/src/librustc_error_codes/error_codes/E0221.md
+++ b/src/librustc_error_codes/error_codes/E0221.md
@@ -1,5 +1,6 @@
 An attempt was made to retrieve an associated type, but the type was ambiguous.
-For example:
+
+Erroneous code example:
 
 ```compile_fail,E0221
 trait T1 {}

--- a/src/librustc_error_codes/error_codes/E0222.md
+++ b/src/librustc_error_codes/error_codes/E0222.md
@@ -1,5 +1,6 @@
 An attempt was made to constrain an associated type.
-For example:
+
+Erroneous code example:
 
 ```compile_fail,E0222
 pub trait Vehicle {

--- a/src/librustc_error_codes/error_codes/E0262.md
+++ b/src/librustc_error_codes/error_codes/E0262.md
@@ -1,8 +1,12 @@
-Declaring certain lifetime names in parameters is disallowed. For example,
-because the `'static` lifetime is a special built-in lifetime name denoting
-the lifetime of the entire program, this is an error:
+An invalid name was used for a lifetime parameter.
+
+Erroneous code example:
 
 ```compile_fail,E0262
 // error, invalid lifetime parameter name `'static`
 fn foo<'static>(x: &'static str) { }
 ```
+
+Declaring certain lifetime names in parameters is disallowed. For example,
+because the `'static` lifetime is a special built-in lifetime name denoting
+the lifetime of the entire program, this is an error:

--- a/src/librustc_mir/const_eval/fn_queries.rs
+++ b/src/librustc_mir/const_eval/fn_queries.rs
@@ -86,6 +86,10 @@ pub fn provide(providers: &mut Providers<'_>) {
     /// Const evaluability whitelist is here to check evaluability at the
     /// top level beforehand.
     fn is_const_intrinsic(tcx: TyCtxt<'_>, def_id: DefId) -> Option<bool> {
+        if tcx.is_closure(def_id) {
+            return None;
+        }
+
         match tcx.fn_sig(def_id).abi() {
             Abi::RustIntrinsic | Abi::PlatformIntrinsic => {
                 Some(tcx.lookup_const_stability(def_id).is_some())

--- a/src/librustc_mir_build/hair/pattern/_match.rs
+++ b/src/librustc_mir_build/hair/pattern/_match.rs
@@ -586,7 +586,7 @@ impl<'a, 'tcx> MatchCheckCtxt<'a, 'tcx> {
         tcx: TyCtxt<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
         module: DefId,
-        f: impl for<'b> FnOnce(MatchCheckCtxt<'b, 'tcx>) -> R,
+        f: impl FnOnce(MatchCheckCtxt<'_, 'tcx>) -> R,
     ) -> R {
         let pattern_arena = TypedArena::default();
 

--- a/src/test/ui/consts/issue-68542-closure-in-array-len.rs
+++ b/src/test/ui/consts/issue-68542-closure-in-array-len.rs
@@ -1,0 +1,10 @@
+// Regression test for issue #68542
+// Tests that we don't ICE when a closure appears
+// in the length part of an array.
+
+struct Bug {
+    a: [(); (|| { 0 })()] //~ ERROR calls in constants are limited to
+    //~^ ERROR evaluation of constant value failed
+}
+
+fn main() {}

--- a/src/test/ui/consts/issue-68542-closure-in-array-len.stderr
+++ b/src/test/ui/consts/issue-68542-closure-in-array-len.stderr
@@ -1,0 +1,16 @@
+error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+  --> $DIR/issue-68542-closure-in-array-len.rs:6:13
+   |
+LL |     a: [(); (|| { 0 })()]
+   |             ^^^^^^^^^^^^
+
+error[E0080]: evaluation of constant value failed
+  --> $DIR/issue-68542-closure-in-array-len.rs:6:13
+   |
+LL |     a: [(); (|| { 0 })()]
+   |             ^^^^^^^^^^^^ calling non-const function `Bug::a::{{constant}}#0::{{closure}}#0`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0015, E0080.
+For more information about an error, try `rustc --explain E0015`.

--- a/src/test/ui/env-funky-keys.rs
+++ b/src/test/ui/env-funky-keys.rs
@@ -6,6 +6,7 @@
 // ignore-cloudabi no execve
 // ignore-emscripten no execve
 // ignore-sgx no execve
+// ignore-vxworks no execve
 // no-prefer-dynamic
 
 #![feature(rustc_private)]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -19,3 +19,14 @@ Thanks! <3
 [instructions]: https://rust-lang.github.io/rustc-guide/ice-breaker/llvm.html
 """
 label = "ICEBreaker-LLVM"
+
+[ping.icebreakers-cleanup-crew]
+message = """\
+Hey Cleanup Crew ICE-breakers! This bug has been identified as a good
+"Cleanup ICE-breaking candidate". In case it's useful, here are some
+[instructions] for tackling these sorts of bugs. Maybe take a look?
+Thanks! <3
+
+[instructions]: https://rust-lang.github.io/rustc-guide/ice-breaker/cleanup-crew.html
+"""
+label = "ICEBreaker-Cleanup-Crew"


### PR DESCRIPTION
Successful merges:

 - #68200 (Stabilize the debug_map_key_value feature)
 - #68383 (Clean up E0205 explanation)
 - #68412 (Clean up E0207 explanation)
 - #68454 (clean up E0214 explanation)
 - #68482 (clean up error codes explanation)
 - #68563 (Don't call `tcx.fn_sig` on closures)
 - #68570 (Bump LLVM submodule to fix LLVM assertion failure in MSP430 interrupt generation.)
 - #68571 (check_match: extract common logic)
 - #68573 (Clean up E0262 explanation)
 - #68575 (Disable the testcase for Vxworks.)
 - #68581 (Add support for icebreakers-cleanup-crew commands)

Failed merges:


r? @ghost