### PR TITLE
[WIP] Add `From<(Vec<T>, C)>` for BinaryHeap a.k.a. flexible `BinaryHeap`

### DIFF
--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -248,8 +248,9 @@ use super::SpecExtend;
 /// [peek]: #method.peek
 /// [peek\_mut]: #method.peek_mut
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct BinaryHeap<T, C = MaxCmp> 
-where C: Fn(&T, &T) -> Option<Ordering>
+pub struct BinaryHeap<T, C = MaxCmp>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     data: Vec<T>,
     cmp: C,
@@ -292,15 +293,17 @@ impl<T: Ord> Fn<(&T, &T)> for MaxCmp {
 /// [`BinaryHeap`]: struct.BinaryHeap.html
 #[stable(feature = "binary_heap_peek_mut", since = "1.12.0")]
 pub struct PeekMut<'a, T: 'a, C = MaxCmp>
-where C: Fn(&T, &T) -> Option<Ordering>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     heap: &'a mut BinaryHeap<T, C>,
     sift: bool,
 }
 
 #[stable(feature = "collection_debug", since = "1.17.0")]
-impl<T: fmt::Debug, C> fmt::Debug for PeekMut<'_, T, C> 
-where C: Fn(&T, &T) -> Option<Ordering> + Debug
+impl<T: fmt::Debug, C> fmt::Debug for PeekMut<'_, T, C>
+where
+    C: Fn(&T, &T) -> Option<Ordering> + Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("PeekMut").field(&self.heap.data[0]).finish()
@@ -308,8 +311,9 @@ where C: Fn(&T, &T) -> Option<Ordering> + Debug
 }
 
 #[stable(feature = "binary_heap_peek_mut", since = "1.12.0")]
-impl<T, C> Drop for PeekMut<'_, T, C> 
-where C: Fn(&T, &T) -> Option<Ordering>
+impl<T, C> Drop for PeekMut<'_, T, C>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     fn drop(&mut self) {
         if self.sift {
@@ -319,8 +323,9 @@ where C: Fn(&T, &T) -> Option<Ordering>
 }
 
 #[stable(feature = "binary_heap_peek_mut", since = "1.12.0")]
-impl<T, C> Deref for PeekMut<'_, T, C> 
-where C: Fn(&T, &T) -> Option<Ordering>
+impl<T, C> Deref for PeekMut<'_, T, C>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     type Target = T;
     fn deref(&self) -> &T {
@@ -331,8 +336,9 @@ where C: Fn(&T, &T) -> Option<Ordering>
 }
 
 #[stable(feature = "binary_heap_peek_mut", since = "1.12.0")]
-impl<T, C> DerefMut for PeekMut<'_, T, C> 
-where C: Fn(&T, &T) -> Option<Ordering>
+impl<T, C> DerefMut for PeekMut<'_, T, C>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     fn deref_mut(&mut self) -> &mut T {
         debug_assert!(!self.heap.is_empty());
@@ -342,7 +348,8 @@ where C: Fn(&T, &T) -> Option<Ordering>
 }
 
 impl<'a, T: Ord, C> PeekMut<'a, T, C>
-where C: Fn(&T, &T) -> Option<Ordering>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     /// Removes the peeked value from the heap and returns it.
     #[stable(feature = "binary_heap_peek_mut_pop", since = "1.18.0")]
@@ -354,8 +361,9 @@ where C: Fn(&T, &T) -> Option<Ordering>
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Clone, C> Clone for BinaryHeap<T, C> 
-where C: Fn(&T, &T) -> Option<Ordering> + Clone
+impl<T: Clone, C> Clone for BinaryHeap<T, C>
+where
+    C: Fn(&T, &T) -> Option<Ordering> + Clone,
 {
     fn clone(&self) -> Self {
         BinaryHeap { data: self.data.clone(), cmp: self.cmp.clone() }
@@ -376,8 +384,9 @@ impl<T: Ord> Default for BinaryHeap<T> {
 }
 
 #[stable(feature = "binaryheap_debug", since = "1.4.0")]
-impl<T: fmt::Debug, C> fmt::Debug for BinaryHeap<T, C> 
-where C: Fn(&T, &T) -> Option<Ordering>
+impl<T: fmt::Debug, C> fmt::Debug for BinaryHeap<T, C>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.iter()).finish()
@@ -421,8 +430,9 @@ impl<T: Ord> BinaryHeap<T> {
     }
 }
 
