### PR TITLE
Optimize core::ptr::align_offset

### DIFF
--- a/src/libcore/ptr/mod.rs
+++ b/src/libcore/ptr/mod.rs
@@ -1083,7 +1083,7 @@ pub(crate) unsafe fn align_offset<T: Sized>(p: *const T, a: usize) -> usize {
                 // anyway.
                 inverse = inverse.wrapping_mul(2usize.wrapping_sub(x.wrapping_mul(inverse)))
                     & (going_mod - 1);
-                if going_mod > m {
+                if going_mod >= m {
                     return inverse & (m - 1);
                 }
                 going_mod = going_mod.wrapping_mul(going_mod);
@@ -1134,7 +1134,7 @@ pub(crate) unsafe fn align_offset<T: Sized>(p: *const T, a: usize) -> usize {
         // to take the result $o mod lcm(s, a)$. We can replace $lcm(s, a)$ with just a $a / g$.
         let j = a.wrapping_sub(pmoda) >> gcdpow;
         let k = smoda >> gcdpow;
-        return intrinsics::unchecked_rem(j.wrapping_mul(mod_inv(k, a)), a >> gcdpow);
+        return (j.wrapping_mul(mod_inv(k, a))) & ((a >> gcdpow).wrapping_sub(1));
     }
 
     // Cannot be aligned at all.

--- a/src/libcore/ptr/mod.rs
+++ b/src/libcore/ptr/mod.rs
@@ -1081,8 +1081,7 @@ pub(crate) unsafe fn align_offset<T: Sized>(p: *const T, a: usize) -> usize {
                 // uses e.g., subtraction `mod n`. It is entirely fine to do them `mod
                 // usize::max_value()` instead, because we take the result `mod n` at the end
                 // anyway.
-                inverse = inverse.wrapping_mul(2usize.wrapping_sub(x.wrapping_mul(inverse)))
-                    & (going_mod - 1);
+                inverse = inverse.wrapping_mul(2usize.wrapping_sub(x.wrapping_mul(inverse)));
                 if going_mod >= m {
                     return inverse & (m - 1);
                 }


### PR DESCRIPTION
- As explained in the comment inside mod_inv, it is valid to work mod
  `usize::max_value()` right until the end.
- When calculating the inverse, it's enough to work $mod a/g$ instead
  of $mod a$.
- Instead of squaring the modulu until it is larger than the required
  one, we calculate the number of required iterations.