### PR TITLE
no more codegen for miri_start_panic

### DIFF
--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -515,12 +515,9 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             return;
         }
 
-        // For normal codegen, this Miri-specific intrinsic is just a NOP.
+        // For normal codegen, this Miri-specific intrinsic should never occur.
         if intrinsic == Some("miri_start_panic") {
-            let target = destination.as_ref().unwrap().1;
-            helper.maybe_sideeffect(self.mir, &mut bx, &[target]);
-            helper.funclet_br(self, &mut bx, target);
-            return;
+            bug!("`miri_start_panic` should never end up in compiled code");
         }
 
         // Emit a panic or a no-op for `panic_if_uninhabited`.


### PR DESCRIPTION
With https://github.com/rust-lang/miri/pull/1136 landed, we don't generate code any more for crates that will be run by Miri. So the LLVM backend does not have to implement the `miri_start_panic` intrinsic any more.

Cc @Aaron1011 