### PR TITLE
Update jobserver crate to 0.1.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b06c1b455f1cf4269a8cfc320ab930a810e2375a42af5075eb8a8b36405ce0"
+checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
Brings in a fix for alexcrichton/jobserver-rs#23 which could cause Cargo
to unnecessarily hang in some situations.