### PR TITLE
[TEST] Defer evaluation of method receiver type

### DIFF
--- a/src/test/ui/inference/deferred-method-receiver-inference.rs
+++ b/src/test/ui/inference/deferred-method-receiver-inference.rs
@@ -1,0 +1,11 @@
+// check-pass
+
+fn foo() -> Vec<u16> {
+    let mut s = vec![].into_iter().collect();
+    s.push(0);
+    s
+}
+
+fn main() {
+    let _ = foo();
+}


### PR DESCRIPTION
When encountering `MethodCall` expressions where the receiver type is
still being inferred, and the receiver expression is a `Path`
(potentially accessing a simple binding), we delay the evaluation of
that receiver until after the rest of the block has been evaluated. This
allows otherwise invalid expressions to be successfully inferred, for
example the following:

```rust
fn foo() -> Vec<u16> {
    let mut s = vec![].into_iter().collect();
    s.push(0);
    s
}
```

now succeeds, just like the following always have:

```rust
fn foo() -> Vec<u16> {
    let s = vec![].into_iter().collect();
    s
}
fn bar() -> Vec<u16> {
    vec![].into_iter().collect()
}
```

These changes will not affect the following, which will continue to
require type annotations:

```rust
fn foo(data: &[u32]) -> String {
    data.iter().sum().to_string()
             // ^^^
             // |
             // type annotations needed
             // specify the type argument: `sum::<S>`
}
```

This last example would fail even if we weren't restricting the new
behavior to `Path` receiver expressions because `S` would be resolved to
`&u32`, which can't be converted to `String`.

https://github.com/rust-lang/rust/issues/68991
https://github.com/rust-lang/rust/issues/42333