### PR TITLE
Fix MIR typeck soundness holes

### DIFF
--- a/src/librustc_mir/borrow_check/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/type_check/mod.rs
@@ -466,33 +466,6 @@ impl<'a, 'b, 'tcx> TypeVerifier<'a, 'b, 'tcx> {
 
         let mut place_ty = PlaceTy::from_ty(self.body.local_decls[place.local].ty);
 
-        if place.projection.is_empty() {
-            if let PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy) = context {
-                let tcx = self.tcx();
-                let trait_ref = ty::TraitRef {
-                    def_id: tcx.lang_items().copy_trait().unwrap(),
-                    substs: tcx.mk_substs_trait(place_ty.ty, &[]),
-                };
-
-                // To have a `Copy` operand, the type `T` of the
-                // value must be `Copy`. Note that we prove that `T: Copy`,
-                // rather than using the `is_copy_modulo_regions`
-                // test. This is important because
-                // `is_copy_modulo_regions` ignores the resulting region
-                // obligations and assumes they pass. This can result in
-                // bounds from `Copy` impls being unsoundly ignored (e.g.,
-                // #29149). Note that we decide to use `Copy` before knowing
-                // whether the bounds fully apply: in effect, the rule is
-                // that if a value of some type could implement `Copy`, then
-                // it must.
-                self.cx.prove_trait_ref(
-                    trait_ref,
-                    location.to_locations(),
-                    ConstraintCategory::CopyBound,
-                );
-            }
-        }
-
         for elem in place.projection.iter() {
             if place_ty.variant_index.is_none() {
                 if place_ty.ty.references_error() {
@@ -501,6 +474,31 @@ impl<'a, 'b, 'tcx> TypeVerifier<'a, 'b, 'tcx> {
                 }
             }
             place_ty = self.sanitize_projection(place_ty, elem, place, location)
+        }
+
+        if let PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy) = context {
+            let tcx = self.tcx();
+            let trait_ref = ty::TraitRef {
+                def_id: tcx.lang_items().copy_trait().unwrap(),
+                substs: tcx.mk_substs_trait(place_ty.ty, &[]),
+            };
+
+            // To have a `Copy` operand, the type `T` of the
+            // value must be `Copy`. Note that we prove that `T: Copy`,
+            // rather than using the `is_copy_modulo_regions`
+            // test. This is important because
+            // `is_copy_modulo_regions` ignores the resulting region
+            // obligations and assumes they pass. This can result in
+            // bounds from `Copy` impls being unsoundly ignored (e.g.,
+            // #29149). Note that we decide to use `Copy` before knowing
+            // whether the bounds fully apply: in effect, the rule is
+            // that if a value of some type could implement `Copy`, then
+            // it must.
+            self.cx.prove_trait_ref(
+                trait_ref,
+                location.to_locations(),
+                ConstraintCategory::CopyBound,
+            );
         }
 
         place_ty

--- a/src/test/ui/nll/do-not-ignore-lifetime-bounds-in-copy-proj.rs
+++ b/src/test/ui/nll/do-not-ignore-lifetime-bounds-in-copy-proj.rs
@@ -1,0 +1,12 @@
+// Test that the 'static bound from the Copy impl is respected. Regression test for #29149.
+
+#[derive(Clone)]
+struct Foo<'a>(&'a u32);
+impl Copy for Foo<'static> {}
+
+fn main() {
+    let s = 2;
+    let a = (Foo(&s),); //~ ERROR `s` does not live long enough [E0597]
+    drop(a.0);
+    drop(a.0);
+}

--- a/src/test/ui/nll/do-not-ignore-lifetime-bounds-in-copy-proj.stderr
+++ b/src/test/ui/nll/do-not-ignore-lifetime-bounds-in-copy-proj.stderr
@@ -1,0 +1,14 @@
+error[E0597]: `s` does not live long enough
+  --> $DIR/do-not-ignore-lifetime-bounds-in-copy-proj.rs:9:18
+   |
+LL |     let a = (Foo(&s),);
+   |                  ^^ borrowed value does not live long enough
+LL |     drop(a.0);
+   |          --- copying this value requires that `s` is borrowed for `'static`
+LL |     drop(a.0);
+LL | }
+   | - `s` dropped here while still borrowed
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/nll/issue-69114-static-mut-ty.rs
+++ b/src/test/ui/nll/issue-69114-static-mut-ty.rs
@@ -1,0 +1,30 @@
+// Check that borrowck ensures that `static mut` items have the expected type.
+
+static FOO: u8 = 42;
+static mut BAR: &'static u8 = &FOO;
+static mut BAR_ELIDED: &u8 = &FOO;
+
+fn main() {
+    unsafe {
+        println!("{} {}", BAR, BAR_ELIDED);
+        set_bar();
+        set_bar_elided();
+        println!("{} {}", BAR, BAR_ELIDED);
+    }
+}
+
+fn set_bar() {
+    let n = 42;
+    unsafe {
+        BAR = &n;
+        //~^ ERROR does not live long enough
+    }
+}
+
+fn set_bar_elided() {
+    let n = 42;
+    unsafe {
+        BAR_ELIDED = &n;
+        //~^ ERROR does not live long enough
+    }
+}

--- a/src/test/ui/nll/issue-69114-static-mut-ty.stderr
+++ b/src/test/ui/nll/issue-69114-static-mut-ty.stderr
@@ -1,0 +1,27 @@
+error[E0597]: `n` does not live long enough
+  --> $DIR/issue-69114-static-mut-ty.rs:19:15
+   |
+LL |         BAR = &n;
+   |         ------^^
+   |         |     |
+   |         |     borrowed value does not live long enough
+   |         assignment requires that `n` is borrowed for `'static`
+...
+LL | }
+   | - `n` dropped here while still borrowed
+
+error[E0597]: `n` does not live long enough
+  --> $DIR/issue-69114-static-mut-ty.rs:27:22
+   |
+LL |         BAR_ELIDED = &n;
+   |         -------------^^
+   |         |            |
+   |         |            borrowed value does not live long enough
+   |         assignment requires that `n` is borrowed for `'static`
+...
+LL | }
+   | - `n` dropped here while still borrowed
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/nll/issue-69114-static-ty.rs
+++ b/src/test/ui/nll/issue-69114-static-ty.rs
@@ -1,0 +1,9 @@
+// Check that borrowck ensures that `static` items have the expected type.
+
+static FOO: &'static (dyn Fn(&'static u8) + Send + Sync) = &drop;
+
+fn main() {
+    let n = 42;
+    FOO(&n);
+    //~^ ERROR does not live long enough
+}

--- a/src/test/ui/nll/issue-69114-static-ty.stderr
+++ b/src/test/ui/nll/issue-69114-static-ty.stderr
@@ -1,0 +1,15 @@
+error[E0597]: `n` does not live long enough
+  --> $DIR/issue-69114-static-ty.rs:7:9
+   |
+LL |     FOO(&n);
+   |     ----^^-
+   |     |   |
+   |     |   borrowed value does not live long enough
+   |     argument requires that `n` is borrowed for `'static`
+LL |
+LL | }
+   | - `n` dropped here while still borrowed
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.


### PR DESCRIPTION
* Check types of static items
* Always check lifetime bounds of `Copy` impls

r? @nikomatsakis 
closes #69114 