### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -105,6 +105,7 @@ impl Step for Docs {
         t!(fs::create_dir_all(&dst));
         let src = builder.doc_out(host);
         builder.cp_r(&src, &dst);
+        builder.install(&builder.src.join("src/doc/robots.txt"), &dst, 0o644);
 
         let mut cmd = rust_installer(builder);
         cmd.arg("generate")

--- a/src/doc/robots.txt
+++ b/src/doc/robots.txt
@@ -1,4 +1,3 @@
-# NB: This file is not automatically deployed. After changes, it needs to be uploaded manually to doc.rust-lang.org
 User-agent: *
 Disallow: /0.3/
 Disallow: /0.4/

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -2,7 +2,8 @@
 //!
 //! [`Box<T>`], casually referred to as a 'box', provides the simplest form of
 //! heap allocation in Rust. Boxes provide ownership for this allocation, and
-//! drop their contents when they go out of scope.
+//! drop their contents when they go out of scope. Boxes also ensure that they
+//! never allocate more than `isize::MAX` bytes.
 //!
 //! # Examples
 //!

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -4,6 +4,8 @@
 //! Vectors have `O(1)` indexing, amortized `O(1)` push (to the end) and
 //! `O(1)` pop (from the end).
 //!
+//! Vectors ensure they never allocate more than `isize::MAX` bytes.
+//!
 //! # Examples
 //!
 //! You can explicitly create a [`Vec<T>`] with [`new`]:

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -327,7 +327,7 @@ pub use self::sources::{empty, Empty};
 pub use self::sources::{from_fn, FromFn};
 #[stable(feature = "iter_once", since = "1.2.0")]
 pub use self::sources::{once, Once};
-#[unstable(feature = "iter_once_with", issue = "57581")]
+#[stable(feature = "iter_once_with", since = "1.43.0")]
 pub use self::sources::{once_with, OnceWith};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::sources::{repeat, Repeat};

