### PR TITLE
Spelling error "represening" to "representing"

### DIFF
--- a/src/librustc_lexer/src/lib.rs
+++ b/src/librustc_lexer/src/lib.rs
@@ -35,7 +35,7 @@ impl Token {
     }
 }
 
-/// Enum represening common lexeme types.
+/// Enum representing common lexeme types.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TokenKind {
     // Multi-char tokens:


### PR DESCRIPTION
Small spelling mistake I noticed when looking through the Rust lexer.