### PR TITLE
Properly use parent generics for opaque types

### DIFF
--- a/src/test/ui/type-alias-impl-trait/issue-67844-nested-opaque.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-67844-nested-opaque.rs
@@ -1,0 +1,32 @@
+// check-pass
+// Regression test for issue #67844
+// Ensures that we properly handle nested TAIT occurences
+// with generic parameters
+
+#![feature(type_alias_impl_trait)]
+
+trait WithAssoc { type AssocType; }
+
+trait WithParam<A> {}
+
+type Return<A> = impl WithAssoc<AssocType = impl WithParam<A>>;
+
+struct MyParam;
+impl<A> WithParam<A> for MyParam {}
+
+struct MyStruct;
+
+impl WithAssoc for MyStruct {
+    type AssocType = MyParam;
+}
+
+
+fn my_fun<A>() -> Return<A> {
+    MyStruct
+}
+
+fn my_other_fn<A>() -> impl WithAssoc<AssocType = impl WithParam<A>> {
+    MyStruct
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #67844

Previously, opaque types would only get parent generics if they
a return-position-impl-trait (e.g. `fn foo<A>() -> impl MyTrait<A>`).

However, it's possible for opaque types to be nested inside one another:

```rust
trait WithAssoc { type AssocType; }

trait WithParam<A> {}

type Return<A> = impl WithAssoc<AssocType = impl WithParam<A>>;
```

When this occurs, we need to ensure that the nested opaque types
properly inherit generic parameters from their parent opaque type.

This commit fixes the `generics_of` query to take the parent item
into account when determining the generics for an opaque type.