### PR TITLE
bootstrap: Remove commit hash from LLVM version suffix to avoid rebuilds

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -241,12 +241,8 @@ impl Step for Llvm {
                 cfg.define("LLVM_VERSION_SUFFIX", suffix);
             }
         } else {
-            let mut default_suffix =
-                format!("-rust-{}-{}", channel::CFG_RELEASE_NUM, builder.config.channel,);
-            if let Some(sha) = llvm_info.sha_short() {
-                default_suffix.push_str("-");
-                default_suffix.push_str(sha);
-            }
+            let default_suffix =
+                format!("-rust-{}-{}", channel::CFG_RELEASE_NUM, builder.config.channel);
             cfg.define("LLVM_VERSION_SUFFIX", default_suffix);
         }
 


### PR DESCRIPTION
The custom LLVM version suffix was introduced to avoid unintentional
library names conflicts. By default it included the LLVM submodule
commit hash. Changing the version suffix requires the complete LLVM
rebuild, and since then every change to the submodules required it as
well.

Remove the commit hash from version suffix to avoid complete rebuilds,
while leaving the `rust` string, the release number and release channel
to disambiguate the library name.

Context: version suffix was introduced by #59173 as solution to #59034.

Resolves #68715.