### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/src/libcore/hash/sip.rs
+++ b/src/libcore/hash/sip.rs
@@ -304,7 +304,7 @@ impl<S: Sip> super::Hasher for Hasher<S> {
 
         if self.ntail != 0 {
             needed = 8 - self.ntail;
-            self.tail |= unsafe { u8to64_le(msg, 0, cmp::min(length, needed)) } << 8 * self.ntail;
+            self.tail |= unsafe { u8to64_le(msg, 0, cmp::min(length, needed)) } << (8 * self.ntail);
             if length < needed {
                 self.ntail += length;
                 return;

--- a/src/librustc/ty/query/on_disk_cache.rs
+++ b/src/librustc/ty/query/on_disk_cache.rs
@@ -997,7 +997,7 @@ impl SpecializedEncoder<IntEncodedWithFixedSize> for opaque::Encoder {
     fn specialized_encode(&mut self, x: &IntEncodedWithFixedSize) -> Result<(), Self::Error> {
         let start_pos = self.position();
         for i in 0..IntEncodedWithFixedSize::ENCODED_SIZE {
-            ((x.0 >> i * 8) as u8).encode(self)?;
+            ((x.0 >> (i * 8)) as u8).encode(self)?;
         }
         let end_pos = self.position();
         assert_eq!((end_pos - start_pos), IntEncodedWithFixedSize::ENCODED_SIZE);

--- a/src/librustc_data_structures/sip128.rs
+++ b/src/librustc_data_structures/sip128.rs
@@ -274,7 +274,7 @@ impl Hasher for SipHasher128 {
 
         if self.ntail != 0 {
             needed = 8 - self.ntail;
-            self.tail |= unsafe { u8to64_le(msg, 0, cmp::min(length, needed)) } << 8 * self.ntail;
+            self.tail |= unsafe { u8to64_le(msg, 0, cmp::min(length, needed)) } << (8 * self.ntail);
             if length < needed {
                 self.ntail += length;
                 return;

--- a/src/librustc_data_structures/sync.rs
+++ b/src/librustc_data_structures/sync.rs
@@ -203,11 +203,7 @@ cfg_if! {
             t.into_iter()
         }
 
-        pub fn par_for_each_in<T: IntoIterator>(
-            t: T,
-            for_each:
-                impl Fn(<<T as IntoIterator>::IntoIter as Iterator>::Item) + Sync + Send
-        ) {
+        pub fn par_for_each_in<T: IntoIterator>(t: T, for_each: impl Fn(T::Item) + Sync + Send) {
             // We catch panics here ensuring that all the loop iterations execute.
             // This makes behavior consistent with the parallel compiler.
             let mut panic = None;
@@ -397,9 +393,7 @@ cfg_if! {
 
         pub fn par_for_each_in<T: IntoParallelIterator>(
             t: T,
-            for_each: impl Fn(
-                <<T as IntoParallelIterator>::Iter as ParallelIterator>::Item
-            ) + Sync + Send
+            for_each: impl Fn(T::Item) + Sync + Send,
         ) {
             t.into_par_iter().for_each(for_each)
         }

--- a/src/librustc_error_codes/error_codes/E0373.md
+++ b/src/librustc_error_codes/error_codes/E0373.md
@@ -1,6 +1,6 @@
-This error occurs when an attempt is made to use data captured by a closure,
-when that data may no longer exist. It's most commonly seen when attempting to
-return a closure:
+A captured variable in a closure may not live long enough.
+
+Erroneous code example:
 
 ```compile_fail,E0373
 fn foo() -> Box<Fn(u32) -> u32> {
@@ -8,6 +8,10 @@ fn foo() -> Box<Fn(u32) -> u32> {
     Box::new(|y| x + y)
 }
 ```
+
+This error occurs when an attempt is made to use data captured by a closure,
+when that data may no longer exist. It's most commonly seen when attempting to
+return a closure as shown in the previous code example.
 
 Notice that `x` is stack-allocated by `foo()`. By default, Rust captures
 closed-over data by reference. This means that once `foo()` returns, `x` no

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -6,9 +6,8 @@ use rustc::session::Session;
 use rustc::ty::{self, DefIdTree};
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::fx::FxHashSet;
-use rustc_errors::{pluralize, struct_span_err, Applicability, DiagnosticBuilder};
+use rustc_errors::{struct_span_err, Applicability, DiagnosticBuilder};
 use rustc_feature::BUILTIN_ATTRIBUTES;
-use rustc_hir as hir;
 use rustc_hir::def::Namespace::{self, *};
 use rustc_hir::def::{self, CtorKind, CtorOf, DefKind, NonMacroAttrKind};
 use rustc_hir::def_id::{DefId, CRATE_DEF_INDEX, LOCAL_CRATE};
@@ -20,7 +19,6 @@ use syntax::ast::{self, Ident, Path};
 use syntax::util::lev_distance::find_best_match_for_name;
 
 use crate::imports::{ImportDirective, ImportDirectiveSubclass, ImportResolver};
-use crate::lifetimes::{ElisionFailureInfo, LifetimeContext};
 use crate::path_names_to_string;
 use crate::{AmbiguityError, AmbiguityErrorMisc, AmbiguityKind};
 use crate::{BindingError, CrateLint, HasGenericParams, LegacyScope, Module, ModuleOrUniformRoot};
@@ -47,40 +45,6 @@ impl TypoSuggestion {
 crate struct ImportSuggestion {
     pub did: Option<DefId>,
     pub path: Path,
-}
-
-crate enum MissingLifetimeSpot<'tcx> {
-    Generics(&'tcx hir::Generics<'tcx>),
-    HigherRanked { span: Span, span_type: ForLifetimeSpanType },
-}
-
-crate enum ForLifetimeSpanType {
-    BoundEmpty,
-    BoundTail,
-    TypeEmpty,
-    TypeTail,
-}
-
-impl ForLifetimeSpanType {
-    crate fn descr(&self) -> &'static str {
-        match self {
-            Self::BoundEmpty | Self::BoundTail => "bound",
-            Self::TypeEmpty | Self::TypeTail => "type",
-        }
-    }
-
-    crate fn suggestion(&self, sugg: &str) -> String {
-        match self {
-            Self::BoundEmpty | Self::TypeEmpty => format!("for<{}> ", sugg),
-            Self::BoundTail | Self::TypeTail => format!(", {}", sugg),
-        }
-    }
-}
-
-impl<'tcx> Into<MissingLifetimeSpot<'tcx>> for &'tcx hir::Generics<'tcx> {
-    fn into(self) -> MissingLifetimeSpot<'tcx> {
-        MissingLifetimeSpot::Generics(self)
-    }
 }
 
 /// Adjust the impl span so that just the `impl` keyword is taken by removing
@@ -1489,210 +1453,5 @@ crate fn show_candidates(
             msg.push_str(&candidate);
         }
         err.note(&msg);
-    }
-}
-
-impl<'tcx> LifetimeContext<'_, 'tcx> {
-    crate fn report_missing_lifetime_specifiers(
-        &self,
-        span: Span,
-        count: usize,
-    ) -> DiagnosticBuilder<'tcx> {
-        struct_span_err!(
-            self.tcx.sess,
-            span,
-            E0106,
-            "missing lifetime specifier{}",
-            pluralize!(count)
-        )
-    }
-
-    crate fn emit_undeclared_lifetime_error(&self, lifetime_ref: &hir::Lifetime) {
-        let mut err = struct_span_err!(
-            self.tcx.sess,
-            lifetime_ref.span,
-            E0261,
-            "use of undeclared lifetime name `{}`",
-            lifetime_ref
-        );
-        err.span_label(lifetime_ref.span, "undeclared lifetime");
-        for missing in &self.missing_named_lifetime_spots {
-            match missing {
-                MissingLifetimeSpot::Generics(generics) => {
-                    let (span, sugg) = if let Some(param) = generics
-                        .params
-                        .iter()
-                        .filter(|p| match p.kind {
-                            hir::GenericParamKind::Type {
-                                synthetic: Some(hir::SyntheticTyParamKind::ImplTrait),
-                                ..
-                            } => false,
-                            _ => true,
-                        })
-                        .next()
-                    {
-                        (param.span.shrink_to_lo(), format!("{}, ", lifetime_ref))
-                    } else {
-                        (generics.span, format!("<{}>", lifetime_ref))
-                    };
-                    err.span_suggestion(
-                        span,
-                        &format!("consider introducing lifetime `{}` here", lifetime_ref),
-                        sugg,
-                        Applicability::MaybeIncorrect,
-                    );
-                }
-                MissingLifetimeSpot::HigherRanked { span, span_type } => {
-                    err.span_suggestion(
-                        *span,
-                        &format!(
-                            "consider making the {} lifetime-generic with a new `{}` lifetime",
-                            span_type.descr(),
-                            lifetime_ref
-                        ),
-                        span_type.suggestion(&lifetime_ref.to_string()),
-                        Applicability::MaybeIncorrect,
-                    );
-                    err.note(
-                        "for more information on higher-ranked polymorphism, visit \
-                            https://doc.rust-lang.org/nomicon/hrtb.html",
-                    );
-                }
-            }
-        }
-        err.emit();
-    }
-
-    crate fn is_trait_ref_fn_scope(&mut self, trait_ref: &'tcx hir::PolyTraitRef<'tcx>) -> bool {
-        if let def::Res::Def(_, did) = trait_ref.trait_ref.path.res {
-            if [
-                self.tcx.lang_items().fn_once_trait(),
-                self.tcx.lang_items().fn_trait(),
-                self.tcx.lang_items().fn_mut_trait(),
-            ]
-            .contains(&Some(did))
-            {
-                let (span, span_type) = match &trait_ref.bound_generic_params {
-                    [] => (trait_ref.span.shrink_to_lo(), ForLifetimeSpanType::BoundEmpty),
-                    [.., bound] => (bound.span.shrink_to_hi(), ForLifetimeSpanType::BoundTail),
-                };
-                self.missing_named_lifetime_spots
-                    .push(MissingLifetimeSpot::HigherRanked { span, span_type });
-                return true;
-            }
-        };
-        false
-    }
-
-    crate fn add_missing_lifetime_specifiers_label(
-        &self,
-        err: &mut DiagnosticBuilder<'_>,
-        span: Span,
-        count: usize,
-        lifetime_names: &FxHashSet<ast::Ident>,
-        params: &[ElisionFailureInfo],
-    ) {
-        if count > 1 {
-            err.span_label(span, format!("expected {} lifetime parameters", count));
-        } else {
-            let snippet = self.tcx.sess.source_map().span_to_snippet(span).ok();
-            let suggest_existing = |err: &mut DiagnosticBuilder<'_>, sugg| {
-                err.span_suggestion(
-                    span,
-                    "consider using the named lifetime",
-                    sugg,
-                    Applicability::MaybeIncorrect,
-                );
-            };
-            let suggest_new =
-                |err: &mut DiagnosticBuilder<'_>, sugg: &str| {
-                    err.span_label(span, "expected named lifetime parameter");
-
-                    for missing in self.missing_named_lifetime_spots.iter().rev() {
-                        let mut introduce_suggestion = vec![];
-                        let msg;
-                        let should_break;
-                        introduce_suggestion.push(match missing {
-                        MissingLifetimeSpot::Generics(generics) => {
-                            msg = "consider introducing a named lifetime parameter".to_string();
-                            should_break = true;
-                            if let Some(param) = generics.params.iter().filter(|p| match p.kind {
-                                hir::GenericParamKind::Type {
-                                    synthetic: Some(hir::SyntheticTyParamKind::ImplTrait),
-                                    ..
-                                } => false,
-                                _ => true,
-                            }).next() {
-                                (param.span.shrink_to_lo(), "'a, ".to_string())
-                            } else {
-                                (generics.span, "<'a>".to_string())
-                            }
-                        }
-                        MissingLifetimeSpot::HigherRanked { span, span_type } => {
-                            msg = format!(
-                                "consider making the {} lifetime-generic with a new `'a` lifetime",
-                                span_type.descr(),
-                            );
-                            should_break = false;
-                            err.note(
-                                "for more information on higher-ranked polymorphism, visit \
-                             https://doc.rust-lang.org/nomicon/hrtb.html",
-                            );
-                            (*span, span_type.suggestion("'a"))
-                        }
-                    });
-                        for param in params {
-                            if let Ok(snippet) =
-                                self.tcx.sess.source_map().span_to_snippet(param.span)
-                            {
-                                if snippet.starts_with("&") && !snippet.starts_with("&'") {
-                                    introduce_suggestion
-                                        .push((param.span, format!("&'a {}", &snippet[1..])));
-                                } else if snippet.starts_with("&'_ ") {
-                                    introduce_suggestion
-                                        .push((param.span, format!("&'a {}", &snippet[4..])));
-                                }
-                            }
-                        }
-                        introduce_suggestion.push((span, sugg.to_string()));
-                        err.multipart_suggestion(
-                            &msg,
-                            introduce_suggestion,
-                            Applicability::MaybeIncorrect,
-                        );
-                        if should_break {
-                            break;
-                        }
-                    }
-                };
-
-            match (
-                lifetime_names.len(),
-                lifetime_names.iter().next(),
-                snippet.as_ref().map(|s| s.as_str()),
-            ) {
-                (1, Some(name), Some("&")) => {
-                    suggest_existing(err, format!("&{} ", name));
-                }
-                (1, Some(name), Some("'_")) => {
-                    suggest_existing(err, name.to_string());
-                }
-                (1, Some(name), Some(snippet)) if !snippet.ends_with(">") => {
-                    suggest_existing(err, format!("{}<{}>", snippet, name));
-                }
-                (0, _, Some("&")) => {
-                    suggest_new(err, "&'a ");
-                }
-                (0, _, Some("'_")) => {
-                    suggest_new(err, "'a");
-                }
-                (0, _, Some(snippet)) if !snippet.ends_with(">") => {
-                    suggest_new(err, &format!("{}<'a>", snippet));
-                }
-                _ => {
-                    err.span_label(span, "expected lifetime parameter");
-                }
-            }
-        }
     }
 }

--- a/src/librustc_resolve/late.rs
+++ b/src/librustc_resolve/late.rs
@@ -32,6 +32,7 @@ use std::collections::BTreeSet;
 use std::mem::replace;
 
 mod diagnostics;
+crate mod lifetimes;
 
 type Res = def::Res<NodeId>;
 

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -1,4 +1,5 @@
 use crate::diagnostics::{ImportSuggestion, TypoSuggestion};
+use crate::late::lifetimes::{ElisionFailureInfo, LifetimeContext};
 use crate::late::{LateResolutionVisitor, RibKind};
 use crate::path_names_to_string;
 use crate::{CrateLint, Module, ModuleKind, ModuleOrUniformRoot};
@@ -6,7 +7,8 @@ use crate::{PathResult, PathSource, Segment};
 
 use rustc::session::config::nightly_options;
 use rustc_data_structures::fx::FxHashSet;
-use rustc_errors::{Applicability, DiagnosticBuilder};
+use rustc_errors::{pluralize, struct_span_err, Applicability, DiagnosticBuilder};
+use rustc_hir as hir;
 use rustc_hir::def::Namespace::{self, *};
 use rustc_hir::def::{self, CtorKind, DefKind};
 use rustc_hir::def_id::{DefId, CRATE_DEF_INDEX};
@@ -26,6 +28,40 @@ enum AssocSuggestion {
     Field,
     MethodWithSelf,
     AssocItem,
+}
+
+crate enum MissingLifetimeSpot<'tcx> {
+    Generics(&'tcx hir::Generics<'tcx>),
+    HigherRanked { span: Span, span_type: ForLifetimeSpanType },
+}
+
+crate enum ForLifetimeSpanType {
+    BoundEmpty,
+    BoundTail,
+    TypeEmpty,
+    TypeTail,
+}
+
+impl ForLifetimeSpanType {
+    crate fn descr(&self) -> &'static str {
+        match self {
+            Self::BoundEmpty | Self::BoundTail => "bound",
+            Self::TypeEmpty | Self::TypeTail => "type",
+        }
+    }
+
+    crate fn suggestion(&self, sugg: &str) -> String {
+        match self {
+            Self::BoundEmpty | Self::TypeEmpty => format!("for<{}> ", sugg),
+            Self::BoundTail | Self::TypeTail => format!(", {}", sugg),
+        }
+    }
+}
+
+impl<'tcx> Into<MissingLifetimeSpot<'tcx>> for &'tcx hir::Generics<'tcx> {
+    fn into(self) -> MissingLifetimeSpot<'tcx> {
+        MissingLifetimeSpot::Generics(self)
+    }
 }
 
 fn is_self_type(path: &[Segment], namespace: Namespace) -> bool {
@@ -902,5 +938,210 @@ impl<'a> LateResolutionVisitor<'a, '_, '_> {
             _ => {}
         }
         None
+    }
+}
+
+impl<'tcx> LifetimeContext<'_, 'tcx> {
+    crate fn report_missing_lifetime_specifiers(
+        &self,
+        span: Span,
+        count: usize,
+    ) -> DiagnosticBuilder<'tcx> {
+        struct_span_err!(
+            self.tcx.sess,
+            span,
+            E0106,
+            "missing lifetime specifier{}",
+            pluralize!(count)
+        )
+    }
+
+    crate fn emit_undeclared_lifetime_error(&self, lifetime_ref: &hir::Lifetime) {
+        let mut err = struct_span_err!(
+            self.tcx.sess,
+            lifetime_ref.span,
+            E0261,
+            "use of undeclared lifetime name `{}`",
+            lifetime_ref
+        );
+        err.span_label(lifetime_ref.span, "undeclared lifetime");
+        for missing in &self.missing_named_lifetime_spots {
+            match missing {
+                MissingLifetimeSpot::Generics(generics) => {
+                    let (span, sugg) = if let Some(param) = generics
+                        .params
+                        .iter()
+                        .filter(|p| match p.kind {
+                            hir::GenericParamKind::Type {
+                                synthetic: Some(hir::SyntheticTyParamKind::ImplTrait),
+                                ..
+                            } => false,
+                            _ => true,
+                        })
+                        .next()
+                    {
+                        (param.span.shrink_to_lo(), format!("{}, ", lifetime_ref))
+                    } else {
+                        (generics.span, format!("<{}>", lifetime_ref))
+                    };
+                    err.span_suggestion(
+                        span,
+                        &format!("consider introducing lifetime `{}` here", lifetime_ref),
+                        sugg,
+                        Applicability::MaybeIncorrect,
+                    );
+                }
+                MissingLifetimeSpot::HigherRanked { span, span_type } => {
+                    err.span_suggestion(
+                        *span,
+                        &format!(
+                            "consider making the {} lifetime-generic with a new `{}` lifetime",
+                            span_type.descr(),
+                            lifetime_ref
+                        ),
+                        span_type.suggestion(&lifetime_ref.to_string()),
+                        Applicability::MaybeIncorrect,
+                    );
+                    err.note(
+                        "for more information on higher-ranked polymorphism, visit \
+                            https://doc.rust-lang.org/nomicon/hrtb.html",
+                    );
+                }
+            }
+        }
+        err.emit();
+    }
+
+    crate fn is_trait_ref_fn_scope(&mut self, trait_ref: &'tcx hir::PolyTraitRef<'tcx>) -> bool {
+        if let def::Res::Def(_, did) = trait_ref.trait_ref.path.res {
+            if [
+                self.tcx.lang_items().fn_once_trait(),
+                self.tcx.lang_items().fn_trait(),
+                self.tcx.lang_items().fn_mut_trait(),
+            ]
+            .contains(&Some(did))
+            {
+                let (span, span_type) = match &trait_ref.bound_generic_params {
+                    [] => (trait_ref.span.shrink_to_lo(), ForLifetimeSpanType::BoundEmpty),
+                    [.., bound] => (bound.span.shrink_to_hi(), ForLifetimeSpanType::BoundTail),
+                };
+                self.missing_named_lifetime_spots
+                    .push(MissingLifetimeSpot::HigherRanked { span, span_type });
+                return true;
+            }
+        };
+        false
+    }
+
+    crate fn add_missing_lifetime_specifiers_label(
+        &self,
+        err: &mut DiagnosticBuilder<'_>,
+        span: Span,
+        count: usize,
+        lifetime_names: &FxHashSet<ast::Ident>,
+        params: &[ElisionFailureInfo],
+    ) {
+        if count > 1 {
+            err.span_label(span, format!("expected {} lifetime parameters", count));
+        } else {
+            let snippet = self.tcx.sess.source_map().span_to_snippet(span).ok();
+            let suggest_existing = |err: &mut DiagnosticBuilder<'_>, sugg| {
+                err.span_suggestion(
+                    span,
+                    "consider using the named lifetime",
+                    sugg,
+                    Applicability::MaybeIncorrect,
+                );
+            };
+            let suggest_new =
+                |err: &mut DiagnosticBuilder<'_>, sugg: &str| {
+                    err.span_label(span, "expected named lifetime parameter");
+
+                    for missing in self.missing_named_lifetime_spots.iter().rev() {
+                        let mut introduce_suggestion = vec![];
+                        let msg;
+                        let should_break;
+                        introduce_suggestion.push(match missing {
+                        MissingLifetimeSpot::Generics(generics) => {
+                            msg = "consider introducing a named lifetime parameter".to_string();
+                            should_break = true;
+                            if let Some(param) = generics.params.iter().filter(|p| match p.kind {
+                                hir::GenericParamKind::Type {
+                                    synthetic: Some(hir::SyntheticTyParamKind::ImplTrait),
+                                    ..
+                                } => false,
+                                _ => true,
+                            }).next() {
+                                (param.span.shrink_to_lo(), "'a, ".to_string())
+                            } else {
+                                (generics.span, "<'a>".to_string())
+                            }
+                        }
+                        MissingLifetimeSpot::HigherRanked { span, span_type } => {
+                            msg = format!(
+                                "consider making the {} lifetime-generic with a new `'a` lifetime",
+                                span_type.descr(),
+                            );
+                            should_break = false;
+                            err.note(
+                                "for more information on higher-ranked polymorphism, visit \
+                             https://doc.rust-lang.org/nomicon/hrtb.html",
+                            );
+                            (*span, span_type.suggestion("'a"))
+                        }
+                    });
+                        for param in params {
+                            if let Ok(snippet) =
+                                self.tcx.sess.source_map().span_to_snippet(param.span)
+                            {
+                                if snippet.starts_with("&") && !snippet.starts_with("&'") {
+                                    introduce_suggestion
+                                        .push((param.span, format!("&'a {}", &snippet[1..])));
+                                } else if snippet.starts_with("&'_ ") {
+                                    introduce_suggestion
+                                        .push((param.span, format!("&'a {}", &snippet[4..])));
+                                }
+                            }
+                        }
+                        introduce_suggestion.push((span, sugg.to_string()));
+                        err.multipart_suggestion(
+                            &msg,
+                            introduce_suggestion,
+                            Applicability::MaybeIncorrect,
+                        );
+                        if should_break {
+                            break;
+                        }
+                    }
+                };
+
+            match (
+                lifetime_names.len(),
+                lifetime_names.iter().next(),
+                snippet.as_ref().map(|s| s.as_str()),
+            ) {
+                (1, Some(name), Some("&")) => {
+                    suggest_existing(err, format!("&{} ", name));
+                }
+                (1, Some(name), Some("'_")) => {
+                    suggest_existing(err, name.to_string());
+                }
+                (1, Some(name), Some(snippet)) if !snippet.ends_with(">") => {
+                    suggest_existing(err, format!("{}<{}>", snippet, name));
+                }
+                (0, _, Some("&")) => {
+                    suggest_new(err, "&'a ");
+                }
+                (0, _, Some("'_")) => {
+                    suggest_new(err, "'a");
+                }
+                (0, _, Some(snippet)) if !snippet.ends_with(">") => {
+                    suggest_new(err, &format!("{}<'a>", snippet));
+                }
+                _ => {
+                    err.span_label(span, "expected lifetime parameter");
+                }
+            }
+        }
     }
 }

