### PR TITLE
Ignore `build` dir formatting

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -6,6 +6,8 @@ merge_derives = false
 # by default we ignore everything in the repository
 # tidy only checks files which are not ignored, each entry follows gitignore style
 ignore = [
+    "build",
+
     # tests for now are not formatted, as they are sometimes pretty-printing constrained
     # (and generally rustfmt can move around comments in UI-testing incompatible ways)
     "src/test",


### PR DESCRIPTION
I've noticed that rustfmt tries to parse and check the formatting of code in `build` if `.git` is missing (which includes test artifacts and generated code). This should fix that.