### PR TITLE
Document `From` implementation for NonZero nums

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -91,8 +91,12 @@ assert_eq!(size_of::<Option<core::num::", stringify!($Ty), ">>(), size_of::<", s
 
             #[stable(feature = "from_nonzero", since = "1.31.0")]
             impl From<$Ty> for $Int {
-                fn from(nonzero: $Ty) -> Self {
-                    nonzero.0
+                doc_comment! {
+                    concat!(
+"Converts a `", stringify!($Ty), "` into an `", stringify!($Int), "`"),
+                    fn from(nonzero: $Ty) -> Self {
+                        nonzero.0
+                    }
                 }
             }
 


### PR DESCRIPTION
This is more of a nitpick than a real change in documentation. I did this for consistency with other documentation (namely Atomic integers).

Related to #51430

r? @steveklabnik

PS: I actually tested the code this time. My CPU died in the process, but I get to open a (hopefully 🤞) working PR