--- a/src/librustc_resolve/late/lifetimes.rs
+++ b/src/librustc_resolve/late/lifetimes.rs
@@ -5,7 +5,7 @@
 //! used between functions, and they operate in a purely top-down
 //! way. Therefore, we break lifetime name resolution into a separate pass.
 
-use crate::diagnostics::{ForLifetimeSpanType, MissingLifetimeSpot};
+use crate::late::diagnostics::{ForLifetimeSpanType, MissingLifetimeSpot};
 use rustc::hir::map::Map;
 use rustc::lint;
 use rustc::middle::resolve_lifetime::*;

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -68,7 +68,6 @@ mod def_collector;
 mod diagnostics;
 mod imports;
 mod late;
-mod lifetimes;
 mod macros;
 
 enum Weak {
@@ -2959,5 +2958,5 @@ impl CrateLint {
 }
 
 pub fn provide(providers: &mut Providers<'_>) {
-    lifetimes::provide(providers);
+    late::lifetimes::provide(providers);
 }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -319,7 +319,7 @@ impl AstConv<'tcx> for ItemCtxt<'tcx> {
     }
 
     fn ty_infer(&self, _: Option<&ty::GenericParamDef>, span: Span) -> Ty<'tcx> {
-        self.tcx().sess.delay_span_bug(span, "bad placeholder type");
+        placeholder_type_error(self.tcx(), span, &[], vec![span], false);
         self.tcx().types.err
     }
 

