### PR TITLE
Return error for current_exe on nonexistent file

### DIFF
--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -329,11 +329,10 @@ pub fn current_exe() -> io::Result<PathBuf> {
 pub fn current_exe() -> io::Result<PathBuf> {
     match crate::fs::read_link("/proc/self/exe") {
         Ok(path) => {
-            let path_str = path.to_str()
-                .ok_or(io::Error::new(
-                       io::ErrorKind::InvalidData,
-                       "path contains invalid UTF-8 data")
-                )?;
+            let path_str = path.to_str().ok_or(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "path contains invalid UTF-8 data",
+            ))?;
             unsafe {
                 if libc::access(path_str.as_ptr() as *const i8, libc::F_OK) == 0 {
                     Ok(path)


### PR DESCRIPTION
The underlying implementation of `current_exe` on linux uses the symlink at `/proc/self/exe` to find its own executable path. Deleting or replacing the original executable results in a PathBuf containing the original path with `" (deleted)" ` appended effectively pointing to a nonexistent file.

This change only tests the existence of the file not whether the user can actually access it.

Fix #69343 