### PR TITLE
Make `u8::is_ascii` a stable `const fn`

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -4300,8 +4300,9 @@ impl u8 {
     /// assert!(!non_ascii.is_ascii());
     /// ```
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
+    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.43.0")]
     #[inline]
-    pub fn is_ascii(&self) -> bool {
+    pub const fn is_ascii(&self) -> bool {
         *self & 128 == 0
     }
 

--- a/src/test/ui/consts/is_ascii.rs
+++ b/src/test/ui/consts/is_ascii.rs
@@ -3,7 +3,13 @@
 static X: bool = 'a'.is_ascii();
 static Y: bool = 'ä'.is_ascii();
 
+static BX: bool = b'a'.is_ascii();
+static BY: bool = 192u8.is_ascii();
+
 fn main() {
     assert!(X);
     assert!(!Y);
+
+    assert!(BX);
+    assert!(!BY);
 }


### PR DESCRIPTION
`char::is_ascii` was already stabilized as `const fn` in #55278, so there is no reason for `u8::is_ascii` to go through an unstable period.

cc @rust-lang/libs 