### PR TITLE
error code examples: replace some more ignore with compile_fail

### DIFF
--- a/src/librustc_error_codes/error_codes/E0511.md
+++ b/src/librustc_error_codes/error_codes/E0511.md
@@ -1,7 +1,7 @@
 Invalid monomorphization of an intrinsic function was used. Erroneous code
 example:
 
-```ignore (error-emitted-at-codegen-which-cannot-be-handled-by-compile_fail)
+```compile_fail,E0511
 #![feature(platform_intrinsics)]
 
 extern "platform-intrinsic" {

--- a/src/librustc_error_codes/error_codes/E0534.md
+++ b/src/librustc_error_codes/error_codes/E0534.md
@@ -2,7 +2,7 @@ The `inline` attribute was malformed.
 
 Erroneous code example:
 
-```ignore (compile_fail not working here; see Issue #43707)
+```compile_fail,E0534
 #[inline()] // error: expected one argument
 pub fn something() {}
 

--- a/src/librustc_error_codes/error_codes/E0535.md
+++ b/src/librustc_error_codes/error_codes/E0535.md
@@ -2,7 +2,7 @@ An unknown argument was given to the `inline` attribute.
 
 Erroneous code example:
 
-```ignore (compile_fail not working here; see Issue #43707)
+```compile_fail,E0535
 #[inline(unknown)] // error: invalid argument
 pub fn something() {}
 

--- a/src/librustc_error_codes/error_codes/E0633.md
+++ b/src/librustc_error_codes/error_codes/E0633.md
@@ -2,7 +2,9 @@ The `unwind` attribute was malformed.
 
 Erroneous code example:
 
-```ignore (compile_fail not working here; see Issue #43707)
+```compile_fail,E0633
+#![feature(unwind_attributes)]
+
 #[unwind()] // error: expected one argument
 pub extern fn something() {}
 

--- a/src/librustc_error_codes/error_codes/E0668.md
+++ b/src/librustc_error_codes/error_codes/E0668.md
@@ -6,7 +6,7 @@ assembly call.
 
 In particular, it can happen if you forgot the closing bracket of a register
 constraint (see issue #51430):
-```ignore (error-emitted-at-codegen-which-cannot-be-handled-by-compile_fail)
+```compile_fail,E0668
 #![feature(asm)]
 
 fn main() {


### PR DESCRIPTION
Now that #68664 has been merged and `compile_fail` attempts a full build rather than `--emit=metadata`, these errors should be caught by `compile_fail` and do not need to be ignored.