### PR TITLE
Suggest a comma if a struct initializer field fails to parse

### DIFF
--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -1832,10 +1832,16 @@ impl<'a> Parser<'a> {
                     }
                 }
                 Err(mut e) => {
+                    e.span_label(struct_sp, "while parsing this struct");
                     if let Some(f) = recovery_field {
                         fields.push(f);
+                        e.span_suggestion(
+                            self.prev_span.shrink_to_hi(),
+                            "try adding a comma",
+                            ",".into(),
+                            Applicability::MachineApplicable,
+                        );
                     }
-                    e.span_label(struct_sp, "while parsing this struct");
                     e.emit();
                     self.recover_stmt_(SemiColonMode::Comma, BlockMode::Ignore);
                     self.eat(&token::Comma);

--- a/src/test/ui/parser/removed-syntax-with-1.stderr
+++ b/src/test/ui/parser/removed-syntax-with-1.stderr
@@ -2,8 +2,9 @@ error: expected one of `,`, `.`, `?`, `}`, or an operator, found `with`
   --> $DIR/removed-syntax-with-1.rs:8:25
    |
 LL |     let b = S { foo: () with a, bar: () };
-   |             -           ^^^^ expected one of `,`, `.`, `?`, `}`, or an operator
-   |             |
+   |             -          -^^^^ expected one of `,`, `.`, `?`, `}`, or an operator
+   |             |          |
+   |             |          help: try adding a comma: `,`
    |             while parsing this struct
 
 error: aborting due to previous error

--- a/src/test/ui/suggestions/struct-initializer-comma.rs
+++ b/src/test/ui/suggestions/struct-initializer-comma.rs
@@ -1,0 +1,13 @@
+struct Foo {
+    first: bool,
+    second: u8,
+}
+
+fn main() {
+    let a = Foo {
+        //~^ ERROR missing field
+        first: true
+        second: 25
+        //~^ ERROR expected one of
+    };
+}

--- a/src/test/ui/suggestions/struct-initializer-comma.stderr
+++ b/src/test/ui/suggestions/struct-initializer-comma.stderr
@@ -1,0 +1,23 @@
+error: expected one of `,`, `.`, `?`, `}`, or an operator, found `second`
+  --> $DIR/struct-initializer-comma.rs:10:9
+   |
+LL |     let a = Foo {
+   |             --- while parsing this struct
+LL |
+LL |         first: true
+   |                    -
+   |                    |
+   |                    expected one of `,`, `.`, `?`, `}`, or an operator
+   |                    help: try adding a comma: `,`
+LL |         second: 25
+   |         ^^^^^^ unexpected token
+
+error[E0063]: missing field `second` in initializer of `Foo`
+  --> $DIR/struct-initializer-comma.rs:7:13
+   |
+LL |     let a = Foo {
+   |             ^^^ missing `second`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0063`.


### PR DESCRIPTION
Currently, we emit a "try adding a comma" suggestion if a comma is
missing in a struct definition. However, we emit no such suggestion if a
comma is missing in a struct initializer.

This commit adds a "try adding a comma" suggestion when we don't find a
comma during the parsing of a struct initializer field.

The change to `src/test/ui/parser/removed-syntax-with-1.stderr` isn't
great, but I don't see a good way of avoiding it.