### PR TITLE
Move the `hir().krate()` method to a query and remove the `Krate` dep node

### DIFF
--- a/src/librustc/arena.rs
+++ b/src/librustc/arena.rs
@@ -127,7 +127,7 @@ macro_rules! arena_types {
             [] tys: rustc::ty::TyS<$tcx>,
 
             // HIR types
-            [few] hir_forest: rustc::hir::map::Forest<$tcx>,
+            [few] hir_krate: rustc_hir::Crate<$tcx>,
             [] arm: rustc_hir::Arm<$tcx>,
             [] attribute: syntax::ast::Attribute,
             [] block: rustc_hir::Block<$tcx>,

--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -35,7 +35,7 @@
 //! "infer" some properties for each kind of `DepNode`:
 //!
 //! * Whether a `DepNode` of a given kind has any parameters at all. Some
-//!   `DepNode`s, like `Krate`, represent global concepts with only one value.
+//!   `DepNode`s, like `AllLocalTraitImpls`, represent global concepts with only one value.
 //! * Whether it is possible, in principle, to reconstruct a query key from a
 //!   given `DepNode`. Many `DepKind`s only require a single `DefId` parameter,
 //!   in which case it is possible to map the node's fingerprint back to the
@@ -399,19 +399,6 @@ impl DefPathHash {
 rustc_dep_node_append!([define_dep_nodes!][ <'tcx>
     // We use this for most things when incr. comp. is turned off.
     [] Null,
-
-    // Represents the `Krate` as a whole (the `hir::Krate` value) (as
-    // distinct from the krate module). This is basically a hash of
-    // the entire krate, so if you read from `Krate` (e.g., by calling
-    // `tcx.hir().krate()`), we will have to assume that any change
-    // means that you need to be recompiled. This is because the
-    // `Krate` value gives you access to all other items. To avoid
-    // this fate, do not call `tcx.hir().krate()`; instead, prefer
-    // wrappers like `tcx.visit_all_items_in_krate()`.  If there is no
-    // suitable wrapper, you can use `tcx.dep_graph.ignore()` to gain
-    // access to the krate, but you must remember to add suitable
-    // edges yourself for the individual items that you read.
-    [eval_always] Krate,
 
     // Represents the body of a function or method. The def-id is that of the
     // function/method.

--- a/src/librustc/hir/map/collector.rs
+++ b/src/librustc/hir/map/collector.rs
@@ -223,12 +223,9 @@ impl<'a, 'hir> NodeCollector<'a, 'hir> {
             (commandline_args_hash, crate_disambiguator.to_fingerprint()),
         );
 
-        let (_, crate_hash) = input_dep_node_and_hash(
-            self.dep_graph,
-            &mut self.hcx,
-            DepNode::new_no_params(DepKind::Krate),
-            crate_hash_input,
-        );
+        let mut stable_hasher = StableHasher::new();
+        crate_hash_input.hash_stable(&mut self.hcx, &mut stable_hasher);
+        let crate_hash: Fingerprint = stable_hasher.finish();
 
         let svh = Svh::new(crate_hash.to_smaller_hash());
         (self.map, svh)

--- a/src/librustc/hir/map/hir_id_validator.rs
+++ b/src/librustc/hir/map/hir_id_validator.rs
@@ -12,7 +12,7 @@ pub fn check_crate(hir_map: &Map<'_>) {
 
     let errors = Lock::new(Vec::new());
 
-    par_iter(&hir_map.forest.krate.modules).for_each(|(module_id, _)| {
+    par_iter(&hir_map.krate.modules).for_each(|(module_id, _)| {
         let local_def_id = hir_map.local_def_id(*module_id);
         hir_map.visit_item_likes_in_module(
             local_def_id,

--- a/src/librustc/hir/map/hir_id_validator.rs
+++ b/src/librustc/hir/map/hir_id_validator.rs
@@ -12,7 +12,7 @@ pub fn check_crate(hir_map: &Map<'_>) {
 
     let errors = Lock::new(Vec::new());
 
-    par_iter(&hir_map.krate().modules).for_each(|(module_id, _)| {
+    par_iter(&hir_map.forest.krate.modules).for_each(|(module_id, _)| {
         let local_def_id = hir_map.local_def_id(*module_id);
         hir_map.visit_item_likes_in_module(
             local_def_id,

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -129,25 +129,6 @@ impl<'hir> Entry<'hir> {
     }
 }
 
-/// Stores a crate and any number of inlined items from other crates.
-pub struct Forest<'hir> {
-    krate: Crate<'hir>,
-    pub dep_graph: DepGraph,
-}
-
-impl Forest<'hir> {
-    pub fn new(krate: Crate<'hir>, dep_graph: &DepGraph) -> Forest<'hir> {
-        Forest { krate, dep_graph: dep_graph.clone() }
-    }
-
-    /// This is used internally in the dependency tracking system.
-    /// Use the `krate` method to ensure your dependency on the
-    /// crate is tracked.
-    pub fn untracked_krate(&self) -> &Crate<'hir> {
-        &self.krate
-    }
-}
-
 /// This type is effectively a `HashMap<HirId, Entry<'hir>>`,
 /// but it is implemented as 2 layers of arrays.
 /// - first we have `A = IndexVec<DefIndex, B>` mapping `DefIndex`s to an inner value
@@ -157,11 +138,8 @@ pub(super) type HirEntryMap<'hir> = IndexVec<DefIndex, IndexVec<ItemLocalId, Opt
 /// Represents a mapping from `NodeId`s to AST elements and their parent `NodeId`s.
 #[derive(Clone)]
 pub struct Map<'hir> {
-    /// The backing storage for all the AST nodes.
-    pub forest: &'hir Forest<'hir>,
+    pub krate: &'hir Crate<'hir>,
 
-    /// Same as the dep_graph in forest, just available with one fewer
-    /// deref. This is a gratuitous micro-optimization.
     pub dep_graph: DepGraph,
 
     /// The SVH of the local crate.
@@ -212,6 +190,13 @@ impl<'hir> Iterator for ParentHirIterator<'_, 'hir> {
 }
 
 impl<'hir> Map<'hir> {
+    /// This is used internally in the dependency tracking system.
+    /// Use the `krate` method to ensure your dependency on the
+    /// crate is tracked.
+    pub fn untracked_krate(&self) -> &Crate<'hir> {
+        &self.krate
+    }
+
     #[inline]
     fn lookup(&self, id: HirId) -> Option<&Entry<'hir>> {
         let local_map = self.map.get(id.owner)?;
@@ -399,33 +384,33 @@ impl<'hir> Map<'hir> {
     pub fn item(&self, id: HirId) -> &'hir Item<'hir> {
         self.read(id);
 
-        // N.B., intentionally bypass `self.forest.krate()` so that we
+        // N.B., intentionally bypass `self.krate()` so that we
         // do not trigger a read of the whole krate here
-        self.forest.krate.item(id)
+        self.krate.item(id)
     }
 
     pub fn trait_item(&self, id: TraitItemId) -> &'hir TraitItem<'hir> {
         self.read(id.hir_id);
 
-        // N.B., intentionally bypass `self.forest.krate()` so that we
+        // N.B., intentionally bypass `self.krate()` so that we
         // do not trigger a read of the whole krate here
-        self.forest.krate.trait_item(id)
+        self.krate.trait_item(id)
     }
 
     pub fn impl_item(&self, id: ImplItemId) -> &'hir ImplItem<'hir> {
         self.read(id.hir_id);
 
-        // N.B., intentionally bypass `self.forest.krate()` so that we
+        // N.B., intentionally bypass `self.krate()` so that we
         // do not trigger a read of the whole krate here
-        self.forest.krate.impl_item(id)
+        self.krate.impl_item(id)
     }
 
     pub fn body(&self, id: BodyId) -> &'hir Body<'hir> {
         self.read(id.hir_id);
 
-        // N.B., intentionally bypass `self.forest.krate()` so that we
+        // N.B., intentionally bypass `self.krate()` so that we
         // do not trigger a read of the whole krate here
-        self.forest.krate.body(id)
+        self.krate.body(id)
     }
 
     pub fn fn_decl_by_hir_id(&self, hir_id: HirId) -> Option<&'hir FnDecl<'hir>> {
@@ -521,9 +506,9 @@ impl<'hir> Map<'hir> {
     pub fn trait_impls(&self, trait_did: DefId) -> &'hir [HirId] {
         self.dep_graph.read(DepNode::new_no_params(DepKind::AllLocalTraitImpls));
 
-        // N.B., intentionally bypass `self.forest.krate()` so that we
+        // N.B., intentionally bypass `self.krate()` so that we
         // do not trigger a read of the whole krate here
-        self.forest.krate.trait_impls.get(&trait_did).map_or(&[], |xs| &xs[..])
+        self.krate.trait_impls.get(&trait_did).map_or(&[], |xs| &xs[..])
     }
 
     /// Gets the attributes on the crate. This is preferable to
@@ -533,7 +518,7 @@ impl<'hir> Map<'hir> {
         let def_path_hash = self.definitions.def_path_hash(CRATE_DEF_INDEX);
 
         self.dep_graph.read(def_path_hash.to_dep_node(DepKind::Hir));
-        &self.forest.krate.attrs
+        &self.krate.attrs
     }
 
     pub fn get_module(&self, module: DefId) -> (&'hir Mod<'hir>, Span, HirId) {
@@ -541,7 +526,7 @@ impl<'hir> Map<'hir> {
         self.read(hir_id);
         match self.find_entry(hir_id).unwrap().node {
             Node::Item(&Item { span, kind: ItemKind::Mod(ref m), .. }) => (m, span, hir_id),
-            Node::Crate => (&self.forest.krate.module, self.forest.krate.span, hir_id),
+            Node::Crate => (&self.krate.module, self.krate.span, hir_id),
             node => panic!("not a module: {:?}", node),
         }
     }
@@ -558,7 +543,7 @@ impl<'hir> Map<'hir> {
         // in the expect_* calls the loops below
         self.read(hir_id);
 
-        let module = &self.forest.krate.modules[&hir_id];
+        let module = &self.krate.modules[&hir_id];
 
         for id in &module.items {
             visitor.visit_item(self.expect_item(*id));
@@ -975,7 +960,7 @@ impl<'hir> Map<'hir> {
             // Unit/tuple structs/variants take the attributes straight from
             // the struct/variant definition.
             Some(Node::Ctor(..)) => return self.attrs(self.get_parent_item(id)),
-            Some(Node::Crate) => Some(&self.forest.krate.attrs[..]),
+            Some(Node::Crate) => Some(&self.krate.attrs[..]),
             _ => None,
         };
         attrs.unwrap_or(&[])
@@ -1054,7 +1039,7 @@ impl<'hir> Map<'hir> {
             Some(Node::Visibility(v)) => bug!("unexpected Visibility {:?}", v),
             Some(Node::Local(local)) => local.span,
             Some(Node::MacroDef(macro_def)) => macro_def.span,
-            Some(Node::Crate) => self.forest.krate.span,
+            Some(Node::Crate) => self.krate.span,
             None => bug!("hir::map::Map::span: id not in map: {:?}", hir_id),
         }
     }
@@ -1222,7 +1207,8 @@ impl Named for ImplItem<'_> {
 pub fn map_crate<'hir>(
     sess: &rustc_session::Session,
     cstore: &CrateStoreDyn,
-    forest: &'hir Forest<'hir>,
+    krate: &'hir Crate<'hir>,
+    dep_graph: DepGraph,
     definitions: Definitions,
 ) -> Map<'hir> {
     let _prof_timer = sess.prof.generic_activity("build_hir_map");
@@ -1235,31 +1221,18 @@ pub fn map_crate<'hir>(
         .collect();
 
     let (map, crate_hash) = {
-        let hcx = crate::ich::StableHashingContext::new(sess, &forest.krate, &definitions, cstore);
+        let hcx = crate::ich::StableHashingContext::new(sess, krate, &definitions, cstore);
 
-        let mut collector = NodeCollector::root(
-            sess,
-            &forest.krate,
-            &forest.dep_graph,
-            &definitions,
-            &hir_to_node_id,
-            hcx,
-        );
-        intravisit::walk_crate(&mut collector, &forest.krate);
+        let mut collector =
+            NodeCollector::root(sess, krate, &dep_graph, &definitions, &hir_to_node_id, hcx);
+        intravisit::walk_crate(&mut collector, krate);
 
         let crate_disambiguator = sess.local_crate_disambiguator();
         let cmdline_args = sess.opts.dep_tracking_hash();
         collector.finalize_and_compute_crate_hash(crate_disambiguator, cstore, cmdline_args)
     };
 
-    let map = Map {
-        forest,
-        dep_graph: forest.dep_graph.clone(),
-        crate_hash,
-        map,
-        hir_to_node_id,
-        definitions,
-    };
+    let map = Map { krate, dep_graph, crate_hash, map, hir_to_node_id, definitions };
 
     sess.time("validate_HIR_map", || {
         hir_id_validator::check_crate(&map);

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -138,7 +138,7 @@ pub(super) type HirEntryMap<'hir> = IndexVec<DefIndex, IndexVec<ItemLocalId, Opt
 /// Represents a mapping from `NodeId`s to AST elements and their parent `NodeId`s.
 #[derive(Clone)]
 pub struct Map<'hir> {
-    pub krate: &'hir Crate<'hir>,
+    krate: &'hir Crate<'hir>,
 
     pub dep_graph: DepGraph,
 

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -140,11 +140,6 @@ impl Forest<'hir> {
         Forest { krate, dep_graph: dep_graph.clone() }
     }
 
-    pub fn krate(&self) -> &Crate<'hir> {
-        self.dep_graph.read(DepNode::new_no_params(DepKind::Krate));
-        &self.krate
-    }
-
     /// This is used internally in the dependency tracking system.
     /// Use the `krate` method to ensure your dependency on the
     /// crate is tracked.
@@ -399,10 +394,6 @@ impl<'hir> Map<'hir> {
 
     fn find_entry(&self, id: HirId) -> Option<Entry<'hir>> {
         self.lookup(id).cloned()
-    }
-
-    pub fn krate(&self) -> &'hir Crate<'hir> {
-        self.forest.krate()
     }
 
     pub fn item(&self, id: HirId) -> &'hir Item<'hir> {

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -49,6 +49,6 @@ impl<'tcx> TyCtxt<'tcx> {
 }
 
 pub fn provide(providers: &mut Providers<'_>) {
-    providers.hir_crate = |tcx, _| tcx.hir_map.forest.untracked_krate();
+    providers.hir_crate = |tcx, _| tcx.hir_map.untracked_krate();
     map::provide(providers);
 }

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -8,7 +8,9 @@ pub mod map;
 
 use crate::ty::query::Providers;
 use crate::ty::TyCtxt;
+use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_hir::print;
+use rustc_hir::Crate;
 use std::ops::Deref;
 
 /// A wrapper type which allows you to access HIR.
@@ -16,6 +18,12 @@ use std::ops::Deref;
 pub struct Hir<'tcx> {
     tcx: TyCtxt<'tcx>,
     map: &'tcx map::Map<'tcx>,
+}
+
+impl<'tcx> Hir<'tcx> {
+    pub fn krate(&self) -> &'tcx Crate<'tcx> {
+        self.tcx.hir_crate(LOCAL_CRATE)
+    }
 }
 
 impl<'tcx> Deref for Hir<'tcx> {

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -41,5 +41,6 @@ impl<'tcx> TyCtxt<'tcx> {
 }
 
 pub fn provide(providers: &mut Providers<'_>) {
+    providers.hir_crate = |tcx, _| tcx.hir_map.forest.untracked_krate();
     map::provide(providers);
 }

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -7,6 +7,38 @@ pub mod exports;
 pub mod map;
 
 use crate::ty::query::Providers;
+use crate::ty::TyCtxt;
+use rustc_hir::print;
+use std::ops::Deref;
+
+/// A wrapper type which allows you to access HIR.
+#[derive(Clone)]
+pub struct Hir<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    map: &'tcx map::Map<'tcx>,
+}
+
+impl<'tcx> Deref for Hir<'tcx> {
+    type Target = &'tcx map::Map<'tcx>;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.map
+    }
+}
+
+impl<'hir> print::PpAnn for Hir<'hir> {
+    fn nested(&self, state: &mut print::State<'_>, nested: print::Nested) {
+        self.map.nested(state, nested)
+    }
+}
+
+impl<'tcx> TyCtxt<'tcx> {
+    #[inline(always)]
+    pub fn hir(self) -> Hir<'tcx> {
+        Hir { tcx: self, map: &self.hir_map }
+    }
+}
 
 pub fn provide(providers: &mut Providers<'_>) {
     map::provide(providers);

--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -43,6 +43,12 @@ rustc_queries! {
     }
 
     Other {
+        query hir_crate(key: CrateNum) -> &'tcx Crate<'tcx> {
+            eval_always
+            no_hash
+            desc { "get the crate HIR" }
+        }
+
         /// Records the type of every item.
         query type_of(key: DefId) -> Ty<'tcx> {
             cache_on_disk_if { key.is_local() }

--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -43,6 +43,12 @@ rustc_queries! {
     }
 
     Other {
+        // Represents crate as a whole (as distinct from the to-level crate module).
+        // If you call `hir_crate` (e.g., indirectly by calling `tcx.hir().krate()`),
+        // we will have to assume that any change means that you need to be recompiled.
+        // This is because the `hir_crate` query gives you access to all other items.
+        // To avoid this fate, do not call `tcx.hir().krate()`; instead,
+        // prefer wrappers like `tcx.visit_all_items_in_krate()`.
         query hir_crate(key: CrateNum) -> &'tcx Crate<'tcx> {
             eval_always
             no_hash

--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -43,7 +43,7 @@ rustc_queries! {
     }
 
     Other {
-        // Represents crate as a whole (as distinct from the to-level crate module).
+        // Represents crate as a whole (as distinct from the top-level crate module).
         // If you call `hir_crate` (e.g., indirectly by calling `tcx.hir().krate()`),
         // we will have to assume that any change means that you need to be recompiled.
         // This is because the `hir_crate` query gives you access to all other items.

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -966,7 +966,7 @@ pub struct GlobalCtxt<'tcx> {
     /// Export map produced by name resolution.
     export_map: FxHashMap<DefId, Vec<Export<hir::HirId>>>,
 
-    hir_map: hir_map::Map<'tcx>,
+    pub(crate) hir_map: hir_map::Map<'tcx>,
 
     /// A map from `DefPathHash` -> `DefId`. Includes `DefId`s from the local crate
     /// as well as all upstream crates. Only populated in incremental mode.
@@ -1019,11 +1019,6 @@ pub struct GlobalCtxt<'tcx> {
 }
 
 impl<'tcx> TyCtxt<'tcx> {
-    #[inline(always)]
-    pub fn hir(self) -> &'tcx hir_map::Map<'tcx> {
-        &self.hir_map
-    }
-
     pub fn alloc_steal_mir(self, mir: BodyAndCache<'tcx>) -> &'tcx Steal<BodyAndCache<'tcx>> {
         self.arena.alloc(Steal::new(mir))
     }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1323,7 +1323,7 @@ impl<'tcx> TyCtxt<'tcx> {
 
     #[inline(always)]
     pub fn create_stable_hashing_context(self) -> StableHashingContext<'tcx> {
-        let krate = self.gcx.hir_map.forest.untracked_krate();
+        let krate = self.gcx.hir_map.untracked_krate();
 
         StableHashingContext::new(self.sess, krate, self.hir().definitions(), &*self.cstore)
     }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -966,6 +966,7 @@ pub struct GlobalCtxt<'tcx> {
     /// Export map produced by name resolution.
     export_map: FxHashMap<DefId, Vec<Export<hir::HirId>>>,
 
+    /// This should usually be accessed with the `tcx.hir()` method.
     pub(crate) hir_map: hir_map::Map<'tcx>,
 
     /// A map from `DefPathHash` -> `DefId`. Includes `DefId`s from the local crate

--- a/src/librustc/ty/query/mod.rs
+++ b/src/librustc/ty/query/mod.rs
@@ -45,7 +45,7 @@ use rustc_data_structures::sync::Lrc;
 use rustc_hir as hir;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, DefIdSet, DefIndex};
-use rustc_hir::{HirIdSet, ItemLocalId, TraitCandidate};
+use rustc_hir::{Crate, HirIdSet, ItemLocalId, TraitCandidate};
 use rustc_index::vec::IndexVec;
 use rustc_target::spec::PanicStrategy;
 

--- a/src/librustc/ty/query/plumbing.rs
+++ b/src/librustc/ty/query/plumbing.rs
@@ -1177,7 +1177,6 @@ pub fn force_from_dep_node(tcx: TyCtxt<'_>, dep_node: &DepNode) -> bool {
         // These are inputs that are expected to be pre-allocated and that
         // should therefore always be red or green already.
         DepKind::AllLocalTraitImpls |
-        DepKind::Krate |
         DepKind::CrateMetadata |
         DepKind::HirBody |
         DepKind::Hir |

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -69,19 +69,19 @@ where
     match *ppmode {
         PpmNormal => {
             let annotation = NoAnn { sess: tcx.sess, tcx: Some(tcx) };
-            f(&annotation, tcx.hir().forest.krate())
+            f(&annotation, tcx.hir().krate())
         }
 
         PpmIdentified => {
             let annotation = IdentifiedAnnotation { sess: tcx.sess, tcx: Some(tcx) };
-            f(&annotation, tcx.hir().forest.krate())
+            f(&annotation, tcx.hir().krate())
         }
         PpmTyped => {
             abort_on_err(tcx.analysis(LOCAL_CRATE), tcx.sess);
 
             let empty_tables = ty::TypeckTables::empty(None);
             let annotation = TypedAnnotation { tcx, tables: Cell::new(&empty_tables) };
-            tcx.dep_graph.with_ignore(|| f(&annotation, tcx.hir().forest.krate()))
+            tcx.dep_graph.with_ignore(|| f(&annotation, tcx.hir().krate()))
         }
         _ => panic!("Should use call_with_pp_support"),
     }

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -143,7 +143,7 @@ impl<'hir> HirPrinterSupport<'hir> for NoAnn<'hir> {
     }
 
     fn hir_map<'a>(&'a self) -> Option<&'a hir_map::Map<'hir>> {
-        self.tcx.map(|tcx| tcx.hir())
+        self.tcx.map(|tcx| *tcx.hir())
     }
 
     fn pp_ann<'a>(&'a self) -> &'a dyn pprust_hir::PpAnn {
@@ -155,7 +155,7 @@ impl<'hir> pprust::PpAnn for NoAnn<'hir> {}
 impl<'hir> pprust_hir::PpAnn for NoAnn<'hir> {
     fn nested(&self, state: &mut pprust_hir::State<'_>, nested: pprust_hir::Nested) {
         if let Some(tcx) = self.tcx {
-            pprust_hir::PpAnn::nested(tcx.hir(), state, nested)
+            pprust_hir::PpAnn::nested(*tcx.hir(), state, nested)
         }
     }
 }
@@ -217,7 +217,7 @@ impl<'hir> HirPrinterSupport<'hir> for IdentifiedAnnotation<'hir> {
     }
 
     fn hir_map<'a>(&'a self) -> Option<&'a hir_map::Map<'hir>> {
-        self.tcx.map(|tcx| tcx.hir())
+        self.tcx.map(|tcx| *tcx.hir())
     }
 
     fn pp_ann<'a>(&'a self) -> &'a dyn pprust_hir::PpAnn {
@@ -228,7 +228,7 @@ impl<'hir> HirPrinterSupport<'hir> for IdentifiedAnnotation<'hir> {
 impl<'hir> pprust_hir::PpAnn for IdentifiedAnnotation<'hir> {
     fn nested(&self, state: &mut pprust_hir::State<'_>, nested: pprust_hir::Nested) {
         if let Some(ref tcx) = self.tcx {
-            pprust_hir::PpAnn::nested(tcx.hir(), state, nested)
+            pprust_hir::PpAnn::nested(*tcx.hir(), state, nested)
         }
     }
     fn pre(&self, s: &mut pprust_hir::State<'_>, node: pprust_hir::AnnNode<'_>) {
@@ -334,7 +334,7 @@ impl<'a, 'tcx> pprust_hir::PpAnn for TypedAnnotation<'a, 'tcx> {
         if let pprust_hir::Nested::Body(id) = nested {
             self.tables.set(self.tcx.body_tables(id));
         }
-        pprust_hir::PpAnn::nested(self.tcx.hir(), state, nested);
+        pprust_hir::PpAnn::nested(*self.tcx.hir(), state, nested);
         self.tables.set(old_tables);
     }
     fn pre(&self, s: &mut pprust_hir::State<'_>, node: pprust_hir::AnnNode<'_>) {

--- a/src/librustc_metadata/rmeta/encoder.rs
+++ b/src/librustc_metadata/rmeta/encoder.rs
@@ -796,7 +796,7 @@ impl EncodeContext<'tcx> {
         record!(self.per_def.kind[def_id] <- match trait_item.kind {
             ty::AssocKind::Const => {
                 let rendered =
-                    hir::print::to_string(self.tcx.hir(), |s| s.print_trait_item(ast_item));
+                    hir::print::to_string(&self.tcx.hir(), |s| s.print_trait_item(ast_item));
                 let rendered_const = self.lazy(RenderedConst(rendered));
 
                 EntryKind::AssocConst(
@@ -1009,7 +1009,7 @@ impl EncodeContext<'tcx> {
 
     fn encode_rendered_const_for_body(&mut self, body_id: hir::BodyId) -> Lazy<RenderedConst> {
         let body = self.tcx.hir().body(body_id);
-        let rendered = hir::print::to_string(self.tcx.hir(), |s| s.print_expr(&body.value));
+        let rendered = hir::print::to_string(&self.tcx.hir(), |s| s.print_expr(&body.value));
         let rendered_const = &RenderedConst(rendered);
         self.lazy(rendered_const)
     }

--- a/src/librustc_passes/check_const.rs
+++ b/src/librustc_passes/check_const.rs
@@ -8,6 +8,7 @@
 //! through, but errors for structured control flow in a `const` should be emitted here.
 
 use rustc::hir::map::Map;
+use rustc::hir::Hir;
 use rustc::session::config::nightly_options;
 use rustc::session::parse::feature_err;
 use rustc::ty::query::Providers;
@@ -74,7 +75,7 @@ enum ConstKind {
 }
 
 impl ConstKind {
-    fn for_body(body: &hir::Body<'_>, hir_map: &Map<'_>) -> Option<Self> {
+    fn for_body(body: &hir::Body<'_>, hir_map: Hir<'_>) -> Option<Self> {
         let is_const_fn = |id| hir_map.fn_sig_by_hir_id(id).unwrap().header.is_const();
 
         let owner = hir_map.body_owner(body.id());

--- a/src/librustc_passes/entry.rs
+++ b/src/librustc_passes/entry.rs
@@ -1,4 +1,4 @@
-use rustc::hir::map as hir_map;
+use rustc::hir::Hir;
 use rustc::session::config::EntryFnType;
 use rustc::session::{config, Session};
 use rustc::ty::query::Providers;
@@ -15,7 +15,7 @@ use syntax::entry::EntryPointType;
 struct EntryContext<'a, 'tcx> {
     session: &'a Session,
 
-    map: &'a hir_map::Map<'tcx>,
+    map: Hir<'tcx>,
 
     /// The top-level function called `main`.
     main_fn: Option<(HirId, Span)>,

--- a/src/librustc_resolve/lifetimes.rs
+++ b/src/librustc_resolve/lifetimes.rs
@@ -612,7 +612,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
                                 let parent_id = self.tcx.hir().get_parent_node(hir_id);
                                 let parent_impl_id = hir::ImplItemId { hir_id: parent_id };
                                 let parent_trait_id = hir::TraitItemId { hir_id: parent_id };
-                                let krate = self.tcx.hir().forest.krate();
+                                let krate = self.tcx.hir().krate();
 
                                 if !(krate.items.contains_key(&parent_id)
                                     || krate.impl_items.contains_key(&parent_impl_id)

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2588,7 +2588,7 @@ fn report_unexpected_variant_res(tcx: TyCtxt<'_>, res: Res, span: Span, qpath: &
         E0533,
         "expected unit struct, unit variant or constant, found {} `{}`",
         res.descr(),
-        hir::print::to_string(tcx.hir(), |s| s.print_qpath(qpath, false))
+        hir::print::to_string(&tcx.hir(), |s| s.print_qpath(qpath, false))
     )
     .emit();
 }

--- a/src/librustc_typeck/check/pat.rs
+++ b/src/librustc_typeck/check/pat.rs
@@ -693,7 +693,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let msg = format!(
                 "expected tuple struct or tuple variant, found {} `{}`",
                 res.descr(),
-                hir::print::to_string(tcx.hir(), |s| s.print_qpath(qpath, false)),
+                hir::print::to_string(&tcx.hir(), |s| s.print_qpath(qpath, false)),
             );
             let mut err = struct_span_err!(tcx.sess, pat.span, E0164, "{}", msg);
             match (res, &pat.kind) {

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -87,7 +87,7 @@ pub fn run(options: Options) -> i32 {
         compiler.enter(|queries| {
             let lower_to_hir = queries.lower_to_hir()?;
 
-            let mut opts = scrape_test_config(lower_to_hir.peek().0.krate());
+            let mut opts = scrape_test_config(lower_to_hir.peek().0.untracked_krate());
             opts.display_warnings |= options.display_warnings;
             let enable_per_target_ignores = options.enable_per_target_ignores;
             let mut collector = Collector::new(

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -107,7 +107,7 @@ pub fn run(options: Options) -> i32 {
                 let mut hir_collector = HirCollector {
                     sess: compiler.session(),
                     collector: &mut collector,
-                    map: tcx.hir(),
+                    map: *tcx.hir(),
                     codes: ErrorCodes::from(
                         compiler.session().opts.unstable_features.is_nightly_build(),
                     ),

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -87,7 +87,7 @@ pub fn run(options: Options) -> i32 {
         compiler.enter(|queries| {
             let lower_to_hir = queries.lower_to_hir()?;
 
-            let mut opts = scrape_test_config(lower_to_hir.peek().0.untracked_krate());
+            let mut opts = scrape_test_config(lower_to_hir.peek().0);
             opts.display_warnings |= options.display_warnings;
             let enable_per_target_ignores = options.enable_per_target_ignores;
             let mut collector = Collector::new(

--- a/src/test/incremental/crate_hash_reorder.rs
+++ b/src/test/incremental/crate_hash_reorder.rs
@@ -7,11 +7,9 @@
 
 // Check that reordering otherwise identical items is not considered a
 // change at all.
-#[rustc_clean(label="Krate", cfg="rpass2")]
-
+#[rustc_clean(label = "hir_crate", cfg = "rpass2")]
 // But removing an item, naturally, is.
-#[rustc_dirty(label="Krate", cfg="rpass3")]
-
+#[rustc_dirty(label = "hir_crate", cfg = "rpass3")]
 #[cfg(rpass1)]
 pub struct X {
     pub x: u32,
@@ -26,4 +24,4 @@ pub struct X {
     pub x: u32,
 }
 
-pub fn main() { }
+pub fn main() {}

--- a/src/test/incremental/issue-38222.rs
+++ b/src/test/incremental/issue-38222.rs
@@ -1,18 +1,14 @@
-// Test that debuginfo does not introduce a dependency edge to the Krate
+// Test that debuginfo does not introduce a dependency edge to the hir_crate
 // dep-node.
 
 // revisions:rpass1 rpass2
 // compile-flags: -Z query-dep-graph
 
-
 #![feature(rustc_attrs)]
-
-
-#![rustc_partition_reused(module="issue_38222-mod1", cfg="rpass2")]
-
-// If codegen had added a dependency edge to the Krate dep-node, nothing would
+#![rustc_partition_reused(module = "issue_38222-mod1", cfg = "rpass2")]
+// If codegen had added a dependency edge to the hir_crate dep-node, nothing would
 // be re-used, so checking that this module was re-used is sufficient.
-#![rustc_partition_reused(module="issue_38222", cfg="rpass2")]
+#![rustc_partition_reused(module = "issue_38222", cfg = "rpass2")]
 
 //[rpass1] compile-flags: -C debuginfo=1
 //[rpass2] compile-flags: -C debuginfo=1

--- a/src/test/incremental/krate-inherent.rs
+++ b/src/test/incremental/krate-inherent.rs
@@ -4,20 +4,20 @@
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
-#![rustc_partition_reused(module="krate_inherent-x", cfg="cfail2")]
+#![rustc_partition_reused(module = "krate_inherent-x", cfg = "cfail2")]
 #![crate_type = "rlib"]
 
 pub mod x {
     pub struct Foo;
     impl Foo {
-        pub fn foo(&self) { }
+        pub fn foo(&self) {}
     }
 
     pub fn method() {
         let x: Foo = Foo;
-        x.foo(); // inherent methods used to add an edge from Krate
+        x.foo(); // inherent methods used to add an edge from hir_crate
     }
 }
 
 #[cfg(cfail1)]
-pub fn bar() { } // remove this unrelated fn in cfail2, which should not affect `x::method`
+pub fn bar() {} // remove this unrelated fn in cfail2, which should not affect `x::method`

--- a/src/test/incremental/krate-inlined.rs
+++ b/src/test/incremental/krate-inlined.rs
@@ -1,5 +1,5 @@
 // Regr. test that using HIR inlined from another krate does *not* add
-// a dependency from the local Krate node. We can't easily test that
+// a dependency from the local hir_crate node. We can't easily test that
 // directly anymore, so now we test that we get reuse.
 
 // revisions: rpass1 rpass2
@@ -7,7 +7,7 @@
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
-#![rustc_partition_reused(module="krate_inlined-x", cfg="rpass2")]
+#![rustc_partition_reused(module = "krate_inlined-x", cfg = "rpass2")]
 
 fn main() {
     x::method();

--- a/src/test/ui/dep-graph/dep-graph-variance-alias.rs
+++ b/src/test/ui/dep-graph/dep-graph-variance-alias.rs
@@ -6,17 +6,16 @@
 #![feature(rustc_attrs)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
-
-fn main() { }
+#![rustc_if_this_changed(hir_crate)]
+fn main() {}
 
 struct Foo<T> {
-    f: T
+    f: T,
 }
 
-#[rustc_if_this_changed(Krate)]
 type TypeAlias<T> = Foo<T>;
 
 #[rustc_then_this_would_need(variances_of)] //~ ERROR OK
 struct Use<T> {
-    x: TypeAlias<T>
+    x: TypeAlias<T>,
 }

--- a/src/test/ui/dep-graph/dep-graph-variance-alias.stderr
+++ b/src/test/ui/dep-graph/dep-graph-variance-alias.stderr
@@ -1,5 +1,5 @@
 error: OK
-  --> $DIR/dep-graph-variance-alias.rs:19:1
+  --> $DIR/dep-graph-variance-alias.rs:18:1
    |
 LL | #[rustc_then_this_would_need(variances_of)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
r? @eddyb cc @michaelwoerister 