### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1515,6 +1515,7 @@ fn overlaps<T>(src: *const T, dst: *const T, count: usize) -> bool {
 /// ```
 ///
 /// [`Vec::append`]: ../../std/vec/struct.Vec.html#method.append
+#[doc(alias = "memcpy")]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[inline]
 pub unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize) {
@@ -1579,6 +1580,7 @@ pub unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize) {
 ///     dst
 /// }
 /// ```
+#[doc(alias = "memmove")]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[inline]
 pub unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {

--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -669,7 +669,7 @@ impl<T> MaybeUninit<T> {
     /// // Now we can use `buf` as a normal slice:
     /// buf.sort_unstable();
     /// assert!(
-    ///     buf.chunks(2).all(|chunk| chunk[0] <= chunk[1]),
+    ///     buf.windows(2).all(|pair| pair[0] <= pair[1]),
     ///     "buffer is sorted",
     /// );
     /// ```

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -2486,7 +2486,7 @@ impl str {
     /// Callers of this function are responsible that these preconditions are
     /// satisfied:
     ///
-    /// * The starting index must come before the ending index;
+    /// * The starting index must not exceed the ending index;
     /// * Indexes must be within bounds of the original slice;
     /// * Indexes must lie on UTF-8 sequence boundaries.
     ///
@@ -2518,7 +2518,7 @@ impl str {
     /// Callers of this function are responsible that these preconditions are
     /// satisfied:
     ///
-    /// * The starting index must come before the ending index;
+    /// * The starting index must not exceed the ending index;
     /// * Indexes must be within bounds of the original slice;
     /// * Indexes must lie on UTF-8 sequence boundaries.
     ///
@@ -2563,7 +2563,7 @@ impl str {
     /// Callers of this function are responsible that three preconditions are
     /// satisfied:
     ///
-    /// * `begin` must come before `end`.
+    /// * `begin` must not exceed `end`.
     /// * `begin` and `end` must be byte positions within the string slice.
     /// * `begin` and `end` must lie on UTF-8 sequence boundaries.
     ///
@@ -2612,7 +2612,7 @@ impl str {
     /// Callers of this function are responsible that three preconditions are
     /// satisfied:
     ///
-    /// * `begin` must come before `end`.
+    /// * `begin` must not exceed `end`.
     /// * `begin` and `end` must be byte positions within the string slice.
     /// * `begin` and `end` must lie on UTF-8 sequence boundaries.
     #[stable(feature = "str_slice_mut", since = "1.5.0")]

--- a/src/librustc_error_codes/error_codes/E0080.md
+++ b/src/librustc_error_codes/error_codes/E0080.md
@@ -14,7 +14,10 @@ constant expression that had to be evaluated. Attempting to divide by 0
 or causing an integer overflow are two ways to induce this error.
 
 Ensure that the expressions given can be evaluated as the desired integer type.
-See the FFI section of the Reference for more information about using a custom
-integer type:
 
-https://doc.rust-lang.org/reference.html#ffi-attributes
+See the [Custom Discriminants][custom-discriminants] section of the Reference
+for more information about setting custom integer types on fieldless enums
+using the [`repr` attribute][repr-attribute].
+
+[custom-discriminants]: https://doc.rust-lang.org/reference/items/enumerations.html#custom-discriminant-values-for-field-less-enumerations
+[repr-attribute]: https://doc.rust-lang.org/reference/type-layout.html#reprc-enums

--- a/src/librustc_error_codes/error_codes/E0133.md
+++ b/src/librustc_error_codes/error_codes/E0133.md
@@ -28,4 +28,6 @@ fn main() {
 }
 ```
 
-See also https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html
+See the [unsafe section][unsafe-section] of the Book for more details.
+
+[unsafe-section]: https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html

--- a/src/librustc_error_codes/error_codes/E0154.md
+++ b/src/librustc_error_codes/error_codes/E0154.md
@@ -27,7 +27,8 @@ fn f() {
 }
 ```
 
-See the Declaration Statements section of the reference for more information
-about what constitutes an Item declaration and what does not:
+See the [Declaration Statements][declaration-statements] section of the
+reference for more information about what constitutes an item declaration
+and what does not.
 
-https://doc.rust-lang.org/reference.html#statements
+[declaration-statements]: https://doc.rust-lang.org/reference/statements.html#declaration-statements

--- a/src/librustc_error_codes/error_codes/E0260.md
+++ b/src/librustc_error_codes/error_codes/E0260.md
@@ -28,7 +28,8 @@ extern crate core as xyz;
 struct abc;
 ```
 
-See the Declaration Statements section of the reference for more information
-about what constitutes an Item declaration and what does not:
+See the [Declaration Statements][declaration-statements] section of the
+reference for more information about what constitutes an item declaration
+and what does not.
 
-https://doc.rust-lang.org/reference.html#statements
+[declaration-statements]: https://doc.rust-lang.org/reference/statements.html#declaration-statements

--- a/src/librustc_error_codes/error_codes/E0303.md
+++ b/src/librustc_error_codes/error_codes/E0303.md
@@ -33,4 +33,6 @@ match Some("hi".to_string()) {
 
 The `op_string_ref` binding has type `&Option<&String>` in both cases.
 
-See also https://github.com/rust-lang/rust/issues/14587
+See also [Issue 14587][issue-14587].
+
+[issue-14587]: https://github.com/rust-lang/rust/issues/14587

--- a/src/librustc_error_codes/error_codes/E0364.md
+++ b/src/librustc_error_codes/error_codes/E0364.md
@@ -26,7 +26,7 @@ pub use foo::X;
 fn main() {}
 ```
 
-See the 'Use Declarations' section of the reference for more information on
-this topic:
+See the [Use Declarations][use-declarations] section of the reference for
+more information on this topic.
 
-https://doc.rust-lang.org/reference.html#use-declarations
+[use-declarations]: https://doc.rust-lang.org/reference/items/use-declarations.html

--- a/src/librustc_error_codes/error_codes/E0365.md
+++ b/src/librustc_error_codes/error_codes/E0365.md
@@ -26,7 +26,7 @@ pub use foo as foo2;
 fn main() {}
 ```
 
-See the 'Use Declarations' section of the reference for more information
-on this topic:
+See the [Use Declarations][use-declarations] section of the reference for
+more information on this topic.
 
-https://doc.rust-lang.org/reference.html#use-declarations
+[use-declarations]: https://doc.rust-lang.org/reference/items/use-declarations.html

--- a/src/librustc_error_codes/error_codes/E0367.md
+++ b/src/librustc_error_codes/error_codes/E0367.md
@@ -1,8 +1,9 @@
 An attempt was made to implement `Drop` on a specialization of a generic type.
-An example is shown below:
+
+Erroneous code example:
 
 ```compile_fail,E0367
-trait Foo{}
+trait Foo {}
 
 struct MyStruct<T> {
     t: T

--- a/src/librustc_error_codes/error_codes/E0382.md
+++ b/src/librustc_error_codes/error_codes/E0382.md
@@ -104,7 +104,7 @@ With this approach, x and y share ownership of the data via the `Rc` (reference
 count type). `RefCell` essentially performs runtime borrow checking: ensuring
 that at most one writer or multiple readers can access the data at any one time.
 
-If you wish to learn more about ownership in Rust, start with the chapter in the
-Book:
+If you wish to learn more about ownership in Rust, start with the
+[Understanding Ownership][understanding-ownership] chapter in the Book.
 
-https://doc.rust-lang.org/book/ch04-00-understanding-ownership.html
+[understanding-ownership]: https://doc.rust-lang.org/book/ch04-00-understanding-ownership.html

--- a/src/librustc_error_codes/error_codes/E0387.md
+++ b/src/librustc_error_codes/error_codes/E0387.md
@@ -52,6 +52,6 @@ fn mutable() {
 }
 ```
 
-You can read more about cell types in the API documentation:
+You can read more in the API documentation for [Cell][std-cell].
 
-https://doc.rust-lang.org/std/cell/
+[std-cell]: https://doc.rust-lang.org/std/cell/

--- a/src/librustc_error_codes/error_codes/E0455.md
+++ b/src/librustc_error_codes/error_codes/E0455.md
@@ -15,5 +15,7 @@ To solve this error you can use conditional compilation:
 extern {}
 ```
 
-See more:
-https://doc.rust-lang.org/reference/attributes.html#conditional-compilation
+Learn more in the [Conditional Compilation][conditional-compilation] section
+of the Reference.
+
+[conditional-compilation]: https://doc.rust-lang.org/reference/attributes.html#conditional-compilation

--- a/src/librustc_error_codes/error_codes/E0499.md
+++ b/src/librustc_error_codes/error_codes/E0499.md
@@ -10,11 +10,13 @@ x;
 // error: cannot borrow `i` as mutable more than once at a time
 ```
 
-Please note that in rust, you can either have many immutable references, or one
-mutable reference. Take a look at
-https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html for more
-information. Example:
+Please note that in Rust, you can either have many immutable references, or one
+mutable reference. For more details you may want to read the
+[References & Borrowing][references-and-borrowing] section of the Book.
 
+[references-and-borrowing]: https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html
+
+Example:
 
 ```
 let mut i = 0;

--- a/src/librustc_error_codes/error_codes/E0501.md
+++ b/src/librustc_error_codes/error_codes/E0501.md
@@ -3,9 +3,10 @@ captured by a closure. Because the closure has borrowed the variable, it is not
 available for use until the closure goes out of scope.
 
 Note that a capture will either move or borrow a variable, but in this
-situation, the closure is borrowing the variable. Take a look at
-http://rustbyexample.com/fn/closures/capture.html for more information about
-capturing.
+situation, the closure is borrowing the variable. Take a look at the chapter
+on [Capturing][capturing] in Rust By Example for more information.
+
+[capturing]: https://doc.rust-lang.org/stable/rust-by-example/fn/closures/capture.html
 
 Erroneous code example:
 

--- a/src/librustc_error_codes/error_codes/E0502.md
+++ b/src/librustc_error_codes/error_codes/E0502.md
@@ -25,5 +25,7 @@ fn foo(a: &mut i32) {
 }
 ```
 
-For more information on the rust ownership system, take a look at
-https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html.
+For more information on Rust's ownership system, take a look at the
+[References & Borrowing][references-and-borrowing] section of the Book.
+
+[references-and-borrowing]: https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html

--- a/src/librustc_error_codes/error_codes/E0503.md
+++ b/src/librustc_error_codes/error_codes/E0503.md
@@ -48,5 +48,7 @@ fn main() {
 }
 ```
 
-You can find more information about borrowing in the rust-book:
-http://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html
+For more information on Rust's ownership system, take a look at the
+[References & Borrowing][references-and-borrowing] section of the Book.
+
+[references-and-borrowing]: https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html

--- a/src/librustc_error_codes/error_codes/E0505.md
+++ b/src/librustc_error_codes/error_codes/E0505.md
@@ -81,5 +81,7 @@ fn main() {
 }
 ```
 
-You can find more information about borrowing in the rust-book:
-http://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html
+For more information on Rust's ownership system, take a look at the
+[References & Borrowing][references-and-borrowing] section of the Book.
+
+[references-and-borrowing]: https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html

--- a/src/librustc_error_codes/error_codes/E0507.md
+++ b/src/librustc_error_codes/error_codes/E0507.md
@@ -127,5 +127,7 @@ let borrowed = &mut cave;
 mem::replace(&mut borrowed.knight, TheDarkKnight).nothing_is_true(); // ok!
 ```
 
-You can find more information about borrowing in the rust-book:
-http://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html
+For more information on Rust's ownership system, take a look at the
+[References & Borrowing][references-and-borrowing] section of the Book.
+
+[references-and-borrowing]: https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html

--- a/src/librustc_error_codes/error_codes/E0525.md
+++ b/src/librustc_error_codes/error_codes/E0525.md
@@ -36,5 +36,7 @@ fn main() {
 }
 ```
 
-To understand better how closures work in Rust, read:
-https://doc.rust-lang.org/book/ch13-01-closures.html
+To better understand how these work in Rust, read the [Closures][closures]
+chapter of the Book.
+
+[closures]: https://doc.rust-lang.org/book/ch13-01-closures.html

--- a/src/librustc_error_codes/error_codes/E0534.md
+++ b/src/librustc_error_codes/error_codes/E0534.md
@@ -31,5 +31,7 @@ compiler about inlining opportunity:
 fn something() {}
 ```
 
-For more information about the inline attribute, read:
-https://doc.rust-lang.org/reference.html#inline-attributes
+For more information see the [`inline` attribute][inline-attribute] section
+of the Reference.
+
+[inline-attribute]: https://doc.rust-lang.org/reference/attributes/codegen.html#the-inline-attribute

--- a/src/librustc_error_codes/error_codes/E0535.md
+++ b/src/librustc_error_codes/error_codes/E0535.md
@@ -24,5 +24,7 @@ pub fn something() {}
 fn main() {}
 ```
 
-For more information about the inline attribute, https:
-read://doc.rust-lang.org/reference.html#inline-attributes
+For more information see the [`inline` Attribute][inline-attribute] section
+of the Reference.
+
+[inline-attribute]: https://doc.rust-lang.org/reference/attributes/codegen.html#the-inline-attribute

--- a/src/librustc_error_codes/error_codes/E0536.md
+++ b/src/librustc_error_codes/error_codes/E0536.md
@@ -18,5 +18,7 @@ pub fn something() {}
 pub fn main() {}
 ```
 
-For more information about the cfg attribute, read:
-https://doc.rust-lang.org/reference.html#conditional-compilation
+For more information about the `cfg` attribute, read the section on
+[Conditional Compilation][conditional-compilation] in the Reference.
+
+[conditional-compilation]: https://doc.rust-lang.org/reference/conditional-compilation.html

--- a/src/librustc_error_codes/error_codes/E0537.md
+++ b/src/librustc_error_codes/error_codes/E0537.md
@@ -24,5 +24,7 @@ pub fn something() {}
 pub fn main() {}
 ```
 
-For more information about the cfg attribute, read:
-https://doc.rust-lang.org/reference.html#conditional-compilation
+For more information about the `cfg` attribute, read the section on
+[Conditional Compilation][conditional-compilation] in the Reference.
+
+[conditional-compilation]: https://doc.rust-lang.org/reference/conditional-compilation.html

--- a/src/librustc_error_codes/error_codes/E0601.md
+++ b/src/librustc_error_codes/error_codes/E0601.md
@@ -8,5 +8,7 @@ fn main() {
 }
 ```
 
-If you don't know the basics of Rust, you can go look to the Rust Book to get
-started: https://doc.rust-lang.org/book/
+If you don't know the basics of Rust, you can look at the
+[Rust Book][rust-book] to get started.
+
+[rust-book]: https://doc.rust-lang.org/book/

--- a/src/librustc_error_codes/error_codes/E0610.md
+++ b/src/librustc_error_codes/error_codes/E0610.md
@@ -24,6 +24,7 @@ let variable = Foo { x: 0, y: -12 };
 println!("x: {}, y: {}", variable.x, variable.y);
 ```
 
-For more information about primitives and structs, take a look at The Book:
-https://doc.rust-lang.org/book/ch03-02-data-types.html
-https://doc.rust-lang.org/book/ch05-00-structs.html
+For more information about [primitives] and [structs], take a look at the Book.
+
+[primitives]: https://doc.rust-lang.org/book/ch03-02-data-types.html
+[structs]: https://doc.rust-lang.org/book/ch05-00-structs.html

--- a/src/librustc_error_codes/error_codes/E0660.md
+++ b/src/librustc_error_codes/error_codes/E0660.md
@@ -6,6 +6,7 @@ Erroneous code example:
 asm!("nop" "nop");
 ```
 
-Considering that this would be a long explanation, we instead recommend you to
-take a look at the unstable book:
-https://doc.rust-lang.org/unstable-book/language-features/asm.html
+Considering that this would be a long explanation, we instead recommend you
+take a look at the [`asm`] chapter of the Unstable book:
+
+[asm]: https://doc.rust-lang.org/stable/unstable-book/library-features/asm.html

--- a/src/librustc_error_codes/error_codes/E0661.md
+++ b/src/librustc_error_codes/error_codes/E0661.md
@@ -7,6 +7,7 @@ let a;
 asm!("nop" : "r"(a));
 ```
 
-Considering that this would be a long explanation, we instead recommend you to
-take a look at the unstable book:
-https://doc.rust-lang.org/unstable-book/language-features/asm.html
+Considering that this would be a long explanation, we instead recommend you
+take a look at the [`asm`] chapter of the Unstable book:
+
+[asm]: https://doc.rust-lang.org/stable/unstable-book/library-features/asm.html

--- a/src/librustc_error_codes/error_codes/E0662.md
+++ b/src/librustc_error_codes/error_codes/E0662.md
@@ -9,6 +9,7 @@ asm!("xor %eax, %eax"
     );
 ```
 
-Considering that this would be a long explanation, we instead recommend you to
-take a look at the unstable book:
-https://doc.rust-lang.org/unstable-book/language-features/asm.html
+Considering that this would be a long explanation, we instead recommend you
+take a look at the [`asm`] chapter of the Unstable book:
+
+[asm]: https://doc.rust-lang.org/stable/unstable-book/library-features/asm.html

--- a/src/librustc_error_codes/error_codes/E0663.md
+++ b/src/librustc_error_codes/error_codes/E0663.md
@@ -9,6 +9,7 @@ asm!("xor %eax, %eax"
     );
 ```
 
-Considering that this would be a long explanation, we instead recommend you to
-take a look at the unstable book:
-https://doc.rust-lang.org/unstable-book/language-features/asm.html
+Considering that this would be a long explanation, we instead recommend you
+take a look at the [`asm`] chapter of the Unstable book:
+
+[asm]: https://doc.rust-lang.org/stable/unstable-book/library-features/asm.html

--- a/src/librustc_error_codes/error_codes/E0664.md
+++ b/src/librustc_error_codes/error_codes/E0664.md
@@ -10,6 +10,7 @@ asm!("mov $$0x200, %eax"
     );
 ```
 
-Considering that this would be a long explanation, we instead recommend you to
-take a look at the unstable book:
-https://doc.rust-lang.org/unstable-book/language-features/asm.html
+Considering that this would be a long explanation, we instead recommend you
+take a look at the [`asm`] chapter of the Unstable book:
+
+[asm]: https://doc.rust-lang.org/stable/unstable-book/library-features/asm.html

--- a/src/test/ui/json-short.stderr
+++ b/src/test/ui/json-short.stderr
@@ -8,8 +8,10 @@ fn main() {
 }
 ```
 
-If you don't know the basics of Rust, you can go look to the Rust Book to get
-started: https://doc.rust-lang.org/book/
+If you don't know the basics of Rust, you can look at the
+[Rust Book][rust-book] to get started.
+
+[rust-book]: https://doc.rust-lang.org/book/
 "},"level":"error","spans":[{"file_name":"$DIR/json-short.rs","byte_start":62,"byte_end":62,"line_start":1,"line_end":1,"column_start":63,"column_end":63,"is_primary":true,"text":[{"text":"// compile-flags: --json=diagnostic-short --error-format=json","highlight_start":63,"highlight_end":63}],"label":"consider adding a `main` function to `$DIR/json-short.rs`","suggested_replacement":null,"suggestion_applicability":null,"expansion":null}],"children":[],"rendered":"$DIR/json-short.rs:1:63: error[E0601]: `main` function not found in crate `json_short`
 "}
 {"message":"aborting due to previous error","code":null,"level":"error","spans":[],"children":[],"rendered":"error: aborting due to previous error


### PR DESCRIPTION
Successful merges:

 - #69372 (Updates links in various Compiler Error Index entries)
 - #69385 (Relax str::get_unchecked precondition to permit empty slicing)
 - #69386 (Fix minor error in `MaybeUninit::get_mut()` doc example)
 - #69391 (Add rustdoc aliases to `ptr::copy` and `ptr::copy_nonoverlapping`)
 - #69394 (Clean up E0367 explanation)

Failed merges:


r? @ghost