### PR TITLE
Test that `#[track_caller]` as `fn()` respects RT / CTFE equivalence

### DIFF
--- a/src/test/ui/rfc-2091-track-caller/caller-location-fnptr-rt-ctfe-equiv.rs
+++ b/src/test/ui/rfc-2091-track-caller/caller-location-fnptr-rt-ctfe-equiv.rs
@@ -1,0 +1,32 @@
+// Ensure that a `#[track_caller]` function, returning `caller_location()`,
+// which coerced (to a function pointer) and called, inside a `const fn`,
+// in turn called, results in the same output irrespective of whether
+// we're in a const or runtime context.
+
+// run-pass
+// compile-flags: -Z unleash-the-miri-inside-of-you
+
+#![feature(core_intrinsics, const_caller_location, track_caller, const_fn)]
+
+type L = &'static std::panic::Location<'static>;
+
+#[track_caller]
+const fn attributed() -> L {
+    std::intrinsics::caller_location()
+}
+
+const fn calling_attributed() -> L {
+    // We need `-Z unleash-the-miri-inside-of-you` for this as we don't have `const fn` pointers.
+    let ptr: fn() -> L = attributed;
+    ptr() //~ WARN skipping const checks
+}
+
+fn main() {
+    const CONSTANT: L = calling_attributed();
+    let runtime = calling_attributed();
+
+    assert_eq!(
+        (runtime.file(), runtime.line(), runtime.column()),
+        (CONSTANT.file(), CONSTANT.line(), CONSTANT.column()),
+    );
+}

--- a/src/test/ui/rfc-2091-track-caller/caller-location-fnptr-rt-ctfe-equiv.stderr
+++ b/src/test/ui/rfc-2091-track-caller/caller-location-fnptr-rt-ctfe-equiv.stderr
@@ -1,0 +1,6 @@
+warning: skipping const checks
+  --> $DIR/caller-location-fnptr-rt-ctfe-equiv.rs:21:5
+   |
+LL |     ptr()
+   |     ^^^^^
+


### PR DESCRIPTION
r? @RalfJung cc @anp @eddyb 