### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/src/liballoc/collections/btree/map.rs
+++ b/src/liballoc/collections/btree/map.rs
@@ -675,13 +675,15 @@ impl<K: Ord, V> BTreeMap<K, V> {
         T: Ord,
         K: Borrow<T>,
     {
-        match self.length {
-            0 => None,
-            _ => Some(OccupiedEntry {
-                handle: self.root.as_mut().first_kv(),
+        let front = self.root.as_mut().first_leaf_edge();
+        if let Ok(kv) = front.right_kv() {
+            Some(OccupiedEntry {
+                handle: kv.forget_node_type(),
                 length: &mut self.length,
                 _marker: PhantomData,
-            }),
+            })
+        } else {
+            None
         }
     }
 
@@ -736,13 +738,15 @@ impl<K: Ord, V> BTreeMap<K, V> {
         T: Ord,
         K: Borrow<T>,
     {
-        match self.length {
-            0 => None,
-            _ => Some(OccupiedEntry {
-                handle: self.root.as_mut().last_kv(),
+        let back = self.root.as_mut().last_leaf_edge();
+        if let Ok(kv) = back.left_kv() {
+            Some(OccupiedEntry {
+                handle: kv.forget_node_type(),
                 length: &mut self.length,
                 _marker: PhantomData,
-            }),
+            })
+        } else {
+            None
         }
     }
 

--- a/src/liballoc/tests/btree/map.rs
+++ b/src/liballoc/tests/btree/map.rs
@@ -23,6 +23,11 @@ fn test_basic_large() {
         assert_eq!(map.len(), i + 1);
     }
 
+    assert_eq!(map.first_key_value(), Some((&0, &0)));
+    assert_eq!(map.last_key_value(), Some((&(size - 1), &(10 * (size - 1)))));
+    assert_eq!(map.first_entry().unwrap().key(), &0);
+    assert_eq!(map.last_entry().unwrap().key(), &(size - 1));
+
     for i in 0..size {
         assert_eq!(map.get(&i).unwrap(), &(i * 10));
     }

--- a/src/liballoc/tests/btree/set.rs
+++ b/src/liballoc/tests/btree/set.rs
@@ -487,21 +487,26 @@ fn test_first_last() {
     a.insert(2);
     assert_eq!(a.first(), Some(&1));
     assert_eq!(a.last(), Some(&2));
-    a.insert(3);
+    for i in 3..=12 {
+        a.insert(i);
+    }
     assert_eq!(a.first(), Some(&1));
-    assert_eq!(a.last(), Some(&3));
-
-    assert_eq!(a.len(), 3);
+    assert_eq!(a.last(), Some(&12));
     assert_eq!(a.pop_first(), Some(1));
-    assert_eq!(a.len(), 2);
-    assert_eq!(a.pop_last(), Some(3));
-    assert_eq!(a.len(), 1);
+    assert_eq!(a.pop_last(), Some(12));
     assert_eq!(a.pop_first(), Some(2));
-    assert_eq!(a.len(), 0);
-    assert_eq!(a.pop_last(), None);
-    assert_eq!(a.len(), 0);
+    assert_eq!(a.pop_last(), Some(11));
+    assert_eq!(a.pop_first(), Some(3));
+    assert_eq!(a.pop_last(), Some(10));
+    assert_eq!(a.pop_first(), Some(4));
+    assert_eq!(a.pop_first(), Some(5));
+    assert_eq!(a.pop_first(), Some(6));
+    assert_eq!(a.pop_first(), Some(7));
+    assert_eq!(a.pop_first(), Some(8));
+    assert_eq!(a.clone().pop_last(), Some(9));
+    assert_eq!(a.pop_first(), Some(9));
     assert_eq!(a.pop_first(), None);
-    assert_eq!(a.len(), 0);
+    assert_eq!(a.pop_last(), None);
 }
 
 fn rand_data(len: usize) -> Vec<u32> {

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -385,12 +385,14 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
                 }
                 Some(Equal) => {
                     self.is_empty = Some(true);
+                    self.start = plus_n.clone();
                     return Some(plus_n);
                 }
                 _ => {}
             }
         }
 
+        self.start = self.end.clone();
         self.is_empty = Some(true);
         None
     }
@@ -477,12 +479,14 @@ impl<A: Step> DoubleEndedIterator for ops::RangeInclusive<A> {
                 }
                 Some(Equal) => {
                     self.is_empty = Some(true);
+                    self.end = minus_n.clone();
                     return Some(minus_n);
                 }
                 _ => {}
             }
         }
 
+        self.end = self.start.clone();
         self.is_empty = Some(true);
         None
     }

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -317,7 +317,7 @@ impl<T> Option<T> {
     // Getting to contained values
     /////////////////////////////////////////////////////////////////////////
 
-    /// Unwraps an option, yielding the content of a [`Some`].
+    /// Returns the contained [`Some`] value, consuming the `self` value.
     ///
     /// # Panics
     ///
@@ -348,17 +348,22 @@ impl<T> Option<T> {
         }
     }
 
-    /// Moves the value `v` out of the `Option<T>` if it is [`Some(v)`].
+    /// Returns the contained [`Some`] value, consuming the `self` value.
     ///
-    /// In general, because this function may panic, its use is discouraged.
+    /// Because this function may panic, its use is generally discouraged.
     /// Instead, prefer to use pattern matching and handle the [`None`]
-    /// case explicitly.
+    /// case explicitly, or call [`unwrap_or`], [`unwrap_or_else`], or
+    /// [`unwrap_or_default`].
+    ///
+    /// [`unwrap_or`]: #method.unwrap_or
+    /// [`unwrap_or_else`]: #method.unwrap_or_else
+    /// [`unwrap_or_default`]: #method.unwrap_or_default
     ///
     /// # Panics
     ///
     /// Panics if the self value equals [`None`].
     ///
-    /// [`Some(v)`]: #variant.Some
+    /// [`Some`]: #variant.Some
     /// [`None`]: #variant.None
     ///
     /// # Examples
@@ -382,12 +387,13 @@ impl<T> Option<T> {
         }
     }
 
-    /// Returns the contained value or a default.
+    /// Returns the contained [`Some`] value or a provided default.
     ///
     /// Arguments passed to `unwrap_or` are eagerly evaluated; if you are passing
     /// the result of a function call, it is recommended to use [`unwrap_or_else`],
     /// which is lazily evaluated.
     ///
+    /// [`Some`]: #variant.Some
     /// [`unwrap_or_else`]: #method.unwrap_or_else
     ///
     /// # Examples
@@ -405,7 +411,7 @@ impl<T> Option<T> {
         }
     }
 
-    /// Returns the contained value or computes it from a closure.
+    /// Returns the contained [`Some`] value or computes it from a closure.
     ///
     /// # Examples
     ///
@@ -980,7 +986,7 @@ impl<T: Clone> Option<&mut T> {
 }
 
 impl<T: fmt::Debug> Option<T> {
-    /// Unwraps an option, expecting [`None`] and returning nothing.
+    /// Consumes `self` while expecting [`None`] and returning nothing.
     ///
     /// # Panics
     ///
@@ -1023,7 +1029,7 @@ impl<T: fmt::Debug> Option<T> {
         }
     }
 
-    /// Unwraps an option, expecting [`None`] and returning nothing.
+    /// Consumes `self` while expecting [`None`] and returning nothing.
     ///
     /// # Panics
     ///
