### PR TITLE
mir-interpret: add method to read wide strings from Memory

### DIFF
--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -591,6 +591,11 @@ impl<'tcx, Tag> ScalarMaybeUndef<Tag> {
     }
 
     #[inline(always)]
+    pub fn to_u16(self) -> InterpResult<'tcx, u16> {
+        self.not_undef()?.to_u16()
+    }
+
+    #[inline(always)]
     pub fn to_u32(self) -> InterpResult<'tcx, u32> {
         self.not_undef()?.to_u32()
     }
@@ -608,6 +613,11 @@ impl<'tcx, Tag> ScalarMaybeUndef<Tag> {
     #[inline(always)]
     pub fn to_i8(self) -> InterpResult<'tcx, i8> {
         self.not_undef()?.to_i8()
+    }
+
+    #[inline(always)]
+    pub fn to_i16(self) -> InterpResult<'tcx, i16> {
+        self.not_undef()?.to_i16()
     }
 
     #[inline(always)]

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -791,6 +791,33 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
         self.get_raw(ptr.alloc_id)?.read_c_str(self, ptr)
     }
 
+    /// Reads a 0x0000-terminated u16-sequence from memory. Returns them as a Vec<u16>.
+    /// Terminator 0x0000 is not included in the returned Vec<u16>.
+    ///
+    /// Performs appropriate bounds checks.
+    pub fn read_wide_str(&self, ptr: Scalar<M::PointerTag>) -> InterpResult<'tcx, Vec<u16>> {
+        let size_2bytes = Size::from_bytes(2);
+        let align_2bytes = Align::from_bytes(2).unwrap();
+        // We need to read at least 2 bytes, so we *need* a ptr.
+        let mut ptr = self.force_ptr(ptr)?;
+        let allocation = self.get_raw(ptr.alloc_id)?;
+        let mut u16_seq = Vec::new();
+
+        loop {
+            ptr = self
+                .check_ptr_access(ptr.into(), size_2bytes, align_2bytes)?
+                .expect("cannot be a ZST");
+            let single_u16 = allocation.read_scalar(self, ptr, size_2bytes)?.to_u16()?;
+            if single_u16 != 0x0000 {
+                u16_seq.push(single_u16);
+                ptr = ptr.offset(size_2bytes, self)?;
+            } else {
+                break;
+            }
+        }
+        Ok(u16_seq)
+    }
+
     /// Writes the given stream of bytes into memory.
     ///
     /// Performs appropriate bounds checks.


### PR DESCRIPTION
Implemented *step2* from [instructions](https://github.com/rust-lang/miri/issues/707#issuecomment-561564057) laid out in rust-lang/miri#707. 

Added 2 new methods to struct `rustc_mir::interpret::InterpCx`.

* `read_os_str_from_wide_str` (src/librustc_mir/interpret/operand.rs)
* `write_os_str_to_wide_str` (src/librustc_mir/interpret/place.rs)
  - used existing logic implemented in [MIRI/src/eval.rs](https://github.com/rust-lang/miri/blob/94732aaf7bf79fd01a4a48d11155c6586b937514/src/eval.rs#L132-L141)

These methods are intended to be used for environment variable emulation in Windows.