### PR TITLE
Suggest path separator for single-colon typos

### DIFF
--- a/src/librustc_parse/parser/path.rs
+++ b/src/librustc_parse/parser/path.rs
@@ -71,15 +71,15 @@ impl<'a> Parser<'a> {
             debug!("parse_qpath: (decrement) count={:?}", self.unmatched_angle_bracket_count);
         }
 
-        let lo_colon = self.token.span;
-        if self.eat(&token::Colon) {
+        if self.token.kind == token::Colon {
             // <Bar as Baz<T>>:Qux
             //                ^
-            let span = lo_colon.to(self.prev_span);
+            self.bump();
+
             self.diagnostic()
-                .struct_span_err(span, "found single colon where type path was expected")
+                .struct_span_err(self.prev_span, "found single colon where type path was expected")
                 .span_suggestion(
-                    span,
+                    self.prev_span,
                     "use double colon",
                     "::".to_string(),
                     Applicability::MachineApplicable,

--- a/src/librustc_parse/parser/path.rs
+++ b/src/librustc_parse/parser/path.rs
@@ -71,21 +71,7 @@ impl<'a> Parser<'a> {
             debug!("parse_qpath: (decrement) count={:?}", self.unmatched_angle_bracket_count);
         }
 
-        if self.token.kind == token::Colon {
-            // <Bar as Baz<T>>:Qux
-            //                ^
-            self.bump();
-
-            self.diagnostic()
-                .struct_span_err(self.prev_span, "found single colon where type path was expected")
-                .span_suggestion(
-                    self.prev_span,
-                    "use double colon",
-                    "::".to_string(),
-                    Applicability::MachineApplicable,
-                )
-                .emit();
-        } else {
+        if !self.recover_colon_before_qpath_proj() {
             self.expect(&token::ModSep)?;
         }
 
@@ -93,6 +79,28 @@ impl<'a> Parser<'a> {
         self.parse_path_segments(&mut path.segments, style)?;
 
         Ok((qself, Path { segments: path.segments, span: lo.to(self.prev_span) }))
+    }
+
+    fn recover_colon_before_qpath_proj(&mut self) -> bool {
+        if self.token.kind != token::Colon {
+            return false;
+        }
+
+        // <Bar as Baz<T>>:Qux
+        //                ^
+        self.bump();
+
+        self.diagnostic()
+            .struct_span_err(self.prev_span, "found single colon where type path was expected")
+            .span_suggestion(
+                self.prev_span,
+                "use double colon",
+                "::".to_string(),
+                Applicability::MachineApplicable,
+            )
+            .emit();
+
+        true
     }
 
     /// Parses simple paths.

--- a/src/librustc_parse/parser/path.rs
+++ b/src/librustc_parse/parser/path.rs
@@ -82,13 +82,17 @@ impl<'a> Parser<'a> {
     }
 
     /// Recover from an invalid single colon, when the user likely meant a qualified path.
+    /// We avoid emitting this if not followed by an identifier, as our assumption that the user
+    /// intended this to be a qualified path may not be correct.
     ///
     /// ```ignore (diagnostics)
     /// <Bar as Baz<T>>:Qux
     ///                ^ help: use double colon
     /// ```
     fn recover_colon_before_qpath_proj(&mut self) -> bool {
-        if self.token.kind != token::Colon {
+        if self.token.kind != token::Colon
+            || self.look_ahead(1, |t| !t.is_ident() || t.is_reserved_ident())
+        {
             return false;
         }
 

--- a/src/librustc_parse/parser/path.rs
+++ b/src/librustc_parse/parser/path.rs
@@ -81,17 +81,24 @@ impl<'a> Parser<'a> {
         Ok((qself, Path { segments: path.segments, span: lo.to(self.prev_span) }))
     }
 
+    /// Recover from an invalid single colon, when the user likely meant a qualified path.
+    ///
+    /// ```ignore (diagnostics)
+    /// <Bar as Baz<T>>:Qux
+    ///                ^ help: use double colon
+    /// ```
     fn recover_colon_before_qpath_proj(&mut self) -> bool {
         if self.token.kind != token::Colon {
             return false;
         }
 
-        // <Bar as Baz<T>>:Qux
-        //                ^
-        self.bump();
+        self.bump(); // colon
 
         self.diagnostic()
-            .struct_span_err(self.prev_span, "found single colon where type path was expected")
+            .struct_span_err(
+                self.prev_span,
+                "found single colon before projection in qualified path",
+            )
             .span_suggestion(
                 self.prev_span,
                 "use double colon",

--- a/src/test/ui/parser/qualified-path-in-turbofish.fixed
+++ b/src/test/ui/parser/qualified-path-in-turbofish.fixed
@@ -15,5 +15,5 @@ fn template<T>() -> i64 {
 
 fn main() {
     template::<<Impl as T>::Ty>();
-    //~^ ERROR found single colon where type path was expected
+    //~^ ERROR found single colon before projection in qualified path
 }

--- a/src/test/ui/parser/qualified-path-in-turbofish.fixed
+++ b/src/test/ui/parser/qualified-path-in-turbofish.fixed
@@ -1,0 +1,19 @@
+// run-rustfix
+trait T {
+    type Ty;
+}
+
+struct Impl;
+
+impl T for Impl {
+    type Ty = u32;
+}
+
+fn template<T>() -> i64 {
+    3
+}
+
+fn main() {
+    template::<<Impl as T>::Ty>();
+    //~^ ERROR found single colon where type path was expected
+}

--- a/src/test/ui/parser/qualified-path-in-turbofish.rs
+++ b/src/test/ui/parser/qualified-path-in-turbofish.rs
@@ -15,5 +15,5 @@ fn template<T>() -> i64 {
 
 fn main() {
     template::<<Impl as T>:Ty>();
-    //~^ ERROR found single colon where type path was expected
+    //~^ ERROR found single colon before projection in qualified path
 }

--- a/src/test/ui/parser/qualified-path-in-turbofish.rs
+++ b/src/test/ui/parser/qualified-path-in-turbofish.rs
@@ -1,0 +1,19 @@
+// run-rustfix
+trait T {
+    type Ty;
+}
+
+struct Impl;
+
+impl T for Impl {
+    type Ty = u32;
+}
+
+fn template<T>() -> i64 {
+    3
+}
+
+fn main() {
+    template::<<Impl as T>:Ty>();
+    //~^ ERROR found single colon where type path was expected
+}

--- a/src/test/ui/parser/qualified-path-in-turbofish.stderr
+++ b/src/test/ui/parser/qualified-path-in-turbofish.stderr
@@ -1,4 +1,4 @@
-error: found single colon where type path was expected
+error: found single colon before projection in qualified path
   --> $DIR/qualified-path-in-turbofish.rs:17:27
    |
 LL |     template::<<Impl as T>:Ty>();

--- a/src/test/ui/parser/qualified-path-in-turbofish.stderr
+++ b/src/test/ui/parser/qualified-path-in-turbofish.stderr
@@ -1,0 +1,8 @@
+error: found single colon where type path was expected
+  --> $DIR/qualified-path-in-turbofish.rs:17:27
+   |
+LL |     template::<<Impl as T>:Ty>();
+   |                           ^ help: use double colon: `::`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This commit adds guidance for when a user means to type a path, but ends
up typing a single colon, such as `<<Impl as T>:Ty>`.

This change seemed pertinent as the current error message is
particularly misleading, emitting `error: unmatched angle bracket`,
despite the angle bracket being matched later on, leaving the user to
track down the typo'd colon.