@@ -1068,7 +1074,7 @@ impl<T: fmt::Debug> Option<T> {
 }
 
 impl<T: Default> Option<T> {
-    /// Returns the contained value or a default
+    /// Returns the contained [`Some`] value or a default
     ///
     /// Consumes the `self` argument then, if [`Some`], returns the contained
     /// value, otherwise if [`None`], returns the [default value] for that

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -998,6 +998,34 @@ impl<T: fmt::Debug, E> Result<T, E> {
     ///
     /// # Panics
     ///
+    /// Panics if the value is an [`Ok`], with a panic message including the
+    /// passed message, and the content of the [`Ok`].
+    ///
+    /// [`Ok`]: enum.Result.html#variant.Ok
+    /// [`Err`]: enum.Result.html#variant.Err
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```{.should_panic}
+    /// let x: Result<u32, &str> = Ok(10);
+    /// x.expect_err("Testing expect_err"); // panics with `Testing expect_err: 10`
+    /// ```
+    #[inline]
+    #[track_caller]
+    #[stable(feature = "result_expect_err", since = "1.17.0")]
+    pub fn expect_err(self, msg: &str) -> E {
+        match self {
+            Ok(t) => unwrap_failed(msg, &t),
+            Err(e) => e,
+        }
+    }
+
+    /// Unwraps a result, yielding the content of an [`Err`].
+    ///
+    /// # Panics
+    ///
     /// Panics if the value is an [`Ok`], with a custom panic message provided
     /// by the [`Ok`]'s value.
     ///
@@ -1022,34 +1050,6 @@ impl<T: fmt::Debug, E> Result<T, E> {
     pub fn unwrap_err(self) -> E {
         match self {
             Ok(t) => unwrap_failed("called `Result::unwrap_err()` on an `Ok` value", &t),
-            Err(e) => e,
-        }
-    }
-
-    /// Unwraps a result, yielding the content of an [`Err`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if the value is an [`Ok`], with a panic message including the
-    /// passed message, and the content of the [`Ok`].
-    ///
-    /// [`Ok`]: enum.Result.html#variant.Ok
-    /// [`Err`]: enum.Result.html#variant.Err
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```{.should_panic}
-    /// let x: Result<u32, &str> = Ok(10);
-    /// x.expect_err("Testing expect_err"); // panics with `Testing expect_err: 10`
-    /// ```
-    #[inline]
-    #[track_caller]
-    #[stable(feature = "result_expect_err", since = "1.17.0")]
-    pub fn expect_err(self, msg: &str) -> E {
-        match self {
-            Ok(t) => unwrap_failed(msg, &t),
             Err(e) => e,
         }
     }

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -935,6 +935,34 @@ impl<T, E: fmt::Debug> Result<T, E> {
     ///
     /// # Panics
     ///
+    /// Panics if the value is an [`Err`], with a panic message including the
+    /// passed message, and the content of the [`Err`].
+    ///
+    /// [`Ok`]: enum.Result.html#variant.Ok
+    /// [`Err`]: enum.Result.html#variant.Err
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```{.should_panic}
+    /// let x: Result<u32, &str> = Err("emergency failure");
+    /// x.expect("Testing expect"); // panics with `Testing expect: emergency failure`
+    /// ```
+    #[inline]
+    #[track_caller]
+    #[stable(feature = "result_expect", since = "1.4.0")]
+    pub fn expect(self, msg: &str) -> T {
+        match self {
+            Ok(t) => t,
+            Err(e) => unwrap_failed(msg, &e),
+        }
+    }
+
+    /// Unwraps a result, yielding the content of an [`Ok`].
+    ///
+    /// # Panics
+    ///
     /// Panics if the value is an [`Err`], with a panic message provided by the
     /// [`Err`]'s value.
     ///
@@ -961,34 +989,6 @@ impl<T, E: fmt::Debug> Result<T, E> {
         match self {
             Ok(t) => t,
             Err(e) => unwrap_failed("called `Result::unwrap()` on an `Err` value", &e),
-        }
-    }
-
-    /// Unwraps a result, yielding the content of an [`Ok`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if the value is an [`Err`], with a panic message including the
-    /// passed message, and the content of the [`Err`].
-    ///
-    /// [`Ok`]: enum.Result.html#variant.Ok
-    /// [`Err`]: enum.Result.html#variant.Err
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```{.should_panic}
-    /// let x: Result<u32, &str> = Err("emergency failure");
-    /// x.expect("Testing expect"); // panics with `Testing expect: emergency failure`
-    /// ```
-    #[inline]
-    #[track_caller]
-    #[stable(feature = "result_expect", since = "1.4.0")]
-    pub fn expect(self, msg: &str) -> T {
-        match self {
-            Ok(t) => t,
-            Err(e) => unwrap_failed(msg, &e),
         }
     }
 }

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -792,8 +792,7 @@ impl<T, E> Result<T, E> {
         }
     }
 
-    /// Unwraps a result, yielding the content of an [`Ok`].
-    /// Else, it returns `optb`.
+    /// Returns the contained [`Ok`] value or a provided default.
     ///
     /// Arguments passed to `unwrap_or` are eagerly evaluated; if you are passing
     /// the result of a function call, it is recommended to use [`unwrap_or_else`],
@@ -808,27 +807,25 @@ impl<T, E> Result<T, E> {
     /// Basic usage:
     ///
     /// ```
-    /// let optb = 2;
+    /// let default = 2;
     /// let x: Result<u32, &str> = Ok(9);
-    /// assert_eq!(x.unwrap_or(optb), 9);
+    /// assert_eq!(x.unwrap_or(default), 9);
     ///
     /// let x: Result<u32, &str> = Err("error");
-    /// assert_eq!(x.unwrap_or(optb), optb);
+    /// assert_eq!(x.unwrap_or(default), default);
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn unwrap_or(self, optb: T) -> T {
+    pub fn unwrap_or(self, default: T) -> T {
         match self {
             Ok(t) => t,
-            Err(_) => optb,
+            Err(_) => default,
         }
     }
 
-    /// Unwraps a result, yielding the content of an [`Ok`].
-    /// If the value is an [`Err`] then it calls `op` with its value.
+    /// Returns the contained [`Ok`] value or computes it from a closure.
     ///
     /// [`Ok`]: enum.Result.html#variant.Ok
-    /// [`Err`]: enum.Result.html#variant.Err
     ///
     /// # Examples
     ///
@@ -931,7 +928,7 @@ impl<T: Clone, E> Result<&mut T, E> {
 }
 
 impl<T, E: fmt::Debug> Result<T, E> {
-    /// Unwraps a result, yielding the content of an [`Ok`].
+    /// Returns the contained [`Ok`] value, consuming the `self` value.
     ///
     /// # Panics
     ///
@@ -959,7 +956,16 @@ impl<T, E: fmt::Debug> Result<T, E> {
         }
     }
 
-    /// Unwraps a result, yielding the content of an [`Ok`].
+    /// Returns the contained [`Ok`] value, consuming the `self` value.
+    ///
+    /// Because this function may panic, its use is generally discouraged.
+    /// Instead, prefer to use pattern matching and handle the [`Err`]
+    /// case explicitly, or call [`unwrap_or`], [`unwrap_or_else`], or
+    /// [`unwrap_or_default`].
+    ///
+    /// [`unwrap_or`]: #method.unwrap_or
+    /// [`unwrap_or_else`]: #method.unwrap_or_else
+    /// [`unwrap_or_default`]: #method.unwrap_or_default
     ///
     /// # Panics
     ///
@@ -994,7 +1000,7 @@ impl<T, E: fmt::Debug> Result<T, E> {
 }
 
 impl<T: fmt::Debug, E> Result<T, E> {
-    /// Unwraps a result, yielding the content of an [`Err`].
+    /// Returns the contained [`Err`] value, consuming the `self` value.
     ///
     /// # Panics
     ///
@@ -1022,7 +1028,7 @@ impl<T: fmt::Debug, E> Result<T, E> {
         }
     }
 
-    /// Unwraps a result, yielding the content of an [`Err`].
+    /// Returns the contained [`Err`] value, consuming the `self` value.
     ///
     /// # Panics
     ///
@@ -1056,7 +1062,7 @@ impl<T: fmt::Debug, E> Result<T, E> {
 }
 
 impl<T: Default, E> Result<T, E> {
-    /// Returns the contained value or a default
+    /// Returns the contained [`Ok`] value or a default
     ///
     /// Consumes the `self` argument then, if [`Ok`], returns the contained
     /// value, otherwise if [`Err`], returns the default value for that
@@ -1095,7 +1101,7 @@ impl<T: Default, E> Result<T, E> {
 
 #[unstable(feature = "unwrap_infallible", reason = "newly added", issue = "61695")]
 impl<T, E: Into<!>> Result<T, E> {
-    /// Unwraps a result that can never be an [`Err`], yielding the content of the [`Ok`].
+    /// Returns the contained [`Ok`] value, but never panics.
     ///
     /// Unlike [`unwrap`], this method is known to never panic on the
     /// result types it is implemented for. Therefore, it can be used

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -12,7 +12,7 @@ use self::pattern::{DoubleEndedSearcher, ReverseSearcher, SearchStep, Searcher};
 use crate::char;
 use crate::fmt::{self, Write};
 use crate::iter::{Chain, FlatMap, Flatten};
-use crate::iter::{Cloned, Filter, FusedIterator, Map, TrustedLen, TrustedRandomAccess};
+use crate::iter::{Copied, Filter, FusedIterator, Map, TrustedLen, TrustedRandomAccess};
 use crate::mem;
 use crate::ops::Try;
 use crate::option;
@@ -750,7 +750,7 @@ impl<'a> CharIndices<'a> {
 /// [`str`]: ../../std/primitive.str.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Clone, Debug)]
-pub struct Bytes<'a>(Cloned<slice::Iter<'a, u8>>);
+pub struct Bytes<'a>(Copied<slice::Iter<'a, u8>>);
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Iterator for Bytes<'_> {
@@ -2778,7 +2778,7 @@ impl str {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn bytes(&self) -> Bytes<'_> {
-        Bytes(self.as_bytes().iter().cloned())
+        Bytes(self.as_bytes().iter().copied())
     }
 
     /// Splits a string slice by whitespace.
@@ -3895,7 +3895,7 @@ impl str {
             debug_assert_eq!(
                 start, 0,
                 "The first search step from Searcher \
-                must include the first character"
+                 must include the first character"
             );
             // SAFETY: `Searcher` is known to return valid indices.
             unsafe { Some(self.get_unchecked(len..)) }
@@ -3934,7 +3934,7 @@ impl str {
                 end,
                 self.len(),
                 "The first search step from ReverseSearcher \
-                must include the last character"
+                 must include the last character"
             );
             // SAFETY: `Searcher` is known to return valid indices.
             unsafe { Some(self.get_unchecked(..start)) }

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1954,10 +1954,18 @@ fn test_range_inclusive_exhaustion() {
     assert_eq!(r.next(), None);
     assert_eq!(r.next(), None);
 
+    assert_eq!(*r.start(), 10);
+    assert_eq!(*r.end(), 10);
+    assert_ne!(r, 10..=10);
+
     let mut r = 10..=10;
     assert_eq!(r.next_back(), Some(10));
     assert!(r.is_empty());
     assert_eq!(r.next_back(), None);
+
+    assert_eq!(*r.start(), 10);
+    assert_eq!(*r.end(), 10);
+    assert_ne!(r, 10..=10);
 
     let mut r = 10..=12;
     assert_eq!(r.next(), Some(10));
@@ -2076,6 +2084,9 @@ fn test_range_inclusive_nth() {
     assert_eq!((10..=15).nth(5), Some(15));
     assert_eq!((10..=15).nth(6), None);
 
+    let mut exhausted_via_next = 10_u8..=20;
+    while exhausted_via_next.next().is_some() {}
+
     let mut r = 10_u8..=20;
     assert_eq!(r.nth(2), Some(12));
     assert_eq!(r, 13..=20);
@@ -2085,6 +2096,7 @@ fn test_range_inclusive_nth() {
     assert_eq!(ExactSizeIterator::is_empty(&r), false);
     assert_eq!(r.nth(10), None);
     assert_eq!(r.is_empty(), true);
+    assert_eq!(r, exhausted_via_next);
     assert_eq!(ExactSizeIterator::is_empty(&r), true);
 }
 
@@ -2096,6 +2108,9 @@ fn test_range_inclusive_nth_back() {
     assert_eq!((10..=15).nth_back(6), None);
     assert_eq!((-120..=80_i8).nth_back(200), Some(-120));
 
+    let mut exhausted_via_next_back = 10_u8..=20;
+    while exhausted_via_next_back.next_back().is_some() {}
+
     let mut r = 10_u8..=20;
     assert_eq!(r.nth_back(2), Some(18));
     assert_eq!(r, 10..=17);
@@ -2105,6 +2120,7 @@ fn test_range_inclusive_nth_back() {
     assert_eq!(ExactSizeIterator::is_empty(&r), false);
     assert_eq!(r.nth_back(10), None);
     assert_eq!(r.is_empty(), true);
+    assert_eq!(r, exhausted_via_next_back);
     assert_eq!(ExactSizeIterator::is_empty(&r), true);
 }
 

--- a/src/librustc/traits/error_reporting/mod.rs
+++ b/src/librustc/traits/error_reporting/mod.rs
@@ -700,11 +700,11 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                             if self.predicate_may_hold(&unit_obligation) {
                                 err.note(
                                     "the trait is implemented for `()`. \
-                                         Possibly this error has been caused by changes to \
-                                         Rust's type-inference algorithm \
-                                         (see: https://github.com/rust-lang/rust/issues/48950 \
-                                         for more info). Consider whether you meant to use the \
-                                         type `()` here instead.",
+                                     Possibly this error has been caused by changes to \
+                                     Rust's type-inference algorithm (see issue #48950 \
+                                     <https://github.com/rust-lang/rust/issues/48950> \
+                                     for more information). Consider whether you meant to use \
+                                     the type `()` here instead.",
                                 );
                             }
                         }

--- a/src/librustc/traits/error_reporting/suggestions.rs
+++ b/src/librustc/traits/error_reporting/suggestions.rs
@@ -1508,9 +1508,9 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 );
                 if suggest_const_in_array_repeat_expressions {
                     err.note(
-                        "this array initializer can be evaluated at compile-time, for more \
-                         information, see issue \
-                         https://github.com/rust-lang/rust/issues/49147",
+                        "this array initializer can be evaluated at compile-time, see issue \
+                         #48147 <https://github.com/rust-lang/rust/issues/49147> \
+                         for more information",
                     );
                     if tcx.sess.opts.unstable_features.is_nightly_build() {
                         err.help(

--- a/src/librustc/ty/error.rs
+++ b/src/librustc/ty/error.rs
@@ -483,8 +483,9 @@ impl Trait for X {
                 if ty.is_closure() || ty.is_generator() {
                     db.note(
                         "closures cannot capture themselves or take themselves as argument;\n\
-                             this error may be the result of a recent compiler bug-fix,\n\
-                             see https://github.com/rust-lang/rust/issues/46062 for more details",
+                         this error may be the result of a recent compiler bug-fix,\n\
+                         see issue #46062 <https://github.com/rust-lang/rust/issues/46062>\n\
+                         for more information",
                     );
                 }
             }

--- a/src/librustc_ast_passes/ast_validation.rs
+++ b/src/librustc_ast_passes/ast_validation.rs
@@ -996,7 +996,8 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     )
                     .span_label(predicate.span, "not supported")
                     .note(
-                        "for more information, see https://github.com/rust-lang/rust/issues/20041",
+                        "see issue #20041 <https://github.com/rust-lang/rust/issues/20041> \
+                         for more information",
                     )
                     .emit();
             }

--- a/src/librustc_ast_pretty/pprust.rs
+++ b/src/librustc_ast_pretty/pprust.rs
@@ -1074,12 +1074,15 @@ impl<'a> State<'a> {
     fn print_associated_type(
         &mut self,
         ident: ast::Ident,
+        generics: &ast::Generics,
         bounds: &ast::GenericBounds,
         ty: Option<&ast::Ty>,
     ) {
         self.word_space("type");
         self.print_ident(ident);
+        self.print_generic_params(&generics.params);
         self.print_type_bounds(":", bounds);
+        self.print_where_clause(&generics.where_clause);
         if let Some(ty) = ty {
             self.s.space();
             self.word_space("=");
@@ -1474,7 +1477,7 @@ impl<'a> State<'a> {
                 self.print_fn_full(sig, item.ident, &item.generics, &item.vis, body, &item.attrs);
             }
             ast::AssocItemKind::TyAlias(bounds, ty) => {
-                self.print_associated_type(item.ident, bounds, ty.as_deref());
+                self.print_associated_type(item.ident, &item.generics, bounds, ty.as_deref());
             }
             ast::AssocItemKind::Macro(mac) => {
                 self.print_mac(mac);

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -569,7 +569,7 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
                 file_metadata,
                 loc.line as c_uint,
                 type_metadata,
-                self.sess().opts.optimize != config::OptLevel::No,
+                true,
                 DIFlags::FlagZero,
                 argument_index,
                 align.bytes() as u32,

--- a/src/librustc_codegen_ssa/mir/debuginfo.rs
+++ b/src/librustc_codegen_ssa/mir/debuginfo.rs
@@ -307,11 +307,8 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 let var_ty = self.monomorphized_place_ty(place.as_ref());
                 let var_kind = if self.mir.local_kind(place.local) == mir::LocalKind::Arg
                     && place.projection.is_empty()
+                    && var.source_info.scope == mir::OUTERMOST_SOURCE_SCOPE
                 {
-                    // FIXME(eddyb, #67586) take `var.source_info.scope` into
-                    // account to avoid using `ArgumentVariable` more than once
-                    // per argument local.
-
                     let arg_index = place.local.index() - 1;
 
                     // FIXME(eddyb) shouldn't `ArgumentVariable` indices be

--- a/src/librustc_hir/print.rs
+++ b/src/librustc_hir/print.rs
@@ -454,14 +454,17 @@ impl<'a> State<'a> {
     fn print_associated_type(
         &mut self,
         ident: ast::Ident,
+        generics: &hir::Generics<'_>,
         bounds: Option<hir::GenericBounds<'_>>,
         ty: Option<&hir::Ty<'_>>,
     ) {
         self.word_space("type");
         self.print_ident(ident);
+        self.print_generic_params(&generics.params);
         if let Some(bounds) = bounds {
             self.print_bounds(":", bounds);
         }
+        self.print_where_clause(&generics.where_clause);
         if let Some(ty) = ty {
             self.s.space();
             self.word_space("=");
@@ -902,6 +905,7 @@ impl<'a> State<'a> {
             hir::TraitItemKind::Type(ref bounds, ref default) => {
                 self.print_associated_type(
                     ti.ident,
+                    &ti.generics,
                     Some(bounds),
                     default.as_ref().map(|ty| &**ty),
                 );
@@ -930,7 +934,7 @@ impl<'a> State<'a> {
                 self.ann.nested(self, Nested::Body(body));
             }
             hir::ImplItemKind::TyAlias(ref ty) => {
-                self.print_associated_type(ii.ident, None, Some(ty));
+                self.print_associated_type(ii.ident, &ii.generics, None, Some(ty));
             }
             hir::ImplItemKind::OpaqueTy(bounds) => {
                 self.word_space("type");

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -324,47 +324,58 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
     );
     store.register_removed(
         "hr_lifetime_in_assoc_type",
-        "converted into hard error, see https://github.com/rust-lang/rust/issues/33685",
+        "converted into hard error, see issue #33685 \
+         <https://github.com/rust-lang/rust/issues/33685> for more information",
     );
     store.register_removed(
         "inaccessible_extern_crate",
-        "converted into hard error, see https://github.com/rust-lang/rust/issues/36886",
+        "converted into hard error, see issue #36886 \
+         <https://github.com/rust-lang/rust/issues/36886> for more information",
     );
     store.register_removed(
         "super_or_self_in_global_path",
-        "converted into hard error, see https://github.com/rust-lang/rust/issues/36888",
+        "converted into hard error, see issue #36888 \
+         <https://github.com/rust-lang/rust/issues/36888> for more information",
     );
     store.register_removed(
         "overlapping_inherent_impls",
-        "converted into hard error, see https://github.com/rust-lang/rust/issues/36889",
+        "converted into hard error, see issue #36889 \
+         <https://github.com/rust-lang/rust/issues/36889> for more information",
     );
     store.register_removed(
         "illegal_floating_point_constant_pattern",
-        "converted into hard error, see https://github.com/rust-lang/rust/issues/36890",
+        "converted into hard error, see issue #36890 \
+         <https://github.com/rust-lang/rust/issues/36890> for more information",
     );
     store.register_removed(
         "illegal_struct_or_enum_constant_pattern",
-        "converted into hard error, see https://github.com/rust-lang/rust/issues/36891",
+        "converted into hard error, see issue #36891 \
+         <https://github.com/rust-lang/rust/issues/36891> for more information",
     );
     store.register_removed(
         "lifetime_underscore",
-        "converted into hard error, see https://github.com/rust-lang/rust/issues/36892",
+        "converted into hard error, see issue #36892 \
+         <https://github.com/rust-lang/rust/issues/36892> for more information",
     );
     store.register_removed(
         "extra_requirement_in_impl",
-        "converted into hard error, see https://github.com/rust-lang/rust/issues/37166",
+        "converted into hard error, see issue #37166 \
+         <https://github.com/rust-lang/rust/issues/37166> for more information",
     );
     store.register_removed(
         "legacy_imports",
-        "converted into hard error, see https://github.com/rust-lang/rust/issues/38260",
+        "converted into hard error, see issue #38260 \
+         <https://github.com/rust-lang/rust/issues/38260> for more information",
     );
     store.register_removed(
         "coerce_never",
-        "converted into hard error, see https://github.com/rust-lang/rust/issues/48950",
+        "converted into hard error, see issue #48950 \
+         <https://github.com/rust-lang/rust/issues/48950> for more information",
     );
     store.register_removed(
         "resolve_trait_on_defaulted_unit",
-        "converted into hard error, see https://github.com/rust-lang/rust/issues/48950",
+        "converted into hard error, see issue #48950 \
+         <https://github.com/rust-lang/rust/issues/48950> for more information",
     );
     store.register_removed(
         "private_no_mangle_fns",
@@ -377,35 +388,43 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
     store.register_removed("bad_repr", "replaced with a generic attribute input check");
     store.register_removed(
         "duplicate_matcher_binding_name",
-        "converted into hard error, see https://github.com/rust-lang/rust/issues/57742",
+        "converted into hard error, see issue #57742 \
+         <https://github.com/rust-lang/rust/issues/57742> for more information",
     );
     store.register_removed(
         "incoherent_fundamental_impls",
-        "converted into hard error, see https://github.com/rust-lang/rust/issues/46205",
+        "converted into hard error, see issue #46205 \
+         <https://github.com/rust-lang/rust/issues/46205> for more information",
     );
     store.register_removed(
         "legacy_constructor_visibility",
-        "converted into hard error, see https://github.com/rust-lang/rust/issues/39207",
+        "converted into hard error, see issue #39207 \
+         <https://github.com/rust-lang/rust/issues/39207> for more information",
     );
     store.register_removed(
         "legacy_directory_ownership",
-        "converted into hard error, see https://github.com/rust-lang/rust/issues/37872",
+        "converted into hard error, see issue #37872 \
+         <https://github.com/rust-lang/rust/issues/37872> for more information",
     );
     store.register_removed(
         "safe_extern_statics",
-        "converted into hard error, see https://github.com/rust-lang/rust/issues/36247",
+        "converted into hard error, see issue #36247 \
+         <https://github.com/rust-lang/rust/issues/36247> for more information",
     );
     store.register_removed(
         "parenthesized_params_in_types_and_modules",
-        "converted into hard error, see https://github.com/rust-lang/rust/issues/42238",
+        "converted into hard error, see issue #42238 \
+         <https://github.com/rust-lang/rust/issues/42238> for more information",
     );
     store.register_removed(
         "duplicate_macro_exports",
-        "converted into hard error, see https://github.com/rust-lang/rust/issues/35896",
+        "converted into hard error, see issue #35896 \
+         <https://github.com/rust-lang/rust/issues/35896> for more information",
     );
     store.register_removed(
         "nested_impl_trait",
-        "converted into hard error, see https://github.com/rust-lang/rust/issues/59014",
+        "converted into hard error, see issue #59014 \
+         <https://github.com/rust-lang/rust/issues/59014> for more information",
     );
     store.register_removed("plugin_as_library", "plugins have been deprecated and retired");
 }

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -565,7 +565,10 @@ impl Visitor<'tcx> for Validator<'_, 'mir, 'tcx> {
 
 fn error_min_const_fn_violation(tcx: TyCtxt<'_>, span: Span, msg: Cow<'_, str>) {
     struct_span_err!(tcx.sess, span, E0723, "{}", msg)
-        .note("for more information, see issue https://github.com/rust-lang/rust/issues/57563")
+        .note(
+            "see issue #57563 <https://github.com/rust-lang/rust/issues/57563> \
+             for more information",
+        )
         .help("add `#![feature(const_fn)]` to the crate attributes to enable")
         .emit();
 }
@@ -593,9 +596,9 @@ fn check_short_circuiting_in_const_local(item: &Item<'_, 'tcx>) {
                 *span,
                 &format!(
                     "use of {} here does not actually short circuit due to \
-                the const evaluator presently not being able to do control flow. \
-                See https://github.com/rust-lang/rust/issues/49146 for more \
-                information.",
+                     the const evaluator presently not being able to do control flow. \
+                     See issue #49146 <https://github.com/rust-lang/rust/issues/49146> \
+                     for more information.",
                     kind
                 ),
             );

--- a/src/librustc_parse/lexer/mod.rs
+++ b/src/librustc_parse/lexer/mod.rs
@@ -248,8 +248,9 @@ impl<'a> StringReader<'a> {
                                    a future release!",
                             )
                             .note(
-                                "for more information, see issue #42326 \
-                                   <https://github.com/rust-lang/rust/issues/42326>",
+                                "see issue #42326 \
+                                 <https://github.com/rust-lang/rust/issues/42326> \
+                                 for more information",
                             )
                             .emit();
                         None

--- a/src/librustc_parse/parser/diagnostics.rs
+++ b/src/librustc_parse/parser/diagnostics.rs
@@ -366,8 +366,8 @@ impl<'a> Parser<'a> {
                           type: `<expr>: <type>`",
                 );
                 err.note(
-                    "for more information, see \
-                          https://github.com/rust-lang/rust/issues/23416",
+                    "see issue #23416 <https://github.com/rust-lang/rust/issues/23416> \
+                     for more information",
                 );
             }
         }

--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -1295,7 +1295,10 @@ impl<'a> Parser<'a> {
                         `proc_macro::Literal::*_unsuffixed` for code that will desugar \
                         to tuple field access",
                 );
-                err.note("for more context, see https://github.com/rust-lang/rust/issues/60210");
+                err.note(
+                    "see issue #60210 <https://github.com/rust-lang/rust/issues/60210> \
+                     for more information",
+                );
                 err
             } else {
                 self.struct_span_err(sp, &format!("suffixes on {} are invalid", kind))

--- a/src/librustc_passes/check_attr.rs
+++ b/src/librustc_passes/check_attr.rs
@@ -120,8 +120,8 @@ impl CheckAttrVisitor<'tcx> {
                        a future release!",
                     )
                     .note(
-                        "for more information, see issue #65833 \
-                       <https://github.com/rust-lang/rust/issues/65833>",
+                        "see issue #65833 <https://github.com/rust-lang/rust/issues/65833> \
+                         for more information",
                     )
                     .emit();
                 true

--- a/src/librustc_session/parse.rs
+++ b/src/librustc_session/parse.rs
@@ -86,8 +86,8 @@ pub fn feature_err_issue<'a>(
 
     if let Some(n) = find_feature_issue(feature, issue) {
         err.note(&format!(
-            "for more information, see https://github.com/rust-lang/rust/issues/{}",
-            n,
+            "see issue #{} <https://github.com/rust-lang/rust/issues/{}> for more information",
+            n, n,
         ));
     }
 

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -1125,7 +1125,8 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
         sess.err(
             "Profile-guided optimization does not yet work in conjunction \
                   with `-Cpanic=unwind` on Windows when targeting MSVC. \
-                  See https://github.com/rust-lang/rust/issues/61002 for details.",
+                  See issue #61002 <https://github.com/rust-lang/rust/issues/61002> \
+                  for more information.",
         );
     }
 

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -797,9 +797,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         );
                         err.warn(
                             "if the rounded value cannot be represented by the target \
-                                  integer type, including `Inf` and `NaN`, casting will cause \
-                                  undefined behavior \
-                                  (https://github.com/rust-lang/rust/issues/10184)",
+                                integer type, including `Inf` and `NaN`, casting will cause \
+                                undefined behavior \
+                                (see issue #10184 <https://github.com/rust-lang/rust/issues/10184> \
+                                for more information)",
                         );
                     }
                     true

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2437,7 +2437,10 @@ fn associated_item_predicates(
                     trait_item.span,
                     &format!("{}-generic associated types are not yet implemented", arg_kind),
                 )
-                .note("for more information, see https://github.com/rust-lang/rust/issues/44265")
+                .note(
+                    "for more information, see issue #44265 \
+                     <https://github.com/rust-lang/rust/issues/44265> for more information",
+                )
                 .emit();
             had_error = true;
         }

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -570,7 +570,10 @@ fn check_deprecated_options(matches: &getopts::Matches, diag: &rustc_errors::Han
         if matches.opt_present(flag) {
             let mut err =
                 diag.struct_warn(&format!("the '{}' flag is considered deprecated", flag));
-            err.warn("please see https://github.com/rust-lang/rust/issues/44136");
+            err.warn(
+                "see issue #44136 <https://github.com/rust-lang/rust/issues/44136> \
+                 for more information",
+            );
 
             if *flag == "no-defaults" {
                 err.help("you may want to use --document-private-items");

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -416,7 +416,10 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
                                                          considered deprecated",
                         name
                     ));
-                    msg.warn("please see https://github.com/rust-lang/rust/issues/44136");
+                    msg.warn(
+                        "see issue #44136 <https://github.com/rust-lang/rust/issues/44136> \
+                         for more information",
+                    );
 
                     if name == "no_default_passes" {
                         msg.help("you may want to use `#![doc(document_private_items)]`");

--- a/src/test/pretty/gat-bounds.pp
+++ b/src/test/pretty/gat-bounds.pp
@@ -1,0 +1,25 @@
+// Check that associated types print generic parameters and where clauses.
+// See issue #67509.
+
+// pretty-compare-only
+// pp-exact:gat-bounds.pp
+
+#![feature(generic_associated_types)]
+
+trait X {
+    type
+    Y<T>: Trait
+    where
+    Self: Sized;
+}
+
+impl X for () {
+    type
+    Y<T>
+    where
+    Self: Sized
+    =
+    u32;
+}
+
+fn main() { }

--- a/src/test/pretty/gat-bounds.rs
+++ b/src/test/pretty/gat-bounds.rs
@@ -1,0 +1,17 @@
+// Check that associated types print generic parameters and where clauses.
+// See issue #67509.
+
+// pretty-compare-only
+// pp-exact:gat-bounds.pp
+
+#![feature(generic_associated_types)]
+
+trait X {
+    type Y<T>: Trait where Self: Sized;
+}
+
+impl X for () {
+    type Y<T> where Self: Sized = u32;
+}
+
+fn main() { }

--- a/src/test/rustdoc-ui/deprecated-attrs.stderr
+++ b/src/test/rustdoc-ui/deprecated-attrs.stderr
@@ -1,9 +1,9 @@
 warning: the `#![doc(no_default_passes)]` attribute is considered deprecated
    |
-   = warning: please see https://github.com/rust-lang/rust/issues/44136
+   = warning: see issue #44136 <https://github.com/rust-lang/rust/issues/44136> for more information
    = help: you may want to use `#![doc(document_private_items)]`
 
 warning: the `#![doc(passes = "...")]` attribute is considered deprecated
    |
-   = warning: please see https://github.com/rust-lang/rust/issues/44136
+   = warning: see issue #44136 <https://github.com/rust-lang/rust/issues/44136> for more information
 

--- a/src/test/ui-fulldeps/feature-gate-plugin.stderr
+++ b/src/test/ui-fulldeps/feature-gate-plugin.stderr
@@ -4,7 +4,7 @@ error[E0658]: compiler plugins are deprecated
 LL | #![plugin(empty_plugin)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29597
+   = note: see issue #29597 <https://github.com/rust-lang/rust/issues/29597> for more information
    = help: add `#![feature(plugin)]` to the crate attributes to enable
 
 warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675

--- a/src/test/ui-fulldeps/gated-plugin.stderr
+++ b/src/test/ui-fulldeps/gated-plugin.stderr
@@ -4,7 +4,7 @@ error[E0658]: compiler plugins are deprecated
 LL | #![plugin(empty_plugin)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29597
+   = note: see issue #29597 <https://github.com/rust-lang/rust/issues/29597> for more information
    = help: add `#![feature(plugin)]` to the crate attributes to enable
 
 warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675

--- a/src/test/ui-fulldeps/hash-stable-is-unstable.stderr
+++ b/src/test/ui-fulldeps/hash-stable-is-unstable.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'rustc_private': this crate is bei
 LL | extern crate rustc_data_structures;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/27812
+   = note: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
    = help: add `#![feature(rustc_private)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
@@ -13,7 +13,7 @@ error[E0658]: use of unstable library feature 'rustc_private': this crate is bei
 LL | extern crate rustc;
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/27812
+   = note: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
    = help: add `#![feature(rustc_private)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
@@ -22,7 +22,7 @@ error[E0658]: use of unstable library feature 'rustc_private': this crate is bei
 LL | extern crate rustc_macros;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/27812
+   = note: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
    = help: add `#![feature(rustc_private)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
@@ -31,7 +31,7 @@ error[E0658]: use of unstable library feature 'rustc_private': this crate is bei
 LL | use rustc_macros::HashStable;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/27812
+   = note: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
    = help: add `#![feature(rustc_private)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
@@ -40,7 +40,7 @@ error[E0658]: use of unstable library feature 'rustc_private': this crate is bei
 LL | #[derive(HashStable)]
    |          ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/27812
+   = note: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
    = help: add `#![feature(rustc_private)]` to the crate attributes to enable
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui-fulldeps/pathless-extern-unstable.stderr
+++ b/src/test/ui-fulldeps/pathless-extern-unstable.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'rustc_private': this crate is bei
 LL | pub use rustc;
    |         ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/27812
+   = note: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
    = help: add `#![feature(rustc_private)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/associated-type/associated-type-projection-from-multiple-supertraits.stderr
+++ b/src/test/ui/associated-type/associated-type-projection-from-multiple-supertraits.stderr
@@ -4,7 +4,7 @@ error: equality constraints are not yet supported in `where` clauses
 LL | fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not supported
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/20041
+   = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
 
 error[E0221]: ambiguous associated type `Color` in bounds of `C`
   --> $DIR/associated-type-projection-from-multiple-supertraits.rs:19:32

--- a/src/test/ui/async-await/feature-async-closure.stderr
+++ b/src/test/ui/async-await/feature-async-closure.stderr
@@ -4,7 +4,7 @@ error[E0658]: async closures are unstable
 LL |     let _ = async || {};
    |             ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/62290
+   = note: see issue #62290 <https://github.com/rust-lang/rust/issues/62290> for more information
    = help: add `#![feature(async_closure)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/borrowck/issue-64453.stderr
+++ b/src/test/ui/borrowck/issue-64453.stderr
@@ -4,7 +4,7 @@ error[E0658]: `match` is not allowed in a `static`
 LL | static settings_dir: String = format!("");
    |                               ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/cast/cast-ptr-to-int-const.stderr
+++ b/src/test/ui/cast/cast-ptr-to-int-const.stderr
@@ -4,7 +4,7 @@ error[E0658]: casting pointers to integers in constants is unstable
 LL |         main as u32
    |         ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51910
+   = note: see issue #51910 <https://github.com/rust-lang/rust/issues/51910> for more information
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error[E0658]: casting pointers to integers in constants is unstable
@@ -13,7 +13,7 @@ error[E0658]: casting pointers to integers in constants is unstable
 LL |         &Y as *const u32 as u32
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51910
+   = note: see issue #51910 <https://github.com/rust-lang/rust/issues/51910> for more information
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/check-static-immutable-mut-slices.stderr
+++ b/src/test/ui/check-static-immutable-mut-slices.stderr
@@ -4,7 +4,7 @@ error[E0658]: references in statics may only refer to immutable values
 LL | static TEST: &'static mut [isize] = &mut [];
    |                                     ^^^^^^^ statics require immutable values
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/closures/issue-52437.stderr
+++ b/src/test/ui/closures/issue-52437.stderr
@@ -10,7 +10,7 @@ error[E0658]: `loop` is not allowed in a `const`
 LL |     [(); &(&'static: loop { |x| {}; }) as *const _ as usize]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0282]: type annotations needed

--- a/src/test/ui/conditional-compilation/cfg-attr-crate-2.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-crate-2.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[no_core]` attribute is an experimental feature
 LL | #![cfg_attr(broken, no_core)]
    |                     ^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29639
+   = note: see issue #29639 <https://github.com/rust-lang/rust/issues/29639> for more information
    = help: add `#![feature(no_core)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/conditional-compilation/cfg-attr-multi-invalid-1.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-multi-invalid-1.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[no_core]` attribute is an experimental feature
 LL | #![cfg_attr(broken, no_core, no_std)]
    |                     ^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29639
+   = note: see issue #29639 <https://github.com/rust-lang/rust/issues/29639> for more information
    = help: add `#![feature(no_core)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/conditional-compilation/cfg-attr-multi-invalid-2.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-multi-invalid-2.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[no_core]` attribute is an experimental feature
 LL | #![cfg_attr(broken, no_std, no_core)]
    |                             ^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29639
+   = note: see issue #29639 <https://github.com/rust-lang/rust/issues/29639> for more information
    = help: add `#![feature(no_core)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/const-generics/const-param-in-trait-ungated.stderr
+++ b/src/test/ui/const-generics/const-param-in-trait-ungated.stderr
@@ -4,7 +4,7 @@ error[E0658]: const generics are unstable
 LL | trait Trait<const T: ()> {}
    |                   ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44580
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
    = help: add `#![feature(const_generics)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/const-generics/const-param-type-depends-on-type-param-ungated.stderr
+++ b/src/test/ui/const-generics/const-param-type-depends-on-type-param-ungated.stderr
@@ -4,7 +4,7 @@ error[E0658]: const generics are unstable
 LL | struct B<T, const N: T>(PhantomData<[T; N]>);
    |                   ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44580
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
    = help: add `#![feature(const_generics)]` to the crate attributes to enable
 
 error[E0741]: the types of const generic parameters must derive `PartialEq` and `Eq`

--- a/src/test/ui/const-generics/issues/issue-60263.stderr
+++ b/src/test/ui/const-generics/issues/issue-60263.stderr
@@ -4,7 +4,7 @@ error[E0658]: const generics are unstable
 LL | struct B<const I: u8>;
    |                ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44580
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
    = help: add `#![feature(const_generics)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/consts/const-address-of-mut.stderr
+++ b/src/test/ui/consts/const-address-of-mut.stderr
@@ -4,7 +4,7 @@ error[E0658]: `&raw mut` is not allowed in constants
 LL | const A: () = { let mut x = 2; &raw mut x; };
    |                                ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0658]: `&raw mut` is not allowed in statics
@@ -13,7 +13,7 @@ error[E0658]: `&raw mut` is not allowed in statics
 LL | static B: () = { let mut x = 2; &raw mut x; };
    |                                 ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0658]: `&raw mut` is not allowed in statics
@@ -22,7 +22,7 @@ error[E0658]: `&raw mut` is not allowed in statics
 LL | static mut C: () = { let mut x = 2; &raw mut x; };
    |                                     ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0658]: `&raw mut` is not allowed in constant functions
@@ -31,7 +31,7 @@ error[E0658]: `&raw mut` is not allowed in constant functions
 LL |     let y = &raw mut x;
    |             ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/consts/const-deref-ptr.stderr
+++ b/src/test/ui/consts/const-deref-ptr.stderr
@@ -4,7 +4,7 @@ error[E0658]: dereferencing raw pointers in statics is unstable
 LL |     static C: u64 = unsafe {*(0xdeadbeef as *const u64)};
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51911
+   = note: see issue #51911 <https://github.com/rust-lang/rust/issues/51911> for more information
    = help: add `#![feature(const_raw_ptr_deref)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/consts/const-eval/feature-gate-const_fn_union.stderr
+++ b/src/test/ui/consts/const-eval/feature-gate-const_fn_union.stderr
@@ -4,7 +4,7 @@ error[E0658]: unions in const fn are unstable
 LL |     Foo { u }.i
    |     ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51909
+   = note: see issue #51909 <https://github.com/rust-lang/rust/issues/51909> for more information
    = help: add `#![feature(const_fn_union)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/consts/const-eval/feature-gate-const_panic.stderr
+++ b/src/test/ui/consts/const-eval/feature-gate-const_panic.stderr
@@ -4,7 +4,7 @@ error[E0658]: panicking in constants is unstable
 LL | const Z: () = panic!("cheese");
    |               ^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51999
+   = note: see issue #51999 <https://github.com/rust-lang/rust/issues/51999> for more information
    = help: add `#![feature(const_panic)]` to the crate attributes to enable
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -14,7 +14,7 @@ error[E0658]: panicking in constants is unstable
 LL | const X: () = unimplemented!();
    |               ^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51999
+   = note: see issue #51999 <https://github.com/rust-lang/rust/issues/51999> for more information
    = help: add `#![feature(const_panic)]` to the crate attributes to enable
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -24,7 +24,7 @@ error[E0658]: panicking in constants is unstable
 LL | const Y: () = unreachable!();
    |               ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51999
+   = note: see issue #51999 <https://github.com/rust-lang/rust/issues/51999> for more information
    = help: add `#![feature(const_panic)]` to the crate attributes to enable
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/consts/const-eval/infinite_loop.stderr
+++ b/src/test/ui/consts/const-eval/infinite_loop.stderr
@@ -9,7 +9,7 @@ LL | |
 LL | |         }
    | |_________^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
@@ -19,7 +19,7 @@ error[E0658]: `if` is not allowed in a `const`
 LL |             n = if n % 2 == 0 { n/2 } else { 3*n + 1 };
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 warning: Constant evaluating a complex constant, this might take some time

--- a/src/test/ui/consts/const-eval/issue-52442.stderr
+++ b/src/test/ui/consts/const-eval/issue-52442.stderr
@@ -4,7 +4,7 @@ error[E0658]: `loop` is not allowed in a `const`
 LL |     [();  { &loop { break } as *const _ as usize } ];
    |              ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0658]: casting pointers to integers in constants is unstable
@@ -13,7 +13,7 @@ error[E0658]: casting pointers to integers in constants is unstable
 LL |     [();  { &loop { break } as *const _ as usize } ];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51910
+   = note: see issue #51910 <https://github.com/rust-lang/rust/issues/51910> for more information
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error[E0080]: evaluation of constant value failed

--- a/src/test/ui/consts/const-eval/issue-52475.stderr
+++ b/src/test/ui/consts/const-eval/issue-52475.stderr
@@ -8,7 +8,7 @@ LL | |             x = &0; // Materialize a new AllocId
 LL | |         }
    | |_________^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 

--- a/src/test/ui/consts/const-eval/issue-62272.stderr
+++ b/src/test/ui/consts/const-eval/issue-62272.stderr
@@ -4,7 +4,7 @@ error[E0658]: `loop` is not allowed in a `const`
 LL | const FOO: () = loop { break; };
    |                 ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0658]: `loop` is not allowed in a `const`
@@ -13,7 +13,7 @@ error[E0658]: `loop` is not allowed in a `const`
 LL |     [FOO; { let x; loop { x = 5; break; } x }];
    |                    ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/consts/const-eval/issue-65394.stderr
+++ b/src/test/ui/consts/const-eval/issue-65394.stderr
@@ -4,7 +4,7 @@ error[E0658]: references in constants may only refer to immutable values
 LL |     let r = &mut x;
    |             ^^^^^^ constants require immutable values
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time

--- a/src/test/ui/consts/const-eval/match-test-ptr-null.stderr
+++ b/src/test/ui/consts/const-eval/match-test-ptr-null.stderr
@@ -10,7 +10,7 @@ LL | |             n => n,
 LL | |         }
    | |_________^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: casting pointers to integers in constants is unstable
@@ -19,7 +19,7 @@ error[E0658]: casting pointers to integers in constants is unstable
 LL |         match &1 as *const i32 as usize {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51910
+   = note: see issue #51910 <https://github.com/rust-lang/rust/issues/51910> for more information
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error[E0080]: evaluation of constant value failed

--- a/src/test/ui/consts/const-extern-fn/const-extern-fn-call-extern-fn.stderr
+++ b/src/test/ui/consts/const-extern-fn/const-extern-fn-call-extern-fn.stderr
@@ -4,7 +4,7 @@ error[E0723]: can only call other `const fn` within a `const fn`, but `const reg
 LL |         regular_in_block();
    |         ^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: can only call other `const fn` within a `const fn`, but `const regular` is not stable as `const fn`
@@ -13,7 +13,7 @@ error[E0723]: can only call other `const fn` within a `const fn`, but `const reg
 LL |         regular();
    |         ^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/consts/const-extern-fn/const-extern-fn-min-const-fn.stderr
+++ b/src/test/ui/consts/const-extern-fn/const-extern-fn-min-const-fn.stderr
@@ -4,7 +4,7 @@ error[E0723]: unsizing casts are not allowed in const fn
 LL | const extern fn unsize(x: &[u8; 3]) -> &[u8] { x }
    |                                                ^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: function pointers in const fn are unstable
@@ -13,7 +13,7 @@ error[E0723]: function pointers in const fn are unstable
 LL | const unsafe extern "C" fn closure() -> fn() { || {} }
    |                                         ^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: only int, `bool` and `char` operations are stable in const fn
@@ -22,7 +22,7 @@ error[E0723]: only int, `bool` and `char` operations are stable in const fn
 LL | const unsafe extern fn use_float() { 1.0 + 1.0; }
    |                                      ^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: casting pointers to ints is unstable in const fn
@@ -31,7 +31,7 @@ error[E0723]: casting pointers to ints is unstable in const fn
 LL | const extern "C" fn ptr_cast(val: *const u8) { val as usize; }
    |                                                ^^^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/consts/const-extern-fn/feature-gate-const_extern_fn.stderr
+++ b/src/test/ui/consts/const-extern-fn/feature-gate-const_extern_fn.stderr
@@ -4,7 +4,7 @@ error[E0658]: `const extern fn` definitions are unstable
 LL | #[cfg(FALSE)] const extern fn foo1() {}
    |               ^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/64926
+   = note: see issue #64926 <https://github.com/rust-lang/rust/issues/64926> for more information
    = help: add `#![feature(const_extern_fn)]` to the crate attributes to enable
 
 error[E0658]: `const extern fn` definitions are unstable
@@ -13,7 +13,7 @@ error[E0658]: `const extern fn` definitions are unstable
 LL | #[cfg(FALSE)] const extern "C" fn foo2() {}
    |               ^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/64926
+   = note: see issue #64926 <https://github.com/rust-lang/rust/issues/64926> for more information
    = help: add `#![feature(const_extern_fn)]` to the crate attributes to enable
 
 error[E0658]: `const extern fn` definitions are unstable
@@ -22,7 +22,7 @@ error[E0658]: `const extern fn` definitions are unstable
 LL | #[cfg(FALSE)] const extern "Rust" fn foo3() {}
    |               ^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/64926
+   = note: see issue #64926 <https://github.com/rust-lang/rust/issues/64926> for more information
    = help: add `#![feature(const_extern_fn)]` to the crate attributes to enable
 
 error[E0658]: `const extern fn` definitions are unstable
@@ -31,7 +31,7 @@ error[E0658]: `const extern fn` definitions are unstable
 LL | #[cfg(FALSE)] const unsafe extern fn bar1() {}
    |               ^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/64926
+   = note: see issue #64926 <https://github.com/rust-lang/rust/issues/64926> for more information
    = help: add `#![feature(const_extern_fn)]` to the crate attributes to enable
 
 error[E0658]: `const extern fn` definitions are unstable
@@ -40,7 +40,7 @@ error[E0658]: `const extern fn` definitions are unstable
 LL | #[cfg(FALSE)] const unsafe extern "C" fn bar2() {}
    |               ^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/64926
+   = note: see issue #64926 <https://github.com/rust-lang/rust/issues/64926> for more information
    = help: add `#![feature(const_extern_fn)]` to the crate attributes to enable
 
 error[E0658]: `const extern fn` definitions are unstable
@@ -49,7 +49,7 @@ error[E0658]: `const extern fn` definitions are unstable
 LL | #[cfg(FALSE)] const unsafe extern "Rust" fn bar3() {}
    |               ^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/64926
+   = note: see issue #64926 <https://github.com/rust-lang/rust/issues/64926> for more information
    = help: add `#![feature(const_extern_fn)]` to the crate attributes to enable
 
 error: aborting due to 6 previous errors

--- a/src/test/ui/consts/const-extern-fn/issue-68062-const-extern-fns-dont-need-fn-specifier.stderr
+++ b/src/test/ui/consts/const-extern-fn/issue-68062-const-extern-fns-dont-need-fn-specifier.stderr
@@ -10,7 +10,7 @@ error[E0658]: `const extern fn` definitions are unstable
 LL |     const extern "Rust" PUT_ANYTHING_YOU_WANT_HERE bug() -> usize { 1 }
    |     ^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/64926
+   = note: see issue #64926 <https://github.com/rust-lang/rust/issues/64926> for more information
    = help: add `#![feature(const_extern_fn)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/consts/const-labeled-break.stderr
+++ b/src/test/ui/consts/const-labeled-break.stderr
@@ -4,7 +4,7 @@ error[E0658]: `while` is not allowed in a `const`
 LL | const CRASH: () = 'a: while break 'a {};
    |                   ^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 

--- a/src/test/ui/consts/const-match-pattern-arm.stderr
+++ b/src/test/ui/consts/const-match-pattern-arm.stderr
@@ -8,7 +8,7 @@ LL | |     _ => false
 LL | | };
    | |_^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `match` is not allowed in a `const`
@@ -20,7 +20,7 @@ LL | |         _ => false
 LL | |     }
    | |_____^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/consts/const-multi-ref.stderr
+++ b/src/test/ui/consts/const-multi-ref.stderr
@@ -4,7 +4,7 @@ error[E0658]: references in constants may only refer to immutable values
 LL |     let p = &mut a;
    |             ^^^^^^ constants require immutable values
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead

--- a/src/test/ui/consts/const-mut-refs/feature-gate-const_mut_refs.stderr
+++ b/src/test/ui/consts/const-mut-refs/feature-gate-const_mut_refs.stderr
@@ -4,7 +4,7 @@ error[E0723]: mutable references in const fn are unstable
 LL | const fn foo(x: &mut i32) -> i32 {
    |              ^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/consts/const_let_assign3.stderr
+++ b/src/test/ui/consts/const_let_assign3.stderr
@@ -10,7 +10,7 @@ error[E0658]: references in constants may only refer to immutable values
 LL |     s.foo(3);
    |     ^ constants require immutable values
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0658]: references in constants may only refer to immutable values
@@ -19,7 +19,7 @@ error[E0658]: references in constants may only refer to immutable values
 LL |     let y = &mut x;
    |             ^^^^^^ constants require immutable values
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0019]: constant contains unimplemented expression type

--- a/src/test/ui/consts/const_let_refutable.stderr
+++ b/src/test/ui/consts/const_let_refutable.stderr
@@ -10,7 +10,7 @@ error[E0723]: loops and conditional expressions are not stable in const fn
 LL | const fn slice(&[a, b]: &[i32]) -> i32 {
    |                 ^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/consts/const_short_circuit.stderr
+++ b/src/test/ui/consts/const_short_circuit.stderr
@@ -4,7 +4,7 @@ error: new features like let bindings are not permitted in constants which also 
 LL |     let mut x = true && false;
    |         ^^^^^
    |
-note: use of `&&` operator here does not actually short circuit due to the const evaluator presently not being able to do control flow. See https://github.com/rust-lang/rust/issues/49146 for more information.
+note: use of `&&` operator here does not actually short circuit due to the const evaluator presently not being able to do control flow. See issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information.
   --> $DIR/const_short_circuit.rs:4:22
    |
 LL |     let mut x = true && false;
@@ -16,7 +16,7 @@ error: new features like let bindings are not permitted in constants which also 
 LL |     let x = true && false;
    |         ^
    |
-note: use of `&&` operator here does not actually short circuit due to the const evaluator presently not being able to do control flow. See https://github.com/rust-lang/rust/issues/49146 for more information.
+note: use of `&&` operator here does not actually short circuit due to the const evaluator presently not being able to do control flow. See issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information.
   --> $DIR/const_short_circuit.rs:9:18
    |
 LL |     let x = true && false;

--- a/src/test/ui/consts/control-flow/assert.if_match.stderr
+++ b/src/test/ui/consts/control-flow/assert.if_match.stderr
@@ -4,7 +4,7 @@ error[E0658]: panicking in constants is unstable
 LL | const _: () = assert!(true);
    |               ^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51999
+   = note: see issue #51999 <https://github.com/rust-lang/rust/issues/51999> for more information
    = help: add `#![feature(const_panic)]` to the crate attributes to enable
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -14,7 +14,7 @@ error[E0658]: panicking in constants is unstable
 LL | const _: () = assert!(false);
    |               ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51999
+   = note: see issue #51999 <https://github.com/rust-lang/rust/issues/51999> for more information
    = help: add `#![feature(const_panic)]` to the crate attributes to enable
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/consts/control-flow/assert.panic.stderr
+++ b/src/test/ui/consts/control-flow/assert.panic.stderr
@@ -4,7 +4,7 @@ error[E0658]: `if` is not allowed in a `const`
 LL | const _: () = assert!(true);
    |               ^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -14,7 +14,7 @@ error[E0658]: `if` is not allowed in a `const`
 LL | const _: () = assert!(false);
    |               ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/consts/control-flow/assert.stock.stderr
+++ b/src/test/ui/consts/control-flow/assert.stock.stderr
@@ -4,7 +4,7 @@ error[E0658]: `if` is not allowed in a `const`
 LL | const _: () = assert!(true);
    |               ^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -14,7 +14,7 @@ error[E0658]: `if` is not allowed in a `const`
 LL | const _: () = assert!(false);
    |               ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/consts/control-flow/feature-gate-const-if-match.stock.stderr
+++ b/src/test/ui/consts/control-flow/feature-gate-const-if-match.stock.stderr
@@ -9,7 +9,7 @@ LL | |     6
 LL | | };
    | |_^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `if` is not allowed in a `const`
@@ -23,7 +23,7 @@ LL | |     1
 LL | | };
    | |_^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `match` is not allowed in a `const`
@@ -37,7 +37,7 @@ LL | |     _ => 0,
 LL | | };
    | |_^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `if` is not allowed in a `static`
@@ -46,7 +46,7 @@ error[E0658]: `if` is not allowed in a `static`
 LL |     let x = if true { 0 } else { 1 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `match` is not allowed in a `static`
@@ -55,7 +55,7 @@ error[E0658]: `match` is not allowed in a `static`
 LL |     let x = match x { 0 => 1, _ => 0 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `if` is not allowed in a `static`
@@ -64,7 +64,7 @@ error[E0658]: `if` is not allowed in a `static`
 LL |     if let Some(x) = Some(x) { x } else { 1 }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `if` is not allowed in a `static mut`
@@ -73,7 +73,7 @@ error[E0658]: `if` is not allowed in a `static mut`
 LL |     let x = if true { 0 } else { 1 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `match` is not allowed in a `static mut`
@@ -82,7 +82,7 @@ error[E0658]: `match` is not allowed in a `static mut`
 LL |     let x = match x { 0 => 1, _ => 0 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `if` is not allowed in a `static mut`
@@ -91,7 +91,7 @@ error[E0658]: `if` is not allowed in a `static mut`
 LL |     if let Some(x) = Some(x) { x } else { 1 }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `if` is not allowed in a `const fn`
@@ -100,7 +100,7 @@ error[E0658]: `if` is not allowed in a `const fn`
 LL |     if true { 5 } else { 6 }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `if` is not allowed in a `const fn`
@@ -113,7 +113,7 @@ LL | |         1
 LL | |     }
    | |_____^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `match` is not allowed in a `const fn`
@@ -126,7 +126,7 @@ LL | |         _ => 0
 LL | |     }
    | |_____^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `if` is not allowed in a `const fn`
@@ -135,7 +135,7 @@ error[E0658]: `if` is not allowed in a `const fn`
 LL |         let x = if y { 0 } else { 1 };
    |                 ^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `match` is not allowed in a `const fn`
@@ -144,7 +144,7 @@ error[E0658]: `match` is not allowed in a `const fn`
 LL |         let x = match x { 0 => 1, _ => 0 };
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `if` is not allowed in a `const fn`
@@ -153,7 +153,7 @@ error[E0658]: `if` is not allowed in a `const fn`
 LL |         if let Some(x) = Some(x) { x } else { 1 }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `if` is not allowed in a `const`
@@ -162,7 +162,7 @@ error[E0658]: `if` is not allowed in a `const`
 LL |         let x = if false { 0 } else { 1 };
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `match` is not allowed in a `const`
@@ -171,7 +171,7 @@ error[E0658]: `match` is not allowed in a `const`
 LL |         let x = match x { 0 => 1, _ => 0 };
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `if` is not allowed in a `const`
@@ -180,7 +180,7 @@ error[E0658]: `if` is not allowed in a `const`
 LL |         if let Some(x) = Some(x) { x } else { 1 }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `if` is not allowed in a `const`
@@ -189,7 +189,7 @@ error[E0658]: `if` is not allowed in a `const`
 LL |     const IF: i32 = if true { 5 } else { 6 };
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `if` is not allowed in a `const`
@@ -198,7 +198,7 @@ error[E0658]: `if` is not allowed in a `const`
 LL |     const IF_LET: i32 = if let Some(true) = None { 5 } else { 6 };
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `match` is not allowed in a `const`
@@ -207,7 +207,7 @@ error[E0658]: `match` is not allowed in a `const`
 LL |     const MATCH: i32 = match 0 { 1 => 2, _ => 0 };
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `if` is not allowed in a `const`
@@ -216,7 +216,7 @@ error[E0658]: `if` is not allowed in a `const`
 LL |     const IF: i32 = if true { 5 } else { 6 };
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `if` is not allowed in a `const`
@@ -225,7 +225,7 @@ error[E0658]: `if` is not allowed in a `const`
 LL |     const IF_LET: i32 = if let Some(true) = None { 5 } else { 6 };
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `match` is not allowed in a `const`
@@ -234,7 +234,7 @@ error[E0658]: `match` is not allowed in a `const`
 LL |     const MATCH: i32 = match 0 { 1 => 2, _ => 0 };
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0019]: constant contains unimplemented expression type

--- a/src/test/ui/consts/control-flow/issue-46843.stock.stderr
+++ b/src/test/ui/consts/control-flow/issue-46843.stock.stderr
@@ -10,7 +10,7 @@ LL | |     Thing::That => 0
 LL | | };
    | |_^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/consts/control-flow/issue-50577.stock.stderr
+++ b/src/test/ui/consts/control-flow/issue-50577.stock.stderr
@@ -4,7 +4,7 @@ error[E0658]: `match` is not allowed in a `const`
 LL |         Drop = assert_eq!(1, 1)
    |                ^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -14,7 +14,7 @@ error[E0658]: `if` is not allowed in a `const`
 LL |         Drop = assert_eq!(1, 1)
    |                ^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -24,7 +24,7 @@ error[E0658]: `match` is not allowed in a `const`
 LL |         Drop = assert_eq!(1, 1)
    |                ^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/consts/control-flow/loop.if_match.stderr
+++ b/src/test/ui/consts/control-flow/loop.if_match.stderr
@@ -4,7 +4,7 @@ error[E0658]: `loop` is not allowed in a `const`
 LL | const _: () = loop {};
    |               ^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0658]: `loop` is not allowed in a `static`
@@ -13,7 +13,7 @@ error[E0658]: `loop` is not allowed in a `static`
 LL | static FOO: i32 = loop { break 4; };
    |                   ^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0658]: `loop` is not allowed in a `const fn`
@@ -22,7 +22,7 @@ error[E0658]: `loop` is not allowed in a `const fn`
 LL |     loop {}
    |     ^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0658]: `loop` is not allowed in a `const fn`
@@ -31,7 +31,7 @@ error[E0658]: `loop` is not allowed in a `const fn`
 LL |         loop {}
    |         ^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0658]: `while` is not allowed in a `const`
@@ -40,7 +40,7 @@ error[E0658]: `while` is not allowed in a `const`
 LL |         while false {}
    |         ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0658]: `while` is not allowed in a `const`
@@ -51,7 +51,7 @@ LL | |         x += 1;
 LL | |     }
    | |_____^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0658]: `while` is not allowed in a `const`
@@ -62,7 +62,7 @@ LL | |         x += 1;
 LL | |     }
    | |_____^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0744]: `for` is not allowed in a `const`
@@ -92,7 +92,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0658]: `loop` is not allowed in a `const`
@@ -106,7 +106,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0658]: `while` is not allowed in a `const`
@@ -115,7 +115,7 @@ error[E0658]: `while` is not allowed in a `const`
 LL |     while let None = Some(x) { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0658]: `while` is not allowed in a `const`
