### PR TITLE
parser: Simplify treatment of macro variables in `Parser::bump`

### DIFF
--- a/src/librustc_expand/mbe/macro_parser.rs
+++ b/src/librustc_expand/mbe/macro_parser.rs
@@ -856,8 +856,6 @@ fn parse_nt(p: &mut Parser<'_>, sp: Span, name: Symbol) -> Nonterminal {
     if name == sym::tt {
         return token::NtTT(p.parse_token_tree());
     }
-    // check at the beginning and the parser checks after each bump
-    p.process_potential_macro_variable();
     match parse_nt_inner(p, sp, name) {
         Ok(nt) => nt,
         Err(mut err) => {

--- a/src/librustc_expand/mbe/macro_rules.rs
+++ b/src/librustc_expand/mbe/macro_rules.rs
@@ -267,7 +267,6 @@ fn generic_extension<'cx>(
                     cx.current_expansion.module.mod_path.last().map(|id| id.to_string());
                 p.last_type_ascription = cx.current_expansion.prior_type_ascription;
 
-                p.process_potential_macro_variable();
                 // Let the context choose how to interpret the result.
                 // Weird, but useful for X-macros.
                 return Box::new(ParserAnyMacro {

--- a/src/librustc_parse/lib.rs
+++ b/src/librustc_parse/lib.rs
@@ -172,6 +172,7 @@ fn maybe_source_file_to_parser(
     parser.unclosed_delims = unclosed_delims;
     if parser.token == token::Eof && parser.token.span.is_dummy() {
         parser.token.span = Span::new(end_pos, end_pos, parser.token.span.ctxt());
+        assert!(parser.unnormalized_token.is_none());
     }
 
     Ok(parser)

--- a/src/librustc_parse/lib.rs
+++ b/src/librustc_parse/lib.rs
@@ -9,7 +9,7 @@ use rustc_errors::{Diagnostic, FatalError, Level, PResult};
 use rustc_session::parse::ParseSess;
 use rustc_span::{FileName, SourceFile, Span};
 use syntax::ast;
-use syntax::token::{self, Nonterminal};
+use syntax::token::{self, Nonterminal, Token};
 use syntax::tokenstream::{self, TokenStream, TokenTree};
 
 use std::path::{Path, PathBuf};
@@ -170,9 +170,9 @@ fn maybe_source_file_to_parser(
     let (stream, unclosed_delims) = maybe_file_to_stream(sess, source_file, None)?;
     let mut parser = stream_to_parser(sess, stream, None);
     parser.unclosed_delims = unclosed_delims;
-    if parser.token == token::Eof && parser.token.span.is_dummy() {
-        parser.token.span = Span::new(end_pos, end_pos, parser.token.span.ctxt());
-        assert!(parser.unnormalized_token.is_none());
+    if parser.token == token::Eof {
+        let span = Span::new(end_pos, end_pos, parser.token.span.ctxt());
+        parser.set_token(Token::new(token::Eof, span));
     }
 
     Ok(parser)

--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -166,7 +166,7 @@ impl<'a> Parser<'a> {
         while let Some(op) = self.check_assoc_op() {
             // Adjust the span for interpolated LHS to point to the `$lhs` token
             // and not to what it refers to.
-            let lhs_span = match self.unnormalized_prev_token().kind {
+            let lhs_span = match self.unnormalized_prev_token.kind {
                 TokenKind::Interpolated(..) => self.prev_span,
                 _ => lhs.span,
             };
@@ -527,7 +527,7 @@ impl<'a> Parser<'a> {
     ) -> PResult<'a, (Span, P<Expr>)> {
         expr.map(|e| {
             (
-                match self.unnormalized_prev_token().kind {
+                match self.unnormalized_prev_token.kind {
                     TokenKind::Interpolated(..) => self.prev_span,
                     _ => e.span,
                 },

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -1400,8 +1400,9 @@ impl<'a> Parser<'a> {
     }
 
     fn report_invalid_macro_expansion_item(&self, args: &MacArgs) {
+        let span = args.span().expect("undelimited macro call");
         let mut err = self.struct_span_err(
-            self.prev_span,
+            span,
             "macros that expand to items must be delimited with braces or followed by a semicolon",
         );
         if self.unclosed_delims.is_empty() {
@@ -1416,14 +1417,14 @@ impl<'a> Parser<'a> {
             );
         } else {
             err.span_suggestion(
-                self.prev_span,
+                span,
                 "change the delimiters to curly braces",
                 " { /* items */ }".to_string(),
                 Applicability::HasPlaceholders,
             );
         }
         err.span_suggestion(
-            self.prev_span.shrink_to_hi(),
+            span.shrink_to_hi(),
             "add a semicolon",
             ';'.to_string(),
             Applicability::MaybeIncorrect,

--- a/src/librustc_parse/parser/mod.rs
+++ b/src/librustc_parse/parser/mod.rs
@@ -95,7 +95,7 @@ pub struct Parser<'a> {
     /// The current non-normalized token if it's different from `token`.
     /// Preferable use is through the `unnormalized_token()` getter.
     /// Use span from this token if you need to concatenate it with some neighbouring spans.
-    unnormalized_token: Option<Token>,
+    pub unnormalized_token: Option<Token>,
     /// The previous normalized token.
     /// Use span from this token if you need an isolated span.
     prev_token: Token,
@@ -1096,15 +1096,15 @@ impl<'a> Parser<'a> {
                     &mut self.token_cursor.frame,
                     self.token_cursor.stack.pop().unwrap(),
                 );
-                self.token.span = frame.span.entire();
+                self.token = Token::new(TokenKind::CloseDelim(frame.delim), frame.span.close);
+                self.unnormalized_token = None;
                 self.bump();
                 TokenTree::Delimited(frame.span, frame.delim, frame.tree_cursor.stream.into())
             }
             token::CloseDelim(_) | token::Eof => unreachable!(),
             _ => {
-                let token = self.token.clone();
                 self.bump();
-                TokenTree::Token(token)
+                TokenTree::Token(self.prev_token.clone())
             }
         }
     }

--- a/src/librustc_parse/parser/path.rs
+++ b/src/librustc_parse/parser/path.rs
@@ -134,7 +134,7 @@ impl<'a> Parser<'a> {
             path
         });
 
-        let lo = self.unnormalized_token().span;
+        let lo = self.unnormalized_token.span;
         let mut segments = Vec::new();
         let mod_sep_ctxt = self.token.span.ctxt();
         if self.eat(&token::ModSep) {

--- a/src/test/ui/issues/issue-6596-1.rs
+++ b/src/test/ui/issues/issue-6596-1.rs
@@ -1,7 +1,7 @@
 macro_rules! e {
     ($inp:ident) => (
         $nonexistent
-        //~^ ERROR unknown macro variable `nonexistent`
+        //~^ ERROR expected expression, found `$`
     );
 }
 

--- a/src/test/ui/issues/issue-6596-1.stderr
+++ b/src/test/ui/issues/issue-6596-1.stderr
@@ -1,8 +1,8 @@
-error: unknown macro variable `nonexistent`
+error: expected expression, found `$`
   --> $DIR/issue-6596-1.rs:3:9
    |
 LL |         $nonexistent
-   |         ^^^^^^^^^^^^ unknown macro variable
+   |         ^^^^^^^^^^^^ expected expression
 ...
 LL |     e!(foo);
    |     -------- in this macro invocation

--- a/src/test/ui/issues/issue-6596-2.rs
+++ b/src/test/ui/issues/issue-6596-2.rs
@@ -3,7 +3,7 @@
 macro_rules! g {
     ($inp:ident) => (
         { $inp $nonexistent }
-        //~^ ERROR unknown macro variable `nonexistent`
+        //~^ ERROR expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `$`
     );
 }
 

--- a/src/test/ui/issues/issue-6596-2.stderr
+++ b/src/test/ui/issues/issue-6596-2.stderr
@@ -1,8 +1,8 @@
-error: unknown macro variable `nonexistent`
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `$`
   --> $DIR/issue-6596-2.rs:5:16
    |
 LL |         { $inp $nonexistent }
-   |                ^^^^^^^^^^^^ unknown macro variable
+   |                ^^^^^^^^^^^^ expected one of 8 possible tokens
 ...
 LL |     g!(foo);
    |     -------- in this macro invocation

--- a/src/test/ui/proc-macro/auxiliary/generate-dollar-ident.rs
+++ b/src/test/ui/proc-macro/auxiliary/generate-dollar-ident.rs
@@ -1,0 +1,17 @@
+// force-host
+// no-prefer-dynamic
+
+#![feature(proc_macro_hygiene)]
+#![feature(proc_macro_quote)]
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+use proc_macro::*;
+
+#[proc_macro]
+pub fn dollar_ident(input: TokenStream) -> TokenStream {
+    let black_hole = input.into_iter().next().unwrap();
+    quote! {
+        $black_hole!($$var);
+    }
+}

--- a/src/test/ui/proc-macro/generate-dollar-ident.rs
+++ b/src/test/ui/proc-macro/generate-dollar-ident.rs
@@ -1,0 +1,18 @@
+// Proc macros can generate token sequence `$ IDENT`
+// without it being recognized as an unknown macro variable.
+
+// check-pass
+// aux-build:generate-dollar-ident.rs
+
+extern crate generate_dollar_ident;
+use generate_dollar_ident::*;
+
+macro_rules! black_hole {
+    ($($tt:tt)*) => {};
+}
+
+black_hole!($var);
+
+dollar_ident!(black_hole);
+
+fn main() {}


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust/pull/69006.

Token normalization for `$ident` and `$lifetime` is merged directly into `bump`.
Special "unknown macro variable" diagnostic for unexpected `$`s is removed as preventing legal code from compiling (as a result `bump` also doesn't call itself recursively anymore and can't make `prev_token` inconsistent).

r? @Centril 