### PR TITLE
Clean out unused directories for extra disk space

### DIFF
--- a/src/ci/azure-pipelines/steps/run.yml
+++ b/src/ci/azure-pipelines/steps/run.yml
@@ -31,6 +31,9 @@ steps:
 - bash: src/ci/scripts/setup-environment.sh
   displayName: Setup environment
 
+- bash: src/ci/scripts/clean-disk.sh
+  displayName: Clean disk
+
 - bash: src/ci/scripts/should-skip-this.sh
   displayName: Decide whether to run this job
 

--- a/src/ci/scripts/clean-disk.sh
+++ b/src/ci/scripts/clean-disk.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# This script deletes some of the Azure-provided artifacts. We don't use these,
+# and disk space is at a premium on our builders.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
+
+# All the Linux builds happen inside Docker.
+if isLinux; then
+    # 6.7GB
+    sudo rm -rf /opt/ghc
+    # 16GB
+    sudo rm -rf /usr/share/dotnet
+fi


### PR DESCRIPTION
This cleans out some of the unused (but large) directories on our linux builders to hopefully allow them to complete without running out of disk space.