--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -399,12 +399,12 @@ pub fn once<T>(value: T) -> Once<T> {
 ///
 /// [`once_with`]: fn.once_with.html
 #[derive(Copy, Clone, Debug)]
-#[unstable(feature = "iter_once_with", issue = "57581")]
+#[stable(feature = "iter_once_with", since = "1.43.0")]
 pub struct OnceWith<F> {
     gen: Option<F>,
 }
 
-#[unstable(feature = "iter_once_with", issue = "57581")]
+#[stable(feature = "iter_once_with", since = "1.43.0")]
 impl<A, F: FnOnce() -> A> Iterator for OnceWith<F> {
     type Item = A;
 
@@ -420,24 +420,24 @@ impl<A, F: FnOnce() -> A> Iterator for OnceWith<F> {
     }
 }
 
-#[unstable(feature = "iter_once_with", issue = "57581")]
+#[stable(feature = "iter_once_with", since = "1.43.0")]
 impl<A, F: FnOnce() -> A> DoubleEndedIterator for OnceWith<F> {
     fn next_back(&mut self) -> Option<A> {
         self.next()
     }
 }
 
-#[unstable(feature = "iter_once_with", issue = "57581")]
+#[stable(feature = "iter_once_with", since = "1.43.0")]
 impl<A, F: FnOnce() -> A> ExactSizeIterator for OnceWith<F> {
     fn len(&self) -> usize {
         self.gen.iter().len()
     }
 }
 
-#[unstable(feature = "iter_once_with", issue = "57581")]
+#[stable(feature = "iter_once_with", since = "1.43.0")]
 impl<A, F: FnOnce() -> A> FusedIterator for OnceWith<F> {}
 
-#[unstable(feature = "iter_once_with", issue = "57581")]
+#[stable(feature = "iter_once_with", since = "1.43.0")]
 unsafe impl<A, F: FnOnce() -> A> TrustedLen for OnceWith<F> {}
 
 /// Creates an iterator that lazily generates a value exactly once by invoking
@@ -458,8 +458,6 @@ unsafe impl<A, F: FnOnce() -> A> TrustedLen for OnceWith<F> {}
 /// Basic usage:
 ///
 /// ```
-/// #![feature(iter_once_with)]
-///
 /// use std::iter;
 ///
 /// // one is the loneliest number
@@ -476,8 +474,6 @@ unsafe impl<A, F: FnOnce() -> A> TrustedLen for OnceWith<F> {}
 /// `.foorc`:
 ///
 /// ```no_run
-/// #![feature(iter_once_with)]
-///
 /// use std::iter;
 /// use std::fs;
 /// use std::path::PathBuf;
@@ -500,7 +496,7 @@ unsafe impl<A, F: FnOnce() -> A> TrustedLen for OnceWith<F> {}
 /// }
 /// ```
 #[inline]
-#[unstable(feature = "iter_once_with", issue = "57581")]
+#[stable(feature = "iter_once_with", since = "1.43.0")]
 pub fn once_with<A, F: FnOnce() -> A>(gen: F) -> OnceWith<F> {
     OnceWith { gen: Some(gen) }
 }

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -87,7 +87,6 @@
 #![feature(intrinsics)]
 #![feature(try_find)]
 #![feature(is_sorted)]
-#![feature(iter_once_with)]
 #![feature(lang_items)]
 #![feature(link_llvm_intrinsics)]
 #![feature(never_type)]

--- a/src/libcore/ptr/mod.rs
+++ b/src/libcore/ptr/mod.rs
@@ -1083,7 +1083,7 @@ pub(crate) unsafe fn align_offset<T: Sized>(p: *const T, a: usize) -> usize {
                 // anyway.
                 inverse = inverse.wrapping_mul(2usize.wrapping_sub(x.wrapping_mul(inverse)))
                     & (going_mod - 1);
-                if going_mod > m {
+                if going_mod >= m {
                     return inverse & (m - 1);
                 }
                 going_mod = going_mod.wrapping_mul(going_mod);
@@ -1134,7 +1134,7 @@ pub(crate) unsafe fn align_offset<T: Sized>(p: *const T, a: usize) -> usize {
         // to take the result $o mod lcm(s, a)$. We can replace $lcm(s, a)$ with just a $a / g$.
         let j = a.wrapping_sub(pmoda) >> gcdpow;
         let k = smoda >> gcdpow;
-        return intrinsics::unchecked_rem(j.wrapping_mul(mod_inv(k, a)), a >> gcdpow);
+        return (j.wrapping_mul(mod_inv(k, a))) & ((a >> gcdpow).wrapping_sub(1));
     }
 
     // Cannot be aligned at all.

--- a/src/libcore/ptr/mod.rs
+++ b/src/libcore/ptr/mod.rs
@@ -1081,8 +1081,7 @@ pub(crate) unsafe fn align_offset<T: Sized>(p: *const T, a: usize) -> usize {
                 // uses e.g., subtraction `mod n`. It is entirely fine to do them `mod
                 // usize::max_value()` instead, because we take the result `mod n` at the end
                 // anyway.
-                inverse = inverse.wrapping_mul(2usize.wrapping_sub(x.wrapping_mul(inverse)))
-                    & (going_mod - 1);
+                inverse = inverse.wrapping_mul(2usize.wrapping_sub(x.wrapping_mul(inverse)));
                 if going_mod >= m {
                     return inverse & (m - 1);
                 }

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -13,7 +13,6 @@
 #![feature(hashmap_internals)]
 #![feature(try_find)]
 #![feature(is_sorted)]
-#![feature(iter_once_with)]
 #![feature(pattern)]
 #![feature(range_is_empty)]
 #![feature(raw)]

--- a/src/librustc_error_codes/error_codes/E0263.md
+++ b/src/librustc_error_codes/error_codes/E0263.md
@@ -1,7 +1,16 @@
-A lifetime name cannot be declared more than once in the same scope. For
-example:
+A lifetime was declared more than once in the same scope.
+
+Erroneous code example:
 
 ```compile_fail,E0263
-// error, lifetime name `'a` declared twice in the same scope
-fn foo<'a, 'b, 'a>(x: &'a str, y: &'b str) { }
+fn foo<'a, 'b, 'a>(x: &'a str, y: &'b str, z: &'a str) { // error!
+}
+```
+
+Two lifetimes cannot have the same name. To fix this example, change
+the second `'a` lifetime into something else (`'c` for example):
+
+```
+fn foo<'a, 'b, 'c>(x: &'a str, y: &'b str, z: &'c str) { // ok!
+}
 ```

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -837,8 +837,11 @@ fn has_typeck_tables(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
         return tcx.has_typeck_tables(outer_def_id);
     }
 
-    let id = tcx.hir().as_local_hir_id(def_id).unwrap();
-    primary_body_of(tcx, id).is_some()
+    if let Some(id) = tcx.hir().as_local_hir_id(def_id) {
+        primary_body_of(tcx, id).is_some()
+    } else {
+        false
+    }
 }
 
 fn used_trait_imports(tcx: TyCtxt<'_>, def_id: DefId) -> &DefIdSet {

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -163,11 +163,11 @@
 //! [`Iterator`]: iter/trait.Iterator.html
 //! [`Mutex`]: sync/struct.Mutex.html
 //! [`Option<T>`]: option/enum.Option.html
-//! [`Rc`]: rc/index.html
+//! [`Rc`]: rc/struct.Rc.html
 //! [`RefCell`]: cell/struct.RefCell.html
 //! [`Result<T, E>`]: result/enum.Result.html
 //! [`String`]: string/struct.String.html
-//! [`Vec<T>`]: vec/index.html
+//! [`Vec<T>`]: vec/struct.Vec.html
 //! [array]: primitive.array.html
 //! [slice]: primitive.slice.html
 //! [`atomic`]: sync/atomic/index.html

--- a/src/test/ui/rfc-2091-track-caller/caller-location-fnptr-rt-ctfe-equiv.rs
+++ b/src/test/ui/rfc-2091-track-caller/caller-location-fnptr-rt-ctfe-equiv.rs
@@ -1,0 +1,32 @@
+// Ensure that a `#[track_caller]` function, returning `caller_location()`,
+// which coerced (to a function pointer) and called, inside a `const fn`,
+// in turn called, results in the same output irrespective of whether
+// we're in a const or runtime context.
+
+// run-pass
+// compile-flags: -Z unleash-the-miri-inside-of-you
+
+#![feature(core_intrinsics, const_caller_location, track_caller, const_fn)]
+
+type L = &'static std::panic::Location<'static>;
+
+#[track_caller]
+const fn attributed() -> L {
+    std::intrinsics::caller_location()
+}
+
+const fn calling_attributed() -> L {
+    // We need `-Z unleash-the-miri-inside-of-you` for this as we don't have `const fn` pointers.
+    let ptr: fn() -> L = attributed;
+    ptr() //~ WARN skipping const checks
+}
+
+fn main() {
+    const CONSTANT: L = calling_attributed();
+    let runtime = calling_attributed();
+
+    assert_eq!(
+        (runtime.file(), runtime.line(), runtime.column()),
+        (CONSTANT.file(), CONSTANT.line(), CONSTANT.column()),
+    );
+}

--- a/src/test/ui/rfc-2091-track-caller/caller-location-fnptr-rt-ctfe-equiv.stderr
+++ b/src/test/ui/rfc-2091-track-caller/caller-location-fnptr-rt-ctfe-equiv.stderr
@@ -1,0 +1,6 @@
+warning: skipping const checks
+  --> $DIR/caller-location-fnptr-rt-ctfe-equiv.rs:21:5
+   |
+LL |     ptr()
+   |     ^^^^^
+

--- a/src/test/ui/save-analysis/issue-68621.rs
+++ b/src/test/ui/save-analysis/issue-68621.rs
@@ -1,0 +1,17 @@
+// compile-flags: -Zsave-analysis
+
+#![feature(type_alias_impl_trait)]
+
+trait Trait {}
+
+trait Service {
+    type Future: Trait;
+}
+
+struct Struct;
+
+impl Service for Struct {
+    type Future = impl Trait; //~ ERROR: could not find defining uses
+}
+
+fn main() {}

--- a/src/test/ui/save-analysis/issue-68621.stderr
+++ b/src/test/ui/save-analysis/issue-68621.stderr
@@ -1,0 +1,8 @@
+error: could not find defining uses
+  --> $DIR/issue-68621.rs:14:5
+   |
+LL |     type Future = impl Trait;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/type-alias-impl-trait/issue-63279.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-63279.rs
@@ -1,3 +1,5 @@
+// compile-flags: -Zsave-analysis
+
 #![feature(type_alias_impl_trait)]
 
 type Closure = impl FnOnce(); //~ ERROR: type mismatch resolving

--- a/src/test/ui/type-alias-impl-trait/issue-63279.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-63279.stderr
@@ -1,5 +1,5 @@
-error[E0271]: type mismatch resolving `<[closure@$DIR/issue-63279.rs:6:5: 6:28] as std::ops::FnOnce<()>>::Output == ()`
-  --> $DIR/issue-63279.rs:3:1
+error[E0271]: type mismatch resolving `<[closure@$DIR/issue-63279.rs:8:5: 8:28] as std::ops::FnOnce<()>>::Output == ()`
+  --> $DIR/issue-63279.rs:5:1
    |
 LL | type Closure = impl FnOnce();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected opaque type, found `()`

--- a/src/test/ui/type-alias-impl-trait/issue-65679-inst-opaque-ty-from-val-twice.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-65679-inst-opaque-ty-from-val-twice.rs
@@ -1,3 +1,4 @@
+// compile-flags: -Zsave-analysis
 // check-pass
 
 #![feature(type_alias_impl_trait)]


### PR DESCRIPTION
Successful merges:

 - #68678 (Install robots.txt into rust-docs tarballs)
 - #68711 (Added upper bound of what vecs and boxes can allocate)
 - #68744 (Do not ICE in `type-alias-impl-trait` with save-analysis)
 - #68777 (Clean up E0263 explanation)
 - #68787 (Optimize core::ptr::align_offset (part 1))
 - #68797 (Fix links to types instead of modules)
 - #68798 (Test that `#[track_caller]` as `fn()` respects RT / CTFE equivalence)
 - #68800 (Stabilize `core::iter::once_with()`)

Failed merges:


r? @ghost