### PR TITLE
Clean up unstable book

### DIFF
--- a/src/doc/unstable-book/src/language-features/const-in-array-repeat-expressions.md
+++ b/src/doc/unstable-book/src/language-features/const-in-array-repeat-expressions.md
@@ -2,7 +2,7 @@
 
 The tracking issue for this feature is: [#49147]
 
-[#44109]: https://github.com/rust-lang/rust/issues/49147
+[#49147]: https://github.com/rust-lang/rust/issues/49147
 
 ------------------------
 

--- a/src/doc/unstable-book/src/language-features/impl-trait-in-bindings.md
+++ b/src/doc/unstable-book/src/language-features/impl-trait-in-bindings.md
@@ -1,8 +1,8 @@
 # `impl_trait_in_bindings`
 
-The tracking issue for this feature is: [#34511]
+The tracking issue for this feature is: [#63065]
 
-[#34511]: https://github.com/rust-lang/rust/issues/34511
+[#63065]: https://github.com/rust-lang/rust/issues/63065
 
 ------------------------
 

--- a/src/doc/unstable-book/src/language-features/link-cfg.md
+++ b/src/doc/unstable-book/src/language-features/link-cfg.md
@@ -1,0 +1,5 @@
+# `link_cfg`
+
+This feature is internal to the Rust compiler and is not intended for general use.
+
+------------------------

--- a/src/doc/unstable-book/src/language-features/trait-alias.md
+++ b/src/doc/unstable-book/src/language-features/trait-alias.md
@@ -2,7 +2,7 @@
 
 The tracking issue for this feature is: [#41517]
 
-[#41417]: https://github.com/rust-lang/rust/issues/41517
+[#41517]: https://github.com/rust-lang/rust/issues/41517
 
 ------------------------
 

--- a/src/doc/unstable-book/src/language-features/transparent-unions.md
+++ b/src/doc/unstable-book/src/language-features/transparent-unions.md
@@ -2,7 +2,7 @@
 
 The tracking issue for this feature is [#60405]
 
-[60405]: https://github.com/rust-lang/rust/issues/60405
+[#60405]: https://github.com/rust-lang/rust/issues/60405
 
 ----
 

--- a/src/doc/unstable-book/src/library-features/read-initializer.md
+++ b/src/doc/unstable-book/src/library-features/read-initializer.md
@@ -1,7 +1,0 @@
-# `read_initializer`
-
-The tracking issue for this feature is: [#42788]
-
-[#0]: https://github.com/rust-lang/rust/issues/42788
-
-------------------------

--- a/src/doc/unstable-book/src/library-features/tidy-test-never-used-anywhere-else.md
+++ b/src/doc/unstable-book/src/library-features/tidy-test-never-used-anywhere-else.md
@@ -1,0 +1,5 @@
+# `tidy_test_never_used_anywhere_else`
+
+This feature is internal to the Rust compiler and is not intended for general use.
+
+------------------------

--- a/src/librustc_feature/active.rs
+++ b/src/librustc_feature/active.rs
@@ -99,6 +99,9 @@ declare_features! (
 
     // no-tracking-issue-start
 
+    /// Allows using `rustc_*` attributes (RFC 572).
+    (active, rustc_attrs, "1.0.0", None, None),
+
     /// Allows using compiler's own crates.
     (active, rustc_private, "1.0.0", Some(27812), None),
 
@@ -127,9 +130,6 @@ declare_features! (
 
     /// Allows using `#[link_name="llvm.*"]`.
     (active, link_llvm_intrinsics, "1.0.0", Some(29602), None),
-
-    /// Allows using `rustc_*` attributes (RFC 572).
-    (active, rustc_attrs, "1.0.0", Some(29642), None),
 
     /// Allows using the `box $expr` syntax.
     (active, box_syntax, "1.0.0", Some(49733), None),

--- a/src/test/ui/consts/min_const_fn/allow_const_fn_ptr_feature_gate.stderr
+++ b/src/test/ui/consts/min_const_fn/allow_const_fn_ptr_feature_gate.stderr
@@ -4,7 +4,6 @@ error[E0658]: internal implementation detail
 LL | #[rustc_allow_const_fn_ptr]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-rustc-attrs-1.stderr
+++ b/src/test/ui/feature-gates/feature-gate-rustc-attrs-1.stderr
@@ -4,7 +4,6 @@ error[E0658]: the `#[rustc_variance]` attribute is just used for rustc unit test
 LL | #[rustc_variance]
    | ^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error[E0658]: the `#[rustc_error]` attribute is just used for rustc unit tests and will never be stable
@@ -13,7 +12,6 @@ error[E0658]: the `#[rustc_error]` attribute is just used for rustc unit tests a
 LL | #[rustc_error]
    | ^^^^^^^^^^^^^^
    |
-   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error[E0658]: the `#[rustc_nonnull_optimization_guaranteed]` attribute is just used to enable niche optimizations in libcore and will never be stable
@@ -22,7 +20,6 @@ error[E0658]: the `#[rustc_nonnull_optimization_guaranteed]` attribute is just u
 LL | #[rustc_nonnull_optimization_guaranteed]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/feature-gates/feature-gate-rustc-attrs.stderr
+++ b/src/test/ui/feature-gates/feature-gate-rustc-attrs.stderr
@@ -4,7 +4,6 @@ error[E0658]: attributes starting with `rustc` are reserved for use by the `rust
 LL | #[rustc::unknown]
    |   ^^^^^
    |
-   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: expected attribute, found macro `rustc::unknown`
@@ -19,7 +18,6 @@ error[E0658]: attributes starting with `rustc` are reserved for use by the `rust
 LL | #[unknown::rustc]
    |            ^^^^^
    |
-   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: expected attribute, found macro `unknown::rustc`
@@ -34,7 +32,6 @@ error[E0658]: attributes starting with `rustc` are reserved for use by the `rust
 LL | #[rustc_unknown]
    |   ^^^^^^^^^^^^^
    |
-   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: cannot find attribute `rustc_unknown` in this scope
@@ -49,7 +46,6 @@ error[E0658]: the `#[rustc_dummy]` attribute is just used for rustc unit tests a
 LL | #[rustc_dummy]
    | ^^^^^^^^^^^^^^
    |
-   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: aborting due to 7 previous errors

--- a/src/test/ui/on-unimplemented/feature-gate-on-unimplemented.stderr
+++ b/src/test/ui/on-unimplemented/feature-gate-on-unimplemented.stderr
@@ -4,7 +4,6 @@ error[E0658]: this is an internal attribute that will never be stable
 LL | #[rustc_on_unimplemented = "test error `{Self}` with `{Bar}`"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/proc-macro/expand-to-unstable-2.stderr
+++ b/src/test/ui/proc-macro/expand-to-unstable-2.stderr
@@ -4,7 +4,6 @@ error[E0658]: attributes starting with `rustc` are reserved for use by the `rust
 LL | #[derive(Unstable)]
    |          ^^^^^^^^
    |
-   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/reserved/reserved-attr-on-macro.stderr
+++ b/src/test/ui/reserved/reserved-attr-on-macro.stderr
@@ -4,7 +4,6 @@ error[E0658]: attributes starting with `rustc` are reserved for use by the `rust
 LL | #[rustc_attribute_should_be_reserved]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: cannot determine resolution for the macro `foo`

--- a/src/test/ui/suggestions/attribute-typos.stderr
+++ b/src/test/ui/suggestions/attribute-typos.stderr
@@ -4,7 +4,6 @@ error[E0658]: attributes starting with `rustc` are reserved for use by the `rust
 LL | #[rustc_err]
    |   ^^^^^^^^^
    |
-   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: cannot find attribute `rustc_err` in this scope

--- a/src/test/ui/tool-attributes/diagnostic_item.stderr
+++ b/src/test/ui/tool-attributes/diagnostic_item.stderr
@@ -4,7 +4,6 @@ error[E0658]: diagnostic items compiler internal support for linting
 LL | #[rustc_diagnostic_item = "foomp"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #29642 <https://github.com/rust-lang/rust/issues/29642> for more information
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -63,20 +63,6 @@ pub struct CollectedFeatures {
 pub fn collect_lib_features(base_src_path: &Path) -> Features {
     let mut lib_features = Features::new();
 
-    // This library feature is defined in the `compiler_builtins` crate, which
-    // has been moved out-of-tree. Now it can no longer be auto-discovered by
-    // `tidy`, because we need to filter out its (submodule) directory. Manually
-    // add it to the set of known library features so we can still generate docs.
-    lib_features.insert(
-        "compiler_builtins_lib".to_owned(),
-        Feature {
-            level: Status::Unstable,
-            since: None,
-            has_gate_test: false,
-            tracking_issue: None,
-        },
-    );
-
     map_lib_features(base_src_path, &mut |res, _, _| {
         if let Ok((name, feature)) = res {
             lib_features.insert(name.to_owned(), feature);

--- a/src/tools/tidy/src/unstable_book.rs
+++ b/src/tools/tidy/src/unstable_book.rs
@@ -1,4 +1,4 @@
-use crate::features::{CollectedFeatures, Feature, Features, Status};
+use crate::features::{CollectedFeatures, Features, Status};
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -73,25 +73,11 @@ fn collect_unstable_book_lib_features_section_file_names(base_src_path: &Path) -
 
 pub fn check(path: &Path, features: CollectedFeatures, bad: &mut bool) {
     let lang_features = features.lang;
-    let mut lib_features = features
+    let lib_features = features
         .lib
         .into_iter()
         .filter(|&(ref name, _)| !lang_features.contains_key(name))
         .collect::<Features>();
-
-    // This library feature is defined in the `compiler_builtins` crate, which
-    // has been moved out-of-tree. Now it can no longer be auto-discovered by
-    // `tidy`, because we need to filter out its (submodule) directory. Manually
-    // add it to the set of known library features so we can still generate docs.
-    lib_features.insert(
-        "compiler_builtins_lib".to_owned(),
-        Feature {
-            level: Status::Unstable,
-            since: None,
-            has_gate_test: false,
-            tracking_issue: None,
-        },
-    );
 
     // Library features
     let unstable_lib_feature_names = collect_unstable_feature_names(&lib_features);


### PR DESCRIPTION
- #58402's feature was renamed to `tidy_test_never_used_anywhere_else` and it is now used for tidy only
- `read_initializer` link is wrong and the doc should be auto-generated so removed
- Add dummy doc for `link_cfg`
- Stop generating `compiler_builtins_lib` doc in favor of b8ccc0f8a60ac16fdc00f4b2e36e1a5db8b78295
- Make `rustc_attrs` tracking issue "None"
