### PR TITLE
Clean up TypeFlags

### DIFF
--- a/src/librustc/ty/flags.rs
+++ b/src/librustc/ty/flags.rs
@@ -80,13 +80,10 @@ impl FlagComputation {
             &ty::Error => self.add_flags(TypeFlags::HAS_TY_ERR),
 
             &ty::Param(_) => {
-                self.add_flags(TypeFlags::HAS_FREE_LOCAL_NAMES);
-                self.add_flags(TypeFlags::HAS_PARAMS);
+                self.add_flags(TypeFlags::HAS_TY_PARAM);
             }
 
             &ty::Generator(_, ref substs, _) => {
-                self.add_flags(TypeFlags::HAS_TY_CLOSURE);
-                self.add_flags(TypeFlags::HAS_FREE_LOCAL_NAMES);
                 self.add_substs(substs);
             }
 
@@ -97,8 +94,6 @@ impl FlagComputation {
             }
 
             &ty::Closure(_, ref substs) => {
-                self.add_flags(TypeFlags::HAS_TY_CLOSURE);
-                self.add_flags(TypeFlags::HAS_FREE_LOCAL_NAMES);
                 self.add_substs(substs);
             }
 
@@ -107,12 +102,10 @@ impl FlagComputation {
             }
 
             &ty::Placeholder(..) => {
-                self.add_flags(TypeFlags::HAS_FREE_LOCAL_NAMES);
                 self.add_flags(TypeFlags::HAS_TY_PLACEHOLDER);
             }
 
             &ty::Infer(infer) => {
-                self.add_flags(TypeFlags::HAS_FREE_LOCAL_NAMES); // it might, right?
                 self.add_flags(TypeFlags::HAS_TY_INFER);
                 match infer {
                     ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_) => {}
@@ -128,17 +121,17 @@ impl FlagComputation {
             }
 
             &ty::Projection(ref data) => {
-                self.add_flags(TypeFlags::HAS_PROJECTION);
+                self.add_flags(TypeFlags::HAS_TY_PROJECTION);
                 self.add_projection_ty(data);
             }
 
             &ty::UnnormalizedProjection(ref data) => {
-                self.add_flags(TypeFlags::HAS_PROJECTION);
+                self.add_flags(TypeFlags::HAS_TY_PROJECTION);
                 self.add_projection_ty(data);
             }
 
             &ty::Opaque(_, substs) => {
-                self.add_flags(TypeFlags::HAS_PROJECTION | TypeFlags::HAS_TY_OPAQUE);
+                self.add_flags(TypeFlags::HAS_TY_OPAQUE);
                 self.add_substs(substs);
             }
 
@@ -221,10 +214,10 @@ impl FlagComputation {
         match c.val {
             ty::ConstKind::Unevaluated(_, substs, _) => {
                 self.add_substs(substs);
-                self.add_flags(TypeFlags::HAS_PROJECTION);
+                self.add_flags(TypeFlags::HAS_CT_PROJECTION);
             }
             ty::ConstKind::Infer(infer) => {
-                self.add_flags(TypeFlags::HAS_FREE_LOCAL_NAMES | TypeFlags::HAS_CT_INFER);
+                self.add_flags(TypeFlags::HAS_CT_INFER);
                 match infer {
                     InferConst::Fresh(_) => {}
                     InferConst::Var(_) => self.add_flags(TypeFlags::KEEP_IN_LOCAL_TCX),
@@ -232,11 +225,9 @@ impl FlagComputation {
             }
             ty::ConstKind::Bound(debruijn, _) => self.add_binder(debruijn),
             ty::ConstKind::Param(_) => {
-                self.add_flags(TypeFlags::HAS_FREE_LOCAL_NAMES);
-                self.add_flags(TypeFlags::HAS_PARAMS);
+                self.add_flags(TypeFlags::HAS_CT_PARAM);
             }
             ty::ConstKind::Placeholder(_) => {
-                self.add_flags(TypeFlags::HAS_FREE_LOCAL_NAMES);
                 self.add_flags(TypeFlags::HAS_CT_PLACEHOLDER);
             }
             ty::ConstKind::Value(_) => {}

--- a/src/librustc/ty/fold.rs
+++ b/src/librustc/ty/fold.rs
@@ -90,6 +90,9 @@ pub trait TypeFoldable<'tcx>: fmt::Debug + Clone {
     fn has_infer_types(&self) -> bool {
         self.has_type_flags(TypeFlags::HAS_TY_INFER)
     }
+    fn has_infer_types_or_consts(&self) -> bool {
+        self.has_type_flags(TypeFlags::HAS_TY_INFER | TypeFlags::HAS_CT_INFER)
+    }
     fn has_infer_consts(&self) -> bool {
         self.has_type_flags(TypeFlags::HAS_CT_INFER)
     }
@@ -113,9 +116,6 @@ pub trait TypeFoldable<'tcx>: fmt::Debug + Clone {
     }
     fn has_re_placeholders(&self) -> bool {
         self.has_type_flags(TypeFlags::HAS_RE_PLACEHOLDER)
-    }
-    fn has_closure_types(&self) -> bool {
-        self.has_type_flags(TypeFlags::HAS_TY_CLOSURE)
     }
     /// "Free" regions in this context means that it has any region
     /// that is not (a) erased or (b) late-bound.

--- a/src/librustc/ty/fold.rs
+++ b/src/librustc/ty/fold.rs
@@ -85,7 +85,7 @@ pub trait TypeFoldable<'tcx>: fmt::Debug + Clone {
         self.has_type_flags(TypeFlags::HAS_TY_ERR)
     }
     fn has_param_types(&self) -> bool {
-        self.has_type_flags(TypeFlags::HAS_PARAMS)
+        self.has_type_flags(TypeFlags::HAS_TY_PARAM | TypeFlags::HAS_CT_PARAM)
     }
     fn has_infer_types(&self) -> bool {
         self.has_type_flags(TypeFlags::HAS_TY_INFER)
@@ -100,9 +100,7 @@ pub trait TypeFoldable<'tcx>: fmt::Debug + Clone {
         self.has_type_flags(TypeFlags::KEEP_IN_LOCAL_TCX)
     }
     fn needs_infer(&self) -> bool {
-        self.has_type_flags(
-            TypeFlags::HAS_TY_INFER | TypeFlags::HAS_RE_INFER | TypeFlags::HAS_CT_INFER,
-        )
+        self.has_type_flags(TypeFlags::NEEDS_INFER)
     }
     fn has_placeholders(&self) -> bool {
         self.has_type_flags(

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -502,7 +502,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
         let univariant = |fields: &[TyLayout<'_>], repr: &ReprOptions, kind| {
             Ok(tcx.intern_layout(self.univariant_uninterned(ty, fields, repr, kind)?))
         };
-        debug_assert!(!ty.has_infer_types());
+        debug_assert!(!ty.has_infer_types_or_consts());
 
         Ok(match ty.kind {
             // Basic scalars.
@@ -1752,7 +1752,7 @@ impl<'tcx> SizeSkeleton<'tcx> {
         tcx: TyCtxt<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
     ) -> Result<SizeSkeleton<'tcx>, LayoutError<'tcx>> {
-        debug_assert!(!ty.has_infer_types());
+        debug_assert!(!ty.has_infer_types_or_consts());
 
         // First try computing a static layout.
         let err = match tcx.layout_of(param_env.and(ty)) {

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1768,7 +1768,7 @@ impl RegionKind {
             }
             ty::ReEarlyBound(..) => {
                 flags = flags | TypeFlags::HAS_FREE_REGIONS;
-                flags = flags | TypeFlags::HAS_RE_EARLY_BOUND;
+                flags = flags | TypeFlags::HAS_RE_PARAM;
             }
             ty::ReEmpty(_) | ty::ReStatic | ty::ReFree { .. } | ty::ReScope { .. } => {
                 flags = flags | TypeFlags::HAS_FREE_REGIONS;
@@ -1779,11 +1779,6 @@ impl RegionKind {
             ty::ReClosureBound(..) => {
                 flags = flags | TypeFlags::HAS_FREE_REGIONS;
             }
-        }
-
-        match *self {
-            ty::ReStatic | ty::ReEmpty(_) | ty::ReErased | ty::ReLateBound(..) => (),
-            _ => flags = flags | TypeFlags::HAS_FREE_LOCAL_NAMES,
         }
 
         debug!("type_flags({:?}) = {:?}", self, flags);

--- a/src/librustc_infer/infer/freshen.rs
+++ b/src/librustc_infer/infer/freshen.rs
@@ -143,10 +143,7 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TypeFreshener<'a, 'tcx> {
     }
 
     fn fold_ty(&mut self, t: Ty<'tcx>) -> Ty<'tcx> {
-        if !(t.needs_infer()
-            || t.has_erasable_regions()
-            || (t.has_closure_types() && self.infcx.in_progress_tables.is_some()))
-        {
+        if !t.needs_infer() && !t.has_erasable_regions() {
             return t;
         }
 

--- a/src/librustc_infer/infer/mod.rs
+++ b/src/librustc_infer/infer/mod.rs
@@ -1482,12 +1482,8 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     ) -> bool {
         let ty = self.resolve_vars_if_possible(&ty);
 
-        // Even if the type may have no inference variables, during
-        // type-checking closure types are in local tables only.
-        if self.in_progress_tables.is_none() || !ty.has_closure_types() {
-            if !(param_env, ty).has_local_value() {
-                return ty.is_copy_modulo_regions(self.tcx, param_env, span);
-            }
+        if !(param_env, ty).has_local_value() {
+            return ty.is_copy_modulo_regions(self.tcx, param_env, span);
         }
 
         let copy_def_id = self.tcx.require_lang_item(lang_items::CopyTraitLangItem, None);

--- a/src/librustc_infer/infer/nll_relate/mod.rs
+++ b/src/librustc_infer/infer/nll_relate/mod.rs
@@ -340,7 +340,7 @@ where
             // In NLL, we don't have type inference variables
             // floating around, so we can do this rather imprecise
             // variant of the occurs-check.
-            assert!(!generalized_ty.has_infer_types());
+            assert!(!generalized_ty.has_infer_types_or_consts());
         }
 
         self.infcx.inner.borrow_mut().type_variables.instantiate(vid, generalized_ty);

--- a/src/librustc_infer/infer/resolve.rs
+++ b/src/librustc_infer/infer/resolve.rs
@@ -28,7 +28,7 @@ impl<'a, 'tcx> TypeFolder<'tcx> for OpportunisticVarResolver<'a, 'tcx> {
     }
 
     fn fold_ty(&mut self, t: Ty<'tcx>) -> Ty<'tcx> {
-        if !t.has_infer_types() && !t.has_infer_consts() {
+        if !t.has_infer_types_or_consts() {
             t // micro-optimize -- if there is nothing in this type that this fold affects...
         } else {
             let t = self.infcx.shallow_resolve(t);
@@ -37,7 +37,7 @@ impl<'a, 'tcx> TypeFolder<'tcx> for OpportunisticVarResolver<'a, 'tcx> {
     }
 
     fn fold_const(&mut self, ct: &'tcx Const<'tcx>) -> &'tcx Const<'tcx> {
-        if !ct.has_infer_consts() {
+        if !ct.has_infer_types_or_consts() {
             ct // micro-optimize -- if there is nothing in this const that this fold affects...
         } else {
             let ct = self.infcx.shallow_resolve(ct);

--- a/src/librustc_infer/traits/error_reporting/mod.rs
+++ b/src/librustc_infer/traits/error_reporting/mod.rs
@@ -647,7 +647,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                         }
 
                         // Try to report a help message
-                        if !trait_ref.has_infer_types()
+                        if !trait_ref.has_infer_types_or_consts()
                             && self.predicate_can_apply(obligation.param_env, trait_ref)
                         {
                             // If a where-clause may be useful, remind the

--- a/src/librustc_infer/traits/error_reporting/suggestions.rs
+++ b/src/librustc_infer/traits/error_reporting/suggestions.rs
@@ -471,7 +471,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 return;
             }
             let trait_ref = self.resolve_vars_if_possible(trait_ref);
-            if trait_ref.has_infer_types() {
+            if trait_ref.has_infer_types_or_consts() {
                 // Do not ICE while trying to find if a reborrow would succeed on a trait with
                 // unresolved bindings.
                 return;

--- a/src/librustc_infer/traits/fulfill.rs
+++ b/src/librustc_infer/traits/fulfill.rs
@@ -299,7 +299,7 @@ impl<'a, 'b, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'tcx> {
 
         let obligation = &mut pending_obligation.obligation;
 
-        if obligation.predicate.has_infer_types() {
+        if obligation.predicate.has_infer_types_or_consts() {
             obligation.predicate =
                 self.selcx.infcx().resolve_vars_if_possible(&obligation.predicate);
         }
@@ -346,16 +346,7 @@ impl<'a, 'b, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'tcx> {
                         // This is a bit subtle: for the most part, the
                         // only reason we can fail to make progress on
                         // trait selection is because we don't have enough
-                        // information about the types in the trait. One
-                        // exception is that we sometimes haven't decided
-                        // what kind of closure a closure is. *But*, in
-                        // that case, it turns out, the type of the
-                        // closure will also change, because the closure
-                        // also includes references to its upvars as part
-                        // of its type, and those types are resolved at
-                        // the same time.
-                        //
-                        // FIXME(#32286) logic seems false if no upvars
+                        // information about the types in the trait.
                         pending_obligation.stalled_on =
                             trait_ref_type_vars(self.selcx, data.to_poly_trait_ref());
 

--- a/src/librustc_infer/traits/mod.rs
+++ b/src/librustc_infer/traits/mod.rs
@@ -213,7 +213,7 @@ pub fn type_known_to_meet_bound_modulo_regions<'a, 'tcx>(
         result
     );
 
-    if result && (ty.has_infer_types() || ty.has_closure_types()) {
+    if result && ty.has_infer_types_or_consts() {
         // Because of inference "guessing", selection can sometimes claim
         // to succeed while the success requires a guess. To ensure
         // this function's result remains infallible, we must confirm

--- a/src/librustc_infer/traits/project.rs
+++ b/src/librustc_infer/traits/project.rs
@@ -490,22 +490,14 @@ fn opt_normalize_projection_type<'a, 'b, 'tcx>(
     match cache_result {
         Ok(()) => {}
         Err(ProjectionCacheEntry::Ambiguous) => {
-            // If we found ambiguity the last time, that generally
-            // means we will continue to do so until some type in the
-            // key changes (and we know it hasn't, because we just
-            // fully resolved it). One exception though is closure
-            // types, which can transition from having a fixed kind to
-            // no kind with no visible change in the key.
-            //
-            // FIXME(#32286) refactor this so that closure type
-            // changes
+            // If we found ambiguity the last time, that means we will continue
+            // to do so until some type in the key changes (and we know it
+            // hasn't, because we just fully resolved it).
             debug!(
                 "opt_normalize_projection_type: \
                  found cache entry: ambiguous"
             );
-            if !projection_ty.has_closure_types() {
-                return None;
-            }
+            return None;
         }
         Err(ProjectionCacheEntry::InProgress) => {
             // If while normalized A::B, we are asked to normalize

--- a/src/librustc_traits/implied_outlives_bounds.rs
+++ b/src/librustc_traits/implied_outlives_bounds.rs
@@ -84,7 +84,7 @@ fn compute_implied_outlives_bounds<'tcx>(
         // to avoids duplicate errors that otherwise show up.
         fulfill_cx.register_predicate_obligations(
             infcx,
-            obligations.iter().filter(|o| o.predicate.has_infer_types()).cloned(),
+            obligations.iter().filter(|o| o.predicate.has_infer_types_or_consts()).cloned(),
         );
 
         // From the full set of obligations, just filter down to the

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2900,14 +2900,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         debug!("resolve_vars_with_obligations(ty={:?})", ty);
 
         // No Infer()? Nothing needs doing.
-        if !ty.has_infer_types() && !ty.has_infer_consts() {
+        if !ty.has_infer_types_or_consts() {
             debug!("resolve_vars_with_obligations: ty={:?}", ty);
             return ty;
         }
 
         // If `ty` is a type variable, see whether we already know what it is.
         ty = self.resolve_vars_if_possible(&ty);
-        if !ty.has_infer_types() && !ty.has_infer_consts() {
+        if !ty.has_infer_types_or_consts() {
             debug!("resolve_vars_with_obligations: ty={:?}", ty);
             return ty;
         }

--- a/src/test/ui/const-generics/array-impls/into-iter-no-impls-length-33.stderr
+++ b/src/test/ui/const-generics/array-impls/into-iter-no-impls-length-33.stderr
@@ -1,8 +1,8 @@
 error[E0277]: arrays only have std trait implementations for lengths 0..=32
-  --> $DIR/into-iter-no-impls-length-33.rs:12:5
+  --> $DIR/into-iter-no-impls-length-33.rs:12:19
    |
 LL |     IntoIter::new([0i32; 33])
-   |     ^^^^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[i32; 33]`
+   |                   ^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[i32; 33]`
    |
    = note: required by `std::array::IntoIter::<T, N>::new`
 
@@ -19,10 +19,10 @@ LL |     IntoIter::new([0i32; 33])
    = note: the return type of a function must have a statically known size
 
 error[E0277]: arrays only have std trait implementations for lengths 0..=32
-  --> $DIR/into-iter-no-impls-length-33.rs:18:5
+  --> $DIR/into-iter-no-impls-length-33.rs:18:19
    |
 LL |     IntoIter::new([0i32; 33])
-   |     ^^^^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[i32; 33]`
+   |                   ^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[i32; 33]`
    |
    = note: required by `std::array::IntoIter::<T, N>::new`
 
@@ -39,10 +39,10 @@ LL |     IntoIter::new([0i32; 33])
    = note: the return type of a function must have a statically known size
 
 error[E0277]: arrays only have std trait implementations for lengths 0..=32
-  --> $DIR/into-iter-no-impls-length-33.rs:24:5
+  --> $DIR/into-iter-no-impls-length-33.rs:24:19
    |
 LL |     IntoIter::new([0i32; 33])
-   |     ^^^^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[i32; 33]`
+   |                   ^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[i32; 33]`
    |
    = note: required by `std::array::IntoIter::<T, N>::new`
 
@@ -59,10 +59,10 @@ LL |     IntoIter::new([0i32; 33])
    = note: the return type of a function must have a statically known size
 
 error[E0277]: arrays only have std trait implementations for lengths 0..=32
-  --> $DIR/into-iter-no-impls-length-33.rs:30:5
+  --> $DIR/into-iter-no-impls-length-33.rs:30:19
    |
 LL |     IntoIter::new([0i32; 33])
-   |     ^^^^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[i32; 33]`
+   |                   ^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[i32; 33]`
    |
    = note: required by `std::array::IntoIter::<T, N>::new`
 
@@ -79,10 +79,10 @@ LL |     IntoIter::new([0i32; 33])
    = note: the return type of a function must have a statically known size
 
 error[E0277]: arrays only have std trait implementations for lengths 0..=32
-  --> $DIR/into-iter-no-impls-length-33.rs:36:5
+  --> $DIR/into-iter-no-impls-length-33.rs:36:19
    |
 LL |     IntoIter::new([0i32; 33])
-   |     ^^^^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[i32; 33]`
+   |                   ^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[i32; 33]`
    |
    = note: required by `std::array::IntoIter::<T, N>::new`
 
@@ -99,10 +99,10 @@ LL |     IntoIter::new([0i32; 33])
    = note: the return type of a function must have a statically known size
 
 error[E0277]: arrays only have std trait implementations for lengths 0..=32
-  --> $DIR/into-iter-no-impls-length-33.rs:42:5
+  --> $DIR/into-iter-no-impls-length-33.rs:42:19
    |
 LL |     IntoIter::new([0i32; 33])
-   |     ^^^^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[i32; 33]`
+   |                   ^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[i32; 33]`
    |
    = note: required by `std::array::IntoIter::<T, N>::new`
 
@@ -119,10 +119,10 @@ LL |     IntoIter::new([0i32; 33])
    = note: the return type of a function must have a statically known size
 
 error[E0277]: arrays only have std trait implementations for lengths 0..=32
-  --> $DIR/into-iter-no-impls-length-33.rs:48:5
+  --> $DIR/into-iter-no-impls-length-33.rs:48:19
    |
 LL |     IntoIter::new([0i32; 33])
-   |     ^^^^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[i32; 33]`
+   |                   ^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[i32; 33]`
    |
    = note: required by `std::array::IntoIter::<T, N>::new`
 


### PR DESCRIPTION
* Add a new method `has_infer_types_or_consts` that's used instead of `has_infer_types` most of the time, since there's generally no reason to only consider types.
*  Remove `has_closure_types`/`HAS_TY_CLOSURE`, because closures are no longer implicitly linked to the `InferCtxt`.
* Reorder flags to group similar ones together
* Make some flags more granular
* Compute `HAS_FREE_LOCAL_NAMES` from the other flags
* Add some more doc comments