### PR TITLE
Don't use the word 'unwrap' to describe core 'unwrap' functions

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -382,13 +382,15 @@ impl<T> Option<T> {
         }
     }
 
-    /// Returns the contained value or a default.
+    /// Moves the value `v` out of the `Option<T>` if it is [`Some(v)`],
+    /// or returns a provided a default.
     ///
     /// Arguments passed to `unwrap_or` are eagerly evaluated; if you are passing
     /// the result of a function call, it is recommended to use [`unwrap_or_else`],
     /// which is lazily evaluated.
     ///
     /// [`unwrap_or_else`]: #method.unwrap_or_else
+    /// [`Some(v)`]: #variant.Some
     ///
     /// # Examples
     ///
@@ -405,7 +407,11 @@ impl<T> Option<T> {
         }
     }
 
-    /// Returns the contained value or computes it from a closure.
+    /// Moves the value `v` out of the `Option<T>` if it is [`Some(v)`],
+    /// or computes it from a closure.
+    ///
+    /// [`Some(v)`]: #variant.Some
+    /// [`None`]: #variant.None
     ///
     /// # Examples
     ///
@@ -416,10 +422,10 @@ impl<T> Option<T> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn unwrap_or_else<F: FnOnce() -> T>(self, f: F) -> T {
+    pub fn unwrap_or_else<F: FnOnce() -> T>(self, op: F) -> T {
         match self {
             Some(x) => x,
-            None => f(),
+            None => op(),
         }
     }
 

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1023,7 +1023,7 @@ impl<T: fmt::Debug> Option<T> {
         }
     }
 
-    /// Unwraps an option, expecting [`None`] and returning nothing.
+    /// Consumes an option, expecting [`None`] and returning nothing.
     ///
     /// # Panics
     ///

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -792,14 +792,15 @@ impl<T, E> Result<T, E> {
         }
     }
 
-    /// Consumes a result, yielding the content of an [`Ok`].
-    /// Else, it returns `optb`.
+    /// Moves the value `v` out of the `Result<T, E>` if it is [`Ok(v)`],
+    /// or returns a provided default.
     ///
     /// Arguments passed to `unwrap_or` are eagerly evaluated; if you are passing
     /// the result of a function call, it is recommended to use [`unwrap_or_else`],
     /// which is lazily evaluated.
     ///
     /// [`Ok`]: enum.Result.html#variant.Ok
+    /// [`Ok(v)`]: enum.Result.html#variant.Ok
     /// [`Err`]: enum.Result.html#variant.Err
     /// [`unwrap_or_else`]: #method.unwrap_or_else
     ///
@@ -808,27 +809,27 @@ impl<T, E> Result<T, E> {
     /// Basic usage:
     ///
     /// ```
-    /// let optb = 2;
+    /// let default = 2;
     /// let x: Result<u32, &str> = Ok(9);
-    /// assert_eq!(x.unwrap_or(optb), 9);
+    /// assert_eq!(x.unwrap_or(default), 9);
     ///
     /// let x: Result<u32, &str> = Err("error");
-    /// assert_eq!(x.unwrap_or(optb), optb);
+    /// assert_eq!(x.unwrap_or(default), default);
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn unwrap_or(self, optb: T) -> T {
+    pub fn unwrap_or(self, default: T) -> T {
         match self {
             Ok(t) => t,
-            Err(_) => optb,
+            Err(_) => default,
         }
     }
 
-    /// Consumes a result, yielding the content of an [`Ok`].
-    /// If the value is an [`Err`] then it calls `op` with its value.
+    /// Moves the value `v` out of the `Result<T, E>` if it is [`Ok(v)`],
+    /// or computes it from a closure.
     ///
+    /// [`Ok(v)`]: enum.Result.html#variant.Ok
     /// [`Ok`]: enum.Result.html#variant.Ok
-    /// [`Err`]: enum.Result.html#variant.Err
     ///
     /// # Examples
     ///
@@ -931,13 +932,14 @@ impl<T: Clone, E> Result<&mut T, E> {
 }
 
 impl<T, E: fmt::Debug> Result<T, E> {
-    /// Consumes a result, yielding the content of an [`Ok`].
+    /// Moves the value `v` out of the `Result<T, E>` if it is [`Ok(v)`].
     ///
     /// # Panics
     ///
     /// Panics if the value is an [`Err`], with a panic message provided by the
     /// [`Err`]'s value.
     ///
+    /// [`Ok(v)`]: enum.Result.html#variant.Ok
     /// [`Ok`]: enum.Result.html#variant.Ok
     /// [`Err`]: enum.Result.html#variant.Err
     ///
@@ -994,13 +996,14 @@ impl<T, E: fmt::Debug> Result<T, E> {
 }
 
 impl<T: fmt::Debug, E> Result<T, E> {
-    /// Consumes a result, yielding the content of an [`Err`].
+    /// Moves the value `v` out of the `Result<T, E>` if it is [`Err(v)`].
     ///
     /// # Panics
     ///
     /// Panics if the value is an [`Ok`], with a custom panic message provided
     /// by the [`Ok`]'s value.
     ///
+    /// [`Err(v)`]: enum.Result.html#variant.Err
     /// [`Ok`]: enum.Result.html#variant.Ok
     /// [`Err`]: enum.Result.html#variant.Err
     ///

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -792,7 +792,7 @@ impl<T, E> Result<T, E> {
         }
     }
 
-    /// Unwraps a result, yielding the content of an [`Ok`].
+    /// Consumes a result, yielding the content of an [`Ok`].
     /// Else, it returns `optb`.
     ///
     /// Arguments passed to `unwrap_or` are eagerly evaluated; if you are passing
@@ -824,7 +824,7 @@ impl<T, E> Result<T, E> {
         }
     }
 
-    /// Unwraps a result, yielding the content of an [`Ok`].
+    /// Consumes a result, yielding the content of an [`Ok`].
     /// If the value is an [`Err`] then it calls `op` with its value.
     ///
     /// [`Ok`]: enum.Result.html#variant.Ok
@@ -931,7 +931,7 @@ impl<T: Clone, E> Result<&mut T, E> {
 }
 
 impl<T, E: fmt::Debug> Result<T, E> {
-    /// Unwraps a result, yielding the content of an [`Ok`].
+    /// Consumes a result, yielding the content of an [`Ok`].
     ///
     /// # Panics
     ///
@@ -964,7 +964,7 @@ impl<T, E: fmt::Debug> Result<T, E> {
         }
     }
 
-    /// Unwraps a result, yielding the content of an [`Ok`].
+    /// Consumes a result, yielding the content of an [`Ok`].
     ///
     /// # Panics
     ///
@@ -994,7 +994,7 @@ impl<T, E: fmt::Debug> Result<T, E> {
 }
 
 impl<T: fmt::Debug, E> Result<T, E> {
-    /// Unwraps a result, yielding the content of an [`Err`].
+    /// Consumes a result, yielding the content of an [`Err`].
     ///
     /// # Panics
     ///


### PR DESCRIPTION
It's tautological, and "unwrap" is essentially Rust-specific jargon.

I was teaching a newbie some Rust, and doing the usual hand-waving about error handling using unwrap. They asked what 'unwrap' means. I said look it up in the docs. The docs read (paraphrased) "unwrap unwraps". I was embarrassed.

This patch just changes the language to "consume", which is at least more general than "unwrap", has a clear English-language meaning, and is not the same word as the function names. It has the downside that "consuming" in the type system is still pretty Rust-specific and may not have obvious meaning in this context.