### PR TITLE
rustc_codegen_llvm: don't generate any type debuginfo for -Cdebuginfo=1.

### DIFF
--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -2299,6 +2299,11 @@ pub fn create_global_var_metadata(cx: &CodegenCx<'ll, '_>, def_id: DefId, global
         return;
     }
 
+    // Only create type information if full debuginfo is enabled
+    if cx.sess().opts.debuginfo != DebugInfo::Full {
+        return;
+    }
+
     let tcx = cx.tcx;
     let attrs = tcx.codegen_fn_attrs(def_id);
 
@@ -2355,6 +2360,11 @@ pub fn create_global_var_metadata(cx: &CodegenCx<'ll, '_>, def_id: DefId, global
 /// Adds the created metadata nodes directly to the crate's IR.
 pub fn create_vtable_metadata(cx: &CodegenCx<'ll, 'tcx>, ty: Ty<'tcx>, vtable: &'ll Value) {
     if cx.dbg_cx.is_none() {
+        return;
+    }
+
+    // Only create type information if full debuginfo is enabled
+    if cx.sess().opts.debuginfo != DebugInfo::Full {
         return;
     }
 

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -475,7 +475,12 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
                     // so avoid methods on other types (e.g., `<*mut T>::null`).
                     match impl_self_ty.kind {
                         ty::Adt(def, ..) if !def.is_box() => {
-                            Some(type_metadata(cx, impl_self_ty, rustc_span::DUMMY_SP))
+                            // Again, only create type information if full debuginfo is enabled
+                            if cx.sess().opts.debuginfo == DebugInfo::Full {
+                                Some(type_metadata(cx, impl_self_ty, rustc_span::DUMMY_SP))
+                            } else {
+                                Some(namespace::item_namespace(cx, def.did))
+                            }
                         }
                         _ => None,
                     }

--- a/src/librustc_llvm/build.rs
+++ b/src/librustc_llvm/build.rs
@@ -151,6 +151,7 @@ fn main() {
 
     if env::var_os("LLVM_NDEBUG").is_some() {
         cfg.define("NDEBUG", None);
+        cfg.debug(false);
     }
 
     build_helper::rerun_if_changed_anything_in_dir(Path::new("../rustllvm"));


### PR DESCRIPTION
Works towards #69074 by adding more checks for `DebugInfo::Full` in a few places in `rustc_codegen_llvm`, bringing us in line with what `clang -g1` generates (no debuginfo types, nor debuginfo for `static`s).

<hr/>

My local build's (`debuginfo-level=1`, `debug-assertions=1`) `librustc_driver-*.so` went from just over 1GiB (1019MiB) down to 402MiB.

It's still bad, but the `.debug_*` sections themselves (as reported by `objdump`) went from something like 853MiB down to 236MiB, i.e. roughly a 3.6x reduction.

<hr/>

Sadly, I don't think this is enough to justify *shipping* all of this debuginfo, but now it's more plausible that we could at least *build* with `debuginfo-level=1` *then* strip it.
That would give us real backtraces for e.g. ICEs during builds, but I don't know how often that's relevant.

We could also look into split DWARF, and maybe have a `rustc-debuginfo` component in `rustup`.

There's also the possibility of making it slimmer by omitting parameters to functions, or perhaps some deduplication (I think right now there is no DWARF reuse across CGUs? maybe ThinLTO helps?).

r? @michaelwoerister cc @rust-lang/wg-codegen @alexcrichton @Mark-Simulacrum 