### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/src/libcore/tests/fmt/num.rs
+++ b/src/libcore/tests/fmt/num.rs
@@ -38,6 +38,16 @@ fn test_format_int() {
     assert_eq!(format!("{:o}", 1i16), "1");
     assert_eq!(format!("{:o}", 1i32), "1");
     assert_eq!(format!("{:o}", 1i64), "1");
+    assert_eq!(format!("{:e}", 1isize), "1e0");
+    assert_eq!(format!("{:e}", 1i8), "1e0");
+    assert_eq!(format!("{:e}", 1i16), "1e0");
+    assert_eq!(format!("{:e}", 1i32), "1e0");
+    assert_eq!(format!("{:e}", 1i64), "1e0");
+    assert_eq!(format!("{:E}", 1isize), "1E0");
+    assert_eq!(format!("{:E}", 1i8), "1E0");
+    assert_eq!(format!("{:E}", 1i16), "1E0");
+    assert_eq!(format!("{:E}", 1i32), "1E0");
+    assert_eq!(format!("{:E}", 1i64), "1E0");
 
     assert_eq!(format!("{}", 1usize), "1");
     assert_eq!(format!("{}", 1u8), "1");
@@ -69,6 +79,14 @@ fn test_format_int() {
     assert_eq!(format!("{:o}", 1u16), "1");
     assert_eq!(format!("{:o}", 1u32), "1");
     assert_eq!(format!("{:o}", 1u64), "1");
+    assert_eq!(format!("{:e}", 1u8), "1e0");
+    assert_eq!(format!("{:e}", 1u16), "1e0");
+    assert_eq!(format!("{:e}", 1u32), "1e0");
+    assert_eq!(format!("{:e}", 1u64), "1e0");
+    assert_eq!(format!("{:E}", 1u8), "1E0");
+    assert_eq!(format!("{:E}", 1u16), "1E0");
+    assert_eq!(format!("{:E}", 1u32), "1E0");
+    assert_eq!(format!("{:E}", 1u64), "1E0");
 
     // Test a larger number
     assert_eq!(format!("{:b}", 55), "110111");
@@ -76,6 +94,64 @@ fn test_format_int() {
     assert_eq!(format!("{}", 55), "55");
     assert_eq!(format!("{:x}", 55), "37");
     assert_eq!(format!("{:X}", 55), "37");
+    assert_eq!(format!("{:e}", 55), "5.5e1");
+    assert_eq!(format!("{:E}", 55), "5.5E1");
+    assert_eq!(format!("{:e}", 10000000000u64), "1e10");
+    assert_eq!(format!("{:E}", 10000000000u64), "1E10");
+    assert_eq!(format!("{:e}", 10000000001u64), "1.0000000001e10");
+    assert_eq!(format!("{:E}", 10000000001u64), "1.0000000001E10");
+}
+
+#[test]
+fn test_format_int_exp_limits() {
+    use core::{i128, i16, i32, i64, i8, u128, u16, u32, u64, u8};
+    assert_eq!(format!("{:e}", i8::MIN), "-1.28e2");
+    assert_eq!(format!("{:e}", i8::MAX), "1.27e2");
+    assert_eq!(format!("{:e}", i16::MIN), "-3.2768e4");
+    assert_eq!(format!("{:e}", i16::MAX), "3.2767e4");
+    assert_eq!(format!("{:e}", i32::MIN), "-2.147483648e9");
+    assert_eq!(format!("{:e}", i32::MAX), "2.147483647e9");
+    assert_eq!(format!("{:e}", i64::MIN), "-9.223372036854775808e18");
+    assert_eq!(format!("{:e}", i64::MAX), "9.223372036854775807e18");
+    assert_eq!(format!("{:e}", i128::MIN), "-1.70141183460469231731687303715884105728e38");
+    assert_eq!(format!("{:e}", i128::MAX), "1.70141183460469231731687303715884105727e38");
+
+    assert_eq!(format!("{:e}", u8::MAX), "2.55e2");
+    assert_eq!(format!("{:e}", u16::MAX), "6.5535e4");
+    assert_eq!(format!("{:e}", u32::MAX), "4.294967295e9");
+    assert_eq!(format!("{:e}", u64::MAX), "1.8446744073709551615e19");
+    assert_eq!(format!("{:e}", u128::MAX), "3.40282366920938463463374607431768211455e38");
+}
+
+#[test]
+fn test_format_int_exp_precision() {
+    use core::{i128, i16, i32, i64, i8};
+
+    //test that float and integer match
+    let big_int: u32 = 314_159_265;
+    assert_eq!(format!("{:.1e}", big_int), format!("{:.1e}", f64::from(big_int)));
+
+    //test adding precision
+    assert_eq!(format!("{:.10e}", i8::MIN), "-1.2800000000e2");
+    assert_eq!(format!("{:.10e}", i16::MIN), "-3.2768000000e4");
+    assert_eq!(format!("{:.10e}", i32::MIN), "-2.1474836480e9");
+    assert_eq!(format!("{:.20e}", i64::MIN), "-9.22337203685477580800e18");
+    assert_eq!(format!("{:.40e}", i128::MIN), "-1.7014118346046923173168730371588410572800e38");
+
+    //test rounding
+    assert_eq!(format!("{:.1e}", i8::MIN), "-1.3e2");
+    assert_eq!(format!("{:.1e}", i16::MIN), "-3.3e4");
+    assert_eq!(format!("{:.1e}", i32::MIN), "-2.1e9");
+    assert_eq!(format!("{:.1e}", i64::MIN), "-9.2e18");
+    assert_eq!(format!("{:.1e}", i128::MIN), "-1.7e38");
+
+    //test huge precision
+    assert_eq!(format!("{:.1000e}", 1), format!("1.{}e0", "0".repeat(1000)));
+    //test zero precision
+    assert_eq!(format!("{:.0e}", 1), format!("1e0",));
+
+    //test padding with precision (and sign)
+    assert_eq!(format!("{:+10.3e}", 1), "  +1.000e0");
 }
 
 #[test]
@@ -86,6 +162,8 @@ fn test_format_int_zero() {
     assert_eq!(format!("{:o}", 0), "0");
     assert_eq!(format!("{:x}", 0), "0");
     assert_eq!(format!("{:X}", 0), "0");
+    assert_eq!(format!("{:e}", 0), "0e0");
+    assert_eq!(format!("{:E}", 0), "0E0");
 
     assert_eq!(format!("{}", 0u32), "0");
     assert_eq!(format!("{:?}", 0u32), "0");
@@ -93,6 +171,8 @@ fn test_format_int_zero() {
     assert_eq!(format!("{:o}", 0u32), "0");
     assert_eq!(format!("{:x}", 0u32), "0");
     assert_eq!(format!("{:X}", 0u32), "0");
+    assert_eq!(format!("{:e}", 0u32), "0e0");
+    assert_eq!(format!("{:E}", 0u32), "0E0");
 }
 
 #[test]

--- a/src/librustc_mir/const_eval/eval_queries.rs
+++ b/src/librustc_mir/const_eval/eval_queries.rs
@@ -288,7 +288,10 @@ pub fn const_eval_raw_provider<'tcx>(
     let cid = key.value;
     let def_id = cid.instance.def.def_id();
 
-    if def_id.is_local() && tcx.typeck_tables_of(def_id).tainted_by_errors {
+    if def_id.is_local()
+        && tcx.has_typeck_tables(def_id)
+        && tcx.typeck_tables_of(def_id).tainted_by_errors
+    {
         return Err(ErrorHandled::Reported);
     }
 

--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -1832,10 +1832,16 @@ impl<'a> Parser<'a> {
                     }
                 }
                 Err(mut e) => {
+                    e.span_label(struct_sp, "while parsing this struct");
                     if let Some(f) = recovery_field {
                         fields.push(f);
+                        e.span_suggestion(
+                            self.prev_span.shrink_to_hi(),
+                            "try adding a comma",
+                            ",".into(),
+                            Applicability::MachineApplicable,
+                        );
                     }
-                    e.span_label(struct_sp, "while parsing this struct");
                     e.emit();
                     self.recover_stmt_(SemiColonMode::Comma, BlockMode::Ignore);
                     self.eat(&token::Comma);

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2877,7 +2877,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
         } else if attr.check_name(sym::thread_local) {
             codegen_fn_attrs.flags |= CodegenFnAttrFlags::THREAD_LOCAL;
         } else if attr.check_name(sym::track_caller) {
-            if tcx.fn_sig(id).abi() != abi::Abi::Rust {
+            if tcx.is_closure(id) || tcx.fn_sig(id).abi() != abi::Abi::Rust {
                 struct_span_err!(tcx.sess, attr.span, E0737, "`#[track_caller]` requires Rust ABI")
                     .emit();
             }
@@ -2898,7 +2898,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
                 codegen_fn_attrs.export_name = Some(s);
             }
         } else if attr.check_name(sym::target_feature) {
-            if tcx.fn_sig(id).unsafety() == Unsafety::Normal {
+            if tcx.is_closure(id) || tcx.fn_sig(id).unsafety() == Unsafety::Normal {
                 let msg = "`#[target_feature(..)]` can only be applied to `unsafe` functions";
                 tcx.sess
                     .struct_span_err(attr.span, msg)

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -310,6 +310,7 @@
 #![feature(unboxed_closures)]
 #![feature(untagged_unions)]
 #![feature(unwind_attributes)]
+#![feature(vec_into_raw_parts)]
 // NB: the above list is sorted to minimize merge conflicts.
 #![default_lib_allocator]
 

--- a/src/libstd/sys/wasi/fs.rs
+++ b/src/libstd/sys/wasi/fs.rs
@@ -12,7 +12,6 @@ use crate::sys::time::SystemTime;
 use crate::sys::unsupported;
 use crate::sys_common::FromInner;
 
-pub use crate::sys_common::fs::copy;
 pub use crate::sys_common::fs::remove_dir_all;
 
 pub struct File {
@@ -646,4 +645,13 @@ fn open_parent(p: &Path) -> io::Result<(ManuallyDrop<WasiFd>, PathBuf)> {
 
 pub fn osstr2str(f: &OsStr) -> io::Result<&str> {
     f.to_str().ok_or_else(|| io::Error::new(io::ErrorKind::Other, "input must be utf-8"))
+}
+
+pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
+    use crate::fs::File;
+
+    let mut reader = File::open(from)?;
+    let mut writer = File::create(to)?;
+
+    io::copy(&mut reader, &mut writer)
 }

--- a/src/test/ui/consts/issue-68684.rs
+++ b/src/test/ui/consts/issue-68684.rs
@@ -1,0 +1,15 @@
+// check-pass
+
+enum _Enum {
+    A(),
+}
+
+type _E = _Enum;
+
+const fn _a() -> _Enum {
+    _E::A()
+}
+
+const _A: _Enum = _a();
+
+fn main() {}

--- a/src/test/ui/macros/issue-68060.rs
+++ b/src/test/ui/macros/issue-68060.rs
@@ -1,0 +1,16 @@
+// build-fail
+
+#![feature(track_caller)]
+
+fn main() {
+    (0..)
+        .map(
+            #[target_feature(enable = "")]
+            //~^ ERROR: the feature named `` is not valid for this target
+            //~| ERROR: `#[target_feature(..)]` can only be applied to `unsafe` functions
+            #[track_caller]
+            //~^ ERROR: `#[track_caller]` requires Rust ABI
+            |_| (),
+        )
+        .next();
+}

--- a/src/test/ui/macros/issue-68060.stderr
+++ b/src/test/ui/macros/issue-68060.stderr
@@ -1,0 +1,24 @@
+error: `#[target_feature(..)]` can only be applied to `unsafe` functions
+  --> $DIR/issue-68060.rs:8:13
+   |
+LL |             #[target_feature(enable = "")]
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can only be applied to `unsafe` functions
+...
+LL |             |_| (),
+   |             ------ not an `unsafe` function
+
+error: the feature named `` is not valid for this target
+  --> $DIR/issue-68060.rs:8:30
+   |
+LL |             #[target_feature(enable = "")]
+   |                              ^^^^^^^^^^^ `` is not valid for this target
+
+error[E0737]: `#[track_caller]` requires Rust ABI
+  --> $DIR/issue-68060.rs:11:13
+   |
+LL |             #[track_caller]
+   |             ^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0737`.

--- a/src/test/ui/parser/removed-syntax-with-1.stderr
+++ b/src/test/ui/parser/removed-syntax-with-1.stderr
@@ -2,8 +2,9 @@ error: expected one of `,`, `.`, `?`, `}`, or an operator, found `with`
   --> $DIR/removed-syntax-with-1.rs:8:25
    |
 LL |     let b = S { foo: () with a, bar: () };
-   |             -           ^^^^ expected one of `,`, `.`, `?`, `}`, or an operator
-   |             |
+   |             -          -^^^^ expected one of `,`, `.`, `?`, `}`, or an operator
+   |             |          |
+   |             |          help: try adding a comma: `,`
    |             while parsing this struct
 
 error: aborting due to previous error

--- a/src/test/ui/suggestions/struct-initializer-comma.rs
+++ b/src/test/ui/suggestions/struct-initializer-comma.rs
@@ -1,0 +1,13 @@
+struct Foo {
+    first: bool,
+    second: u8,
+}
+
+fn main() {
+    let a = Foo {
+        //~^ ERROR missing field
+        first: true
+        second: 25
+        //~^ ERROR expected one of
+    };
+}

--- a/src/test/ui/suggestions/struct-initializer-comma.stderr
+++ b/src/test/ui/suggestions/struct-initializer-comma.stderr
@@ -1,0 +1,23 @@
+error: expected one of `,`, `.`, `?`, `}`, or an operator, found `second`
+  --> $DIR/struct-initializer-comma.rs:10:9
+   |
+LL |     let a = Foo {
+   |             --- while parsing this struct
+LL |
+LL |         first: true
+   |                    -
+   |                    |
+   |                    expected one of `,`, `.`, `?`, `}`, or an operator
+   |                    help: try adding a comma: `,`
+LL |         second: 25
+   |         ^^^^^^ unexpected token
+
+error[E0063]: missing field `second` in initializer of `Foo`
+  --> $DIR/struct-initializer-comma.rs:7:13
+   |
+LL |     let a = Foo {
+   |             ^^^ missing `second`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0063`.


### PR DESCRIPTION
Successful merges:

 - #64069 (Added From<Vec<NonZeroU8>> for CString)
 - #66721 (implement LowerExp and UpperExp for integers)
 - #69106 (Fix std::fs::copy on WASI target)
 - #69154 (Avoid calling `fn_sig` on closures)
 - #69166 (Check `has_typeck_tables` before calling `typeck_tables_of`)
 - #69180 (Suggest a comma if a struct initializer field fails to parse)

Failed merges:


r? @ghost