--- a/src/test/ui/did_you_mean/bad-assoc-ty.rs
+++ b/src/test/ui/did_you_mean/bad-assoc-ty.rs
@@ -17,6 +17,7 @@ type D = (u8, u8)::AssocTy;
 type E = _::AssocTy;
 //~^ ERROR missing angle brackets in associated item path
 //~| ERROR the type placeholder `_` is not allowed within types on item signatures
+//~| ERROR the type placeholder `_` is not allowed within types on item signatures
 
 type F = &'static (u8)::AssocTy;
 //~^ ERROR missing angle brackets in associated item path

--- a/src/test/ui/did_you_mean/bad-assoc-ty.stderr
+++ b/src/test/ui/did_you_mean/bad-assoc-ty.stderr
@@ -29,25 +29,25 @@ LL | type E = _::AssocTy;
    |          ^^^^^^^^^^ help: try: `<_>::AssocTy`
 
 error: missing angle brackets in associated item path
-  --> $DIR/bad-assoc-ty.rs:21:19
+  --> $DIR/bad-assoc-ty.rs:22:19
    |
 LL | type F = &'static (u8)::AssocTy;
    |                   ^^^^^^^^^^^^^ help: try: `<(u8)>::AssocTy`
 
 error: missing angle brackets in associated item path
