### PR TITLE
Split non macro portion of unused_doc_comment from macro part into two passes/lints

### DIFF
--- a/src/librustc_expand/expand.rs
+++ b/src/librustc_expand/expand.rs
@@ -14,8 +14,8 @@ use rustc_parse::configure;
 use rustc_parse::parser::Parser;
 use rustc_parse::validate_attr;
 use rustc_parse::DirectoryOwnership;
-use rustc_session::lint::BuiltinLintDiagnostics;
 use rustc_session::lint::builtin::UNUSED_DOC_COMMENTS;
+use rustc_session::lint::BuiltinLintDiagnostics;
 use rustc_session::parse::{feature_err, ParseSess};
 use rustc_span::source_map::respan;
 use rustc_span::symbol::{sym, Symbol};
@@ -1099,7 +1099,8 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
                     attr.span,
                     ast::CRATE_NODE_ID,
                     "unused doc comment",
-                    BuiltinLintDiagnostics::UnusedDocComment(attr.span));
+                    BuiltinLintDiagnostics::UnusedDocComment(attr.span),
+                );
             }
         }
     }

--- a/src/librustc_expand/expand.rs
+++ b/src/librustc_expand/expand.rs
@@ -14,6 +14,7 @@ use rustc_parse::configure;
 use rustc_parse::parser::Parser;
 use rustc_parse::validate_attr;
 use rustc_parse::DirectoryOwnership;
+use rustc_session::lint::builtin::UNUSED_DOC_COMMENTS;
 use rustc_session::parse::{feature_err, ParseSess};
 use rustc_span::source_map::respan;
 use rustc_span::symbol::{sym, Symbol};
@@ -1089,6 +1090,10 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
                     .struct_span_warn(attr.span, "`#[derive]` does nothing on macro invocations")
                     .note("this may become a hard error in a future release")
                     .emit();
+            }
+
+            if attr.doc_str().is_some() {
+                self.cx.parse_sess.buffer_lint(&UNUSED_DOC_COMMENTS, attr.span, ast::CRATE_NODE_ID, "yep, it's unused");
             }
         }
     }

--- a/src/librustc_expand/expand.rs
+++ b/src/librustc_expand/expand.rs
@@ -14,6 +14,7 @@ use rustc_parse::configure;
 use rustc_parse::parser::Parser;
 use rustc_parse::validate_attr;
 use rustc_parse::DirectoryOwnership;
+use rustc_session::lint::BuiltinLintDiagnostics;
 use rustc_session::lint::builtin::UNUSED_DOC_COMMENTS;
 use rustc_session::parse::{feature_err, ParseSess};
 use rustc_span::source_map::respan;
@@ -1093,7 +1094,12 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
             }
 
             if attr.doc_str().is_some() {
-                self.cx.parse_sess.buffer_lint(&UNUSED_DOC_COMMENTS, attr.span, ast::CRATE_NODE_ID, "yep, it's unused");
+                self.cx.parse_sess.buffer_lint_with_diagnostic(
+                    &UNUSED_DOC_COMMENTS,
+                    attr.span,
+                    ast::CRATE_NODE_ID,
+                    "unused doc comment",
+                    BuiltinLintDiagnostics::UnusedDocComment(attr.span));
             }
         }
     }

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -738,15 +738,18 @@ impl EarlyLintPass for DeprecatedAttr {
     }
 }
 
