### PR TITLE
Parse & reject postfix operators after casts

### DIFF
--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -659,8 +659,7 @@ impl<'a> Parser<'a> {
                     ExprKind::MethodCall(_, _) => "a method call",
                     ExprKind::Call(_, _) => "a function call",
                     ExprKind::Await(_) => "`.await`",
-                    ref kind =>
-                        unreachable!("parse_dot_or_call_expr_with_ shouldn't produce a {:?}", kind),
+                    _ => unreachable!("parse_dot_or_call_expr_with_ shouldn't produce this"),
                 }
             );
             let mut err = self.struct_span_err(span, &msg);

--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -665,17 +665,23 @@ impl<'a> Parser<'a> {
             );
             let mut err = self.struct_span_err(span, &msg);
             let suggestion = "try surrounding the expression in parentheses";
-            if let Ok(expr_str) = expr_str {
-                err.span_suggestion(
-                    span,
-                    suggestion,
-                    format!("({})", expr_str),
-                    Applicability::MachineApplicable,
-                )
+            // if type ascription is "likely an error", the user will already be getting a useful
+            // help message, and doesn't need a second.
+            if self.last_type_ascription.map_or(false, |last_ascription| last_ascription.1) {
+                self.maybe_annotate_with_ascription(&mut err, false);
             } else {
-                err.span_help(span, suggestion)
+                if let Ok(expr_str) = expr_str {
+                    err.span_suggestion(
+                        span,
+                        suggestion,
+                        format!("({})", expr_str),
+                        Applicability::MachineApplicable,
+                    );
+                } else {
+                    err.span_help(span, suggestion);
+                }
             }
-            .emit();
+            err.emit();
         };
         Ok(with_postfix)
     }

