### PR TITLE
Test failure of unchecked arithmetic intrinsics in const eval

### DIFF
--- a/src/test/ui/consts/const-int-unchecked.rs
+++ b/src/test/ui/consts/const-int-unchecked.rs
@@ -1,4 +1,5 @@
 #![feature(core_intrinsics)]
+#![feature(const_int_unchecked_arith)]
 
 use std::intrinsics;
 
@@ -115,6 +116,27 @@ const SHR_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -25) }
 const SHR_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -30) };
 //~^ ERROR any use of this value will cause an error
 const SHR_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -93) };
+//~^ ERROR any use of this value will cause an error
+
+// Other arithmetic functions:
+
+const _: u16 = unsafe { std::intrinsics::unchecked_add(40000u16, 30000) };
+//~^ ERROR any use of this value will cause an error
+
+const _: u32 = unsafe { std::intrinsics::unchecked_sub(14u32, 22) };
+//~^ ERROR any use of this value will cause an error
+
+const _: u16 = unsafe { std::intrinsics::unchecked_mul(300u16, 250u16) };
+//~^ ERROR any use of this value will cause an error
+
+const _: i32 = unsafe { std::intrinsics::unchecked_div(1, 0) };
+//~^ ERROR any use of this value will cause an error
+const _: i32 = unsafe { std::intrinsics::unchecked_div(i32::min_value(), -1) };
+//~^ ERROR any use of this value will cause an error
+
+const _: i32 = unsafe { std::intrinsics::unchecked_rem(1, 0) };
+//~^ ERROR any use of this value will cause an error
+const _: i32 = unsafe { std::intrinsics::unchecked_rem(i32::min_value(), -1) };
 //~^ ERROR any use of this value will cause an error
 
 fn main() {}

--- a/src/test/ui/consts/const-int-unchecked.stderr
+++ b/src/test/ui/consts/const-int-unchecked.stderr
@@ -1,5 +1,5 @@
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:14:29
+  --> $DIR/const-int-unchecked.rs:15:29
    |
 LL | const SHL_U8: u8 = unsafe { intrinsics::unchecked_shl(5_u8, 8) };
    | ----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -9,7 +9,7 @@ LL | const SHL_U8: u8 = unsafe { intrinsics::unchecked_shl(5_u8, 8) };
    = note: `#[deny(const_err)]` on by default
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:16:31
+  --> $DIR/const-int-unchecked.rs:17:31
    |
 LL | const SHL_U16: u16 = unsafe { intrinsics::unchecked_shl(5_u16, 16) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -17,7 +17,7 @@ LL | const SHL_U16: u16 = unsafe { intrinsics::unchecked_shl(5_u16, 16) };
    |                               Overflowing shift by 16 in `unchecked_shl`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:18:31
+  --> $DIR/const-int-unchecked.rs:19:31
    |
 LL | const SHL_U32: u32 = unsafe { intrinsics::unchecked_shl(5_u32, 32) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -25,7 +25,7 @@ LL | const SHL_U32: u32 = unsafe { intrinsics::unchecked_shl(5_u32, 32) };
    |                               Overflowing shift by 32 in `unchecked_shl`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:20:31
+  --> $DIR/const-int-unchecked.rs:21:31
    |
 LL | const SHL_U64: u64 = unsafe { intrinsics::unchecked_shl(5_u64, 64) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -33,7 +33,7 @@ LL | const SHL_U64: u64 = unsafe { intrinsics::unchecked_shl(5_u64, 64) };
    |                               Overflowing shift by 64 in `unchecked_shl`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:22:33
+  --> $DIR/const-int-unchecked.rs:23:33
    |
 LL | const SHL_U128: u128 = unsafe { intrinsics::unchecked_shl(5_u128, 128) };
    | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -41,7 +41,7 @@ LL | const SHL_U128: u128 = unsafe { intrinsics::unchecked_shl(5_u128, 128) };
    |                                 Overflowing shift by 128 in `unchecked_shl`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:27:29
+  --> $DIR/const-int-unchecked.rs:28:29
    |
 LL | const SHL_I8: i8 = unsafe { intrinsics::unchecked_shl(5_i8, 8) };
    | ----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -49,7 +49,7 @@ LL | const SHL_I8: i8 = unsafe { intrinsics::unchecked_shl(5_i8, 8) };
    |                             Overflowing shift by 8 in `unchecked_shl`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:29:31
+  --> $DIR/const-int-unchecked.rs:30:31
    |
 LL | const SHL_I16: i16 = unsafe { intrinsics::unchecked_shl(5_16, 16) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -57,7 +57,7 @@ LL | const SHL_I16: i16 = unsafe { intrinsics::unchecked_shl(5_16, 16) };
    |                               Overflowing shift by 16 in `unchecked_shl`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:31:31
+  --> $DIR/const-int-unchecked.rs:32:31
    |
 LL | const SHL_I32: i32 = unsafe { intrinsics::unchecked_shl(5_i32, 32) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -65,7 +65,7 @@ LL | const SHL_I32: i32 = unsafe { intrinsics::unchecked_shl(5_i32, 32) };
    |                               Overflowing shift by 32 in `unchecked_shl`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:33:31
+  --> $DIR/const-int-unchecked.rs:34:31
    |
 LL | const SHL_I64: i64 = unsafe { intrinsics::unchecked_shl(5_i64, 64) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -73,7 +73,7 @@ LL | const SHL_I64: i64 = unsafe { intrinsics::unchecked_shl(5_i64, 64) };
    |                               Overflowing shift by 64 in `unchecked_shl`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:35:33
+  --> $DIR/const-int-unchecked.rs:36:33
    |
 LL | const SHL_I128: i128 = unsafe { intrinsics::unchecked_shl(5_i128, 128) };
    | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -81,7 +81,7 @@ LL | const SHL_I128: i128 = unsafe { intrinsics::unchecked_shl(5_i128, 128) };
    |                                 Overflowing shift by 128 in `unchecked_shl`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:40:33
+  --> $DIR/const-int-unchecked.rs:41:33
    |
 LL | const SHL_I8_NEG: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -1) };
    | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -89,7 +89,7 @@ LL | const SHL_I8_NEG: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -1) };
    |                                 Overflowing shift by 255 in `unchecked_shl`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:42:35
+  --> $DIR/const-int-unchecked.rs:43:35
    |
 LL | const SHL_I16_NEG: i16 = unsafe { intrinsics::unchecked_shl(5_16, -1) };
    | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -97,7 +97,7 @@ LL | const SHL_I16_NEG: i16 = unsafe { intrinsics::unchecked_shl(5_16, -1) };
    |                                   Overflowing shift by 65535 in `unchecked_shl`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:44:35
+  --> $DIR/const-int-unchecked.rs:45:35
    |
 LL | const SHL_I32_NEG: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -1) };
    | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -105,7 +105,7 @@ LL | const SHL_I32_NEG: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -1) };
    |                                   Overflowing shift by 4294967295 in `unchecked_shl`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:46:35
