### PR TITLE
Backtrace Debug tweaks

### DIFF
--- a/src/libstd/backtrace.rs
+++ b/src/libstd/backtrace.rs
@@ -162,8 +162,8 @@ enum BytesOrWide {
 impl fmt::Debug for Backtrace {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut capture = match &self.inner {
-            Inner::Unsupported => return fmt.write_str("unsupported backtrace"),
-            Inner::Disabled => return fmt.write_str("disabled backtrace"),
+            Inner::Unsupported => return fmt.write_str("<unsupported>"),
+            Inner::Disabled => return fmt.write_str("<disabled>"),
             Inner::Captured(c) => c.lock().unwrap(),
         };
         capture.resolve();

--- a/src/libstd/backtrace.rs
+++ b/src/libstd/backtrace.rs
@@ -197,7 +197,7 @@ impl fmt::Debug for BacktraceSymbol {
         }
 
         if let Some(fname) = self.filename.as_ref() {
-            write!(fmt, ", file: {:?}", fname)?;
+            write!(fmt, ", file: \"{:?}\"", fname)?;
         }
 
         if let Some(line) = self.lineno.as_ref() {

--- a/src/libstd/backtrace.rs
+++ b/src/libstd/backtrace.rs
@@ -433,3 +433,55 @@ impl RawFrame {
         }
     }
 }
+
+#[test]
+fn test_debug() {
+    let backtrace = Backtrace {
+        inner: Inner::Captured(Mutex::new(Capture {
+            actual_start: 1,
+            resolved: true,
+            frames: vec![
+                BacktraceFrame {
+                    frame: RawFrame::Fake,
+                    symbols: vec![BacktraceSymbol {
+                        name: Some(b"std::backtrace::Backtrace::create".to_vec()),
+                        filename: Some(BytesOrWide::Bytes(b"/rust/backtrace.rs".to_vec())),
+                        lineno: Some(100),
+                    }],
+                },
+                BacktraceFrame {
+                    frame: RawFrame::Fake,
+                    symbols: vec![BacktraceSymbol {
+                        name: Some(b"__rust_maybe_catch_panic".to_vec()),
+                        filename: None,
+                        lineno: None,
+                    }],
+                },
+                BacktraceFrame {
+                    frame: RawFrame::Fake,
+                    symbols: vec![
+                        BacktraceSymbol {
+                            name: Some(b"std::rt::lang_start_internal".to_vec()),
+                            filename: Some(BytesOrWide::Bytes(b"/rust/rt.rs".to_vec())),
+                            lineno: Some(300),
+                        },
+                        BacktraceSymbol {
+                            name: Some(b"std::rt::lang_start".to_vec()),
+                            filename: Some(BytesOrWide::Bytes(b"/rust/rt.rs".to_vec())),
+                            lineno: Some(400),
+                        },
+                    ],
+                },
+            ],
+        })),
+    };
+
+    #[rustfmt::skip]
+    let expected = "Backtrace [\
+    \n    { fn: \"__rust_maybe_catch_panic\" },\
+    \n    { fn: \"std::rt::lang_start_internal\", file: \"/rust/rt.rs\", line: 300 },\
+    \n    { fn: \"std::rt::lang_start\", file: \"/rust/rt.rs\", line: 400 },\
+    \n]";
+
+    assert_eq!(format!("{:#?}", backtrace), expected);
+}

--- a/src/libstd/backtrace.rs
+++ b/src/libstd/backtrace.rs
@@ -193,7 +193,7 @@ impl fmt::Debug for BacktraceSymbol {
         if let Some(fn_name) = self.name.as_ref().map(|b| backtrace::SymbolName::new(b)) {
             write!(fmt, "fn: \"{:#}\"", fn_name)?;
         } else {
-            write!(fmt, "fn: \"<unknown>\"")?;
+            write!(fmt, "fn: <unknown>")?;
         }
 
         if let Some(fname) = self.filename.as_ref() {

--- a/src/libstd/backtrace.rs
+++ b/src/libstd/backtrace.rs
@@ -445,7 +445,7 @@ fn test_debug() {
                     frame: RawFrame::Fake,
                     symbols: vec![BacktraceSymbol {
                         name: Some(b"std::backtrace::Backtrace::create".to_vec()),
-                        filename: Some(BytesOrWide::Bytes(b"/rust/backtrace.rs".to_vec())),
+                        filename: Some(BytesOrWide::Bytes(b"rust/backtrace.rs".to_vec())),
                         lineno: Some(100),
                     }],
                 },
@@ -462,12 +462,12 @@ fn test_debug() {
                     symbols: vec![
                         BacktraceSymbol {
                             name: Some(b"std::rt::lang_start_internal".to_vec()),
-                            filename: Some(BytesOrWide::Bytes(b"/rust/rt.rs".to_vec())),
+                            filename: Some(BytesOrWide::Bytes(b"rust/rt.rs".to_vec())),
                             lineno: Some(300),
                         },
                         BacktraceSymbol {
                             name: Some(b"std::rt::lang_start".to_vec()),
-                            filename: Some(BytesOrWide::Bytes(b"/rust/rt.rs".to_vec())),
+                            filename: Some(BytesOrWide::Bytes(b"rust/rt.rs".to_vec())),
                             lineno: Some(400),
                         },
                     ],
@@ -479,8 +479,8 @@ fn test_debug() {
     #[rustfmt::skip]
     let expected = "Backtrace [\
     \n    { fn: \"__rust_maybe_catch_panic\" },\
-    \n    { fn: \"std::rt::lang_start_internal\", file: \"/rust/rt.rs\", line: 300 },\
-    \n    { fn: \"std::rt::lang_start\", file: \"/rust/rt.rs\", line: 400 },\
+    \n    { fn: \"std::rt::lang_start_internal\", file: \"rust/rt.rs\", line: 300 },\
+    \n    { fn: \"std::rt::lang_start\", file: \"rust/rt.rs\", line: 400 },\
     \n]";
 
     assert_eq!(format!("{:#?}", backtrace), expected);


### PR DESCRIPTION
- Change Debug representation of disabled and unsupported backtraces to use \<placeholder\> style, same as what we do for debug printing locked mutexes and mutably borrowed refcells;

    ```diff
    - Error { msg: "...", backtrace: disabled backtrace }
    + Error { msg: "...", backtrace: <disabled> }
    ```

- Remove quotes around unresolved symbol names;

    ```diff
    - Backtrace [{ fn: "<unknown>" }]
    + Backtrace [{ fn: <unknown> }]
    ```

- Add quotes around file paths;

    ```diff
    - Backtrace [{ fn: "krate::main", file: /path/to/main.rs, line: 10 }]
    + Backtrace [{ fn: "krate::main", file: "/path/to/main.rs", line: 10 }]
    ```

- Add test.