### PR TITLE
Expose target libdir information via print command

### DIFF
--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -146,6 +146,7 @@ The valid types of print values are:
 - `crate-name` — The name of the crate.
 - `file-names` — The names of the files created by the `link` emit kind.
 - `sysroot` — Path to the sysroot.
+- `target-libdir` - Path to the target libdir.
 - `cfg` — List of cfg values. See [conditional compilation] for more
   information about cfg values.
 - `target-list` — List of known targets. The target may be selected with the

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -676,6 +676,10 @@ impl RustcDefaultCalls {
                     println!("{}", targets.join("\n"));
                 }
                 Sysroot => println!("{}", sess.sysroot.display()),
+                TargetLibdir => println!(
+                    "{}",
+                    sess.target_tlib_path.as_ref().unwrap_or(&sess.host_tlib_path).dir.display()
+                ),
                 TargetSpec => println!("{}", sess.target.target.to_json().pretty()),
                 FileNames | CrateName => {
                     let input = input.unwrap_or_else(|| {

--- a/src/librustc_session/config.rs
+++ b/src/librustc_session/config.rs
@@ -391,6 +391,7 @@ impl ExternEntry {
 pub enum PrintRequest {
     FileNames,
     Sysroot,
+    TargetLibdir,
     CrateName,
     Cfg,
     TargetList,
@@ -1344,6 +1345,7 @@ fn collect_print_requests(
         "crate-name" => PrintRequest::CrateName,
         "file-names" => PrintRequest::FileNames,
         "sysroot" => PrintRequest::Sysroot,
+        "target-libdir" => PrintRequest::TargetLibdir,
         "cfg" => PrintRequest::Cfg,
         "target-list" => PrintRequest::TargetList,
         "target-cpus" => PrintRequest::TargetCPUs,

--- a/src/librustc_session/config.rs
+++ b/src/librustc_session/config.rs
@@ -913,7 +913,7 @@ pub fn rustc_short_optgroups() -> Vec<RustcOptGroup> {
             "",
             "print",
             "Compiler information to print on stdout",
-            "[crate-name|file-names|sysroot|cfg|target-list|\
+            "[crate-name|file-names|sysroot|target-libdir|cfg|target-list|\
              target-cpus|target-features|relocation-models|\
              code-models|tls-models|target-spec-json|native-static-libs]",
         ),


### PR DESCRIPTION
With custom libdir it is required to have an access to library placement.

See https://github.com/RazrFalcon/cargo-bloat/issues/51