### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -180,7 +180,7 @@ pub struct Target {
 impl Target {
     pub fn from_triple(triple: &str) -> Self {
         let mut target: Self = Default::default();
-        if triple.contains("-none-") || triple.contains("nvptx") {
+        if triple.contains("-none") || triple.contains("nvptx") {
             target.no_std = true;
         }
         target

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -3823,7 +3823,7 @@ where
         // The last index of self.v is already checked and found to match
         // by the last iteration, so we start searching a new match
         // one index to the left.
-        let remainder = if self.v.len() == 0 { &[] } else { &self.v[..(self.v.len() - 1)] };
+        let remainder = if self.v.is_empty() { &[] } else { &self.v[..(self.v.len() - 1)] };
         let idx = remainder.iter().rposition(|x| (self.pred)(x)).map(|idx| idx + 1).unwrap_or(0);
         if idx == 0 {
             self.finished = true;
@@ -4033,7 +4033,7 @@ where
             return None;
         }
 
-        let idx_opt = if self.v.len() == 0 {
+        let idx_opt = if self.v.is_empty() {
             None
         } else {
             // work around borrowck limitations

--- a/src/libcore/tests/hash/sip.rs
+++ b/src/libcore/tests/hash/sip.rs
@@ -238,7 +238,7 @@ fn test_siphash_2_4() {
 #[cfg(target_pointer_width = "32")]
 fn test_hash_usize() {
     let val = 0xdeadbeef_deadbeef_u64;
-    assert!(hash(&(val as u64)) != hash(&(val as usize)));
+    assert_ne!(hash(&(val as u64)), hash(&(val as usize)));
     assert_eq!(hash(&(val as u32)), hash(&(val as usize)));
 }
 
@@ -247,7 +247,7 @@ fn test_hash_usize() {
 fn test_hash_usize() {
     let val = 0xdeadbeef_deadbeef_u64;
     assert_eq!(hash(&(val as u64)), hash(&(val as usize)));
-    assert!(hash(&(val as u32)) != hash(&(val as usize)));
+    assert_ne!(hash(&(val as u32)), hash(&(val as usize)));
 }
 
 #[test]
@@ -262,14 +262,14 @@ fn test_hash_idempotent() {
 fn test_hash_no_bytes_dropped_64() {
     let val = 0xdeadbeef_deadbeef_u64;
 
-    assert!(hash(&val) != hash(&zero_byte(val, 0)));
-    assert!(hash(&val) != hash(&zero_byte(val, 1)));
-    assert!(hash(&val) != hash(&zero_byte(val, 2)));
-    assert!(hash(&val) != hash(&zero_byte(val, 3)));
-    assert!(hash(&val) != hash(&zero_byte(val, 4)));
-    assert!(hash(&val) != hash(&zero_byte(val, 5)));
-    assert!(hash(&val) != hash(&zero_byte(val, 6)));
-    assert!(hash(&val) != hash(&zero_byte(val, 7)));
+    assert_ne!(hash(&val), hash(&zero_byte(val, 0)));
+    assert_ne!(hash(&val), hash(&zero_byte(val, 1)));
+    assert_ne!(hash(&val), hash(&zero_byte(val, 2)));
+    assert_ne!(hash(&val), hash(&zero_byte(val, 3)));
+    assert_ne!(hash(&val), hash(&zero_byte(val, 4)));
+    assert_ne!(hash(&val), hash(&zero_byte(val, 5)));
+    assert_ne!(hash(&val), hash(&zero_byte(val, 6)));
+    assert_ne!(hash(&val), hash(&zero_byte(val, 7)));
 
     fn zero_byte(val: u64, byte: usize) -> u64 {
         assert!(byte < 8);
@@ -281,10 +281,10 @@ fn test_hash_no_bytes_dropped_64() {
 fn test_hash_no_bytes_dropped_32() {
     let val = 0xdeadbeef_u32;
 
-    assert!(hash(&val) != hash(&zero_byte(val, 0)));
-    assert!(hash(&val) != hash(&zero_byte(val, 1)));
-    assert!(hash(&val) != hash(&zero_byte(val, 2)));
-    assert!(hash(&val) != hash(&zero_byte(val, 3)));
+    assert_ne!(hash(&val), hash(&zero_byte(val, 0)));
+    assert_ne!(hash(&val), hash(&zero_byte(val, 1)));
+    assert_ne!(hash(&val), hash(&zero_byte(val, 2)));
+    assert_ne!(hash(&val), hash(&zero_byte(val, 3)));
 
     fn zero_byte(val: u32, byte: usize) -> u32 {
         assert!(byte < 4);
@@ -299,14 +299,17 @@ fn test_hash_no_concat_alias() {
     let u = ("a", "abb");
 
     assert!(s != t && t != u);
-    assert!(hash(&s) != hash(&t) && hash(&s) != hash(&u));
+    assert_ne!(s, t);
+    assert_ne!(t, u);
+    assert_ne!(hash(&s), hash(&t));
+    assert_ne!(hash(&s), hash(&u));
 
     let u = [1, 0, 0, 0];
     let v = (&u[..1], &u[1..3], &u[3..]);
     let w = (&u[..], &u[4..4], &u[4..4]);
 
-    assert!(v != w);
-    assert!(hash(&v) != hash(&w));
+    assert_ne!(v, w);
+    assert_ne!(hash(&v), hash(&w));
 }
 
 #[test]

--- a/src/librustc/arena.rs
+++ b/src/librustc/arena.rs
@@ -250,7 +250,7 @@ impl<'tcx> Arena<'tcx> {
 
     #[inline]
     pub fn alloc_slice<T: Copy>(&self, value: &[T]) -> &mut [T] {
-        if value.len() == 0 {
+        if value.is_empty() {
             return &mut [];
         }
         self.dropless.alloc_slice(value)

--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -809,7 +809,7 @@ impl DepGraph {
             dep_node
         );
 
-        if unlikely!(diagnostics.len() > 0) {
+        if unlikely!(!diagnostics.is_empty()) {
             self.emit_diagnostics(tcx, data, dep_node_index, prev_dep_node_index, diagnostics);
         }
 

--- a/src/librustc/ich/hcx.rs
+++ b/src/librustc/ich/hcx.rs
@@ -19,7 +19,7 @@ use smallvec::SmallVec;
 use std::cmp::Ord;
 
 fn compute_ignored_attr_names() -> FxHashSet<Symbol> {
-    debug_assert!(ich::IGNORED_ATTRIBUTES.len() > 0);
+    debug_assert!(!ich::IGNORED_ATTRIBUTES.is_empty());
     ich::IGNORED_ATTRIBUTES.iter().map(|&s| s).collect()
 }
 

--- a/src/librustc/ich/impls_syntax.rs
+++ b/src/librustc/ich/impls_syntax.rs
@@ -14,7 +14,7 @@ impl<'ctx> rustc_target::HashStableContext for StableHashingContext<'ctx> {}
 
 impl<'a> HashStable<StableHashingContext<'a>> for [ast::Attribute] {
     fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
-        if self.len() == 0 {
+        if self.is_empty() {
             self.len().hash_stable(hcx, hasher);
             return;
         }

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -171,7 +171,7 @@ impl<'tcx> ConstEvalErr<'tcx> {
             // Skip the last, which is just the environment of the constant.  The stacktrace
             // is sometimes empty because we create "fake" eval contexts in CTFE to do work
             // on constant values.
-            if self.stacktrace.len() > 0 {
+            if !self.stacktrace.is_empty() {
                 for frame_info in &self.stacktrace[..self.stacktrace.len() - 1] {
                     err.span_label(frame_info.call_site, frame_info.to_string());
                 }

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -2219,7 +2219,7 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                 });
                 let region = if print_region {
                     let mut region = region.to_string();
-                    if region.len() > 0 {
+                    if !region.is_empty() {
                         region.push(' ');
                     }
                     region

--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -18,7 +18,7 @@ use std::borrow::Cow;
 
 fn describe_as_module(def_id: DefId, tcx: TyCtxt<'_>) -> String {
     if def_id.is_top_level_module() {
-        format!("top-level module")
+        "top-level module".to_string()
     } else {
         format!("module `{}`", tcx.def_path_str(def_id))
     }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -2473,7 +2473,7 @@ impl<'tcx> TyCtxt<'tcx> {
         // FIXME consider asking the input slice to be sorted to avoid
         // re-interning permutations, in which case that would be asserted
         // here.
-        if preds.len() == 0 {
+        if preds.is_empty() {
             // The macro-generated method below asserts we don't intern an empty slice.
             List::empty()
         } else {
@@ -2482,31 +2482,31 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     pub fn intern_type_list(self, ts: &[Ty<'tcx>]) -> &'tcx List<Ty<'tcx>> {
-        if ts.len() == 0 { List::empty() } else { self._intern_type_list(ts) }
+        if ts.is_empty() { List::empty() } else { self._intern_type_list(ts) }
     }
 
     pub fn intern_substs(self, ts: &[GenericArg<'tcx>]) -> &'tcx List<GenericArg<'tcx>> {
-        if ts.len() == 0 { List::empty() } else { self._intern_substs(ts) }
+        if ts.is_empty() { List::empty() } else { self._intern_substs(ts) }
     }
 
     pub fn intern_projs(self, ps: &[ProjectionKind]) -> &'tcx List<ProjectionKind> {
-        if ps.len() == 0 { List::empty() } else { self._intern_projs(ps) }
+        if ps.is_empty() { List::empty() } else { self._intern_projs(ps) }
     }
 
     pub fn intern_place_elems(self, ts: &[PlaceElem<'tcx>]) -> &'tcx List<PlaceElem<'tcx>> {
-        if ts.len() == 0 { List::empty() } else { self._intern_place_elems(ts) }
+        if ts.is_empty() { List::empty() } else { self._intern_place_elems(ts) }
     }
 
     pub fn intern_canonical_var_infos(self, ts: &[CanonicalVarInfo]) -> CanonicalVarInfos<'tcx> {
-        if ts.len() == 0 { List::empty() } else { self._intern_canonical_var_infos(ts) }
+        if ts.is_empty() { List::empty() } else { self._intern_canonical_var_infos(ts) }
     }
 
     pub fn intern_clauses(self, ts: &[Clause<'tcx>]) -> Clauses<'tcx> {
-        if ts.len() == 0 { List::empty() } else { self._intern_clauses(ts) }
+        if ts.is_empty() { List::empty() } else { self._intern_clauses(ts) }
     }
 
     pub fn intern_goals(self, ts: &[Goal<'tcx>]) -> Goals<'tcx> {
-        if ts.len() == 0 { List::empty() } else { self._intern_goals(ts) }
+        if ts.is_empty() { List::empty() } else { self._intern_goals(ts) }
     }
 
     pub fn mk_fn_sig<I>(

--- a/src/librustc/ty/instance.rs
+++ b/src/librustc/ty/instance.rs
@@ -314,7 +314,7 @@ impl<'tcx> Instance<'tcx> {
     ) -> Option<Instance<'tcx>> {
         debug!("resolve(def_id={:?}, substs={:?})", def_id, substs);
         let fn_sig = tcx.fn_sig(def_id);
-        let is_vtable_shim = fn_sig.inputs().skip_binder().len() > 0
+        let is_vtable_shim = !fn_sig.inputs().skip_binder().is_empty()
             && fn_sig.input(0).skip_binder().is_param(0)
             && tcx.generics_of(def_id).has_self;
         if is_vtable_shim {

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -798,7 +798,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                     // (Typechecking will reject discriminant-sizing attrs.)
 
                     let v = present_first.unwrap();
-                    let kind = if def.is_enum() || variants[v].len() == 0 {
+                    let kind = if def.is_enum() || variants[v].is_empty() {
                         StructKind::AlwaysSized
                     } else {
                         let param_env = tcx.param_env(def.did);

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -698,7 +698,7 @@ impl<T: Copy> List<T> {
     fn from_arena<'tcx>(arena: &'tcx Arena<'tcx>, slice: &[T]) -> &'tcx List<T> {
         assert!(!mem::needs_drop::<T>());
         assert!(mem::size_of::<T>() != 0);
-        assert!(slice.len() != 0);
+        assert!(!slice.is_empty());
 
         // Align up the size of the len (usize) field
         let align = mem::align_of::<T>();

--- a/src/librustc_ast_lowering/path.rs
+++ b/src/librustc_ast_lowering/path.rs
@@ -229,7 +229,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         err.span_label(data.span, "only `Fn` traits may use parentheses");
                         if let Ok(snippet) = self.sess.source_map().span_to_snippet(data.span) {
                             // Do not suggest going from `Trait()` to `Trait<>`
-                            if data.inputs.len() > 0 {
+                            if !data.inputs.is_empty() {
                                 if let Some(split) = snippet.find('(') {
                                     let trait_name = &snippet[0..split];
                                     let args = &snippet[split + 1..snippet.len() - 1];

--- a/src/librustc_ast_pretty/pprust.rs
+++ b/src/librustc_ast_pretty/pprust.rs
@@ -791,7 +791,7 @@ impl<'a> PrintState<'a> for State<'a> {
                     s.print_generic_arg(generic_arg)
                 });
 
-                let mut comma = data.args.len() != 0;
+                let mut comma = !data.args.is_empty();
 
                 for constraint in data.constraints.iter() {
                     if comma {

--- a/src/librustc_attr/builtin.rs
+++ b/src/librustc_attr/builtin.rs
@@ -53,7 +53,7 @@ fn handle_errors(sess: &ParseSess, span: Span, error: AttrError) {
                     err.span_suggestion(
                         span,
                         "consider removing the prefix",
-                        format!("{}", &lint_str[1..]),
+                        lint_str[1..].to_string(),
                         Applicability::MaybeIncorrect,
                     );
                 }

--- a/src/librustc_builtin_macros/concat.rs
+++ b/src/librustc_builtin_macros/concat.rs
@@ -49,7 +49,7 @@ pub fn expand_concat(
             }
         }
     }
-    if missing_literal.len() > 0 {
+    if !missing_literal.is_empty() {
         let mut err = cx.struct_span_err(missing_literal, "expected a literal");
         err.note("only literals (like `\"foo\"`, `42` and `3.14`) can be passed to `concat!()`");
         err.emit();

--- a/src/librustc_builtin_macros/deriving/generic/mod.rs
+++ b/src/librustc_builtin_macros/deriving/generic/mod.rs
@@ -588,14 +588,14 @@ impl<'a> TraitDef<'a> {
                         span: self.span,
                         bound_generic_params: wb.bound_generic_params.clone(),
                         bounded_ty: wb.bounded_ty.clone(),
-                        bounds: wb.bounds.iter().cloned().collect(),
+                        bounds: wb.bounds.to_vec(),
                     })
                 }
                 ast::WherePredicate::RegionPredicate(ref rb) => {
                     ast::WherePredicate::RegionPredicate(ast::WhereRegionPredicate {
                         span: self.span,
                         lifetime: rb.lifetime,
-                        bounds: rb.bounds.iter().cloned().collect(),
+                        bounds: rb.bounds.to_vec(),
                     })
                 }
                 ast::WherePredicate::EqPredicate(ref we) => {

--- a/src/librustc_builtin_macros/format.rs
+++ b/src/librustc_builtin_macros/format.rs
@@ -1096,7 +1096,7 @@ pub fn expand_preparsed_format_args(
         cx.str_pieces.push(s);
     }
 
-    if cx.invalid_refs.len() >= 1 {
+    if !cx.invalid_refs.is_empty() {
         cx.report_invalid_references(numbered_position_args);
     }
 

--- a/src/librustc_codegen_llvm/back/lto.rs
+++ b/src/librustc_codegen_llvm/back/lto.rs
@@ -237,7 +237,7 @@ fn fat_lto(
     let module: ModuleCodegen<ModuleLlvm> = match costliest_module {
         Some((_cost, i)) => in_memory.remove(i),
         None => {
-            assert!(serialized_modules.len() > 0, "must have at least one serialized module");
+            assert!(!serialized_modules.is_empty(), "must have at least one serialized module");
             let (buffer, name) = serialized_modules.remove(0);
             info!("no in-memory regular modules to choose from, parsing {:?}", name);
             ModuleCodegen {

--- a/src/librustc_codegen_llvm/llvm_util.rs
+++ b/src/librustc_codegen_llvm/llvm_util.rs
@@ -61,7 +61,7 @@ unsafe fn configure_llvm(sess: &Session) {
     let sess_args = cg_opts.chain(tg_opts);
 
     let user_specified_args: FxHashSet<_> =
-        sess_args.clone().map(|s| llvm_arg_to_arg_name(s)).filter(|s| s.len() > 0).collect();
+        sess_args.clone().map(|s| llvm_arg_to_arg_name(s)).filter(|s| !s.is_empty()).collect();
 
     {
         // This adds the given argument to LLVM. Unless `force` is true

--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -1524,12 +1524,12 @@ fn add_upstream_rust_crates<'a, B: ArchiveBuilder<'a>>(
     for &(cnum, _) in deps.iter().rev() {
         if let Some(missing) = info.missing_lang_items.get(&cnum) {
             end_with.extend(missing.iter().cloned());
-            if end_with.len() > 0 && group_end.is_none() {
+            if !end_with.is_empty() && group_end.is_none() {
                 group_end = Some(cnum);
             }
         }
         end_with.retain(|item| info.lang_item_to_crate.get(item) != Some(&cnum));
-        if end_with.len() == 0 && group_end.is_some() {
+        if end_with.is_empty() && group_end.is_some() {
             group_start = Some(cnum);
             break;
         }

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -1244,11 +1244,11 @@ fn start_executing_work<B: ExtraBackendMethods>(
         while !codegen_done
             || running > 0
             || (!codegen_aborted
-                && (!work_items.is_empty()
-                    || !needs_fat_lto.is_empty()
-                    || !needs_thin_lto.is_empty()
-                    || !lto_import_only_modules.is_empty()
-                    || main_thread_worker_state != MainThreadWorkerState::Idle))
+                && !(work_items.is_empty()
+                    && needs_fat_lto.is_empty()
+                    && needs_thin_lto.is_empty()
+                    && lto_import_only_modules.is_empty()
+                    && main_thread_worker_state == MainThreadWorkerState::Idle))
         {
             // While there are still CGUs to be codegened, the coordinator has
             // to decide how to utilize the compiler processes implicit Token:

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -1244,10 +1244,10 @@ fn start_executing_work<B: ExtraBackendMethods>(
         while !codegen_done
             || running > 0
             || (!codegen_aborted
-                && (work_items.len() > 0
-                    || needs_fat_lto.len() > 0
-                    || needs_thin_lto.len() > 0
-                    || lto_import_only_modules.len() > 0
+                && (!work_items.is_empty()
+                    || !needs_fat_lto.is_empty()
+                    || !needs_thin_lto.is_empty()
+                    || !lto_import_only_modules.is_empty()
                     || main_thread_worker_state != MainThreadWorkerState::Idle))
         {
             // While there are still CGUs to be codegened, the coordinator has
@@ -1289,7 +1289,7 @@ fn start_executing_work<B: ExtraBackendMethods>(
                 // Perform the serial work here of figuring out what we're
                 // going to LTO and then push a bunch of work items onto our
                 // queue to do LTO
-                if work_items.len() == 0
+                if work_items.is_empty()
                     && running == 0
                     && main_thread_worker_state == MainThreadWorkerState::Idle
                 {
@@ -1354,7 +1354,7 @@ fn start_executing_work<B: ExtraBackendMethods>(
 
             // Spin up what work we can, only doing this while we've got available
             // parallelism slots and work left to spawn.
-            while !codegen_aborted && work_items.len() > 0 && running < tokens.len() {
+            while !codegen_aborted && !work_items.is_empty() && running < tokens.len() {
                 let (item, _) = work_items.pop().unwrap();
 
                 maybe_start_llvm_timer(prof, cgcx.config(item.module_kind()), &mut llvm_start_time);

--- a/src/librustc_data_structures/profiling.rs
+++ b/src/librustc_data_structures/profiling.rs
@@ -425,7 +425,7 @@ impl SelfProfiler {
             }
 
             // Warn about any unknown event names
-            if unknown_events.len() > 0 {
+            if !unknown_events.is_empty() {
                 unknown_events.sort();
                 unknown_events.dedup();
 

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -167,17 +167,17 @@ impl Diagnostic {
         found: DiagnosticStyledString,
     ) -> &mut Self {
         let mut msg: Vec<_> =
-            vec![(format!("required when trying to coerce from type `"), Style::NoStyle)];
+            vec![("required when trying to coerce from type `".to_string(), Style::NoStyle)];
         msg.extend(expected.0.iter().map(|x| match *x {
             StringPart::Normal(ref s) => (s.to_owned(), Style::NoStyle),
             StringPart::Highlighted(ref s) => (s.to_owned(), Style::Highlight),
         }));
-        msg.push((format!("` to type '"), Style::NoStyle));
+        msg.push(("` to type '".to_string(), Style::NoStyle));
         msg.extend(found.0.iter().map(|x| match *x {
             StringPart::Normal(ref s) => (s.to_owned(), Style::NoStyle),
             StringPart::Highlighted(ref s) => (s.to_owned(), Style::Highlight),
         }));
-        msg.push((format!("`"), Style::NoStyle));
+        msg.push(("`".to_string(), Style::NoStyle));
 
         // For now, just attach these as notes
         self.highlighted_note(msg);

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -231,7 +231,7 @@ pub trait Emitter {
                ].contains(&sugg.style)
             {
                 let substitution = &sugg.substitutions[0].parts[0].snippet.trim();
-                let msg = if substitution.len() == 0 || sugg.style.hide_inline() {
+                let msg = if substitution.is_empty() || sugg.style.hide_inline() {
                     // This substitution is only removal OR we explicitly don't want to show the
                     // code inline (`hide_inline`). Therefore, we don't show the substitution.
                     format!("help: {}", sugg.msg)

--- a/src/librustc_errors/snippet.rs
+++ b/src/librustc_errors/snippet.rs
@@ -152,7 +152,7 @@ impl Annotation {
             //       |
             //
             // Note that this would be the complete output users would see.
-            label.len() > 0
+            !label.is_empty()
         } else {
             false
         }

--- a/src/librustc_infer/infer/canonical/query_response.rs
+++ b/src/librustc_infer/infer/canonical/query_response.rs
@@ -421,7 +421,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
         for _ in num_universes_in_query..num_universes_in_response {
             universe_map.push(self.create_next_universe());
         }
-        assert!(universe_map.len() >= 1); // always have the root universe
+        assert!(!universe_map.is_empty()); // always have the root universe
         assert_eq!(universe_map[ty::UniverseIndex::ROOT.as_usize()], ty::UniverseIndex::ROOT);
 
         // Every canonical query result includes values for each of

--- a/src/librustc_infer/infer/error_reporting/mod.rs
+++ b/src/librustc_infer/infer/error_reporting/mod.rs
@@ -143,7 +143,7 @@ pub(super) fn note_and_explain_region(
         // uh oh, hope no user ever sees THIS
         ty::ReEmpty(ui) => (format!("the empty lifetime in universe {:?}", ui), None),
 
-        ty::RePlaceholder(_) => (format!("any other region"), None),
+        ty::RePlaceholder(_) => ("any other region".to_string(), None),
 
         // FIXME(#13998) RePlaceholder should probably print like
         // ReFree rather than dumping Debug output on the user.

--- a/src/librustc_infer/infer/region_constraints/mod.rs
+++ b/src/librustc_infer/infer/region_constraints/mod.rs
@@ -587,7 +587,7 @@ impl<'tcx> RegionConstraintCollector<'tcx> {
 
         // skip no-op cases known to be satisfied
         if let VerifyBound::AllBounds(ref bs) = verify.bound {
-            if bs.len() == 0 {
+            if bs.is_empty() {
                 return;
             }
         }

--- a/src/librustc_infer/traits/error_reporting/mod.rs
+++ b/src/librustc_infer/traits/error_reporting/mod.rs
@@ -440,7 +440,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     /// going to help).
     pub fn report_overflow_error_cycle(&self, cycle: &[PredicateObligation<'tcx>]) -> ! {
         let cycle = self.resolve_vars_if_possible(&cycle.to_owned());
-        assert!(cycle.len() > 0);
+        assert!(!cycle.is_empty());
 
         debug!("report_overflow_error_cycle: cycle={:?}", cycle);
 

--- a/src/librustc_infer/traits/select.rs
+++ b/src/librustc_infer/traits/select.rs
@@ -2157,7 +2157,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 debug!("builtin_bound: nested={:?}", nested);
                 candidates
                     .vec
-                    .push(BuiltinCandidate { has_nested: nested.skip_binder().len() > 0 });
+                    .push(BuiltinCandidate { has_nested: !nested.skip_binder().is_empty() });
             }
             BuiltinImplConditions::None => {}
             BuiltinImplConditions::Ambiguous => {

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1919,21 +1919,21 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidValue {
             use rustc::ty::TyKind::*;
             match ty.kind {
                 // Primitive types that don't like 0 as a value.
-                Ref(..) => Some((format!("references must be non-null"), None)),
-                Adt(..) if ty.is_box() => Some((format!("`Box` must be non-null"), None)),
-                FnPtr(..) => Some((format!("function pointers must be non-null"), None)),
-                Never => Some((format!("the `!` type has no valid value"), None)),
+                Ref(..) => Some(("references must be non-null".to_string(), None)),
+                Adt(..) if ty.is_box() => Some(("`Box` must be non-null".to_string(), None)),
+                FnPtr(..) => Some(("function pointers must be non-null".to_string(), None)),
+                Never => Some(("the `!` type has no valid value".to_string(), None)),
                 RawPtr(tm) if matches!(tm.ty.kind, Dynamic(..)) =>
                 // raw ptr to dyn Trait
                 {
-                    Some((format!("the vtable of a wide raw pointer must be non-null"), None))
+                    Some(("the vtable of a wide raw pointer must be non-null".to_string(), None))
                 }
                 // Primitive types with other constraints.
                 Bool if init == InitKind::Uninit => {
-                    Some((format!("booleans must be either `true` or `false`"), None))
+                    Some(("booleans must be either `true` or `false`".to_string(), None))
                 }
                 Char if init == InitKind::Uninit => {
-                    Some((format!("characters must be a valid Unicode codepoint"), None))
+                    Some(("characters must be a valid Unicode codepoint".to_string(), None))
                 }
                 // Recurse and checks for some compound types.
                 Adt(adt_def, substs) if !adt_def.is_union() => {
@@ -1961,7 +1961,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidValue {
                     }
                     // Now, recurse.
                     match adt_def.variants.len() {
-                        0 => Some((format!("enums with no variants have no valid value"), None)),
+                        0 => Some(("enums with no variants have no valid value".to_string(), None)),
                         1 => {
                             // Struct, or enum with exactly one variant.
                             // Proceed recursively, check all fields.

--- a/src/librustc_lint/levels.rs
+++ b/src/librustc_lint/levels.rs
@@ -375,7 +375,7 @@ impl<'s> LintLevelsBuilder<'s> {
         }
 
         let prev = self.cur;
-        if specs.len() > 0 {
+        if !specs.is_empty() {
             self.cur = self.sets.list.len() as u32;
             self.sets.list.push(LintSet::Node { specs: specs, parent: prev });
         }

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -83,9 +83,9 @@ fn lint_overflowing_range_endpoint<'a, 'tcx>(
                     // We need to preserve the literal's suffix,
                     // as it may determine typing information.
                     let suffix = match lit.node {
-                        LitKind::Int(_, LitIntType::Signed(s)) => format!("{}", s.name_str()),
-                        LitKind::Int(_, LitIntType::Unsigned(s)) => format!("{}", s.name_str()),
-                        LitKind::Int(_, LitIntType::Unsuffixed) => "".to_owned(),
+                        LitKind::Int(_, LitIntType::Signed(s)) => s.name_str().to_string(),
+                        LitKind::Int(_, LitIntType::Unsigned(s)) => s.name_str().to_string(),
+                        LitKind::Int(_, LitIntType::Unsuffixed) => "".to_string(),
                         _ => bug!(),
                     };
                     let suggestion = format!("{}..={}{}", start, lit_val - 1, suffix);

--- a/src/librustc_metadata/dependency_format.rs
+++ b/src/librustc_metadata/dependency_format.rs
@@ -339,7 +339,7 @@ fn activate_injected_dep(
 // there's only going to be one allocator in the output.
 fn verify_ok(tcx: TyCtxt<'_>, list: &[Linkage]) {
     let sess = &tcx.sess;
-    if list.len() == 0 {
+    if list.is_empty() {
         return;
     }
     let mut panic_runtime = None;

--- a/src/librustc_mir/borrow_check/diagnostics/mod.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/mod.rs
@@ -619,14 +619,14 @@ pub(super) enum BorrowedContentSource<'tcx> {
 impl BorrowedContentSource<'tcx> {
     pub(super) fn describe_for_unnamed_place(&self) -> String {
         match *self {
-            BorrowedContentSource::DerefRawPointer => format!("a raw pointer"),
-            BorrowedContentSource::DerefSharedRef => format!("a shared reference"),
-            BorrowedContentSource::DerefMutableRef => format!("a mutable reference"),
+            BorrowedContentSource::DerefRawPointer => "a raw pointer".to_string(),
+            BorrowedContentSource::DerefSharedRef => "a shared reference".to_string(),
+            BorrowedContentSource::DerefMutableRef => "a mutable reference".to_string(),
             BorrowedContentSource::OverloadedDeref(ty) => {
                 if ty.is_rc() {
-                    format!("an `Rc`")
+                    "an `Rc`".to_string()
                 } else if ty.is_arc() {
-                    format!("an `Arc`")
+                    "an `Arc`".to_string()
                 } else {
                     format!("dereference of `{}`", ty)
                 }
@@ -649,16 +649,16 @@ impl BorrowedContentSource<'tcx> {
 
     pub(super) fn describe_for_immutable_place(&self) -> String {
         match *self {
-            BorrowedContentSource::DerefRawPointer => format!("a `*const` pointer"),
-            BorrowedContentSource::DerefSharedRef => format!("a `&` reference"),
+            BorrowedContentSource::DerefRawPointer => "a `*const` pointer".to_string(),
+            BorrowedContentSource::DerefSharedRef => "a `&` reference".to_string(),
             BorrowedContentSource::DerefMutableRef => {
                 bug!("describe_for_immutable_place: DerefMutableRef isn't immutable")
             }
             BorrowedContentSource::OverloadedDeref(ty) => {
                 if ty.is_rc() {
-                    format!("an `Rc`")
+                    "an `Rc`".to_string()
                 } else if ty.is_arc() {
-                    format!("an `Arc`")
+                    "an `Arc`".to_string()
                 } else {
                     format!("a dereference of `{}`", ty)
                 }

--- a/src/librustc_mir/borrow_check/diagnostics/move_errors.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/move_errors.rs
@@ -443,7 +443,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                     let place_ty = move_from.ty(*self.body, self.infcx.tcx).ty;
                     let place_desc = match self.describe_place(move_from.as_ref()) {
                         Some(desc) => format!("`{}`", desc),
-                        None => format!("value"),
+                        None => "value".to_string(),
                     };
 
                     self.note_type_does_not_implement_copy(err, &place_desc, place_ty, Some(span));
@@ -466,7 +466,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                 let place_ty = original_path.ty(*self.body, self.infcx.tcx).ty;
                 let place_desc = match self.describe_place(original_path.as_ref()) {
                     Some(desc) => format!("`{}`", desc),
-                    None => format!("value"),
+                    None => "value".to_string(),
                 };
                 self.note_type_does_not_implement_copy(err, &place_desc, place_ty, Some(span));
 

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -264,7 +264,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
     #[inline(always)]
     pub fn cur_frame(&self) -> usize {
-        assert!(self.stack.len() > 0);
+        assert!(!self.stack.is_empty());
         self.stack.len() - 1
     }
 
@@ -505,7 +505,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         return_place: Option<PlaceTy<'tcx, M::PointerTag>>,
         return_to_block: StackPopCleanup,
     ) -> InterpResult<'tcx> {
-        if self.stack.len() > 0 {
+        if !self.stack.is_empty() {
             info!("PAUSING({}) {}", self.cur_frame(), self.frame().instance);
         }
         ::log_settings::settings().indentation += 1;
@@ -698,7 +698,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
         }
 
-        if self.stack.len() > 0 {
+        if !self.stack.is_empty() {
             info!(
                 "CONTINUING({}) {} (unwinding = {})",
                 self.cur_frame(),

--- a/src/librustc_mir/transform/uninhabited_enum_branching.rs
+++ b/src/librustc_mir/transform/uninhabited_enum_branching.rs
@@ -28,7 +28,7 @@ fn get_switched_on_type<'tcx>(
 
     // Only bother checking blocks which terminate by switching on a local.
     if let Some(local) = get_discriminant_local(&terminator.kind) {
-        let stmt_before_term = (block_data.statements.len() > 0)
+        let stmt_before_term = (!block_data.statements.is_empty())
             .then(|| &block_data.statements[block_data.statements.len() - 1].kind);
 
         if let Some(StatementKind::Assign(box (l, Rvalue::Discriminant(place)))) = stmt_before_term

--- a/src/librustc_mir/util/elaborate_drops.rs
+++ b/src/librustc_mir/util/elaborate_drops.rs
@@ -369,7 +369,7 @@ where
 
     fn open_drop_for_adt(&mut self, adt: &'tcx ty::AdtDef, substs: SubstsRef<'tcx>) -> BasicBlock {
         debug!("open_drop_for_adt({:?}, {:?}, {:?})", self, adt, substs);
-        if adt.variants.len() == 0 {
+        if adt.variants.is_empty() {
             return self.elaborator.patch().new_block(BasicBlockData {
                 statements: vec![],
                 terminator: Some(Terminator {

--- a/src/librustc_mir/util/patch.rs
+++ b/src/librustc_mir/util/patch.rs
@@ -37,7 +37,7 @@ impl<'tcx> MirPatch<'tcx> {
         let mut resume_stmt_block = None;
         for (bb, block) in body.basic_blocks().iter_enumerated() {
             if let TerminatorKind::Resume = block.terminator().kind {
-                if block.statements.len() > 0 {
+                if !block.statements.is_empty() {
                     assert!(resume_stmt_block.is_none());
                     resume_stmt_block = Some(bb);
                 } else {

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -477,7 +477,7 @@ fn write_scope_tree(
         indented_decl.push_str(";");
 
         let local_name =
-            if local == RETURN_PLACE { format!(" return place") } else { String::new() };
+            if local == RETURN_PLACE { " return place".to_string() } else { String::new() };
 
         writeln!(
             w,

--- a/src/librustc_mir_build/build/matches/mod.rs
+++ b/src/librustc_mir_build/build/matches/mod.rs
@@ -1438,7 +1438,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             let target_blocks: Vec<_> = target_candidates
                 .into_iter()
                 .map(|mut candidates| {
-                    if candidates.len() != 0 {
+                    if !candidates.is_empty() {
                         let candidate_start = this.cfg.start_new_block();
                         this.match_candidates(
                             span,

--- a/src/librustc_mir_build/build/matches/test.rs
+++ b/src/librustc_mir_build/build/matches/test.rs
@@ -222,7 +222,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             TestKind::SwitchInt { switch_ty, ref options, indices: _ } => {
                 let target_blocks = make_target_blocks(self);
                 let terminator = if switch_ty.kind == ty::Bool {
-                    assert!(options.len() > 0 && options.len() <= 2);
+                    assert!(!options.is_empty() && options.len() <= 2);
                     if let [first_bb, second_bb] = *target_blocks {
                         let (true_bb, false_bb) = match options[0] {
                             1 => (first_bb, second_bb),

--- a/src/librustc_parse/lexer/tokentrees.rs
+++ b/src/librustc_parse/lexer/tokentrees.rs
@@ -141,7 +141,7 @@ impl<'a> TokenTreesReader<'a> {
                             self.last_delim_empty_block_spans.insert(delim, empty_block_span);
                         }
 
-                        if self.open_braces.len() == 0 {
+                        if self.open_braces.is_empty() {
                             // Clear up these spans to avoid suggesting them as we've found
                             // properly matched delimiters so far for an entire block.
                             self.matching_delim_spans.clear();

--- a/src/librustc_parse/lib.rs
+++ b/src/librustc_parse/lib.rs
@@ -371,7 +371,7 @@ fn prepend_attrs(
     span: rustc_span::Span,
 ) -> Option<tokenstream::TokenStream> {
     let tokens = tokens?;
-    if attrs.len() == 0 {
+    if attrs.is_empty() {
         return Some(tokens.clone());
     }
     let mut builder = tokenstream::TokenStreamBuilder::new();

--- a/src/librustc_parse/parser/pat.rs
+++ b/src/librustc_parse/parser/pat.rs
@@ -216,7 +216,7 @@ impl<'a> Parser<'a> {
             .span_suggestion(
                 seq_span,
                 "...or a vertical bar to match on multiple alternatives",
-                format!("{}", seq_snippet.replace(",", " |")),
+                seq_snippet.replace(",", " |"),
                 Applicability::MachineApplicable,
             );
         }

--- a/src/librustc_parse/parser/path.rs
+++ b/src/librustc_parse/parser/path.rs
@@ -470,7 +470,7 @@ impl<'a> Parser<'a> {
         // FIXME: we would like to report this in ast_validation instead, but we currently do not
         // preserve ordering of generic parameters with respect to associated type binding, so we
         // lose that information after parsing.
-        if misplaced_assoc_ty_constraints.len() > 0 {
+        if !misplaced_assoc_ty_constraints.is_empty() {
             let mut err = self.struct_span_err(
                 args_lo.to(self.prev_span),
                 "associated type bindings must be declared after generic parameters",

--- a/src/librustc_passes/check_const.rs
+++ b/src/librustc_passes/check_const.rs
@@ -35,7 +35,7 @@ impl NonConstExpr {
         match self {
             Self::Loop(src) => format!("`{}`", src.name()),
             Self::Match(src) => format!("`{}`", src.name()),
-            Self::OrPattern => format!("or-pattern"),
+            Self::OrPattern => "or-pattern".to_string(),
         }
     }
 

--- a/src/librustc_resolve/check_unused.rs
+++ b/src/librustc_resolve/check_unused.rs
@@ -158,7 +158,7 @@ fn calc_unused_spans(
             }
         }
         ast::UseTreeKind::Nested(ref nested) => {
-            if nested.len() == 0 {
+            if nested.is_empty() {
                 return UnusedSpanResult::FlatUnused(use_tree.span, full_span);
             }
 

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -98,7 +98,7 @@ impl<'a> Resolver<'a> {
                     E0401,
                     "can't use generic parameters from outer function",
                 );
-                err.span_label(span, format!("use of generic parameter from outer function"));
+                err.span_label(span, "use of generic parameter from outer function".to_string());
 
                 let sm = self.session.source_map();
                 match outer_res {
@@ -155,7 +155,8 @@ impl<'a> Resolver<'a> {
                     } else if let Some(sp) = sm.generate_fn_name_span(span) {
                         err.span_label(
                             sp,
-                            format!("try adding a local generic parameter in this method instead"),
+                            "try adding a local generic parameter in this method instead"
+                                .to_string(),
                         );
                     } else {
                         err.help("try using a local generic parameter instead");

--- a/src/librustc_resolve/imports.rs
+++ b/src/librustc_resolve/imports.rs
@@ -1478,7 +1478,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
             }
         });
 
-        if reexports.len() > 0 {
+        if !reexports.is_empty() {
             if let Some(def_id) = module.def_id() {
                 self.r.export_map.insert(def_id, reexports);
             }

--- a/src/librustc_resolve/late.rs
+++ b/src/librustc_resolve/late.rs
@@ -1016,7 +1016,7 @@ impl<'a, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
             trait_items
                 .iter()
                 .filter_map(|item| match &item.kind {
-                    AssocItemKind::TyAlias(_, _, bounds, _) if bounds.len() == 0 => {
+                    AssocItemKind::TyAlias(_, _, bounds, _) if bounds.is_empty() => {
                         Some(item.ident)
                     }
                     _ => None,

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -354,7 +354,7 @@ impl<'a> LateResolutionVisitor<'a, '_, '_> {
         let mut has_self_arg = None;
         if let PathSource::Expr(parent) = source {
             match &parent?.kind {
-                ExprKind::Call(_, args) if args.len() > 0 => {
+                ExprKind::Call(_, args) if !args.is_empty() => {
                     let mut expr_kind = &args[0].kind;
                     loop {
                         match expr_kind {
@@ -968,18 +968,14 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
         for missing in &self.missing_named_lifetime_spots {
             match missing {
                 MissingLifetimeSpot::Generics(generics) => {
-                    let (span, sugg) = if let Some(param) = generics
-                        .params
-                        .iter()
-                        .filter(|p| match p.kind {
+                    let (span, sugg) = if let Some(param) =
+                        generics.params.iter().find(|p| match p.kind {
                             hir::GenericParamKind::Type {
                                 synthetic: Some(hir::SyntheticTyParamKind::ImplTrait),
                                 ..
                             } => false,
                             _ => true,
-                        })
-                        .next()
-                    {
+                        }) {
                         (param.span.shrink_to_lo(), format!("{}, ", lifetime_ref))
                     } else {
                         (generics.span, format!("<{}>", lifetime_ref))

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -177,7 +177,7 @@ impl<'a> LateResolutionVisitor<'a, '_, '_> {
             err.code(rustc_errors::error_code!(E0411));
             err.span_label(
                 span,
-                format!("`Self` is only available in impls, traits, and type definitions"),
+                "`Self` is only available in impls, traits, and type definitions".to_string(),
             );
             return (err, Vec::new());
         }
@@ -186,12 +186,10 @@ impl<'a> LateResolutionVisitor<'a, '_, '_> {
 
             err.code(rustc_errors::error_code!(E0424));
             err.span_label(span, match source {
-                PathSource::Pat => format!(
-                    "`self` value is a keyword and may not be bound to variables or shadowed",
-                ),
-                _ => format!(
-                    "`self` value is a keyword only available in methods with a `self` parameter",
-                ),
+                PathSource::Pat => "`self` value is a keyword and may not be bound to variables or shadowed"
+                                   .to_string(),
+                _ => "`self` value is a keyword only available in methods with a `self` parameter"
+                     .to_string(),
             });
             if let Some(span) = &self.diagnostic_metadata.current_function {
                 err.span_label(*span, "this function doesn't have a `self` parameter");
@@ -558,7 +556,7 @@ impl<'a> LateResolutionVisitor<'a, '_, '_> {
                     if is_expected(ctor_def) && !accessible_ctor {
                         err.span_label(
                             span,
-                            format!("constructor is not visible here due to private fields"),
+                            "constructor is not visible here due to private fields".to_string(),
                         );
                     }
                 } else {

--- a/src/librustc_session/config.rs
+++ b/src/librustc_session/config.rs
@@ -1129,7 +1129,7 @@ pub fn parse_error_format(
         // Conservatively require that the `--json` argument is coupled with
         // `--error-format=json`. This means that `--json` is specified we
         // should actually be emitting JSON blobs.
-        _ if matches.opt_strs("json").len() > 0 => {
+        _ if !matches.opt_strs("json").is_empty() => {
             early_error(
                 ErrorOutputType::default(),
                 "using `--json` requires also using `--error-format=json`",

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -1205,7 +1205,7 @@ impl SourceFile {
     /// number. If the source_file is empty or the position is located before the
     /// first line, `None` is returned.
     pub fn lookup_line(&self, pos: BytePos) -> Option<usize> {
-        if self.lines.len() == 0 {
+        if self.lines.is_empty() {
             return None;
         }
 

--- a/src/librustc_traits/dropck_outlives.rs
+++ b/src/librustc_traits/dropck_outlives.rs
@@ -92,7 +92,7 @@ fn dropck_outlives<'tcx>(
                 // information and will just decrease the speed at which we can emit these errors
                 // (since we'll be printing for just that much longer for the often enormous types
                 // that result here).
-                if result.overflows.len() >= 1 {
+                if !result.overflows.is_empty() {
                     break;
                 }
 

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1743,7 +1743,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         potential_assoc_types: Vec<Span>,
         trait_bounds: &[hir::PolyTraitRef<'_>],
     ) {
-        if !associated_types.values().any(|v| v.len() > 0) {
+        if !associated_types.values().any(|v| !v.is_empty()) {
             return;
         }
         let tcx = self.tcx();

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -529,7 +529,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 .lookup_op_method(fn_sig.output(), &[other_ty], Op::Binary(op, is_assign))
                 .is_ok()
             {
-                let (variable_snippet, applicability) = if fn_sig.inputs().len() > 0 {
+                let (variable_snippet, applicability) = if !fn_sig.inputs().is_empty() {
                     (
                         format!("{}( /* arguments */ )", source_map.span_to_snippet(span).unwrap()),
                         Applicability::HasPlaceholders,

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -605,7 +605,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 if lstring.starts_with('&') {
                                     // let a = String::new();
                                     // let _ = &a + "bar";
-                                    format!("{}", &lstring[1..])
+                                    lstring[1..].to_string()
                                 } else {
                                     format!("{}.to_owned()", lstring)
                                 },
@@ -633,7 +633,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         let to_string = if l.starts_with('&') {
                             // let a = String::new(); let b = String::new();
                             // let _ = &a + b;
-                            format!("{}", &l[1..])
+                            l[1..].to_string()
                         } else {
                             format!("{}.to_owned()", l)
                         };

--- a/src/librustc_typeck/check/pat.rs
+++ b/src/librustc_typeck/check/pat.rs
@@ -339,7 +339,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             });
         }
 
-        if pat_adjustments.len() > 0 {
+        if !pat_adjustments.is_empty() {
             debug!("default binding mode is now {:?}", def_bm);
             self.inh.tables.borrow_mut().pat_adjustments_mut().insert(pat.hir_id, pat_adjustments);
         }
@@ -987,7 +987,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             .filter(|ident| !used_fields.contains_key(&ident))
             .collect::<Vec<_>>();
 
-        if inexistent_fields.len() > 0 && !variant.recovered {
+        if !inexistent_fields.is_empty() && !variant.recovered {
             self.error_inexistent_fields(
                 kind_name,
                 &inexistent_fields,
@@ -1018,7 +1018,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             if etc {
                 tcx.sess.struct_span_err(span, "`..` cannot be used in union patterns").emit();
             }
-        } else if !etc && unmentioned_fields.len() > 0 {
+        } else if !etc && !unmentioned_fields.is_empty() {
             self.error_unmentioned_fields(span, &unmentioned_fields, variant);
         }
         no_field_errors

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -160,7 +160,7 @@ crate fn placeholder_type_error(
     }) {
         // Account for `_` already present in cases like `struct S<_>(_);` and suggest
         // `struct S<T>(T);` instead of `struct S<_, T>(T);`.
-        sugg.push((arg.span, format!("{}", type_name)));
+        sugg.push((arg.span, type_name.to_string()));
     } else {
         sugg.push((
             generics.iter().last().unwrap().span.shrink_to_hi(),
@@ -475,7 +475,7 @@ fn get_new_lifetime_name<'tcx>(
 
     let a_to_z_repeat_n = |n| {
         (b'a'..=b'z').map(move |c| {
-            let mut s = format!("'");
+            let mut s = '\''.to_string();
             s.extend(std::iter::repeat(char::from(c)).take(n));
             s
         })

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2481,7 +2481,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
     // purpose functions as they wouldn't have the right target features
     // enabled. For that reason we also forbid #[inline(always)] as it can't be
     // respected.
-    if codegen_fn_attrs.target_features.len() > 0 {
+    if !codegen_fn_attrs.target_features.is_empty() {
         if codegen_fn_attrs.inline == InlineAttr::Always {
             if let Some(span) = inline_span {
                 tcx.sess.span_err(

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -398,7 +398,7 @@ impl Clean<Lifetime> for hir::GenericParam<'_> {
     fn clean(&self, _: &DocContext<'_>) -> Lifetime {
         match self.kind {
             hir::GenericParamKind::Lifetime { .. } => {
-                if self.bounds.len() > 0 {
+                if !self.bounds.is_empty() {
                     let mut bounds = self.bounds.iter().map(|bound| match bound {
                         hir::GenericBound::Outlives(lt) => lt,
                         _ => panic!(),
@@ -607,7 +607,7 @@ impl Clean<GenericParamDef> for hir::GenericParam<'_> {
     fn clean(&self, cx: &DocContext<'_>) -> GenericParamDef {
         let (name, kind) = match self.kind {
             hir::GenericParamKind::Lifetime { .. } => {
-                let name = if self.bounds.len() > 0 {
+                let name = if !self.bounds.is_empty() {
                     let mut bounds = self.bounds.iter().map(|bound| match bound {
                         hir::GenericBound::Outlives(lt) => lt,
                         _ => panic!(),

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -201,7 +201,7 @@ impl Item {
                 classes.push("deprecated");
             }
 
-            if classes.len() != 0 { Some(classes.join(" ")) } else { None }
+            if !classes.is_empty() { Some(classes.join(" ")) } else { None }
         })
     }
 

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2783,7 +2783,7 @@ fn assoc_type(
 
 fn render_stability_since_raw(w: &mut Buffer, ver: Option<&str>, containing_ver: Option<&str>) {
     if let Some(v) = ver {
-        if containing_ver != ver && v.len() > 0 {
+        if containing_ver != ver && !v.is_empty() {
             write!(w, "<span class='since' title='Stable since Rust version {0}'>{0}</span>", v)
         }
     }
@@ -3143,7 +3143,7 @@ fn render_attribute(attr: &ast::MetaItem) -> Option<String> {
             .filter_map(|attr| attr.meta_item().and_then(|mi| render_attribute(mi)))
             .collect();
 
-        if display.len() > 0 { Some(format!("{}({})", path, display.join(", "))) } else { None }
+        if !display.is_empty() { Some(format!("{}({})", path, display.join(", "))) } else { None }
     } else {
         None
     }
@@ -3178,7 +3178,7 @@ fn render_attributes(w: &mut Buffer, it: &clean::Item, top: bool) {
             attrs.push_str(&format!("#[{}]\n", s));
         }
     }
-    if attrs.len() > 0 {
+    if !attrs.is_empty() {
         write!(
             w,
             "<span class=\"docblock attributes{}\">{}</span>",

--- a/src/librustdoc/theme.rs
+++ b/src/librustdoc/theme.rs
@@ -191,7 +191,7 @@ fn build_rule(v: &[u8], positions: &[usize]) -> String {
             .replace("{", "")
             .replace("}", "")
             .split(' ')
-            .filter(|s| s.len() > 0)
+            .filter(|s| !s.is_empty())
             .collect::<Vec<&str>>()
             .join(" "),
     )

--- a/src/libstd/backtrace.rs
+++ b/src/libstd/backtrace.rs
@@ -304,7 +304,7 @@ impl Backtrace {
         // If no frames came out assume that this is an unsupported platform
         // since `backtrace` doesn't provide a way of learning this right now,
         // and this should be a good enough approximation.
-        let inner = if frames.len() == 0 {
+        let inner = if frames.is_empty() {
             Inner::Unsupported
         } else {
             Inner::Captured(Mutex::new(Capture {

--- a/src/libstd/keyword_docs.rs
+++ b/src/libstd/keyword_docs.rs
@@ -895,6 +895,15 @@ mod mod_keyword {}
 /// // x is no longer available
 /// ```
 ///
+/// `move` is also valid before an async block.
+///
+/// ```rust
+/// let capture = "hello";
+/// let block = async move {
+///     println!("rust says {} from async block", capture);
+/// };
+/// ```
+///
 /// For more information on the `move` keyword, see the [closure]'s section
 /// of the Rust book or the [threads] section
 ///

--- a/src/libtest/formatters/json.rs
+++ b/src/libtest/formatters/json.rs
@@ -80,7 +80,7 @@ impl<T: Write> OutputFormatter for JsonFormatter<T> {
         state: &ConsoleTestState,
     ) -> io::Result<()> {
         let display_stdout = state.options.display_output || *result != TestResult::TrOk;
-        let stdout = if display_stdout && stdout.len() > 0 {
+        let stdout = if display_stdout && !stdout.is_empty() {
             Some(String::from_utf8_lossy(stdout))
         } else {
             None


### PR DESCRIPTION
Successful merges:

 - #69477 (docs: add mention of async blocks in move keyword docs)
 - #69504 (Use assert_ne in hash tests)
 - #69546 (use to_vec() instead of .iter().cloned().collect() to convert slices to vecs.)
 - #69551 (use is_empty() instead of len() == x  to determine if structs are empty.)
 - #69563 (Fix no_std detection for target triples)
 - #69567 (use .to_string() instead of format!() macro to create strings)

Failed merges:


r? @ghost