### PR TITLE
fix couple of perf related clippy warnings

### DIFF
--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1344,7 +1344,7 @@ pub trait ToPredicate<'tcx> {
 impl<'tcx> ToPredicate<'tcx> for ConstnessAnd<TraitRef<'tcx>> {
     fn to_predicate(&self) -> Predicate<'tcx> {
         ty::Predicate::Trait(
-            ty::Binder::dummy(ty::TraitPredicate { trait_ref: self.value.clone() }),
+            ty::Binder::dummy(ty::TraitPredicate { trait_ref: self.value }),
             self.constness,
         )
     }

--- a/src/librustc_incremental/persist/file_format.rs
+++ b/src/librustc_incremental/persist/file_format.rs
@@ -90,8 +90,7 @@ pub fn read_file(
         let mut rustc_version_str_len = [0u8; 1];
         file.read_exact(&mut rustc_version_str_len)?;
         let rustc_version_str_len = rustc_version_str_len[0] as usize;
-        let mut buffer = Vec::with_capacity(rustc_version_str_len);
-        buffer.resize(rustc_version_str_len, 0);
+        let mut buffer = vec![0; rustc_version_str_len];
         file.read_exact(&mut buffer)?;
 
         if buffer != rustc_version().as_bytes() {

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1438,10 +1438,8 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 
         // Expand trait aliases recursively and check that only one regular (non-auto) trait
         // is used and no 'maybe' bounds are used.
-        let expanded_traits = traits::expand_trait_aliases(
-            tcx,
-            bounds.trait_bounds.iter().map(|&(a, b, _)| (a.clone(), b)),
-        );
+        let expanded_traits =
+            traits::expand_trait_aliases(tcx, bounds.trait_bounds.iter().map(|&(a, b, _)| (a, b)));
         let (mut auto_traits, regular_traits): (Vec<_>, Vec<_>) =
             expanded_traits.partition(|i| tcx.trait_is_auto(i.trait_ref().def_id()));
         if regular_traits.len() > 1 {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -3629,14 +3629,7 @@ fn render_impl(
                 for it in &i.inner_impl().items {
                     if let clean::TypedefItem(ref tydef, _) = it.inner {
                         write!(w, "<span class=\"where fmt-newline\">  ");
-                        assoc_type(
-                            w,
-                            it,
-                            &vec![],
-                            Some(&tydef.type_),
-                            AssocItemLink::Anchor(None),
-                            "",
-                        );
+                        assoc_type(w, it, &[], Some(&tydef.type_), AssocItemLink::Anchor(None), "");
                         write!(w, ";</span>");
                     }
                 }


### PR DESCRIPTION
librustc: don't clone a type that is copy
librustc_incremental: use faster vector initialization
librustc_typeck: don't clone a type that is copy
librustdoc: don't create a vector where a slice will do