### PR TITLE
rustdoc: attempt full build for compile_fail test

### DIFF
--- a/src/librustc_error_codes/error_codes/E0454.md
+++ b/src/librustc_error_codes/error_codes/E0454.md
@@ -1,6 +1,6 @@
 A link name was given with an empty name. Erroneous code example:
 
-```ignore (cannot-test-this-because-rustdoc-stops-compile-fail-before-codegen)
+```compile_fail,E0454
 #[link(name = "")] extern {}
 // error: `#[link(name = "")]` given with empty name
 ```

--- a/src/librustc_error_codes/error_codes/E0458.md
+++ b/src/librustc_error_codes/error_codes/E0458.md
@@ -1,6 +1,6 @@
 An unknown "kind" was specified for a link attribute. Erroneous code example:
 
-```ignore (cannot-test-this-because-rustdoc-stops-compile-fail-before-codegen)
+```compile_fail,E0458
 #[link(kind = "wonderful_unicorn")] extern {}
 // error: unknown kind: `wonderful_unicorn`
 ```

--- a/src/librustc_error_codes/error_codes/E0459.md
+++ b/src/librustc_error_codes/error_codes/E0459.md
@@ -1,6 +1,6 @@
 A link was used without a name parameter. Erroneous code example:
 
-```ignore (cannot-test-this-because-rustdoc-stops-compile-fail-before-codegen)
+```compile_fail,E0459
 #[link(kind = "dylib")] extern {}
 // error: `#[link(...)]` specified without `name = "foo"`
 ```

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -282,7 +282,7 @@ fn run_test(
     for debugging_option_str in &options.debugging_options_strs {
         compiler.arg("-Z").arg(&debugging_option_str);
     }
-    if no_run {
+    if no_run && !compile_fail {
         compiler.arg("--emit=metadata");
     }
     compiler.arg("--target").arg(target.to_string());


### PR DESCRIPTION
Some code fails when doing a full build but does not fail when only emitting metadata. This commit makes sure compile_fail tests for such code behave as expected, that is, the test succeeds because the compilation fails.

Fixes #67771.