### PR TITLE
Accept `Enum::<Param>::Variant {}` over `Enum::Variant::<Param> {}`

### DIFF
--- a/src/librustc_ast_lowering/lib.rs
+++ b/src/librustc_ast_lowering/lib.rs
@@ -1977,6 +1977,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             args: &[],
             bindings: arena_vec![self; self.output_ty_binding(span, output_ty)],
             parenthesized: false,
+            span,
         });
 
         // ::std::future::Future<future_params>
@@ -2655,11 +2656,12 @@ impl<'hir> GenericArgsCtor<'hir> {
         self.args.is_empty() && self.bindings.is_empty() && !self.parenthesized
     }
 
-    fn into_generic_args(self, arena: &'hir Arena<'hir>) -> hir::GenericArgs<'hir> {
+    fn into_generic_args(self, arena: &'hir Arena<'hir>, span: Span) -> hir::GenericArgs<'hir> {
         hir::GenericArgs {
             args: arena.alloc_from_iter(self.args),
             bindings: self.bindings,
             parenthesized: self.parenthesized,
+            span,
         }
     }
 }

--- a/src/librustc_ast_lowering/path.rs
+++ b/src/librustc_ast_lowering/path.rs
@@ -360,7 +360,8 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             segment.ident, segment.id, id,
         );
 
-        let param_span = path_span.with_lo(segment.ident.span.shrink_to_hi().lo());
+        let param_sp =
+            segment.args.as_ref().map_or(segment.ident.span.shrink_to_hi(), |args| args.span());
         hir::PathSegment {
             ident: segment.ident,
             hir_id: Some(id),
@@ -369,7 +370,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             args: if generic_args.is_empty() {
                 None
             } else {
-                Some(self.arena.alloc(generic_args.into_generic_args(self.arena, param_span)))
+                Some(self.arena.alloc(generic_args.into_generic_args(self.arena, param_sp)))
             },
         }
     }

--- a/src/librustc_ast_lowering/path.rs
+++ b/src/librustc_ast_lowering/path.rs
@@ -360,6 +360,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             segment.ident, segment.id, id,
         );
 
+        let param_span = path_span.with_lo(segment.ident.span.shrink_to_hi().lo());
         hir::PathSegment {
             ident: segment.ident,
             hir_id: Some(id),
@@ -368,7 +369,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             args: if generic_args.is_empty() {
                 None
             } else {
-                Some(self.arena.alloc(generic_args.into_generic_args(self.arena)))
+                Some(self.arena.alloc(generic_args.into_generic_args(self.arena, param_span)))
             },
         }
     }

--- a/src/librustc_error_codes/error_codes/E0109.md
+++ b/src/librustc_error_codes/error_codes/E0109.md
@@ -17,6 +17,6 @@ type X = u32; // ok!
 type Y = bool; // ok!
 ```
 
-Note that generic arguments for enum variant constructors go after the variant,
-not after the enum. For example, you would write `Option::None::<u32>`,
-rather than `Option::<u32>::None`.
+Note that generic arguments for enum variant constructors can go after the
+variant or after the enum. For example, you can write `Option::None::<u32>`,
+rather than `Option::<u32>::None`, but the later style is preferred.

--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -311,11 +311,13 @@ pub struct GenericArgs<'hir> {
     /// This is required mostly for pretty-printing and diagnostics,
     /// but also for changing lifetime elision rules to be "function-like".
     pub parenthesized: bool,
+    /// The `Span` encompassing the entirety of the parameters `<A, B>` or `(A, B)`.
+    pub span: Span,
 }
 
 impl GenericArgs<'_> {
     pub const fn none() -> Self {
-        Self { args: &[], bindings: &[], parenthesized: false }
+        Self { args: &[], bindings: &[], parenthesized: false, span: DUMMY_SP }
     }
 
     pub fn is_empty(&self) -> bool {

--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -257,6 +257,13 @@ declare_lint! {
 }
 
 declare_lint! {
+    pub TYPE_PARAM_ON_VARIANT_CTOR,
+    Warn,
+    "detects generic arguments in path segments corresponding to an enum variant instead of the \
+     enum itself",
+}
+
+declare_lint! {
     pub ORDER_DEPENDENT_TRAIT_OBJECTS,
     Deny,
     "trait-object types were treated as different depending on marker-trait order",
@@ -531,6 +538,7 @@ declare_lint_pass! {
         PATTERNS_IN_FNS_WITHOUT_BODY,
         MISSING_FRAGMENT_SPECIFIER,
         LATE_BOUND_LIFETIME_ARGUMENTS,
+        TYPE_PARAM_ON_VARIANT_CTOR,
         ORDER_DEPENDENT_TRAIT_OBJECTS,
         COHERENCE_LEAK_CHECK,
         DEPRECATED,

--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -258,7 +258,7 @@ declare_lint! {
 
 declare_lint! {
     pub TYPE_PARAM_ON_VARIANT_CTOR,
-    Warn,
+    Allow,
     "detects generic arguments in path segments corresponding to an enum variant instead of the \
      enum itself",
 }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -87,7 +87,7 @@ mod upvar;
 mod wfcheck;
 pub mod writeback;
 
-use crate::astconv::{AstConv, PathSeg};
+use crate::astconv::{AstConv, GenericArgPosition, PathSeg};
 use crate::middle::lang_items;
 use rustc::hir::map::blocks::FnLikeNode;
 use rustc::hir::map::Map;
@@ -2787,6 +2787,7 @@ impl<'a, 'tcx> AstConv<'tcx> for FnCtxt<'a, 'tcx> {
             item_def_id,
             item_segment,
             trait_ref.substs,
+            GenericArgPosition::Type,
         );
 
         self.tcx().mk_projection(item_def_id, item_substs)
@@ -4381,7 +4382,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         match *qpath {
             QPath::Resolved(ref maybe_qself, ref path) => {
                 let self_ty = maybe_qself.as_ref().map(|qself| self.to_ty(qself));
-                let ty = AstConv::res_to_ty(self, self_ty, path, true);
+                let ty = AstConv::res_to_ty(self, self_ty, path, GenericArgPosition::Value);
                 (path.res, ty)
             }
             QPath::TypeRelative(ref qself, ref segment) => {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -14,7 +14,7 @@
 //! At present, however, we do run collection across all items in the
 //! crate as a kind of pass. This should eventually be factored away.
 
-use crate::astconv::{AstConv, Bounds, SizedByDefault};
+use crate::astconv::{AstConv, Bounds, GenericArgPosition, SizedByDefault};
 use crate::check::intrinsic::intrinsic_operation_unsafety;
 use crate::constrained_generic_params as cgp;
 use crate::lint;
@@ -349,6 +349,7 @@ impl AstConv<'tcx> for ItemCtxt<'tcx> {
                 item_def_id,
                 item_segment,
                 trait_ref.substs,
+                GenericArgPosition::Type,
             );
             self.tcx().mk_projection(item_def_id, item_substs)
         } else {

--- a/src/test/ui/binding/simple-generic-match.rs
+++ b/src/test/ui/binding/simple-generic-match.rs
@@ -1,5 +1,5 @@
 // run-pass
-#![allow(non_camel_case_types)]
+#![allow(non_camel_case_types, type_param_on_variant_ctor)]
 
 // pretty-expanded FIXME #23616
 

--- a/src/test/ui/binding/use-uninit-match.rs
+++ b/src/test/ui/binding/use-uninit-match.rs
@@ -1,13 +1,15 @@
 // run-pass
-#![allow(dead_code)]
-#![allow(non_camel_case_types)]
-
+#![allow(dead_code, non_camel_case_types, type_param_on_variant_ctor)]
 
 fn foo<T>(o: myoption<T>) -> isize {
     let mut x: isize = 5;
     match o {
         myoption::none::<T> => { }
-        myoption::some::<T>(_t) => { x += 1; }
+        myoption::some::<T>(_) => { x += 1; }
+    }
+    match o {
+        myoption::<T>::none => { }
+        myoption::<T>::some(_t) => { x += 1; }
     }
     return x;
 }

--- a/src/test/ui/binding/use-uninit-match2.rs
+++ b/src/test/ui/binding/use-uninit-match2.rs
@@ -1,14 +1,17 @@
 // run-pass
-#![allow(dead_code)]
-#![allow(unused_mut)]
-#![allow(non_camel_case_types)]
+#![allow(dead_code, unused_mut, non_camel_case_types, type_param_on_variant_ctor)]
 
 
 fn foo<T>(o: myoption<T>) -> isize {
     let mut x: isize;
     match o {
         myoption::none::<T> => { panic!(); }
-        myoption::some::<T>(_t) => { x = 5; }
+        myoption::some::<T>(_) => { x = 5; }
+    }
+    let _ = x;
+    match o {
+        myoption::<T>::none => { panic!(); }
+        myoption::<T>::some(_t) => { x = 5; }
     }
     return x;
 }

--- a/src/test/ui/constructor-lifetime-args.rs
+++ b/src/test/ui/constructor-lifetime-args.rs
@@ -21,6 +21,12 @@ fn main() {
     E::V(&0); // OK
     E::V::<'static>(&0);
     //~^ ERROR wrong number of lifetime arguments: expected 2, found 1
+    //~| WARNING type parameter on variant
     E::V::<'static, 'static, 'static>(&0);
+    //~^ ERROR wrong number of lifetime arguments: expected 2, found 3
+    //~| WARNING type parameter on variant
+    E::<'static>::V(&0);
+    //~^ ERROR wrong number of lifetime arguments: expected 2, found 1
+    E::<'static, 'static, 'static>::V(&0);
     //~^ ERROR wrong number of lifetime arguments: expected 2, found 3
 }

--- a/src/test/ui/constructor-lifetime-args.rs
+++ b/src/test/ui/constructor-lifetime-args.rs
@@ -1,3 +1,4 @@
+#![deny(type_param_on_variant_ctor)]
 // All lifetime parameters in struct constructors are currently considered early bound,
 // i.e., `S::<ARGS>` is interpreted kinda like an associated item `S::<ARGS>::ctor`.
 // This behavior is a bit weird, because if equivalent constructor were written manually
@@ -21,10 +22,10 @@ fn main() {
     E::V(&0); // OK
     E::V::<'static>(&0);
     //~^ ERROR wrong number of lifetime arguments: expected 2, found 1
-    //~| WARNING type parameter on variant
+    //~| ERROR type parameter on variant
     E::V::<'static, 'static, 'static>(&0);
     //~^ ERROR wrong number of lifetime arguments: expected 2, found 3
-    //~| WARNING type parameter on variant
+    //~| ERROR type parameter on variant
     E::<'static>::V(&0);
     //~^ ERROR wrong number of lifetime arguments: expected 2, found 1
     E::<'static, 'static, 'static>::V(&0);

--- a/src/test/ui/constructor-lifetime-args.stderr
+++ b/src/test/ui/constructor-lifetime-args.stderr
@@ -10,18 +10,53 @@ error[E0107]: wrong number of lifetime arguments: expected 2, found 3
 LL |     S::<'static, 'static, 'static>(&0, &0);
    |                           ^^^^^^^ unexpected lifetime argument
 
+warning: type parameter on variant
+  --> $DIR/constructor-lifetime-args.rs:22:9
+   |
+LL |     E::V::<'static>(&0);
+   |         ^^^^^^^^^^^
+   |
+   = note: `#[warn(type_param_on_variant_ctor)]` on by default
+help: set the type parameter on the enum
+   |
+LL |     E::<'static>::V(&0);
+   |      ^^^^^^^^^^^  --
+
 error[E0107]: wrong number of lifetime arguments: expected 2, found 1
   --> $DIR/constructor-lifetime-args.rs:22:5
    |
 LL |     E::V::<'static>(&0);
    |     ^^^^^^^^^^^^^^^ expected 2 lifetime arguments
 
