### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1515,6 +1515,7 @@ fn overlaps<T>(src: *const T, dst: *const T, count: usize) -> bool {
 /// ```
 ///
 /// [`Vec::append`]: ../../std/vec/struct.Vec.html#method.append
+#[doc(alias = "memcpy")]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[inline]
 pub unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize) {
@@ -1579,6 +1580,7 @@ pub unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize) {
 ///     dst
 /// }
 /// ```
+#[doc(alias = "memmove")]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[inline]
 pub unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {

--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -669,7 +669,7 @@ impl<T> MaybeUninit<T> {
     /// // Now we can use `buf` as a normal slice:
     /// buf.sort_unstable();
     /// assert!(
-    ///     buf.chunks(2).all(|chunk| chunk[0] <= chunk[1]),
+    ///     buf.windows(2).all(|pair| pair[0] <= pair[1]),
     ///     "buffer is sorted",
     /// );
     /// ```

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -2486,7 +2486,7 @@ impl str {
     /// Callers of this function are responsible that these preconditions are
     /// satisfied:
     ///
-    /// * The starting index must come before the ending index;
+    /// * The starting index must not exceed the ending index;
     /// * Indexes must be within bounds of the original slice;
     /// * Indexes must lie on UTF-8 sequence boundaries.
     ///
@@ -2518,7 +2518,7 @@ impl str {
     /// Callers of this function are responsible that these preconditions are
     /// satisfied:
     ///
-    /// * The starting index must come before the ending index;
+    /// * The starting index must not exceed the ending index;
     /// * Indexes must be within bounds of the original slice;
     /// * Indexes must lie on UTF-8 sequence boundaries.
     ///
@@ -2563,7 +2563,7 @@ impl str {
     /// Callers of this function are responsible that three preconditions are
     /// satisfied:
     ///
-    /// * `begin` must come before `end`.
+    /// * `begin` must not exceed `end`.
     /// * `begin` and `end` must be byte positions within the string slice.
     /// * `begin` and `end` must lie on UTF-8 sequence boundaries.
     ///
@@ -2612,7 +2612,7 @@ impl str {
     /// Callers of this function are responsible that three preconditions are
     /// satisfied:
     ///
-    /// * `begin` must come before `end`.
+    /// * `begin` must not exceed `end`.
     /// * `begin` and `end` must be byte positions within the string slice.
     /// * `begin` and `end` must lie on UTF-8 sequence boundaries.
     #[stable(feature = "str_slice_mut", since = "1.5.0")]

--- a/src/librustc_error_codes/error_codes/E0367.md
+++ b/src/librustc_error_codes/error_codes/E0367.md
@@ -1,8 +1,9 @@
 An attempt was made to implement `Drop` on a specialization of a generic type.
-An example is shown below:
+
+Erroneous code example:
 
 ```compile_fail,E0367
-trait Foo{}
+trait Foo {}
 
 struct MyStruct<T> {
     t: T


### PR DESCRIPTION
Successful merges:

 - #69385 (Relax str::get_unchecked precondition to permit empty slicing)
 - #69386 (Fix minor error in `MaybeUninit::get_mut()` doc example)
 - #69391 (Add rustdoc aliases to `ptr::copy` and `ptr::copy_nonoverlapping`)
 - #69394 (Clean up E0367 explanation)

Failed merges:


r? @ghost