### PR TITLE
 Implement unused crate lint for 2018 edition 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3505,7 +3505,6 @@ version = "0.0.0"
 dependencies = [
  "log",
  "rustc_ast",
- "rustc_data_structures",
  "rustc_span",
 ]
 
@@ -3522,7 +3521,6 @@ dependencies = [
  "rustc_session",
  "rustc_span",
  "serialize",
- "smallvec 1.0.0",
 ]
 
 [[package]]
@@ -3781,7 +3779,6 @@ dependencies = [
  "rustc_ast",
  "rustc_attr",
  "rustc_data_structures",
- "rustc_error_codes",
  "rustc_errors",
  "rustc_hir",
  "rustc_index",
@@ -3948,7 +3945,6 @@ dependencies = [
  "rustc_hir",
  "rustc_index",
  "rustc_infer",
- "rustc_macros",
  "rustc_session",
  "rustc_span",
  "rustc_target",
@@ -3985,7 +3981,6 @@ dependencies = [
  "rustc_attr",
  "rustc_data_structures",
  "rustc_errors",
- "rustc_feature",
  "rustc_hir",
  "rustc_index",
  "rustc_infer",
@@ -4039,7 +4034,6 @@ dependencies = [
  "rustc_expand",
  "rustc_feature",
  "rustc_hir",
- "rustc_infer",
  "rustc_metadata",
  "rustc_session",
  "rustc_span",
@@ -4075,7 +4069,6 @@ dependencies = [
  "rustc_errors",
  "rustc_feature",
  "rustc_fs_util",
- "rustc_index",
  "rustc_span",
  "rustc_target",
  "serialize",
@@ -4129,9 +4122,7 @@ dependencies = [
  "rustc_data_structures",
  "rustc_hir",
  "rustc_infer",
- "rustc_macros",
  "rustc_span",
- "rustc_target",
  "smallvec 1.0.0",
 ]
 

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -691,6 +691,7 @@ class RustBuild(object):
         target_linker = self.get_toml("linker", build_section)
         if target_linker is not None:
             env["RUSTFLAGS"] += " -C linker=" + target_linker
+        # After the next cfg(bootstrap) bump, add "-Wunused_extern_options" to RUSTFLAGS
         env["RUSTFLAGS"] += " -Wrust_2018_idioms -Wunused_lifetimes"
         if self.get_toml("deny-warnings", "rust") != "false":
             env["RUSTFLAGS"] += " -Dwarnings"

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1067,6 +1067,10 @@ impl<'a> Builder<'a> {
             // some code doesn't go through this `rustc` wrapper.
             rustflags.arg("-Wrust_2018_idioms");
             rustflags.arg("-Wunused_lifetimes");
+            // Remove this after the next cfg(bootstrap) bump
+            if stage != 0 {
+                rustflags.arg("-Wunused_extern_options");
+            }
 
             if self.config.deny_warnings {
                 rustflags.arg("-Dwarnings");

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -174,3 +174,7 @@ mod std {
 pub mod __export {
     pub use core::format_args;
 }
+
+// Suppress warning: this is only used in benchmarks
+#[cfg(test)]
+use rand_xorshift as _;

--- a/src/liballoc/tests/lib.rs
+++ b/src/liballoc/tests/lib.rs
@@ -17,6 +17,13 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
+// Supress warning: this crate is only used in benchmarks
+use rand_xorshift as _;
+
+// Supress warning: these crates are used indirectly
+use alloc as _;
+use compiler_builtins as _;
+
 mod arc;
 mod binary_heap;
 mod boxed;

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -91,3 +91,8 @@ pub mod util {
 
 // Allows macros to refer to this crate as `::rustc`
 extern crate self as rustc;
+
+// Suppress warning: these crates will be unused when cfg(parallel_compiler) is not enabled
+use rustc_rayon as _;
+use rustc_rayon_core as _;
+use jobserver as _;

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -93,6 +93,6 @@ pub mod util {
 extern crate self as rustc;
 
 // Suppress warning: these crates will be unused when cfg(parallel_compiler) is not enabled
+use jobserver as _;
 use rustc_rayon as _;
 use rustc_rayon_core as _;
-use jobserver as _;

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -138,7 +138,7 @@ pub struct ResolverOutputs {
     pub extern_prelude: FxHashMap<Name, bool>,
     /// All crates that ended up getting loaded.
     /// Used to determine which `--extern` entries are unused
-    pub used_crates: FxHashSet<Symbol>,
+    pub used_crates: Option<FxHashSet<Symbol>>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, HashStable)]

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -30,8 +30,8 @@ use rustc_ast::ast::{self, Ident, Name};
 use rustc_ast::node_id::{NodeId, NodeMap, NodeSet};
 use rustc_attr as attr;
 use rustc_data_structures::captures::Captures;
-use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::fx::FxIndexMap;
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::sorted_map::SortedIndexMultiMap;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::{self, par_iter, Lrc, ParallelIterator};
@@ -136,6 +136,9 @@ pub struct ResolverOutputs {
     /// Extern prelude entries. The value is `true` if the entry was introduced
     /// via `extern crate` item and not `--extern` option or compiler built-in.
     pub extern_prelude: FxHashMap<Name, bool>,
+    /// All crates that ended up getting loaded.
+    /// Used to determine which `--extern` entries are unused
+    pub used_crates: FxHashSet<Symbol>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, HashStable)]

--- a/src/librustc/ty/print/pretty.rs
+++ b/src/librustc/ty/print/pretty.rs
@@ -383,7 +383,7 @@ pub trait PrettyPrinter<'tcx>:
                     .tcx()
                     .item_children(visible_parent)
                     .iter()
-                    .find(|child| child.res.def_id() == def_id)
+                    .find(|child| child.res.opt_def_id() == Some(def_id))
                     .map(|child| child.ident.name);
                 if let Some(reexport) = reexport {
                     *name = reexport;

--- a/src/librustc_ast_pretty/Cargo.toml
+++ b/src/librustc_ast_pretty/Cargo.toml
@@ -12,5 +12,4 @@ doctest = false
 [dependencies]
 log = "0.4"
 rustc_span = { path = "../librustc_span" }
-rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_ast = { path = "../librustc_ast" }

--- a/src/librustc_attr/Cargo.toml
+++ b/src/librustc_attr/Cargo.toml
@@ -17,6 +17,5 @@ rustc_span = { path = "../librustc_span" }
 rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_feature = { path = "../librustc_feature" }
 rustc_macros = { path = "../librustc_macros" }
-smallvec = { version = "1.0", features = ["union", "may_dangle"] }
 rustc_session = { path = "../librustc_session" }
 rustc_ast = { path = "../librustc_ast" }

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -24,6 +24,11 @@
 #![feature(thread_id_value)]
 #![allow(rustc::default_hash_types)]
 
+// Suppress warning: these crates will be unused when cfg(parallel_compiler) is not enabled
+use crossbeam_utils as _;
+use rayon as _;
+use rayon_core as _;
+
 #[macro_use]
 extern crate log;
 #[cfg(unix)]

--- a/src/librustc_infer/Cargo.toml
+++ b/src/librustc_infer/Cargo.toml
@@ -17,7 +17,6 @@ rustc_attr = { path = "../librustc_attr" }
 rustc = { path = "../librustc" }
 rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_errors = { path = "../librustc_errors" }
-rustc_error_codes = { path = "../librustc_error_codes" }
 rustc_hir = { path = "../librustc_hir" }
 rustc_index = { path = "../librustc_index" }
 rustc_macros = { path = "../librustc_macros" }

--- a/src/librustc_interface/lib.rs
+++ b/src/librustc_interface/lib.rs
@@ -21,3 +21,6 @@ pub use queries::Queries;
 
 #[cfg(test)]
 mod tests;
+
+// Suppress warning: this crate will be unused when cfg(parallel_compiler) is not enable
+use rayon as _;

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -738,7 +738,7 @@ pub fn create_global_ctxt<'tcx>(
     }
 
     let extern_prelude = resolver_outputs.extern_prelude.clone();
-    let used_crates = resolver_outputs.used_crates.clone();
+    let used_crates = resolver_outputs.used_crates.as_ref().unwrap().clone();
 
     let gcx = sess.time("setup_global_ctxt", || {
         global_ctxt.init_locking(|| {

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -858,6 +858,10 @@ impl<'a> CrateLoader<'a> {
         });
     }
 
+    pub fn loaded_crates(&self) -> &FxHashSet<Symbol> {
+        self.loaded_crates.as_ref().unwrap()
+    }
+
     pub fn take_loaded_crates(&mut self) -> FxHashSet<Symbol> {
         self.loaded_crates.take().unwrap()
     }

--- a/src/librustc_mir_build/Cargo.toml
+++ b/src/librustc_mir_build/Cargo.toml
@@ -20,7 +20,6 @@ rustc_index = { path = "../librustc_index" }
 rustc_errors = { path = "../librustc_errors" }
 rustc_hir = { path = "../librustc_hir" }
 rustc_infer = { path = "../librustc_infer" }
-rustc_macros = { path = "../librustc_macros" }
 rustc_serialize = { path = "../libserialize", package = "serialize" }
 rustc_session = { path = "../librustc_session" }
 rustc_span = { path = "../librustc_span" }

--- a/src/librustc_passes/Cargo.toml
+++ b/src/librustc_passes/Cargo.toml
@@ -14,7 +14,6 @@ rustc = { path = "../librustc" }
 rustc_attr = { path = "../librustc_attr" }
 rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_errors = { path = "../librustc_errors" }
-rustc_feature = { path = "../librustc_feature" }
 rustc_hir = { path = "../librustc_hir" }
 rustc_index = { path = "../librustc_index" }
 rustc_infer = { path = "../librustc_infer" }

--- a/src/librustc_resolve/Cargo.toml
+++ b/src/librustc_resolve/Cargo.toml
@@ -24,7 +24,6 @@ rustc_errors = { path = "../librustc_errors" }
 rustc_expand = { path = "../librustc_expand" }
 rustc_feature = { path = "../librustc_feature" }
 rustc_hir = { path = "../librustc_hir" }
-rustc_infer = { path = "../librustc_infer" }
 rustc_metadata = { path = "../librustc_metadata" }
 rustc_session = { path = "../librustc_session" }
 rustc_span = { path = "../librustc_span" }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1276,7 +1276,6 @@ impl<'a> Resolver<'a> {
                 .iter()
                 .map(|(ident, entry)| (ident.name, entry.introduced_by_item))
                 .collect(),
-            // The used crates are finalized at this point
             used_crates: Some(used_crates),
         }
     }
@@ -1296,13 +1295,7 @@ impl<'a> Resolver<'a> {
                 .iter()
                 .map(|(ident, entry)| (ident.name, entry.introduced_by_item))
                 .collect(),
-            // The used crates are not finalized at this point - lowering the AST
-            // may cause us to call `Resolver.extern_prelude_get`,
-            // which may update the set of used crates even if a
-            // new crate is not loaded from disk
-            // We should never actually need to access this, but we set it to
-            // `None` so that we get an ICE if we try to unwrap it
-            used_crates: None,
+            used_crates: Some(self.crate_loader.loaded_crates().clone()),
         }
     }
 

--- a/src/librustc_session/Cargo.toml
+++ b/src/librustc_session/Cargo.toml
@@ -16,7 +16,6 @@ rustc_target = { path = "../librustc_target" }
 rustc_serialize = { path = "../libserialize", package = "serialize" }
 rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_span = { path = "../librustc_span" }
-rustc_index = { path = "../librustc_index" }
 rustc_fs_util = { path = "../librustc_fs_util" }
 num_cpus = "1.0"
 rustc_ast = { path = "../librustc_ast" }

--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -72,6 +72,12 @@ declare_lint! {
 }
 
 declare_lint! {
+    pub UNUSED_EXTERN_OPTIONS,
+    Allow,
+    "extern path crates that are never used"
+}
+
+declare_lint! {
     pub UNUSED_QUALIFICATIONS,
     Allow,
     "detects unnecessarily qualified names"
@@ -505,6 +511,7 @@ declare_lint_pass! {
         UNCONDITIONAL_PANIC,
         UNUSED_IMPORTS,
         UNUSED_EXTERN_CRATES,
+        UNUSED_EXTERN_OPTIONS,
         UNUSED_QUALIFICATIONS,
         UNKNOWN_LINTS,
         UNUSED_VARIABLES,

--- a/src/librustc_traits/Cargo.toml
+++ b/src/librustc_traits/Cargo.toml
@@ -13,8 +13,6 @@ log = { version = "0.4" }
 rustc = { path = "../librustc" }
 rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_hir = { path = "../librustc_hir" }
-rustc_macros = { path = "../librustc_macros" }
-rustc_target = { path = "../librustc_target" }
 rustc_ast = { path = "../librustc_ast" }
 rustc_span = { path = "../librustc_span" }
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -40,6 +40,9 @@ pub use self::types::*;
 pub use self::ColorConfig::*;
 pub use cli::TestOpts;
 
+// Suppress warning: we need this crate in the sysroot
+use proc_macro as _;
+
 // Module to be used by rustc to compile tests in libtest
 pub mod test {
     pub use crate::{

--- a/src/rustc/rustc.rs
+++ b/src/rustc/rustc.rs
@@ -1,3 +1,6 @@
+// Suppress warning: we need this crate in the sysroot
+use rustc_codegen_ssa;
+
 fn main() {
     // Pull in jemalloc when enabled.
     //

--- a/src/rustc/rustc.rs
+++ b/src/rustc/rustc.rs
@@ -1,5 +1,5 @@
 // Suppress warning: we need this crate in the sysroot
-use rustc_codegen_ssa;
+use rustc_codegen_ssa as _;
 
 fn main() {
     // Pull in jemalloc when enabled.

--- a/src/test/ui/lint/auxiliary/unused_crate.rs
+++ b/src/test/ui/lint/auxiliary/unused_crate.rs
@@ -1,0 +1,1 @@
+// Deliberately empty

--- a/src/test/ui/lint/unused_extern_options.rs
+++ b/src/test/ui/lint/unused_extern_options.rs
@@ -1,0 +1,5 @@
+// aux-crate:unused_crate=unused_crate.rs
+
+#![deny(unused_extern_options)]
+
+fn main() {}

--- a/src/test/ui/lint/unused_extern_options.stderr
+++ b/src/test/ui/lint/unused_extern_options.stderr
@@ -1,0 +1,11 @@
+error: crate `unused_crate` is unused in crate `unused_extern_options`
+   |
+note: the lint level is defined here
+  --> $DIR/unused_extern_options.rs:3:9
+   |
+LL | #![deny(unused_extern_options)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
+   = help: try removing `unused_crate` from your `Cargo.toml`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #57274

This PR fixes the `unused_extern_crate` lint to work with the 2018 edition. We now separately track whether or not crates in the extern prelude ended up getting used, and lint those that do not.

Notes:
* This lint ignores crates that have an `extern crate` statement. That is, `exern crate mycrate as renamed` will not trigger a lint for `mycrate` (but the existing `extern crate`-based lints will still run). This avoids false-positives when `#[macro_use]` is involved, and allows this lint to be suppressed using either `use mycrate as _` or `extern mycrate`.
* I added in a hack which ignores crates named `panic_abort` and `panic_unwind`, to avoid lints in `libstd`. Ideally, we could just do `use panic_abort as _` and `use panic_unwind as _` - however, this currently triggers an error due to two different panic runtimes being linked in.
* The `extern crate`-based lint (e.g. the already existing lint) performs several checks on the metadata of unused crates (e.g. `is_compiler_builtins`) to see if it should skip linting an otherwise unused crate. Unfortuantely, the nature of the extern prelude means that if a crate ends up unused, we will never have loaded the metadata for it. Unless we want to deliberately load unused crates during the new lint (which seems like a horrible hack), we can only use command line flags to determine if we should skip linting a crate. This prevents us from detecting `panic_abort` and `panic_unwind` via crate metadata instead of crate names.
* There is no span associated with the new warning - by its very nature, there isn't any location that makes sense. Because of this, I chose to include the current crate name in the warning message - otherwise, the messages become useless when multiple crates in a workspace are built in parallel.