### PR TITLE
prepare_relocation_copy: check for integer overflow in the multiplica…

### DIFF
--- a/src/librustc/mir/interpret/allocation.rs
+++ b/src/librustc/mir/interpret/allocation.rs
@@ -725,7 +725,7 @@ impl<Tag: Copy, Extra> Allocation<Tag, Extra> {
             return AllocationRelocations { relative_relocations: Vec::new() };
         }
 
-        let mut new_relocations = Vec::with_capacity(relocations.len() * (length as usize));
+        let mut new_relocations = Vec::with_capacity(relocations.len().checked_mul(length as usize).expect("capacity overflow"));
 
         for i in 0..length {
             new_relocations.extend(relocations.iter().map(|&(offset, reloc)| {


### PR DESCRIPTION
…tion calculation for allocation size

The allocation done by prepare_relocation_copy is of size relocations.len() * length. Usually, this kind of unsafe calculation is trivially memory corruption (allocate small chunk, and then in a wildcopy write a lot, as a function of one of the operands). A good example is https://github.com/rust-lang/rust/pull/54398/commits/4d1d1beea6020cb2b760169c215da693b4fa4d13. However, since this function is internal and I don't believe is accessible as str::repeat (with is easy as "AAAA".repeat(0x4000000000000001)), it's not qualifies as a security issue. Still, I think it's more correct and elegant to check for those stuff.

Please note that in copy_repeatedly(), which calls this function, there is a comment about that: Expects the caller to have checked bounds and alignment. However, in eval_rvalue_into_place, there is no such a check (only that length > 1 due to passing length-1). I'm not sure why it hasn't been like this in first place (maybe optimization?), so I figure out I just ask :)

Thanks!