-  --> $DIR/bad-assoc-ty.rs:27:10
+  --> $DIR/bad-assoc-ty.rs:28:10
    |
 LL | type G = dyn 'static + (Send)::AssocTy;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `<dyn 'static + (Send)>::AssocTy`
 
 error: missing angle brackets in associated item path
-  --> $DIR/bad-assoc-ty.rs:44:10
+  --> $DIR/bad-assoc-ty.rs:45:10
    |
 LL | type I = ty!()::AssocTy;
    |          ^^^^^^^^^^^^^^ help: try: `<ty!()>::AssocTy`
 
 error: missing angle brackets in associated item path
-  --> $DIR/bad-assoc-ty.rs:37:19
+  --> $DIR/bad-assoc-ty.rs:38:19
    |
 LL |     ($ty: ty) => ($ty::AssocTy);
    |                   ^^^^^^^^^^^^ help: try: `<$ty>::AssocTy`
@@ -87,26 +87,32 @@ error[E0121]: the type placeholder `_` is not allowed within types on item signa
 LL | type E = _::AssocTy;
    |          ^ not allowed in type signatures
 
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/bad-assoc-ty.rs:17:10
+   |
+LL | type E = _::AssocTy;
+   |          ^ not allowed in type signatures
+
 error[E0223]: ambiguous associated type
-  --> $DIR/bad-assoc-ty.rs:21:19
+  --> $DIR/bad-assoc-ty.rs:22:19
    |
 LL | type F = &'static (u8)::AssocTy;
    |                   ^^^^^^^^^^^^^ help: use fully-qualified syntax: `<u8 as Trait>::AssocTy`
 
 error[E0223]: ambiguous associated type
-  --> $DIR/bad-assoc-ty.rs:27:10
+  --> $DIR/bad-assoc-ty.rs:28:10
    |
 LL | type G = dyn 'static + (Send)::AssocTy;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use fully-qualified syntax: `<(dyn std::marker::Send + 'static) as Trait>::AssocTy`
 
 error[E0223]: ambiguous associated type
-  --> $DIR/bad-assoc-ty.rs:33:10
+  --> $DIR/bad-assoc-ty.rs:34:10
    |
 LL | type H = Fn(u8) -> (u8)::Output;
    |          ^^^^^^^^^^^^^^^^^^^^^^ help: use fully-qualified syntax: `<(dyn std::ops::Fn(u8) -> u8 + 'static) as Trait>::Output`
 
 error[E0223]: ambiguous associated type
-  --> $DIR/bad-assoc-ty.rs:37:19
+  --> $DIR/bad-assoc-ty.rs:38:19
    |
 LL |     ($ty: ty) => ($ty::AssocTy);
    |                   ^^^^^^^^^^^^ help: use fully-qualified syntax: `<u8 as Trait>::AssocTy`
@@ -117,12 +123,12 @@ LL | type J = ty!(u8);
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0223]: ambiguous associated type
-  --> $DIR/bad-assoc-ty.rs:44:10
+  --> $DIR/bad-assoc-ty.rs:45:10
    |
 LL | type I = ty!()::AssocTy;
    |          ^^^^^^^^^^^^^^ help: use fully-qualified syntax: `<u8 as Trait>::AssocTy`
 
