### PR TITLE
[experiment] proc_macro: Redirect `Span::call_site` to `Span::mixed_site`

### DIFF
--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -267,7 +267,8 @@ impl Span {
     /// at the macro call site will be able to refer to them as well.
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     pub fn call_site() -> Span {
-        Span(bridge::client::Span::call_site())
+        let _ = bridge::client::Span::call_site;
+        Self::mixed_site()
     }
 
     /// A span that represents `macro_rules` hygiene, and sometimes resolves at the macro

--- a/src/test/ui/proc-macro/call-site.rs
+++ b/src/test/ui/proc-macro/call-site.rs
@@ -1,4 +1,5 @@
 // run-pass
+// ignore-test
 
 #![allow(unused_variables)]
 #![allow(unused_imports)]


### PR DESCRIPTION
The goal is to approximately check how much disruption will be caused by crates like `quote` changing the default hygiene to the `macro_rules` one.

r? @ghost