@@ -124,7 +124,7 @@ error[E0658]: `while` is not allowed in a `const`
 LL |     while let None = Some(x) { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0658]: `loop` is not allowed in a `const`
@@ -133,7 +133,7 @@ error[E0658]: `loop` is not allowed in a `const`
 LL |     const BAR: i32 = loop { break 4; };
    |                      ^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0658]: `loop` is not allowed in a `const`
@@ -142,7 +142,7 @@ error[E0658]: `loop` is not allowed in a `const`
 LL |     const BAR: i32 = loop { break 4; };
    |                      ^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error: aborting due to 15 previous errors

--- a/src/test/ui/consts/control-flow/loop.loop_.stderr
+++ b/src/test/ui/consts/control-flow/loop.loop_.stderr
@@ -4,7 +4,7 @@ error[E0658]: `while` is not allowed in a `const`
 LL |         while false {}
    |         ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
    = note: `#![feature(const_loop)]` alone is not sufficient, since this loop expression contains an implicit conditional
 
@@ -16,7 +16,7 @@ LL | |         x += 1;
 LL | |     }
    | |_____^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
    = note: `#![feature(const_loop)]` alone is not sufficient, since this loop expression contains an implicit conditional
 
@@ -28,7 +28,7 @@ LL | |         x += 1;
 LL | |     }
    | |_____^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
    = note: `#![feature(const_loop)]` alone is not sufficient, since this loop expression contains an implicit conditional
 
@@ -56,7 +56,7 @@ LL | |             break;
 LL | |         }
    | |_________^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `if` is not allowed in a `const`
@@ -67,7 +67,7 @@ LL | |             break;
 LL | |         }
    | |_________^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `while` is not allowed in a `const`
@@ -76,7 +76,7 @@ error[E0658]: `while` is not allowed in a `const`
 LL |     while let None = Some(x) { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
    = note: `#![feature(const_loop)]` alone is not sufficient, since this loop expression contains an implicit conditional
 
@@ -86,7 +86,7 @@ error[E0658]: `while` is not allowed in a `const`
 LL |     while let None = Some(x) { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
    = note: `#![feature(const_loop)]` alone is not sufficient, since this loop expression contains an implicit conditional
 

--- a/src/test/ui/consts/control-flow/loop.stock.stderr
+++ b/src/test/ui/consts/control-flow/loop.stock.stderr
@@ -4,7 +4,7 @@ error[E0658]: `loop` is not allowed in a `const`
 LL | const _: () = loop {};
    |               ^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0658]: `loop` is not allowed in a `static`
@@ -13,7 +13,7 @@ error[E0658]: `loop` is not allowed in a `static`
 LL | static FOO: i32 = loop { break 4; };
    |                   ^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0658]: `loop` is not allowed in a `const fn`
@@ -22,7 +22,7 @@ error[E0658]: `loop` is not allowed in a `const fn`
 LL |     loop {}
    |     ^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0658]: `loop` is not allowed in a `const fn`
@@ -31,7 +31,7 @@ error[E0658]: `loop` is not allowed in a `const fn`
 LL |         loop {}
    |         ^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0658]: `while` is not allowed in a `const`
@@ -40,7 +40,7 @@ error[E0658]: `while` is not allowed in a `const`
 LL |         while false {}
    |         ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
@@ -52,7 +52,7 @@ LL | |         x += 1;
 LL | |     }
    | |_____^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
@@ -64,7 +64,7 @@ LL | |         x += 1;
 LL | |     }
    | |_____^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
@@ -95,7 +95,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0658]: `if` is not allowed in a `const`
@@ -106,7 +106,7 @@ LL | |             break;
 LL | |         }
    | |_________^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `loop` is not allowed in a `const`
@@ -120,7 +120,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0658]: `if` is not allowed in a `const`
@@ -131,7 +131,7 @@ LL | |             break;
 LL | |         }
    | |_________^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `while` is not allowed in a `const`
@@ -140,7 +140,7 @@ error[E0658]: `while` is not allowed in a `const`
 LL |     while let None = Some(x) { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
@@ -150,7 +150,7 @@ error[E0658]: `while` is not allowed in a `const`
 LL |     while let None = Some(x) { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
@@ -160,7 +160,7 @@ error[E0658]: `loop` is not allowed in a `const`
 LL |     const BAR: i32 = loop { break 4; };
    |                      ^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error[E0658]: `loop` is not allowed in a `const`
@@ -169,7 +169,7 @@ error[E0658]: `loop` is not allowed in a `const`
 LL |     const BAR: i32 = loop { break 4; };
    |                      ^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error: aborting due to 17 previous errors

--- a/src/test/ui/consts/min_const_fn/address_of.stderr
+++ b/src/test/ui/consts/min_const_fn/address_of.stderr
@@ -4,7 +4,7 @@ error[E0658]: `&raw mut` is not allowed in constant functions
 LL |     let b = &raw mut a;
    |             ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0658]: `&raw mut` is not allowed in constant functions
@@ -13,7 +13,7 @@ error[E0658]: `&raw mut` is not allowed in constant functions
 LL |         let b = &raw mut a;
    |                 ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.stderr
+++ b/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.stderr
@@ -4,7 +4,7 @@ error[E0723]: function pointers in const fn are unstable
 LL | const fn error(_: fn()) {}
    |                ^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/consts/min_const_fn/allow_const_fn_ptr_feature_gate.stderr
+++ b/src/test/ui/consts/min_const_fn/allow_const_fn_ptr_feature_gate.stderr
@@ -4,7 +4,7 @@ error[E0658]: internal implementation detail
 LL | #[rustc_allow_const_fn_ptr]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/consts/min_const_fn/bad_const_fn_body_ice.stderr
+++ b/src/test/ui/consts/min_const_fn/bad_const_fn_body_ice.stderr
@@ -4,7 +4,7 @@ error[E0723]: heap allocations are not allowed in const fn
 LL |     vec![1, 2, 3]
    |     ^^^^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/consts/min_const_fn/cast_errors.stderr
+++ b/src/test/ui/consts/min_const_fn/cast_errors.stderr
@@ -4,7 +4,7 @@ error[E0723]: unsizing casts are not allowed in const fn
 LL | const fn unsize(x: &[u8; 3]) -> &[u8] { x }
    |                                         ^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: function pointers in const fn are unstable
@@ -13,7 +13,7 @@ error[E0723]: function pointers in const fn are unstable
 LL | const fn closure() -> fn() { || {} }
    |                       ^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: function pointers in const fn are unstable
@@ -22,7 +22,7 @@ error[E0723]: function pointers in const fn are unstable
 LL |     (|| {}) as fn();
    |     ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: function pointers in const fn are unstable
@@ -31,7 +31,7 @@ error[E0723]: function pointers in const fn are unstable
 LL | const fn reify(f: fn()) -> unsafe fn() { f }
    |                            ^^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: function pointers in const fn are unstable
@@ -40,7 +40,7 @@ error[E0723]: function pointers in const fn are unstable
 LL | const fn reify2() { main as unsafe fn(); }
    |                     ^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 5 previous errors

--- a/src/test/ui/consts/min_const_fn/cmp_fn_pointers.stderr
+++ b/src/test/ui/consts/min_const_fn/cmp_fn_pointers.stderr
@@ -4,7 +4,7 @@ error[E0723]: function pointers in const fn are unstable
 LL | const fn cmp(x: fn(), y: fn()) -> bool {
    |              ^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/consts/min_const_fn/loop_ice.stderr
+++ b/src/test/ui/consts/min_const_fn/loop_ice.stderr
@@ -4,7 +4,7 @@ error[E0658]: `loop` is not allowed in a `const fn`
 LL |     loop {}
    |     ^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/consts/min_const_fn/min_const_fn.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn.stderr
@@ -10,7 +10,7 @@ error[E0723]: mutable references in const fn are unstable
 LL |     const fn get_mut(&mut self) -> &mut T { &mut self.0 }
    |                                    ^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
@@ -25,7 +25,7 @@ error[E0723]: mutable references in const fn are unstable
 LL |     const fn get_mut_lt(&'a mut self) -> &mut T { &mut self.0 }
    |                                          ^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
@@ -40,7 +40,7 @@ error[E0723]: mutable references in const fn are unstable
 LL |     const fn get_mut_s(&mut self) -> &mut T { &mut self.0 }
    |                                      ^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: mutable references in const fn are unstable
@@ -49,7 +49,7 @@ error[E0723]: mutable references in const fn are unstable
 LL |     const fn get_mut_sq(&mut self) -> &mut T { &mut self.0 }
    |                                       ^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
@@ -58,7 +58,7 @@ error[E0723]: trait bounds other than `Sized` on const fn parameters are unstabl
 LL | const fn foo11<T: std::fmt::Display>(t: T) -> T { t }
    |                ^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
@@ -67,7 +67,7 @@ error[E0723]: trait bounds other than `Sized` on const fn parameters are unstabl
 LL | const fn foo11_2<T: Send>(t: T) -> T { t }
    |                  ^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: only int, `bool` and `char` operations are stable in const fn
@@ -76,7 +76,7 @@ error[E0723]: only int, `bool` and `char` operations are stable in const fn
 LL | const fn foo19(f: f32) -> f32 { f * 2.0 }
    |                                 ^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: only int, `bool` and `char` operations are stable in const fn
@@ -85,7 +85,7 @@ error[E0723]: only int, `bool` and `char` operations are stable in const fn
 LL | const fn foo19_2(f: f32) -> f32 { 2.0 - f }
    |                                   ^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: only int and `bool` operations are stable in const fn
@@ -94,7 +94,7 @@ error[E0723]: only int and `bool` operations are stable in const fn
 LL | const fn foo19_3(f: f32) -> f32 { -f }
    |                                   ^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: only int, `bool` and `char` operations are stable in const fn
@@ -103,7 +103,7 @@ error[E0723]: only int, `bool` and `char` operations are stable in const fn
 LL | const fn foo19_4(f: f32, g: f32) -> f32 { f / g }
    |                                           ^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: cannot access `static` items in const fn
@@ -112,7 +112,7 @@ error[E0723]: cannot access `static` items in const fn
 LL | const fn foo25() -> u32 { BAR }
    |                           ^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: cannot access `static` items in const fn
@@ -121,7 +121,7 @@ error[E0723]: cannot access `static` items in const fn
 LL | const fn foo26() -> &'static u32 { &BAR }
    |                                     ^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: casting pointers to ints is unstable in const fn
@@ -130,7 +130,7 @@ error[E0723]: casting pointers to ints is unstable in const fn
 LL | const fn foo30(x: *const u32) -> usize { x as usize }
    |                                          ^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: casting pointers to ints is unstable in const fn
@@ -139,7 +139,7 @@ error[E0723]: casting pointers to ints is unstable in const fn
 LL | const fn foo30_with_unsafe(x: *const u32) -> usize { unsafe { x as usize } }
    |                                                               ^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: casting pointers to ints is unstable in const fn
@@ -148,7 +148,7 @@ error[E0723]: casting pointers to ints is unstable in const fn
 LL | const fn foo30_2(x: *mut u32) -> usize { x as usize }
    |                                          ^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: casting pointers to ints is unstable in const fn
@@ -157,7 +157,7 @@ error[E0723]: casting pointers to ints is unstable in const fn
 LL | const fn foo30_2_with_unsafe(x: *mut u32) -> usize { unsafe { x as usize } }
    |                                                               ^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: loops and conditional expressions are not stable in const fn
@@ -166,7 +166,7 @@ error[E0723]: loops and conditional expressions are not stable in const fn
 LL | const fn foo36(a: bool, b: bool) -> bool { a && b }
    |                                            ^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: loops and conditional expressions are not stable in const fn
@@ -175,7 +175,7 @@ error[E0723]: loops and conditional expressions are not stable in const fn
 LL | const fn foo37(a: bool, b: bool) -> bool { a || b }
    |                                            ^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: mutable references in const fn are unstable
@@ -184,7 +184,7 @@ error[E0723]: mutable references in const fn are unstable
 LL | const fn inc(x: &mut i32) { *x += 1 }
    |              ^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
@@ -193,7 +193,7 @@ error[E0723]: trait bounds other than `Sized` on const fn parameters are unstabl
 LL | impl<T: std::fmt::Debug> Foo<T> {
    |      ^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
@@ -202,7 +202,7 @@ error[E0723]: trait bounds other than `Sized` on const fn parameters are unstabl
 LL | impl<T: std::fmt::Debug + Sized> Foo<T> {
    |      ^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
@@ -211,7 +211,7 @@ error[E0723]: trait bounds other than `Sized` on const fn parameters are unstabl
 LL | impl<T: Sync + Sized> Foo<T> {
    |      ^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: `impl Trait` in const fn is unstable
@@ -220,7 +220,7 @@ error[E0723]: `impl Trait` in const fn is unstable
 LL | const fn no_rpit2() -> AlanTuring<impl std::fmt::Debug> { AlanTuring(0) }
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
@@ -229,7 +229,7 @@ error[E0723]: trait bounds other than `Sized` on const fn parameters are unstabl
 LL | const fn no_apit2(_x: AlanTuring<impl std::fmt::Debug>) {}
    |                                  ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
@@ -238,7 +238,7 @@ error[E0723]: trait bounds other than `Sized` on const fn parameters are unstabl
 LL | const fn no_apit(_x: impl std::fmt::Debug) {}
    |                      ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: `impl Trait` in const fn is unstable
@@ -247,7 +247,7 @@ error[E0723]: `impl Trait` in const fn is unstable
 LL | const fn no_rpit() -> impl std::fmt::Debug {}
    |                       ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
@@ -256,7 +256,7 @@ error[E0723]: trait bounds other than `Sized` on const fn parameters are unstabl
 LL | const fn no_dyn_trait(_x: &dyn std::fmt::Debug) {}
    |                       ^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
@@ -265,7 +265,7 @@ error[E0723]: trait bounds other than `Sized` on const fn parameters are unstabl
 LL | const fn no_dyn_trait_ret() -> &'static dyn std::fmt::Debug { &() }
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
@@ -274,7 +274,7 @@ error[E0723]: trait bounds other than `Sized` on const fn parameters are unstabl
 LL | const fn really_no_traits_i_mean_it() { (&() as &dyn std::fmt::Debug, ()).1 }
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: function pointers in const fn are unstable
@@ -283,7 +283,7 @@ error[E0723]: function pointers in const fn are unstable
 LL | const fn no_fn_ptrs(_x: fn()) {}
    |                     ^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: function pointers in const fn are unstable
@@ -292,7 +292,7 @@ error[E0723]: function pointers in const fn are unstable
 LL | const fn no_fn_ptrs2() -> fn() { fn foo() {} foo }
    |                           ^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 34 previous errors

--- a/src/test/ui/consts/min_const_fn/min_const_fn_dyn.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_dyn.stderr
@@ -4,7 +4,7 @@ error[E0723]: trait bounds other than `Sized` on const fn parameters are unstabl
 LL |     x.0.field;
    |     ^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
@@ -13,7 +13,7 @@ error[E0723]: trait bounds other than `Sized` on const fn parameters are unstabl
 LL | const fn no_inner_dyn_trait_ret() -> Hide { Hide(HasDyn { field: &0 }) }
    |                                                                  ^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/consts/min_const_fn/min_const_fn_fn_ptr.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_fn_ptr.stderr
@@ -4,7 +4,7 @@ error[E0723]: function pointers in const fn are unstable
 LL |     x.0.field;
    |     ^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: function pointers in const fn are unstable
@@ -13,7 +13,7 @@ error[E0723]: function pointers in const fn are unstable
 LL | const fn no_inner_dyn_trait_ret() -> Hide { Hide(HasPtr { field }) }
    |                                                           ^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.stderr
@@ -4,7 +4,7 @@ error[E0723]: can only call other `const fn` within a `const fn`, but `const foo
 LL | const fn bar() -> u32 { foo() }
    |                         ^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2` is not stable as `const fn`
@@ -13,7 +13,7 @@ error[E0723]: can only call other `const fn` within a `const fn`, but `const foo
 LL | const fn bar2() -> u32 { foo2() }
    |                          ^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: only int, `bool` and `char` operations are stable in const fn
@@ -22,7 +22,7 @@ error[E0723]: only int, `bool` and `char` operations are stable in const fn
 LL | const fn bar3() -> u32 { (5f32 + 6f32) as u32 }
    |                          ^^^^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2_gated` is not stable as `const fn`
@@ -31,7 +31,7 @@ error[E0723]: can only call other `const fn` within a `const fn`, but `const foo
 LL | const fn bar2_gated() -> u32 { foo2_gated() }
    |                                ^^^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/consts/min_const_fn/min_const_fn_unsafe_bad.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_unsafe_bad.stderr
@@ -4,7 +4,7 @@ error[E0658]: dereferencing raw pointers in constant functions is unstable
 LL | const fn bad_const_fn_deref_raw(x: *mut usize) -> &'static usize { unsafe { &*x } }
    |                                                                             ^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51911
+   = note: see issue #51911 <https://github.com/rust-lang/rust/issues/51911> for more information
    = help: add `#![feature(const_raw_ptr_deref)]` to the crate attributes to enable
 
 error[E0658]: dereferencing raw pointers in constant functions is unstable
@@ -13,7 +13,7 @@ error[E0658]: dereferencing raw pointers in constant functions is unstable
 LL | const unsafe fn bad_const_unsafe_deref_raw(x: *mut usize) -> usize { *x }
    |                                                                      ^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51911
+   = note: see issue #51911 <https://github.com/rust-lang/rust/issues/51911> for more information
    = help: add `#![feature(const_raw_ptr_deref)]` to the crate attributes to enable
 
 error[E0658]: dereferencing raw pointers in constant functions is unstable
@@ -22,7 +22,7 @@ error[E0658]: dereferencing raw pointers in constant functions is unstable
 LL | const unsafe fn bad_const_unsafe_deref_raw_ref(x: *mut usize) -> &'static usize { &*x }
    |                                                                                   ^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51911
+   = note: see issue #51911 <https://github.com/rust-lang/rust/issues/51911> for more information
    = help: add `#![feature(const_raw_ptr_deref)]` to the crate attributes to enable
 
 error[E0723]: accessing union fields is unstable
@@ -31,7 +31,7 @@ error[E0723]: accessing union fields is unstable
 LL |     Foo { x: () }.y
    |     ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block

--- a/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.stderr
@@ -4,7 +4,7 @@ error[E0723]: can only call other `const fn` within a `const fn`, but `const foo
 LL | const unsafe fn bar() -> u32 { unsafe { foo() } }
    |                                         ^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2` is not stable as `const fn`
@@ -13,7 +13,7 @@ error[E0723]: can only call other `const fn` within a `const fn`, but `const foo
 LL | const unsafe fn bar2() -> u32 { unsafe { foo2() } }
    |                                          ^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: only int, `bool` and `char` operations are stable in const fn
@@ -22,7 +22,7 @@ error[E0723]: only int, `bool` and `char` operations are stable in const fn
 LL | const unsafe fn bar3() -> u32 { (5f32 + 6f32) as u32 }
    |                                 ^^^^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2_gated` is not stable as `const fn`
@@ -31,7 +31,7 @@ error[E0723]: can only call other `const fn` within a `const fn`, but `const foo
 LL | const unsafe fn bar2_gated() -> u32 { unsafe { foo2_gated() } }
    |                                                ^^^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability2.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability2.stderr
@@ -4,7 +4,7 @@ error[E0723]: can only call other `const fn` within a `const fn`, but `const foo
 LL | const unsafe fn bar() -> u32 { foo() }
    |                                ^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2` is not stable as `const fn`
@@ -13,7 +13,7 @@ error[E0723]: can only call other `const fn` within a `const fn`, but `const foo
 LL | const unsafe fn bar2() -> u32 { foo2() }
    |                                 ^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2_gated` is not stable as `const fn`
@@ -22,7 +22,7 @@ error[E0723]: can only call other `const fn` within a `const fn`, but `const foo
 LL | const unsafe fn bar2_gated() -> u32 { foo2_gated() }
    |                                       ^^^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/consts/min_const_fn/mutable_borrow.stderr
+++ b/src/test/ui/consts/min_const_fn/mutable_borrow.stderr
@@ -4,7 +4,7 @@ error[E0723]: mutable references in const fn are unstable
 LL |     let b = &mut a;
    |         ^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: mutable references in const fn are unstable
@@ -13,7 +13,7 @@ error[E0723]: mutable references in const fn are unstable
 LL |         let b = &mut a;
    |             ^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/consts/projection_qualif.mut_refs.stderr
+++ b/src/test/ui/consts/projection_qualif.mut_refs.stderr
@@ -4,7 +4,7 @@ error[E0658]: dereferencing raw pointers in constants is unstable
 LL |         unsafe { *b = 5; }
    |                  ^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51911
+   = note: see issue #51911 <https://github.com/rust-lang/rust/issues/51911> for more information
    = help: add `#![feature(const_raw_ptr_deref)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/consts/projection_qualif.stock.stderr
+++ b/src/test/ui/consts/projection_qualif.stock.stderr
@@ -4,7 +4,7 @@ error[E0658]: references in constants may only refer to immutable values
 LL |         let b: *mut u32 = &mut a;
    |                           ^^^^^^ constants require immutable values
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0658]: dereferencing raw pointers in constants is unstable
@@ -13,7 +13,7 @@ error[E0658]: dereferencing raw pointers in constants is unstable
 LL |         unsafe { *b = 5; }
    |                  ^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51911
+   = note: see issue #51911 <https://github.com/rust-lang/rust/issues/51911> for more information
    = help: add `#![feature(const_raw_ptr_deref)]` to the crate attributes to enable
 
 error[E0019]: constant contains unimplemented expression type

--- a/src/test/ui/consts/static_mut_containing_mut_ref2.stock.stderr
+++ b/src/test/ui/consts/static_mut_containing_mut_ref2.stock.stderr
@@ -4,7 +4,7 @@ error[E0658]: references in statics may only refer to immutable values
 LL | pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 42; };
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ statics require immutable values
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0019]: static contains unimplemented expression type

--- a/src/test/ui/enum-discriminant/feature-gate-arbitrary_enum_discriminant.stderr
+++ b/src/test/ui/enum-discriminant/feature-gate-arbitrary_enum_discriminant.stderr
@@ -4,7 +4,7 @@ error[E0658]: discriminants on non-unit variants are experimental
 LL |   Tuple() = 2,
    |             ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/60553
+   = note: see issue #60553 <https://github.com/rust-lang/rust/issues/60553> for more information
    = help: add `#![feature(arbitrary_enum_discriminant)]` to the crate attributes to enable
 
 error[E0658]: discriminants on non-unit variants are experimental
@@ -13,7 +13,7 @@ error[E0658]: discriminants on non-unit variants are experimental
 LL |   Struct{} = 3,
    |              ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/60553
+   = note: see issue #60553 <https://github.com/rust-lang/rust/issues/60553> for more information
    = help: add `#![feature(arbitrary_enum_discriminant)]` to the crate attributes to enable
 
 error[E0658]: custom discriminant values are not allowed in enums with tuple or struct variants
@@ -28,7 +28,7 @@ LL |
 LL |   Struct{} = 3,
    |   ------------ struct variant defined here
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/60553
+   = note: see issue #60553 <https://github.com/rust-lang/rust/issues/60553> for more information
    = help: add `#![feature(arbitrary_enum_discriminant)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/error-codes/E0017.stderr
+++ b/src/test/ui/error-codes/E0017.stderr
@@ -4,7 +4,7 @@ error[E0658]: references in constants may only refer to immutable values
 LL | const CR: &'static mut i32 = &mut C;
    |                              ^^^^^^ constants require immutable values
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0019]: static contains unimplemented expression type
@@ -19,7 +19,7 @@ error[E0658]: references in statics may only refer to immutable values
 LL | static STATIC_REF: &'static mut i32 = &mut X;
    |                                       ^^^^^^ statics require immutable values
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0596]: cannot borrow immutable static item `X` as mutable
@@ -34,7 +34,7 @@ error[E0658]: references in statics may only refer to immutable values
 LL | static CONST_REF: &'static mut i32 = &mut C;
    |                                      ^^^^^^ statics require immutable values
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0658]: references in statics may only refer to immutable values
@@ -43,7 +43,7 @@ error[E0658]: references in statics may only refer to immutable values
 LL | static STATIC_MUT_REF: &'static mut i32 = unsafe { &mut M };
    |                                                    ^^^^^^ statics require immutable values
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error: aborting due to 6 previous errors

--- a/src/test/ui/error-codes/E0388.stderr
+++ b/src/test/ui/error-codes/E0388.stderr
@@ -4,7 +4,7 @@ error[E0658]: references in constants may only refer to immutable values
 LL | const CR: &'static mut i32 = &mut C;
    |                              ^^^^^^ constants require immutable values
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0019]: static contains unimplemented expression type
@@ -19,7 +19,7 @@ error[E0658]: references in statics may only refer to immutable values
 LL | static STATIC_REF: &'static mut i32 = &mut X;
    |                                       ^^^^^^ statics require immutable values
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0596]: cannot borrow immutable static item `X` as mutable
@@ -34,7 +34,7 @@ error[E0658]: references in statics may only refer to immutable values
 LL | static CONST_REF: &'static mut i32 = &mut C;
    |                                      ^^^^^^ statics require immutable values
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error: aborting due to 5 previous errors

--- a/src/test/ui/error-codes/E0395.stderr
+++ b/src/test/ui/error-codes/E0395.stderr
@@ -4,7 +4,7 @@ error[E0658]: comparing raw pointers inside static
 LL | static BAZ: bool = unsafe { (&FOO as *const i32) == (&BAR as *const i32) };
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53020
+   = note: see issue #53020 <https://github.com/rust-lang/rust/issues/53020> for more information
    = help: add `#![feature(const_compare_raw_pointers)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/error-codes/E0396.stderr
+++ b/src/test/ui/error-codes/E0396.stderr
@@ -4,7 +4,7 @@ error[E0658]: dereferencing raw pointers in constants is unstable
 LL | const VALUE: u8 = unsafe { *REG_ADDR };
    |                            ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51911
+   = note: see issue #51911 <https://github.com/rust-lang/rust/issues/51911> for more information
    = help: add `#![feature(const_raw_ptr_deref)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/error-codes/E0658.stderr
+++ b/src/test/ui/error-codes/E0658.stderr
@@ -6,7 +6,7 @@ LL | |     Bar(u64),
 LL | | }
    | |_^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/56071
+   = note: see issue #56071 <https://github.com/rust-lang/rust/issues/56071> for more information
    = help: add `#![feature(repr128)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/explore-issue-38412.stderr
+++ b/src/test/ui/explore-issue-38412.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'unstable_undeclared'
 LL |     let Record { a_stable_pub: _, a_unstable_declared_pub: _, a_unstable_undeclared_pub: _, .. } =
    |                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38412
+   = note: see issue #38412 <https://github.com/rust-lang/rust/issues/38412> for more information
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
@@ -13,7 +13,7 @@ error[E0658]: use of unstable library feature 'unstable_undeclared'
 LL |     r.a_unstable_undeclared_pub;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38412
+   = note: see issue #38412 <https://github.com/rust-lang/rust/issues/38412> for more information
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0616]: field `b_crate` of struct `pub_and_stability::Record` is private
@@ -40,7 +40,7 @@ error[E0658]: use of unstable library feature 'unstable_undeclared'
 LL |     t.2;
    |     ^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38412
+   = note: see issue #38412 <https://github.com/rust-lang/rust/issues/38412> for more information
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0616]: field `3` of struct `pub_and_stability::Tuple` is private
@@ -67,7 +67,7 @@ error[E0658]: use of unstable library feature 'unstable_undeclared'
 LL |     r.unstable_undeclared_trait_method();
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38412
+   = note: see issue #38412 <https://github.com/rust-lang/rust/issues/38412> for more information
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
@@ -76,7 +76,7 @@ error[E0658]: use of unstable library feature 'unstable_undeclared'
 LL |     r.unstable_undeclared();
    |       ^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38412
+   = note: see issue #38412 <https://github.com/rust-lang/rust/issues/38412> for more information
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0624]: method `pub_crate` is private
@@ -103,7 +103,7 @@ error[E0658]: use of unstable library feature 'unstable_undeclared'
 LL |     t.unstable_undeclared_trait_method();
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38412
+   = note: see issue #38412 <https://github.com/rust-lang/rust/issues/38412> for more information
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
@@ -112,7 +112,7 @@ error[E0658]: use of unstable library feature 'unstable_undeclared'
 LL |     t.unstable_undeclared();
    |       ^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38412
+   = note: see issue #38412 <https://github.com/rust-lang/rust/issues/38412> for more information
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0624]: method `pub_crate` is private

