### PR TITLE
Do not ping the infrastructure team on toolstate changes

### DIFF
--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -211,14 +211,14 @@ def update_latest(
                 if new > old:
                     # things got fixed or at least the status quo improved
                     changed = True
-                    message += '🎉 {} on {}: {} → {} (cc {}, @rust-lang/infra).\n' \
+                    message += '🎉 {} on {}: {} → {} (cc {}).\n' \
                         .format(tool, os, old, new, maintainers)
                 elif new < old:
                     # tests or builds are failing and were not failing before
                     changed = True
                     title = '💔 {} on {}: {} → {}' \
                         .format(tool, os, old, new)
-                    message += '{} (cc {}, @rust-lang/infra).\n' \
+                    message += '{} (cc {}).\n' \
                         .format(title, maintainers)
                     # See if we need to create an issue.
                     if tool == 'miri':


### PR DESCRIPTION
To my knowledge, there is essentially never any particular action that the infra team needs to take on these pings, and they are currently relatively annoying.

cc rust-lang/infra -- does anyone *want* these notifications?