### PR TITLE
nightly: bootstrap from 1.42.0-beta.5 (4e1c5f0e9 2020-02-28)

### DIFF
--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,7 +12,7 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.x.0` for Cargo where they were released on `date`.
 
-date: 2020-01-30
+date: 2020-02-29
 rustc: beta
 cargo: beta
 


### PR DESCRIPTION
This beta snapshot has the llvm miscompilation fix included and is bootstrapped from a stable version that also has it included.