### PR TITLE
Step stage0 to bootstrap from 1.42

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -397,7 +397,7 @@ class RustBuild(object):
 
         if self.rustfmt() and self.rustfmt().startswith(self.bin_root()) and (
             not os.path.exists(self.rustfmt())
-            or self.program_out_of_date(self.rustfmt_stamp())
+            or self.program_out_of_date(self.rustfmt_stamp(), self.rustfmt_channel)
         ):
             if rustfmt_channel:
                 tarball_suffix = '.tar.xz' if support_xz() else '.tar.gz'
@@ -407,7 +407,7 @@ class RustBuild(object):
                 self.fix_executable("{}/bin/rustfmt".format(self.bin_root()))
                 self.fix_executable("{}/bin/cargo-fmt".format(self.bin_root()))
                 with output(self.rustfmt_stamp()) as rustfmt_stamp:
-                    rustfmt_stamp.write(self.date)
+                    rustfmt_stamp.write(self.date + self.rustfmt_channel)
 
     def _download_stage0_helper(self, filename, pattern, tarball_suffix, date=None):
         if date is None:
@@ -521,12 +521,12 @@ class RustBuild(object):
         """
         return os.path.join(self.bin_root(), '.rustfmt-stamp')
 
-    def program_out_of_date(self, stamp_path):
+    def program_out_of_date(self, stamp_path, extra=""):
         """Check if the given program stamp is out of date"""
         if not os.path.exists(stamp_path) or self.clean:
             return True
         with open(stamp_path, 'r') as stamp:
-            return self.date != stamp.read()
+            return (self.date + extra) != stamp.read()
 
     def bin_root(self):
         """Return the binary root directory

--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -13,7 +13,7 @@ use build_helper::output;
 use crate::Build;
 
 // The version number
-pub const CFG_RELEASE_NUM: &str = "1.42.0";
+pub const CFG_RELEASE_NUM: &str = "1.43.0";
 
 pub struct GitInfo {
     inner: Option<Info>,

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1026,7 +1026,7 @@ impl Build {
     }
 
     fn llvm_link_tools_dynamically(&self, target: Interned<String>) -> bool {
-        (target.contains("linux-gnu") || target.contains("apple-darwin"))
+        target.contains("linux-gnu") || target.contains("apple-darwin")
     }
 
     /// Returns the `version` string associated with this compiler for Rust

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1080,18 +1080,7 @@ fn run(fmt: &mut Formatter<'_>, arg: &rt::v1::Argument, args: &[ArgumentV1<'_>])
     fmt.precision = getcount(args, &arg.format.precision);
 
     // Extract the correct argument
-    let value = {
-        #[cfg(bootstrap)]
-        {
-            match arg.position {
-                rt::v1::Position::At(i) => args[i],
-            }
-        }
-        #[cfg(not(bootstrap))]
-        {
-            args[arg.position]
-        }
-    };
+    let value = args[arg.position];
 
     // Then actually do some printing
     (value.formatter)(value.value, fmt)

--- a/src/libcore/fmt/rt/v1.rs
+++ b/src/libcore/fmt/rt/v1.rs
@@ -7,9 +7,6 @@
 
 #[derive(Copy, Clone)]
 pub struct Argument {
-    #[cfg(bootstrap)]
-    pub position: Position,
-    #[cfg(not(bootstrap))]
     pub position: usize,
     pub format: FormatSpec,
 }
@@ -41,10 +38,4 @@ pub enum Count {
     Is(usize),
     Param(usize),
     Implied,
-}
-
-#[cfg(bootstrap)]
-#[derive(Copy, Clone)]
-pub enum Position {
-    At(usize),
 }

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -133,7 +133,6 @@
 #![feature(associated_type_bounds)]
 #![feature(const_type_id)]
 #![feature(const_caller_location)]
-#![cfg_attr(bootstrap, feature(slice_patterns))]
 #![feature(assoc_int_consts)]
 
 #[prelude_import]

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -18,7 +18,6 @@
 #![feature(range_is_empty)]
 #![feature(raw)]
 #![feature(saturating_neg)]
-#![cfg_attr(bootstrap, feature(slice_patterns))]
 #![feature(sort_internals)]
 #![feature(slice_partition_at_index)]
 #![feature(specialization)]

