### PR TITLE
Stabilize `Span::mixed_site`

### DIFF
--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -303,7 +303,7 @@ impl Span {
     /// definition site (local variables, labels, `$crate`) and sometimes at the macro
     /// call site (everything else).
     /// The span location is taken from the call-site.
-    #[unstable(feature = "proc_macro_mixed_site", issue = "65049")]
+    #[stable(feature = "proc_macro_mixed_site", since = "1.45.0")]
     pub fn mixed_site() -> Span {
         Span(bridge::client::Span::mixed_site())
     }

--- a/src/test/ui/proc-macro/auxiliary/mixed-site-span.rs
+++ b/src/test/ui/proc-macro/auxiliary/mixed-site-span.rs
@@ -2,7 +2,6 @@
 // no-prefer-dynamic
 
 #![feature(proc_macro_hygiene)]
-#![feature(proc_macro_mixed_site)]
 #![feature(proc_macro_quote)]
 
 #![crate_type = "proc-macro"]


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/65049.
cc https://github.com/rust-lang/rust/issues/54727#issuecomment-580647446

Pre-requisite for https://github.com/rust-lang/rust/pull/68717 ("Stabilize fn-like proc macros in expression, pattern and statement positions").

Stabilization report: https://github.com/rust-lang/rust/pull/68716#issuecomment-581076337.