### PR TITLE
rustc_span: Add `Symbol::to_ident_string` for use in diagnostic messages

### DIFF
--- a/src/librustc_span/symbol.rs
+++ b/src/librustc_span/symbol.rs
@@ -1023,6 +1023,14 @@ impl Symbol {
     pub fn as_u32(self) -> u32 {
         self.0.as_u32()
     }
+
+    /// This method is supposed to be used in error messages, so it's expected to be
+    /// identical to printing the original identifier token written in source code
+    /// (`token_to_string`, `Ident::to_string`), except that symbols don't keep the rawness flag
+    /// or edition, so we have to guess the rawness using the global edition.
+    pub fn to_ident_string(self) -> String {
+        Ident::with_dummy_span(self).to_string()
+    }
 }
 
 impl fmt::Debug for Symbol {


### PR DESCRIPTION
Covers the same error reporting use case (https://github.com/rust-lang/rust/pull/69387#discussion_r382999205) as the `Display` impl for `Ident`.
cc https://github.com/rust-lang/rust/issues/69053

Follow-up to https://github.com/rust-lang/rust/pull/69387.
r? @Mark-Simulacrum 