--- a/src/test/ui/feature-gate-optimize_attribute.stderr
+++ b/src/test/ui/feature-gate-optimize_attribute.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[optimize]` attribute is an experimental feature
 LL | #[optimize(size)]
    | ^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54882
+   = note: see issue #54882 <https://github.com/rust-lang/rust/issues/54882> for more information
    = help: add `#![feature(optimize_attribute)]` to the crate attributes to enable
 
 error[E0658]: the `#[optimize]` attribute is an experimental feature
@@ -13,7 +13,7 @@ error[E0658]: the `#[optimize]` attribute is an experimental feature
 LL | #[optimize(speed)]
    | ^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54882
+   = note: see issue #54882 <https://github.com/rust-lang/rust/issues/54882> for more information
    = help: add `#![feature(optimize_attribute)]` to the crate attributes to enable
 
 error[E0658]: the `#[optimize]` attribute is an experimental feature
@@ -22,7 +22,7 @@ error[E0658]: the `#[optimize]` attribute is an experimental feature
 LL | #[optimize(banana)]
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54882
+   = note: see issue #54882 <https://github.com/rust-lang/rust/issues/54882> for more information
    = help: add `#![feature(optimize_attribute)]` to the crate attributes to enable
 
 error[E0658]: the `#[optimize]` attribute is an experimental feature
@@ -31,7 +31,7 @@ error[E0658]: the `#[optimize]` attribute is an experimental feature
 LL | #[optimize(size)]
    | ^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54882
+   = note: see issue #54882 <https://github.com/rust-lang/rust/issues/54882> for more information
    = help: add `#![feature(optimize_attribute)]` to the crate attributes to enable
 
 error[E0658]: the `#[optimize]` attribute is an experimental feature
@@ -40,7 +40,7 @@ error[E0658]: the `#[optimize]` attribute is an experimental feature
 LL | #![optimize(speed)]
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54882
+   = note: see issue #54882 <https://github.com/rust-lang/rust/issues/54882> for more information
    = help: add `#![feature(optimize_attribute)]` to the crate attributes to enable
 
 error[E0722]: invalid argument

