### PR TITLE
Merge item id stable hashing functions

### DIFF
--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -47,30 +47,11 @@ impl<'ctx> rustc_hir::HashStableContext for StableHashingContext<'ctx> {
     // want to pick up on a reference changing its target, so we hash the NodeIds
     // in "DefPath Mode".
 
-    fn hash_item_id(&mut self, id: hir::ItemId, hasher: &mut StableHasher) {
+    fn hash_reference_to_item(&mut self, id: hir::HirId, hasher: &mut StableHasher) {
         let hcx = self;
-        let hir::ItemId { id } = id;
 
         hcx.with_node_id_hashing_mode(NodeIdHashingMode::HashDefPath, |hcx| {
             id.hash_stable(hcx, hasher);
-        })
-    }
-
-    fn hash_impl_item_id(&mut self, id: hir::ImplItemId, hasher: &mut StableHasher) {
-        let hcx = self;
-        let hir::ImplItemId { hir_id } = id;
-
-        hcx.with_node_id_hashing_mode(NodeIdHashingMode::HashDefPath, |hcx| {
-            hir_id.hash_stable(hcx, hasher);
-        })
-    }
-
-    fn hash_trait_item_id(&mut self, id: hir::TraitItemId, hasher: &mut StableHasher) {
-        let hcx = self;
-        let hir::TraitItemId { hir_id } = id;
-
-        hcx.with_node_id_hashing_mode(NodeIdHashingMode::HashDefPath, |hcx| {
-            hir_id.hash_stable(hcx, hasher);
         })
     }
 

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -40,13 +40,6 @@ impl<'ctx> rustc_hir::HashStableContext for StableHashingContext<'ctx> {
         }
     }
 
-    // The following implementations of HashStable for `ItemId`, `TraitItemId`, and
-    // `ImplItemId` deserve special attention. Normally we do not hash `NodeId`s within
-    // the HIR, since they just signify a HIR nodes own path. But `ItemId` et al
-    // are used when another item in the HIR is *referenced* and we certainly
-    // want to pick up on a reference changing its target, so we hash the NodeIds
-    // in "DefPath Mode".
-
     fn hash_reference_to_item(&mut self, id: hir::HirId, hasher: &mut StableHasher) {
         let hcx = self;
 

--- a/src/librustc_hir/stable_hash_impls.rs
+++ b/src/librustc_hir/stable_hash_impls.rs
@@ -11,9 +11,7 @@ pub trait HashStableContext: syntax::HashStableContext + rustc_target::HashStabl
     fn hash_def_id(&mut self, _: DefId, hasher: &mut StableHasher);
     fn hash_hir_id(&mut self, _: HirId, hasher: &mut StableHasher);
     fn hash_body_id(&mut self, _: BodyId, hasher: &mut StableHasher);
-    fn hash_item_id(&mut self, _: ItemId, hasher: &mut StableHasher);
-    fn hash_impl_item_id(&mut self, _: ImplItemId, hasher: &mut StableHasher);
-    fn hash_trait_item_id(&mut self, _: TraitItemId, hasher: &mut StableHasher);
+    fn hash_reference_to_item(&mut self, _: HirId, hasher: &mut StableHasher);
     fn hash_hir_mod(&mut self, _: &Mod<'_>, hasher: &mut StableHasher);
     fn hash_hir_expr(&mut self, _: &Expr<'_>, hasher: &mut StableHasher);
     fn hash_hir_ty(&mut self, _: &Ty<'_>, hasher: &mut StableHasher);
@@ -40,19 +38,19 @@ impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for BodyId {
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for ItemId {
     fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
-        hcx.hash_item_id(*self, hasher)
+        hcx.hash_reference_to_item(self.id, hasher)
     }
 }
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for ImplItemId {
     fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
-        hcx.hash_impl_item_id(*self, hasher)
+        hcx.hash_reference_to_item(self.hir_id, hasher)
     }
 }
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for TraitItemId {
     fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
-        hcx.hash_trait_item_id(*self, hasher)
+        hcx.hash_reference_to_item(self.hir_id, hasher)
     }
 }
 

--- a/src/librustc_hir/stable_hash_impls.rs
+++ b/src/librustc_hir/stable_hash_impls.rs
@@ -36,6 +36,13 @@ impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for BodyId {
     }
 }
 
+// The following implementations of HashStable for `ItemId`, `TraitItemId`, and
+// `ImplItemId` deserve special attention. Normally we do not hash `NodeId`s within
+// the HIR, since they just signify a HIR nodes own path. But `ItemId` et al
+// are used when another item in the HIR is *referenced* and we certainly
+// want to pick up on a reference changing its target, so we hash the NodeIds
+// in "DefPath Mode".
+
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for ItemId {
     fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
         hcx.hash_reference_to_item(self.id, hasher)


### PR DESCRIPTION
Supersedes https://github.com/rust-lang/rust/pull/67999 splitting out the pure cleanup bits, i.e. merging `hash_item_id`, `hash_impl_item_id` and `hash_trait_item_id` into a common `hash_reference_to_item`.

r? @michaelwoerister 