### PR TITLE
traits: preallocate 2 Vecs of known initial size

### DIFF
--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -3486,7 +3486,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         // that order.
         let predicates = tcx.predicates_of(def_id);
         assert_eq!(predicates.parent, None);
-        let mut obligations = Vec::new();
+        let mut obligations = Vec::with_capacity(predicates.predicates.len());
         for (predicate, _) in predicates.predicates {
             let predicate = normalize_with_depth_to(
                 self,

--- a/src/librustc/traits/wf.rs
+++ b/src/librustc/traits/wf.rs
@@ -143,14 +143,15 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
         let cause = self.cause(traits::MiscObligation);
         let infcx = &mut self.infcx;
         let param_env = self.param_env;
-        let mut obligations = Vec::new();
-        self.out.iter().inspect(|pred| assert!(!pred.has_escaping_bound_vars())).for_each(|pred| {
+        let mut obligations = Vec::with_capacity(self.out.len());
+        for pred in &self.out {
+            assert!(!pred.has_escaping_bound_vars());
             let mut selcx = traits::SelectionContext::new(infcx);
             let i = obligations.len();
             let value =
                 traits::normalize_to(&mut selcx, param_env, cause.clone(), pred, &mut obligations);
             obligations.insert(i, value);
-        });
+        }
         obligations
     }
 


### PR DESCRIPTION
The 2 preallocations are pretty obvious; both vectors will be as big as or larger than the collections they are created from.

In `WfPredicates::normalize` the change from a functional style improves readability and should be perf-friendly, too.