### PR TITLE
Revert #69280

### DIFF
--- a/src/librustc_mir/const_eval/eval_queries.rs
+++ b/src/librustc_mir/const_eval/eval_queries.rs
@@ -72,8 +72,8 @@ fn eval_body_using_ecx<'mir, 'tcx>(
     Ok(ret)
 }
 
-/// The `InterpCx` is only meant to be used to do field and index projections into promoteds
-/// and const patterns in match arms.
+/// The `InterpCx` is only meant to be used to do field and index projections into constants for
+/// `simd_shuffle` and const patterns in match arms.
 ///
 /// The function containing the `match` that is currently being analyzed may have generic bounds
 /// that inform us about the generic bounds of the constant. E.g., using an associated constant

--- a/src/test/incremental/issue-61530.rs
+++ b/src/test/incremental/issue-61530.rs
@@ -1,4 +1,4 @@
-#![feature(repr_simd, platform_intrinsics, rustc_attrs)]
+#![feature(repr_simd, platform_intrinsics)]
 
 // revisions:rpass1 rpass2
 
@@ -6,7 +6,6 @@
 struct I32x2(i32, i32);
 
 extern "platform-intrinsic" {
-    #[rustc_args_required_const(2)]
     fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
 }
 

--- a/src/test/ui/issues/issue-38074.rs
+++ b/src/test/ui/issues/issue-38074.rs
@@ -1,10 +1,9 @@
 // run-pass
 // ignore-emscripten FIXME(#45351)
 
-#![feature(platform_intrinsics, repr_simd, rustc_attrs)]
+#![feature(platform_intrinsics, repr_simd)]
 
 extern "platform-intrinsic" {
-    #[rustc_args_required_const(2)]
     fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
 }
 

--- a/src/test/ui/simd-intrinsic/simd-intrinsic-generic-elements.rs
+++ b/src/test/ui/simd-intrinsic/simd-intrinsic-generic-elements.rs
@@ -42,13 +42,9 @@ extern "platform-intrinsic" {
     fn simd_insert<T, E>(x: T, idx: u32, y: E) -> T;
     fn simd_extract<T, E>(x: T, idx: u32) -> E;
 
-    #[rustc_args_required_const(2)]
     fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
-    #[rustc_args_required_const(2)]
     fn simd_shuffle3<T, U>(x: T, y: T, idx: [u32; 3]) -> U;
-    #[rustc_args_required_const(2)]
     fn simd_shuffle4<T, U>(x: T, y: T, idx: [u32; 4]) -> U;
-    #[rustc_args_required_const(2)]
     fn simd_shuffle8<T, U>(x: T, y: T, idx: [u32; 8]) -> U;
 }
 

