### PR TITLE
Use `dyn Trait` more in tests

### DIFF
--- a/src/test/ui/hygiene/assoc_ty_bindings.rs
+++ b/src/test/ui/hygiene/assoc_ty_bindings.rs
@@ -12,8 +12,8 @@ trait Derived: Base {
 }
 
 macro mac() {
-    type A = Base<AssocTy = u8>;
-    type B = Derived<AssocTy = u8>;
+    type A = dyn Base<AssocTy = u8>;
+    type B = dyn Derived<AssocTy = u8>;
 
     impl Base for u8 {
         type AssocTy = u8;

--- a/src/test/ui/privacy/associated-item-privacy-type-binding.rs
+++ b/src/test/ui/privacy/associated-item-privacy-type-binding.rs
@@ -8,19 +8,19 @@ mod priv_trait {
     pub trait PubTr: PrivTr {}
 
     pub macro mac1() {
-        let _: Box<PubTr<AssocTy = u8>>;
+        let _: Box<dyn PubTr<AssocTy = u8>>;
         //~^ ERROR trait `priv_trait::PrivTr` is private
         //~| ERROR trait `priv_trait::PrivTr` is private
-        type InSignatureTy2 = Box<PubTr<AssocTy = u8>>;
+        type InSignatureTy2 = Box<dyn PubTr<AssocTy = u8>>;
         //~^ ERROR trait `priv_trait::PrivTr` is private
         trait InSignatureTr2: PubTr<AssocTy = u8> {}
         //~^ ERROR trait `priv_trait::PrivTr` is private
     }
     pub macro mac2() {
-        let _: Box<PrivTr<AssocTy = u8>>;
+        let _: Box<dyn PrivTr<AssocTy = u8>>;
         //~^ ERROR trait `priv_trait::PrivTr` is private
         //~| ERROR trait `priv_trait::PrivTr` is private
-        type InSignatureTy1 = Box<PrivTr<AssocTy = u8>>;
+        type InSignatureTy1 = Box<dyn PrivTr<AssocTy = u8>>;
         //~^ ERROR trait `priv_trait::PrivTr` is private
         trait InSignatureTr1: PrivTr<AssocTy = u8> {}
         //~^ ERROR trait `priv_trait::PrivTr` is private
@@ -41,15 +41,15 @@ mod priv_parent_substs {
     pub trait PubTr: PubTrWithParam<Priv> {}
 
     pub macro mac() {
-        let _: Box<PubTrWithParam<AssocTy = u8>>;
+        let _: Box<dyn PubTrWithParam<AssocTy = u8>>;
         //~^ ERROR type `priv_parent_substs::Priv` is private
         //~| ERROR type `priv_parent_substs::Priv` is private
-        let _: Box<PubTr<AssocTy = u8>>;
+        let _: Box<dyn PubTr<AssocTy = u8>>;
         //~^ ERROR type `priv_parent_substs::Priv` is private
         //~| ERROR type `priv_parent_substs::Priv` is private
-        pub type InSignatureTy1 = Box<PubTrWithParam<AssocTy = u8>>;
+        pub type InSignatureTy1 = Box<dyn PubTrWithParam<AssocTy = u8>>;
         //~^ ERROR type `priv_parent_substs::Priv` is private
-        pub type InSignatureTy2 = Box<PubTr<AssocTy = u8>>;
+        pub type InSignatureTy2 = Box<dyn PubTr<AssocTy = u8>>;
         //~^ ERROR type `priv_parent_substs::Priv` is private
         trait InSignatureTr1: PubTrWithParam<AssocTy = u8> {}
         //~^ ERROR type `priv_parent_substs::Priv` is private

--- a/src/test/ui/privacy/associated-item-privacy-type-binding.stderr
+++ b/src/test/ui/privacy/associated-item-privacy-type-binding.stderr
@@ -1,7 +1,7 @@
 error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:11:13
    |
-LL |         let _: Box<PubTr<AssocTy = u8>>;
+LL |         let _: Box<dyn PubTr<AssocTy = u8>>;
    |             ^
 ...
 LL |     priv_trait::mac1!();
@@ -12,8 +12,8 @@ LL |     priv_trait::mac1!();
 error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:11:16
    |
-LL |         let _: Box<PubTr<AssocTy = u8>>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         let _: Box<dyn PubTr<AssocTy = u8>>;
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     priv_trait::mac1!();
    |     -------------------- in this macro invocation
@@ -23,8 +23,8 @@ LL |     priv_trait::mac1!();
 error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:14:31
    |
-LL |         type InSignatureTy2 = Box<PubTr<AssocTy = u8>>;
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         type InSignatureTy2 = Box<dyn PubTr<AssocTy = u8>>;
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     priv_trait::mac1!();
    |     -------------------- in this macro invocation
@@ -45,7 +45,7 @@ LL |     priv_trait::mac1!();
 error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:20:13
    |
-LL |         let _: Box<PrivTr<AssocTy = u8>>;
+LL |         let _: Box<dyn PrivTr<AssocTy = u8>>;
    |             ^
 ...
 LL |     priv_trait::mac2!();
@@ -56,8 +56,8 @@ LL |     priv_trait::mac2!();
 error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:20:16
    |
-LL |         let _: Box<PrivTr<AssocTy = u8>>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         let _: Box<dyn PrivTr<AssocTy = u8>>;
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     priv_trait::mac2!();
    |     -------------------- in this macro invocation
@@ -67,8 +67,8 @@ LL |     priv_trait::mac2!();
 error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:23:31
    |
-LL |         type InSignatureTy1 = Box<PrivTr<AssocTy = u8>>;
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         type InSignatureTy1 = Box<dyn PrivTr<AssocTy = u8>>;
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     priv_trait::mac2!();
    |     -------------------- in this macro invocation
@@ -89,7 +89,7 @@ LL |     priv_trait::mac2!();
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:44:13
    |
-LL |         let _: Box<PubTrWithParam<AssocTy = u8>>;
+LL |         let _: Box<dyn PubTrWithParam<AssocTy = u8>>;
    |             ^
 ...
 LL |     priv_parent_substs::mac!();
@@ -100,8 +100,8 @@ LL |     priv_parent_substs::mac!();
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:44:16
    |
-LL |         let _: Box<PubTrWithParam<AssocTy = u8>>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         let _: Box<dyn PubTrWithParam<AssocTy = u8>>;
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -111,7 +111,7 @@ LL |     priv_parent_substs::mac!();
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:47:13
    |
-LL |         let _: Box<PubTr<AssocTy = u8>>;
+LL |         let _: Box<dyn PubTr<AssocTy = u8>>;
    |             ^
 ...
 LL |     priv_parent_substs::mac!();
@@ -122,8 +122,8 @@ LL |     priv_parent_substs::mac!();
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:47:16
    |
-LL |         let _: Box<PubTr<AssocTy = u8>>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         let _: Box<dyn PubTr<AssocTy = u8>>;
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -133,8 +133,8 @@ LL |     priv_parent_substs::mac!();
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:50:35
    |
-LL |         pub type InSignatureTy1 = Box<PubTrWithParam<AssocTy = u8>>;
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         pub type InSignatureTy1 = Box<dyn PubTrWithParam<AssocTy = u8>>;
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -144,8 +144,8 @@ LL |     priv_parent_substs::mac!();
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:52:35
    |
-LL |         pub type InSignatureTy2 = Box<PubTr<AssocTy = u8>>;
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         pub type InSignatureTy2 = Box<dyn PubTr<AssocTy = u8>>;
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation


### PR DESCRIPTION
Here are some tests using the old trait object type syntax which are not testing the syntax itself.

This has been extracted from https://github.com/rust-lang/rust/pull/66364.