### PR TITLE
Blacklist powerpc-unknown-linux-{gnu,musl} as having non-ignored GNU C ZSTs.

### DIFF
--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -2541,14 +2541,15 @@ where
         };
 
         let target = &cx.tcx().sess.target.target;
+        let target_env_gnu_like = matches!(&target.target_env[..], "gnu" | "musl");
         let win_x64_gnu =
             target.target_os == "windows" && target.arch == "x86_64" && target.target_env == "gnu";
-        let linux_s390x =
-            target.target_os == "linux" && target.arch == "s390x" && target.target_env == "gnu";
-        let linux_sparc64 =
-            target.target_os == "linux" && target.arch == "sparc64" && target.target_env == "gnu";
-        let linux_powerpc =
-            target.target_os == "linux" && target.arch == "powerpc" && target.target_env == "gnu";
+        let linux_s390x_gnu_like =
+            target.target_os == "linux" && target.arch == "s390x" && target_env_gnu_like;
+        let linux_sparc64_gnu_like =
+            target.target_os == "linux" && target.arch == "sparc64" && target_env_gnu_like;
+        let linux_powerpc_gnu_like =
+            target.target_os == "linux" && target.arch == "powerpc" && target_env_gnu_like;
         let rust_abi = match sig.abi {
             RustIntrinsic | PlatformIntrinsic | Rust | RustCall => true,
             _ => false,
@@ -2619,11 +2620,13 @@ where
             if arg.layout.is_zst() {
                 // For some forsaken reason, x86_64-pc-windows-gnu
                 // doesn't ignore zero-sized struct arguments.
-                // The same is true for s390x-unknown-linux-gnu,
-                // sparc64-unknown-linux-gnu and powerpc-unknown-linux-gnu.
+                // The same is true for {s390x,sparc64,powerpc}-unknown-linux-{gnu,musl}.
                 if is_return
                     || rust_abi
-                    || (!win_x64_gnu && !linux_s390x && !linux_sparc64 && !linux_powerpc)
+                    || (!win_x64_gnu
+                        && !linux_s390x_gnu_like
+                        && !linux_sparc64_gnu_like
+                        && !linux_powerpc_gnu_like)
                 {
                     arg.mode = PassMode::Ignore;
                 }

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -2547,6 +2547,8 @@ where
             target.target_os == "linux" && target.arch == "s390x" && target.target_env == "gnu";
         let linux_sparc64 =
             target.target_os == "linux" && target.arch == "sparc64" && target.target_env == "gnu";
+        let linux_powerpc =
+            target.target_os == "linux" && target.arch == "powerpc" && target.target_env == "gnu";
         let rust_abi = match sig.abi {
             RustIntrinsic | PlatformIntrinsic | Rust | RustCall => true,
             _ => false,
@@ -2617,9 +2619,12 @@ where
             if arg.layout.is_zst() {
                 // For some forsaken reason, x86_64-pc-windows-gnu
                 // doesn't ignore zero-sized struct arguments.
-                // The same is true for s390x-unknown-linux-gnu
-                // and sparc64-unknown-linux-gnu.
-                if is_return || rust_abi || (!win_x64_gnu && !linux_s390x && !linux_sparc64) {
+                // The same is true for s390x-unknown-linux-gnu,
+                // sparc64-unknown-linux-gnu and powerpc-unknown-linux-gnu.
+                if is_return
+                    || rust_abi
+                    || (!win_x64_gnu && !linux_s390x && !linux_sparc64 && !linux_powerpc)
+                {
                     arg.mode = PassMode::Ignore;
                 }
             }


### PR DESCRIPTION
Ref #64259 (this is a simpler alternative to that). See also https://github.com/rust-lang/rust/pull/64259#issuecomment-585815831.