### PR TITLE
Add an early-exit to `QueryNormalizer::fold_ty`

### DIFF
--- a/src/librustc/traits/query/normalize.rs
+++ b/src/librustc/traits/query/normalize.rs
@@ -81,6 +81,10 @@ impl<'cx, 'tcx> TypeFolder<'tcx> for QueryNormalizer<'cx, 'tcx> {
     }
 
     fn fold_ty(&mut self, ty: Ty<'tcx>) -> Ty<'tcx> {
+        if !ty.has_projections() {
+            return ty;
+        }
+
         let ty = ty.super_fold_with(self);
         match ty.kind {
             ty::Opaque(def_id, substs) if !substs.has_escaping_bound_vars() => {


### PR DESCRIPTION
Pulled out from https://github.com/rust-lang/rust/pull/68524, this results in a ~60-70% reduction in compile time for the await-call-tree benchmarks. This should unblock https://github.com/rust-lang/rust/issues/67982 as well.

r? @Zoxc 