### PR TITLE
Support static linking LLVM with ThinLTO

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -567,8 +567,11 @@ pub fn rustc_cargo_env(builder: &Builder<'_>, cargo: &mut Cargo, target: Interne
             let file = compiler_file(builder, builder.cxx(target).unwrap(), target, "libstdc++.a");
             cargo.env("LLVM_STATIC_STDCPP", file);
         }
-        if builder.config.llvm_link_shared || builder.config.llvm_thin_lto {
+        if builder.config.llvm_link_shared {
             cargo.env("LLVM_LINK_SHARED", "1");
+        }
+        if builder.config.llvm_thin_lto {
+            cargo.env("LLVM_LTO", "thin");
         }
         if builder.config.llvm_use_libcxx {
             cargo.env("LLVM_USE_LIBCXX", "1");

--- a/src/ci/docker/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/dist-x86_64-linux/Dockerfile
@@ -101,6 +101,7 @@ ENV RUST_CONFIGURE_ARGS \
       --set target.x86_64-unknown-linux-gnu.linker=clang \
       --set target.x86_64-unknown-linux-gnu.ar=/rustroot/bin/llvm-ar \
       --set target.x86_64-unknown-linux-gnu.ranlib=/rustroot/bin/llvm-ranlib \
+      --set llvm.link-shared=true \
       --set llvm.thin-lto=true \
       --set rust.jemalloc
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/x86_64-gnu-llvm-7/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-llvm-7/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-# using llvm-link-shared due to libffi issues -- see #34486
+# using llvm.link-shared due to libffi issues -- see #34486
 ENV RUST_CONFIGURE_ARGS \
       --build=x86_64-unknown-linux-gnu \
       --llvm-root=/usr/lib/llvm-7 \
-      --enable-llvm-link-shared \
+      --set llvm.link-shared=true \
       --set rust.thin-lto-import-instr-limit=10
 
 ENV SCRIPT python2.7 ../x.py test src/tools/tidy && python2.7 ../x.py test

--- a/src/librustc_llvm/build.rs
+++ b/src/librustc_llvm/build.rs
@@ -127,6 +127,7 @@ fn main() {
         }
 
         if flag.starts_with("-flto") {
+            // Handled below.
             continue;
         }
 
@@ -151,6 +152,10 @@ fn main() {
 
     if env::var_os("LLVM_NDEBUG").is_some() {
         cfg.define("NDEBUG", None);
+    }
+
+    if let Ok(kind) = env::var("LLVM_LTO") {
+        cfg.flag(&format!("-flto={}", kind));
     }
 
     build_helper::rerun_if_changed_anything_in_dir(Path::new("../rustllvm"));


### PR DESCRIPTION
As [discussed here](https://github.com/rust-lang/rust/pull/57286#issuecomment-559197822), we'd like to support static linking LLVM with ThinLTO, even if that isn't what happens on our CI bots. This changes the `llvm.link-shared` config flag to default to `true` if `llvm.thinlto` is enabled, but allows the user to override that default instead of forcing shared linking.

r? @Mark-Simulacrum 
cc @alexcrichton @petrhosek 