### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -62,9 +62,9 @@ o("missing-tools", "dist.missing-tools", "allow failures when building tools")
 o("use-libcxx", "llvm.use-libcxx", "build LLVM with libc++")
 o("control-flow-guard", "rust.control-flow-guard", "Enable Control Flow Guard")
 
-o("cflags", "llvm.cflags", "build LLVM with these extra compiler flags")
-o("cxxflags", "llvm.cxxflags", "build LLVM with these extra compiler flags")
-o("ldflags", "llvm.ldflags", "build LLVM with these extra linker flags")
+v("llvm-cflags", "llvm.cflags", "build LLVM with these extra compiler flags")
+v("llvm-cxxflags", "llvm.cxxflags", "build LLVM with these extra compiler flags")
+v("llvm-ldflags", "llvm.ldflags", "build LLVM with these extra linker flags")
 
 o("llvm-libunwind", "rust.llvm-libunwind", "use LLVM libunwind")
 

--- a/src/ci/azure-pipelines/steps/run.yml
+++ b/src/ci/azure-pipelines/steps/run.yml
@@ -31,6 +31,9 @@ steps:
 - bash: src/ci/scripts/setup-environment.sh
   displayName: Setup environment
 
+- bash: src/ci/scripts/clean-disk.sh
+  displayName: Clean disk
+
 - bash: src/ci/scripts/should-skip-this.sh
   displayName: Decide whether to run this job
 

--- a/src/ci/scripts/clean-disk.sh
+++ b/src/ci/scripts/clean-disk.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# This script deletes some of the Azure-provided artifacts. We don't use these,
+# and disk space is at a premium on our builders.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
+
+# All the Linux builds happen inside Docker.
+if isLinux; then
+    # 6.7GB
+    sudo rm -rf /opt/ghc
+    # 16GB
+    sudo rm -rf /usr/share/dotnet
+fi

--- a/src/ci/scripts/dump-environment.sh
+++ b/src/ci/scripts/dump-environment.sh
@@ -17,3 +17,9 @@ set +o pipefail
 du . | sort -nr | head -n100
 set -o pipefail
 echo
+
+echo "biggest files:"
+set +o pipefail
+du -h / 2>/dev/null | sort -hr | head -n100
+set -o pipefail
+echo

