### PR TITLE
parser: Remove `Parser::prev_span`

### DIFF
--- a/src/librustc_builtin_macros/asm.rs
+++ b/src/librustc_builtin_macros/asm.rs
@@ -151,7 +151,7 @@ fn parse_inline_asm<'a>(
 
                     let constraint = parse_asm_str(&mut p)?;
 
-                    let span = p.prev_span;
+                    let span = p.prev_token.span;
 
                     p.expect(&token::OpenDelim(token::Paren))?;
                     let expr = p.parse_expr()?;
@@ -202,7 +202,7 @@ fn parse_inline_asm<'a>(
                     if constraint.as_str().starts_with('=') {
                         struct_span_err!(
                             cx.parse_sess.span_diagnostic,
-                            p.prev_span,
+                            p.prev_token.span,
                             E0662,
                             "input operand constraint contains '='"
                         )
@@ -210,7 +210,7 @@ fn parse_inline_asm<'a>(
                     } else if constraint.as_str().starts_with('+') {
                         struct_span_err!(
                             cx.parse_sess.span_diagnostic,
-                            p.prev_span,
+                            p.prev_token.span,
                             E0663,
                             "input operand constraint contains '+'"
                         )
@@ -233,11 +233,11 @@ fn parse_inline_asm<'a>(
                     let s = parse_asm_str(&mut p)?;
 
                     if OPTIONS.iter().any(|&opt| s == opt) {
-                        cx.span_warn(p.prev_span, "expected a clobber, found an option");
+                        cx.span_warn(p.prev_token.span, "expected a clobber, found an option");
                     } else if s.as_str().starts_with('{') || s.as_str().ends_with('}') {
                         struct_span_err!(
                             cx.parse_sess.span_diagnostic,
-                            p.prev_span,
+                            p.prev_token.span,
                             E0664,
                             "clobber should not be surrounded by braces"
                         )
@@ -259,7 +259,7 @@ fn parse_inline_asm<'a>(
                 } else if option == sym::intel {
                     dialect = AsmDialect::Intel;
                 } else {
-                    cx.span_warn(p.prev_span, "unrecognized option");
+                    cx.span_warn(p.prev_token.span, "unrecognized option");
                 }
 
                 if p.token == token::Comma {

--- a/src/librustc_builtin_macros/assert.rs
+++ b/src/librustc_builtin_macros/assert.rs
@@ -106,7 +106,7 @@ fn parse_assert<'a>(
     let custom_message =
         if let token::Literal(token::Lit { kind: token::Str, .. }) = parser.token.kind {
             let mut err = cx.struct_span_warn(parser.token.span, "unexpected string literal");
-            let comma_span = parser.prev_span.shrink_to_hi();
+            let comma_span = parser.prev_token.span.shrink_to_hi();
             err.span_suggestion_short(
                 comma_span,
                 "try adding a comma",

--- a/src/librustc_parse/parser/attr.rs
+++ b/src/librustc_parse/parser/attr.rs
@@ -116,7 +116,7 @@ impl<'a> Parser<'a> {
                 self.expect(&token::OpenDelim(token::Bracket))?;
                 let item = self.parse_attr_item()?;
                 self.expect(&token::CloseDelim(token::Bracket))?;
-                let hi = self.prev_span;
+                let hi = self.prev_token.span;
 
                 let attr_sp = lo.to(hi);
 
@@ -255,7 +255,7 @@ impl<'a> Parser<'a> {
         while self.token.kind != token::Eof {
             let lo = self.token.span;
             let item = self.parse_attr_item()?;
-            expanded_attrs.push((item, lo.to(self.prev_span)));
+            expanded_attrs.push((item, lo.to(self.prev_token.span)));
             if !self.eat(&token::Comma) {
                 break;
             }
@@ -303,7 +303,7 @@ impl<'a> Parser<'a> {
         let lo = self.token.span;
         let path = self.parse_path(PathStyle::Mod)?;
         let kind = self.parse_meta_item_kind()?;
-        let span = lo.to(self.prev_span);
+        let span = lo.to(self.prev_token.span);
         Ok(ast::MetaItem { path, kind, span })
     }
 

--- a/src/librustc_parse/parser/diagnostics.rs
+++ b/src/librustc_parse/parser/diagnostics.rs
@@ -260,24 +260,24 @@ impl<'a> Parser<'a> {
             };
             (
                 format!("expected one of {}, found {}", expect, actual),
-                (self.prev_span.shrink_to_hi(), format!("expected one of {}", short_expect)),
+                (self.prev_token.span.shrink_to_hi(), format!("expected one of {}", short_expect)),
             )
         } else if expected.is_empty() {
             (
                 format!("unexpected token: {}", actual),
-                (self.prev_span, "unexpected token after this".to_string()),
+                (self.prev_token.span, "unexpected token after this".to_string()),
             )
         } else {
             (
                 format!("expected {}, found {}", expect, actual),
-                (self.prev_span.shrink_to_hi(), format!("expected {}", expect)),
+                (self.prev_token.span.shrink_to_hi(), format!("expected {}", expect)),
             )
         };
         self.last_unexpected_token_span = Some(self.token.span);
         let mut err = self.struct_span_err(self.token.span, &msg_exp);
         let sp = if self.token == token::Eof {
             // This is EOF; don't want to point at the following char, but rather the last token.
-            self.prev_span
+            self.prev_token.span
         } else {
             label_sp
         };
@@ -298,7 +298,7 @@ impl<'a> Parser<'a> {
         }
 
         let sm = self.sess.source_map();
-        if self.prev_span == DUMMY_SP {
+        if self.prev_token.span == DUMMY_SP {
             // Account for macro context where the previous span might not be
             // available to avoid incorrect output (#54841).
             err.span_label(self.token.span, label_exp);
@@ -577,7 +577,7 @@ impl<'a> Parser<'a> {
         match inner_op.kind {
             ExprKind::Binary(op, _, _) if op.node.is_comparison() => {
                 // Respan to include both operators.
-                let op_span = op.span.to(self.prev_span);
+                let op_span = op.span.to(self.prev_token.span);
                 let mut err =
                     self.struct_span_err(op_span, "comparison operators cannot be chained");
 
@@ -632,7 +632,7 @@ impl<'a> Parser<'a> {
                                 // FIXME: actually check that the two expressions in the binop are
                                 // paths and resynthesize new fn call expression instead of using
                                 // `ExprKind::Err` placeholder.
-                                mk_err_expr(self, inner_op.span.to(self.prev_span))
+                                mk_err_expr(self, inner_op.span.to(self.prev_token.span))
                             }
                             Err(mut expr_err) => {
                                 expr_err.cancel();
@@ -654,7 +654,7 @@ impl<'a> Parser<'a> {
                                 // FIXME: actually check that the two expressions in the binop are
                                 // paths and resynthesize new fn call expression instead of using
                                 // `ExprKind::Err` placeholder.
-                                mk_err_expr(self, inner_op.span.to(self.prev_span))
+                                mk_err_expr(self, inner_op.span.to(self.prev_token.span))
                             }
                         }
                     } else {
@@ -723,7 +723,7 @@ impl<'a> Parser<'a> {
 
         self.bump(); // `+`
         let bounds = self.parse_generic_bounds(None)?;
-        let sum_span = ty.span.to(self.prev_span);
+        let sum_span = ty.span.to(self.prev_token.span);
 
         let mut err = struct_span_err!(
             self.sess.span_diagnostic,
@@ -790,7 +790,7 @@ impl<'a> Parser<'a> {
 
         let mut path = ast::Path { segments: Vec::new(), span: DUMMY_SP };
         self.parse_path_segments(&mut path.segments, T::PATH_STYLE)?;
-        path.span = ty_span.to(self.prev_span);
+        path.span = ty_span.to(self.prev_token.span);
 
         let ty_str = self.span_to_snippet(ty_span).unwrap_or_else(|_| pprust::ty_to_string(&ty));
         self.struct_span_err(path.span, "missing angle brackets in associated item path")
@@ -809,9 +809,9 @@ impl<'a> Parser<'a> {
 
     pub(super) fn maybe_consume_incorrect_semicolon(&mut self, items: &[P<Item>]) -> bool {
         if self.eat(&token::Semi) {
-            let mut err = self.struct_span_err(self.prev_span, "expected item, found `;`");
+            let mut err = self.struct_span_err(self.prev_token.span, "expected item, found `;`");
             err.span_suggestion_short(
-                self.prev_span,
+                self.prev_token.span,
                 "remove this semicolon",
                 String::new(),
                 Applicability::MachineApplicable,
@@ -854,10 +854,10 @@ impl<'a> Parser<'a> {
             }
             // We don't want to point at the following span after DUMMY_SP.
             // This happens when the parser finds an empty TokenStream.
-            _ if self.prev_span == DUMMY_SP => (self.token.span, self.token.span),
+            _ if self.prev_token.span == DUMMY_SP => (self.token.span, self.token.span),
             // EOF, don't want to point at the following char, but rather the last token.
-            (token::Eof, None) => (self.prev_span, self.token.span),
-            _ => (self.prev_span.shrink_to_hi(), self.token.span),
+            (token::Eof, None) => (self.prev_token.span, self.token.span),
+            _ => (self.prev_token.span.shrink_to_hi(), self.token.span),
         };
         let msg = format!(
             "expected `{}`, found {}",
@@ -894,10 +894,10 @@ impl<'a> Parser<'a> {
         let sm = self.sess.source_map();
         let msg = format!("expected `;`, found `{}`", super::token_descr(&self.token));
         let appl = Applicability::MachineApplicable;
-        if self.token.span == DUMMY_SP || self.prev_span == DUMMY_SP {
+        if self.token.span == DUMMY_SP || self.prev_token.span == DUMMY_SP {
             // Likely inside a macro, can't provide meaninful suggestions.
             return self.expect(&token::Semi).map(drop);
-        } else if !sm.is_multiline(self.prev_span.until(self.token.span)) {
+        } else if !sm.is_multiline(self.prev_token.span.until(self.token.span)) {
             // The current token is in the same line as the prior token, not recoverable.
         } else if self.look_ahead(1, |t| {
             t == &token::CloseDelim(token::Brace) || t.can_begin_expr() && t.kind != token::Colon
@@ -910,7 +910,7 @@ impl<'a> Parser<'a> {
             //   let x = 32:
             //   let y = 42;
             self.bump();
-            let sp = self.prev_span;
+            let sp = self.prev_token.span;
             self.struct_span_err(sp, &msg)
                 .span_suggestion(sp, "change this to `;`", ";".to_string(), appl)
                 .emit();
@@ -927,7 +927,7 @@ impl<'a> Parser<'a> {
             //
             //   let x = 32
             //   let y = 42;
-            let sp = self.prev_span.shrink_to_hi();
+            let sp = self.prev_token.span.shrink_to_hi();
             self.struct_span_err(sp, &msg)
                 .span_label(self.token.span, "unexpected token")
                 .span_suggestion_short(sp, "add `;` here", ";".to_string(), appl)
@@ -961,7 +961,7 @@ impl<'a> Parser<'a> {
         self.expect(&token::OpenDelim(token::Paren))?;
         let expr = self.parse_expr()?;
         self.expect(&token::CloseDelim(token::Paren))?;
-        Ok((self.prev_span, expr, false))
+        Ok((self.prev_token.span, expr, false))
     }
 
     fn recover_await_prefix(&mut self, await_sp: Span) -> PResult<'a, (Span, P<Expr>, bool)> {
@@ -1036,10 +1036,10 @@ impl<'a> Parser<'a> {
                     .span_to_snippet(pat.span.trim_start(begin_par_sp).unwrap())
                     .unwrap_or_else(|_| pprust::pat_to_string(&pat));
 
-                self.struct_span_err(self.prev_span, "unexpected closing `)`")
+                self.struct_span_err(self.prev_token.span, "unexpected closing `)`")
                     .span_label(begin_par_sp, "opening `(`")
                     .span_suggestion(
-                        begin_par_sp.to(self.prev_span),
+                        begin_par_sp.to(self.prev_token.span),
                         "remove parenthesis in `for` loop",
                         format!("{} in {}", pat_str, pprust::expr_to_string(&expr)),
                         // With e.g. `for (x) in y)` this would replace `(x) in y)`
@@ -1091,7 +1091,7 @@ impl<'a> Parser<'a> {
                 err.emit();
                 // Recover from parse error, callers expect the closing delim to be consumed.
                 self.consume_block(delim, ConsumeClosingDelim::Yes);
-                self.mk_expr(lo.to(self.prev_span), ExprKind::Err, AttrVec::new())
+                self.mk_expr(lo.to(self.prev_token.span), ExprKind::Err, AttrVec::new())
             }
         }
     }
@@ -1138,7 +1138,7 @@ impl<'a> Parser<'a> {
                     err.span_label(sp, "unclosed delimiter");
                 }
                 err.span_suggestion_short(
-                    self.prev_span.shrink_to_hi(),
+                    self.prev_token.span.shrink_to_hi(),
                     &format!("{} may belong here", delim.to_string()),
                     delim.to_string(),
                     Applicability::MaybeIncorrect,
@@ -1246,9 +1246,9 @@ impl<'a> Parser<'a> {
     pub(super) fn check_for_for_in_in_typo(&mut self, in_span: Span) {
         if self.eat_keyword(kw::In) {
             // a common typo: `for _ in in bar {}`
-            self.struct_span_err(self.prev_span, "expected iterable, found keyword `in`")
+            self.struct_span_err(self.prev_token.span, "expected iterable, found keyword `in`")
                 .span_suggestion_short(
-                    in_span.until(self.prev_span),
+                    in_span.until(self.prev_token.span),
                     "remove the duplicated `in`",
                     String::new(),
                     Applicability::MachineApplicable,

--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -1348,7 +1348,7 @@ impl<'a> Parser<'a> {
             if self.normalized_token.span.rust_2018() { self.parse_asyncness() } else { Async::No };
         if asyncness.is_async() {
             // Feature-gate `async ||` closures.
-            self.sess.gated_spans.gate(sym::async_closure, self.prev_span);
+            self.sess.gated_spans.gate(sym::async_closure, self.normalized_prev_token.span);
         }
 
         let capture_clause = self.parse_capture_clause();

--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -166,7 +166,7 @@ impl<'a> Parser<'a> {
             // Adjust the span for interpolated LHS to point to the `$lhs` token
             // and not to what it refers to.
             let lhs_span = match self.prev_token.kind {
-                TokenKind::Interpolated(..) => self.prev_span,
+                TokenKind::Interpolated(..) => self.prev_token.span,
                 _ => lhs.span,
             };
 
@@ -523,7 +523,7 @@ impl<'a> Parser<'a> {
         expr.map(|e| {
             (
                 match self.prev_token.kind {
-                    TokenKind::Interpolated(..) => self.prev_span,
+                    TokenKind::Interpolated(..) => self.prev_token.span,
                     _ => e.span,
                 },
                 e,
@@ -614,7 +614,7 @@ impl<'a> Parser<'a> {
 
     fn parse_assoc_op_ascribe(&mut self, lhs: P<Expr>, lhs_span: Span) -> PResult<'a, P<Expr>> {
         let maybe_path = self.could_ascription_be_path(&lhs.kind);
-        self.last_type_ascription = Some((self.prev_span, maybe_path));
+        self.last_type_ascription = Some((self.prev_token.span, maybe_path));
         let lhs = self.parse_assoc_op_cast(lhs, lhs_span, ExprKind::Type)?;
         self.sess.gated_spans.gate(sym::type_ascription, lhs.span);
         Ok(lhs)
@@ -636,7 +636,7 @@ impl<'a> Parser<'a> {
             let found_raw = self.eat_keyword(kw::Raw);
             assert!(found_raw);
             let mutability = self.parse_const_or_mut().unwrap();
-            self.sess.gated_spans.gate(sym::raw_ref_op, lo.to(self.prev_span));
+            self.sess.gated_spans.gate(sym::raw_ref_op, lo.to(self.prev_token.span));
             (ast::BorrowKind::Raw, mutability)
         } else {
             // `mut?`
@@ -683,7 +683,7 @@ impl<'a> Parser<'a> {
         loop {
             if self.eat(&token::Question) {
                 // `expr?`
-                e = self.mk_expr(lo.to(self.prev_span), ExprKind::Try(e), AttrVec::new());
+                e = self.mk_expr(lo.to(self.prev_token.span), ExprKind::Try(e), AttrVec::new());
                 continue;
             }
             if self.eat(&token::Dot) {
@@ -735,8 +735,8 @@ impl<'a> Parser<'a> {
         let fstr = sym.as_str();
         let msg = format!("unexpected token: `{}`", sym);
 
-        let mut err = self.struct_span_err(self.prev_span, &msg);
-        err.span_label(self.prev_span, "unexpected token");
+        let mut err = self.struct_span_err(self.prev_token.span, &msg);
+        err.span_label(self.prev_token.span, "unexpected token");
 
         if fstr.chars().all(|x| "0123456789.".contains(x)) {
             let float = match fstr.parse::<f64>() {
@@ -756,7 +756,7 @@ impl<'a> Parser<'a> {
                 s.s.word(fstr.splitn(2, '.').last().unwrap().to_string())
             });
             err.span_suggestion(
-                lo.to(self.prev_span),
+                lo.to(self.prev_token.span),
                 "try parenthesizing the first index",
                 sugg,
                 Applicability::MachineApplicable,
@@ -782,7 +782,7 @@ impl<'a> Parser<'a> {
     /// Parse a function call expression, `expr(...)`.
     fn parse_fn_call_expr(&mut self, lo: Span, fun: P<Expr>) -> P<Expr> {
         let seq = self.parse_paren_expr_seq().map(|args| {
-            self.mk_expr(lo.to(self.prev_span), self.mk_call(fun, args), AttrVec::new())
+            self.mk_expr(lo.to(self.prev_token.span), self.mk_call(fun, args), AttrVec::new())
         });
         self.recover_seq_parse_error(token::Paren, lo, seq)
     }
@@ -792,7 +792,7 @@ impl<'a> Parser<'a> {
         self.bump(); // `[`
         let index = self.parse_expr()?;
         self.expect(&token::CloseDelim(token::Bracket))?;
-        Ok(self.mk_expr(lo.to(self.prev_span), self.mk_index(base, index), AttrVec::new()))
+        Ok(self.mk_expr(lo.to(self.prev_token.span), self.mk_index(base, index), AttrVec::new()))
     }
 
     /// Assuming we have just parsed `.`, continue parsing into an expression.
@@ -809,7 +809,7 @@ impl<'a> Parser<'a> {
             let mut args = self.parse_paren_expr_seq()?;
             args.insert(0, self_arg);
 
-            let span = lo.to(self.prev_span);
+            let span = lo.to(self.prev_token.span);
             Ok(self.mk_expr(span, ExprKind::MethodCall(segment, args), AttrVec::new()))
         } else {
             // Field access `expr.f`
@@ -821,7 +821,7 @@ impl<'a> Parser<'a> {
                 .emit();
             }
 
-            let span = lo.to(self.prev_span);
+            let span = lo.to(self.prev_token.span);
             Ok(self.mk_expr(span, ExprKind::Field(self_arg, segment.ident), AttrVec::new()))
         }
     }
@@ -867,18 +867,18 @@ impl<'a> Parser<'a> {
         } else if self.eat_keyword(kw::If) {
             self.parse_if_expr(attrs)
         } else if self.eat_keyword(kw::For) {
-            self.parse_for_expr(None, self.prev_span, attrs)
+            self.parse_for_expr(None, self.prev_token.span, attrs)
         } else if self.eat_keyword(kw::While) {
-            self.parse_while_expr(None, self.prev_span, attrs)
+            self.parse_while_expr(None, self.prev_token.span, attrs)
         } else if let Some(label) = self.eat_label() {
             self.parse_labeled_expr(label, attrs)
         } else if self.eat_keyword(kw::Loop) {
-            self.parse_loop_expr(None, self.prev_span, attrs)
+            self.parse_loop_expr(None, self.prev_token.span, attrs)
         } else if self.eat_keyword(kw::Continue) {
             let kind = ExprKind::Continue(self.eat_label());
-            Ok(self.mk_expr(lo.to(self.prev_span), kind, attrs))
+            Ok(self.mk_expr(lo.to(self.prev_token.span), kind, attrs))
         } else if self.eat_keyword(kw::Match) {
-            let match_sp = self.prev_span;
+            let match_sp = self.prev_token.span;
             self.parse_match_expr(attrs).map_err(|mut err| {
                 err.span_label(match_sp, "while parsing this match expression");
                 err
@@ -921,7 +921,7 @@ impl<'a> Parser<'a> {
                     self.parse_closure_expr(attrs)
                 }
             } else if self.eat_keyword(kw::Await) {
-                self.recover_incorrect_await_syntax(lo, self.prev_span, attrs)
+                self.recover_incorrect_await_syntax(lo, self.prev_token.span, attrs)
             } else {
                 self.parse_lit_expr(attrs)
             }
@@ -934,7 +934,7 @@ impl<'a> Parser<'a> {
         let lo = self.token.span;
         match self.parse_opt_lit() {
             Some(literal) => {
-                let expr = self.mk_expr(lo.to(self.prev_span), ExprKind::Lit(literal), attrs);
+                let expr = self.mk_expr(lo.to(self.prev_token.span), ExprKind::Lit(literal), attrs);
                 self.maybe_recover_from_bad_qpath(expr, true)
             }
             None => return Err(self.expected_expression_found()),
@@ -960,7 +960,7 @@ impl<'a> Parser<'a> {
             // `(e,)` is a tuple with only one field, `e`.
             ExprKind::Tup(es)
         };
-        let expr = self.mk_expr(lo.to(self.prev_span), kind, attrs);
+        let expr = self.mk_expr(lo.to(self.prev_token.span), kind, attrs);
         self.maybe_recover_from_bad_qpath(expr, true)
     }
 
@@ -995,7 +995,7 @@ impl<'a> Parser<'a> {
                 ExprKind::Array(vec![first_expr])
             }
         };
-        let expr = self.mk_expr(lo.to(self.prev_span), kind, attrs);
+        let expr = self.mk_expr(lo.to(self.prev_token.span), kind, attrs);
         self.maybe_recover_from_bad_qpath(expr, true)
     }
 
@@ -1011,7 +1011,7 @@ impl<'a> Parser<'a> {
                 args: self.parse_mac_args()?,
                 prior_type_ascription: self.last_type_ascription,
             };
-            (self.prev_span, ExprKind::Mac(mac))
+            (self.prev_token.span, ExprKind::Mac(mac))
         } else if self.check(&token::OpenDelim(token::Brace)) {
             if let Some(expr) = self.maybe_parse_struct_expr(lo, &path, &attrs) {
                 return expr;
@@ -1055,7 +1055,7 @@ impl<'a> Parser<'a> {
         self.bump(); // `do`
         self.bump(); // `catch`
 
-        let span_dc = lo.to(self.prev_span);
+        let span_dc = lo.to(self.prev_token.span);
         self.struct_span_err(span_dc, "found removed `do catch` syntax")
             .span_suggestion(
                 span_dc,
@@ -1076,15 +1076,15 @@ impl<'a> Parser<'a> {
 
     /// Parse `"return" expr?`.
     fn parse_return_expr(&mut self, attrs: AttrVec) -> PResult<'a, P<Expr>> {
-        let lo = self.prev_span;
+        let lo = self.prev_token.span;
         let kind = ExprKind::Ret(self.parse_expr_opt()?);
-        let expr = self.mk_expr(lo.to(self.prev_span), kind, attrs);
+        let expr = self.mk_expr(lo.to(self.prev_token.span), kind, attrs);
         self.maybe_recover_from_bad_qpath(expr, true)
     }
 
     /// Parse `"('label ":")? break expr?`.
     fn parse_break_expr(&mut self, attrs: AttrVec) -> PResult<'a, P<Expr>> {
-        let lo = self.prev_span;
+        let lo = self.prev_token.span;
         let label = self.eat_label();
         let kind = if self.token != token::OpenDelim(token::Brace)
             || !self.restrictions.contains(Restrictions::NO_STRUCT_LITERAL)
@@ -1093,15 +1093,15 @@ impl<'a> Parser<'a> {
         } else {
             None
         };
-        let expr = self.mk_expr(lo.to(self.prev_span), ExprKind::Break(label, kind), attrs);
+        let expr = self.mk_expr(lo.to(self.prev_token.span), ExprKind::Break(label, kind), attrs);
         self.maybe_recover_from_bad_qpath(expr, true)
     }
 
     /// Parse `"yield" expr?`.
     fn parse_yield_expr(&mut self, attrs: AttrVec) -> PResult<'a, P<Expr>> {
-        let lo = self.prev_span;
+        let lo = self.prev_token.span;
         let kind = ExprKind::Yield(self.parse_expr_opt()?);
-        let span = lo.to(self.prev_span);
+        let span = lo.to(self.prev_token.span);
         self.sess.gated_spans.gate(sym::generators, span);
         let expr = self.mk_expr(span, kind, attrs);
         self.maybe_recover_from_bad_qpath(expr, true)
@@ -1306,7 +1306,11 @@ impl<'a> Parser<'a> {
         let expr = self.mk_expr(lit.span, ExprKind::Lit(lit), AttrVec::new());
 
         if minus_present {
-            Ok(self.mk_expr(lo.to(self.prev_span), self.mk_unary(UnOp::Neg, expr), AttrVec::new()))
+            Ok(self.mk_expr(
+                lo.to(self.prev_token.span),
+                self.mk_unary(UnOp::Neg, expr),
+                AttrVec::new(),
+            ))
         } else {
             Ok(expr)
         }
@@ -1349,7 +1353,7 @@ impl<'a> Parser<'a> {
 
         let capture_clause = self.parse_capture_clause();
         let decl = self.parse_fn_block_decl()?;
-        let decl_hi = self.prev_span;
+        let decl_hi = self.prev_token.span;
         let body = match decl.output {
             FnRetTy::Default(_) => {
                 let restrictions = self.restrictions - Restrictions::STMT_EXPR;
@@ -1404,7 +1408,7 @@ impl<'a> Parser<'a> {
         let ty = if self.eat(&token::Colon) {
             self.parse_ty()?
         } else {
-            self.mk_ty(self.prev_span, TyKind::Infer)
+            self.mk_ty(self.prev_token.span, TyKind::Infer)
         };
         Ok(Param {
             attrs: attrs.into(),
@@ -1418,7 +1422,7 @@ impl<'a> Parser<'a> {
 
     /// Parses an `if` expression (`if` token already eaten).
     fn parse_if_expr(&mut self, attrs: AttrVec) -> PResult<'a, P<Expr>> {
-        let lo = self.prev_span;
+        let lo = self.prev_token.span;
         let cond = self.parse_cond_expr()?;
 
         // Verify that the parsed `if` condition makes sense as a condition. If it is a block, then
@@ -1437,7 +1441,7 @@ impl<'a> Parser<'a> {
             })?
         };
         let els = if self.eat_keyword(kw::Else) { Some(self.parse_else_expr()?) } else { None };
-        Ok(self.mk_expr(lo.to(self.prev_span), ExprKind::If(cond, thn, els), attrs))
+        Ok(self.mk_expr(lo.to(self.prev_token.span), ExprKind::If(cond, thn, els), attrs))
     }
 
     fn error_missing_if_cond(&self, lo: Span, span: Span) -> P<ast::Block> {
@@ -1463,7 +1467,7 @@ impl<'a> Parser<'a> {
     /// Parses a `let $pat = $expr` pseudo-expression.
     /// The `let` token has already been eaten.
     fn parse_let_expr(&mut self, attrs: AttrVec) -> PResult<'a, P<Expr>> {
-        let lo = self.prev_span;
+        let lo = self.prev_token.span;
         let pat = self.parse_top_pat(GateOr::No)?;
         self.expect(&token::Eq)?;
         let expr = self.with_res(Restrictions::NO_STRUCT_LITERAL, |this| {
@@ -1503,7 +1507,7 @@ impl<'a> Parser<'a> {
         if !self.eat_keyword(kw::In) {
             self.error_missing_in_for_loop();
         }
-        self.check_for_for_in_in_typo(self.prev_span);
+        self.check_for_for_in_in_typo(self.prev_token.span);
         let expr = self.parse_expr_res(Restrictions::NO_STRUCT_LITERAL, None)?;
 
         let pat = self.recover_parens_around_for_head(pat, &expr, begin_paren);
@@ -1512,11 +1516,11 @@ impl<'a> Parser<'a> {
         attrs.extend(iattrs);
 
         let kind = ExprKind::ForLoop(pat, expr, loop_block, opt_label);
-        Ok(self.mk_expr(lo.to(self.prev_span), kind, attrs))
+        Ok(self.mk_expr(lo.to(self.prev_token.span), kind, attrs))
     }
 
     fn error_missing_in_for_loop(&self) {
-        let in_span = self.prev_span.between(self.token.span);
+        let in_span = self.prev_token.span.between(self.token.span);
         self.struct_span_err(in_span, "missing `in` in `for` loop")
             .span_suggestion_short(
                 in_span,
@@ -1538,7 +1542,7 @@ impl<'a> Parser<'a> {
         let cond = self.parse_cond_expr()?;
         let (iattrs, body) = self.parse_inner_attrs_and_block()?;
         attrs.extend(iattrs);
-        Ok(self.mk_expr(lo.to(self.prev_span), ExprKind::While(cond, body, opt_label), attrs))
+        Ok(self.mk_expr(lo.to(self.prev_token.span), ExprKind::While(cond, body, opt_label), attrs))
     }
 
     /// Parses `loop { ... }` (`loop` token already eaten).
@@ -1550,7 +1554,7 @@ impl<'a> Parser<'a> {
     ) -> PResult<'a, P<Expr>> {
         let (iattrs, body) = self.parse_inner_attrs_and_block()?;
         attrs.extend(iattrs);
-        Ok(self.mk_expr(lo.to(self.prev_span), ExprKind::Loop(body, opt_label), attrs))
+        Ok(self.mk_expr(lo.to(self.prev_token.span), ExprKind::Loop(body, opt_label), attrs))
     }
 
     fn eat_label(&mut self) -> Option<Label> {
@@ -1562,8 +1566,8 @@ impl<'a> Parser<'a> {
 
     /// Parses a `match ... { ... }` expression (`match` token already eaten).
     fn parse_match_expr(&mut self, mut attrs: AttrVec) -> PResult<'a, P<Expr>> {
-        let match_span = self.prev_span;
-        let lo = self.prev_span;
+        let match_span = self.prev_token.span;
+        let lo = self.prev_token.span;
         let scrutinee = self.parse_expr_res(Restrictions::NO_STRUCT_LITERAL, None)?;
         if let Err(mut e) = self.expect(&token::OpenDelim(token::Brace)) {
             if self.token == token::Semi {
@@ -1676,8 +1680,10 @@ impl<'a> Parser<'a> {
         let (iattrs, body) = self.parse_inner_attrs_and_block()?;
         attrs.extend(iattrs);
         if self.eat_keyword(kw::Catch) {
-            let mut error =
-                self.struct_span_err(self.prev_span, "keyword `catch` cannot follow a `try` block");
+            let mut error = self.struct_span_err(
+                self.prev_token.span,
+                "keyword `catch` cannot follow a `try` block",
+            );
             error.help("try using `match` on the result of the `try` block instead");
             error.emit();
             Err(error)
@@ -1711,7 +1717,7 @@ impl<'a> Parser<'a> {
         let (iattrs, body) = self.parse_inner_attrs_and_block()?;
         attrs.extend(iattrs);
         let kind = ExprKind::Async(capture_clause, DUMMY_NODE_ID, body);
-        Ok(self.mk_expr(lo.to(self.prev_span), kind, attrs))
+        Ok(self.mk_expr(lo.to(self.prev_token.span), kind, attrs))
     }
 
     fn is_async_block(&self) -> bool {
@@ -1775,7 +1781,7 @@ impl<'a> Parser<'a> {
         pth: ast::Path,
         mut attrs: AttrVec,
     ) -> PResult<'a, P<Expr>> {
-        let struct_sp = lo.to(self.prev_span);
+        let struct_sp = lo.to(self.prev_token.span);
         self.bump();
         let mut fields = Vec::new();
         let mut base = None;
@@ -1784,7 +1790,7 @@ impl<'a> Parser<'a> {
 
         while self.token != token::CloseDelim(token::Brace) {
             if self.eat(&token::DotDot) {
-                let exp_span = self.prev_span;
+                let exp_span = self.prev_token.span;
                 match self.parse_expr() {
                     Ok(e) => base = Some(e),
                     Err(mut e) => {
@@ -1828,7 +1834,7 @@ impl<'a> Parser<'a> {
                     if let Some(f) = recovery_field {
                         fields.push(f);
                         e.span_suggestion(
-                            self.prev_span.shrink_to_hi(),
+                            self.prev_token.span.shrink_to_hi(),
                             "try adding a comma",
                             ",".into(),
                             Applicability::MachineApplicable,
@@ -1868,15 +1874,18 @@ impl<'a> Parser<'a> {
         if self.token != token::Comma {
             return;
         }
-        self.struct_span_err(span.to(self.prev_span), "cannot use a comma after the base struct")
-            .span_suggestion_short(
-                self.token.span,
-                "remove this comma",
-                String::new(),
-                Applicability::MachineApplicable,
-            )
-            .note("the base struct must always be the last field")
-            .emit();
+        self.struct_span_err(
+            span.to(self.prev_token.span),
+            "cannot use a comma after the base struct",
+        )
+        .span_suggestion_short(
+            self.token.span,
+            "remove this comma",
+            String::new(),
+            Applicability::MachineApplicable,
+        )
+        .note("the base struct must always be the last field")
+        .emit();
         self.recover_stmt();
     }
 
@@ -1966,7 +1975,7 @@ impl<'a> Parser<'a> {
         limits: RangeLimits,
     ) -> PResult<'a, ExprKind> {
         if end.is_none() && limits == RangeLimits::Closed {
-            self.error_inclusive_range_with_no_end(self.prev_span);
+            self.error_inclusive_range_with_no_end(self.prev_token.span);
             Ok(ExprKind::Err)
         } else {
             Ok(ExprKind::Range(start, end, limits))
@@ -1990,7 +1999,7 @@ impl<'a> Parser<'a> {
     }
 
     fn mk_await_expr(&mut self, self_arg: P<Expr>, lo: Span) -> PResult<'a, P<Expr>> {
-        let span = lo.to(self.prev_span);
+        let span = lo.to(self.prev_token.span);
         let await_expr = self.mk_expr(span, ExprKind::Await(self_arg), AttrVec::new());
         self.recover_from_await_method_call();
         Ok(await_expr)

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -90,7 +90,7 @@ impl<'a> Parser<'a> {
         let kind = self.parse_item_kind(&mut attrs, mac_allowed, lo, &vis, &mut def, req_name)?;
         if let Some((ident, kind)) = kind {
             self.error_on_unconsumed_default(def, &kind);
-            let span = lo.to(self.prev_span);
+            let span = lo.to(self.prev_token.span);
             let id = DUMMY_NODE_ID;
             let item = Item { ident, attrs, id, kind, vis, span, tokens: None };
             return Ok(Some(item));
@@ -242,8 +242,8 @@ impl<'a> Parser<'a> {
         //
         //     pub   S {}
         //        ^^^ `sp` points here
-        let sp = self.prev_span.between(self.token.span);
-        let full_sp = self.prev_span.to(self.token.span);
+        let sp = self.prev_token.span.between(self.token.span);
+        let full_sp = self.prev_token.span.to(self.token.span);
         let ident_sp = self.token.span;
         if self.look_ahead(1, |t| *t == token::OpenDelim(token::Brace)) {
             // possible public struct definition where `struct` was forgotten
@@ -397,7 +397,7 @@ impl<'a> Parser<'a> {
             let mut generics = Generics::default();
             // impl A for B {}
             //    /\ this is where `generics.span` should point when there are no type params.
-            generics.span = self.prev_span.shrink_to_hi();
+            generics.span = self.prev_token.span.shrink_to_hi();
             generics
         };
 
@@ -418,7 +418,7 @@ impl<'a> Parser<'a> {
         let err_path = |span| ast::Path::from_ident(Ident::new(kw::Invalid, span));
         let ty_first = if self.token.is_keyword(kw::For) && self.look_ahead(1, |t| t != &token::Lt)
         {
-            let span = self.prev_span.between(self.token.span);
+            let span = self.prev_token.span.between(self.token.span);
             self.struct_span_err(span, "missing trait in a trait impl").emit();
             P(Ty { kind: TyKind::Path(None, err_path(span)), span, id: DUMMY_NODE_ID })
         } else {
@@ -427,12 +427,12 @@ impl<'a> Parser<'a> {
 
         // If `for` is missing we try to recover.
         let has_for = self.eat_keyword(kw::For);
-        let missing_for_span = self.prev_span.between(self.token.span);
+        let missing_for_span = self.prev_token.span.between(self.token.span);
 
         let ty_second = if self.token == token::DotDot {
             // We need to report this error after `cfg` expansion for compatibility reasons
             self.bump(); // `..`, do not add it to expected tokens
-            Some(self.mk_ty(self.prev_span, TyKind::Err))
+            Some(self.mk_ty(self.prev_token.span, TyKind::Err))
         } else if has_for || self.token.can_begin_type() {
             Some(self.parse_ty()?)
         } else {
@@ -519,7 +519,7 @@ impl<'a> Parser<'a> {
                     self.struct_span_err(non_item_span, "non-item in item list")
                         .span_label(open_brace_span, "item list starts here")
                         .span_label(non_item_span, "non-item starts here")
-                        .span_label(self.prev_span, "item list ends here")
+                        .span_label(self.prev_token.span, "item list ends here")
                         .emit();
                     break;
                 }
@@ -527,7 +527,7 @@ impl<'a> Parser<'a> {
                 Err(mut err) => {
                     self.consume_block(token::Brace, ConsumeClosingDelim::Yes);
                     err.span_label(open_brace_span, "while parsing this item list starting here")
-                        .span_label(self.prev_span, "the item list ends here")
+                        .span_label(self.prev_token.span, "the item list ends here")
                         .emit();
                     break;
                 }
@@ -594,11 +594,14 @@ impl<'a> Parser<'a> {
 
         // Parse optional colon and supertrait bounds.
         let had_colon = self.eat(&token::Colon);
-        let span_at_colon = self.prev_span;
-        let bounds =
-            if had_colon { self.parse_generic_bounds(Some(self.prev_span))? } else { Vec::new() };
+        let span_at_colon = self.prev_token.span;
+        let bounds = if had_colon {
+            self.parse_generic_bounds(Some(self.prev_token.span))?
+        } else {
+            Vec::new()
+        };
 
-        let span_before_eq = self.prev_span;
+        let span_before_eq = self.prev_token.span;
         if self.eat(&token::Eq) {
             // It's a trait alias.
             if had_colon {
@@ -610,7 +613,7 @@ impl<'a> Parser<'a> {
             tps.where_clause = self.parse_where_clause()?;
             self.expect_semi()?;
 
-            let whole_span = lo.to(self.prev_span);
+            let whole_span = lo.to(self.prev_token.span);
             if is_auto == IsAuto::Yes {
                 let msg = "trait aliases cannot be `auto`";
                 self.struct_span_err(whole_span, msg).span_label(whole_span, msg).emit();
@@ -714,7 +717,7 @@ impl<'a> Parser<'a> {
             }
         };
 
-        Ok(UseTree { prefix, kind, span: lo.to(self.prev_span) })
+        Ok(UseTree { prefix, kind, span: lo.to(self.prev_token.span) })
     }
 
     /// Parses `*` or `{...}`.
@@ -788,7 +791,7 @@ impl<'a> Parser<'a> {
             // Do not include `-` as part of the expected tokens list.
             while self.eat(&dash) {
                 fixed_crate_name = true;
-                replacement.push((self.prev_span, "_".to_string()));
+                replacement.push((self.prev_token.span, "_".to_string()));
                 idents.push(self.parse_ident()?);
             }
         }
@@ -882,7 +885,7 @@ impl<'a> Parser<'a> {
     /// Recover on `const mut` with `const` already eaten.
     fn recover_const_mut(&mut self, const_span: Span) {
         if self.eat_keyword(kw::Mut) {
-            let span = self.prev_span;
+            let span = self.prev_token.span;
             self.struct_span_err(span, "const globals cannot be mutable")
                 .span_label(span, "cannot be mutable")
                 .span_suggestion(
@@ -989,7 +992,7 @@ impl<'a> Parser<'a> {
             attrs: variant_attrs,
             data: struct_def,
             disr_expr,
-            span: vlo.to(self.prev_span),
+            span: vlo.to(self.prev_token.span),
             is_placeholder: false,
         };
 
@@ -1156,7 +1159,7 @@ impl<'a> Parser<'a> {
             }
             token::CloseDelim(token::Brace) => {}
             token::DocComment(_) => {
-                let previous_span = self.prev_span;
+                let previous_span = self.prev_token.span;
                 let mut err = self.span_fatal_err(self.token.span, Error::UselessDocComment);
                 self.bump(); // consume the doc comment
                 let comma_after_doc_seen = self.eat(&token::Comma);
@@ -1181,7 +1184,7 @@ impl<'a> Parser<'a> {
                 }
             }
             _ => {
-                let sp = self.prev_span.shrink_to_hi();
+                let sp = self.prev_token.span.shrink_to_hi();
                 let mut err = self.struct_span_err(
                     sp,
                     &format!("expected `,`, or `}}`, found {}", super::token_descr(&self.token)),
@@ -1214,7 +1217,7 @@ impl<'a> Parser<'a> {
         self.expect(&token::Colon)?;
         let ty = self.parse_ty()?;
         Ok(StructField {
-            span: lo.to(self.prev_span),
+            span: lo.to(self.prev_token.span),
             ident: Some(name),
             vis,
             id: DUMMY_NODE_ID,
@@ -1252,7 +1255,7 @@ impl<'a> Parser<'a> {
             return self.unexpected();
         };
 
-        self.sess.gated_spans.gate(sym::decl_macro, lo.to(self.prev_span));
+        self.sess.gated_spans.gate(sym::decl_macro, lo.to(self.prev_token.span));
         Ok((ident, ItemKind::MacroDef(ast::MacroDef { body, legacy: false })))
     }
 
@@ -1506,11 +1509,11 @@ impl<'a> Parser<'a> {
         let (mut params, _) = self.parse_paren_comma_seq(|p| {
             let param = p.parse_param_general(req_name, first_param).or_else(|mut e| {
                 e.emit();
-                let lo = p.prev_span;
+                let lo = p.prev_token.span;
                 // Skip every token until next possible arg or end.
                 p.eat_to_tokens(&[&token::Comma, &token::CloseDelim(token::Paren)]);
                 // Create a placeholder argument for proper arg count (issue #34264).
-                Ok(dummy_arg(Ident::new(kw::Invalid, lo.to(p.prev_span))))
+                Ok(dummy_arg(Ident::new(kw::Invalid, lo.to(p.prev_token.span))))
             });
             // ...now that we've parsed the first argument, `self` is no longer allowed.
             first_param = false;
@@ -1570,7 +1573,7 @@ impl<'a> Parser<'a> {
             }
             match ty {
                 Ok(ty) => {
-                    let ident = Ident::new(kw::Invalid, self.prev_span);
+                    let ident = Ident::new(kw::Invalid, self.prev_token.span);
                     let bm = BindingMode::ByValue(Mutability::Not);
                     let pat = self.mk_pat_ident(ty.span, bm, ident);
                     (pat, ty)
@@ -1622,7 +1625,7 @@ impl<'a> Parser<'a> {
         // Parse `self` or `self: TYPE`. We already know the current token is `self`.
         let parse_self_possibly_typed = |this: &mut Self, m| {
             let eself_ident = expect_self_ident(this);
-            let eself_hi = this.prev_span;
+            let eself_hi = this.prev_token.span;
             let eself = if this.eat(&token::Colon) {
                 SelfKind::Explicit(this.parse_ty()?, m)
             } else {
@@ -1636,7 +1639,7 @@ impl<'a> Parser<'a> {
             let span = this.token.span;
             this.struct_span_err(span, msg).span_label(span, msg).emit();
 
-            Ok((SelfKind::Value(Mutability::Not), expect_self_ident(this), this.prev_span))
+            Ok((SelfKind::Value(Mutability::Not), expect_self_ident(this), this.prev_token.span))
         };
 
         // Parse optional `self` parameter of a method.
@@ -1669,7 +1672,7 @@ impl<'a> Parser<'a> {
                     // `&not_self`
                     return Ok(None);
                 };
-                (eself, expect_self_ident(self), self.prev_span)
+                (eself, expect_self_ident(self), self.prev_token.span)
             }
             // `*self`
             token::BinOp(token::Star) if is_isolated_self(self, 1) => {

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -568,7 +568,7 @@ impl<'a> Parser<'a> {
             && self.look_ahead(1, |t| t.is_non_raw_ident_where(|i| i.name != kw::As))
         {
             self.bump(); // `default`
-            Defaultness::Default(self.prev_span)
+            Defaultness::Default(self.normalized_prev_token.span)
         } else {
             Defaultness::Final
         }

--- a/src/librustc_parse/parser/module.rs
+++ b/src/librustc_parse/parser/module.rs
@@ -90,7 +90,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        let hi = if self.token.span.is_dummy() { inner_lo } else { self.prev_span };
+        let hi = if self.token.span.is_dummy() { inner_lo } else { self.prev_token.span };
 
         Ok(Mod { inner: inner_lo.to(hi), items, inline: true })
     }

--- a/src/librustc_parse/parser/pat.rs
+++ b/src/librustc_parse/parser/pat.rs
@@ -46,7 +46,7 @@ impl<'a> Parser<'a> {
     pub(super) fn parse_top_pat(&mut self, gate_or: GateOr) -> PResult<'a, P<Pat>> {
         // Allow a '|' before the pats (RFCs 1925, 2530, and 2535).
         let gated_leading_vert = self.eat_or_separator(None) && gate_or == GateOr::Yes;
-        let leading_vert_span = self.prev_span;
+        let leading_vert_span = self.prev_token.span;
 
         // Parse the possibly-or-pattern.
         let pat = self.parse_pat_with_or(None, gate_or, RecoverComma::Yes)?;
@@ -113,7 +113,7 @@ impl<'a> Parser<'a> {
             self.maybe_recover_unexpected_comma(pat.span, rc)?;
             pats.push(pat);
         }
-        let or_pattern_span = lo.to(self.prev_span);
+        let or_pattern_span = lo.to(self.prev_token.span);
 
         // Feature gate the or-pattern if instructed:
         if gate_or == GateOr::Yes {
@@ -204,7 +204,7 @@ impl<'a> Parser<'a> {
             // end of the comma-sequence so we know the span to suggest parenthesizing.
             err.cancel();
         }
-        let seq_span = lo.to(self.prev_span);
+        let seq_span = lo.to(self.prev_token.span);
         let mut err = self.struct_span_err(comma_span, "unexpected `,` in pattern");
         if let Ok(seq_snippet) = self.span_to_snippet(seq_span) {
             err.span_suggestion(
@@ -309,7 +309,7 @@ impl<'a> Parser<'a> {
         } else if self.eat_keyword(kw::Box) {
             // Parse `box pat`
             let pat = self.parse_pat_with_range_pat(false, None)?;
-            self.sess.gated_spans.gate(sym::box_patterns, lo.to(self.prev_span));
+            self.sess.gated_spans.gate(sym::box_patterns, lo.to(self.prev_token.span));
             PatKind::Box(pat)
         } else if self.can_be_ident_pat() {
             // Parse `ident @ pat`
@@ -326,7 +326,7 @@ impl<'a> Parser<'a> {
                 // Parse an unqualified path
                 (None, self.parse_path(PathStyle::Expr)?)
             };
-            let span = lo.to(self.prev_span);
+            let span = lo.to(self.prev_token.span);
 
             if qself.is_none() && self.check(&token::Not) {
                 self.parse_pat_mac_invoc(path)?
@@ -351,7 +351,7 @@ impl<'a> Parser<'a> {
             }
         };
 
-        let pat = self.mk_pat(lo.to(self.prev_span), pat);
+        let pat = self.mk_pat(lo.to(self.prev_token.span), pat);
         let pat = self.maybe_recover_from_bad_qpath(pat, true)?;
         let pat = self.recover_intersection_pat(pat)?;
 
@@ -457,7 +457,7 @@ impl<'a> Parser<'a> {
         if let token::Lifetime(name) = self.token.kind {
             self.bump(); // `'a`
 
-            let span = self.prev_span;
+            let span = self.prev_token.span;
             self.struct_span_err(span, &format!("unexpected lifetime `{}` in pattern", name))
                 .span_suggestion(
                     span,
@@ -485,7 +485,7 @@ impl<'a> Parser<'a> {
 
     /// Parse a mutable binding with the `mut` token already eaten.
     fn parse_pat_ident_mut(&mut self) -> PResult<'a, PatKind> {
-        let mut_span = self.prev_span;
+        let mut_span = self.prev_token.span;
 
         if self.eat_keyword(kw::Ref) {
             return self.recover_mut_ref_ident(mut_span);
@@ -520,7 +520,7 @@ impl<'a> Parser<'a> {
     /// Recover on `mut ref? ident @ pat` and suggest
     /// that the order of `mut` and `ref` is incorrect.
     fn recover_mut_ref_ident(&mut self, lo: Span) -> PResult<'a, PatKind> {
-        let mutref_span = lo.to(self.prev_span);
+        let mutref_span = lo.to(self.prev_token.span);
         self.struct_span_err(mutref_span, "the order of `mut` and `ref` is incorrect")
             .span_suggestion(
                 mutref_span,
@@ -580,7 +580,7 @@ impl<'a> Parser<'a> {
             return;
         }
 
-        let span = lo.to(self.prev_span);
+        let span = lo.to(self.prev_token.span);
         self.struct_span_err(span, "`mut` on a binding may not be repeated")
             .span_suggestion(
                 span,
@@ -627,12 +627,12 @@ impl<'a> Parser<'a> {
         } else if self.eat(&token::DotDotEq) {
             RangeEnd::Included(RangeSyntax::DotDotEq)
         } else if self.eat(&token::DotDot) {
-            self.sess.gated_spans.gate(sym::exclusive_range_pattern, self.prev_span);
+            self.sess.gated_spans.gate(sym::exclusive_range_pattern, self.prev_token.span);
             RangeEnd::Excluded
         } else {
             return None;
         };
-        Some(respan(self.prev_span, re))
+        Some(respan(self.prev_token.span, re))
     }
 
     /// Parse a range pattern `$begin $form $end?` where `$form = ".." | "..." | "..=" ;`.
@@ -676,7 +676,7 @@ impl<'a> Parser<'a> {
     /// expression syntax `...expr` for splatting in expressions.
     fn parse_pat_range_to(&mut self, mut re: Spanned<RangeEnd>) -> PResult<'a, PatKind> {
         let end = self.parse_pat_range_end()?;
-        self.sess.gated_spans.gate(sym::half_open_range_patterns, re.span.to(self.prev_span));
+        self.sess.gated_spans.gate(sym::half_open_range_patterns, re.span.to(self.prev_token.span));
         if let RangeEnd::Included(ref mut syn @ RangeSyntax::DotDotDot) = &mut re.node {
             *syn = RangeSyntax::DotDotEq;
             self.struct_span_err(re.span, "range-to patterns with `...` are not allowed")
@@ -712,7 +712,7 @@ impl<'a> Parser<'a> {
                 // Parse an unqualified path
                 (None, self.parse_path(PathStyle::Expr)?)
             };
-            let hi = self.prev_span;
+            let hi = self.prev_token.span;
             Ok(self.mk_expr(lo.to(hi), ExprKind::Path(qself, path), AttrVec::new()))
         } else {
             self.parse_literal_maybe_minus()
@@ -760,9 +760,8 @@ impl<'a> Parser<'a> {
         // binding mode then we do not end up here, because the lookahead
         // will direct us over to `parse_enum_variant()`.
         if self.token == token::OpenDelim(token::Paren) {
-            return Err(
-                self.struct_span_err(self.prev_span, "expected identifier, found enum pattern")
-            );
+            return Err(self
+                .struct_span_err(self.prev_token.span, "expected identifier, found enum pattern"));
         }
 
         Ok(PatKind::Ident(binding_mode, ident, sub))
@@ -824,7 +823,7 @@ impl<'a> Parser<'a> {
 
             // check that a comma comes after every field
             if !ate_comma {
-                let err = self.struct_span_err(self.prev_span, "expected `,`");
+                let err = self.struct_span_err(self.prev_token.span, "expected `,`");
                 if let Some(mut delayed) = delayed_err {
                     delayed.emit();
                 }
@@ -956,7 +955,7 @@ impl<'a> Parser<'a> {
             let is_ref = self.eat_keyword(kw::Ref);
             let is_mut = self.eat_keyword(kw::Mut);
             let fieldname = self.parse_ident()?;
-            hi = self.prev_span;
+            hi = self.prev_token.span;
 
             let bind_type = match (is_ref, is_mut) {
                 (true, true) => BindingMode::ByRef(Mutability::Mut),

--- a/src/librustc_parse/parser/path.rs
+++ b/src/librustc_parse/parser/path.rs
@@ -48,7 +48,7 @@ impl<'a> Parser<'a> {
     /// `<T as U>::F::a<S>` (without disambiguator)
     /// `<T as U>::F::a::<S>` (with disambiguator)
     pub(super) fn parse_qpath(&mut self, style: PathStyle) -> PResult<'a, (QSelf, Path)> {
-        let lo = self.prev_span;
+        let lo = self.prev_token.span;
         let ty = self.parse_ty()?;
 
         // `path` will contain the prefix of the path up to the `>`,
@@ -59,7 +59,7 @@ impl<'a> Parser<'a> {
         if self.eat_keyword(kw::As) {
             let path_lo = self.token.span;
             path = self.parse_path(PathStyle::Type)?;
-            path_span = path_lo.to(self.prev_span);
+            path_span = path_lo.to(self.prev_token.span);
         } else {
             path_span = self.token.span.to(self.token.span);
             path = ast::Path { segments: Vec::new(), span: path_span };
@@ -79,7 +79,7 @@ impl<'a> Parser<'a> {
         let qself = QSelf { ty, path_span, position: path.segments.len() };
         self.parse_path_segments(&mut path.segments, style)?;
 
-        Ok((qself, Path { segments: path.segments, span: lo.to(self.prev_span) }))
+        Ok((qself, Path { segments: path.segments, span: lo.to(self.prev_token.span) }))
     }
 
     /// Recover from an invalid single colon, when the user likely meant a qualified path.
@@ -101,11 +101,11 @@ impl<'a> Parser<'a> {
 
         self.diagnostic()
             .struct_span_err(
-                self.prev_span,
+                self.prev_token.span,
                 "found single colon before projection in qualified path",
             )
             .span_suggestion(
-                self.prev_span,
+                self.prev_token.span,
                 "use double colon",
                 "::".to_string(),
                 Applicability::MachineApplicable,
@@ -142,7 +142,7 @@ impl<'a> Parser<'a> {
         }
         self.parse_path_segments(&mut segments, style)?;
 
-        Ok(Path { segments, span: lo.to(self.prev_span) })
+        Ok(Path { segments, span: lo.to(self.prev_token.span) })
     }
 
     pub(super) fn parse_path_segments(
@@ -219,12 +219,12 @@ impl<'a> Parser<'a> {
                     let (args, constraints) =
                         self.parse_generic_args_with_leading_angle_bracket_recovery(style, lo)?;
                     self.expect_gt()?;
-                    let span = lo.to(self.prev_span);
+                    let span = lo.to(self.prev_token.span);
                     AngleBracketedArgs { args, constraints, span }.into()
                 } else {
                     // `(T, U) -> R`
                     let (inputs, _) = self.parse_paren_comma_seq(|p| p.parse_ty())?;
-                    let span = ident.span.to(self.prev_span);
+                    let span = ident.span.to(self.prev_token.span);
                     let output = self.parse_ret_ty(AllowPlus::No, RecoverQPath::No)?;
                     ParenthesizedArgs { inputs, output, span }.into()
                 };
@@ -410,13 +410,13 @@ impl<'a> Parser<'a> {
                     AssocTyConstraintKind::Equality { ty: self.parse_ty()? }
                 } else if self.eat(&token::Colon) {
                     AssocTyConstraintKind::Bound {
-                        bounds: self.parse_generic_bounds(Some(self.prev_span))?,
+                        bounds: self.parse_generic_bounds(Some(self.prev_token.span))?,
                     }
                 } else {
                     unreachable!();
                 };
 
-                let span = lo.to(self.prev_span);
+                let span = lo.to(self.prev_token.span);
 
                 // Gate associated type bounds, e.g., `Iterator<Item: Ord>`.
                 if let AssocTyConstraintKind::Bound { .. } = kind {
@@ -471,7 +471,7 @@ impl<'a> Parser<'a> {
         // lose that information after parsing.
         if misplaced_assoc_ty_constraints.len() > 0 {
             let mut err = self.struct_span_err(
-                args_lo.to(self.prev_span),
+                args_lo.to(self.prev_token.span),
                 "associated type bindings must be declared after generic parameters",
             );
             for span in misplaced_assoc_ty_constraints {


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust/pull/69384.
r? @Centril 