-error: aborting due to 19 previous errors
+error: aborting due to 20 previous errors
 
 Some errors have detailed explanations: E0121, E0223.
 For more information about an error, try `rustc --explain E0121`.

--- a/src/test/ui/self/self-infer.rs
+++ b/src/test/ui/self/self-infer.rs
@@ -2,7 +2,9 @@ struct S;
 
 impl S {
     fn f(self: _) {} //~ERROR the type placeholder `_` is not allowed within types on item sig
+    //~^ ERROR the type placeholder `_` is not allowed within types on item sig
     fn g(self: &_) {} //~ERROR the type placeholder `_` is not allowed within types on item sig
+    //~^ ERROR the type placeholder `_` is not allowed within types on item sig
 }
 
 fn main() {}

--- a/src/test/ui/self/self-infer.stderr
+++ b/src/test/ui/self/self-infer.stderr
@@ -3,6 +3,12 @@ error[E0121]: the type placeholder `_` is not allowed within types on item signa
    |
 LL |     fn f(self: _) {}
    |                ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/self-infer.rs:4:16
+   |
+LL |     fn f(self: _) {}
+   |                ^ not allowed in type signatures
    |
 help: use type parameters instead
    |
@@ -10,7 +16,13 @@ LL |     fn f<T>(self: T) {}
    |         ^^^       ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/self-infer.rs:5:17
+  --> $DIR/self-infer.rs:6:17
+   |
+LL |     fn g(self: &_) {}
+   |                 ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/self-infer.rs:6:17
    |
 LL |     fn g(self: &_) {}
    |                 ^ not allowed in type signatures
@@ -20,6 +32,6 @@ help: use type parameters instead
 LL |     fn g<T>(self: &T) {}
    |         ^^^        ^
 
