### PR TITLE
rustc_codegen_ssa: don't treat inlined variables as debuginfo arguments.

### DIFF
--- a/src/librustc_codegen_ssa/mir/debuginfo.rs
+++ b/src/librustc_codegen_ssa/mir/debuginfo.rs
@@ -307,11 +307,8 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 let var_ty = self.monomorphized_place_ty(place.as_ref());
                 let var_kind = if self.mir.local_kind(place.local) == mir::LocalKind::Arg
                     && place.projection.is_empty()
+                    && var.source_info.scope == mir::OUTERMOST_SOURCE_SCOPE
                 {
-                    // FIXME(eddyb, #67586) take `var.source_info.scope` into
-                    // account to avoid using `ArgumentVariable` more than once
-                    // per argument local.
-
                     let arg_index = place.local.index() - 1;
 
                     // FIXME(eddyb) shouldn't `ArgumentVariable` indices be

--- a/src/test/ui/mir/mir-inlining/var-debuginfo-issue-67586.rs
+++ b/src/test/ui/mir/mir-inlining/var-debuginfo-issue-67586.rs
@@ -1,0 +1,11 @@
+// run-pass
+// compile-flags: -Z mir-opt-level=2 -C opt-level=0 -C debuginfo=2
+
+#[inline(never)]
+pub fn foo(bar: usize) -> usize {
+    std::convert::identity(bar)
+}
+
+fn main() {
+    foo(0);
+}


### PR DESCRIPTION
Fixes #67586 by limiting `ArgumentVariable` special-casing to `VarDebugInfo` entries that are in `OUTERMOST_SOURCE_SCOPE`, i.e. the function's own argument scope.
That excludes `VarDebugInfo` from inlined callees, which can also point to the caller's argument locals.

This is a snippet from the optimized MIR (including inlining) of the testcase:
```rust
fn  foo(_1: usize) -> usize {
    debug bar => _1;                     // in scope 0 at ./example.rs:2:12: 2:15
    let mut _0: usize;                   // return place in scope 0 at ./example.rs:2:27: 2:32
    scope 1 {
        debug x => _1;                   // in scope 1 at /rustc/9ed29b6ff6aa2e048b09c27af8f62ee3040bdb37/src/libcore/convert/mod.rs:106:26: 106:27
    }
```
`scope 1` is from inlining the `identity` call, and `debug x => _1;` comes from the body of `core::convert::identity`, so they are now ignored for the purposes of determining the `ArgumentVariable` debuginfo associated to `_1`.