### PR TITLE
`lit_to_const`: gracefully bubble up type errors.

### DIFF
--- a/src/librustc/mir/interpret/mod.rs
+++ b/src/librustc/mir/interpret/mod.rs
@@ -148,6 +148,10 @@ pub struct LitToConstInput<'tcx> {
 /// Error type for `tcx.lit_to_const`.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, HashStable)]
 pub enum LitToConstError {
+    /// The literal's inferred type did not match the expected `ty` in the input.
+    /// This is used for graceful error handling (`delay_span_bug`) in
+    /// type checking (`AstConv::ast_const_to_const`).
+    TypeError,
     UnparseableFloat,
     Reported,
 }

--- a/src/librustc_mir_build/hair/cx/mod.rs
+++ b/src/librustc_mir_build/hair/cx/mod.rs
@@ -148,6 +148,7 @@ impl<'a, 'tcx> Cx<'a, 'tcx> {
                 // create a dummy value and continue compiling
                 Const::from_bits(self.tcx, 0, self.param_env.and(ty))
             }
+            Err(LitToConstError::TypeError) => bug!("const_eval_literal: had type error"),
         }
     }
 

--- a/src/librustc_mir_build/hair/pattern/mod.rs
+++ b/src/librustc_mir_build/hair/pattern/mod.rs
@@ -846,6 +846,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                     PatKind::Wild
                 }
                 Err(LitToConstError::Reported) => PatKind::Wild,
+                Err(LitToConstError::TypeError) => bug!("lower_lit: had type error"),
             }
         }
     }

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -2740,6 +2740,8 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             // mir.
             if let Ok(c) = tcx.at(expr.span).lit_to_const(lit_input) {
                 return c;
+            } else {
+                tcx.sess.delay_span_bug(expr.span, "ast_const_to_const: couldn't lit_to_const");
             }
         }
 

--- a/src/test/ui/consts/issue-69310-array-size-lit-wrong-ty.rs
+++ b/src/test/ui/consts/issue-69310-array-size-lit-wrong-ty.rs
@@ -1,0 +1,11 @@
+// This is a regression test for #69310, which was injected by #68118.
+// The issue here was that as a performance optimization,
+// we call the query `lit_to_const(input);`.
+// However, the literal `input.lit` would not be of the type expected by `input.ty`.
+// As a result, we immediately called `bug!(...)` instead of bubbling up the problem
+// so that it could be handled by the caller of `lit_to_const` (`ast_const_to_const`).
+
+fn main() {}
+
+const A: [(); 0.1] = [()]; //~ ERROR mismatched types
+const B: [(); b"a"] = [()]; //~ ERROR mismatched types

--- a/src/test/ui/consts/issue-69310-array-size-lit-wrong-ty.stderr
+++ b/src/test/ui/consts/issue-69310-array-size-lit-wrong-ty.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-69310-array-size-lit-wrong-ty.rs:10:15
+   |
+LL | const A: [(); 0.1] = [()];
+   |               ^^^ expected `usize`, found floating-point number
+
+error[E0308]: mismatched types
+  --> $DIR/issue-69310-array-size-lit-wrong-ty.rs:11:15
+   |
+LL | const B: [(); b"a"] = [()];
+   |               ^^^^ expected `usize`, found `&[u8; 1]`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/69310 which was injected by https://github.com/rust-lang/rust/pull/68118.

r? @pnkfelix @varkor @eddyb 
cc @skinny121 