### PR TITLE
use def_path_str for missing_debug_impls message

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -567,7 +567,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingCopyImplementations {
 declare_lint! {
     MISSING_DEBUG_IMPLEMENTATIONS,
     Allow,
-    "detects missing implementations of fmt::Debug"
+    "detects missing implementations of Debug"
 }
 
 #[derive(Default)]
@@ -611,9 +611,12 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingDebugImplementations {
             cx.span_lint(
                 MISSING_DEBUG_IMPLEMENTATIONS,
                 item.span,
-                "type does not implement `fmt::Debug`; consider adding `#[derive(Debug)]` \
-                          or a manual implementation",
-            )
+                &format!(
+                    "type does not implement `{}`; consider adding `#[derive(Debug)]` \
+                     or a manual implementation",
+                    cx.tcx.def_path_str(debug)
+                ),
+            );
         }
     }
 }

--- a/src/test/ui/missing_debug_impls.rs
+++ b/src/test/ui/missing_debug_impls.rs
@@ -4,7 +4,7 @@
 
 use std::fmt;
 
-pub enum A {} //~ ERROR type does not implement `fmt::Debug`
+pub enum A {} //~ ERROR type does not implement `std::fmt::Debug`
 
 #[derive(Debug)]
 pub enum B {}
@@ -17,7 +17,7 @@ impl fmt::Debug for C {
     }
 }
 
-pub struct Foo; //~ ERROR type does not implement `fmt::Debug`
+pub struct Foo; //~ ERROR type does not implement `std::fmt::Debug`
 
 #[derive(Debug)]
 pub struct Bar;

--- a/src/test/ui/missing_debug_impls.stderr
+++ b/src/test/ui/missing_debug_impls.stderr
@@ -1,4 +1,4 @@
-error: type does not implement `fmt::Debug`; consider adding `#[derive(Debug)]` or a manual implementation
+error: type does not implement `std::fmt::Debug`; consider adding `#[derive(Debug)]` or a manual implementation
   --> $DIR/missing_debug_impls.rs:7:1
    |
 LL | pub enum A {}
@@ -10,7 +10,7 @@ note: the lint level is defined here
 LL | #![deny(missing_debug_implementations)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: type does not implement `fmt::Debug`; consider adding `#[derive(Debug)]` or a manual implementation
+error: type does not implement `std::fmt::Debug`; consider adding `#[derive(Debug)]` or a manual implementation
   --> $DIR/missing_debug_impls.rs:20:1
    |
 LL | pub struct Foo;


### PR DESCRIPTION
The lint message will now use the full, correct path to the `Debug`
trait, even in `no_std`.