-error: aborting due to 2 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0121`.

--- a/src/test/ui/typeck/typeck_type_placeholder_item.rs
+++ b/src/test/ui/typeck/typeck_type_placeholder_item.rs
@@ -19,18 +19,23 @@ static TEST5: (_, _) = (1, 2);
 
 fn test6(_: _) { }
 //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~| ERROR the type placeholder `_` is not allowed within types on item signatures
 
 fn test6_b<T>(_: _, _: T) { }
 //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~| ERROR the type placeholder `_` is not allowed within types on item signatures
 
 fn test6_c<T, K, L, A, B>(_: _, _: (T, K, L, A, B)) { }
 //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~| ERROR the type placeholder `_` is not allowed within types on item signatures
 
 fn test7(x: _) { let _x: usize = x; }
 //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~| ERROR the type placeholder `_` is not allowed within types on item signatures
 
 fn test8(_f: fn() -> _) { }
 //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~| ERROR the type placeholder `_` is not allowed within types on item signatures
 //~| ERROR the type placeholder `_` is not allowed within types on item signatures
 
 struct Test9;
@@ -41,6 +46,7 @@ impl Test9 {
 
     fn test10(&self, _x : _) { }
     //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~| ERROR the type placeholder `_` is not allowed within types on item signatures
 }
 
 fn test11(x: &usize) -> &_ {
@@ -59,12 +65,16 @@ impl Clone for Test9 {
 
     fn clone_from(&mut self, other: _) { *self = Test9; }
     //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~| ERROR the type placeholder `_` is not allowed within types on item signatures
 }
 
 struct Test10 {
     a: _,
     //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~| ERROR the type placeholder `_` is not allowed within types on item signatures
     b: (_, _),
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~| ERROR the type placeholder `_` is not allowed within types on item signatures
 }
 
 pub fn main() {
@@ -92,12 +102,15 @@ pub fn main() {
 
     fn fn_test6(_: _) { }
     //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~| ERROR the type placeholder `_` is not allowed within types on item signatures
 
     fn fn_test7(x: _) { let _x: usize = x; }
     //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~| ERROR the type placeholder `_` is not allowed within types on item signatures
 
     fn fn_test8(_f: fn() -> _) { }
     //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~| ERROR the type placeholder `_` is not allowed within types on item signatures
     //~| ERROR the type placeholder `_` is not allowed within types on item signatures
 
     struct FnTest9;
@@ -108,6 +121,7 @@ pub fn main() {
 
         fn fn_test10(&self, _x : _) { }
         //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+        //~| ERROR the type placeholder `_` is not allowed within types on item signatures
     }
 
     impl Clone for FnTest9 {
@@ -116,12 +130,16 @@ pub fn main() {
 
         fn clone_from(&mut self, other: _) { *self = FnTest9; }
         //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+        //~| ERROR the type placeholder `_` is not allowed within types on item signatures
     }
 
     struct FnTest10 {
         a: _,
         //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+        //~| ERROR the type placeholder `_` is not allowed within types on item signatures
         b: (_, _),
+        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+        //~| ERROR the type placeholder `_` is not allowed within types on item signatures
     }
 
     fn fn_test11(_: _) -> (_, _) { panic!() }
@@ -138,28 +156,40 @@ pub fn main() {
 trait T {
     fn method_test1(&self, x: _);
     //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~| ERROR the type placeholder `_` is not allowed within types on item signatures
     fn method_test2(&self, x: _) -> _;
     //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~| ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~| ERROR the type placeholder `_` is not allowed within types on item signatures
     fn method_test3(&self) -> _;
     //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~| ERROR the type placeholder `_` is not allowed within types on item signatures
     fn assoc_fn_test1(x: _);
     //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~| ERROR the type placeholder `_` is not allowed within types on item signatures
     fn assoc_fn_test2(x: _) -> _;
     //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~| ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~| ERROR the type placeholder `_` is not allowed within types on item signatures
     fn assoc_fn_test3() -> _;
     //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~| ERROR the type placeholder `_` is not allowed within types on item signatures
 }
 
 struct BadStruct<_>(_);
 //~^ ERROR expected identifier, found reserved identifier `_`
 //~| ERROR the type placeholder `_` is not allowed within types on item signatures
+//~| ERROR the type placeholder `_` is not allowed within types on item signatures
 trait BadTrait<_> {}
 //~^ ERROR expected identifier, found reserved identifier `_`
 impl BadTrait<_> for BadStruct<_> {}
 //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~| ERROR the type placeholder `_` is not allowed within types on item signatures
+//~| ERROR the type placeholder `_` is not allowed within types on item signatures
 
 fn impl_trait() -> impl BadTrait<_> {
 //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~| ERROR the type placeholder `_` is not allowed within types on item signatures
     unimplemented!()
 }
 
@@ -168,18 +198,22 @@ struct BadStruct1<_, _>(_);
 //~| ERROR expected identifier, found reserved identifier `_`
 //~| ERROR the name `_` is already used
 //~| ERROR the type placeholder `_` is not allowed within types on item signatures
+//~| ERROR the type placeholder `_` is not allowed within types on item signatures
 struct BadStruct2<_, T>(_, T);
 //~^ ERROR expected identifier, found reserved identifier `_`
+//~| ERROR the type placeholder `_` is not allowed within types on item signatures
 //~| ERROR the type placeholder `_` is not allowed within types on item signatures
 
 type X = Box<_>;
 //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~| ERROR the type placeholder `_` is not allowed within types on item signatures
 
 struct Struct;
 trait Trait<T> {}
 impl Trait<usize> for Struct {}
 type Y = impl Trait<_>;
 //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~| ERROR the type placeholder `_` is not allowed within types on item signatures
 fn foo() -> Y {
     Struct
 }

--- a/src/test/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/src/test/ui/typeck/typeck_type_placeholder_item.stderr
@@ -1,35 +1,35 @@
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:153:18
+  --> $DIR/typeck_type_placeholder_item.rs:179:18
    |
 LL | struct BadStruct<_>(_);
    |                  ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:156:16
+  --> $DIR/typeck_type_placeholder_item.rs:183:16
    |
 LL | trait BadTrait<_> {}
    |                ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:166:19
+  --> $DIR/typeck_type_placeholder_item.rs:196:19
    |
 LL | struct BadStruct1<_, _>(_);
    |                   ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:166:22
+  --> $DIR/typeck_type_placeholder_item.rs:196:22
    |
 LL | struct BadStruct1<_, _>(_);
    |                      ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:171:19
+  --> $DIR/typeck_type_placeholder_item.rs:202:19
    |
 LL | struct BadStruct2<_, T>(_, T);
    |                   ^ expected identifier, found reserved identifier
 
 error[E0403]: the name `_` is already used for a generic parameter in this item's generic parameters
-  --> $DIR/typeck_type_placeholder_item.rs:166:22
+  --> $DIR/typeck_type_placeholder_item.rs:196:22
    |
 LL | struct BadStruct1<_, _>(_);
    |                   -  ^ already used
@@ -84,6 +84,12 @@ error[E0121]: the type placeholder `_` is not allowed within types on item signa
    |
 LL | fn test6(_: _) { }
    |             ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:20:13
+   |
+LL | fn test6(_: _) { }
+   |             ^ not allowed in type signatures
    |
 help: use type parameters instead
    |
@@ -91,7 +97,13 @@ LL | fn test6<T>(_: T) { }
    |         ^^^    ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:23:18
+  --> $DIR/typeck_type_placeholder_item.rs:24:18
+   |
+LL | fn test6_b<T>(_: _, _: T) { }
+   |                  ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:24:18
    |
 LL | fn test6_b<T>(_: _, _: T) { }
    |                  ^ not allowed in type signatures
@@ -102,7 +114,13 @@ LL | fn test6_b<T, K>(_: K, _: T) { }
    |             ^^^     ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:26:30
+  --> $DIR/typeck_type_placeholder_item.rs:28:30
+   |
+LL | fn test6_c<T, K, L, A, B>(_: _, _: (T, K, L, A, B)) { }
+   |                              ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:28:30
    |
 LL | fn test6_c<T, K, L, A, B>(_: _, _: (T, K, L, A, B)) { }
    |                              ^ not allowed in type signatures
@@ -113,7 +131,13 @@ LL | fn test6_c<T, K, L, A, B, C>(_: C, _: (T, K, L, A, B)) { }
    |                         ^^^     ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:29:13
+  --> $DIR/typeck_type_placeholder_item.rs:32:13
+   |
+LL | fn test7(x: _) { let _x: usize = x; }
+   |             ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:32:13
    |
 LL | fn test7(x: _) { let _x: usize = x; }
    |             ^ not allowed in type signatures
@@ -124,13 +148,19 @@ LL | fn test7<T>(x: T) { let _x: usize = x; }
    |         ^^^    ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:32:22
+  --> $DIR/typeck_type_placeholder_item.rs:36:22
    |
 LL | fn test8(_f: fn() -> _) { }
    |                      ^ not allowed in type signatures
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:32:22
+  --> $DIR/typeck_type_placeholder_item.rs:36:22
+   |
+LL | fn test8(_f: fn() -> _) { }
+   |                      ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:36:22
    |
 LL | fn test8(_f: fn() -> _) { }
    |                      ^ not allowed in type signatures
@@ -141,7 +171,61 @@ LL | fn test8<T>(_f: fn() -> T) { }
    |         ^^^             ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:46:26
+  --> $DIR/typeck_type_placeholder_item.rs:72:8
+   |
+LL |     a: _,
+   |        ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:75:9
+   |
+LL |     b: (_, _),
+   |         ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:75:12
+   |
+LL |     b: (_, _),
+   |            ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:137:12
+   |
+LL |         a: _,
+   |            ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:140:13
+   |
+LL |         b: (_, _),
+   |             ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:140:16
+   |
+LL |         b: (_, _),
+   |                ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:179:21
+   |
+LL | struct BadStruct<_>(_);
+   |                     ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:196:25
+   |
+LL | struct BadStruct1<_, _>(_);
+   |                         ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:202:25
+   |
+LL | struct BadStruct2<_, T>(_, T);
+   |                         ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:52:26
    |
 LL | fn test11(x: &usize) -> &_ {
    |                         -^
@@ -150,7 +234,7 @@ LL | fn test11(x: &usize) -> &_ {
    |                         help: replace with the correct return type: `&&usize`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:51:52
+  --> $DIR/typeck_type_placeholder_item.rs:57:52
    |
 LL | unsafe fn test12(x: *const usize) -> *const *const _ {
    |                                      --------------^
@@ -159,11 +243,11 @@ LL | unsafe fn test12(x: *const usize) -> *const *const _ {
    |                                      help: replace with the correct return type: `*const *const usize`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:65:8
+  --> $DIR/typeck_type_placeholder_item.rs:72:8
    |
 LL |     a: _,
    |        ^ not allowed in type signatures
-LL |
+...
 LL |     b: (_, _),
    |         ^  ^ not allowed in type signatures
    |         |
@@ -174,17 +258,18 @@ help: use type parameters instead
 LL | struct Test10<T> {
 LL |     a: T,
 LL |
+LL |
 LL |     b: (T, T),
    |
 
 error: missing type for `static` item
-  --> $DIR/typeck_type_placeholder_item.rs:71:12
+  --> $DIR/typeck_type_placeholder_item.rs:81:12
    |
 LL |     static A = 42;
    |            ^ help: provide a type for the item: `A: i32`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:73:15
+  --> $DIR/typeck_type_placeholder_item.rs:83:15
    |
 LL |     static B: _ = 42;
    |               ^
@@ -193,13 +278,13 @@ LL |     static B: _ = 42;
    |               help: replace `_` with the correct type: `i32`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:75:15
+  --> $DIR/typeck_type_placeholder_item.rs:85:15
    |
 LL |     static C: Option<_> = Some(42);
    |               ^^^^^^^^^ not allowed in type signatures
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:78:21
+  --> $DIR/typeck_type_placeholder_item.rs:88:21
    |
 LL |     fn fn_test() -> _ { 5 }
    |                     ^
@@ -208,7 +293,7 @@ LL |     fn fn_test() -> _ { 5 }
    |                     help: replace with the correct return type: `i32`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:81:23
+  --> $DIR/typeck_type_placeholder_item.rs:91:23
    |
 LL |     fn fn_test2() -> (_, _) { (5, 5) }
    |                      -^--^-
@@ -218,7 +303,7 @@ LL |     fn fn_test2() -> (_, _) { (5, 5) }
    |                      help: replace with the correct return type: `(i32, i32)`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:84:22
+  --> $DIR/typeck_type_placeholder_item.rs:94:22
    |
 LL |     static FN_TEST3: _ = "test";
    |                      ^
@@ -227,7 +312,7 @@ LL |     static FN_TEST3: _ = "test";
    |                      help: replace `_` with the correct type: `&'static str`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:87:22
