### PR TITLE
Disallow } as fill character in format strings

### DIFF
--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -481,12 +481,14 @@ impl<'a> Parser<'a> {
 
         // fill character
         if let Some(&(_, c)) = self.cur.peek() {
-            match self.cur.clone().nth(1) {
-                Some((_, '>')) | Some((_, '<')) | Some((_, '^')) => {
-                    spec.fill = Some(c);
-                    self.cur.next();
+            if c != '}' {
+                match self.cur.clone().nth(1) {
+                    Some((_, '>')) | Some((_, '<')) | Some((_, '^')) => {
+                        spec.fill = Some(c);
+                        self.cur.next();
+                    }
+                    _ => {}
                 }
-                _ => {}
             }
         }
         // Alignment

--- a/src/test/ui/ifmt.rs
+++ b/src/test/ui/ifmt.rs
@@ -237,6 +237,11 @@ pub fn main() {
     format!("{foo}", foo="test",);
 
     test_refcell();
+
+    // test that } cannot be a fill character
+    t!(format!("{:}<}}", 4), "4<}");
+    t!(format!("{:}>}}", 4), "4>}");
+    t!(format!("{:}^}}", 4), "4^}");
 }
 
 // Basic test to make sure that we can invoke the `write!` macro with an


### PR DESCRIPTION
Fixes #68707. Strictly speaking a breaking change, but it's unlikely this feature was depended on.