### PR TITLE
ICE in nightly-2020-02-08: handle TerminatorKind::Yield in librustc_mir::transform::promote_consts::Validator method

### DIFF
--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -463,6 +463,7 @@ impl<'tcx> Validator<'_, 'tcx> {
                 let terminator = self.body[loc.block].terminator();
                 match &terminator.kind {
                     TerminatorKind::Call { func, args, .. } => self.validate_call(func, args),
+                    TerminatorKind::Yield { .. } => Err(Unpromotable),
                     kind => {
                         span_bug!(terminator.source_info.span, "{:?} not promotable", kind);
                     }

--- a/src/test/ui/generator/issue-69017.rs
+++ b/src/test/ui/generator/issue-69017.rs
@@ -1,0 +1,16 @@
+// This issue reproduces an ICE on compile
+// Fails on 2020-02-08 nightly
+// regressed commit: https://github.com/rust-lang/rust/commit/f8fd4624474a68bd26694eff3536b9f3a127b2d3
+//
+// check-pass
+
+#![feature(generator_trait)]
+#![feature(generators)]
+
+use std::ops::Generator;
+
+fn gen() -> impl Generator<usize> {
+    |_: usize| {
+        println!("-> {}", yield);
+    }
+}

--- a/src/test/ui/generator/issue-69017.rs
+++ b/src/test/ui/generator/issue-69017.rs
@@ -14,3 +14,5 @@ fn gen() -> impl Generator<usize> {
         println!("-> {}", yield);
     }
 }
+
+fn main() {}


### PR DESCRIPTION
IR: https://github.com/rust-lang/rust/issues/69017
regressed commit: https://github.com/rust-lang/rust/commit/f8fd4624474a68bd26694eff3536b9f3a127b2d3
Source: https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=55e65a869e1f5fef64cc4462b1a5a087

Addresses ICE reported in #69017 by handling `TerminatorKind::Yield` in https://github.com/rust-lang/rust/blob/4d1241f5158ffd66730e094d8f199ed654ed52ae/src/librustc_mir/transform/promote_consts.rs#L465-L468.

<details><summary>Nightly build</summary>
<p>

```
$ cargo +nightly build
Compiling yielder v0.1.0 (/Users/chris/Desktop/tests/rustlang-tests/yielder)
error: internal compiler error: src/librustc_mir/transform/promote_consts.rs:467: _1 = suspend(move _21) -> [resume: bb2, drop: bb3] not promotable
 --> src/main.rs:8:27
  |
8 |         println!("-> {}", yield);
  |                           ^^^^^

thread 'rustc' panicked at 'Box<Any>', <::std::macros::panic macros>:2:4
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

note: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports

note: rustc 1.43.0-nightly (71c7e149e 2020-02-09) running on x86_64-apple-darwin

note: compiler flags: -C debuginfo=2 -C incremental --crate-type bin

note: some of the compiler flags provided by cargo are hidden

error: aborting due to previous error

error: could not compile `yielder`.

To learn more, run the command again with --verbose.
```

</p>
</details>

<details><summary>Stage 1 dev build</summary>
<p>

```
$ cargo +stage1 build
Compiling yielder v0.1.0 (/Users/chris/Desktop/tests/rustlang-tests/yielder)
warning: function is never used: `gen`
 --> src/main.rs:6:4
  |
6 | fn gen() -> impl Generator<usize> {
  |    ^^^
  |
  = note: `#[warn(dead_code)]` on by default

    Finished dev [unoptimized + debuginfo] target(s) in 0.53s
```

</p>
</details>


@jonas-schievink @oli-obk 
