### PR TITLE
rustc_codegen_llvm: always set AlwaysPreserve on all debuginfo variables

### DIFF
--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -569,7 +569,7 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
                 file_metadata,
                 loc.line as c_uint,
                 type_metadata,
-                self.sess().opts.optimize != config::OptLevel::No,
+                true,
                 DIFlags::FlagZero,
                 argument_index,
                 align.bytes() as u32,


### PR DESCRIPTION
Making this depend on the optimization level appears to have been a copy-paste mistake (other LLVM functions called in this module also take a `bool` argument, but there it means something unrelated).
Also see https://github.com/rust-lang/rust/pull/8855#discussion_r374392128.

I don't believe we have any reason to let LLVM omit user variables from DWARF, and we were already setting this to `true` when LLVM *could* optimize them away, so this PR should have no effect anyway.

r? @michaelwoerister or @nagisa cc @hanna-kruppe @nikomatsakis 