### PR TITLE
Don't eliminate frame pointers on thumb targets

### DIFF
--- a/src/librustc_target/spec/thumb_base.rs
+++ b/src/librustc_target/spec/thumb_base.rs
@@ -50,7 +50,7 @@ pub fn opts() -> TargetOptions {
         // until we figure a way to add the pretty printers without requiring a volatile load cf.
         // rust-lang/rust#44993.
         emit_debug_gdb_scripts: false,
-        // LLVM is eager to trash the link register when calling `nounwind` functions, which
+        // LLVM is eager to trash the link register when calling `noreturn` functions, which
         // breaks debugging. Preserve LR by default to prevent that from happening.
         eliminate_frame_pointer: false,
         ..Default::default()

--- a/src/librustc_target/spec/thumb_base.rs
+++ b/src/librustc_target/spec/thumb_base.rs
@@ -50,6 +50,9 @@ pub fn opts() -> TargetOptions {
         // until we figure a way to add the pretty printers without requiring a volatile load cf.
         // rust-lang/rust#44993.
         emit_debug_gdb_scripts: false,
+        // LLVM is eager to trash the link register when calling `nounwind` functions, which
+        // breaks debugging. Preserve LR by default to prevent that from happening.
+        eliminate_frame_pointer: false,
         ..Default::default()
     }
 }


### PR DESCRIPTION
This should hopefully fix issues https://github.com/rust-lang/rust/issues/69231 and https://github.com/rust-embedded/cortex-m-rt/issues/139.

~~I couldn't test this locally as the rustc I produced does not create binaries (no idea why).~~ Resolved.