### PR TITLE
Do not emit note suggesting to implement operation trait to foreign type

### DIFF
--- a/src/test/ui/autoderef-full-lval.stderr
+++ b/src/test/ui/autoderef-full-lval.stderr
@@ -5,8 +5,6 @@ LL |     let z: isize = a.x + b.y;
    |                    --- ^ --- std::boxed::Box<isize>
    |                    |
    |                    std::boxed::Box<isize>
-   |
-   = note: an implementation of `std::ops::Add` might be missing for `std::boxed::Box<isize>`
 
 error[E0369]: cannot add `std::boxed::Box<isize>` to `std::boxed::Box<isize>`
   --> $DIR/autoderef-full-lval.rs:21:33
@@ -15,8 +13,6 @@ LL |     let answer: isize = forty.a + two.a;
    |                         ------- ^ ----- std::boxed::Box<isize>
    |                         |
    |                         std::boxed::Box<isize>
-   |
-   = note: an implementation of `std::ops::Add` might be missing for `std::boxed::Box<isize>`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/binop/binop-bitxor-str.stderr
+++ b/src/test/ui/binop/binop-bitxor-str.stderr
@@ -5,8 +5,6 @@ LL | fn main() { let x = "a".to_string() ^ "b".to_string(); }
    |                     --------------- ^ --------------- std::string::String
    |                     |
    |                     std::string::String
-   |
-   = note: an implementation of `std::ops::BitXor` might be missing for `std::string::String`
 
 error: aborting due to previous error
 

--- a/src/test/ui/binop/binop-mul-bool.stderr
+++ b/src/test/ui/binop/binop-mul-bool.stderr
@@ -5,8 +5,6 @@ LL | fn main() { let x = true * false; }
    |                     ---- ^ ----- bool
    |                     |
    |                     bool
-   |
-   = note: an implementation of `std::ops::Mul` might be missing for `bool`
 
 error: aborting due to previous error
 

--- a/src/test/ui/binop/binop-typeck.stderr
+++ b/src/test/ui/binop/binop-typeck.stderr
@@ -5,8 +5,6 @@ LL |     let z = x + y;
    |             - ^ - {integer}
    |             |
    |             bool
-   |
-   = note: an implementation of `std::ops::Add` might be missing for `bool`
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/array-impls/core-traits-no-impls-length-33.stderr
+++ b/src/test/ui/const-generics/array-impls/core-traits-no-impls-length-33.stderr
@@ -23,8 +23,6 @@ LL |     [0_usize; 33] == [1_usize; 33]
    |     ------------- ^^ ------------- [usize; 33]
    |     |
    |     [usize; 33]
-   |
-   = note: an implementation of `std::cmp::PartialEq` might be missing for `[usize; 33]`
 
 error[E0369]: binary operation `<` cannot be applied to type `[usize; 33]`
   --> $DIR/core-traits-no-impls-length-33.rs:19:19
@@ -33,8 +31,6 @@ LL |     [0_usize; 33] < [1_usize; 33]
    |     ------------- ^ ------------- [usize; 33]
    |     |
    |     [usize; 33]
-   |
-   = note: an implementation of `std::cmp::PartialOrd` might be missing for `[usize; 33]`
 
 error[E0277]: the trait bound `&[usize; 33]: std::iter::IntoIterator` is not satisfied
   --> $DIR/core-traits-no-impls-length-33.rs:24:14

--- a/src/test/ui/destructuring-assignment/note-unsupported.stderr
+++ b/src/test/ui/destructuring-assignment/note-unsupported.stderr
@@ -16,8 +16,6 @@ LL |     (a, b) += (3, 4);
    |     ------^^^^^^^^^^
    |     |
    |     cannot use `+=` on type `({integer}, {integer})`
-   |
-   = note: an implementation of `std::ops::AddAssign` might be missing for `({integer}, {integer})`
 
 error[E0067]: invalid left-hand side of assignment
   --> $DIR/note-unsupported.rs:7:12
@@ -48,8 +46,6 @@ LL |     [a, b] += [3, 4];
    |     ------^^^^^^^^^^
    |     |
    |     cannot use `+=` on type `[{integer}; 2]`
-   |
-   = note: an implementation of `std::ops::AddAssign` might be missing for `[{integer}; 2]`
 
 error[E0067]: invalid left-hand side of assignment
   --> $DIR/note-unsupported.rs:11:12

--- a/src/test/ui/error-codes/E0067.stderr
+++ b/src/test/ui/error-codes/E0067.stderr
@@ -5,8 +5,6 @@ LL |     LinkedList::new() += 1;
    |     -----------------^^^^^
    |     |
    |     cannot use `+=` on type `std::collections::LinkedList<_>`
