### PR TITLE
[WIP] traits/select: use global vs per-infcx caches more uniformly.

### DIFF
--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -17,7 +17,7 @@ use rustc_hir::def_id::DefId;
 pub struct SelectionCache<'tcx> {
     pub hashmap: Lock<
         FxHashMap<
-            ty::ParamEnvAnd<'tcx, ty::TraitRef<'tcx>>,
+            ty::ParamEnvAnd<'tcx, ty::PolyTraitPredicate<'tcx>>,
             WithDepNode<SelectionResult<'tcx, SelectionCandidate<'tcx>>>,
         >,
     >,
@@ -261,7 +261,10 @@ impl<'tcx> From<OverflowError> for SelectionError<'tcx> {
 #[derive(Clone, Default)]
 pub struct EvaluationCache<'tcx> {
     pub hashmap: Lock<
-        FxHashMap<ty::ParamEnvAnd<'tcx, ty::PolyTraitRef<'tcx>>, WithDepNode<EvaluationResult>>,
+        FxHashMap<
+            ty::ParamEnvAnd<'tcx, ty::PolyTraitPredicate<'tcx>>,
+            WithDepNode<EvaluationResult>,
+        >,
     >,
 }
 

--- a/src/librustc_infer/traits/select.rs
+++ b/src/librustc_infer/traits/select.rs
@@ -1285,9 +1285,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         result: &SelectionResult<'tcx, SelectionCandidate<'tcx>>,
     ) -> bool {
         match result {
-            Ok(Some(SelectionCandidate::ParamCandidate(trait_ref))) => {
-                !trait_ref.skip_binder().input_types().any(|t| t.walk().any(|t_| t_.is_ty_infer()))
-            }
+            Ok(Some(SelectionCandidate::ParamCandidate(trait_ref))) => !trait_ref.needs_infer(),
             _ => true,
         }
     }


### PR DESCRIPTION
~~*Note: this is based on an older `master` to avoid perf interference before https://github.com/rust-lang/rust/pull/67953#issuecomment-587031702 is resolved.*~~ **EDIT**: sadly not workable due https://github.com/rust-lang/rust/pull/69294#issuecomment-588360527.

So far this PR only has the first couple steps towards making the decision of which cache ("global" vs "per-`InferCtxt`") to use for trait evaluation/selection, only once (at the time of checking the cache).

The goal here is to actually make per-`InferCtxt` caches not track `DepNode`s, and maybe even enforce that once `SelectionContext::in_task` is entered, the `InferCtxt` is effectively unused.

My assumption is that if you *need* inference variables in your cache key (i.e. `ParamEnv` and/or `PolyTraitPredicate`) to ever end up doing anything "non-global", and you can't get there from a "global cache key" (which would still use `DepNode`s and `in_task` etc.).

Perhaps another path forward is to redirect "global cache keys" to a query, but I'm not sure how that would handle cycles (badly?), and it feels like stepping on Chalk's toes.

r? @nikomatsakis cc @rust-lang/wg-traits @Zoxc @michaelwoerister