+  --> $DIR/typeck_type_placeholder_item.rs:97:22
    |
 LL |     static FN_TEST4: _ = 145;
    |                      ^
@@ -236,13 +321,19 @@ LL |     static FN_TEST4: _ = 145;
    |                      help: replace `_` with the correct type: `i32`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:90:22
+  --> $DIR/typeck_type_placeholder_item.rs:100:22
    |
 LL |     static FN_TEST5: (_, _) = (1, 2);
    |                      ^^^^^^ not allowed in type signatures
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:93:20
+  --> $DIR/typeck_type_placeholder_item.rs:103:20
+   |
+LL |     fn fn_test6(_: _) { }
+   |                    ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:103:20
    |
 LL |     fn fn_test6(_: _) { }
    |                    ^ not allowed in type signatures
@@ -253,7 +344,13 @@ LL |     fn fn_test6<T>(_: T) { }
    |                ^^^    ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:96:20
+  --> $DIR/typeck_type_placeholder_item.rs:107:20
+   |
+LL |     fn fn_test7(x: _) { let _x: usize = x; }
+   |                    ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:107:20
    |
 LL |     fn fn_test7(x: _) { let _x: usize = x; }
    |                    ^ not allowed in type signatures
@@ -264,13 +361,19 @@ LL |     fn fn_test7<T>(x: T) { let _x: usize = x; }
    |                ^^^    ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:99:29
+  --> $DIR/typeck_type_placeholder_item.rs:111:29
    |
 LL |     fn fn_test8(_f: fn() -> _) { }
    |                             ^ not allowed in type signatures
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:99:29
+  --> $DIR/typeck_type_placeholder_item.rs:111:29
+   |
+LL |     fn fn_test8(_f: fn() -> _) { }
+   |                             ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:111:29
    |
 LL |     fn fn_test8(_f: fn() -> _) { }
    |                             ^ not allowed in type signatures
@@ -281,11 +384,11 @@ LL |     fn fn_test8<T>(_f: fn() -> T) { }
    |                ^^^             ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:122:12
+  --> $DIR/typeck_type_placeholder_item.rs:137:12
    |
 LL |         a: _,
    |            ^ not allowed in type signatures
-LL |
+...
 LL |         b: (_, _),
    |             ^  ^ not allowed in type signatures
    |             |
