### PR TITLE
Change const eval to just return the value 

### DIFF
--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -2,6 +2,7 @@ use super::{CheckInAllocMsg, Pointer, RawConst, ScalarMaybeUndef};
 
 use crate::hir::map::definitions::DefPathData;
 use crate::mir;
+use crate::mir::interpret::ConstValue;
 use crate::ty::layout::{Align, LayoutError, Size};
 use crate::ty::query::TyCtxtAt;
 use crate::ty::{self, layout, Ty};
@@ -40,7 +41,7 @@ CloneTypeFoldableImpls! {
 }
 
 pub type ConstEvalRawResult<'tcx> = Result<RawConst<'tcx>, ErrorHandled>;
-pub type ConstEvalResult<'tcx> = Result<&'tcx ty::Const<'tcx>, ErrorHandled>;
+pub type ConstEvalResult<'tcx> = Result<ConstValue<'tcx>, ErrorHandled>;
 
 #[derive(Debug)]
 pub struct ConstEvalErr<'tcx> {

--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -89,8 +89,8 @@ impl<'tcx> ConstValue<'tcx> {
         ConstValue::Scalar(Scalar::from_u64(i))
     }
 
-    pub fn from_machine_usize(cx: &impl HasDataLayout, i: u64) -> Self {
-        ConstValue::Scalar(Scalar::from_machine_usize(cx, i))
+    pub fn from_machine_usize(i: u64, cx: &impl HasDataLayout) -> Self {
+        ConstValue::Scalar(Scalar::from_machine_usize(i, cx))
     }
 }
 
@@ -314,7 +314,7 @@ impl<'tcx, Tag> Scalar<Tag> {
     }
 
     #[inline]
-    pub fn from_machine_usize(cx: &impl HasDataLayout, i: u64) -> Self {
+    pub fn from_machine_usize(i: u64, cx: &impl HasDataLayout) -> Self {
         Self::from_uint(i, cx.data_layout().pointer_size)
     }
 
@@ -335,6 +335,11 @@ impl<'tcx, Tag> Scalar<Tag> {
         let i = i.into();
         Self::try_from_int(i, size)
             .unwrap_or_else(|| bug!("Signed value {:#x} does not fit in {} bits", i, size.bits()))
+    }
+
+    #[inline]
+    pub fn from_machine_isize(i: i64, cx: &impl HasDataLayout) -> Self {
+        Self::from_int(i, cx.data_layout().pointer_size)
     }
 
     #[inline]

--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -517,7 +517,7 @@ rustc_queries! {
         /// Extracts a field of a (variant of a) const.
         query const_field(
             key: ty::ParamEnvAnd<'tcx, (&'tcx ty::Const<'tcx>, mir::Field)>
-        ) -> &'tcx ty::Const<'tcx> {
+        ) -> ConstValue<'tcx> {
             no_force
             desc { "extract field of const" }
         }
@@ -531,7 +531,7 @@ rustc_queries! {
             desc { "destructure constant" }
         }
 
