### PR TITLE
Improve linking of crates with circular dependencies

### DIFF
--- a/src/test/run-make-fulldeps/issue-69368/Makefile
+++ b/src/test/run-make-fulldeps/issue-69368/Makefile
@@ -1,0 +1,18 @@
+-include ../tools.mk
+
+# Test that previously triggered a linker failure with root cause
+# similar to one found in the issue #69368.
+#
+# The crate that provides oom lang item is missing some other lang
+# items. Necessary to prevent the use of start-group / end-group.
+#
+# The weak lang items are defined in a separate compilation units,
+# so that linker could omit them if not used.
+#
+# The crates that need those weak lang items are dependencies of
+# crates that provide them.
+
+all:
+	$(RUSTC) a.rs
+	$(RUSTC) b.rs
+	$(RUSTC) c.rs

--- a/src/test/run-make-fulldeps/issue-69368/a.rs
+++ b/src/test/run-make-fulldeps/issue-69368/a.rs
@@ -1,0 +1,16 @@
+#![crate_type = "rlib"]
+#![feature(lang_items)]
+#![feature(panic_unwind)]
+#![no_std]
+
+extern crate panic_unwind;
+
+#[panic_handler]
+pub fn panic_handler(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[no_mangle]
+extern "C" fn __rust_drop_panic() -> ! {
+    loop {}
+}

--- a/src/test/run-make-fulldeps/issue-69368/b.rs
+++ b/src/test/run-make-fulldeps/issue-69368/b.rs
@@ -1,0 +1,8 @@
+#![crate_type = "rlib"]
+#![feature(alloc_error_handler)]
+#![no_std]
+
+#[alloc_error_handler]
+pub fn error_handler(_: core::alloc::Layout) -> ! {
+    panic!();
+}

--- a/src/test/run-make-fulldeps/issue-69368/c.rs
+++ b/src/test/run-make-fulldeps/issue-69368/c.rs
@@ -1,0 +1,34 @@
+#![crate_type = "bin"]
+#![feature(start)]
+#![no_std]
+
+extern crate alloc;
+extern crate a;
+extern crate b;
+
+use alloc::vec::Vec;
+use core::alloc::*;
+
+struct Allocator;
+
+unsafe impl GlobalAlloc for Allocator {
+    unsafe fn alloc(&self, _: Layout) -> *mut u8 {
+        loop {}
+    }
+
+    unsafe fn dealloc(&self, _: *mut u8, _: Layout) {
+        loop {}
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Allocator = Allocator;
+
+#[start]
+fn main(argc: isize, _argv: *const *const u8) -> isize {
+    let mut v = Vec::new();
+    for i in 0..argc {
+        v.push(i);
+    }
+    v.iter().sum()
+}


### PR DESCRIPTION
Previously, the code responsible for handling the cycles between crates
introduces through weak lang items, would keep a set of missing language
items:

* extending it with items missing from the current crate,
* removing items provided by the current crate,
* grouping the crates when the set changed from non-empty back to empty.

This could produce incorrect results, if a lang item was missing from a
crate that comes after the crate that provides it (in the loop iteration
order). In that case the grouping would not take place.

The changes here address this specific failure scenario by keeping track
of two separate sets of crates. Those that are required to link successfully,
and those that are available for linking.

Verified using test case from #69368.