### PR TITLE
Add rustdoc aliases to `ptr::copy` and `ptr::copy_nonoverlapping`

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1515,6 +1515,7 @@ fn overlaps<T>(src: *const T, dst: *const T, count: usize) -> bool {
 /// ```
 ///
 /// [`Vec::append`]: ../../std/vec/struct.Vec.html#method.append
+#[doc(alias = "memcpy")]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[inline]
 pub unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize) {
@@ -1579,6 +1580,7 @@ pub unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize) {
 ///     dst
 /// }
 /// ```
+#[doc(alias = "memmove")]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[inline]
 pub unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {


### PR DESCRIPTION
This PR adds a [rustdoc alias](https://doc.rust-lang.org/nightly/rustdoc/unstable-features.html#add-aliases-for-an-item-in-documentation-search) to `ptr::copy` and `ptr::copy_nonoverlapping` using the commonly used terms `memcpy` and `memmove`. The motivation for this PR is to improve discoverability for these functions, since I've noticed users overlook these functions on multiple occasions (and they have thus reached for [libc](https://crates.io/crates/libc) without need). Currently std docs state:

https://doc.rust-lang.org/nightly/std/ptr/fn.copy_nonoverlapping.html
> `copy_nonoverlapping` is semantically equivalent to C's `memcpy`, but with the argument order swapped.

https://doc.rust-lang.org/nightly/std/ptr/fn.copy.html
> `copy` is semantically equivalent to C's `memmove`, but with the argument order swapped.

#### search results before adding a rustdoc alias:
![screenshot 6517](https://user-images.githubusercontent.com/6868531/75102985-78fbb680-55c2-11ea-8e41-04979e6fa6f6.png)
![screenshot 6518](https://user-images.githubusercontent.com/6868531/75102984-78632000-55c2-11ea-9673-8822aae636d1.png)


#### after adding `#[doc(alias = "memcpy")]` and `#[doc(alias = "memmove")]`:
![screenshot 6516](https://user-images.githubusercontent.com/6868531/75102986-78fbb680-55c2-11ea-93b9-1929be940043.png)
![screenshot 6515](https://user-images.githubusercontent.com/6868531/75102987-78fbb680-55c2-11ea-9861-ce8a77a0c3b9.png)

