### PR TITLE
Allow getting `no_std` from the config file

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -177,6 +177,15 @@ pub struct Target {
     pub no_std: bool,
 }
 
+impl Target {
+    pub fn from_triple(triple: &str) -> Self {
+        let mut target: Self = Default::default();
+        if triple.contains("-none-") || triple.contains("nvptx") {
+            target.no_std = true;
+        }
+        target
+    }
+}
 /// Structure of the `config.toml` file that configuration is read from.
 ///
 /// This structure uses `Decodable` to automatically decode a TOML configuration
@@ -596,7 +605,7 @@ impl Config {
 
         if let Some(ref t) = toml.target {
             for (triple, cfg) in t {
-                let mut target = Target::default();
+                let mut target = Target::from_triple(triple);
 
                 if let Some(ref s) = cfg.llvm_config {
                     target.llvm_config = Some(config.src.join(s));
@@ -607,6 +616,9 @@ impl Config {
                 if let Some(ref s) = cfg.android_ndk {
                     target.ndk = Some(config.src.join(s));
                 }
+                if let Some(s) = cfg.no_std {
+                    target.no_std = s;
+                }
                 target.cc = cfg.cc.clone().map(PathBuf::from);
                 target.cxx = cfg.cxx.clone().map(PathBuf::from);
                 target.ar = cfg.ar.clone().map(PathBuf::from);
@@ -616,8 +628,6 @@ impl Config {
                 target.musl_root = cfg.musl_root.clone().map(PathBuf::from);
                 target.wasi_root = cfg.wasi_root.clone().map(PathBuf::from);
                 target.qemu_rootfs = cfg.qemu_rootfs.clone().map(PathBuf::from);
-                target.no_std =
-                    cfg.no_std.unwrap_or(triple.contains("-none-") || triple.contains("nvptx"));
 
                 config.target_config.insert(INTERNER.intern_string(triple.clone()), target);
             }

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -353,6 +353,7 @@ struct TomlTarget {
     musl_root: Option<String>,
     wasi_root: Option<String>,
     qemu_rootfs: Option<String>,
+    no_std: Option<bool>,
 }
 
 impl Config {
@@ -615,6 +616,8 @@ impl Config {
                 target.musl_root = cfg.musl_root.clone().map(PathBuf::from);
                 target.wasi_root = cfg.wasi_root.clone().map(PathBuf::from);
                 target.qemu_rootfs = cfg.qemu_rootfs.clone().map(PathBuf::from);
+                target.no_std =
+                    cfg.no_std.unwrap_or(triple.contains("-none-") || triple.contains("nvptx"));
 
                 config.target_config.insert(INTERNER.intern_string(triple.clone()), target);
             }

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -17,6 +17,7 @@ use std::process::Command;
 
 use build_helper::{output, t};
 
+use crate::config::Target;
 use crate::Build;
 
 struct Finder {
@@ -192,11 +193,9 @@ pub fn check(build: &mut Build) {
             panic!("the iOS target is only supported on macOS");
         }
 
-        if target.contains("-none-") || target.contains("nvptx") {
-            if build.no_std(*target).is_none() {
-                build.config.target_config.entry(target.clone()).or_default();
-            }
+        build.config.target_config.entry(target.clone()).or_insert(Target::from_triple(target));
 
+        if target.contains("-none-") || target.contains("nvptx") {
             if build.no_std(*target) == Some(false) {
                 panic!("All the *-none-* and nvptx* targets are no-std targets")
             }

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -194,9 +194,7 @@ pub fn check(build: &mut Build) {
 
         if target.contains("-none-") || target.contains("nvptx") {
             if build.no_std(*target).is_none() {
-                let target = build.config.target_config.entry(target.clone()).or_default();
-
-                target.no_std = true;
+                build.config.target_config.entry(target.clone()).or_default();
             }
 
             if build.no_std(*target) == Some(false) {


### PR DESCRIPTION
Currently, it is only set correctly in the sanity checking implicit
default fallback code. Having a config file at all will for force
`no_std = false`.