### PR TITLE
codegen: misc cleanups around debuginfo scopes and locations.

### DIFF
--- a/src/librustc_codegen_llvm/debuginfo/create_scope_map.rs
+++ b/src/librustc_codegen_llvm/debuginfo/create_scope_map.rs
@@ -66,14 +66,8 @@ fn make_mir_scope(
     if !has_variables.contains(scope) {
         // Do not create a DIScope if there are no variables
         // defined in this MIR Scope, to avoid debuginfo bloat.
-
-        // However, we don't skip creating a nested scope if
-        // our parent is the root, because we might want to
-        // put arguments in the root and not have shadowing.
-        if parent_scope.scope_metadata.unwrap() != fn_metadata {
-            debug_context.scopes[scope] = parent_scope;
-            return;
-        }
+        debug_context.scopes[scope] = parent_scope;
+        return;
     }
 
     let loc = span_start(cx, scope_data.span);

--- a/src/librustc_codegen_llvm/debuginfo/source_loc.rs
+++ b/src/librustc_codegen_llvm/debuginfo/source_loc.rs
@@ -1,37 +1,13 @@
 use super::metadata::UNKNOWN_COLUMN_NUMBER;
 use super::utils::{debug_context, span_start};
-use rustc_codegen_ssa::mir::debuginfo::FunctionDebugContext;
 
-use crate::builder::Builder;
 use crate::common::CodegenCx;
 use crate::llvm::debuginfo::DIScope;
 use crate::llvm::{self, Value};
-use log::debug;
 use rustc_codegen_ssa::traits::*;
 
 use libc::c_uint;
 use rustc_span::{Pos, Span};
-
-/// Sets the current debug location at the beginning of the span.
-///
-/// Maps to a call to llvm::LLVMSetCurrentDebugLocation(...).
-pub fn set_source_location<D>(
-    debug_context: &FunctionDebugContext<D>,
-    bx: &Builder<'_, 'll, '_>,
-    scope: &'ll DIScope,
-    span: Span,
-) {
-    let dbg_loc = if debug_context.source_locations_enabled {
-        debug!("set_source_location: {}", bx.sess().source_map().span_to_string(span));
-        Some(bx.cx().create_debug_loc(scope, span))
-    } else {
-        None
-    };
-
-    unsafe {
-        llvm::LLVMSetCurrentDebugLocation(bx.llbuilder, dbg_loc);
-    }
-}
 
 impl CodegenCx<'ll, '_> {
     pub fn create_debug_loc(&self, scope: &'ll DIScope, span: Span) -> &'ll Value {

--- a/src/librustc_codegen_llvm/debuginfo/source_loc.rs
+++ b/src/librustc_codegen_llvm/debuginfo/source_loc.rs
@@ -1,12 +1,11 @@
-use self::InternalDebugLocation::*;
-
 use super::metadata::UNKNOWN_COLUMN_NUMBER;
 use super::utils::{debug_context, span_start};
 use rustc_codegen_ssa::mir::debuginfo::FunctionDebugContext;
 
 use crate::builder::Builder;
-use crate::llvm;
+use crate::common::CodegenCx;
 use crate::llvm::debuginfo::DIScope;
+use crate::llvm::{self, Value};
 use log::debug;
 use rustc_codegen_ssa::traits::*;
 
@@ -24,56 +23,37 @@ pub fn set_source_location<D>(
 ) {
     let dbg_loc = if debug_context.source_locations_enabled {
         debug!("set_source_location: {}", bx.sess().source_map().span_to_string(span));
-        let loc = span_start(bx.cx(), span);
-        InternalDebugLocation::new(scope, loc.line, loc.col.to_usize())
+        Some(bx.cx().create_debug_loc(scope, span))
     } else {
-        UnknownLocation
-    };
-    set_debug_location(bx, dbg_loc);
-}
-
-#[derive(Copy, Clone, PartialEq)]
-pub enum InternalDebugLocation<'ll> {
-    KnownLocation { scope: &'ll DIScope, line: usize, col: usize },
-    UnknownLocation,
-}
-
-impl InternalDebugLocation<'ll> {
-    pub fn new(scope: &'ll DIScope, line: usize, col: usize) -> Self {
-        KnownLocation { scope, line, col }
-    }
-}
-
-pub fn set_debug_location(bx: &Builder<'_, 'll, '_>, debug_location: InternalDebugLocation<'ll>) {
-    let metadata_node = match debug_location {
-        KnownLocation { scope, line, col } => {
-            // For MSVC, set the column number to zero.
-            // Otherwise, emit it. This mimics clang behaviour.
-            // See discussion in https://github.com/rust-lang/rust/issues/42921
-            let col_used = if bx.sess().target.target.options.is_like_msvc {
-                UNKNOWN_COLUMN_NUMBER
-            } else {
-                col as c_uint
-            };
-            debug!("setting debug location to {} {}", line, col);
-
-            unsafe {
-                Some(llvm::LLVMRustDIBuilderCreateDebugLocation(
-                    debug_context(bx.cx()).llcontext,
-                    line as c_uint,
-                    col_used,
-                    scope,
-                    None,
-                ))
-            }
-        }
-        UnknownLocation => {
-            debug!("clearing debug location ");
-            None
-        }
+        None
     };
 
     unsafe {
-        llvm::LLVMSetCurrentDebugLocation(bx.llbuilder, metadata_node);
+        llvm::LLVMSetCurrentDebugLocation(bx.llbuilder, dbg_loc);
+    }
+}
+
+impl CodegenCx<'ll, '_> {
+    pub fn create_debug_loc(&self, scope: &'ll DIScope, span: Span) -> &'ll Value {
+        let loc = span_start(self, span);
+
+        // For MSVC, set the column number to zero.
+        // Otherwise, emit it. This mimics clang behaviour.
+        // See discussion in https://github.com/rust-lang/rust/issues/42921
+        let col_used = if self.sess().target.target.options.is_like_msvc {
+            UNKNOWN_COLUMN_NUMBER
+        } else {
+            loc.col.to_usize() as c_uint
+        };
+
+        unsafe {
+            llvm::LLVMRustDIBuilderCreateDebugLocation(
+                debug_context(self).llcontext,
+                loc.line as c_uint,
+                col_used,
+                scope,
+                None,
+            )
+        }
     }
 }

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -909,7 +909,7 @@ extern "C" {
     pub fn LLVMDisposeBuilder(Builder: &'a mut Builder<'a>);
 
     // Metadata
-    pub fn LLVMSetCurrentDebugLocation(Builder: &Builder<'a>, L: Option<&'a Value>);
+    pub fn LLVMSetCurrentDebugLocation(Builder: &Builder<'a>, L: &'a Value);
 
     // Terminators
     pub fn LLVMBuildRetVoid(B: &Builder<'a>) -> &'a Value;

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -910,8 +910,6 @@ extern "C" {
 
     // Metadata
     pub fn LLVMSetCurrentDebugLocation(Builder: &Builder<'a>, L: Option<&'a Value>);
-    pub fn LLVMGetCurrentDebugLocation(Builder: &Builder<'a>) -> &'a Value;
-    pub fn LLVMSetInstDebugLocation(Builder: &Builder<'a>, Inst: &'a Value);
 
     // Terminators
     pub fn LLVMBuildRetVoid(B: &Builder<'a>) -> &'a Value;

--- a/src/librustc_codegen_ssa/mir/debuginfo.rs
+++ b/src/librustc_codegen_ssa/mir/debuginfo.rs
@@ -14,7 +14,6 @@ use super::{FunctionCx, LocalRef};
 
 pub struct FunctionDebugContext<D> {
     pub scopes: IndexVec<mir::SourceScope, DebugScope<D>>,
-    pub source_locations_enabled: bool,
     pub defining_crate: CrateNum,
 }
 
@@ -53,11 +52,10 @@ impl<D> DebugScope<D> {
 }
 
 impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
-    pub fn set_debug_loc(&mut self, bx: &mut Bx, source_info: mir::SourceInfo) {
+    pub fn set_debug_loc(&self, bx: &mut Bx, source_info: mir::SourceInfo) {
         let (scope, span) = self.debug_loc(source_info);
-        if let Some(debug_context) = &mut self.debug_context {
-            // FIXME(eddyb) get rid of this unwrap somehow.
-            bx.set_source_location(debug_context, scope.unwrap(), span);
+        if let Some(scope) = scope {
+            bx.set_source_location(scope, span);
         }
     }
 

--- a/src/librustc_codegen_ssa/mir/debuginfo.rs
+++ b/src/librustc_codegen_ssa/mir/debuginfo.rs
@@ -210,11 +210,6 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             return;
         }
 
-        let debug_context = match &self.debug_context {
-            Some(debug_context) => debug_context,
-            None => return,
-        };
-
         // FIXME(eddyb) add debuginfo for unsized places too.
         let base = match local_ref {
             LocalRef::Place(place) => place,
@@ -264,7 +259,6 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             if let Some(scope) = scope {
                 if let Some(dbg_var) = var.dbg_var {
                     bx.dbg_var_addr(
-                        debug_context,
                         dbg_var,
                         scope,
                         base.llval,

--- a/src/librustc_codegen_ssa/mir/mod.rs
+++ b/src/librustc_codegen_ssa/mir/mod.rs
@@ -230,13 +230,6 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         bx.br(fx.blocks[mir::START_BLOCK]);
     }
 
-    // Up until here, IR instructions for this function have explicitly not been annotated with
-    // source code location, so we don't step into call setup code. From here on, source location
-    // emitting should be enabled.
-    if let Some(debug_context) = &mut fx.debug_context {
-        debug_context.source_locations_enabled = true;
-    }
-
     let rpo = traversal::reverse_postorder(&mir_body);
     let mut visited = BitSet::new_empty(mir_body.basic_blocks().len());
 

--- a/src/librustc_codegen_ssa/traits/debuginfo.rs
+++ b/src/librustc_codegen_ssa/traits/debuginfo.rs
@@ -49,7 +49,6 @@ pub trait DebugInfoBuilderMethods: BackendTypes {
     // names (choose between `dbg`, `debug`, `debuginfo`, `debug_info` etc.).
     fn dbg_var_addr(
         &mut self,
-        dbg_context: &FunctionDebugContext<Self::DIScope>,
         dbg_var: Self::DIVariable,
         scope_metadata: Self::DIScope,
         variable_alloca: Self::Value,

--- a/src/librustc_codegen_ssa/traits/debuginfo.rs
+++ b/src/librustc_codegen_ssa/traits/debuginfo.rs
@@ -57,12 +57,7 @@ pub trait DebugInfoBuilderMethods: BackendTypes {
         indirect_offsets: &[Size],
         span: Span,
     );
-    fn set_source_location(
-        &mut self,
-        debug_context: &mut FunctionDebugContext<Self::DIScope>,
-        scope: Self::DIScope,
-        span: Span,
-    );
+    fn set_source_location(&mut self, scope: Self::DIScope, span: Span);
     fn insert_reference_to_gdb_debug_scripts_section_global(&mut self);
     fn set_var_name(&mut self, value: Self::Value, name: &str);
 }


### PR DESCRIPTION
See each commit message. Most of these seem to be leftovers from the transition to MIR codegen.

r? @nagisa cc @bjorn3