### PR TITLE
clarify "incorrect issue" error

### DIFF
--- a/src/test/ui/feature-gate/unstable-attribute-allow-issue-0.rs
+++ b/src/test/ui/feature-gate/unstable-attribute-allow-issue-0.rs
@@ -9,5 +9,5 @@ fn unstable_issue_0() {}
 #[unstable(feature = "unstable_test_feature", issue = "none")]
 fn unstable_issue_none() {}
 
-#[unstable(feature = "unstable_test_feature", issue = "something")] //~ ERROR incorrect 'issue'
-fn unstable_issue_not_allowed() {}
+#[unstable(feature = "unstable_test_feature", issue = "something")]
+fn unstable_issue_not_allowed() {} //~^ ERROR `issue` must be a numeric string or "none"

--- a/src/test/ui/feature-gate/unstable-attribute-allow-issue-0.stderr
+++ b/src/test/ui/feature-gate/unstable-attribute-allow-issue-0.stderr
@@ -1,8 +1,10 @@
-error[E0545]: incorrect 'issue'
-  --> $DIR/unstable-attribute-allow-issue-0.rs:12:1
+error[E0545]: `issue` must be a numeric string or "none"
+  --> $DIR/unstable-attribute-allow-issue-0.rs:12:47
    |
 LL | #[unstable(feature = "unstable_test_feature", issue = "something")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                               ^^^^^^^^-----------
+   |                                                       |
+   |                                                       invalid digit found in string
 
 error: aborting due to previous error
 

--- a/src/test/ui/stability-attribute/stability-attribute-sanity-2.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity-2.rs
@@ -10,7 +10,7 @@ fn f1() { }
 #[stable(feature = "a", sinse = "1.0.0")] //~ ERROR unknown meta item 'sinse'
 fn f2() { }
 
-#[unstable(feature = "a", issue = "no")] //~ ERROR incorrect 'issue'
+#[unstable(feature = "a", issue = "no")] //~ ERROR `issue` must be a numeric string or "none"
 fn f3() { }
 
 fn main() { }

--- a/src/test/ui/stability-attribute/stability-attribute-sanity-2.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity-2.stderr
@@ -10,11 +10,13 @@ error[E0541]: unknown meta item 'sinse'
 LL | #[stable(feature = "a", sinse = "1.0.0")]
    |                         ^^^^^^^^^^^^^^^ expected one of `since`, `note`
 
-error[E0545]: incorrect 'issue'
-  --> $DIR/stability-attribute-sanity-2.rs:13:1
+error[E0545]: `issue` must be a numeric string or "none"
+  --> $DIR/stability-attribute-sanity-2.rs:13:27
    |
 LL | #[unstable(feature = "a", issue = "no")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                           ^^^^^^^^----
+   |                                   |
+   |                                   invalid digit found in string
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Changes the message to be more precise, shrinks the span and adds a label specifying why the `issue` field is incorrect.