### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,9 @@ is a bug or not, feel free to file a bug anyway.
 **If you believe reporting your bug publicly represents a security risk to Rust users,
 please follow our [instructions for reporting security vulnerabilities](https://www.rust-lang.org/policies/security)**.
 
+If you're using the nightly channel, please check if the bug exists in the
+latest toolchain before filing your bug. It might be fixed already.
+
 If you have the chance, before reporting a bug, please [search existing
 issues](https://github.com/rust-lang/rust/search?q=&type=Issues&utf8=%E2%9C%93),
 as it's possible that someone else has already reported your error. This doesn't

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -6,6 +6,8 @@ merge_derives = false
 # by default we ignore everything in the repository
 # tidy only checks files which are not ignored, each entry follows gitignore style
 ignore = [
+    "build",
+
     # tests for now are not formatted, as they are sometimes pretty-printing constrained
     # (and generally rustfmt can move around comments in UI-testing incompatible ways)
     "src/test",

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -2,7 +2,8 @@
 //!
 //! [`Box<T>`], casually referred to as a 'box', provides the simplest form of
 //! heap allocation in Rust. Boxes provide ownership for this allocation, and
-//! drop their contents when they go out of scope.
+//! drop their contents when they go out of scope. Boxes also ensure that they
+//! never allocate more than `isize::MAX` bytes.
 //!
 //! # Examples
 //!

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -4,6 +4,8 @@
 //! Vectors have `O(1)` indexing, amortized `O(1)` push (to the end) and
 //! `O(1)` pop (from the end).
 //!
+//! Vectors ensure they never allocate more than `isize::MAX` bytes.
+//!
 //! # Examples
 //!
 //! You can explicitly create a [`Vec<T>`] with [`new`]:

--- a/src/librustc_data_structures/obligation_forest/graphviz.rs
+++ b/src/librustc_data_structures/obligation_forest/graphviz.rs
@@ -2,6 +2,7 @@ use crate::obligation_forest::{ForestObligation, ObligationForest};
 use graphviz as dot;
 use std::env::var_os;
 use std::fs::File;
+use std::io::BufWriter;
 use std::path::Path;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
@@ -31,7 +32,7 @@ impl<O: ForestObligation> ObligationForest<O> {
 
         let file_path = dir.as_ref().join(format!("{:010}_{}.gv", counter, description));
 
-        let mut gv_file = File::create(file_path).unwrap();
+        let mut gv_file = BufWriter::new(File::create(file_path).unwrap());
 
         dot::render(&self, &mut gv_file).unwrap();
     }

--- a/src/librustc_incremental/assert_dep_graph.rs
+++ b/src/librustc_incremental/assert_dep_graph.rs
@@ -49,7 +49,7 @@ use syntax::ast;
 
 use std::env;
 use std::fs::{self, File};
-use std::io::Write;
+use std::io::{BufWriter, Write};
 
 pub fn assert_dep_graph(tcx: TyCtxt<'_>) {
     tcx.dep_graph.with_ignore(|| {
@@ -235,7 +235,7 @@ fn dump_graph(tcx: TyCtxt<'_>) {
     {
         // dump a .txt file with just the edges:
         let txt_path = format!("{}.txt", path);
-        let mut file = File::create(&txt_path).unwrap();
+        let mut file = BufWriter::new(File::create(&txt_path).unwrap());
         for &(ref source, ref target) in &edges {
             write!(file, "{:?} -> {:?}\n", source, target).unwrap();
         }

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -49,7 +49,7 @@ use tempfile::Builder as TempFileBuilder;
 use std::any::Any;
 use std::cell::RefCell;
 use std::ffi::OsString;
-use std::io::{self, Write};
+use std::io::{self, BufWriter, Write};
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::{env, fs, iter, mem};
@@ -575,7 +575,7 @@ fn write_out_deps(
             });
         }
 
-        let mut file = fs::File::create(&deps_filename)?;
+        let mut file = BufWriter::new(fs::File::create(&deps_filename)?);
         for path in out_filenames {
             writeln!(file, "{}: {}\n", path.display(), files.join(" "))?;
         }

--- a/src/librustc_mir/borrow_check/facts.rs
+++ b/src/librustc_mir/borrow_check/facts.rs
@@ -8,7 +8,7 @@ use rustc_index::vec::Idx;
 use std::error::Error;
 use std::fmt::Debug;
 use std::fs::{self, File};
-use std::io::Write;
+use std::io::{BufWriter, Write};
 use std::path::Path;
 
 #[derive(Copy, Clone, Debug)]
@@ -117,7 +117,7 @@ impl<'w> FactWriter<'w> {
         T: FactRow,
     {
         let file = &self.dir.join(file_name);
-        let mut file = File::create(file)?;
+        let mut file = BufWriter::new(File::create(file)?);
         for row in rows {
             row.write(&mut file, self.location_table)?;
         }
@@ -126,11 +126,19 @@ impl<'w> FactWriter<'w> {
 }
 
 trait FactRow {
-    fn write(&self, out: &mut File, location_table: &LocationTable) -> Result<(), Box<dyn Error>>;
+    fn write(
+        &self,
+        out: &mut dyn Write,
+        location_table: &LocationTable,
+    ) -> Result<(), Box<dyn Error>>;
 }
 
 impl FactRow for RegionVid {
-    fn write(&self, out: &mut File, location_table: &LocationTable) -> Result<(), Box<dyn Error>> {
+    fn write(
+        &self,
+        out: &mut dyn Write,
+        location_table: &LocationTable,
+    ) -> Result<(), Box<dyn Error>> {
         write_row(out, location_table, &[self])
     }
 }
@@ -140,7 +148,11 @@ where
     A: FactCell,
     B: FactCell,
 {
-    fn write(&self, out: &mut File, location_table: &LocationTable) -> Result<(), Box<dyn Error>> {
+    fn write(
+        &self,
+        out: &mut dyn Write,
+        location_table: &LocationTable,
+    ) -> Result<(), Box<dyn Error>> {
         write_row(out, location_table, &[&self.0, &self.1])
     }
 }
@@ -151,7 +163,11 @@ where
     B: FactCell,
     C: FactCell,
 {
-    fn write(&self, out: &mut File, location_table: &LocationTable) -> Result<(), Box<dyn Error>> {
+    fn write(
+        &self,
+        out: &mut dyn Write,
+        location_table: &LocationTable,
+    ) -> Result<(), Box<dyn Error>> {
         write_row(out, location_table, &[&self.0, &self.1, &self.2])
     }
 }
@@ -163,7 +179,11 @@ where
     C: FactCell,
     D: FactCell,
 {
-    fn write(&self, out: &mut File, location_table: &LocationTable) -> Result<(), Box<dyn Error>> {
+    fn write(
+        &self,
+        out: &mut dyn Write,
+        location_table: &LocationTable,
+    ) -> Result<(), Box<dyn Error>> {
         write_row(out, location_table, &[&self.0, &self.1, &self.2, &self.3])
     }
 }

--- a/src/librustc_mir/transform/dump_mir.rs
+++ b/src/librustc_mir/transform/dump_mir.rs
@@ -61,7 +61,7 @@ pub fn on_mir_pass<'tcx>(
 
 pub fn emit_mir(tcx: TyCtxt<'_>, outputs: &OutputFilenames) -> io::Result<()> {
     let path = outputs.path(OutputType::Mir);
-    let mut f = File::create(&path)?;
+    let mut f = io::BufWriter::new(File::create(&path)?);
     mir_util::write_mir_pretty(tcx, None, &mut f)?;
     Ok(())
 }

--- a/src/librustc_mir/util/liveness.rs
+++ b/src/librustc_mir/util/liveness.rs
@@ -36,7 +36,7 @@ use rustc_data_structures::work_queue::WorkQueue;
 use rustc_index::bit_set::BitSet;
 use rustc_index::vec::{Idx, IndexVec};
 use std::fs;
-use std::io::{self, Write};
+use std::io::{self, BufWriter, Write};
 use std::path::{Path, PathBuf};
 
 pub type LiveVarSet = BitSet<Local>;
@@ -288,7 +288,8 @@ fn dump_matched_mir_node<'tcx>(
     let item_id = tcx.hir().as_local_hir_id(source.def_id()).unwrap();
     let file_name = format!("rustc.node{}{}-liveness.mir", item_id, pass_name);
     file_path.push(&file_name);
-    let _ = fs::File::create(&file_path).and_then(|mut file| {
+    let _ = fs::File::create(&file_path).and_then(|file| {
+        let mut file = BufWriter::new(file);
         writeln!(file, "// MIR local liveness analysis for `{}`", node_path)?;
         writeln!(file, "// source = {:?}", source)?;
         writeln!(file, "// pass_name = {}", pass_name)?;

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -769,6 +769,11 @@ impl<'a> Resolver<'a> {
         span: Span,
     ) -> bool {
         if let Some(suggestion) = suggestion {
+            // We shouldn't suggest underscore.
+            if suggestion.candidate == kw::Underscore {
+                return false;
+            }
+
             let msg = format!(
                 "{} {} with a similar name exists",
                 suggestion.res.article(),

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1364,14 +1364,15 @@ function getSearchElement() {
             var href;
             var type = itemTypes[item.ty];
             var name = item.name;
+            var path = item.path;
 
             if (type === "mod") {
-                displayPath = item.path + "::";
-                href = rootPath + item.path.replace(/::/g, "/") + "/" +
+                displayPath = path + "::";
+                href = rootPath + path.replace(/::/g, "/") + "/" +
                        name + "/index.html";
             } else if (type === "primitive" || type === "keyword") {
                 displayPath = "";
-                href = rootPath + item.path.replace(/::/g, "/") +
+                href = rootPath + path.replace(/::/g, "/") +
                        "/" + type + "." + name + ".html";
             } else if (type === "externcrate") {
                 displayPath = "";
@@ -1380,14 +1381,27 @@ function getSearchElement() {
                 var myparent = item.parent;
                 var anchor = "#" + type + "." + name;
                 var parentType = itemTypes[myparent.ty];
+                var pageType = parentType;
+                var pageName = myparent.name;
+
                 if (parentType === "primitive") {
                     displayPath = myparent.name + "::";
+                } else if (type === "structfield" && parentType === "variant") {
+                    // Structfields belonging to variants are special: the
+                    // final path element is the enum name.
+                    var splitPath = item.path.split("::");
+                    var enumName = splitPath.pop();
+                    path = splitPath.join("::");
+                    displayPath = path + "::" + enumName + "::" + myparent.name + "::";
+                    anchor = "#variant." + myparent.name + ".field." + name;
+                    pageType = "enum";
+                    pageName = enumName;
                 } else {
-                    displayPath = item.path + "::" + myparent.name + "::";
+                    displayPath = path + "::" + myparent.name + "::";
                 }
-                href = rootPath + item.path.replace(/::/g, "/") +
-                       "/" + parentType +
-                       "." + myparent.name +
+                href = rootPath + path.replace(/::/g, "/") +
+                       "/" + pageType +
+                       "." + pageName +
                        ".html" + anchor;
             } else {
                 displayPath = item.path + "::";
@@ -1668,7 +1682,7 @@ function getSearchElement() {
                 //              (String) name]
                 var paths = rawSearchIndex[crate].p;
 
-                // convert `paths` into an object form
+                // convert `rawPaths` entries into object form
                 var len = paths.length;
                 for (i = 0; i < len; ++i) {
                     paths[i] = {ty: paths[i][0], name: paths[i][1]};

--- a/src/test/rustdoc-js/struct-like-variant.js
+++ b/src/test/rustdoc-js/struct-like-variant.js
@@ -1,0 +1,7 @@
+const QUERY = 'name';
+
+const EXPECTED = {
+    'others': [
+        { 'path': 'struct_like_variant::Enum::Bar::name', 'name': 'l' },
+    ],
+};

--- a/src/test/rustdoc-js/struct-like-variant.rs
+++ b/src/test/rustdoc-js/struct-like-variant.rs
@@ -1,0 +1,5 @@
+#![crate_name = "struct_like_variant"]
+
+pub enum Enum {
+    Bar { name: String }
+}

--- a/src/test/ui/ifmt.rs
+++ b/src/test/ui/ifmt.rs
@@ -99,7 +99,6 @@ pub fn main() {
     let a: &dyn fmt::Debug = &1;
     t!(format!("{:?}", a), "1");
 
-
     // Formatting strings and their arguments
     t!(format!("{}", "a"), "a");
     t!(format!("{:4}", "a"), "a   ");
@@ -187,10 +186,6 @@ pub fn main() {
     // Ergonomic format_args!
     t!(format!("{0:x} {0:X}", 15), "f F");
     t!(format!("{0:x} {0:X} {}", 15), "f F 15");
-    // NOTE: For now the longer test cases must not be followed immediately by
-    // >1 empty lines, or the pretty printer will break. Since no one wants to
-    // touch the current pretty printer (#751), we have no choice but to work
-    // around it. Some of the following test cases are also affected.
     t!(format!("{:x}{0:X}{a:x}{:X}{1:x}{a:X}", 13, 14, a=15), "dDfEeF");
     t!(format!("{a:x} {a:X}", a=15), "f F");
 
@@ -200,7 +195,6 @@ pub fn main() {
                "abcd hijk 4\nabc hij 3");
     t!(format!("{a:.*} {0} {:.*}", 4, 3, "efgh", a="abcdef"), "abcd 4 efg");
     t!(format!("{:.a$} {a} {a:#x}", "aaaaaa", a=2), "aa 2 0x2");
-
 
     // Test that pointers don't get truncated.
     {

--- a/src/test/ui/resolve/typo-suggestion-named-underscore.rs
+++ b/src/test/ui/resolve/typo-suggestion-named-underscore.rs
@@ -1,0 +1,14 @@
+const _: () = ();
+
+fn main() {
+    a // Shouldn't suggest underscore
+    //~^ ERROR: cannot find value `a` in this scope
+}
+
+trait Unknown {}
+
+#[allow(unused_imports)]
+use Unknown as _;
+
+fn foo<T: A>(x: T) {} // Shouldn't suggest underscore
+//~^ ERROR: cannot find trait `A` in this scope

--- a/src/test/ui/resolve/typo-suggestion-named-underscore.stderr
+++ b/src/test/ui/resolve/typo-suggestion-named-underscore.stderr
@@ -1,0 +1,16 @@
+error[E0425]: cannot find value `a` in this scope
+  --> $DIR/typo-suggestion-named-underscore.rs:4:5
+   |
+LL |     a // Shouldn't suggest underscore
+   |     ^ not found in this scope
+
+error[E0405]: cannot find trait `A` in this scope
+  --> $DIR/typo-suggestion-named-underscore.rs:13:11
+   |
+LL | fn foo<T: A>(x: T) {} // Shouldn't suggest underscore
+   |           ^ not found in this scope
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0405, E0425.
+For more information about an error, try `rustc --explain E0405`.


### PR DESCRIPTION
Successful merges:

 - #68460 (Use BufWriter for emitting MIR)
 - #68668 (Struct variant field search)
 - #68688 ([docs] remind bug reporters to update nightly)
 - #68704 (Ignore `build` dir formatting)
 - #68711 (Added upper bound of what vecs and boxes can allocate)
 - #68727 (Remove a comment about pretty printer in formatting tests)
 - #68740 (Do not suggest things named underscore)

Failed merges:


r? @ghost