### PR TITLE
Remove Copy impl from OnceWith

### DIFF
--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -398,7 +398,7 @@ pub fn once<T>(value: T) -> Once<T> {
 /// See its documentation for more.
 ///
 /// [`once_with`]: fn.once_with.html
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 #[stable(feature = "iter_once_with", since = "1.43.0")]
 pub struct OnceWith<F> {
     gen: Option<F>,


### PR DESCRIPTION
Iterators typically don't implement `Copy` and this shouldn't be an exception.