-impl<T, C> BinaryHeap<T, C> 
-where C: Fn(&T, &T) -> Option<Ordering>
+impl<T, C> BinaryHeap<T, C>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     /// Returns a mutable reference to the greatest item in the binary heap, or
     /// `None` if it is empty.
@@ -589,13 +599,15 @@ where C: Fn(&T, &T) -> Option<Ordering>
             while child < end {
                 let right = child + 1;
                 // compare with the greater of the two children
-                if right < end && (self.cmp)(hole.get(child), hole.get(right)) != Some(Ordering::Greater) {
+                if right < end
+                    && (self.cmp)(hole.get(child), hole.get(right)) != Some(Ordering::Greater)
+                {
                     child = right;
                 }
                 // if we are already in order, stop.
                 let res = (self.cmp)(hole.element(), hole.get(child));
                 if res == Some(Ordering::Greater) || res == Some(Ordering::Equal) {
-                        break;
+                    break;
                 }
                 hole.move_to(child);
                 child = 2 * hole.pos() + 1;
@@ -622,7 +634,9 @@ where C: Fn(&T, &T) -> Option<Ordering>
             while child < end {
                 let right = child + 1;
                 // compare with the greater of the two children
-                if right < end && (self.cmp)(hole.get(child), hole.get(right)) != Some(Ordering::Greater) {
+                if right < end
+                    && (self.cmp)(hole.get(child), hole.get(right)) != Some(Ordering::Greater)
+                {
                     child = right;
                 }
                 hole.move_to(child);
@@ -723,8 +737,9 @@ where C: Fn(&T, &T) -> Option<Ordering>
     }
 }
 
-impl<T, C> BinaryHeap<T, C> 
-where C: Fn(&T, &T) -> Option<Ordering>
+impl<T, C> BinaryHeap<T, C>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     /// Returns an iterator visiting all values in the underlying vector, in
     /// arbitrary order.
@@ -1203,15 +1218,17 @@ impl<T> FusedIterator for IntoIter<T> {}
 
 #[unstable(feature = "binary_heap_into_iter_sorted", issue = "59278")]
 #[derive(Clone, Debug)]
-pub struct IntoIterSorted<T, C = MaxCmp> 
-where C: Fn(&T, &T) -> Option<Ordering>
+pub struct IntoIterSorted<T, C = MaxCmp>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     inner: BinaryHeap<T, C>,
 }
 
 #[unstable(feature = "binary_heap_into_iter_sorted", issue = "59278")]
 impl<T, C> Iterator for IntoIterSorted<T, C>
-where C: Fn(&T, &T) -> Option<Ordering>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     type Item = T;
 
@@ -1228,19 +1245,13 @@ where C: Fn(&T, &T) -> Option<Ordering>
 }
 
 #[unstable(feature = "binary_heap_into_iter_sorted", issue = "59278")]
-impl<T, C: Debug> ExactSizeIterator for IntoIterSorted<T, C> 
-where C: Fn(&T, &T) -> Option<Ordering>
-{}
+impl<T, C: Debug> ExactSizeIterator for IntoIterSorted<T, C> where C: Fn(&T, &T) -> Option<Ordering> {}
 
 #[unstable(feature = "binary_heap_into_iter_sorted", issue = "59278")]
