### PR TITLE
Impl From between Option<NonZeroInt> <-> Int

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -100,6 +100,17 @@ assert_eq!(size_of::<Option<core::num::", stringify!($Ty), ">>(), size_of::<", s
                 }
             }
 
+            #[stable(feature = "from_nonzeroopt", since = "1.43.0")]
+            impl From<Option<$Ty>> for $Int {
+                doc_comment! {
+                    concat!(
+"Converts an `Option<", stringify!($Ty), ">` into an `", stringify!($Int), "`"),
+                    fn from(nonzero: Option<$Ty>) -> Self {
+                        nonzero.map_or(0, $Ty::get)
+                    }
+                }
+            }
+
             impl_nonzero_fmt! {
                 #[$stability] (Debug, Display, Binary, Octal, LowerHex, UpperHex) for $Ty
             }

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -111,6 +111,17 @@ assert_eq!(size_of::<Option<core::num::", stringify!($Ty), ">>(), size_of::<", s
                 }
             }
 
+            #[stable(feature = "from_nonzeroopt", since = "1.43.0")]
+            impl From<$Int> for Option<$Ty> {
+                doc_comment! {
+                    concat!(
+"Converts an `", stringify!($Int), "` into an `Option<", stringify!($Ty), ">`"),
+                    fn from(n: $Int) -> Self {
+                        $Ty::new(n)
+                    }
+                }
+            }
+
             impl_nonzero_fmt! {
                 #[$stability] (Debug, Display, Binary, Octal, LowerHex, UpperHex) for $Ty
             }

--- a/src/libcore/tests/nonzero.rs
+++ b/src/libcore/tests/nonzero.rs
@@ -125,6 +125,30 @@ fn test_from_signed_nonzero() {
 }
 
 #[test]
+fn test_from_nonzero_option() {
+    let one: Option<NonZeroU32> = NonZeroU32::new(1);
+    let one: u32 = one.into();
+
+    let zero: Option<NonZeroU32> = NonZeroU32::new(0);
+    let zero: u32 = zero.into();
+
+    assert_eq!(one, 1u32);
+    assert_eq!(zero, 0u32);
+}
+
+#[test]
+fn test_from_num() {
+    let one: u32 = 1;
+    let one: Option<NonZeroU32> = one.into();
+
+    let zero: u32 = 0;
+    let zero: Option<NonZeroU32> = zero.into();
+
+    assert_eq!(one.unwrap().get(), 1u32);
+    assert!(zero.is_none());
+}
+
+#[test]
 fn test_from_str() {
     assert_eq!("123".parse::<NonZeroU8>(), Ok(NonZeroU8::new(123).unwrap()));
     assert_eq!("0".parse::<NonZeroU8>().err().map(|e| e.kind().clone()), Some(IntErrorKind::Zero));

--- a/src/test/ui/try-block/try-block-bad-type.stderr
+++ b/src/test/ui/try-block/try-block-bad-type.stderr
@@ -10,7 +10,7 @@ LL |         Err("")?;
              <i32 as std::convert::From<i16>>
              <i32 as std::convert::From<i8>>
              <i32 as std::convert::From<std::num::NonZeroI32>>
-           and 2 others
+           and 3 others
    = note: required by `std::convert::From::from`
 
 error[E0271]: type mismatch resolving `<std::result::Result<i32, i32> as std::ops::Try>::Ok == &str`


### PR DESCRIPTION
Those types have same memory layout and often converted each other
but conversion is little verbose

```rust

let a: Option<NonZeroU32> = NonZeroU32::new(0);
let b: u32 = 0;

// Before
fn foo(n: Option<NonZeroU32>);
fn bar(n: u32);

foo(a);
foo(NonZeroU32::new(b));
bar(a.map_or(0, |a| a.get()));
bar(b);

// After
fn foo(n: impl Into<Option<NonZeroU32>>);
fn bar(n: impl Into<u32>);

foo(a);
foo(b);
bar(a);
bar(b);
```