### PR TITLE
docs: Stdin::read_line: mention the appending

### DIFF
--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -302,7 +302,7 @@ impl Stdin {
         StdinLock { inner: self.inner.lock().unwrap_or_else(|e| e.into_inner()) }
     }
 
-    /// Locks this handle and reads a line of input into the specified buffer.
+    /// Locks this handle and reads a line of input, appending it to the specified buffer.
     ///
     /// For detailed semantics of this method, see the documentation on
     /// [`BufRead::read_line`].


### PR DESCRIPTION
The fact that `stdin().read_line()` is an [unpleasant](https://twitter.com/Michcioperz/status/1231646797661167617?s=20) [footgun](https://rustbattle.net/battle/straight-finch-8-e4f4). Let's make it clearer in the documentation.