### PR TITLE
librustc_driver: Make --print file-names do a minor accounting of --emit

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -669,9 +669,13 @@ impl RustcDefaultCalls {
                         continue;
                     }
                     let crate_types = rustc_interface::util::collect_crate_types(sess, attrs);
-                    for &style in &crate_types {
+                    let should_codegen = sess.opts.output_types.should_codegen();
+                    for &crate_type in &crate_types {
+                        if !should_codegen && crate_type.requires_codegen() {
+                            continue;
+                        }
                         let fname = rustc_codegen_utils::link::filename_for_input(
-                            sess, style, &id, &t_outputs,
+                            sess, crate_type, &id, &t_outputs,
                         );
                         println!("{}", fname.file_name().unwrap().to_string_lossy());
                     }

--- a/src/librustc_session/config.rs
+++ b/src/librustc_session/config.rs
@@ -651,6 +651,21 @@ pub enum CrateType {
     ProcMacro,
 }
 
+impl CrateType {
+    /// Whether the output of this crate type requires codegen to be generated.
+    ///
+    /// This is a bit of a hack to prevent bogus library names being outputted
+    /// from the PrintRequest code. Ideally that code would be fully aware of
+    /// the output requests, but that seems hard to do generally.
+    pub fn requires_codegen(self) -> bool {
+        use CrateType::*;
+        match self {
+            Cdylib | Dylib | Executable | Staticlib => true,
+            ProcMacro | Rlib => false,
+        }
+    }
+}
+
 impl_stable_hash_via_hash!(CrateType);
 
 #[derive(Clone, Hash)]

--- a/src/test/run-make-fulldeps/crate-data-smoke/Makefile
+++ b/src/test/run-make-fulldeps/crate-data-smoke/Makefile
@@ -6,5 +6,6 @@ all:
 	[ `$(RUSTC) --print file-names --crate-type=lib \
 		--test crate.rs` = "$(call BIN,foo)" ]
 	[ `$(RUSTC) --print file-names --test lib.rs` = "$(call BIN,mylib)" ]
+	[ "`$(RUSTC) --emit=dep-info,metadata --print file-names crate.rs`" = "" ] # Shouldn't print the binary name.
 	$(RUSTC) --print file-names lib.rs
 	$(RUSTC) --print file-names rlib.rs


### PR DESCRIPTION
Otherwise we print bogus output which prevents using `cargo check` with sccache,
see https://bugzilla.mozilla.org/show_bug.cgi?id=1612855#c2 for a reduced
test-case.

Ideally --print file-names will emit only the files emitted by the session, but
that seems a bit hard to do in a general way, so this is a best effort thing
which fixes the cargo check use-case.