### PR TITLE
change an instance of span_bug() to struct_span_err() to avoid ICE

### DIFF
--- a/src/librustc_parse/parser/ty.rs
+++ b/src/librustc_parse/parser/ty.rs
@@ -214,7 +214,10 @@ impl<'a> Parser<'a> {
                     let path = match bounds.remove(0) {
                         GenericBound::Trait(pt, ..) => pt.trait_ref.path,
                         GenericBound::Outlives(..) => {
-                            self.span_bug(ty.span, "unexpected lifetime bound")
+                            return Err(self.struct_span_err(
+                                ty.span,
+                                "expected trait bound, not lifetime bound",
+                            ));
                         }
                     };
                     self.parse_remaining_bounds(Vec::new(), path, lo, true)

--- a/src/test/ui/parser/issue-68890.rs
+++ b/src/test/ui/parser/issue-68890.rs
@@ -1,0 +1,4 @@
+enum e{A((?'a a+?+l))}
+//~^ ERROR `?` may only modify trait bounds, not lifetime bounds
+//~| ERROR expected one of `)`, `+`, or `,`
+//~| ERROR expected trait bound, not lifetime bound

--- a/src/test/ui/parser/issue-68890.stderr
+++ b/src/test/ui/parser/issue-68890.stderr
@@ -1,0 +1,20 @@
+error: `?` may only modify trait bounds, not lifetime bounds
+  --> $DIR/issue-68890.rs:1:11
+   |
+LL | enum e{A((?'a a+?+l))}
+   |           ^
+
+error: expected one of `)`, `+`, or `,`, found `a`
+  --> $DIR/issue-68890.rs:1:15
+   |
+LL | enum e{A((?'a a+?+l))}
+   |               ^ expected one of `)`, `+`, or `,`
+
+error: expected trait bound, not lifetime bound
+  --> $DIR/issue-68890.rs:1:11
+   |
+LL | enum e{A((?'a a+?+l))}
+   |           ^^^
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
After #67148, the `span_bug()` in `parse_ty_tuple_or_parens()` is reachable because `parse_paren_comma_seq()` can return an `Ok()` even in cases where it encounters an error.
This pull request prevents an ICE in such cases by replacing the `span_bug()` with `struct_span_error()`.

Fixes #68890.