### PR TITLE
[beta] backports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b06c1b455f1cf4269a8cfc320ab930a810e2375a42af5075eb8a8b36405ce0"
+checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
 dependencies = [
  "libc",
 ]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -62,9 +62,9 @@ Cargo
 - [Cargo.lock now uses a more git friendly format that should help to reduce
   merge conflicts.][cargo/7579]
 - [You can now override specific dependencies's build settings][cargo/7591] E.g.
-  `[profile.dev.overrides.image] opt-level = 2` sets the `image` crate's
+  `[profile.dev.package.image] opt-level = 2` sets the `image` crate's
   optimisation level to `2` for debug builds. You can also use
-  `[profile.<profile>.build_overrides]` to override build scripts and
+  `[profile.<profile>.build-override]` to override build scripts and
   their dependencies.
 
 Misc

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,7 +12,7 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.x.0` for Cargo where they were released on `date`.
 
-date: 2020-01-27
+date: 2020-01-30
 rustc: 1.41.0
 cargo: 0.42.0
 
@@ -39,4 +39,4 @@ cargo: 0.42.0
 # looking at a beta source tarball and it's uncommented we'll shortly comment it
 # out.
 
-dev: 1
+#dev: 1


### PR DESCRIPTION
*  Update jobserver crate to 0.1.21 #68663 
* Changelog: Demonstrate final build-override syntax #68603 
*  [beta] Update cargo #68900 
* Uses static.r-l.o instead of dev-static as well.