### PR TITLE
fix some error on mips.

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -695,6 +695,10 @@ class RustBuild(object):
         if self.get_toml("deny-warnings", "rust") != "false":
             env["RUSTFLAGS"] += " -Dwarnings"
 
+        # Fix hit the limit of 8K GOT entries per single object file
+        if self.build_triple().startswith('mips'):
+            env["RUSTFLAGS"] += " -Cllvm-args=-mxgot"
+
         env["PATH"] = os.path.join(self.bin_root(), "bin") + \
             os.pathsep + env["PATH"]
         if not os.path.isfile(self.cargo()):

--- a/src/libstd/sys/unix/rand.rs
+++ b/src/libstd/sys/unix/rand.rs
@@ -52,7 +52,7 @@ mod imp {
                 let err = errno() as libc::c_int;
                 if err == libc::EINTR {
                     continue;
-                } else if err == libc::ENOSYS || err == libc::EPERM {
+                } else if err == libc::ENOSYS || err == libc::EPERM || err == libc::EINVAL {
                     // Fall back to reading /dev/urandom if `getrandom` is not
                     // supported on the current kernel.
                     //


### PR DESCRIPTION
It mainly fixes two errors:

1) occurs when build:
/cargo/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.6.2/src/raw/mod.rs:1071:(.text._ZN95_$LT$hashbrown..raw..RawTable$LT$T$GT$$u20$as$u20$core..iter..traits..collect..IntoIterator$GT$9into_iter17hd24b8e25407575e5E+0x68):relocation truncated to fit: R_MIPS_CALL16 against `_Unwind_Resume@@GCC_3.0'

2) Fix `getrandom` is not correct on the current kernel.

? @nikomatsakis 