### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -719,6 +719,8 @@ pub trait Iterator {
     /// ```
     ///
     /// of these layers.
+    ///
+    /// Note that `iter.filter(f).next()` is equivalent to `iter.find(f)`.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn filter<P>(self, predicate: P) -> Filter<Self, P>
@@ -2152,6 +2154,8 @@ pub trait Iterator {
     /// // we can still use `iter`, as there are more elements.
     /// assert_eq!(iter.next(), Some(&3));
     /// ```
+    ///
+    /// Note that `iter.find(f)` is equivalent to `iter.filter(f).next()`.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn find<P>(&mut self, predicate: P) -> Option<Self::Item>

--- a/src/libcore/str/pattern.rs
+++ b/src/libcore/str/pattern.rs
@@ -1050,7 +1050,7 @@ impl TwoWaySearcher {
         // &v[..period]. If it is, we use "Algorithm CP1". Otherwise we use
         // "Algorithm CP2", which is optimized for when the period of the needle
         // is large.
-        if &needle[..crit_pos] == &needle[period..period + crit_pos] {
+        if needle[..crit_pos] == needle[period..period + crit_pos] {
             // short period case -- the period is exact
             // compute a separate critical factorization for the reversed needle
             // x = u' v' where |v'| < period(x).

--- a/src/librustc/mir/interpret/allocation.rs
+++ b/src/librustc/mir/interpret/allocation.rs
@@ -472,7 +472,7 @@ impl<'tcx, Tag: Copy, Extra: AllocationExtra<Tag>> Allocation<Tag, Extra> {
         val: ScalarMaybeUndef<Tag>,
     ) -> InterpResult<'tcx> {
         let ptr_size = cx.data_layout().pointer_size;
-        self.write_scalar(cx, ptr.into(), val, ptr_size)
+        self.write_scalar(cx, ptr, val, ptr_size)
     }
 }
 

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1519,7 +1519,7 @@ impl<'tcx> TerminatorKind<'tcx> {
                 values
                     .iter()
                     .map(|&u| {
-                        ty::Const::from_scalar(tcx, Scalar::from_uint(u, size).into(), switch_ty)
+                        ty::Const::from_scalar(tcx, Scalar::from_uint(u, size), switch_ty)
                             .to_string()
                             .into()
                     })

--- a/src/librustc/mir/tcx.rs
+++ b/src/librustc/mir/tcx.rs
@@ -156,7 +156,7 @@ impl<'tcx> Rvalue<'tcx> {
             }
             Rvalue::AddressOf(mutability, ref place) => {
                 let place_ty = place.ty(local_decls, tcx).ty;
-                tcx.mk_ptr(ty::TypeAndMut { ty: place_ty, mutbl: mutability.into() })
+                tcx.mk_ptr(ty::TypeAndMut { ty: place_ty, mutbl: mutability })
             }
             Rvalue::Len(..) => tcx.types.usize,
             Rvalue::Cast(.., ty) => ty,

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -820,8 +820,7 @@ impl ObjectSafetyViolation {
                 MethodViolationCode::UndispatchableReceiver,
                 span,
             ) => (
-                format!("consider changing method `{}`'s `self` parameter to be `&self`", name)
-                    .into(),
+                format!("consider changing method `{}`'s `self` parameter to be `&self`", name),
                 Some(("&Self".to_string(), span)),
             ),
             ObjectSafetyViolation::AssocConst(name, _)

--- a/src/librustc/ty/error.rs
+++ b/src/librustc/ty/error.rs
@@ -341,7 +341,7 @@ impl<'tcx> TyCtxt<'tcx> {
                     db.note("distinct uses of `impl Trait` result in different opaque types");
                     let e_str = values.expected.to_string();
                     let f_str = values.found.to_string();
-                    if &e_str == &f_str && &e_str == "impl std::future::Future" {
+                    if e_str == f_str && &e_str == "impl std::future::Future" {
                         // FIXME: use non-string based check.
                         db.help(
                             "if both `Future`s have the same `Output` type, consider \

--- a/src/librustc/ty/print/pretty.rs
+++ b/src/librustc/ty/print/pretty.rs
@@ -136,7 +136,7 @@ impl RegionHighlightMode {
     pub fn highlighting_region(&mut self, region: ty::Region<'_>, number: usize) {
         let num_slots = self.highlight_regions.len();
         let first_avail_slot =
-            self.highlight_regions.iter_mut().filter(|s| s.is_none()).next().unwrap_or_else(|| {
+            self.highlight_regions.iter_mut().find(|s| s.is_none()).unwrap_or_else(|| {
                 bug!("can only highlight {} placeholders at a time", num_slots,)
             });
         *first_avail_slot = Some((*region, number));

--- a/src/librustc_ast_lowering/expr.rs
+++ b/src/librustc_ast_lowering/expr.rs
@@ -831,8 +831,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 .last()
                 .cloned()
                 .map(|id| Ok(self.lower_node_id(id)))
-                .unwrap_or(Err(hir::LoopIdError::OutsideLoopScope))
-                .into(),
+                .unwrap_or(Err(hir::LoopIdError::OutsideLoopScope)),
         };
         hir::Destination { label: destination.map(|(_, label)| label), target_id }
     }
@@ -841,7 +840,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         if self.is_in_loop_condition && opt_label.is_none() {
             hir::Destination {
                 label: None,
-                target_id: Err(hir::LoopIdError::UnlabeledCfInWhileCondition).into(),
+                target_id: Err(hir::LoopIdError::UnlabeledCfInWhileCondition),
             }
         } else {
             self.lower_loop_destination(opt_label.map(|label| (id, label)))
@@ -912,7 +911,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 .collect(),
             asm: asm.asm,
             asm_str_style: asm.asm_str_style,
-            clobbers: asm.clobbers.clone().into(),
+            clobbers: asm.clobbers.clone(),
             volatile: asm.volatile,
             alignstack: asm.alignstack,
             dialect: asm.dialect,

--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -437,10 +437,10 @@ pub fn maybe_create_entry_wrapper<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         // listing.
         let main_ret_ty = cx.tcx().erase_regions(&main_ret_ty.no_bound_vars().unwrap());
 
-        if cx.get_defined_value("main").is_some() {
+        if cx.get_declared_value("main").is_some() {
             // FIXME: We should be smart and show a better diagnostic here.
             cx.sess()
-                .struct_span_err(sp, "entry symbol `main` defined multiple times")
+                .struct_span_err(sp, "entry symbol `main` declared multiple times")
                 .help("did you use `#[no_mangle]` on `fn main`? Use `#[start]` instead")
                 .emit();
             cx.sess().abort_if_errors();

--- a/src/librustc_codegen_ssa/mir/operand.rs
+++ b/src/librustc_codegen_ssa/mir/operand.rs
@@ -92,8 +92,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
                 let a = Scalar::from(Pointer::new(
                     bx.tcx().alloc_map.lock().create_memory_alloc(data),
                     Size::from_bytes(start as u64),
-                ))
-                .into();
+                ));
                 let a_llval = bx.scalar_to_backend(
                     a,
                     a_scalar,

--- a/src/librustc_codegen_ssa/mir/rvalue.rs
+++ b/src/librustc_codegen_ssa/mir/rvalue.rs
@@ -387,7 +387,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
 
             mir::Rvalue::AddressOf(mutability, ref place) => {
                 let mk_ptr = move |tcx: TyCtxt<'tcx>, ty: Ty<'tcx>| {
-                    tcx.mk_ptr(ty::TypeAndMut { ty, mutbl: mutability.into() })
+                    tcx.mk_ptr(ty::TypeAndMut { ty, mutbl: mutability })
                 };
                 self.codegen_place_to_pointer(bx, place, mk_ptr)
             }

--- a/src/librustc_expand/mbe/quoted.rs
+++ b/src/librustc_expand/mbe/quoted.rs
@@ -112,7 +112,7 @@ fn parse_tree(
                     sess.span_diagnostic.span_err(span.entire(), &msg);
                 }
                 // Parse the contents of the sequence itself
-                let sequence = parse(tts.into(), expect_matchers, sess);
+                let sequence = parse(tts, expect_matchers, sess);
                 // Get the Kleene operator and optional separator
                 let (separator, kleene) = parse_sep_and_kleene_op(trees, span.entire(), sess);
                 // Count the number of captured "names" (i.e., named metavars)
@@ -159,7 +159,7 @@ fn parse_tree(
         // descend into the delimited set and further parse it.
         tokenstream::TokenTree::Delimited(span, delim, tts) => TokenTree::Delimited(
             span,
-            Lrc::new(Delimited { delim, tts: parse(tts.into(), expect_matchers, sess) }),
+            Lrc::new(Delimited { delim, tts: parse(tts, expect_matchers, sess) }),
         ),
     }
 }

--- a/src/librustc_expand/mbe/transcribe.rs
+++ b/src/librustc_expand/mbe/transcribe.rs
@@ -155,8 +155,7 @@ pub(super) fn transcribe(
                     }
 
                     // Step back into the parent Delimited.
-                    let tree =
-                        TokenTree::Delimited(span, forest.delim, TokenStream::new(result).into());
+                    let tree = TokenTree::Delimited(span, forest.delim, TokenStream::new(result));
                     result = result_stack.pop().unwrap();
                     result.push(tree.into());
                 }

--- a/src/librustc_expand/proc_macro_server.rs
+++ b/src/librustc_expand/proc_macro_server.rs
@@ -60,7 +60,7 @@ impl FromInternal<(TreeAndJoint, &'_ ParseSess, &'_ mut Vec<Self>)>
         let Token { kind, span } = match tree {
             tokenstream::TokenTree::Delimited(span, delim, tts) => {
                 let delimiter = Delimiter::from_internal(delim);
-                return TokenTree::Group(Group { delimiter, stream: tts.into(), span });
+                return TokenTree::Group(Group { delimiter, stream: tts, span });
             }
             tokenstream::TokenTree::Token(token) => token,
         };
@@ -196,12 +196,8 @@ impl ToInternal<TokenStream> for TokenTree<Group, Punct, Ident, Literal> {
         let (ch, joint, span) = match self {
             TokenTree::Punct(Punct { ch, joint, span }) => (ch, joint, span),
             TokenTree::Group(Group { delimiter, stream, span }) => {
-                return tokenstream::TokenTree::Delimited(
-                    span,
-                    delimiter.to_internal(),
-                    stream.into(),
-                )
-                .into();
+                return tokenstream::TokenTree::Delimited(span, delimiter.to_internal(), stream)
+                    .into();
             }
             TokenTree::Ident(self::Ident { sym, is_raw, span }) => {
                 return tokenstream::TokenTree::token(Ident(sym, is_raw), span).into();

--- a/src/librustc_infer/infer/canonical/canonicalizer.rs
+++ b/src/librustc_infer/infer/canonical/canonicalizer.rs
@@ -669,7 +669,7 @@ impl<'cx, 'tcx> Canonicalizer<'cx, 'tcx> {
         } else {
             let var = self.canonical_var(info, const_var.into());
             self.tcx().mk_const(ty::Const {
-                val: ty::ConstKind::Bound(self.binder_index, var.into()),
+                val: ty::ConstKind::Bound(self.binder_index, var),
                 ty: self.fold_ty(const_var.ty),
             })
         }

--- a/src/librustc_infer/infer/error_reporting/mod.rs
+++ b/src/librustc_infer/infer/error_reporting/mod.rs
@@ -745,7 +745,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             .join(", ");
         if !lifetimes.is_empty() {
             if sub.regions().count() < len {
-                value.push_normal(lifetimes + &", ");
+                value.push_normal(lifetimes + ", ");
             } else {
                 value.push_normal(lifetimes);
             }

--- a/src/librustc_infer/infer/outlives/verify.rs
+++ b/src/librustc_infer/infer/outlives/verify.rs
@@ -140,7 +140,6 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
         // Extend with bounds that we can find from the trait.
         let trait_bounds = self
             .projection_declared_bounds_from_trait(projection_ty)
-            .into_iter()
             .map(|r| VerifyBound::OutlivedBy(r));
 
         // see the extensive comment in projection_must_outlive

--- a/src/librustc_infer/traits/coherence.rs
+++ b/src/librustc_infer/traits/coherence.rs
@@ -399,8 +399,7 @@ fn orphan_check_trait_ref<'tcx>(
             let local_type = trait_ref
                 .input_types()
                 .flat_map(|ty| uncover_fundamental_ty(tcx, ty, in_crate))
-                .filter(|ty| ty_is_non_local_constructor(ty, in_crate).is_none())
-                .next();
+                .find(|ty| ty_is_non_local_constructor(ty, in_crate).is_none());
 
             debug!("orphan_check_trait_ref: uncovered ty local_type: `{:?}`", local_type);
 

--- a/src/librustc_infer/traits/error_reporting/mod.rs
+++ b/src/librustc_infer/traits/error_reporting/mod.rs
@@ -1442,7 +1442,7 @@ pub fn suggest_constraining_type_param(
     const MSG_RESTRICT_TYPE: &str = "consider restricting this type parameter with";
     const MSG_RESTRICT_TYPE_FURTHER: &str = "consider further restricting this type parameter with";
 
-    let param = generics.params.iter().filter(|p| p.name.ident().as_str() == param_name).next();
+    let param = generics.params.iter().find(|p| p.name.ident().as_str() == param_name);
 
     let param = if let Some(param) = param {
         param

--- a/src/librustc_infer/traits/select.rs
+++ b/src/librustc_infer/traits/select.rs
@@ -3202,7 +3202,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     obligation.predicate.def_id(),
                     obligation.recursion_depth + 1,
                     a_last.expect_ty(),
-                    &[b_last.into()],
+                    &[b_last],
                 ));
             }
 

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -639,7 +639,7 @@ impl<'a, 'b> ReplaceBodyWithLoop<'a, 'b> {
                                     ast::GenericArg::Type(ty) => Some(ty),
                                     _ => None,
                                 });
-                                any_involves_impl_trait(types.into_iter())
+                                any_involves_impl_trait(types)
                                     || data.constraints.iter().any(|c| match c.kind {
                                         ast::AssocTyConstraintKind::Bound { .. } => true,
                                         ast::AssocTyConstraintKind::Equality { ref ty } => {

--- a/src/librustc_mir/borrow_check/region_infer/reverse_sccs.rs
+++ b/src/librustc_mir/borrow_check/region_infer/reverse_sccs.rs
@@ -56,7 +56,7 @@ impl RegionInferenceContext<'_> {
         let mut scc_regions = FxHashMap::default();
         let mut start = 0;
         for (scc, group) in &paired_scc_regions.into_iter().group_by(|(scc, _)| *scc) {
-            let group_size = group.into_iter().count();
+            let group_size = group.count();
             scc_regions.insert(scc, start..start + group_size);
             start += group_size;
         }

--- a/src/librustc_mir/const_eval/mod.rs
+++ b/src/librustc_mir/const_eval/mod.rs
@@ -52,7 +52,7 @@ pub(crate) fn const_caller_location<'tcx>(
 
     let loc_place = ecx.alloc_caller_location(file, line, col);
     intern_const_alloc_recursive(&mut ecx, InternKind::Constant, loc_place, false).unwrap();
-    ConstValue::Scalar(loc_place.ptr.into())
+    ConstValue::Scalar(loc_place.ptr)
 }
 
 // this function uses `unwrap` copiously, because an already validated constant

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -67,7 +67,7 @@ crate fn eval_nullary_intrinsic<'tcx>(
             };
             ConstValue::from_machine_usize(n, &tcx)
         }
-        sym::type_id => ConstValue::from_u64(tcx.type_id_hash(tp_ty).into()),
+        sym::type_id => ConstValue::from_u64(tcx.type_id_hash(tp_ty)),
         other => bug!("`{}` is not a zero arg intrinsic", other),
     })
 }

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -293,7 +293,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                                 let (&untuple_arg, args) = args.split_last().unwrap();
                                 trace!("eval_fn_call: Will pass last argument by untupling");
                                 Cow::from(args.iter().map(|&a| Ok(a))
-                                .chain((0..untuple_arg.layout.fields.count()).into_iter()
+                                .chain((0..untuple_arg.layout.fields.count())
                                     .map(|i| self.operand_field(untuple_arg, i as u64))
                                 )
                                 .collect::<InterpResult<'_, Vec<OpTy<'tcx, M::PointerTag>>>>()?)

--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -209,7 +209,7 @@ fn mir_const_qualif(tcx: TyCtxt<'_>, def_id: DefId) -> ConstQualifs {
 
     // We return the qualifs in the return place for every MIR body, even though it is only used
     // when deciding to promote a reference to a `const` for now.
-    validator.qualifs_in_return_place().into()
+    validator.qualifs_in_return_place()
 }
 
 fn mir_const(tcx: TyCtxt<'_>, def_id: DefId) -> &Steal<BodyAndCache<'_>> {

--- a/src/librustc_mir/util/aggregate.rs
+++ b/src/librustc_mir/util/aggregate.rs
@@ -49,7 +49,6 @@ pub fn expand_aggregate<'tcx>(
     };
 
     operands
-        .into_iter()
         .enumerate()
         .map(move |(i, (op, ty))| {
             let lhs_field = if let AggregateKind::Array(_) = kind {

--- a/src/librustc_mir_build/build/matches/mod.rs
+++ b/src/librustc_mir_build/build/matches/mod.rs
@@ -1942,8 +1942,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let tcx = self.hir.tcx();
         let debug_source_info = SourceInfo { span: source_info.span, scope: visibility_scope };
         let binding_mode = match mode {
-            BindingMode::ByValue => ty::BindingMode::BindByValue(mutability.into()),
-            BindingMode::ByRef(_) => ty::BindingMode::BindByReference(mutability.into()),
+            BindingMode::ByValue => ty::BindingMode::BindByValue(mutability),
+            BindingMode::ByRef(_) => ty::BindingMode::BindByReference(mutability),
         };
         debug!("declare_binding: user_ty={:?}", user_ty);
         let local = LocalDecl::<'tcx> {

--- a/src/librustc_mir_build/build/mod.rs
+++ b/src/librustc_mir_build/build/mod.rs
@@ -882,7 +882,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             span: tcx_hir.span(var_id),
                         },
                         place: Place {
-                            local: closure_env_arg.into(),
+                            local: closure_env_arg,
                             projection: tcx.intern_place_elems(&projs),
                         },
                     });
@@ -927,7 +927,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         self.local_decls[local].local_info = if let Some(kind) = self_binding {
                             LocalInfo::User(ClearCrossCrate::Set(BindingForm::ImplicitSelf(*kind)))
                         } else {
-                            let binding_mode = ty::BindingMode::BindByValue(mutability.into());
+                            let binding_mode = ty::BindingMode::BindByValue(mutability);
                             LocalInfo::User(ClearCrossCrate::Set(BindingForm::Var(
                                 VarBindingForm {
                                     binding_mode,

--- a/src/librustc_parse/lexer/mod.rs
+++ b/src/librustc_parse/lexer/mod.rs
@@ -327,8 +327,7 @@ impl<'a> StringReader<'a> {
         match kind {
             rustc_lexer::LiteralKind::Char { terminated } => {
                 if !terminated {
-                    self.fatal_span_(start, suffix_start, "unterminated character literal".into())
-                        .raise()
+                    self.fatal_span_(start, suffix_start, "unterminated character literal").raise()
                 }
                 let content_start = start + BytePos(1);
                 let content_end = suffix_start - BytePos(1);
@@ -338,12 +337,8 @@ impl<'a> StringReader<'a> {
             }
             rustc_lexer::LiteralKind::Byte { terminated } => {
                 if !terminated {
-                    self.fatal_span_(
-                        start + BytePos(1),
-                        suffix_start,
-                        "unterminated byte constant".into(),
-                    )
-                    .raise()
+                    self.fatal_span_(start + BytePos(1), suffix_start, "unterminated byte constant")
+                        .raise()
                 }
                 let content_start = start + BytePos(2);
                 let content_end = suffix_start - BytePos(1);
@@ -353,7 +348,7 @@ impl<'a> StringReader<'a> {
             }
             rustc_lexer::LiteralKind::Str { terminated } => {
                 if !terminated {
-                    self.fatal_span_(start, suffix_start, "unterminated double quote string".into())
+                    self.fatal_span_(start, suffix_start, "unterminated double quote string")
                         .raise()
                 }
                 let content_start = start + BytePos(1);
@@ -367,7 +362,7 @@ impl<'a> StringReader<'a> {
                     self.fatal_span_(
                         start + BytePos(1),
                         suffix_start,
-                        "unterminated double quote byte string".into(),
+                        "unterminated double quote byte string",
                     )
                     .raise()
                 }

--- a/src/librustc_parse/lexer/tokentrees.rs
+++ b/src/librustc_parse/lexer/tokentrees.rs
@@ -212,7 +212,7 @@ impl<'a> TokenTreesReader<'a> {
                     _ => {}
                 }
 
-                Ok(TokenTree::Delimited(delim_span, delim, tts.into()).into())
+                Ok(TokenTree::Delimited(delim_span, delim, tts).into())
             }
             token::CloseDelim(delim) => {
                 // An unexpected closing delimiter (i.e., there is no

--- a/src/librustc_parse/lexer/tokentrees.rs
+++ b/src/librustc_parse/lexer/tokentrees.rs
@@ -93,10 +93,8 @@ impl<'a> TokenTreesReader<'a> {
                 }
 
                 if let Some((delim, _)) = self.open_braces.last() {
-                    if let Some((_, open_sp, close_sp)) = self
-                        .matching_delim_spans
-                        .iter()
-                        .filter(|(d, open_sp, close_sp)| {
+                    if let Some((_, open_sp, close_sp)) =
+                        self.matching_delim_spans.iter().find(|(d, open_sp, close_sp)| {
                             if let Some(close_padding) = sm.span_to_margin(*close_sp) {
                                 if let Some(open_padding) = sm.span_to_margin(*open_sp) {
                                     return delim == d && close_padding != open_padding;
@@ -104,7 +102,6 @@ impl<'a> TokenTreesReader<'a> {
                             }
                             false
                         })
-                        .next()
                     // these are in reverse order as they get inserted on close, but
                     {
                         // we want the last open/first close

--- a/src/librustc_parse/lib.rs
+++ b/src/librustc_parse/lib.rs
@@ -420,7 +420,7 @@ fn prepend_attrs(
         builder.push(tokenstream::TokenTree::Delimited(
             delim_span,
             token::DelimToken::Bracket,
-            brackets.build().into(),
+            brackets.build(),
         ));
     }
     builder.push(tokens.clone());

--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -225,12 +225,8 @@ impl<'a> Parser<'a> {
 
             // Make sure that the span of the parent node is larger than the span of lhs and rhs,
             // including the attributes.
-            let lhs_span = lhs
-                .attrs
-                .iter()
-                .filter(|a| a.style == AttrStyle::Outer)
-                .next()
-                .map_or(lhs_span, |a| a.span);
+            let lhs_span =
+                lhs.attrs.iter().find(|a| a.style == AttrStyle::Outer).map_or(lhs_span, |a| a.span);
             let span = lhs_span.to(rhs.span);
             lhs = match op {
                 AssocOp::Add

--- a/src/librustc_parse/parser/mod.rs
+++ b/src/librustc_parse/parser/mod.rs
@@ -263,8 +263,7 @@ impl TokenCursor {
             ]
             .iter()
             .cloned()
-            .collect::<TokenStream>()
-            .into(),
+            .collect::<TokenStream>(),
         );
 
         self.stack.push(mem::replace(
@@ -389,7 +388,7 @@ impl<'a> Parser<'a> {
             root_module_name: None,
             expected_tokens: Vec::new(),
             token_cursor: TokenCursor {
-                frame: TokenCursorFrame::new(DelimSpan::dummy(), token::NoDelim, &tokens.into()),
+                frame: TokenCursorFrame::new(DelimSpan::dummy(), token::NoDelim, &tokens),
                 stack: Vec::new(),
             },
             desugar_doc_comments,
@@ -1006,7 +1005,7 @@ impl<'a> Parser<'a> {
                 );
                 self.set_token(Token::new(TokenKind::CloseDelim(frame.delim), frame.span.close));
                 self.bump();
-                TokenTree::Delimited(frame.span, frame.delim, frame.tree_cursor.stream.into())
+                TokenTree::Delimited(frame.span, frame.delim, frame.tree_cursor.stream)
             }
             token::CloseDelim(_) | token::Eof => unreachable!(),
             _ => {

--- a/src/librustc_parse/parser/stmt.rs
+++ b/src/librustc_parse/parser/stmt.rs
@@ -169,7 +169,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_local_mk(&mut self, lo: Span, attrs: AttrVec) -> PResult<'a, Stmt> {
-        let local = self.parse_local(attrs.into())?;
+        let local = self.parse_local(attrs)?;
         Ok(self.mk_stmt(lo.to(self.prev_span), StmtKind::Local(local)))
     }
 

--- a/src/librustc_passes/loops.rs
+++ b/src/librustc_passes/loops.rs
@@ -77,7 +77,7 @@ impl<'a, 'hir> Visitor<'hir> for CheckLoopVisitor<'a, 'hir> {
                     return;
                 }
 
-                let loop_id = match label.target_id.into() {
+                let loop_id = match label.target_id {
                     Ok(loop_id) => loop_id,
                     Err(hir::LoopIdError::OutsideLoopScope) => hir::DUMMY_HIR_ID,
                     Err(hir::LoopIdError::UnlabeledCfInWhileCondition) => {

--- a/src/librustc_span/symbol.rs
+++ b/src/librustc_span/symbol.rs
@@ -1023,6 +1023,14 @@ impl Symbol {
     pub fn as_u32(self) -> u32 {
         self.0.as_u32()
     }
+
+    /// This method is supposed to be used in error messages, so it's expected to be
+    /// identical to printing the original identifier token written in source code
+    /// (`token_to_string`, `Ident::to_string`), except that symbols don't keep the rawness flag
+    /// or edition, so we have to guess the rawness using the global edition.
+    pub fn to_ident_string(self) -> String {
+        Ident::with_dummy_span(self).to_string()
+    }
 }
 
 impl fmt::Debug for Symbol {

--- a/src/librustc_traits/generic_types.rs
+++ b/src/librustc_traits/generic_types.rs
@@ -24,7 +24,6 @@ crate fn fn_ptr(
 ) -> Ty<'tcx> {
     let inputs_and_output = tcx.mk_type_list(
         (0..arity_and_output)
-            .into_iter()
             .map(|i| ty::BoundVar::from(i))
             // DebruijnIndex(1) because we are going to inject these in a `PolyFnSig`
             .map(|var| tcx.mk_ty(ty::Bound(ty::DebruijnIndex::from(1usize), var.into()))),
@@ -37,7 +36,6 @@ crate fn fn_ptr(
 crate fn type_list(tcx: TyCtxt<'tcx>, arity: usize) -> SubstsRef<'tcx> {
     tcx.mk_substs(
         (0..arity)
-            .into_iter()
             .map(|i| ty::BoundVar::from(i))
             .map(|var| tcx.mk_ty(ty::Bound(ty::INNERMOST, var.into())))
             .map(|ty| GenericArg::from(ty)),

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -2358,10 +2358,11 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     break;
                 }
             }
-            for binding in segment.generic_args().bindings {
+
+            // Only emit the first error to avoid overloading the user with error messages.
+            if let [binding, ..] = segment.generic_args().bindings {
                 has_err = true;
                 Self::prohibit_assoc_ty_binding(self.tcx(), binding.span);
-                break;
             }
         }
         has_err

--- a/src/librustc_typeck/outlives/implicit_infer.rs
+++ b/src/librustc_typeck/outlives/implicit_infer.rs
@@ -312,6 +312,6 @@ pub fn check_explicit_predicates<'tcx>(
 
         let predicate = outlives_predicate.subst(tcx, substs);
         debug!("predicate = {:?}", &predicate);
-        insert_outlives_predicate(tcx, predicate.0.into(), predicate.1, span, required_predicates);
+        insert_outlives_predicate(tcx, predicate.0, predicate.1, span, required_predicates);
     }
 }

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -565,8 +565,7 @@ impl Attributes {
 
         let inner_docs = attrs
             .iter()
-            .filter(|a| a.doc_str().is_some())
-            .next()
+            .find(|a| a.doc_str().is_some())
             .map_or(true, |a| a.style == AttrStyle::Inner);
 
         Attributes {

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -283,7 +283,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
         .filter_map(|lint| {
             // We don't want to whitelist *all* lints so let's
             // ignore those ones.
-            if whitelisted_lints.iter().any(|l| &lint.name == l) {
+            if whitelisted_lints.iter().any(|l| lint.name == l) {
                 None
             } else {
                 Some((lint::LintId::of(lint), lint::Allow))

--- a/src/libstd/sys/unix/process/process_common.rs
+++ b/src/libstd/sys/unix/process/process_common.rs
@@ -287,9 +287,7 @@ impl CStringArray {
 
 fn construct_envp(env: BTreeMap<OsString, OsString>, saw_nul: &mut bool) -> CStringArray {
     let mut result = CStringArray::with_capacity(env.len());
-    for (k, v) in env {
-        let mut k: OsString = k.into();
-
+    for (mut k, v) in env {
         // Reserve additional space for '=' and null terminator
         k.reserve_exact(v.len() + 2);
         k.push("=");

--- a/src/libsyntax/attr/mod.rs
+++ b/src/libsyntax/attr/mod.rs
@@ -529,7 +529,7 @@ impl MetaItemKind {
                     TokenTree::Delimited(
                         DelimSpan::from_single(span),
                         token::Paren,
-                        TokenStream::new(tokens).into(),
+                        TokenStream::new(tokens),
                     )
                     .into(),
                 ]

--- a/src/test/ui/duplicate/dupe-symbols-7.rs
+++ b/src/test/ui/duplicate/dupe-symbols-7.rs
@@ -1,7 +1,7 @@
 // build-fail
 
 //
-// error-pattern: entry symbol `main` defined multiple times
+// error-pattern: entry symbol `main` declared multiple times
 
 // FIXME https://github.com/rust-lang/rust/issues/59774
 // normalize-stderr-test "thread.*panicked.*Metadata module not compiled.*\n" -> ""

--- a/src/test/ui/duplicate/dupe-symbols-8.rs
+++ b/src/test/ui/duplicate/dupe-symbols-8.rs
@@ -1,0 +1,12 @@
+// build-fail
+// error-pattern: entry symbol `main` declared multiple times
+//
+// See #67946.
+
+#![allow(warnings)]
+fn main() {
+    extern "Rust" {
+     fn main();
+    }
+    unsafe { main(); }
+}

--- a/src/test/ui/duplicate/dupe-symbols-8.stderr
+++ b/src/test/ui/duplicate/dupe-symbols-8.stderr
@@ -1,8 +1,13 @@
 error: entry symbol `main` declared multiple times
-  --> $DIR/dupe-symbols-7.rs:12:1
+  --> $DIR/dupe-symbols-8.rs:7:1
    |
-LL | fn main(){}
-   | ^^^^^^^^^^^
+LL | / fn main() {
+LL | |     extern "Rust" {
+LL | |      fn main();
+LL | |     }
+LL | |     unsafe { main(); }
+LL | | }
+   | |_^
    |
    = help: did you use `#[no_mangle]` on `fn main`? Use `#[start]` instead
 

--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -131,7 +131,6 @@ def issue(
     assignees,
     relevant_pr_number,
     relevant_pr_user,
-    pr_reviewer,
 ):
     # Open an issue about the toolstate failure.
     if status == 'test-fail':
@@ -147,11 +146,11 @@ def issue(
         cc @{}, do you think you would have time to do the follow-up work?
         If so, that would be great!
 
-        cc @{}, the PR reviewer, and nominating for compiler team prioritization.
+        And nominating for compiler team prioritization.
 
         ''').format(
             relevant_pr_number, tool, status_description,
-            REPOS.get(tool), relevant_pr_user, pr_reviewer
+            REPOS.get(tool), relevant_pr_user
         )),
         'title': '`{}` no longer builds after {}'.format(tool, relevant_pr_number),
         'assignees': list(assignees),
@@ -236,7 +235,7 @@ def update_latest(
                 try:
                     issue(
                         tool, create_issue_for_status, MAINTAINERS.get(tool, ''),
-                        relevant_pr_number, relevant_pr_user, pr_reviewer,
+                        relevant_pr_number, relevant_pr_user,
                     )
                 except urllib2.HTTPError as e:
                     # network errors will simply end up not creating an issue, but that's better


### PR DESCRIPTION
Successful merges:

 - #69379 (Fail on multiple declarations of `main`.)
 - #69430 (librustc_typeck: remove loop that never actually loops)
 - #69449 (Do not ping PR reviewers in toolstate breakage)
 - #69491 (rustc_span: Add `Symbol::to_ident_string` for use in diagnostic messages)
 - #69495 (don't take redundant references to operands)
 - #69496 (use find(x) instead of filter(x).next())
 - #69501 (note that find(f) is equivalent to filter(f).next() in the docs.)
 - #69527 (Ignore untracked paths when running `rustfmt` on repository.)
 - #69529 (don't use .into() to convert types into identical types.)

Failed merges:


r? @ghost