### PR TITLE
Implement `unused_parens` for `const` and `static` items

### DIFF
--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -587,6 +587,14 @@ impl EarlyLintPass for UnusedParens {
             }
         }
     }
+
+    fn check_item(&mut self, cx: &EarlyContext<'_>, item: &ast::Item) {
+        use ast::ItemKind::*;
+
+        if let Const(.., ref expr) | Static(.., ref expr) = item.kind {
+            self.check_unused_parens_expr(cx, expr, "assigned value", false, None, None);
+        }
+    }
 }
 
 declare_lint! {

--- a/src/test/ui/lint/lint-unnecessary-parens.rs
+++ b/src/test/ui/lint/lint-unnecessary-parens.rs
@@ -38,6 +38,9 @@ macro_rules! baz {
     }
 }
 
+const CONST_ITEM: usize = (10); //~ ERROR unnecessary parentheses around assigned value
+static STATIC_ITEM: usize = (10); //~ ERROR unnecessary parentheses around assigned value
+
 fn main() {
     foo();
     bar((true)); //~ ERROR unnecessary parentheses around function argument

--- a/src/test/ui/lint/lint-unnecessary-parens.stderr
+++ b/src/test/ui/lint/lint-unnecessary-parens.stderr
@@ -34,26 +34,38 @@ error: unnecessary parentheses around block return value
 LL |     (5)
    |     ^^^ help: remove these parentheses
 
+error: unnecessary parentheses around assigned value
+  --> $DIR/lint-unnecessary-parens.rs:41:27
+   |
+LL | const CONST_ITEM: usize = (10);
+   |                           ^^^^ help: remove these parentheses
+
+error: unnecessary parentheses around assigned value
+  --> $DIR/lint-unnecessary-parens.rs:42:29
+   |
+LL | static STATIC_ITEM: usize = (10);
+   |                             ^^^^ help: remove these parentheses
+
 error: unnecessary parentheses around function argument
-  --> $DIR/lint-unnecessary-parens.rs:43:9
+  --> $DIR/lint-unnecessary-parens.rs:46:9
    |
 LL |     bar((true));
    |         ^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around `if` condition
-  --> $DIR/lint-unnecessary-parens.rs:45:8
+  --> $DIR/lint-unnecessary-parens.rs:48:8
    |
 LL |     if (true) {}
    |        ^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around `while` condition
-  --> $DIR/lint-unnecessary-parens.rs:46:11
+  --> $DIR/lint-unnecessary-parens.rs:49:11
    |
 LL |     while (true) {}
    |           ^^^^^^ help: remove these parentheses
 
 warning: denote infinite loops with `loop { ... }`
-  --> $DIR/lint-unnecessary-parens.rs:46:5
+  --> $DIR/lint-unnecessary-parens.rs:49:5
    |
 LL |     while (true) {}
    |     ^^^^^^^^^^^^ help: use `loop`
@@ -61,46 +73,46 @@ LL |     while (true) {}
    = note: `#[warn(while_true)]` on by default
 
 error: unnecessary parentheses around `match` head expression
-  --> $DIR/lint-unnecessary-parens.rs:48:11
+  --> $DIR/lint-unnecessary-parens.rs:51:11
    |
 LL |     match (true) {
    |           ^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around `let` head expression
-  --> $DIR/lint-unnecessary-parens.rs:51:16
+  --> $DIR/lint-unnecessary-parens.rs:54:16
    |
 LL |     if let 1 = (1) {}
    |                ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around `let` head expression
-  --> $DIR/lint-unnecessary-parens.rs:52:19
+  --> $DIR/lint-unnecessary-parens.rs:55:19
    |
 LL |     while let 1 = (2) {}
    |                   ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around method argument
-  --> $DIR/lint-unnecessary-parens.rs:66:24
+  --> $DIR/lint-unnecessary-parens.rs:69:24
    |
 LL |     X { y: false }.foo((true));
    |                        ^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around assigned value
-  --> $DIR/lint-unnecessary-parens.rs:68:18
+  --> $DIR/lint-unnecessary-parens.rs:71:18
    |
 LL |     let mut _a = (0);
    |                  ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around assigned value
-  --> $DIR/lint-unnecessary-parens.rs:69:10
+  --> $DIR/lint-unnecessary-parens.rs:72:10
    |
 LL |     _a = (0);
    |          ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around assigned value
-  --> $DIR/lint-unnecessary-parens.rs:70:11
+  --> $DIR/lint-unnecessary-parens.rs:73:11
    |
 LL |     _a += (1);
    |           ^^^ help: remove these parentheses
 
-error: aborting due to 15 previous errors
+error: aborting due to 17 previous errors
 

--- a/src/test/ui/super-fast-paren-parsing.rs
+++ b/src/test/ui/super-fast-paren-parsing.rs
@@ -1,5 +1,6 @@
 // run-pass
 
+#![allow(unused_parens)]
 #![allow(non_upper_case_globals)]
 #![allow(dead_code)]
 // exec-env:RUST_MIN_STACK=16000000


### PR DESCRIPTION
Fixes #67942