### PR TITLE
Mark attributes consumed by `check_mod_attrs` as normal

### DIFF
--- a/src/librustc_feature/builtin_attrs.rs
+++ b/src/librustc_feature/builtin_attrs.rs
@@ -234,7 +234,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ungated!(export_name, Whitelisted, template!(NameValueStr: "name")),
     ungated!(link_section, Whitelisted, template!(NameValueStr: "name")),
     ungated!(no_mangle, Whitelisted, template!(Word)),
-    ungated!(used, Whitelisted, template!(Word)),
+    ungated!(used, Normal, template!(Word)),
 
     // Limits:
     ungated!(recursion_limit, CrateLevel, template!(NameValueStr: "N")),
@@ -250,17 +250,17 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ungated!(path, Normal, template!(NameValueStr: "file")),
     ungated!(no_std, CrateLevel, template!(Word)),
     ungated!(no_implicit_prelude, Normal, template!(Word)),
-    ungated!(non_exhaustive, Whitelisted, template!(Word)),
+    ungated!(non_exhaustive, Normal, template!(Word)),
 
     // Runtime
     ungated!(windows_subsystem, Whitelisted, template!(NameValueStr: "windows|console")),
     ungated!(panic_handler, Normal, template!(Word)), // RFC 2070
 
     // Code generation:
-    ungated!(inline, Whitelisted, template!(Word, List: "always|never")),
+    ungated!(inline, Normal, template!(Word, List: "always|never")),
     ungated!(cold, Whitelisted, template!(Word)),
     ungated!(no_builtins, Whitelisted, template!(Word)),
-    ungated!(target_feature, Whitelisted, template!(List: r#"enable = "name""#)),
+    ungated!(target_feature, Normal, template!(List: r#"enable = "name""#)),
     gated!(
         no_sanitize, Whitelisted,
         template!(List: "address, memory, thread"),
@@ -275,7 +275,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     // Linking:
-    gated!(naked, Whitelisted, template!(Word), naked_functions, experimental!(naked)),
+    gated!(naked, Normal, template!(Word), naked_functions, experimental!(naked)),
     gated!(
         link_args, Normal, template!(NameValueStr: "args"),
         "the `link_args` attribute is experimental and not portable across platforms, \
@@ -332,7 +332,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
 
     gated!(ffi_returns_twice, Whitelisted, template!(Word), experimental!(ffi_returns_twice)),
-    gated!(track_caller, Whitelisted, template!(Word), experimental!(track_caller)),
+    gated!(track_caller, Normal, template!(Word), experimental!(track_caller)),
     gated!(
         register_attr, CrateLevel, template!(List: "attr1, attr2, ..."),
         experimental!(register_attr),

--- a/src/test/ui/unused/unused-attr-crate.rs
+++ b/src/test/ui/unused/unused-attr-crate.rs
@@ -1,0 +1,13 @@
+#![deny(unused_attributes)]
+
+#![feature(naked_functions)]
+#![feature(track_caller)]
+
+#![used] //~ ERROR unused attribute
+#![non_exhaustive] //~ ERROR unused attribute
+#![inline] //~ ERROR unused attribute
+#![target_feature(enable = "")] //~ ERROR unused attribute
+#![naked] //~ ERROR unused attribute
+#![track_caller] //~ ERROR unused attribute
+
+fn main() {}

--- a/src/test/ui/unused/unused-attr-crate.stderr
+++ b/src/test/ui/unused/unused-attr-crate.stderr
@@ -1,0 +1,44 @@
+error: unused attribute
+  --> $DIR/unused-attr-crate.rs:6:1
+   |
+LL | #![used]
+   | ^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-attr-crate.rs:1:9
+   |
+LL | #![deny(unused_attributes)]
+   |         ^^^^^^^^^^^^^^^^^
+
+error: unused attribute
+  --> $DIR/unused-attr-crate.rs:7:1
+   |
+LL | #![non_exhaustive]
+   | ^^^^^^^^^^^^^^^^^^
+
+error: unused attribute
+  --> $DIR/unused-attr-crate.rs:8:1
+   |
+LL | #![inline]
+   | ^^^^^^^^^^
+
+error: unused attribute
+  --> $DIR/unused-attr-crate.rs:9:1
+   |
+LL | #![target_feature(enable = "")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unused attribute
+  --> $DIR/unused-attr-crate.rs:10:1
+   |
+LL | #![naked]
+   | ^^^^^^^^^
+
+error: unused attribute
+  --> $DIR/unused-attr-crate.rs:11:1
+   |
+LL | #![track_caller]
+   | ^^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
+


### PR DESCRIPTION
Take advantage of the fact that `check_mod_attrs` marks attributes as
used and change their type to normal, so that any remaining uses will be
warned about by the unused attribute lint.