### PR TITLE
Fix MIR check for MIN % -1 in exact_div

### DIFF
--- a/src/librustc_mir/interpret/operator.rs
+++ b/src/librustc_mir/interpret/operator.rs
@@ -201,7 +201,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 match bin_op {
                     Rem => {
                         if r == -1 && l == (1 << (size.bits() - 1)) {
-                            return Ok((Scalar::from_int(0, size), true, left_layout.ty));
+                            return Ok((Scalar::from_uint(l, size), true, left_layout.ty));
                         }
                     }
                     _ => {}


### PR DESCRIPTION
Hi,
I hope I understood the bug correctly, because I'm not too familiar with the code here.

I've found this while playing with Miri, it seems like this if condition is no longer executed: https://github.com/rust-lang/rust/blob/master/src/librustc_mir/interpret/intrinsics.rs#L414
Because this commit https://github.com/rust-lang/rust/commit/28f85c6ffad77554150e7cab4ccac38b26621bdb made it return `0` in the `MIN % -1` case, while the if explicitly tests if it's *not 0*

So I reverted to the old behavior which returned the left side (`MIN`) instead of 0.

r? @RalfJung 

FWIW, Before this the `exact_div4` test in Miri failed and after this it passes