-   |
-   = note: an implementation of `std::ops::AddAssign` might be missing for `std::collections::LinkedList<_>`
 
 error[E0067]: invalid left-hand side of assignment
   --> $DIR/E0067.rs:4:23

--- a/src/test/ui/error-festival.stderr
+++ b/src/test/ui/error-festival.stderr
@@ -23,8 +23,6 @@ LL |     x += 2;
    |     -^^^^^
    |     |
    |     cannot use `+=` on type `&str`
-   |
-   = note: an implementation of `std::ops::AddAssign` might be missing for `&str`
 
 error[E0599]: no method named `z` found for reference `&str` in the current scope
   --> $DIR/error-festival.rs:16:7

--- a/src/test/ui/for/for-loop-type-error.stderr
+++ b/src/test/ui/for/for-loop-type-error.stderr
@@ -5,8 +5,6 @@ LL |     let x = () + ();
    |             -- ^ -- ()
    |             |
    |             ()
-   |
-   = note: an implementation of `std::ops::Add` might be missing for `()`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-14915.stderr
+++ b/src/test/ui/issues/issue-14915.stderr
@@ -5,8 +5,6 @@ LL |     println!("{}", x + 1);
    |                    - ^ - {integer}
    |                    |
    |                    std::boxed::Box<isize>
-   |
-   = note: an implementation of `std::ops::Add` might be missing for `std::boxed::Box<isize>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-24363.stderr
+++ b/src/test/ui/issues/issue-24363.stderr
@@ -11,8 +11,6 @@ LL |         ()+()
    |         --^-- ()
    |         |
    |         ()
-   |
-   = note: an implementation of `std::ops::Add` might be missing for `()`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-31076.stderr
+++ b/src/test/ui/issues/issue-31076.stderr
@@ -5,8 +5,6 @@ LL |     let x = 5 + 6;
    |             - ^ - {integer}
    |             |
    |             {integer}
-   |
-   = note: an implementation of `std::ops::Add` might be missing for `{integer}`
 
 error[E0369]: cannot add `i32` to `i32`
   --> $DIR/issue-31076.rs:15:18
@@ -15,8 +13,6 @@ LL |     let y = 5i32 + 6i32;
    |             ---- ^ ---- i32
    |             |
    |             i32
-   |
-   = note: an implementation of `std::ops::Add` might be missing for `i32`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-35668.stderr
+++ b/src/test/ui/issues/issue-35668.stderr
@@ -5,8 +5,6 @@ LL |     a.iter().map(|a| a*a)
    |                      -^- &T
    |                      |
    |                      &T
-   |
-   = note: an implementation of `std::ops::Mul` might be missing for `&T`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-40610.stderr
+++ b/src/test/ui/issues/issue-40610.stderr
@@ -5,8 +5,6 @@ LL |     () + f(&[1.0]);
    |     -- ^ --------- ()
    |     |
    |     ()
-   |
-   = note: an implementation of `std::ops::Add` might be missing for `()`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-41394.stderr
+++ b/src/test/ui/issues/issue-41394.stderr
@@ -5,8 +5,6 @@ LL |     A = "" + 1
    |         -- ^ - {integer}
    |         |
    |         &str
-   |
-   = note: an implementation of `std::ops::Add` might be missing for `&str`
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/issue-41394.rs:7:9

--- a/src/test/ui/issues/issue-59488.stderr
+++ b/src/test/ui/issues/issue-59488.stderr
@@ -58,8 +58,6 @@ LL |     foo > bar;
    |     --- ^ --- fn(i64) -> i64 {bar}
    |     |
    |     fn() -> i32 {foo}
-   |
-   = note: an implementation of `std::cmp::PartialOrd` might be missing for `fn() -> i32 {foo}`
 
 error[E0308]: mismatched types
   --> $DIR/issue-59488.rs:25:11
@@ -79,7 +77,6 @@ LL |     assert_eq!(Foo::Bar, i);
    |     fn(usize) -> Foo {Foo::Bar}
    |     fn(usize) -> Foo {Foo::Bar}
    |
-   = note: an implementation of `std::cmp::PartialEq` might be missing for `fn(usize) -> Foo {Foo::Bar}`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `fn(usize) -> Foo {Foo::Bar}` doesn't implement `std::fmt::Debug`

--- a/src/test/ui/minus-string.stderr
+++ b/src/test/ui/minus-string.stderr
@@ -3,8 +3,6 @@ error[E0600]: cannot apply unary operator `-` to type `std::string::String`
    |
 LL | fn main() { -"foo".to_string(); }
    |             ^^^^^^^^^^^^^^^^^^ cannot apply unary operator `-`
-   |
-   = note: an implementation of `std::ops::Neg` might be missing for `std::string::String`
 
 error: aborting due to previous error
 

--- a/src/test/ui/pattern/pattern-tyvar-2.stderr
+++ b/src/test/ui/pattern/pattern-tyvar-2.stderr
@@ -5,8 +5,6 @@ LL | fn foo(t: Bar) -> isize { match t { Bar::T1(_, Some(x)) => { return x * 3; 
    |                                                                     - ^ - {integer}
    |                                                                     |
    |                                                                     std::vec::Vec<isize>
-   |
-   = note: an implementation of `std::ops::Mul` might be missing for `std::vec::Vec<isize>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -560,8 +560,6 @@ error[E0600]: cannot apply unary operator `-` to type `bool`
    |
 LL |     if -let 0 = 0 {}
    |        ^^^^^^^^^^ cannot apply unary operator `-`
