### PR TITLE
experiment: Use llvm.dbg.value instead of llvm.dbg.declare when possible.

### DIFF
--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -1730,6 +1730,16 @@ extern "C" {
         InsertAtEnd: &'a BasicBlock,
     ) -> &'a Value;
 
+    pub fn LLVMRustDIBuilderInsertDbgValueAtEnd(
+        Builder: &DIBuilder<'a>,
+        Val: &'a Value,
+        VarInfo: &'a DIVariable,
+        AddrOps: *const i64,
+        AddrOpsCount: c_uint,
+        DL: &'a Value,
+        InsertAtEnd: &'a BasicBlock,
+    ) -> &'a Value;
+
     pub fn LLVMRustDIBuilderCreateEnumerator(
         Builder: &DIBuilder<'a>,
         Name: *const c_char,

--- a/src/librustc_codegen_ssa/mir/debuginfo.rs
+++ b/src/librustc_codegen_ssa/mir/debuginfo.rs
@@ -307,11 +307,8 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 let var_ty = self.monomorphized_place_ty(place.as_ref());
                 let var_kind = if self.mir.local_kind(place.local) == mir::LocalKind::Arg
                     && place.projection.is_empty()
+                    && var.source_info.scope == mir::OUTERMOST_SOURCE_SCOPE
                 {
-                    // FIXME(eddyb, #67586) take `var.source_info.scope` into
-                    // account to avoid using `ArgumentVariable` more than once
-                    // per argument local.
-
                     let arg_index = place.local.index() - 1;
 
                     // FIXME(eddyb) shouldn't `ArgumentVariable` indices be

--- a/src/librustc_codegen_ssa/traits/debuginfo.rs
+++ b/src/librustc_codegen_ssa/traits/debuginfo.rs
@@ -57,6 +57,7 @@ pub trait DebugInfoBuilderMethods: BackendTypes {
         // NB: each offset implies a deref (i.e. they're steps in a pointer chain).
         indirect_offsets: &[Size],
         span: Span,
+        is_by_value: bool,
     );
     fn set_source_location(
         &mut self,

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -891,6 +891,17 @@ extern "C" LLVMValueRef LLVMRustDIBuilderInsertDeclareAtEnd(
       unwrap(InsertAtEnd)));
 }
 
+extern "C" LLVMValueRef LLVMRustDIBuilderInsertDbgValueAtEnd(
+    LLVMRustDIBuilderRef Builder, LLVMValueRef V, LLVMMetadataRef VarInfo,
+    int64_t *AddrOps, unsigned AddrOpsCount, LLVMValueRef DL,
+    LLVMBasicBlockRef InsertAtEnd) {
+  return wrap(Builder->insertDbgValueIntrinsic(
+      unwrap(V), unwrap<DILocalVariable>(VarInfo),
+      Builder->createExpression(llvm::ArrayRef<int64_t>(AddrOps, AddrOpsCount)),
+      DebugLoc(cast<MDNode>(unwrap<MetadataAsValue>(DL)->getMetadata())),
+      unwrap(InsertAtEnd)));
+}
+
 extern "C" LLVMMetadataRef
 LLVMRustDIBuilderCreateEnumerator(LLVMRustDIBuilderRef Builder,
                                   const char *Name, uint64_t Val) {

--- a/src/test/debuginfo/borrowed-c-style-enum.rs
+++ b/src/test/debuginfo/borrowed-c-style-enum.rs
@@ -40,7 +40,7 @@
 
 enum ABC { TheA, TheB, TheC }
 
-fn main() {
+pub fn main() {
     let the_a = ABC::TheA;
     let the_a_ref: &ABC = &the_a;
 

--- a/src/test/ui/mir/mir-inlining/var-debuginfo-issue-67586.rs
+++ b/src/test/ui/mir/mir-inlining/var-debuginfo-issue-67586.rs
@@ -1,0 +1,11 @@
+// run-pass
+// compile-flags: -Z mir-opt-level=2 -C opt-level=0 -C debuginfo=2
+
+#[inline(never)]
+pub fn foo(bar: usize) -> usize {
+    std::convert::identity(bar)
+}
+
+fn main() {
+    foo(0);
+}


### PR DESCRIPTION
This is an almost-worst-case approach to #68817 (see the last commit which uses inline assembly).

I'm opening this PR for two reasons:
* in case anyone else (or myself in the future) want to take another stab, the code should be available (it's mostly straight-forward, minus the hacks)
* I want to see what impact it has on compile times