### PR TITLE
Do not ping PR reviewers in toolstate breakage

### DIFF
--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -131,7 +131,6 @@ def issue(
     assignees,
     relevant_pr_number,
     relevant_pr_user,
-    pr_reviewer,
 ):
     # Open an issue about the toolstate failure.
     if status == 'test-fail':
@@ -147,11 +146,11 @@ def issue(
         cc @{}, do you think you would have time to do the follow-up work?
         If so, that would be great!
 
-        cc @{}, the PR reviewer, and nominating for compiler team prioritization.
+        And nominating for compiler team prioritization.
 
         ''').format(
             relevant_pr_number, tool, status_description,
-            REPOS.get(tool), relevant_pr_user, pr_reviewer
+            REPOS.get(tool), relevant_pr_user
         )),
         'title': '`{}` no longer builds after {}'.format(tool, relevant_pr_number),
         'assignees': list(assignees),
@@ -236,7 +235,7 @@ def update_latest(
                 try:
                     issue(
                         tool, create_issue_for_status, MAINTAINERS.get(tool, ''),
-                        relevant_pr_number, relevant_pr_user, pr_reviewer,
+                        relevant_pr_number, relevant_pr_user,
                     )
                 except urllib2.HTTPError as e:
                     # network errors will simply end up not creating an issue, but that's better


### PR DESCRIPTION
As per https://github.com/rust-lang/rust/issues/69419#issuecomment-590470520

We should also remove author part?

