### PR TITLE
Stabilize fn-like proc macros in expression, pattern and statement positions

### DIFF
--- a/src/librustc_feature/active.rs
+++ b/src/librustc_feature/active.rs
@@ -430,8 +430,7 @@ declare_features! (
     /// Allows `#[marker]` on certain traits allowing overlapping implementations.
     (active, marker_trait_attr, "1.30.0", Some(29864), None),
 
-    /// Allows macro invocations on modules expressions and statements and
-    /// procedural macros to expand to non-items.
+    /// Allows macro attributes on expressions, statements and non-inline modules.
     (active, proc_macro_hygiene, "1.30.0", Some(54727), None),
 
     /// Allows unsized rvalues at arguments and parameters.

--- a/src/test/ui/auxiliary/cond_plugin.rs
+++ b/src/test/ui/auxiliary/cond_plugin.rs
@@ -2,7 +2,6 @@
 // no-prefer-dynamic
 
 #![crate_type = "proc-macro"]
-#![feature(proc_macro_hygiene)]
 #![feature(proc_macro_quote)]
 
 extern crate proc_macro;

--- a/src/test/ui/auxiliary/hello_macro.rs
+++ b/src/test/ui/auxiliary/hello_macro.rs
@@ -2,7 +2,7 @@
 // no-prefer-dynamic
 
 #![crate_type = "proc-macro"]
-#![feature(proc_macro_hygiene, proc_macro_quote)]
+#![feature(proc_macro_quote)]
 
 extern crate proc_macro;
 

--- a/src/test/ui/auxiliary/proc_macro_def.rs
+++ b/src/test/ui/auxiliary/proc_macro_def.rs
@@ -2,7 +2,6 @@
 // no-prefer-dynamic
 
 #![crate_type = "proc-macro"]
-#![feature(proc_macro_hygiene)]
 #![feature(proc_macro_quote)]
 
 extern crate proc_macro;

--- a/src/test/ui/macro-quote-cond.rs
+++ b/src/test/ui/macro-quote-cond.rs
@@ -1,9 +1,7 @@
 // run-pass
-
-#![allow(unused_parens)]
 // aux-build:cond_plugin.rs
 
-#![feature(proc_macro_hygiene)]
+#![allow(unused_parens)]
 
 extern crate cond_plugin;
 

--- a/src/test/ui/macro-quote-test.rs
+++ b/src/test/ui/macro-quote-test.rs
@@ -1,9 +1,7 @@
-// run-pass
 // Test that a macro can emit delimiters with nothing inside - `()`, `{}`
 
+// run-pass
 // aux-build:hello_macro.rs
-
-#![feature(proc_macro_hygiene)]
 
 extern crate hello_macro;
 

--- a/src/test/ui/macros/auxiliary/proc_macro_sequence.rs
+++ b/src/test/ui/macros/auxiliary/proc_macro_sequence.rs
@@ -2,7 +2,7 @@
 // no-prefer-dynamic
 
 #![crate_type = "proc-macro"]
-#![feature(proc_macro_span, proc_macro_hygiene, proc_macro_quote)]
+#![feature(proc_macro_span, proc_macro_quote)]
 
 extern crate proc_macro;
 

--- a/src/test/ui/proc-macro/attr-invalid-exprs.rs
+++ b/src/test/ui/proc-macro/attr-invalid-exprs.rs
@@ -1,8 +1,9 @@
-// aux-build:attr-stmt-expr.rs
-
 //! Attributes producing expressions in invalid locations
 
-#![feature(stmt_expr_attributes, proc_macro_hygiene)]
+// aux-build:attr-stmt-expr.rs
+
+#![feature(proc_macro_hygiene)]
+#![feature(stmt_expr_attributes)]
 
 extern crate attr_stmt_expr;
 use attr_stmt_expr::{duplicate, no_output};

--- a/src/test/ui/proc-macro/attr-invalid-exprs.stderr
+++ b/src/test/ui/proc-macro/attr-invalid-exprs.stderr
@@ -1,11 +1,11 @@
 error: expected expression, found end of macro arguments
-  --> $DIR/attr-invalid-exprs.rs:11:13
+  --> $DIR/attr-invalid-exprs.rs:12:13
    |
 LL |     let _ = #[no_output] "Hello, world!";
    |             ^^^^^^^^^^^^
 
 error: macro expansion ignores token `,` and any following
-  --> $DIR/attr-invalid-exprs.rs:14:13
+  --> $DIR/attr-invalid-exprs.rs:15:13
    |
 LL |     let _ = #[duplicate] "Hello, world!";
    |             ^^^^^^^^^^^^- help: you might be missing a semicolon here: `;`
@@ -15,7 +15,7 @@ LL |     let _ = #[duplicate] "Hello, world!";
    = note: the usage of `duplicate!` is likely invalid in expression context
 
 error: macro expansion ignores token `,` and any following
-  --> $DIR/attr-invalid-exprs.rs:23:9
+  --> $DIR/attr-invalid-exprs.rs:24:9
    |
 LL |         #[duplicate]
    |         ^^^^^^^^^^^^- help: you might be missing a semicolon here: `;`

--- a/src/test/ui/proc-macro/auxiliary/count_compound_ops.rs
+++ b/src/test/ui/proc-macro/auxiliary/count_compound_ops.rs
@@ -1,7 +1,7 @@
 // force-host
 // no-prefer-dynamic
 
-#![feature(proc_macro_hygiene, proc_macro_quote)]
+#![feature(proc_macro_quote)]
 #![crate_type = "proc-macro"]
 
 extern crate proc_macro;

--- a/src/test/ui/proc-macro/auxiliary/generate-dollar-ident.rs
+++ b/src/test/ui/proc-macro/auxiliary/generate-dollar-ident.rs
@@ -1,7 +1,6 @@
 // force-host
 // no-prefer-dynamic
 
-#![feature(proc_macro_hygiene)]
 #![feature(proc_macro_quote)]
 #![crate_type = "proc-macro"]
 

--- a/src/test/ui/proc-macro/auxiliary/hygiene_example_codegen.rs
+++ b/src/test/ui/proc-macro/auxiliary/hygiene_example_codegen.rs
@@ -1,7 +1,7 @@
 // force-host
 // no-prefer-dynamic
 
-#![feature(proc_macro_quote, proc_macro_hygiene)]
+#![feature(proc_macro_quote)]
 #![crate_type = "proc-macro"]
 
 extern crate proc_macro as proc_macro_renamed; // This does not break `quote!`

--- a/src/test/ui/proc-macro/auxiliary/mixed-site-span.rs
+++ b/src/test/ui/proc-macro/auxiliary/mixed-site-span.rs
@@ -1,7 +1,6 @@
 // force-host
 // no-prefer-dynamic
 
-#![feature(proc_macro_hygiene)]
 #![feature(proc_macro_quote)]
 
 #![crate_type = "proc-macro"]

--- a/src/test/ui/proc-macro/auxiliary/resolved-located-at.rs
+++ b/src/test/ui/proc-macro/auxiliary/resolved-located-at.rs
@@ -3,7 +3,6 @@
 
 #![feature(proc_macro_def_site)]
 #![feature(proc_macro_diagnostic)]
-#![feature(proc_macro_hygiene)]
 #![feature(proc_macro_quote)]
 #![crate_type = "proc-macro"]
 

--- a/src/test/ui/proc-macro/bang-macro.rs
+++ b/src/test/ui/proc-macro/bang-macro.rs
@@ -1,8 +1,6 @@
 // run-pass
 // aux-build:bang-macro.rs
 
-#![feature(proc_macro_hygiene)]
-
 extern crate bang_macro;
 use bang_macro::rewrite;
 

--- a/src/test/ui/proc-macro/call-site.rs
+++ b/src/test/ui/proc-macro/call-site.rs
@@ -1,13 +1,7 @@
-// run-pass
-
-#![allow(unused_variables)]
-#![allow(unused_imports)]
+// check-pass
 // aux-build:call-site.rs
 
-#![feature(proc_macro_hygiene)]
-
 extern crate call_site;
-use call_site::*;
 
 fn main() {
     let x1 = 10;

--- a/src/test/ui/proc-macro/count_compound_ops.rs
+++ b/src/test/ui/proc-macro/count_compound_ops.rs
@@ -1,8 +1,6 @@
 // run-pass
 // aux-build:count_compound_ops.rs
 
-#![feature(proc_macro_hygiene)]
-
 extern crate count_compound_ops;
 use count_compound_ops::count_compound_ops;
 

--- a/src/test/ui/proc-macro/hygiene_example.rs
+++ b/src/test/ui/proc-macro/hygiene_example.rs
@@ -1,10 +1,6 @@
-// run-pass
-
-#![allow(unused_macros)]
+// check-pass
 // aux-build:hygiene_example_codegen.rs
 // aux-build:hygiene_example.rs
-
-#![feature(proc_macro_hygiene)]
 
 extern crate hygiene_example;
 use hygiene_example::hello;

--- a/src/test/ui/proc-macro/is-available.rs
+++ b/src/test/ui/proc-macro/is-available.rs
@@ -1,6 +1,6 @@
 // run-pass
 
-#![feature(proc_macro_hygiene, proc_macro_is_available)]
+#![feature(proc_macro_is_available)]
 
 extern crate proc_macro;
 

--- a/src/test/ui/proc-macro/lints_in_proc_macros.rs
+++ b/src/test/ui/proc-macro/lints_in_proc_macros.rs
@@ -1,8 +1,5 @@
 // aux-build:bang_proc_macro2.rs
 
-#![feature(proc_macro_hygiene)]
-#![allow(unused_macros)]
-
 extern crate bang_proc_macro2;
 
 use bang_proc_macro2::bang_proc_macro2;

--- a/src/test/ui/proc-macro/lints_in_proc_macros.stderr
+++ b/src/test/ui/proc-macro/lints_in_proc_macros.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find value `foobar2` in this scope
-  --> $DIR/lints_in_proc_macros.rs:12:5
+  --> $DIR/lints_in_proc_macros.rs:9:5
    |
 LL |     bang_proc_macro2!();
    |     ^^^^^^^^^^^^^^^^^^^^ help: a local variable with a similar name exists: `foobar`

--- a/src/test/ui/proc-macro/macro-use-bang.rs
+++ b/src/test/ui/proc-macro/macro-use-bang.rs
@@ -1,8 +1,6 @@
 // build-pass (FIXME(62277): could be check-pass?)
 // aux-build:test-macros.rs
 
-#![feature(proc_macro_hygiene)]
-
 #[macro_use]
 extern crate test_macros;
 

--- a/src/test/ui/proc-macro/mixed-site-span.rs
+++ b/src/test/ui/proc-macro/mixed-site-span.rs
@@ -2,8 +2,6 @@
 
 // aux-build:mixed-site-span.rs
 
-#![feature(proc_macro_hygiene)]
-
 #[macro_use]
 extern crate mixed_site_span;
 

--- a/src/test/ui/proc-macro/mixed-site-span.stderr
+++ b/src/test/ui/proc-macro/mixed-site-span.stderr
@@ -1,5 +1,5 @@
 error[E0426]: use of undeclared label `'label_use`
-  --> $DIR/mixed-site-span.rs:15:9
+  --> $DIR/mixed-site-span.rs:13:9
    |
 LL |         proc_macro_rules!();
    |         ^^^^^^^^^^^^^^^^^^^^ undeclared label `'label_use`
@@ -7,7 +7,7 @@ LL |         proc_macro_rules!();
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `local_use` in this scope
-  --> $DIR/mixed-site-span.rs:15:9
+  --> $DIR/mixed-site-span.rs:13:9
    |
 LL |         proc_macro_rules!();
    |         ^^^^^^^^^^^^^^^^^^^^ not found in this scope
@@ -15,13 +15,13 @@ LL |         proc_macro_rules!();
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `local_def` in this scope
-  --> $DIR/mixed-site-span.rs:19:9
+  --> $DIR/mixed-site-span.rs:17:9
    |
 LL |         local_def;
    |         ^^^^^^^^^ not found in this scope
 
 error[E0412]: cannot find type `ItemUse` in crate `$crate`
-  --> $DIR/mixed-site-span.rs:26:1
+  --> $DIR/mixed-site-span.rs:24:1
    |
 LL | pass_dollar_crate!();
    | ^^^^^^^^^^^^^^^^^^^^^ not found in `$crate`

--- a/src/test/ui/proc-macro/multispan.rs
+++ b/src/test/ui/proc-macro/multispan.rs
@@ -1,7 +1,5 @@
 // aux-build:multispan.rs
 
-#![feature(proc_macro_hygiene)]
-
 extern crate multispan;
 
 use multispan::hello;

--- a/src/test/ui/proc-macro/multispan.stderr
+++ b/src/test/ui/proc-macro/multispan.stderr
@@ -1,89 +1,89 @@
 error: hello to you, too!
-  --> $DIR/multispan.rs:14:5
+  --> $DIR/multispan.rs:12:5
    |
 LL |     hello!(hi);
    |     ^^^^^^^^^^^
    |
 note: found these 'hi's
-  --> $DIR/multispan.rs:14:12
+  --> $DIR/multispan.rs:12:12
    |
 LL |     hello!(hi);
    |            ^^
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: hello to you, too!
-  --> $DIR/multispan.rs:17:5
+  --> $DIR/multispan.rs:15:5
    |
 LL |     hello!(hi hi);
    |     ^^^^^^^^^^^^^^
    |
 note: found these 'hi's
-  --> $DIR/multispan.rs:17:12
+  --> $DIR/multispan.rs:15:12
    |
 LL |     hello!(hi hi);
    |            ^^ ^^
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: hello to you, too!
-  --> $DIR/multispan.rs:20:5
+  --> $DIR/multispan.rs:18:5
    |
 LL |     hello!(hi hi hi);
    |     ^^^^^^^^^^^^^^^^^
    |
 note: found these 'hi's
-  --> $DIR/multispan.rs:20:12
+  --> $DIR/multispan.rs:18:12
    |
 LL |     hello!(hi hi hi);
    |            ^^ ^^ ^^
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: hello to you, too!
-  --> $DIR/multispan.rs:23:5
+  --> $DIR/multispan.rs:21:5
    |
 LL |     hello!(hi hey hi yo hi beep beep hi hi);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: found these 'hi's
-  --> $DIR/multispan.rs:23:12
+  --> $DIR/multispan.rs:21:12
    |
 LL |     hello!(hi hey hi yo hi beep beep hi hi);
    |            ^^     ^^    ^^           ^^ ^^
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: hello to you, too!
-  --> $DIR/multispan.rs:24:5
+  --> $DIR/multispan.rs:22:5
    |
 LL |     hello!(hi there, hi how are you? hi... hi.);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: found these 'hi's
-  --> $DIR/multispan.rs:24:12
+  --> $DIR/multispan.rs:22:12
    |
 LL |     hello!(hi there, hi how are you? hi... hi.);
    |            ^^        ^^              ^^    ^^
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: hello to you, too!
-  --> $DIR/multispan.rs:25:5
+  --> $DIR/multispan.rs:23:5
    |
 LL |     hello!(whoah. hi di hi di ho);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: found these 'hi's
-  --> $DIR/multispan.rs:25:19
+  --> $DIR/multispan.rs:23:19
    |
 LL |     hello!(whoah. hi di hi di ho);
    |                   ^^    ^^
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: hello to you, too!
-  --> $DIR/multispan.rs:26:5
+  --> $DIR/multispan.rs:24:5
    |
 LL |     hello!(hi good hi and good bye);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: found these 'hi's
-  --> $DIR/multispan.rs:26:12
+  --> $DIR/multispan.rs:24:12
    |
 LL |     hello!(hi good hi and good bye);
    |            ^^      ^^

--- a/src/test/ui/proc-macro/negative-token.rs
+++ b/src/test/ui/proc-macro/negative-token.rs
@@ -1,8 +1,6 @@
 // run-pass
 // aux-build:negative-token.rs
 
-#![feature(proc_macro_hygiene)]
-
 extern crate negative_token;
 
 use negative_token::*;

--- a/src/test/ui/proc-macro/parent-source-spans.rs
+++ b/src/test/ui/proc-macro/parent-source-spans.rs
@@ -1,5 +1,6 @@
 // aux-build:parent-source-spans.rs
-#![feature(decl_macro, proc_macro_hygiene)]
+
+#![feature(decl_macro)]
 
 extern crate parent_source_spans;
 

--- a/src/test/ui/proc-macro/parent-source-spans.stderr
+++ b/src/test/ui/proc-macro/parent-source-spans.stderr
@@ -1,5 +1,5 @@
 error: first final: "hello"
-  --> $DIR/parent-source-spans.rs:15:12
+  --> $DIR/parent-source-spans.rs:16:12
    |
 LL |     three!($a, $b);
    |            ^^
@@ -10,7 +10,7 @@ LL |     one!("hello", "world");
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: second final: "world"
-  --> $DIR/parent-source-spans.rs:15:16
+  --> $DIR/parent-source-spans.rs:16:16
    |
 LL |     three!($a, $b);
    |                ^^
@@ -21,7 +21,7 @@ LL |     one!("hello", "world");
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: first parent: "hello"
-  --> $DIR/parent-source-spans.rs:9:5
+  --> $DIR/parent-source-spans.rs:10:5
    |
 LL |     two!($a, $b);
    |     ^^^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL |     one!("hello", "world");
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: second parent: "world"
-  --> $DIR/parent-source-spans.rs:9:5
+  --> $DIR/parent-source-spans.rs:10:5
    |
 LL |     two!($a, $b);
    |     ^^^^^^^^^^^^^
@@ -43,31 +43,31 @@ LL |     one!("hello", "world");
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: first grandparent: "hello"
-  --> $DIR/parent-source-spans.rs:35:5
+  --> $DIR/parent-source-spans.rs:36:5
    |
 LL |     one!("hello", "world");
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: second grandparent: "world"
-  --> $DIR/parent-source-spans.rs:35:5
+  --> $DIR/parent-source-spans.rs:36:5
    |
 LL |     one!("hello", "world");
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: first source: "hello"
-  --> $DIR/parent-source-spans.rs:35:5
+  --> $DIR/parent-source-spans.rs:36:5
    |
 LL |     one!("hello", "world");
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: second source: "world"
-  --> $DIR/parent-source-spans.rs:35:5
+  --> $DIR/parent-source-spans.rs:36:5
    |
 LL |     one!("hello", "world");
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: first final: "yay"
-  --> $DIR/parent-source-spans.rs:15:12
+  --> $DIR/parent-source-spans.rs:16:12
    |
 LL |     three!($a, $b);
    |            ^^
@@ -78,7 +78,7 @@ LL |     two!("yay", "rust");
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: second final: "rust"
-  --> $DIR/parent-source-spans.rs:15:16
+  --> $DIR/parent-source-spans.rs:16:16
    |
 LL |     three!($a, $b);
    |                ^^
@@ -89,55 +89,55 @@ LL |     two!("yay", "rust");
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: first parent: "yay"
-  --> $DIR/parent-source-spans.rs:41:5
+  --> $DIR/parent-source-spans.rs:42:5
    |
 LL |     two!("yay", "rust");
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: second parent: "rust"
-  --> $DIR/parent-source-spans.rs:41:5
+  --> $DIR/parent-source-spans.rs:42:5
    |
 LL |     two!("yay", "rust");
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: first source: "yay"
-  --> $DIR/parent-source-spans.rs:41:5
+  --> $DIR/parent-source-spans.rs:42:5
    |
 LL |     two!("yay", "rust");
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: second source: "rust"
-  --> $DIR/parent-source-spans.rs:41:5
+  --> $DIR/parent-source-spans.rs:42:5
    |
 LL |     two!("yay", "rust");
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: first final: "hip"
-  --> $DIR/parent-source-spans.rs:47:12
+  --> $DIR/parent-source-spans.rs:48:12
    |
 LL |     three!("hip", "hop");
    |            ^^^^^
 
 error: second final: "hop"
-  --> $DIR/parent-source-spans.rs:47:19
+  --> $DIR/parent-source-spans.rs:48:19
    |
 LL |     three!("hip", "hop");
    |                   ^^^^^
 
 error: first source: "hip"
-  --> $DIR/parent-source-spans.rs:47:12
+  --> $DIR/parent-source-spans.rs:48:12
    |
 LL |     three!("hip", "hop");
    |            ^^^^^
 
 error: second source: "hop"
-  --> $DIR/parent-source-spans.rs:47:19
+  --> $DIR/parent-source-spans.rs:48:19
    |
 LL |     three!("hip", "hop");
    |                   ^^^^^
 
 error[E0425]: cannot find value `ok` in this scope
-  --> $DIR/parent-source-spans.rs:28:5
+  --> $DIR/parent-source-spans.rs:29:5
    |
 LL |     parent_source_spans!($($tokens)*);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a tuple variant with a similar name exists: `Ok`
@@ -153,7 +153,7 @@ LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `ok` in this scope
-  --> $DIR/parent-source-spans.rs:28:5
+  --> $DIR/parent-source-spans.rs:29:5
    |
 LL |     parent_source_spans!($($tokens)*);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a tuple variant with a similar name exists: `Ok`
@@ -169,7 +169,7 @@ LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `ok` in this scope
-  --> $DIR/parent-source-spans.rs:28:5
+  --> $DIR/parent-source-spans.rs:29:5
    |
 LL |     parent_source_spans!($($tokens)*);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a tuple variant with a similar name exists: `Ok`

--- a/src/test/ui/proc-macro/proc-macro-gates.rs
+++ b/src/test/ui/proc-macro/proc-macro-gates.rs
@@ -45,13 +45,4 @@ fn attrs() {
     //~^ ERROR: custom attributes cannot be applied to expressions
 }
 
-fn main() {
-    if let identity!(Some(_x)) = Some(3) {}
-    //~^ ERROR: procedural macros cannot be expanded to patterns
-
-    empty!(struct S;); //~ ERROR: procedural macros cannot be expanded to statements
-    empty!(let _x = 3;); //~ ERROR: procedural macros cannot be expanded to statements
-
-    let _x = identity!(3); //~ ERROR: procedural macros cannot be expanded to expressions
-    let _x = [empty!(3)]; //~ ERROR: procedural macros cannot be expanded to expressions
-}
+fn main() {}

--- a/src/test/ui/proc-macro/proc-macro-gates.stderr
+++ b/src/test/ui/proc-macro/proc-macro-gates.stderr
@@ -76,51 +76,6 @@ LL |     let _x = #[identity_attr] println!();
    = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
-error[E0658]: procedural macros cannot be expanded to patterns
-  --> $DIR/proc-macro-gates.rs:49:12
-   |
-LL |     if let identity!(Some(_x)) = Some(3) {}
-   |            ^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
-   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
-
-error[E0658]: procedural macros cannot be expanded to statements
-  --> $DIR/proc-macro-gates.rs:52:5
-   |
-LL |     empty!(struct S;);
-   |     ^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
-   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
-
-error[E0658]: procedural macros cannot be expanded to statements
-  --> $DIR/proc-macro-gates.rs:53:5
-   |
-LL |     empty!(let _x = 3;);
-   |     ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
-   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
-
-error[E0658]: procedural macros cannot be expanded to expressions
-  --> $DIR/proc-macro-gates.rs:55:14
-   |
-LL |     let _x = identity!(3);
-   |              ^^^^^^^^^^^^
-   |
-   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
-   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
-
-error[E0658]: procedural macros cannot be expanded to expressions
-  --> $DIR/proc-macro-gates.rs:56:15
-   |
-LL |     let _x = [empty!(3)];
-   |               ^^^^^^^^^
-   |
-   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
-   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
-
-error: aborting due to 14 previous errors
+error: aborting due to 9 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/proc-macro/resolved-located-at.rs
+++ b/src/test/ui/proc-macro/resolved-located-at.rs
@@ -1,7 +1,5 @@
 // aux-build:resolved-located-at.rs
 
-#![feature(proc_macro_hygiene)]
-
 #[macro_use]
 extern crate resolved_located_at;
 

--- a/src/test/ui/proc-macro/resolved-located-at.stderr
+++ b/src/test/ui/proc-macro/resolved-located-at.stderr
@@ -1,5 +1,5 @@
 error: expected error
-  --> $DIR/resolved-located-at.rs:9:25
+  --> $DIR/resolved-located-at.rs:7:25
    |
 LL |     resolve_located_at!(a b)
    |                         ^
@@ -7,7 +7,7 @@ LL |     resolve_located_at!(a b)
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
-  --> $DIR/resolved-located-at.rs:9:27
+  --> $DIR/resolved-located-at.rs:7:27
    |
 LL | fn main() {
    |           - expected `()` because of default return type

--- a/src/test/ui/proc-macro/span-api-tests.rs
+++ b/src/test/ui/proc-macro/span-api-tests.rs
@@ -1,10 +1,7 @@
 // run-pass
+// ignore-pretty
 // aux-build:span-api-tests.rs
 // aux-build:span-test-macros.rs
-
-// ignore-pretty
-
-#![feature(proc_macro_hygiene)]
 
 #[macro_use]
 extern crate span_test_macros;

--- a/src/test/ui/proc-macro/three-equals.rs
+++ b/src/test/ui/proc-macro/three-equals.rs
@@ -1,8 +1,5 @@
 // aux-build:three-equals.rs
 
-
-#![feature(proc_macro_hygiene)]
-
 extern crate three_equals;
 
 use three_equals::three_equals;

--- a/src/test/ui/proc-macro/three-equals.stderr
+++ b/src/test/ui/proc-macro/three-equals.stderr
@@ -1,5 +1,5 @@
 error: found 2 equal signs, need exactly 3
-  --> $DIR/three-equals.rs:15:5
+  --> $DIR/three-equals.rs:12:5
    |
 LL |     three_equals!(==);
    |     ^^^^^^^^^^^^^^^^^^
@@ -8,38 +8,38 @@ LL |     three_equals!(==);
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected EOF, found `=`.
-  --> $DIR/three-equals.rs:18:21
+  --> $DIR/three-equals.rs:15:21
    |
 LL |     three_equals!(=====);
    |                     ^^
    |
 note: last good input was here
-  --> $DIR/three-equals.rs:18:21
+  --> $DIR/three-equals.rs:15:21
    |
 LL |     three_equals!(=====);
    |                     ^^
    = help: input must be: `===`
 
 error: expected `=`, found `abc`.
-  --> $DIR/three-equals.rs:21:19
+  --> $DIR/three-equals.rs:18:19
    |
 LL |     three_equals!(abc);
    |                   ^^^
 
 error: expected `=`, found `!`.
-  --> $DIR/three-equals.rs:24:19
+  --> $DIR/three-equals.rs:21:19
    |
 LL |     three_equals!(!!);
    |                   ^
 
 error: expected EOF, found `a`.
-  --> $DIR/three-equals.rs:27:22
+  --> $DIR/three-equals.rs:24:22
    |
 LL |     three_equals!(===a);
    |                      ^
    |
 note: last good input was here
-  --> $DIR/three-equals.rs:27:21
+  --> $DIR/three-equals.rs:24:21
    |
 LL |     three_equals!(===a);
    |                     ^

--- a/src/test/ui/proc_macro.rs
+++ b/src/test/ui/proc_macro.rs
@@ -2,8 +2,6 @@
 // aux-build:proc_macro_def.rs
 // ignore-cross-compile
 
-#![feature(proc_macro_hygiene)]
-
 extern crate proc_macro_def;
 
 use proc_macro_def::{attr_tru, attr_identity, identity, ret_tru, tru};

--- a/src/tools/clippy/mini-macro/src/lib.rs
+++ b/src/tools/clippy/mini-macro/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_quote, proc_macro_hygiene)]
+#![feature(proc_macro_quote)]
 #![deny(rust_2018_idioms)]
 // FIXME: Remove this attribute once the weird failure is gone.
 #![allow(unused_extern_crates)]

--- a/src/tools/clippy/tests/ui/auxiliary/proc_macro_derive.rs
+++ b/src/tools/clippy/tests/ui/auxiliary/proc_macro_derive.rs
@@ -1,7 +1,7 @@
 // no-prefer-dynamic
 
 #![crate_type = "proc-macro"]
-#![feature(repr128, proc_macro_hygiene, proc_macro_quote)]
+#![feature(repr128, proc_macro_quote)]
 
 extern crate proc_macro;
 

--- a/src/tools/clippy/tests/ui/crashes/ice-3741.rs
+++ b/src/tools/clippy/tests/ui/crashes/ice-3741.rs
@@ -1,7 +1,6 @@
 // aux-build:proc_macro_crash.rs
 // run-pass
 
-#![feature(proc_macro_hygiene)]
 #![warn(clippy::suspicious_else_formatting)]
 
 extern crate proc_macro_crash;


### PR DESCRIPTION
I.e. all the positions in which stable `macro_rules` macros are supported.

Depends on https://github.com/rust-lang/rust/pull/68716 ("Stabilize `Span::mixed_site`").

cc https://github.com/rust-lang/rust/issues/54727
cc https://github.com/rust-lang/rust/issues/54727#issuecomment-580647446

Stabilization report: https://github.com/rust-lang/rust/pull/68717#issuecomment-623197503.