### PR TITLE
tidy: replace `make check` with `./x.py test` in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ the issue in question.
 Please make sure your pull request is in compliance with Rust's style
 guidelines by running
 
-    $ python x.py test src/tools/tidy
+    $ python x.py test tidy
 
 Make this check before every pull request (and every new commit in a pull
 request); you can add [git hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks)

--- a/src/bootstrap/README.md
+++ b/src/bootstrap/README.md
@@ -55,6 +55,9 @@ The script accepts commands, flags, and arguments to determine what to do:
   # run all unit tests
   ./x.py test
 
+  # execute tool tests
+  ./x.py test tidy
+
   # execute the UI test suite
   ./x.py test src/test/ui
 

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -359,7 +359,7 @@ Arguments:
                 subcommand_help.push_str(
                     "\n
 Arguments:
-    This subcommand accepts a number of paths to directories to tests that
+    This subcommand accepts a number of paths to test directories that
     should be compiled and run. For example:
 
         ./x.py test src/test/ui
@@ -367,10 +367,14 @@ Arguments:
         ./x.py test src/libstd --stage 0 --no-doc
         ./x.py test src/test/ui --bless
         ./x.py test src/test/ui --compare-mode nll
-
+    
     Note that `test src/test/* --stage N` does NOT depend on `build src/rustc --stage N`;
     just like `build src/libstd --stage N` it tests the compiler produced by the previous
     stage.
+
+    Execute tool tests with a tool name argument:
+
+        ./x.py test tidy
 
     If no arguments are passed then the complete artifacts for that stage are
     compiled and tested.

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -367,7 +367,7 @@ Arguments:
         ./x.py test src/libstd --stage 0 --no-doc
         ./x.py test src/test/ui --bless
         ./x.py test src/test/ui --compare-mode nll
-    
+
     Note that `test src/test/* --stage N` does NOT depend on `build src/rustc --stage N`;
     just like `build src/libstd --stage N` it tests the compiler produced by the previous
     stage.

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! This program runs all of the various tidy checks for style, cleanliness,
 //! etc. This is run by default on `./x.py test` and as part of the auto
-//! builders. The tidy checks can be executed with `./x.py test src/tools/tidy`.
+//! builders. The tidy checks can be executed with `./x.py test tidy`.
 
 #![deny(warnings)]
 

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -1,8 +1,8 @@
 //! Tidy checks source code in this repository.
 //!
 //! This program runs all of the various tidy checks for style, cleanliness,
-//! etc. This is run by default on `make check` and as part of the auto
-//! builders.
+//! etc. This is run by default on `./x.py test` and as part of the auto
+//! builders. The tidy checks can be executed with `./x.py test src/tools/tidy`.
 
 #![deny(warnings)]
 


### PR DESCRIPTION
This PR includes a minor documentation update for tidy.  It replaces the `make check` approach with `./x.py test` and describes how to execute the tidy checks (only) with ~~`./x.py test src/tools/tidy`~~ `./x.py test tidy`.