### PR TITLE
Add Display and Error impls for proc_macro::LexError

### DIFF
--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -69,7 +69,7 @@ pub struct LexError {
 #[stable(feature = "proc_macro_lexerror_impls", since = "1.44.0")]
 impl fmt::Display for LexError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("lex error")
+        f.write_str("cannot parse string into token stream")
     }
 }
 

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -66,14 +66,14 @@ pub struct LexError {
     _inner: (),
 }
 
-#[stable(feature = "proc_macro_lib", since = "1.15.0")]
+#[stable(feature = "proc_macro_lexerror_impls", since = "1.44.0")]
 impl fmt::Display for LexError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("lex error")
     }
 }
 
-#[stable(feature = "proc_macro_lib", since = "1.15.0")]
+#[stable(feature = "proc_macro_lexerror_impls", since = "1.44.0")]
 impl error::Error for LexError {}
 
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -41,7 +41,7 @@ pub use diagnostic::{Diagnostic, Level, MultiSpan};
 use std::ops::{Bound, RangeBounds};
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::{fmt, iter, mem};
+use std::{error, fmt, iter, mem};
 
 /// The main type provided by this crate, representing an abstract stream of
 /// tokens, or, more specifically, a sequence of token trees.
@@ -65,6 +65,16 @@ impl !Sync for TokenStream {}
 pub struct LexError {
     _inner: (),
 }
+
+#[stable(feature = "proc_macro_lib", since = "1.15.0")]
+impl fmt::Display for LexError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("lex error")
+    }
+}
+
+#[stable(feature = "proc_macro_lib", since = "1.15.0")]
+impl error::Error for LexError {}
 
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 impl !Send for LexError {}


### PR DESCRIPTION
This should allow LexError to play much nicer with the `?` operator.

Fixes #68896.

(I'm not sure if I did the stability attributes right, so if I need to change them, please let me know!)