### PR TITLE
rustdoc: HTML escape crate version

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1313,7 +1313,8 @@ impl Context {
                          <p>Version {}</p>\
                      </div>\
                      <a id='all-types' href='index.html'><p>Back to index</p></a>",
-                crate_name, version
+                crate_name,
+                Escape(version),
             )
         } else {
             String::new()
@@ -3974,7 +3975,7 @@ fn print_sidebar(cx: &Context, it: &clean::Item, buffer: &mut Buffer) {
                 "<div class='block version'>\
                     <p>Version {}</p>\
                     </div>",
-                version
+                Escape(version)
             );
         }
     }

--- a/src/test/rustdoc/crate-version-escape.rs
+++ b/src/test/rustdoc/crate-version-escape.rs
@@ -1,0 +1,6 @@
+// compile-flags: --crate-version=<script>alert("hi")</script> -Z unstable-options
+
+#![crate_name = "foo"]
+
+// @has 'foo/index.html' '//div[@class="block version"]/p' 'Version <script>alert("hi")</script>'
+// @has 'foo/all.html' '//div[@class="block version"]/p' 'Version <script>alert("hi")</script>'


### PR DESCRIPTION
As `--crate-version` accepts arbitrary strings they need to be escaped.

r? @GuillaumeGomez