-impl<T, C: Debug> FusedIterator for IntoIterSorted<T, C> 
-where C: Fn(&T, &T) -> Option<Ordering>
-{}
+impl<T, C: Debug> FusedIterator for IntoIterSorted<T, C> where C: Fn(&T, &T) -> Option<Ordering> {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
-unsafe impl<T, C: Debug> TrustedLen for IntoIterSorted<T, C> 
-where C: Fn(&T, &T) -> Option<Ordering>
-{}
+unsafe impl<T, C: Debug> TrustedLen for IntoIterSorted<T, C> where C: Fn(&T, &T) -> Option<Ordering> {}
 
 /// A draining iterator over the elements of a `BinaryHeap`.
 ///
@@ -1297,15 +1308,17 @@ impl<T> FusedIterator for Drain<'_, T> {}
 /// [`BinaryHeap`]: struct.BinaryHeap.html
 #[unstable(feature = "binary_heap_drain_sorted", issue = "59278")]
 #[derive(Debug)]
-pub struct DrainSorted<'a, T, C = MaxCmp> 
-where C: Fn(&T, &T) -> Option<Ordering>
+pub struct DrainSorted<'a, T, C = MaxCmp>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     inner: &'a mut BinaryHeap<T, C>,
 }
 
 #[unstable(feature = "binary_heap_drain_sorted", issue = "59278")]
 impl<'a, T, C> Drop for DrainSorted<'a, T, C>
-where C: Fn(&T, &T) -> Option<Ordering>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     /// Removes heap elements in heap order.
     fn drop(&mut self) {
@@ -1315,7 +1328,8 @@ where C: Fn(&T, &T) -> Option<Ordering>
 
 #[unstable(feature = "binary_heap_drain_sorted", issue = "59278")]
 impl<T, C> Iterator for DrainSorted<'_, T, C>
-where C: Fn(&T, &T) -> Option<Ordering>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     type Item = T;
 
@@ -1332,19 +1346,13 @@ where C: Fn(&T, &T) -> Option<Ordering>
 }
 
 #[unstable(feature = "binary_heap_drain_sorted", issue = "59278")]
-impl<T, C> ExactSizeIterator for DrainSorted<'_, T, C>
-where C: Fn(&T, &T) -> Option<Ordering>
-{}
+impl<T, C> ExactSizeIterator for DrainSorted<'_, T, C> where C: Fn(&T, &T) -> Option<Ordering> {}
 
 #[unstable(feature = "binary_heap_drain_sorted", issue = "59278")]