+warning: type parameter on variant
+  --> $DIR/constructor-lifetime-args.rs:25:9
+   |
+LL |     E::V::<'static, 'static, 'static>(&0);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: set the type parameter on the enum
+   |
+LL |     E::<'static, 'static, 'static>::V(&0);
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  --
+
 error[E0107]: wrong number of lifetime arguments: expected 2, found 3
-  --> $DIR/constructor-lifetime-args.rs:24:30
+  --> $DIR/constructor-lifetime-args.rs:25:30
    |
 LL |     E::V::<'static, 'static, 'static>(&0);
    |                              ^^^^^^^ unexpected lifetime argument
 
-error: aborting due to 4 previous errors
+error[E0107]: wrong number of lifetime arguments: expected 2, found 1
+  --> $DIR/constructor-lifetime-args.rs:28:5
+   |
+LL |     E::<'static>::V(&0);
+   |     ^^^^^^^^^^^^^^^ expected 2 lifetime arguments
+
+error[E0107]: wrong number of lifetime arguments: expected 2, found 3
+  --> $DIR/constructor-lifetime-args.rs:30:27
+   |
+LL |     E::<'static, 'static, 'static>::V(&0);
+   |                           ^^^^^^^ unexpected lifetime argument
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0107`.

--- a/src/test/ui/constructor-lifetime-args.stderr
+++ b/src/test/ui/constructor-lifetime-args.stderr
@@ -1,35 +1,39 @@
 error[E0107]: wrong number of lifetime arguments: expected 2, found 1
-  --> $DIR/constructor-lifetime-args.rs:17:5
+  --> $DIR/constructor-lifetime-args.rs:18:5
    |
 LL |     S::<'static>(&0, &0);
    |     ^^^^^^^^^^^^ expected 2 lifetime arguments
 
 error[E0107]: wrong number of lifetime arguments: expected 2, found 3
-  --> $DIR/constructor-lifetime-args.rs:19:27
+  --> $DIR/constructor-lifetime-args.rs:20:27
    |
 LL |     S::<'static, 'static, 'static>(&0, &0);
    |                           ^^^^^^^ unexpected lifetime argument
 
-warning: type parameter on variant
-  --> $DIR/constructor-lifetime-args.rs:22:11
+error: type parameter on variant
+  --> $DIR/constructor-lifetime-args.rs:23:11
    |
 LL |     E::V::<'static>(&0);
    |           ^^^^^^^^^
    |
-   = note: `#[warn(type_param_on_variant_ctor)]` on by default
+note: the lint level is defined here
+  --> $DIR/constructor-lifetime-args.rs:1:9
+   |
+LL | #![deny(type_param_on_variant_ctor)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: set the type parameter on the enum
    |
 LL |     E::<'static>::V(&0);
    |      ^^^^^^^^^^^  --
 
 error[E0107]: wrong number of lifetime arguments: expected 2, found 1
-  --> $DIR/constructor-lifetime-args.rs:22:5
+  --> $DIR/constructor-lifetime-args.rs:23:5
    |
 LL |     E::V::<'static>(&0);
    |     ^^^^^^^^^^^^^^^ expected 2 lifetime arguments
 
-warning: type parameter on variant
-  --> $DIR/constructor-lifetime-args.rs:25:11
+error: type parameter on variant
+  --> $DIR/constructor-lifetime-args.rs:26:11
    |
 LL |     E::V::<'static, 'static, 'static>(&0);
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -40,23 +44,23 @@ LL |     E::<'static, 'static, 'static>::V(&0);
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  --
 
 error[E0107]: wrong number of lifetime arguments: expected 2, found 3
-  --> $DIR/constructor-lifetime-args.rs:25:30
+  --> $DIR/constructor-lifetime-args.rs:26:30
    |
 LL |     E::V::<'static, 'static, 'static>(&0);
    |                              ^^^^^^^ unexpected lifetime argument
 
 error[E0107]: wrong number of lifetime arguments: expected 2, found 1
-  --> $DIR/constructor-lifetime-args.rs:28:5
+  --> $DIR/constructor-lifetime-args.rs:29:5
    |
 LL |     E::<'static>::V(&0);
    |     ^^^^^^^^^^^^^^^ expected 2 lifetime arguments
 
 error[E0107]: wrong number of lifetime arguments: expected 2, found 3
-  --> $DIR/constructor-lifetime-args.rs:30:27
+  --> $DIR/constructor-lifetime-args.rs:31:27
    |
 LL |     E::<'static, 'static, 'static>::V(&0);
    |                           ^^^^^^^ unexpected lifetime argument
 
-error: aborting due to 6 previous errors
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0107`.

--- a/src/test/ui/constructor-lifetime-args.stderr
+++ b/src/test/ui/constructor-lifetime-args.stderr
@@ -11,10 +11,10 @@ LL |     S::<'static, 'static, 'static>(&0, &0);
    |                           ^^^^^^^ unexpected lifetime argument
 
 warning: type parameter on variant
-  --> $DIR/constructor-lifetime-args.rs:22:9
+  --> $DIR/constructor-lifetime-args.rs:22:11
    |
 LL |     E::V::<'static>(&0);
-   |         ^^^^^^^^^^^
+   |           ^^^^^^^^^
    |
    = note: `#[warn(type_param_on_variant_ctor)]` on by default
 help: set the type parameter on the enum
@@ -29,10 +29,10 @@ LL |     E::V::<'static>(&0);
    |     ^^^^^^^^^^^^^^^ expected 2 lifetime arguments
 
 warning: type parameter on variant
-  --> $DIR/constructor-lifetime-args.rs:25:9
+  --> $DIR/constructor-lifetime-args.rs:25:11
    |
 LL |     E::V::<'static, 'static, 'static>(&0);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: set the type parameter on the enum
    |

--- a/src/test/ui/deriving/deriving-associated-types.rs
+++ b/src/test/ui/deriving/deriving-associated-types.rs
@@ -1,4 +1,5 @@
 // run-pass
+#![allow(type_param_on_variant_ctor)]
 pub trait DeclaredTrait {
     type Type;
 }

--- a/src/test/ui/deriving/deriving-clone-generic-enum.rs
+++ b/src/test/ui/deriving/deriving-clone-generic-enum.rs
@@ -1,5 +1,5 @@
 // run-pass
-#![allow(dead_code)]
+#![allow(dead_code, type_param_on_variant_ctor)]
 // pretty-expanded FIXME #23616
 
 #[derive(Clone)]

--- a/src/test/ui/dropck/dropck_no_diverge_on_nonregular_3.rs
+++ b/src/test/ui/dropck/dropck_no_diverge_on_nonregular_3.rs
@@ -33,4 +33,9 @@ fn main() {
         Some(Wrapper::Simple::<u32>);
     //~^ ERROR overflow while adding drop-check rules for std::option::Option
     //~| ERROR overflow while adding drop-check rules for Wrapper
+    //~| WARNING type parameter on variant
+    let v = //~ ERROR overflow while adding drop-check rules for std::option
+        Some(Wrapper::<u32>::Simple);
+    //~^ ERROR overflow while adding drop-check rules for std::option::Option
+    //~| ERROR overflow while adding drop-check rules for Wrapper
 }

--- a/src/test/ui/dropck/dropck_no_diverge_on_nonregular_3.rs
+++ b/src/test/ui/dropck/dropck_no_diverge_on_nonregular_3.rs
@@ -1,3 +1,4 @@
+#![warn(type_param_on_variant_ctor)]
 // Issue 22443: Reject code using non-regular types that would
 // otherwise cause dropck to loop infinitely.
 //

--- a/src/test/ui/dropck/dropck_no_diverge_on_nonregular_3.stderr
+++ b/src/test/ui/dropck/dropck_no_diverge_on_nonregular_3.stderr
@@ -1,3 +1,15 @@
+warning: type parameter on variant
+  --> $DIR/dropck_no_diverge_on_nonregular_3.rs:33:29
+   |
+LL |         Some(Wrapper::Simple::<u32>);
+   |                             ^^^^^^^
+   |
+   = note: `#[warn(type_param_on_variant_ctor)]` on by default
+help: set the type parameter on the enum
+   |
+LL |         Some(Wrapper::<u32>::Simple);
+   |                     ^^^^^^^       --
+
 error[E0320]: overflow while adding drop-check rules for std::option::Option<Wrapper<u32>>
   --> $DIR/dropck_no_diverge_on_nonregular_3.rs:32:9
    |
@@ -22,5 +34,29 @@ LL |         Some(Wrapper::Simple::<u32>);
    |
    = note: overflowed on FingerTree<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<u32>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
-error: aborting due to 3 previous errors
+error[E0320]: overflow while adding drop-check rules for std::option::Option<Wrapper<u32>>
+  --> $DIR/dropck_no_diverge_on_nonregular_3.rs:37:9
+   |
+LL |     let v =
+   |         ^
+   |
+   = note: overflowed on FingerTree<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<u32>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+error[E0320]: overflow while adding drop-check rules for std::option::Option<Wrapper<u32>>
+  --> $DIR/dropck_no_diverge_on_nonregular_3.rs:38:9
+   |
+LL |         Some(Wrapper::<u32>::Simple);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: overflowed on FingerTree<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<u32>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+error[E0320]: overflow while adding drop-check rules for Wrapper<u32>
+  --> $DIR/dropck_no_diverge_on_nonregular_3.rs:38:14
+   |
+LL |         Some(Wrapper::<u32>::Simple);
+   |              ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: overflowed on FingerTree<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<u32>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/dropck/dropck_no_diverge_on_nonregular_3.stderr
+++ b/src/test/ui/dropck/dropck_no_diverge_on_nonregular_3.stderr
@@ -1,17 +1,21 @@
 warning: type parameter on variant
-  --> $DIR/dropck_no_diverge_on_nonregular_3.rs:33:31
+  --> $DIR/dropck_no_diverge_on_nonregular_3.rs:34:31
    |
 LL |         Some(Wrapper::Simple::<u32>);
    |                               ^^^^^
    |
-   = note: `#[warn(type_param_on_variant_ctor)]` on by default
+note: the lint level is defined here
+  --> $DIR/dropck_no_diverge_on_nonregular_3.rs:1:9
+   |
+LL | #![warn(type_param_on_variant_ctor)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: set the type parameter on the enum
    |
 LL |         Some(Wrapper::<u32>::Simple);
    |                     ^^^^^^^       --
 
 error[E0320]: overflow while adding drop-check rules for std::option::Option<Wrapper<u32>>
-  --> $DIR/dropck_no_diverge_on_nonregular_3.rs:32:9
+  --> $DIR/dropck_no_diverge_on_nonregular_3.rs:33:9
    |
 LL |     let w =
    |         ^
@@ -19,7 +23,7 @@ LL |     let w =
    = note: overflowed on FingerTree<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<u32>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 error[E0320]: overflow while adding drop-check rules for std::option::Option<Wrapper<u32>>
-  --> $DIR/dropck_no_diverge_on_nonregular_3.rs:33:9
+  --> $DIR/dropck_no_diverge_on_nonregular_3.rs:34:9
    |
 LL |         Some(Wrapper::Simple::<u32>);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -27,7 +31,7 @@ LL |         Some(Wrapper::Simple::<u32>);
    = note: overflowed on FingerTree<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<u32>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 error[E0320]: overflow while adding drop-check rules for Wrapper<u32>
-  --> $DIR/dropck_no_diverge_on_nonregular_3.rs:33:14
+  --> $DIR/dropck_no_diverge_on_nonregular_3.rs:34:14
    |
 LL |         Some(Wrapper::Simple::<u32>);
    |              ^^^^^^^^^^^^^^^^^^^^^^
@@ -35,7 +39,7 @@ LL |         Some(Wrapper::Simple::<u32>);
    = note: overflowed on FingerTree<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<u32>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 error[E0320]: overflow while adding drop-check rules for std::option::Option<Wrapper<u32>>
