### PR TITLE
Fix how the `RUSTC_CTFE_BACKTRACE` env var is gotten.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3086,6 +3086,7 @@ dependencies = [
  "fmt_macros",
  "graphviz",
  "jobserver",
+ "lazy_static 1.4.0",
  "log",
  "measureme",
  "parking_lot",

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -16,6 +16,7 @@ fmt_macros = { path = "../libfmt_macros" }
 graphviz = { path = "../libgraphviz" }
 jobserver = "0.1"
 scoped-tls = "1.0"
+lazy_static = "1.3"
 log = { version = "0.4", features = ["release_max_level_info", "std"] }
 rustc-rayon = "0.3.0"
 rustc-rayon-core = "0.3.0"

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -223,7 +223,11 @@ impl From<ErrorHandled> for InterpErrorInfo<'tcx> {
 
 impl<'tcx> From<InterpError<'tcx>> for InterpErrorInfo<'tcx> {
     fn from(kind: InterpError<'tcx>) -> Self {
-        let backtrace = match env::var("RUSTC_CTFE_BACKTRACE") {
+        lazy_static::lazy_static! {
+            static ref ENV_VAR: Result<String, env::VarError> = env::var("RUSTC_CTFE_BACKTRACE");
+        }
+
+        let backtrace = match *ENV_VAR {
             // Matching `RUST_BACKTRACE` -- we treat "0" the same as "not present".
             Ok(ref val) if val != "0" => {
                 let mut backtrace = Backtrace::new_unresolved();


### PR DESCRIPTION
This environment variable is currently obtained very frequently in
CTFE-heavy code; using `lazy_static` avoids repeating the work.

For the `ctfe-stress-4` benchmark this eliminates 67% of allocations
done, and for `coercions` it eliminates 17% of allocations done.

r? @RalfJung