### PR TITLE
Enable use after scope detection in the new LLVM pass manager

### DIFF
--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -761,14 +761,14 @@ LLVMRustOptimizeWithNewPassManager(
     }
 
     if (SanitizerOptions->SanitizeAddress) {
-      // FIXME: Rust does not expose the UseAfterScope option.
       PipelineStartEPCallbacks.push_back([&](ModulePassManager &MPM) {
         MPM.addPass(RequireAnalysisPass<ASanGlobalsMetadataAnalysis, Module>());
       });
       OptimizerLastEPCallbacks.push_back(
         [SanitizerOptions](FunctionPassManager &FPM, PassBuilder::OptimizationLevel Level) {
           FPM.addPass(AddressSanitizerPass(
-              /*CompileKernel=*/false, SanitizerOptions->SanitizeRecover));
+              /*CompileKernel=*/false, SanitizerOptions->SanitizeRecover,
+              /*UseAfterScope=*/true));
         }
       );
       PipelineStartEPCallbacks.push_back(


### PR DESCRIPTION
Implementation of 08a1c566a792dcf9657d293155f7ada87746bb65 for the new LLVM pass manager, support for which landed in the meantime.