-  --> $DIR/dropck_no_diverge_on_nonregular_3.rs:37:9
+  --> $DIR/dropck_no_diverge_on_nonregular_3.rs:38:9
    |
 LL |     let v =
    |         ^
@@ -43,7 +47,7 @@ LL |     let v =
    = note: overflowed on FingerTree<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<u32>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 error[E0320]: overflow while adding drop-check rules for std::option::Option<Wrapper<u32>>
-  --> $DIR/dropck_no_diverge_on_nonregular_3.rs:38:9
+  --> $DIR/dropck_no_diverge_on_nonregular_3.rs:39:9
    |
 LL |         Some(Wrapper::<u32>::Simple);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -51,7 +55,7 @@ LL |         Some(Wrapper::<u32>::Simple);
    = note: overflowed on FingerTree<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<Node<u32>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 error[E0320]: overflow while adding drop-check rules for Wrapper<u32>
-  --> $DIR/dropck_no_diverge_on_nonregular_3.rs:38:14
+  --> $DIR/dropck_no_diverge_on_nonregular_3.rs:39:14
    |
 LL |         Some(Wrapper::<u32>::Simple);
    |              ^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/dropck/dropck_no_diverge_on_nonregular_3.stderr
+++ b/src/test/ui/dropck/dropck_no_diverge_on_nonregular_3.stderr
@@ -1,8 +1,8 @@
 warning: type parameter on variant
-  --> $DIR/dropck_no_diverge_on_nonregular_3.rs:33:29
+  --> $DIR/dropck_no_diverge_on_nonregular_3.rs:33:31
    |
 LL |         Some(Wrapper::Simple::<u32>);
-   |                             ^^^^^^^
+   |                               ^^^^^
    |
    = note: `#[warn(type_param_on_variant_ctor)]` on by default
 help: set the type parameter on the enum

--- a/src/test/ui/enum-discriminant/niche.rs
+++ b/src/test/ui/enum-discriminant/niche.rs
@@ -2,6 +2,7 @@
 
 #![feature(const_panic)]
 #![feature(const_if_match)]
+#![allow(type_param_on_variant_ctor)]
 
 //! Make sure that we read and write enum discriminants correctly for corner cases caused
 //! by layout optimizations.