+  --> $DIR/const-int-unchecked.rs:47:35
    |
 LL | const SHL_I64_NEG: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -1) };
    | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -113,7 +113,7 @@ LL | const SHL_I64_NEG: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -1) };
    |                                   Overflowing shift by 18446744073709551615 in `unchecked_shl`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:48:37
+  --> $DIR/const-int-unchecked.rs:49:37
    |
 LL | const SHL_I128_NEG: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -1) };
    | ------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -121,7 +121,7 @@ LL | const SHL_I128_NEG: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -1) }
    |                                     Overflowing shift by 340282366920938463463374607431768211455 in `unchecked_shl`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:54:40
+  --> $DIR/const-int-unchecked.rs:55:40
    |
 LL | const SHL_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -6) };
    | ---------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -129,7 +129,7 @@ LL | const SHL_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -6) 
    |                                        Overflowing shift by 250 in `unchecked_shl`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:56:42
+  --> $DIR/const-int-unchecked.rs:57:42
    |
 LL | const SHL_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shl(5_16, -13) };
    | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -137,7 +137,7 @@ LL | const SHL_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shl(5_16, -1
    |                                          Overflowing shift by 65523 in `unchecked_shl`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:58:42
+  --> $DIR/const-int-unchecked.rs:59:42
    |
 LL | const SHL_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -25) };
    | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -145,7 +145,7 @@ LL | const SHL_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -
    |                                          Overflowing shift by 4294967271 in `unchecked_shl`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:60:42
+  --> $DIR/const-int-unchecked.rs:61:42
    |
 LL | const SHL_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -30) };
    | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -153,7 +153,7 @@ LL | const SHL_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -
    |                                          Overflowing shift by 18446744073709551586 in `unchecked_shl`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:62:44
