### PR TITLE
Avoid calling `fn_sig` on closures

### DIFF
--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2877,7 +2877,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
         } else if attr.check_name(sym::thread_local) {
             codegen_fn_attrs.flags |= CodegenFnAttrFlags::THREAD_LOCAL;
         } else if attr.check_name(sym::track_caller) {
-            if tcx.fn_sig(id).abi() != abi::Abi::Rust {
+            if tcx.is_closure(id) || tcx.fn_sig(id).abi() != abi::Abi::Rust {
                 struct_span_err!(tcx.sess, attr.span, E0737, "`#[track_caller]` requires Rust ABI")
                     .emit();
             }
@@ -2898,7 +2898,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
                 codegen_fn_attrs.export_name = Some(s);
             }
         } else if attr.check_name(sym::target_feature) {
-            if tcx.fn_sig(id).unsafety() == Unsafety::Normal {
+            if tcx.is_closure(id) || tcx.fn_sig(id).unsafety() == Unsafety::Normal {
                 let msg = "`#[target_feature(..)]` can only be applied to `unsafe` functions";
                 tcx.sess
                     .struct_span_err(attr.span, msg)

--- a/src/test/ui/macros/issue-68060.rs
+++ b/src/test/ui/macros/issue-68060.rs
@@ -1,0 +1,16 @@
+// build-fail
+
+#![feature(track_caller)]
+
+fn main() {
+    (0..)
+        .map(
+            #[target_feature(enable = "")]
+            //~^ ERROR: the feature named `` is not valid for this target
+            //~| ERROR: `#[target_feature(..)]` can only be applied to `unsafe` functions
+            #[track_caller]
+            //~^ ERROR: `#[track_caller]` requires Rust ABI
+            |_| (),
+        )
+        .next();
+}

--- a/src/test/ui/macros/issue-68060.stderr
+++ b/src/test/ui/macros/issue-68060.stderr
@@ -1,0 +1,24 @@
+error: `#[target_feature(..)]` can only be applied to `unsafe` functions
+  --> $DIR/issue-68060.rs:8:13
+   |
+LL |             #[target_feature(enable = "")]
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can only be applied to `unsafe` functions
+...
+LL |             |_| (),
+   |             ------ not an `unsafe` function
+
+error: the feature named `` is not valid for this target
+  --> $DIR/issue-68060.rs:8:30
+   |
+LL |             #[target_feature(enable = "")]
+   |                              ^^^^^^^^^^^ `` is not valid for this target
+
+error[E0737]: `#[track_caller]` requires Rust ABI
+  --> $DIR/issue-68060.rs:11:13
+   |
+LL |             #[track_caller]
+   |             ^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0737`.


### PR DESCRIPTION
Fixes #68060

r? @petrochenkov