### PR TITLE
Stabilize most common subset of alloc_layout_extras

### DIFF
--- a/src/libcore/alloc/layout.rs
+++ b/src/libcore/alloc/layout.rs
@@ -274,7 +274,8 @@ impl Layout {
     ///
     /// # Examples
     ///
-    /// To calculate the layout of a `#[repr(C)]` structure from its fields' layouts:
+    /// To calculate the layout of a `#[repr(C)]` structure and the offsets of
+    /// the fields from its fields' layouts:
     ///
     /// ```rust
     /// # use std::alloc::{Layout, LayoutErr};
@@ -286,6 +287,7 @@ impl Layout {
     ///         layout = new_layout;
     ///         offsets.push(offset);
     ///     }
+    ///     // Remember to finalize with `pad_to_align`!
     ///     Ok((layout.pad_to_align(), offsets))
     /// }
     /// # // test that it works

--- a/src/libcore/alloc/layout.rs
+++ b/src/libcore/alloc/layout.rs
@@ -258,7 +258,7 @@ impl Layout {
 
     /// Creates a layout describing the record for `self` followed by
     /// `next`, including any necessary padding to ensure that `next`
-    /// will be properly aligned, but no trailing padding. Note that
+    /// will be properly aligned, but *no trailing padding*. Note that
     /// the resulting layout will satisfy the alignment properties of
     /// both `self` and `next`, in order to ensure field alignment.
     ///

--- a/src/libcore/alloc/layout.rs
+++ b/src/libcore/alloc/layout.rs
@@ -258,9 +258,10 @@ impl Layout {
 
     /// Creates a layout describing the record for `self` followed by
     /// `next`, including any necessary padding to ensure that `next`
-    /// will be properly aligned, but *no trailing padding*. In order
-    /// to match C representation layout `repr(C)`, you should call
-    /// `pad_to_align` after extending the layout with all fields.
+    /// will be properly aligned, but *no trailing padding*.
+    ///
+    /// In order to match C representation layout `repr(C)`, you should
+    /// call `pad_to_align` after extending the layout with all fields.
     /// (There is no way to match the default Rust representation
     /// layout `repr(Rust)`, as it is unspecified.)
     ///

--- a/src/libcore/alloc/layout.rs
+++ b/src/libcore/alloc/layout.rs
@@ -264,8 +264,8 @@ impl Layout {
     /// (There is no way to match the default Rust representation
     /// layout `repr(Rust)`, as it is unspecified.)
     ///
-    /// Note that the resulting layout will satisfy the alignment properties
-    /// of both `self` and `next`, in order to ensure alignment of both parts.
+    /// Note that the alignment of the resulting layout will be the maximum of
+    /// those of `self` and `next`, in order to ensure alignment of both parts.
     ///
     /// Returns `Ok((k, offset))`, where `k` is layout of the concatenated
     /// record and `offset` is the relative location, in bytes, of the

--- a/src/libcore/alloc/layout.rs
+++ b/src/libcore/alloc/layout.rs
@@ -258,9 +258,11 @@ impl Layout {
 
     /// Creates a layout describing the record for `self` followed by
     /// `next`, including any necessary padding to ensure that `next`
-    /// will be properly aligned, but *no trailing padding*. In order to
-    /// match C representation layout, you should call `pad_to_align`
-    /// after extending the layout with all fields.
+    /// will be properly aligned, but *no trailing padding*. In order
+    /// to match C representation layout `repr(C)`, you should call
+    /// `pad_to_align` after extending the layout with all fields.
+    /// (There is no way to match the default Rust representation
+    /// layout `repr(Rust)`, as it is unspecified.)
     ///
     /// Note that the resulting layout will satisfy the alignment properties
     /// of both `self` and `next`, in order to ensure alignment of both parts.


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/55724

Specifically, this stabilizes:

```rust
pub fn Layout::align_to(&self, align: usize) -> Result<Layout, LayoutErr>;
pub fn Layout::pad_to_align(&self) -> Layout;
pub fn Layout::extend(&self, next: Layout) -> Result<(Layout, usize), LayoutErr>;
pub fn Layout::array<T>(n: usize) -> Result<Layout, LayoutErr>;
```

Methods that are tracked by #55724 but are not stabilized here:

```rust
pub fn Layout::padding_needed_for(&self, align: usize) -> usize;
pub fn Layout::repeat(&self, n: usize) -> Result<(Layout, usize), LayoutErr>;
pub fn Layout::repeat_packed(&self, n: usize) -> Result<Layout, LayoutErr>;
pub fn Layout::extend_packed(&self, next: Layout) -> Result<Layout, LayoutErr>;
```

Combined, these stabilized functions allow code to construct and manipulate `repr(C)` layouts while letting the standard library handle correctness in the face of edge cases. For example use cases, consider the usage in [hashbrown](https://github.com/Amanieu/hashbrown/blob/2f2af1d/src/raw/mod.rs#L143), [crossbeam-skiplist](https://github.com/crossbeam-rs/crossbeam-skiplist/blob/master/src/base.rs#L99), [pointer-utils/slice-dst](https://github.com/CAD97/pointer-utils/blob/92aeefeed9399f28d1b1654b63f8dcbe1242d8d4/crates/slice-dst/src/layout_polyfill.rs), and of course the standard library itself.

Providing a higher-level API such as `Layout::repr_c<const N: usize>(fields: [Layout; N]) -> Result<(Layout, [usize; N]), LayoutErr>` is blocked on const generics, which are a ways off. Providing an API that doesn't provide offsets would be quite suboptimal, as the reason for calculating the layout like this rather than `Layout::new` is to get the field offsets.

The primary issue with the current API is having to call `.pad_to_align()` to match the layout of a `repr(C)` struct. However, I think this is not just a (failing? limitation?) of the API, but rather intrinsic complexity. While all Rust-defined types have size==stride, and probably will for the foreseeable future, there is no inherent reason why this is a limitation of all allocations. As such, the `Layout` manipulation APIs shouldn't impose this limitation, and instead the higher level api of `repr_c` (or just plain old using `Layout::new`) can make keeping it simple.

cc @matklad r? @rust-lang/libs 