### PR TITLE
Remove backtrace header text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,9 +121,9 @@ checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "backtrace"
-version = "0.3.40"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
+checksum = "e4036b9bf40f3cf16aba72a3d65e8a520fc4bafcdc7079aea8f848c58c5b5536"
 dependencies = [
  "backtrace-sys",
  "cfg-if",

--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -27,7 +27,7 @@ hashbrown = { version = "0.6.2", default-features = false, features = ['rustc-de
 
 [dependencies.backtrace_rs]
 package = "backtrace"
-version = "0.3.37"
+version = "0.3.44"
 default-features = false # without the libstd `backtrace` feature, stub out everything
 features = [ "rustc-dep-of-std" ] # enable build support for integrating into libstd
 

--- a/src/libstd/sys_common/backtrace.rs
+++ b/src/libstd/sys_common/backtrace.rs
@@ -70,6 +70,7 @@ unsafe fn _print_fmt(fmt: &mut fmt::Formatter<'_>, print_fmt: PrintFmt) -> fmt::
     let mut print_path = move |fmt: &mut fmt::Formatter<'_>, bows: BytesOrWideString<'_>| {
         output_filename(fmt, bows, print_fmt, cwd.as_ref())
     };
+    write!(fmt, "stack backtrace:\n")?;
     let mut bt_fmt = BacktraceFmt::new(fmt, print_fmt, &mut print_path);
     bt_fmt.add_context()?;
     let mut idx = 0;

--- a/src/test/ui/std-backtrace.rs
+++ b/src/test/ui/std-backtrace.rs
@@ -16,9 +16,9 @@ use std::str;
 fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() >= 2 && args[1] == "force" {
-        println!("{}", std::backtrace::Backtrace::force_capture());
+        println!("stack backtrace:\n{}", std::backtrace::Backtrace::force_capture());
     } else if args.len() >= 2 {
-        println!("{}", std::backtrace::Backtrace::capture());
+        println!("stack backtrace:\n{}", std::backtrace::Backtrace::capture());
     } else {
         runtest(&args[0]);
         println!("test ok");


### PR DESCRIPTION
Fixes point 3 from https://github.com/rust-lang/rust/issues/65280

related to https://github.com/rust-lang/rust/issues/53487, https://github.com/rust-lang/backtrace-rs/pull/286

This should probably be double checked by someone who works on fuschia because theres some extra fuschia specific output in `add_context` that is also removed by this change.