--- a/src/test/ui/feature-gate/feature-gate-c_variadic.stderr
+++ b/src/test/ui/feature-gate/feature-gate-c_variadic.stderr
@@ -4,7 +4,7 @@ error[E0658]: C-variadic functions are unstable
 LL | pub unsafe extern "C" fn test(_: i32, ap: ...) { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44930
+   = note: see issue #44930 <https://github.com/rust-lang/rust/issues/44930> for more information
    = help: add `#![feature(c_variadic)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gate/feature-gate-static-nobundle-2.stderr
+++ b/src/test/ui/feature-gate/feature-gate-static-nobundle-2.stderr
@@ -1,6 +1,6 @@
 error[E0658]: kind="static-nobundle" is unstable
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/37403
+   = note: see issue #37403 <https://github.com/rust-lang/rust/issues/37403> for more information
    = help: add `#![feature(static_nobundle)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gate/rustc-private.stderr
+++ b/src/test/ui/feature-gate/rustc-private.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'rustc_private': this crate is bei
 LL | extern crate libc;
    | ^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/27812
+   = note: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
    = help: add `#![feature(rustc_private)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-abi-msp430-interrupt.stderr
+++ b/src/test/ui/feature-gates/feature-gate-abi-msp430-interrupt.stderr
@@ -4,7 +4,7 @@ error[E0658]: msp430-interrupt ABI is experimental and subject to change
 LL | extern "msp430-interrupt" fn foo() {}
    |        ^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38487
+   = note: see issue #38487 <https://github.com/rust-lang/rust/issues/38487> for more information
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-abi.stderr
+++ b/src/test/ui/feature-gates/feature-gate-abi.stderr
@@ -12,7 +12,7 @@ error[E0658]: platform intrinsics are experimental and possibly buggy
 LL | extern "platform-intrinsic" fn f2() {}
    |        ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
@@ -29,7 +29,7 @@ error[E0658]: rust-call ABI is subject to change
 LL | extern "rust-call" fn f4() {}
    |        ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
@@ -38,7 +38,7 @@ error[E0658]: msp430-interrupt ABI is experimental and subject to change
 LL | extern "msp430-interrupt" fn f5() {}
    |        ^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38487
+   = note: see issue #38487 <https://github.com/rust-lang/rust/issues/38487> for more information
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change
@@ -47,7 +47,7 @@ error[E0658]: PTX ABIs are experimental and subject to change
 LL | extern "ptx-kernel" fn f6() {}
    |        ^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38788
+   = note: see issue #38788 <https://github.com/rust-lang/rust/issues/38788> for more information
    = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
@@ -56,7 +56,7 @@ error[E0658]: x86-interrupt ABI is experimental and subject to change
 LL | extern "x86-interrupt" fn f7() {}
    |        ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/40180
+   = note: see issue #40180 <https://github.com/rust-lang/rust/issues/40180> for more information
    = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
@@ -73,7 +73,7 @@ error[E0658]: amdgpu-kernel ABI is experimental and subject to change
 LL | extern "amdgpu-kernel" fn f9() {}
    |        ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51575
+   = note: see issue #51575 <https://github.com/rust-lang/rust/issues/51575> for more information
    = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
 
 error[E0658]: efiapi ABI is experimental and subject to change
@@ -82,7 +82,7 @@ error[E0658]: efiapi ABI is experimental and subject to change
 LL | extern "efiapi" fn f10() {}
    |        ^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/65815
+   = note: see issue #65815 <https://github.com/rust-lang/rust/issues/65815> for more information
    = help: add `#![feature(abi_efiapi)]` to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
@@ -99,7 +99,7 @@ error[E0658]: platform intrinsics are experimental and possibly buggy
 LL |     extern "platform-intrinsic" fn m2();
    |            ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
@@ -116,7 +116,7 @@ error[E0658]: rust-call ABI is subject to change
 LL |     extern "rust-call" fn m4();
    |            ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
@@ -125,7 +125,7 @@ error[E0658]: msp430-interrupt ABI is experimental and subject to change
 LL |     extern "msp430-interrupt" fn m5();
    |            ^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38487
+   = note: see issue #38487 <https://github.com/rust-lang/rust/issues/38487> for more information
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change
@@ -134,7 +134,7 @@ error[E0658]: PTX ABIs are experimental and subject to change
 LL |     extern "ptx-kernel" fn m6();
    |            ^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38788
+   = note: see issue #38788 <https://github.com/rust-lang/rust/issues/38788> for more information
    = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
@@ -143,7 +143,7 @@ error[E0658]: x86-interrupt ABI is experimental and subject to change
 LL |     extern "x86-interrupt" fn m7();
    |            ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/40180
+   = note: see issue #40180 <https://github.com/rust-lang/rust/issues/40180> for more information
    = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
@@ -160,7 +160,7 @@ error[E0658]: amdgpu-kernel ABI is experimental and subject to change
 LL |     extern "amdgpu-kernel" fn m9();
    |            ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51575
+   = note: see issue #51575 <https://github.com/rust-lang/rust/issues/51575> for more information
    = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
 
 error[E0658]: efiapi ABI is experimental and subject to change
@@ -169,7 +169,7 @@ error[E0658]: efiapi ABI is experimental and subject to change
 LL |     extern "efiapi" fn m10();
    |            ^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/65815
+   = note: see issue #65815 <https://github.com/rust-lang/rust/issues/65815> for more information
    = help: add `#![feature(abi_efiapi)]` to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
@@ -186,7 +186,7 @@ error[E0658]: rust-call ABI is subject to change
 LL |     extern "rust-call" fn dm4() {}
    |            ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
@@ -195,7 +195,7 @@ error[E0658]: msp430-interrupt ABI is experimental and subject to change
 LL |     extern "msp430-interrupt" fn dm5() {}
    |            ^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38487
+   = note: see issue #38487 <https://github.com/rust-lang/rust/issues/38487> for more information
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change
@@ -204,7 +204,7 @@ error[E0658]: PTX ABIs are experimental and subject to change
 LL |     extern "ptx-kernel" fn dm6() {}
    |            ^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38788
+   = note: see issue #38788 <https://github.com/rust-lang/rust/issues/38788> for more information
    = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
@@ -213,7 +213,7 @@ error[E0658]: x86-interrupt ABI is experimental and subject to change
 LL |     extern "x86-interrupt" fn dm7() {}
    |            ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/40180
+   = note: see issue #40180 <https://github.com/rust-lang/rust/issues/40180> for more information
    = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
@@ -230,7 +230,7 @@ error[E0658]: amdgpu-kernel ABI is experimental and subject to change
 LL |     extern "amdgpu-kernel" fn dm9() {}
    |            ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51575
+   = note: see issue #51575 <https://github.com/rust-lang/rust/issues/51575> for more information
    = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
 
 error[E0658]: efiapi ABI is experimental and subject to change
@@ -239,7 +239,7 @@ error[E0658]: efiapi ABI is experimental and subject to change
 LL |     extern "efiapi" fn dm10() {}
    |            ^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/65815
+   = note: see issue #65815 <https://github.com/rust-lang/rust/issues/65815> for more information
    = help: add `#![feature(abi_efiapi)]` to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
@@ -256,7 +256,7 @@ error[E0658]: platform intrinsics are experimental and possibly buggy
 LL |     extern "platform-intrinsic" fn m2() {}
    |            ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
@@ -273,7 +273,7 @@ error[E0658]: rust-call ABI is subject to change
 LL |     extern "rust-call" fn m4() {}
    |            ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
@@ -282,7 +282,7 @@ error[E0658]: msp430-interrupt ABI is experimental and subject to change
 LL |     extern "msp430-interrupt" fn m5() {}
    |            ^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38487
+   = note: see issue #38487 <https://github.com/rust-lang/rust/issues/38487> for more information
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change
@@ -291,7 +291,7 @@ error[E0658]: PTX ABIs are experimental and subject to change
 LL |     extern "ptx-kernel" fn m6() {}
    |            ^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38788
+   = note: see issue #38788 <https://github.com/rust-lang/rust/issues/38788> for more information
    = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
@@ -300,7 +300,7 @@ error[E0658]: x86-interrupt ABI is experimental and subject to change
 LL |     extern "x86-interrupt" fn m7() {}
    |            ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/40180
+   = note: see issue #40180 <https://github.com/rust-lang/rust/issues/40180> for more information
    = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
@@ -317,7 +317,7 @@ error[E0658]: amdgpu-kernel ABI is experimental and subject to change
 LL |     extern "amdgpu-kernel" fn m9() {}
    |            ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51575
+   = note: see issue #51575 <https://github.com/rust-lang/rust/issues/51575> for more information
    = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
 
 error[E0658]: efiapi ABI is experimental and subject to change
@@ -326,7 +326,7 @@ error[E0658]: efiapi ABI is experimental and subject to change
 LL |     extern "efiapi" fn m10() {}
    |            ^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/65815
+   = note: see issue #65815 <https://github.com/rust-lang/rust/issues/65815> for more information
    = help: add `#![feature(abi_efiapi)]` to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
@@ -343,7 +343,7 @@ error[E0658]: platform intrinsics are experimental and possibly buggy
 LL |     extern "platform-intrinsic" fn im2() {}
    |            ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
@@ -360,7 +360,7 @@ error[E0658]: rust-call ABI is subject to change
 LL |     extern "rust-call" fn im4() {}
    |            ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
@@ -369,7 +369,7 @@ error[E0658]: msp430-interrupt ABI is experimental and subject to change
 LL |     extern "msp430-interrupt" fn im5() {}
    |            ^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38487
+   = note: see issue #38487 <https://github.com/rust-lang/rust/issues/38487> for more information
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change
@@ -378,7 +378,7 @@ error[E0658]: PTX ABIs are experimental and subject to change
 LL |     extern "ptx-kernel" fn im6() {}
    |            ^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38788
+   = note: see issue #38788 <https://github.com/rust-lang/rust/issues/38788> for more information
    = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
@@ -387,7 +387,7 @@ error[E0658]: x86-interrupt ABI is experimental and subject to change
 LL |     extern "x86-interrupt" fn im7() {}
    |            ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/40180
+   = note: see issue #40180 <https://github.com/rust-lang/rust/issues/40180> for more information
    = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
@@ -404,7 +404,7 @@ error[E0658]: amdgpu-kernel ABI is experimental and subject to change
 LL |     extern "amdgpu-kernel" fn im9() {}
    |            ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51575
+   = note: see issue #51575 <https://github.com/rust-lang/rust/issues/51575> for more information
    = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
 
 error[E0658]: efiapi ABI is experimental and subject to change
@@ -413,7 +413,7 @@ error[E0658]: efiapi ABI is experimental and subject to change
 LL |     extern "efiapi" fn im10() {}
    |            ^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/65815
+   = note: see issue #65815 <https://github.com/rust-lang/rust/issues/65815> for more information
    = help: add `#![feature(abi_efiapi)]` to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
@@ -430,7 +430,7 @@ error[E0658]: platform intrinsics are experimental and possibly buggy
 LL | type A2 = extern "platform-intrinsic" fn();
    |                  ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
@@ -447,7 +447,7 @@ error[E0658]: rust-call ABI is subject to change
 LL | type A4 = extern "rust-call" fn();
    |                  ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
@@ -456,7 +456,7 @@ error[E0658]: msp430-interrupt ABI is experimental and subject to change
 LL | type A5 = extern "msp430-interrupt" fn();
    |                  ^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38487
+   = note: see issue #38487 <https://github.com/rust-lang/rust/issues/38487> for more information
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change
@@ -465,7 +465,7 @@ error[E0658]: PTX ABIs are experimental and subject to change
 LL | type A6 = extern "ptx-kernel" fn ();
    |                  ^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38788
+   = note: see issue #38788 <https://github.com/rust-lang/rust/issues/38788> for more information
    = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
@@ -474,7 +474,7 @@ error[E0658]: x86-interrupt ABI is experimental and subject to change
 LL | type A7 = extern "x86-interrupt" fn();
    |                  ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/40180
+   = note: see issue #40180 <https://github.com/rust-lang/rust/issues/40180> for more information
    = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
@@ -491,7 +491,7 @@ error[E0658]: amdgpu-kernel ABI is experimental and subject to change
 LL | type A9 = extern "amdgpu-kernel" fn();
    |                  ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51575
+   = note: see issue #51575 <https://github.com/rust-lang/rust/issues/51575> for more information
    = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
 
 error[E0658]: efiapi ABI is experimental and subject to change
@@ -500,7 +500,7 @@ error[E0658]: efiapi ABI is experimental and subject to change
 LL | type A10 = extern "efiapi" fn();
    |                   ^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/65815
+   = note: see issue #65815 <https://github.com/rust-lang/rust/issues/65815> for more information
    = help: add `#![feature(abi_efiapi)]` to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
@@ -517,7 +517,7 @@ error[E0658]: platform intrinsics are experimental and possibly buggy
 LL | extern "platform-intrinsic" {}
    |        ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
@@ -534,7 +534,7 @@ error[E0658]: rust-call ABI is subject to change
 LL | extern "rust-call" {}
    |        ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
@@ -543,7 +543,7 @@ error[E0658]: msp430-interrupt ABI is experimental and subject to change
 LL | extern "msp430-interrupt" {}
    |        ^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38487
+   = note: see issue #38487 <https://github.com/rust-lang/rust/issues/38487> for more information
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change
@@ -552,7 +552,7 @@ error[E0658]: PTX ABIs are experimental and subject to change
 LL | extern "ptx-kernel" {}
    |        ^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/38788
+   = note: see issue #38788 <https://github.com/rust-lang/rust/issues/38788> for more information
    = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
@@ -561,7 +561,7 @@ error[E0658]: x86-interrupt ABI is experimental and subject to change
 LL | extern "x86-interrupt" {}
    |        ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/40180
+   = note: see issue #40180 <https://github.com/rust-lang/rust/issues/40180> for more information
    = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
@@ -578,7 +578,7 @@ error[E0658]: amdgpu-kernel ABI is experimental and subject to change
 LL | extern "amdgpu-kernel" {}
    |        ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51575
+   = note: see issue #51575 <https://github.com/rust-lang/rust/issues/51575> for more information
    = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
 
 error[E0658]: efiapi ABI is experimental and subject to change
@@ -587,7 +587,7 @@ error[E0658]: efiapi ABI is experimental and subject to change
 LL | extern "efiapi" {}
    |        ^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/65815
+   = note: see issue #65815 <https://github.com/rust-lang/rust/issues/65815> for more information
    = help: add `#![feature(abi_efiapi)]` to the crate attributes to enable
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block

--- a/src/test/ui/feature-gates/feature-gate-alloc-error-handler.stderr
+++ b/src/test/ui/feature-gates/feature-gate-alloc-error-handler.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[alloc_error_handler]` attribute is an experimental feature
 LL | #[alloc_error_handler]
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51540
+   = note: see issue #51540 <https://github.com/rust-lang/rust/issues/51540> for more information
    = help: add `#![feature(alloc_error_handler)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-allow_fail.stderr
+++ b/src/test/ui/feature-gates/feature-gate-allow_fail.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[allow_fail]` attribute is an experimental feature
 LL | #[allow_fail]
    | ^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/46488
+   = note: see issue #46488 <https://github.com/rust-lang/rust/issues/46488> for more information
    = help: add `#![feature(allow_fail)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-arbitrary-self-types.stderr
+++ b/src/test/ui/feature-gates/feature-gate-arbitrary-self-types.stderr
@@ -4,7 +4,7 @@ error[E0658]: `Ptr<Self>` cannot be used as the type of `self` without the `arbi
 LL |     fn foo(self: Ptr<Self>);
    |                  ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44874
+   = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
    = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
@@ -14,7 +14,7 @@ error[E0658]: `Ptr<Bar>` cannot be used as the type of `self` without the `arbit
 LL |     fn foo(self: Ptr<Self>) {}
    |                  ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44874
+   = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
    = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
@@ -24,7 +24,7 @@ error[E0658]: `std::boxed::Box<Ptr<Bar>>` cannot be used as the type of `self` w
 LL |     fn bar(self: Box<Ptr<Self>>) {}
    |                  ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44874
+   = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
    = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 

--- a/src/test/ui/feature-gates/feature-gate-arbitrary_self_types-raw-pointer.stderr
+++ b/src/test/ui/feature-gates/feature-gate-arbitrary_self_types-raw-pointer.stderr
@@ -4,7 +4,7 @@ error[E0658]: `*const Self` cannot be used as the type of `self` without the `ar
 LL |     fn bar(self: *const Self);
    |                  ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44874
+   = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
    = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
@@ -14,7 +14,7 @@ error[E0658]: `*const Foo` cannot be used as the type of `self` without the `arb
 LL |     fn foo(self: *const Self) {}
    |                  ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44874
+   = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
    = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
@@ -24,7 +24,7 @@ error[E0658]: `*const ()` cannot be used as the type of `self` without the `arbi
 LL |     fn bar(self: *const Self) {}
    |                  ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44874
+   = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
    = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 

--- a/src/test/ui/feature-gates/feature-gate-asm.stderr
+++ b/src/test/ui/feature-gates/feature-gate-asm.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'asm': inline assembly is not stab
 LL |         asm!("");
    |         ^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29722
+   = note: see issue #29722 <https://github.com/rust-lang/rust/issues/29722> for more information
    = help: add `#![feature(asm)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-asm2.stderr
+++ b/src/test/ui/feature-gates/feature-gate-asm2.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'asm': inline assembly is not stab
 LL |         println!("{:?}", asm!(""));
    |                          ^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29722
+   = note: see issue #29722 <https://github.com/rust-lang/rust/issues/29722> for more information
    = help: add `#![feature(asm)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-assoc-type-defaults.stderr
+++ b/src/test/ui/feature-gates/feature-gate-assoc-type-defaults.stderr
@@ -4,7 +4,7 @@ error[E0658]: associated type defaults are unstable
 LL |     type Bar = u8;
    |     ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29661
+   = note: see issue #29661 <https://github.com/rust-lang/rust/issues/29661> for more information
    = help: add `#![feature(associated_type_defaults)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-associated_type_bounds.stderr
+++ b/src/test/ui/feature-gates/feature-gate-associated_type_bounds.stderr
@@ -4,7 +4,7 @@ error[E0658]: associated type bounds are unstable
 LL |     type A: Iterator<Item: Copy>;
    |                      ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52662
+   = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
@@ -13,7 +13,7 @@ error[E0658]: associated type bounds are unstable
 LL |     type B: Iterator<Item: 'static>;
    |                      ^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52662
+   = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
@@ -22,7 +22,7 @@ error[E0658]: associated type bounds are unstable
 LL | struct _St1<T: Tr1<As1: Tr2>> {
    |                    ^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52662
+   = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
@@ -31,7 +31,7 @@ error[E0658]: associated type bounds are unstable
 LL | enum _En1<T: Tr1<As1: Tr2>> {
    |                  ^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52662
+   = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
@@ -40,7 +40,7 @@ error[E0658]: associated type bounds are unstable
 LL | union _Un1<T: Tr1<As1: Tr2>> {
    |                   ^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52662
+   = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
@@ -49,7 +49,7 @@ error[E0658]: associated type bounds are unstable
 LL | type _TaWhere1<T> where T: Iterator<Item: Copy> = T;
    |                                     ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52662
+   = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
@@ -58,7 +58,7 @@ error[E0658]: associated type bounds are unstable
 LL | fn _apit(_: impl Tr1<As1: Copy>) {}
    |                      ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52662
+   = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
@@ -67,7 +67,7 @@ error[E0658]: associated type bounds are unstable
 LL | fn _apit_dyn(_: &dyn Tr1<As1: Copy>) {}
    |                          ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52662
+   = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
@@ -76,7 +76,7 @@ error[E0658]: associated type bounds are unstable
 LL | fn _rpit() -> impl Tr1<As1: Copy> { S1 }
    |                        ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52662
+   = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
@@ -85,7 +85,7 @@ error[E0658]: associated type bounds are unstable
 LL | fn _rpit_dyn() -> Box<dyn Tr1<As1: Copy>> { Box::new(S1) }
    |                               ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52662
+   = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
@@ -94,7 +94,7 @@ error[E0658]: associated type bounds are unstable
 LL | const _cdef: impl Tr1<As1: Copy> = S1;
    |                       ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52662
+   = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
@@ -103,7 +103,7 @@ error[E0658]: associated type bounds are unstable
 LL | static _sdef: impl Tr1<As1: Copy> = S1;
    |                        ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52662
+   = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
@@ -112,7 +112,7 @@ error[E0658]: associated type bounds are unstable
 LL |     let _: impl Tr1<As1: Copy> = S1;
    |                     ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52662
+   = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0562]: `impl Trait` not allowed outside of function and inherent method return types

--- a/src/test/ui/feature-gates/feature-gate-box-expr.stderr
+++ b/src/test/ui/feature-gates/feature-gate-box-expr.stderr
@@ -4,7 +4,7 @@ error[E0658]: box expression syntax is experimental; you can call `Box::new` ins
 LL |     let x = box 'c';
    |             ^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49733
+   = note: see issue #49733 <https://github.com/rust-lang/rust/issues/49733> for more information
    = help: add `#![feature(box_syntax)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-box_patterns.stderr
+++ b/src/test/ui/feature-gates/feature-gate-box_patterns.stderr
@@ -4,7 +4,7 @@ error[E0658]: box pattern syntax is experimental
 LL |     let box x = Box::new('c');
    |         ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29641
+   = note: see issue #29641 <https://github.com/rust-lang/rust/issues/29641> for more information
    = help: add `#![feature(box_patterns)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-box_syntax.stderr
+++ b/src/test/ui/feature-gates/feature-gate-box_syntax.stderr
@@ -4,7 +4,7 @@ error[E0658]: box expression syntax is experimental; you can call `Box::new` ins
 LL |     let x = box 3;
    |             ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49733
+   = note: see issue #49733 <https://github.com/rust-lang/rust/issues/49733> for more information
    = help: add `#![feature(box_syntax)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-cfg-target-has-atomic.stderr
+++ b/src/test/ui/feature-gates/feature-gate-cfg-target-has-atomic.stderr
@@ -4,7 +4,7 @@ error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
 LL | #[cfg(target_has_atomic = "8")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32976
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
@@ -13,7 +13,7 @@ error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
 LL | #[cfg(target_has_atomic = "8")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32976
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
@@ -22,7 +22,7 @@ error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
 LL | #[cfg(target_has_atomic = "16")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32976
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
@@ -31,7 +31,7 @@ error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
 LL | #[cfg(target_has_atomic = "16")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32976
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
@@ -40,7 +40,7 @@ error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
 LL | #[cfg(target_has_atomic = "32")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32976
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
@@ -49,7 +49,7 @@ error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
 LL | #[cfg(target_has_atomic = "32")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32976
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
@@ -58,7 +58,7 @@ error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
 LL | #[cfg(target_has_atomic = "64")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32976
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
@@ -67,7 +67,7 @@ error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
 LL | #[cfg(target_has_atomic = "64")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32976
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
@@ -76,7 +76,7 @@ error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
 LL | #[cfg(target_has_atomic = "128")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32976
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
@@ -85,7 +85,7 @@ error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
 LL | #[cfg(target_has_atomic = "128")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32976
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
@@ -94,7 +94,7 @@ error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
 LL | #[cfg(target_has_atomic = "ptr")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32976
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
@@ -103,7 +103,7 @@ error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
 LL | #[cfg(target_has_atomic = "ptr")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32976
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
@@ -112,7 +112,7 @@ error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
 LL |     cfg!(target_has_atomic = "8");
    |          ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32976
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
@@ -121,7 +121,7 @@ error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
 LL |     cfg!(target_has_atomic = "16");
    |          ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32976
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
@@ -130,7 +130,7 @@ error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
 LL |     cfg!(target_has_atomic = "32");
    |          ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32976
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
@@ -139,7 +139,7 @@ error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
 LL |     cfg!(target_has_atomic = "64");
    |          ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32976
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
@@ -148,7 +148,7 @@ error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
 LL |     cfg!(target_has_atomic = "128");
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32976
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
@@ -157,7 +157,7 @@ error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
 LL |     cfg!(target_has_atomic = "ptr");
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32976
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error: aborting due to 18 previous errors

--- a/src/test/ui/feature-gates/feature-gate-cfg-target-thread-local.stderr
+++ b/src/test/ui/feature-gates/feature-gate-cfg-target-thread-local.stderr
@@ -4,7 +4,7 @@ error[E0658]: `cfg(target_thread_local)` is experimental and subject to change
 LL |     #[cfg_attr(target_thread_local, thread_local)]
    |                ^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29594
+   = note: see issue #29594 <https://github.com/rust-lang/rust/issues/29594> for more information
    = help: add `#![feature(cfg_target_thread_local)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-cfg_sanitize.stderr
+++ b/src/test/ui/feature-gates/feature-gate-cfg_sanitize.stderr
@@ -4,7 +4,7 @@ error[E0658]: `cfg(sanitize)` is experimental and subject to change
 LL | #[cfg(not(sanitize = "thread"))]
    |           ^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/39699
+   = note: see issue #39699 <https://github.com/rust-lang/rust/issues/39699> for more information
    = help: add `#![feature(cfg_sanitize)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-concat_idents.stderr
+++ b/src/test/ui/feature-gates/feature-gate-concat_idents.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'concat_idents': `concat_idents` i
 LL |     let a = concat_idents!(X, Y_1);
    |             ^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29599
+   = note: see issue #29599 <https://github.com/rust-lang/rust/issues/29599> for more information
    = help: add `#![feature(concat_idents)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'concat_idents': `concat_idents` is not stable enough for use and is subject to change
@@ -13,7 +13,7 @@ error[E0658]: use of unstable library feature 'concat_idents': `concat_idents` i
 LL |     let b = concat_idents!(X, Y_2);
    |             ^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29599
+   = note: see issue #29599 <https://github.com/rust-lang/rust/issues/29599> for more information
    = help: add `#![feature(concat_idents)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/feature-gates/feature-gate-concat_idents2.stderr
+++ b/src/test/ui/feature-gates/feature-gate-concat_idents2.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'concat_idents': `concat_idents` i
 LL |     concat_idents!(a, b);
    |     ^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29599
+   = note: see issue #29599 <https://github.com/rust-lang/rust/issues/29599> for more information
    = help: add `#![feature(concat_idents)]` to the crate attributes to enable
 
 error[E0425]: cannot find value `ab` in this scope

--- a/src/test/ui/feature-gates/feature-gate-concat_idents3.stderr
+++ b/src/test/ui/feature-gates/feature-gate-concat_idents3.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'concat_idents': `concat_idents` i
 LL |     assert_eq!(10, concat_idents!(X, Y_1));
    |                    ^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29599
+   = note: see issue #29599 <https://github.com/rust-lang/rust/issues/29599> for more information
    = help: add `#![feature(concat_idents)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'concat_idents': `concat_idents` is not stable enough for use and is subject to change
@@ -13,7 +13,7 @@ error[E0658]: use of unstable library feature 'concat_idents': `concat_idents` i
 LL |     assert_eq!(20, concat_idents!(X, Y_2));
    |                    ^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29599
+   = note: see issue #29599 <https://github.com/rust-lang/rust/issues/29599> for more information
    = help: add `#![feature(concat_idents)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/feature-gates/feature-gate-const_fn.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_fn.stderr
@@ -22,7 +22,7 @@ error[E0658]: const fn is unstable
 LL |     const fn foo() -> u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0658]: const fn is unstable
@@ -31,7 +31,7 @@ error[E0658]: const fn is unstable
 LL |     const fn bar() -> u32 { 0 }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 5 previous errors

--- a/src/test/ui/feature-gates/feature-gate-const_generics-ptr.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_generics-ptr.stderr
@@ -4,7 +4,7 @@ error[E0658]: const generics are unstable
 LL | struct ConstFn<const F: fn()>;
    |                      ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44580
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
    = help: add `#![feature(const_generics)]` to the crate attributes to enable
 
 error[E0658]: const generics are unstable
@@ -13,7 +13,7 @@ error[E0658]: const generics are unstable
 LL | struct ConstPtr<const P: *const u32>;
    |                       ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44580
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
    = help: add `#![feature(const_generics)]` to the crate attributes to enable
 
 error[E0658]: using function pointers as const generic parameters is unstable
@@ -22,7 +22,7 @@ error[E0658]: using function pointers as const generic parameters is unstable
 LL | struct ConstFn<const F: fn()>;
    |                         ^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53020
+   = note: see issue #53020 <https://github.com/rust-lang/rust/issues/53020> for more information
    = help: add `#![feature(const_compare_raw_pointers)]` to the crate attributes to enable
 
 error[E0658]: using raw pointers as const generic parameters is unstable
@@ -31,7 +31,7 @@ error[E0658]: using raw pointers as const generic parameters is unstable
 LL | struct ConstPtr<const P: *const u32>;
    |                          ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53020
+   = note: see issue #53020 <https://github.com/rust-lang/rust/issues/53020> for more information
    = help: add `#![feature(const_compare_raw_pointers)]` to the crate attributes to enable
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/feature-gates/feature-gate-const_generics.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_generics.stderr
@@ -4,7 +4,7 @@ error[E0658]: const generics are unstable
 LL | fn foo<const X: ()>() {}
    |              ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44580
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
    = help: add `#![feature(const_generics)]` to the crate attributes to enable
 
 error[E0658]: const generics are unstable
@@ -13,7 +13,7 @@ error[E0658]: const generics are unstable
 LL | struct Foo<const X: usize>([(); X]);
    |                  ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44580
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
    = help: add `#![feature(const_generics)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/feature-gates/feature-gate-const_in_array_repeat_expressions.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_in_array_repeat_expressions.stderr
@@ -7,7 +7,7 @@ LL |     let arr: [Option<String>; 2] = [None::<String>; 2];
    = help: the following implementations were found:
              <std::option::Option<T> as std::marker::Copy>
    = note: the `Copy` trait is required because the repeated element will be copied
-   = note: this array initializer can be evaluated at compile-time, for more information, see issue https://github.com/rust-lang/rust/issues/49147
+   = note: this array initializer can be evaluated at compile-time, see issue #48147 <https://github.com/rust-lang/rust/issues/49147> for more information
    = help: add `#![feature(const_in_array_repeat_expressions)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `std::option::Option<std::string::String>: std::marker::Copy` is not satisfied

--- a/src/test/ui/feature-gates/feature-gate-crate_visibility_modifier.stderr
+++ b/src/test/ui/feature-gates/feature-gate-crate_visibility_modifier.stderr
@@ -4,7 +4,7 @@ error[E0658]: `crate` visibility modifier is experimental
 LL | crate struct Bender {
    | ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53120
+   = note: see issue #53120 <https://github.com/rust-lang/rust/issues/53120> for more information
    = help: add `#![feature(crate_visibility_modifier)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-custom_test_frameworks.stderr
+++ b/src/test/ui/feature-gates/feature-gate-custom_test_frameworks.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'custom_test_frameworks': custom t
 LL | #[test_case]
    |   ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/50297
+   = note: see issue #50297 <https://github.com/rust-lang/rust/issues/50297> for more information
    = help: add `#![feature(custom_test_frameworks)]` to the crate attributes to enable
 
 error[E0658]: custom test frameworks are an unstable feature
@@ -13,7 +13,7 @@ error[E0658]: custom test frameworks are an unstable feature
 LL | #![test_runner(main)]
    | ^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/50297
+   = note: see issue #50297 <https://github.com/rust-lang/rust/issues/50297> for more information
    = help: add `#![feature(custom_test_frameworks)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/feature-gates/feature-gate-decl_macro.stderr
+++ b/src/test/ui/feature-gates/feature-gate-decl_macro.stderr
@@ -4,7 +4,7 @@ error[E0658]: `macro` is experimental
 LL | macro m() {}
    | ^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/39412
+   = note: see issue #39412 <https://github.com/rust-lang/rust/issues/39412> for more information
    = help: add `#![feature(decl_macro)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-doc_alias.stderr
+++ b/src/test/ui/feature-gates/feature-gate-doc_alias.stderr
@@ -4,7 +4,7 @@ error[E0658]: `#[doc(alias)]` is experimental
 LL | #[doc(alias = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/50146
+   = note: see issue #50146 <https://github.com/rust-lang/rust/issues/50146> for more information
    = help: add `#![feature(doc_alias)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-doc_cfg.stderr
+++ b/src/test/ui/feature-gates/feature-gate-doc_cfg.stderr
@@ -4,7 +4,7 @@ error[E0658]: `#[doc(cfg)]` is experimental
 LL | #[doc(cfg(unix))]
    | ^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/43781
+   = note: see issue #43781 <https://github.com/rust-lang/rust/issues/43781> for more information
    = help: add `#![feature(doc_cfg)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-doc_keyword.stderr
+++ b/src/test/ui/feature-gates/feature-gate-doc_keyword.stderr
@@ -4,7 +4,7 @@ error[E0658]: `#[doc(keyword)]` is experimental
 LL | #[doc(keyword = "match")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51315
+   = note: see issue #51315 <https://github.com/rust-lang/rust/issues/51315> for more information
    = help: add `#![feature(doc_keyword)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-doc_masked.stderr
+++ b/src/test/ui/feature-gates/feature-gate-doc_masked.stderr
@@ -4,7 +4,7 @@ error[E0658]: `#[doc(masked)]` is experimental
 LL | #[doc(masked)]
    | ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44027
+   = note: see issue #44027 <https://github.com/rust-lang/rust/issues/44027> for more information
    = help: add `#![feature(doc_masked)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-doc_spotlight.stderr
+++ b/src/test/ui/feature-gates/feature-gate-doc_spotlight.stderr
@@ -4,7 +4,7 @@ error[E0658]: `#[doc(spotlight)]` is experimental
 LL | #[doc(spotlight)]
    | ^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/45040
+   = note: see issue #45040 <https://github.com/rust-lang/rust/issues/45040> for more information
    = help: add `#![feature(doc_spotlight)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-exclusive-range-pattern.stderr
+++ b/src/test/ui/feature-gates/feature-gate-exclusive-range-pattern.stderr
@@ -4,7 +4,7 @@ error[E0658]: exclusive range pattern syntax is experimental
 LL |         0 .. 3 => {}
    |         ^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/37854
+   = note: see issue #37854 <https://github.com/rust-lang/rust/issues/37854> for more information
    = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-extern_types.stderr
+++ b/src/test/ui/feature-gates/feature-gate-extern_types.stderr
@@ -4,7 +4,7 @@ error[E0658]: extern types are experimental
 LL |     type T;
    |     ^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/43467
+   = note: see issue #43467 <https://github.com/rust-lang/rust/issues/43467> for more information
    = help: add `#![feature(extern_types)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-external_doc.stderr
+++ b/src/test/ui/feature-gates/feature-gate-external_doc.stderr
@@ -4,7 +4,7 @@ error[E0658]: `#[doc(include)]` is experimental
 LL | #[doc(include="asdf.md")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44732
+   = note: see issue #44732 <https://github.com/rust-lang/rust/issues/44732> for more information
    = help: add `#![feature(external_doc)]` to the crate attributes to enable
 
 error[E0658]: `#[doc(include)]` is experimental
@@ -13,7 +13,7 @@ error[E0658]: `#[doc(include)]` is experimental
 LL | #[doc(include="asdf.md")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44732
+   = note: see issue #44732 <https://github.com/rust-lang/rust/issues/44732> for more information
    = help: add `#![feature(external_doc)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/feature-gates/feature-gate-ffi_returns_twice.stderr
+++ b/src/test/ui/feature-gates/feature-gate-ffi_returns_twice.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[ffi_returns_twice]` attribute is an experimental feature
 LL |     #[ffi_returns_twice]
    |     ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/58314
+   = note: see issue #58314 <https://github.com/rust-lang/rust/issues/58314> for more information
    = help: add `#![feature(ffi_returns_twice)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-fundamental.stderr
+++ b/src/test/ui/feature-gates/feature-gate-fundamental.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[fundamental]` attribute is an experimental feature
 LL | #[fundamental]
    | ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29635
+   = note: see issue #29635 <https://github.com/rust-lang/rust/issues/29635> for more information
    = help: add `#![feature(fundamental)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-generators.stderr
+++ b/src/test/ui/feature-gates/feature-gate-generators.stderr
@@ -4,7 +4,7 @@ error[E0658]: yield syntax is experimental
 LL |     yield true;
    |     ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/43122
+   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
    = help: add `#![feature(generators)]` to the crate attributes to enable
 
 error[E0658]: yield syntax is experimental
@@ -13,7 +13,7 @@ error[E0658]: yield syntax is experimental
 LL |     yield;
    |     ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/43122
+   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
    = help: add `#![feature(generators)]` to the crate attributes to enable
 
 error[E0658]: yield syntax is experimental
@@ -22,7 +22,7 @@ error[E0658]: yield syntax is experimental
 LL |     yield 0;
    |     ^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/43122
+   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
    = help: add `#![feature(generators)]` to the crate attributes to enable
 
 error[E0627]: yield expression outside of generator literal

--- a/src/test/ui/feature-gates/feature-gate-generic_associated_types.stderr
+++ b/src/test/ui/feature-gates/feature-gate-generic_associated_types.stderr
@@ -4,7 +4,7 @@ error[E0658]: generic associated types are unstable
 LL |     type Pointer<T>: Deref<Target = T>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
    = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable
 
 error[E0658]: generic associated types are unstable
@@ -13,7 +13,7 @@ error[E0658]: generic associated types are unstable
 LL |     type Pointer2<T>: Deref<Target = T> where T: Clone, U: Clone;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
    = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable
 
 error[E0658]: where clauses on associated types are unstable
@@ -22,7 +22,7 @@ error[E0658]: where clauses on associated types are unstable
 LL |     type Pointer2<T>: Deref<Target = T> where T: Clone, U: Clone;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
    = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable
 
 error[E0658]: generic associated types are unstable
@@ -31,7 +31,7 @@ error[E0658]: generic associated types are unstable
 LL |     type Pointer<Usize> = Box<Usize>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
    = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable
 
 error[E0658]: generic associated types are unstable
@@ -40,7 +40,7 @@ error[E0658]: generic associated types are unstable
 LL |     type Pointer2<U32> = Box<U32>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
    = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable
 
 error[E0658]: where clauses on associated types are unstable
@@ -49,7 +49,7 @@ error[E0658]: where clauses on associated types are unstable
 LL |     type Assoc where Self: Sized;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
    = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable
 
 error[E0658]: where clauses on associated types are unstable
@@ -58,7 +58,7 @@ error[E0658]: where clauses on associated types are unstable
 LL |     type Assoc where Self: Sized = Foo;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
    = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable
 
 error: type-generic associated types are not yet implemented
@@ -67,7 +67,7 @@ error: type-generic associated types are not yet implemented
 LL |     type Pointer<T>: Deref<Target = T>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: for more information, see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
 
 error: type-generic associated types are not yet implemented
   --> $DIR/feature-gate-generic_associated_types.rs:7:5
@@ -75,7 +75,7 @@ error: type-generic associated types are not yet implemented
 LL |     type Pointer2<T>: Deref<Target = T> where T: Clone, U: Clone;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: for more information, see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-global_asm.stderr
+++ b/src/test/ui/feature-gates/feature-gate-global_asm.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'global_asm': `global_asm!` is not
 LL | global_asm!("");
    | ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/35119
+   = note: see issue #35119 <https://github.com/rust-lang/rust/issues/35119> for more information
    = help: add `#![feature(global_asm)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-is_sorted.stderr
+++ b/src/test/ui/feature-gates/feature-gate-is_sorted.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'is_sorted': new API
 LL |     assert!([1, 2, 2, 9].iter().is_sorted());
    |                                 ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53485
+   = note: see issue #53485 <https://github.com/rust-lang/rust/issues/53485> for more information
    = help: add `#![feature(is_sorted)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'is_sorted': new API
@@ -13,7 +13,7 @@ error[E0658]: use of unstable library feature 'is_sorted': new API
 LL |     assert!(![-2i32, -1, 0, 3].iter().is_sorted_by_key(|n| n.abs()));
    |                                       ^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53485
+   = note: see issue #53485 <https://github.com/rust-lang/rust/issues/53485> for more information
    = help: add `#![feature(is_sorted)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'is_sorted': new API
@@ -22,7 +22,7 @@ error[E0658]: use of unstable library feature 'is_sorted': new API
 LL |     assert!([1, 2, 2, 9].is_sorted());
    |                          ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53485
+   = note: see issue #53485 <https://github.com/rust-lang/rust/issues/53485> for more information
    = help: add `#![feature(is_sorted)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'is_sorted': new API
@@ -31,7 +31,7 @@ error[E0658]: use of unstable library feature 'is_sorted': new API
 LL |     assert!(![-2i32, -1, 0, 3].is_sorted_by_key(|n| n.abs()));
    |                                ^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53485
+   = note: see issue #53485 <https://github.com/rust-lang/rust/issues/53485> for more information
    = help: add `#![feature(is_sorted)]` to the crate attributes to enable
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/feature-gates/feature-gate-label_break_value.stderr
+++ b/src/test/ui/feature-gates/feature-gate-label_break_value.stderr
@@ -4,7 +4,7 @@ error[E0658]: labels on blocks are unstable
 LL |     'a: {
    |     ^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/48594
+   = note: see issue #48594 <https://github.com/rust-lang/rust/issues/48594> for more information
    = help: add `#![feature(label_break_value)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-link_args.stderr
+++ b/src/test/ui/feature-gates/feature-gate-link_args.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `link_args` attribute is experimental and not portable across 
 LL | #[link_args = "-l expected_use_case"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29596
+   = note: see issue #29596 <https://github.com/rust-lang/rust/issues/29596> for more information
    = help: add `#![feature(link_args)]` to the crate attributes to enable
 
 error[E0658]: the `link_args` attribute is experimental and not portable across platforms, it is recommended to use `#[link(name = "foo")] instead
@@ -13,7 +13,7 @@ error[E0658]: the `link_args` attribute is experimental and not portable across 
 LL | #[link_args = "-l unexected_use_on_non_extern_item"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29596
+   = note: see issue #29596 <https://github.com/rust-lang/rust/issues/29596> for more information
    = help: add `#![feature(link_args)]` to the crate attributes to enable
 
 error[E0658]: the `link_args` attribute is experimental and not portable across platforms, it is recommended to use `#[link(name = "foo")] instead
@@ -22,7 +22,7 @@ error[E0658]: the `link_args` attribute is experimental and not portable across 
 LL | #![link_args = "-l unexpected_use_as_inner_attr_on_mod"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29596
+   = note: see issue #29596 <https://github.com/rust-lang/rust/issues/29596> for more information
    = help: add `#![feature(link_args)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/feature-gates/feature-gate-link_cfg.stderr
+++ b/src/test/ui/feature-gates/feature-gate-link_cfg.stderr
@@ -4,7 +4,7 @@ error[E0658]: is unstable
 LL | #[link(name = "foo", cfg(foo))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/37406
+   = note: see issue #37406 <https://github.com/rust-lang/rust/issues/37406> for more information
    = help: add `#![feature(link_cfg)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-link_llvm_intrinsics.stderr
+++ b/src/test/ui/feature-gates/feature-gate-link_llvm_intrinsics.stderr
@@ -4,7 +4,7 @@ error[E0658]: linking to LLVM intrinsics is experimental
 LL |     fn sqrt(x: f32) -> f32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29602
+   = note: see issue #29602 <https://github.com/rust-lang/rust/issues/29602> for more information
    = help: add `#![feature(link_llvm_intrinsics)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-linkage.stderr
+++ b/src/test/ui/feature-gates/feature-gate-linkage.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `linkage` attribute is experimental and not portable across pl
 LL |     #[linkage = "extern_weak"] static foo: isize;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29603
+   = note: see issue #29603 <https://github.com/rust-lang/rust/issues/29603> for more information
    = help: add `#![feature(linkage)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-lint-reasons.stderr
+++ b/src/test/ui/feature-gates/feature-gate-lint-reasons.stderr
@@ -4,7 +4,7 @@ error[E0658]: lint reasons are experimental
 LL | #![warn(nonstandard_style, reason = "the standard should be respected")]
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54503
+   = note: see issue #54503 <https://github.com/rust-lang/rust/issues/54503> for more information
    = help: add `#![feature(lint_reasons)]` to the crate attributes to enable
 
 error[E0658]: lint reasons are experimental
@@ -13,7 +13,7 @@ error[E0658]: lint reasons are experimental
 LL | #![warn(nonstandard_style, reason = "the standard should be respected")]
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54503
+   = note: see issue #54503 <https://github.com/rust-lang/rust/issues/54503> for more information
    = help: add `#![feature(lint_reasons)]` to the crate attributes to enable
 
 error[E0658]: lint reasons are experimental
@@ -22,7 +22,7 @@ error[E0658]: lint reasons are experimental
 LL | #![warn(nonstandard_style, reason = "the standard should be respected")]
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54503
+   = note: see issue #54503 <https://github.com/rust-lang/rust/issues/54503> for more information
    = help: add `#![feature(lint_reasons)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/feature-gates/feature-gate-log_syntax.stderr
+++ b/src/test/ui/feature-gates/feature-gate-log_syntax.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'log_syntax': `log_syntax!` is not
 LL |     log_syntax!()
    |     ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29598
+   = note: see issue #29598 <https://github.com/rust-lang/rust/issues/29598> for more information
    = help: add `#![feature(log_syntax)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-log_syntax2.stderr
+++ b/src/test/ui/feature-gates/feature-gate-log_syntax2.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'log_syntax': `log_syntax!` is not
 LL |     println!("{:?}", log_syntax!());
    |                      ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29598
+   = note: see issue #29598 <https://github.com/rust-lang/rust/issues/29598> for more information
    = help: add `#![feature(log_syntax)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-main.stderr
+++ b/src/test/ui/feature-gates/feature-gate-main.stderr
@@ -4,7 +4,7 @@ error[E0658]: declaration of a non-standard `#[main]` function may change over t
 LL | fn foo() {}
    | ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29634
+   = note: see issue #29634 <https://github.com/rust-lang/rust/issues/29634> for more information
    = help: add `#![feature(main)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-marker_trait_attr.stderr
+++ b/src/test/ui/feature-gates/feature-gate-marker_trait_attr.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[marker]` attribute is an experimental feature
 LL | #[marker] trait ExplicitMarker {}
    | ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29864
+   = note: see issue #29864 <https://github.com/rust-lang/rust/issues/29864> for more information
    = help: add `#![feature(marker_trait_attr)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-may-dangle.stderr
+++ b/src/test/ui/feature-gates/feature-gate-may-dangle.stderr
@@ -4,7 +4,7 @@ error[E0658]: `may_dangle` has unstable semantics and may be removed in the futu
 LL | unsafe impl<#[may_dangle] A> Drop for Pt<A> {
    |             ^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/34761
+   = note: see issue #34761 <https://github.com/rust-lang/rust/issues/34761> for more information
    = help: add `#![feature(dropck_eyepatch)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-min_const_fn.stderr
+++ b/src/test/ui/feature-gates/feature-gate-min_const_fn.stderr
@@ -22,7 +22,7 @@ error[E0658]: const fn is unstable
 LL |     const fn foo() -> u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0658]: const fn is unstable
@@ -31,7 +31,7 @@ error[E0658]: const fn is unstable
 LL |     const fn bar() -> u32 { 0 }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 5 previous errors

--- a/src/test/ui/feature-gates/feature-gate-naked_functions.stderr
+++ b/src/test/ui/feature-gates/feature-gate-naked_functions.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[naked]` attribute is an experimental feature
 LL | #[naked]
    | ^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32408
+   = note: see issue #32408 <https://github.com/rust-lang/rust/issues/32408> for more information
    = help: add `#![feature(naked_functions)]` to the crate attributes to enable
 
 error[E0658]: the `#[naked]` attribute is an experimental feature
@@ -13,7 +13,7 @@ error[E0658]: the `#[naked]` attribute is an experimental feature
 LL | #[naked]
    | ^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32408
+   = note: see issue #32408 <https://github.com/rust-lang/rust/issues/32408> for more information
    = help: add `#![feature(naked_functions)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/feature-gates/feature-gate-never_type.stderr
+++ b/src/test/ui/feature-gates/feature-gate-never_type.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `!` type is experimental
 LL | type Ma = (u32, !, i32);
    |                 ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/35121
+   = note: see issue #35121 <https://github.com/rust-lang/rust/issues/35121> for more information
    = help: add `#![feature(never_type)]` to the crate attributes to enable
 
 error[E0658]: the `!` type is experimental
@@ -13,7 +13,7 @@ error[E0658]: the `!` type is experimental
 LL | type Meeshka = Vec<!>;
    |                    ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/35121
+   = note: see issue #35121 <https://github.com/rust-lang/rust/issues/35121> for more information
    = help: add `#![feature(never_type)]` to the crate attributes to enable
 
 error[E0658]: the `!` type is experimental
@@ -22,7 +22,7 @@ error[E0658]: the `!` type is experimental
 LL | type Mow = &'static fn(!) -> !;
    |                        ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/35121
+   = note: see issue #35121 <https://github.com/rust-lang/rust/issues/35121> for more information
    = help: add `#![feature(never_type)]` to the crate attributes to enable
 
 error[E0658]: the `!` type is experimental
@@ -31,7 +31,7 @@ error[E0658]: the `!` type is experimental
 LL | type Skwoz = &'static mut !;
    |                           ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/35121
+   = note: see issue #35121 <https://github.com/rust-lang/rust/issues/35121> for more information
    = help: add `#![feature(never_type)]` to the crate attributes to enable
 
 error[E0658]: the `!` type is experimental
@@ -40,7 +40,7 @@ error[E0658]: the `!` type is experimental
 LL |     type Wub = !;
    |                ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/35121
+   = note: see issue #35121 <https://github.com/rust-lang/rust/issues/35121> for more information
    = help: add `#![feature(never_type)]` to the crate attributes to enable
 
 error: aborting due to 5 previous errors

--- a/src/test/ui/feature-gates/feature-gate-no-debug.stderr
+++ b/src/test/ui/feature-gates/feature-gate-no-debug.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[no_debug]` attribute was an experimental feature that has b
 LL | #[no_debug]
    | ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29721
+   = note: see issue #29721 <https://github.com/rust-lang/rust/issues/29721> for more information
    = help: add `#![feature(no_debug)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-no_core.stderr
+++ b/src/test/ui/feature-gates/feature-gate-no_core.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[no_core]` attribute is an experimental feature
 LL | #![no_core]
    | ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29639
+   = note: see issue #29639 <https://github.com/rust-lang/rust/issues/29639> for more information
    = help: add `#![feature(no_core)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-non_ascii_idents.stderr
+++ b/src/test/ui/feature-gates/feature-gate-non_ascii_idents.stderr
@@ -4,7 +4,7 @@ error[E0658]: non-ascii idents are not fully supported
 LL | extern crate core as bäz;
    |                      ^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55467
+   = note: see issue #55467 <https://github.com/rust-lang/rust/issues/55467> for more information
    = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
@@ -13,7 +13,7 @@ error[E0658]: non-ascii idents are not fully supported
 LL | use föö::bar;
    |     ^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55467
+   = note: see issue #55467 <https://github.com/rust-lang/rust/issues/55467> for more information
    = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
@@ -22,7 +22,7 @@ error[E0658]: non-ascii idents are not fully supported
 LL | mod föö {
    |     ^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55467
+   = note: see issue #55467 <https://github.com/rust-lang/rust/issues/55467> for more information
    = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
@@ -31,7 +31,7 @@ error[E0658]: non-ascii idents are not fully supported
 LL | fn bär(
    |    ^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55467
+   = note: see issue #55467 <https://github.com/rust-lang/rust/issues/55467> for more information
    = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
@@ -40,7 +40,7 @@ error[E0658]: non-ascii idents are not fully supported
 LL |     bäz: isize
    |     ^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55467
+   = note: see issue #55467 <https://github.com/rust-lang/rust/issues/55467> for more information
    = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
@@ -49,7 +49,7 @@ error[E0658]: non-ascii idents are not fully supported
 LL |     let _ö: isize;
    |         ^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55467
+   = note: see issue #55467 <https://github.com/rust-lang/rust/issues/55467> for more information
    = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
@@ -58,7 +58,7 @@ error[E0658]: non-ascii idents are not fully supported
 LL |         (_ä, _) => {}
    |          ^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55467
+   = note: see issue #55467 <https://github.com/rust-lang/rust/issues/55467> for more information
    = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
@@ -67,7 +67,7 @@ error[E0658]: non-ascii idents are not fully supported
 LL | struct Föö {
    |        ^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55467
+   = note: see issue #55467 <https://github.com/rust-lang/rust/issues/55467> for more information
    = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
@@ -76,7 +76,7 @@ error[E0658]: non-ascii idents are not fully supported
 LL |     föö: isize
    |     ^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55467
+   = note: see issue #55467 <https://github.com/rust-lang/rust/issues/55467> for more information
    = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
@@ -85,7 +85,7 @@ error[E0658]: non-ascii idents are not fully supported
 LL | enum Bär {
    |      ^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55467
+   = note: see issue #55467 <https://github.com/rust-lang/rust/issues/55467> for more information
    = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
@@ -94,7 +94,7 @@ error[E0658]: non-ascii idents are not fully supported
 LL |     Bäz {
    |     ^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55467
+   = note: see issue #55467 <https://github.com/rust-lang/rust/issues/55467> for more information
    = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
@@ -103,7 +103,7 @@ error[E0658]: non-ascii idents are not fully supported
 LL |         qüx: isize
    |         ^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55467
+   = note: see issue #55467 <https://github.com/rust-lang/rust/issues/55467> for more information
    = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
@@ -112,7 +112,7 @@ error[E0658]: non-ascii idents are not fully supported
 LL |     fn qüx();
    |        ^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55467
+   = note: see issue #55467 <https://github.com/rust-lang/rust/issues/55467> for more information
    = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error: aborting due to 13 previous errors

--- a/src/test/ui/feature-gates/feature-gate-optin-builtin-traits.stderr
+++ b/src/test/ui/feature-gates/feature-gate-optin-builtin-traits.stderr
@@ -4,7 +4,7 @@ error[E0658]: auto traits are experimental and possibly buggy
 LL | auto trait AutoDummyTrait {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/13231
+   = note: see issue #13231 <https://github.com/rust-lang/rust/issues/13231> for more information
    = help: add `#![feature(optin_builtin_traits)]` to the crate attributes to enable
 
 error[E0658]: negative trait bounds are not yet fully implemented; use marker types for now
@@ -13,7 +13,7 @@ error[E0658]: negative trait bounds are not yet fully implemented; use marker ty
 LL | impl !AutoDummyTrait for DummyStruct {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/13231
+   = note: see issue #13231 <https://github.com/rust-lang/rust/issues/13231> for more information
    = help: add `#![feature(optin_builtin_traits)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/feature-gates/feature-gate-plugin_registrar.stderr
+++ b/src/test/ui/feature-gates/feature-gate-plugin_registrar.stderr
@@ -4,7 +4,7 @@ error[E0658]: compiler plugins are experimental and possibly buggy
 LL | pub fn registrar() {}
    | ^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29597
+   = note: see issue #29597 <https://github.com/rust-lang/rust/issues/29597> for more information
    = help: add `#![feature(plugin_registrar)]` to the crate attributes to enable
 
 error[E0658]: compiler plugins are deprecated
@@ -13,7 +13,7 @@ error[E0658]: compiler plugins are deprecated
 LL | #[plugin_registrar]
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29597
+   = note: see issue #29597 <https://github.com/rust-lang/rust/issues/29597> for more information
    = help: add `#![feature(plugin_registrar)]` to the crate attributes to enable
 
 warning: use of deprecated attribute `plugin_registrar`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675

--- a/src/test/ui/feature-gates/feature-gate-register_attr.stderr
+++ b/src/test/ui/feature-gates/feature-gate-register_attr.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[register_attr]` attribute is an experimental feature
 LL | #![register_attr(attr)]
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/66080
+   = note: see issue #66080 <https://github.com/rust-lang/rust/issues/66080> for more information
    = help: add `#![feature(register_attr)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-register_tool.stderr
+++ b/src/test/ui/feature-gates/feature-gate-register_tool.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[register_tool]` attribute is an experimental feature
 LL | #![register_tool(tool)]
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/66079
+   = note: see issue #66079 <https://github.com/rust-lang/rust/issues/66079> for more information
    = help: add `#![feature(register_tool)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-repr-simd.stderr
+++ b/src/test/ui/feature-gates/feature-gate-repr-simd.stderr
@@ -4,7 +4,7 @@ error[E0658]: SIMD types are experimental and possibly buggy
 LL | #[repr(simd)]
    | ^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable
 
 error[E0658]: SIMD types are experimental and possibly buggy
@@ -13,7 +13,7 @@ error[E0658]: SIMD types are experimental and possibly buggy
 LL | #[repr(simd)]
    | ^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable
 
 error[E0566]: conflicting representation hints

--- a/src/test/ui/feature-gates/feature-gate-repr128.stderr
+++ b/src/test/ui/feature-gates/feature-gate-repr128.stderr
@@ -6,7 +6,7 @@ LL | |     A(u64)
 LL | | }
    | |_^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/56071
+   = note: see issue #56071 <https://github.com/rust-lang/rust/issues/56071> for more information
    = help: add `#![feature(repr128)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-rustc-attrs-1.stderr
+++ b/src/test/ui/feature-gates/feature-gate-rustc-attrs-1.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[rustc_variance]` attribute is just used for rustc unit test
 LL | #[rustc_variance]
    | ^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error[E0658]: the `#[rustc_error]` attribute is just used for rustc unit tests and will never be stable
@@ -13,7 +13,7 @@ error[E0658]: the `#[rustc_error]` attribute is just used for rustc unit tests a
 LL | #[rustc_error]
    | ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error[E0658]: the `#[rustc_nonnull_optimization_guaranteed]` attribute is just used to enable niche optimizations in libcore and will never be stable
@@ -22,7 +22,7 @@ error[E0658]: the `#[rustc_nonnull_optimization_guaranteed]` attribute is just u
 LL | #[rustc_nonnull_optimization_guaranteed]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/feature-gates/feature-gate-rustc-attrs.stderr
+++ b/src/test/ui/feature-gates/feature-gate-rustc-attrs.stderr
@@ -4,7 +4,7 @@ error[E0658]: attributes starting with `rustc` are reserved for use by the `rust
 LL | #[rustc::unknown]
    |   ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: expected attribute, found macro `rustc::unknown`
@@ -19,7 +19,7 @@ error[E0658]: attributes starting with `rustc` are reserved for use by the `rust
 LL | #[unknown::rustc]
    |            ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: expected attribute, found macro `unknown::rustc`
@@ -34,7 +34,7 @@ error[E0658]: attributes starting with `rustc` are reserved for use by the `rust
 LL | #[rustc_unknown]
    |   ^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: cannot find attribute `rustc_unknown` in this scope
@@ -49,7 +49,7 @@ error[E0658]: the `#[rustc_dummy]` attribute is just used for rustc unit tests a
 LL | #[rustc_dummy]
    | ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: aborting due to 7 previous errors

--- a/src/test/ui/feature-gates/feature-gate-simd.stderr
+++ b/src/test/ui/feature-gates/feature-gate-simd.stderr
@@ -4,7 +4,7 @@ error[E0658]: SIMD types are experimental and possibly buggy
 LL | #[repr(simd)]
    | ^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-start.stderr
+++ b/src/test/ui/feature-gates/feature-gate-start.stderr
@@ -4,7 +4,7 @@ error[E0658]: `#[start]` functions are experimental and their signature may chan
 LL | fn foo(_: isize, _: *const *const u8) -> isize { 0 }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29633
+   = note: see issue #29633 <https://github.com/rust-lang/rust/issues/29633> for more information
    = help: add `#![feature(start)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-static-nobundle.stderr
+++ b/src/test/ui/feature-gates/feature-gate-static-nobundle.stderr
@@ -4,7 +4,7 @@ error[E0658]: kind="static-nobundle" is unstable
 LL | #[link(name="foo", kind="static-nobundle")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/37403
+   = note: see issue #37403 <https://github.com/rust-lang/rust/issues/37403> for more information
    = help: add `#![feature(static_nobundle)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-stmt_expr_attributes.stderr
+++ b/src/test/ui/feature-gates/feature-gate-stmt_expr_attributes.stderr
@@ -4,7 +4,7 @@ error[E0658]: attributes on expressions are experimental
 LL | const X: i32 = #[allow(dead_code)] 8;
    |                ^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/15701
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-thread_local.stderr
+++ b/src/test/ui/feature-gates/feature-gate-thread_local.stderr
@@ -4,7 +4,7 @@ error[E0658]: `#[thread_local]` is an experimental feature, and does not current
 LL | #[thread_local]
    | ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29594
+   = note: see issue #29594 <https://github.com/rust-lang/rust/issues/29594> for more information
    = help: add `#![feature(thread_local)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-trace_macros.stderr
+++ b/src/test/ui/feature-gates/feature-gate-trace_macros.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'trace_macros': `trace_macros` is 
 LL |     trace_macros!(true);
    |     ^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29598
+   = note: see issue #29598 <https://github.com/rust-lang/rust/issues/29598> for more information
    = help: add `#![feature(trace_macros)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-track_caller.stderr
+++ b/src/test/ui/feature-gates/feature-gate-track_caller.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[track_caller]` attribute is an experimental feature
 LL | #[track_caller]
    | ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/47809
+   = note: see issue #47809 <https://github.com/rust-lang/rust/issues/47809> for more information
    = help: add `#![feature(track_caller)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-trait-alias.stderr
+++ b/src/test/ui/feature-gates/feature-gate-trait-alias.stderr
@@ -4,7 +4,7 @@ error[E0658]: trait aliases are experimental
 LL | trait Foo = Default;
    | ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/41517
+   = note: see issue #41517 <https://github.com/rust-lang/rust/issues/41517> for more information
    = help: add `#![feature(trait_alias)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-transparent_unions.stderr
+++ b/src/test/ui/feature-gates/feature-gate-transparent_unions.stderr
@@ -4,7 +4,7 @@ error[E0658]: transparent unions are unstable
 LL | union OkButUnstableUnion {
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/60405
+   = note: see issue #60405 <https://github.com/rust-lang/rust/issues/60405> for more information
    = help: add `#![feature(transparent_unions)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-try_blocks.stderr
+++ b/src/test/ui/feature-gates/feature-gate-try_blocks.stderr
@@ -8,7 +8,7 @@ LL | |         x
 LL | |     };
    | |_____^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/31436
+   = note: see issue #31436 <https://github.com/rust-lang/rust/issues/31436> for more information
    = help: add `#![feature(try_blocks)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-try_reserve.stderr
+++ b/src/test/ui/feature-gates/feature-gate-try_reserve.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'try_reserve': new API
 LL |     v.try_reserve(10);
    |       ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/48043
+   = note: see issue #48043 <https://github.com/rust-lang/rust/issues/48043> for more information
    = help: add `#![feature(try_reserve)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-type_alias_impl_trait.stderr
+++ b/src/test/ui/feature-gates/feature-gate-type_alias_impl_trait.stderr
@@ -4,7 +4,7 @@ error[E0658]: `impl Trait` in type aliases is unstable
 LL | type Foo = impl Debug;
    |            ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in type aliases is unstable
@@ -13,7 +13,7 @@ error[E0658]: `impl Trait` in type aliases is unstable
 LL |     type Baa = impl Debug;
    |                ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0658]: associated type defaults are unstable
@@ -22,7 +22,7 @@ error[E0658]: associated type defaults are unstable
 LL |     type Assoc = impl Debug;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29661
+   = note: see issue #29661 <https://github.com/rust-lang/rust/issues/29661> for more information
    = help: add `#![feature(associated_type_defaults)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in type aliases is unstable
@@ -31,7 +31,7 @@ error[E0658]: `impl Trait` in type aliases is unstable
 LL |     type Assoc = impl Debug;
    |                  ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in type aliases is unstable
@@ -40,7 +40,7 @@ error[E0658]: `impl Trait` in type aliases is unstable
 LL | type NestedFree = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
    |                        ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in type aliases is unstable
@@ -49,7 +49,7 @@ error[E0658]: `impl Trait` in type aliases is unstable
 LL | type NestedFree = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
    |                                     ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in type aliases is unstable
@@ -58,7 +58,7 @@ error[E0658]: `impl Trait` in type aliases is unstable
 LL | type NestedFree = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in type aliases is unstable
@@ -67,7 +67,7 @@ error[E0658]: `impl Trait` in type aliases is unstable
 LL | type NestedFree = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
    |                                                                      ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in type aliases is unstable
@@ -76,7 +76,7 @@ error[E0658]: `impl Trait` in type aliases is unstable
 LL |     type Baa = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
    |                     ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in type aliases is unstable
@@ -85,7 +85,7 @@ error[E0658]: `impl Trait` in type aliases is unstable
 LL |     type Baa = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
    |                                  ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in type aliases is unstable
@@ -94,7 +94,7 @@ error[E0658]: `impl Trait` in type aliases is unstable
 LL |     type Baa = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in type aliases is unstable
@@ -103,7 +103,7 @@ error[E0658]: `impl Trait` in type aliases is unstable
 LL |     type Baa = (Vec<impl Debug>, impl Debug, impl Iterator<Item = impl Debug>);
    |                                                                   ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0562]: `impl Trait` not allowed outside of function and inherent method return types

--- a/src/test/ui/feature-gates/feature-gate-type_ascription.stderr
+++ b/src/test/ui/feature-gates/feature-gate-type_ascription.stderr
@@ -4,7 +4,7 @@ error[E0658]: type ascription is experimental
 LL |     let a = 10: u8;
    |             ^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
+   = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
    = help: add `#![feature(type_ascription)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
@@ -4,7 +4,7 @@ error[E0658]: rust-call ABI is subject to change
 LL |     extern "rust-call" fn call(self, args: ()) -> () {}
    |            ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
@@ -13,7 +13,7 @@ error[E0658]: rust-call ABI is subject to change
 LL |     extern "rust-call" fn call_once(self, args: ()) -> () {}
    |            ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
@@ -22,7 +22,7 @@ error[E0658]: rust-call ABI is subject to change
 LL |     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
    |            ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
@@ -31,7 +31,7 @@ error[E0658]: rust-call ABI is subject to change
 LL |     extern "rust-call" fn call_once(&self, args: ()) -> () {}
    |            ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
@@ -40,7 +40,7 @@ error[E0658]: the precise format of `Fn`-family traits' type parameters is subje
 LL | impl Fn<()> for Foo {
    |      ^^^^^^ help: use parenthetical notation instead: `Fn() -> ()`
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0229]: associated type bindings are not allowed here
@@ -55,7 +55,7 @@ error[E0658]: the precise format of `Fn`-family traits' type parameters is subje
 LL | impl FnMut<()> for Bar {
    |      ^^^^^^^^^ help: use parenthetical notation instead: `FnMut() -> ()`
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
@@ -64,7 +64,7 @@ error[E0658]: the precise format of `Fn`-family traits' type parameters is subje
 LL | impl FnOnce<()> for Baz {
    |      ^^^^^^^^^^ help: use parenthetical notation instead: `FnOnce() -> ()`
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error: aborting due to 8 previous errors

--- a/src/test/ui/feature-gates/feature-gate-unboxed-closures-method-calls.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unboxed-closures-method-calls.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'fn_traits'
 LL |     f.call(());
    |       ^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(fn_traits)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'fn_traits'
@@ -13,7 +13,7 @@ error[E0658]: use of unstable library feature 'fn_traits'
 LL |     f.call_mut(());
    |       ^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(fn_traits)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'fn_traits'
@@ -22,7 +22,7 @@ error[E0658]: use of unstable library feature 'fn_traits'
 LL |     f.call_once(());
    |       ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(fn_traits)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/feature-gates/feature-gate-unboxed-closures-ufcs-calls.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unboxed-closures-ufcs-calls.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'fn_traits'
 LL |     Fn::call(&f, ());
    |     ^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(fn_traits)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'fn_traits'
@@ -13,7 +13,7 @@ error[E0658]: use of unstable library feature 'fn_traits'
 LL |     FnMut::call_mut(&mut f, ());
    |     ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(fn_traits)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'fn_traits'
@@ -22,7 +22,7 @@ error[E0658]: use of unstable library feature 'fn_traits'
 LL |     FnOnce::call_once(f, ());
    |     ^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(fn_traits)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/feature-gates/feature-gate-unboxed-closures.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unboxed-closures.stderr
@@ -4,7 +4,7 @@ error[E0658]: rust-call ABI is subject to change
 LL |     extern "rust-call" fn call_once(self, (a, b): (u32, u32)) -> u32 {
    |            ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
@@ -13,7 +13,7 @@ error[E0658]: the precise format of `Fn`-family traits' type parameters is subje
 LL | impl FnOnce<(u32, u32)> for Test {
    |      ^^^^^^^^^^^^^^^^^^ help: use parenthetical notation instead: `FnOnce(u32, u32) -> ()`
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/feature-gates/feature-gate-unsized_tuple_coercion.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unsized_tuple_coercion.stderr
@@ -4,7 +4,7 @@ error[E0658]: unsized tuple coercion is not stable enough for use and is subject
 LL |     let _ : &(dyn Send,) = &((),);
    |                            ^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/42877
+   = note: see issue #42877 <https://github.com/rust-lang/rust/issues/42877> for more information
    = help: add `#![feature(unsized_tuple_coercion)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-untagged_unions.stderr
+++ b/src/test/ui/feature-gates/feature-gate-untagged_unions.stderr
@@ -6,7 +6,7 @@ LL | |     a: String,
 LL | | }
    | |_^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55149
+   = note: see issue #55149 <https://github.com/rust-lang/rust/issues/55149> for more information
    = help: add `#![feature(untagged_unions)]` to the crate attributes to enable
 
 error[E0658]: unions with non-`Copy` fields are unstable
@@ -17,7 +17,7 @@ LL | |     a: T,
 LL | | }
    | |_^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55149
+   = note: see issue #55149 <https://github.com/rust-lang/rust/issues/55149> for more information
    = help: add `#![feature(untagged_unions)]` to the crate attributes to enable
 
 error[E0658]: unions with `Drop` implementations are unstable
@@ -28,7 +28,7 @@ LL | |     a: u8,
 LL | | }
    | |_^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55149
+   = note: see issue #55149 <https://github.com/rust-lang/rust/issues/55149> for more information
    = help: add `#![feature(untagged_unions)]` to the crate attributes to enable
 
 error[E0740]: unions may not contain fields that need dropping

--- a/src/test/ui/feature-gates/feature-gate-unwind-attributes.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unwind-attributes.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[unwind]` attribute is an experimental feature
 LL |     #[unwind(allowed)]
    |     ^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/58760
+   = note: see issue #58760 <https://github.com/rust-lang/rust/issues/58760> for more information
    = help: add `#![feature(unwind_attributes)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/generator-yielding-or-returning-itself.stderr
+++ b/src/test/ui/generator-yielding-or-returning-itself.stderr
@@ -11,7 +11,8 @@ LL |     want_cyclic_generator_return(|| {
    |
    = note: closures cannot capture themselves or take themselves as argument;
            this error may be the result of a recent compiler bug-fix,
-           see https://github.com/rust-lang/rust/issues/46062 for more details
+           see issue #46062 <https://github.com/rust-lang/rust/issues/46062>
+           for more information
 
 error[E0271]: type mismatch resolving `<[generator@$DIR/generator-yielding-or-returning-itself.rs:28:33: 32:6 _] as std::ops::Generator>::Yield == [generator@$DIR/generator-yielding-or-returning-itself.rs:28:33: 32:6 _]`
   --> $DIR/generator-yielding-or-returning-itself.rs:28:5
@@ -26,7 +27,8 @@ LL |     want_cyclic_generator_yield(|| {
    |
    = note: closures cannot capture themselves or take themselves as argument;
            this error may be the result of a recent compiler bug-fix,
-           see https://github.com/rust-lang/rust/issues/46062 for more details
+           see issue #46062 <https://github.com/rust-lang/rust/issues/46062>
+           for more information
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generic-associated-types/collections.stderr
+++ b/src/test/ui/generic-associated-types/collections.stderr
@@ -5,7 +5,7 @@ LL | /     type Sibling<U>: Collection<U> =
 LL | |         <<Self as Collection<T>>::Family as CollectionFamily>::Member<U>;
    | |_________________________________________________________________________^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: for more information, see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
 
 error: type-generic associated types are not yet implemented
   --> $DIR/collections.rs:25:5
@@ -13,7 +13,7 @@ error: type-generic associated types are not yet implemented
 LL |     type Member<T>: Collection<T, Family = Self>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: for more information, see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generic-associated-types/gat-dont-ice-on-absent-feature-2.stderr
+++ b/src/test/ui/generic-associated-types/gat-dont-ice-on-absent-feature-2.stderr
@@ -4,7 +4,7 @@ error[E0658]: generic associated types are unstable
 LL |     type Item<T>;
    |     ^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
    = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable
 
 error[E0658]: generic associated types are unstable
@@ -13,7 +13,7 @@ error[E0658]: generic associated types are unstable
 LL |     type Item<T> = T;
    |     ^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
    = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable
 
 error: type-generic associated types are not yet implemented
@@ -22,7 +22,7 @@ error: type-generic associated types are not yet implemented
 LL |     type Item<T>;
    |     ^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: for more information, see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/generic-associated-types/gat-dont-ice-on-absent-feature.stderr
+++ b/src/test/ui/generic-associated-types/gat-dont-ice-on-absent-feature.stderr
@@ -4,7 +4,7 @@ error[E0658]: generic associated types are unstable
 LL |     type Item<'b> = &'b Foo;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
    = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable
 
 error[E0195]: lifetime parameters or bounds on type `Item` do not match the trait declaration

--- a/src/test/ui/generic-associated-types/generic-associated-types-where.stderr
+++ b/src/test/ui/generic-associated-types/generic-associated-types-where.stderr
@@ -4,7 +4,7 @@ error: type-generic associated types are not yet implemented
 LL |     type Assoc2<T> where T: Display;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: for more information, see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
 
 error: type-generic associated types are not yet implemented
   --> $DIR/generic-associated-types-where.rs:13:5
@@ -12,7 +12,7 @@ error: type-generic associated types are not yet implemented
 LL |     type Assoc3<T>;
    |     ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: for more information, see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
 
 error: type-generic associated types are not yet implemented
   --> $DIR/generic-associated-types-where.rs:15:5
@@ -20,7 +20,7 @@ error: type-generic associated types are not yet implemented
 LL |     type WithDefault<'a, T: Debug + 'a> = dyn Iterator<Item=T>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: for more information, see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/generic-associated-types/issue-47206-where-clause.stderr
+++ b/src/test/ui/generic-associated-types/issue-47206-where-clause.stderr
@@ -4,7 +4,7 @@ error: type-generic associated types are not yet implemented
 LL |     type Assoc3<T>;
    |     ^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: for more information, see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/issue-67424.stderr
+++ b/src/test/ui/generic-associated-types/issue-67424.stderr
@@ -4,7 +4,7 @@ error[E0658]: generic associated types are unstable
 LL |     type Type1<B>: Trait1<A=B>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
    = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable
 
 error: type-generic associated types are not yet implemented
@@ -13,7 +13,7 @@ error: type-generic associated types are not yet implemented
 LL |     type Type1<B>: Trait1<A=B>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: for more information, see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generic-associated-types/parameter_number_and_kind.stderr
+++ b/src/test/ui/generic-associated-types/parameter_number_and_kind.stderr
@@ -4,7 +4,7 @@ error: type-generic associated types are not yet implemented
 LL |     type D<T>;
    |     ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: for more information, see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
 
 error: type-generic associated types are not yet implemented
   --> $DIR/parameter_number_and_kind.rs:11:5
@@ -12,7 +12,7 @@ error: type-generic associated types are not yet implemented
 LL |     type E<'a, T>;
    |     ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: for more information, see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
 
 error: type-generic associated types are not yet implemented
   --> $DIR/parameter_number_and_kind.rs:14:5
@@ -20,7 +20,7 @@ error: type-generic associated types are not yet implemented
 LL |     type FOk<T> = Self::E<'static, T>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: for more information, see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
 
 error: type-generic associated types are not yet implemented
   --> $DIR/parameter_number_and_kind.rs:19:5
@@ -28,7 +28,7 @@ error: type-generic associated types are not yet implemented
 LL |     type FErr2<T> = Self::E<'static, T, u32>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: for more information, see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
 
 error[E0107]: wrong number of lifetime arguments: expected 1, found 2
   --> $DIR/parameter_number_and_kind.rs:16:35

--- a/src/test/ui/generic-associated-types/pointer_family.stderr
+++ b/src/test/ui/generic-associated-types/pointer_family.stderr
@@ -4,7 +4,7 @@ error: type-generic associated types are not yet implemented
 LL |     type Pointer<T>: Deref<Target = T>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: for more information, see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/shadowing.stderr
+++ b/src/test/ui/generic-associated-types/shadowing.stderr
@@ -20,7 +20,7 @@ error: type-generic associated types are not yet implemented
 LL |     type Bar<T>;
    |     ^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: for more information, see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
 
 error: type-generic associated types are not yet implemented
   --> $DIR/shadowing.rs:25:5
@@ -28,7 +28,7 @@ error: type-generic associated types are not yet implemented
 LL |     type Bar<U>; // OK
    |     ^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44265
+   = note: for more information, see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/half-open-range-patterns/feature-gate-half-open-range-patterns.stderr
+++ b/src/test/ui/half-open-range-patterns/feature-gate-half-open-range-patterns.stderr
@@ -26,7 +26,7 @@ error[E0658]: half-open range patterns are unstable
 LL |     if let ..=5 = 0 {}
    |            ^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/67264
+   = note: see issue #67264 <https://github.com/rust-lang/rust/issues/67264> for more information
    = help: add `#![feature(half_open_range_patterns)]` to the crate attributes to enable
 
 error[E0658]: half-open range patterns are unstable
@@ -35,7 +35,7 @@ error[E0658]: half-open range patterns are unstable
 LL |     if let ...5 = 0 {}
    |            ^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/67264
+   = note: see issue #67264 <https://github.com/rust-lang/rust/issues/67264> for more information
    = help: add `#![feature(half_open_range_patterns)]` to the crate attributes to enable
 
 error[E0658]: half-open range patterns are unstable
@@ -44,7 +44,7 @@ error[E0658]: half-open range patterns are unstable
 LL |     if let ..5 = 0 {}
    |            ^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/67264
+   = note: see issue #67264 <https://github.com/rust-lang/rust/issues/67264> for more information
    = help: add `#![feature(half_open_range_patterns)]` to the crate attributes to enable
 
 error[E0658]: half-open range patterns are unstable
@@ -53,7 +53,7 @@ error[E0658]: half-open range patterns are unstable
 LL |     if let 5.. = 0 {}
    |            ^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/67264
+   = note: see issue #67264 <https://github.com/rust-lang/rust/issues/67264> for more information
    = help: add `#![feature(half_open_range_patterns)]` to the crate attributes to enable
 
 error[E0658]: half-open range patterns are unstable
@@ -62,7 +62,7 @@ error[E0658]: half-open range patterns are unstable
 LL |     if let 5..= = 0 {}
    |            ^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/67264
+   = note: see issue #67264 <https://github.com/rust-lang/rust/issues/67264> for more information
    = help: add `#![feature(half_open_range_patterns)]` to the crate attributes to enable
 
 error[E0658]: half-open range patterns are unstable
@@ -71,7 +71,7 @@ error[E0658]: half-open range patterns are unstable
 LL |     if let 5... = 0 {}
    |            ^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/67264
+   = note: see issue #67264 <https://github.com/rust-lang/rust/issues/67264> for more information
    = help: add `#![feature(half_open_range_patterns)]` to the crate attributes to enable
 
 error: aborting due to 9 previous errors

--- a/src/test/ui/impl-trait/where-allowed.stderr
+++ b/src/test/ui/impl-trait/where-allowed.stderr
@@ -22,7 +22,7 @@ error[E0658]: `impl Trait` in type aliases is unstable
 LL |     type Out = impl Debug;
    |                ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in type aliases is unstable
@@ -31,7 +31,7 @@ error[E0658]: `impl Trait` in type aliases is unstable
 LL | type InTypeAlias<R> = impl Debug;
    |                       ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in type aliases is unstable
@@ -40,7 +40,7 @@ error[E0658]: `impl Trait` in type aliases is unstable
 LL | type InReturnInTypeAlias<R> = fn() -> impl Debug;
    |                                       ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0562]: `impl Trait` not allowed outside of function and inherent method return types

--- a/src/test/ui/imports/local-modularized-tricky-fail-2.stderr
+++ b/src/test/ui/imports/local-modularized-tricky-fail-2.stderr
@@ -7,7 +7,7 @@ LL | exported!();
 LL |                 () => ( struct Б; )
    |                                ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55467
+   = note: see issue #55467 <https://github.com/rust-lang/rust/issues/55467> for more information
    = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -20,7 +20,7 @@ LL |     panic!();
 LL |         () => ( struct Г; )
    |                        ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55467
+   = note: see issue #55467 <https://github.com/rust-lang/rust/issues/55467> for more information
    = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -33,7 +33,7 @@ LL | include!();
 LL |         () => ( struct Д; )
    |                        ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55467
+   = note: see issue #55467 <https://github.com/rust-lang/rust/issues/55467> for more information
    = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/inference/inference_unstable_forced.stderr
+++ b/src/test/ui/inference/inference_unstable_forced.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'ipu_flatten'
 LL |     assert_eq!('x'.ipu_flatten(), 0);
    |                    ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/99999
+   = note: see issue #99999 <https://github.com/rust-lang/rust/issues/99999> for more information
    = help: add `#![feature(ipu_flatten)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/internal/internal-unstable-const.stderr
+++ b/src/test/ui/internal/internal-unstable-const.stderr
@@ -4,7 +4,7 @@ error[E0723]: loops and conditional expressions are not stable in const fn
 LL |     if true { 4 } else { 5 }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-17458.stderr
+++ b/src/test/ui/issues/issue-17458.stderr
@@ -4,7 +4,7 @@ error[E0658]: casting pointers to integers in statics is unstable
 LL | static X: usize = unsafe { core::ptr::null::<usize>() as usize };
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51910
+   = note: see issue #51910 <https://github.com/rust-lang/rust/issues/51910> for more information
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-17718-const-bad-values.stderr
+++ b/src/test/ui/issues/issue-17718-const-bad-values.stderr
@@ -4,7 +4,7 @@ error[E0658]: references in constants may only refer to immutable values
 LL | const C1: &'static mut [usize] = &mut [];
    |                                  ^^^^^^^ constants require immutable values
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0013]: constants cannot refer to statics
@@ -29,7 +29,7 @@ error[E0658]: references in constants may only refer to immutable values
 LL | const C2: &'static mut usize = unsafe { &mut S };
    |                                         ^^^^^^ constants require immutable values
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/issues/issue-18294.stderr
+++ b/src/test/ui/issues/issue-18294.stderr
@@ -4,7 +4,7 @@ error[E0658]: casting pointers to integers in constants is unstable
 LL |     const Y: usize = unsafe { &X as *const u32 as usize };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51910
+   = note: see issue #51910 <https://github.com/rust-lang/rust/issues/51910> for more information
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-20313.stderr
+++ b/src/test/ui/issues/issue-20313.stderr
@@ -4,7 +4,7 @@ error[E0658]: linking to LLVM intrinsics is experimental
 LL |     fn sqrt(x: f32) -> f32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29602
+   = note: see issue #29602 <https://github.com/rust-lang/rust/issues/29602> for more information
    = help: add `#![feature(link_llvm_intrinsics)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-22644.stderr
+++ b/src/test/ui/issues/issue-22644.stderr
@@ -94,7 +94,7 @@ LL |     println!("{}", a: &mut 4);
    |                     tried to parse a type due to this type ascription
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
+   = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/issues/issue-23024.stderr
+++ b/src/test/ui/issues/issue-23024.stderr
@@ -4,7 +4,7 @@ error[E0658]: the precise format of `Fn`-family traits' type parameters is subje
 LL |     println!("{:?}",(vfnfer[0] as dyn Fn)(3));
    |                                       ^^ help: use parenthetical notation instead: `Fn() -> ()`
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0107]: wrong number of type arguments: expected 1, found 0

--- a/src/test/ui/issues/issue-25439.stderr
+++ b/src/test/ui/issues/issue-25439.stderr
@@ -6,7 +6,8 @@ LL |     fix(|_, x| x);
    |
    = note: closures cannot capture themselves or take themselves as argument;
            this error may be the result of a recent compiler bug-fix,
-           see https://github.com/rust-lang/rust/issues/46062 for more details
+           see issue #46062 <https://github.com/rust-lang/rust/issues/46062>
+           for more information
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-25826.stderr
+++ b/src/test/ui/issues/issue-25826.stderr
@@ -4,7 +4,7 @@ error[E0658]: comparing raw pointers inside constant
 LL |     const A: bool = unsafe { id::<u8> as *const () < id::<u16> as *const () };
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53020
+   = note: see issue #53020 <https://github.com/rust-lang/rust/issues/53020> for more information
    = help: add `#![feature(const_compare_raw_pointers)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-32829.stderr
+++ b/src/test/ui/issues/issue-32829.stderr
@@ -4,7 +4,7 @@ error[E0658]: panicking in statics is unstable
 LL | static S : u64 = { { panic!("foo"); 0 } };
    |                      ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51999
+   = note: see issue #51999 <https://github.com/rust-lang/rust/issues/51999> for more information
    = help: add `#![feature(const_panic)]` to the crate attributes to enable
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/issues/issue-34255-1.stderr
+++ b/src/test/ui/issues/issue-34255-1.stderr
@@ -7,7 +7,7 @@ LL |     Test::Drill(field: 42);
    |                      tried to parse a type due to this type ascription
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
+   = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-37550.stderr
+++ b/src/test/ui/issues/issue-37550.stderr
@@ -4,7 +4,7 @@ error[E0723]: function pointers in const fn are unstable
 LL |     let x = || t;
    |         ^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-37887.stderr
+++ b/src/test/ui/issues/issue-37887.stderr
@@ -10,7 +10,7 @@ error[E0658]: use of unstable library feature 'rustc_private': this crate is bei
 LL |     extern crate libc;
    |     ^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/27812
+   = note: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
    = help: add `#![feature(rustc_private)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/issues/issue-44406.stderr
+++ b/src/test/ui/issues/issue-44406.stderr
@@ -19,7 +19,7 @@ LL |     foo!(true);
    |          ^^^^ expected type
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
+   = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-46604.stderr
+++ b/src/test/ui/issues/issue-46604.stderr
@@ -4,7 +4,7 @@ error[E0658]: references in statics may only refer to immutable values
 LL | static buf: &mut [u8] = &mut [1u8,2,3,4,5,7];
    |                         ^^^^^^^^^^^^^^^^^^^^ statics require immutable values
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/57349
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0594]: cannot assign to `buf[_]`, as `buf` is an immutable static item

--- a/src/test/ui/issues/issue-51714.stderr
+++ b/src/test/ui/issues/issue-51714.stderr
@@ -4,7 +4,7 @@ error[E0658]: `while` is not allowed in a `const`
 LL |     [(); return while let Some(n) = Some(0) {}];
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52000
+   = note: see issue #52000 <https://github.com/rust-lang/rust/issues/52000> for more information
    = help: add `#![feature(const_loop)]` to the crate attributes to enable
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 

--- a/src/test/ui/issues/issue-52023-array-size-pointer-cast.stderr
+++ b/src/test/ui/issues/issue-52023-array-size-pointer-cast.stderr
@@ -4,7 +4,7 @@ error[E0658]: casting pointers to integers in constants is unstable
 LL |     let _ = [0; (&0 as *const i32) as usize];
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/51910
+   = note: see issue #51910 <https://github.com/rust-lang/rust/issues/51910> for more information
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error[E0080]: evaluation of constant value failed

--- a/src/test/ui/lifetime_starts_expressions.stderr
+++ b/src/test/ui/lifetime_starts_expressions.stderr
@@ -18,7 +18,7 @@ LL |     loop { break 'label: loop { break 'label 42; }; }
    |                        tried to parse a type due to this type ascription
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
+   = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/linkage-attr/linkage4.stderr
+++ b/src/test/ui/linkage-attr/linkage4.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `linkage` attribute is experimental and not portable across pl
 LL | #[linkage = "external"]
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29603
+   = note: see issue #29603 <https://github.com/rust-lang/rust/issues/29603> for more information
    = help: add `#![feature(linkage)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/lint/inline-trait-and-foreign-items.stderr
+++ b/src/test/ui/lint/inline-trait-and-foreign-items.stderr
@@ -26,7 +26,7 @@ note: the lint level is defined here
 LL | #![warn(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #65833 <https://github.com/rust-lang/rust/issues/65833>
+   = note: see issue #65833 <https://github.com/rust-lang/rust/issues/65833> for more information
 
 error[E0518]: attribute should be applied to function or closure
   --> $DIR/inline-trait-and-foreign-items.rs:11:5
@@ -43,7 +43,7 @@ LL |     #[inline]
    |     ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #65833 <https://github.com/rust-lang/rust/issues/65833>
+   = note: see issue #65833 <https://github.com/rust-lang/rust/issues/65833> for more information
 
 error[E0518]: attribute should be applied to function or closure
   --> $DIR/inline-trait-and-foreign-items.rs:22:5

--- a/src/test/ui/mir/mir-inlining/var-debuginfo-issue-67586.rs
+++ b/src/test/ui/mir/mir-inlining/var-debuginfo-issue-67586.rs
@@ -1,0 +1,11 @@
+// run-pass
+// compile-flags: -Z mir-opt-level=2 -C opt-level=0 -C debuginfo=2
+
+#[inline(never)]
+pub fn foo(bar: usize) -> usize {
+    std::convert::identity(bar)
+}
+
+fn main() {
+    foo(0);
+}

--- a/src/test/ui/never_type/defaulted-never-note.stderr
+++ b/src/test/ui/never_type/defaulted-never-note.stderr
@@ -7,7 +7,7 @@ LL | fn foo<T: ImplementedForUnitButNotNever>(_t: T) {}
 LL |     foo(_x);
    |     ^^^ the trait `ImplementedForUnitButNotNever` is not implemented for `!`
    |
-   = note: the trait is implemented for `()`. Possibly this error has been caused by changes to Rust's type-inference algorithm (see: https://github.com/rust-lang/rust/issues/48950 for more info). Consider whether you meant to use the type `()` here instead.
+   = note: the trait is implemented for `()`. Possibly this error has been caused by changes to Rust's type-inference algorithm (see issue #48950 <https://github.com/rust-lang/rust/issues/48950> for more information). Consider whether you meant to use the type `()` here instead.
 
 error: aborting due to previous error
 

--- a/src/test/ui/on-unimplemented/feature-gate-on-unimplemented.stderr
+++ b/src/test/ui/on-unimplemented/feature-gate-on-unimplemented.stderr
@@ -4,7 +4,7 @@ error[E0658]: this is an internal attribute that will never be stable
 LL | #[rustc_on_unimplemented = "test error `{Self}` with `{Bar}`"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/or-patterns/feature-gate-const-fn.stderr
+++ b/src/test/ui/or-patterns/feature-gate-const-fn.stderr
@@ -4,7 +4,7 @@ error[E0658]: or-pattern is not allowed in a `const fn`
 LL | const fn foo((Ok(a) | Err(a)): Result<i32, i32>) {
    |               ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: or-pattern is not allowed in a `const fn`
@@ -13,7 +13,7 @@ error[E0658]: or-pattern is not allowed in a `const fn`
 LL |     let Ok(y) | Err(y) = x;
    |         ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: or-pattern is not allowed in a `const`
@@ -22,7 +22,7 @@ error[E0658]: or-pattern is not allowed in a `const`
 LL |     let Ok(y) | Err(y) = x;
    |         ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: or-pattern is not allowed in a `static`
@@ -31,7 +31,7 @@ error[E0658]: or-pattern is not allowed in a `static`
 LL |     let Ok(y) | Err(y) = x;
    |         ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: or-pattern is not allowed in a `static mut`
@@ -40,7 +40,7 @@ error[E0658]: or-pattern is not allowed in a `static mut`
 LL |     let Ok(y) | Err(y) = x;
    |         ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: or-pattern is not allowed in a `const`
@@ -49,7 +49,7 @@ error[E0658]: or-pattern is not allowed in a `const`
 LL |         let Ok(y) | Err(y) = x;
    |             ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0019]: constant contains unimplemented expression type

--- a/src/test/ui/or-patterns/feature-gate-or_patterns-leading-for.stderr
+++ b/src/test/ui/or-patterns/feature-gate-or_patterns-leading-for.stderr
@@ -4,7 +4,7 @@ error[E0658]: or-patterns syntax is experimental
 LL |     for | A in 0 {}
    |         ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(or_patterns)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/or-patterns/feature-gate-or_patterns-leading-let.stderr
+++ b/src/test/ui/or-patterns/feature-gate-or_patterns-leading-let.stderr
@@ -4,7 +4,7 @@ error[E0658]: or-patterns syntax is experimental
 LL |     let | A;
    |         ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(or_patterns)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/or-patterns/feature-gate-or_patterns.stderr
+++ b/src/test/ui/or-patterns/feature-gate-or_patterns.stderr
@@ -4,7 +4,7 @@ error[E0658]: or-patterns syntax is experimental
 LL |         Some(0 | 1 | 2) => {}
    |              ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(or_patterns)]` to the crate attributes to enable
 
 error[E0658]: or-patterns syntax is experimental
@@ -13,7 +13,7 @@ error[E0658]: or-patterns syntax is experimental
 LL |     let | A | B;
    |           ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(or_patterns)]` to the crate attributes to enable
 
 error[E0658]: or-patterns syntax is experimental
@@ -22,7 +22,7 @@ error[E0658]: or-patterns syntax is experimental
 LL |     let A | B;
    |         ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(or_patterns)]` to the crate attributes to enable
 
 error[E0658]: or-patterns syntax is experimental
@@ -31,7 +31,7 @@ error[E0658]: or-patterns syntax is experimental
 LL |     for | A | B in 0 {}
    |           ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(or_patterns)]` to the crate attributes to enable
 
 error[E0658]: or-patterns syntax is experimental
@@ -40,7 +40,7 @@ error[E0658]: or-patterns syntax is experimental
 LL |     for A | B in 0 {}
    |         ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(or_patterns)]` to the crate attributes to enable
 
 error[E0658]: or-patterns syntax is experimental
@@ -49,7 +49,7 @@ error[E0658]: or-patterns syntax is experimental
 LL |     fn fun((A | B): _) {}
    |             ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(or_patterns)]` to the crate attributes to enable
 
 error[E0658]: or-patterns syntax is experimental
@@ -58,7 +58,7 @@ error[E0658]: or-patterns syntax is experimental
 LL |     let _ = |(A | B): u8| ();
    |               ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(or_patterns)]` to the crate attributes to enable
 
 error[E0658]: or-patterns syntax is experimental
@@ -67,7 +67,7 @@ error[E0658]: or-patterns syntax is experimental
 LL |     let (A | B);
    |          ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(or_patterns)]` to the crate attributes to enable
 
 error[E0658]: or-patterns syntax is experimental
@@ -76,7 +76,7 @@ error[E0658]: or-patterns syntax is experimental
 LL |     let (A | B,);
    |          ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(or_patterns)]` to the crate attributes to enable
 
 error[E0658]: or-patterns syntax is experimental
@@ -85,7 +85,7 @@ error[E0658]: or-patterns syntax is experimental
 LL |     let A(B | C);
    |           ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(or_patterns)]` to the crate attributes to enable
 
 error[E0658]: or-patterns syntax is experimental
@@ -94,7 +94,7 @@ error[E0658]: or-patterns syntax is experimental
 LL |     let E::V(B | C);
    |              ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(or_patterns)]` to the crate attributes to enable
 
 error[E0658]: or-patterns syntax is experimental
@@ -103,7 +103,7 @@ error[E0658]: or-patterns syntax is experimental
 LL |     let S { f1: B | C, f2 };
    |                 ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(or_patterns)]` to the crate attributes to enable
 
 error[E0658]: or-patterns syntax is experimental
@@ -112,7 +112,7 @@ error[E0658]: or-patterns syntax is experimental
 LL |     let E::V { f1: B | C, f2 };
    |                    ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(or_patterns)]` to the crate attributes to enable
 
 error[E0658]: or-patterns syntax is experimental
@@ -121,7 +121,7 @@ error[E0658]: or-patterns syntax is experimental
 LL |     let [A | B];
    |          ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(or_patterns)]` to the crate attributes to enable
 
 error[E0658]: or-patterns syntax is experimental
@@ -130,7 +130,7 @@ error[E0658]: or-patterns syntax is experimental
 LL | accept_pat!((p | q));
    |              ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(or_patterns)]` to the crate attributes to enable
 
 error[E0658]: or-patterns syntax is experimental
@@ -139,7 +139,7 @@ error[E0658]: or-patterns syntax is experimental
 LL | accept_pat!((p | q,));
    |              ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(or_patterns)]` to the crate attributes to enable
 
 error[E0658]: or-patterns syntax is experimental
@@ -148,7 +148,7 @@ error[E0658]: or-patterns syntax is experimental
 LL | accept_pat!(TS(p | q));
    |                ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(or_patterns)]` to the crate attributes to enable
 
 error[E0658]: or-patterns syntax is experimental
@@ -157,7 +157,7 @@ error[E0658]: or-patterns syntax is experimental
 LL | accept_pat!(NS { f: p | q });
    |                     ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(or_patterns)]` to the crate attributes to enable
 
 error[E0658]: or-patterns syntax is experimental
@@ -166,7 +166,7 @@ error[E0658]: or-patterns syntax is experimental
 LL | accept_pat!([p | q]);
    |              ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(or_patterns)]` to the crate attributes to enable
 
 error: aborting due to 19 previous errors