-        query const_caller_location(key: (rustc_span::Symbol, u32, u32)) -> &'tcx ty::Const<'tcx> {
+        query const_caller_location(key: (rustc_span::Symbol, u32, u32)) -> ConstValue<'tcx> {
             no_force
             desc { "get a &core::panic::Location referring to a span" }
         }

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2380,10 +2380,10 @@ impl<'tcx> AdtDef {
         let repr_type = self.repr.discr_type();
         match tcx.const_eval_poly(expr_did) {
             Ok(val) => {
-                // FIXME: Find the right type and use it instead of `val.ty` here
-                if let Some(b) = val.try_eval_bits(tcx, param_env, val.ty) {
+                let ty = repr_type.to_ty(tcx);
+                if let Some(b) = val.try_to_bits_for_ty(tcx, param_env, ty) {
                     trace!("discriminants: {} ({:?})", b, repr_type);
-                    Some(Discr { val: b, ty: val.ty })
+                    Some(Discr { val: b, ty })
                 } else {
                     info!("invalid enum discriminant: {:#?}", val);
                     crate::mir::interpret::struct_error(

--- a/src/librustc/ty/query/mod.rs
+++ b/src/librustc/ty/query/mod.rs
@@ -14,7 +14,7 @@ use crate::middle::resolve_lifetime::{ObjectLifetimeDefault, Region, ResolveLife
 use crate::middle::stability::{self, DeprecationEntry};
 use crate::mir;
 use crate::mir::interpret::GlobalId;
-use crate::mir::interpret::{ConstEvalRawResult, ConstEvalResult};
+use crate::mir::interpret::{ConstEvalRawResult, ConstEvalResult, ConstValue};
 use crate::mir::interpret::{LitToConstError, LitToConstInput};
 use crate::mir::mono::CodegenUnit;
 use crate::session::config::{EntryFnType, OptLevel, OutputFilenames, SymbolManglingVersion};

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -2471,7 +2471,9 @@ impl<'tcx> Const<'tcx> {
 
             // try to resolve e.g. associated constants to their definition on an impl, and then
             // evaluate the const.
-            tcx.const_eval_resolve(param_env, did, substs, promoted, None).ok()
+            tcx.const_eval_resolve(param_env, did, substs, promoted, None)
+                .ok()
+                .map(|val| tcx.mk_const(Const { val: ConstKind::Value(val), ty: self.ty }))
         };
 
         match self.val {

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -2416,8 +2416,13 @@ static_assert_size!(Const<'_>, 48);
 
 impl<'tcx> Const<'tcx> {
     #[inline]
+    pub fn from_value(tcx: TyCtxt<'tcx>, val: ConstValue<'tcx>, ty: Ty<'tcx>) -> &'tcx Self {
+        tcx.mk_const(Self { val: ConstKind::Value(val), ty })
+    }
+
+    #[inline]
     pub fn from_scalar(tcx: TyCtxt<'tcx>, val: Scalar, ty: Ty<'tcx>) -> &'tcx Self {
-        tcx.mk_const(Self { val: ConstKind::Value(ConstValue::Scalar(val)), ty })
+        Self::from_value(tcx, ConstValue::Scalar(val), ty)
     }
 
     #[inline]
@@ -2473,7 +2478,7 @@ impl<'tcx> Const<'tcx> {
             // evaluate the const.
             tcx.const_eval_resolve(param_env, did, substs, promoted, None)
                 .ok()
-                .map(|val| tcx.mk_const(Const { val: ConstKind::Value(val), ty: self.ty }))
+                .map(|val| Const::from_value(tcx, val, self.ty))
         };
 
         match self.val {

--- a/src/librustc_codegen_llvm/consts.rs
+++ b/src/librustc_codegen_llvm/consts.rs
@@ -78,11 +78,9 @@ pub fn codegen_static_initializer(
     cx: &CodegenCx<'ll, 'tcx>,
     def_id: DefId,
 ) -> Result<(&'ll Value, &'tcx Allocation), ErrorHandled> {
-    let static_ = cx.tcx.const_eval_poly(def_id)?;
-
-    let alloc = match static_.val {
-        ty::ConstKind::Value(ConstValue::ByRef { alloc, offset }) if offset.bytes() == 0 => alloc,
-        _ => bug!("static const eval returned {:#?}", static_),
+    let alloc = match cx.tcx.const_eval_poly(def_id)? {
+        ConstValue::ByRef { alloc, offset } if offset.bytes() == 0 => alloc,
+        val => bug!("static const eval returned {:#?}", val),
     };
     Ok((const_alloc_to_llvm(cx, alloc), alloc))
 }

--- a/src/librustc_codegen_llvm/intrinsic.rs
+++ b/src/librustc_codegen_llvm/intrinsic.rs
@@ -193,8 +193,7 @@ impl IntrinsicCallMethods<'tcx> for Builder<'a, 'll, 'tcx> {
                     .tcx
                     .const_eval_instance(ty::ParamEnv::reveal_all(), instance, None)
                     .unwrap();
-                let const_ = ty::Const { val: ty::ConstKind::Value(ty_name), ty: ret_ty };
-                OperandRef::from_const(self, &const_).immediate_or_packed_pair(self)
+                OperandRef::from_const(self, ty_name, ret_ty).immediate_or_packed_pair(self)
             }
             "init" => {
                 let ty = substs.type_at(0);

--- a/src/librustc_codegen_llvm/intrinsic.rs
+++ b/src/librustc_codegen_llvm/intrinsic.rs
@@ -193,7 +193,8 @@ impl IntrinsicCallMethods<'tcx> for Builder<'a, 'll, 'tcx> {
                     .tcx
                     .const_eval_instance(ty::ParamEnv::reveal_all(), instance, None)
                     .unwrap();
-                OperandRef::from_const(self, ty_name).immediate_or_packed_pair(self)
+                let const_ = ty::Const { val: ty::ConstKind::Value(ty_name), ty: ret_ty };
+                OperandRef::from_const(self, &const_).immediate_or_packed_pair(self)
             }
             "init" => {
                 let ty = substs.type_at(0);

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -991,7 +991,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 caller.line as u32,
                 caller.col_display as u32 + 1,
             ));
-            OperandRef::from_const(bx, const_loc)
+            OperandRef::from_const(bx, const_loc, bx.tcx().caller_location_ty())
         })
     }
 

--- a/src/librustc_codegen_ssa/mir/constant.rs
+++ b/src/librustc_codegen_ssa/mir/constant.rs
@@ -62,7 +62,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 if let ty::ConstKind::Value(value) = const_.val {
                     Ok(value)
                 } else {
-                    bug!("encountered bad ConstKind in codegen");
+                    span_bug!(constant.span, "encountered bad ConstKind in codegen: {:?}", const_);
                 }
             }
         }
@@ -83,7 +83,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     ty::Array(_, n) => n.eval_usize(bx.tcx(), ty::ParamEnv::reveal_all()),
                     _ => bug!("invalid simd shuffle type: {}", ty),
                 };
-                let c = bx.tcx().mk_const(ty::Const { val: ty::ConstKind::Value(val), ty });
+                let c = ty::Const::from_value(bx.tcx(), val, ty);
                 let values: Vec<_> = (0..fields)
                     .map(|field| {
                         let field = bx.tcx().const_field(

--- a/src/librustc_codegen_ssa/mir/constant.rs
+++ b/src/librustc_codegen_ssa/mir/constant.rs
@@ -30,7 +30,8 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             }
             _ => {
                 let val = self.eval_mir_constant(constant)?;
-                Ok(OperandRef::from_const(bx, val.clone(), constant.literal.ty))
+                let ty = self.monomorphize(&constant.literal.ty);
+                Ok(OperandRef::from_const(bx, val.clone(), ty))
             }
         }
     }

--- a/src/librustc_codegen_ssa/mir/constant.rs
+++ b/src/librustc_codegen_ssa/mir/constant.rs
@@ -30,7 +30,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             }
             _ => {
                 let val = self.eval_mir_constant(constant)?;
-                Ok(OperandRef::from_const(bx, val))
+                Ok(OperandRef::from_const(bx, &val))
             }
         }
     }
@@ -45,6 +45,12 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 self.cx
                     .tcx()
                     .const_eval_resolve(ty::ParamEnv::reveal_all(), def_id, substs, promoted, None)
+                    .map(|val| {
+                        self.cx.tcx().mk_const(ty::Const {
+                            val: ty::ConstKind::Value(val),
+                            ty: constant.literal.ty,
+                        })
+                    })
                     .map_err(|err| {
                         if promoted.is_none() {
                             self.cx

--- a/src/librustc_codegen_ssa/mir/constant.rs
+++ b/src/librustc_codegen_ssa/mir/constant.rs
@@ -1,7 +1,7 @@
 use crate::mir::operand::OperandRef;
 use crate::traits::*;
 use rustc::mir;
-use rustc::mir::interpret::ErrorHandled;
+use rustc::mir::interpret::{ConstValue, ErrorHandled};
 use rustc::ty::layout::{self, HasTyCtxt};
 use rustc::ty::{self, Ty};
 use rustc_index::vec::Idx;
@@ -30,7 +30,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             }
             _ => {
                 let val = self.eval_mir_constant(constant)?;
-                Ok(OperandRef::from_const(bx, &val))
+                Ok(OperandRef::from_const(bx, val.clone(), constant.literal.ty))
             }
         }
     }
@@ -38,19 +38,13 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     pub fn eval_mir_constant(
         &mut self,
         constant: &mir::Constant<'tcx>,
-    ) -> Result<&'tcx ty::Const<'tcx>, ErrorHandled> {
+    ) -> Result<ConstValue<'tcx>, ErrorHandled> {
         match constant.literal.val {
             ty::ConstKind::Unevaluated(def_id, substs, promoted) => {
                 let substs = self.monomorphize(&substs);
                 self.cx
                     .tcx()
                     .const_eval_resolve(ty::ParamEnv::reveal_all(), def_id, substs, promoted, None)
-                    .map(|val| {
-                        self.cx.tcx().mk_const(ty::Const {
-                            val: ty::ConstKind::Value(val),
-                            ty: constant.literal.ty,
-                        })
-                    })
                     .map_err(|err| {
                         if promoted.is_none() {
                             self.cx
@@ -61,7 +55,15 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         err
                     })
             }
-            _ => Ok(self.monomorphize(&constant.literal)),
+            ty::ConstKind::Value(value) => Ok(value),
+            _ => {
+                let const_ = self.monomorphize(&constant.literal);
+                if let ty::ConstKind::Value(value) = const_.val {
+                    Ok(value)
+                } else {
+                    bug!("encountered bad ConstKind in codegen");
+                }
+            }
         }
     }
 
@@ -71,21 +73,22 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         bx: &Bx,
         span: Span,
         ty: Ty<'tcx>,
-        constant: Result<&'tcx ty::Const<'tcx>, ErrorHandled>,
+        constant: Result<ConstValue<'tcx>, ErrorHandled>,
     ) -> (Bx::Value, Ty<'tcx>) {
         constant
-            .map(|c| {
-                let field_ty = c.ty.builtin_index().unwrap();
-                let fields = match c.ty.kind {
+            .map(|val| {
+                let field_ty = ty.builtin_index().unwrap();
+                let fields = match ty.kind {
                     ty::Array(_, n) => n.eval_usize(bx.tcx(), ty::ParamEnv::reveal_all()),
-                    _ => bug!("invalid simd shuffle type: {}", c.ty),
+                    _ => bug!("invalid simd shuffle type: {}", ty),
                 };
+                let c = bx.tcx().mk_const(ty::Const { val: ty::ConstKind::Value(val), ty });
                 let values: Vec<_> = (0..fields)
                     .map(|field| {
                         let field = bx.tcx().const_field(
                             ty::ParamEnv::reveal_all().and((&c, mir::Field::new(field as usize))),
                         );
-                        if let Some(prim) = field.val.try_to_scalar() {
+                        if let Some(prim) = field.try_to_scalar() {
                             let layout = bx.layout_of(field_ty);
                             let scalar = match layout.abi {
                                 layout::Abi::Scalar(ref x) => x,

--- a/src/librustc_codegen_ssa/mir/operand.rs
+++ b/src/librustc_codegen_ssa/mir/operand.rs
@@ -8,8 +8,8 @@ use crate::MemFlags;
 
 use rustc::mir;
 use rustc::mir::interpret::{ConstValue, ErrorHandled, Pointer, Scalar};
-use rustc::ty;
 use rustc::ty::layout::{self, Align, LayoutOf, Size, TyLayout};
+use rustc::ty::Ty;
 
 use std::fmt;
 
@@ -66,20 +66,16 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
 
     pub fn from_const<Bx: BuilderMethods<'a, 'tcx, Value = V>>(
         bx: &mut Bx,
-        val: &ty::Const<'tcx>,
+        val: ConstValue<'tcx>,
+        ty: Ty<'tcx>,
     ) -> Self {
-        let layout = bx.layout_of(val.ty);
+        let layout = bx.layout_of(ty);
 
         if layout.is_zst() {
             return OperandRef::new_zst(bx, layout);
         }
 
-        let val_val = match val.val {
-            ty::ConstKind::Value(val_val) => val_val,
-            _ => bug!("encountered bad ConstKind in codegen"),
-        };
-
-        let val = match val_val {
+        let val = match val {
             ConstValue::Scalar(x) => {
                 let scalar = match layout.abi {
                     layout::Abi::Scalar(ref x) => x,

--- a/src/librustc_codegen_ssa/mir/operand.rs
+++ b/src/librustc_codegen_ssa/mir/operand.rs
@@ -66,7 +66,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
 
     pub fn from_const<Bx: BuilderMethods<'a, 'tcx, Value = V>>(
         bx: &mut Bx,
-        val: &'tcx ty::Const<'tcx>,
+        val: &ty::Const<'tcx>,
     ) -> Self {
         let layout = bx.layout_of(val.ty);
 

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -79,7 +79,7 @@ pub(crate) fn destructure_const<'tcx>(
     let fields_iter = (0..field_count).map(|i| {
         let field_op = ecx.operand_field(down, i).unwrap();
         let val = op_to_const(&ecx, field_op);
-        tcx.mk_const(ty::Const { val: ty::ConstKind::Value(val), ty: field_op.layout.ty })
+        ty::Const::from_value(tcx, val, field_op.layout.ty)
     });
     let fields = tcx.arena.alloc_from_iter(fields_iter);
 

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -40,7 +40,8 @@ pub(crate) fn const_field<'tcx>(
     let field = ecx.operand_field(down, field.index() as u64).unwrap();
     // and finally move back to the const world, always normalizing because
     // this is not called for statics.
-    op_to_const(&ecx, field)
+    let val = op_to_const(&ecx, field);
+    tcx.mk_const(ty::Const { val: ty::ConstKind::Value(val), ty: op.layout.ty })
 }
 
 pub(crate) fn const_caller_location<'tcx>(
@@ -84,7 +85,8 @@ pub(crate) fn destructure_const<'tcx>(
     let down = ecx.operand_downcast(op, variant).unwrap();
     let fields_iter = (0..field_count).map(|i| {
         let field_op = ecx.operand_field(down, i).unwrap();
-        op_to_const(&ecx, field_op)
+        let val = op_to_const(&ecx, field_op);
+        tcx.mk_const(ty::Const { val: ty::ConstKind::Value(val), ty: field_op.layout.ty })
     });
     let fields = tcx.arena.alloc_from_iter(fields_iter);
 

--- a/src/librustc_mir/const_eval/eval_queries.rs
+++ b/src/librustc_mir/const_eval/eval_queries.rs
@@ -97,7 +97,7 @@ pub(super) fn mk_eval_cx<'mir, 'tcx>(
 pub(super) fn op_to_const<'tcx>(
     ecx: &CompileTimeEvalContext<'_, 'tcx>,
     op: OpTy<'tcx>,
-) -> &'tcx ty::Const<'tcx> {
+) -> ConstValue<'tcx> {
     // We do not have value optimizations for everything.
     // Only scalars and slices, since they are very common.
     // Note that further down we turn scalars of undefined bits back to `ByRef`. These can result
@@ -144,7 +144,7 @@ pub(super) fn op_to_const<'tcx>(
             ConstValue::Scalar(Scalar::zst())
         }
     };
-    let val = match immediate {
+    match immediate {
         Ok(mplace) => to_const_value(mplace),
         // see comment on `let try_as_immediate` above
         Err(ImmTy { imm: Immediate::Scalar(x), .. }) => match x {
@@ -166,8 +166,7 @@ pub(super) fn op_to_const<'tcx>(
             let len: usize = len.try_into().unwrap();
             ConstValue::Slice { data, start, end: start + len }
         }
-    };
-    ecx.tcx.mk_const(ty::Const { val: ty::ConstKind::Value(val), ty: op.layout.ty })
+    }
 }
 
 fn validate_and_turn_into_const<'tcx>(
@@ -195,13 +194,10 @@ fn validate_and_turn_into_const<'tcx>(
         // whether they become immediates.
         if is_static || cid.promoted.is_some() {
             let ptr = mplace.ptr.assert_ptr();
-            Ok(tcx.mk_const(ty::Const {
-                val: ty::ConstKind::Value(ConstValue::ByRef {
-                    alloc: ecx.tcx.alloc_map.lock().unwrap_memory(ptr.alloc_id),
-                    offset: ptr.offset,
-                }),
-                ty: mplace.layout.ty,
-            }))
+            Ok(ConstValue::ByRef {
+                alloc: ecx.tcx.alloc_map.lock().unwrap_memory(ptr.alloc_id),
+                offset: ptr.offset,
+            })
         } else {
             Ok(op_to_const(&ecx, mplace.into()))
         }

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -756,6 +756,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
     pub(super) fn const_eval(
         &self,
         gid: GlobalId<'tcx>,
+        ty: Ty<'tcx>,
     ) -> InterpResult<'tcx, OpTy<'tcx, M::PointerTag>> {
         // For statics we pick `ParamEnv::reveal_all`, because statics don't have generics
         // and thus don't care about the parameter environment. While we could just use
@@ -777,7 +778,8 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         // recursion deeper than one level, because the `tcx.const_eval` above is guaranteed to not
         // return `ConstValue::Unevaluated`, which is the only way that `eval_const_to_op` will call
         // `ecx.const_eval`.
-        self.eval_const_to_op(val, None)
+        let const_ = ty::Const { val: ty::ConstKind::Value(val), ty };
+        self.eval_const_to_op(&const_, None)
     }
 
     pub fn const_eval_raw(

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -110,7 +110,14 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             | sym::type_id
             | sym::type_name => {
                 let gid = GlobalId { instance, promoted: None };
-                let val = self.const_eval(gid, dest.layout.ty)?;
+                let ty = match intrinsic_name {
+                    sym::min_align_of | sym::pref_align_of | sym::size_of => self.tcx.types.usize,
+                    sym::needs_drop => self.tcx.types.bool,
+                    sym::type_id => self.tcx.types.u64,
+                    sym::type_name => self.tcx.mk_static_str(),
+                    _ => span_bug!(span, "Already checked for nullary intrinsics"),
+                };
+                let val = self.const_eval(gid, ty)?;
                 self.copy_op(val, dest)?;
             }
 

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -110,8 +110,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             | sym::type_id
             | sym::type_name => {
                 let gid = GlobalId { instance, promoted: None };
-                let ty = instance.ty_env(*self.tcx, self.param_env);
-                let val = self.const_eval(gid, ty)?;
+                let val = self.const_eval(gid, dest.layout.ty)?;
                 self.copy_op(val, dest)?;
             }
 

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -48,22 +48,15 @@ crate fn eval_nullary_intrinsic<'tcx>(
     param_env: ty::ParamEnv<'tcx>,
     def_id: DefId,
     substs: SubstsRef<'tcx>,
-) -> InterpResult<'tcx, &'tcx ty::Const<'tcx>> {
+) -> InterpResult<'tcx, ConstValue<'tcx>> {
     let tp_ty = substs.type_at(0);
     let name = tcx.item_name(def_id);
     Ok(match name {
         sym::type_name => {
             let alloc = type_name::alloc_type_name(tcx, tp_ty);
-            tcx.mk_const(ty::Const {
-                val: ty::ConstKind::Value(ConstValue::Slice {
-                    data: alloc,
-                    start: 0,
-                    end: alloc.len(),
-                }),
-                ty: tcx.mk_static_str(),
-            })
+            ConstValue::Slice { data: alloc, start: 0, end: alloc.len() }
         }
-        sym::needs_drop => ty::Const::from_bool(tcx, tp_ty.needs_drop(tcx, param_env)),
+        sym::needs_drop => ConstValue::from_bool(tp_ty.needs_drop(tcx, param_env)),
         sym::size_of | sym::min_align_of | sym::pref_align_of => {
             let layout = tcx.layout_of(param_env.and(tp_ty)).map_err(|e| err_inval!(Layout(e)))?;
             let n = match name {
@@ -72,11 +65,9 @@ crate fn eval_nullary_intrinsic<'tcx>(
                 sym::size_of => layout.size.bytes(),
                 _ => bug!(),
             };
-            ty::Const::from_usize(tcx, n)
+            ConstValue::from_machine_usize(&tcx, n)
         }
-        sym::type_id => {
-            ty::Const::from_bits(tcx, tcx.type_id_hash(tp_ty).into(), param_env.and(tcx.types.u64))
-        }
+        sym::type_id => ConstValue::from_u64(tcx.type_id_hash(tp_ty).into()),
         other => bug!("`{}` is not a zero arg intrinsic", other),
     })
 }
@@ -119,7 +110,8 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             | sym::type_id
             | sym::type_name => {
                 let gid = GlobalId { instance, promoted: None };
-                let val = self.const_eval(gid)?;
+                let ty = instance.ty_env(*self.tcx, self.param_env);
+                let val = self.const_eval(gid, ty)?;
                 self.copy_op(val, dest)?;
             }
 

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -65,7 +65,7 @@ crate fn eval_nullary_intrinsic<'tcx>(
                 sym::size_of => layout.size.bytes(),
                 _ => bug!(),
             };
-            ConstValue::from_machine_usize(&tcx, n)
+            ConstValue::from_machine_usize(n, &tcx)
         }
         sym::type_id => ConstValue::from_u64(tcx.type_id_hash(tp_ty).into()),
         other => bug!("`{}` is not a zero arg intrinsic", other),

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -518,7 +518,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
     /// "universe" (param_env).
     crate fn eval_const_to_op(
         &self,
-        val: &'tcx ty::Const<'tcx>,
+        val: &ty::Const<'tcx>,
         layout: Option<TyLayout<'tcx>>,
     ) -> InterpResult<'tcx, OpTy<'tcx, M::PointerTag>> {
         let tag_scalar = |scalar| match scalar {
@@ -536,7 +536,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 // potentially requiring the current static to be evaluated again. This is not a
                 // problem here, because we are building an operand which means an actual read is
                 // happening.
-                return Ok(OpTy::from(self.const_eval(GlobalId { instance, promoted })?));
+                return Ok(self.const_eval(GlobalId { instance, promoted }, val.ty)?);
             }
             ty::ConstKind::Infer(..)
             | ty::ConstKind::Bound(..)

--- a/src/librustc_mir_build/hair/constant.rs
+++ b/src/librustc_mir_build/hair/constant.rs
@@ -65,7 +65,7 @@ crate fn lit_to_const<'tcx>(
         ast::LitKind::Char(c) => ConstValue::Scalar(Scalar::from_char(c)),
         ast::LitKind::Err(_) => return Err(LitToConstError::Reported),
     };
-    Ok(tcx.mk_const(ty::Const { val: ty::ConstKind::Value(lit), ty }))
+    Ok(ty::Const::from_value(tcx, lit, ty))
 }
 
 fn parse_float<'tcx>(num: Symbol, fty: ast::FloatTy, neg: bool) -> Result<ConstValue<'tcx>, ()> {

--- a/src/librustc_mir_build/hair/cx/expr.rs
+++ b/src/librustc_mir_build/hair/cx/expr.rs
@@ -418,7 +418,17 @@ fn make_mirror_unadjusted<'a, 'tcx>(
                 None,
                 Some(span),
             ) {
-                Ok(cv) => cv.eval_usize(cx.tcx, ty::ParamEnv::reveal_all()),
+                Ok(cv) => {
+                    if let Some(count) = cv.try_to_bits_for_ty(
+                        cx.tcx,
+                        ty::ParamEnv::reveal_all(),
+                        cx.tcx.types.usize,
+                    ) {
+                        count as u64
+                    } else {
+                        bug!("repeat count constant value can't be converted to usize");
+                    }
+                }
                 Err(ErrorHandled::Reported) => 0,
                 Err(ErrorHandled::TooGeneric) => {
                     let span = cx.tcx.def_span(def_id);

--- a/src/librustc_mir_build/hair/pattern/_match.rs
+++ b/src/librustc_mir_build/hair/pattern/_match.rs
@@ -343,12 +343,11 @@ impl<'tcx> PatternFolder<'tcx> for LiteralExpander<'tcx> {
                         ty: rty,
                         span: pat.span,
                         kind: box PatKind::Constant {
-                            value: self.tcx.mk_const(Const {
-                                val: ty::ConstKind::Value(
-                                    self.fold_const_value_deref(*val, rty, crty),
-                                ),
-                                ty: rty,
-                            }),
+                            value: Const::from_value(
+                                self.tcx,
+                                self.fold_const_value_deref(*val, rty, crty),
+                                rty,
+                            ),
                         },
                     },
                 },

--- a/src/librustc_mir_build/hair/pattern/mod.rs
+++ b/src/librustc_mir_build/hair/pattern/mod.rs
@@ -769,7 +769,12 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                     Some(span),
                 ) {
                     Ok(value) => {
-                        let pattern = self.const_to_pat(value, id, span);
+                        let const_ = self.tcx.mk_const(ty::Const {
+                            val: ty::ConstKind::Value(value),
+                            ty: self.tables.node_type(id),
+                        });
+
+                        let pattern = self.const_to_pat(&const_, id, span);
                         if !is_associated_const {
                             return pattern;
                         }
@@ -789,7 +794,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                                         user_ty_span: span,
                                     },
                                 }),
-                                ty: value.ty,
+                                ty: const_.ty,
                             }
                         } else {
                             pattern

--- a/src/librustc_mir_build/hair/pattern/mod.rs
+++ b/src/librustc_mir_build/hair/pattern/mod.rs
@@ -769,10 +769,8 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                     Some(span),
                 ) {
                     Ok(value) => {
-                        let const_ = self.tcx.mk_const(ty::Const {
-                            val: ty::ConstKind::Value(value),
-                            ty: self.tables.node_type(id),
-                        });
+                        let const_ =
+                            ty::Const::from_value(self.tcx, value, self.tables.node_type(id));
 
                         let pattern = self.const_to_pat(&const_, id, span);
                         if !is_associated_const {

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -25,7 +25,7 @@ use rustc::ty;
 use rustc::ty::adjustment::{Adjust, Adjustment, AllowTwoPhase, AutoBorrow, AutoBorrowMutability};
 use rustc::ty::Ty;
 use rustc::ty::TypeFoldable;
-use rustc::ty::{AdtKind, Visibility};
+use rustc::ty::{AdtKind, ConstKind, Visibility};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::{pluralize, struct_span_err, Applicability, DiagnosticBuilder, DiagnosticId};
 use rustc_hir as hir;
@@ -1011,7 +1011,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let count = if self.const_param_def_id(count).is_some() {
             Ok(self.to_const(count, tcx.type_of(count_def_id)))
         } else {
-            tcx.const_eval_poly(count_def_id)
+            tcx.const_eval_poly(count_def_id).map(|val| {
+                tcx.mk_const(ty::Const {
+                    val: ConstKind::Value(val),
+                    ty: tcx.type_of(count_def_id),
+                })
+            })
         };
 
         let uty = match expected {

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -25,7 +25,7 @@ use rustc::ty;
 use rustc::ty::adjustment::{Adjust, Adjustment, AllowTwoPhase, AutoBorrow, AutoBorrowMutability};
 use rustc::ty::Ty;
 use rustc::ty::TypeFoldable;
-use rustc::ty::{AdtKind, ConstKind, Visibility};
+use rustc::ty::{AdtKind, Visibility};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::{pluralize, struct_span_err, Applicability, DiagnosticBuilder, DiagnosticId};
 use rustc_hir as hir;
@@ -1011,12 +1011,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let count = if self.const_param_def_id(count).is_some() {
             Ok(self.to_const(count, tcx.type_of(count_def_id)))
         } else {
-            tcx.const_eval_poly(count_def_id).map(|val| {
-                tcx.mk_const(ty::Const {
-                    val: ConstKind::Value(val),
-                    ty: tcx.type_of(count_def_id),
-                })
-            })
+            tcx.const_eval_poly(count_def_id)
+                .map(|val| ty::Const::from_value(tcx, val, tcx.type_of(count_def_id)))
         };
 
         let uty = match expected {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1332,7 +1332,11 @@ impl Clean<Type> for hir::Ty<'_> {
             TyKind::Array(ref ty, ref length) => {
                 let def_id = cx.tcx.hir().local_def_id(length.hir_id);
                 let length = match cx.tcx.const_eval_poly(def_id) {
-                    Ok(length) => print_const(cx, length),
+                    Ok(length) => {
+                        let const_ =
+                            ty::Const { val: ty::ConstKind::Value(length), ty: cx.tcx.types.usize };
+                        print_const(cx, &const_)
+                    }
                     Err(_) => cx
                         .sess()
                         .source_map()

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1333,9 +1333,7 @@ impl Clean<Type> for hir::Ty<'_> {
                 let def_id = cx.tcx.hir().local_def_id(length.hir_id);
                 let length = match cx.tcx.const_eval_poly(def_id) {
                     Ok(length) => {
-                        let const_ =
-                            ty::Const { val: ty::ConstKind::Value(length), ty: cx.tcx.types.usize };
-                        print_const(cx, &const_)
+                        print_const(cx, ty::Const::from_value(cx.tcx, length, cx.tcx.types.usize))
                     }
                     Err(_) => cx
                         .sess()

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -457,7 +457,7 @@ pub fn name_from_pat(p: &hir::Pat) -> String {
     }
 }
 
-pub fn print_const(cx: &DocContext<'_>, n: &ty::Const<'_>) -> String {
+pub fn print_const(cx: &DocContext<'_>, n: &'tcx ty::Const<'_>) -> String {
     match n.val {
         ty::ConstKind::Unevaluated(def_id, _, promoted) => {
             let mut s = if let Some(hir_id) = cx.tcx.hir().as_local_hir_id(def_id) {
@@ -493,8 +493,8 @@ pub fn print_evaluated_const(cx: &DocContext<'_>, def_id: DefId) -> Option<Strin
             (_, &ty::Ref(..)) => None,
             (ConstValue::Scalar(_), &ty::Adt(_, _)) => None,
             (ConstValue::Scalar(_), _) => {
-                let const_ = ty::Const { val: ty::ConstKind::Value(val), ty };
-                Some(print_const_with_custom_print_scalar(cx, &const_))
+                let const_ = ty::Const::from_value(cx.tcx, val, ty);
+                Some(print_const_with_custom_print_scalar(cx, const_))
             }
             _ => None,
         }
@@ -513,7 +513,7 @@ fn format_integer_with_underscore_sep(num: &str) -> String {
         .collect()
 }
 
-fn print_const_with_custom_print_scalar(cx: &DocContext<'_>, ct: &ty::Const<'tcx>) -> String {
+fn print_const_with_custom_print_scalar(cx: &DocContext<'_>, ct: &'tcx ty::Const<'tcx>) -> String {
     // Use a slightly different format for integer types which always shows the actual value.
     // For all other types, fallback to the original `pretty_print_const`.
     match (ct.val, &ct.ty.kind) {


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/rust/pull/68505#discussion_r370956535, the type of consts shouldn't be returned from const eval queries. 

r? @eddyb 
cc @nikomatsakis