### PR TITLE
Fix minor error in `MaybeUninit::get_mut()` doc example

### DIFF
--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -669,7 +669,7 @@ impl<T> MaybeUninit<T> {
     /// // Now we can use `buf` as a normal slice:
     /// buf.sort_unstable();
     /// assert!(
-    ///     buf.chunks(2).all(|chunk| chunk[0] <= chunk[1]),
+    ///     buf.windows(2).all(|pair| pair[0] <= pair[1]),
     ///     "buffer is sorted",
     /// );
     /// ```


### PR DESCRIPTION
In the `MaybeUninit::get_mut()` example I wanted to assert that the slice was sorted and mistakenly used `.chunks(2)` rather than `.windows(2)` to assert it, as @ametisf pointed out in https://github.com/rust-lang/rust/pull/65948#issuecomment-589988183 .

This fixes it.

