### PR TITLE
Remove special case for `simd_shuffle` arg promotion

### DIFF
--- a/src/librustc_mir/const_eval/eval_queries.rs
+++ b/src/librustc_mir/const_eval/eval_queries.rs
@@ -72,8 +72,8 @@ fn eval_body_using_ecx<'mir, 'tcx>(
     Ok(ret)
 }
 
-/// The `InterpCx` is only meant to be used to do field and index projections into constants for
-/// `simd_shuffle` and const patterns in match arms.
+/// The `InterpCx` is only meant to be used to do field and index projections into promoteds
+/// and const patterns in match arms.
 ///
 /// The function containing the `match` that is currently being analyzed may have generic bounds
 /// that inform us about the generic bounds of the constant. E.g., using an associated constant

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -105,11 +105,10 @@ pub enum Candidate {
     /// Promotion of the `x` in `[x; 32]`.
     Repeat(Location),
 
-    /// Currently applied to function calls where the callee has the unstable
-    /// `#[rustc_args_required_const]` attribute as well as the SIMD shuffle
-    /// intrinsic. The intrinsic requires the arguments are indeed constant and
-    /// the attribute currently provides the semantic requirement that arguments
-    /// must be constant.
+    /// Function calls where the callee has the unstable
+    /// `#[rustc_args_required_const]` attribute. The attribute requires that
+    /// the arguments be constant, usually because they are encoded as an
+    /// immediate operand in a platform intrinsic.
     Argument { bb: BasicBlock, index: usize },
 }
 