--- a/src/test/ui/enum/forbid-many-type-params.rs
+++ b/src/test/ui/enum/forbid-many-type-params.rs
@@ -1,0 +1,21 @@
+pub enum Foo<'a, T: 'a> {
+    Struct {},
+    Tuple(),
+    Unit,
+    Usage(&'a T),
+}
+
+pub fn main() {
+    let _ = Foo::<String>::Unit::<String>; //~ ERROR multiple segments with type parameters
+    let _ = Foo::<String>::Tuple::<String>(); //~ ERROR multiple segments with type parameters
+    let _ = Foo::<String>::Struct::<String> {}; //~ ERROR multiple segments with type parameters
+    if let Foo::<String>::Unit::<String> = Foo::<String>::Unit::<String> {}
+    //~^ ERROR multiple segments with type parameters are not allowed
+    //~| ERROR multiple segments with type parameters are not allowed
+    if let Foo::<String>::Tuple::<String>() = Foo::<String>::Tuple::<String>() {}
+    //~^ ERROR multiple segments with type parameters are not allowed
+    //~| ERROR multiple segments with type parameters are not allowed
+    if let Foo::<String>::Struct::<String> {} = (Foo::<String>::Struct::<String> {}) {}
+    //~^ ERROR multiple segments with type parameters are not allowed
+    //~| ERROR multiple segments with type parameters are not allowed
+}

--- a/src/test/ui/enum/forbid-many-type-params.stderr
+++ b/src/test/ui/enum/forbid-many-type-params.stderr
@@ -1,0 +1,74 @@
+error: multiple segments with type parameters are not allowed
+  --> $DIR/forbid-many-type-params.rs:9:18
+   |
+LL |     let _ = Foo::<String>::Unit::<String>;
+   |                  ^^^^^^^^        ^^^^^^^^
+   |
+   = note: only a single path segment can specify type parameters
+
+error: multiple segments with type parameters are not allowed
+  --> $DIR/forbid-many-type-params.rs:10:18
+   |
+LL |     let _ = Foo::<String>::Tuple::<String>();
+   |                  ^^^^^^^^         ^^^^^^^^
+   |
+   = note: only a single path segment can specify type parameters
+
+error: multiple segments with type parameters are not allowed
+  --> $DIR/forbid-many-type-params.rs:11:18
+   |
+LL |     let _ = Foo::<String>::Struct::<String> {};
+   |                  ^^^^^^^^          ^^^^^^^^
+   |
+   = note: only a single path segment can specify type parameters
+
+error: multiple segments with type parameters are not allowed
+  --> $DIR/forbid-many-type-params.rs:12:49
+   |
+LL |     if let Foo::<String>::Unit::<String> = Foo::<String>::Unit::<String> {}
+   |                                                 ^^^^^^^^        ^^^^^^^^
+   |
+   = note: only a single path segment can specify type parameters
+
+error: multiple segments with type parameters are not allowed
+  --> $DIR/forbid-many-type-params.rs:12:17
+   |
+LL |     if let Foo::<String>::Unit::<String> = Foo::<String>::Unit::<String> {}
+   |                 ^^^^^^^^        ^^^^^^^^
+   |
+   = note: only a single path segment can specify type parameters
+
+error: multiple segments with type parameters are not allowed
+  --> $DIR/forbid-many-type-params.rs:15:52
+   |
+LL |     if let Foo::<String>::Tuple::<String>() = Foo::<String>::Tuple::<String>() {}
+   |                                                    ^^^^^^^^         ^^^^^^^^
+   |
+   = note: only a single path segment can specify type parameters
+
+error: multiple segments with type parameters are not allowed
+  --> $DIR/forbid-many-type-params.rs:15:17
+   |
+LL |     if let Foo::<String>::Tuple::<String>() = Foo::<String>::Tuple::<String>() {}
+   |                 ^^^^^^^^         ^^^^^^^^
+   |
+   = note: only a single path segment can specify type parameters
+
+error: multiple segments with type parameters are not allowed
+  --> $DIR/forbid-many-type-params.rs:18:55
+   |
+LL |     if let Foo::<String>::Struct::<String> {} = (Foo::<String>::Struct::<String> {}) {}
+   |                                                       ^^^^^^^^          ^^^^^^^^
+   |
+   = note: only a single path segment can specify type parameters
+
+error: multiple segments with type parameters are not allowed
+  --> $DIR/forbid-many-type-params.rs:18:17
+   |
+LL |     if let Foo::<String>::Struct::<String> {} = (Foo::<String>::Struct::<String> {}) {}
+   |                 ^^^^^^^^          ^^^^^^^^
+   |
+   = note: only a single path segment can specify type parameters
+
+error: aborting due to 9 previous errors
+

--- a/src/test/ui/enum/lifetime-in-def-not-in-path-issue-69356.rs
+++ b/src/test/ui/enum/lifetime-in-def-not-in-path-issue-69356.rs
@@ -1,4 +1,5 @@
 // check-pass
+#![warn(type_param_on_variant_ctor)]
 
 pub enum Foo<'a, T: 'a> {
     Struct {},

--- a/src/test/ui/enum/lifetime-in-def-not-in-path-issue-69356.rs
+++ b/src/test/ui/enum/lifetime-in-def-not-in-path-issue-69356.rs
@@ -1,0 +1,24 @@
+// check-pass
+
+pub enum Foo<'a, T: 'a> {
+    Struct {},
+    Tuple(),
+    Unit,
+    Usage(&'a T),
+}
+
+pub fn main() {
+    let _ = Foo::<String>::Unit;
+    let _ = Foo::<String>::Tuple();
+    let _ = Foo::<String>::Struct {};
+    if let Foo::<String>::Unit = Foo::<String>::Unit {}
+    if let Foo::<String>::Tuple() = Foo::<String>::Tuple() {}
+    if let Foo::<String>::Struct {} = (Foo::<String>::Struct {}) {}
+    // // FIXME: these should be linted against.
+    let _ = Foo::Unit::<String>;
+    let _ = Foo::Tuple::<String>();
+    let _ = Foo::Struct::<String> {};
+    if let Foo::Unit::<String> = Foo::Unit::<String> {}
+    if let Foo::Tuple::<String>() = Foo::Tuple::<String>() {}
+    if let Foo::Struct::<String> {} = (Foo::Struct::<String> {}) {}
+}

--- a/src/test/ui/enum/lifetime-in-def-not-in-path-issue-69356.rs
+++ b/src/test/ui/enum/lifetime-in-def-not-in-path-issue-69356.rs
@@ -14,11 +14,17 @@ pub fn main() {
     if let Foo::<String>::Unit = Foo::<String>::Unit {}
     if let Foo::<String>::Tuple() = Foo::<String>::Tuple() {}
     if let Foo::<String>::Struct {} = (Foo::<String>::Struct {}) {}
-    // // FIXME: these should be linted against.
-    let _ = Foo::Unit::<String>;
-    let _ = Foo::Tuple::<String>();
-    let _ = Foo::Struct::<String> {};
+
+    let _ = Foo::Unit::<String>; //~ WARNING type parameter on variant
+    let _ = Foo::Tuple::<String>(); //~ WARNING type parameter on variant
+    let _ = Foo::Struct::<String> {}; //~ WARNING type parameter on variant
     if let Foo::Unit::<String> = Foo::Unit::<String> {}
+    //~^ WARNING type parameter on variant
+    //~| WARNING type parameter on variant
     if let Foo::Tuple::<String>() = Foo::Tuple::<String>() {}
+    //~^ WARNING type parameter on variant
+    //~| WARNING type parameter on variant
     if let Foo::Struct::<String> {} = (Foo::Struct::<String> {}) {}
+    //~^ WARNING type parameter on variant
+    //~| WARNING type parameter on variant
 }

--- a/src/test/ui/enum/lifetime-in-def-not-in-path-issue-69356.stderr
+++ b/src/test/ui/enum/lifetime-in-def-not-in-path-issue-69356.stderr
@@ -1,17 +1,21 @@
 warning: type parameter on variant
-  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:18:24
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:19:24
    |
 LL |     let _ = Foo::Unit::<String>;
    |                        ^^^^^^^^
    |
-   = note: `#[warn(type_param_on_variant_ctor)]` on by default
+note: the lint level is defined here
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:2:9
+   |
+LL | #![warn(type_param_on_variant_ctor)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: set the type parameter on the enum
    |
 LL |     let _ = Foo::<String>::Unit;
    |                ^^^^^^^^^^     --
 
 warning: type parameter on variant
-  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:19:25
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:20:25
    |
 LL |     let _ = Foo::Tuple::<String>();
    |                         ^^^^^^^^
@@ -22,7 +26,7 @@ LL |     let _ = Foo::<String>::Tuple();
    |                ^^^^^^^^^^      --
 
 warning: type parameter on variant
-  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:20:26
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:21:26
    |
 LL |     let _ = Foo::Struct::<String> {};
    |                          ^^^^^^^^
@@ -33,7 +37,7 @@ LL |     let _ = Foo::<String>::Struct {};
    |                ^^^^^^^^^^       --
 
 warning: type parameter on variant
-  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:21:45
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:22:45
    |
 LL |     if let Foo::Unit::<String> = Foo::Unit::<String> {}
    |                                             ^^^^^^^^
@@ -44,7 +48,7 @@ LL |     if let Foo::Unit::<String> = Foo::<String>::Unit {}
    |                                     ^^^^^^^^^^     --
 
 warning: type parameter on variant
-  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:21:23
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:22:23
    |
 LL |     if let Foo::Unit::<String> = Foo::Unit::<String> {}
    |                       ^^^^^^^^
@@ -55,7 +59,7 @@ LL |     if let Foo::<String>::Unit = Foo::Unit::<String> {}
    |               ^^^^^^^^^^     --
 
 warning: type parameter on variant
-  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:24:49
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:25:49
    |
 LL |     if let Foo::Tuple::<String>() = Foo::Tuple::<String>() {}
    |                                                 ^^^^^^^^
@@ -66,7 +70,7 @@ LL |     if let Foo::Tuple::<String>() = Foo::<String>::Tuple() {}
    |                                        ^^^^^^^^^^      --
 
 warning: type parameter on variant
-  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:24:24
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:25:24
    |
 LL |     if let Foo::Tuple::<String>() = Foo::Tuple::<String>() {}
    |                        ^^^^^^^^
@@ -77,7 +81,7 @@ LL |     if let Foo::<String>::Tuple() = Foo::Tuple::<String>() {}
    |               ^^^^^^^^^^      --
 
 warning: type parameter on variant
-  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:27:53
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:28:53
    |
 LL |     if let Foo::Struct::<String> {} = (Foo::Struct::<String> {}) {}
    |                                                     ^^^^^^^^
@@ -88,7 +92,7 @@ LL |     if let Foo::Struct::<String> {} = (Foo::<String>::Struct {}) {}
    |                                           ^^^^^^^^^^       --
 
 warning: type parameter on variant
-  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:27:25
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:28:25
    |
 LL |     if let Foo::Struct::<String> {} = (Foo::Struct::<String> {}) {}
    |                         ^^^^^^^^

--- a/src/test/ui/enum/lifetime-in-def-not-in-path-issue-69356.stderr
+++ b/src/test/ui/enum/lifetime-in-def-not-in-path-issue-69356.stderr
@@ -1,8 +1,8 @@
 warning: type parameter on variant
-  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:18:22
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:18:24
    |
 LL |     let _ = Foo::Unit::<String>;
-   |                      ^^^^^^^^^^
+   |                        ^^^^^^^^
    |
    = note: `#[warn(type_param_on_variant_ctor)]` on by default
 help: set the type parameter on the enum
@@ -11,10 +11,10 @@ LL |     let _ = Foo::<String>::Unit;
    |                ^^^^^^^^^^     --
 
 warning: type parameter on variant
-  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:19:23
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:19:25
    |
 LL |     let _ = Foo::Tuple::<String>();
-   |                       ^^^^^^^^^^
+   |                         ^^^^^^^^
    |
 help: set the type parameter on the enum
    |
@@ -22,10 +22,10 @@ LL |     let _ = Foo::<String>::Tuple();
    |                ^^^^^^^^^^      --
 
 warning: type parameter on variant
-  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:20:24
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:20:26
    |
 LL |     let _ = Foo::Struct::<String> {};
-   |                        ^^^^^^^^^^
+   |                          ^^^^^^^^
    |
 help: set the type parameter on the enum
    |
@@ -33,10 +33,10 @@ LL |     let _ = Foo::<String>::Struct {};
    |                ^^^^^^^^^^       --
 
 warning: type parameter on variant
-  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:21:43
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:21:45
    |
 LL |     if let Foo::Unit::<String> = Foo::Unit::<String> {}
-   |                                           ^^^^^^^^^^
+   |                                             ^^^^^^^^
    |
 help: set the type parameter on the enum
    |
@@ -44,10 +44,10 @@ LL |     if let Foo::Unit::<String> = Foo::<String>::Unit {}
    |                                     ^^^^^^^^^^     --
 
 warning: type parameter on variant
-  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:21:21
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:21:23
    |
 LL |     if let Foo::Unit::<String> = Foo::Unit::<String> {}
-   |                     ^^^^^^^^^^
+   |                       ^^^^^^^^
    |
 help: set the type parameter on the enum
    |
@@ -55,10 +55,10 @@ LL |     if let Foo::<String>::Unit = Foo::Unit::<String> {}
    |               ^^^^^^^^^^     --
 
 warning: type parameter on variant
-  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:24:47
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:24:49
    |
 LL |     if let Foo::Tuple::<String>() = Foo::Tuple::<String>() {}
-   |                                               ^^^^^^^^^^
+   |                                                 ^^^^^^^^
    |
 help: set the type parameter on the enum
    |
@@ -66,10 +66,10 @@ LL |     if let Foo::Tuple::<String>() = Foo::<String>::Tuple() {}
    |                                        ^^^^^^^^^^      --
 
 warning: type parameter on variant
-  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:24:22
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:24:24
    |
 LL |     if let Foo::Tuple::<String>() = Foo::Tuple::<String>() {}
-   |                      ^^^^^^^^^^
+   |                        ^^^^^^^^
    |
 help: set the type parameter on the enum
    |
@@ -77,10 +77,10 @@ LL |     if let Foo::<String>::Tuple() = Foo::Tuple::<String>() {}
    |               ^^^^^^^^^^      --
 
 warning: type parameter on variant
-  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:27:51
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:27:53
    |
 LL |     if let Foo::Struct::<String> {} = (Foo::Struct::<String> {}) {}
-   |                                                   ^^^^^^^^^^
+   |                                                     ^^^^^^^^
    |
 help: set the type parameter on the enum
    |
@@ -88,10 +88,10 @@ LL |     if let Foo::Struct::<String> {} = (Foo::<String>::Struct {}) {}
    |                                           ^^^^^^^^^^       --
 
 warning: type parameter on variant
-  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:27:23
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:27:25
    |
 LL |     if let Foo::Struct::<String> {} = (Foo::Struct::<String> {}) {}
-   |                       ^^^^^^^^^^
+   |                         ^^^^^^^^
    |
 help: set the type parameter on the enum
    |

--- a/src/test/ui/enum/lifetime-in-def-not-in-path-issue-69356.stderr
+++ b/src/test/ui/enum/lifetime-in-def-not-in-path-issue-69356.stderr
@@ -1,0 +1,100 @@
+warning: type parameter on variant
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:18:22
+   |
+LL |     let _ = Foo::Unit::<String>;
+   |                      ^^^^^^^^^^
+   |
+   = note: `#[warn(type_param_on_variant_ctor)]` on by default
+help: set the type parameter on the enum
+   |
+LL |     let _ = Foo::<String>::Unit;
+   |                ^^^^^^^^^^     --
+
+warning: type parameter on variant
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:19:23
+   |
+LL |     let _ = Foo::Tuple::<String>();
+   |                       ^^^^^^^^^^
+   |
+help: set the type parameter on the enum
+   |
+LL |     let _ = Foo::<String>::Tuple();
+   |                ^^^^^^^^^^      --
+
+warning: type parameter on variant
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:20:24
+   |
+LL |     let _ = Foo::Struct::<String> {};
+   |                        ^^^^^^^^^^
+   |
+help: set the type parameter on the enum
+   |
+LL |     let _ = Foo::<String>::Struct {};
+   |                ^^^^^^^^^^       --
+
+warning: type parameter on variant
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:21:43
+   |
+LL |     if let Foo::Unit::<String> = Foo::Unit::<String> {}
+   |                                           ^^^^^^^^^^
+   |
+help: set the type parameter on the enum
+   |
+LL |     if let Foo::Unit::<String> = Foo::<String>::Unit {}
+   |                                     ^^^^^^^^^^     --
+
+warning: type parameter on variant
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:21:21
+   |
+LL |     if let Foo::Unit::<String> = Foo::Unit::<String> {}
+   |                     ^^^^^^^^^^
+   |
+help: set the type parameter on the enum
+   |
+LL |     if let Foo::<String>::Unit = Foo::Unit::<String> {}
+   |               ^^^^^^^^^^     --
+
+warning: type parameter on variant
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:24:47
+   |
+LL |     if let Foo::Tuple::<String>() = Foo::Tuple::<String>() {}
+   |                                               ^^^^^^^^^^
+   |
+help: set the type parameter on the enum
+   |
+LL |     if let Foo::Tuple::<String>() = Foo::<String>::Tuple() {}
+   |                                        ^^^^^^^^^^      --
+
+warning: type parameter on variant
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:24:22
+   |
+LL |     if let Foo::Tuple::<String>() = Foo::Tuple::<String>() {}
+   |                      ^^^^^^^^^^
+   |
+help: set the type parameter on the enum
+   |
+LL |     if let Foo::<String>::Tuple() = Foo::Tuple::<String>() {}
+   |               ^^^^^^^^^^      --
+
+warning: type parameter on variant
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:27:51
+   |
+LL |     if let Foo::Struct::<String> {} = (Foo::Struct::<String> {}) {}
+   |                                                   ^^^^^^^^^^
+   |
+help: set the type parameter on the enum
+   |
+LL |     if let Foo::Struct::<String> {} = (Foo::<String>::Struct {}) {}
+   |                                           ^^^^^^^^^^       --
+
+warning: type parameter on variant
+  --> $DIR/lifetime-in-def-not-in-path-issue-69356.rs:27:23
+   |
+LL |     if let Foo::Struct::<String> {} = (Foo::Struct::<String> {}) {}
+   |                       ^^^^^^^^^^
+   |
+help: set the type parameter on the enum
+   |
+LL |     if let Foo::<String>::Struct {} = (Foo::Struct::<String> {}) {}
+   |               ^^^^^^^^^^       --
+

--- a/src/test/ui/generics/generic-recursive-tag.rs
+++ b/src/test/ui/generics/generic-recursive-tag.rs
@@ -1,5 +1,5 @@
 // run-pass
-#![allow(non_camel_case_types)]
+#![allow(non_camel_case_types, type_param_on_variant_ctor)]
 #![feature(box_syntax)]
 
 enum list<T> { cons(Box<T>, Box<list<T>>), nil, }

--- a/src/test/ui/generics/generic-tag-match.rs
+++ b/src/test/ui/generics/generic-tag-match.rs
@@ -1,6 +1,5 @@
 // run-pass
-#![allow(unused_assignments)]
-#![allow(non_camel_case_types)]
+#![allow(unused_assignments, non_camel_case_types, type_param_on_variant_ctor)]
 
 enum foo<T> { arm(T), }
 

--- a/src/test/ui/generics/generic-tag-values.rs
+++ b/src/test/ui/generics/generic-tag-values.rs
@@ -1,5 +1,5 @@
 // run-pass
-#![allow(non_camel_case_types)]
+#![allow(non_camel_case_types, type_param_on_variant_ctor)]
 
 enum noption<T> { some(T), }
 

--- a/src/test/ui/generics/generic-tag.rs
+++ b/src/test/ui/generics/generic-tag.rs
@@ -1,6 +1,5 @@
 // run-pass
-#![allow(unused_assignments)]
-#![allow(non_camel_case_types)]
+#![allow(unused_assignments, non_camel_case_types, type_param_on_variant_ctor)]
 
 // pretty-expanded FIXME #23616
 

--- a/src/test/ui/issues/issue-22546.rs
+++ b/src/test/ui/issues/issue-22546.rs
@@ -1,5 +1,5 @@
 // run-pass
-#![allow(unused_variables)]
+#![allow(unused_variables, type_param_on_variant_ctor)]
 // Parsing patterns with paths with type parameters (issue #22544)
 
 use std::default::Default;
@@ -47,6 +47,9 @@ fn main() {
         panic!();
     }
     if let Option::None::<u8> { .. } = Some(8) {
+        panic!();
+    }
+    if let Option::<u8>::None { .. } = Some(8) {
         panic!();
     }
 }

--- a/src/test/ui/issues/issue-40003.rs
+++ b/src/test/ui/issues/issue-40003.rs
@@ -1,5 +1,5 @@
 // run-pass
-#![allow(unused_must_use)]
+#![allow(unused_must_use, type_param_on_variant_ctor)]
 fn main() {
     if false { test(); }
 }

--- a/src/test/ui/issues/issue-61696.rs
+++ b/src/test/ui/issues/issue-61696.rs
@@ -1,4 +1,5 @@
 // run-pass
+#![allow(type_param_on_variant_ctor)]
 
 pub enum Infallible {}
 

--- a/src/test/ui/nll/user-annotations/adt-brace-enums.rs
+++ b/src/test/ui/nll/user-annotations/adt-brace-enums.rs
@@ -12,38 +12,78 @@ fn no_annot() {
 
 fn annot_underscore() {
     let c = 66;
-    SomeEnum::SomeVariant::<_> { t: &c };
+    SomeEnum::<_>::SomeVariant { t: &c };
+}
+
+fn annot_underscore2() {
+    let c = 66;
+    SomeEnum::SomeVariant::<_> { t: &c }; //~ WARNING
 }
 
 fn annot_reference_any_lifetime() {
     let c = 66;
-    SomeEnum::SomeVariant::<&u32> { t: &c };
+    SomeEnum::<&u32>::SomeVariant { t: &c };
+}
+
+fn annot_reference_any_lifetime2() {
+    let c = 66;
+    SomeEnum::SomeVariant::<&u32> { t: &c }; //~ WARNING
 }
 
 fn annot_reference_static_lifetime() {
     let c = 66;
+    SomeEnum::<&'static u32>::SomeVariant { t: &c }; //~ ERROR
+}
+
+fn annot_reference_static_lifetime2() {
+    let c = 66;
     SomeEnum::SomeVariant::<&'static u32> { t: &c }; //~ ERROR
+    //~^ WARNING
 }
 
 fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
     let c = 66;
+    SomeEnum::<&'a u32>::SomeVariant { t: &c }; //~ ERROR
+}
+
+fn annot_reference_named_lifetime2<'a>(_d: &'a u32) {
+    let c = 66;
     SomeEnum::SomeVariant::<&'a u32> { t: &c }; //~ ERROR
+    //~^ WARNING
 }
 
 fn annot_reference_named_lifetime_ok<'a>(c: &'a u32) {
-    SomeEnum::SomeVariant::<&'a u32> { t: c };
+    SomeEnum::<&'a u32>::SomeVariant { t: c };
+}
+
+fn annot_reference_named_lifetime_ok2<'a>(c: &'a u32) {
+    SomeEnum::SomeVariant::<&'a u32> { t: c }; //~ WARNING
 }
 
 fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
     let _closure = || {
         let c = 66;
+        SomeEnum::<&'a u32>::SomeVariant { t: &c }; //~ ERROR
+    };
+}
+
+fn annot_reference_named_lifetime_in_closure2<'a>(_: &'a u32) {
+    let _closure = || {
+        let c = 66;
         SomeEnum::SomeVariant::<&'a u32> { t: &c }; //~ ERROR
+        //~^ WARNING
     };
 }
 
 fn annot_reference_named_lifetime_in_closure_ok<'a>(c: &'a u32) {
     let _closure = || {
-        SomeEnum::SomeVariant::<&'a u32> { t: c };
+        SomeEnum::<&'a u32>::SomeVariant { t: c };
+    };
+}
+
+fn annot_reference_named_lifetime_in_closure_ok2<'a>(c: &'a u32) {
+    let _closure = || {
+        SomeEnum::SomeVariant::<&'a u32> { t: c }; //~ WARNING
     };
 }
 