--- a/src/test/ui/panic-runtime/needs-gate.stderr
+++ b/src/test/ui/panic-runtime/needs-gate.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[panic_runtime]` attribute is an experimental feature
 LL | #![panic_runtime]
    | ^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32837
+   = note: see issue #32837 <https://github.com/rust-lang/rust/issues/32837> for more information
    = help: add `#![feature(panic_runtime)]` to the crate attributes to enable
 
 error[E0658]: the `#[needs_panic_runtime]` attribute is an experimental feature
@@ -13,7 +13,7 @@ error[E0658]: the `#[needs_panic_runtime]` attribute is an experimental feature
 LL | #![needs_panic_runtime]
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32837
+   = note: see issue #32837 <https://github.com/rust-lang/rust/issues/32837> for more information
    = help: add `#![feature(needs_panic_runtime)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/parser/issue-17383.stderr
+++ b/src/test/ui/parser/issue-17383.stderr
@@ -7,7 +7,7 @@ LL |
 LL |     B(usize)
    |     -------- tuple variant defined here
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/60553
+   = note: see issue #60553 <https://github.com/rust-lang/rust/issues/60553> for more information
    = help: add `#![feature(arbitrary_enum_discriminant)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/parser/recover-from-bad-variant.stderr
+++ b/src/test/ui/parser/recover-from-bad-variant.stderr
@@ -7,7 +7,7 @@ LL |     let x = Enum::Foo(a: 3, b: 4);
    |                        tried to parse a type due to this type ascription
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
+   = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
 
 error[E0532]: expected tuple struct or tuple variant, found struct variant `Enum::Foo`
   --> $DIR/recover-from-bad-variant.rs:10:9