-impl<T, C> FusedIterator for DrainSorted<'_, T, C>
-where C: Fn(&T, &T) -> Option<Ordering>
-{}
+impl<T, C> FusedIterator for DrainSorted<'_, T, C> where C: Fn(&T, &T) -> Option<Ordering> {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
-unsafe impl<T, C> TrustedLen for DrainSorted<'_, T, C>
-where C: Fn(&T, &T) -> Option<Ordering>
-{}
+unsafe impl<T, C> TrustedLen for DrainSorted<'_, T, C> where C: Fn(&T, &T) -> Option<Ordering> {}
 
 #[stable(feature = "binary_heap_extras_15", since = "1.5.0")]
 impl<T: Ord> From<Vec<T>> for BinaryHeap<T> {
@@ -1357,8 +1365,9 @@ impl<T: Ord> From<Vec<T>> for BinaryHeap<T> {
 }
 
 #[unstable(feature = "binary_heap_from_vec_cmp", issue = "38886")]
-impl<T, C> From<(Vec<T>, C)> for BinaryHeap<T, C> 
-where C: Fn(&T, &T) -> Option<Ordering>
+impl<T, C> From<(Vec<T>, C)> for BinaryHeap<T, C>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     /// Converts a `Vec<T>` and comparator into a `BinaryHeap<T>`.
     ///
@@ -1372,7 +1381,8 @@ where C: Fn(&T, &T) -> Option<Ordering>
 
 #[stable(feature = "binary_heap_extras_15", since = "1.5.0")]
 impl<T, C> From<BinaryHeap<T, C>> for Vec<T>
-where C: Fn(&T, &T) -> Option<Ordering>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     fn from(heap: BinaryHeap<T, C>) -> Vec<T> {
         heap.data
@@ -1387,8 +1397,9 @@ impl<T: Ord> FromIterator<T> for BinaryHeap<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T, C> IntoIterator for BinaryHeap<T, C> 
-where C: Fn(&T, &T) -> Option<Ordering>
+impl<T, C> IntoIterator for BinaryHeap<T, C>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     type Item = T;
     type IntoIter = IntoIter<T>;
@@ -1417,8 +1428,9 @@ where C: Fn(&T, &T) -> Option<Ordering>
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T, C> IntoIterator for &'a BinaryHeap<T, C> 
-where C: Fn(&T, &T) -> Option<Ordering>
+impl<'a, T, C> IntoIterator for &'a BinaryHeap<T, C>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;
@@ -1430,7 +1442,8 @@ where C: Fn(&T, &T) -> Option<Ordering>
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T, C> Extend<T> for BinaryHeap<T, C>
-where C: Fn(&T, &T) -> Option<Ordering>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     #[inline]
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
@@ -1439,7 +1452,8 @@ where C: Fn(&T, &T) -> Option<Ordering>
 }
 
 impl<T, I: IntoIterator<Item = T>, C> SpecExtend<I> for BinaryHeap<T, C>
-where C: Fn(&T, &T) -> Option<Ordering>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     default fn spec_extend(&mut self, iter: I) {
         self.extend_desugared(iter.into_iter());
@@ -1447,7 +1461,8 @@ where C: Fn(&T, &T) -> Option<Ordering>
 }
 
 impl<T, C> SpecExtend<BinaryHeap<T, C>> for BinaryHeap<T, C>
-where C: Fn(&T, &T) -> Option<Ordering>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     fn spec_extend(&mut self, ref mut other: BinaryHeap<T, C>) {
         self.append(other);
@@ -1455,7 +1470,8 @@ where C: Fn(&T, &T) -> Option<Ordering>
 }
 
 impl<T, C> BinaryHeap<T, C>
-where C: Fn(&T, &T) -> Option<Ordering>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     fn extend_desugared<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         let iterator = iter.into_iter();
@@ -1469,7 +1485,8 @@ where C: Fn(&T, &T) -> Option<Ordering>
 
 #[stable(feature = "extend_ref", since = "1.2.0")]
 impl<'a, T: 'a + Copy, C> Extend<&'a T> for BinaryHeap<T, C>
-where C: Fn(&T, &T) -> Option<Ordering>
+where
+    C: Fn(&T, &T) -> Option<Ordering>,
 {
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
         self.extend(iter.into_iter().cloned());

--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -255,12 +255,12 @@ where C: Fn(&T, &T) -> Option<Ordering>
     cmp: C,
 }
 
-/// Default comparator
-#[unstable(feature = "binary_heap_from_vec_cmp", issue = "38886")]
+/// Default comparator which is used in Max heap.
+#[unstable(feature = "binary_heap_max_cmp", issue = "38886")]
 #[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
 pub struct MaxCmp;
 
-#[unstable(feature = "binary_heap_from_vec_cmp", issue = "38886")]
+#[unstable(feature = "binary_heap_max_cmp", issue = "38886")]
 impl<T: Ord> FnOnce<(&T, &T)> for MaxCmp {
     type Output = Option<Ordering>;
     extern "rust-call" fn call_once(self, args: (&T, &T)) -> Self::Output {
@@ -268,14 +268,14 @@ impl<T: Ord> FnOnce<(&T, &T)> for MaxCmp {
     }
 }
 
-#[unstable(feature = "binary_heap_from_vec_cmp", issue = "38886")]
+#[unstable(feature = "binary_heap_max_cmp", issue = "38886")]
 impl<T: Ord> FnMut<(&T, &T)> for MaxCmp {
     extern "rust-call" fn call_mut(&mut self, args: (&T, &T)) -> Self::Output {
         args.0.partial_cmp(args.1)
     }
 }
 
-#[unstable(feature = "binary_heap_from_vec_cmp", issue = "38886")]
+#[unstable(feature = "binary_heap_max_cmp", issue = "38886")]
 impl<T: Ord> Fn<(&T, &T)> for MaxCmp {
     extern "rust-call" fn call(&self, args: (&T, &T)) -> Self::Output {
         args.0.partial_cmp(args.1)

--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -255,11 +255,6 @@ where C: Fn(&T, &T) -> Option<Ordering>
     cmp: C,
 }
 
-/// Comparation trait
-#[unstable(feature = "binary_heap_from_vec_cmp", issue = "38886")]
-pub trait Compare<T> {
-    fn compare(&self, a: &T, b: &T) -> Option<Ordering>;
-}
 /// Default comparator
 #[unstable(feature = "binary_heap_from_vec_cmp", issue = "38886")]
 #[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
@@ -287,8 +282,6 @@ impl<T: Ord> Fn<(&T, &T)> for MaxCmp {
     }
 }
 
-
-
 /// Structure wrapping a mutable reference to the greatest item on a
 /// `BinaryHeap`.
 ///
@@ -298,7 +291,7 @@ impl<T: Ord> Fn<(&T, &T)> for MaxCmp {
 /// [`peek_mut`]: struct.BinaryHeap.html#method.peek_mut
 /// [`BinaryHeap`]: struct.BinaryHeap.html
 #[stable(feature = "binary_heap_peek_mut", since = "1.12.0")]
-pub struct PeekMut<'a, T: 'a + Ord, C = MaxCmp>
+pub struct PeekMut<'a, T: 'a, C = MaxCmp>
 where C: Fn(&T, &T) -> Option<Ordering>
 {
     heap: &'a mut BinaryHeap<T, C>,
@@ -306,7 +299,7 @@ where C: Fn(&T, &T) -> Option<Ordering>
 }
 
 #[stable(feature = "collection_debug", since = "1.17.0")]
-impl<T: Ord + fmt::Debug, C> fmt::Debug for PeekMut<'_, T, C> 
+impl<T: fmt::Debug, C> fmt::Debug for PeekMut<'_, T, C> 
 where C: Fn(&T, &T) -> Option<Ordering> + Debug
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -315,7 +308,7 @@ where C: Fn(&T, &T) -> Option<Ordering> + Debug
 }
 
 #[stable(feature = "binary_heap_peek_mut", since = "1.12.0")]
-impl<T: Ord, C> Drop for PeekMut<'_, T, C> 
+impl<T, C> Drop for PeekMut<'_, T, C> 
 where C: Fn(&T, &T) -> Option<Ordering>
 {
     fn drop(&mut self) {
@@ -326,7 +319,7 @@ where C: Fn(&T, &T) -> Option<Ordering>
 }
 
 #[stable(feature = "binary_heap_peek_mut", since = "1.12.0")]
-impl<T: Ord, C> Deref for PeekMut<'_, T, C> 
+impl<T, C> Deref for PeekMut<'_, T, C> 
 where C: Fn(&T, &T) -> Option<Ordering>
 {
     type Target = T;
@@ -338,7 +331,7 @@ where C: Fn(&T, &T) -> Option<Ordering>
 }
 
 #[stable(feature = "binary_heap_peek_mut", since = "1.12.0")]
-impl<T: Ord, C> DerefMut for PeekMut<'_, T, C> 
+impl<T, C> DerefMut for PeekMut<'_, T, C> 
 where C: Fn(&T, &T) -> Option<Ordering>
 {
     fn deref_mut(&mut self) -> &mut T {
@@ -428,7 +421,7 @@ impl<T: Ord> BinaryHeap<T> {
     }
 }
 
-impl<T: Ord, C> BinaryHeap<T, C> 
+impl<T, C> BinaryHeap<T, C> 
 where C: Fn(&T, &T) -> Option<Ordering>
 {
     /// Returns a mutable reference to the greatest item in the binary heap, or
@@ -1217,7 +1210,7 @@ where C: Fn(&T, &T) -> Option<Ordering>
 }
 
 #[unstable(feature = "binary_heap_into_iter_sorted", issue = "59278")]
-impl<T: Ord, C> Iterator for IntoIterSorted<T, C>
+impl<T, C> Iterator for IntoIterSorted<T, C>
 where C: Fn(&T, &T) -> Option<Ordering>
 {
     type Item = T;
@@ -1235,17 +1228,17 @@ where C: Fn(&T, &T) -> Option<Ordering>
 }
 
 #[unstable(feature = "binary_heap_into_iter_sorted", issue = "59278")]
-impl<T: Ord, C: Debug> ExactSizeIterator for IntoIterSorted<T, C> 
+impl<T, C: Debug> ExactSizeIterator for IntoIterSorted<T, C> 
 where C: Fn(&T, &T) -> Option<Ordering>
 {}
 
 #[unstable(feature = "binary_heap_into_iter_sorted", issue = "59278")]
-impl<T: Ord, C: Debug> FusedIterator for IntoIterSorted<T, C> 
+impl<T, C: Debug> FusedIterator for IntoIterSorted<T, C> 
 where C: Fn(&T, &T) -> Option<Ordering>
 {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
-unsafe impl<T: Ord, C: Debug> TrustedLen for IntoIterSorted<T, C> 
+unsafe impl<T, C: Debug> TrustedLen for IntoIterSorted<T, C> 
 where C: Fn(&T, &T) -> Option<Ordering>
 {}
 
@@ -1304,14 +1297,14 @@ impl<T> FusedIterator for Drain<'_, T> {}
 /// [`BinaryHeap`]: struct.BinaryHeap.html
 #[unstable(feature = "binary_heap_drain_sorted", issue = "59278")]
 #[derive(Debug)]
-pub struct DrainSorted<'a, T: Ord, C = MaxCmp> 
+pub struct DrainSorted<'a, T, C = MaxCmp> 
 where C: Fn(&T, &T) -> Option<Ordering>
 {
     inner: &'a mut BinaryHeap<T, C>,
 }
 
 #[unstable(feature = "binary_heap_drain_sorted", issue = "59278")]
-impl<'a, T: Ord, C> Drop for DrainSorted<'a, T, C>
+impl<'a, T, C> Drop for DrainSorted<'a, T, C>
 where C: Fn(&T, &T) -> Option<Ordering>
 {
     /// Removes heap elements in heap order.
@@ -1321,7 +1314,7 @@ where C: Fn(&T, &T) -> Option<Ordering>
 }
 
 #[unstable(feature = "binary_heap_drain_sorted", issue = "59278")]
-impl<T: Ord, C> Iterator for DrainSorted<'_, T, C>
+impl<T, C> Iterator for DrainSorted<'_, T, C>
 where C: Fn(&T, &T) -> Option<Ordering>
 {
     type Item = T;
@@ -1339,17 +1332,17 @@ where C: Fn(&T, &T) -> Option<Ordering>
 }
 
 #[unstable(feature = "binary_heap_drain_sorted", issue = "59278")]
-impl<T: Ord, C> ExactSizeIterator for DrainSorted<'_, T, C>
+impl<T, C> ExactSizeIterator for DrainSorted<'_, T, C>
 where C: Fn(&T, &T) -> Option<Ordering>
 {}
 
 #[unstable(feature = "binary_heap_drain_sorted", issue = "59278")]
-impl<T: Ord, C> FusedIterator for DrainSorted<'_, T, C>
+impl<T, C> FusedIterator for DrainSorted<'_, T, C>
 where C: Fn(&T, &T) -> Option<Ordering>
 {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
-unsafe impl<T: Ord, C> TrustedLen for DrainSorted<'_, T, C>
+unsafe impl<T, C> TrustedLen for DrainSorted<'_, T, C>
 where C: Fn(&T, &T) -> Option<Ordering>
 {}
 
@@ -1366,7 +1359,7 @@ impl<T: Ord> From<Vec<T>> for BinaryHeap<T> {
 }
 
 #[unstable(feature = "binary_heap_from_vec_cmp", issue = "38886")]
-impl<T: Ord, C> From<(Vec<T>, C)> for BinaryHeap<T, C> 
+impl<T, C> From<(Vec<T>, C)> for BinaryHeap<T, C> 
 where C: Fn(&T, &T) -> Option<Ordering>
 {
     /// Converts a `Vec<T>` and comparator into a `BinaryHeap<T>`.
@@ -1438,7 +1431,7 @@ where C: Fn(&T, &T) -> Option<Ordering>
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Ord, C> Extend<T> for BinaryHeap<T, C>
+impl<T, C> Extend<T> for BinaryHeap<T, C>
 where C: Fn(&T, &T) -> Option<Ordering>
 {
     #[inline]
@@ -1447,7 +1440,7 @@ where C: Fn(&T, &T) -> Option<Ordering>
     }
 }
 
-impl<T: Ord, I: IntoIterator<Item = T>, C> SpecExtend<I> for BinaryHeap<T, C>
+impl<T, I: IntoIterator<Item = T>, C> SpecExtend<I> for BinaryHeap<T, C>
 where C: Fn(&T, &T) -> Option<Ordering>
 {
     default fn spec_extend(&mut self, iter: I) {
@@ -1455,7 +1448,7 @@ where C: Fn(&T, &T) -> Option<Ordering>
     }
 }
 
-impl<T: Ord, C> SpecExtend<BinaryHeap<T, C>> for BinaryHeap<T, C>
+impl<T, C> SpecExtend<BinaryHeap<T, C>> for BinaryHeap<T, C>
 where C: Fn(&T, &T) -> Option<Ordering>
 {
     fn spec_extend(&mut self, ref mut other: BinaryHeap<T, C>) {
@@ -1463,7 +1456,7 @@ where C: Fn(&T, &T) -> Option<Ordering>
     }
 }
 
-impl<T: Ord, C> BinaryHeap<T, C>
+impl<T, C> BinaryHeap<T, C>
 where C: Fn(&T, &T) -> Option<Ordering>
 {
     fn extend_desugared<I: IntoIterator<Item = T>>(&mut self, iter: I) {
@@ -1477,7 +1470,7 @@ where C: Fn(&T, &T) -> Option<Ordering>
 }
 
 #[stable(feature = "extend_ref", since = "1.2.0")]
-impl<'a, T: 'a + Ord + Copy, C> Extend<&'a T> for BinaryHeap<T, C>
+impl<'a, T: 'a + Copy, C> Extend<&'a T> for BinaryHeap<T, C>
 where C: Fn(&T, &T) -> Option<Ordering>
 {
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {

--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -1352,9 +1352,7 @@ impl<T: Ord> From<Vec<T>> for BinaryHeap<T> {
     ///
     /// This conversion happens in-place, and has `O(n)` time complexity.
     fn from(vec: Vec<T>) -> BinaryHeap<T> {
-        let mut heap = BinaryHeap { data: vec, cmp: MaxCmp::default() };
-        heap.rebuild();
-        heap
+        BinaryHeap::from((vec, MaxCmp::default()))
     }
 }
 

--- a/src/liballoc/tests/binary_heap.rs
+++ b/src/liballoc/tests/binary_heap.rs
@@ -260,18 +260,24 @@ fn test_from_iter() {
 #[test]
 fn test_from_vec_cmp() {
     // closure
-    let heap = BinaryHeap::from((vec![2, 3, 89, 5, 8, 1, 13, 21, 34, 55, 1],
-                                 |a: &i32, b: &i32| b.partial_cmp(a)));
-    assert_eq!(heap.into_iter_sorted().collect::<Vec<_>>(),
-               vec![1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89]);
+    let heap =
+        BinaryHeap::from((vec![2, 3, 89, 5, 8, 1, 13, 21, 34, 55, 1], |a: &i32, b: &i32| {
+            b.partial_cmp(a)
+        }));
+    assert_eq!(
+        heap.into_iter_sorted().collect::<Vec<_>>(),
+        vec![1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89]
+    );
 }
 
 #[test]
 fn test_from_vec_cmp_boxed_closure() {
     // boxed closure
     let vec = vec![2, 3, 89, 5, 8, 1, 13, 21, 34, 55, 1];
-    let cmp1: Box<dyn Fn(&i32, &i32) -> Option<core::cmp::Ordering>> = Box::new(|a: &i32, b: &i32| a.partial_cmp(b));
-    let cmp2: Box<dyn Fn(&i32, &i32) -> Option<core::cmp::Ordering>> = Box::new(|a: &i32, b: &i32| b.partial_cmp(a));
+    let cmp1: Box<dyn Fn(&i32, &i32) -> Option<core::cmp::Ordering>> =
+        Box::new(|a: &i32, b: &i32| a.partial_cmp(b));
+    let cmp2: Box<dyn Fn(&i32, &i32) -> Option<core::cmp::Ordering>> =
+        Box::new(|a: &i32, b: &i32| b.partial_cmp(a));
 
     let mut heap = BinaryHeap::from((vec, cmp1));
     assert_eq!(heap.pop(), Some(89));

--- a/src/liballoc/tests/binary_heap.rs
+++ b/src/liballoc/tests/binary_heap.rs
@@ -259,12 +259,26 @@ fn test_from_iter() {
 
 #[test]
 fn test_from_vec_cmp() {
-    let vec = vec![9, 8, 7, 6, 5, 4, 3, 2, 1];
-    let cmp = |a: &i32, b: &i32| b.partial_cmp(a);
+    // closure
+    let heap = BinaryHeap::from((vec![2, 3, 89, 5, 8, 1, 13, 21, 34, 55, 1],
+                                 |a: &i32, b: &i32| b.partial_cmp(a)));
+    assert_eq!(heap.into_iter_sorted().collect::<Vec<_>>(),
+               vec![1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89]);
+}
 
-    let heap = BinaryHeap::from((vec, cmp));
-    assert_eq!(heap.into_iter_sorted().collect::<Vec<_>>(), 
-        vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+#[test]
+fn test_from_vec_cmp_boxed_closure() {
+    // boxed closure
+    let vec = vec![2, 3, 89, 5, 8, 1, 13, 21, 34, 55, 1];
+    let cmp1: Box<dyn Fn(&i32, &i32) -> Option<core::cmp::Ordering>> = Box::new(|a: &i32, b: &i32| a.partial_cmp(b));
+    let cmp2: Box<dyn Fn(&i32, &i32) -> Option<core::cmp::Ordering>> = Box::new(|a: &i32, b: &i32| b.partial_cmp(a));
+
+    let mut heap = BinaryHeap::from((vec, cmp1));
+    assert_eq!(heap.pop(), Some(89));
+
+    // re-heapify using different comparator
+    heap = BinaryHeap::from((heap.into(), cmp2));
+    assert_eq!(heap.pop(), Some(1));
 }
 
 #[test]

--- a/src/liballoc/tests/binary_heap.rs
+++ b/src/liballoc/tests/binary_heap.rs
@@ -258,6 +258,16 @@ fn test_from_iter() {
 }
 
 #[test]
+fn test_from_vec_cmp() {
+    let vec = vec![9, 8, 7, 6, 5, 4, 3, 2, 1];
+    let cmp = |a: &i32, b: &i32| b.partial_cmp(a);
+
+    let heap = BinaryHeap::from((vec, cmp));
+    assert_eq!(heap.into_iter_sorted().collect::<Vec<_>>(), 
+        vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+}
+
+#[test]
 fn test_drain() {
     let mut q: BinaryHeap<_> = [9, 8, 7, 6, 5, 4, 3, 2, 1].iter().cloned().collect();
 

--- a/src/liballoc/tests/lib.rs
+++ b/src/liballoc/tests/lib.rs
@@ -11,6 +11,7 @@
 #![feature(associated_type_bounds)]
 #![feature(binary_heap_into_iter_sorted)]
 #![feature(binary_heap_drain_sorted)]
+#![feature(binary_heap_from_vec_cmp)]
 #![feature(vec_remove_item)]
 
 use std::collections::hash_map::DefaultHasher;


### PR DESCRIPTION
This PR will
- add the second type parameter `C: Fn(&T, &T) -> Option<Ordering>` to the existing `BinaryHeap<T>`. 
- add `pub struct MaxCmp` which can be used as the default `C`.
  - feature gated by `binary_heap_max_cmp` 
- add `From<(Vec<T>, C)>` impl to support generic `BinaryHeap<T, C>` creation. 
  - feature gated by `binary_heap_from_vec_cmp`
- remove `T: Ord` bound where possible.

The features refer to #38886.

## Unresolved questions

### Comparator type
I used `C: Fn(&T, &T) -> Option<Ordering>` which is compatible with `PartialOrd::partial_cmp()` return type.
`C: Fn(&T, &T) -> Ordering` is more straightforward but it broke some corner-case test.  
Should we go with the latter and fix tests instead?

### Needs crater run?
While stage 0 unit tests `$ ./x.py test src/liballoc --stage 0` run fine, `serde` was failed to build.

### `serde` needs to be patched before it lands?
The below in `serde-1.0.99` conflicts with this PR#.
https://github.com/serde-rs/serde/blob/192f5cd647dfb67bfd6158e7234c78c95894c071/serde/src/de/impls.rs#L786-L794