### PR TITLE
Remove incorrect debug assertions from catch_unwind

### DIFF
--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -286,11 +286,9 @@ pub unsafe fn r#try<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any + Send>>
     );
 
     return if r == 0 {
-        debug_assert!(update_panic_count(0) == 0);
         Ok(ManuallyDrop::into_inner(data.r))
     } else {
         update_panic_count(-1);
-        debug_assert!(update_panic_count(0) == 0);
         Err(mem::transmute(raw::TraitObject {
             data: any_data as *mut _,
             vtable: any_vtable as *mut _,

--- a/src/test/ui/issues/issue-68696-catch-during-unwind.rs
+++ b/src/test/ui/issues/issue-68696-catch-during-unwind.rs
@@ -1,0 +1,26 @@
+// Checks that catch_unwind can be used if unwinding is already in progress.
+// Used to fail when standard library had been compiled with debug assertions,
+// due to incorrect assumption that a current thread is not panicking when
+// entering the catch_unwind.
+//
+// run-pass
+// ignore-wasm       no panic support
+// ignore-emscripten no panic support
+
+use std::panic::catch_unwind;
+
+#[derive(Default)]
+struct Guard;
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        let _ = catch_unwind(|| {});
+    }
+}
+
+fn main() {
+    let _ = catch_unwind(|| {
+        let _guard = Guard::default();
+        panic!();
+    });
+}


### PR DESCRIPTION
Previously the debug assertions in the implementation of catch_unwind
used to verify consistency of the panic count by checking that the count
is zero just before leaving the function. This incorrectly assumed that
no panic was in progress when entering `catch_unwind`.

Fixes #68696.