### PR TITLE
Update compiler-builtins to 0.1.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9975aefa63997ef75ca9cf013ff1bb81487aaa0b622c21053afd3b92979a7af"
+checksum = "438ac08ddc5efe81452f984a9e33ba425b00b31d1f48e6acd9e2210aa28cc52e"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",


### PR DESCRIPTION
- https://github.com/rust-lang/compiler-builtins/pull/340 Set probestack visibility to hidden on ELF targets

Fixes https://github.com/rust-lang/rust/issues/68794.

Tested in CI: https://github.com/rust-lang/rust/pull/69045.

r? @Mark-Simulacrum 