### PR TITLE
EXPERIMENT: Recover on stmts/exprs at module level, suggesting to wrap in function

### DIFF
--- a/src/librustc_expand/expand.rs
+++ b/src/librustc_expand/expand.rs
@@ -892,7 +892,7 @@ pub fn parse_ast_fragment<'a>(
             let mut stmts = SmallVec::new();
             // Won't make progress on a `}`.
             while this.token != token::Eof && this.token != token::CloseDelim(token::Brace) {
-                if let Some(stmt) = this.parse_full_stmt()? {
+                if let Some(stmt) = this.parse_full_stmt(false)? {
                     stmts.push(stmt);
                 }
             }

--- a/src/librustc_parse/parser/stmt.rs
+++ b/src/librustc_parse/parser/stmt.rs
@@ -92,7 +92,7 @@ impl<'a> Parser<'a> {
 
     fn parse_stmt_item(&mut self, attrs: Vec<Attribute>) -> PResult<'a, Option<ast::Item>> {
         let old = mem::replace(&mut self.directory.ownership, DirectoryOwnership::UnownedViaBlock);
-        let item = self.parse_item_common(attrs.clone(), false, true, |_| true)?;
+        let item = self.parse_item_common(attrs.clone(), false, true, |_| true, false)?;
         self.directory.ownership = old;
         Ok(item)
     }

--- a/src/test/ui/did_you_mean/issue-40006.rs
+++ b/src/test/ui/did_you_mean/issue-40006.rs
@@ -1,11 +1,11 @@
 impl dyn A {
-    Y
-} //~ ERROR expected one of `!` or `::`, found `}`
+    Y //~ ERROR non-item in item list
+}
 
 struct S;
 
 trait X {
-    X() {} //~ ERROR expected one of `!` or `::`, found `(`
+    X() {} //~ ERROR non-item in item list
     fn xxx() { ### }
     L = M;
     Z = { 2 + 3 };
@@ -13,19 +13,19 @@ trait X {
 }
 
 trait A {
-    X() {} //~ ERROR expected one of `!` or `::`, found `(`
+    X() {} //~ ERROR non-item in item list
 }
 trait B {
     fn xxx() { ### } //~ ERROR expected
 }
 trait C {
-    L = M; //~ ERROR expected one of `!` or `::`, found `=`
+    L = M; //~ ERROR non-item in item list
 }
 trait D {
-    Z = { 2 + 3 }; //~ ERROR expected one of `!` or `::`, found `=`
+    Z = { 2 + 3 }; //~ ERROR non-item in item list
 }
 trait E {
-    ::Y (); //~ ERROR expected one of
+    ::Y (); //~ ERROR non-item in item list
 }
 
 impl S {

--- a/src/test/ui/did_you_mean/issue-40006.stderr
+++ b/src/test/ui/did_you_mean/issue-40006.stderr
@@ -1,36 +1,33 @@
-error: expected one of `!` or `::`, found `}`
-  --> $DIR/issue-40006.rs:3:1
+error: non-item in item list
+  --> $DIR/issue-40006.rs:2:5
    |
 LL | impl dyn A {
-   |            - while parsing this item list starting here
+   |            - item list starts here
 LL |     Y
-   |      - expected one of `!` or `::`
+   |     ^ non-item starts here
 LL | }
-   | ^
-   | |
-   | unexpected token
-   | the item list ends here
+   | - item list ends here
 
-error: expected one of `!` or `::`, found `(`
-  --> $DIR/issue-40006.rs:8:6
+error: non-item in item list
+  --> $DIR/issue-40006.rs:8:5
    |
 LL | trait X {
-   |         - while parsing this item list starting here
+   |         - item list starts here
 LL |     X() {}
-   |      ^ expected one of `!` or `::`
+   |     ^ non-item starts here
 ...
 LL | }
-   | - the item list ends here
+   | - item list ends here
 
-error: expected one of `!` or `::`, found `(`
-  --> $DIR/issue-40006.rs:16:6
+error: non-item in item list
+  --> $DIR/issue-40006.rs:16:5
    |
 LL | trait A {
-   |         - while parsing this item list starting here
+   |         - item list starts here
 LL |     X() {}
-   |      ^ expected one of `!` or `::`
+   |     ^ non-item starts here
 LL | }
-   | - the item list ends here
+   | - item list ends here
 
 error: expected `[`, found `#`
   --> $DIR/issue-40006.rs:19:17
@@ -38,35 +35,35 @@ error: expected `[`, found `#`
 LL |     fn xxx() { ### }
    |                 ^ expected `[`
 
-error: expected one of `!` or `::`, found `=`
-  --> $DIR/issue-40006.rs:22:7
+error: non-item in item list
+  --> $DIR/issue-40006.rs:22:5
    |
 LL | trait C {
-   |         - while parsing this item list starting here
+   |         - item list starts here
 LL |     L = M;
-   |       ^ expected one of `!` or `::`
+   |     ^ non-item starts here
 LL | }
-   | - the item list ends here
+   | - item list ends here
 
-error: expected one of `!` or `::`, found `=`
-  --> $DIR/issue-40006.rs:25:7
+error: non-item in item list
+  --> $DIR/issue-40006.rs:25:5
    |
 LL | trait D {
-   |         - while parsing this item list starting here
+   |         - item list starts here
 LL |     Z = { 2 + 3 };
-   |       ^ expected one of `!` or `::`
+   |     ^ non-item starts here
 LL | }
-   | - the item list ends here
+   | - item list ends here
 
-error: expected one of `!` or `::`, found `(`
-  --> $DIR/issue-40006.rs:28:9
+error: non-item in item list
+  --> $DIR/issue-40006.rs:28:5
    |
 LL | trait E {
-   |         - while parsing this item list starting here
+   |         - item list starts here
 LL |     ::Y ();
-   |         ^ expected one of `!` or `::`
+   |     ^^ non-item starts here
 LL | }
-   | - the item list ends here
+   | - item list ends here
 
 error: missing `fn` for method definition
   --> $DIR/issue-40006.rs:32:8

--- a/src/test/ui/feature-gates/feature-gate-extern_prelude.rs
+++ b/src/test/ui/feature-gates/feature-gate-extern_prelude.rs
@@ -1,1 +1,1 @@
-can-only-test-this-in-run-make-fulldeps //~ ERROR expected one of `!` or `::`, found `-`
+can-only-test-this-in-run-make-fulldeps //~ ERROR expected item, found `can`

--- a/src/test/ui/feature-gates/feature-gate-extern_prelude.stderr
+++ b/src/test/ui/feature-gates/feature-gate-extern_prelude.stderr
@@ -1,8 +1,8 @@
-error: expected one of `!` or `::`, found `-`
-  --> $DIR/feature-gate-extern_prelude.rs:1:4
+error: expected item, found `can`
+  --> $DIR/feature-gate-extern_prelude.rs:1:1
    |
 LL | can-only-test-this-in-run-make-fulldeps
-   |    ^ expected one of `!` or `::`
+   | ^^^ expected item
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-21146.rs
+++ b/src/test/ui/issues/issue-21146.rs
@@ -1,3 +1,3 @@
-// error-pattern: expected one of `!` or `::`, found `<eof>`
+// error-pattern: expected item, found `parse_error`
 include!("auxiliary/issue-21146-inc.rs");
 fn main() {}

--- a/src/test/ui/issues/issue-21146.stderr
+++ b/src/test/ui/issues/issue-21146.stderr
@@ -1,8 +1,8 @@
-error: expected one of `!` or `::`, found `<eof>`
+error: expected item, found `parse_error`
   --> $DIR/auxiliary/issue-21146-inc.rs:3:1
    |
 LL | parse_error
-   | ^^^^^^^^^^^ expected one of `!` or `::`
+   | ^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-49040.rs
+++ b/src/test/ui/issues/issue-49040.rs
@@ -1,3 +1,3 @@
-#![allow(unused_variables)]; //~ ERROR expected item, found `;`
+#![allow(unused_variables)]; //~ ERROR statements cannot reside in modules
 //~^ ERROR `main` function
 fn foo() {}

--- a/src/test/ui/issues/issue-49040.stderr
+++ b/src/test/ui/issues/issue-49040.stderr
@@ -1,8 +1,15 @@
-error: expected item, found `;`
+error: statements cannot reside in modules
   --> $DIR/issue-49040.rs:1:28
    |
 LL | #![allow(unused_variables)];
-   |                            ^ help: remove this semicolon
+   |                            ^
+   |
+   = note: the program entry point starts in `fn main() { ... }`, defined in `main.rs`
+   = note: for more on functions and how to structure your program, see https://doc.rust-lang.org/book/ch03-03-how-functions-work.html
+help: consider moving the statements into a function
+   |
+LL | #![allow(unused_variables)]fn my_function() { }
+   |                            ^^^^^^^^^^^^^^^^^^^^
 
 error[E0601]: `main` function not found in crate `issue_49040`
   --> $DIR/issue-49040.rs:1:1
@@ -10,7 +17,7 @@ error[E0601]: `main` function not found in crate `issue_49040`
 LL | / #![allow(unused_variables)];
 LL | |
 LL | | fn foo() {}
-   | |__^ consider adding a `main` function to `$DIR/issue-49040.rs`
+   | |___________^ consider adding a `main` function to `$DIR/issue-49040.rs`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-62554.stderr
+++ b/src/test/ui/issues/issue-62554.stderr
@@ -60,12 +60,6 @@ LL | fn foo(u: u8) { if u8 macro_rules! u8 { (u6) => { fn uuuuuuuuuuu() { use s 
    |                 --    ^^^^^^^^^^^ expected `{`
    |                 |
    |                 this `if` expression has a condition, but no block
-   |
-help: try placing this code inside a block
-   |
-LL | fn foo(u: u8) { if u8 { macro_rules! u8 { (u6) => { fn uuuuuuuuuuu() { use s loo mod u8 {
-LL |  }
-   |
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/parser/class-implements-bad-trait.stderr
+++ b/src/test/ui/parser/class-implements-bad-trait.stderr
@@ -1,8 +1,36 @@
-error: expected one of `!` or `::`, found `cat`
-  --> $DIR/class-implements-bad-trait.rs:2:7
+error: expected one of `.`, `;`, `?`, `}`, or an operator, found `{`
+  --> $DIR/class-implements-bad-trait.rs:4:21
    |
-LL | class cat : nonexistent {
-   |       ^^^ expected one of `!` or `::`
+LL |   new(in_x : usize) { self.meows = in_x; }
+   |                     ^ expected one of `.`, `;`, `?`, `}`, or an operator
 
-error: aborting due to previous error
+error: statements cannot reside in modules
+  --> $DIR/class-implements-bad-trait.rs:2:1
+   |
+LL |   class cat : nonexistent {
+   |  _^^^^^___________________^
+LL | |   let meows: usize;
+LL | |   new(in_x : usize) { self.meows = in_x; }
+LL | | }
+   | |_^
+   |
+   = note: the program entry point starts in `fn main() { ... }`, defined in `main.rs`
+   = note: for more on functions and how to structure your program, see https://doc.rust-lang.org/book/ch03-03-how-functions-work.html
+help: consider moving the statements into a function
+   |
+LL | fn my_function() -> _ {
+LL |     class;
+LL |     cat: nonexistent;
+LL |     { let meows: usize; (/*ERROR*/) }
+LL | }
+   |
 
+error[E0425]: cannot find function `cat` in this scope
+  --> $DIR/class-implements-bad-trait.rs:8:14
+   |
+LL |   let nyan = cat(0);
+   |              ^^^ not found in this scope
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0425`.

--- a/src/test/ui/parser/extern-no-fn.rs
+++ b/src/test/ui/parser/extern-no-fn.rs
@@ -1,5 +1,5 @@
 extern {
-    f(); //~ ERROR expected one of `!` or `::`, found `(`
+    f(); //~ ERROR non-item in item list
 }
 
 fn main() {

--- a/src/test/ui/parser/extern-no-fn.stderr
+++ b/src/test/ui/parser/extern-no-fn.stderr
@@ -1,12 +1,12 @@
-error: expected one of `!` or `::`, found `(`
-  --> $DIR/extern-no-fn.rs:2:6
+error: non-item in item list
+  --> $DIR/extern-no-fn.rs:2:5
    |
 LL | extern {
-   |        - while parsing this item list starting here
+   |        - item list starts here
 LL |     f();
-   |      ^ expected one of `!` or `::`
+   |     ^ non-item starts here
 LL | }
-   | - the item list ends here
+   | - item list ends here
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issue-21153.rs
+++ b/src/test/ui/parser/issue-21153.rs
@@ -1,6 +1,6 @@
 trait MyTrait<T>: Iterator {
     Item = T;
-    //~^ ERROR expected one of `!` or `::`, found `=`
+    //~^ ERROR non-item in item list
 }
 
 fn main() {}

--- a/src/test/ui/parser/issue-21153.stderr
+++ b/src/test/ui/parser/issue-21153.stderr
@@ -1,13 +1,13 @@
-error: expected one of `!` or `::`, found `=`
-  --> $DIR/issue-21153.rs:2:10
+error: non-item in item list
+  --> $DIR/issue-21153.rs:2:5
    |
 LL | trait MyTrait<T>: Iterator {
-   |                            - while parsing this item list starting here
+   |                            - item list starts here
 LL |     Item = T;
-   |          ^ expected one of `!` or `::`
+   |     ^^^^ non-item starts here
 LL |
 LL | }
-   | - the item list ends here
+   | - item list ends here
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issue-62913.rs
+++ b/src/test/ui/parser/issue-62913.rs
@@ -1,4 +1,5 @@
 "\u\\"
 //~^ ERROR incorrect unicode escape sequence
 //~| ERROR invalid trailing slash in literal
-//~| ERROR expected item, found `"\u\\"`
+//~| ERROR statements cannot reside in modules
+//~| ERROR `main` function not found

--- a/src/test/ui/parser/issue-62913.stderr
+++ b/src/test/ui/parser/issue-62913.stderr
@@ -12,11 +12,25 @@ error: invalid trailing slash in literal
 LL | "\u\"
    |     ^
 
-error: expected item, found `"\u\"`
+error: statements cannot reside in modules
   --> $DIR/issue-62913.rs:1:1
    |
 LL | "\u\"
-   | ^^^^^^ expected item
+   | ^^^^^^
+   |
+   = note: the program entry point starts in `fn main() { ... }`, defined in `main.rs`
+   = note: for more on functions and how to structure your program, see https://doc.rust-lang.org/book/ch03-03-how-functions-work.html
+help: consider moving the statements into a function
+   |
+LL | fn my_function() -> _ { "\u\" }
+   |
 
-error: aborting due to 3 previous errors
+error[E0601]: `main` function not found in crate `issue_62913`
+  --> $DIR/issue-62913.rs:1:1
+   |
+LL | "\u\"
+   | ^^^^^^ consider adding a `main` function to `$DIR/issue-62913.rs`
 
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0601`.

--- a/src/test/ui/parser/module-statement-recovery/main.rs
+++ b/src/test/ui/parser/module-statement-recovery/main.rs
@@ -15,3 +15,9 @@ Ok(42u16)
 struct X;
 
 if true {} //~ ERROR statements cannot reside in modules
+
+enum E {}
+
+x.y(); //~ ERROR statements cannot reside in modules
+let x = 0;
+x;

--- a/src/test/ui/parser/module-statement-recovery/main.rs
+++ b/src/test/ui/parser/module-statement-recovery/main.rs
@@ -1,0 +1,17 @@
+fn main() {}
+
+fn foo() {}
+
+let x = 0; //~ ERROR statements cannot reside in modules
+x;
+x;
+x;
+x;
+x;
+x;
+foo()?;
+Ok(42u16)
+
+struct X;
+
+if true {} //~ ERROR statements cannot reside in modules

--- a/src/test/ui/parser/module-statement-recovery/main.stderr
+++ b/src/test/ui/parser/module-statement-recovery/main.stderr
@@ -1,0 +1,36 @@
+error: statements cannot reside in modules
+  --> $DIR/main.rs:5:1
+   |
+LL | let x = 0;
+   | ^^^^^^^^^^
+...
+LL | Ok(42u16)
+   | ^^^^^^^^^
+   |
+   = note: the program entry point starts in `fn main() { ... }`, defined in `main.rs`
+   = note: for more on functions and how to structure your program, see https://doc.rust-lang.org/book/ch03-03-how-functions-work.html
+help: consider moving the statements into a function
+   |
+LL | fn my_function() -> Result<_, _> {
+LL |     let x = 0;
+LL |     x;
+LL |     x;
+LL |     x;
+LL |     x;
+ ...
+
+error: statements cannot reside in modules
+  --> $DIR/main.rs:17:1
+   |
+LL | if true {}
+   | ^^^^^^^^^^
+   |
+   = note: the program entry point starts in `fn main() { ... }`, defined in `main.rs`
+   = note: for more on functions and how to structure your program, see https://doc.rust-lang.org/book/ch03-03-how-functions-work.html
+help: consider moving the statements into a function
+   |
+LL | fn my_function() -> _ { if true { } }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/parser/module-statement-recovery/main.stderr
+++ b/src/test/ui/parser/module-statement-recovery/main.stderr
@@ -32,5 +32,21 @@ help: consider moving the statements into a function
 LL | fn my_function() -> _ { if true { } }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: statements cannot reside in modules
+  --> $DIR/main.rs:21:1
+   |
+LL | x.y();
+   | ^^^^^^
+LL | let x = 0;
+LL | x;
+   | ^^
+   |
+   = note: the program entry point starts in `fn main() { ... }`, defined in `main.rs`
+   = note: for more on functions and how to structure your program, see https://doc.rust-lang.org/book/ch03-03-how-functions-work.html
+help: consider moving the statements into a function
+   |
+LL | fn my_function() { x.y(); let x = 0; x; }
+   |
+
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/parser/module-statement-recovery/recover-statements-not-main.rs
+++ b/src/test/ui/parser/module-statement-recovery/recover-statements-not-main.rs
@@ -18,6 +18,6 @@ if true {} //~ ERROR statements cannot reside in modules
 
 enum E {}
 
-x.y();
+x.y(); //~ ERROR statements cannot reside in modules
 let x = 0;
 x;

--- a/src/test/ui/parser/module-statement-recovery/recover-statements-not-main.rs
+++ b/src/test/ui/parser/module-statement-recovery/recover-statements-not-main.rs
@@ -1,0 +1,23 @@
+fn main() {}
+
+fn foo() {}
+
+let x = 0; //~ ERROR statements cannot reside in modules
+x;
+x;
+x;
+x;
+x;
+x;
+foo()?;
+Ok(42u16)
+
+struct X;
+
+if true {} //~ ERROR statements cannot reside in modules
+
+enum E {}
+
+x.y();
+let x = 0;
+x;

--- a/src/test/ui/parser/module-statement-recovery/recover-statements-not-main.stderr
+++ b/src/test/ui/parser/module-statement-recovery/recover-statements-not-main.stderr
@@ -1,0 +1,42 @@
+error: statements cannot reside in modules
+  --> $DIR/recover-statements-not-main.rs:5:1
+   |
+LL | let x = 0;
+   | ^^^^^^^^^^
+...
+LL | Ok(42u16)
+   | ^^^^^^^^^
+   |
+   = note: the program entry point starts in `fn main() { ... }`, defined in `main.rs`
+   = note: for more on functions and how to structure your program, see https://doc.rust-lang.org/book/ch03-03-how-functions-work.html
+help: consider moving the statements into a function
+   |
+LL | fn my_function() -> Result<_, _> {
+LL |     let x = 0;
+LL |     x;
+LL |     x;
+LL |     x;
+LL |     x;
+ ...
+
+error: statements cannot reside in modules
+  --> $DIR/recover-statements-not-main.rs:17:1
+   |
+LL | if true {}
+   | ^^^^^^^^^^
+   |
+   = note: the program entry point starts in `fn main() { ... }`, defined in `main.rs`
+   = note: for more on functions and how to structure your program, see https://doc.rust-lang.org/book/ch03-03-how-functions-work.html
+help: consider moving the statements into a function
+   |
+LL | fn my_function() -> _ { if true { } }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected one of `!` or `::`, found `.`
+  --> $DIR/recover-statements-not-main.rs:21:2
+   |
+LL | x.y();
+   |  ^ expected one of `!` or `::`
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/parser/module-statement-recovery/recover-statements-not-main.stderr
+++ b/src/test/ui/parser/module-statement-recovery/recover-statements-not-main.stderr
@@ -32,11 +32,21 @@ help: consider moving the statements into a function
 LL | fn my_function() -> _ { if true { } }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected one of `!` or `::`, found `.`
-  --> $DIR/recover-statements-not-main.rs:21:2
+error: statements cannot reside in modules
+  --> $DIR/recover-statements-not-main.rs:21:1
    |
 LL | x.y();
-   |  ^ expected one of `!` or `::`
+   | ^^^^^^
+LL | let x = 0;
+LL | x;
+   | ^^
+   |
+   = note: the program entry point starts in `fn main() { ... }`, defined in `main.rs`
+   = note: for more on functions and how to structure your program, see https://doc.rust-lang.org/book/ch03-03-how-functions-work.html
+help: consider moving the statements into a function
+   |
+LL | fn my_function() { x.y(); let x = 0; x; }
+   |
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/parser/underscore_item_not_const.rs
+++ b/src/test/ui/parser/underscore_item_not_const.rs
@@ -11,6 +11,8 @@ use _ as g; //~ ERROR expected identifier, found reserved identifier `_`
 trait _ {} //~ ERROR expected identifier, found reserved identifier `_`
 trait _ = Copy; //~ ERROR expected identifier, found reserved identifier `_`
 macro_rules! _ { () => {} } //~ ERROR expected identifier, found reserved identifier `_`
-union _ { f: u8 } //~ ERROR expected one of `!` or `::`, found reserved identifier `_`
+union _ { f: u8 }
+//~^ ERROR statements cannot reside in modules
+//~| ERROR expected item, found reserved identifier `_`
 
 fn main() {}

--- a/src/test/ui/parser/underscore_item_not_const.stderr
+++ b/src/test/ui/parser/underscore_item_not_const.stderr
@@ -64,11 +64,24 @@ error: expected identifier, found reserved identifier `_`
 LL | macro_rules! _ { () => {} }
    |              ^ expected identifier, found reserved identifier
 
-error: expected one of `!` or `::`, found reserved identifier `_`
+error: statements cannot reside in modules
+  --> $DIR/underscore_item_not_const.rs:14:1
+   |
+LL | union _ { f: u8 }
+   | ^^^^^
+   |
+   = note: the program entry point starts in `fn main() { ... }`, defined in `main.rs`
+   = note: for more on functions and how to structure your program, see https://doc.rust-lang.org/book/ch03-03-how-functions-work.html
+help: consider moving the statements into a function
+   |
+LL | fn my_function() -> _ { union } _ { f: u8 }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected item, found reserved identifier `_`
   --> $DIR/underscore_item_not_const.rs:14:7
    |
 LL | union _ { f: u8 }
-   |       ^ expected one of `!` or `::`
+   |       ^ expected item
 
-error: aborting due to 12 previous errors
+error: aborting due to 13 previous errors
 

--- a/src/test/ui/pub/pub-restricted-error-fn.rs
+++ b/src/test/ui/pub/pub-restricted-error-fn.rs
@@ -1,2 +1,4 @@
-pub(crate) () fn foo() {} //~ ERROR visibility `pub(crate)` is not followed by an item
-//~^ ERROR expected item, found `(`
+pub(crate) () fn foo() {}
+//~^ ERROR visibility `pub(crate)` is not followed by an item
+//~| ERROR statements cannot reside in modules
+//~| ERROR `main` function not found

--- a/src/test/ui/pub/pub-restricted-error-fn.stderr
+++ b/src/test/ui/pub/pub-restricted-error-fn.stderr
@@ -6,11 +6,25 @@ LL | pub(crate) () fn foo() {}
    |
    = help: you likely meant to define an item, e.g., `pub(crate) fn foo() {}`
 
-error: expected item, found `(`
+error: statements cannot reside in modules
   --> $DIR/pub-restricted-error-fn.rs:1:12
    |
 LL | pub(crate) () fn foo() {}
-   |            ^ expected item
+   |            ^^
+   |
+   = note: the program entry point starts in `fn main() { ... }`, defined in `main.rs`
+   = note: for more on functions and how to structure your program, see https://doc.rust-lang.org/book/ch03-03-how-functions-work.html
+help: consider moving the statements into a function
+   |
+LL | pub(crate) fn my_function() -> _ { () } fn foo() {}
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0601]: `main` function not found in crate `pub_restricted_error_fn`
+  --> $DIR/pub-restricted-error-fn.rs:1:1
+   |
+LL | pub(crate) () fn foo() {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ consider adding a `main` function to `$DIR/pub-restricted-error-fn.rs`
 
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0601`.


### PR DESCRIPTION
Suppose we have the following file, let's call it `foo.rs`:

```rust
$ cat foo.rs

x.y(); //~ ERROR statements cannot reside in modules
let x = 0;
x;
```

In that case, we will attempt to parse these contiguous sequence of statements as-if they were part of a function body, recover, and suggest that the user move the statements into a function:

```rust
error: statements cannot reside in modules
  --> $DIR/recover-statements-not-main.rs:21:1
   |
LL | x.y();
   | ^^^^^^
LL | let x = 0;
LL | x;
   | ^^
   |
   = note: the program entry point starts in `fn main() { ... }`, defined in `main.rs`
   = note: for more on functions and how to structure your program, see https://doc.rust-lang.org/book/ch03-03-how-functions-work.html
help: consider moving the statements into a function
   |
LL | fn my_function() { x.y(); let x = 0; x; }
   |
```

When emitting the error, we also attempt lightweight return type inference based on the parsed list of statements. In particular, if we detect `return` we assume a default return type (`fn foo() { ... }`), if we find `return $expr` or a tail expression, we assume not-`()` and suggest `-> _`, if we find `$expr?` we suggest `-> Result<_, _>`. Finally, we also attempt to account for `fn main` as the function name by considering the inference result as well as the file name.

After parsing the sequence of statements, we will continue by parsing an item, and if that fails, we again attempt statement parsing as above, and so on, and so forth. That is, we interleave item parsing with statement-list-as-function-body parsing.

This PR implements the "super goal" in https://github.com/rust-lang/rust/pull/69366#issuecomment-589942893.

r? @petrochenkov @estebank 