### PR TITLE
 Account for type params on method without parentheses

### DIFF
--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -828,7 +828,7 @@ impl<'a> Parser<'a> {
             if let Some(args) = segment.args {
                 self.struct_span_err(
                     args.span(),
-                    "field expressions may not have generic arguments",
+                    "field expressions cannot have generic arguments",
                 )
                 .emit();
             }

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -1586,7 +1586,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 &format!("a method `{}` also exists, call it with parentheses", field),
                 field,
                 expr_t,
-                expr.hir_id,
+                expr,
             );
         }
         err.emit();
@@ -1609,7 +1609,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 "use parentheses to call the method",
                 field,
                 expr_t,
-                expr.hir_id,
+                expr,
             );
         } else {
             err.help("methods are immutable and cannot be assigned to");

--- a/src/test/ui/parser/type-parameters-in-field-exprs.rs
+++ b/src/test/ui/parser/type-parameters-in-field-exprs.rs
@@ -9,9 +9,9 @@ fn main() {
         y: 2,
     };
     f.x::<isize>;
-    //~^ ERROR field expressions may not have generic arguments
+    //~^ ERROR field expressions cannot have generic arguments
     f.x::<>;
-    //~^ ERROR field expressions may not have generic arguments
+    //~^ ERROR field expressions cannot have generic arguments
     f.x::();
-    //~^ ERROR field expressions may not have generic arguments
+    //~^ ERROR field expressions cannot have generic arguments
 }

--- a/src/test/ui/parser/type-parameters-in-field-exprs.stderr
+++ b/src/test/ui/parser/type-parameters-in-field-exprs.stderr
@@ -1,16 +1,16 @@
-error: field expressions may not have generic arguments
+error: field expressions cannot have generic arguments
   --> $DIR/type-parameters-in-field-exprs.rs:11:10
    |
 LL |     f.x::<isize>;
    |          ^^^^^^^
 
-error: field expressions may not have generic arguments
+error: field expressions cannot have generic arguments
   --> $DIR/type-parameters-in-field-exprs.rs:13:10
    |
 LL |     f.x::<>;
    |          ^^
 
-error: field expressions may not have generic arguments
+error: field expressions cannot have generic arguments
   --> $DIR/type-parameters-in-field-exprs.rs:15:7
    |
 LL |     f.x::();

--- a/src/test/ui/suggestions/method-missing-parentheses.rs
+++ b/src/test/ui/suggestions/method-missing-parentheses.rs
@@ -1,5 +1,5 @@
 fn main() {
     let _ = vec![].into_iter().collect::<usize>;
     //~^ ERROR attempted to take value of method `collect` on type `std::vec::IntoIter<_>`
-    //~| ERROR field expressions may not have generic arguments
+    //~| ERROR field expressions cannot have generic arguments
 }

--- a/src/test/ui/suggestions/method-missing-parentheses.rs
+++ b/src/test/ui/suggestions/method-missing-parentheses.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let _ = vec![].into_iter().collect::<usize>;
+    //~^ ERROR attempted to take value of method `collect` on type `std::vec::IntoIter<_>`
+    //~| ERROR field expressions may not have generic arguments
+}

--- a/src/test/ui/suggestions/method-missing-parentheses.stderr
+++ b/src/test/ui/suggestions/method-missing-parentheses.stderr
@@ -1,4 +1,4 @@
-error: field expressions may not have generic arguments
+error: field expressions cannot have generic arguments
   --> $DIR/method-missing-parentheses.rs:2:41
    |
 LL |     let _ = vec![].into_iter().collect::<usize>;

--- a/src/test/ui/suggestions/method-missing-parentheses.stderr
+++ b/src/test/ui/suggestions/method-missing-parentheses.stderr
@@ -1,0 +1,17 @@
+error: field expressions may not have generic arguments
+  --> $DIR/method-missing-parentheses.rs:2:41
+   |
+LL |     let _ = vec![].into_iter().collect::<usize>;
+   |                                         ^^^^^^^
+
+error[E0615]: attempted to take value of method `collect` on type `std::vec::IntoIter<_>`
+  --> $DIR/method-missing-parentheses.rs:2:32
+   |
+LL |     let _ = vec![].into_iter().collect::<usize>;
+   |                                ^^^^^^^---------
+   |                                |
+   |                                help: use parentheses to call the method: `collect::<usize>()`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0615`.


### PR DESCRIPTION
Account for those type parameters in the structured suggestion when forgetting to call method:

```
error[E0615]: attempted to take value of method `collect` on type `std::vec::IntoIter<_>`
  --> $DIR/method-missing-parentheses.rs:2:32
   |
LL |     let _ = vec![].into_iter().collect::<usize>;
   |                                ^^^^^^^---------
   |                                |
   |                                help: use parentheses to call the method: `collect::<usize>()`
```