### PR TITLE
Use &raw in A/Rc::allocate_for_layout

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -103,6 +103,7 @@
 #![feature(pattern)]
 #![feature(ptr_internals)]
 #![feature(ptr_offset_from)]
+#![feature(raw_ref_op)]
 #![feature(rustc_attrs)]
 #![feature(receiver_trait)]
 #![feature(specialization)]

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -929,8 +929,8 @@ impl<T: ?Sized> Rc<T> {
         let inner = mem_to_rcbox(mem.as_ptr());
         debug_assert_eq!(Layout::for_value(&*inner), layout);
 
-        ptr::write(&mut (*inner).strong, Cell::new(1));
-        ptr::write(&mut (*inner).weak, Cell::new(1));
+        ptr::write(&raw mut (*inner).strong, Cell::new(1));
+        ptr::write(&raw mut (*inner).weak, Cell::new(1));
 
         inner
     }

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -929,8 +929,16 @@ impl<T: ?Sized> Rc<T> {
         let inner = mem_to_rcbox(mem.as_ptr());
         debug_assert_eq!(Layout::for_value(&*inner), layout);
 
-        ptr::write(&raw mut (*inner).strong, Cell::new(1));
-        ptr::write(&raw mut (*inner).weak, Cell::new(1));
+        #[cfg(stage0)]
+        {
+            ptr::write(&mut (*inner).strong, Cell::new(1));
+            ptr::write(&mut (*inner).weak, Cell::new(1));
+        }
+        #[cfg(not(stage0))]
+        {
+            ptr::write(&raw mut (*inner).strong, Cell::new(1));
+            ptr::write(&raw mut (*inner).weak, Cell::new(1));
+        }
 
         inner
     }

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -790,8 +790,8 @@ impl<T: ?Sized> Arc<T> {
         let inner = mem_to_arcinner(mem.as_ptr());
         debug_assert_eq!(Layout::for_value(&*inner), layout);
 
-        ptr::write(&mut (*inner).strong, atomic::AtomicUsize::new(1));
-        ptr::write(&mut (*inner).weak, atomic::AtomicUsize::new(1));
+        ptr::write(&raw mut (*inner).strong, atomic::AtomicUsize::new(1));
+        ptr::write(&raw mut (*inner).weak, atomic::AtomicUsize::new(1));
 
         inner
     }

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -790,8 +790,16 @@ impl<T: ?Sized> Arc<T> {
         let inner = mem_to_arcinner(mem.as_ptr());
         debug_assert_eq!(Layout::for_value(&*inner), layout);
 
-        ptr::write(&raw mut (*inner).strong, atomic::AtomicUsize::new(1));
-        ptr::write(&raw mut (*inner).weak, atomic::AtomicUsize::new(1));
+        #[cfg(stage0)]
+        {
+            ptr::write(&mut (*inner).strong, atomic::AtomicUsize::new(1));
+            ptr::write(&mut (*inner).weak, atomic::AtomicUsize::new(1));
+        }
+        #[cfg(not(stage0))]
+        {
+            ptr::write(&raw mut (*inner).strong, atomic::AtomicUsize::new(1));
+            ptr::write(&raw mut (*inner).weak, atomic::AtomicUsize::new(1));
+        }
 
         inner
     }


### PR DESCRIPTION
This avoids manifesting references to uninitalized places.