### PR TITLE
Fix box_region.rs

### DIFF
--- a/src/librustc_data_structures/box_region.rs
+++ b/src/librustc_data_structures/box_region.rs
@@ -47,7 +47,7 @@ impl<I, A, R> PinnedGenerator<I, A, R> {
         let mut result = PinnedGenerator { generator: Box::pin(generator) };
 
         // Run it to the first yield to set it up
-        let init = match Pin::new(&mut result.generator).resume(()) {
+        let init = match Pin::new(&mut result.generator).resume() {
             GeneratorState::Yielded(YieldType::Initial(y)) => y,
             _ => panic!(),
         };
@@ -74,7 +74,7 @@ impl<I, A, R> PinnedGenerator<I, A, R> {
         });
 
         // Call the generator, which in turn will call the closure in BOX_REGION_ARG
-        if let GeneratorState::Complete(_) = Pin::new(&mut self.generator).resume(()) {
+        if let GeneratorState::Complete(_) = Pin::new(&mut self.generator).resume() {
             panic!()
         }
     }
@@ -93,7 +93,7 @@ impl<I, A, R> PinnedGenerator<I, A, R> {
         // Tell the generator we want it to complete, consuming it and yielding a result
         BOX_REGION_ARG.with(|i| i.set(Action::Complete));
 
-        let result = Pin::new(&mut self.generator).resume(());
+        let result = Pin::new(&mut self.generator).resume();
         if let GeneratorState::Complete(r) = result { r } else { panic!() }
     }
 }


### PR DESCRIPTION
As reported in https://github.com/racer-rust/racer/issues/1093,
When building `racer`, compiler throws error E0061, that the method
`resume()` expect 0 parameter, but 1 parameter `()` is supplied.

This commit removed the wrongly supplied parameter to `resume()`.