### PR TITLE
Do not ICE when encountering `yield` inside `async` block

### DIFF
--- a/src/librustc/hir/map/hir_id_validator.rs
+++ b/src/librustc/hir/map/hir_id_validator.rs
@@ -7,7 +7,7 @@ use rustc_hir::intravisit;
 use rustc_hir::itemlikevisit::ItemLikeVisitor;
 use rustc_hir::{HirId, ItemLocalId};
 
-pub fn check_crate(hir_map: &Map<'_>) {
+pub fn check_crate(hir_map: &Map<'_>, sess: &rustc_session::Session) {
     hir_map.dep_graph.assert_ignored();
 
     let errors = Lock::new(Vec::new());
@@ -24,7 +24,7 @@ pub fn check_crate(hir_map: &Map<'_>) {
 
     if !errors.is_empty() {
         let message = errors.iter().fold(String::new(), |s1, s2| s1 + "\n" + s2);
-        bug!("{}", message);
+        sess.delay_span_bug(rustc_span::DUMMY_SP, &message);
     }
 }
 

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -1235,7 +1235,7 @@ pub fn map_crate<'hir>(
     let map = Map { krate, dep_graph, crate_hash, map, hir_to_node_id, definitions };
 
     sess.time("validate_HIR_map", || {
-        hir_id_validator::check_crate(&map);
+        hir_id_validator::check_crate(&map, sess);
     });
 
     map

--- a/src/test/ui/generator/async-generator-issue-67158.rs
+++ b/src/test/ui/generator/async-generator-issue-67158.rs
@@ -1,0 +1,6 @@
+#![feature(generators)]
+// edition:2018
+// Regression test for #67158.
+fn main() {
+    async { yield print!(":C") }; //~ ERROR `async` generators are not yet supported
+}

--- a/src/test/ui/generator/async-generator-issue-67158.stderr
+++ b/src/test/ui/generator/async-generator-issue-67158.stderr
@@ -1,0 +1,9 @@
+error[E0727]: `async` generators are not yet supported
+  --> $DIR/async-generator-issue-67158.rs:5:13
+   |
+LL |     async { yield print!(":C") };
+   |             ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0727`.


### PR DESCRIPTION
Fix #67158.