### PR TITLE
 Don't use static crt by default when build proc-macro

### DIFF
--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -1288,7 +1288,8 @@ fn link_args<'a, B: ArchiveBuilder<'a>>(
             let more_args = &sess.opts.cg.link_arg;
             let mut args = args.iter().chain(more_args.iter()).chain(used_link_args.iter());
 
-            if is_pic(sess) && !sess.crt_static(Some(crate_type)) && !args.any(|x| *x == "-static") {
+            if is_pic(sess) && !sess.crt_static(Some(crate_type)) && !args.any(|x| *x == "-static")
+            {
                 position_independent_executable = true;
             }
         }

--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -497,7 +497,7 @@ fn link_natively<'a, B: ArchiveBuilder<'a>>(
         cmd.args(args);
     }
     if let Some(args) = sess.target.target.options.pre_link_args_crt.get(&flavor) {
-        if sess.crt_static() {
+        if sess.crt_static(Some(crate_type)) {
             cmd.args(args);
         }
     }
@@ -523,7 +523,7 @@ fn link_natively<'a, B: ArchiveBuilder<'a>>(
         cmd.arg(get_file_path(sess, obj));
     }
 
-    if crate_type == config::CrateType::Executable && sess.crt_static() {
+    if crate_type == config::CrateType::Executable && sess.crt_static(Some(crate_type)) {
         for obj in &sess.target.target.options.pre_link_objects_exe_crt {
             cmd.arg(get_file_path(sess, obj));
         }
@@ -558,7 +558,7 @@ fn link_natively<'a, B: ArchiveBuilder<'a>>(
     for obj in &sess.target.target.options.post_link_objects {
         cmd.arg(get_file_path(sess, obj));
     }
-    if sess.crt_static() {
+    if sess.crt_static(Some(crate_type)) {
         for obj in &sess.target.target.options.post_link_objects_crt {
             cmd.arg(get_file_path(sess, obj));
         }
@@ -1288,7 +1288,7 @@ fn link_args<'a, B: ArchiveBuilder<'a>>(
             let more_args = &sess.opts.cg.link_arg;
             let mut args = args.iter().chain(more_args.iter()).chain(used_link_args.iter());
 
-            if is_pic(sess) && !sess.crt_static() && !args.any(|x| *x == "-static") {
+            if is_pic(sess) && !sess.crt_static(Some(crate_type)) && !args.any(|x| *x == "-static") {
                 position_independent_executable = true;
             }
         }
@@ -1373,7 +1373,7 @@ fn link_args<'a, B: ArchiveBuilder<'a>>(
     if crate_type != config::CrateType::Executable {
         cmd.build_dylib(out_filename);
     }
-    if crate_type == config::CrateType::Executable && sess.crt_static() {
+    if crate_type == config::CrateType::Executable && sess.crt_static(Some(crate_type)) {
         cmd.build_static_executable();
     }
 

--- a/src/librustc_codegen_utils/link.rs
+++ b/src/librustc_codegen_utils/link.rs
@@ -167,7 +167,7 @@ pub fn invalid_output_for_target(sess: &Session, crate_type: config::CrateType) 
             if !sess.target.target.options.dynamic_linking {
                 return true;
             }
-            if sess.crt_static() && !sess.target.target.options.crt_static_allows_dylibs {
+            if sess.crt_static(Some(crate_type)) && !sess.target.target.options.crt_static_allows_dylibs {
                 return true;
             }
         }

--- a/src/librustc_codegen_utils/link.rs
+++ b/src/librustc_codegen_utils/link.rs
@@ -167,7 +167,9 @@ pub fn invalid_output_for_target(sess: &Session, crate_type: config::CrateType) 
             if !sess.target.target.options.dynamic_linking {
                 return true;
             }
-            if sess.crt_static(Some(crate_type)) && !sess.target.target.options.crt_static_allows_dylibs {
+            if sess.crt_static(Some(crate_type))
+                && !sess.target.target.options.crt_static_allows_dylibs
+            {
                 return true;
             }
         }

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -49,7 +49,7 @@ pub fn add_configuration(
 
     cfg.extend(codegen_backend.target_features(sess).into_iter().map(|feat| (tf, Some(feat))));
 
-    if sess.crt_static_feature() {
+    if sess.crt_static_feature(None) {
         cfg.insert((tf, Some(Symbol::intern("crt-static"))));
     }
 }

--- a/src/librustc_metadata/dependency_format.rs
+++ b/src/librustc_metadata/dependency_format.rs
@@ -97,7 +97,7 @@ fn calculate_type(tcx: TyCtxt<'_>, ty: config::CrateType) -> DependencyList {
 
         // If the global prefer_dynamic switch is turned off, or the final
         // executable will be statically linked, prefer static crate linkage.
-        config::CrateType::Executable if !sess.opts.cg.prefer_dynamic || sess.crt_static() => {
+        config::CrateType::Executable if !sess.opts.cg.prefer_dynamic || sess.crt_static(Some(ty)) => {
             Linkage::Static
         }
         config::CrateType::Executable => Linkage::Dynamic,
@@ -129,7 +129,7 @@ fn calculate_type(tcx: TyCtxt<'_>, ty: config::CrateType) -> DependencyList {
         // If any are not found, generate some nice pretty errors.
         if ty == config::CrateType::Staticlib
             || (ty == config::CrateType::Executable
-                && sess.crt_static()
+                && sess.crt_static(Some(ty))
                 && !sess.target.target.options.crt_static_allows_dylibs)
         {
             for &cnum in tcx.crates().iter() {

--- a/src/librustc_metadata/dependency_format.rs
+++ b/src/librustc_metadata/dependency_format.rs
@@ -97,7 +97,9 @@ fn calculate_type(tcx: TyCtxt<'_>, ty: config::CrateType) -> DependencyList {
 
         // If the global prefer_dynamic switch is turned off, or the final
         // executable will be statically linked, prefer static crate linkage.
-        config::CrateType::Executable if !sess.opts.cg.prefer_dynamic || sess.crt_static(Some(ty)) => {
+        config::CrateType::Executable
+            if !sess.opts.cg.prefer_dynamic || sess.crt_static(Some(ty)) =>
+        {
             Linkage::Static
         }
         config::CrateType::Executable => Linkage::Dynamic,

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -540,25 +540,50 @@ impl Session {
             .unwrap_or(self.opts.debug_assertions)
     }
 
-    pub fn crt_static(&self) -> bool {
+    /// Check whether this compile session and crate type use static crt.
+    pub fn crt_static(&self, crate_type: Option<config::CrateType>) -> bool {
         // If the target does not opt in to crt-static support, use its default.
         if self.target.target.options.crt_static_respected {
-            self.crt_static_feature()
+            self.crt_static_feature(crate_type)
         } else {
             self.target.target.options.crt_static_default
         }
     }
 
-    pub fn crt_static_feature(&self) -> bool {
+    /// Check whether this compile session and crate type use `crt-static` feature.
+    pub fn crt_static_feature(&self, crate_type: Option<config::CrateType>) -> bool {
         let requested_features = self.opts.cg.target_feature.split(',');
         let found_negative = requested_features.clone().any(|r| r == "-crt-static");
         let found_positive = requested_features.clone().any(|r| r == "+crt-static");
 
-        // If the target we're compiling for requests a static crt by default,
-        // then see if the `-crt-static` feature was passed to disable that.
-        // Otherwise if we don't have a static crt by default then see if the
-        // `+crt-static` feature was passed.
-        if self.target.target.options.crt_static_default { !found_negative } else { found_positive }
+        if self.target.target.options.crt_static_default {
+            // `proc-macro` always required to be compiled to dylibs.
+            // We don't use a static crt unless the `+crt-static` feature was passed.
+            if !self.target.target.options.crt_static_allows_dylibs {
+                match crate_type {
+                    Some(config::CrateType::ProcMacro) => found_positive,
+                    Some(_) => !found_negative,
+                    None => {
+                        // FIXME: When crate_type is not available, 
+                        // we use compiler options to determine the crate_type.
+                        // We can't check `#![crate_type = "proc-macro"]` here.
+                        if self.opts.crate_types.contains(&config::CrateType::ProcMacro) {
+                            found_positive
+                        } else {
+                            !found_negative
+                        }
+                    }
+                }
+            } else {
+                // If the target we're compiling for requests a static crt by default,
+                // then see if the `-crt-static` feature was passed to disable that.
+                !found_negative
+            }
+        } else {
+            // If the target we're compiling for don't have a static crt by default then see if the
+            // `+crt-static` feature was passed.
+            found_positive
+        }
     }
 
     pub fn must_not_eliminate_frame_pointers(&self) -> bool {

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -559,7 +559,7 @@ impl Session {
         if found_positive || found_negative {
             found_positive
         } else if crate_type == Some(config::CrateType::ProcMacro)
-            || self.opts.crate_types.contains(&config::CrateType::ProcMacro)
+            || crate_type == None && self.opts.crate_types.contains(&config::CrateType::ProcMacro)
         {
             // FIXME: When crate_type is not available,
             // we use compiler options to determine the crate_type.

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -564,7 +564,7 @@ impl Session {
                     Some(config::CrateType::ProcMacro) => found_positive,
                     Some(_) => !found_negative,
                     None => {
-                        // FIXME: When crate_type is not available, 
+                        // FIXME: When crate_type is not available,
                         // we use compiler options to determine the crate_type.
                         // We can't check `#![crate_type = "proc-macro"]` here.
                         if self.opts.crate_types.contains(&config::CrateType::ProcMacro) {

--- a/src/test/ui/proc-macro/crt-static.rs
+++ b/src/test/ui/proc-macro/crt-static.rs
@@ -3,7 +3,6 @@
 // override -Ctarget-feature=-crt-static from compiletest
 // compile-flags: -Ctarget-feature=
 // build-pass
-// only-musl
 #![crate_type = "proc-macro"]
 
 extern crate proc_macro;

--- a/src/test/ui/proc-macro/crt-static.rs
+++ b/src/test/ui/proc-macro/crt-static.rs
@@ -2,6 +2,7 @@
 // on musl target
 // override -Ctarget-feature=-crt-static from compiletest
 // compile-flags: -Ctarget-feature=
+// ignore-wasm32
 // build-pass
 #![crate_type = "proc-macro"]
 

--- a/src/test/ui/proc-macro/musl-proc-macro.rs
+++ b/src/test/ui/proc-macro/musl-proc-macro.rs
@@ -1,6 +1,7 @@
 // Test proc-macro crate can be built without addtional RUSTFLAGS
 // on musl target
-
+// override -Ctarget-feature=-crt-static from compiletest
+// compile-flags: -Ctarget-feature=
 // build-pass
 // only-musl
 #![crate_type = "proc-macro"]

--- a/src/test/ui/proc-macro/musl-proc-macro.rs
+++ b/src/test/ui/proc-macro/musl-proc-macro.rs
@@ -1,8 +1,8 @@
 // Test proc-macro crate can be built without addtional RUSTFLAGS
 // on musl target
 
-// run-pass
-// compile-flags: --target=x86_64-unknown-linux-musl
+// build-pass
+// only-musl 
 #![crate_type = "proc-macro"]
 
 extern crate proc_macro;

--- a/src/test/ui/proc-macro/musl-proc-macro.rs
+++ b/src/test/ui/proc-macro/musl-proc-macro.rs
@@ -1,0 +1,15 @@
+// Test proc-macro crate can be built without addtional RUSTFLAGS
+// on musl target
+
+// run-pass
+// compile-flags: --target=x86_64-unknown-linux-musl
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_derive(Foo)]
+pub fn derive_foo(input: TokenStream) -> TokenStream {
+    input
+}

--- a/src/test/ui/proc-macro/musl-proc-macro.rs
+++ b/src/test/ui/proc-macro/musl-proc-macro.rs
@@ -2,7 +2,7 @@
 // on musl target
 
 // build-pass
-// only-musl 
+// only-musl
 #![crate_type = "proc-macro"]
 
 extern crate proc_macro;


### PR DESCRIPTION
Don't check value of `crt-static` when build proc-macro crates, since they are always built dynamically.
For more information, see https://github.com/rust-lang/cargo/issues/7563#issuecomment-591965320
I hope this will fix issues about compiling `proc_macro` crates on musl host without bring more issues.
Fix https://github.com/rust-lang/cargo/issues/7563