### PR TITLE
check_binding_alt_eq_ty: improve precision wrt. `if let`

### DIFF
--- a/src/librustc_typeck/check/pat.rs
+++ b/src/librustc_typeck/check/pat.rs
@@ -559,8 +559,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let var_ty = self.resolve_vars_with_obligations(var_ty);
             let msg = format!("first introduced with type `{}` here", var_ty);
             err.span_label(hir.span(var_id), msg);
-            let in_arm = hir.parent_iter(var_id).any(|(_, n)| matches!(n, hir::Node::Arm(..)));
-            let pre = if in_arm { "in the same arm, " } else { "" };
+            let in_match = hir.parent_iter(var_id).any(|(_, n)| {
+                matches!(
+                    n,
+                    hir::Node::Expr(hir::Expr {
+                        kind: hir::ExprKind::Match(.., hir::MatchSource::Normal),
+                        ..
+                    })
+                )
+            });
+            let pre = if in_match { "in the same arm, " } else { "" };
             err.note(&format!("{}a binding must have the same type in all alternatives", pre));
             err.emit();
         }

--- a/src/test/ui/or-patterns/or-patterns-binding-type-mismatch.stderr
+++ b/src/test/ui/or-patterns/or-patterns-binding-type-mismatch.stderr
@@ -101,7 +101,7 @@ LL |     if let Blah::A(_, x, y) | Blah::B(x, y) = Blah::A(1, 1, 2) {
    |                          |               expected `usize`, found `isize`
    |                          first introduced with type `usize` here
    |
-   = note: in the same arm, a binding must have the same type in all alternatives
+   = note: a binding must have the same type in all alternatives
 
 error[E0308]: mismatched types
   --> $DIR/or-patterns-binding-type-mismatch.rs:38:47
@@ -112,7 +112,7 @@ LL |     if let Some(Blah::A(_, x, y) | Blah::B(x, y)) = Some(Blah::A(1, 1, 2)) 
    |                               |               expected `usize`, found `isize`
    |                               first introduced with type `usize` here
    |
-   = note: in the same arm, a binding must have the same type in all alternatives
+   = note: a binding must have the same type in all alternatives
 
 error[E0308]: mismatched types
   --> $DIR/or-patterns-binding-type-mismatch.rs:42:22
@@ -123,7 +123,7 @@ LL |     if let (x, y) | (y, x) = (0u8, 1u16) {
    |                |     expected `u16`, found `u8`
    |                first introduced with type `u16` here
    |
-   = note: in the same arm, a binding must have the same type in all alternatives
+   = note: a binding must have the same type in all alternatives
 
 error[E0308]: mismatched types
   --> $DIR/or-patterns-binding-type-mismatch.rs:42:25
@@ -134,7 +134,7 @@ LL |     if let (x, y) | (y, x) = (0u8, 1u16) {
    |             |           expected `u8`, found `u16`
    |             first introduced with type `u8` here
    |
-   = note: in the same arm, a binding must have the same type in all alternatives
+   = note: a binding must have the same type in all alternatives
 
 error[E0308]: mismatched types
   --> $DIR/or-patterns-binding-type-mismatch.rs:47:44
@@ -147,7 +147,7 @@ LL |     if let Some((x, Some((y, z)))) | Some((y, Some((x, z) | (z, x))))
 LL |     = Some((0u8, Some((1u16, 2u32))))
    |       ------------------------------- this expression has type `std::option::Option<(u8, std::option::Option<(u16, u32)>)>`
    |
-   = note: in the same arm, a binding must have the same type in all alternatives
+   = note: a binding must have the same type in all alternatives
 
 error[E0308]: mismatched types
   --> $DIR/or-patterns-binding-type-mismatch.rs:47:53
@@ -160,7 +160,7 @@ LL |     if let Some((x, Some((y, z)))) | Some((y, Some((x, z) | (z, x))))
 LL |     = Some((0u8, Some((1u16, 2u32))))
    |       ------------------------------- this expression has type `std::option::Option<(u8, std::option::Option<(u16, u32)>)>`
    |
-   = note: in the same arm, a binding must have the same type in all alternatives
+   = note: a binding must have the same type in all alternatives
 
 error[E0308]: mismatched types
   --> $DIR/or-patterns-binding-type-mismatch.rs:47:62
@@ -173,7 +173,7 @@ LL |     if let Some((x, Some((y, z)))) | Some((y, Some((x, z) | (z, x))))
 LL |     = Some((0u8, Some((1u16, 2u32))))
    |       ------------------------------- this expression has type `std::option::Option<(u8, std::option::Option<(u16, u32)>)>`
    |
-   = note: in the same arm, a binding must have the same type in all alternatives
+   = note: a binding must have the same type in all alternatives
 
 error[E0308]: mismatched types
   --> $DIR/or-patterns-binding-type-mismatch.rs:47:65
@@ -184,7 +184,7 @@ LL |     if let Some((x, Some((y, z)))) | Some((y, Some((x, z) | (z, x))))
 LL |     = Some((0u8, Some((1u16, 2u32))))
    |       ------------------------------- this expression has type `std::option::Option<(u8, std::option::Option<(u16, u32)>)>`
    |
-   = note: in the same arm, a binding must have the same type in all alternatives
+   = note: a binding must have the same type in all alternatives
 
 error[E0308]: mismatched types
   --> $DIR/or-patterns-binding-type-mismatch.rs:55:39


### PR DESCRIPTION
Follow up to https://github.com/rust-lang/rust/pull/69452 -- this tweaks the `check_binding_alt_eq_ty` logic wrt. wording so that `if let` doesn't include "in this arm" (because there can only ever be one arm).

r? @estebank 