### PR TITLE
WIP: Suggest similar type or module on resolve failure

### DIFF
--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -1006,10 +1006,11 @@ impl<'a> Resolver<'a> {
     crate fn make_undeclared_type_suggestion(
         &mut self,
         ident: Ident,
+        parent_scope: &ParentScope<'a>,
+        ns: Namespace,
     ) -> (String, Option<Suggestion>) {
-        let parent_scope = &ParentScope::module(self.graph_root);
         let typo_suggestion = self.early_lookup_typo_candidate(
-            ScopeSet::AbsolutePath(TypeNS),
+            ScopeSet::All(ns, false),
             parent_scope,
             ident,
             &|_| true,

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -491,7 +491,7 @@ impl<'a> Resolver<'a> {
     }
 
     /// Lookup typo candidate in scope for a macro or import.
-    fn early_lookup_typo_candidate(
+    crate fn early_lookup_typo_candidate(
         &mut self,
         scope_set: ScopeSet,
         parent_scope: &ParentScope<'a>,

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -797,6 +797,14 @@ impl<'a> Resolver<'a> {
         }
     }
 
+    fn typo_suggestion_text(&self, suggestion: &TypoSuggestion) -> String {
+        format!(
+            "{} {} with a similar name exists",
+            suggestion.res.article(),
+            suggestion.res.descr()
+        )
+    }
+
     crate fn add_typo_suggestion(
         &self,
         err: &mut DiagnosticBuilder<'_>,
@@ -809,14 +817,9 @@ impl<'a> Resolver<'a> {
                 return false;
             }
 
-            let msg = format!(
-                "{} {} with a similar name exists",
-                suggestion.res.article(),
-                suggestion.res.descr()
-            );
             err.span_suggestion(
                 span,
-                &msg,
+                &self.typo_suggestion_text(&suggestion),
                 suggestion.candidate.to_string(),
                 Applicability::MaybeIncorrect,
             );
@@ -1016,7 +1019,7 @@ impl<'a> Resolver<'a> {
                 format!("use of undeclared type or module `{}`", ident),
                 Some((
                     vec![(ident.span, format!("{}", typo_suggestion.candidate.as_str()))],
-                    String::from("did you mean"),
+                    self.typo_suggestion_text(&typo_suggestion),
                     Applicability::MaybeIncorrect,
                 )),
             )

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2195,7 +2195,7 @@ impl<'a> Resolver<'a> {
                             return PathResult::NonModule(PartialRes::new(Res::Err));
                         }
                     } else if i == 0 {
-                        self.make_undeclared_type_suggestion(ident)
+                        self.make_undeclared_type_suggestion(ident, &parent_scope, ns)
                     } else {
                         (format!("could not find `{}` in `{}`", ident, path[i - 1].ident), None)
                     };

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2195,28 +2195,7 @@ impl<'a> Resolver<'a> {
                             return PathResult::NonModule(PartialRes::new(Res::Err));
                         }
                     } else if i == 0 {
-                        let parent_scope = &ParentScope::module(self.graph_root);
-                        let typo_suggestion = self.early_lookup_typo_candidate(
-                            ScopeSet::AbsolutePath(TypeNS),
-                            parent_scope,
-                            ident,
-                            &|_| true,
-                        );
-                        if let Some(typo_suggestion) = typo_suggestion {
-                            (
-                                format!("use of undeclared type or module `{}`", ident),
-                                Some((
-                                    vec![(
-                                        ident.span,
-                                        format!("{}", typo_suggestion.candidate.as_str()),
-                                    )],
-                                    String::from("did you mean"),
-                                    Applicability::MaybeIncorrect,
-                                )),
-                            )
-                        } else {
-                            (format!("use of undeclared type or module `{}`", ident), None)
-                        }
+                        self.make_undeclared_type_suggestion(ident)
                     } else {
                         (format!("could not find `{}` in `{}`", ident, path[i - 1].ident), None)
                     };

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2195,7 +2195,28 @@ impl<'a> Resolver<'a> {
                             return PathResult::NonModule(PartialRes::new(Res::Err));
                         }
                     } else if i == 0 {
-                        (format!("use of undeclared type or module `{}`", ident), None)
+                        let parent_scope = &ParentScope::module(self.graph_root);
+                        let typo_suggestion = self.early_lookup_typo_candidate(
+                            ScopeSet::AbsolutePath(TypeNS),
+                            parent_scope,
+                            ident,
+                            &|_| true,
+                        );
+                        if let Some(typo_suggestion) = typo_suggestion {
+                            (
+                                format!("use of undeclared type or module `{}`", ident),
+                                Some((
+                                    vec![(
+                                        ident.span,
+                                        format!("{}", typo_suggestion.candidate.as_str()),
+                                    )],
+                                    String::from("did you mean"),
+                                    Applicability::MaybeIncorrect,
+                                )),
+                            )
+                        } else {
+                            (format!("use of undeclared type or module `{}`", ident), None)
+                        }
                     } else {
                         (format!("could not find `{}` in `{}`", ident, path[i - 1].ident), None)
                     };

--- a/src/test/ui/macros/macro-inner-attributes.stderr
+++ b/src/test/ui/macros/macro-inner-attributes.stderr
@@ -5,7 +5,7 @@ LL |     a::bar();
    |     ^
    |     |
    |     use of undeclared type or module `a`
-   |     help: did you mean: `b`
+   |     help: a module with a similar name exists: `b`
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/macro-inner-attributes.stderr
+++ b/src/test/ui/macros/macro-inner-attributes.stderr
@@ -2,7 +2,10 @@ error[E0433]: failed to resolve: use of undeclared type or module `a`
   --> $DIR/macro-inner-attributes.rs:17:5
    |
 LL |     a::bar();
-   |     ^ use of undeclared type or module `a`
+   |     ^
+   |     |
+   |     use of undeclared type or module `a`
+   |     help: did you mean: `b`
 
 error: aborting due to previous error
 

--- a/src/test/ui/pattern/pattern-error-continue.stderr
+++ b/src/test/ui/pattern/pattern-error-continue.stderr
@@ -5,7 +5,7 @@ LL |         E::V => {}
    |         ^
    |         |
    |         use of undeclared type or module `E`
-   |         help: did you mean: `A`
+   |         help: an enum with a similar name exists: `A`
 
 error[E0532]: expected tuple struct or tuple variant, found unit variant `A::D`
   --> $DIR/pattern-error-continue.rs:18:9

--- a/src/test/ui/pattern/pattern-error-continue.stderr
+++ b/src/test/ui/pattern/pattern-error-continue.stderr
@@ -2,7 +2,10 @@ error[E0433]: failed to resolve: use of undeclared type or module `E`
   --> $DIR/pattern-error-continue.rs:33:9
    |
 LL |         E::V => {}
-   |         ^ use of undeclared type or module `E`
+   |         ^
+   |         |
+   |         use of undeclared type or module `E`
+   |         help: did you mean: `A`
 
 error[E0532]: expected tuple struct or tuple variant, found unit variant `A::D`
   --> $DIR/pattern-error-continue.rs:18:9

--- a/src/test/ui/resolve/suggest-type.rs
+++ b/src/test/ui/resolve/suggest-type.rs
@@ -1,7 +1,14 @@
 use std::ffi::CString;
 
 mod foo {
-    fn bar() {}
+    use std::collections::HashMap;
+
+    fn bar() {
+        let _ = HashNap::new();
+        //~^ ERROR failed to resolve: use of undeclared type or module `HashNap`
+        //~| HELP a struct with a similar name exists
+        //~| SUGGESTION HashMap
+    }
 }
 
 fn main() {

--- a/src/test/ui/resolve/suggest-type.rs
+++ b/src/test/ui/resolve/suggest-type.rs
@@ -7,7 +7,11 @@ mod foo {
 fn main() {
     let _ = Cstring::new("hello").unwrap();
     //~^ ERROR failed to resolve: use of undeclared type or module `Cstring`
+    //~| HELP a struct with a similar name exists
+    //~| SUGGESTION CString
 
     let _ = foO::bar();
     //~^ ERROR failed to resolve: use of undeclared type or module `foO`
+    //~| HELP a module with a similar name exists
+    //~| SUGGESTION foo
 }

--- a/src/test/ui/resolve/suggest-type.rs
+++ b/src/test/ui/resolve/suggest-type.rs
@@ -1,0 +1,19 @@
+use std::ffi::CString;
+
+mod foo {
+    fn bar() {}
+}
+
+fn main() {
+    let _ = Cstring::new("hello").unwrap();
+    //~^ ERROR failed to resolve: use of undeclared type or module `Cstring`
+
+    let _ = CStRiNg::new("hello").unwrap();
+    //~^ ERROR failed to resolve: use of undeclared type or module `CStRiNg`
+
+    let _ = cStrIng::new("hello").unwrap();
+    //~^ ERROR failed to resolve: use of undeclared type or module `cStrIng`
+
+    let _ = foO::bar();
+    //~^ ERROR failed to resolve: use of undeclared type or module `foO`
+}

--- a/src/test/ui/resolve/suggest-type.rs
+++ b/src/test/ui/resolve/suggest-type.rs
@@ -8,12 +8,6 @@ fn main() {
     let _ = Cstring::new("hello").unwrap();
     //~^ ERROR failed to resolve: use of undeclared type or module `Cstring`
 
-    let _ = CStRiNg::new("hello").unwrap();
-    //~^ ERROR failed to resolve: use of undeclared type or module `CStRiNg`
-
-    let _ = cStrIng::new("hello").unwrap();
-    //~^ ERROR failed to resolve: use of undeclared type or module `cStrIng`
-
     let _ = foO::bar();
     //~^ ERROR failed to resolve: use of undeclared type or module `foO`
 }

--- a/src/test/ui/resolve/suggest-type.stderr
+++ b/src/test/ui/resolve/suggest-type.stderr
@@ -5,7 +5,7 @@ LL |     let _ = Cstring::new("hello").unwrap();
    |             ^^^^^^^
    |             |
    |             use of undeclared type or module `Cstring`
-   |             help: did you mean (notice the capitalization): `CString`
+   |             help: a struct with a similar name exists (notice the capitalization): `CString`
 
 error[E0433]: failed to resolve: use of undeclared type or module `foO`
   --> $DIR/suggest-type.rs:11:13
@@ -14,7 +14,7 @@ LL |     let _ = foO::bar();
    |             ^^^
    |             |
    |             use of undeclared type or module `foO`
-   |             help: did you mean (notice the capitalization): `foo`
+   |             help: a module with a similar name exists (notice the capitalization): `foo`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/resolve/suggest-type.stderr
+++ b/src/test/ui/resolve/suggest-type.stderr
@@ -8,7 +8,7 @@ LL |     let _ = Cstring::new("hello").unwrap();
    |             help: a struct with a similar name exists (notice the capitalization): `CString`
 
 error[E0433]: failed to resolve: use of undeclared type or module `foO`
-  --> $DIR/suggest-type.rs:11:13
+  --> $DIR/suggest-type.rs:13:13
    |
 LL |     let _ = foO::bar();
    |             ^^^

--- a/src/test/ui/resolve/suggest-type.stderr
+++ b/src/test/ui/resolve/suggest-type.stderr
@@ -1,5 +1,14 @@
+error[E0433]: failed to resolve: use of undeclared type or module `HashNap`
+  --> $DIR/suggest-type.rs:7:17
+   |
+LL |         let _ = HashNap::new();
+   |                 ^^^^^^^
+   |                 |
+   |                 use of undeclared type or module `HashNap`
+   |                 help: a struct with a similar name exists: `HashMap`
+
 error[E0433]: failed to resolve: use of undeclared type or module `Cstring`
-  --> $DIR/suggest-type.rs:8:13
+  --> $DIR/suggest-type.rs:15:13
    |
 LL |     let _ = Cstring::new("hello").unwrap();
    |             ^^^^^^^
@@ -8,7 +17,7 @@ LL |     let _ = Cstring::new("hello").unwrap();
    |             help: a struct with a similar name exists (notice the capitalization): `CString`
 
 error[E0433]: failed to resolve: use of undeclared type or module `foO`
-  --> $DIR/suggest-type.rs:13:13
+  --> $DIR/suggest-type.rs:20:13
    |
 LL |     let _ = foO::bar();
    |             ^^^
@@ -16,6 +25,6 @@ LL |     let _ = foO::bar();
    |             use of undeclared type or module `foO`
    |             help: a module with a similar name exists (notice the capitalization): `foo`
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0433`.

--- a/src/test/ui/resolve/suggest-type.stderr
+++ b/src/test/ui/resolve/suggest-type.stderr
@@ -1,0 +1,39 @@
+error[E0433]: failed to resolve: use of undeclared type or module `Cstring`
+  --> $DIR/suggest-type.rs:8:13
+   |
+LL |     let _ = Cstring::new("hello").unwrap();
+   |             ^^^^^^^
+   |             |
+   |             use of undeclared type or module `Cstring`
+   |             help: did you mean (notice the capitalization): `CString`
+
+error[E0433]: failed to resolve: use of undeclared type or module `CStRiNg`
+  --> $DIR/suggest-type.rs:11:13
+   |
+LL |     let _ = CStRiNg::new("hello").unwrap();
+   |             ^^^^^^^
+   |             |
+   |             use of undeclared type or module `CStRiNg`
+   |             help: did you mean: `CString`
+
+error[E0433]: failed to resolve: use of undeclared type or module `cStrIng`
+  --> $DIR/suggest-type.rs:14:13
+   |
+LL |     let _ = cStrIng::new("hello").unwrap();
+   |             ^^^^^^^
+   |             |
+   |             use of undeclared type or module `cStrIng`
+   |             help: did you mean (notice the capitalization): `CString`
+
+error[E0433]: failed to resolve: use of undeclared type or module `foO`
+  --> $DIR/suggest-type.rs:17:13
+   |
+LL |     let _ = foO::bar();
+   |             ^^^
+   |             |
+   |             use of undeclared type or module `foO`
+   |             help: did you mean (notice the capitalization): `foo`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0433`.

--- a/src/test/ui/resolve/suggest-type.stderr
+++ b/src/test/ui/resolve/suggest-type.stderr
@@ -7,26 +7,8 @@ LL |     let _ = Cstring::new("hello").unwrap();
    |             use of undeclared type or module `Cstring`
    |             help: did you mean (notice the capitalization): `CString`
 
-error[E0433]: failed to resolve: use of undeclared type or module `CStRiNg`
-  --> $DIR/suggest-type.rs:11:13
-   |
-LL |     let _ = CStRiNg::new("hello").unwrap();
-   |             ^^^^^^^
-   |             |
-   |             use of undeclared type or module `CStRiNg`
-   |             help: did you mean: `CString`
-
-error[E0433]: failed to resolve: use of undeclared type or module `cStrIng`
-  --> $DIR/suggest-type.rs:14:13
-   |
-LL |     let _ = cStrIng::new("hello").unwrap();
-   |             ^^^^^^^
-   |             |
-   |             use of undeclared type or module `cStrIng`
-   |             help: did you mean (notice the capitalization): `CString`
-
 error[E0433]: failed to resolve: use of undeclared type or module `foO`
-  --> $DIR/suggest-type.rs:17:13
+  --> $DIR/suggest-type.rs:11:13
    |
 LL |     let _ = foO::bar();
    |             ^^^
@@ -34,6 +16,6 @@ LL |     let _ = foO::bar();
    |             use of undeclared type or module `foO`
    |             help: did you mean (notice the capitalization): `foo`
 
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
When failing to resolve types or modules, this change tries to provide a
suggestion with similarly named candidates.

If desired, I can try and move some of the diagnostics code in `resolve/lib.rs` to `resolve/diagnostics.rs` as it seems to accumulate a bit in lib.rs. 

Fixes #56982