### PR TITLE
Separate `dealloc` from `AllocRef` into `DeallocRef`

### DIFF
--- a/src/liballoc/alloc.rs
+++ b/src/liballoc/alloc.rs
@@ -163,15 +163,18 @@ pub unsafe fn alloc_zeroed(layout: Layout) -> *mut u8 {
 }
 
 #[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl DeallocRef for Global {
+    #[inline]
+    unsafe fn dealloc(&mut self, ptr: NonNull<u8>, layout: Layout) {
+        dealloc(ptr.as_ptr(), layout)
+    }
+}
+
+#[unstable(feature = "allocator_api", issue = "32838")]
 unsafe impl AllocRef for Global {
     #[inline]
     unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
         NonNull::new(alloc(layout)).ok_or(AllocErr)
-    }
-
-    #[inline]
-    unsafe fn dealloc(&mut self, ptr: NonNull<u8>, layout: Layout) {
-        dealloc(ptr.as_ptr(), layout)
     }
 
     #[inline]

--- a/src/liballoc/collections/btree/node.rs
+++ b/src/liballoc/collections/btree/node.rs
@@ -37,7 +37,7 @@ use core::mem::{self, MaybeUninit};
 use core::ptr::{self, NonNull, Unique};
 use core::slice;
 
-use crate::alloc::{AllocRef, Global, Layout};
+use crate::alloc::{DeallocRef, Global, Layout};
 use crate::boxed::Box;
 
 const B: usize = 6;

--- a/src/liballoc/raw_vec/tests.rs
+++ b/src/liballoc/raw_vec/tests.rs
@@ -19,6 +19,11 @@ fn allocator_param() {
     struct BoundedAlloc {
         fuel: usize,
     }
+    unsafe impl DeallocRef for BoundedAlloc {
+        unsafe fn dealloc(&mut self, ptr: NonNull<u8>, layout: Layout) {
+            Global.dealloc(ptr, layout)
+        }
+    }
     unsafe impl AllocRef for BoundedAlloc {
         unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
             let size = layout.size();
@@ -32,9 +37,6 @@ fn allocator_param() {
                 }
                 err @ Err(_) => err,
             }
-        }
-        unsafe fn dealloc(&mut self, ptr: NonNull<u8>, layout: Layout) {
-            Global.dealloc(ptr, layout)
         }
     }
 

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -252,7 +252,7 @@ use core::ptr::{self, NonNull};
 use core::slice::{self, from_raw_parts_mut};
 use core::usize;
 
-use crate::alloc::{box_free, handle_alloc_error, AllocRef, Global, Layout};
+use crate::alloc::{box_free, handle_alloc_error, AllocRef, DeallocRef, Global, Layout};
 use crate::string::String;
 use crate::vec::Vec;
 

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -25,7 +25,7 @@ use core::sync::atomic;
 use core::sync::atomic::Ordering::{Acquire, Relaxed, Release, SeqCst};
 use core::{isize, usize};
 
-use crate::alloc::{box_free, handle_alloc_error, AllocRef, Global, Layout};
+use crate::alloc::{box_free, handle_alloc_error, AllocRef, DeallocRef, Global, Layout};
 use crate::boxed::Box;
 use crate::rc::is_dangling;
 use crate::string::String;

--- a/src/libstd/alloc.rs
+++ b/src/libstd/alloc.rs
@@ -133,7 +133,15 @@ pub use alloc_crate::alloc::*;
 #[derive(Debug, Default, Copy, Clone)]
 pub struct System;
 
-// The AllocRef impl just forwards to the GlobalAlloc impl, which is in `std::sys::*::alloc`.
+// The (De-)allocRef impl just forwards to the GlobalAlloc impl, which is in `std::sys::*::alloc`.
+#[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl DeallocRef for System {
+    #[inline]
+    unsafe fn dealloc(&mut self, ptr: NonNull<u8>, layout: Layout) {
+        GlobalAlloc::dealloc(self, ptr.as_ptr(), layout)
+    }
+}
+
 #[unstable(feature = "allocator_api", issue = "32838")]
 unsafe impl AllocRef for System {
     #[inline]
@@ -144,11 +152,6 @@ unsafe impl AllocRef for System {
     #[inline]
     unsafe fn alloc_zeroed(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
         NonNull::new(GlobalAlloc::alloc_zeroed(self, layout)).ok_or(AllocErr)
-    }
-
-    #[inline]
-    unsafe fn dealloc(&mut self, ptr: NonNull<u8>, layout: Layout) {
-        GlobalAlloc::dealloc(self, ptr.as_ptr(), layout)
     }
 
     #[inline]

--- a/src/test/ui/allocator/custom.rs
+++ b/src/test/ui/allocator/custom.rs
@@ -7,7 +7,7 @@
 
 extern crate helper;
 
-use std::alloc::{self, Global, AllocRef, System, Layout};
+use std::alloc::{self, Global, AllocRef, DeallocRef, System, Layout};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 static HITS: AtomicUsize = AtomicUsize::new(0);

--- a/src/test/ui/allocator/xcrate-use.rs
+++ b/src/test/ui/allocator/xcrate-use.rs
@@ -9,7 +9,7 @@
 extern crate custom;
 extern crate helper;
 
-use std::alloc::{Global, AllocRef, System, Layout};
+use std::alloc::{Global, AllocRef, DeallocRef, System, Layout};
 use std::sync::atomic::{Ordering, AtomicUsize};
 
 #[global_allocator]

--- a/src/test/ui/realloc-16687.rs
+++ b/src/test/ui/realloc-16687.rs
@@ -6,7 +6,7 @@
 
 #![feature(allocator_api)]
 
-use std::alloc::{Global, AllocRef, Layout, handle_alloc_error};
+use std::alloc::{Global, AllocRef, DeallocRef, Layout, handle_alloc_error};
 use std::ptr::{self, NonNull};
 
 fn main() {

--- a/src/test/ui/regions/regions-mock-codegen.rs
+++ b/src/test/ui/regions/regions-mock-codegen.rs
@@ -6,7 +6,7 @@
 
 #![feature(allocator_api)]
 
-use std::alloc::{AllocRef, Global, Layout, handle_alloc_error};
+use std::alloc::{AllocRef, DeallocRef, Global, Layout, handle_alloc_error};
 use std::ptr::NonNull;
 
 struct arena(());


### PR DESCRIPTION
This creates a new trait `DeallocRef`, makes it a supertrait of `AllocRef` and moves `dealloc` into the new trait.

With this way, it is possible to have allocators, which cannot allocate new memory, but free old one. This comes in handy when dealing with FFI interfaces, which returns a pointer and a `free` function.

For a full discussion on this topic please see https://github.com/rust-lang/wg-allocators/issues/9

r? @Amanieu 

closes rust-lang/wg-allocators#9