### PR TITLE
libunwind: also build with C++ compiler on musl

### DIFF
--- a/src/libunwind/build.rs
+++ b/src/libunwind/build.rs
@@ -106,9 +106,6 @@ mod llvm_libunwind {
         }
 
         if target_env == "musl" {
-            // use the same C compiler command to compile C++ code so we do not need to setup the
-            // C++ compiler env variables on the builders
-            cfg.cpp(false);
             // linking for musl is handled in lib.rs
             cfg.cargo_metadata(false);
             println!("cargo:rustc-link-search=native={}", env::var("OUT_DIR").unwrap());


### PR DESCRIPTION
Clang 9 (the C compiler) errors out and refuses to build anything if -stdlib=c++11 is set. This ensures that libunwind will be built with the C++ compiler just like on glibc.

Closes #69222.