### PR TITLE
[perf] Skip iterating over impls that could not possibly apply

### DIFF
--- a/src/librustc/ich/mod.rs
+++ b/src/librustc/ich/mod.rs
@@ -1,7 +1,8 @@
 //! ICH - Incremental Compilation Hash
 
 pub use self::hcx::{
-    hash_stable_trait_impls, NodeIdHashingMode, StableHashingContext, StableHashingContextProvider,
+    hash_stable_trait_impls, hash_stable_trait_impls_by_crate, NodeIdHashingMode,
+    StableHashingContext, StableHashingContextProvider,
 };
 crate use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_span::symbol::{sym, Symbol};

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -33,6 +33,7 @@
 #![feature(exhaustive_patterns)]
 #![feature(marker_trait_attr)]
 #![feature(extern_types)]
+#![feature(fn_traits)]
 #![feature(nll)]
 #![feature(option_expect_none)]
 #![feature(range_is_empty)]

--- a/src/librustc_infer/traits/select.rs
+++ b/src/librustc_infer/traits/select.rs
@@ -1714,9 +1714,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     ) -> Result<(), SelectionError<'tcx>> {
         debug!("assemble_candidates_from_impls(obligation={:?})", obligation);
 
-        self.tcx().for_each_relevant_impl(
+        self.tcx().for_each_relevant_impl_trait_ref(
             obligation.predicate.def_id(),
-            obligation.predicate.skip_binder().trait_ref.self_ty(),
+            obligation.predicate.skip_binder().trait_ref,
             |impl_def_id| {
                 self.infcx.probe(|snapshot| {
                     if let Ok(_substs) = self.match_impl(impl_def_id, obligation, snapshot) {


### PR DESCRIPTION
Currently, `tcx.for_each_relevant_impl` invokes the provided callback
with every non-blanket impl that has the right 'structure', based on
`fast_reject::simplify_type`. However, this will still consider impls
from crates that could not possibly define an impl for `self_ty`, based
on the orphan rule.

For example, imagine we have the following crates and code:

Crate A: `trait MyTrait {}`

Crate B:
```rust
struct CrateBStruct;
impl MyTrait for CrateBStruct
```

Crate C:
```rust
struct CrateCStruct;
impl MyTrait for CrateCStruct
```

if we call `tcx.for_each_relevant_impl` with `MyTrait` and
`CrateBStruct`, we will end up passing `impl MyTrait for CrateCStruct`
to the provided callback. However, crate C does not define `MyTrait`,
nor are any types from crate C used the self type `CrateBStruct`.
This makes it impossible for any impl from crate C to apply (crate C
cannot provide a blanket impl, and any non-blanket impls will not apply
due to the fact that we don't mention any types for crate C).

This results in unecessary work being performed in the caller of
`for_each_relevant_impl`. For example, trait selection will enter
an `infcx.probe` environment that is guarnateed to fail, resulting in a
pointless snapshot and restore.

This PR creates a new version of `tcx.for_each_relevant_impl` called
`tcx.for_each_relevant_impl_trait_ref`, which takes into account the
orphan rule when deciding which impls to pass to the callback. A
`TraitRef` is needed rather than a plain `Ty` because we allow code like
this:

```rust
struct MyStruct;
impl PartialEq<MyStruct> for str { ... }
```

which requires us to consider both type parameters for the trait,
as well as the self type.

This implementation uses a conservative overapproximation of the
orphan rule. Invoking the callback for every single impl in existence
would be perfectly valid (though incredibly inefficient), so it's fine
if we have false positives.

Specifically, we check if every type mentioned in the `TraitRef` (not
considering nested types) has a clear 'defining crate'. If so, we
require that all impls come from the same crate as one of the types in
the `TraitRef`. If we could not determine a 'defining crate' for any
type, we just pass all impls to the callback to be safe.

For now, we treat `&_`, `&mut _`, and `#[fundamental]` types as having
no 'defining crate', and revert to the old behavior as described above.
This is for both simplicitly and performance - to properly determine the
'defining crate', it would be necessary to recursively 'peel away' such
types until we hit a non-fundamental/non-reference type. Otherwise, we
will fail to locate impl like:

```rust
struct MyStruct<T>(T);
impl<T> ForeignTrait for Box<MyStruct<T>> {}
```

When trying to find an impl for `<Box<MyStruct<_>> as ForeignTrait>`,
failing to consider `#[fundamental]` types would cause us to only check
for impls in the defining crate of `Box` (liballoc) and the defining
crate of `ForeignTrait`, meaning that we would incorrectly ignore impls
in the crate where `MyStruct` is defined.