### PR TITLE
Fail on multiple declarations of `main`.

### DIFF
--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -437,10 +437,10 @@ pub fn maybe_create_entry_wrapper<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         // listing.
         let main_ret_ty = cx.tcx().erase_regions(&main_ret_ty.no_bound_vars().unwrap());
 
-        if cx.get_defined_value("main").is_some() {
+        if cx.get_declared_value("main").is_some() {
             // FIXME: We should be smart and show a better diagnostic here.
             cx.sess()
-                .struct_span_err(sp, "entry symbol `main` defined multiple times")
+                .struct_span_err(sp, "entry symbol `main` declared multiple times")
                 .help("did you use `#[no_mangle]` on `fn main`? Use `#[start]` instead")
                 .emit();
             cx.sess().abort_if_errors();

--- a/src/test/ui/duplicate/dupe-symbols-7.rs
+++ b/src/test/ui/duplicate/dupe-symbols-7.rs
@@ -1,7 +1,7 @@
 // build-fail
 
 //
-// error-pattern: entry symbol `main` defined multiple times
+// error-pattern: entry symbol `main` declared multiple times
 
 // FIXME https://github.com/rust-lang/rust/issues/59774
 // normalize-stderr-test "thread.*panicked.*Metadata module not compiled.*\n" -> ""

--- a/src/test/ui/duplicate/dupe-symbols-8.rs
+++ b/src/test/ui/duplicate/dupe-symbols-8.rs
@@ -1,0 +1,12 @@
+// build-fail
+// error-pattern: entry symbol `main` declared multiple times
+//
+// See #67946.
+
+#![allow(warnings)]
+fn main() {
+    extern "Rust" {
+     fn main();
+    }
+    unsafe { main(); }
+}

--- a/src/test/ui/duplicate/dupe-symbols-8.stderr
+++ b/src/test/ui/duplicate/dupe-symbols-8.stderr
@@ -1,8 +1,13 @@
 error: entry symbol `main` declared multiple times
-  --> $DIR/dupe-symbols-7.rs:12:1
+  --> $DIR/dupe-symbols-8.rs:7:1
    |
-LL | fn main(){}
-   | ^^^^^^^^^^^
+LL | / fn main() {
+LL | |     extern "Rust" {
+LL | |      fn main();
+LL | |     }
+LL | |     unsafe { main(); }
+LL | | }
+   | |_^
    |
    = help: did you use `#[no_mangle]` on `fn main`? Use `#[start]` instead
 


### PR DESCRIPTION
Closes #67946.

Previously, when inserting the entry function, we only checked for
duplicate _definitions_ of `main`.  However, it's possible to cause
problems even only having a duplicate _declaration_. For example,
shadowing `main` using an extern block isn't caught by the current
check, and causes an assertion failure down the line in in LLVM code.

r? @pnkfelix 