### PR TITLE
Invert control in struct_lint_level.

### DIFF
--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -1701,7 +1701,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         sub: Region<'tcx>,
     ) {
         self.construct_generic_bound_failure(region_scope_tree, span, origin, bound_kind, sub)
-            .emit()
+            .emit();
     }
 
     pub fn construct_generic_bound_failure(

--- a/src/librustc/lint.rs
+++ b/src/librustc/lint.rs
@@ -11,7 +11,6 @@ use rustc_span::hygiene::MacroKind;
 use rustc_span::source_map::{DesugaringKind, ExpnKind, MultiSpan};
 use rustc_span::{Span, Symbol};
 
-
 /// How a lint level was set.
 #[derive(Clone, Copy, PartialEq, Eq, HashStable)]
 pub enum LintSource {
@@ -175,7 +174,6 @@ impl<'a> HashStable<StableHashingContext<'a>> for LintLevelMap {
     }
 }
 
-
 pub struct LintDiagnosticBuilder<'a>(DiagnosticBuilder<'a>);
 
 impl<'a> LintDiagnosticBuilder<'a> {
@@ -186,7 +184,7 @@ impl<'a> LintDiagnosticBuilder<'a> {
     }
 
     /// Create a LintDiagnosticBuilder from some existing DiagnosticBuilder.
-    pub fn new(err: DiagnosticBuilder<'a>) -> LintDiagnosticBuilder<'a>{
+    pub fn new(err: DiagnosticBuilder<'a>) -> LintDiagnosticBuilder<'a> {
         LintDiagnosticBuilder(err)
     }
 }
@@ -207,14 +205,17 @@ pub fn struct_lint_level<'s, 'd>(
         level: Level,
         src: LintSource,
         span: Option<MultiSpan>,
-        decorate: Box<dyn for<'b> FnOnce(LintDiagnosticBuilder<'b>) + 'd>) {
+        decorate: Box<dyn for<'b> FnOnce(LintDiagnosticBuilder<'b>) + 'd>,
+    ) {
         let mut err = match (level, span) {
             (Level::Allow, _) => {
                 return;
             }
             (Level::Warn, Some(span)) => sess.struct_span_warn(span, ""),
             (Level::Warn, None) => sess.struct_warn(""),
-            (Level::Deny, Some(span)) | (Level::Forbid, Some(span)) => sess.struct_span_err(span, ""),
+            (Level::Deny, Some(span)) | (Level::Forbid, Some(span)) => {
+                sess.struct_span_err(span, "")
+            }
             (Level::Deny, None) | (Level::Forbid, None) => sess.struct_err(""),
         };
 

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -120,19 +120,18 @@ impl<'tcx> ConstEvalErr<'tcx> {
                     }
                 }
                 lint.emit();
-            }
-        , Some(lint_root)) {
-            Ok(_) => {
-                ErrorHandled::Reported
-            }
+            },
+            Some(lint_root),
+        ) {
+            Ok(_) => ErrorHandled::Reported,
             Err(err) => err,
         }
     }
 
