### PR TITLE
Strip unnecessary subexpression

### DIFF
--- a/src/libstd/sys/unix/time.rs
+++ b/src/libstd/sys/unix/time.rs
@@ -282,7 +282,6 @@ mod inner {
             (cfg!(target_os = "linux") && cfg!(target_arch = "x86_64"))
                 || (cfg!(target_os = "linux") && cfg!(target_arch = "x86"))
                 || cfg!(target_os = "fuchsia")
-                || false // last clause, used so `||` is always trailing above
         }
 
         pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {


### PR DESCRIPTION
It became unnecessary since a06baa56b95674fc626b3c3fd680d6a65357fe60 reformatted the file. The comment is currently a bit misleading.