--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -645,7 +645,9 @@ impl<'a> Parser<'a> {
 
         // Check if an illegal postfix operator has been added after the cast.
         // If the resulting expression is not a cast, or has a different memory location, it is an illegal postfix operator.
-        if !matches!(with_postfix.kind, ExprKind::Cast(_, _)) || after_hash != before_hash {
+        if !matches!(with_postfix.kind, ExprKind::Cast(_, _) | ExprKind::Type(_, _))
+            || after_hash != before_hash
+        {
             let expr_str = self.span_to_snippet(span);
 
             let msg = format!(

--- a/src/test/ui/parser/issue-35813-postfix-after-cast.rs
+++ b/src/test/ui/parser/issue-35813-postfix-after-cast.rs
@@ -58,6 +58,13 @@ pub fn cast_cast_method_call() {
     //~^ ERROR: casts cannot be followed by a method call
 }
 
+pub fn multiline_error() {
+    let _ = 0
+        as i32
+        .count_ones();
+    //~^^^ ERROR: casts cannot be followed by a method call
+}
+
 // this tests that the precedence for `!x as Y.Z` is still what we expect
 pub fn precedence() {
     let x: i32 = &vec![1, 2, 3] as &Vec<i32>[0];

--- a/src/test/ui/parser/issue-35813-postfix-after-cast.rs
+++ b/src/test/ui/parser/issue-35813-postfix-after-cast.rs
@@ -35,6 +35,29 @@ pub fn cast_after_cast() {
     let _ = 0i32: i32: i32 as u32 as i32;
 }
 
+pub fn cast_cast_method_call() {
+    let _ = 0i32: i32: i32.count_ones();
+    //~^ ERROR: casts cannot be followed by a method call
+    let _ = 0 as i32: i32.count_ones();
+    //~^ ERROR: casts cannot be followed by a method call
+    let _ = 0i32: i32 as i32.count_ones();
+    //~^ ERROR: casts cannot be followed by a method call
+    let _ = 0 as i32 as i32.count_ones();
+    //~^ ERROR: casts cannot be followed by a method call
+    let _ = 0i32: i32: i32 as u32 as i32.count_ones();
+    //~^ ERROR: casts cannot be followed by a method call
+    let _ = 0i32: i32.count_ones(): u32;
+    //~^ ERROR: casts cannot be followed by a method call
+    let _ = 0 as i32.count_ones(): u32;
+    //~^ ERROR: casts cannot be followed by a method call
+    let _ = 0i32: i32.count_ones() as u32;
+    //~^ ERROR: casts cannot be followed by a method call
+    let _ = 0 as i32.count_ones() as u32;
+    //~^ ERROR: casts cannot be followed by a method call
+    let _ = 0i32: i32: i32.count_ones() as u32 as i32;
+    //~^ ERROR: casts cannot be followed by a method call
+}
+
 // this tests that the precedence for `!x as Y.Z` is still what we expect
 pub fn precedence() {
     let x: i32 = &vec![1, 2, 3] as &Vec<i32>[0];

--- a/src/test/ui/parser/issue-35813-postfix-after-cast.rs
+++ b/src/test/ui/parser/issue-35813-postfix-after-cast.rs
@@ -1,5 +1,6 @@
 // edition:2018
 #![crate_type = "lib"]
+#![feature(type_ascription)]
 use std::future::Future;
 use std::pin::Pin;
 
@@ -7,47 +8,122 @@ use std::pin::Pin;
 // errors and parse such that further code gives useful errors.
 pub fn index_after_as_cast() {
     vec![1, 2, 3] as Vec<i32>[0];
-    //~^ ERROR: casts followed by index operators are not supported
+    //~^ ERROR: casts cannot be followed by indexing
+    vec![1, 2, 3]: Vec<i32>[0];
+    //~^ ERROR: casts cannot be followed by indexing
 }
 
 pub fn index_after_cast_to_index() {
     (&[0]) as &[i32][0];
-    //~^ ERROR: casts followed by index operators are not supported
+    //~^ ERROR: casts cannot be followed by indexing
+    (&[0i32]): &[i32; 1][0];
+    //~^ ERROR: casts cannot be followed by indexing
+}
+
+pub fn cast_after_cast() {
+    if 5u64 as i32 as u16 == 0u16 {
+        
+    }
+    if 5u64: u64: u64 == 0u64 {
+       
+    }
+    let _ = 5u64: u64: u64 as u8 as i8 == 9i8;
+    let _ = 0i32: i32: i32;
+    let _ = 0 as i32: i32;
+    let _ = 0i32: i32 as i32;
+    let _ = 0 as i32 as i32;
+    let _ = 0i32: i32: i32 as u32 as i32;
 }
 
 // this tests that the precedence for `!x as Y.Z` is still what we expect
 pub fn precedence() {
     let x: i32 = &vec![1, 2, 3] as &Vec<i32>[0];
-    //~^ ERROR: casts followed by index operators are not supported
+    //~^ ERROR: casts cannot be followed by indexing
+}
+
+pub fn method_calls() {
+    0 as i32.max(0);
+    //~^ ERROR: casts cannot be followed by a method call
+    0: i32.max(0);
+    //~^ ERROR: casts cannot be followed by a method call
 }
 
 pub fn complex() {
     let _ = format!(
-        "{}",
-        if true { 33 } else { 44 } as i32.max(0)
-        //~^ ERROR: casts followed by method call expressions are not supported
+        "{} and {}",
+        if true { 33 } else { 44 } as i32.max(0),
+        //~^ ERROR: casts cannot be followed by a method call
+        if true { 33 } else { 44 }: i32.max(0)
+        //~^ ERROR: casts cannot be followed by a method call
     );
 }
 
 pub fn in_condition() {
     if 5u64 as i32.max(0) == 0 {
-        //~^ ERROR: casts followed by method call expressions are not supported
+        //~^ ERROR: casts cannot be followed by a method call
+    }
+    if 5u64: u64.max(0) == 0 {
+        //~^ ERROR: casts cannot be followed by a method call
     }
 }
 
 pub fn inside_block() {
     let _ = if true {
         5u64 as u32.max(0) == 0
-        //~^ ERROR: casts followed by method call expressions are not supported
+        //~^ ERROR: casts cannot be followed by a method call
+    } else { false };
+    let _ = if true {
+        5u64: u64.max(0) == 0
+        //~^ ERROR: casts cannot be followed by a method call
     } else { false };
 }
 
 static bar: &[i32] = &(&[1,2,3] as &[i32][0..1]);
-//~^ ERROR: casts followed by index operators are not supported
+//~^ ERROR: casts cannot be followed by indexing
+
+static bar2: &[i32] = &(&[1i32,2,3]: &[i32; 3][0..1]);
+//~^ ERROR: casts cannot be followed by indexing
+
+
+pub fn cast_then_try() -> Result<u64,u64> {
+    Err(0u64) as Result<u64,u64>?;
+    //~^ ERROR: casts cannot be followed by ?
+    Err(0u64): Result<u64,u64>?;
+    //~^ ERROR: casts cannot be followed by ?
+    Ok(1)
+}
+
+
+pub fn cast_then_call() {
+    type F = fn(u8);
+    // type ascription won't actually do [unique drop fn type] -> fn(u8) casts.
+    let drop_ptr = drop as fn(u8);
+    drop as F();
+    //~^ ERROR: parenthesized type parameters may only be used with a `Fn` trait [E0214]
+    drop_ptr: F();
+    //~^ ERROR: parenthesized type parameters may only be used with a `Fn` trait [E0214]
+}
+
+pub fn cast_to_fn_should_work() {
+    let drop_ptr = drop as fn(u8);
+    drop as fn(u8);
+    drop_ptr: fn(u8); 
+}
+
+pub fn parens_after_cast_error() {
+    let drop_ptr = drop as fn(u8);
+    drop as fn(u8)(0);
+    //~^ ERROR: casts cannot be followed by a function call
+    drop_ptr: fn(u8)(0);
+    //~^ ERROR: casts cannot be followed by a function call
+}
 
 pub async fn cast_then_await() {
     Box::pin(noop()) as Pin<Box<dyn Future<Output = ()>>>.await;
-    //~^ ERROR: casts followed by awaits are not supported
+    //~^ ERROR: casts cannot be followed by `.await`
+
+    Box::pin(noop()): Pin<Box<_>>.await;
+    //~^ ERROR: casts cannot be followed by `.await`
 }
 
 pub async fn noop() {}
@@ -59,5 +135,7 @@ pub struct Foo {
 
 pub fn struct_field() {
     Foo::default() as Foo.bar;
-    //~^ ERROR: casts followed by field access expressions are not supported
+    //~^ ERROR: cannot be followed by a field access
+    Foo::default(): Foo.bar;
+    //~^ ERROR: cannot be followed by a field access
 }

--- a/src/test/ui/parser/issue-35813-postfix-after-cast.rs
+++ b/src/test/ui/parser/issue-35813-postfix-after-cast.rs
@@ -22,10 +22,10 @@ pub fn index_after_cast_to_index() {
 
 pub fn cast_after_cast() {
     if 5u64 as i32 as u16 == 0u16 {
-        
+
     }
     if 5u64: u64: u64 == 0u64 {
-       
+
     }
     let _ = 5u64: u64: u64 as u8 as i8 == 9i8;
     let _ = 0i32: i32: i32;
@@ -107,7 +107,7 @@ pub fn cast_then_call() {
 pub fn cast_to_fn_should_work() {
     let drop_ptr = drop as fn(u8);
     drop as fn(u8);
-    drop_ptr: fn(u8); 
+    drop_ptr: fn(u8);
 }
 
 pub fn parens_after_cast_error() {

--- a/src/test/ui/parser/issue-35813-postfix-after-cast.rs
+++ b/src/test/ui/parser/issue-35813-postfix-after-cast.rs
@@ -1,0 +1,63 @@
+// edition:2018
+#![crate_type = "lib"]
+use std::future::Future;
+use std::pin::Pin;
+
+// This tests the parser for "x as Y[z]". It errors, but we want to give useful
+// errors and parse such that further code gives useful errors.
+pub fn index_after_as_cast() {
+    vec![1, 2, 3] as Vec<i32>[0];
+    //~^ ERROR: casts followed by index operators are not supported
+}
+
+pub fn index_after_cast_to_index() {
+    (&[0]) as &[i32][0];
+    //~^ ERROR: casts followed by index operators are not supported
+}
+
+// this tests that the precedence for `!x as Y.Z` is still what we expect
+pub fn precedence() {
+    let x: i32 = &vec![1, 2, 3] as &Vec<i32>[0];
+    //~^ ERROR: casts followed by index operators are not supported
+}
+
+pub fn complex() {
+    let _ = format!(
+        "{}",
+        if true { 33 } else { 44 } as i32.max(0)
+        //~^ ERROR: casts followed by method call expressions are not supported
+    );
+}
+
+pub fn in_condition() {
+    if 5u64 as i32.max(0) == 0 {
+        //~^ ERROR: casts followed by method call expressions are not supported
+    }
+}
+
+pub fn inside_block() {
+    let _ = if true {
+        5u64 as u32.max(0) == 0
+        //~^ ERROR: casts followed by method call expressions are not supported
+    } else { false };
+}
+
+static bar: &[i32] = &(&[1,2,3] as &[i32][0..1]);
+//~^ ERROR: casts followed by index operators are not supported
+
+pub async fn cast_then_await() {
+    Box::pin(noop()) as Pin<Box<dyn Future<Output = ()>>>.await;
+    //~^ ERROR: casts followed by awaits are not supported
+}
+
+pub async fn noop() {}
+
+#[derive(Default)]
+pub struct Foo {
+    pub bar: u32,
+}
+
+pub fn struct_field() {
+    Foo::default() as Foo.bar;
+    //~^ ERROR: casts followed by field access expressions are not supported
+}

--- a/src/test/ui/parser/issue-35813-postfix-after-cast.stderr
+++ b/src/test/ui/parser/issue-35813-postfix-after-cast.stderr
@@ -1,0 +1,74 @@
+error: casts followed by index operators are not supported
+  --> $DIR/issue-35813-postfix-after-cast.rs:9:5
+   |
+LL |     vec![1, 2, 3] as Vec<i32>[0];
+   |     -------------------------^^^
+   |     |
+   |     help: try surrounding the expression with parentheses: `(vec![1, 2, 3] as Vec<i32>)`
+
+error: casts followed by index operators are not supported
+  --> $DIR/issue-35813-postfix-after-cast.rs:14:5
+   |
+LL |     (&[0]) as &[i32][0];
+   |     ----------------^^^
+   |     |
+   |     help: try surrounding the expression with parentheses: `((&[0]) as &[i32])`
+
+error: casts followed by index operators are not supported
+  --> $DIR/issue-35813-postfix-after-cast.rs:20:18
+   |
+LL |     let x: i32 = &vec![1, 2, 3] as &Vec<i32>[0];
+   |                  ---------------------------^^^
+   |                  |
+   |                  help: try surrounding the expression with parentheses: `(&vec![1, 2, 3] as &Vec<i32>)`
+
+error: casts followed by method call expressions are not supported
+  --> $DIR/issue-35813-postfix-after-cast.rs:33:8
+   |
+LL |     if 5u64 as i32.max(0) == 0 {
+   |        -----------^^^^^^^
+   |        |
+   |        help: try surrounding the expression with parentheses: `(5u64 as i32)`
+
+error: casts followed by method call expressions are not supported
+  --> $DIR/issue-35813-postfix-after-cast.rs:40:9
+   |
+LL |         5u64 as u32.max(0) == 0
+   |         -----------^^^^^^^
+   |         |
+   |         help: try surrounding the expression with parentheses: `(5u64 as u32)`
+
+error: casts followed by index operators are not supported
+  --> $DIR/issue-35813-postfix-after-cast.rs:45:24
+   |
+LL | static bar: &[i32] = &(&[1,2,3] as &[i32][0..1]);
+   |                        ------------------^^^^^^
+   |                        |
+   |                        help: try surrounding the expression with parentheses: `(&[1,2,3] as &[i32])`
+
+error: casts followed by awaits are not supported
+  --> $DIR/issue-35813-postfix-after-cast.rs:49:5
+   |
+LL |     Box::pin(noop()) as Pin<Box<dyn Future<Output = ()>>>.await;
+   |     -----------------------------------------------------^^^^^^
+   |     |
+   |     help: try surrounding the expression with parentheses: `(Box::pin(noop()) as Pin<Box<dyn Future<Output = ()>>>)`
+
+error: casts followed by field access expressions are not supported
+  --> $DIR/issue-35813-postfix-after-cast.rs:61:5
+   |
+LL |     Foo::default() as Foo.bar;
+   |     ---------------------^^^^
+   |     |
+   |     help: try surrounding the expression with parentheses: `(Foo::default() as Foo)`
+
+error: casts followed by method call expressions are not supported
+  --> $DIR/issue-35813-postfix-after-cast.rs:27:9
+   |
+LL |         if true { 33 } else { 44 } as i32.max(0)
+   |         ---------------------------------^^^^^^^
+   |         |
+   |         help: try surrounding the expression with parentheses: `(if true { 33 } else { 44 } as i32)`
+
+error: aborting due to 9 previous errors
+

--- a/src/test/ui/parser/issue-35813-postfix-after-cast.stderr
+++ b/src/test/ui/parser/issue-35813-postfix-after-cast.stderr
@@ -1,74 +1,163 @@
-error: casts followed by index operators are not supported
-  --> $DIR/issue-35813-postfix-after-cast.rs:9:5
+error: casts cannot be followed by indexing
+  --> $DIR/issue-35813-postfix-after-cast.rs:10:5
    |
 LL |     vec![1, 2, 3] as Vec<i32>[0];
-   |     -------------------------^^^
-   |     |
-   |     help: try surrounding the expression with parentheses: `(vec![1, 2, 3] as Vec<i32>)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(vec![1, 2, 3] as Vec<i32>)`
 
-error: casts followed by index operators are not supported
-  --> $DIR/issue-35813-postfix-after-cast.rs:14:5
+error: casts cannot be followed by indexing
+  --> $DIR/issue-35813-postfix-after-cast.rs:12:5
+   |
+LL |     vec![1, 2, 3]: Vec<i32>[0];
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(vec![1, 2, 3]: Vec<i32>)`
+
+error: casts cannot be followed by indexing
+  --> $DIR/issue-35813-postfix-after-cast.rs:17:5
    |
 LL |     (&[0]) as &[i32][0];
-   |     ----------------^^^
-   |     |
-   |     help: try surrounding the expression with parentheses: `((&[0]) as &[i32])`
+   |     ^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `((&[0]) as &[i32])`
 
-error: casts followed by index operators are not supported
-  --> $DIR/issue-35813-postfix-after-cast.rs:20:18
+error: casts cannot be followed by indexing
+  --> $DIR/issue-35813-postfix-after-cast.rs:19:5
+   |
+LL |     (&[0i32]): &[i32; 1][0];
+   |     ^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `((&[0i32]): &[i32; 1])`
+
+error: casts cannot be followed by indexing
+  --> $DIR/issue-35813-postfix-after-cast.rs:40:18
    |
 LL |     let x: i32 = &vec![1, 2, 3] as &Vec<i32>[0];
-   |                  ---------------------------^^^
-   |                  |
-   |                  help: try surrounding the expression with parentheses: `(&vec![1, 2, 3] as &Vec<i32>)`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(&vec![1, 2, 3] as &Vec<i32>)`
 
-error: casts followed by method call expressions are not supported
-  --> $DIR/issue-35813-postfix-after-cast.rs:33:8
+error: casts cannot be followed by a method call
+  --> $DIR/issue-35813-postfix-after-cast.rs:45:5
+   |
+LL |     0 as i32.max(0);
+   |     ^^^^^^^^ help: try surrounding the expression in parentheses: `(0 as i32)`
+
+error: casts cannot be followed by a method call
+  --> $DIR/issue-35813-postfix-after-cast.rs:47:5
+   |
+LL |     0: i32.max(0);
+   |     ^^^^^^ help: try surrounding the expression in parentheses: `(0: i32)`
+
+error: casts cannot be followed by a method call
+  --> $DIR/issue-35813-postfix-after-cast.rs:62:8
    |
 LL |     if 5u64 as i32.max(0) == 0 {
-   |        -----------^^^^^^^
-   |        |
-   |        help: try surrounding the expression with parentheses: `(5u64 as i32)`
+   |        ^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(5u64 as i32)`
 
-error: casts followed by method call expressions are not supported
-  --> $DIR/issue-35813-postfix-after-cast.rs:40:9
+error: casts cannot be followed by a method call
+  --> $DIR/issue-35813-postfix-after-cast.rs:65:8
+   |
+LL |     if 5u64: u64.max(0) == 0 {
+   |        ^^^^^^^^^ help: try surrounding the expression in parentheses: `(5u64: u64)`
+
+error: casts cannot be followed by a method call
+  --> $DIR/issue-35813-postfix-after-cast.rs:72:9
    |
 LL |         5u64 as u32.max(0) == 0
-   |         -----------^^^^^^^
-   |         |
-   |         help: try surrounding the expression with parentheses: `(5u64 as u32)`
+   |         ^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(5u64 as u32)`
 
-error: casts followed by index operators are not supported
-  --> $DIR/issue-35813-postfix-after-cast.rs:45:24
+error: casts cannot be followed by a method call
+  --> $DIR/issue-35813-postfix-after-cast.rs:76:9
+   |
+LL |         5u64: u64.max(0) == 0
+   |         ^^^^^^^^^ help: try surrounding the expression in parentheses: `(5u64: u64)`
+
+error: casts cannot be followed by indexing
+  --> $DIR/issue-35813-postfix-after-cast.rs:81:24
    |
 LL | static bar: &[i32] = &(&[1,2,3] as &[i32][0..1]);
-   |                        ------------------^^^^^^
-   |                        |
-   |                        help: try surrounding the expression with parentheses: `(&[1,2,3] as &[i32])`
+   |                        ^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(&[1,2,3] as &[i32])`
 
-error: casts followed by awaits are not supported
-  --> $DIR/issue-35813-postfix-after-cast.rs:49:5
+error: casts cannot be followed by indexing
+  --> $DIR/issue-35813-postfix-after-cast.rs:84:25
+   |
+LL | static bar2: &[i32] = &(&[1i32,2,3]: &[i32; 3][0..1]);
+   |                         ^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(&[1i32,2,3]: &[i32; 3])`
+
+error: casts cannot be followed by ?
+  --> $DIR/issue-35813-postfix-after-cast.rs:89:5
+   |
+LL |     Err(0u64) as Result<u64,u64>?;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(Err(0u64) as Result<u64,u64>)`
+
+error: casts cannot be followed by ?
+  --> $DIR/issue-35813-postfix-after-cast.rs:91:5
+   |
+LL |     Err(0u64): Result<u64,u64>?;
+   |     ^^^^^^^^^-^^^^^^^^^^^^^^^^
+   |              |
+   |              help: maybe write a path separator here: `::`
+   |
+   = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
+   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
+
+error: casts cannot be followed by a function call
+  --> $DIR/issue-35813-postfix-after-cast.rs:115:5
+   |
+LL |     drop as fn(u8)(0);
+   |     ^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(drop as fn(u8))`
+
+error: casts cannot be followed by a function call
+  --> $DIR/issue-35813-postfix-after-cast.rs:117:5
+   |
+LL |     drop_ptr: fn(u8)(0);
+   |     ^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(drop_ptr: fn(u8))`
+
+error: casts cannot be followed by `.await`
+  --> $DIR/issue-35813-postfix-after-cast.rs:122:5
    |
 LL |     Box::pin(noop()) as Pin<Box<dyn Future<Output = ()>>>.await;
-   |     -----------------------------------------------------^^^^^^
-   |     |
-   |     help: try surrounding the expression with parentheses: `(Box::pin(noop()) as Pin<Box<dyn Future<Output = ()>>>)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(Box::pin(noop()) as Pin<Box<dyn Future<Output = ()>>>)`
 
-error: casts followed by field access expressions are not supported
-  --> $DIR/issue-35813-postfix-after-cast.rs:61:5
+error: casts cannot be followed by `.await`
+  --> $DIR/issue-35813-postfix-after-cast.rs:125:5
+   |
+LL |     Box::pin(noop()): Pin<Box<_>>.await;
+   |     ^^^^^^^^^^^^^^^^-^^^^^^^^^^^^
+   |                     |
+   |                     help: maybe write a path separator here: `::`
+   |
+   = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
+   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
+
+error: casts cannot be followed by a field access
+  --> $DIR/issue-35813-postfix-after-cast.rs:137:5
    |
 LL |     Foo::default() as Foo.bar;
-   |     ---------------------^^^^
-   |     |
-   |     help: try surrounding the expression with parentheses: `(Foo::default() as Foo)`
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(Foo::default() as Foo)`
 
-error: casts followed by method call expressions are not supported
-  --> $DIR/issue-35813-postfix-after-cast.rs:27:9
+error: casts cannot be followed by a field access
+  --> $DIR/issue-35813-postfix-after-cast.rs:139:5
    |
-LL |         if true { 33 } else { 44 } as i32.max(0)
-   |         ---------------------------------^^^^^^^
-   |         |
-   |         help: try surrounding the expression with parentheses: `(if true { 33 } else { 44 } as i32)`
+LL |     Foo::default(): Foo.bar;
+   |     ^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(Foo::default(): Foo)`
 
-error: aborting due to 9 previous errors
+error: casts cannot be followed by a method call
+  --> $DIR/issue-35813-postfix-after-cast.rs:54:9
+   |
+LL |         if true { 33 } else { 44 } as i32.max(0),
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(if true { 33 } else { 44 } as i32)`
 
+error: casts cannot be followed by a method call
+  --> $DIR/issue-35813-postfix-after-cast.rs:56:9
+   |
+LL |         if true { 33 } else { 44 }: i32.max(0)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(if true { 33 } else { 44 }: i32)`
+
+error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
+  --> $DIR/issue-35813-postfix-after-cast.rs:101:13
+   |
+LL |     drop as F();
+   |             ^^^ only `Fn` traits may use parentheses
+
+error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
+  --> $DIR/issue-35813-postfix-after-cast.rs:103:15
+   |
+LL |     drop_ptr: F();
+   |               ^^^ only `Fn` traits may use parentheses
+
+error: aborting due to 25 previous errors
+
+For more information about this error, try `rustc --explain E0214`.

--- a/src/test/ui/parser/issue-35813-postfix-after-cast.stderr
+++ b/src/test/ui/parser/issue-35813-postfix-after-cast.stderr
@@ -91,7 +91,7 @@ LL |     Err(0u64): Result<u64,u64>?;
    |              help: maybe write a path separator here: `::`
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
+   = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
 
 error: casts cannot be followed by a function call
   --> $DIR/issue-35813-postfix-after-cast.rs:115:5
@@ -120,7 +120,7 @@ LL |     Box::pin(noop()): Pin<Box<_>>.await;
    |                     help: maybe write a path separator here: `::`
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
+   = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
 
 error: casts cannot be followed by a field access
   --> $DIR/issue-35813-postfix-after-cast.rs:137:5

--- a/src/test/ui/parser/issue-35813-postfix-after-cast.stderr
+++ b/src/test/ui/parser/issue-35813-postfix-after-cast.stderr
@@ -22,68 +22,128 @@ error: casts cannot be followed by indexing
 LL |     (&[0i32]): &[i32; 1][0];
    |     ^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `((&[0i32]): &[i32; 1])`
 
+error: casts cannot be followed by a method call
+  --> $DIR/issue-35813-postfix-after-cast.rs:39:13
+   |
+LL |     let _ = 0i32: i32: i32.count_ones();
+   |             ^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(0i32: i32: i32)`
+
+error: casts cannot be followed by a method call
+  --> $DIR/issue-35813-postfix-after-cast.rs:41:13
+   |
+LL |     let _ = 0 as i32: i32.count_ones();
+   |             ^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(0 as i32: i32)`
+
+error: casts cannot be followed by a method call
+  --> $DIR/issue-35813-postfix-after-cast.rs:43:13
+   |
+LL |     let _ = 0i32: i32 as i32.count_ones();
+   |             ^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(0i32: i32 as i32)`
+
+error: casts cannot be followed by a method call
+  --> $DIR/issue-35813-postfix-after-cast.rs:45:13
+   |
+LL |     let _ = 0 as i32 as i32.count_ones();
+   |             ^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(0 as i32 as i32)`
+
+error: casts cannot be followed by a method call
+  --> $DIR/issue-35813-postfix-after-cast.rs:47:13
+   |
+LL |     let _ = 0i32: i32: i32 as u32 as i32.count_ones();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(0i32: i32: i32 as u32 as i32)`
+
+error: casts cannot be followed by a method call
+  --> $DIR/issue-35813-postfix-after-cast.rs:49:13
+   |
+LL |     let _ = 0i32: i32.count_ones(): u32;
+   |             ^^^^^^^^^ help: try surrounding the expression in parentheses: `(0i32: i32)`
+
+error: casts cannot be followed by a method call
+  --> $DIR/issue-35813-postfix-after-cast.rs:51:13
+   |
+LL |     let _ = 0 as i32.count_ones(): u32;
+   |             ^^^^^^^^ help: try surrounding the expression in parentheses: `(0 as i32)`
+
+error: casts cannot be followed by a method call
+  --> $DIR/issue-35813-postfix-after-cast.rs:53:13
+   |
+LL |     let _ = 0i32: i32.count_ones() as u32;
+   |             ^^^^^^^^^ help: try surrounding the expression in parentheses: `(0i32: i32)`
+
+error: casts cannot be followed by a method call
+  --> $DIR/issue-35813-postfix-after-cast.rs:55:13
+   |
+LL |     let _ = 0 as i32.count_ones() as u32;
+   |             ^^^^^^^^ help: try surrounding the expression in parentheses: `(0 as i32)`
+
+error: casts cannot be followed by a method call
+  --> $DIR/issue-35813-postfix-after-cast.rs:57:13
+   |
+LL |     let _ = 0i32: i32: i32.count_ones() as u32 as i32;
+   |             ^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(0i32: i32: i32)`
+
 error: casts cannot be followed by indexing
-  --> $DIR/issue-35813-postfix-after-cast.rs:40:18
+  --> $DIR/issue-35813-postfix-after-cast.rs:63:18
    |
 LL |     let x: i32 = &vec![1, 2, 3] as &Vec<i32>[0];
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(&vec![1, 2, 3] as &Vec<i32>)`
 
 error: casts cannot be followed by a method call
-  --> $DIR/issue-35813-postfix-after-cast.rs:45:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:68:5
    |
 LL |     0 as i32.max(0);
    |     ^^^^^^^^ help: try surrounding the expression in parentheses: `(0 as i32)`
 
 error: casts cannot be followed by a method call
-  --> $DIR/issue-35813-postfix-after-cast.rs:47:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:70:5
    |
 LL |     0: i32.max(0);
    |     ^^^^^^ help: try surrounding the expression in parentheses: `(0: i32)`
 
 error: casts cannot be followed by a method call
-  --> $DIR/issue-35813-postfix-after-cast.rs:62:8
+  --> $DIR/issue-35813-postfix-after-cast.rs:85:8
    |
 LL |     if 5u64 as i32.max(0) == 0 {
    |        ^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(5u64 as i32)`
 
 error: casts cannot be followed by a method call
-  --> $DIR/issue-35813-postfix-after-cast.rs:65:8
+  --> $DIR/issue-35813-postfix-after-cast.rs:88:8
    |
 LL |     if 5u64: u64.max(0) == 0 {
    |        ^^^^^^^^^ help: try surrounding the expression in parentheses: `(5u64: u64)`
 
 error: casts cannot be followed by a method call
-  --> $DIR/issue-35813-postfix-after-cast.rs:72:9
+  --> $DIR/issue-35813-postfix-after-cast.rs:95:9
    |
 LL |         5u64 as u32.max(0) == 0
    |         ^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(5u64 as u32)`
 
 error: casts cannot be followed by a method call
-  --> $DIR/issue-35813-postfix-after-cast.rs:76:9
+  --> $DIR/issue-35813-postfix-after-cast.rs:99:9
    |
 LL |         5u64: u64.max(0) == 0
    |         ^^^^^^^^^ help: try surrounding the expression in parentheses: `(5u64: u64)`
 
 error: casts cannot be followed by indexing
-  --> $DIR/issue-35813-postfix-after-cast.rs:81:24
+  --> $DIR/issue-35813-postfix-after-cast.rs:104:24
    |
 LL | static bar: &[i32] = &(&[1,2,3] as &[i32][0..1]);
    |                        ^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(&[1,2,3] as &[i32])`
 
 error: casts cannot be followed by indexing
-  --> $DIR/issue-35813-postfix-after-cast.rs:84:25
+  --> $DIR/issue-35813-postfix-after-cast.rs:107:25
    |
 LL | static bar2: &[i32] = &(&[1i32,2,3]: &[i32; 3][0..1]);
    |                         ^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(&[1i32,2,3]: &[i32; 3])`
 
 error: casts cannot be followed by ?
-  --> $DIR/issue-35813-postfix-after-cast.rs:89:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:112:5
    |
 LL |     Err(0u64) as Result<u64,u64>?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(Err(0u64) as Result<u64,u64>)`
 
 error: casts cannot be followed by ?
-  --> $DIR/issue-35813-postfix-after-cast.rs:91:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:114:5
    |
 LL |     Err(0u64): Result<u64,u64>?;
    |     ^^^^^^^^^-^^^^^^^^^^^^^^^^
@@ -94,25 +154,25 @@ LL |     Err(0u64): Result<u64,u64>?;
    = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
 
 error: casts cannot be followed by a function call
-  --> $DIR/issue-35813-postfix-after-cast.rs:115:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:138:5
    |
 LL |     drop as fn(u8)(0);
    |     ^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(drop as fn(u8))`
 
 error: casts cannot be followed by a function call
-  --> $DIR/issue-35813-postfix-after-cast.rs:117:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:140:5
    |
 LL |     drop_ptr: fn(u8)(0);
    |     ^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(drop_ptr: fn(u8))`
 
 error: casts cannot be followed by `.await`
-  --> $DIR/issue-35813-postfix-after-cast.rs:122:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:145:5
    |
 LL |     Box::pin(noop()) as Pin<Box<dyn Future<Output = ()>>>.await;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(Box::pin(noop()) as Pin<Box<dyn Future<Output = ()>>>)`
 
 error: casts cannot be followed by `.await`
-  --> $DIR/issue-35813-postfix-after-cast.rs:125:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:148:5
    |
 LL |     Box::pin(noop()): Pin<Box<_>>.await;
    |     ^^^^^^^^^^^^^^^^-^^^^^^^^^^^^
@@ -123,41 +183,41 @@ LL |     Box::pin(noop()): Pin<Box<_>>.await;
    = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
 
 error: casts cannot be followed by a field access
-  --> $DIR/issue-35813-postfix-after-cast.rs:137:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:160:5
    |
 LL |     Foo::default() as Foo.bar;
    |     ^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(Foo::default() as Foo)`
 
 error: casts cannot be followed by a field access
-  --> $DIR/issue-35813-postfix-after-cast.rs:139:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:162:5
    |
 LL |     Foo::default(): Foo.bar;
    |     ^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(Foo::default(): Foo)`
 
 error: casts cannot be followed by a method call
-  --> $DIR/issue-35813-postfix-after-cast.rs:54:9
+  --> $DIR/issue-35813-postfix-after-cast.rs:77:9
    |
 LL |         if true { 33 } else { 44 } as i32.max(0),
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(if true { 33 } else { 44 } as i32)`
 
 error: casts cannot be followed by a method call
-  --> $DIR/issue-35813-postfix-after-cast.rs:56:9
+  --> $DIR/issue-35813-postfix-after-cast.rs:79:9
    |
 LL |         if true { 33 } else { 44 }: i32.max(0)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(if true { 33 } else { 44 }: i32)`
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-35813-postfix-after-cast.rs:101:13
+  --> $DIR/issue-35813-postfix-after-cast.rs:124:13
    |
 LL |     drop as F();
    |             ^^^ only `Fn` traits may use parentheses
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-35813-postfix-after-cast.rs:103:15
+  --> $DIR/issue-35813-postfix-after-cast.rs:126:15
    |
 LL |     drop_ptr: F();
    |               ^^^ only `Fn` traits may use parentheses
 
-error: aborting due to 25 previous errors
+error: aborting due to 35 previous errors
 
 For more information about this error, try `rustc --explain E0214`.

--- a/src/test/ui/parser/issue-35813-postfix-after-cast.stderr
+++ b/src/test/ui/parser/issue-35813-postfix-after-cast.stderr
@@ -2,148 +2,282 @@ error: casts cannot be followed by indexing
   --> $DIR/issue-35813-postfix-after-cast.rs:10:5
    |
 LL |     vec![1, 2, 3] as Vec<i32>[0];
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(vec![1, 2, 3] as Vec<i32>)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     (vec![1, 2, 3] as Vec<i32>)[0];
+   |     ^                         ^
 
 error: casts cannot be followed by indexing
   --> $DIR/issue-35813-postfix-after-cast.rs:12:5
    |
 LL |     vec![1, 2, 3]: Vec<i32>[0];
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(vec![1, 2, 3]: Vec<i32>)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     (vec![1, 2, 3]: Vec<i32>)[0];
+   |     ^                       ^
 
 error: casts cannot be followed by indexing
   --> $DIR/issue-35813-postfix-after-cast.rs:17:5
    |
 LL |     (&[0]) as &[i32][0];
-   |     ^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `((&[0]) as &[i32])`
+   |     ^^^^^^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     ((&[0]) as &[i32])[0];
+   |     ^                ^
 
 error: casts cannot be followed by indexing
   --> $DIR/issue-35813-postfix-after-cast.rs:19:5
    |
 LL |     (&[0i32]): &[i32; 1][0];
-   |     ^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `((&[0i32]): &[i32; 1])`
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     ((&[0i32]): &[i32; 1])[0];
+   |     ^                    ^
 
 error: casts cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:39:13
    |
 LL |     let _ = 0i32: i32: i32.count_ones();
-   |             ^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(0i32: i32: i32)`
+   |             ^^^^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     let _ = (0i32: i32: i32).count_ones();
+   |             ^              ^
 
 error: casts cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:41:13
    |
 LL |     let _ = 0 as i32: i32.count_ones();
-   |             ^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(0 as i32: i32)`
+   |             ^^^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     let _ = (0 as i32: i32).count_ones();
+   |             ^             ^
 
 error: casts cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:43:13
    |
 LL |     let _ = 0i32: i32 as i32.count_ones();
-   |             ^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(0i32: i32 as i32)`
+   |             ^^^^^^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     let _ = (0i32: i32 as i32).count_ones();
+   |             ^                ^
 
 error: casts cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:45:13
    |
 LL |     let _ = 0 as i32 as i32.count_ones();
-   |             ^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(0 as i32 as i32)`
+   |             ^^^^^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     let _ = (0 as i32 as i32).count_ones();
+   |             ^               ^
 
 error: casts cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:47:13
    |
 LL |     let _ = 0i32: i32: i32 as u32 as i32.count_ones();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(0i32: i32: i32 as u32 as i32)`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     let _ = (0i32: i32: i32 as u32 as i32).count_ones();
+   |             ^                            ^
 
 error: casts cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:49:13
    |
 LL |     let _ = 0i32: i32.count_ones(): u32;
-   |             ^^^^^^^^^ help: try surrounding the expression in parentheses: `(0i32: i32)`
+   |             ^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     let _ = (0i32: i32).count_ones(): u32;
+   |             ^         ^
 
 error: casts cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:51:13
    |
 LL |     let _ = 0 as i32.count_ones(): u32;
-   |             ^^^^^^^^ help: try surrounding the expression in parentheses: `(0 as i32)`
+   |             ^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     let _ = (0 as i32).count_ones(): u32;
+   |             ^        ^
 
 error: casts cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:53:13
    |
 LL |     let _ = 0i32: i32.count_ones() as u32;
-   |             ^^^^^^^^^ help: try surrounding the expression in parentheses: `(0i32: i32)`
+   |             ^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     let _ = (0i32: i32).count_ones() as u32;
+   |             ^         ^
 
 error: casts cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:55:13
    |
 LL |     let _ = 0 as i32.count_ones() as u32;
-   |             ^^^^^^^^ help: try surrounding the expression in parentheses: `(0 as i32)`
+   |             ^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     let _ = (0 as i32).count_ones() as u32;
+   |             ^        ^
 
 error: casts cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:57:13
    |
 LL |     let _ = 0i32: i32: i32.count_ones() as u32 as i32;
-   |             ^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(0i32: i32: i32)`
+   |             ^^^^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     let _ = (0i32: i32: i32).count_ones() as u32 as i32;
+   |             ^              ^
+
+error: casts cannot be followed by a method call
+  --> $DIR/issue-35813-postfix-after-cast.rs:62:13
+   |
+LL |       let _ = 0
+   |  _____________^
+LL | |         as i32
+   | |______________^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     let _ = (0
+LL |         as i32)
+   |
 
 error: casts cannot be followed by indexing
-  --> $DIR/issue-35813-postfix-after-cast.rs:63:18
+  --> $DIR/issue-35813-postfix-after-cast.rs:70:18
    |
 LL |     let x: i32 = &vec![1, 2, 3] as &Vec<i32>[0];
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(&vec![1, 2, 3] as &Vec<i32>)`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     let x: i32 = (&vec![1, 2, 3] as &Vec<i32>)[0];
+   |                  ^                           ^
 
 error: casts cannot be followed by a method call
-  --> $DIR/issue-35813-postfix-after-cast.rs:68:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:75:5
    |
 LL |     0 as i32.max(0);
-   |     ^^^^^^^^ help: try surrounding the expression in parentheses: `(0 as i32)`
+   |     ^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     (0 as i32).max(0);
+   |     ^        ^
 
 error: casts cannot be followed by a method call
-  --> $DIR/issue-35813-postfix-after-cast.rs:70:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:77:5
    |
 LL |     0: i32.max(0);
-   |     ^^^^^^ help: try surrounding the expression in parentheses: `(0: i32)`
+   |     ^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     (0: i32).max(0);
+   |     ^      ^
 
 error: casts cannot be followed by a method call
-  --> $DIR/issue-35813-postfix-after-cast.rs:85:8
+  --> $DIR/issue-35813-postfix-after-cast.rs:92:8
    |
 LL |     if 5u64 as i32.max(0) == 0 {
-   |        ^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(5u64 as i32)`
+   |        ^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     if (5u64 as i32).max(0) == 0 {
+   |        ^           ^
 
 error: casts cannot be followed by a method call
-  --> $DIR/issue-35813-postfix-after-cast.rs:88:8
+  --> $DIR/issue-35813-postfix-after-cast.rs:95:8
    |
 LL |     if 5u64: u64.max(0) == 0 {
-   |        ^^^^^^^^^ help: try surrounding the expression in parentheses: `(5u64: u64)`
+   |        ^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     if (5u64: u64).max(0) == 0 {
+   |        ^         ^
 
 error: casts cannot be followed by a method call
-  --> $DIR/issue-35813-postfix-after-cast.rs:95:9
+  --> $DIR/issue-35813-postfix-after-cast.rs:102:9
    |
 LL |         5u64 as u32.max(0) == 0
-   |         ^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(5u64 as u32)`
+   |         ^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |         (5u64 as u32).max(0) == 0
+   |         ^           ^
 
 error: casts cannot be followed by a method call
-  --> $DIR/issue-35813-postfix-after-cast.rs:99:9
+  --> $DIR/issue-35813-postfix-after-cast.rs:106:9
    |
 LL |         5u64: u64.max(0) == 0
-   |         ^^^^^^^^^ help: try surrounding the expression in parentheses: `(5u64: u64)`
+   |         ^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |         (5u64: u64).max(0) == 0
+   |         ^         ^
 
 error: casts cannot be followed by indexing
-  --> $DIR/issue-35813-postfix-after-cast.rs:104:24
+  --> $DIR/issue-35813-postfix-after-cast.rs:111:24
    |
 LL | static bar: &[i32] = &(&[1,2,3] as &[i32][0..1]);
-   |                        ^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(&[1,2,3] as &[i32])`
+   |                        ^^^^^^^^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL | static bar: &[i32] = &((&[1,2,3] as &[i32])[0..1]);
+   |                        ^                  ^
 
 error: casts cannot be followed by indexing
-  --> $DIR/issue-35813-postfix-after-cast.rs:107:25
+  --> $DIR/issue-35813-postfix-after-cast.rs:114:25
    |
 LL | static bar2: &[i32] = &(&[1i32,2,3]: &[i32; 3][0..1]);
-   |                         ^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(&[1i32,2,3]: &[i32; 3])`
+   |                         ^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL | static bar2: &[i32] = &((&[1i32,2,3]: &[i32; 3])[0..1]);
+   |                         ^                      ^
 
 error: casts cannot be followed by ?
-  --> $DIR/issue-35813-postfix-after-cast.rs:112:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:119:5
    |
 LL |     Err(0u64) as Result<u64,u64>?;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(Err(0u64) as Result<u64,u64>)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     (Err(0u64) as Result<u64,u64>)?;
+   |     ^                            ^
 
 error: casts cannot be followed by ?
-  --> $DIR/issue-35813-postfix-after-cast.rs:114:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:121:5
    |
 LL |     Err(0u64): Result<u64,u64>?;
    |     ^^^^^^^^^-^^^^^^^^^^^^^^^^
@@ -154,25 +288,40 @@ LL |     Err(0u64): Result<u64,u64>?;
    = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
 
 error: casts cannot be followed by a function call
-  --> $DIR/issue-35813-postfix-after-cast.rs:138:5
-   |
-LL |     drop as fn(u8)(0);
-   |     ^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(drop as fn(u8))`
-
-error: casts cannot be followed by a function call
-  --> $DIR/issue-35813-postfix-after-cast.rs:140:5
-   |
-LL |     drop_ptr: fn(u8)(0);
-   |     ^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(drop_ptr: fn(u8))`
-
-error: casts cannot be followed by `.await`
   --> $DIR/issue-35813-postfix-after-cast.rs:145:5
    |
-LL |     Box::pin(noop()) as Pin<Box<dyn Future<Output = ()>>>.await;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(Box::pin(noop()) as Pin<Box<dyn Future<Output = ()>>>)`
+LL |     drop as fn(u8)(0);
+   |     ^^^^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     (drop as fn(u8))(0);
+   |     ^              ^
+
+error: casts cannot be followed by a function call
+  --> $DIR/issue-35813-postfix-after-cast.rs:147:5
+   |
+LL |     drop_ptr: fn(u8)(0);
+   |     ^^^^^^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     (drop_ptr: fn(u8))(0);
+   |     ^                ^
 
 error: casts cannot be followed by `.await`
-  --> $DIR/issue-35813-postfix-after-cast.rs:148:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:152:5
+   |
+LL |     Box::pin(noop()) as Pin<Box<dyn Future<Output = ()>>>.await;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     (Box::pin(noop()) as Pin<Box<dyn Future<Output = ()>>>).await;
+   |     ^                                                     ^
+
+error: casts cannot be followed by `.await`
+  --> $DIR/issue-35813-postfix-after-cast.rs:155:5
    |
 LL |     Box::pin(noop()): Pin<Box<_>>.await;
    |     ^^^^^^^^^^^^^^^^-^^^^^^^^^^^^
@@ -183,41 +332,61 @@ LL |     Box::pin(noop()): Pin<Box<_>>.await;
    = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
 
 error: casts cannot be followed by a field access
-  --> $DIR/issue-35813-postfix-after-cast.rs:160:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:167:5
    |
 LL |     Foo::default() as Foo.bar;
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(Foo::default() as Foo)`
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     (Foo::default() as Foo).bar;
+   |     ^                     ^
 
 error: casts cannot be followed by a field access
-  --> $DIR/issue-35813-postfix-after-cast.rs:162:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:169:5
    |
 LL |     Foo::default(): Foo.bar;
-   |     ^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(Foo::default(): Foo)`
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |     (Foo::default(): Foo).bar;
+   |     ^                   ^
 
 error: casts cannot be followed by a method call
-  --> $DIR/issue-35813-postfix-after-cast.rs:77:9
+  --> $DIR/issue-35813-postfix-after-cast.rs:84:9
    |
 LL |         if true { 33 } else { 44 } as i32.max(0),
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(if true { 33 } else { 44 } as i32)`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |         (if true { 33 } else { 44 } as i32).max(0),
+   |         ^                                 ^
 
 error: casts cannot be followed by a method call
-  --> $DIR/issue-35813-postfix-after-cast.rs:79:9
+  --> $DIR/issue-35813-postfix-after-cast.rs:86:9
    |
 LL |         if true { 33 } else { 44 }: i32.max(0)
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try surrounding the expression in parentheses: `(if true { 33 } else { 44 }: i32)`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |         (if true { 33 } else { 44 }: i32).max(0)
+   |         ^                               ^
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-35813-postfix-after-cast.rs:124:13
+  --> $DIR/issue-35813-postfix-after-cast.rs:131:13
    |
 LL |     drop as F();
    |             ^^^ only `Fn` traits may use parentheses
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-35813-postfix-after-cast.rs:126:15
+  --> $DIR/issue-35813-postfix-after-cast.rs:133:15
    |
 LL |     drop_ptr: F();
    |               ^^^ only `Fn` traits may use parentheses
 
-error: aborting due to 35 previous errors
+error: aborting due to 36 previous errors
 
 For more information about this error, try `rustc --explain E0214`.

--- a/src/test/ui/type/ascription/issue-54516.rs
+++ b/src/test/ui/type/ascription/issue-54516.rs
@@ -2,5 +2,7 @@ use std::collections::BTreeMap;
 
 fn main() {
     println!("{}", std::mem:size_of::<BTreeMap<u32, u32>>());
-    //~^ ERROR expected one of
+    //~^ ERROR casts cannot be followed by a function call
+    //~| ERROR expected value, found module `std::mem` [E0423]
+    //~| ERROR cannot find type `size_of` in this scope [E0412]
 }

--- a/src/test/ui/type/ascription/issue-54516.stderr
+++ b/src/test/ui/type/ascription/issue-54516.stderr
@@ -1,13 +1,31 @@
-error: expected one of `!`, `,`, or `::`, found `(`
-  --> $DIR/issue-54516.rs:4:58
+error: casts cannot be followed by a function call
+  --> $DIR/issue-54516.rs:4:20
    |
 LL |     println!("{}", std::mem:size_of::<BTreeMap<u32, u32>>());
-   |                            -                             ^ expected one of `!`, `,`, or `::`
+   |                    ^^^^^^^^-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                            |
    |                            help: maybe write a path separator here: `::`
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
    = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
 
-error: aborting due to previous error
+error[E0423]: expected value, found module `std::mem`
+  --> $DIR/issue-54516.rs:4:20
+   |
+LL |     println!("{}", std::mem:size_of::<BTreeMap<u32, u32>>());
+   |                    ^^^^^^^^- help: maybe you meant to write a path separator here: `::`
+   |                    |
+   |                    not a value
 
+error[E0412]: cannot find type `size_of` in this scope
+  --> $DIR/issue-54516.rs:4:29
+   |
+LL |     println!("{}", std::mem:size_of::<BTreeMap<u32, u32>>());
+   |                            -^^^^^^^ not found in this scope
+   |                            |
+   |                            help: maybe you meant to write a path separator here: `::`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0412, E0423.
+For more information about an error, try `rustc --explain E0412`.

--- a/src/test/ui/type/ascription/issue-60933.rs
+++ b/src/test/ui/type/ascription/issue-60933.rs
@@ -1,4 +1,6 @@
 fn main() {
     let u: usize = std::mem:size_of::<u32>();
-    //~^ ERROR expected one of
+    //~^ ERROR casts cannot be followed by a function call
+    //~| ERROR expected value, found module `std::mem` [E0423]
+    //~| ERROR cannot find type `size_of` in this scope [E0412]
 }

--- a/src/test/ui/type/ascription/issue-60933.stderr
+++ b/src/test/ui/type/ascription/issue-60933.stderr
@@ -1,13 +1,31 @@
-error: expected one of `!`, `::`, or `;`, found `(`
-  --> $DIR/issue-60933.rs:2:43
+error: casts cannot be followed by a function call
+  --> $DIR/issue-60933.rs:2:20
    |
 LL |     let u: usize = std::mem:size_of::<u32>();
-   |                            -              ^ expected one of `!`, `::`, or `;`
+   |                    ^^^^^^^^-^^^^^^^^^^^^^^
    |                            |
    |                            help: maybe write a path separator here: `::`
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
    = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
 
-error: aborting due to previous error
+error[E0423]: expected value, found module `std::mem`
+  --> $DIR/issue-60933.rs:2:20
+   |
+LL |     let u: usize = std::mem:size_of::<u32>();
+   |                    ^^^^^^^^- help: maybe you meant to write a path separator here: `::`
+   |                    |
+   |                    not a value
 
+error[E0412]: cannot find type `size_of` in this scope
+  --> $DIR/issue-60933.rs:2:29
+   |
+LL |     let u: usize = std::mem:size_of::<u32>();
+   |                            -^^^^^^^ not found in this scope
+   |                            |
+   |                            help: maybe you meant to write a path separator here: `::`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0412, E0423.
+For more information about an error, try `rustc --explain E0412`.


### PR DESCRIPTION
This adds an explicit error messages for when parsing `x as Type[0]` or similar expressions. Our add an extra parse case for parsing any postfix operator (dot, indexing, method calls, await) that triggers directly after parsing `as` expressions.

My friend and I worked on this together, but they're still deciding on a github username and thus I'm submitting this for both of us.

It will immediately error out, but will also provide the rest of the parser with a useful parse tree to deal with.

There's one decision we made in how this produces the parse tree. In the situation `&x as T[0]`, one could imagine this parsing as either `&((x as T)[0])` or `((&x) as T)[0]`. We chose the latter for ease of implementation, and as it seemed the most intuitive.

Feedback welcome! This is our first change to the parser section, and it might be completely horrible.

Fixes #35813.