--- a/src/test/ui/parser/tag-variant-disr-non-nullary.stderr
+++ b/src/test/ui/parser/tag-variant-disr-non-nullary.stderr
@@ -17,7 +17,7 @@ LL |     Other(usize),
 LL |     Other2(usize, usize),
    |     -------------------- tuple variant defined here
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/60553
+   = note: see issue #60553 <https://github.com/rust-lang/rust/issues/60553> for more information
    = help: add `#![feature(arbitrary_enum_discriminant)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/parser/underscore-suffix-for-string.stderr
+++ b/src/test/ui/parser/underscore-suffix-for-string.stderr
@@ -5,5 +5,5 @@ LL |     let _ = "Foo"_;
    |                  ^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #42326 <https://github.com/rust-lang/rust/issues/42326>
+   = note: see issue #42326 <https://github.com/rust-lang/rust/issues/42326> for more information
 

--- a/src/test/ui/pattern/bindings-after-at/feature-gate-bindings_after_at.stderr
+++ b/src/test/ui/pattern/bindings-after-at/feature-gate-bindings_after_at.stderr
@@ -4,7 +4,7 @@ error[E0658]: pattern bindings after an `@` are unstable
 LL |     let x @ y = 0;
    |             ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/65490
+   = note: see issue #65490 <https://github.com/rust-lang/rust/issues/65490> for more information
    = help: add `#![feature(bindings_after_at)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/proc-macro/attr-stmt-expr.stderr
