### PR TITLE
configure: set LLVM flags with a value

### DIFF
--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -62,9 +62,9 @@ o("missing-tools", "dist.missing-tools", "allow failures when building tools")
 o("use-libcxx", "llvm.use-libcxx", "build LLVM with libc++")
 o("control-flow-guard", "rust.control-flow-guard", "Enable Control Flow Guard")
 
-o("cflags", "llvm.cflags", "build LLVM with these extra compiler flags")
-o("cxxflags", "llvm.cxxflags", "build LLVM with these extra compiler flags")
-o("ldflags", "llvm.ldflags", "build LLVM with these extra linker flags")
+v("llvm-cflags", "llvm.cflags", "build LLVM with these extra compiler flags")
+v("llvm-cxxflags", "llvm.cxxflags", "build LLVM with these extra compiler flags")
+v("llvm-ldflags", "llvm.ldflags", "build LLVM with these extra linker flags")
 
 o("llvm-libunwind", "rust.llvm-libunwind", "use LLVM libunwind")
 


### PR DESCRIPTION
Rather than a boolean `--enable-cflags` etc., these options should
reflect that they are for LLVM, and that they need a value. You would
now use `./configure --llvm-cflags="..."`.