### PR TITLE
Fix false "never constructed" warnings for `Self::` variant paths (resolved conflict)

### DIFF
--- a/src/librustc_passes/dead.rs
+++ b/src/librustc_passes/dead.rs
@@ -286,8 +286,12 @@ impl<'a, 'tcx> Visitor<'tcx> for MarkSymbolVisitor<'a, 'tcx> {
         self.in_pat = false;
     }
 
-    fn visit_qpath(&mut self, qpath: &'tcx hir::QPath<'tcx>,
-                   id: hir::HirId, span: rustc_span::Span) {
+    fn visit_qpath(
+        &mut self,
+        qpath: &'tcx hir::QPath<'tcx>,
+        id: hir::HirId,
+        span: rustc_span::Span,
+    ) {
         let res = self.tables.qpath_res(qpath, id);
         self.handle_res(res);
         intravisit::walk_qpath(self, qpath, id, span);

--- a/src/test/ui/lint/dead-code/lint-dead-code-5.rs
+++ b/src/test/ui/lint/dead-code/lint-dead-code-5.rs
@@ -13,6 +13,23 @@ enum Enum2 {
     Variant5 { _x: isize }, //~ ERROR: variant is never constructed: `Variant5`
     Variant6(isize), //~ ERROR: variant is never constructed: `Variant6`
     _Variant7,
+    Variant8 { _field: bool },
+    Variant9,
+    Variant10(usize)
+}
+
+impl Enum2 {
+    fn new_variant8() -> Enum2 {
+        Self::Variant8 { _field: true }
+    }
+
+    fn new_variant9() -> Enum2 {
+        Self::Variant9
+    }
+
+    fn new_variant10() -> Enum2 {
+        Self::Variant10(10)
+    }
 }
 
 enum Enum3 { //~ ERROR: enum is never used
@@ -26,5 +43,8 @@ fn main() {
         Enum1::Variant1(_) => (),
         Enum1::Variant2 => ()
     }
-    let x = Enum2::Variant3(true);
+    let _ = Enum2::Variant3(true);
+    let _ = Enum2::new_variant8();
+    let _ = Enum2::new_variant9();
+    let _ = Enum2::new_variant10();
 }

--- a/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
@@ -23,7 +23,7 @@ LL |     Variant6(isize),
    |     ^^^^^^^^^^^^^^^
 
 error: enum is never used: `Enum3`
-  --> $DIR/lint-dead-code-5.rs:18:6
+  --> $DIR/lint-dead-code-5.rs:35:6
    |
 LL | enum Enum3 {
    |      ^^^^^


### PR DESCRIPTION
Closes #64362.
Resolved conflict of original PR #64424