### PR TITLE
Mark fn map_or() as eagerly evaluated.

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -455,6 +455,12 @@ impl<T> Option<T> {
     /// Applies a function to the contained value (if any),
     /// or returns the provided default (if not).
     ///
+    /// Arguments passed to `map_or` are eagerly evaluated; if you are passing
+    /// the result of a function call, it is recommended to use [`map_or_else`],
+    /// which is lazily evaluated.
+    ///
+    /// [`map_or_else`]: #method.map_or_else
+    ///
     /// # Examples
     ///
     /// ```

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -524,6 +524,12 @@ impl<T, E> Result<T, E> {
     /// Applies a function to the contained value (if any),
     /// or returns the provided default (if not).
     ///
+    /// Arguments passed to `map_or` are eagerly evaluated; if you are passing
+    /// the result of a function call, it is recommended to use [`map_or_else`],
+    /// which is lazily evaluated.
+    ///
+    /// [`map_or_else`]: #method.map_or_else
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
In the docs for option.rs and result.rs, it is noted for all *_or()
functions that they are eagerly evaluated, except for the map_or()
function.
This commit adds this missing documentation to the two files.

Closes #68866