### PR TITLE
Use termize instead of term_size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3540,8 +3540,8 @@ dependencies = [
  "rustc_data_structures",
  "rustc_span",
  "serialize",
- "term_size",
  "termcolor",
+ "termize",
  "unicode-width",
  "winapi 0.3.8",
 ]
@@ -4578,6 +4578,16 @@ dependencies = [
  "libc",
  "redox_syscall",
  "redox_termios",
+]
+
+[[package]]
+name = "termize"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1706be6b564323ce7092f5f7e6b118a14c8ef7ed0e69c8c5329c914a9f101295"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
 ]
 
 [[package]]

--- a/src/librustc_errors/Cargo.toml
+++ b/src/librustc_errors/Cargo.toml
@@ -18,7 +18,7 @@ unicode-width = "0.1.4"
 atty = "0.2"
 termcolor = "1.0"
 annotate-snippets = "0.6.1"
-term_size = "0.3.1"
+termize = "0.1.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["handleapi", "synchapi", "winbase"] }

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -1366,7 +1366,7 @@ impl EmitterWriter {
                 } else if self.ui_testing {
                     140
                 } else {
-                    term_size::dimensions()
+                    termize::dimensions()
                         .map(|(w, _)| w.saturating_sub(code_offset))
                         .unwrap_or(std::usize::MAX)
                 };

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -167,7 +167,7 @@ const WHITELIST: &[Crate<'_>] = &[
     Crate("termcolor"),
     Crate("terminon"),
     Crate("termion"),
-    Crate("term_size"),
+    Crate("termize"),
     Crate("thread_local"),
     Crate("ucd-util"),
     Crate("unicode-normalization"),


### PR DESCRIPTION
`termize` is a fork of `term_size` which uses `winapi` 0.3 instead of 0.2. This is a step towards removing the `winapi` 0.2 dependency.

r? @Mark-Simulacrum 