### PR TITLE
Cleanup debuginfo generation a bit

### DIFF
--- a/src/librustc_codegen_llvm/consts.rs
+++ b/src/librustc_codegen_llvm/consts.rs
@@ -402,7 +402,9 @@ impl StaticMethods for CodegenCx<'ll, 'tcx> {
                 }
             }
 
-            debuginfo::create_global_var_metadata(&self, def_id, g);
+            if let Some(dbg_cx) = self.dbg_cx.as_ref() {
+                debuginfo::create_global_var_metadata(dbg_cx, def_id, g);
+            }
 
             if attrs.flags.contains(CodegenFnAttrFlags::THREAD_LOCAL) {
                 llvm::set_thread_local_mode(g, self.tls_model);

--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -298,7 +298,7 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
         let (llcx, llmod) = (&*llvm_module.llcx, llvm_module.llmod());
 
         let dbg_cx = if tcx.sess.opts.debuginfo != DebugInfo::None {
-            let dctx = debuginfo::CrateDebugContext::new(llmod);
+            let dctx = debuginfo::CrateDebugContext::new(tcx, llmod);
             debuginfo::metadata::compile_unit_metadata(tcx, &codegen_unit.name().as_str(), &dctx);
             Some(dctx)
         } else {

--- a/src/librustc_codegen_llvm/debuginfo/create_scope_map.rs
+++ b/src/librustc_codegen_llvm/debuginfo/create_scope_map.rs
@@ -67,13 +67,8 @@ fn make_mir_scope(
         // Do not create a DIScope if there are no variables
         // defined in this MIR Scope, to avoid debuginfo bloat.
 
-        // However, we don't skip creating a nested scope if
-        // our parent is the root, because we might want to
-        // put arguments in the root and not have shadowing.
-        if parent_scope.scope_metadata.unwrap() != fn_metadata {
-            debug_context.scopes[scope] = parent_scope;
-            return;
-        }
+        debug_context.scopes[scope] = parent_scope;
+        return;
     }
 
     let loc = span_start(cx, scope_data.span);

--- a/src/librustc_codegen_llvm/debuginfo/doc.rs
+++ b/src/librustc_codegen_llvm/debuginfo/doc.rs
@@ -28,7 +28,7 @@
 //! utilizing a cache. The way to get a shared metadata node when needed is
 //! thus to just call the corresponding function in this module:
 //!
-//!     let file_metadata = file_metadata(crate_context, path);
+//!     let file_metadata = file_metadata(debug_context, path);
 //!
 //! The function will take care of probing the cache for an existing node for
 //! that exact file path.

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -9,7 +9,6 @@ use super::utils::{
 };
 use super::CrateDebugContext;
 
-use crate::abi;
 use crate::common::CodegenCx;
 use crate::llvm;
 use crate::llvm::debuginfo::{
@@ -495,8 +494,8 @@ fn trait_pointer_metadata(
 
     let layout = cx.layout_of(cx.tcx.mk_mut_ptr(trait_type));
 
-    assert_eq!(abi::FAT_PTR_ADDR, 0);
-    assert_eq!(abi::FAT_PTR_EXTRA, 1);
+    assert_eq!(layout::FAT_PTR_ADDR, 0);
+    assert_eq!(layout::FAT_PTR_EXTRA, 1);
 
     let data_ptr_field = layout.field(cx, 0);
     let vtable_field = layout.field(cx, 1);

--- a/src/librustc_codegen_llvm/debuginfo/source_loc.rs
+++ b/src/librustc_codegen_llvm/debuginfo/source_loc.rs
@@ -24,7 +24,7 @@ pub fn set_source_location<D>(
 ) {
     let dbg_loc = if debug_context.source_locations_enabled {
         debug!("set_source_location: {}", bx.sess().source_map().span_to_string(span));
-        let loc = span_start(bx.cx(), span);
+        let loc = span_start(bx.cx().tcx, span);
         InternalDebugLocation::new(scope, loc.line, loc.col.to_usize())
     } else {
         UnknownLocation


### PR DESCRIPTION
This removes an no longer necessary hack. This also uses `CrateDebugContext` in favor of `CodegenCx` in debuginfo generation.