### PR TITLE
[beta] beta backports

### DIFF
--- a/src/ci/azure-pipelines/steps/run.yml
+++ b/src/ci/azure-pipelines/steps/run.yml
@@ -31,6 +31,9 @@ steps:
 - bash: src/ci/scripts/setup-environment.sh
   displayName: Setup environment
 
+- bash: src/ci/scripts/clean-disk.sh
+  displayName: Clean disk
+
 - bash: src/ci/scripts/should-skip-this.sh
   displayName: Decide whether to run this job
 

--- a/src/ci/scripts/clean-disk.sh
+++ b/src/ci/scripts/clean-disk.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# This script deletes some of the Azure-provided artifacts. We don't use these,
+# and disk space is at a premium on our builders.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
+
+# All the Linux builds happen inside Docker.
+if isLinux; then
+    # 6.7GB
+    sudo rm -rf /opt/ghc
+    # 16GB
+    sudo rm -rf /usr/share/dotnet
+fi

--- a/src/libcore/alloc.rs
+++ b/src/libcore/alloc.rs
@@ -241,11 +241,13 @@ impl Layout {
     #[unstable(feature = "alloc_layout_extra", issue = "55724")]
     #[inline]
     pub fn repeat(&self, n: usize) -> Result<(Self, usize), LayoutErr> {
-        // This cannot overflow. Quoting from the invariant of Layout:
-        // > `size`, when rounded up to the nearest multiple of `align`,
-        // > must not overflow (i.e., the rounded value must be less than
-        // > `usize::MAX`)
-        let padded_size = self.size() + self.padding_needed_for(self.align());
+        // Warning, removing the checked_add here led to segfaults in #67174. Further
+        // analysis in #69225 seems to indicate that this is an LTO-related
+        // miscompilation, so #67174 might be able to be reapplied in the future.
+        let padded_size = self
+            .size()
+            .checked_add(self.padding_needed_for(self.align()))
+            .ok_or(LayoutErr { private: () })?;
         let alloc_size = padded_size.checked_mul(n).ok_or(LayoutErr { private: () })?;
 
         unsafe {

--- a/src/librustc/hir/map/hir_id_validator.rs
+++ b/src/librustc/hir/map/hir_id_validator.rs
@@ -7,7 +7,7 @@ use rustc_hir::intravisit;
 use rustc_hir::itemlikevisit::ItemLikeVisitor;
 use rustc_hir::{HirId, ItemLocalId};
 
-pub fn check_crate(hir_map: &Map<'_>) {
+pub fn check_crate(hir_map: &Map<'_>, sess: &rustc_session::Session) {
     hir_map.dep_graph.assert_ignored();
 
     let errors = Lock::new(Vec::new());
@@ -24,7 +24,7 @@ pub fn check_crate(hir_map: &Map<'_>) {
 
     if !errors.is_empty() {
         let message = errors.iter().fold(String::new(), |s1, s2| s1 + "\n" + s2);
-        bug!("{}", message);
+        sess.delay_span_bug(rustc_span::DUMMY_SP, &message);
     }
 }
 

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -1271,7 +1271,7 @@ pub fn map_crate<'hir>(
     };
 
     sess.time("validate_HIR_map", || {
-        hir_id_validator::check_crate(&map);
+        hir_id_validator::check_crate(&map, sess);
     });
 
     map

--- a/src/librustc_mir/borrow_check/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/type_check/mod.rs
@@ -467,33 +467,6 @@ impl<'a, 'b, 'tcx> TypeVerifier<'a, 'b, 'tcx> {
 
         let mut place_ty = PlaceTy::from_ty(self.body.local_decls[place.local].ty);
 
-        if place.projection.is_empty() {
-            if let PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy) = context {
-                let tcx = self.tcx();
-                let trait_ref = ty::TraitRef {
-                    def_id: tcx.lang_items().copy_trait().unwrap(),
-                    substs: tcx.mk_substs_trait(place_ty.ty, &[]),
-                };
-
-                // To have a `Copy` operand, the type `T` of the
-                // value must be `Copy`. Note that we prove that `T: Copy`,
-                // rather than using the `is_copy_modulo_regions`
-                // test. This is important because
-                // `is_copy_modulo_regions` ignores the resulting region
-                // obligations and assumes they pass. This can result in
-                // bounds from `Copy` impls being unsoundly ignored (e.g.,
-                // #29149). Note that we decide to use `Copy` before knowing
-                // whether the bounds fully apply: in effect, the rule is
-                // that if a value of some type could implement `Copy`, then
-                // it must.
-                self.cx.prove_trait_ref(
-                    trait_ref,
-                    location.to_locations(),
-                    ConstraintCategory::CopyBound,
-                );
-            }
-        }
-
         for elem in place.projection.iter() {
             if place_ty.variant_index.is_none() {
                 if place_ty.ty.references_error() {
@@ -502,6 +475,31 @@ impl<'a, 'b, 'tcx> TypeVerifier<'a, 'b, 'tcx> {
                 }
             }
             place_ty = self.sanitize_projection(place_ty, elem, place, location)
+        }
+
+        if let PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy) = context {
+            let tcx = self.tcx();
+            let trait_ref = ty::TraitRef {
+                def_id: tcx.lang_items().copy_trait().unwrap(),
+                substs: tcx.mk_substs_trait(place_ty.ty, &[]),
+            };
+
+            // To have a `Copy` operand, the type `T` of the
+            // value must be `Copy`. Note that we prove that `T: Copy`,
+            // rather than using the `is_copy_modulo_regions`
+            // test. This is important because
+            // `is_copy_modulo_regions` ignores the resulting region
+            // obligations and assumes they pass. This can result in
+            // bounds from `Copy` impls being unsoundly ignored (e.g.,
+            // #29149). Note that we decide to use `Copy` before knowing
+            // whether the bounds fully apply: in effect, the rule is
+            // that if a value of some type could implement `Copy`, then
+            // it must.
+            self.cx.prove_trait_ref(
+                trait_ref,
+                location.to_locations(),
+                ConstraintCategory::CopyBound,
+            );
         }
 
         place_ty

--- a/src/librustc_mir/borrow_check/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/type_check/mod.rs
@@ -310,6 +310,7 @@ impl<'a, 'b, 'tcx> Visitor<'tcx> for TypeVerifier<'a, 'b, 'tcx> {
                 );
             }
         } else {
+            let tcx = self.tcx();
             if let ty::ConstKind::Unevaluated(def_id, substs, promoted) = constant.literal.val {
                 if let Some(promoted) = promoted {
                     let check_err = |verifier: &mut TypeVerifier<'a, 'b, 'tcx>,
@@ -359,10 +360,23 @@ impl<'a, 'b, 'tcx> Visitor<'tcx> for TypeVerifier<'a, 'b, 'tcx> {
                         );
                     }
                 }
-            }
-            if let ty::FnDef(def_id, substs) = constant.literal.ty.kind {
-                let tcx = self.tcx();
+            } else if let Some(static_def_id) = constant.check_static_ptr(tcx) {
+                let unnormalized_ty = tcx.type_of(static_def_id);
+                let locations = location.to_locations();
+                let normalized_ty = self.cx.normalize(unnormalized_ty, locations);
+                let literal_ty = constant.literal.ty.builtin_deref(true).unwrap().ty;
 
+                if let Err(terr) = self.cx.eq_types(
+                    normalized_ty,
+                    literal_ty,
+                    locations,
+                    ConstraintCategory::Boring,
+                ) {
+                    span_mirbug!(self, constant, "bad static type {:?} ({:?})", constant, terr);
+                }
+            }
+
+            if let ty::FnDef(def_id, substs) = constant.literal.ty.kind {
                 let instantiated_predicates = tcx.predicates_of(def_id).instantiate(tcx, substs);
                 self.cx.normalize_and_prove_instantiated_predicates(
                     instantiated_predicates,

--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -19,6 +19,16 @@ declare_lint! {
 }
 
 declare_lint! {
+    pub CONFLICTING_REPR_HINTS,
+    Deny,
+    "conflicts between `#[repr(..)]` hints that were previously accepted and used in practice",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #68585 <https://github.com/rust-lang/rust/issues/68585>",
+        edition: None,
+    };
+}
+
+declare_lint! {
     pub META_VARIABLE_MISUSE,
     Allow,
     "possible meta-variable misuse at macro definition"
@@ -520,6 +530,7 @@ declare_lint_pass! {
         MACRO_USE_EXTERN_CRATE,
         MACRO_EXPANDED_MACRO_EXPORTS_ACCESSED_BY_ABSOLUTE_PATHS,
         ILL_FORMED_ATTRIBUTE_INPUT,
+        CONFLICTING_REPR_HINTS,
         META_VARIABLE_MISUSE,
         DEPRECATED_IN_FUTURE,
         AMBIGUOUS_ASSOCIATED_ITEMS,

--- a/src/test/ui/array-slice-vec/issue-69103-extra-binding-subslice.rs
+++ b/src/test/ui/array-slice-vec/issue-69103-extra-binding-subslice.rs
@@ -1,0 +1,18 @@
+// We used to not lower the extra `b @ ..` into `b @ _` which meant that no type
+// was registered for the binding `b` although it passed through resolve.
+// This resulted in an ICE (#69103).
+
+fn main() {
+    let [a @ .., b @ ..] = &mut [1, 2];
+    //~^ ERROR `..` can only be used once per slice pattern
+    b;
+
+    let [.., c @ ..] = [1, 2];
+    //~^ ERROR `..` can only be used once per slice pattern
+    c;
+
+    // This never ICEd, but let's make sure it won't regress either.
+    let (.., d @ ..) = (1, 2);
+    //~^ ERROR `..` patterns are not allowed here
+    d;
+}

--- a/src/test/ui/array-slice-vec/issue-69103-extra-binding-subslice.stderr
+++ b/src/test/ui/array-slice-vec/issue-69103-extra-binding-subslice.stderr
@@ -1,0 +1,26 @@
+error: `..` can only be used once per slice pattern
+  --> $DIR/issue-69103-extra-binding-subslice.rs:6:22
+   |
+LL |     let [a @ .., b @ ..] = &mut [1, 2];
+   |              --      ^^ can only be used once per slice pattern
+   |              |
+   |              previously used here
+
+error: `..` can only be used once per slice pattern
+  --> $DIR/issue-69103-extra-binding-subslice.rs:10:18
+   |
+LL |     let [.., c @ ..] = [1, 2];
+   |          --      ^^ can only be used once per slice pattern
+   |          |
+   |          previously used here
+
+error: `..` patterns are not allowed here
+  --> $DIR/issue-69103-extra-binding-subslice.rs:15:18
+   |
+LL |     let (.., d @ ..) = (1, 2);
+   |                  ^^
+   |
+   = note: only allowed in tuple, tuple struct, and slice patterns
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/conflicting-repr-hints.rs
+++ b/src/test/ui/conflicting-repr-hints.rs
@@ -11,11 +11,13 @@ enum B {
 }
 
 #[repr(C, u64)] //~ ERROR conflicting representation hints
+//~^ WARN this was previously accepted
 enum C {
     C,
 }
 
 #[repr(u32, u64)] //~ ERROR conflicting representation hints
+//~^ WARN this was previously accepted
 enum D {
     D,
 }

--- a/src/test/ui/conflicting-repr-hints.stderr
+++ b/src/test/ui/conflicting-repr-hints.stderr
@@ -3,45 +3,52 @@ error[E0566]: conflicting representation hints
    |
 LL | #[repr(C, u64)]
    |        ^  ^^^
+   |
+   = note: `#[deny(conflicting_repr_hints)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
 
 error[E0566]: conflicting representation hints
-  --> $DIR/conflicting-repr-hints.rs:18:8
+  --> $DIR/conflicting-repr-hints.rs:19:8
    |
 LL | #[repr(u32, u64)]
    |        ^^^  ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
 
 error[E0587]: type has conflicting packed and align representation hints
-  --> $DIR/conflicting-repr-hints.rs:27:1
+  --> $DIR/conflicting-repr-hints.rs:29:1
    |
 LL | struct F(i32);
    | ^^^^^^^^^^^^^^
 
 error[E0587]: type has conflicting packed and align representation hints
-  --> $DIR/conflicting-repr-hints.rs:31:1
+  --> $DIR/conflicting-repr-hints.rs:33:1
    |
 LL | struct G(i32);
    | ^^^^^^^^^^^^^^
 
 error[E0587]: type has conflicting packed and align representation hints
-  --> $DIR/conflicting-repr-hints.rs:35:1
+  --> $DIR/conflicting-repr-hints.rs:37:1
    |
 LL | struct H(i32);
    | ^^^^^^^^^^^^^^
 
 error[E0634]: type has conflicting packed representation hints
-  --> $DIR/conflicting-repr-hints.rs:38:1
+  --> $DIR/conflicting-repr-hints.rs:40:1
    |
 LL | struct I(i32);
    | ^^^^^^^^^^^^^^
 
 error[E0634]: type has conflicting packed representation hints
-  --> $DIR/conflicting-repr-hints.rs:42:1
+  --> $DIR/conflicting-repr-hints.rs:44:1
    |
 LL | struct J(i32);
    | ^^^^^^^^^^^^^^
 
 error[E0587]: type has conflicting packed and align representation hints
-  --> $DIR/conflicting-repr-hints.rs:48:1
+  --> $DIR/conflicting-repr-hints.rs:50:1
    |
 LL | / union X {
 LL | |
@@ -50,7 +57,7 @@ LL | | }
    | |_^
 
 error[E0587]: type has conflicting packed and align representation hints
-  --> $DIR/conflicting-repr-hints.rs:55:1
+  --> $DIR/conflicting-repr-hints.rs:57:1
    |
 LL | / union Y {
 LL | |
@@ -59,7 +66,7 @@ LL | | }
    | |_^
 
 error[E0587]: type has conflicting packed and align representation hints
-  --> $DIR/conflicting-repr-hints.rs:62:1
+  --> $DIR/conflicting-repr-hints.rs:64:1
    |
 LL | / union Z {
 LL | |

--- a/src/test/ui/feature-gates/feature-gate-repr-simd.rs
+++ b/src/test/ui/feature-gates/feature-gate-repr-simd.rs
@@ -2,6 +2,7 @@
 struct Foo(u64, u64);
 
 #[repr(C)] //~ ERROR conflicting representation hints
+//~^ WARN this was previously accepted
 #[repr(simd)] //~ error: SIMD types are experimental
 struct Bar(u64, u64);
 

--- a/src/test/ui/feature-gates/feature-gate-repr-simd.stderr
+++ b/src/test/ui/feature-gates/feature-gate-repr-simd.stderr
@@ -8,7 +8,7 @@ LL | #[repr(simd)]
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable
 
 error[E0658]: SIMD types are experimental and possibly buggy
-  --> $DIR/feature-gate-repr-simd.rs:5:1
+  --> $DIR/feature-gate-repr-simd.rs:6:1
    |
 LL | #[repr(simd)]
    | ^^^^^^^^^^^^^
@@ -21,8 +21,13 @@ error[E0566]: conflicting representation hints
    |
 LL | #[repr(C)]
    |        ^
+LL |
 LL | #[repr(simd)]
    |        ^^^^
+   |
+   = note: `#[deny(conflicting_repr_hints)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/generator/async-generator-issue-67158.rs
+++ b/src/test/ui/generator/async-generator-issue-67158.rs
@@ -1,0 +1,6 @@
+#![feature(generators)]
+// edition:2018
+// Regression test for #67158.
+fn main() {
+    async { yield print!(":C") }; //~ ERROR `async` generators are not yet supported
+}

--- a/src/test/ui/generator/async-generator-issue-67158.stderr
+++ b/src/test/ui/generator/async-generator-issue-67158.stderr
@@ -1,0 +1,9 @@
+error[E0727]: `async` generators are not yet supported
+  --> $DIR/async-generator-issue-67158.rs:5:13
+   |
+LL |     async { yield print!(":C") };
+   |             ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0727`.

--- a/src/test/ui/generator/async-generator-issue-67158.stderr
+++ b/src/test/ui/generator/async-generator-issue-67158.stderr
@@ -6,4 +6,3 @@ LL |     async { yield print!(":C") };
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0727`.

--- a/src/test/ui/issues/issue-47094.rs
+++ b/src/test/ui/issues/issue-47094.rs
@@ -1,10 +1,12 @@
 #[repr(C, u8)] //~ ERROR conflicting representation hints
+//~^ WARN this was previously accepted
 enum Foo {
     A,
     B,
 }
 
 #[repr(C)] //~ ERROR conflicting representation hints
+//~^ WARN this was previously accepted
 #[repr(u8)]
 enum Bar {
     A,

--- a/src/test/ui/issues/issue-47094.stderr
+++ b/src/test/ui/issues/issue-47094.stderr
@@ -3,14 +3,22 @@ error[E0566]: conflicting representation hints
    |
 LL | #[repr(C, u8)]
    |        ^  ^^
+   |
+   = note: `#[deny(conflicting_repr_hints)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
 
 error[E0566]: conflicting representation hints
-  --> $DIR/issue-47094.rs:7:8
+  --> $DIR/issue-47094.rs:8:8
    |
 LL | #[repr(C)]
    |        ^
+LL |
 LL | #[repr(u8)]
    |        ^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-69225-layout-repeated-checked-add.rs
+++ b/src/test/ui/issues/issue-69225-layout-repeated-checked-add.rs
@@ -1,0 +1,31 @@
+// Ensure we appropriately error instead of overflowing a calculation when creating a new Alloc
+// Layout
+
+// run-fail
+// compile-flags: -C opt-level=3
+// error-pattern: index out of bounds: the len is 0 but the index is 16777216
+// ignore-wasm no panic or subprocess support
+// ignore-emscripten no panic or subprocess support
+
+fn do_test(x: usize) {
+    let arr = vec![vec![0u8; 3]];
+
+    let mut z = Vec::new();
+    for arr_ref in arr {
+        for y in 0..x {
+            for _ in 0..1 {
+                z.extend(std::iter::repeat(0).take(x));
+                let a = y * x;
+                let b = (y + 1) * x - 1;
+                let slice = &arr_ref[a..b];
+                eprintln!("{} {} {} {}", a, b, arr_ref.len(), slice.len());
+                eprintln!("{:?}", slice[1 << 24]);
+            }
+        }
+    }
+}
+
+fn main() {
+    do_test(1);
+    do_test(2);
+}

--- a/src/test/ui/nll/do-not-ignore-lifetime-bounds-in-copy-proj.rs
+++ b/src/test/ui/nll/do-not-ignore-lifetime-bounds-in-copy-proj.rs
@@ -1,0 +1,12 @@
+// Test that the 'static bound from the Copy impl is respected. Regression test for #29149.
+
+#[derive(Clone)]
+struct Foo<'a>(&'a u32);
+impl Copy for Foo<'static> {}
+
+fn main() {
+    let s = 2;
+    let a = (Foo(&s),); //~ ERROR `s` does not live long enough [E0597]
+    drop(a.0);
+    drop(a.0);
+}

--- a/src/test/ui/nll/do-not-ignore-lifetime-bounds-in-copy-proj.stderr
+++ b/src/test/ui/nll/do-not-ignore-lifetime-bounds-in-copy-proj.stderr
@@ -1,0 +1,14 @@
+error[E0597]: `s` does not live long enough
+  --> $DIR/do-not-ignore-lifetime-bounds-in-copy-proj.rs:9:18
+   |
+LL |     let a = (Foo(&s),);
+   |                  ^^ borrowed value does not live long enough
+LL |     drop(a.0);
+   |          --- copying this value requires that `s` is borrowed for `'static`
+LL |     drop(a.0);
+LL | }
+   | - `s` dropped here while still borrowed
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/nll/issue-69114-static-mut-ty.rs
+++ b/src/test/ui/nll/issue-69114-static-mut-ty.rs
@@ -1,0 +1,30 @@
+// Check that borrowck ensures that `static mut` items have the expected type.
+
+static FOO: u8 = 42;
+static mut BAR: &'static u8 = &FOO;
+static mut BAR_ELIDED: &u8 = &FOO;
+
+fn main() {
+    unsafe {
+        println!("{} {}", BAR, BAR_ELIDED);
+        set_bar();
+        set_bar_elided();
+        println!("{} {}", BAR, BAR_ELIDED);
+    }
+}
+
+fn set_bar() {
+    let n = 42;
+    unsafe {
+        BAR = &n;
+        //~^ ERROR does not live long enough
+    }
+}
+
+fn set_bar_elided() {
+    let n = 42;
+    unsafe {
+        BAR_ELIDED = &n;
+        //~^ ERROR does not live long enough
+    }
+}

--- a/src/test/ui/nll/issue-69114-static-mut-ty.stderr
+++ b/src/test/ui/nll/issue-69114-static-mut-ty.stderr
@@ -1,0 +1,27 @@
+error[E0597]: `n` does not live long enough
+  --> $DIR/issue-69114-static-mut-ty.rs:19:15
+   |
+LL |         BAR = &n;
+   |         ------^^
+   |         |     |
+   |         |     borrowed value does not live long enough
+   |         assignment requires that `n` is borrowed for `'static`
+...
+LL | }
+   | - `n` dropped here while still borrowed
+
+error[E0597]: `n` does not live long enough
+  --> $DIR/issue-69114-static-mut-ty.rs:27:22
+   |
+LL |         BAR_ELIDED = &n;
+   |         -------------^^
+   |         |            |
+   |         |            borrowed value does not live long enough
+   |         assignment requires that `n` is borrowed for `'static`
+...
+LL | }
+   | - `n` dropped here while still borrowed
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/nll/issue-69114-static-ty.rs
+++ b/src/test/ui/nll/issue-69114-static-ty.rs
@@ -1,0 +1,9 @@
+// Check that borrowck ensures that `static` items have the expected type.
+
+static FOO: &'static (dyn Fn(&'static u8) + Send + Sync) = &drop;
+
+fn main() {
+    let n = 42;
+    FOO(&n);
+    //~^ ERROR does not live long enough
+}

--- a/src/test/ui/nll/issue-69114-static-ty.stderr
+++ b/src/test/ui/nll/issue-69114-static-ty.stderr
@@ -1,0 +1,15 @@
+error[E0597]: `n` does not live long enough
+  --> $DIR/issue-69114-static-ty.rs:7:9
+   |
+LL |     FOO(&n);
+   |     ----^^-
+   |     |   |
+   |     |   borrowed value does not live long enough
+   |     argument requires that `n` is borrowed for `'static`
+LL |
+LL | }
+   | - `n` dropped here while still borrowed
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.


### PR DESCRIPTION
This backports the following PRs:

* Revert "Remove `checked_add` in `Layout::repeat`" #69241 
* Do not ICE when encountering `yield` inside `async` block #69175 
* Fix MIR typeck soundness holes #69145 
* Fix extra subslice lowering #69128 
* Correct ICE caused by macros generating invalid spans. #68611 
* Make conflicting_repr_hints a deny-by-default c-future-compat lint #68586 