--- a/src/test/ui/nll/user-annotations/adt-brace-enums.rs
+++ b/src/test/ui/nll/user-annotations/adt-brace-enums.rs
@@ -1,3 +1,4 @@
+#![warn(type_param_on_variant_ctor)]
 // Unit test for the "user substitutions" that are annotated on each
 // node.
 

--- a/src/test/ui/nll/user-annotations/adt-brace-enums.stderr
+++ b/src/test/ui/nll/user-annotations/adt-brace-enums.stderr
@@ -1,17 +1,21 @@
 warning: type parameter on variant
-  --> $DIR/adt-brace-enums.rs:20:28
+  --> $DIR/adt-brace-enums.rs:21:28
    |
 LL |     SomeEnum::SomeVariant::<_> { t: &c };
    |                            ^^^
    |
-   = note: `#[warn(type_param_on_variant_ctor)]` on by default
+note: the lint level is defined here
+  --> $DIR/adt-brace-enums.rs:1:9
+   |
+LL | #![warn(type_param_on_variant_ctor)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: set the type parameter on the enum
    |
 LL |     SomeEnum::<_>::SomeVariant { t: &c };
    |             ^^^^^            --
 
 warning: type parameter on variant
-  --> $DIR/adt-brace-enums.rs:30:28
+  --> $DIR/adt-brace-enums.rs:31:28
    |
 LL |     SomeEnum::SomeVariant::<&u32> { t: &c };
    |                            ^^^^^^
@@ -22,7 +26,7 @@ LL |     SomeEnum::<&u32>::SomeVariant { t: &c };
    |             ^^^^^^^^            --
 
 warning: type parameter on variant
-  --> $DIR/adt-brace-enums.rs:40:28
+  --> $DIR/adt-brace-enums.rs:41:28
    |
 LL |     SomeEnum::SomeVariant::<&'static u32> { t: &c };
    |                            ^^^^^^^^^^^^^^
@@ -33,7 +37,7 @@ LL |     SomeEnum::<&'static u32>::SomeVariant { t: &c };
    |             ^^^^^^^^^^^^^^^^            --
 
 warning: type parameter on variant
-  --> $DIR/adt-brace-enums.rs:51:28
+  --> $DIR/adt-brace-enums.rs:52:28
    |
 LL |     SomeEnum::SomeVariant::<&'a u32> { t: &c };
    |                            ^^^^^^^^^
@@ -44,7 +48,7 @@ LL |     SomeEnum::<&'a u32>::SomeVariant { t: &c };
    |             ^^^^^^^^^^^            --
 
 warning: type parameter on variant
-  --> $DIR/adt-brace-enums.rs:60:28
+  --> $DIR/adt-brace-enums.rs:61:28
    |
 LL |     SomeEnum::SomeVariant::<&'a u32> { t: c };
    |                            ^^^^^^^^^
@@ -55,7 +59,7 @@ LL |     SomeEnum::<&'a u32>::SomeVariant { t: c };
    |             ^^^^^^^^^^^            --
 
 warning: type parameter on variant
-  --> $DIR/adt-brace-enums.rs:73:32
+  --> $DIR/adt-brace-enums.rs:74:32
    |
 LL |         SomeEnum::SomeVariant::<&'a u32> { t: &c };
    |                                ^^^^^^^^^
@@ -66,7 +70,7 @@ LL |         SomeEnum::<&'a u32>::SomeVariant { t: &c };
    |                 ^^^^^^^^^^^            --
 
 warning: type parameter on variant
-  --> $DIR/adt-brace-enums.rs:86:32
+  --> $DIR/adt-brace-enums.rs:87:32
    |
 LL |         SomeEnum::SomeVariant::<&'a u32> { t: c };
    |                                ^^^^^^^^^
@@ -77,7 +81,7 @@ LL |         SomeEnum::<&'a u32>::SomeVariant { t: c };
    |                 ^^^^^^^^^^^            --
 
 error[E0597]: `c` does not live long enough
-  --> $DIR/adt-brace-enums.rs:35:48
+  --> $DIR/adt-brace-enums.rs:36:48
    |
 LL |     SomeEnum::<&'static u32>::SomeVariant { t: &c };
    |                                                ^^
@@ -88,7 +92,7 @@ LL | }
    | - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
-  --> $DIR/adt-brace-enums.rs:40:48
+  --> $DIR/adt-brace-enums.rs:41:48
    |
 LL |     SomeEnum::SomeVariant::<&'static u32> { t: &c };
    |                                                ^^
@@ -100,7 +104,7 @@ LL | }
    | - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
-  --> $DIR/adt-brace-enums.rs:46:43
+  --> $DIR/adt-brace-enums.rs:47:43
    |
 LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
    |                                   -- lifetime `'a` defined here
@@ -114,7 +118,7 @@ LL | }
    | - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
-  --> $DIR/adt-brace-enums.rs:51:43
+  --> $DIR/adt-brace-enums.rs:52:43
    |
 LL | fn annot_reference_named_lifetime2<'a>(_d: &'a u32) {
    |                                    -- lifetime `'a` defined here
@@ -129,7 +133,7 @@ LL | }
    | - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
-  --> $DIR/adt-brace-enums.rs:66:47
+  --> $DIR/adt-brace-enums.rs:67:47
    |
 LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
    |                                              -- lifetime `'a` defined here
@@ -143,7 +147,7 @@ LL |     };
    |     - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
