### PR TITLE
Set lld flavor for MSVC to link.exe

### DIFF
--- a/src/librustc_target/spec/windows_msvc_base.rs
+++ b/src/librustc_target/spec/windows_msvc_base.rs
@@ -1,9 +1,11 @@
-use crate::spec::{LinkArgs, LinkerFlavor, TargetOptions};
+use crate::spec::{LinkArgs, LinkerFlavor, LldFlavor, TargetOptions};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {
+    let pre_args = vec!["/NOLOGO".to_string(), "/NXCOMPAT".to_string()];
     let mut args = LinkArgs::new();
-    args.insert(LinkerFlavor::Msvc, vec!["/NOLOGO".to_string(), "/NXCOMPAT".to_string()]);
+    args.insert(LinkerFlavor::Msvc, pre_args.clone());
+    args.insert(LinkerFlavor::Lld(LldFlavor::Link), pre_args);
 
     TargetOptions {
         function_sections: true,
@@ -21,6 +23,7 @@ pub fn opts() -> TargetOptions {
         // language packs, and avoid generating Non-UTF-8 error
         // messages if a link error occurred.
         link_env: vec![("VSLANG".to_string(), "1033".to_string())],
+        lld_flavor: LldFlavor::Link,
         pre_link_args: args,
         crt_static_allows_dylibs: true,
         crt_static_respected: true,


### PR DESCRIPTION
This enables linking with LLD on Windows with just `-C linker=rust-lld` instead of needing `-C linker=rust-lld -C linker-flavor=lld-link`.