-   |
-   = note: an implementation of `std::ops::Neg` might be missing for `bool`
 
 error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
   --> $DIR/disallowed-positions.rs:46:8
@@ -748,8 +746,6 @@ error[E0600]: cannot apply unary operator `-` to type `bool`
    |
 LL |     while -let 0 = 0 {}
    |           ^^^^^^^^^^ cannot apply unary operator `-`
-   |
-   = note: an implementation of `std::ops::Neg` might be missing for `bool`
 
 error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
   --> $DIR/disallowed-positions.rs:110:11
@@ -927,8 +923,6 @@ error[E0600]: cannot apply unary operator `-` to type `bool`
    |
 LL |     -let 0 = 0;
    |     ^^^^^^^^^^ cannot apply unary operator `-`
-   |
-   = note: an implementation of `std::ops::Neg` might be missing for `bool`
 
 error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
   --> $DIR/disallowed-positions.rs:183:5

--- a/src/test/ui/span/issue-39018.stderr
+++ b/src/test/ui/span/issue-39018.stderr
@@ -136,8 +136,6 @@ LL |     let _ = &c + &d;
    |             -- ^ -- &&str
    |             |
    |             &&str
-   |
-   = note: an implementation of `std::ops::Add` might be missing for `&&str`
 
 error[E0369]: cannot add `&str` to `&&str`
   --> $DIR/issue-39018.rs:35:16
@@ -146,8 +144,6 @@ LL |     let _ = &c + d;
    |             -- ^ - &str
    |             |
    |             &&str
-   |
-   = note: an implementation of `std::ops::Add` might be missing for `&&str`
 
 error[E0369]: cannot add `&&str` to `&str`
   --> $DIR/issue-39018.rs:36:15

--- a/src/test/ui/traits/trait-resolution-in-overloaded-op.stderr
+++ b/src/test/ui/traits/trait-resolution-in-overloaded-op.stderr
@@ -5,8 +5,6 @@ LL |     a * b
    |     - ^ - f64
    |     |
    |     &T
-   |
-   = note: an implementation of `std::ops::Mul` might be missing for `&T`
 
 error: aborting due to previous error
 

--- a/src/test/ui/unop-neg-bool.stderr
+++ b/src/test/ui/unop-neg-bool.stderr
@@ -3,8 +3,6 @@ error[E0600]: cannot apply unary operator `-` to type `bool`
    |
 LL |     -true;
    |     ^^^^^ cannot apply unary operator `-`
-   |
-   = note: an implementation of `std::ops::Neg` might be missing for `bool`
 
 error: aborting due to previous error
 

--- a/src/test/ui/vec/vec-res-add.stderr
+++ b/src/test/ui/vec/vec-res-add.stderr
@@ -5,8 +5,6 @@ LL |     let k = i + j;
    |             - ^ - std::vec::Vec<R>
    |             |
    |             std::vec::Vec<R>
-   |
-   = note: an implementation of `std::ops::Add` might be missing for `std::vec::Vec<R>`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
When a binary operation isn't valid, you will get a lint proposing to add a trait implementation to make the operation possible. However, this cannot be done for foreign types, such as types from `core` or `std`.

For example:
```
= note: an implementation of `std::ops::Add` might be missing for `std::option::Option<i8>`
```
As mentioned in https://github.com/rust-lang/rust/issues/60497#issuecomment-562665539:
> The note suggesting implementing Add<i8> should only be emitted if Option<i8> were local to the current crate, which it isn't, so in this case it shouldn't be emitted.


(I will use the CI to check tests for me, or my computer will just burn... and running IDEs is not possible on a pile of ashes)

r? @estebank 