### PR TITLE
Avoid mutable/owned references to BTreemap's shared root

### DIFF
--- a/src/liballoc/collections/btree/map.rs
+++ b/src/liballoc/collections/btree/map.rs
@@ -1199,8 +1199,8 @@ impl<K: Ord, V> BTreeMap<K, V> {
             loop {
                 let mut split_edge = match search::search_node(left_node, key) {
                     // key is going to the right tree
-                    Found(handle) => handle.left_edge(),
-                    GoDown(handle) => handle,
+                    Found(kv) => kv.left_edge(),
+                    GoDown(edge) => edge,
                 };
 
                 split_edge.move_suffix(&mut right_node);
@@ -1354,7 +1354,7 @@ impl<'a, K: 'a, V: 'a> Iterator for Iter<'a, K, V> {
             None
         } else {
             self.length -= 1;
-            unsafe { Some(self.range.next_unchecked()) }
+            Some(unsafe { self.range.next_unchecked() })
         }
     }
 
@@ -1377,7 +1377,7 @@ impl<'a, K: 'a, V: 'a> DoubleEndedIterator for Iter<'a, K, V> {
             None
         } else {
             self.length -= 1;
-            unsafe { Some(self.range.next_back_unchecked()) }
+            Some(unsafe { self.range.next_back_unchecked() })
         }
     }
 }
@@ -1626,7 +1626,7 @@ impl<'a, K, V> Iterator for Range<'a, K, V> {
     type Item = (&'a K, &'a V);
 
     fn next(&mut self) -> Option<(&'a K, &'a V)> {
-        if self.is_empty() { None } else { unsafe { Some(self.next_unchecked()) } }
+        if self.is_empty() { None } else { Some(unsafe { self.next_unchecked() }) }
     }
 
     fn last(mut self) -> Option<(&'a K, &'a V)> {

--- a/src/liballoc/collections/btree/node.rs
+++ b/src/liballoc/collections/btree/node.rs
@@ -221,6 +221,7 @@ impl<K, V> Root<K, V> {
     }
 
     pub fn as_mut(&mut self) -> NodeRef<marker::Mut<'_>, K, V, marker::LeafOrInternal> {
+        debug_assert!(!self.is_shared_root());
         NodeRef {
             height: self.height,
             node: self.node.as_ptr(),
@@ -230,6 +231,7 @@ impl<K, V> Root<K, V> {
     }
 
     pub fn into_ref(self) -> NodeRef<marker::Owned, K, V, marker::LeafOrInternal> {
+        debug_assert!(!self.is_shared_root());
         NodeRef {
             height: self.height,
             node: self.node.as_ptr(),


### PR DESCRIPTION
Rust ensures that mutable references have exclusive access to what they refer to, and Mark pointed out earlier (or that was my interpretation) that in BTreeMap, a type `NodeRef<marker::Mut<'_>, _, _, _> ` is pretty close to a mutable reference to a tree node. Multiple threads can be live with multiple values of such types, each with `node` pointing to a single shared root, not to mention `NodeRef<marker::Immut<'_>, _, _, _> ` values pointing to the same shared root. Those "mutable near-references" are never converted into actual `&mut` references (though you could have easily believed that they are fed to something like `into_key_slice`), and obviously they never actually mutate the shared root. I don't know if that leads to undefined behavior, now or ever.

Out of concern and curiosity, this PR avoids all mutable and owned `NodeRef` values pointing to something shared. Every mutable method on a BTreeMap that does not replace the shared root (`ensure_root_is_owned`) must explicitly deal with it in a separate implementation, which is always trivial. That's the part I like. For iterators, the code becomes rather messy and I think it doesn't help to make the code more robust.

r? @Mark-Simulacrum