--- a/src/libpanic_unwind/seh.rs
+++ b/src/libpanic_unwind/seh.rs
@@ -282,12 +282,7 @@ pub unsafe fn panic(data: Box<dyn Any + Send>) -> u32 {
     //
     // In any case, we basically need to do something like this until we can
     // express more operations in statics (and we may never be able to).
-    if !cfg!(bootstrap) {
-        atomic_store(
-            &mut THROW_INFO.pmfnUnwind as *mut _ as *mut u32,
-            ptr!(exception_cleanup) as u32,
-        );
-    }
+    atomic_store(&mut THROW_INFO.pmfnUnwind as *mut _ as *mut u32, ptr!(exception_cleanup) as u32);
     atomic_store(
         &mut THROW_INFO.pCatchableTypeArray as *mut _ as *mut u32,
         ptr!(&CATCHABLE_TYPE_ARRAY as *const _) as u32,
@@ -300,12 +295,10 @@ pub unsafe fn panic(data: Box<dyn Any + Send>) -> u32 {
         &mut CATCHABLE_TYPE.pType as *mut _ as *mut u32,
         ptr!(&TYPE_DESCRIPTOR as *const _) as u32,
     );
-    if !cfg!(bootstrap) {
-        atomic_store(
-            &mut CATCHABLE_TYPE.copyFunction as *mut _ as *mut u32,
-            ptr!(exception_copy) as u32,
-        );
-    }
+    atomic_store(
+        &mut CATCHABLE_TYPE.copyFunction as *mut _ as *mut u32,
+        ptr!(exception_copy) as u32,
+    );
 
     extern "system" {
         #[unwind(allowed)]

--- a/src/librustc/benches/lib.rs
+++ b/src/librustc/benches/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(bootstrap, feature(slice_patterns))]
 #![feature(test)]
 
 extern crate test;

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -42,7 +42,6 @@
 #![feature(optin_builtin_traits)]
 #![feature(option_expect_none)]
 #![feature(range_is_empty)]
-#![cfg_attr(bootstrap, feature(slice_patterns))]
 #![feature(specialization)]
 #![feature(unboxed_closures)]
 #![feature(thread_local)]

--- a/src/librustc_ast_passes/lib.rs
+++ b/src/librustc_ast_passes/lib.rs
@@ -2,8 +2,6 @@
 //! parsed by `rustc_parse` and then lowered, after the passes in this crate,
 //! by `rustc_ast_lowering`.
 
-#![cfg_attr(bootstrap, feature(slice_patterns))]
-
 pub mod ast_validation;
 pub mod feature_gate;
 pub mod show_span;

--- a/src/librustc_codegen_ssa/lib.rs
+++ b/src/librustc_codegen_ssa/lib.rs
@@ -4,7 +4,6 @@
 #![feature(box_syntax)]
 #![feature(core_intrinsics)]
 #![feature(libc)]
-#![cfg_attr(bootstrap, feature(slice_patterns))]
 #![feature(stmt_expr_attributes)]
 #![feature(try_blocks)]
 #![feature(in_band_lifetimes)]

--- a/src/librustc_macros/src/lib.rs
+++ b/src/librustc_macros/src/lib.rs
@@ -1,8 +1,6 @@
 #![allow(rustc::default_hash_types)]
 #![recursion_limit = "128"]
 
-extern crate proc_macro;
-
 use synstructure::decl_derive;
 
 use proc_macro::TokenStream;

--- a/src/librustc_metadata/lib.rs
+++ b/src/librustc_metadata/lib.rs
@@ -10,7 +10,6 @@
 #![feature(proc_macro_internals)]
 #![feature(proc_macro_quote)]
 #![feature(rustc_private)]
-#![cfg_attr(bootstrap, feature(slice_patterns))]
 #![feature(specialization)]
 #![feature(stmt_expr_attributes)]
 #![recursion_limit = "256"]

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -7,7 +7,6 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 #![feature(nll)]
 #![feature(in_band_lifetimes)]
 #![feature(inner_deref)]
-#![cfg_attr(bootstrap, feature(slice_patterns))]
 #![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(box_syntax)]

--- a/src/librustc_mir_build/lib.rs
+++ b/src/librustc_mir_build/lib.rs
@@ -5,7 +5,6 @@
 #![feature(box_patterns)]
 #![feature(box_syntax)]
 #![feature(crate_visibility_modifier)]
-#![cfg_attr(bootstrap, feature(slice_patterns))]
 #![feature(bool_to_option)]
 #![recursion_limit = "256"]
 

--- a/src/librustc_parse/lib.rs
+++ b/src/librustc_parse/lib.rs
@@ -2,7 +2,6 @@
 
 #![feature(bool_to_option)]
 #![feature(crate_visibility_modifier)]
-#![cfg_attr(bootstrap, feature(slice_patterns))]
 
 use syntax::ast;
 use syntax::print::pprust;

--- a/src/librustc_passes/lib.rs
+++ b/src/librustc_passes/lib.rs
@@ -7,7 +7,6 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 #![feature(in_band_lifetimes)]
 #![feature(nll)]
-#![cfg_attr(bootstrap, feature(slice_patterns))]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -11,7 +11,6 @@
 #![feature(crate_visibility_modifier)]
 #![feature(label_break_value)]
 #![feature(nll)]
-#![cfg_attr(bootstrap, feature(slice_patterns))]
 #![recursion_limit = "256"]
 
 pub use rustc_hir::def::{Namespace, PerNS};

--- a/src/librustc_target/lib.rs
+++ b/src/librustc_target/lib.rs
@@ -11,7 +11,6 @@
 #![feature(box_syntax)]
 #![feature(bool_to_option)]
 #![feature(nll)]
-#![cfg_attr(bootstrap, feature(slice_patterns))]
 
 #[macro_use]
 extern crate log;

--- a/src/librustc_ty/lib.rs
+++ b/src/librustc_ty/lib.rs
@@ -8,7 +8,6 @@
 #![feature(bool_to_option)]
 #![feature(in_band_lifetimes)]
 #![feature(nll)]
-#![cfg_attr(bootstrap, feature(slice_patterns))]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -64,7 +64,6 @@ This API is completely unstable and subject to change.
 #![feature(exhaustive_patterns)]
 #![feature(in_band_lifetimes)]
 #![feature(nll)]
-#![cfg_attr(bootstrap, feature(slice_patterns))]
 #![feature(try_blocks)]
 #![feature(never_type)]
 #![recursion_limit = "256"]

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -294,7 +294,6 @@
 #![feature(shrink_to)]
 #![feature(slice_concat_ext)]
 #![feature(slice_internals)]
-#![cfg_attr(bootstrap, feature(slice_patterns))]
 #![feature(specialization)]
 #![feature(staged_api)]
 #![feature(std_internals)]

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -4,27 +4,6 @@
 //! library. Each macro is available for use when linking against the standard
 //! library.
 
-#[cfg(bootstrap)]
-#[doc(include = "../libcore/macros/panic.md")]
-#[macro_export]
-#[stable(feature = "rust1", since = "1.0.0")]
-#[allow_internal_unstable(libstd_sys_internals)]
-macro_rules! panic {
-    () => ({
-        $crate::panic!("explicit panic")
-    });
-    ($msg:expr) => ({
-        $crate::rt::begin_panic($msg, &($crate::file!(), $crate::line!(), $crate::column!()))
-    });
-    ($msg:expr,) => ({
-        $crate::panic!($msg)
-    });
-    ($fmt:expr, $($arg:tt)+) => ({
-        $crate::rt::begin_panic_fmt(&$crate::format_args!($fmt, $($arg)+))
-    });
-}
-
-#[cfg(not(bootstrap))]
 #[doc(include = "../libcore/macros/panic.md")]
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -391,7 +391,7 @@ pub fn begin_panic_handler(info: &PanicInfo<'_>) -> ! {
 #[cfg_attr(not(feature = "panic_immediate_abort"), inline(never))]
 #[cold]
 #[track_caller]
-pub fn begin_panic<M: Any + Send>(msg: M, #[cfg(bootstrap)] _: &(&str, u32, u32)) -> ! {
+pub fn begin_panic<M: Any + Send>(msg: M) -> ! {
     if cfg!(feature = "panic_immediate_abort") {
         unsafe { intrinsics::abort() }
     }

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -13,7 +13,6 @@
 #![feature(label_break_value)]
 #![feature(nll)]
 #![feature(try_trait)]
-#![cfg_attr(bootstrap, feature(slice_patterns))]
 #![feature(unicode_internals)]
 #![recursion_limit = "256"]
 

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,14 +12,15 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.x.0` for Cargo where they were released on `date`.
 
-date: 2019-12-18
+date: 2020-01-30
 rustc: beta
 cargo: beta
 
-# We use a nightly rustfmt to format the source because it solves some bootstrapping
-# issues with use of new syntax in this repo. If you're looking at the beta/stable branch, this key should be omitted,
-# as we don't want to depend on rustfmt from nightly there.
-rustfmt: nightly-2019-12-18
+# We use a nightly rustfmt to format the source because it solves some
+# bootstrapping issues with use of new syntax in this repo. If you're looking at
+# the beta/stable branch, this key should be omitted, as we don't want to depend
+# on rustfmt from nightly there.
+rustfmt: nightly-2020-01-31
 
 # When making a stable release the process currently looks like:
 #


### PR DESCRIPTION
This also includes a commit which fixes the rustfmt downloading logic to redownload when the rustfmt channel changes, and bumps rustfmt to a more recent version.