### PR TITLE
[beta] bootstrap from 1.41.1 stable

### DIFF
--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,8 +12,8 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.x.0` for Cargo where they were released on `date`.
 
-date: 2020-01-30
-rustc: 1.41.0
+date: 2020-02-27
+rustc: 1.41.1
 cargo: 0.42.0
 
 # We use a nightly rustfmt to format the source because it solves some bootstrapping


### PR DESCRIPTION
1.41.1 contains fixes to miscompilations, we should bootstrap from that to avoid potential hazards.