### PR TITLE
Fix extra subslice lowering

### DIFF
--- a/src/test/ui/array-slice-vec/issue-69103-extra-binding-subslice.rs
+++ b/src/test/ui/array-slice-vec/issue-69103-extra-binding-subslice.rs
@@ -1,0 +1,18 @@
+// We used to not lower the extra `b @ ..` into `b @ _` which meant that no type
+// was registered for the binding `b` although it passed through resolve.
+// This resulted in an ICE (#69103).
+
+fn main() {
+    let [a @ .., b @ ..] = &mut [1, 2];
+    //~^ ERROR `..` can only be used once per slice pattern
+    b;
+
+    let [.., c @ ..] = [1, 2];
+    //~^ ERROR `..` can only be used once per slice pattern
+    c;
+
+    // This never ICEd, but let's make sure it won't regress either.
+    let (.., d @ ..) = (1, 2);
+    //~^ ERROR `..` patterns are not allowed here
+    d;
+}

--- a/src/test/ui/array-slice-vec/issue-69103-extra-binding-subslice.stderr
+++ b/src/test/ui/array-slice-vec/issue-69103-extra-binding-subslice.stderr
@@ -1,0 +1,26 @@
+error: `..` can only be used once per slice pattern
+  --> $DIR/issue-69103-extra-binding-subslice.rs:6:22
+   |
+LL |     let [a @ .., b @ ..] = &mut [1, 2];
+   |              --      ^^ can only be used once per slice pattern
+   |              |
+   |              previously used here
+
+error: `..` can only be used once per slice pattern
+  --> $DIR/issue-69103-extra-binding-subslice.rs:10:18
+   |
+LL |     let [.., c @ ..] = [1, 2];
+   |          --      ^^ can only be used once per slice pattern
+   |          |
+   |          previously used here
+
+error: `..` patterns are not allowed here
+  --> $DIR/issue-69103-extra-binding-subslice.rs:15:18
+   |
+LL |     let (.., d @ ..) = (1, 2);
+   |                  ^^
+   |
+   = note: only allowed in tuple, tuple struct, and slice patterns
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
We are currently ICEing on e.g.
```rust
fn main() {
    let [.., b @ ..] = [1, 2];
    b;
}
```
This happens because `b @ ..` registers a binding such that `b;` is OK, but then we forget to lower that binding in `rustc_ast_lowering`.

Fixes #69103.

r? @davidtwco 