@@ -718,8 +717,7 @@ pub fn validate_candidates(
         .filter(|&candidate| {
             validator.explicit = candidate.forces_explicit_promotion();
 
-            // FIXME(eddyb) also emit the errors for shuffle indices
-            // and `#[rustc_args_required_const]` arguments here.
+            // FIXME(eddyb) also emit the errors for `#[rustc_args_required_const]` arguments here.
 
             let is_promotable = validator.validate_candidate(candidate).is_ok();
             match candidate {

--- a/src/test/incremental/issue-61530.rs
+++ b/src/test/incremental/issue-61530.rs
@@ -1,4 +1,4 @@
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, platform_intrinsics, rustc_attrs)]
 
 // revisions:rpass1 rpass2
 
@@ -6,6 +6,7 @@
 struct I32x2(i32, i32);
 
 extern "platform-intrinsic" {
+    #[rustc_args_required_const(2)]
     fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
 }
 

--- a/src/test/ui/issues/issue-38074.rs
+++ b/src/test/ui/issues/issue-38074.rs
@@ -1,9 +1,10 @@
 // run-pass
 // ignore-emscripten FIXME(#45351)
 
-#![feature(platform_intrinsics, repr_simd)]
+#![feature(platform_intrinsics, repr_simd, rustc_attrs)]
 
 extern "platform-intrinsic" {
+    #[rustc_args_required_const(2)]
     fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
 }
 

--- a/src/test/ui/simd-intrinsic/simd-intrinsic-generic-elements.rs
+++ b/src/test/ui/simd-intrinsic/simd-intrinsic-generic-elements.rs
@@ -42,9 +42,13 @@ extern "platform-intrinsic" {
     fn simd_insert<T, E>(x: T, idx: u32, y: E) -> T;
     fn simd_extract<T, E>(x: T, idx: u32) -> E;
 
+    #[rustc_args_required_const(2)]
     fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
+    #[rustc_args_required_const(2)]
     fn simd_shuffle3<T, U>(x: T, y: T, idx: [u32; 3]) -> U;
+    #[rustc_args_required_const(2)]
     fn simd_shuffle4<T, U>(x: T, y: T, idx: [u32; 4]) -> U;
+    #[rustc_args_required_const(2)]
     fn simd_shuffle8<T, U>(x: T, y: T, idx: [u32; 8]) -> U;
 }
 

--- a/src/test/ui/simd-intrinsic/simd-intrinsic-generic-elements.stderr
+++ b/src/test/ui/simd-intrinsic/simd-intrinsic-generic-elements.stderr
@@ -1,89 +1,89 @@
 error[E0511]: invalid monomorphization of `simd_insert` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/simd-intrinsic-generic-elements.rs:55:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:59:9
    |
 LL |         simd_insert(0, 0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_insert` intrinsic: expected inserted type `i32` (element of input `i32x4`), found `f64`
-  --> $DIR/simd-intrinsic-generic-elements.rs:57:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:61:9
    |
 LL |         simd_insert(x, 0, 1.0);
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_extract` intrinsic: expected return type `i32` (element of input `i32x4`), found `f32`
-  --> $DIR/simd-intrinsic-generic-elements.rs:59:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:63:9
    |
 LL |         simd_extract::<_, f32>(x, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle2` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/simd-intrinsic-generic-elements.rs:62:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:66:9
    |
 LL |         simd_shuffle2::<i32, i32>(0, 0, [0; 2]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle3` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/simd-intrinsic-generic-elements.rs:64:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:68:9
    |
 LL |         simd_shuffle3::<i32, i32>(0, 0, [0; 3]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle4` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/simd-intrinsic-generic-elements.rs:66:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:70:9
    |
 LL |         simd_shuffle4::<i32, i32>(0, 0, [0; 4]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle8` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/simd-intrinsic-generic-elements.rs:68:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:72:9
    |
 LL |         simd_shuffle8::<i32, i32>(0, 0, [0; 8]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle2` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x2` with element type `f32`
-  --> $DIR/simd-intrinsic-generic-elements.rs:71:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:75:9
    |
 LL |         simd_shuffle2::<_, f32x2>(x, x, [0; 2]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle3` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x3` with element type `f32`
-  --> $DIR/simd-intrinsic-generic-elements.rs:73:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:77:9
    |
 LL |         simd_shuffle3::<_, f32x3>(x, x, [0; 3]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle4` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x4` with element type `f32`
-  --> $DIR/simd-intrinsic-generic-elements.rs:75:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:79:9
    |
 LL |         simd_shuffle4::<_, f32x4>(x, x, [0; 4]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle8` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x8` with element type `f32`
-  --> $DIR/simd-intrinsic-generic-elements.rs:77:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:81:9
    |
 LL |         simd_shuffle8::<_, f32x8>(x, x, [0; 8]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle2` intrinsic: expected return type of length 2, found `i32x8` with length 8
-  --> $DIR/simd-intrinsic-generic-elements.rs:80:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:84:9
    |
 LL |         simd_shuffle2::<_, i32x8>(x, x, [0; 2]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle3` intrinsic: expected return type of length 3, found `i32x4` with length 4
-  --> $DIR/simd-intrinsic-generic-elements.rs:82:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:86:9
    |
 LL |         simd_shuffle3::<_, i32x4>(x, x, [0; 3]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle4` intrinsic: expected return type of length 4, found `i32x3` with length 3
-  --> $DIR/simd-intrinsic-generic-elements.rs:84:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:88:9
    |
 LL |         simd_shuffle4::<_, i32x3>(x, x, [0; 4]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle8` intrinsic: expected return type of length 8, found `i32x2` with length 2
-  --> $DIR/simd-intrinsic-generic-elements.rs:86:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:90:9
    |
 LL |         simd_shuffle8::<_, i32x2>(x, x, [0; 8]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/simd-intrinsic/simd-intrinsic-inlining-issue67557-ice.rs
+++ b/src/test/ui/simd-intrinsic/simd-intrinsic-inlining-issue67557-ice.rs
@@ -3,9 +3,10 @@
 //
 // run-pass
 // compile-flags: -Zmir-opt-level=3
-#![feature(platform_intrinsics, repr_simd)]
+#![feature(platform_intrinsics, repr_simd, rustc_attrs)]
 
 extern "platform-intrinsic" {
+    #[rustc_args_required_const(2)]
     fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
 }
 

--- a/src/test/ui/simd-intrinsic/simd-intrinsic-inlining-issue67557.rs
+++ b/src/test/ui/simd-intrinsic/simd-intrinsic-inlining-issue67557.rs
@@ -3,9 +3,10 @@
 //
 // run-pass
 // compile-flags: -Zmir-opt-level=3
-#![feature(platform_intrinsics, repr_simd)]
+#![feature(platform_intrinsics, repr_simd, rustc_attrs)]
 
 extern "platform-intrinsic" {
+    #[rustc_args_required_const(2)]
     fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
 }
 

--- a/src/test/ui/simd/simd-intrinsic-generic-elements.rs
+++ b/src/test/ui/simd/simd-intrinsic-generic-elements.rs
@@ -1,7 +1,7 @@
 // run-pass
 // ignore-emscripten FIXME(#45351) hits an LLVM assert
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, platform_intrinsics, rustc_attrs)]
 
 #[repr(simd)]
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -25,9 +25,13 @@ extern "platform-intrinsic" {
     fn simd_insert<T, E>(x: T, idx: u32, y: E) -> T;
     fn simd_extract<T, E>(x: T, idx: u32) -> E;
 
+    #[rustc_args_required_const(2)]
     fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
+    #[rustc_args_required_const(2)]
     fn simd_shuffle3<T, U>(x: T, y: T, idx: [u32; 3]) -> U;
+    #[rustc_args_required_const(2)]
     fn simd_shuffle4<T, U>(x: T, y: T, idx: [u32; 4]) -> U;
+    #[rustc_args_required_const(2)]
     fn simd_shuffle8<T, U>(x: T, y: T, idx: [u32; 8]) -> U;
 }
 


### PR DESCRIPTION
After rust-lang/stdarch#825, these intrinsics are now defined with `#[rustc_args_required_const(2)]`, so the special-case is no longer necessary.