--- a/src/test/ui/simd-intrinsic/simd-intrinsic-generic-elements.stderr
+++ b/src/test/ui/simd-intrinsic/simd-intrinsic-generic-elements.stderr
@@ -1,89 +1,89 @@
 error[E0511]: invalid monomorphization of `simd_insert` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/simd-intrinsic-generic-elements.rs:59:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:55:9
    |
 LL |         simd_insert(0, 0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_insert` intrinsic: expected inserted type `i32` (element of input `i32x4`), found `f64`
-  --> $DIR/simd-intrinsic-generic-elements.rs:61:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:57:9
    |
 LL |         simd_insert(x, 0, 1.0);
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_extract` intrinsic: expected return type `i32` (element of input `i32x4`), found `f32`
-  --> $DIR/simd-intrinsic-generic-elements.rs:63:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:59:9
    |
 LL |         simd_extract::<_, f32>(x, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle2` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/simd-intrinsic-generic-elements.rs:66:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:62:9
    |
 LL |         simd_shuffle2::<i32, i32>(0, 0, [0; 2]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle3` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/simd-intrinsic-generic-elements.rs:68:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:64:9
    |
 LL |         simd_shuffle3::<i32, i32>(0, 0, [0; 3]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle4` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/simd-intrinsic-generic-elements.rs:70:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:66:9
    |
 LL |         simd_shuffle4::<i32, i32>(0, 0, [0; 4]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle8` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/simd-intrinsic-generic-elements.rs:72:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:68:9
    |
 LL |         simd_shuffle8::<i32, i32>(0, 0, [0; 8]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle2` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x2` with element type `f32`
-  --> $DIR/simd-intrinsic-generic-elements.rs:75:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:71:9
    |
 LL |         simd_shuffle2::<_, f32x2>(x, x, [0; 2]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle3` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x3` with element type `f32`
-  --> $DIR/simd-intrinsic-generic-elements.rs:77:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:73:9
    |
 LL |         simd_shuffle3::<_, f32x3>(x, x, [0; 3]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle4` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x4` with element type `f32`
-  --> $DIR/simd-intrinsic-generic-elements.rs:79:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:75:9
    |
 LL |         simd_shuffle4::<_, f32x4>(x, x, [0; 4]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle8` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x8` with element type `f32`
-  --> $DIR/simd-intrinsic-generic-elements.rs:81:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:77:9
    |
 LL |         simd_shuffle8::<_, f32x8>(x, x, [0; 8]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle2` intrinsic: expected return type of length 2, found `i32x8` with length 8
-  --> $DIR/simd-intrinsic-generic-elements.rs:84:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:80:9
    |
 LL |         simd_shuffle2::<_, i32x8>(x, x, [0; 2]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle3` intrinsic: expected return type of length 3, found `i32x4` with length 4
-  --> $DIR/simd-intrinsic-generic-elements.rs:86:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:82:9
    |
 LL |         simd_shuffle3::<_, i32x4>(x, x, [0; 3]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle4` intrinsic: expected return type of length 4, found `i32x3` with length 3
-  --> $DIR/simd-intrinsic-generic-elements.rs:88:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:84:9
    |
 LL |         simd_shuffle4::<_, i32x3>(x, x, [0; 4]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle8` intrinsic: expected return type of length 8, found `i32x2` with length 2
-  --> $DIR/simd-intrinsic-generic-elements.rs:90:9
+  --> $DIR/simd-intrinsic-generic-elements.rs:86:9
    |
 LL |         simd_shuffle8::<_, i32x2>(x, x, [0; 8]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/simd-intrinsic/simd-intrinsic-inlining-issue67557-ice.rs
+++ b/src/test/ui/simd-intrinsic/simd-intrinsic-inlining-issue67557-ice.rs
@@ -3,10 +3,9 @@
 //
 // run-pass
 // compile-flags: -Zmir-opt-level=3
-#![feature(platform_intrinsics, repr_simd, rustc_attrs)]
+#![feature(platform_intrinsics, repr_simd)]
 
 extern "platform-intrinsic" {
-    #[rustc_args_required_const(2)]
     fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
 }
 

--- a/src/test/ui/simd-intrinsic/simd-intrinsic-inlining-issue67557.rs
+++ b/src/test/ui/simd-intrinsic/simd-intrinsic-inlining-issue67557.rs
@@ -3,10 +3,9 @@
 //
 // run-pass
 // compile-flags: -Zmir-opt-level=3
-#![feature(platform_intrinsics, repr_simd, rustc_attrs)]
+#![feature(platform_intrinsics, repr_simd)]
 
 extern "platform-intrinsic" {
-    #[rustc_args_required_const(2)]
     fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
 }
 

--- a/src/test/ui/simd/simd-intrinsic-generic-elements.rs
+++ b/src/test/ui/simd/simd-intrinsic-generic-elements.rs
@@ -1,7 +1,7 @@
 // run-pass
 // ignore-emscripten FIXME(#45351) hits an LLVM assert
 
-#![feature(repr_simd, platform_intrinsics, rustc_attrs)]
+#![feature(repr_simd, platform_intrinsics)]
 
 #[repr(simd)]
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -25,13 +25,9 @@ extern "platform-intrinsic" {
     fn simd_insert<T, E>(x: T, idx: u32, y: E) -> T;
     fn simd_extract<T, E>(x: T, idx: u32) -> E;
 
-    #[rustc_args_required_const(2)]
     fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
-    #[rustc_args_required_const(2)]
     fn simd_shuffle3<T, U>(x: T, y: T, idx: [u32; 3]) -> U;
-    #[rustc_args_required_const(2)]
     fn simd_shuffle4<T, U>(x: T, y: T, idx: [u32; 4]) -> U;
-    #[rustc_args_required_const(2)]
     fn simd_shuffle8<T, U>(x: T, y: T, idx: [u32; 8]) -> U;
 }
 


### PR DESCRIPTION
Resolves #69313 by reverting #69280.

After #69280, `#[rustc_args_required_const(2)]` is required on the declaration of `simd_shuffle` intrinsics. This is allowed breakage, since you can't define platform intrinsics on stable. However, the latest release of the widely used `packed_simd` crate defines these intrinsics without the requisite attribute. Since there's no urgency to merge #69280, let's revert it. We can reconsider when rust-lang/packed_simd#278 is included in a point release of `packed_simd`.

r? @petrochenkov 