--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -1801,17 +1801,15 @@ where
     #[inline]
     fn nth(&mut self, n: usize) -> Option<I::Item> {
         // Can't just add n + self.n due to overflow.
-        if self.n == 0 {
-            self.iter.nth(n)
-        } else {
+        if self.n > 0 {
             let to_skip = self.n;
             self.n = 0;
             // nth(n) skips n+1
             if self.iter.nth(to_skip - 1).is_none() {
                 return None;
             }
-            self.iter.nth(n)
         }
+        self.iter.nth(n)
     }
 
     #[inline]
@@ -1827,17 +1825,13 @@ where
 
     #[inline]
     fn last(mut self) -> Option<I::Item> {
-        if self.n == 0 {
-            self.iter.last()
-        } else {
-            let next = self.next();
-            if next.is_some() {
-                // recurse. n should be 0.
-                self.last().or(next)
-            } else {
-                None
+        if self.n > 0 {
+            // nth(n) skips n+1
+            if self.iter.nth(self.n - 1).is_none() {
+                return None;
             }
         }
+        self.iter.last()
     }
 
     #[inline]

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -130,7 +130,7 @@ pub mod consts {
     pub const LOG2_E: f32 = 1.44269504088896340735992468100189214_f32;
 
     /// log<sub>2</sub>(10)
-    #[unstable(feature = "extra_log_consts", issue = "50540")]
+    #[stable(feature = "extra_log_consts", since = "1.43.0")]
     pub const LOG2_10: f32 = 3.32192809488736234787031942948939018_f32;
 
     /// log<sub>10</sub>(e)
@@ -138,7 +138,7 @@ pub mod consts {
     pub const LOG10_E: f32 = 0.434294481903251827651128918916605082_f32;
 
     /// log<sub>10</sub>(2)
-    #[unstable(feature = "extra_log_consts", issue = "50540")]
+    #[stable(feature = "extra_log_consts", since = "1.43.0")]
     pub const LOG10_2: f32 = 0.301029995663981195213738894724493027_f32;
 
     /// ln(2)

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -126,7 +126,7 @@ pub mod consts {
     pub const E: f64 = 2.71828182845904523536028747135266250_f64;
 
     /// log<sub>2</sub>(10)
-    #[unstable(feature = "extra_log_consts", issue = "50540")]
+    #[stable(feature = "extra_log_consts", since = "1.43.0")]
     pub const LOG2_10: f64 = 3.32192809488736234787031942948939018_f64;
 
     /// log<sub>2</sub>(e)
@@ -134,7 +134,7 @@ pub mod consts {
     pub const LOG2_E: f64 = 1.44269504088896340735992468100189214_f64;
 
     /// log<sub>10</sub>(2)
-    #[unstable(feature = "extra_log_consts", issue = "50540")]
+    #[stable(feature = "extra_log_consts", since = "1.43.0")]
     pub const LOG10_2: f64 = 0.301029995663981195213738894724493027_f64;
 
     /// log<sub>10</sub>(e)

--- a/src/librustc/hir/map/hir_id_validator.rs
+++ b/src/librustc/hir/map/hir_id_validator.rs
@@ -7,7 +7,7 @@ use rustc_hir::intravisit;
 use rustc_hir::itemlikevisit::ItemLikeVisitor;
 use rustc_hir::{HirId, ItemLocalId};
 
-pub fn check_crate(hir_map: &Map<'_>) {
+pub fn check_crate(hir_map: &Map<'_>, sess: &rustc_session::Session) {
     hir_map.dep_graph.assert_ignored();
 
     let errors = Lock::new(Vec::new());
@@ -24,7 +24,7 @@ pub fn check_crate(hir_map: &Map<'_>) {
 
     if !errors.is_empty() {
         let message = errors.iter().fold(String::new(), |s1, s2| s1 + "\n" + s2);
-        bug!("{}", message);
+        sess.delay_span_bug(rustc_span::DUMMY_SP, &message);
     }
 }
 

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -1235,7 +1235,7 @@ pub fn map_crate<'hir>(
     let map = Map { krate, dep_graph, crate_hash, map, hir_to_node_id, definitions };
 
     sess.time("validate_HIR_map", || {
-        hir_id_validator::check_crate(&map);
+        hir_id_validator::check_crate(&map, sess);
     });
 
     map

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -50,6 +50,7 @@
 #![feature(associated_type_bounds)]
 #![feature(rustc_attrs)]
 #![feature(hash_raw_entry)]
+#![feature(int_error_matching)]
 #![recursion_limit = "512"]
 
 #[macro_use]

--- a/src/librustc/middle/recursion_limit.rs
+++ b/src/librustc/middle/recursion_limit.rs
@@ -6,26 +6,60 @@
 // just peeks and looks for that attribute.
 
 use crate::session::Session;
+use core::num::IntErrorKind;
+use rustc::bug;
 use rustc_span::symbol::{sym, Symbol};
 use syntax::ast;
 
 use rustc_data_structures::sync::Once;
 
 pub fn update_limits(sess: &Session, krate: &ast::Crate) {
-    update_limit(krate, &sess.recursion_limit, sym::recursion_limit, 128);
-    update_limit(krate, &sess.type_length_limit, sym::type_length_limit, 1048576);
+    update_limit(sess, krate, &sess.recursion_limit, sym::recursion_limit, 128);
+    update_limit(sess, krate, &sess.type_length_limit, sym::type_length_limit, 1048576);
 }
 
-fn update_limit(krate: &ast::Crate, limit: &Once<usize>, name: Symbol, default: usize) {
+fn update_limit(
+    sess: &Session,
+    krate: &ast::Crate,
+    limit: &Once<usize>,
+    name: Symbol,
+    default: usize,
+) {
     for attr in &krate.attrs {
         if !attr.check_name(name) {
             continue;
         }
 
         if let Some(s) = attr.value_str() {
-            if let Some(n) = s.as_str().parse().ok() {
-                limit.set(n);
-                return;
+            match s.as_str().parse() {
+                Ok(n) => {
+                    limit.set(n);
+                    return;
+                }
+                Err(e) => {
+                    let mut err = sess.struct_span_err(
+                        attr.span,
+                        "`recursion_limit` must be a non-negative integer",
+                    );
+
+                    let value_span = attr
+                        .meta()
+                        .and_then(|meta| meta.name_value_literal().cloned())
+                        .map(|lit| lit.span)
+                        .unwrap_or(attr.span);
+
+                    let error_str = match e.kind() {
+                        IntErrorKind::Overflow => "`recursion_limit` is too large",
+                        IntErrorKind::Empty => "`recursion_limit` must be a non-negative integer",
+                        IntErrorKind::InvalidDigit => "not a valid integer",
+                        IntErrorKind::Underflow => bug!("`recursion_limit` should never underflow"),
+                        IntErrorKind::Zero => bug!("zero is a valid `recursion_limit`"),
+                        kind => bug!("unimplemented IntErrorKind variant: {:?}", kind),
+                    };
+
+                    err.span_label(value_span, error_str);
+                    err.emit();
+                }
             }
         }
     }

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -255,8 +255,9 @@ pub mod guard {
 
     #[cfg(target_os = "macos")]
     unsafe fn get_stack_start() -> Option<*mut libc::c_void> {
-        let stackaddr = libc::pthread_get_stackaddr_np(libc::pthread_self()) as usize
-            - libc::pthread_get_stacksize_np(libc::pthread_self());
+        let th = libc::pthread_self();
+        let stackaddr =
+            libc::pthread_get_stackaddr_np(th) as usize - libc::pthread_get_stacksize_np(th);
         Some(stackaddr as *mut libc::c_void)
     }
 

--- a/src/test/debuginfo/empty-string.rs
+++ b/src/test/debuginfo/empty-string.rs
@@ -2,6 +2,7 @@
 // ignore-android: FIXME(#10381)
 // compile-flags:-g
 // min-gdb-version: 7.7
+// ignore-gdb-version: 7.11.90 - 8.0.9
 // min-lldb-version: 310
 
 // === GDB TESTS ===================================================================================

--- a/src/test/ui/generator/async-generator-issue-67158.rs
+++ b/src/test/ui/generator/async-generator-issue-67158.rs
@@ -1,0 +1,6 @@
+#![feature(generators)]
+// edition:2018
+// Regression test for #67158.
+fn main() {
+    async { yield print!(":C") }; //~ ERROR `async` generators are not yet supported
+}

--- a/src/test/ui/generator/async-generator-issue-67158.stderr
+++ b/src/test/ui/generator/async-generator-issue-67158.stderr
@@ -1,0 +1,9 @@
+error[E0727]: `async` generators are not yet supported
+  --> $DIR/async-generator-issue-67158.rs:5:13
+   |
+LL |     async { yield print!(":C") };
+   |             ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0727`.

--- a/src/test/ui/recursion_limit/empty.rs
+++ b/src/test/ui/recursion_limit/empty.rs
@@ -1,0 +1,6 @@
+// Test the parse error for an empty recursion_limit
+
+#![recursion_limit = ""] //~ ERROR `recursion_limit` must be a non-negative integer
+                         //~| `recursion_limit` must be a non-negative integer
+
+fn main() {}

--- a/src/test/ui/recursion_limit/empty.stderr
+++ b/src/test/ui/recursion_limit/empty.stderr
@@ -1,0 +1,10 @@
+error: `recursion_limit` must be a non-negative integer
+  --> $DIR/empty.rs:3:1
+   |
+LL | #![recursion_limit = ""]
+   | ^^^^^^^^^^^^^^^^^^^^^--^
+   |                      |
+   |                      `recursion_limit` must be a non-negative integer
+
+error: aborting due to previous error
+

--- a/src/test/ui/recursion_limit/invalid_digit.rs
+++ b/src/test/ui/recursion_limit/invalid_digit.rs
@@ -1,0 +1,6 @@
+// Test the parse error for an invalid digit in recursion_limit
+
+#![recursion_limit = "-100"] //~ ERROR `recursion_limit` must be a non-negative integer
+                             //~| not a valid integer
+
+fn main() {}

--- a/src/test/ui/recursion_limit/invalid_digit.stderr
+++ b/src/test/ui/recursion_limit/invalid_digit.stderr
@@ -1,0 +1,10 @@
+error: `recursion_limit` must be a non-negative integer
+  --> $DIR/invalid_digit.rs:3:1
+   |
+LL | #![recursion_limit = "-100"]
+   | ^^^^^^^^^^^^^^^^^^^^^------^
+   |                      |
+   |                      not a valid integer
+
+error: aborting due to previous error
+

--- a/src/test/ui/recursion_limit/overflow.rs
+++ b/src/test/ui/recursion_limit/overflow.rs
@@ -1,0 +1,7 @@
+// Test the parse error for an overflowing recursion_limit
+
+#![recursion_limit = "999999999999999999999999"]
+//~^ ERROR `recursion_limit` must be a non-negative integer
+//~| `recursion_limit` is too large
+
+fn main() {}

--- a/src/test/ui/recursion_limit/overflow.stderr
+++ b/src/test/ui/recursion_limit/overflow.stderr
@@ -1,0 +1,10 @@
+error: `recursion_limit` must be a non-negative integer
+  --> $DIR/overflow.rs:3:1
+   |
+LL | #![recursion_limit = "999999999999999999999999"]
+   | ^^^^^^^^^^^^^^^^^^^^^--------------------------^
+   |                      |
+   |                      `recursion_limit` is too large
+
+error: aborting due to previous error
+

--- a/src/test/ui/recursion_limit/zero.rs
+++ b/src/test/ui/recursion_limit/zero.rs
@@ -1,0 +1,12 @@
+// Test that a `recursion_limit` of 0 is valid
+
+#![recursion_limit = "0"]
+
+macro_rules! test {
+    () => {};
+    ($tt:tt) => { test!(); };
+}
+
+test!(test); //~ ERROR 10:1: 10:13: recursion limit reached while expanding `test!`
+
+fn main() {}

--- a/src/test/ui/recursion_limit/zero.stderr
+++ b/src/test/ui/recursion_limit/zero.stderr
@@ -1,0 +1,10 @@
+error: recursion limit reached while expanding `test!`
+  --> $DIR/zero.rs:10:1
+   |
+LL | test!(test);
+   | ^^^^^^^^^^^^
+   |
+   = help: consider adding a `#![recursion_limit="0"]` attribute to your crate (`zero`)
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Successful merges:

 - #67272 (recursion_limit parsing handles overflows)
 - #68597 (Simplify `Skip::nth` and `Skip::last` implementations)
 - #68767 (macOS: avoid calling pthread_self() twice)
 - #69175 (Do not ICE when encountering `yield` inside `async` block)
 - #69223 (Ignore GDB versions with broken str printing.)
 - #69244 (configure: set LLVM flags with a value)
 - #69249 (Stabilize {f32, f64}::{LOG2_10, LOG10_2})
 - #69252 (Clean out unused directories for extra disk space)

Failed merges:


r? @ghost