-  --> $DIR/adt-brace-enums.rs:73:47
+  --> $DIR/adt-brace-enums.rs:74:47
    |
 LL | fn annot_reference_named_lifetime_in_closure2<'a>(_: &'a u32) {
    |                                               -- lifetime `'a` defined here

--- a/src/test/ui/nll/user-annotations/adt-brace-enums.stderr
+++ b/src/test/ui/nll/user-annotations/adt-brace-enums.stderr
@@ -1,8 +1,8 @@
 warning: type parameter on variant
-  --> $DIR/adt-brace-enums.rs:20:26
+  --> $DIR/adt-brace-enums.rs:20:28
    |
 LL |     SomeEnum::SomeVariant::<_> { t: &c };
-   |                          ^^^^^
+   |                            ^^^
    |
    = note: `#[warn(type_param_on_variant_ctor)]` on by default
 help: set the type parameter on the enum
@@ -11,10 +11,10 @@ LL |     SomeEnum::<_>::SomeVariant { t: &c };
    |             ^^^^^            --
 
 warning: type parameter on variant
-  --> $DIR/adt-brace-enums.rs:30:26
+  --> $DIR/adt-brace-enums.rs:30:28
    |
 LL |     SomeEnum::SomeVariant::<&u32> { t: &c };
-   |                          ^^^^^^^^
+   |                            ^^^^^^
    |
 help: set the type parameter on the enum
    |
@@ -22,10 +22,10 @@ LL |     SomeEnum::<&u32>::SomeVariant { t: &c };
    |             ^^^^^^^^            --
 
 warning: type parameter on variant
-  --> $DIR/adt-brace-enums.rs:40:26
+  --> $DIR/adt-brace-enums.rs:40:28
    |
 LL |     SomeEnum::SomeVariant::<&'static u32> { t: &c };
-   |                          ^^^^^^^^^^^^^^^^
+   |                            ^^^^^^^^^^^^^^
    |
 help: set the type parameter on the enum
    |
@@ -33,10 +33,10 @@ LL |     SomeEnum::<&'static u32>::SomeVariant { t: &c };
    |             ^^^^^^^^^^^^^^^^            --
 
 warning: type parameter on variant
-  --> $DIR/adt-brace-enums.rs:51:26
+  --> $DIR/adt-brace-enums.rs:51:28
    |
 LL |     SomeEnum::SomeVariant::<&'a u32> { t: &c };
-   |                          ^^^^^^^^^^^
+   |                            ^^^^^^^^^
    |
 help: set the type parameter on the enum
    |
@@ -44,10 +44,10 @@ LL |     SomeEnum::<&'a u32>::SomeVariant { t: &c };
    |             ^^^^^^^^^^^            --
 
 warning: type parameter on variant
-  --> $DIR/adt-brace-enums.rs:60:26
+  --> $DIR/adt-brace-enums.rs:60:28
    |
 LL |     SomeEnum::SomeVariant::<&'a u32> { t: c };
-   |                          ^^^^^^^^^^^
+   |                            ^^^^^^^^^
    |
 help: set the type parameter on the enum
    |
@@ -55,10 +55,10 @@ LL |     SomeEnum::<&'a u32>::SomeVariant { t: c };
    |             ^^^^^^^^^^^            --
 
 warning: type parameter on variant
-  --> $DIR/adt-brace-enums.rs:73:30
+  --> $DIR/adt-brace-enums.rs:73:32
    |
 LL |         SomeEnum::SomeVariant::<&'a u32> { t: &c };
-   |                              ^^^^^^^^^^^
+   |                                ^^^^^^^^^
    |
 help: set the type parameter on the enum
    |
@@ -66,10 +66,10 @@ LL |         SomeEnum::<&'a u32>::SomeVariant { t: &c };
    |                 ^^^^^^^^^^^            --
 
 warning: type parameter on variant
-  --> $DIR/adt-brace-enums.rs:86:30
+  --> $DIR/adt-brace-enums.rs:86:32
    |
 LL |         SomeEnum::SomeVariant::<&'a u32> { t: c };
-   |                              ^^^^^^^^^^^
+   |                                ^^^^^^^^^
    |
 help: set the type parameter on the enum
    |

--- a/src/test/ui/nll/user-annotations/adt-brace-enums.stderr
+++ b/src/test/ui/nll/user-annotations/adt-brace-enums.stderr
@@ -1,7 +1,85 @@
-error[E0597]: `c` does not live long enough
-  --> $DIR/adt-brace-enums.rs:25:48
+warning: type parameter on variant
+  --> $DIR/adt-brace-enums.rs:20:26
+   |
+LL |     SomeEnum::SomeVariant::<_> { t: &c };
+   |                          ^^^^^
+   |
+   = note: `#[warn(type_param_on_variant_ctor)]` on by default
+help: set the type parameter on the enum
+   |
+LL |     SomeEnum::<_>::SomeVariant { t: &c };
+   |             ^^^^^            --
+
+warning: type parameter on variant
+  --> $DIR/adt-brace-enums.rs:30:26
+   |
+LL |     SomeEnum::SomeVariant::<&u32> { t: &c };
+   |                          ^^^^^^^^
+   |
+help: set the type parameter on the enum
+   |
+LL |     SomeEnum::<&u32>::SomeVariant { t: &c };
+   |             ^^^^^^^^            --
+
+warning: type parameter on variant
+  --> $DIR/adt-brace-enums.rs:40:26
    |
 LL |     SomeEnum::SomeVariant::<&'static u32> { t: &c };
+   |                          ^^^^^^^^^^^^^^^^
+   |
+help: set the type parameter on the enum
+   |
+LL |     SomeEnum::<&'static u32>::SomeVariant { t: &c };
+   |             ^^^^^^^^^^^^^^^^            --
+
+warning: type parameter on variant
+  --> $DIR/adt-brace-enums.rs:51:26
+   |
+LL |     SomeEnum::SomeVariant::<&'a u32> { t: &c };
+   |                          ^^^^^^^^^^^
+   |
+help: set the type parameter on the enum
+   |
+LL |     SomeEnum::<&'a u32>::SomeVariant { t: &c };
+   |             ^^^^^^^^^^^            --
+
+warning: type parameter on variant
+  --> $DIR/adt-brace-enums.rs:60:26
+   |
+LL |     SomeEnum::SomeVariant::<&'a u32> { t: c };
+   |                          ^^^^^^^^^^^
+   |
+help: set the type parameter on the enum
+   |
+LL |     SomeEnum::<&'a u32>::SomeVariant { t: c };
+   |             ^^^^^^^^^^^            --
+
+warning: type parameter on variant
+  --> $DIR/adt-brace-enums.rs:73:30
+   |
+LL |         SomeEnum::SomeVariant::<&'a u32> { t: &c };
+   |                              ^^^^^^^^^^^
+   |
+help: set the type parameter on the enum
+   |
+LL |         SomeEnum::<&'a u32>::SomeVariant { t: &c };
+   |                 ^^^^^^^^^^^            --
+
+warning: type parameter on variant
+  --> $DIR/adt-brace-enums.rs:86:30
+   |
+LL |         SomeEnum::SomeVariant::<&'a u32> { t: c };
+   |                              ^^^^^^^^^^^
+   |
+help: set the type parameter on the enum
+   |
+LL |         SomeEnum::<&'a u32>::SomeVariant { t: c };
+   |                 ^^^^^^^^^^^            --
+
+error[E0597]: `c` does not live long enough
+  --> $DIR/adt-brace-enums.rs:35:48
+   |
+LL |     SomeEnum::<&'static u32>::SomeVariant { t: &c };
    |                                                ^^
    |                                                |
    |                                                borrowed value does not live long enough
@@ -10,12 +88,24 @@ LL | }
    | - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
-  --> $DIR/adt-brace-enums.rs:30:43
+  --> $DIR/adt-brace-enums.rs:40:48
+   |
+LL |     SomeEnum::SomeVariant::<&'static u32> { t: &c };
+   |                                                ^^
+   |                                                |
+   |                                                borrowed value does not live long enough
+   |                                                requires that `c` is borrowed for `'static`
+LL |
+LL | }
+   | - `c` dropped here while still borrowed
+
+error[E0597]: `c` does not live long enough
+  --> $DIR/adt-brace-enums.rs:46:43
    |
 LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
    |                                   -- lifetime `'a` defined here
 LL |     let c = 66;
-LL |     SomeEnum::SomeVariant::<&'a u32> { t: &c };
+LL |     SomeEnum::<&'a u32>::SomeVariant { t: &c };
    |                                           ^^
    |                                           |
    |                                           borrowed value does not live long enough
@@ -24,12 +114,27 @@ LL | }
    | - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
-  --> $DIR/adt-brace-enums.rs:40:47
+  --> $DIR/adt-brace-enums.rs:51:43
+   |
+LL | fn annot_reference_named_lifetime2<'a>(_d: &'a u32) {
+   |                                    -- lifetime `'a` defined here
+LL |     let c = 66;
+LL |     SomeEnum::SomeVariant::<&'a u32> { t: &c };
+   |                                           ^^
+   |                                           |
+   |                                           borrowed value does not live long enough
+   |                                           requires that `c` is borrowed for `'a`
+LL |
+LL | }
+   | - `c` dropped here while still borrowed
+
+error[E0597]: `c` does not live long enough
+  --> $DIR/adt-brace-enums.rs:66:47
    |
 LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
    |                                              -- lifetime `'a` defined here
 ...
-LL |         SomeEnum::SomeVariant::<&'a u32> { t: &c };
+LL |         SomeEnum::<&'a u32>::SomeVariant { t: &c };
    |                                               ^^
    |                                               |
    |                                               borrowed value does not live long enough
@@ -37,6 +142,21 @@ LL |         SomeEnum::SomeVariant::<&'a u32> { t: &c };
 LL |     };
    |     - `c` dropped here while still borrowed
 
-error: aborting due to 3 previous errors
+error[E0597]: `c` does not live long enough
+  --> $DIR/adt-brace-enums.rs:73:47
+   |
+LL | fn annot_reference_named_lifetime_in_closure2<'a>(_: &'a u32) {
+   |                                               -- lifetime `'a` defined here
+...
+LL |         SomeEnum::SomeVariant::<&'a u32> { t: &c };
+   |                                               ^^
+   |                                               |
+   |                                               borrowed value does not live long enough
+   |                                               requires that `c` is borrowed for `'a`
+LL |
+LL |     };
+   |     - `c` dropped here while still borrowed
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/nll/user-annotations/pattern_substs_on_brace_enum_variant.rs
+++ b/src/test/ui/nll/user-annotations/pattern_substs_on_brace_enum_variant.rs
@@ -1,3 +1,4 @@
+#![warn(type_param_on_variant_ctor)]
 enum Foo<'a> {
     Bar { field: &'a u32 }
 }

--- a/src/test/ui/nll/user-annotations/pattern_substs_on_brace_enum_variant.rs
+++ b/src/test/ui/nll/user-annotations/pattern_substs_on_brace_enum_variant.rs
@@ -6,7 +6,7 @@ fn in_let() {
    let y = 22;
    let foo = Foo::Bar { field: &y };
    //~^ ERROR `y` does not live long enough
-   let Foo::Bar::<'static> { field: _z } = foo;
+   let Foo::Bar::<'static> { field: _z } = foo; //~ WARNING
 }
 
 fn in_match() {
@@ -14,7 +14,7 @@ fn in_match() {
    let foo = Foo::Bar { field: &y };
    //~^ ERROR `y` does not live long enough
    match foo {
-       Foo::Bar::<'static> { field: _z } => {}
+       Foo::Bar::<'static> { field: _z } => {} //~ WARNING
    }
 }
 

--- a/src/test/ui/nll/user-annotations/pattern_substs_on_brace_enum_variant.rs
+++ b/src/test/ui/nll/user-annotations/pattern_substs_on_brace_enum_variant.rs
@@ -3,19 +3,48 @@ enum Foo<'a> {
 }
 
 fn in_let() {
-    let y = 22;
-    let foo = Foo::Bar { field: &y };
-    //~^ ERROR `y` does not live long enough
-    let Foo::Bar::<'static> { field: _z } = foo;
+   let y = 22;
+   let foo = Foo::Bar { field: &y };
+   //~^ ERROR `y` does not live long enough
+   let Foo::Bar::<'static> { field: _z } = foo;
 }
 
 fn in_match() {
+   let y = 22;
+   let foo = Foo::Bar { field: &y };
+   //~^ ERROR `y` does not live long enough
+   match foo {
+       Foo::Bar::<'static> { field: _z } => {}
+   }
+}
+
+fn in_let_2() {
+   let y = 22;
+   let foo = Foo::Bar { field: &y };
+   //~^ ERROR `y` does not live long enough
+   let Foo::<'static>::Bar { field: _z } = foo;
+}
+
+fn in_match_2() {
+   let y = 22;
+   let foo = Foo::Bar { field: &y };
+   //~^ ERROR `y` does not live long enough
+   match foo {
+       Foo::<'static>::Bar { field: _z } => {}
+   }
+}
+
+fn in_let_3() {
     let y = 22;
     let foo = Foo::Bar { field: &y };
-    //~^ ERROR `y` does not live long enough
+    let Foo::Bar { field: _z } = foo;
+}
+
+fn in_match_3() {
+    let y = 22;
+    let foo = Foo::Bar { field: &y };
     match foo {
-        Foo::Bar::<'static> { field: _z } => {
-        }
+        Foo::Bar { field: _z } => {}
     }
 }
 

--- a/src/test/ui/nll/user-annotations/pattern_substs_on_brace_enum_variant.stderr
+++ b/src/test/ui/nll/user-annotations/pattern_substs_on_brace_enum_variant.stderr
@@ -1,26 +1,49 @@
 error[E0597]: `y` does not live long enough
-  --> $DIR/pattern_substs_on_brace_enum_variant.rs:7:33
+  --> $DIR/pattern_substs_on_brace_enum_variant.rs:7:32
    |
-LL |     let foo = Foo::Bar { field: &y };
-   |                                 ^^ borrowed value does not live long enough
+LL |    let foo = Foo::Bar { field: &y };
+   |                                ^^ borrowed value does not live long enough
 LL |
-LL |     let Foo::Bar::<'static> { field: _z } = foo;
-   |         --------------------------------- type annotation requires that `y` is borrowed for `'static`
+LL |    let Foo::Bar::<'static> { field: _z } = foo;
+   |        --------------------------------- type annotation requires that `y` is borrowed for `'static`
 LL | }
    | - `y` dropped here while still borrowed
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/pattern_substs_on_brace_enum_variant.rs:14:33
+  --> $DIR/pattern_substs_on_brace_enum_variant.rs:14:32
    |
-LL |     let foo = Foo::Bar { field: &y };
-   |                                 ^^ borrowed value does not live long enough
+LL |    let foo = Foo::Bar { field: &y };
+   |                                ^^ borrowed value does not live long enough
 ...
-LL |         Foo::Bar::<'static> { field: _z } => {
-   |         --------------------------------- type annotation requires that `y` is borrowed for `'static`
-...
+LL |        Foo::Bar::<'static> { field: _z } => {}
+   |        --------------------------------- type annotation requires that `y` is borrowed for `'static`
+LL |    }
 LL | }
    | - `y` dropped here while still borrowed
 
