### PR TITLE
Ignore GDB versions with broken str printing.

### DIFF
--- a/src/test/debuginfo/empty-string.rs
+++ b/src/test/debuginfo/empty-string.rs
@@ -2,6 +2,7 @@
 // ignore-android: FIXME(#10381)
 // compile-flags:-g
 // min-gdb-version: 7.7
+// ignore-gdb-version: 7.11.90 - 8.0.9
 // min-lldb-version: 310
 
 // === GDB TESTS ===================================================================================


### PR DESCRIPTION
https://sourceware.org/bugzilla/show_bug.cgi?id=22236