### PR TITLE
add regression test for issue #68794

### DIFF
--- a/src/test/run-make-fulldeps/issue-68794-textrel-on-minimal-lib/Makefile
+++ b/src/test/run-make-fulldeps/issue-68794-textrel-on-minimal-lib/Makefile
@@ -1,0 +1,17 @@
+# Regression test for issue #68794
+#
+# Verify that no text relocations are accidentally introduced by linking a
+# minimal rust staticlib.
+#
+# The test links a rust static library into a shared library, and checks that
+# the linker doesn't have to flag the resulting file as containing TEXTRELs.
+
+-include ../tools.mk
+
+# only-linux
+
+all:
+	$(RUSTC) foo.rs
+	$(CC) bar.c $(call STATICLIB,foo) -fPIC -shared -o $(call DYLIB,bar) \
+		$(EXTRACFLAGS) $(EXTRACXXFLAGS)
+	readelf -d $(call DYLIB,bar) | grep TEXTREL; test $$? -eq 1

--- a/src/test/run-make-fulldeps/issue-68794-textrel-on-minimal-lib/bar.c
+++ b/src/test/run-make-fulldeps/issue-68794-textrel-on-minimal-lib/bar.c
@@ -1,0 +1,6 @@
+void foo();
+
+int main() {
+    foo();
+    return 0;
+}

--- a/src/test/run-make-fulldeps/issue-68794-textrel-on-minimal-lib/foo.rs
+++ b/src/test/run-make-fulldeps/issue-68794-textrel-on-minimal-lib/foo.rs
@@ -1,0 +1,8 @@
+#![crate_type = "staticlib"]
+
+#[no_mangle]
+pub extern "C" fn foo(x: u32) {
+    // using the println! makes it so that enough code from the standard
+    // library is included (see issue #68794)
+    println!("foo: {}", x);
+}


### PR DESCRIPTION
This is a minimal regression test for the issue #68794: "TEXTREL in
i686", which was fixed with e86019c4a0968a1e393cdd0731649168624a88b8.

The test links a minimal rust static library into a shared library, and
checks that the linker didn't have to add the TEXTREL flag.