-error: aborting due to 2 previous errors
+error[E0597]: `y` does not live long enough
+  --> $DIR/pattern_substs_on_brace_enum_variant.rs:23:32
+   |
+LL |    let foo = Foo::Bar { field: &y };
+   |                                ^^ borrowed value does not live long enough
+LL |
+LL |    let Foo::<'static>::Bar { field: _z } = foo;
+   |        --------------------------------- type annotation requires that `y` is borrowed for `'static`
+LL | }
+   | - `y` dropped here while still borrowed
+
+error[E0597]: `y` does not live long enough
+  --> $DIR/pattern_substs_on_brace_enum_variant.rs:30:32
+   |
+LL |    let foo = Foo::Bar { field: &y };
+   |                                ^^ borrowed value does not live long enough
+...
+LL |        Foo::<'static>::Bar { field: _z } => {}
+   |        --------------------------------- type annotation requires that `y` is borrowed for `'static`
+LL |    }
+LL | }
+   | - `y` dropped here while still borrowed
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/nll/user-annotations/pattern_substs_on_brace_enum_variant.stderr
+++ b/src/test/ui/nll/user-annotations/pattern_substs_on_brace_enum_variant.stderr
@@ -1,3 +1,26 @@
+warning: type parameter on variant
+  --> $DIR/pattern_substs_on_brace_enum_variant.rs:9:16
+   |
+LL |    let Foo::Bar::<'static> { field: _z } = foo;
+   |                ^^^^^^^^^^^
+   |
+   = note: `#[warn(type_param_on_variant_ctor)]` on by default
+help: set the type parameter on the enum
+   |
+LL |    let Foo::<'static>::Bar { field: _z } = foo;
+   |           ^^^^^^^^^^^    --
+
+warning: type parameter on variant
+  --> $DIR/pattern_substs_on_brace_enum_variant.rs:17:16
+   |
+LL |        Foo::Bar::<'static> { field: _z } => {}
+   |                ^^^^^^^^^^^
+   |
+help: set the type parameter on the enum
+   |
+LL |        Foo::<'static>::Bar { field: _z } => {}
+   |           ^^^^^^^^^^^    --
+
 error[E0597]: `y` does not live long enough
   --> $DIR/pattern_substs_on_brace_enum_variant.rs:7:32
    |

--- a/src/test/ui/nll/user-annotations/pattern_substs_on_brace_enum_variant.stderr
+++ b/src/test/ui/nll/user-annotations/pattern_substs_on_brace_enum_variant.stderr
@@ -1,17 +1,21 @@
 warning: type parameter on variant
-  --> $DIR/pattern_substs_on_brace_enum_variant.rs:9:18
+  --> $DIR/pattern_substs_on_brace_enum_variant.rs:10:18
    |
 LL |    let Foo::Bar::<'static> { field: _z } = foo;
    |                  ^^^^^^^^^
    |
-   = note: `#[warn(type_param_on_variant_ctor)]` on by default
+note: the lint level is defined here
+  --> $DIR/pattern_substs_on_brace_enum_variant.rs:1:9
+   |
+LL | #![warn(type_param_on_variant_ctor)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: set the type parameter on the enum
    |
 LL |    let Foo::<'static>::Bar { field: _z } = foo;
    |           ^^^^^^^^^^^    --
 
 warning: type parameter on variant
-  --> $DIR/pattern_substs_on_brace_enum_variant.rs:17:18
+  --> $DIR/pattern_substs_on_brace_enum_variant.rs:18:18
    |
 LL |        Foo::Bar::<'static> { field: _z } => {}
    |                  ^^^^^^^^^
@@ -22,7 +26,7 @@ LL |        Foo::<'static>::Bar { field: _z } => {}
    |           ^^^^^^^^^^^    --
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/pattern_substs_on_brace_enum_variant.rs:7:32
+  --> $DIR/pattern_substs_on_brace_enum_variant.rs:8:32
    |
 LL |    let foo = Foo::Bar { field: &y };
    |                                ^^ borrowed value does not live long enough
@@ -33,7 +37,7 @@ LL | }
    | - `y` dropped here while still borrowed
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/pattern_substs_on_brace_enum_variant.rs:14:32
+  --> $DIR/pattern_substs_on_brace_enum_variant.rs:15:32
    |
 LL |    let foo = Foo::Bar { field: &y };
    |                                ^^ borrowed value does not live long enough
@@ -45,7 +49,7 @@ LL | }
    | - `y` dropped here while still borrowed
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/pattern_substs_on_brace_enum_variant.rs:23:32
+  --> $DIR/pattern_substs_on_brace_enum_variant.rs:24:32
    |
 LL |    let foo = Foo::Bar { field: &y };
    |                                ^^ borrowed value does not live long enough
@@ -56,7 +60,7 @@ LL | }
    | - `y` dropped here while still borrowed
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/pattern_substs_on_brace_enum_variant.rs:30:32
+  --> $DIR/pattern_substs_on_brace_enum_variant.rs:31:32
    |
 LL |    let foo = Foo::Bar { field: &y };
    |                                ^^ borrowed value does not live long enough

--- a/src/test/ui/nll/user-annotations/pattern_substs_on_brace_enum_variant.stderr
+++ b/src/test/ui/nll/user-annotations/pattern_substs_on_brace_enum_variant.stderr
@@ -1,8 +1,8 @@
 warning: type parameter on variant
-  --> $DIR/pattern_substs_on_brace_enum_variant.rs:9:16
+  --> $DIR/pattern_substs_on_brace_enum_variant.rs:9:18
    |
 LL |    let Foo::Bar::<'static> { field: _z } = foo;
-   |                ^^^^^^^^^^^
+   |                  ^^^^^^^^^
    |
    = note: `#[warn(type_param_on_variant_ctor)]` on by default
 help: set the type parameter on the enum
@@ -11,10 +11,10 @@ LL |    let Foo::<'static>::Bar { field: _z } = foo;
    |           ^^^^^^^^^^^    --
 
 warning: type parameter on variant
-  --> $DIR/pattern_substs_on_brace_enum_variant.rs:17:16
+  --> $DIR/pattern_substs_on_brace_enum_variant.rs:17:18
    |
 LL |        Foo::Bar::<'static> { field: _z } => {}
-   |                ^^^^^^^^^^^
+   |                  ^^^^^^^^^
    |
 help: set the type parameter on the enum
    |

--- a/src/test/ui/nll/user-annotations/pattern_substs_on_tuple_enum_variant.rs
+++ b/src/test/ui/nll/user-annotations/pattern_substs_on_tuple_enum_variant.rs
@@ -6,7 +6,7 @@ fn in_let() {
     let y = 22;
     let foo = Foo::Bar(&y);
     //~^ ERROR `y` does not live long enough
-    let Foo::Bar::<'static>(_z) = foo;
+    let Foo::Bar::<'static>(_z) = foo; //~ WARNING
 }
 
 fn in_match() {
@@ -14,8 +14,7 @@ fn in_match() {
     let foo = Foo::Bar(&y);
     //~^ ERROR `y` does not live long enough
     match foo {
-        Foo::Bar::<'static>(_z) => {
-        }
+        Foo::Bar::<'static>(_z) => {} //~ WARNING
     }
 }
 

--- a/src/test/ui/nll/user-annotations/pattern_substs_on_tuple_enum_variant.rs
+++ b/src/test/ui/nll/user-annotations/pattern_substs_on_tuple_enum_variant.rs
@@ -1,3 +1,4 @@
+#![warn(type_param_on_variant_ctor)]
 enum Foo<'a> {
     Bar(&'a u32)
 }

--- a/src/test/ui/nll/user-annotations/pattern_substs_on_tuple_enum_variant.stderr
+++ b/src/test/ui/nll/user-annotations/pattern_substs_on_tuple_enum_variant.stderr
@@ -1,17 +1,21 @@
 warning: type parameter on variant
-  --> $DIR/pattern_substs_on_tuple_enum_variant.rs:9:19
+  --> $DIR/pattern_substs_on_tuple_enum_variant.rs:10:19
    |
 LL |     let Foo::Bar::<'static>(_z) = foo;
    |                   ^^^^^^^^^
    |
-   = note: `#[warn(type_param_on_variant_ctor)]` on by default
+note: the lint level is defined here
+  --> $DIR/pattern_substs_on_tuple_enum_variant.rs:1:9
+   |
+LL | #![warn(type_param_on_variant_ctor)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: set the type parameter on the enum
    |
 LL |     let Foo::<'static>::Bar(_z) = foo;
    |            ^^^^^^^^^^^    --
 
 warning: type parameter on variant
-  --> $DIR/pattern_substs_on_tuple_enum_variant.rs:17:19
+  --> $DIR/pattern_substs_on_tuple_enum_variant.rs:18:19
    |
 LL |         Foo::Bar::<'static>(_z) => {}
    |                   ^^^^^^^^^
@@ -22,7 +26,7 @@ LL |         Foo::<'static>::Bar(_z) => {}
    |            ^^^^^^^^^^^    --
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/pattern_substs_on_tuple_enum_variant.rs:7:24
+  --> $DIR/pattern_substs_on_tuple_enum_variant.rs:8:24
    |
 LL |     let foo = Foo::Bar(&y);
    |                        ^^ borrowed value does not live long enough
@@ -33,7 +37,7 @@ LL | }
    | - `y` dropped here while still borrowed
 
 error[E0597]: `y` does not live long enough
-  --> $DIR/pattern_substs_on_tuple_enum_variant.rs:14:24
+  --> $DIR/pattern_substs_on_tuple_enum_variant.rs:15:24
    |
 LL |     let foo = Foo::Bar(&y);
    |                        ^^ borrowed value does not live long enough

--- a/src/test/ui/nll/user-annotations/pattern_substs_on_tuple_enum_variant.stderr
+++ b/src/test/ui/nll/user-annotations/pattern_substs_on_tuple_enum_variant.stderr
@@ -1,8 +1,8 @@
 warning: type parameter on variant
-  --> $DIR/pattern_substs_on_tuple_enum_variant.rs:9:17
+  --> $DIR/pattern_substs_on_tuple_enum_variant.rs:9:19
    |
 LL |     let Foo::Bar::<'static>(_z) = foo;
-   |                 ^^^^^^^^^^^
+   |                   ^^^^^^^^^
    |
    = note: `#[warn(type_param_on_variant_ctor)]` on by default
 help: set the type parameter on the enum
@@ -11,10 +11,10 @@ LL |     let Foo::<'static>::Bar(_z) = foo;
    |            ^^^^^^^^^^^    --
 
 warning: type parameter on variant
-  --> $DIR/pattern_substs_on_tuple_enum_variant.rs:17:17
+  --> $DIR/pattern_substs_on_tuple_enum_variant.rs:17:19
    |
 LL |         Foo::Bar::<'static>(_z) => {}
-   |                 ^^^^^^^^^^^
+   |                   ^^^^^^^^^
    |
 help: set the type parameter on the enum
    |

--- a/src/test/ui/nll/user-annotations/pattern_substs_on_tuple_enum_variant.stderr
+++ b/src/test/ui/nll/user-annotations/pattern_substs_on_tuple_enum_variant.stderr
@@ -1,3 +1,26 @@
+warning: type parameter on variant
+  --> $DIR/pattern_substs_on_tuple_enum_variant.rs:9:17
+   |
+LL |     let Foo::Bar::<'static>(_z) = foo;
+   |                 ^^^^^^^^^^^
+   |
+   = note: `#[warn(type_param_on_variant_ctor)]` on by default
+help: set the type parameter on the enum
+   |
+LL |     let Foo::<'static>::Bar(_z) = foo;
+   |            ^^^^^^^^^^^    --
+
+warning: type parameter on variant
+  --> $DIR/pattern_substs_on_tuple_enum_variant.rs:17:17
+   |
+LL |         Foo::Bar::<'static>(_z) => {}
+   |                 ^^^^^^^^^^^
+   |
+help: set the type parameter on the enum
+   |
+LL |         Foo::<'static>::Bar(_z) => {}
+   |            ^^^^^^^^^^^    --
+
 error[E0597]: `y` does not live long enough
   --> $DIR/pattern_substs_on_tuple_enum_variant.rs:7:24
    |