-   /// Sets the message passed in via `message`, then adds the span labels for you, before applying
-   /// further modifications in `emit`. It's up to you to call emit(), stash(..), etc. within the
-   /// `emit` method. If you don't need to do any additional processing, just use
-   /// struct_generic.
+    /// Sets the message passed in via `message`, then adds the span labels for you, before applying
+    /// further modifications in `emit`. It's up to you to call emit(), stash(..), etc. within the
+    /// `emit` method. If you don't need to do any additional processing, just use
+    /// struct_generic.
     fn struct_generic(
         &self,
         tcx: TyCtxtAt<'tcx>,

--- a/src/librustc/traits/object_safety.rs
+++ b/src/librustc/traits/object_safety.rs
@@ -227,37 +227,39 @@ fn object_safety_violations_for_trait(
             {
                 // Using `CRATE_NODE_ID` is wrong, but it's hard to get a more precise id.
                 // It's also hard to get a use site span, so we use the method definition span.
-                let mut err = tcx.struct_span_lint_hir(
+                tcx.struct_span_lint_hir(
                     WHERE_CLAUSES_OBJECT_SAFETY,
                     hir::CRATE_HIR_ID,
                     *span,
-                    &format!(
-                        "the trait `{}` cannot be made into an object",
-                        tcx.def_path_str(trait_def_id)
-                    ),
+                    |lint| {
+                        let mut err = lint.build(&format!(
+                            "the trait `{}` cannot be made into an object",
+                            tcx.def_path_str(trait_def_id)
+                        ));
+                        let node = tcx.hir().get_if_local(trait_def_id);
+                        let msg = if let Some(hir::Node::Item(item)) = node {
+                            err.span_label(item.ident.span, "this trait cannot be made into an object...");
+                            format!("...because {}", violation.error_msg())
+                        } else {
+                            format!(
+                                "the trait cannot be made into an object because {}",
+                                violation.error_msg()
+                            )
+                        };
+                        err.span_label(*span, &msg);
+                        match (node, violation.solution()) {
+                            (Some(_), Some((note, None))) => {
+                                err.help(&note);
+                            }
+                            (Some(_), Some((note, Some((sugg, span))))) => {
+                                err.span_suggestion(span, &note, sugg, Applicability::MachineApplicable);
+                            }
+                            // Only provide the help if its a local trait, otherwise it's not actionable.
+                            _ => {}
+                        }
+                        err.emit();
+                    },
                 );
-                let node = tcx.hir().get_if_local(trait_def_id);
-                let msg = if let Some(hir::Node::Item(item)) = node {
-                    err.span_label(item.ident.span, "this trait cannot be made into an object...");
-                    format!("...because {}", violation.error_msg())
-                } else {
-                    format!(
-                        "the trait cannot be made into an object because {}",
-                        violation.error_msg()
-                    )
-                };
-                err.span_label(*span, &msg);
-                match (node, violation.solution()) {
-                    (Some(_), Some((note, None))) => {
-                        err.help(&note);
-                    }
-                    (Some(_), Some((note, Some((sugg, span))))) => {
-                        err.span_suggestion(span, &note, sugg, Applicability::MachineApplicable);
-                    }
-                    // Only provide the help if its a local trait, otherwise it's not actionable.
-                    _ => {}
-                }
-                err.emit();
                 false
             } else {
                 true

--- a/src/librustc/traits/object_safety.rs
+++ b/src/librustc/traits/object_safety.rs
@@ -238,7 +238,10 @@ fn object_safety_violations_for_trait(
                         ));
                         let node = tcx.hir().get_if_local(trait_def_id);
                         let msg = if let Some(hir::Node::Item(item)) = node {
-                            err.span_label(item.ident.span, "this trait cannot be made into an object...");
+                            err.span_label(
+                                item.ident.span,
+                                "this trait cannot be made into an object...",
+                            );
                             format!("...because {}", violation.error_msg())
                         } else {
                             format!(
@@ -252,7 +255,12 @@ fn object_safety_violations_for_trait(
                                 err.help(&note);
                             }
                             (Some(_), Some((note, Some((sugg, span))))) => {
-                                err.span_suggestion(span, &note, sugg, Applicability::MachineApplicable);
+                                err.span_suggestion(
+                                    span,
+                                    &note,
+                                    sugg,
+                                    Applicability::MachineApplicable,
+                                );
                             }
                             // Only provide the help if its a local trait, otherwise it's not actionable.
                             _ => {}

--- a/src/librustc/traits/specialize/mod.rs
+++ b/src/librustc/traits/specialize/mod.rs
@@ -22,6 +22,7 @@ use rustc_hir::def_id::DefId;
 use rustc_session::lint::builtin::COHERENCE_LEAK_CHECK;
 use rustc_session::lint::builtin::ORDER_DEPENDENT_TRAIT_OBJECTS;
 use rustc_span::DUMMY_SP;
+use rustc::lint::LintDiagnosticBuilder;
 
 use super::util::impl_trait_ref_and_oblig;
 use super::{FulfillmentContext, SelectionContext};
@@ -317,22 +318,69 @@ pub(super) fn specialization_graph_provider(
             };
 
             if let Some(overlap) = overlap {
-                let msg = format!(
-                    "conflicting implementations of trait `{}`{}:{}",
-                    overlap.trait_desc,
-                    overlap
-                        .self_desc
-                        .clone()
-                        .map_or(String::new(), |ty| { format!(" for type `{}`", ty) }),
-                    match used_to_be_allowed {
-                        Some(FutureCompatOverlapErrorKind::Issue33140) => " (E0119)",
-                        _ => "",
-                    }
-                );
                 let impl_span =
                     tcx.sess.source_map().def_span(tcx.span_of_impl(impl_def_id).unwrap());
-                let mut err = match used_to_be_allowed {
-                    None => struct_span_err!(tcx.sess, impl_span, E0119, "{}", msg),
+
+                // Work to be done after we've built the DiagnosticBuilder. We have to define it
+                // now because the struct_lint methods don't return back the DiagnosticBuilder
+                // that's passed in.
+                let decorate = |err: LintDiagnosticBuilder<'_>| {
+                    let msg = format!(
+                        "conflicting implementations of trait `{}`{}:{}",
+                        overlap.trait_desc,
+                        overlap
+                            .self_desc
+                            .clone()
+                            .map_or(String::new(), |ty| { format!(" for type `{}`", ty) }),
+                        match used_to_be_allowed {
+                            Some(FutureCompatOverlapErrorKind::Issue33140) => " (E0119)",
+                            _ => "",
+                        }
+                    );
+                    let mut err = err.build(&msg);
+                    match tcx.span_of_impl(overlap.with_impl) {
+                        Ok(span) => {
+                            err.span_label(
+                                tcx.sess.source_map().def_span(span),
+                                "first implementation here".to_string(),
+                            );
+
+                            err.span_label(
+                                impl_span,
+                                format!(
+                                    "conflicting implementation{}",
+                                    overlap
+                                        .self_desc
+                                        .map_or(String::new(), |ty| format!(" for `{}`", ty))
+                                ),
+                            );
+                        }
+                        Err(cname) => {
+                            let msg = match to_pretty_impl_header(tcx, overlap.with_impl) {
+                                Some(s) => {
+                                    format!("conflicting implementation in crate `{}`:\n- {}", cname, s)
+                                }
+                                None => format!("conflicting implementation in crate `{}`", cname),
+                            };
+                            err.note(&msg);
+                        }
+                    }
+
+                    for cause in &overlap.intercrate_ambiguity_causes {
+                        cause.add_intercrate_ambiguity_hint(&mut err);
+                    }
+
+                    if overlap.involves_placeholder {
+                        coherence::add_placeholder_note(&mut err);
+                    }
+                    err.emit()
+                };
+
+                match used_to_be_allowed {
+                    None => {
+                        let err = struct_span_err!(tcx.sess, impl_span, E0119, "");
+                        decorate(LintDiagnosticBuilder::new(err));
+                    }
                     Some(kind) => {
                         let lint = match kind {
                             FutureCompatOverlapErrorKind::Issue33140 => {
@@ -344,47 +392,11 @@ pub(super) fn specialization_graph_provider(
                             lint,
                             tcx.hir().as_local_hir_id(impl_def_id).unwrap(),
                             impl_span,
-                            &msg,
+                            decorate,
                         )
                     }
                 };
 
-                match tcx.span_of_impl(overlap.with_impl) {
-                    Ok(span) => {
-                        err.span_label(
-                            tcx.sess.source_map().def_span(span),
-                            "first implementation here".to_string(),
-                        );
-                        err.span_label(
-                            impl_span,
-                            format!(
-                                "conflicting implementation{}",
-                                overlap
-                                    .self_desc
-                                    .map_or(String::new(), |ty| format!(" for `{}`", ty))
-                            ),
-                        );
-                    }
-                    Err(cname) => {
-                        let msg = match to_pretty_impl_header(tcx, overlap.with_impl) {
-                            Some(s) => {
-                                format!("conflicting implementation in crate `{}`:\n- {}", cname, s)
-                            }
-                            None => format!("conflicting implementation in crate `{}`", cname),
-                        };
-                        err.note(&msg);
-                    }
-                }
-
-                for cause in &overlap.intercrate_ambiguity_causes {
-                    cause.add_intercrate_ambiguity_hint(&mut err);
-                }
-
-                if overlap.involves_placeholder {
-                    coherence::add_placeholder_note(&mut err);
-                }
-
-                err.emit();
             }
         } else {
             let parent = tcx.impl_parent(impl_def_id).unwrap_or(trait_id);

--- a/src/librustc/traits/specialize/mod.rs
+++ b/src/librustc/traits/specialize/mod.rs
@@ -16,13 +16,13 @@ use crate::traits::select::IntercrateAmbiguityCause;
 use crate::traits::{self, coherence, FutureCompatOverlapErrorKind, ObligationCause, TraitEngine};
 use crate::ty::subst::{InternalSubsts, Subst, SubstsRef};
 use crate::ty::{self, TyCtxt, TypeFoldable};
+use rustc::lint::LintDiagnosticBuilder;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::struct_span_err;
 use rustc_hir::def_id::DefId;
 use rustc_session::lint::builtin::COHERENCE_LEAK_CHECK;
 use rustc_session::lint::builtin::ORDER_DEPENDENT_TRAIT_OBJECTS;
 use rustc_span::DUMMY_SP;
-use rustc::lint::LintDiagnosticBuilder;
 
 use super::util::impl_trait_ref_and_oblig;
 use super::{FulfillmentContext, SelectionContext};
@@ -357,9 +357,10 @@ pub(super) fn specialization_graph_provider(
                         }
                         Err(cname) => {
                             let msg = match to_pretty_impl_header(tcx, overlap.with_impl) {
-                                Some(s) => {
-                                    format!("conflicting implementation in crate `{}`:\n- {}", cname, s)
-                                }
+                                Some(s) => format!(
+                                    "conflicting implementation in crate `{}`:\n- {}",
+                                    cname, s
+                                ),
                                 None => format!("conflicting implementation in crate `{}`", cname),
                             };
                             err.note(&msg);
@@ -396,7 +397,6 @@ pub(super) fn specialization_graph_provider(
                         )
                     }
                 };
-
             }
         } else {
             let parent = tcx.impl_parent(impl_def_id).unwrap_or(trait_id);

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -42,6 +42,7 @@ use crate::ty::{InferConst, ParamConst};
 use crate::ty::{List, TyKind, TyS};
 use crate::util::common::ErrorReported;
 use rustc_attr as attr;
+use rustc::lint::LintDiagnosticBuilder;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::profiling::SelfProfilerRef;
 use rustc_data_structures::sharded::{IntoPointer, ShardedHashMap};
@@ -49,7 +50,6 @@ use rustc_data_structures::stable_hasher::{
     hash_stable_hashmap, HashStable, StableHasher, StableVec,
 };
 use rustc_data_structures::sync::{self, Lock, Lrc, WorkerLocal};
-use rustc_errors::DiagnosticBuilder;
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, DefIdSet, DefIndex, LOCAL_CRATE};
@@ -2551,16 +2551,6 @@ impl<'tcx> TyCtxt<'tcx> {
         iter.intern_with(|xs| self.intern_goals(xs))
     }
 
-    pub fn lint_hir(
-        self,
-        lint: &'static Lint,
-        hir_id: HirId,
-        span: impl Into<MultiSpan>,
-        msg: &str,
-    ) {
-        self.struct_span_lint_hir(lint, hir_id, span.into(), msg).emit()
-    }
-
     /// Walks upwards from `id` to find a node which might change lint levels with attributes.
     /// It stops at `bound` and just returns it if reached.
     pub fn maybe_lint_level_root_bounded(self, mut id: HirId, bound: HirId) -> HirId {
@@ -2604,20 +2594,20 @@ impl<'tcx> TyCtxt<'tcx> {
         lint: &'static Lint,
         hir_id: HirId,
         span: impl Into<MultiSpan>,
-        msg: &str,
-    ) -> DiagnosticBuilder<'tcx> {
+        decorate: impl for<'a> FnOnce(LintDiagnosticBuilder<'a>)
+    ) {
         let (level, src) = self.lint_level_at_node(lint, hir_id);
-        struct_lint_level(self.sess, lint, level, src, Some(span.into()), msg)
+        struct_lint_level(self.sess, lint, level, src, Some(span.into()), decorate);
     }
 
     pub fn struct_lint_node(
         self,
         lint: &'static Lint,
         id: HirId,
-        msg: &str,
-    ) -> DiagnosticBuilder<'tcx> {
+        decorate: impl for<'a> FnOnce(LintDiagnosticBuilder<'a>),
+    ) {
         let (level, src) = self.lint_level_at_node(lint, id);
-        struct_lint_level(self.sess, lint, level, src, None, msg)
+        struct_lint_level(self.sess, lint, level, src, None, decorate);
     }
 
     pub fn in_scope_traits(self, id: HirId) -> Option<&'tcx StableVec<TraitCandidate>> {

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -41,8 +41,8 @@ use crate::ty::{ExistentialPredicate, InferTy, ParamTy, PolyFnSig, Predicate, Pr
 use crate::ty::{InferConst, ParamConst};
 use crate::ty::{List, TyKind, TyS};
 use crate::util::common::ErrorReported;
-use rustc_attr as attr;
 use rustc::lint::LintDiagnosticBuilder;
+use rustc_attr as attr;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::profiling::SelfProfilerRef;
 use rustc_data_structures::sharded::{IntoPointer, ShardedHashMap};
@@ -2594,7 +2594,7 @@ impl<'tcx> TyCtxt<'tcx> {
         lint: &'static Lint,
         hir_id: HirId,
         span: impl Into<MultiSpan>,
-        decorate: impl for<'a> FnOnce(LintDiagnosticBuilder<'a>)
+        decorate: impl for<'a> FnOnce(LintDiagnosticBuilder<'a>),
     ) {
         let (level, src) = self.lint_level_at_node(lint, hir_id);
         struct_lint_level(self.sess, lint, level, src, Some(span.into()), decorate);

--- a/src/librustc_attr/builtin.rs
+++ b/src/librustc_attr/builtin.rs
@@ -37,7 +37,9 @@ fn handle_errors(sess: &ParseSess, span: Span, error: AttrError) {
                 .span_label(span, format!("expected one of {}", expected.join(", ")))
                 .emit();
         }
-        AttrError::MissingSince => { struct_span_err!(diag, span, E0542, "missing 'since'").emit(); },
+        AttrError::MissingSince => {
+            struct_span_err!(diag, span, E0542, "missing 'since'").emit();
+        }
         AttrError::MissingFeature => {
             struct_span_err!(diag, span, E0546, "missing 'feature'").emit();
         }

--- a/src/librustc_attr/builtin.rs
+++ b/src/librustc_attr/builtin.rs
@@ -37,7 +37,7 @@ fn handle_errors(sess: &ParseSess, span: Span, error: AttrError) {
                 .span_label(span, format!("expected one of {}", expected.join(", ")))
                 .emit();
         }
-        AttrError::MissingSince => struct_span_err!(diag, span, E0542, "missing 'since'").emit(),
+        AttrError::MissingSince => { struct_span_err!(diag, span, E0542, "missing 'since'").emit(); },
         AttrError::MissingFeature => {
             struct_span_err!(diag, span, E0546, "missing 'feature'").emit();
         }
@@ -639,7 +639,7 @@ fn gate_cfg(gated_cfg: &GatedCfg, cfg_span: Span, sess: &ParseSess, features: &F
     let (cfg, feature, has_feature) = gated_cfg;
     if !has_feature(features) && !cfg_span.allows_unstable(*feature) {
         let explain = format!("`cfg({})` is experimental and subject to change", cfg);
-        feature_err(sess, *feature, cfg_span, &explain).emit()
+        feature_err(sess, *feature, cfg_span, &explain).emit();
     }
 }
 

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -194,6 +194,7 @@ impl Diagnostic {
         found_extra: &dyn fmt::Display,
     ) -> &mut Self {
         let expected_label = format!("expected {}", expected_label);
+
         let found_label = format!("found {}", found_label);
         let (found_padding, expected_padding) = if expected_label.len() > found_label.len() {
             (expected_label.len() - found_label.len(), 0)

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -106,7 +106,11 @@ impl<'a> DiagnosticBuilder<'a> {
     ///
     /// See `emit` and `delay_as_bug` for details.
     pub fn emit_unless(&mut self, delay: bool) {
-        if delay { self.delay_as_bug(); } else { self.emit(); }
+        if delay {
+            self.delay_as_bug();
+        } else {
+            self.emit();
+        }
     }
 
     /// Stashes diagnostic for possible later improvement in a different,

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -106,7 +106,7 @@ impl<'a> DiagnosticBuilder<'a> {
     ///
     /// See `emit` and `delay_as_bug` for details.
     pub fn emit_unless(&mut self, delay: bool) {
-        if delay { self.delay_as_bug() } else { self.emit() }
+        if delay { self.delay_as_bug(); } else { self.emit(); }
     }
 
     /// Stashes diagnostic for possible later improvement in a different,
@@ -369,6 +369,7 @@ impl<'a> DiagnosticBuilder<'a> {
     /// Creates a new `DiagnosticBuilder` with an already constructed
     /// diagnostic.
     crate fn new_diagnostic(handler: &'a Handler, diagnostic: Diagnostic) -> DiagnosticBuilder<'a> {
+        debug!("Created new diagnostic");
         DiagnosticBuilder(Box::new(DiagnosticBuilderInner {
             handler,
             diagnostic,

--- a/src/librustc_expand/base.rs
+++ b/src/librustc_expand/base.rs
@@ -1113,7 +1113,11 @@ pub fn expr_to_string(
     err_msg: &str,
 ) -> Option<(Symbol, ast::StrStyle)> {
     expr_to_spanned_string(cx, expr, err_msg)
-        .map_err(|err| err.map(|mut err| { err.emit(); }))
+        .map_err(|err| {
+            err.map(|mut err| {
+                err.emit();
+            })
+        })
         .ok()
         .map(|(symbol, style, _)| (symbol, style))
 }

--- a/src/librustc_expand/base.rs
+++ b/src/librustc_expand/base.rs
@@ -1113,7 +1113,7 @@ pub fn expr_to_string(
     err_msg: &str,
 ) -> Option<(Symbol, ast::StrStyle)> {
     expr_to_spanned_string(cx, expr, err_msg)
-        .map_err(|err| err.map(|mut err| err.emit()))
+        .map_err(|err| err.map(|mut err| { err.emit(); }))
         .ok()
         .map(|(symbol, style, _)| (symbol, style))
 }

--- a/src/librustc_lint/array_into_iter.rs
+++ b/src/librustc_lint/array_into_iter.rs
@@ -77,13 +77,13 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ArrayIntoIter {
                 // to an array or to a slice.
                 _ => bug!("array type coerced to something other than array or slice"),
             };
-            let msg = format!(
+            cx.struct_span_lint(ARRAY_INTO_ITER, *span, |lint| {
+                lint.build(&format!(
                 "this method call currently resolves to `<&{} as IntoIterator>::into_iter` (due \
                     to autoref coercions), but that might change in the future when \
                     `IntoIterator` impls for arrays are added.",
                 target,
-            );
-            cx.struct_span_lint(ARRAY_INTO_ITER, *span, &msg)
+                ))
                 .span_suggestion(
                     call.ident.span,
                     "use `.iter()` instead of `.into_iter()` to avoid ambiguity",
@@ -91,6 +91,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ArrayIntoIter {
                     Applicability::MachineApplicable,
                 )
                 .emit();
+            })
         }
     }
 }

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -645,15 +645,15 @@ impl EarlyLintPass for AnonymousParameters {
                     match arg.pat.kind {
                         ast::PatKind::Ident(_, ident, None) => {
                             if ident.name == kw::Invalid {
-                                let ty_snip = cx.sess.source_map().span_to_snippet(arg.ty.span);
-
-                                let (ty_snip, appl) = if let Ok(snip) = ty_snip {
-                                    (snip, Applicability::MachineApplicable)
-                                } else {
-                                    ("<type>".to_owned(), Applicability::HasPlaceholders)
-                                };
-
                                 cx.struct_span_lint(ANONYMOUS_PARAMETERS, arg.pat.span, |lint| {
+                                    let ty_snip = cx.sess.source_map().span_to_snippet(arg.ty.span);
+
+                                    let (ty_snip, appl) = if let Ok(snip) = ty_snip {
+                                        (snip, Applicability::MachineApplicable)
+                                    } else {
+                                        ("<type>".to_owned(), Applicability::HasPlaceholders)
+                                    };
+
                                     lint.build(
                                         "anonymous parameters are deprecated and will be \
                                      removed in the next edition.",
@@ -869,8 +869,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidNoMangleItems {
                 if attr::contains_name(&it.attrs, sym::no_mangle) {
                     // Const items do not refer to a particular location in memory, and therefore
                     // don't have anything to attach a symbol to
-                    let msg = "const items should never be `#[no_mangle]`";
                     cx.struct_span_lint(NO_MANGLE_CONST_ITEMS, it.span, |lint| {
+                        let msg = "const items should never be `#[no_mangle]`";
                         let mut err = lint.build(msg);
 
                         // account for "pub const" (#45562)
@@ -910,11 +910,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MutableTransmutes {
     fn check_expr(&mut self, cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>) {
         use rustc_target::spec::abi::Abi::RustIntrinsic;
 
-        let msg = "mutating transmuted &mut T from &T may cause undefined behavior, \
-                   consider instead using an UnsafeCell";
         match get_transmute_from_to(cx, expr).map(|(ty1, ty2)| (&ty1.kind, &ty2.kind)) {
             Some((&ty::Ref(_, _, from_mt), &ty::Ref(_, _, to_mt))) => {
                 if to_mt == hir::Mutability::Mut && from_mt == hir::Mutability::Not {
+                    let msg = "mutating transmuted &mut T from &T may cause undefined behavior, \
+                               consider instead using an UnsafeCell";
                     cx.struct_span_lint(MUTABLE_TRANSMUTES, expr.span, |lint| {
                         lint.build(msg).emit()
                     });
@@ -1335,12 +1335,12 @@ impl EarlyLintPass for EllipsisInclusiveRangePatterns {
             let suggestion = "use `..=` for an inclusive range";
             if parenthesise {
                 self.node_id = Some(pat.id);
-                let end = expr_to_string(&end);
-                let replace = match start {
-                    Some(start) => format!("&({}..={})", expr_to_string(&start), end),
-                    None => format!("&(..={})", end),
-                };
                 cx.struct_span_lint(ELLIPSIS_INCLUSIVE_RANGE_PATTERNS, pat.span, |lint| {
+                    let end = expr_to_string(&end);
+                    let replace = match start {
+                        Some(start) => format!("&({}..={})", expr_to_string(&start), end),
+                        None => format!("&(..={})", end),
+                    };
                     lint.build(msg)
                         .span_suggestion(
                             pat.span,

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -80,12 +80,12 @@ impl EarlyLintPass for WhileTrue {
                         cx.struct_span_lint(WHILE_TRUE, condition_span, |lint| {
                             lint.build(msg)
                                 .span_suggestion_short(
-                                condition_span,
-                                "use `loop`",
-                                "loop".to_owned(),
-                                Applicability::MachineApplicable,
-                            )
-                            .emit();
+                                    condition_span,
+                                    "use `loop`",
+                                    "loop".to_owned(),
+                                    Applicability::MachineApplicable,
+                                )
+                                .emit();
                         })
                     }
                 }
@@ -176,31 +176,28 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonShorthandFieldPatterns {
                     if cx.tcx.find_field_index(ident, &variant)
                         == Some(cx.tcx.field_index(fieldpat.hir_id, cx.tables))
                     {
-                        cx.struct_span_lint(
-                            NON_SHORTHAND_FIELD_PATTERNS,
-                            fieldpat.span,
-                            |lint| {
-                                let mut err = lint.build(&format!("the `{}:` in this pattern is redundant", ident));
-                                let binding = match binding_annot {
-                                    hir::BindingAnnotation::Unannotated => None,
-                                    hir::BindingAnnotation::Mutable => Some("mut"),
-                                    hir::BindingAnnotation::Ref => Some("ref"),
-                                    hir::BindingAnnotation::RefMut => Some("ref mut"),
-                                };
-                                let ident = if let Some(binding) = binding {
-                                    format!("{} {}", binding, ident)
-                                } else {
-                                    ident.to_string()
-                                };
-                                err.span_suggestion(
-                                    fieldpat.span,
-                                    "use shorthand field pattern",
-                                    ident,
-                                    Applicability::MachineApplicable,
-                                );
-                                err.emit();
-                            }
-                        );
+                        cx.struct_span_lint(NON_SHORTHAND_FIELD_PATTERNS, fieldpat.span, |lint| {
+                            let mut err = lint
+                                .build(&format!("the `{}:` in this pattern is redundant", ident));
+                            let binding = match binding_annot {
+                                hir::BindingAnnotation::Unannotated => None,
+                                hir::BindingAnnotation::Mutable => Some("mut"),
+                                hir::BindingAnnotation::Ref => Some("ref"),
+                                hir::BindingAnnotation::RefMut => Some("ref mut"),
+                            };
+                            let ident = if let Some(binding) = binding {
+                                format!("{} {}", binding, ident)
+                            } else {
+                                ident.to_string()
+                            };
+                            err.span_suggestion(
+                                fieldpat.span,
+                                "use shorthand field pattern",
+                                ident,
+                                Applicability::MachineApplicable,
+                            );
+                            err.emit();
+                        });
                     }
                 }
             }
@@ -644,22 +641,20 @@ impl EarlyLintPass for AnonymousParameters {
                                     ("<type>".to_owned(), Applicability::HasPlaceholders)
                                 };
 
-                                cx.struct_span_lint(
-                                    ANONYMOUS_PARAMETERS,
-                                    arg.pat.span,
-                                    |lint| {
-                                    lint.build("anonymous parameters are deprecated and will be \
-                                     removed in the next edition.")
-                                        .span_suggestion(
-                                            arg.pat.span,
-                                            "try naming the parameter or explicitly \
+                                cx.struct_span_lint(ANONYMOUS_PARAMETERS, arg.pat.span, |lint| {
+                                    lint.build(
+                                        "anonymous parameters are deprecated and will be \
+                                     removed in the next edition.",
+                                    )
+                                    .span_suggestion(
+                                        arg.pat.span,
+                                        "try naming the parameter or explicitly \
                                             ignoring it",
-                                            format!("_: {}", ty_snip),
-                                            appl,
-                                        )
-                                        .emit();
-                                    },
-                                )
+                                        format!("_: {}", ty_snip),
+                                        appl,
+                                    )
+                                    .emit();
+                                })
                             }
                         }
                         _ => (),
@@ -838,22 +833,20 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidNoMangleItems {
                         match param.kind {
                             GenericParamKind::Lifetime { .. } => {}
                             GenericParamKind::Type { .. } | GenericParamKind::Const { .. } => {
-                                cx.struct_span_lint(
-                                    NO_MANGLE_GENERIC_ITEMS,
-                                    it.span,
-                                    |lint| {
-                                        lint.build("functions generic over types or consts must be mangled")
-                                            .span_suggestion_short(
-                                                no_mangle_attr.span,
-                                                "remove this attribute",
-                                                String::new(),
-                                                // Use of `#[no_mangle]` suggests FFI intent; correct
-                                                // fix may be to monomorphize source by hand
-                                                Applicability::MaybeIncorrect,
-                                            )
-                                            .emit();
-                                    },
-                                );
+                                cx.struct_span_lint(NO_MANGLE_GENERIC_ITEMS, it.span, |lint| {
+                                    lint.build(
+                                        "functions generic over types or consts must be mangled",
+                                    )
+                                    .span_suggestion_short(
+                                        no_mangle_attr.span,
+                                        "remove this attribute",
+                                        String::new(),
+                                        // Use of `#[no_mangle]` suggests FFI intent; correct
+                                        // fix may be to monomorphize source by hand
+                                        Applicability::MaybeIncorrect,
+                                    )
+                                    .emit();
+                                });
                                 break;
                             }
                         }
@@ -995,30 +988,26 @@ impl UnreachablePub {
                     applicability = Applicability::MaybeIncorrect;
                 }
                 let def_span = cx.tcx.sess.source_map().def_span(span);
-                cx.struct_span_lint(
-                    UNREACHABLE_PUB,
-                    def_span,
-                    |lint| {
-                        let mut err = lint.build(&format!("unreachable `pub` {}", what));
-                        let replacement = if cx.tcx.features().crate_visibility_modifier {
-                            "crate"
-                        } else {
-                            "pub(crate)"
-                        }
-                        .to_owned();
-
-                        err.span_suggestion(
-                            vis.span,
-                            "consider restricting its visibility",
-                            replacement,
-                            applicability,
-                        );
-                        if exportable {
-                            err.help("or consider exporting it for use by other crates");
-                        }
-                        err.emit();
+                cx.struct_span_lint(UNREACHABLE_PUB, def_span, |lint| {
+                    let mut err = lint.build(&format!("unreachable `pub` {}", what));
+                    let replacement = if cx.tcx.features().crate_visibility_modifier {
+                        "crate"
+                    } else {
+                        "pub(crate)"
                     }
-                );
+                    .to_owned();
+
+                    err.span_suggestion(
+                        vis.span,
+                        "consider restricting its visibility",
+                        replacement,
+                        applicability,
+                    );
+                    if exportable {
+                        err.help("or consider exporting it for use by other crates");
+                    }
+                    err.emit();
+                });
             }
             _ => {}
         }
@@ -1163,21 +1152,18 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeAliasBounds {
                 })
                 .collect();
             if !spans.is_empty() {
-                cx.struct_span_lint(
-                    TYPE_ALIAS_BOUNDS,
-                    spans,
-                    |lint| {
-                        let mut err = lint.build("bounds on generic parameters are not enforced in type aliases");
-                        let msg = "the bound will not be checked when the type alias is used, \
+                cx.struct_span_lint(TYPE_ALIAS_BOUNDS, spans, |lint| {
+                    let mut err =
+                        lint.build("bounds on generic parameters are not enforced in type aliases");
+                    let msg = "the bound will not be checked when the type alias is used, \
                                    and should be removed";
-                        err.multipart_suggestion(&msg, suggestion, Applicability::MachineApplicable);
-                        if !suggested_changing_assoc_types {
-                            TypeAliasBounds::suggest_changing_assoc_types(ty, &mut err);
-                            suggested_changing_assoc_types = true;
-                        }
-                        err.emit();
-                    },
-                );
+                    err.multipart_suggestion(&msg, suggestion, Applicability::MachineApplicable);
+                    if !suggested_changing_assoc_types {
+                        TypeAliasBounds::suggest_changing_assoc_types(ty, &mut err);
+                        suggested_changing_assoc_types = true;
+                    }
+                    err.emit();
+                });
             }
         }
     }
@@ -1356,7 +1342,7 @@ impl EarlyLintPass for EllipsisInclusiveRangePatterns {
                             join,
                             suggestion,
                             "..=".to_owned(),
-                            Applicability::MachineApplicable
+                            Applicability::MachineApplicable,
                         )
                         .emit();
                 });
@@ -1405,7 +1391,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnnameableTestItems {
         }
 
         if let Some(attr) = attr::find_by_name(&it.attrs, sym::rustc_test_marker) {
-            cx.struct_span_lint(UNNAMEABLE_TEST_ITEMS, attr.span, |lint| lint.build("cannot test inner items").emit());
+            cx.struct_span_lint(UNNAMEABLE_TEST_ITEMS, attr.span, |lint| {
+                lint.build("cannot test inner items").emit()
+            });
         }
     }
 
@@ -1486,20 +1474,16 @@ impl KeywordIdents {
             return;
         }
 
-        cx.struct_span_lint(
-            KEYWORD_IDENTS,
-            ident.span,
-            |lint| {
-                lint.build(&format!("`{}` is a keyword in the {} edition", ident, next_edition))
-                    .span_suggestion(
-                        ident.span,
-                        "you can use a raw identifier to stay compatible",
-                        format!("r#{}", ident),
-                        Applicability::MachineApplicable,
-                    )
-                    .emit()
-            },
-        );
+        cx.struct_span_lint(KEYWORD_IDENTS, ident.span, |lint| {
+            lint.build(&format!("`{}` is a keyword in the {} edition", ident, next_edition))
+                .span_suggestion(
+                    ident.span,
+                    "you can use a raw identifier to stay compatible",
+                    format!("r#{}", ident),
+                    Applicability::MachineApplicable,
+                )
+                .emit()
+        });
     }
 }
 
@@ -1803,19 +1787,22 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ExplicitOutlivesRequirements {
             }
 
             if !lint_spans.is_empty() {
-                cx.struct_span_lint(
-                    EXPLICIT_OUTLIVES_REQUIREMENTS,
-                    lint_spans.clone(),
-                    |lint| {
-                        lint.build("outlives requirements can be inferred")
-                            .multipart_suggestion(
-                                if bound_count == 1 { "remove this bound" } else { "remove these bounds" },
-                                lint_spans.into_iter().map(|span| (span, "".to_owned())).collect::<Vec<_>>(),
-                                Applicability::MachineApplicable,
-                            )
-                            .emit();
-                    },
-                );
+                cx.struct_span_lint(EXPLICIT_OUTLIVES_REQUIREMENTS, lint_spans.clone(), |lint| {
+                    lint.build("outlives requirements can be inferred")
+                        .multipart_suggestion(
+                            if bound_count == 1 {
+                                "remove this bound"
+                            } else {
+                                "remove these bounds"
+                            },
+                            lint_spans
+                                .into_iter()
+                                .map(|span| (span, "".to_owned()))
+                                .collect::<Vec<_>>(),
+                            Applicability::MachineApplicable,
+                        )
+                        .emit();
+                });
             }
         }
     }
@@ -1842,14 +1829,13 @@ impl EarlyLintPass for IncompleteFeatures {
             .chain(features.declared_lib_features.iter().map(|(name, span)| (name, span)))
             .filter(|(name, _)| rustc_feature::INCOMPLETE_FEATURES.iter().any(|f| name == &f))
             .for_each(|(name, &span)| {
-                cx.struct_span_lint(
-                    INCOMPLETE_FEATURES,
-                    span,
-                    |lint| lint.build(&format!(
+                cx.struct_span_lint(INCOMPLETE_FEATURES, span, |lint| {
+                    lint.build(&format!(
                         "the feature `{}` is incomplete and may cause the compiler to crash",
                         name,
-                    )).emit(),
-                )
+                    ))
+                    .emit()
+                })
             });
     }
 }
@@ -2039,32 +2025,28 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidValue {
             // We are extremely conservative with what we warn about.
             let conjured_ty = cx.tables.expr_ty(expr);
             if let Some((msg, span)) = ty_find_init_error(cx.tcx, conjured_ty, init) {
-                cx.struct_span_lint(
-                    INVALID_VALUE,
-                    expr.span,
-                    |lint| {
-                        let mut err = lint.build(&format!(
-                            "the type `{}` does not permit {}",
-                            conjured_ty,
-                            match init {
-                                InitKind::Zeroed => "zero-initialization",
-                                InitKind::Uninit => "being left uninitialized",
-                            },
-                        ));
-                        err.span_label(expr.span, "this code causes undefined behavior when executed");
-                        err.span_label(
-                            expr.span,
-                            "help: use `MaybeUninit<T>` instead, \
+                cx.struct_span_lint(INVALID_VALUE, expr.span, |lint| {
+                    let mut err = lint.build(&format!(
+                        "the type `{}` does not permit {}",
+                        conjured_ty,
+                        match init {
+                            InitKind::Zeroed => "zero-initialization",
+                            InitKind::Uninit => "being left uninitialized",
+                        },
+                    ));
+                    err.span_label(expr.span, "this code causes undefined behavior when executed");
+                    err.span_label(
+                        expr.span,
+                        "help: use `MaybeUninit<T>` instead, \
                             and only call `assume_init` after initialization is done",
-                        );
-                        if let Some(span) = span {
-                            err.span_note(span, &msg);
-                        } else {
-                            err.note(&msg);
-                        }
-                        err.emit();
-                    },
-                );
+                    );
+                    if let Some(span) = span {
+                        err.span_note(span, &msg);
+                    } else {
+                        err.note(&msg);
+                    }
+                    err.emit();
+                });
             }
         }
     }

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -648,10 +648,10 @@ impl EarlyLintPass for AnonymousParameters {
                                 cx.struct_span_lint(ANONYMOUS_PARAMETERS, arg.pat.span, |lint| {
                                     let ty_snip = cx.sess.source_map().span_to_snippet(arg.ty.span);
 
-                                    let (ty_snip, appl) = if let Ok(snip) = ty_snip {
-                                        (snip, Applicability::MachineApplicable)
+                                    let (ty_snip, appl) = if let Ok(ref snip) = ty_snip {
+                                        (snip.as_str(), Applicability::MachineApplicable)
                                     } else {
-                                        ("<type>".to_owned(), Applicability::HasPlaceholders)
+                                        ("<type>", Applicability::HasPlaceholders)
                                     };
 
                                     lint.build(
@@ -1132,17 +1132,17 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeAliasBounds {
         let mut suggested_changing_assoc_types = false;
         // There must not be a where clause
         if !type_alias_generics.where_clause.predicates.is_empty() {
-            let spans: Vec<_> = type_alias_generics
-                .where_clause
-                .predicates
-                .iter()
-                .map(|pred| pred.span())
-                .collect();
-            cx.struct_span_lint(
+            cx.lint(
                 TYPE_ALIAS_BOUNDS,
-                spans,
                 |lint| {
                     let mut err = lint.build("where clauses are not enforced in type aliases");
+                    let spans: Vec<_> = type_alias_generics
+                        .where_clause
+                        .predicates
+                        .iter()
+                        .map(|pred| pred.span())
+                        .collect();
+                    err.set_span(spans);
                     err.span_suggestion(
                         type_alias_generics.where_clause.span_for_predicates_or_empty_place(),
                         "the clause will not be checked when the type alias is used, and should be removed",

--- a/src/librustc_lint/context.rs
+++ b/src/librustc_lint/context.rs
@@ -20,6 +20,7 @@ use crate::levels::LintLevelsBuilder;
 use crate::passes::{EarlyLintPassObject, LateLintPassObject};
 use rustc::hir::map::definitions::{DefPathData, DisambiguatedDefPathData};
 use rustc::lint::add_elided_lifetime_in_path_suggestion;
+use rustc::lint::LintDiagnosticBuilder;
 use rustc::middle::privacy::AccessLevels;
 use rustc::middle::stability;
 use rustc::ty::layout::{LayoutError, LayoutOf, TyLayout};
@@ -27,7 +28,6 @@ use rustc::ty::{self, print::Printer, subst::GenericArg, Ty, TyCtxt};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync;
 use rustc_errors::{struct_span_err, Applicability};
-use rustc::lint::LintDiagnosticBuilder;
 use rustc_hir as hir;
 use rustc_hir::def_id::{CrateNum, DefId};
 use rustc_session::lint::BuiltinLintDiagnostics;
@@ -505,7 +505,8 @@ pub trait LintContext: Sized {
                         Ok(ref s) => {
                             // FIXME(Manishearth) ideally the emitting code
                             // can tell us whether or not this is global
-                            let opt_colon = if s.trim_start().starts_with("::") { "" } else { "::" };
+                            let opt_colon =
+                                if s.trim_start().starts_with("::") { "" } else { "::" };
 
                             (format!("crate{}{}", opt_colon, s), Applicability::MachineApplicable)
                         }
@@ -519,7 +520,9 @@ pub trait LintContext: Sized {
                         "names from parent modules are not accessible without an explicit import",
                     );
                 }
-                BuiltinLintDiagnostics::MacroExpandedMacroExportsAccessedByAbsolutePaths(span_def) => {
+                BuiltinLintDiagnostics::MacroExpandedMacroExportsAccessedByAbsolutePaths(
+                    span_def,
+                ) => {
                     db.span_note(span_def, "the macro is defined here");
                 }
                 BuiltinLintDiagnostics::ElidedLifetimesInPaths(
@@ -585,7 +588,7 @@ pub trait LintContext: Sized {
         &self,
         lint: &'static Lint,
         span: S,
-        decorate: impl for<'a> FnOnce(LintDiagnosticBuilder<'a>)
+        decorate: impl for<'a> FnOnce(LintDiagnosticBuilder<'a>),
     ) {
         self.lookup(lint, Some(span), decorate);
     }

--- a/src/librustc_lint/context.rs
+++ b/src/librustc_lint/context.rs
@@ -474,10 +474,10 @@ pub trait LintContext: Sized {
     fn sess(&self) -> &Session;
     fn lints(&self) -> &LintStore;
 
-    fn lookup_with_diagnostics<S: Into<MultiSpan>>(
+    fn lookup_with_diagnostics(
         &self,
         lint: &'static Lint,
-        span: Option<S>,
+        span: Option<impl Into<MultiSpan>>,
         decorate: impl for<'a> FnOnce(LintDiagnosticBuilder<'a>),
         diagnostic: BuiltinLintDiagnostics,
     ) {

--- a/src/librustc_lint/context.rs
+++ b/src/librustc_lint/context.rs
@@ -571,6 +571,8 @@ pub trait LintContext: Sized {
         });
     }
 
+    // FIXME: These methods should not take an Into<MultiSpan> -- instead, callers should need to
+    // set the span in their `decorate` function (preferably using set_span).
     fn lookup<S: Into<MultiSpan>>(
         &self,
         lint: &'static Lint,

--- a/src/librustc_lint/early.rs
+++ b/src/librustc_lint/early.rs
@@ -37,11 +37,12 @@ struct EarlyContextAndPass<'a, T: EarlyLintPass> {
 impl<'a, T: EarlyLintPass> EarlyContextAndPass<'a, T> {
     fn check_id(&mut self, id: ast::NodeId) {
         for early_lint in self.context.buffered.take(id) {
-            self.context.lookup_and_emit_with_diagnostics(
+            let rustc_session::lint::BufferedEarlyLint { span, msg, node_id: _, lint_id: _, diagnostic } = early_lint;
+            self.context.lookup_with_diagnostics(
                 early_lint.lint_id.lint,
-                Some(early_lint.span.clone()),
-                &early_lint.msg,
-                early_lint.diagnostic,
+                Some(span),
+                |lint| lint.build(&msg).emit(),
+                diagnostic,
             );
         }
     }

--- a/src/librustc_lint/early.rs
+++ b/src/librustc_lint/early.rs
@@ -37,7 +37,13 @@ struct EarlyContextAndPass<'a, T: EarlyLintPass> {
 impl<'a, T: EarlyLintPass> EarlyContextAndPass<'a, T> {
     fn check_id(&mut self, id: ast::NodeId) {
         for early_lint in self.context.buffered.take(id) {
-            let rustc_session::lint::BufferedEarlyLint { span, msg, node_id: _, lint_id: _, diagnostic } = early_lint;
+            let rustc_session::lint::BufferedEarlyLint {
+                span,
+                msg,
+                node_id: _,
+                lint_id: _,
+                diagnostic,
+            } = early_lint;
             self.context.lookup_with_diagnostics(
                 early_lint.lint_id.lint,
                 Some(span),

--- a/src/librustc_lint/early.rs
+++ b/src/librustc_lint/early.rs
@@ -41,11 +41,11 @@ impl<'a, T: EarlyLintPass> EarlyContextAndPass<'a, T> {
                 span,
                 msg,
                 node_id: _,
-                lint_id: _,
+                lint_id,
                 diagnostic,
             } = early_lint;
             self.context.lookup_with_diagnostics(
-                early_lint.lint_id.lint,
+                lint_id.lint,
                 Some(span),
                 |lint| lint.build(&msg).emit(),
                 diagnostic,

--- a/src/librustc_lint/internal.rs
+++ b/src/librustc_lint/internal.rs
@@ -47,7 +47,10 @@ impl EarlyLintPass for DefaultHashTypes {
                         replace.to_string(),
                         Applicability::MaybeIncorrect, // FxHashMap, ... needs another import
                     )
-                    .note(&format!("a `use rustc_data_structures::fx::{}` may be necessary", replace))
+                    .note(&format!(
+                        "a `use rustc_data_structures::fx::{}` may be necessary",
+                        replace
+                    ))
                     .emit();
             });
         }
@@ -90,13 +93,13 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TyTyKind {
             if lint_ty_kind_usage(cx, last) {
                 cx.struct_span_lint(USAGE_OF_TY_TYKIND, span, |lint| {
                     lint.build("usage of `ty::TyKind::<kind>`")
-                    .span_suggestion(
-                        span,
-                        "try using ty::<kind> directly",
-                        "ty".to_string(),
-                        Applicability::MaybeIncorrect, // ty maybe needs an import
-                    )
-                    .emit();
+                        .span_suggestion(
+                            span,
+                            "try using ty::<kind> directly",
+                            "ty".to_string(),
+                            Applicability::MaybeIncorrect, // ty maybe needs an import
+                        )
+                        .emit();
                 })
             }
         }
@@ -108,36 +111,28 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TyTyKind {
                 if let QPath::Resolved(_, path) = qpath {
                     if let Some(last) = path.segments.iter().last() {
                         if lint_ty_kind_usage(cx, last) {
-                            cx.struct_span_lint(
-                                USAGE_OF_TY_TYKIND,
-                                path.span,
-                                |lint| {
-                                    lint.build("usage of `ty::TyKind`")
-                                        .help("try using `Ty` instead")
-                                        .emit();
-                                },
-                            )
+                            cx.struct_span_lint(USAGE_OF_TY_TYKIND, path.span, |lint| {
+                                lint.build("usage of `ty::TyKind`")
+                                    .help("try using `Ty` instead")
+                                    .emit();
+                            })
                         } else {
                             if ty.span.from_expansion() {
                                 return;
                             }
                             if let Some(t) = is_ty_or_ty_ctxt(cx, ty) {
                                 if path.segments.len() > 1 {
-                                    cx.struct_span_lint(
-                                        USAGE_OF_QUALIFIED_TY,
-                                        path.span,
-                                        |lint| {
-                                            lint.build(&format!("usage of qualified `ty::{}`", t))
-                                                .span_suggestion(
-                                                    path.span,
-                                                    "try using it unqualified",
-                                                    t,
-                                                    // The import probably needs to be changed
-                                                    Applicability::MaybeIncorrect,
-                                                )
-                                                .emit();
-                                        },
-                                    )
+                                    cx.struct_span_lint(USAGE_OF_QUALIFIED_TY, path.span, |lint| {
+                                        lint.build(&format!("usage of qualified `ty::{}`", t))
+                                            .span_suggestion(
+                                                path.span,
+                                                "try using it unqualified",
+                                                t,
+                                                // The import probably needs to be changed
+                                                Applicability::MaybeIncorrect,
+                                            )
+                                            .emit();
+                                    })
                                 }
                             }
                         }
@@ -151,11 +146,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TyTyKind {
                     }
                 }
                 if let Some(t) = is_ty_or_ty_ctxt(cx, &inner_ty) {
-                    cx.struct_span_lint(
-                        TY_PASS_BY_REFERENCE,
-                        ty.span,
-                        |lint| {
-                            lint.build(&format!("passing `{}` by reference", t))
+                    cx.struct_span_lint(TY_PASS_BY_REFERENCE, ty.span, |lint| {
+                        lint.build(&format!("passing `{}` by reference", t))
                             .span_suggestion(
                                 ty.span,
                                 "try passing by value",
@@ -164,8 +156,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TyTyKind {
                                 Applicability::MaybeIncorrect,
                             )
                             .emit();
-                        },
-                    )
+                    })
                 }
             }
             _ => {}

--- a/src/librustc_lint/internal.rs
+++ b/src/librustc_lint/internal.rs
@@ -37,16 +37,19 @@ impl_lint_pass!(DefaultHashTypes => [DEFAULT_HASH_TYPES]);
 impl EarlyLintPass for DefaultHashTypes {
     fn check_ident(&mut self, cx: &EarlyContext<'_>, ident: Ident) {
         if let Some(replace) = self.map.get(&ident.name) {
+            // FIXME: We can avoid a copy here. Would require us to take String instead of &str.
             let msg = format!("Prefer {} over {}, it has better performance", replace, ident);
-            let mut db = cx.struct_span_lint(DEFAULT_HASH_TYPES, ident.span, &msg);
-            db.span_suggestion(
-                ident.span,
-                "use",
-                replace.to_string(),
-                Applicability::MaybeIncorrect, // FxHashMap, ... needs another import
-            );
-            db.note(&format!("a `use rustc_data_structures::fx::{}` may be necessary", replace))
-                .emit();
+            cx.struct_span_lint(DEFAULT_HASH_TYPES, ident.span, |lint| {
+                lint.build(&msg)
+                    .span_suggestion(
+                        ident.span,
+                        "use",
+                        replace.to_string(),
+                        Applicability::MaybeIncorrect, // FxHashMap, ... needs another import
+                    )
+                    .note(&format!("a `use rustc_data_structures::fx::{}` may be necessary", replace))
+                    .emit();
+            });
         }
     }
 }
@@ -85,7 +88,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TyTyKind {
         if let Some(last) = segments.last() {
             let span = path.span.with_hi(last.ident.span.hi());
             if lint_ty_kind_usage(cx, last) {
-                cx.struct_span_lint(USAGE_OF_TY_TYKIND, span, "usage of `ty::TyKind::<kind>`")
+                cx.struct_span_lint(USAGE_OF_TY_TYKIND, span, |lint| {
+                    lint.build("usage of `ty::TyKind::<kind>`")
                     .span_suggestion(
                         span,
                         "try using ty::<kind> directly",
@@ -93,6 +97,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TyTyKind {
                         Applicability::MaybeIncorrect, // ty maybe needs an import
                     )
                     .emit();
+                })
             }
         }
     }
@@ -106,10 +111,12 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TyTyKind {
                             cx.struct_span_lint(
                                 USAGE_OF_TY_TYKIND,
                                 path.span,
-                                "usage of `ty::TyKind`",
+                                |lint| {
+                                    lint.build("usage of `ty::TyKind`")
+                                        .help("try using `Ty` instead")
+                                        .emit();
+                                },
                             )
-                            .help("try using `Ty` instead")
-                            .emit();
                         } else {
                             if ty.span.from_expansion() {
                                 return;
@@ -119,16 +126,18 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TyTyKind {
                                     cx.struct_span_lint(
                                         USAGE_OF_QUALIFIED_TY,
                                         path.span,
-                                        &format!("usage of qualified `ty::{}`", t),
+                                        |lint| {
+                                            lint.build(&format!("usage of qualified `ty::{}`", t))
+                                                .span_suggestion(
+                                                    path.span,
+                                                    "try using it unqualified",
+                                                    t,
+                                                    // The import probably needs to be changed
+                                                    Applicability::MaybeIncorrect,
+                                                )
+                                                .emit();
+                                        },
                                     )
-                                    .span_suggestion(
-                                        path.span,
-                                        "try using it unqualified",
-                                        t,
-                                        // The import probably needs to be changed
-                                        Applicability::MaybeIncorrect,
-                                    )
-                                    .emit();
                                 }
                             }
                         }
@@ -145,16 +154,18 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TyTyKind {
                     cx.struct_span_lint(
                         TY_PASS_BY_REFERENCE,
                         ty.span,
-                        &format!("passing `{}` by reference", t),
+                        |lint| {
+                            lint.build(&format!("passing `{}` by reference", t))
+                            .span_suggestion(
+                                ty.span,
+                                "try passing by value",
+                                t,
+                                // Changing type of function argument
+                                Applicability::MaybeIncorrect,
+                            )
+                            .emit();
+                        },
                     )
-                    .span_suggestion(
-                        ty.span,
-                        "try passing by value",
-                        t,
-                        // Changing type of function argument
-                        Applicability::MaybeIncorrect,
-                    )
-                    .emit();
                 }
             }
             _ => {}
@@ -234,10 +245,12 @@ impl EarlyLintPass for LintPassImpl {
                         cx.struct_span_lint(
                             LINT_PASS_IMPL_WITHOUT_MACRO,
                             lint_pass.path.span,
-                            "implementing `LintPass` by hand",
+                            |lint| {
+                                lint.build("implementing `LintPass` by hand")
+                                    .help("try using `declare_lint_pass!` or `impl_lint_pass!` instead")
+                                    .emit();
+                            },
                         )
-                        .help("try using `declare_lint_pass!` or `impl_lint_pass!` instead")
-                        .emit();
                     }
                 }
             }

--- a/src/librustc_lint/internal.rs
+++ b/src/librustc_lint/internal.rs
@@ -37,9 +37,9 @@ impl_lint_pass!(DefaultHashTypes => [DEFAULT_HASH_TYPES]);
 impl EarlyLintPass for DefaultHashTypes {
     fn check_ident(&mut self, cx: &EarlyContext<'_>, ident: Ident) {
         if let Some(replace) = self.map.get(&ident.name) {
-            // FIXME: We can avoid a copy here. Would require us to take String instead of &str.
-            let msg = format!("Prefer {} over {}, it has better performance", replace, ident);
             cx.struct_span_lint(DEFAULT_HASH_TYPES, ident.span, |lint| {
+                // FIXME: We can avoid a copy here. Would require us to take String instead of &str.
+                let msg = format!("Prefer {} over {}, it has better performance", replace, ident);
                 lint.build(&msg)
                     .span_suggestion(
                         ident.span,

--- a/src/librustc_lint/levels.rs
+++ b/src/librustc_lint/levels.rs
@@ -1,13 +1,13 @@
 use crate::context::{CheckLintNameResult, LintStore};
 use crate::late::unerased_lint_store;
 use rustc::hir::map::Map;
+use rustc::lint::LintDiagnosticBuilder;
 use rustc::lint::{struct_lint_level, LintLevelMap, LintLevelSets, LintSet, LintSource};
 use rustc::ty::query::Providers;
 use rustc::ty::TyCtxt;
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::{struct_span_err, Applicability};
-use rustc::lint::LintDiagnosticBuilder;
 use rustc_hir as hir;
 use rustc_hir::def_id::{CrateNum, LOCAL_CRATE};
 use rustc_hir::{intravisit, HirId};
@@ -248,13 +248,13 @@ impl<'s> LintLevelsBuilder<'s> {
                                     Some(li.span().into()),
                                     |lint| {
                                         lint.build(&msg)
-                                        .span_suggestion(
-                                            li.span(),
-                                            "change it to",
-                                            new_lint_name.to_string(),
-                                            Applicability::MachineApplicable,
-                                        )
-                                        .emit();
+                                            .span_suggestion(
+                                                li.span(),
+                                                "change it to",
+                                                new_lint_name.to_string(),
+                                                Applicability::MachineApplicable,
+                                            )
+                                            .emit();
                                     },
                                 );
 
@@ -326,7 +326,6 @@ impl<'s> LintLevelsBuilder<'s> {
                                 db.emit();
                             },
                         );
-
                     }
                 }
             }

--- a/src/librustc_lint/levels.rs
+++ b/src/librustc_lint/levels.rs
@@ -234,12 +234,6 @@ impl<'s> LintLevelsBuilder<'s> {
                                 let lint = builtin::RENAMED_AND_REMOVED_LINTS;
                                 let (lvl, src) =
                                     self.sets.get_lint_level(lint, self.cur, Some(&specs), &sess);
-                                let msg = format!(
-                                    "lint name `{}` is deprecated \
-                                     and may not have an effect in the future. \
-                                     Also `cfg_attr(cargo-clippy)` won't be necessary anymore",
-                                    name
-                                );
                                 struct_lint_level(
                                     self.sess,
                                     lint,
@@ -247,6 +241,12 @@ impl<'s> LintLevelsBuilder<'s> {
                                     src,
                                     Some(li.span().into()),
                                     |lint| {
+                                        let msg = format!(
+                                            "lint name `{}` is deprecated \
+                                             and may not have an effect in the future. \
+                                             Also `cfg_attr(cargo-clippy)` won't be necessary anymore",
+                                            name
+                                        );
                                         lint.build(&msg)
                                             .span_suggestion(
                                                 li.span(),
@@ -306,7 +306,6 @@ impl<'s> LintLevelsBuilder<'s> {
                         let lint = builtin::UNKNOWN_LINTS;
                         let (level, src) =
                             self.sets.get_lint_level(lint, self.cur, Some(&specs), self.sess);
-                        let msg = format!("unknown lint: `{}`", name);
                         struct_lint_level(
                             self.sess,
                             lint,
@@ -314,7 +313,7 @@ impl<'s> LintLevelsBuilder<'s> {
                             src,
                             Some(li.span().into()),
                             |lint| {
-                                let mut db = lint.build(&msg);
+                                let mut db = lint.build(&format!("unknown lint: `{}`", name));
                                 if let Some(suggestion) = suggestion {
                                     db.span_suggestion(
                                         li.span(),

--- a/src/librustc_lint/non_ascii_idents.rs
+++ b/src/librustc_lint/non_ascii_idents.rs
@@ -25,16 +25,14 @@ impl EarlyLintPass for NonAsciiIdents {
         cx.struct_span_lint(
             NON_ASCII_IDENTS,
             ident.span,
-            "identifier contains non-ASCII characters",
-        )
-        .emit();
+            |lint| lint.build("identifier contains non-ASCII characters").emit(),
+        );
         if !name_str.chars().all(GeneralSecurityProfile::identifier_allowed) {
             cx.struct_span_lint(
                 UNCOMMON_CODEPOINTS,
                 ident.span,
-                "identifier contains uncommon Unicode codepoints",
+                |lint| lint.build("identifier contains uncommon Unicode codepoints").emit(),
             )
-            .emit();
         }
     }
 }

--- a/src/librustc_lint/non_ascii_idents.rs
+++ b/src/librustc_lint/non_ascii_idents.rs
@@ -22,17 +22,13 @@ impl EarlyLintPass for NonAsciiIdents {
         if name_str.is_ascii() {
             return;
         }
-        cx.struct_span_lint(
-            NON_ASCII_IDENTS,
-            ident.span,
-            |lint| lint.build("identifier contains non-ASCII characters").emit(),
-        );
+        cx.struct_span_lint(NON_ASCII_IDENTS, ident.span, |lint| {
+            lint.build("identifier contains non-ASCII characters").emit()
+        });
         if !name_str.chars().all(GeneralSecurityProfile::identifier_allowed) {
-            cx.struct_span_lint(
-                UNCOMMON_CODEPOINTS,
-                ident.span,
-                |lint| lint.build("identifier contains uncommon Unicode codepoints").emit(),
-            )
+            cx.struct_span_lint(UNCOMMON_CODEPOINTS, ident.span, |lint| {
+                lint.build("identifier contains uncommon Unicode codepoints").emit()
+            })
         }
     }
 }

--- a/src/librustc_lint/nonstandard_style.rs
+++ b/src/librustc_lint/nonstandard_style.rs
@@ -107,8 +107,8 @@ impl NonCamelCaseTypes {
         let name = &ident.name.as_str();
 
         if !is_camel_case(name) {
-            let msg = format!("{} `{}` should have an upper camel case name", sort, name);
             cx.struct_span_lint(NON_CAMEL_CASE_TYPES, ident.span, |lint| {
+                let msg = format!("{} `{}` should have an upper camel case name", sort, name);
                 lint.build(&msg)
                     .span_suggestion(
                         ident.span,
@@ -227,8 +227,8 @@ impl NonSnakeCase {
         if !is_snake_case(name) {
             let sc = NonSnakeCase::to_snake_case(name);
 
-            let msg = format!("{} `{}` should have a snake case name", sort, name);
             cx.struct_span_lint(NON_SNAKE_CASE, ident.span, |lint| {
+                let msg = format!("{} `{}` should have a snake case name", sort, name);
                 let mut err = lint.build(&msg);
                 // We have a valid span in almost all cases, but we don't have one when linting a crate
                 // name provided via the command line.
@@ -389,11 +389,9 @@ declare_lint_pass!(NonUpperCaseGlobals => [NON_UPPER_CASE_GLOBALS]);
 impl NonUpperCaseGlobals {
     fn check_upper_case(cx: &LateContext<'_, '_>, sort: &str, ident: &Ident) {
         let name = &ident.name.as_str();
-
         if name.chars().any(|c| c.is_lowercase()) {
-            let uc = NonSnakeCase::to_snake_case(&name).to_uppercase();
-
             cx.struct_span_lint(NON_UPPER_CASE_GLOBALS, ident.span, |lint| {
+                let uc = NonSnakeCase::to_snake_case(&name).to_uppercase();
                 lint.build(&format!("{} `{}` should have an upper case name", sort, name))
                     .span_suggestion(
                         ident.span,

--- a/src/librustc_lint/nonstandard_style.rs
+++ b/src/librustc_lint/nonstandard_style.rs
@@ -109,12 +109,14 @@ impl NonCamelCaseTypes {
         if !is_camel_case(name) {
             let msg = format!("{} `{}` should have an upper camel case name", sort, name);
             cx.struct_span_lint(NON_CAMEL_CASE_TYPES, ident.span, |lint| {
-                lint.build(&msg).span_suggestion(
-                    ident.span,
-                    "convert the identifier to upper camel case",
-                    to_camel_case(name),
-                    Applicability::MaybeIncorrect,
-                ).emit()
+                lint.build(&msg)
+                    .span_suggestion(
+                        ident.span,
+                        "convert the identifier to upper camel case",
+                        to_camel_case(name),
+                        Applicability::MaybeIncorrect,
+                    )
+                    .emit()
             })
         }
     }
@@ -243,7 +245,6 @@ impl NonSnakeCase {
 
                 err.emit();
             });
-
         }
     }
 }
@@ -394,13 +395,13 @@ impl NonUpperCaseGlobals {
 
             cx.struct_span_lint(NON_UPPER_CASE_GLOBALS, ident.span, |lint| {
                 lint.build(&format!("{} `{}` should have an upper case name", sort, name))
-                .span_suggestion(
-                    ident.span,
-                    "convert the identifier to upper case",
-                    uc,
-                    Applicability::MaybeIncorrect,
-                )
-                .emit();
+                    .span_suggestion(
+                        ident.span,
+                        "convert the identifier to upper case",
+                        uc,
+                        Applicability::MaybeIncorrect,
+                    )
+                    .emit();
             })
         }
     }

--- a/src/librustc_lint/nonstandard_style.rs
+++ b/src/librustc_lint/nonstandard_style.rs
@@ -225,9 +225,8 @@ impl NonSnakeCase {
         let name = &ident.name.as_str();
 
         if !is_snake_case(name) {
-            let sc = NonSnakeCase::to_snake_case(name);
-
             cx.struct_span_lint(NON_SNAKE_CASE, ident.span, |lint| {
+                let sc = NonSnakeCase::to_snake_case(name);
                 let msg = format!("{} `{}` should have a snake case name", sort, name);
                 let mut err = lint.build(&msg);
                 // We have a valid span in almost all cases, but we don't have one when linting a crate

--- a/src/librustc_lint/redundant_semicolon.rs
+++ b/src/librustc_lint/redundant_semicolon.rs
@@ -26,19 +26,21 @@ impl EarlyLintPass for RedundantSemicolon {
                             } else {
                                 "unnecessary trailing semicolon"
                             };
-                            let mut err = cx.struct_span_lint(REDUNDANT_SEMICOLON, stmt.span, &msg);
-                            let suggest_msg = if multiple {
-                                "remove these semicolons"
-                            } else {
-                                "remove this semicolon"
-                            };
-                            err.span_suggestion(
-                                stmt.span,
-                                &suggest_msg,
-                                String::new(),
-                                Applicability::MaybeIncorrect,
-                            );
-                            err.emit();
+                            cx.struct_span_lint(REDUNDANT_SEMICOLON, stmt.span, |lint| {
+                                let mut err = lint.build(&msg);
+                                let suggest_msg = if multiple {
+                                    "remove these semicolons"
+                                } else {
+                                    "remove this semicolon"
+                                };
+                                err.span_suggestion(
+                                    stmt.span,
+                                    &suggest_msg,
+                                    String::new(),
+                                    Applicability::MaybeIncorrect,
+                                );
+                                err.emit();
+                            });
                         }
                     }
                 }

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -266,10 +266,10 @@ fn lint_int_literal<'a, 'tcx>(
             }
         }
 
-        cx.span_lint(
+        cx.struct_span_lint(
             OVERFLOWING_LITERALS,
             e.span,
-            &format!("literal out of range for `{}`", t.name_str()),
+            |lint| lint.build(&format!("literal out of range for `{}`", t.name_str())).emit(),
         );
     }
 }
@@ -321,10 +321,10 @@ fn lint_uint_literal<'a, 'tcx>(
             report_bin_hex_error(cx, e, attr::IntType::UnsignedInt(t), repr_str, lit_val, false);
             return;
         }
-        cx.span_lint(
+        cx.struct_span_lint(
             OVERFLOWING_LITERALS,
             e.span,
-            &format!("literal out of range for `{}`", t.name_str()),
+            |lint| lint.build(&format!("literal out of range for `{}`", t.name_str())).emit(),
         );
     }
 }
@@ -355,10 +355,10 @@ fn lint_literal<'a, 'tcx>(
                 _ => bug!(),
             };
             if is_infinite == Ok(true) {
-                cx.span_lint(
+                cx.struct_span_lint(
                     OVERFLOWING_LITERALS,
                     e.span,
-                    &format!("literal out of range for `{}`", t.name_str()),
+                    |lint| lint.build(&format!("literal out of range for `{}`", t.name_str())).emit(),
                 );
             }
         }
@@ -377,10 +377,10 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
             }
             hir::ExprKind::Binary(binop, ref l, ref r) => {
                 if is_comparison(binop) && !check_limits(cx, binop, &l, &r) {
-                    cx.span_lint(
+                    cx.struct_span_lint(
                         UNUSED_COMPARISONS,
                         e.span,
-                        "comparison is useless due to type limits",
+                        |lint| lint.build("comparison is useless due to type limits").emit(),
                     );
                 }
             }
@@ -1055,14 +1055,14 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for VariantSizeDifferences {
             // We only warn if the largest variant is at least thrice as large as
             // the second-largest.
             if largest > slargest * 3 && slargest > 0 {
-                cx.span_lint(
+                cx.struct_span_lint(
                     VARIANT_SIZE_DIFFERENCES,
                     enum_definition.variants[largest_index].span,
-                    &format!(
+                    |lint| lint.build(&format!(
                         "enum variant is more than three times \
                                           larger ({} bytes) than the next largest",
                         largest
-                    ),
+                    )).emit(),
                 );
             }
         }

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -266,11 +266,9 @@ fn lint_int_literal<'a, 'tcx>(
             }
         }
 
-        cx.struct_span_lint(
-            OVERFLOWING_LITERALS,
-            e.span,
-            |lint| lint.build(&format!("literal out of range for `{}`", t.name_str())).emit(),
-        );
+        cx.struct_span_lint(OVERFLOWING_LITERALS, e.span, |lint| {
+            lint.build(&format!("literal out of range for `{}`", t.name_str())).emit()
+        });
     }
 }
 
@@ -321,11 +319,9 @@ fn lint_uint_literal<'a, 'tcx>(
             report_bin_hex_error(cx, e, attr::IntType::UnsignedInt(t), repr_str, lit_val, false);
             return;
         }
-        cx.struct_span_lint(
-            OVERFLOWING_LITERALS,
-            e.span,
-            |lint| lint.build(&format!("literal out of range for `{}`", t.name_str())).emit(),
-        );
+        cx.struct_span_lint(OVERFLOWING_LITERALS, e.span, |lint| {
+            lint.build(&format!("literal out of range for `{}`", t.name_str())).emit()
+        });
     }
 }
 
@@ -355,11 +351,9 @@ fn lint_literal<'a, 'tcx>(
                 _ => bug!(),
             };
             if is_infinite == Ok(true) {
-                cx.struct_span_lint(
-                    OVERFLOWING_LITERALS,
-                    e.span,
-                    |lint| lint.build(&format!("literal out of range for `{}`", t.name_str())).emit(),
-                );
+                cx.struct_span_lint(OVERFLOWING_LITERALS, e.span, |lint| {
+                    lint.build(&format!("literal out of range for `{}`", t.name_str())).emit()
+                });
             }
         }
         _ => {}
@@ -377,11 +371,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
             }
             hir::ExprKind::Binary(binop, ref l, ref r) => {
                 if is_comparison(binop) && !check_limits(cx, binop, &l, &r) {
-                    cx.struct_span_lint(
-                        UNUSED_COMPARISONS,
-                        e.span,
-                        |lint| lint.build("comparison is useless due to type limits").emit(),
-                    );
+                    cx.struct_span_lint(UNUSED_COMPARISONS, e.span, |lint| {
+                        lint.build("comparison is useless due to type limits").emit()
+                    });
                 }
             }
             hir::ExprKind::Lit(ref lit) => lint_literal(cx, self, e, lit),
@@ -1058,11 +1050,14 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for VariantSizeDifferences {
                 cx.struct_span_lint(
                     VARIANT_SIZE_DIFFERENCES,
                     enum_definition.variants[largest_index].span,
-                    |lint| lint.build(&format!(
-                        "enum variant is more than three times \
+                    |lint| {
+                        lint.build(&format!(
+                            "enum variant is more than three times \
                                           larger ({} bytes) than the next largest",
-                        largest
-                    )).emit(),
+                            largest
+                        ))
+                        .emit()
+                    },
                 );
             }
         }

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -151,17 +151,17 @@ fn report_bin_hex_error(
     negative: bool,
 ) {
     let size = layout::Integer::from_attr(&cx.tcx, ty).size();
-    let (t, actually) = match ty {
-        attr::IntType::SignedInt(t) => {
-            let actually = sign_extend(val, size) as i128;
-            (t.name_str(), actually.to_string())
-        }
-        attr::IntType::UnsignedInt(t) => {
-            let actually = truncate(val, size);
-            (t.name_str(), actually.to_string())
-        }
-    };
     cx.struct_span_lint(OVERFLOWING_LITERALS, expr.span, |lint| {
+        let (t, actually) = match ty {
+            attr::IntType::SignedInt(t) => {
+                let actually = sign_extend(val, size) as i128;
+                (t.name_str(), actually.to_string())
+            }
+            attr::IntType::UnsignedInt(t) => {
+                let actually = truncate(val, size);
+                (t.name_str(), actually.to_string())
+            }
+        };
         let mut err = lint.build(&format!("literal out of range for {}", t));
         err.note(&format!(
             "the literal `{}` (decimal `{}`) does not fit into \

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -202,6 +202,10 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
         }
 
         // Returns whether an error has been emitted (and thus another does not need to be later).
+        // FIXME: Args desc_{pre,post}_path could be made lazy by taking Fn() -> &str, but this
+        // would make calling it a big awkward. Could also take String (so args are moved), but
+        // this would still require a copy into the format string, which would only be executed
+        // when needed.
         fn check_must_use_def(
             cx: &LateContext<'_, '_>,
             def_id: DefId,

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -104,11 +104,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
         };
 
         if let Some(must_use_op) = must_use_op {
-            cx.struct_span_lint(
-                UNUSED_MUST_USE,
-                expr.span,
-                |lint| lint.build(&format!("unused {} that must be used", must_use_op)).emit(),
-            );
+            cx.struct_span_lint(UNUSED_MUST_USE, expr.span, |lint| {
+                lint.build(&format!("unused {} that must be used", must_use_op)).emit()
+            });
             op_warned = true;
         }
 
@@ -247,7 +245,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for PathStatements {
     fn check_stmt(&mut self, cx: &LateContext<'_, '_>, s: &hir::Stmt<'_>) {
         if let hir::StmtKind::Semi(ref expr) = s.kind {
             if let hir::ExprKind::Path(_) = expr.kind {
-                cx.struct_span_lint(PATH_STATEMENTS, s.span, |lint| lint.build("path statement with no effect").emit());
+                cx.struct_span_lint(PATH_STATEMENTS, s.span, |lint| {
+                    lint.build("path statement with no effect").emit()
+                });
             }
         }
     }
@@ -288,7 +288,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedAttributes {
 
         if !attr::is_used(attr) {
             debug!("emitting warning for: {:?}", attr);
-            cx.struct_span_lint(UNUSED_ATTRIBUTES, attr.span, |lint| lint.build("unused attribute").emit());
+            cx.struct_span_lint(UNUSED_ATTRIBUTES, attr.span, |lint| {
+                lint.build("unused attribute").emit()
+            });
             // Is it a builtin attribute that must be used at the crate level?
             if attr_info.map_or(false, |(_, ty, ..)| ty == &AttributeType::CrateLevel) {
                 cx.struct_span_lint(UNUSED_ATTRIBUTES, attr.span, |lint| {
@@ -637,9 +639,9 @@ impl UnusedImportBraces {
                 ast::UseTreeKind::Nested(_) => return,
             };
 
-            cx.struct_span_lint(UNUSED_IMPORT_BRACES, item.span, |lint|
-            lint.build(&format!("braces around {} is unnecessary", node_name)).emit()
-            );
+            cx.struct_span_lint(UNUSED_IMPORT_BRACES, item.span, |lint| {
+                lint.build(&format!("braces around {} is unnecessary", node_name)).emit()
+            });
         }
     }
 }

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -379,12 +379,8 @@ fn do_mir_borrowck<'a, 'tcx>(
         }
 
         let mut_span = tcx.sess.source_map().span_until_non_whitespace(span);
-        tcx.struct_span_lint_hir(
-            UNUSED_MUT,
-            lint_root,
-            span,
-            |lint| {
-                lint.build("variable does not need to be mutable")
+        tcx.struct_span_lint_hir(UNUSED_MUT, lint_root, span, |lint| {
+            lint.build("variable does not need to be mutable")
                 .span_suggestion_short(
                     mut_span,
                     "remove this `mut`",
@@ -392,8 +388,7 @@ fn do_mir_borrowck<'a, 'tcx>(
                     Applicability::MachineApplicable,
                 )
                 .emit();
-            },
-        )
+        })
     }
 
     // Buffer any move errors that we collected and de-duplicated.

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -378,8 +378,8 @@ fn do_mir_borrowck<'a, 'tcx>(
             continue;
         }
 
-        let mut_span = tcx.sess.source_map().span_until_non_whitespace(span);
         tcx.struct_span_lint_hir(UNUSED_MUT, lint_root, span, |lint| {
+            let mut_span = tcx.sess.source_map().span_until_non_whitespace(span);
             lint.build("variable does not need to be mutable")
                 .span_suggestion_short(
                     mut_span,

--- a/src/librustc_mir/const_eval/eval_queries.rs
+++ b/src/librustc_mir/const_eval/eval_queries.rs
@@ -213,9 +213,7 @@ fn validate_and_turn_into_const<'tcx>(
             diag.note(note_on_undefined_behavior_error());
             diag.emit();
         }) {
-            Ok(_) => {
-                ErrorHandled::Reported
-            }
+            Ok(_) => ErrorHandled::Reported,
             Err(err) => err,
         }
     })

--- a/src/librustc_mir/const_eval/eval_queries.rs
+++ b/src/librustc_mir/const_eval/eval_queries.rs
@@ -209,10 +209,11 @@ fn validate_and_turn_into_const<'tcx>(
 
     val.map_err(|error| {
         let err = error_to_const_error(&ecx, error);
-        match err.struct_error(ecx.tcx, "it is undefined behavior to use this value") {
-            Ok(mut diag) => {
-                diag.note(note_on_undefined_behavior_error());
-                diag.emit();
+        match err.struct_error(ecx.tcx, "it is undefined behavior to use this value", |mut diag| {
+            diag.note(note_on_undefined_behavior_error());
+            diag.emit();
+        }) {
+            Ok(_) => {
                 ErrorHandled::Reported
             }
             Err(err) => err,

--- a/src/librustc_mir/interpret/intern.rs
+++ b/src/librustc_mir/interpret/intern.rs
@@ -326,12 +326,15 @@ pub fn intern_const_alloc_recursive<M: CompileTimeMachine<'mir, 'tcx>>(
             // to read enum discriminants in order to find references in enum variant fields.
             if let err_unsup!(ValidationFailure(_)) = error.kind {
                 let err = crate::const_eval::error_to_const_error(&ecx, error);
-                match err.struct_error(ecx.tcx, "it is undefined behavior to use this value") {
-                    Ok(mut diag) => {
+                match err.struct_error(
+                    ecx.tcx,
+                    "it is undefined behavior to use this value",
+                    |mut diag| {
                         diag.note(crate::const_eval::note_on_undefined_behavior_error());
                         diag.emit();
-                    }
-                    Err(ErrorHandled::TooGeneric) | Err(ErrorHandled::Reported) => {}
+                    },
+                ) {
+                    Ok(()) | Err(ErrorHandled::TooGeneric) | Err(ErrorHandled::Reported) => {}
                 }
             }
         }

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -624,15 +624,13 @@ pub fn check_unsafety(tcx: TyCtxt<'_>, def_id: DefId) {
                         lint_hir_id,
                         source_info.span,
                         |lint| {
-                            lint.build(
-                                &format!(
-                                    "{} is unsafe and requires unsafe function or block (error E0133)",
-                                    description
-                                )
-                            )
+                            lint.build(&format!(
+                                "{} is unsafe and requires unsafe function or block (error E0133)",
+                                description
+                            ))
                             .note(&details.as_str())
                             .emit()
-                        }
+                        },
                     )
                 }
             }

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -516,18 +516,18 @@ fn unsafe_derive_on_repr_packed(tcx: TyCtxt<'_>, def_id: DefId) {
         .as_local_hir_id(def_id)
         .unwrap_or_else(|| bug!("checking unsafety for non-local def id {:?}", def_id));
 
-    // FIXME: when we make this a hard error, this should have its
-    // own error code.
-    let message = if tcx.generics_of(def_id).own_requires_monomorphization() {
-        "`#[derive]` can't be used on a `#[repr(packed)]` struct with \
-         type or const parameters (error E0133)"
-            .to_string()
-    } else {
-        "`#[derive]` can't be used on a `#[repr(packed)]` struct that \
-         does not derive Copy (error E0133)"
-            .to_string()
-    };
     tcx.struct_span_lint_hir(SAFE_PACKED_BORROWS, lint_hir_id, tcx.def_span(def_id), |lint| {
+        // FIXME: when we make this a hard error, this should have its
+        // own error code.
+        let message = if tcx.generics_of(def_id).own_requires_monomorphization() {
+            "`#[derive]` can't be used on a `#[repr(packed)]` struct with \
+             type or const parameters (error E0133)"
+                .to_string()
+        } else {
+            "`#[derive]` can't be used on a `#[repr(packed)]` struct that \
+             does not derive Copy (error E0133)"
+                .to_string()
+        };
         lint.build(&message).emit()
     });
 }
@@ -560,8 +560,8 @@ fn is_enclosed(
 
 fn report_unused_unsafe(tcx: TyCtxt<'_>, used_unsafe: &FxHashSet<hir::HirId>, id: hir::HirId) {
     let span = tcx.sess.source_map().def_span(tcx.hir().span(id));
-    let msg = "unnecessary `unsafe` block";
     tcx.struct_span_lint_hir(UNUSED_UNSAFE, id, span, |lint| {
+        let msg = "unnecessary `unsafe` block";
         let mut db = lint.build(msg);
         db.span_label(span, msg);
         if let Some((kind, id)) = is_enclosed(tcx, used_unsafe, id) {

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -923,17 +923,24 @@ impl<'mir, 'tcx> MutVisitor<'tcx> for ConstPropagator<'mir, 'tcx> {
                                     | PanicInfo::DivisionByZero
                                     | PanicInfo::RemainderByZero => msg.description().to_owned(),
                                     PanicInfo::BoundsCheck { ref len, ref index } => {
-                                        let len =
-                                            self.eval_operand(len, source_info).expect("len must be const");
+                                        let len = self
+                                            .eval_operand(len, source_info)
+                                            .expect("len must be const");
                                         let len = match self.ecx.read_scalar(len) {
-                                            Ok(ScalarMaybeUndef::Scalar(Scalar::Raw { data, .. })) => data,
+                                            Ok(ScalarMaybeUndef::Scalar(Scalar::Raw {
+                                                data,
+                                                ..
+                                            })) => data,
                                             other => bug!("const len not primitive: {:?}", other),
                                         };
                                         let index = self
                                             .eval_operand(index, source_info)
                                             .expect("index must be const");
                                         let index = match self.ecx.read_scalar(index) {
-                                            Ok(ScalarMaybeUndef::Scalar(Scalar::Raw { data, .. })) => data,
+                                            Ok(ScalarMaybeUndef::Scalar(Scalar::Raw {
+                                                data,
+                                                ..
+                                            })) => data,
                                             other => bug!("const index not primitive: {:?}", other),
                                         };
                                         format!(

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -556,12 +556,14 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
             let r_bits = r.to_scalar().and_then(|r| r.to_bits(right_size));
             if r_bits.map_or(false, |b| b >= left_bits as u128) {
                 let lint_root = self.lint_root(source_info)?;
-                let dir = if op == BinOp::Shr { "right" } else { "left" };
                 self.tcx.struct_span_lint_hir(
                     ::rustc::lint::builtin::EXCEEDING_BITSHIFTS,
                     lint_root,
                     source_info.span,
-                    |lint| lint.build(&format!("attempt to shift {} with overflow", dir)).emit(),
+                    |lint| {
+                        let dir = if op == BinOp::Shr { "right" } else { "left" };
+                        lint.build(&format!("attempt to shift {} with overflow", dir)).emit()
+                    },
                 );
                 return None;
             }

--- a/src/librustc_mir_build/hair/pattern/check_match.rs
+++ b/src/librustc_mir_build/hair/pattern/check_match.rs
@@ -286,12 +286,12 @@ fn check_for_bindings_named_same_as_variants(cx: &MatchVisitor<'_, '_>, pat: &Pa
                             variant.ident == ident && variant.ctor_kind == CtorKind::Const
                         })
                     {
-                        let ty_path = cx.tcx.def_path_str(edef.did);
                         cx.tcx.struct_span_lint_hir(
                             BINDINGS_WITH_VARIANT_NAME,
                             p.hir_id,
                             p.span,
                             |lint| {
+                                let ty_path = cx.tcx.def_path_str(edef.did);
                                 lint.build(&format!(
                                     "pattern binding `{}` is named the same as one \
                                                 of the variants of the type `{}`",
@@ -338,12 +338,14 @@ fn unreachable_pattern(tcx: TyCtxt<'_>, span: Span, id: HirId, catchall: Option<
 }
 
 fn irrefutable_let_pattern(tcx: TyCtxt<'_>, span: Span, id: HirId, source: hir::MatchSource) {
-    let msg = match source {
-        hir::MatchSource::IfLetDesugar { .. } => "irrefutable if-let pattern",
-        hir::MatchSource::WhileLetDesugar => "irrefutable while-let pattern",
-        _ => bug!(),
-    };
-    tcx.struct_span_lint_hir(IRREFUTABLE_LET_PATTERNS, id, span, |lint| lint.build(msg).emit());
+    tcx.struct_span_lint_hir(IRREFUTABLE_LET_PATTERNS, id, span, |lint| {
+        let msg = match source {
+            hir::MatchSource::IfLetDesugar { .. } => "irrefutable if-let pattern",
+            hir::MatchSource::WhileLetDesugar => "irrefutable while-let pattern",
+            _ => bug!(),
+        };
+        lint.build(msg).emit()
+    });
 }
 
 /// Check for unreachable patterns.

--- a/src/librustc_mir_build/hair/pattern/check_match.rs
+++ b/src/librustc_mir_build/hair/pattern/check_match.rs
@@ -292,20 +292,25 @@ fn check_for_bindings_named_same_as_variants(cx: &MatchVisitor<'_, '_>, pat: &Pa
                                 BINDINGS_WITH_VARIANT_NAME,
                                 p.hir_id,
                                 p.span,
-                                &format!(
-                                    "pattern binding `{}` is named the same as one \
-                                    of the variants of the type `{}`",
-                                    ident, ty_path
-                                ),
+                                |lint| {
+                                    lint
+                                        .build(
+                                            &format!(
+                                                "pattern binding `{}` is named the same as one \
+                                                of the variants of the type `{}`",
+                                                ident, ty_path
+                                            )
+                                        )
+                                        .code(error_code!(E0170))
+                                        .span_suggestion(
+                                            p.span,
+                                            "to match on the variant, qualify the path",
+                                            format!("{}::{}", ty_path, ident),
+                                            Applicability::MachineApplicable,
+                                        )
+                                        .emit();
+                                },
                             )
-                            .code(error_code!(E0170))
-                            .span_suggestion(
-                                p.span,
-                                "to match on the variant, qualify the path",
-                                format!("{}::{}", ty_path, ident),
-                                Applicability::MachineApplicable,
-                            )
-                            .emit();
                     }
                 }
             }
@@ -325,13 +330,15 @@ fn pat_is_catchall(pat: &super::Pat<'_>) -> bool {
 }
 
 fn unreachable_pattern(tcx: TyCtxt<'_>, span: Span, id: HirId, catchall: Option<Span>) {
-    let mut err = tcx.struct_span_lint_hir(UNREACHABLE_PATTERNS, id, span, "unreachable pattern");
-    if let Some(catchall) = catchall {
-        // We had a catchall pattern, hint at that.
-        err.span_label(span, "unreachable pattern");
-        err.span_label(catchall, "matches any value");
-    }
-    err.emit();
+    tcx.struct_span_lint_hir(UNREACHABLE_PATTERNS, id, span, |lint| {
+        let mut err = lint.build("unreachable pattern");
+        if let Some(catchall) = catchall {
+            // We had a catchall pattern, hint at that.
+            err.span_label(span, "unreachable pattern");
+            err.span_label(catchall, "matches any value");
+        }
+        err.emit();
+    });
 }
 
 fn irrefutable_let_pattern(tcx: TyCtxt<'_>, span: Span, id: HirId, source: hir::MatchSource) {
@@ -340,7 +347,7 @@ fn irrefutable_let_pattern(tcx: TyCtxt<'_>, span: Span, id: HirId, source: hir::
         hir::MatchSource::WhileLetDesugar => "irrefutable while-let pattern",
         _ => bug!(),
     };
-    tcx.lint_hir(IRREFUTABLE_LET_PATTERNS, id, span, msg);
+    tcx.struct_span_lint_hir(IRREFUTABLE_LET_PATTERNS, id, span, |lint| lint.build(msg).emit());
 }
 
 /// Check for unreachable patterns.

--- a/src/librustc_mir_build/hair/pattern/check_match.rs
+++ b/src/librustc_mir_build/hair/pattern/check_match.rs
@@ -287,30 +287,26 @@ fn check_for_bindings_named_same_as_variants(cx: &MatchVisitor<'_, '_>, pat: &Pa
                         })
                     {
                         let ty_path = cx.tcx.def_path_str(edef.did);
-                        cx.tcx
-                            .struct_span_lint_hir(
-                                BINDINGS_WITH_VARIANT_NAME,
-                                p.hir_id,
-                                p.span,
-                                |lint| {
-                                    lint
-                                        .build(
-                                            &format!(
-                                                "pattern binding `{}` is named the same as one \
+                        cx.tcx.struct_span_lint_hir(
+                            BINDINGS_WITH_VARIANT_NAME,
+                            p.hir_id,
+                            p.span,
+                            |lint| {
+                                lint.build(&format!(
+                                    "pattern binding `{}` is named the same as one \
                                                 of the variants of the type `{}`",
-                                                ident, ty_path
-                                            )
-                                        )
-                                        .code(error_code!(E0170))
-                                        .span_suggestion(
-                                            p.span,
-                                            "to match on the variant, qualify the path",
-                                            format!("{}::{}", ty_path, ident),
-                                            Applicability::MachineApplicable,
-                                        )
-                                        .emit();
-                                },
-                            )
+                                    ident, ty_path
+                                ))
+                                .code(error_code!(E0170))
+                                .span_suggestion(
+                                    p.span,
+                                    "to match on the variant, qualify the path",
+                                    format!("{}::{}", ty_path, ident),
+                                    Applicability::MachineApplicable,
+                                )
+                                .emit();
+                            },
+                        )
                     }
                 }
             }

--- a/src/librustc_mir_build/lints.rs
+++ b/src/librustc_mir_build/lints.rs
@@ -124,20 +124,15 @@ fn check_fn_for_unconditional_recursion<'tcx>(
     if !reached_exit_without_self_call && !self_call_locations.is_empty() {
         let hir_id = tcx.hir().as_local_hir_id(def_id).unwrap();
         let sp = tcx.sess.source_map().def_span(tcx.hir().span(hir_id));
-        tcx.struct_span_lint_hir(
-            UNCONDITIONAL_RECURSION,
-            hir_id,
-            sp,
-            |lint| {
-                let mut db = lint.build("function cannot return without recursing");
-                db.span_label(sp, "cannot return without recursing");
-                // offer some help to the programmer.
-                for location in &self_call_locations {
-                    db.span_label(location.span, "recursive call site");
-                }
-                db.help("a `loop` may express intention better if this is on purpose");
-                db.emit();
-            },
-        );
+        tcx.struct_span_lint_hir(UNCONDITIONAL_RECURSION, hir_id, sp, |lint| {
+            let mut db = lint.build("function cannot return without recursing");
+            db.span_label(sp, "cannot return without recursing");
+            // offer some help to the programmer.
+            for location in &self_call_locations {
+                db.span_label(location.span, "recursive call site");
+            }
+            db.help("a `loop` may express intention better if this is on purpose");
+            db.emit();
+        });
     }
 }

--- a/src/librustc_mir_build/lints.rs
+++ b/src/librustc_mir_build/lints.rs
@@ -124,18 +124,20 @@ fn check_fn_for_unconditional_recursion<'tcx>(
     if !reached_exit_without_self_call && !self_call_locations.is_empty() {
         let hir_id = tcx.hir().as_local_hir_id(def_id).unwrap();
         let sp = tcx.sess.source_map().def_span(tcx.hir().span(hir_id));
-        let mut db = tcx.struct_span_lint_hir(
+        tcx.struct_span_lint_hir(
             UNCONDITIONAL_RECURSION,
             hir_id,
             sp,
-            "function cannot return without recursing",
+            |lint| {
+                let mut db = lint.build("function cannot return without recursing");
+                db.span_label(sp, "cannot return without recursing");
+                // offer some help to the programmer.
+                for location in &self_call_locations {
+                    db.span_label(location.span, "recursive call site");
+                }
+                db.help("a `loop` may express intention better if this is on purpose");
+                db.emit();
+            },
         );
-        db.span_label(sp, "cannot return without recursing");
-        // offer some help to the programmer.
-        for location in &self_call_locations {
-            db.span_label(location.span, "recursive call site");
-        }
-        db.help("a `loop` may express intention better if this is on purpose");
-        db.emit();
     }
 }

--- a/src/librustc_parse/config.rs
+++ b/src/librustc_parse/config.rs
@@ -315,10 +315,11 @@ impl<'a> StripUnconfigured<'a> {
                 validate_attr::check_meta_bad_delim(self.sess, dspan, delim, msg);
                 match parse_in(self.sess, tts.clone(), "`cfg_attr` input", |p| p.parse_cfg_attr()) {
                     Ok(r) => return Some(r),
-                    Err(mut e) => e
-                        .help(&format!("the valid syntax is `{}`", CFG_ATTR_GRAMMAR_HELP))
+                    Err(mut e) => {
+                        e.help(&format!("the valid syntax is `{}`", CFG_ATTR_GRAMMAR_HELP))
                         .note(CFG_ATTR_NOTE_REF)
-                        .emit(),
+                        .emit();
+                    },
                 }
             }
             _ => self.error_malformed_cfg_attr_missing(attr.span),

--- a/src/librustc_parse/config.rs
+++ b/src/librustc_parse/config.rs
@@ -317,9 +317,9 @@ impl<'a> StripUnconfigured<'a> {
                     Ok(r) => return Some(r),
                     Err(mut e) => {
                         e.help(&format!("the valid syntax is `{}`", CFG_ATTR_GRAMMAR_HELP))
-                        .note(CFG_ATTR_NOTE_REF)
-                        .emit();
-                    },
+                            .note(CFG_ATTR_NOTE_REF)
+                            .emit();
+                    }
                 }
             }
             _ => self.error_malformed_cfg_attr_missing(attr.span),

--- a/src/librustc_parse/lexer/unescape_error_reporting.rs
+++ b/src/librustc_parse/lexer/unescape_error_reporting.rs
@@ -69,7 +69,7 @@ pub(crate) fn emit_unescape_error(
                     format!("\"{}\"", lit),
                     Applicability::MachineApplicable,
                 )
-                .emit()
+                .emit();
         }
         EscapeError::EscapeOnlyChar => {
             let (c, _span) = last_char();

--- a/src/librustc_parse/parser/attr.rs
+++ b/src/librustc_parse/parser/attr.rs
@@ -149,7 +149,7 @@ impl<'a> Parser<'a> {
                                    source files. Outer attributes, like `#[test]`, annotate the \
                                    item following them.",
                             )
-                            .emit()
+                            .emit();
                     }
                 }
 
@@ -239,7 +239,7 @@ impl<'a> Parser<'a> {
                                     (`1u8`, `1.0f32`, etc.), use an unsuffixed version \
                                     (`1`, `1.0`, etc.)",
                 )
-                .emit()
+                .emit();
         }
 
         Ok(lit)

--- a/src/librustc_parse/parser/diagnostics.rs
+++ b/src/librustc_parse/parser/diagnostics.rs
@@ -1014,7 +1014,7 @@ impl<'a> Parser<'a> {
                     String::new(),
                     Applicability::MachineApplicable,
                 )
-                .emit()
+                .emit();
         }
     }
 

--- a/src/librustc_parse/parser/mod.rs
+++ b/src/librustc_parse/parser/mod.rs
@@ -1407,6 +1407,6 @@ pub fn emit_unclosed_delims(unclosed_delims: &mut Vec<UnmatchedBrace>, sess: &Pa
     *sess.reached_eof.borrow_mut() |=
         unclosed_delims.iter().any(|unmatched_delim| unmatched_delim.found_delim.is_none());
     for unmatched in unclosed_delims.drain(..) {
-        make_unclosed_delims_error(unmatched, sess).map(|mut e| e.emit());
+        make_unclosed_delims_error(unmatched, sess).map(|mut e| { e.emit(); });
     }
 }

--- a/src/librustc_parse/parser/mod.rs
+++ b/src/librustc_parse/parser/mod.rs
@@ -1407,6 +1407,8 @@ pub fn emit_unclosed_delims(unclosed_delims: &mut Vec<UnmatchedBrace>, sess: &Pa
     *sess.reached_eof.borrow_mut() |=
         unclosed_delims.iter().any(|unmatched_delim| unmatched_delim.found_delim.is_none());
     for unmatched in unclosed_delims.drain(..) {
-        make_unclosed_delims_error(unmatched, sess).map(|mut e| { e.emit(); });
+        make_unclosed_delims_error(unmatched, sess).map(|mut e| {
+            e.emit();
+        });
     }
 }

--- a/src/librustc_parse/parser/pat.rs
+++ b/src/librustc_parse/parser/pat.rs
@@ -572,7 +572,7 @@ impl<'a> Parser<'a> {
         self.struct_span_err(span, problem)
             .span_suggestion(span, suggestion, fix, Applicability::MachineApplicable)
             .note("`mut` may be followed by `variable` and `variable @ pattern`")
-            .emit()
+            .emit();
     }
 
     /// Eat any extraneous `mut`s and error + recover if we ate any.

--- a/src/librustc_parse/validate_attr.rs
+++ b/src/librustc_parse/validate_attr.rs
@@ -27,7 +27,11 @@ pub fn check_meta(sess: &ParseSess, attr: &Attribute) {
         _ => {
             if let MacArgs::Eq(..) = attr.get_normal_item().args {
                 // All key-value attributes are restricted to meta-item syntax.
-                parse_meta(sess, attr).map_err(|mut err| { err.emit(); }).ok();
+                parse_meta(sess, attr)
+                    .map_err(|mut err| {
+                        err.emit();
+                    })
+                    .ok();
             }
         }
     }
@@ -152,6 +156,8 @@ pub fn check_builtin_attribute(
                 }
             }
         }
-        Err(mut err) => { err.emit(); },
+        Err(mut err) => {
+            err.emit();
+        }
     }
 }

--- a/src/librustc_parse/validate_attr.rs
+++ b/src/librustc_parse/validate_attr.rs
@@ -27,7 +27,7 @@ pub fn check_meta(sess: &ParseSess, attr: &Attribute) {
         _ => {
             if let MacArgs::Eq(..) = attr.get_normal_item().args {
                 // All key-value attributes are restricted to meta-item syntax.
-                parse_meta(sess, attr).map_err(|mut err| err.emit()).ok();
+                parse_meta(sess, attr).map_err(|mut err| { err.emit(); }).ok();
             }
         }
     }
@@ -152,6 +152,6 @@ pub fn check_builtin_attribute(
                 }
             }
         }
-        Err(mut err) => err.emit(),
+        Err(mut err) => { err.emit(); },
     }
 }

--- a/src/librustc_passes/check_attr.rs
+++ b/src/librustc_passes/check_attr.rs
@@ -97,9 +97,8 @@ impl CheckAttrVisitor<'tcx> {
                         UNUSED_ATTRIBUTES,
                         hir_id,
                         attr.span,
-                        "`#[inline]` is ignored on function prototypes",
-                    )
-                    .emit();
+                        |lint| lint.build("`#[inline]` is ignored on function prototypes").emit(),
+                    );
                 true
             }
             // FIXME(#65833): We permit associated consts to have an `#[inline]` attribute with
@@ -112,18 +111,19 @@ impl CheckAttrVisitor<'tcx> {
                         UNUSED_ATTRIBUTES,
                         hir_id,
                         attr.span,
-                        "`#[inline]` is ignored on constants",
-                    )
-                    .warn(
-                        "this was previously accepted by the compiler but is \
-                       being phased out; it will become a hard error in \
-                       a future release!",
-                    )
-                    .note(
-                        "see issue #65833 <https://github.com/rust-lang/rust/issues/65833> \
-                         for more information",
-                    )
-                    .emit();
+                        |lint| {
+                            lint.build("`#[inline]` is ignored on constants")
+                            .warn(
+                                "this was previously accepted by the compiler but is \
+                               being phased out; it will become a hard error in \
+                               a future release!",
+                            )
+                            .note(
+                                "see issue #65833 <https://github.com/rust-lang/rust/issues/65833> \
+                                 for more information",
+                            )
+                            .emit();
+                        });
                 true
             }
             _ => {
@@ -336,10 +336,12 @@ impl CheckAttrVisitor<'tcx> {
                     CONFLICTING_REPR_HINTS,
                     hir_id,
                     hint_spans.collect::<Vec<Span>>(),
-                    "conflicting representation hints",
-                )
-                .code(rustc_errors::error_code!(E0566))
-                .emit();
+                    |lint| {
+                        lint.build("conflicting representation hints")
+                            .code(rustc_errors::error_code!(E0566))
+                            .emit();
+                    }
+                );
         }
     }
 

--- a/src/librustc_passes/check_attr.rs
+++ b/src/librustc_passes/check_attr.rs
@@ -102,24 +102,19 @@ impl CheckAttrVisitor<'tcx> {
             // accidentally, to to be compatible with crates depending on them, we can't throw an
             // error here.
             Target::AssocConst => {
-                self.tcx
-                    .struct_span_lint_hir(
-                        UNUSED_ATTRIBUTES,
-                        hir_id,
-                        attr.span,
-                        |lint| {
-                            lint.build("`#[inline]` is ignored on constants")
-                            .warn(
-                                "this was previously accepted by the compiler but is \
+                self.tcx.struct_span_lint_hir(UNUSED_ATTRIBUTES, hir_id, attr.span, |lint| {
+                    lint.build("`#[inline]` is ignored on constants")
+                        .warn(
+                            "this was previously accepted by the compiler but is \
                                being phased out; it will become a hard error in \
                                a future release!",
-                            )
-                            .note(
-                                "see issue #65833 <https://github.com/rust-lang/rust/issues/65833> \
+                        )
+                        .note(
+                            "see issue #65833 <https://github.com/rust-lang/rust/issues/65833> \
                                  for more information",
-                            )
-                            .emit();
-                        });
+                        )
+                        .emit();
+                });
                 true
             }
             _ => {

--- a/src/librustc_passes/check_attr.rs
+++ b/src/librustc_passes/check_attr.rs
@@ -92,13 +92,9 @@ impl CheckAttrVisitor<'tcx> {
             | Target::Method(MethodKind::Trait { body: true })
             | Target::Method(MethodKind::Inherent) => true,
             Target::Method(MethodKind::Trait { body: false }) | Target::ForeignFn => {
-                self.tcx
-                    .struct_span_lint_hir(
-                        UNUSED_ATTRIBUTES,
-                        hir_id,
-                        attr.span,
-                        |lint| lint.build("`#[inline]` is ignored on function prototypes").emit(),
-                    );
+                self.tcx.struct_span_lint_hir(UNUSED_ATTRIBUTES, hir_id, attr.span, |lint| {
+                    lint.build("`#[inline]` is ignored on function prototypes").emit()
+                });
                 true
             }
             // FIXME(#65833): We permit associated consts to have an `#[inline]` attribute with
@@ -331,17 +327,16 @@ impl CheckAttrVisitor<'tcx> {
             || (is_simd && is_c)
             || (int_reprs == 1 && is_c && item.map_or(false, |item| is_c_like_enum(item)))
         {
-            self.tcx
-                .struct_span_lint_hir(
-                    CONFLICTING_REPR_HINTS,
-                    hir_id,
-                    hint_spans.collect::<Vec<Span>>(),
-                    |lint| {
-                        lint.build("conflicting representation hints")
-                            .code(rustc_errors::error_code!(E0566))
-                            .emit();
-                    }
-                );
+            self.tcx.struct_span_lint_hir(
+                CONFLICTING_REPR_HINTS,
+                hir_id,
+                hint_spans.collect::<Vec<Span>>(),
+                |lint| {
+                    lint.build("conflicting representation hints")
+                        .code(rustc_errors::error_code!(E0566))
+                        .emit();
+                },
+            );
         }
     }
 

--- a/src/librustc_passes/dead.rs
+++ b/src/librustc_passes/dead.rs
@@ -554,12 +554,9 @@ impl DeadVisitor<'tcx> {
         participle: &str,
     ) {
         if !name.as_str().starts_with("_") {
-            self.tcx.lint_hir(
-                lint::builtin::DEAD_CODE,
-                id,
-                span,
-                &format!("{} is never {}: `{}`", node_type, participle, name),
-            );
+            self.tcx.struct_span_lint_hir(lint::builtin::DEAD_CODE, id, span, |lint| {
+                lint.build(&format!("{} is never {}: `{}`", node_type, participle, name)).emit()
+            });
         }
     }
 }

--- a/src/librustc_passes/liveness.rs
+++ b/src/librustc_passes/liveness.rs
@@ -1521,18 +1521,16 @@ impl<'tcx> Liveness<'_, 'tcx> {
                 if ln == self.s.exit_ln { false } else { self.assigned_on_exit(ln, var).is_some() };
 
             if is_assigned {
-                self.ir
-                    .tcx
-                    .struct_span_lint_hir(
-                        lint::builtin::UNUSED_VARIABLES,
-                        hir_id,
-                        spans,
-                        |lint| {
-                            lint.build(&format!("variable `{}` is assigned to, but never used", name))
-                                .note(&format!("consider using `_{}` instead", name))
-                                .emit();
-                        },
-                    )
+                self.ir.tcx.struct_span_lint_hir(
+                    lint::builtin::UNUSED_VARIABLES,
+                    hir_id,
+                    spans,
+                    |lint| {
+                        lint.build(&format!("variable `{}` is assigned to, but never used", name))
+                            .note(&format!("consider using `_{}` instead", name))
+                            .emit();
+                    },
+                )
             } else {
                 self.ir.tcx.struct_span_lint_hir(
                     lint::builtin::UNUSED_VARIABLES,
@@ -1543,8 +1541,10 @@ impl<'tcx> Liveness<'_, 'tcx> {
                         if self.ir.variable_is_shorthand(var) {
                             if let Node::Binding(pat) = self.ir.tcx.hir().get(hir_id) {
                                 // Handle `ref` and `ref mut`.
-                                let spans =
-                                    spans.iter().map(|_span| (pat.span, format!("{}: _", name))).collect();
+                                let spans = spans
+                                    .iter()
+                                    .map(|_span| (pat.span, format!("{}: _", name)))
+                                    .collect();
 
                                 err.multipart_suggestion(
                                     "try ignoring the field",
@@ -1575,31 +1575,27 @@ impl<'tcx> Liveness<'_, 'tcx> {
     fn report_dead_assign(&self, hir_id: HirId, spans: Vec<Span>, var: Variable, is_param: bool) {
         if let Some(name) = self.should_warn(var) {
             if is_param {
-                self.ir
-                    .tcx
-                    .struct_span_lint_hir(
-                        lint::builtin::UNUSED_ASSIGNMENTS,
-                        hir_id,
-                        spans,
-                        |lint| {
-                            lint.build(&format!("value passed to `{}` is never read", name))
-                                .help("maybe it is overwritten before being read?")
-                                .emit();
-                        },
-                    )
+                self.ir.tcx.struct_span_lint_hir(
+                    lint::builtin::UNUSED_ASSIGNMENTS,
+                    hir_id,
+                    spans,
+                    |lint| {
+                        lint.build(&format!("value passed to `{}` is never read", name))
+                            .help("maybe it is overwritten before being read?")
+                            .emit();
+                    },
+                )
             } else {
-                self.ir
-                    .tcx
-                    .struct_span_lint_hir(
-                        lint::builtin::UNUSED_ASSIGNMENTS,
-                        hir_id,
-                        spans,
-                        |lint| {
-                            lint.build(&format!("value assigned to `{}` is never read", name))
-                                .help("maybe it is overwritten before being read?")
-                                .emit();
-                        },
-                    )
+                self.ir.tcx.struct_span_lint_hir(
+                    lint::builtin::UNUSED_ASSIGNMENTS,
+                    hir_id,
+                    spans,
+                    |lint| {
+                        lint.build(&format!("value assigned to `{}` is never read", name))
+                            .help("maybe it is overwritten before being read?")
+                            .emit();
+                    },
+                )
             }
         }
     }

--- a/src/librustc_passes/stability.rs
+++ b/src/librustc_passes/stability.rs
@@ -608,10 +608,10 @@ fn unnecessary_stable_feature_lint(tcx: TyCtxt<'_>, span: Span, feature: Symbol,
         lint.build(&format!(
             "the feature `{}` has been stable since {} and no longer requires \
                       an attribute to enable",
-                feature, since
-            )).emit();
-        }
-    );
+            feature, since
+        ))
+        .emit();
+    });
 }
 
 fn duplicate_feature_err(sess: &Session, span: Span, feature: Symbol) {

--- a/src/librustc_passes/stability.rs
+++ b/src/librustc_passes/stability.rs
@@ -604,15 +604,13 @@ pub fn check_unused_or_stable_features(tcx: TyCtxt<'_>) {
 }
 
 fn unnecessary_stable_feature_lint(tcx: TyCtxt<'_>, span: Span, feature: Symbol, since: Symbol) {
-    tcx.lint_hir(
-        lint::builtin::STABLE_FEATURES,
-        hir::CRATE_HIR_ID,
-        span,
-        &format!(
+    tcx.struct_span_lint_hir(lint::builtin::STABLE_FEATURES, hir::CRATE_HIR_ID, span, |lint| {
+        lint.build(&format!(
             "the feature `{}` has been stable since {} and no longer requires \
-                  an attribute to enable",
-            feature, since
-        ),
+                      an attribute to enable",
+                feature, since
+            )).emit();
+        }
     );
 }
 

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -1786,15 +1786,14 @@ impl SearchInterfaceForPrivateItemsVisitor<'tcx> {
                 self.item_id,
                 self.span,
                 |lint| {
-                    lint.build(
-                            &format!(
-                            "{} `{}` from private dependency '{}' in public \
+                    lint.build(&format!(
+                        "{} `{}` from private dependency '{}' in public \
                                                 interface",
-                            kind,
-                            descr,
-                            self.tcx.crate_name(def_id.krate)
-                            )
-                    ).emit()
+                        kind,
+                        descr,
+                        self.tcx.crate_name(def_id.krate)
+                    ))
+                    .emit()
                 },
             );
         }
@@ -1818,9 +1817,12 @@ impl SearchInterfaceForPrivateItemsVisitor<'tcx> {
                 err.emit();
             } else {
                 let err_code = if kind == "trait" { "E0445" } else { "E0446" };
-                self.tcx.struct_span_lint_hir(lint::builtin::PRIVATE_IN_PUBLIC, hir_id, self.span, |lint| {
-                    lint.build(&format!("{} (error {})", msg, err_code)).emit()
-                });
+                self.tcx.struct_span_lint_hir(
+                    lint::builtin::PRIVATE_IN_PUBLIC,
+                    hir_id,
+                    self.span,
+                    |lint| lint.build(&format!("{} (error {})", msg, err_code)).emit(),
+                );
             }
         }
 

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -1805,12 +1805,12 @@ impl SearchInterfaceForPrivateItemsVisitor<'tcx> {
 
         let (vis, vis_span, vis_descr) = def_id_visibility(self.tcx, def_id);
         if !vis.is_at_least(self.required_visibility, self.tcx) {
-            let msg = format!("{} {} `{}` in public interface", vis_descr, kind, descr);
+            let make_msg = || format!("{} {} `{}` in public interface", vis_descr, kind, descr);
             if self.has_pub_restricted || self.has_old_errors || self.in_assoc_ty {
                 let mut err = if kind == "trait" {
-                    struct_span_err!(self.tcx.sess, self.span, E0445, "{}", msg)
+                    struct_span_err!(self.tcx.sess, self.span, E0445, "{}", make_msg())
                 } else {
-                    struct_span_err!(self.tcx.sess, self.span, E0446, "{}", msg)
+                    struct_span_err!(self.tcx.sess, self.span, E0446, "{}", make_msg())
                 };
                 err.span_label(self.span, format!("can't leak {} {}", vis_descr, kind));
                 err.span_label(vis_span, format!("`{}` declared as {}", descr, vis_descr));
@@ -1821,7 +1821,7 @@ impl SearchInterfaceForPrivateItemsVisitor<'tcx> {
                     lint::builtin::PRIVATE_IN_PUBLIC,
                     hir_id,
                     self.span,
-                    |lint| lint.build(&format!("{} (error {})", msg, err_code)).emit(),
+                    |lint| lint.build(&format!("{} (error {})", make_msg(), err_code)).emit(),
                 );
             }
         }

--- a/src/librustc_resolve/lifetimes.rs
+++ b/src/librustc_resolve/lifetimes.rs
@@ -1580,7 +1580,10 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                             id,
                             span,
                             |lint| {
-                                let mut err = lint.build(&format!("lifetime parameter `{}` only used once", name));
+                                let mut err = lint.build(&format!(
+                                    "lifetime parameter `{}` only used once",
+                                    name
+                                ));
                                 if span == lifetime.span {
                                     // spans are the same for in-band lifetime declarations
                                     err.span_label(span, "this lifetime is only used here");
@@ -1588,7 +1591,9 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                                     err.span_label(span, "this lifetime...");
                                     err.span_label(lifetime.span, "...is used only here");
                                 }
-                                self.suggest_eliding_single_use_lifetime(&mut err, def_id, lifetime);
+                                self.suggest_eliding_single_use_lifetime(
+                                    &mut err, def_id, lifetime,
+                                );
                                 err.emit();
                             },
                         );
@@ -1616,10 +1621,14 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                             id,
                             span,
                             |lint| {
-                                let mut err = lint.build(&format!("lifetime parameter `{}` never used", name));
+                                let mut err = lint
+                                    .build(&format!("lifetime parameter `{}` never used", name));
                                 if let Some(parent_def_id) = self.tcx.parent(def_id) {
-                                    if let Some(generics) = self.tcx.hir().get_generics(parent_def_id) {
-                                        let unused_lt_span = self.lifetime_deletion_span(name, generics);
+                                    if let Some(generics) =
+                                        self.tcx.hir().get_generics(parent_def_id)
+                                    {
+                                        let unused_lt_span =
+                                            self.lifetime_deletion_span(name, generics);
                                         if let Some(span) = unused_lt_span {
                                             err.span_suggestion(
                                                 span,

--- a/src/librustc_resolve/lifetimes.rs
+++ b/src/librustc_resolve/lifetimes.rs
@@ -1575,22 +1575,23 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                             }
                         }
 
-                        let mut err = self.tcx.struct_span_lint_hir(
+                        self.tcx.struct_span_lint_hir(
                             lint::builtin::SINGLE_USE_LIFETIMES,
                             id,
                             span,
-                            &format!("lifetime parameter `{}` only used once", name),
+                            |lint| {
+                                let mut err = lint.build(&format!("lifetime parameter `{}` only used once", name));
+                                if span == lifetime.span {
+                                    // spans are the same for in-band lifetime declarations
+                                    err.span_label(span, "this lifetime is only used here");
+                                } else {
+                                    err.span_label(span, "this lifetime...");
+                                    err.span_label(lifetime.span, "...is used only here");
+                                }
+                                self.suggest_eliding_single_use_lifetime(&mut err, def_id, lifetime);
+                                err.emit();
+                            },
                         );
-
-                        if span == lifetime.span {
-                            // spans are the same for in-band lifetime declarations
-                            err.span_label(span, "this lifetime is only used here");
-                        } else {
-                            err.span_label(span, "this lifetime...");
-                            err.span_label(lifetime.span, "...is used only here");
-                        }
-                        self.suggest_eliding_single_use_lifetime(&mut err, def_id, lifetime);
-                        err.emit();
                     }
                 }
                 Some(LifetimeUseSet::Many) => {
@@ -1610,26 +1611,28 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                         _ => None,
                     } {
                         debug!("id ={:?} span = {:?} name = {:?}", id, span, name);
-                        let mut err = self.tcx.struct_span_lint_hir(
+                        self.tcx.struct_span_lint_hir(
                             lint::builtin::UNUSED_LIFETIMES,
                             id,
                             span,
-                            &format!("lifetime parameter `{}` never used", name),
-                        );
-                        if let Some(parent_def_id) = self.tcx.parent(def_id) {
-                            if let Some(generics) = self.tcx.hir().get_generics(parent_def_id) {
-                                let unused_lt_span = self.lifetime_deletion_span(name, generics);
-                                if let Some(span) = unused_lt_span {
-                                    err.span_suggestion(
-                                        span,
-                                        "elide the unused lifetime",
-                                        String::new(),
-                                        Applicability::MachineApplicable,
-                                    );
+                            |lint| {
+                                let mut err = lint.build(&format!("lifetime parameter `{}` never used", name));
+                                if let Some(parent_def_id) = self.tcx.parent(def_id) {
+                                    if let Some(generics) = self.tcx.hir().get_generics(parent_def_id) {
+                                        let unused_lt_span = self.lifetime_deletion_span(name, generics);
+                                        if let Some(span) = unused_lt_span {
+                                            err.span_suggestion(
+                                                span,
+                                                "elide the unused lifetime",
+                                                String::new(),
+                                                Applicability::MachineApplicable,
+                                            );
+                                        }
+                                    }
                                 }
-                            }
-                        }
-                        err.emit();
+                                err.emit();
+                            },
+                        );
                     }
                 }
             }

--- a/src/librustc_typeck/check/cast.rs
+++ b/src/librustc_typeck/check/cast.rs
@@ -468,23 +468,27 @@ impl<'a, 'tcx> CastCheck<'tcx> {
         } else {
             ("", lint::builtin::TRIVIAL_CASTS)
         };
-        let mut err = fcx.tcx.struct_span_lint_hir(
+        fcx.tcx.struct_span_lint_hir(
             lint,
             self.expr.hir_id,
             self.span,
-            &format!(
-                "trivial {}cast: `{}` as `{}`",
-                adjective,
-                fcx.ty_to_string(t_expr),
-                fcx.ty_to_string(t_cast)
-            ),
+            |err| {
+                err.build(
+                    &format!(
+                        "trivial {}cast: `{}` as `{}`",
+                        adjective,
+                        fcx.ty_to_string(t_expr),
+                        fcx.ty_to_string(t_cast)
+                    )
+                )
+                .help(&format!(
+                    "cast can be replaced by coercion; this might \
+                                   require {}a temporary variable",
+                    type_asc_or
+                ))
+                .emit();
+            },
         );
-        err.help(&format!(
-            "cast can be replaced by coercion; this might \
-                           require {}a temporary variable",
-            type_asc_or
-        ));
-        err.emit();
     }
 
     pub fn check(mut self, fcx: &FnCtxt<'a, 'tcx>) {

--- a/src/librustc_typeck/check/cast.rs
+++ b/src/librustc_typeck/check/cast.rs
@@ -468,27 +468,20 @@ impl<'a, 'tcx> CastCheck<'tcx> {
         } else {
             ("", lint::builtin::TRIVIAL_CASTS)
         };
-        fcx.tcx.struct_span_lint_hir(
-            lint,
-            self.expr.hir_id,
-            self.span,
-            |err| {
-                err.build(
-                    &format!(
-                        "trivial {}cast: `{}` as `{}`",
-                        adjective,
-                        fcx.ty_to_string(t_expr),
-                        fcx.ty_to_string(t_cast)
-                    )
-                )
-                .help(&format!(
-                    "cast can be replaced by coercion; this might \
+        fcx.tcx.struct_span_lint_hir(lint, self.expr.hir_id, self.span, |err| {
+            err.build(&format!(
+                "trivial {}cast: `{}` as `{}`",
+                adjective,
+                fcx.ty_to_string(t_expr),
+                fcx.ty_to_string(t_cast)
+            ))
+            .help(&format!(
+                "cast can be replaced by coercion; this might \
                                    require {}a temporary variable",
-                    type_asc_or
-                ))
-                .emit();
-            },
-        );
+                type_asc_or
+            ))
+            .emit();
+        });
     }
 
     pub fn check(mut self, fcx: &FnCtxt<'a, 'tcx>) {

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -1285,7 +1285,9 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             self.fcx.body_id,
             self.span,
             |lint| {
-                let mut diag = lint.build("a method with this name may be added to the standard library in the future");
+                let mut diag = lint.build(
+                    "a method with this name may be added to the standard library in the future",
+                );
                 // FIXME: This should be a `span_suggestion` instead of `help`
                 // However `self.span` only
                 // highlights the method name, so we can't use it. Also consider reusing the code from

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2895,15 +2895,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
                 debug!("warn_if_unreachable: id={:?} span={:?} kind={}", id, span, kind);
 
-                let msg = format!("unreachable {}", kind);
                 self.tcx()
-                    .struct_span_lint_hir(lint::builtin::UNREACHABLE_CODE, id, span, &msg)
-                    .span_label(span, &msg)
-                    .span_label(
-                        orig_span,
-                        custom_note.unwrap_or("any code following this expression is unreachable"),
-                    )
-                    .emit();
+                    .struct_span_lint_hir(lint::builtin::UNREACHABLE_CODE, id, span, |lint| {
+                        let msg = format!("unreachable {}", kind);
+                        lint.build(&msg)
+                            .span_label(span, &msg)
+                            .span_label(
+                                orig_span,
+                                custom_note.unwrap_or("any code following this expression is unreachable"),
+                            )
+                            .emit();
+                    })
             }
         }
     }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2895,17 +2895,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
                 debug!("warn_if_unreachable: id={:?} span={:?} kind={}", id, span, kind);
 
-                self.tcx()
-                    .struct_span_lint_hir(lint::builtin::UNREACHABLE_CODE, id, span, |lint| {
-                        let msg = format!("unreachable {}", kind);
-                        lint.build(&msg)
-                            .span_label(span, &msg)
-                            .span_label(
-                                orig_span,
-                                custom_note.unwrap_or("any code following this expression is unreachable"),
-                            )
-                            .emit();
-                    })
+                self.tcx().struct_span_lint_hir(lint::builtin::UNREACHABLE_CODE, id, span, |lint| {
+                    let msg = format!("unreachable {}", kind);
+                    lint.build(&msg)
+                        .span_label(span, &msg)
+                        .span_label(
+                            orig_span,
+                            custom_note
+                                .unwrap_or("any code following this expression is unreachable"),
+                        )
+                        .emit();
+                })
             }
         }
     }

--- a/src/librustc_typeck/check_unused.rs
+++ b/src/librustc_typeck/check_unused.rs
@@ -55,12 +55,14 @@ impl CheckVisitor<'tcx> {
             return;
         }
 
-        let msg = if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(span) {
-            format!("unused import: `{}`", snippet)
-        } else {
-            "unused import".to_owned()
-        };
-        self.tcx.lint_hir(lint::builtin::UNUSED_IMPORTS, id, span, &msg);
+        self.tcx.struct_span_lint_hir(lint::builtin::UNUSED_IMPORTS, id, span, |lint| {
+            let msg = if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(span) {
+                format!("unused import: `{}`", snippet)
+            } else {
+                "unused import".to_owned()
+            };
+            lint.build(&msg).emit();
+        });
     }
 }
 
@@ -130,14 +132,16 @@ fn unused_crates_lint(tcx: TyCtxt<'_>) {
                     .map(|attr| attr.span)
                     .fold(span, |acc, attr_span| acc.to(attr_span));
 
-                tcx.struct_span_lint_hir(lint, id, span, msg)
-                    .span_suggestion_short(
-                        span_with_attrs,
-                        "remove it",
-                        String::new(),
-                        Applicability::MachineApplicable,
-                    )
-                    .emit();
+                tcx.struct_span_lint_hir(lint, id, span, |lint| {
+                    lint.build(msg)
+                        .span_suggestion_short(
+                            span_with_attrs,
+                            "remove it",
+                            String::new(),
+                            Applicability::MachineApplicable,
+                        )
+                        .emit();
+                });
                 continue;
             }
         }
@@ -170,21 +174,25 @@ fn unused_crates_lint(tcx: TyCtxt<'_>) {
         }
 
         // Otherwise, we can convert it into a `use` of some kind.
-        let msg = "`extern crate` is not idiomatic in the new edition";
-        let help = format!("convert it to a `{}`", visibility_qualified(&item.vis, "use"));
         let base_replacement = match extern_crate.orig_name {
             Some(orig_name) => format!("use {} as {};", orig_name, item.ident.name),
             None => format!("use {};", item.ident.name),
         };
         let replacement = visibility_qualified(&item.vis, base_replacement);
-        tcx.struct_span_lint_hir(lint, id, extern_crate.span, msg)
-            .span_suggestion_short(
-                extern_crate.span,
-                &help,
-                replacement,
-                Applicability::MachineApplicable,
-            )
-            .emit();
+        tcx.struct_span_lint_hir(lint, id, extern_crate.span, |lint| {
+
+            let msg = "`extern crate` is not idiomatic in the new edition";
+            let help = format!("convert it to a `{}`", visibility_qualified(&item.vis, "use"));
+
+            lint.build(msg)
+                .span_suggestion_short(
+                    extern_crate.span,
+                    &help,
+                    replacement,
+                    Applicability::MachineApplicable,
+                )
+                .emit();
+        })
     }
 }
 