+  --> $DIR/const-int-unchecked.rs:63:44
    |
 LL | const SHL_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -93) };
    | -------------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -161,7 +161,7 @@ LL | const SHL_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shl(5_i128
    |                                            Overflowing shift by 340282366920938463463374607431768211363 in `unchecked_shl`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:69:29
+  --> $DIR/const-int-unchecked.rs:70:29
    |
 LL | const SHR_U8: u8 = unsafe { intrinsics::unchecked_shr(5_u8, 8) };
    | ----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -169,7 +169,7 @@ LL | const SHR_U8: u8 = unsafe { intrinsics::unchecked_shr(5_u8, 8) };
    |                             Overflowing shift by 8 in `unchecked_shr`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:71:31
+  --> $DIR/const-int-unchecked.rs:72:31
    |
 LL | const SHR_U16: u16 = unsafe { intrinsics::unchecked_shr(5_u16, 16) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -177,7 +177,7 @@ LL | const SHR_U16: u16 = unsafe { intrinsics::unchecked_shr(5_u16, 16) };
    |                               Overflowing shift by 16 in `unchecked_shr`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:73:31
+  --> $DIR/const-int-unchecked.rs:74:31
    |
 LL | const SHR_U32: u32 = unsafe { intrinsics::unchecked_shr(5_u32, 32) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -185,7 +185,7 @@ LL | const SHR_U32: u32 = unsafe { intrinsics::unchecked_shr(5_u32, 32) };
    |                               Overflowing shift by 32 in `unchecked_shr`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:75:31
+  --> $DIR/const-int-unchecked.rs:76:31
    |
 LL | const SHR_U64: u64 = unsafe { intrinsics::unchecked_shr(5_u64, 64) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -193,7 +193,7 @@ LL | const SHR_U64: u64 = unsafe { intrinsics::unchecked_shr(5_u64, 64) };
    |                               Overflowing shift by 64 in `unchecked_shr`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:77:33
+  --> $DIR/const-int-unchecked.rs:78:33
    |
 LL | const SHR_U128: u128 = unsafe { intrinsics::unchecked_shr(5_u128, 128) };
    | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -201,7 +201,7 @@ LL | const SHR_U128: u128 = unsafe { intrinsics::unchecked_shr(5_u128, 128) };
    |                                 Overflowing shift by 128 in `unchecked_shr`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:82:29
+  --> $DIR/const-int-unchecked.rs:83:29
    |
 LL | const SHR_I8: i8 = unsafe { intrinsics::unchecked_shr(5_i8, 8) };
    | ----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -209,7 +209,7 @@ LL | const SHR_I8: i8 = unsafe { intrinsics::unchecked_shr(5_i8, 8) };
    |                             Overflowing shift by 8 in `unchecked_shr`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:84:31
+  --> $DIR/const-int-unchecked.rs:85:31
    |
 LL | const SHR_I16: i16 = unsafe { intrinsics::unchecked_shr(5_16, 16) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -217,7 +217,7 @@ LL | const SHR_I16: i16 = unsafe { intrinsics::unchecked_shr(5_16, 16) };
    |                               Overflowing shift by 16 in `unchecked_shr`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:86:31
+  --> $DIR/const-int-unchecked.rs:87:31
    |
 LL | const SHR_I32: i32 = unsafe { intrinsics::unchecked_shr(5_i32, 32) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -225,7 +225,7 @@ LL | const SHR_I32: i32 = unsafe { intrinsics::unchecked_shr(5_i32, 32) };
    |                               Overflowing shift by 32 in `unchecked_shr`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:88:31
+  --> $DIR/const-int-unchecked.rs:89:31
    |
 LL | const SHR_I64: i64 = unsafe { intrinsics::unchecked_shr(5_i64, 64) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -233,7 +233,7 @@ LL | const SHR_I64: i64 = unsafe { intrinsics::unchecked_shr(5_i64, 64) };
    |                               Overflowing shift by 64 in `unchecked_shr`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:90:33
+  --> $DIR/const-int-unchecked.rs:91:33
    |
 LL | const SHR_I128: i128 = unsafe { intrinsics::unchecked_shr(5_i128, 128) };
    | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -241,7 +241,7 @@ LL | const SHR_I128: i128 = unsafe { intrinsics::unchecked_shr(5_i128, 128) };
    |                                 Overflowing shift by 128 in `unchecked_shr`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:95:33
+  --> $DIR/const-int-unchecked.rs:96:33
    |
 LL | const SHR_I8_NEG: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -1) };
    | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -249,7 +249,7 @@ LL | const SHR_I8_NEG: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -1) };
    |                                 Overflowing shift by 255 in `unchecked_shr`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:97:35
+  --> $DIR/const-int-unchecked.rs:98:35
    |
 LL | const SHR_I16_NEG: i16 = unsafe { intrinsics::unchecked_shr(5_16, -1) };
    | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -257,7 +257,7 @@ LL | const SHR_I16_NEG: i16 = unsafe { intrinsics::unchecked_shr(5_16, -1) };
    |                                   Overflowing shift by 65535 in `unchecked_shr`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:99:35
+  --> $DIR/const-int-unchecked.rs:100:35
    |
 LL | const SHR_I32_NEG: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -1) };
    | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -265,7 +265,7 @@ LL | const SHR_I32_NEG: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -1) };
    |                                   Overflowing shift by 4294967295 in `unchecked_shr`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:101:35
