### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -62,9 +62,9 @@ Cargo
 - [Cargo.lock now uses a more git friendly format that should help to reduce
   merge conflicts.][cargo/7579]
 - [You can now override specific dependencies's build settings][cargo/7591] E.g.
-  `[profile.dev.overrides.image] opt-level = 2` sets the `image` crate's
+  `[profile.dev.package.image] opt-level = 2` sets the `image` crate's
   optimisation level to `2` for debug builds. You can also use
-  `[profile.<profile>.build_overrides]` to override build scripts and
+  `[profile.<profile>.build-override]` to override build scripts and
   their dependencies.
 
 Misc

--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -194,7 +194,9 @@ impl dyn Any {
     #[inline]
     pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
         if self.is::<T>() {
-            // SAFETY: just checked whether we are pointing to the correct type
+            // SAFETY: just checked whether we are pointing to the correct type, and we can rely on
+            // that check for memory safety because we have implemented Any for all types; no other
+            // impls can exist as they would conflict with our impl.
             unsafe { Some(&*(self as *const dyn Any as *const T)) }
         } else {
             None
@@ -228,7 +230,9 @@ impl dyn Any {
     #[inline]
     pub fn downcast_mut<T: Any>(&mut self) -> Option<&mut T> {
         if self.is::<T>() {
-            // SAFETY: just checked whether we are pointing to the correct type
+            // SAFETY: just checked whether we are pointing to the correct type, and we can rely on
+            // that check for memory safety because we have implemented Any for all types; no other
+            // impls can exist as they would conflict with our impl.
             unsafe { Some(&mut *(self as *mut dyn Any as *mut T)) }
         } else {
             None

--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -19,6 +19,16 @@ declare_lint! {
 }
 
 declare_lint! {
+    pub CONFLICTING_REPR_HINTS,
+    Deny,
+    "conflicts between `#[repr(..)]` hints that were previously accepted and used in practice",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #68585 <https://github.com/rust-lang/rust/issues/68585>",
+        edition: None,
+    };
+}
+
+declare_lint! {
     pub META_VARIABLE_MISUSE,
     Allow,
     "possible meta-variable misuse at macro definition"
@@ -520,6 +530,7 @@ declare_lint_pass! {
         MACRO_USE_EXTERN_CRATE,
         MACRO_EXPANDED_MACRO_EXPORTS_ACCESSED_BY_ABSOLUTE_PATHS,
         ILL_FORMED_ATTRIBUTE_INPUT,
+        CONFLICTING_REPR_HINTS,
         META_VARIABLE_MISUSE,
         DEPRECATED_IN_FUTURE,
         AMBIGUOUS_ASSOCIATED_ITEMS,

--- a/src/librustc_target/spec/windows_msvc_base.rs
+++ b/src/librustc_target/spec/windows_msvc_base.rs
@@ -1,9 +1,11 @@
-use crate::spec::{LinkArgs, LinkerFlavor, TargetOptions};
+use crate::spec::{LinkArgs, LinkerFlavor, LldFlavor, TargetOptions};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {
+    let pre_args = vec!["/NOLOGO".to_string(), "/NXCOMPAT".to_string()];
     let mut args = LinkArgs::new();
-    args.insert(LinkerFlavor::Msvc, vec!["/NOLOGO".to_string(), "/NXCOMPAT".to_string()]);
+    args.insert(LinkerFlavor::Msvc, pre_args.clone());
+    args.insert(LinkerFlavor::Lld(LldFlavor::Link), pre_args);
 
     TargetOptions {
         function_sections: true,
@@ -21,6 +23,7 @@ pub fn opts() -> TargetOptions {
         // language packs, and avoid generating Non-UTF-8 error
         // messages if a link error occurred.
         link_env: vec![("VSLANG".to_string(), "1033".to_string())],
+        lld_flavor: LldFlavor::Link,
         pre_link_args: args,
         crt_static_allows_dylibs: true,
         crt_static_respected: true,

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1895,21 +1895,23 @@ function getSearchElement() {
         var implementors = document.getElementById("implementors-list");
         var synthetic_implementors = document.getElementById("synthetic-implementors-list");
 
-        // This `inlined_types` variable is used to avoid having the same implementation showing
-        // up twice. For example "String" in the "Sync" doc page.
-        //
-        // By the way, this is only used by and useful for traits implemented automatically (like
-        // "Send" and "Sync").
-        var inlined_types = new Set();
-        onEachLazy(synthetic_implementors.getElementsByClassName("impl"), function(el) {
-            var aliases = el.getAttribute("aliases");
-            if (!aliases) {
-                return;
-            }
-            aliases.split(",").forEach(function(alias) {
-                inlined_types.add(alias);
+        if (synthetic_implementors) {
+            // This `inlined_types` variable is used to avoid having the same implementation
+            // showing up twice. For example "String" in the "Sync" doc page.
+            //
+            // By the way, this is only used by and useful for traits implemented automatically
+            // (like "Send" and "Sync").
+            var inlined_types = new Set();
+            onEachLazy(synthetic_implementors.getElementsByClassName("impl"), function(el) {
+                var aliases = el.getAttribute("aliases");
+                if (!aliases) {
+                    return;
+                }
+                aliases.split(",").forEach(function(alias) {
+                    inlined_types.add(alias);
+                });
             });
-        });
+        }
 
         var libs = Object.getOwnPropertyNames(imp);
         var llength = libs.length;

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1327,6 +1327,8 @@ pub trait Write {
     /// not of [`ErrorKind::Interrupted`] kind generated from this method will be
     /// returned.
     ///
+    /// If the buffer contains no data, this will never call [`write`].
+    ///
     /// # Errors
     ///
     /// This function will return the first error of

--- a/src/test/ui/conflicting-repr-hints.rs
+++ b/src/test/ui/conflicting-repr-hints.rs
@@ -11,11 +11,13 @@ enum B {
 }
 
 #[repr(C, u64)] //~ ERROR conflicting representation hints
+//~^ WARN this was previously accepted
 enum C {
     C,
 }
 
 #[repr(u32, u64)] //~ ERROR conflicting representation hints
+//~^ WARN this was previously accepted
 enum D {
     D,
 }

--- a/src/test/ui/conflicting-repr-hints.stderr
+++ b/src/test/ui/conflicting-repr-hints.stderr
@@ -3,45 +3,52 @@ error[E0566]: conflicting representation hints
    |
 LL | #[repr(C, u64)]
    |        ^  ^^^
+   |
+   = note: `#[deny(conflicting_repr_hints)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
 
 error[E0566]: conflicting representation hints
-  --> $DIR/conflicting-repr-hints.rs:18:8
+  --> $DIR/conflicting-repr-hints.rs:19:8
    |
 LL | #[repr(u32, u64)]
    |        ^^^  ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
 
 error[E0587]: type has conflicting packed and align representation hints
-  --> $DIR/conflicting-repr-hints.rs:27:1
+  --> $DIR/conflicting-repr-hints.rs:29:1
    |
 LL | struct F(i32);
    | ^^^^^^^^^^^^^^
 
 error[E0587]: type has conflicting packed and align representation hints
-  --> $DIR/conflicting-repr-hints.rs:31:1
+  --> $DIR/conflicting-repr-hints.rs:33:1
    |
 LL | struct G(i32);
    | ^^^^^^^^^^^^^^
 
 error[E0587]: type has conflicting packed and align representation hints
-  --> $DIR/conflicting-repr-hints.rs:35:1
+  --> $DIR/conflicting-repr-hints.rs:37:1
    |
 LL | struct H(i32);
    | ^^^^^^^^^^^^^^
 
 error[E0634]: type has conflicting packed representation hints
-  --> $DIR/conflicting-repr-hints.rs:38:1
+  --> $DIR/conflicting-repr-hints.rs:40:1
    |
 LL | struct I(i32);
    | ^^^^^^^^^^^^^^
 
 error[E0634]: type has conflicting packed representation hints
-  --> $DIR/conflicting-repr-hints.rs:42:1
+  --> $DIR/conflicting-repr-hints.rs:44:1
    |
 LL | struct J(i32);
    | ^^^^^^^^^^^^^^
 
 error[E0587]: type has conflicting packed and align representation hints
-  --> $DIR/conflicting-repr-hints.rs:48:1
+  --> $DIR/conflicting-repr-hints.rs:50:1
    |
 LL | / union X {
 LL | |
@@ -50,7 +57,7 @@ LL | | }
    | |_^
 
 error[E0587]: type has conflicting packed and align representation hints
-  --> $DIR/conflicting-repr-hints.rs:55:1
+  --> $DIR/conflicting-repr-hints.rs:57:1
    |
 LL | / union Y {
 LL | |
@@ -59,7 +66,7 @@ LL | | }
    | |_^
 
 error[E0587]: type has conflicting packed and align representation hints
-  --> $DIR/conflicting-repr-hints.rs:62:1
+  --> $DIR/conflicting-repr-hints.rs:64:1
    |
 LL | / union Z {
 LL | |

--- a/src/test/ui/feature-gates/feature-gate-repr-simd.rs
+++ b/src/test/ui/feature-gates/feature-gate-repr-simd.rs
@@ -2,6 +2,7 @@
 struct Foo(u64, u64);
 
 #[repr(C)] //~ ERROR conflicting representation hints
+//~^ WARN this was previously accepted
 #[repr(simd)] //~ error: SIMD types are experimental
 struct Bar(u64, u64);
 

--- a/src/test/ui/feature-gates/feature-gate-repr-simd.stderr
+++ b/src/test/ui/feature-gates/feature-gate-repr-simd.stderr
@@ -8,7 +8,7 @@ LL | #[repr(simd)]
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable
 
 error[E0658]: SIMD types are experimental and possibly buggy
-  --> $DIR/feature-gate-repr-simd.rs:5:1
+  --> $DIR/feature-gate-repr-simd.rs:6:1
    |
 LL | #[repr(simd)]
    | ^^^^^^^^^^^^^
@@ -21,8 +21,13 @@ error[E0566]: conflicting representation hints
    |
 LL | #[repr(C)]
    |        ^
+LL |
 LL | #[repr(simd)]
    |        ^^^^
+   |
+   = note: `#[deny(conflicting_repr_hints)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-47094.rs
+++ b/src/test/ui/issues/issue-47094.rs
@@ -1,10 +1,12 @@
 #[repr(C, u8)] //~ ERROR conflicting representation hints
+//~^ WARN this was previously accepted
 enum Foo {
     A,
     B,
 }
 
 #[repr(C)] //~ ERROR conflicting representation hints
+//~^ WARN this was previously accepted
 #[repr(u8)]
 enum Bar {
     A,

--- a/src/test/ui/issues/issue-47094.stderr
+++ b/src/test/ui/issues/issue-47094.stderr
@@ -3,14 +3,22 @@ error[E0566]: conflicting representation hints
    |
 LL | #[repr(C, u8)]
    |        ^  ^^
+   |
+   = note: `#[deny(conflicting_repr_hints)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
 
 error[E0566]: conflicting representation hints
-  --> $DIR/issue-47094.rs:7:8
+  --> $DIR/issue-47094.rs:8:8
    |
 LL | #[repr(C)]
    |        ^
+LL |
 LL | #[repr(u8)]
    |        ^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #67722 (Minor: note how Any is an unsafe trait in SAFETY comments)
 - #68586 (Make conflicting_repr_hints a deny-by-default c-future-compat lint)
 - #68598 (Fix null synthetic_implementors error)
 - #68603 (Changelog: Demonstrate final build-override syntax)
 - #68609 (Set lld flavor for MSVC to link.exe)
 - #68611 (Correct ICE caused by macros generating invalid spans.)
 - #68627 (Document that write_all will not call write if given an empty buffer)

Failed merges:


r? @ghost