### PR TITLE
Don't rustfmt check the vendor directory.

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -7,6 +7,7 @@ merge_derives = false
 # tidy only checks files which are not ignored, each entry follows gitignore style
 ignore = [
     "build",
+    "/vendor/",
 
     # tests for now are not formatted, as they are sometimes pretty-printing constrained
     # (and generally rustfmt can move around comments in UI-testing incompatible ways)


### PR DESCRIPTION
I need to be able to run `x.py tidy` to do license checks (which requires vendored dependencies).  However, when vendoring is enabled, it wants to rustfmt check the entire vendor directory, which doesn't work.
