### PR TITLE
Correct comment to match behavior

### DIFF
--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -284,7 +284,7 @@ impl Instant {
     }
 
     /// Returns the amount of time elapsed from another instant to this one,
-    /// or zero duration if that instant is earlier than this one.
+    /// or zero duration if that instant is later than this one.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Corrects the header comment on `saturating_duration_since` to match the behavior of returning 0 if the other timestamp is _later_ than the invocant, not earlier, 

This is purely a documentation change, so hopefully it doesn't require an issue; if it does, I'll open one and resubmit. 
