### PR TITLE
use .to_string() instead of format!() macro to create strings

### DIFF
--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -18,7 +18,7 @@ use std::borrow::Cow;
 
 fn describe_as_module(def_id: DefId, tcx: TyCtxt<'_>) -> String {
     if def_id.is_top_level_module() {
-        format!("top-level module")
+        "top-level module".to_string()
     } else {
         format!("module `{}`", tcx.def_path_str(def_id))
     }

--- a/src/librustc_attr/builtin.rs
+++ b/src/librustc_attr/builtin.rs
@@ -53,7 +53,7 @@ fn handle_errors(sess: &ParseSess, span: Span, error: AttrError) {
                     err.span_suggestion(
                         span,
                         "consider removing the prefix",
-                        format!("{}", &lint_str[1..]),
+                        lint_str[1..].to_string(),
                         Applicability::MaybeIncorrect,
                     );
                 }

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -167,17 +167,17 @@ impl Diagnostic {
         found: DiagnosticStyledString,
     ) -> &mut Self {
         let mut msg: Vec<_> =
-            vec![(format!("required when trying to coerce from type `"), Style::NoStyle)];
+            vec![("required when trying to coerce from type `".to_string(), Style::NoStyle)];
         msg.extend(expected.0.iter().map(|x| match *x {
             StringPart::Normal(ref s) => (s.to_owned(), Style::NoStyle),
             StringPart::Highlighted(ref s) => (s.to_owned(), Style::Highlight),
         }));
-        msg.push((format!("` to type '"), Style::NoStyle));
+        msg.push(("` to type '".to_string(), Style::NoStyle));
         msg.extend(found.0.iter().map(|x| match *x {
             StringPart::Normal(ref s) => (s.to_owned(), Style::NoStyle),
             StringPart::Highlighted(ref s) => (s.to_owned(), Style::Highlight),
         }));
-        msg.push((format!("`"), Style::NoStyle));
+        msg.push(("`".to_string(), Style::NoStyle));
 
         // For now, just attach these as notes
         self.highlighted_note(msg);

--- a/src/librustc_infer/infer/error_reporting/mod.rs
+++ b/src/librustc_infer/infer/error_reporting/mod.rs
@@ -143,7 +143,7 @@ pub(super) fn note_and_explain_region(
         // uh oh, hope no user ever sees THIS
         ty::ReEmpty(ui) => (format!("the empty lifetime in universe {:?}", ui), None),
 
-        ty::RePlaceholder(_) => (format!("any other region"), None),
+        ty::RePlaceholder(_) => ("any other region".to_string(), None),
 
         // FIXME(#13998) RePlaceholder should probably print like
         // ReFree rather than dumping Debug output on the user.

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1919,21 +1919,21 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidValue {
             use rustc::ty::TyKind::*;
             match ty.kind {
                 // Primitive types that don't like 0 as a value.
-                Ref(..) => Some((format!("references must be non-null"), None)),
-                Adt(..) if ty.is_box() => Some((format!("`Box` must be non-null"), None)),
-                FnPtr(..) => Some((format!("function pointers must be non-null"), None)),
-                Never => Some((format!("the `!` type has no valid value"), None)),
+                Ref(..) => Some(("references must be non-null".to_string(), None)),
+                Adt(..) if ty.is_box() => Some(("`Box` must be non-null".to_string(), None)),
+                FnPtr(..) => Some(("function pointers must be non-null".to_string(), None)),
+                Never => Some(("the `!` type has no valid value".to_string(), None)),
                 RawPtr(tm) if matches!(tm.ty.kind, Dynamic(..)) =>
                 // raw ptr to dyn Trait
                 {
-                    Some((format!("the vtable of a wide raw pointer must be non-null"), None))
+                    Some(("the vtable of a wide raw pointer must be non-null".to_string(), None))
                 }
                 // Primitive types with other constraints.
                 Bool if init == InitKind::Uninit => {
-                    Some((format!("booleans must be either `true` or `false`"), None))
+                    Some(("booleans must be either `true` or `false`".to_string(), None))
                 }
                 Char if init == InitKind::Uninit => {
-                    Some((format!("characters must be a valid Unicode codepoint"), None))
+                    Some(("characters must be a valid Unicode codepoint".to_string(), None))
                 }
                 // Recurse and checks for some compound types.
                 Adt(adt_def, substs) if !adt_def.is_union() => {
@@ -1961,7 +1961,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidValue {
                     }
                     // Now, recurse.
                     match adt_def.variants.len() {
-                        0 => Some((format!("enums with no variants have no valid value"), None)),
+                        0 => Some(("enums with no variants have no valid value".to_string(), None)),
                         1 => {
                             // Struct, or enum with exactly one variant.
                             // Proceed recursively, check all fields.

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -83,9 +83,9 @@ fn lint_overflowing_range_endpoint<'a, 'tcx>(
                     // We need to preserve the literal's suffix,
                     // as it may determine typing information.
                     let suffix = match lit.node {
-                        LitKind::Int(_, LitIntType::Signed(s)) => format!("{}", s.name_str()),
-                        LitKind::Int(_, LitIntType::Unsigned(s)) => format!("{}", s.name_str()),
-                        LitKind::Int(_, LitIntType::Unsuffixed) => "".to_owned(),
+                        LitKind::Int(_, LitIntType::Signed(s)) => s.name_str().to_string(),
+                        LitKind::Int(_, LitIntType::Unsigned(s)) => s.name_str().to_string(),
+                        LitKind::Int(_, LitIntType::Unsuffixed) => "".to_string(),
                         _ => bug!(),
                     };
                     let suggestion = format!("{}..={}{}", start, lit_val - 1, suffix);

--- a/src/librustc_mir/borrow_check/diagnostics/mod.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/mod.rs
@@ -619,14 +619,14 @@ pub(super) enum BorrowedContentSource<'tcx> {
 impl BorrowedContentSource<'tcx> {
     pub(super) fn describe_for_unnamed_place(&self) -> String {
         match *self {
-            BorrowedContentSource::DerefRawPointer => format!("a raw pointer"),
-            BorrowedContentSource::DerefSharedRef => format!("a shared reference"),
-            BorrowedContentSource::DerefMutableRef => format!("a mutable reference"),
+            BorrowedContentSource::DerefRawPointer => "a raw pointer".to_string(),
+            BorrowedContentSource::DerefSharedRef => "a shared reference".to_string(),
+            BorrowedContentSource::DerefMutableRef => "a mutable reference".to_string(),
             BorrowedContentSource::OverloadedDeref(ty) => {
                 if ty.is_rc() {
-                    format!("an `Rc`")
+                    "an `Rc`".to_string()
                 } else if ty.is_arc() {
-                    format!("an `Arc`")
+                    "an `Arc`".to_string()
                 } else {
                     format!("dereference of `{}`", ty)
                 }
@@ -649,16 +649,16 @@ impl BorrowedContentSource<'tcx> {
 
     pub(super) fn describe_for_immutable_place(&self) -> String {
         match *self {
-            BorrowedContentSource::DerefRawPointer => format!("a `*const` pointer"),
-            BorrowedContentSource::DerefSharedRef => format!("a `&` reference"),
+            BorrowedContentSource::DerefRawPointer => "a `*const` pointer".to_string(),
+            BorrowedContentSource::DerefSharedRef => "a `&` reference".to_string(),
             BorrowedContentSource::DerefMutableRef => {
                 bug!("describe_for_immutable_place: DerefMutableRef isn't immutable")
             }
             BorrowedContentSource::OverloadedDeref(ty) => {
                 if ty.is_rc() {
-                    format!("an `Rc`")
+                    "an `Rc`".to_string()
                 } else if ty.is_arc() {
-                    format!("an `Arc`")
+                    "an `Arc`".to_string()
                 } else {
                     format!("a dereference of `{}`", ty)
                 }

--- a/src/librustc_mir/borrow_check/diagnostics/move_errors.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/move_errors.rs
@@ -443,7 +443,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                     let place_ty = move_from.ty(*self.body, self.infcx.tcx).ty;
                     let place_desc = match self.describe_place(move_from.as_ref()) {
                         Some(desc) => format!("`{}`", desc),
-                        None => format!("value"),
+                        None => "value".to_string(),
                     };
 
                     self.note_type_does_not_implement_copy(err, &place_desc, place_ty, Some(span));
@@ -466,7 +466,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                 let place_ty = original_path.ty(*self.body, self.infcx.tcx).ty;
                 let place_desc = match self.describe_place(original_path.as_ref()) {
                     Some(desc) => format!("`{}`", desc),
-                    None => format!("value"),
+                    None => "value".to_string(),
                 };
                 self.note_type_does_not_implement_copy(err, &place_desc, place_ty, Some(span));
 

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -477,7 +477,7 @@ fn write_scope_tree(
         indented_decl.push_str(";");
 
         let local_name =
-            if local == RETURN_PLACE { format!(" return place") } else { String::new() };
+            if local == RETURN_PLACE { " return place".to_string() } else { String::new() };
 
         writeln!(
             w,

--- a/src/librustc_parse/parser/pat.rs
+++ b/src/librustc_parse/parser/pat.rs
@@ -216,7 +216,7 @@ impl<'a> Parser<'a> {
             .span_suggestion(
                 seq_span,
                 "...or a vertical bar to match on multiple alternatives",
-                format!("{}", seq_snippet.replace(",", " |")),
+                seq_snippet.replace(",", " |"),
                 Applicability::MachineApplicable,
             );
         }

--- a/src/librustc_passes/check_const.rs
+++ b/src/librustc_passes/check_const.rs
@@ -35,7 +35,7 @@ impl NonConstExpr {
         match self {
             Self::Loop(src) => format!("`{}`", src.name()),
             Self::Match(src) => format!("`{}`", src.name()),
-            Self::OrPattern => format!("or-pattern"),
+            Self::OrPattern => "or-pattern".to_string(),
         }
     }
 

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -98,7 +98,7 @@ impl<'a> Resolver<'a> {
                     E0401,
                     "can't use generic parameters from outer function",
                 );
-                err.span_label(span, format!("use of generic parameter from outer function"));
+                err.span_label(span, "use of generic parameter from outer function".to_string());
 
                 let sm = self.session.source_map();
                 match outer_res {
@@ -155,7 +155,8 @@ impl<'a> Resolver<'a> {
                     } else if let Some(sp) = sm.generate_fn_name_span(span) {
                         err.span_label(
                             sp,
-                            format!("try adding a local generic parameter in this method instead"),
+                            "try adding a local generic parameter in this method instead"
+                                .to_string(),
                         );
                     } else {
                         err.help("try using a local generic parameter instead");

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -177,7 +177,7 @@ impl<'a> LateResolutionVisitor<'a, '_, '_> {
             err.code(rustc_errors::error_code!(E0411));
             err.span_label(
                 span,
-                format!("`Self` is only available in impls, traits, and type definitions"),
+                "`Self` is only available in impls, traits, and type definitions".to_string(),
             );
             return (err, Vec::new());
         }
@@ -186,12 +186,10 @@ impl<'a> LateResolutionVisitor<'a, '_, '_> {
 
             err.code(rustc_errors::error_code!(E0424));
             err.span_label(span, match source {
-                PathSource::Pat => format!(
-                    "`self` value is a keyword and may not be bound to variables or shadowed",
-                ),
-                _ => format!(
-                    "`self` value is a keyword only available in methods with a `self` parameter",
-                ),
+                PathSource::Pat => "`self` value is a keyword and may not be bound to variables or shadowed"
+                                   .to_string(),
+                _ => "`self` value is a keyword only available in methods with a `self` parameter"
+                     .to_string(),
             });
             if let Some(span) = &self.diagnostic_metadata.current_function {
                 err.span_label(*span, "this function doesn't have a `self` parameter");
@@ -558,7 +556,7 @@ impl<'a> LateResolutionVisitor<'a, '_, '_> {
                     if is_expected(ctor_def) && !accessible_ctor {
                         err.span_label(
                             span,
-                            format!("constructor is not visible here due to private fields"),
+                            "constructor is not visible here due to private fields".to_string(),
                         );
                     }
                 } else {

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -605,7 +605,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 if lstring.starts_with('&') {
                                     // let a = String::new();
                                     // let _ = &a + "bar";
-                                    format!("{}", &lstring[1..])
+                                    lstring[1..].to_string()
                                 } else {
                                     format!("{}.to_owned()", lstring)
                                 },
@@ -633,7 +633,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         let to_string = if l.starts_with('&') {
                             // let a = String::new(); let b = String::new();
                             // let _ = &a + b;
-                            format!("{}", &l[1..])
+                            l[1..].to_string()
                         } else {
                             format!("{}.to_owned()", l)
                         };

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -160,7 +160,7 @@ crate fn placeholder_type_error(
     }) {
         // Account for `_` already present in cases like `struct S<_>(_);` and suggest
         // `struct S<T>(T);` instead of `struct S<_, T>(T);`.
-        sugg.push((arg.span, format!("{}", type_name)));
+        sugg.push((arg.span, type_name.to_string()));
     } else {
         sugg.push((
             generics.iter().last().unwrap().span.shrink_to_hi(),
@@ -475,7 +475,7 @@ fn get_new_lifetime_name<'tcx>(
 
     let a_to_z_repeat_n = |n| {
         (b'a'..=b'z').map(move |c| {
-            let mut s = format!("'");
+            let mut s = '\''.to_string();
             s.extend(std::iter::repeat(char::from(c)).take(n));
             s
         })


### PR DESCRIPTION
handles what is left after https://github.com/rust-lang/rust/pull/69541