### PR TITLE
Use assert_ne in hash tests

### DIFF
--- a/src/libcore/tests/hash/sip.rs
+++ b/src/libcore/tests/hash/sip.rs
@@ -298,7 +298,6 @@ fn test_hash_no_concat_alias() {
     let t = ("aabb", "");
     let u = ("a", "abb");
 
-    assert!(s != t && t != u);
     assert_ne!(s, t);
     assert_ne!(t, u);
     assert_ne!(hash(&s), hash(&t));


### PR DESCRIPTION
The hash tests were written before the assert_ne macro was added to the standard library. The assert_ne macro provides better output in case of a failure.