@@ -15,9 +38,9 @@ error[E0597]: `y` does not live long enough
 LL |     let foo = Foo::Bar(&y);
    |                        ^^ borrowed value does not live long enough
 ...
-LL |         Foo::Bar::<'static>(_z) => {
+LL |         Foo::Bar::<'static>(_z) => {}
    |         ----------------------- type annotation requires that `y` is borrowed for `'static`
-...
+LL |     }
 LL | }
    | - `y` dropped here while still borrowed
 

--- a/src/test/ui/nullable-pointer-iotareduction.rs
+++ b/src/test/ui/nullable-pointer-iotareduction.rs
@@ -1,6 +1,7 @@
 // run-pass
 
 #![feature(box_syntax)]
+#![allow(type_param_on_variant_ctor)]
 
 // Iota-reduction is a rule in the Calculus of (Co-)Inductive Constructions,
 // which "says that a destructor applied to an object built from a constructor

--- a/src/test/ui/occurs-check-3.rs
+++ b/src/test/ui/occurs-check-3.rs
@@ -1,4 +1,5 @@
 // From Issue #778
+#![allow(type_param_on_variant_ctor)]
 
 enum Clam<T> { A(T) }
 fn main() { let c; c = Clam::A(c); match c { Clam::A::<isize>(_) => { } } }

--- a/src/test/ui/occurs-check-3.stderr
+++ b/src/test/ui/occurs-check-3.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/occurs-check-3.rs:4:24
+  --> $DIR/occurs-check-3.rs:5:24
    |
 LL | fn main() { let c; c = Clam::A(c); match c { Clam::A::<isize>(_) => { } } }
    |                        ^^^^^^^^^^ cyclic type of infinite size

--- a/src/test/ui/shadow.rs
+++ b/src/test/ui/shadow.rs
@@ -1,7 +1,6 @@
 // run-pass
 
-#![allow(non_camel_case_types)]
-#![allow(dead_code)]
+#![allow(non_camel_case_types, type_param_on_variant_ctor, dead_code)]
 fn foo(c: Vec<isize> ) {
     let a: isize = 5;
     let mut b: Vec<isize> = Vec::new();

--- a/src/test/ui/size-and-align.rs
+++ b/src/test/ui/size-and-align.rs
@@ -1,6 +1,6 @@
 // run-pass
 
-#![allow(non_camel_case_types)]
+#![allow(non_camel_case_types, type_param_on_variant_ctor)]
 enum clam<T> { a(T, isize), b, }
 
 fn uhoh<T>(v: Vec<clam<T>> ) {

--- a/src/test/ui/structs-enums/simple-match-generic-tag.rs
+++ b/src/test/ui/structs-enums/simple-match-generic-tag.rs
@@ -1,6 +1,5 @@
 // run-pass
-#![allow(dead_code)]
-#![allow(non_camel_case_types)]
+#![allow(dead_code, non_camel_case_types, type_param_on_variant_ctor)]
 
 enum opt<T> { none, some(T) }
 

--- a/src/test/ui/try-poll.rs
+++ b/src/test/ui/try-poll.rs
@@ -1,6 +1,6 @@
 // build-pass (FIXME(62277): could be check-pass?)
 
-#![allow(dead_code, unused)]
+#![allow(dead_code, unused, type_param_on_variant_ctor)]
 
 use std::task::Poll;
 

--- a/src/test/ui/type-alias-enum-variants/enum-variant-generic-args-pass.rs
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-generic-args-pass.rs
@@ -1,4 +1,5 @@
 // run-pass
+#![allow(type_param_on_variant_ctor)]
 
 // Check that resolving, in the value namespace, to an `enum` variant
 // through a type alias is well behaved in the presence of generics.

--- a/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.rs
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.rs
@@ -70,7 +70,7 @@ fn main() {
     // Struct variant
 
     Enum::<()>::SVariant::<()> { v: () };
-    //~^ ERROR type arguments are not allowed for this type [E0109]
+    //~^ ERROR multiple segments with type parameters are not allowed
 
     Alias::SVariant::<()> { v: () };
     //~^ ERROR type arguments are not allowed for this type [E0109]

--- a/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.rs
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.rs
@@ -52,7 +52,7 @@ fn main() {
     // Tuple struct variant
 
     Enum::<()>::TSVariant::<()>(());
-    //~^ ERROR type arguments are not allowed for this type [E0109]
+    //~^ ERROR multiple segments with type parameters are not allowed
 
     Alias::TSVariant::<()>(());
     //~^ ERROR type arguments are not allowed for this type [E0109]
@@ -88,7 +88,7 @@ fn main() {
     // Unit variant
 
     Enum::<()>::UVariant::<()>;
-    //~^ ERROR type arguments are not allowed for this type [E0109]
+    //~^ ERROR multiple segments with type parameters are not allowed
 
     Alias::UVariant::<()>;
     //~^ ERROR type arguments are not allowed for this type [E0109]

--- a/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
@@ -154,11 +154,13 @@ error[E0109]: type arguments are not allowed for this type
 LL |         Self::<()>::UVariant::<()>;
    |                                ^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed for this type
-  --> $DIR/enum-variant-generic-args.rs:54:29
+error: multiple segments with type parameters are not allowed
+  --> $DIR/enum-variant-generic-args.rs:54:11
    |
 LL |     Enum::<()>::TSVariant::<()>(());
-   |                             ^^ type argument not allowed
+   |           ^^^^             ^^^^
+   |
+   = note: only a single path segment can specify type parameters
 
 error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:57:24
@@ -197,10 +199,10 @@ LL |     AliasFixed::<()>::TSVariant::<()>(());
    |                                   ^^ type argument not allowed
 
 error: multiple segments with type parameters are not allowed
-  --> $DIR/enum-variant-generic-args.rs:72:5
+  --> $DIR/enum-variant-generic-args.rs:72:11
    |
 LL |     Enum::<()>::SVariant::<()> { v: () };
-   |     ^^^^        ^^^^^^^^
+   |           ^^^^            ^^^^
    |
    = note: only a single path segment can specify type parameters
 
@@ -240,11 +242,13 @@ error[E0109]: type arguments are not allowed for this type
 LL |     AliasFixed::<()>::SVariant::<()> { v: () };
    |                                  ^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed for this type
-  --> $DIR/enum-variant-generic-args.rs:90:28
+error: multiple segments with type parameters are not allowed
+  --> $DIR/enum-variant-generic-args.rs:90:11
    |
 LL |     Enum::<()>::UVariant::<()>;
-   |                            ^^ type argument not allowed
+   |           ^^^^            ^^^^
+   |
+   = note: only a single path segment can specify type parameters
 
 error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:93:23

--- a/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
@@ -196,11 +196,13 @@ error[E0109]: type arguments are not allowed for this type
 LL |     AliasFixed::<()>::TSVariant::<()>(());
    |                                   ^^ type argument not allowed
 
-error[E0109]: type arguments are not allowed for this type
-  --> $DIR/enum-variant-generic-args.rs:72:28
+error: multiple segments with type parameters are not allowed
+  --> $DIR/enum-variant-generic-args.rs:72:5
    |
 LL |     Enum::<()>::SVariant::<()> { v: () };
-   |                            ^^ type argument not allowed
+   |     ^^^^        ^^^^^^^^
+   |
+   = note: only a single path segment can specify type parameters
 
 error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:75:23

--- a/src/test/ui/type-alias-enum-variants/no-type-application-on-aliased-enum-variant.rs
+++ b/src/test/ui/type-alias-enum-variants/no-type-application-on-aliased-enum-variant.rs
@@ -1,3 +1,4 @@
+#![deny(type_param_on_variant_ctor)]
 // Check that a generic type for an `enum` admits type application
 // on both the type constructor and the generic type's variant.
 //
@@ -8,7 +9,7 @@ type Alias<T> = Option<T>;
 
 fn main() {
     let _ = Option::<u8>::None; // OK
-    let _ = Option::None::<u8>; //~ WARNING type parameter on variant
+    let _ = Option::None::<u8>; //~ ERROR type parameter on variant
     let _ = Alias::<u8>::None; // OK
     let _ = Alias::None::<u8>; //~ ERROR type arguments are not allowed for this type
 }

--- a/src/test/ui/type-alias-enum-variants/no-type-application-on-aliased-enum-variant.rs
+++ b/src/test/ui/type-alias-enum-variants/no-type-application-on-aliased-enum-variant.rs
@@ -8,7 +8,7 @@ type Alias<T> = Option<T>;
 
 fn main() {
     let _ = Option::<u8>::None; // OK
-    let _ = Option::None::<u8>; // OK (Lint in future!)
+    let _ = Option::None::<u8>; //~ WARNING type parameter on variant
     let _ = Alias::<u8>::None; // OK
     let _ = Alias::None::<u8>; //~ ERROR type arguments are not allowed for this type
 }

--- a/src/test/ui/type-alias-enum-variants/no-type-application-on-aliased-enum-variant.stderr
+++ b/src/test/ui/type-alias-enum-variants/no-type-application-on-aliased-enum-variant.stderr
@@ -1,21 +1,25 @@
-warning: type parameter on variant
-  --> $DIR/no-type-application-on-aliased-enum-variant.rs:11:27
+error: type parameter on variant
+  --> $DIR/no-type-application-on-aliased-enum-variant.rs:12:27
    |
 LL |     let _ = Option::None::<u8>;
    |                           ^^^^
    |
-   = note: `#[warn(type_param_on_variant_ctor)]` on by default
+note: the lint level is defined here
+  --> $DIR/no-type-application-on-aliased-enum-variant.rs:1:9
+   |
+LL | #![deny(type_param_on_variant_ctor)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: set the type parameter on the enum
    |
 LL |     let _ = Option::<u8>::None;
    |                   ^^^^^^     --
 
 error[E0109]: type arguments are not allowed for this type
-  --> $DIR/no-type-application-on-aliased-enum-variant.rs:13:27
+  --> $DIR/no-type-application-on-aliased-enum-variant.rs:14:27
    |
 LL |     let _ = Alias::None::<u8>;
    |                           ^^ type argument not allowed
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0109`.

--- a/src/test/ui/type-alias-enum-variants/no-type-application-on-aliased-enum-variant.stderr
+++ b/src/test/ui/type-alias-enum-variants/no-type-application-on-aliased-enum-variant.stderr
@@ -1,3 +1,15 @@
+warning: type parameter on variant
+  --> $DIR/no-type-application-on-aliased-enum-variant.rs:11:25
+   |
+LL |     let _ = Option::None::<u8>;
+   |                         ^^^^^^
+   |
+   = note: `#[warn(type_param_on_variant_ctor)]` on by default
+help: set the type parameter on the enum
+   |
+LL |     let _ = Option::<u8>::None;
+   |                   ^^^^^^     --
+
 error[E0109]: type arguments are not allowed for this type
   --> $DIR/no-type-application-on-aliased-enum-variant.rs:13:27
    |

--- a/src/test/ui/type-alias-enum-variants/no-type-application-on-aliased-enum-variant.stderr
+++ b/src/test/ui/type-alias-enum-variants/no-type-application-on-aliased-enum-variant.stderr
@@ -1,8 +1,8 @@
 warning: type parameter on variant
-  --> $DIR/no-type-application-on-aliased-enum-variant.rs:11:25
+  --> $DIR/no-type-application-on-aliased-enum-variant.rs:11:27
    |
 LL |     let _ = Option::None::<u8>;
-   |                         ^^^^^^
+   |                           ^^^^
    |
    = note: `#[warn(type_param_on_variant_ctor)]` on by default
 help: set the type parameter on the enum


### PR DESCRIPTION
Fix https://github.com/rust-lang/rust/issues/69356.

r? @petrochenkov @eddyb @Centril 