### PR TITLE
Document that write_all will not call write if given an empty buffer

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1327,6 +1327,8 @@ pub trait Write {
     /// not of [`ErrorKind::Interrupted`] kind generated from this method will be
     /// returned.
     ///
+    /// If the buffer contains no data, this will never call [`write`].
+    ///
     /// # Errors
     ///
     /// This function will return the first error of


### PR DESCRIPTION
Some types of Write instances have a semantic meaning associated with
writing an empty buffer, such as sending an empty packet. This works
when calling `write` directly, and supplying an empty buffer. However,
calling `write_all` on an empty buffer will simply never call `write`,
because `write_all` assumes it has no work to do.

Document this behavior, to help prospective users of
datagram-packet-style Write instances.