### PR TITLE
Wrong error message for move_ref_pattern

### DIFF
--- a/src/librustc_mir_build/hair/pattern/check_match.rs
+++ b/src/librustc_mir_build/hair/pattern/check_match.rs
@@ -659,7 +659,7 @@ fn check_borrow_conflicts_in_at_patterns(cx: &MatchVisitor<'_, '_>, pat: &Pat<'_
             });
             if !conflicts_ref.is_empty() {
                 let occurs_because = format!(
-                    "move occurs because `{}` has type `{}` which does implement the `Copy` trait",
+                    "move occurs because `{}` has type `{}` which does not implement the `Copy` trait",
                     name,
                     tables.node_type(pat.hir_id),
                 );

--- a/src/test/ui/pattern/bindings-after-at/bind-by-move-neither-can-live-while-the-other-survives-1.stderr
+++ b/src/test/ui/pattern/bindings-after-at/bind-by-move-neither-can-live-while-the-other-survives-1.stderr
@@ -15,7 +15,7 @@ LL |         Some(_z @ ref _y) => {}
    |              |    |
    |              |    value borrowed here after move
    |              value moved into `_z` here
-   |              move occurs because `_z` has type `X` which does implement the `Copy` trait
+   |              move occurs because `_z` has type `X` which does not implement the `Copy` trait
 
 error: cannot move out of value because it is borrowed
   --> $DIR/bind-by-move-neither-can-live-while-the-other-survives-1.rs:29:14
@@ -34,7 +34,7 @@ LL |         Some(_z @ ref mut _y) => {}
    |              |    |
    |              |    value borrowed here after move
    |              value moved into `_z` here
-   |              move occurs because `_z` has type `X` which does implement the `Copy` trait
+   |              move occurs because `_z` has type `X` which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value
   --> $DIR/bind-by-move-neither-can-live-while-the-other-survives-1.rs:21:19

--- a/src/test/ui/pattern/bindings-after-at/borrowck-pat-by-move-and-ref-inverse-promotion.stderr
+++ b/src/test/ui/pattern/bindings-after-at/borrowck-pat-by-move-and-ref-inverse-promotion.stderr
@@ -6,7 +6,7 @@ LL |     let a @ ref b = U;
    |         |   |
    |         |   value borrowed here after move
    |         value moved into `a` here
-   |         move occurs because `a` has type `main::U` which does implement the `Copy` trait
+   |         move occurs because `a` has type `main::U` which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/pattern/bindings-after-at/borrowck-pat-by-move-and-ref-inverse.stderr
+++ b/src/test/ui/pattern/bindings-after-at/borrowck-pat-by-move-and-ref-inverse.stderr
@@ -6,7 +6,7 @@ LL |     let a @ ref b = U;
    |         |   |
    |         |   value borrowed here after move
    |         value moved into `a` here
-   |         move occurs because `a` has type `main::U` which does implement the `Copy` trait
+   |         move occurs because `a` has type `main::U` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:31:9
@@ -17,7 +17,7 @@ LL |     let a @ (mut b @ ref mut c, d @ ref e) = (U, U);
    |         |            |              value borrowed here after move
    |         |            value borrowed here after move
    |         value moved into `a` here
-   |         move occurs because `a` has type `(main::U, main::U)` which does implement the `Copy` trait
+   |         move occurs because `a` has type `(main::U, main::U)` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:31:14
@@ -27,7 +27,7 @@ LL |     let a @ (mut b @ ref mut c, d @ ref e) = (U, U);
    |              |       |
    |              |       value borrowed here after move
    |              value moved into `b` here
-   |              move occurs because `b` has type `main::U` which does implement the `Copy` trait
+   |              move occurs because `b` has type `main::U` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:31:33
@@ -37,7 +37,7 @@ LL |     let a @ (mut b @ ref mut c, d @ ref e) = (U, U);
    |                                 |   |
    |                                 |   value borrowed here after move
    |                                 value moved into `d` here
-   |                                 move occurs because `d` has type `main::U` which does implement the `Copy` trait
+   |                                 move occurs because `d` has type `main::U` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:38:9
@@ -48,7 +48,7 @@ LL |     let a @ [ref mut b, ref c] = [U, U];
    |         |    |          value borrowed here after move
    |         |    value borrowed here after move
    |         value moved into `a` here
-   |         move occurs because `a` has type `[main::U; 2]` which does implement the `Copy` trait
+   |         move occurs because `a` has type `[main::U; 2]` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:41:9
@@ -58,7 +58,7 @@ LL |     let a @ ref b = u();
    |         |   |
    |         |   value borrowed here after move
    |         value moved into `a` here
-   |         move occurs because `a` has type `main::U` which does implement the `Copy` trait
+   |         move occurs because `a` has type `main::U` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:44:9
@@ -69,7 +69,7 @@ LL |     let a @ (mut b @ ref mut c, d @ ref e) = (u(), u());
    |         |            |              value borrowed here after move
    |         |            value borrowed here after move
    |         value moved into `a` here
-   |         move occurs because `a` has type `(main::U, main::U)` which does implement the `Copy` trait
+   |         move occurs because `a` has type `(main::U, main::U)` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:44:14
@@ -79,7 +79,7 @@ LL |     let a @ (mut b @ ref mut c, d @ ref e) = (u(), u());
    |              |       |
    |              |       value borrowed here after move
    |              value moved into `b` here
-   |              move occurs because `b` has type `main::U` which does implement the `Copy` trait
+   |              move occurs because `b` has type `main::U` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:44:33
@@ -89,7 +89,7 @@ LL |     let a @ (mut b @ ref mut c, d @ ref e) = (u(), u());
    |                                 |   |
    |                                 |   value borrowed here after move
    |                                 value moved into `d` here
-   |                                 move occurs because `d` has type `main::U` which does implement the `Copy` trait
+   |                                 move occurs because `d` has type `main::U` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:51:9
@@ -100,7 +100,7 @@ LL |     let a @ [ref mut b, ref c] = [u(), u()];
    |         |    |          value borrowed here after move
    |         |    value borrowed here after move
    |         value moved into `a` here
-   |         move occurs because `a` has type `[main::U; 2]` which does implement the `Copy` trait
+   |         move occurs because `a` has type `[main::U; 2]` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:56:9
@@ -110,7 +110,7 @@ LL |         a @ Some(ref b) => {}
    |         |        |
    |         |        value borrowed here after move
    |         value moved into `a` here
-   |         move occurs because `a` has type `std::option::Option<main::U>` which does implement the `Copy` trait
+   |         move occurs because `a` has type `std::option::Option<main::U>` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:61:9
@@ -121,7 +121,7 @@ LL |         a @ Some((mut b @ ref mut c, d @ ref e)) => {}
    |         |                 |              value borrowed here after move
    |         |                 value borrowed here after move
    |         value moved into `a` here
-   |         move occurs because `a` has type `std::option::Option<(main::U, main::U)>` which does implement the `Copy` trait
+   |         move occurs because `a` has type `std::option::Option<(main::U, main::U)>` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:61:19
@@ -131,7 +131,7 @@ LL |         a @ Some((mut b @ ref mut c, d @ ref e)) => {}
    |                   |       |
    |                   |       value borrowed here after move
    |                   value moved into `b` here
-   |                   move occurs because `b` has type `main::U` which does implement the `Copy` trait
+   |                   move occurs because `b` has type `main::U` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:61:38
@@ -141,7 +141,7 @@ LL |         a @ Some((mut b @ ref mut c, d @ ref e)) => {}
    |                                      |   |
    |                                      |   value borrowed here after move
    |                                      value moved into `d` here
-   |                                      move occurs because `d` has type `main::U` which does implement the `Copy` trait
+   |                                      move occurs because `d` has type `main::U` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:71:9
@@ -152,7 +152,7 @@ LL |         mut a @ Some([ref b, ref mut c]) => {}
    |         |             |      value borrowed here after move
    |         |             value borrowed here after move
    |         value moved into `a` here
-   |         move occurs because `a` has type `std::option::Option<[main::U; 2]>` which does implement the `Copy` trait
+   |         move occurs because `a` has type `std::option::Option<[main::U; 2]>` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:77:9
@@ -162,7 +162,7 @@ LL |         a @ Some(ref b) => {}
    |         |        |
    |         |        value borrowed here after move
    |         value moved into `a` here
-   |         move occurs because `a` has type `std::option::Option<main::U>` which does implement the `Copy` trait
+   |         move occurs because `a` has type `std::option::Option<main::U>` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:83:9
@@ -173,7 +173,7 @@ LL |         a @ Some((mut b @ ref mut c, d @ ref e)) => {}
    |         |                 |              value borrowed here after move
    |         |                 value borrowed here after move
    |         value moved into `a` here
-   |         move occurs because `a` has type `std::option::Option<(main::U, main::U)>` which does implement the `Copy` trait
+   |         move occurs because `a` has type `std::option::Option<(main::U, main::U)>` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:83:19
@@ -183,7 +183,7 @@ LL |         a @ Some((mut b @ ref mut c, d @ ref e)) => {}
    |                   |       |
    |                   |       value borrowed here after move
    |                   value moved into `b` here
-   |                   move occurs because `b` has type `main::U` which does implement the `Copy` trait
+   |                   move occurs because `b` has type `main::U` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:83:38
@@ -193,7 +193,7 @@ LL |         a @ Some((mut b @ ref mut c, d @ ref e)) => {}
    |                                      |   |
    |                                      |   value borrowed here after move
    |                                      value moved into `d` here
-   |                                      move occurs because `d` has type `main::U` which does implement the `Copy` trait
+   |                                      move occurs because `d` has type `main::U` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:93:9
@@ -204,7 +204,7 @@ LL |         mut a @ Some([ref b, ref mut c]) => {}
    |         |             |      value borrowed here after move
    |         |             value borrowed here after move
    |         value moved into `a` here
-   |         move occurs because `a` has type `std::option::Option<[main::U; 2]>` which does implement the `Copy` trait
+   |         move occurs because `a` has type `std::option::Option<[main::U; 2]>` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:14:11
@@ -214,7 +214,7 @@ LL |     fn f1(a @ ref b: U) {}
    |           |   |
    |           |   value borrowed here after move
    |           value moved into `a` here
-   |           move occurs because `a` has type `main::U` which does implement the `Copy` trait
+   |           move occurs because `a` has type `main::U` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:18:11
@@ -225,7 +225,7 @@ LL |     fn f2(mut a @ (b @ ref c, mut d @ ref e): (U, U)) {}
    |           |            |              value borrowed here after move
    |           |            value borrowed here after move
    |           value moved into `a` here
-   |           move occurs because `a` has type `(main::U, main::U)` which does implement the `Copy` trait
+   |           move occurs because `a` has type `(main::U, main::U)` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:18:20
@@ -235,7 +235,7 @@ LL |     fn f2(mut a @ (b @ ref c, mut d @ ref e): (U, U)) {}
    |                    |   |
    |                    |   value borrowed here after move
    |                    value moved into `b` here
-   |                    move occurs because `b` has type `main::U` which does implement the `Copy` trait
+   |                    move occurs because `b` has type `main::U` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:18:31
@@ -245,7 +245,7 @@ LL |     fn f2(mut a @ (b @ ref c, mut d @ ref e): (U, U)) {}
    |                               |       |
    |                               |       value borrowed here after move
    |                               value moved into `d` here
-   |                               move occurs because `d` has type `main::U` which does implement the `Copy` trait
+   |                               move occurs because `d` has type `main::U` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:25:11
@@ -256,7 +256,7 @@ LL |     fn f3(a @ [ref mut b, ref c]: [U; 2]) {}
    |           |    |          value borrowed here after move
    |           |    value borrowed here after move
    |           value moved into `a` here
-   |           move occurs because `a` has type `[main::U; 2]` which does implement the `Copy` trait
+   |           move occurs because `a` has type `[main::U; 2]` which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value
   --> $DIR/borrowck-pat-by-move-and-ref-inverse.rs:31:22

--- a/src/test/ui/pattern/bindings-after-at/borrowck-pat-ref-mut-twice.stderr
+++ b/src/test/ui/pattern/bindings-after-at/borrowck-pat-ref-mut-twice.stderr
@@ -96,7 +96,7 @@ LL |     let a @ (ref mut b, ref mut c) = (U, U);
    |         |    |          value borrowed here after move
    |         |    value borrowed here after move
    |         value moved into `a` here
-   |         move occurs because `a` has type `(main::U, main::U)` which does implement the `Copy` trait
+   |         move occurs because `a` has type `(main::U, main::U)` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-ref-mut-twice.rs:70:9
@@ -108,7 +108,7 @@ LL |     let a @ (b, [c, d]) = &mut val; // Same as ^--
    |         |    |   value borrowed here after move
    |         |    value borrowed here after move
    |         value moved into `a` here
-   |         move occurs because `a` has type `&mut (main::U, [main::U; 2])` which does implement the `Copy` trait
+   |         move occurs because `a` has type `&mut (main::U, [main::U; 2])` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-ref-mut-twice.rs:74:9
@@ -118,7 +118,7 @@ LL |     let a @ &mut ref mut b = &mut U;
    |         |        |
    |         |        value borrowed here after move
    |         value moved into `a` here
-   |         move occurs because `a` has type `&mut main::U` which does implement the `Copy` trait
+   |         move occurs because `a` has type `&mut main::U` which does not implement the `Copy` trait
 
 error: borrow of moved value
   --> $DIR/borrowck-pat-ref-mut-twice.rs:77:9
@@ -129,7 +129,7 @@ LL |     let a @ &mut (ref mut b, ref mut c) = &mut (U, U);
    |         |         |          value borrowed here after move
    |         |         value borrowed here after move
    |         value moved into `a` here
-   |         move occurs because `a` has type `&mut (main::U, main::U)` which does implement the `Copy` trait
+   |         move occurs because `a` has type `&mut (main::U, main::U)` which does not implement the `Copy` trait
 
 error: cannot borrow value as mutable more than once at a time
   --> $DIR/borrowck-pat-ref-mut-twice.rs:82:9

--- a/src/test/ui/pattern/bindings-after-at/default-binding-modes-both-sides-independent.stderr
+++ b/src/test/ui/pattern/bindings-after-at/default-binding-modes-both-sides-independent.stderr
@@ -33,7 +33,7 @@ LL |         Ok(ref a @ b) | Err(b @ ref a) => {
    |                             |   |
    |                             |   value borrowed here after move
    |                             value moved into `b` here
-   |                             move occurs because `b` has type `main::NotCopy` which does implement the `Copy` trait
+   |                             move occurs because `b` has type `main::NotCopy` which does not implement the `Copy` trait
 
 error: cannot move out of value because it is borrowed
   --> $DIR/default-binding-modes-both-sides-independent.rs:44:9


### PR DESCRIPTION
The current error message states that move occurs *because of `Copy`*:
```Rust
"move occurs because `{}` has type `{}` which does implement the `Copy` trait."
```
I found this randomly when surfing through the sources. This means, I don't have any context and might be completely wrong.

r? @Centril 