--- a/src/librustc_typeck/check_unused.rs
+++ b/src/librustc_typeck/check_unused.rs
@@ -180,7 +180,6 @@ fn unused_crates_lint(tcx: TyCtxt<'_>) {
         };
         let replacement = visibility_qualified(&item.vis, base_replacement);
         tcx.struct_span_lint_hir(lint, id, extern_crate.span, |lint| {
-
             let msg = "`extern crate` is not idiomatic in the new edition";
             let help = format!("convert it to a `{}`", visibility_qualified(&item.vis, "use"));
 

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1157,9 +1157,10 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> &ty::Generics {
                             param.span,
                             |lint| {
                                 lint.build(&format!(
-                                "defaults for type parameters are only allowed in \
+                                    "defaults for type parameters are only allowed in \
                                         `struct`, `enum`, `type`, or `trait` definitions."
-                                )).emit();
+                                ))
+                                .emit();
                             },
                         );
                     }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1151,14 +1151,16 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> &ty::Generics {
             GenericParamKind::Type { ref default, synthetic, .. } => {
                 if !allow_defaults && default.is_some() {
                     if !tcx.features().default_type_parameter_fallback {
-                        tcx.lint_hir(
+                        tcx.struct_span_lint_hir(
                             lint::builtin::INVALID_TYPE_PARAM_DEFAULT,
                             param.hir_id,
                             param.span,
-                            &format!(
+                            |lint| {
+                                lint.build(&format!(
                                 "defaults for type parameters are only allowed in \
                                         `struct`, `enum`, `type`, or `trait` definitions."
-                            ),
+                                )).emit();
+                            },
                         );
                     }
                 }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2959,10 +2959,12 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
                     lint::builtin::INLINE_NO_SANITIZE,
                     hir_id,
                     no_sanitize_span,
-                    "`no_sanitize` will have no effect after inlining",
+                    |lint| {
+                        lint.build("`no_sanitize` will have no effect after inlining")
+                            .span_note(inline_span, "inlining requested here")
+                            .emit();
+                    },
                 )
-                .span_note(inline_span, "inlining requested here")
-                .emit();
             }
         }
     }

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -669,39 +669,41 @@ fn build_diagnostic(
     let attrs = &item.attrs;
     let sp = span_of_attrs(attrs).unwrap_or(item.source.span());
 
-    let mut diag = cx.tcx.struct_span_lint_hir(
+    cx.tcx.struct_span_lint_hir(
         lint::builtin::INTRA_DOC_LINK_RESOLUTION_FAILURE,
         hir_id,
         sp,
-        &format!("`[{}]` {}", path_str, err_msg),
-    );
-    if let Some(link_range) = link_range {
-        if let Some(sp) = super::source_span_for_markdown_range(cx, dox, &link_range, attrs) {
-            diag.set_span(sp);
-            diag.span_label(sp, short_err_msg);
-        } else {
-            // blah blah blah\nblah\nblah [blah] blah blah\nblah blah
-            //                       ^     ~~~~
-            //                       |     link_range
-            //                       last_new_line_offset
-            let last_new_line_offset = dox[..link_range.start].rfind('\n').map_or(0, |n| n + 1);
-            let line = dox[last_new_line_offset..].lines().next().unwrap_or("");
+        |lint| {
+            let mut diag = lint.build(&format!("`[{}]` {}", path_str, err_msg));
+            if let Some(link_range) = link_range {
+                if let Some(sp) = super::source_span_for_markdown_range(cx, dox, &link_range, attrs) {
+                    diag.set_span(sp);
+                    diag.span_label(sp, short_err_msg);
+                } else {
+                    // blah blah blah\nblah\nblah [blah] blah blah\nblah blah
+                    //                       ^     ~~~~
+                    //                       |     link_range
+                    //                       last_new_line_offset
+                    let last_new_line_offset = dox[..link_range.start].rfind('\n').map_or(0, |n| n + 1);
+                    let line = dox[last_new_line_offset..].lines().next().unwrap_or("");
 
-            // Print the line containing the `link_range` and manually mark it with '^'s.
-            diag.note(&format!(
-                "the link appears in this line:\n\n{line}\n\
-                 {indicator: <before$}{indicator:^<found$}",
-                line = line,
-                indicator = "",
-                before = link_range.start - last_new_line_offset,
-                found = link_range.len(),
-            ));
-        }
-    };
-    if let Some(help_msg) = help_msg {
-        diag.help(help_msg);
-    }
-    diag.emit();
+                    // Print the line containing the `link_range` and manually mark it with '^'s.
+                    diag.note(&format!(
+                        "the link appears in this line:\n\n{line}\n\
+                         {indicator: <before$}{indicator:^<found$}",
+                        line = line,
+                        indicator = "",
+                        before = link_range.start - last_new_line_offset,
+                        found = link_range.len(),
+                    ));
+                }
+            };
+            if let Some(help_msg) = help_msg {
+                diag.help(help_msg);
+            }
+            diag.emit();
+        },
+    );
 }
 
 /// Reports a resolution failure diagnostic.
