### PR TITLE
Remove a few unused objects

### DIFF
--- a/src/librustc/infer/region_constraints/mod.rs
+++ b/src/librustc/infer/region_constraints/mod.rs
@@ -339,8 +339,6 @@ impl TaintDirections {
     }
 }
 
-pub struct ConstraintInfo {}
-
 impl<'tcx> RegionConstraintCollector<'tcx> {
     pub fn new() -> Self {
         Self::default()

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -123,10 +123,6 @@ pub trait Callbacks {
     }
 }
 
-pub struct DefaultCallbacks;
-
-impl Callbacks for DefaultCallbacks {}
-
 #[derive(Default)]
 pub struct TimePassesCallbacks {
     time_passes: bool,


### PR DESCRIPTION
As far as I can tell, these won't be missed:

- `infer::region_constraints::ConstraintInfo`
- `driver::DefaultCallbacks`
- ~~`hir::intravisit::ParDeepVisitor`~~