+++ b/src/test/ui/proc-macro/attr-stmt-expr.stderr
@@ -4,7 +4,7 @@ error[E0658]: attributes on expressions are experimental
 LL |     #[expect_print_expr]
    |     ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/15701
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
@@ -13,7 +13,7 @@ error[E0658]: attributes on expressions are experimental
 LL |     #[expect_expr]
    |     ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/15701
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/proc-macro/attributes-on-modules-fail.stderr
+++ b/src/test/ui/proc-macro/attributes-on-modules-fail.stderr
@@ -10,7 +10,7 @@ error[E0658]: non-inline modules in proc macro input are unstable
 LL | mod module;
    | ^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54727
+   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: non-inline modules in proc macro input are unstable
@@ -19,7 +19,7 @@ error[E0658]: non-inline modules in proc macro input are unstable
 LL |     mod inner;
    |     ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54727
+   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: non-inline modules in proc macro input are unstable
@@ -28,7 +28,7 @@ error[E0658]: non-inline modules in proc macro input are unstable
 LL |         mod inner;
    |         ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54727
+   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: non-inline modules in proc macro input are unstable
@@ -37,7 +37,7 @@ error[E0658]: non-inline modules in proc macro input are unstable
 LL |     mod inner;
    |     ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54727
+   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0412]: cannot find type `Y` in this scope

--- a/src/test/ui/proc-macro/expand-to-unstable-2.stderr
+++ b/src/test/ui/proc-macro/expand-to-unstable-2.stderr
@@ -4,7 +4,7 @@ error[E0658]: attributes starting with `rustc` are reserved for use by the `rust
 LL | #[derive(Unstable)]
    |          ^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/proc-macro/proc-macro-gates.stderr
+++ b/src/test/ui/proc-macro/proc-macro-gates.stderr
@@ -4,7 +4,7 @@ error[E0658]: non-builtin inner attributes are unstable
 LL |     #![empty_attr]
    |     ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54726
+   = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
 
 error[E0658]: non-builtin inner attributes are unstable
@@ -13,7 +13,7 @@ error[E0658]: non-builtin inner attributes are unstable
 LL |     #![empty_attr]
    |     ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54726
+   = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
 
 error: key-value macro attributes are not supported
@@ -28,7 +28,7 @@ error[E0658]: custom attributes cannot be applied to statements
 LL |     #[empty_attr]
    |     ^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54727
+   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: custom attributes cannot be applied to statements
@@ -37,7 +37,7 @@ error[E0658]: custom attributes cannot be applied to statements
 LL |     #[empty_attr]
    |     ^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54727
+   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: custom attributes cannot be applied to statements
@@ -46,7 +46,7 @@ error[E0658]: custom attributes cannot be applied to statements
 LL |     #[empty_attr]
    |     ^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54727
+   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: custom attributes cannot be applied to expressions
@@ -55,7 +55,7 @@ error[E0658]: custom attributes cannot be applied to expressions
 LL |     let _x = #[identity_attr] 2;
    |              ^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54727
+   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: custom attributes cannot be applied to expressions
@@ -64,7 +64,7 @@ error[E0658]: custom attributes cannot be applied to expressions
 LL |     let _x = [#[identity_attr] 2];
    |               ^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54727
+   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: custom attributes cannot be applied to expressions
@@ -73,7 +73,7 @@ error[E0658]: custom attributes cannot be applied to expressions
 LL |     let _x = #[identity_attr] println!();
    |              ^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54727
+   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: procedural macros cannot be expanded to patterns
@@ -82,7 +82,7 @@ error[E0658]: procedural macros cannot be expanded to patterns
 LL |     if let identity!(Some(_x)) = Some(3) {}
    |            ^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54727
+   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: procedural macros cannot be expanded to statements
@@ -91,7 +91,7 @@ error[E0658]: procedural macros cannot be expanded to statements
 LL |     empty!(struct S;);
    |     ^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54727
+   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: procedural macros cannot be expanded to statements
@@ -100,7 +100,7 @@ error[E0658]: procedural macros cannot be expanded to statements
 LL |     empty!(let _x = 3;);
    |     ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54727
+   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: procedural macros cannot be expanded to expressions
@@ -109,7 +109,7 @@ error[E0658]: procedural macros cannot be expanded to expressions
 LL |     let _x = identity!(3);
    |              ^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54727
+   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: procedural macros cannot be expanded to expressions
@@ -118,7 +118,7 @@ error[E0658]: procedural macros cannot be expanded to expressions
 LL |     let _x = [empty!(3)];
    |               ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54727
+   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error: aborting due to 14 previous errors

--- a/src/test/ui/raw-ref-op/feature-raw-ref-op.stderr
+++ b/src/test/ui/raw-ref-op/feature-raw-ref-op.stderr
@@ -4,7 +4,7 @@ error[E0658]: raw address of syntax is experimental
 LL |     &raw const a;
    |     ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+   = note: see issue #64490 <https://github.com/rust-lang/rust/issues/64490> for more information
    = help: add `#![feature(raw_ref_op)]` to the crate attributes to enable
 
 error[E0658]: raw address of syntax is experimental
@@ -13,7 +13,7 @@ error[E0658]: raw address of syntax is experimental
 LL |     &raw mut a;
    |     ^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+   = note: see issue #64490 <https://github.com/rust-lang/rust/issues/64490> for more information
    = help: add `#![feature(raw_ref_op)]` to the crate attributes to enable
 
 error[E0658]: raw address of syntax is experimental
@@ -22,7 +22,7 @@ error[E0658]: raw address of syntax is experimental
 LL |     let x = &raw const y;
    |             ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+   = note: see issue #64490 <https://github.com/rust-lang/rust/issues/64490> for more information
    = help: add `#![feature(raw_ref_op)]` to the crate attributes to enable
 
 error[E0658]: raw address of syntax is experimental
@@ -31,7 +31,7 @@ error[E0658]: raw address of syntax is experimental
 LL |     let x = &raw mut y;
    |             ^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+   = note: see issue #64490 <https://github.com/rust-lang/rust/issues/64490> for more information
    = help: add `#![feature(raw_ref_op)]` to the crate attributes to enable
 
 error[E0658]: raw address of syntax is experimental
@@ -40,7 +40,7 @@ error[E0658]: raw address of syntax is experimental
 LL | is_expr!(&raw const a);
    |          ^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+   = note: see issue #64490 <https://github.com/rust-lang/rust/issues/64490> for more information
    = help: add `#![feature(raw_ref_op)]` to the crate attributes to enable
 
 error[E0658]: raw address of syntax is experimental
@@ -49,7 +49,7 @@ error[E0658]: raw address of syntax is experimental
 LL | is_expr!(&raw mut a);
    |          ^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/64490
+   = note: see issue #64490 <https://github.com/rust-lang/rust/issues/64490> for more information
    = help: add `#![feature(raw_ref_op)]` to the crate attributes to enable
 
 error: aborting due to 6 previous errors

--- a/src/test/ui/reserved/reserved-attr-on-macro.stderr
+++ b/src/test/ui/reserved/reserved-attr-on-macro.stderr
@@ -4,7 +4,7 @@ error[E0658]: attributes starting with `rustc` are reserved for use by the `rust
 LL | #[rustc_attribute_should_be_reserved]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: cannot determine resolution for the macro `foo`

--- a/src/test/ui/return/return-match-array-const.stderr
+++ b/src/test/ui/return/return-match-array-const.stderr
@@ -4,7 +4,7 @@ error[E0658]: `match` is not allowed in a `const`
 LL |     [(); return match 0 { n => n }];
    |                 ^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `match` is not allowed in a `const`
@@ -13,7 +13,7 @@ error[E0658]: `match` is not allowed in a `const`
 LL |     [(); return match 0 { 0 => 0 }];
    |                 ^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `match` is not allowed in a `const`
@@ -22,7 +22,7 @@ error[E0658]: `match` is not allowed in a `const`
 LL |     [(); return match () { 'a' => 0, _ => 0 }];
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0572]: return statement outside of function body

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -519,7 +519,7 @@ error[E0658]: `match` is not allowed in a `const`
 LL |         true && let 1 = 1
    |                 ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `match` is not allowed in a `const`
@@ -528,7 +528,7 @@ error[E0658]: `match` is not allowed in a `const`
 LL |         true && let 1 = 1
    |                 ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0658]: `match` is not allowed in a `const`
@@ -537,7 +537,7 @@ error[E0658]: `match` is not allowed in a `const`
 LL |         true && let 1 = 1
    |                 ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/49146
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
    = help: add `#![feature(const_if_match)]` to the crate attributes to enable
 
 error[E0308]: mismatched types

--- a/src/test/ui/rfc-2497-if-let-chains/feature-gate.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/feature-gate.stderr
@@ -13,7 +13,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     if (let 0 = 1) {}
    |         ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -22,7 +22,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     if (((let 0 = 1))) {}
    |           ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -31,7 +31,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     if true && let 0 = 1 {}
    |                ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -40,7 +40,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     if let 0 = 1 && true {}
    |        ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -49,7 +49,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     if (let 0 = 1) && true {}
    |         ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -58,7 +58,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     if true && (let 0 = 1) {}
    |                 ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -67,7 +67,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     if (let 0 = 1) && (let 0 = 1) {}
    |         ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -76,7 +76,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     if (let 0 = 1) && (let 0 = 1) {}
    |                        ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -85,7 +85,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |        ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -94,7 +94,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                     ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -103,7 +103,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                   ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -112,7 +112,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                                ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -121,7 +121,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                                             ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -130,7 +130,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     if let Range { start: _, end: _ } = (true..true) && false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -139,7 +139,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     while (let 0 = 1) {}
    |            ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -148,7 +148,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     while (((let 0 = 1))) {}
    |              ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -157,7 +157,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     while true && let 0 = 1 {}
    |                   ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -166,7 +166,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     while let 0 = 1 && true {}
    |           ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -175,7 +175,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     while (let 0 = 1) && true {}
    |            ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -184,7 +184,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     while true && (let 0 = 1) {}
    |                    ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -193,7 +193,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     while (let 0 = 1) && (let 0 = 1) {}
    |            ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -202,7 +202,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     while (let 0 = 1) && (let 0 = 1) {}
    |                           ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -211,7 +211,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |           ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -220,7 +220,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                        ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -229,7 +229,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                      ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -238,7 +238,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                                   ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -247,7 +247,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                                                ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -256,7 +256,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     while let Range { start: _, end: _ } = (true..true) && false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -265,7 +265,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     #[cfg(FALSE)] (let 0 = 1);
    |                    ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -274,7 +274,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     noop_expr!((let 0 = 1));
    |                 ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -283,7 +283,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     use_expr!((let 0 = 1 && 0 == 0));
    |                ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
@@ -292,7 +292,7 @@ error[E0658]: `let` expressions in this position are experimental
 LL |     use_expr!((let 0 = 1));
    |                ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53667
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error: `let` expressions are not supported here

--- a/src/test/ui/rfc-2627-raw-dylib/feature-gate-raw-dylib-2.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/feature-gate-raw-dylib-2.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[link_ordinal]` attribute is an experimental feature
 LL |     #[link_ordinal(42)]
    |     ^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/58713
+   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
    = help: add `#![feature(raw_dylib)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/rfc-2627-raw-dylib/feature-gate-raw-dylib.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/feature-gate-raw-dylib.stderr
@@ -4,7 +4,7 @@ error[E0658]: kind="raw-dylib" is unstable
 LL | #[link(name="foo", kind="raw-dylib")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/58713
+   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
    = help: add `#![feature(raw_dylib)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/rfc-2632-const-trait-impl/const-trait-bound-opt-out/feature-gate.stock.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-trait-bound-opt-out/feature-gate.stock.stderr
@@ -4,7 +4,7 @@ error[E0658]: `?const` on trait bounds is experimental
 LL | const fn get_assoc_const<S: ?const T>() -> i32 { <S as T>::CONST }
    |                             ^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/67794
+   = note: see issue #67794 <https://github.com/rust-lang/rust/issues/67794> for more information
    = help: add `#![feature(const_trait_bound_opt_out)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/rfc-2632-const-trait-impl/feature-gate.stock.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/feature-gate.stock.stderr
@@ -4,7 +4,7 @@ error[E0658]: const trait impls are experimental
 LL | impl const T for S {}
    |      ^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/67792
+   = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
 
 error: const trait impls are not yet implemented

--- a/src/test/ui/rfc1445/feature-gate.no_gate.stderr
+++ b/src/test/ui/rfc1445/feature-gate.no_gate.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'structural_match'
 LL | impl std::marker::StructuralPartialEq for Foo { }
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/31434
+   = note: see issue #31434 <https://github.com/rust-lang/rust/issues/31434> for more information
    = help: add `#![feature(structural_match)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'structural_match'
@@ -13,7 +13,7 @@ error[E0658]: use of unstable library feature 'structural_match'
 LL | impl std::marker::StructuralEq for Foo { }
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/31434
+   = note: see issue #31434 <https://github.com/rust-lang/rust/issues/31434> for more information
    = help: add `#![feature(structural_match)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/self/elision/ref-self-async.nll.stderr
+++ b/src/test/ui/self/elision/ref-self-async.nll.stderr
@@ -4,7 +4,7 @@ error[E0658]: `Wrap<&Struct, Struct>` cannot be used as the type of `self` witho
 LL |     async fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {
    |                                       ^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44874
+   = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
    = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 

--- a/src/test/ui/span/gated-features-attr-spans.stderr
+++ b/src/test/ui/span/gated-features-attr-spans.stderr
@@ -4,7 +4,7 @@ error[E0658]: SIMD types are experimental and possibly buggy
 LL | #[repr(simd)]
    | ^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/span/issue-36530.stderr
+++ b/src/test/ui/span/issue-36530.stderr
@@ -4,7 +4,7 @@ error[E0658]: non-builtin inner attributes are unstable
 LL |     #![foo]
    |     ^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/54726
+   = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/specialization/defaultimpl/specialization-feature-gate-default.stderr
+++ b/src/test/ui/specialization/defaultimpl/specialization-feature-gate-default.stderr
@@ -6,7 +6,7 @@ LL | |     fn foo(&self) {}
 LL | | }
    | |_^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/31844
+   = note: see issue #31844 <https://github.com/rust-lang/rust/issues/31844> for more information
    = help: add `#![feature(specialization)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/specialization/soundness/partial_eq_range_inclusive.rs
+++ b/src/test/ui/specialization/soundness/partial_eq_range_inclusive.rs
@@ -1,0 +1,35 @@
+// run-pass
+
+use std::cell::RefCell;
+use std::cmp::Ordering;
+
+struct Evil<'a, 'b> {
+    values: RefCell<Vec<&'a str>>,
+    to_insert: &'b String,
+}
+
+impl<'a, 'b> PartialEq for Evil<'a, 'b> {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl<'a> PartialOrd for Evil<'a, 'a> {
+    fn partial_cmp(&self, _other: &Self) -> Option<Ordering> {
+        self.values.borrow_mut().push(self.to_insert);
+        None
+    }
+}
+
+fn main() {
+    let e;
+    let values;
+    {
+        let to_insert = String::from("Hello, world!");
+        e = Evil { values: RefCell::new(Vec::new()), to_insert: &to_insert };
+        let range = &e..=&e;
+        let _ = range == range;
+        values = e.values;
+    }
+    assert_eq!(*values.borrow(), Vec::<&str>::new());
+}

--- a/src/test/ui/specialization/soundness/partial_ord_slice.rs
+++ b/src/test/ui/specialization/soundness/partial_ord_slice.rs
@@ -1,0 +1,42 @@
+// Check that we aren't using unsound specialization in slice comparisons.
+
+// run-pass
+
+use std::cell::Cell;
+use std::cmp::Ordering;
+
+struct Evil<'a, 'b>(Cell<(&'a [i32], &'b [i32])>);
+
+impl PartialEq for Evil<'_, '_> {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for Evil<'_, '_> {}
+
+impl PartialOrd for Evil<'_, '_> {
+    fn partial_cmp(&self, _other: &Self) -> Option<Ordering> {
+        Some(Ordering::Equal)
+    }
+}
+
+impl<'a> Ord for Evil<'a, 'a> {
+    fn cmp(&self, _other: &Self) -> Ordering {
+        let (a, b) = self.0.get();
+        self.0.set((b, a));
+        Ordering::Equal
+    }
+}
+
+fn main() {
+    let x = &[1, 2, 3, 4];
+    let u = {
+        let a = Box::new([7, 8, 9, 10]);
+        let y = [Evil(Cell::new((x, &*a)))];
+        let _ = &y[..] <= &y[..];
+        let [Evil(c)] = y;
+        c.get().0
+    };
+    assert_eq!(u, &[1, 2, 3, 4]);
+}

--- a/src/test/ui/specialization/specialization-feature-gate-default.stderr
+++ b/src/test/ui/specialization/specialization-feature-gate-default.stderr
@@ -4,7 +4,7 @@ error[E0658]: specialization is unstable
 LL |     default fn foo(&self) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/31844
+   = note: see issue #31844 <https://github.com/rust-lang/rust/issues/31844> for more information
    = help: add `#![feature(specialization)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/stability-attribute/stability-attribute-issue.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-issue.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |     unstable();
    |     ^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/1
+   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': message
@@ -13,7 +13,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature': message
 LL |     unstable_msg();
    |     ^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/2
+   = note: see issue #2 <https://github.com/rust-lang/rust/issues/2> for more information
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/stmt_expr_attrs_no_feature.stderr
+++ b/src/test/ui/stmt_expr_attrs_no_feature.stderr
@@ -4,7 +4,7 @@ error[E0658]: attributes on expressions are experimental
 LL |     #[rustfmt::skip]
    |     ^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/15701
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
@@ -13,7 +13,7 @@ error[E0658]: attributes on expressions are experimental
 LL |     fn y(a: [u8; #[rustc_dummy] 5]);
    |                  ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/15701
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
@@ -22,7 +22,7 @@ error[E0658]: attributes on expressions are experimental
 LL |     const Y: u8 = #[rustc_dummy] 5;
    |                   ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/15701
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
@@ -31,7 +31,7 @@ error[E0658]: attributes on expressions are experimental
 LL |     const Y: [u8; #[rustc_dummy] 5];
    |                   ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/15701
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
@@ -40,7 +40,7 @@ error[E0658]: attributes on expressions are experimental
 LL |     field2: [u8; #[rustc_dummy] 5]
    |                  ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/15701
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
@@ -49,7 +49,7 @@ error[E0658]: attributes on expressions are experimental
 LL |     [u8; #[rustc_dummy] 5]
    |          ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/15701
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
@@ -58,7 +58,7 @@ error[E0658]: attributes on expressions are experimental
 LL |         [u8; #[rustc_dummy] 5]
    |              ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/15701
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
@@ -67,7 +67,7 @@ error[E0658]: attributes on expressions are experimental
 LL |         field2: [u8; #[rustc_dummy] 5]
    |                      ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/15701
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
@@ -76,7 +76,7 @@ error[E0658]: attributes on expressions are experimental
 LL |         6 => #[rustc_dummy] (),
    |              ^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/15701
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error: aborting due to 9 previous errors

--- a/src/test/ui/suggestions/attribute-typos.stderr
+++ b/src/test/ui/suggestions/attribute-typos.stderr
@@ -4,7 +4,7 @@ error[E0658]: attributes starting with `rustc` are reserved for use by the `rust
 LL | #[rustc_err]
    |   ^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: cannot find attribute `rustc_err` in this scope

--- a/src/test/ui/suggestions/type-ascription-instead-of-method.stderr
+++ b/src/test/ui/suggestions/type-ascription-instead-of-method.stderr
@@ -7,7 +7,7 @@ LL |     Box:new("foo".to_string())
    |        help: maybe write a path separator here: `::`
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
+   = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/type-ascription-instead-of-path-2.stderr
+++ b/src/test/ui/suggestions/type-ascription-instead-of-path-2.stderr
@@ -7,7 +7,7 @@ LL |     vec![Ok(2)].into_iter().collect:<Result<Vec<_>,_>>()?;
    |                                    help: maybe write a path separator here: `::`
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
+   = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/type-ascription-instead-of-variant.stderr
+++ b/src/test/ui/suggestions/type-ascription-instead-of-variant.stderr
@@ -7,7 +7,7 @@ LL |     let _ = Option:Some("");
    |                   help: maybe write a path separator here: `::`
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
+   = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
 
 error: aborting due to previous error
 

--- a/src/test/ui/syntax-trait-polarity-feature-gate.stderr
+++ b/src/test/ui/syntax-trait-polarity-feature-gate.stderr
@@ -4,7 +4,7 @@ error[E0658]: negative trait bounds are not yet fully implemented; use marker ty
 LL | impl !Send for TestType {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/13231
+   = note: see issue #13231 <https://github.com/rust-lang/rust/issues/13231> for more information
    = help: add `#![feature(optin_builtin_traits)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/target-feature/gate.stderr
+++ b/src/test/ui/target-feature/gate.stderr
@@ -4,7 +4,7 @@ error[E0658]: the target feature `avx512bw` is currently unstable
 LL | #[target_feature(enable = "avx512bw")]
    |                  ^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44839
+   = note: see issue #44839 <https://github.com/rust-lang/rust/issues/44839> for more information
    = help: add `#![feature(avx512_target_feature)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/tool-attributes/diagnostic_item.stderr
+++ b/src/test/ui/tool-attributes/diagnostic_item.stderr
@@ -4,7 +4,7 @@ error[E0658]: diagnostic items compiler internal support for linting
 LL | #[rustc_diagnostic_item = "foomp"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/trace_macros-gate.stderr
+++ b/src/test/ui/trace_macros-gate.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'trace_macros': `trace_macros` is 
 LL |     trace_macros!();
    |     ^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29598
+   = note: see issue #29598 <https://github.com/rust-lang/rust/issues/29598> for more information
    = help: add `#![feature(trace_macros)]` to the crate attributes to enable
 
 error: trace_macros! accepts only `true` or `false`
@@ -19,7 +19,7 @@ error[E0658]: use of unstable library feature 'trace_macros': `trace_macros` is 
 LL |     trace_macros!(true);
    |     ^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29598
+   = note: see issue #29598 <https://github.com/rust-lang/rust/issues/29598> for more information
    = help: add `#![feature(trace_macros)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'trace_macros': `trace_macros` is not stable enough for use and is subject to change
@@ -28,7 +28,7 @@ error[E0658]: use of unstable library feature 'trace_macros': `trace_macros` is 
 LL |     trace_macros!(false);
    |     ^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29598
+   = note: see issue #29598 <https://github.com/rust-lang/rust/issues/29598> for more information
    = help: add `#![feature(trace_macros)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'trace_macros': `trace_macros` is not stable enough for use and is subject to change
@@ -40,7 +40,7 @@ LL |         ($x: ident) => { trace_macros!($x) }
 LL |     expando!(true);
    |     --------------- in this macro invocation
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29598
+   = note: see issue #29598 <https://github.com/rust-lang/rust/issues/29598> for more information
    = help: add `#![feature(trace_macros)]` to the crate attributes to enable
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/type-alias-impl-trait/issue-60371.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-60371.stderr
@@ -4,7 +4,7 @@ error[E0658]: `impl Trait` in type aliases is unstable
 LL |     type Item = impl Bug;
    |                 ^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/63063
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `(): Bug` is not satisfied

--- a/src/test/ui/type/ascription/issue-47666.stderr
+++ b/src/test/ui/type/ascription/issue-47666.stderr
@@ -10,7 +10,7 @@ LL |     let _ = Option:Some(vec![0, 1]);
    |                   help: maybe write a path separator here: `::`
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
+   = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/type/ascription/issue-54516.stderr
+++ b/src/test/ui/type/ascription/issue-54516.stderr
@@ -7,7 +7,7 @@ LL |     println!("{}", std::mem:size_of::<BTreeMap<u32, u32>>());
    |                            help: maybe write a path separator here: `::`
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
+   = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/ascription/issue-60933.stderr
+++ b/src/test/ui/type/ascription/issue-60933.stderr
@@ -7,7 +7,7 @@ LL |     let u: usize = std::mem:size_of::<u32>();
    |                            help: maybe write a path separator here: `::`
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
+   = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/type-ascription-instead-of-statement-end.stderr
+++ b/src/test/ui/type/type-ascription-instead-of-statement-end.stderr
@@ -7,7 +7,7 @@ LL |     0;
    |     ^ expected type
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
+   = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
 
 error: expected type, found `0`
   --> $DIR/type-ascription-instead-of-statement-end.rs:9:23
@@ -18,7 +18,7 @@ LL |     println!("test"): 0;
    |                     tried to parse a type due to this type ascription
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
+   = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-feature-gate.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-feature-gate.stderr
@@ -4,7 +4,7 @@ error[E0658]: parenthetical notation is only stable when used with `Fn`-family t
 LL |     let x: Box<dyn Foo(isize)>;
    |                    ^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/unboxed-closures/unboxed-closure-no-cyclic-sig.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-no-cyclic-sig.stderr
@@ -6,7 +6,8 @@ LL |     g(|_| {  });
    |
    = note: closures cannot capture themselves or take themselves as argument;
            this error may be the result of a recent compiler bug-fix,
-           see https://github.com/rust-lang/rust/issues/46062 for more details
+           see issue #46062 <https://github.com/rust-lang/rust/issues/46062>
+           for more information
 
 error: aborting due to previous error
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-not-used-on-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-not-used-on-fn.stderr
@@ -4,7 +4,7 @@ error[E0658]: the precise format of `Fn`-family traits' type parameters is subje
 LL | fn bar1(x: &dyn Fn<(), Output=()>) {
    |                 ^^ help: use parenthetical notation instead: `Fn() -> ()`
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
@@ -13,7 +13,7 @@ error[E0658]: the precise format of `Fn`-family traits' type parameters is subje
 LL | fn bar2<T>(x: &T) where T: Fn<()> {
    |                            ^^ help: use parenthetical notation instead: `Fn() -> ()`
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29625
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/unsafe/ranged_ints2_const.stderr
+++ b/src/test/ui/unsafe/ranged_ints2_const.stderr
@@ -4,7 +4,7 @@ error[E0723]: mutable references in const fn are unstable
 LL |     let y = &mut x.0;
    |         ^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: mutable references in const fn are unstable
@@ -13,7 +13,7 @@ error[E0723]: mutable references in const fn are unstable
 LL |     let y = unsafe { &mut x.0 };
    |         ^
    |
-   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0133]: mutation of layout constrained field is unsafe and requires unsafe function or block

--- a/src/test/ui/utf8_idents.stderr
+++ b/src/test/ui/utf8_idents.stderr
@@ -4,7 +4,7 @@ error[E0658]: non-ascii idents are not fully supported
 LL |     'β,
    |     ^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55467
+   = note: see issue #55467 <https://github.com/rust-lang/rust/issues/55467> for more information
    = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
@@ -13,7 +13,7 @@ error[E0658]: non-ascii idents are not fully supported
 LL |     γ
    |     ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55467
+   = note: see issue #55467 <https://github.com/rust-lang/rust/issues/55467> for more information
    = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
@@ -22,7 +22,7 @@ error[E0658]: non-ascii idents are not fully supported
 LL |     δ: usize
    |     ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55467
+   = note: see issue #55467 <https://github.com/rust-lang/rust/issues/55467> for more information
    = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
@@ -31,7 +31,7 @@ error[E0658]: non-ascii idents are not fully supported
 LL |     let α = 0.00001f64;
    |         ^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/55467
+   = note: see issue #55467 <https://github.com/rust-lang/rust/issues/55467> for more information
    = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 warning: type parameter `γ` should have an upper camel case name

--- a/src/test/ui/where-clauses/where-equality-constraints.stderr
+++ b/src/test/ui/where-clauses/where-equality-constraints.stderr
@@ -4,7 +4,7 @@ error: equality constraints are not yet supported in `where` clauses
 LL | fn f() where u8 = u16 {}
    |              ^^^^^^^^ not supported
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/20041
+   = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
 
 error: equality constraints are not yet supported in `where` clauses
   --> $DIR/where-equality-constraints.rs:3:14
@@ -12,7 +12,7 @@ error: equality constraints are not yet supported in `where` clauses
 LL | fn g() where for<'a> &'static (u8,) == u16, {}
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not supported
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/20041
+   = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #68358 (Remove some unsound specializations)
 - #68802 (rustc_codegen_ssa: don't treat inlined variables as debuginfo arguments.)
 - #68834 (Fix and test implementation of BTreeMap's first/last_entry, pop_first/last)
 - #68881 (rustc_codegen_llvm: always set AlwaysPreserve on all debuginfo variables)
 - #68913 (Pretty-print generic params and where clauses on associated types)
 - #68918 (Don't use the word "unwrap" to describe "unwrap" methods)
 - #68929 (Make issue references consistent)

Failed merges:


r? @ghost