### PR TITLE
Fix no_std detection for target triples

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -180,7 +180,7 @@ pub struct Target {
 impl Target {
     pub fn from_triple(triple: &str) -> Self {
         let mut target: Self = Default::default();
-        if triple.contains("-none-") || triple.contains("nvptx") {
+        if triple.contains("-none") || triple.contains("nvptx") {
             target.no_std = true;
         }
         target


### PR DESCRIPTION
The current check for wether a target is no_std or not is matching for the string `-none-` in a target triple. This doesn't work for triples that end in `-none`, like `aarch64-unknown-none`.

Fix this by matching for `-none` instead.

I checked for all the current target triples containing `none`, and this should not generate any false positives.

This fixes an issue encountered in https://github.com/rust-lang/rust/pull/68334