### PR TITLE
Test `Duration::new` panics on overflow

### DIFF
--- a/src/libcore/tests/time.rs
+++ b/src/libcore/tests/time.rs
@@ -12,6 +12,12 @@ fn creation() {
 }
 
 #[test]
+#[should_panic]
+fn new_overflow() {
+    let _ = Duration::new(::core::u64::MAX, 1_000_000_000);
+}
+
+#[test]
 fn secs() {
     assert_eq!(Duration::new(0, 0).as_secs(), 0);
     assert_eq!(Duration::new(0, 500_000_005).as_secs(), 0);


### PR DESCRIPTION
A `Duration` is created from a second and nanoseconds variable. The
documentation says: "This constructor will panic if the carry from the
nanoseconds overflows the seconds counter". This was, however, not tested
in the tests. I doubt the behavior will ever regress, but it is usually a
good idea to test all documented behavior.