### PR TITLE
make `.stash(..)` work in macros without ICEing

### DIFF
--- a/src/librustc/lint.rs
+++ b/src/librustc/lint.rs
@@ -342,7 +342,8 @@ pub fn in_external_macro(sess: &Session, span: Span) -> bool {
     let expn_data = span.ctxt().outer_expn_data();
     match expn_data.kind {
         ExpnKind::Root | ExpnKind::Desugaring(DesugaringKind::ForLoop) => false,
-        ExpnKind::AstPass(_) | ExpnKind::Desugaring(_) => true, // well, it's "external"
+        // well, it's "external"
+        ExpnKind::AstPass(_) | ExpnKind::Desugaring(_) | ExpnKind::ParserRecovery => true,
         ExpnKind::Macro(MacroKind::Bang, _) => {
             if expn_data.def_site.is_dummy() {
                 // Dummy span for the `def_site` means it's an external macro.

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -2,7 +2,7 @@ use crate::{Applicability, Handler, Level, StashKey};
 use crate::{Diagnostic, DiagnosticId, DiagnosticStyledString};
 
 use log::debug;
-use rustc_span::{MultiSpan, Span};
+use rustc_span::{ExpnData, ExpnKind, MultiSpan, Span};
 use std::fmt::{self, Debug};
 use std::ops::{Deref, DerefMut};
 use std::thread::panicking;
@@ -133,7 +133,8 @@ impl<'a> DiagnosticBuilder<'a> {
             // suite! { len; is_empty; }
             // ```
             // ...would result in overwriting due to using the same `def_site` span for `A`.
-            let span = span.fresh_expansion(span.ctxt().outer_expn_data());
+            let data = ExpnData::default(ExpnKind::ParserRecovery, span, span.edition());
+            let span = span.fresh_expansion(data);
             handler.stash_diagnostic(span, key, diag);
             span
         })

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -293,7 +293,9 @@ pub trait Emitter {
 
                         // Skip past non-macro entries, just in case there
                         // are some which do actually involve macros.
-                        ExpnKind::Desugaring(..) | ExpnKind::AstPass(..) => None,
+                        ExpnKind::Desugaring(..)
+                        | ExpnKind::AstPass(..)
+                        | ExpnKind::ParserRecovery => None,
 
                         ExpnKind::Macro(macro_kind, _) => Some(macro_kind),
                     }

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -936,11 +936,11 @@ impl<'a> Parser<'a> {
             format!("{}: <type>", id),
             Applicability::HasPlaceholders,
         );
-        err.stash(id.span, StashKey::ItemNoType);
+        let span = err.stash(id.span, StashKey::ItemNoType);
 
         // The user intended that the type be inferred,
         // so treat this as if the user wrote e.g. `const A: _ = expr;`.
-        P(Ty { kind: TyKind::Infer, span: id.span, id: ast::DUMMY_NODE_ID })
+        P(Ty { kind: TyKind::Infer, span, id: ast::DUMMY_NODE_ID })
     }
 
     /// Parses an enum declaration.

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -789,7 +789,10 @@ impl<'l, 'tcx> SaveContext<'l, 'tcx> {
 
             // These are not macros.
             // FIXME(eddyb) maybe there is a way to handle them usefully?
-            ExpnKind::Root | ExpnKind::AstPass(_) | ExpnKind::Desugaring(_) => return None,
+            ExpnKind::Root
+            | ExpnKind::AstPass(_)
+            | ExpnKind::Desugaring(_)
+            | ExpnKind::ParserRecovery => return None,
         };
 
         // If the callee is an imported macro from an external crate, need to get

--- a/src/librustc_span/hygiene.rs
+++ b/src/librustc_span/hygiene.rs
@@ -729,6 +729,8 @@ pub enum ExpnKind {
     AstPass(AstPass),
     /// Desugaring done by the compiler during HIR lowering.
     Desugaring(DesugaringKind),
+    /// AST fragements produced by parser recovery.
+    ParserRecovery,
 }
 
 impl ExpnKind {
@@ -742,6 +744,7 @@ impl ExpnKind {
             },
             ExpnKind::AstPass(kind) => kind.descr().to_string(),
             ExpnKind::Desugaring(kind) => format!("desugaring of {}", kind.descr()),
+            ExpnKind::ParserRecovery => "parser recovery".to_string(),
         }
     }
 }

--- a/src/test/ui/issues/issue-69396-const-no-type-in-macro.rs
+++ b/src/test/ui/issues/issue-69396-const-no-type-in-macro.rs
@@ -1,0 +1,17 @@
+macro_rules! suite {
+    ( $( $fn:ident; )* ) => {
+        $(
+            const A = "A".$fn();
+            //~^ ERROR the name `A` is defined multiple times
+            //~| ERROR missing type for `const` item
+            //~| ERROR missing type for `const` item
+        )*
+    }
+}
+
+suite! {
+    len;
+    is_empty;
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-69396-const-no-type-in-macro.stderr
+++ b/src/test/ui/issues/issue-69396-const-no-type-in-macro.stderr
@@ -1,0 +1,49 @@
+error[E0428]: the name `A` is defined multiple times
+  --> $DIR/issue-69396-const-no-type-in-macro.rs:4:13
+   |
+LL |               const A = "A".$fn();
+   |               ^^^^^^^^^^^^^^^^^^^^
+   |               |
+   |               `A` redefined here
+   |               previous definition of the value `A` here
+...
+LL | / suite! {
+LL | |     len;
+LL | |     is_empty;
+LL | | }
+   | |_- in this macro invocation
+   |
+   = note: `A` must be defined only once in the value namespace of this module
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: missing type for `const` item
+  --> $DIR/issue-69396-const-no-type-in-macro.rs:4:19
+   |
+LL |               const A = "A".$fn();
+   |                     ^ help: provide a type for the item: `A: usize`
+...
+LL | / suite! {
+LL | |     len;
+LL | |     is_empty;
+LL | | }
+   | |_- in this macro invocation
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: missing type for `const` item
+  --> $DIR/issue-69396-const-no-type-in-macro.rs:4:19
+   |
+LL |               const A = "A".$fn();
+   |                     ^ help: provide a type for the item: `A: bool`
+...
+LL | / suite! {
+LL | |     len;
+LL | |     is_empty;
+LL | | }
+   | |_- in this macro invocation
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0428`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/69396, which was injected by https://github.com/rust-lang/rust/pull/64698, by unique-ifying the `Span` part of the key used when stashing the diagnostic such that the key's slot isn't overwritten in `handler.stash_diagnostic(..)`.

This is similar to the usage of `fresh_expansion` in `mark_span_with_reason` (but that's not used for unique-ifying). Stashing is somewhat similar in the sense that it is sort of about compiler generated code as well.

An alternative approach would be to store `Vec<Diagnostic>` instead of `Diagnostic`, but the disadvantage of such a solution is that it might handle non-determinism poorly when stealing diagnostics (e.g. if stealing order would be different than stashing order). The approach in this PR feels more robust in comparison.

r? @petrochenkov 