-declare_lint! {
-    pub UNUSED_DOC_COMMENTS,
-    Warn,
-    "detects doc comments that aren't used by rustdoc"
+trait UnusedDocCommentExt {
+    fn warn_if_doc(
+        &self,
+        cx: &EarlyContext<'_>,
+        node_span: Span,
+        node_kind: &str,
+        is_macro_expansion: bool,
+        attrs: &[ast::Attribute],
+    );
 }
 
-declare_lint_pass!(UnusedDocComment => [UNUSED_DOC_COMMENTS]);
-
-impl UnusedDocComment {
+impl UnusedDocCommentExt for UnusedDocComment {
     fn warn_if_doc(
         &self,
         cx: &EarlyContext<'_>,

--- a/src/librustc_lint/context.rs
+++ b/src/librustc_lint/context.rs
@@ -565,6 +565,11 @@ pub trait LintContext: Sized {
                 BuiltinLintDiagnostics::DeprecatedMacro(suggestion, span) => {
                     stability::deprecation_suggestion(&mut db, suggestion, span)
                 }
+                BuiltinLintDiagnostics::UnusedDocComment(span) => {
+                    db.span_label(span, "rustdoc does not generate documentation for macros");
+                    db.help("to document an item produced by a macro, \
+                                  the macro must produce the documentation as part of its expansion");
+                }
             }
             // Rewrap `db`, and pass control to the user.
             decorate(LintDiagnosticBuilder::new(db));

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -94,7 +94,7 @@ fn lint_mod(tcx: TyCtxt<'_>, module_def_id: DefId) {
 
 macro_rules! pre_expansion_lint_passes {
     ($macro:path, $args:tt) => {
-        $macro!($args, [KeywordIdents: KeywordIdents, UnusedDocComment: UnusedDocComment,]);
+        $macro!($args, [KeywordIdents: KeywordIdents,]);
     };
 }
 
@@ -114,6 +114,7 @@ macro_rules! early_lint_passes {
                 NonAsciiIdents: NonAsciiIdents,
                 IncompleteFeatures: IncompleteFeatures,
                 RedundantSemicolon: RedundantSemicolon,
+                UnusedDocComment: UnusedDocComment,
             ]
         );
     };

--- a/src/librustc_session/lint.rs
+++ b/src/librustc_session/lint.rs
@@ -190,6 +190,7 @@ pub enum BuiltinLintDiagnostics {
     UnusedImports(String, Vec<(Span, String)>),
     RedundantImport(Vec<(Span, bool)>, Ident),
     DeprecatedMacro(Option<Symbol>, Span),
+    UnusedDocComment(Span),
 }
 
 /// Lints that are buffered up early on in the `Session` before the

--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -557,3 +557,11 @@ declare_lint_pass! {
         INLINE_NO_SANITIZE,
     ]
 }
+
+declare_lint! {
+    pub UNUSED_DOC_COMMENTS,
+    Warn,
+    "detects doc comments that aren't used by rustdoc"
+}
+
+declare_lint_pass!(UnusedDocComment => [UNUSED_DOC_COMMENTS]);

--- a/src/librustc_session/parse.rs
+++ b/src/librustc_session/parse.rs
@@ -176,6 +176,25 @@ impl ParseSess {
         });
     }
 