@@ -296,17 +399,18 @@ help: use type parameters instead
 LL |     struct FnTest10<T> {
 LL |         a: T,
 LL |
+LL |
 LL |         b: (T, T),
    |
 
 error[E0282]: type annotations needed
-  --> $DIR/typeck_type_placeholder_item.rs:127:18
+  --> $DIR/typeck_type_placeholder_item.rs:145:18
    |
 LL |     fn fn_test11(_: _) -> (_, _) { panic!() }
    |                  ^ cannot infer type
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:127:28
+  --> $DIR/typeck_type_placeholder_item.rs:145:28
    |
 LL |     fn fn_test11(_: _) -> (_, _) { panic!() }
    |                            ^  ^ not allowed in type signatures
@@ -314,7 +418,7 @@ LL |     fn fn_test11(_: _) -> (_, _) { panic!() }
    |                            not allowed in type signatures
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:131:30
+  --> $DIR/typeck_type_placeholder_item.rs:149:30
    |
 LL |     fn fn_test12(x: i32) -> (_, _) { (x, x) }
    |                             -^--^-
@@ -324,7 +428,7 @@ LL |     fn fn_test12(x: i32) -> (_, _) { (x, x) }
    |                             help: replace with the correct return type: `(i32, i32)`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:134:33
+  --> $DIR/typeck_type_placeholder_item.rs:152:33
    |
 LL |     fn fn_test13(x: _) -> (i32, _) { (x, x) }
    |                           ------^-
@@ -333,7 +437,7 @@ LL |     fn fn_test13(x: _) -> (i32, _) { (x, x) }
    |                           help: replace with the correct return type: `(i32, i32)`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:153:21
+  --> $DIR/typeck_type_placeholder_item.rs:179:21
    |
 LL | struct BadStruct<_>(_);
    |                     ^ not allowed in type signatures
@@ -344,7 +448,19 @@ LL | struct BadStruct<T>(T);
    |                  ^  ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:158:15
+  --> $DIR/typeck_type_placeholder_item.rs:185:32
+   |
+LL | impl BadTrait<_> for BadStruct<_> {}
+   |                                ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:185:15
+   |
+LL | impl BadTrait<_> for BadStruct<_> {}
+   |               ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:185:15
    |
 LL | impl BadTrait<_> for BadStruct<_> {}
    |               ^                ^ not allowed in type signatures
@@ -357,13 +473,13 @@ LL | impl<T> BadTrait<T> for BadStruct<T> {}
    |     ^^^          ^                ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:161:34
+  --> $DIR/typeck_type_placeholder_item.rs:190:34
    |
 LL | fn impl_trait() -> impl BadTrait<_> {
    |                                  ^ not allowed in type signatures
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:166:25
+  --> $DIR/typeck_type_placeholder_item.rs:196:25
    |
 LL | struct BadStruct1<_, _>(_);
    |                         ^ not allowed in type signatures
@@ -374,7 +490,7 @@ LL | struct BadStruct1<T, _>(T);
    |                   ^     ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:171:25
+  --> $DIR/typeck_type_placeholder_item.rs:202:25
    |
 LL | struct BadStruct2<_, T>(_, T);
    |                         ^ not allowed in type signatures
@@ -385,13 +501,25 @@ LL | struct BadStruct2<K, T>(K, T);
    |                   ^     ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:175:14
+  --> $DIR/typeck_type_placeholder_item.rs:207:14
    |
 LL | type X = Box<_>;
    |              ^ not allowed in type signatures
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:42:27
+  --> $DIR/typeck_type_placeholder_item.rs:207:14
+   |
+LL | type X = Box<_>;
+   |              ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:47:27
+   |
+LL |     fn test10(&self, _x : _) { }
+   |                           ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:47:27
    |
 LL |     fn test10(&self, _x : _) { }
    |                           ^ not allowed in type signatures
@@ -402,7 +530,13 @@ LL |     fn test10<T>(&self, _x : T) { }
    |              ^^^             ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:139:31
+  --> $DIR/typeck_type_placeholder_item.rs:157:31
+   |
+LL |     fn method_test1(&self, x: _);
+   |                               ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:157:31
    |
 LL |     fn method_test1(&self, x: _);
    |                               ^ not allowed in type signatures
@@ -413,7 +547,19 @@ LL |     fn method_test1<T>(&self, x: T);
    |                    ^^^           ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:141:31
+  --> $DIR/typeck_type_placeholder_item.rs:160:37
+   |
+LL |     fn method_test2(&self, x: _) -> _;
+   |                                     ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:160:31
+   |
+LL |     fn method_test2(&self, x: _) -> _;
+   |                               ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:160:31
    |
 LL |     fn method_test2(&self, x: _) -> _;
    |                               ^     ^ not allowed in type signatures
@@ -426,7 +572,13 @@ LL |     fn method_test2<T>(&self, x: T) -> T;
    |                    ^^^           ^     ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:143:31
+  --> $DIR/typeck_type_placeholder_item.rs:164:31
+   |
+LL |     fn method_test3(&self) -> _;
+   |                               ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:164:31
    |
 LL |     fn method_test3(&self) -> _;
    |                               ^ not allowed in type signatures
@@ -437,7 +589,13 @@ LL |     fn method_test3<T>(&self) -> T;
    |                    ^^^           ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:145:26
+  --> $DIR/typeck_type_placeholder_item.rs:167:26
+   |
+LL |     fn assoc_fn_test1(x: _);
+   |                          ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:167:26
    |
 LL |     fn assoc_fn_test1(x: _);
    |                          ^ not allowed in type signatures
@@ -448,7 +606,19 @@ LL |     fn assoc_fn_test1<T>(x: T);
    |                      ^^^    ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:147:26
+  --> $DIR/typeck_type_placeholder_item.rs:170:32
+   |
+LL |     fn assoc_fn_test2(x: _) -> _;
+   |                                ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:170:26
+   |
+LL |     fn assoc_fn_test2(x: _) -> _;
+   |                          ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:170:26
    |
 LL |     fn assoc_fn_test2(x: _) -> _;
    |                          ^     ^ not allowed in type signatures
@@ -461,7 +631,13 @@ LL |     fn assoc_fn_test2<T>(x: T) -> T;
    |                      ^^^    ^     ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:149:28
+  --> $DIR/typeck_type_placeholder_item.rs:174:28
+   |
+LL |     fn assoc_fn_test3() -> _;
+   |                            ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:174:28
    |
 LL |     fn assoc_fn_test3() -> _;
    |                            ^ not allowed in type signatures
@@ -472,7 +648,13 @@ LL |     fn assoc_fn_test3<T>() -> T;
    |                      ^^^      ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:60:37
+  --> $DIR/typeck_type_placeholder_item.rs:66:37
+   |
+LL |     fn clone_from(&mut self, other: _) { *self = Test9; }
+   |                                     ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:66:37
    |
 LL |     fn clone_from(&mut self, other: _) { *self = Test9; }
    |                                     ^ not allowed in type signatures
@@ -483,7 +665,13 @@ LL |     fn clone_from<T>(&mut self, other: T) { *self = Test9; }
    |                  ^^^                   ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:109:34
+  --> $DIR/typeck_type_placeholder_item.rs:122:34
+   |
+LL |         fn fn_test10(&self, _x : _) { }
+   |                                  ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:122:34
    |
 LL |         fn fn_test10(&self, _x : _) { }
    |                                  ^ not allowed in type signatures
@@ -494,7 +682,13 @@ LL |         fn fn_test10<T>(&self, _x : T) { }
    |                     ^^^             ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:117:41
+  --> $DIR/typeck_type_placeholder_item.rs:131:41
+   |
+LL |         fn clone_from(&mut self, other: _) { *self = FnTest9; }
+   |                                         ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:131:41
    |
 LL |         fn clone_from(&mut self, other: _) { *self = FnTest9; }
    |                                         ^ not allowed in type signatures
@@ -505,13 +699,25 @@ LL |         fn clone_from<T>(&mut self, other: T) { *self = FnTest9; }
    |                      ^^^                   ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:181:21
+  --> $DIR/typeck_type_placeholder_item.rs:190:34
+   |
+LL | fn impl_trait() -> impl BadTrait<_> {
+   |                                  ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:214:21
    |
 LL | type Y = impl Trait<_>;
    |                     ^ not allowed in type signatures
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:39:24
+  --> $DIR/typeck_type_placeholder_item.rs:214:21
+   |
+LL | type Y = impl Trait<_>;
+   |                     ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:44:24
    |
 LL |     fn test9(&self) -> _ { () }
    |                        ^
@@ -520,7 +726,7 @@ LL |     fn test9(&self) -> _ { () }
    |                        help: replace with the correct return type: `()`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:57:24
+  --> $DIR/typeck_type_placeholder_item.rs:63:24
    |
 LL |     fn clone(&self) -> _ { Test9 }
    |                        ^
@@ -529,7 +735,7 @@ LL |     fn clone(&self) -> _ { Test9 }
    |                        help: replace with the correct return type: `Test9`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:106:31
+  --> $DIR/typeck_type_placeholder_item.rs:119:31
    |
 LL |         fn fn_test9(&self) -> _ { () }
    |                               ^
@@ -538,7 +744,7 @@ LL |         fn fn_test9(&self) -> _ { () }
    |                               help: replace with the correct return type: `()`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:114:28
+  --> $DIR/typeck_type_placeholder_item.rs:128:28
    |
 LL |         fn clone(&self) -> _ { FnTest9 }
    |                            ^
@@ -546,7 +752,7 @@ LL |         fn clone(&self) -> _ { FnTest9 }
    |                            not allowed in type signatures
    |                            help: replace with the correct return type: `main::FnTest9`
 
-error: aborting due to 58 previous errors
+error: aborting due to 92 previous errors
 
 Some errors have detailed explanations: E0121, E0282, E0403.
 For more information about an error, try `rustc --explain E0121`.

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,6 +1,7 @@
 [relabel]
 allow-unauthenticated = [
     "C-*", "A-*", "E-*", "NLL-*", "O-*", "S-*", "T-*", "WG-*", "F-*",
+    "D-*",
     "requires-nightly",
     # I-* without I-nominated
     "I-*", "!I-nominated",


### PR DESCRIPTION
Successful merges:

 - #69324 (Backport only: avoid ICE on bad placeholder type)
 - #69439 (resolve: `lifetimes.rs` -> `late/lifetimes.rs`)
 - #69473 (update llvm to silence gcc 9 warnings)
 - #69479 (clarify operator precedence)
 - #69480 (Clean up E0373 explanation)
 - #69500 (Simplify the signature of par_for_each_in)
 - #69505 (Enable setting diagnostic labels)

Failed merges:


r? @ghost