### PR TITLE
Canonicalize path when displaying a `FileName::Real`

### DIFF
--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -557,13 +557,13 @@ fn write_out_deps(
                 for cnum in resolver.cstore().crates_untracked() {
                     let source = resolver.cstore().crate_source_untracked(cnum);
                     if let Some((path, _)) = source.dylib {
-                        files.push(escape_dep_filename(&FileName::Real(path)));
+                        files.push(escape_dep_filename(&path.into()));
                     }
                     if let Some((path, _)) = source.rlib {
-                        files.push(escape_dep_filename(&FileName::Real(path)));
+                        files.push(escape_dep_filename(&path.into()));
                     }
                     if let Some((path, _)) = source.rmeta {
-                        files.push(escape_dep_filename(&FileName::Real(path)));
+                        files.push(escape_dep_filename(&path.into()));
                     }
                 }
             });

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -124,7 +124,7 @@ impl From<PathBuf> for FileName {
     fn from(p: PathBuf) -> Self {
         assert!(!p.to_string_lossy().ends_with('>'));
         if cfg!(not(windows)) {
-            FileName::Real(p.canonlicalize().unwrap_or(p))
+            FileName::Real(p.canonicalize().unwrap_or(p))
         } else {
             FileName::Real(p)
         }

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -123,7 +123,11 @@ impl std::fmt::Display for FileName {
 impl From<PathBuf> for FileName {
     fn from(p: PathBuf) -> Self {
         assert!(!p.to_string_lossy().ends_with('>'));
-        FileName::Real(p)
+        if cfg!(not(windows)) {
+            FileName::Real(p.canonlicalize().unwrap_or(p))
+        } else {
+            FileName::Real(p)
+        }
     }
 }
 

--- a/src/test/ui/consts/miri_unleashed/mutable_const2.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_const2.stderr
@@ -10,7 +10,7 @@ error: internal compiler error: mutable allocation in constant
 LL | const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-thread 'rustc' panicked at 'no errors encountered even though `delay_span_bug` issued', src/librustc_errors/lib.rs:355:17
+thread 'rustc' panicked at 'no errors encountered even though `delay_span_bug` issued', $SRC_DIR/librustc_errors/lib.rs:LL:COL
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 error: internal compiler error: unexpected panic

--- a/src/test/ui/consts/miri_unleashed/mutable_references_ice.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_references_ice.stderr
@@ -6,7 +6,7 @@ LL |     x: &UnsafeCell::new(42),
 
 thread 'rustc' panicked at 'assertion failed: `(left != right)`
   left: `Const`,
- right: `Const`: UnsafeCells are not allowed behind references in constants. This should have been prevented statically by const qualification. If this were allowed one would be able to change a constant at one use site and other use sites could observe that mutation.', src/librustc_mir/interpret/intern.rs:LL:CC
+ right: `Const`: UnsafeCells are not allowed behind references in constants. This should have been prevented statically by const qualification. If this were allowed one would be able to change a constant at one use site and other use sites could observe that mutation.', $SRC_DIR/librustc_mir/interpret/intern.rs:LL:COL
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 error: internal compiler error: unexpected panic

--- a/src/test/ui/pattern/const-pat-ice.stderr
+++ b/src/test/ui/pattern/const-pat-ice.stderr
@@ -1,4 +1,4 @@
-thread 'rustc' panicked at 'assertion failed: rows.iter().all(|r| r.len() == v.len())', src/librustc_mir_build/hair/pattern/_match.rs:LL:CC
+thread 'rustc' panicked at 'assertion failed: rows.iter().all(|r| r.len() == v.len())', $SRC_DIR/librustc_mir_build/hair/pattern/_match.rs:LL:COL
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 error: internal compiler error: unexpected panic


### PR DESCRIPTION
Addresses #51349 (?)

I'm also not sure if failing to canonicalize the path should result in failing to display the `FileName`, or if the original path should be used as a fallback. My current implementation uses the latter, as it seemed the "wisest" solution to me.

r? @estebank