+    pub fn buffer_lint_with_diagnostic(
+        &self,
+        lint: &'static Lint,
+        span: impl Into<MultiSpan>,
+        node_id: NodeId,
+        msg: &str,
+        diagnostic: BuiltinLintDiagnostics,
+    ) {
+        self.buffered_lints.with_lock(|buffered_lints| {
+            buffered_lints.push(BufferedEarlyLint {
+                span: span.into(),
+                node_id,
+                msg: msg.into(),
+                lint_id: LintId::of(lint),
+                diagnostic,
+            });
+        });
+    }
+
     /// Extend an error with a suggestion to wrap an expression with parentheses to allow the
     /// parser to continue parsing the following operation as part of the same expression.
     pub fn expr_parentheses_needed(

--- a/src/libstd/sys/wasi/fd.rs
+++ b/src/libstd/sys/wasi/fd.rs
@@ -13,7 +13,7 @@ pub struct WasiFd {
 fn iovec<'a>(a: &'a mut [IoSliceMut<'_>]) -> &'a [wasi::Iovec] {
     assert_eq!(mem::size_of::<IoSliceMut<'_>>(), mem::size_of::<wasi::Iovec>());
     assert_eq!(mem::align_of::<IoSliceMut<'_>>(), mem::align_of::<wasi::Iovec>());
-    /// SAFETY: `IoSliceMut` and `IoVec` have exactly the same memory layout
+    // SAFETY: `IoSliceMut` and `IoVec` have exactly the same memory layout
     unsafe {
         mem::transmute(a)
     }
@@ -22,7 +22,7 @@ fn iovec<'a>(a: &'a mut [IoSliceMut<'_>]) -> &'a [wasi::Iovec] {
 fn ciovec<'a>(a: &'a [IoSlice<'_>]) -> &'a [wasi::Ciovec] {
     assert_eq!(mem::size_of::<IoSlice<'_>>(), mem::size_of::<wasi::Ciovec>());
     assert_eq!(mem::align_of::<IoSlice<'_>>(), mem::align_of::<wasi::Ciovec>());
-    /// SAFETY: `IoSlice` and `CIoVec` have exactly the same memory layout
+    // SAFETY: `IoSlice` and `CIoVec` have exactly the same memory layout
     unsafe {
         mem::transmute(a)
     }

--- a/src/libstd/sys/wasi/fd.rs
+++ b/src/libstd/sys/wasi/fd.rs
@@ -14,18 +14,14 @@ fn iovec<'a>(a: &'a mut [IoSliceMut<'_>]) -> &'a [wasi::Iovec] {
     assert_eq!(mem::size_of::<IoSliceMut<'_>>(), mem::size_of::<wasi::Iovec>());
     assert_eq!(mem::align_of::<IoSliceMut<'_>>(), mem::align_of::<wasi::Iovec>());
     // SAFETY: `IoSliceMut` and `IoVec` have exactly the same memory layout
-    unsafe {
-        mem::transmute(a)
-    }
+    unsafe { mem::transmute(a) }
 }
 
 fn ciovec<'a>(a: &'a [IoSlice<'_>]) -> &'a [wasi::Ciovec] {
     assert_eq!(mem::size_of::<IoSlice<'_>>(), mem::size_of::<wasi::Ciovec>());
     assert_eq!(mem::align_of::<IoSlice<'_>>(), mem::align_of::<wasi::Ciovec>());
     // SAFETY: `IoSlice` and `CIoVec` have exactly the same memory layout
-    unsafe {
-        mem::transmute(a)
-    }
+    unsafe { mem::transmute(a) }
 }
 
 impl WasiFd {

--- a/src/test/ui/useless-comment.rs
+++ b/src/test/ui/useless-comment.rs
@@ -6,7 +6,7 @@ macro_rules! mac {
     () => {}
 }
 
-/// foo //~ ERROR unused doc comment
+/// foo //FIXME ERROR unused doc comment
 mac!();
 
 fn foo() {
@@ -29,7 +29,7 @@ fn foo() {
     #[doc = "bar"] //~ ERROR unused doc comment
     3;
 
-    /// bar //~ ERROR unused doc comment
+    /// bar //FIXME ERROR unused doc comment
     mac!();
 
     let x = /** comment */ 47; //~ ERROR unused doc comment

--- a/src/test/ui/useless-comment.rs
+++ b/src/test/ui/useless-comment.rs
@@ -6,7 +6,7 @@ macro_rules! mac {
     () => {}
 }
 
-/// foo //FIXME ERROR unused doc comment
+/// foo //~ ERROR yep, it's unused
 mac!();
 
 fn foo() {
@@ -29,7 +29,7 @@ fn foo() {
     #[doc = "bar"] //~ ERROR unused doc comment
     3;
 
-    /// bar //FIXME ERROR unused doc comment
+    /// bar //~ ERROR yep, it's unused
     mac!();
 
     let x = /** comment */ 47; //~ ERROR unused doc comment

--- a/src/test/ui/useless-comment.rs
+++ b/src/test/ui/useless-comment.rs
@@ -6,7 +6,7 @@ macro_rules! mac {
     () => {}
 }
 
-/// foo //~ ERROR yep, it's unused
+/// foo //~ ERROR unused doc comment
 mac!();
 
 fn foo() {
@@ -29,7 +29,7 @@ fn foo() {
     #[doc = "bar"] //~ ERROR unused doc comment
     3;
 
-    /// bar //~ ERROR yep, it's unused
+    /// bar //~ ERROR unused doc comment
     mac!();
 
     let x = /** comment */ 47; //~ ERROR unused doc comment

--- a/src/test/ui/useless-comment.stderr
+++ b/src/test/ui/useless-comment.stderr
@@ -1,25 +1,16 @@
 error: unused doc comment
-  --> $DIR/useless-comment.rs:9:1
-   |
-LL | /// foo
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL | mac!();
-   | ------- rustdoc does not generate documentation for macro expansions
-   |
-note: the lint level is defined here
-  --> $DIR/useless-comment.rs:3:9
-   |
-LL | #![deny(unused_doc_comments)]
-   |         ^^^^^^^^^^^^^^^^^^^
-   = help: to document an item produced by a macro, the macro must produce the documentation as part of its expansion
-
-error: unused doc comment
   --> $DIR/useless-comment.rs:13:5
    |
 LL |     /// a
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |     let x = 12;
    |     ----------- rustdoc does not generate documentation for statements
+   |
+note: the lint level is defined here
+  --> $DIR/useless-comment.rs:3:9
+   |
+LL | #![deny(unused_doc_comments)]
+   |         ^^^^^^^^^^^^^^^^^^^
 
 error: unused doc comment
   --> $DIR/useless-comment.rs:16:5
@@ -69,16 +60,6 @@ LL |     3;
    |     - rustdoc does not generate documentation for expressions
 
 error: unused doc comment
-  --> $DIR/useless-comment.rs:32:5
-   |
-LL |     /// bar
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |     mac!();
-   |     ------- rustdoc does not generate documentation for macro expansions
-   |
-   = help: to document an item produced by a macro, the macro must produce the documentation as part of its expansion
-
-error: unused doc comment
   --> $DIR/useless-comment.rs:35:13
    |
 LL |     let x = /** comment */ 47;
@@ -94,5 +75,5 @@ LL | |
 LL | |     }
    | |_____- rustdoc does not generate documentation for expressions
 
-error: aborting due to 10 previous errors
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/useless-comment.stderr
+++ b/src/test/ui/useless-comment.stderr
@@ -1,20 +1,23 @@
-error: yep, it's unused
+error: unused doc comment
   --> $DIR/useless-comment.rs:9:1
    |
 LL | /// foo
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ rustdoc does not generate documentation for macros
    |
 note: the lint level is defined here
   --> $DIR/useless-comment.rs:3:9
    |
 LL | #![deny(unused_doc_comments)]
    |         ^^^^^^^^^^^^^^^^^^^
+   = help: to document an item produced by a macro, the macro must produce the documentation as part of its expansion
 
-error: yep, it's unused
+error: unused doc comment
   --> $DIR/useless-comment.rs:32:5
    |
 LL |     /// bar
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ rustdoc does not generate documentation for macros
+   |
+   = help: to document an item produced by a macro, the macro must produce the documentation as part of its expansion
 
 error: unused doc comment
   --> $DIR/useless-comment.rs:13:5

--- a/src/test/ui/useless-comment.stderr
+++ b/src/test/ui/useless-comment.stderr
@@ -1,3 +1,21 @@
+error: yep, it's unused
+  --> $DIR/useless-comment.rs:9:1
+   |
+LL | /// foo
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/useless-comment.rs:3:9
+   |
+LL | #![deny(unused_doc_comments)]
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: yep, it's unused
+  --> $DIR/useless-comment.rs:32:5
+   |
+LL |     /// bar
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: unused doc comment
   --> $DIR/useless-comment.rs:13:5
    |
@@ -5,12 +23,6 @@ LL |     /// a
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |     let x = 12;
    |     ----------- rustdoc does not generate documentation for statements
-   |
-note: the lint level is defined here
-  --> $DIR/useless-comment.rs:3:9
-   |
-LL | #![deny(unused_doc_comments)]
-   |         ^^^^^^^^^^^^^^^^^^^
 
 error: unused doc comment
   --> $DIR/useless-comment.rs:16:5
@@ -75,5 +87,5 @@ LL | |
 LL | |     }
    | |_____- rustdoc does not generate documentation for expressions
 
-error: aborting due to 8 previous errors
+error: aborting due to 10 previous errors
 


### PR DESCRIPTION
## Motivation

This change is motivated by the needs of the [spandoc library](https://github.com/yaahc/spandoc). The specific use case is that my macro is removing doc comments when an attribute is applied to a fn with doc comments, but I would like the lint to still appear when I forget to add the `#[spandoc]` attribute to a fn, so I don't want to have to silence the lint globally.

## Approach

This change splits the `unused _doc_comment` lint into two lints, `unused_macro_doc_comment` and `unused_doc_comment`. The non macro portion is moved into an `early_lint_pass` rather than a pre_expansion_pass. This allows proc macros to silence `unused_doc_comment` warnings by either adding an attribute to silence it or by removing the doc comment before the early_pass runs.

The `unused_macro_doc_comment` lint however will still be impossible for proc-macros to silence, but the only alternative that I can see is to remove this lint entirely, which I don't think is acceptable / is a decision I'm not comfortable making personally, so instead I opted to split the macro portion of the check into a separate lint so that it can be silenced globally with an attribute if necessary without needing to globally silence the `unused_doc_comment` lint as well, which is still desireable.

fixes https://github.com/rust-lang/rust/issues/67838