@@ -766,105 +768,107 @@ fn ambiguity_error(
     let attrs = &item.attrs;
     let sp = span_of_attrs(attrs).unwrap_or(item.source.span());
 
-    let mut msg = format!("`{}` is ", path_str);
-
-    let candidates = [TypeNS, ValueNS, MacroNS]
-        .iter()
-        .filter_map(|&ns| candidates[ns].map(|res| (res, ns)))
-        .collect::<Vec<_>>();
-    match candidates.as_slice() {
-        [(first_def, _), (second_def, _)] => {
-            msg += &format!(
-                "both {} {} and {} {}",
-                first_def.article(),
-                first_def.descr(),
-                second_def.article(),
-                second_def.descr(),
-            );
-        }
-        _ => {
-            let mut candidates = candidates.iter().peekable();
-            while let Some((res, _)) = candidates.next() {
-                if candidates.peek().is_some() {
-                    msg += &format!("{} {}, ", res.article(), res.descr());
-                } else {
-                    msg += &format!("and {} {}", res.article(), res.descr());
-                }
-            }
-        }
-    }
-
-    let mut diag = cx.tcx.struct_span_lint_hir(
+    cx.tcx.struct_span_lint_hir(
         lint::builtin::INTRA_DOC_LINK_RESOLUTION_FAILURE,
         hir_id,
         sp,
-        &msg,
-    );
+        |lint| {
+            let mut msg = format!("`{}` is ", path_str);
 
-    if let Some(link_range) = link_range {
-        if let Some(sp) = super::source_span_for_markdown_range(cx, dox, &link_range, attrs) {
-            diag.set_span(sp);
-            diag.span_label(sp, "ambiguous link");
+            let candidates = [TypeNS, ValueNS, MacroNS]
+                .iter()
+                .filter_map(|&ns| candidates[ns].map(|res| (res, ns)))
+                .collect::<Vec<_>>();
+            match candidates.as_slice() {
+                [(first_def, _), (second_def, _)] => {
+                    msg += &format!(
+                        "both {} {} and {} {}",
+                        first_def.article(),
+                        first_def.descr(),
+                        second_def.article(),
+                        second_def.descr(),
+                    );
+                }
+                _ => {
+                    let mut candidates = candidates.iter().peekable();
+                    while let Some((res, _)) = candidates.next() {
+                        if candidates.peek().is_some() {
+                            msg += &format!("{} {}, ", res.article(), res.descr());
+                        } else {
+                            msg += &format!("and {} {}", res.article(), res.descr());
+                        }
+                    }
+                }
+            }
 
-            for (res, ns) in candidates {
-                let (action, mut suggestion) = match res {
-                    Res::Def(DefKind::Method, _) | Res::Def(DefKind::Fn, _) => {
-                        ("add parentheses", format!("{}()", path_str))
-                    }
-                    Res::Def(DefKind::Macro(..), _) => {
-                        ("add an exclamation mark", format!("{}!", path_str))
-                    }
-                    _ => {
-                        let type_ = match (res, ns) {
-                            (Res::Def(DefKind::Const, _), _) => "const",
-                            (Res::Def(DefKind::Static, _), _) => "static",
-                            (Res::Def(DefKind::Struct, _), _) => "struct",
-                            (Res::Def(DefKind::Enum, _), _) => "enum",
-                            (Res::Def(DefKind::Union, _), _) => "union",
-                            (Res::Def(DefKind::Trait, _), _) => "trait",
-                            (Res::Def(DefKind::Mod, _), _) => "module",
-                            (_, TypeNS) => "type",
-                            (_, ValueNS) => "value",
-                            (_, MacroNS) => "macro",
+            let mut diag = lint.build(&msg);
+
+            if let Some(link_range) = link_range {
+                if let Some(sp) = super::source_span_for_markdown_range(cx, dox, &link_range, attrs) {
+                    diag.set_span(sp);
+                    diag.span_label(sp, "ambiguous link");
+
+                    for (res, ns) in candidates {
+                        let (action, mut suggestion) = match res {
+                            Res::Def(DefKind::Method, _) | Res::Def(DefKind::Fn, _) => {
+                                ("add parentheses", format!("{}()", path_str))
+                            }
+                            Res::Def(DefKind::Macro(..), _) => {
+                                ("add an exclamation mark", format!("{}!", path_str))
+                            }
+                            _ => {
+                                let type_ = match (res, ns) {
+                                    (Res::Def(DefKind::Const, _), _) => "const",
+                                    (Res::Def(DefKind::Static, _), _) => "static",
+                                    (Res::Def(DefKind::Struct, _), _) => "struct",
+                                    (Res::Def(DefKind::Enum, _), _) => "enum",
+                                    (Res::Def(DefKind::Union, _), _) => "union",
+                                    (Res::Def(DefKind::Trait, _), _) => "trait",
+                                    (Res::Def(DefKind::Mod, _), _) => "module",
+                                    (_, TypeNS) => "type",
+                                    (_, ValueNS) => "value",
+                                    (_, MacroNS) => "macro",
+                                };
+
+                                // FIXME: if this is an implied shortcut link, it's bad style to suggest `@`
+                                ("prefix with the item type", format!("{}@{}", type_, path_str))
+                            }
                         };
 
-                        // FIXME: if this is an implied shortcut link, it's bad style to suggest `@`
-                        ("prefix with the item type", format!("{}@{}", type_, path_str))
+                        if dox.bytes().nth(link_range.start) == Some(b'`') {
+                            suggestion = format!("`{}`", suggestion);
+                        }
+
+                        diag.span_suggestion(
+                            sp,
+                            &format!("to link to the {}, {}", res.descr(), action),
+                            suggestion,
+                            Applicability::MaybeIncorrect,
+                        );
                     }
-                };
+                } else {
+                    // blah blah blah\nblah\nblah [blah] blah blah\nblah blah
+                    //                       ^     ~~~~
+                    //                       |     link_range
+                    //                       last_new_line_offset
+                    let last_new_line_offset = dox[..link_range.start].rfind('\n').map_or(0, |n| n + 1);
+                    let line = dox[last_new_line_offset..].lines().next().unwrap_or("");
 
-                if dox.bytes().nth(link_range.start) == Some(b'`') {
-                    suggestion = format!("`{}`", suggestion);
+                    // Print the line containing the `link_range` and manually mark it with '^'s.
+                    diag.note(&format!(
+                        "the link appears in this line:\n\n{line}\n\
+                         {indicator: <before$}{indicator:^<found$}",
+                        line = line,
+                        indicator = "",
+                        before = link_range.start - last_new_line_offset,
+                        found = link_range.len(),
+                    ));
                 }
-
-                diag.span_suggestion(
-                    sp,
-                    &format!("to link to the {}, {}", res.descr(), action),
-                    suggestion,
-                    Applicability::MaybeIncorrect,
-                );
             }
-        } else {
-            // blah blah blah\nblah\nblah [blah] blah blah\nblah blah
-            //                       ^     ~~~~
-            //                       |     link_range
-            //                       last_new_line_offset
-            let last_new_line_offset = dox[..link_range.start].rfind('\n').map_or(0, |n| n + 1);
-            let line = dox[last_new_line_offset..].lines().next().unwrap_or("");
+            diag.emit();
+        },
+    );
 
-            // Print the line containing the `link_range` and manually mark it with '^'s.
-            diag.note(&format!(
-                "the link appears in this line:\n\n{line}\n\
-                 {indicator: <before$}{indicator:^<found$}",
-                line = line,
-                indicator = "",
-                before = link_range.start - last_new_line_offset,
-                found = link_range.len(),
-            ));
-        }
-    }
-
-    diag.emit();
 }
 
 /// Given an enum variant's res, return the res of its enum and the associated fragment.

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -676,7 +676,8 @@ fn build_diagnostic(
         |lint| {
             let mut diag = lint.build(&format!("`[{}]` {}", path_str, err_msg));
             if let Some(link_range) = link_range {
-                if let Some(sp) = super::source_span_for_markdown_range(cx, dox, &link_range, attrs) {
+                if let Some(sp) = super::source_span_for_markdown_range(cx, dox, &link_range, attrs)
+                {
                     diag.set_span(sp);
                     diag.span_label(sp, short_err_msg);
                 } else {
@@ -684,7 +685,8 @@ fn build_diagnostic(
                     //                       ^     ~~~~
                     //                       |     link_range
                     //                       last_new_line_offset
-                    let last_new_line_offset = dox[..link_range.start].rfind('\n').map_or(0, |n| n + 1);
+                    let last_new_line_offset =
+                        dox[..link_range.start].rfind('\n').map_or(0, |n| n + 1);
                     let line = dox[last_new_line_offset..].lines().next().unwrap_or("");
 
                     // Print the line containing the `link_range` and manually mark it with '^'s.
@@ -804,7 +806,8 @@ fn ambiguity_error(
             let mut diag = lint.build(&msg);
 
             if let Some(link_range) = link_range {
-                if let Some(sp) = super::source_span_for_markdown_range(cx, dox, &link_range, attrs) {
+                if let Some(sp) = super::source_span_for_markdown_range(cx, dox, &link_range, attrs)
+                {
                     diag.set_span(sp);
                     diag.span_label(sp, "ambiguous link");
 
@@ -851,7 +854,8 @@ fn ambiguity_error(
                     //                       ^     ~~~~
                     //                       |     link_range
                     //                       last_new_line_offset
-                    let last_new_line_offset = dox[..link_range.start].rfind('\n').map_or(0, |n| n + 1);
+                    let last_new_line_offset =
+                        dox[..link_range.start].rfind('\n').map_or(0, |n| n + 1);
                     let line = dox[last_new_line_offset..].lines().next().unwrap_or("");
 
                     // Print the line containing the `link_range` and manually mark it with '^'s.
@@ -868,7 +872,6 @@ fn ambiguity_error(
             diag.emit();
         },
     );
-
 }
 
 /// Given an enum variant's res, return the res of its enum and the associated fragment.

--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -342,12 +342,9 @@ pub fn look_for_tests<'tcx>(
 
     if check_missing_code == true && tests.found_tests == 0 {
         let sp = span_of_attrs(&item.attrs).unwrap_or(item.source.span());
-        cx.tcx.struct_span_lint_hir(
-            lint::builtin::MISSING_DOC_CODE_EXAMPLES,
-            hir_id,
-            sp,
-            |lint| lint.build("missing code example in this documentation").emit(),
-        );
+        cx.tcx.struct_span_lint_hir(lint::builtin::MISSING_DOC_CODE_EXAMPLES, hir_id, sp, |lint| {
+            lint.build("missing code example in this documentation").emit()
+        });
     } else if check_missing_code == false
         && tests.found_tests > 0
         && !cx.renderinfo.borrow().access_levels.is_public(item.def_id)

--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -342,24 +342,22 @@ pub fn look_for_tests<'tcx>(
 
     if check_missing_code == true && tests.found_tests == 0 {
         let sp = span_of_attrs(&item.attrs).unwrap_or(item.source.span());
-        let mut diag = cx.tcx.struct_span_lint_hir(
+        cx.tcx.struct_span_lint_hir(
             lint::builtin::MISSING_DOC_CODE_EXAMPLES,
             hir_id,
             sp,
-            "missing code example in this documentation",
+            |lint| lint.build("missing code example in this documentation").emit(),
         );
-        diag.emit();
     } else if check_missing_code == false
         && tests.found_tests > 0
         && !cx.renderinfo.borrow().access_levels.is_public(item.def_id)
     {
-        let mut diag = cx.tcx.struct_span_lint_hir(
+        cx.tcx.struct_span_lint_hir(
             lint::builtin::PRIVATE_DOC_TESTS,
             hir_id,
             span_of_attrs(&item.attrs).unwrap_or(item.source.span()),
-            "documentation test in private item",
+            |lint| lint.build("documentation test in private item").emit(),
         );
-        diag.emit();
     }
 }
 

--- a/src/test/ui-fulldeps/auxiliary/lint-for-crate-rpass.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-for-crate-rpass.rs
@@ -5,12 +5,14 @@
 extern crate rustc_driver;
 extern crate rustc_hir;
 extern crate rustc_span;
-#[macro_use] extern crate rustc_lint;
-#[macro_use] extern crate rustc_session;
+#[macro_use]
+extern crate rustc_lint;
+#[macro_use]
+extern crate rustc_session;
 extern crate syntax;
 
-use rustc_lint::{LateContext, LintContext, LintPass, LateLintPass};
 use rustc_driver::plugin::Registry;
+use rustc_lint::{LateContext, LateLintPass, LintContext, LintPass};
 use rustc_span::symbol::Symbol;
 use syntax::attr;
 
@@ -28,8 +30,10 @@ macro_rules! fake_lint_pass {
             fn check_crate(&mut self, cx: &LateContext, krate: &rustc_hir::Crate) {
                 $(
                     if !attr::contains_name(&krate.attrs, $attr) {
-                        cx.span_lint(CRATE_NOT_OKAY, krate.span,
-                                     &format!("crate is not marked with #![{}]", $attr));
+                        cx.lint(CRATE_NOT_OKAY, |lint| {
+                             let msg = format!("crate is not marked with #![{}]", $attr);
+                             lint.build(&msg).set_span(krate.span).emit()
+                        });
                     }
                 )*
             }

--- a/src/test/ui-fulldeps/auxiliary/lint-for-crate.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-for-crate.rs
@@ -5,13 +5,15 @@
 
 extern crate rustc_driver;
 extern crate rustc_hir;
-#[macro_use] extern crate rustc_lint;
-#[macro_use] extern crate rustc_session;
+#[macro_use]
+extern crate rustc_lint;
+#[macro_use]
+extern crate rustc_session;
 extern crate rustc_span;
 extern crate syntax;
 
-use rustc_lint::{LateContext, LintContext, LintPass, LateLintPass, LintArray};
 use rustc_driver::plugin::Registry;
+use rustc_lint::{LateContext, LateLintPass, LintArray, LintContext, LintPass};
 use rustc_span::symbol::Symbol;
 use syntax::attr;
 
@@ -26,8 +28,11 @@ declare_lint_pass!(Pass => [CRATE_NOT_OKAY]);
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
     fn check_crate(&mut self, cx: &LateContext, krate: &rustc_hir::Crate) {
         if !attr::contains_name(&krate.attrs, Symbol::intern("crate_okay")) {
-            cx.span_lint(CRATE_NOT_OKAY, krate.span,
-                         "crate is not marked with #![crate_okay]");
+            cx.lint(CRATE_NOT_OKAY, |lint| {
+                lint.build("crate is not marked with #![crate_okay]")
+                    .set_span(krate.span)
+                    .emit()
+            });
         }
     }
 }

--- a/src/test/ui-fulldeps/auxiliary/lint-plugin-test.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-plugin-test.rs
@@ -7,11 +7,13 @@ extern crate syntax;
 
 // Load rustc as a plugin to get macros
 extern crate rustc_driver;
-#[macro_use] extern crate rustc_lint;
-#[macro_use] extern crate rustc_session;
+#[macro_use]
+extern crate rustc_lint;
+#[macro_use]
+extern crate rustc_session;
 
-use rustc_lint::{EarlyContext, LintContext, LintPass, EarlyLintPass, LintArray};
 use rustc_driver::plugin::Registry;
+use rustc_lint::{EarlyContext, EarlyLintPass, LintArray, LintContext, LintPass};
 use syntax::ast;
 declare_lint!(TEST_LINT, Warn, "Warn about items named 'lintme'");
 
@@ -20,7 +22,9 @@ declare_lint_pass!(Pass => [TEST_LINT]);
 impl EarlyLintPass for Pass {
     fn check_item(&mut self, cx: &EarlyContext, it: &ast::Item) {
         if it.ident.name.as_str() == "lintme" {
-            cx.span_lint(TEST_LINT, it.span, "item is named 'lintme'");
+            cx.lint(TEST_LINT, |lint| {
+                lint.build("item is named 'lintme'").set_span(it.span).emit()
+            });
         }
     }
 }

--- a/src/test/ui-fulldeps/auxiliary/lint-tool-test.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-tool-test.rs
@@ -5,11 +5,13 @@ extern crate syntax;
 
 // Load rustc as a plugin to get macros
 extern crate rustc_driver;
-#[macro_use] extern crate rustc_lint;
-#[macro_use] extern crate rustc_session;
+#[macro_use]
+extern crate rustc_lint;
+#[macro_use]
+extern crate rustc_session;
 
-use rustc_lint::{EarlyContext, EarlyLintPass, LintArray, LintContext, LintPass, LintId};
 use rustc_driver::plugin::Registry;
+use rustc_lint::{EarlyContext, EarlyLintPass, LintArray, LintContext, LintId, LintPass};
 use syntax::ast;
 declare_tool_lint!(pub clippy::TEST_LINT, Warn, "Warn about stuff");
 declare_tool_lint!(
@@ -30,10 +32,14 @@ declare_lint_pass!(Pass => [TEST_LINT, TEST_GROUP, TEST_RUSTC_TOOL_LINT]);
 impl EarlyLintPass for Pass {
     fn check_item(&mut self, cx: &EarlyContext, it: &ast::Item) {
         if it.ident.name.as_str() == "lintme" {
-            cx.span_lint(TEST_LINT, it.span, "item is named 'lintme'");
+            cx.lint(TEST_LINT, |lint| {
+                lint.build("item is named 'lintme'").set_span(it.span).emit()
+            });
         }
         if it.ident.name.as_str() == "lintmetoo" {
-            cx.span_lint(TEST_GROUP, it.span, "item is named 'lintmetoo'");
+            cx.lint(TEST_GROUP, |lint| {
+                lint.build("item is named 'lintmetoo'").set_span(it.span).emit()
+            });
         }
     }
 }
@@ -42,6 +48,10 @@ impl EarlyLintPass for Pass {
 pub fn plugin_registrar(reg: &mut Registry) {
     reg.lint_store.register_lints(&[&TEST_RUSTC_TOOL_LINT, &TEST_LINT, &TEST_GROUP]);
     reg.lint_store.register_early_pass(|| box Pass);
-    reg.lint_store.register_group(true, "clippy::group", Some("clippy_group"),
-        vec![LintId::of(&TEST_LINT), LintId::of(&TEST_GROUP)]);
+    reg.lint_store.register_group(
+        true,
+        "clippy::group",
+        Some("clippy_group"),
+        vec![LintId::of(&TEST_LINT), LintId::of(&TEST_GROUP)],
+    );
 }

--- a/src/test/ui/type-alias-enum-variants/enum-variant-priority-lint-ambiguous_associated_items.rs
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-priority-lint-ambiguous_associated_items.rs
@@ -32,6 +32,7 @@ impl Tr for E {
     fn f() -> Self::V { 0 }
     //~^ ERROR ambiguous associated item
     //~| WARN this was previously accepted
+    //~| HELP use fully-qualified syntax
 }
 
 fn main() {}


### PR DESCRIPTION
Closes #67927 

Changes the `struct_lint*` methods to take a  `decorate` function instead of a message string. This decorate function is also responsible for eventually stashing, emitting or cancelling the diagnostic. If the lint was allowed after all, the decorate function is not run at all, saving us from spending time formatting messages (and potentially other expensive work) for lints that don't end up being emitted.

r? @Centril