### PR TITLE
pretty: print attrs in struct expr

### DIFF
--- a/src/librustc_ast_pretty/pprust.rs
+++ b/src/librustc_ast_pretty/pprust.rs
@@ -1749,6 +1749,7 @@ impl<'a> State<'a> {
             Consistent,
             &fields[..],
             |s, field| {
+                s.print_outer_attributes(&field.attrs);
                 s.ibox(INDENT_UNIT);
                 if !field.is_shorthand {
                     s.print_ident(field.ident);

--- a/src/test/pretty/issue-68710-field-attr-proc-mac-lost.rs
+++ b/src/test/pretty/issue-68710-field-attr-proc-mac-lost.rs
@@ -1,0 +1,16 @@
+// pp-exact
+
+fn main() { }
+
+struct C {
+    field: u8,
+}
+
+#[allow()]
+const C: C =
+    C{
+      #[cfg(debug_assertions)]
+      field: 0,
+
+      #[cfg(not (debug_assertions))]
+      field: 1,};


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/68710 by printing the attributes on struct expression fields.

r? @petrochenkov 
cc @dtolnay 