+  --> $DIR/const-int-unchecked.rs:102:35
    |
 LL | const SHR_I64_NEG: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -1) };
    | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -273,7 +273,7 @@ LL | const SHR_I64_NEG: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -1) };
    |                                   Overflowing shift by 18446744073709551615 in `unchecked_shr`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:103:37
+  --> $DIR/const-int-unchecked.rs:104:37
    |
 LL | const SHR_I128_NEG: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -1) };
    | ------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -281,7 +281,7 @@ LL | const SHR_I128_NEG: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -1) }
    |                                     Overflowing shift by 340282366920938463463374607431768211455 in `unchecked_shr`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:109:40
+  --> $DIR/const-int-unchecked.rs:110:40
    |
 LL | const SHR_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -6) };
    | ---------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -289,7 +289,7 @@ LL | const SHR_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -6) 
    |                                        Overflowing shift by 250 in `unchecked_shr`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:111:42
+  --> $DIR/const-int-unchecked.rs:112:42
    |
 LL | const SHR_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shr(5_16, -13) };
    | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -297,7 +297,7 @@ LL | const SHR_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shr(5_16, -1
    |                                          Overflowing shift by 65523 in `unchecked_shr`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:113:42
+  --> $DIR/const-int-unchecked.rs:114:42
    |
 LL | const SHR_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -25) };
    | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -305,7 +305,7 @@ LL | const SHR_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -
    |                                          Overflowing shift by 4294967271 in `unchecked_shr`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:115:42
+  --> $DIR/const-int-unchecked.rs:116:42
    |
 LL | const SHR_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -30) };
    | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -313,12 +313,68 @@ LL | const SHR_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -
    |                                          Overflowing shift by 18446744073709551586 in `unchecked_shr`
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:117:44
+  --> $DIR/const-int-unchecked.rs:118:44
    |
 LL | const SHR_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -93) };
    | -------------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                            |
    |                                            Overflowing shift by 340282366920938463463374607431768211363 in `unchecked_shr`
 
-error: aborting due to 40 previous errors
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:123:25
+   |
+LL | const _: u16 = unsafe { std::intrinsics::unchecked_add(40000u16, 30000) };
+   | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
+   |                         |
+   |                         Overflow executing `unchecked_add`
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:126:25
+   |
+LL | const _: u32 = unsafe { std::intrinsics::unchecked_sub(14u32, 22) };
+   | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
+   |                         |
+   |                         Overflow executing `unchecked_sub`
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:129:25
+   |
+LL | const _: u16 = unsafe { std::intrinsics::unchecked_mul(300u16, 250u16) };
+   | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
+   |                         |
+   |                         Overflow executing `unchecked_mul`
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:132:25
+   |
+LL | const _: i32 = unsafe { std::intrinsics::unchecked_div(1, 0) };
+   | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
+   |                         |
+   |                         dividing by zero
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:134:25
+   |
+LL | const _: i32 = unsafe { std::intrinsics::unchecked_div(i32::min_value(), -1) };
+   | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
+   |                         |
+   |                         Overflow executing `unchecked_div`
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:137:25
+   |
+LL | const _: i32 = unsafe { std::intrinsics::unchecked_rem(1, 0) };
+   | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
+   |                         |
+   |                         calculating the remainder with a divisor of zero
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:139:25
+   |
+LL | const _: i32 = unsafe { std::intrinsics::unchecked_rem(i32::min_value(), -1) };
+   | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
+   |                         |
+   |                         Overflow executing `unchecked_rem`
+
+error: aborting due to 47 previous errors
 


### PR DESCRIPTION
Test that the unchecked arithmetic intrinsics that were made unstably const in #68809 emit an error during const-eval if given invalid input.

Addresses [this comment](https://github.com/rust-lang/rust/pull/68809#discussion_r375753066).

r? @RalfJung 