### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -536,7 +536,7 @@ impl<T: Ord> BinaryHeap<T> {
             while child < end {
                 let right = child + 1;
                 // compare with the greater of the two children
-                if right < end && !(hole.get(child) > hole.get(right)) {
+                if right < end && hole.get(child) <= hole.get(right) {
                     child = right;
                 }
                 // if we are already in order, stop.
@@ -568,7 +568,7 @@ impl<T: Ord> BinaryHeap<T> {
             while child < end {
                 let right = child + 1;
                 // compare with the greater of the two children
-                if right < end && !(hole.get(child) > hole.get(right)) {
+                if right < end && hole.get(child) <= hole.get(right) {
                     child = right;
                 }
                 hole.move_to(child);

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1472,7 +1472,7 @@ impl<T: Clone> Vec<T> {
     /// difference, with each additional slot filled with `value`.
     /// If `new_len` is less than `len`, the `Vec` is simply truncated.
     ///
-    /// This method requires `value` to implement [`Clone`], 
+    /// This method requires `T` to implement [`Clone`], 
     /// in order to be able to clone the passed value.
     /// If you need more flexibility (or want to rely on [`Default`] instead of
     /// [`Clone`]), use [`resize_with`].

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1472,7 +1472,7 @@ impl<T: Clone> Vec<T> {
     /// difference, with each additional slot filled with `value`.
     /// If `new_len` is less than `len`, the `Vec` is simply truncated.
     ///
-    /// This method requires `T` to implement [`Clone`], 
+    /// This method requires `T` to implement [`Clone`],
     /// in order to be able to clone the passed value.
     /// If you need more flexibility (or want to rely on [`Default`] instead of
     /// [`Clone`]), use [`resize_with`].

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1472,8 +1472,9 @@ impl<T: Clone> Vec<T> {
     /// difference, with each additional slot filled with `value`.
     /// If `new_len` is less than `len`, the `Vec` is simply truncated.
     ///
-    /// This method requires [`Clone`] to be able clone the passed value. If
-    /// you need more flexibility (or want to rely on [`Default`] instead of
+    /// This method requires `value` to implement [`Clone`], 
+    /// in order to be able to clone the passed value.
+    /// If you need more flexibility (or want to rely on [`Default`] instead of
     /// [`Clone`]), use [`resize_with`].
     ///
     /// # Examples

--- a/src/libcore/tests/hash/sip.rs
+++ b/src/libcore/tests/hash/sip.rs
@@ -298,7 +298,6 @@ fn test_hash_no_concat_alias() {
     let t = ("aabb", "");
     let u = ("a", "abb");
 
-    assert!(s != t && t != u);
     assert_ne!(s, t);
     assert_ne!(t, u);
     assert_ne!(hash(&s), hash(&t));

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -2135,7 +2135,7 @@ fn set_members_of_composite_type(
 /// Computes the type parameters for a type, if any, for the given metadata.
 fn compute_type_parameters(cx: &CodegenCx<'ll, 'tcx>, ty: Ty<'tcx>) -> Option<&'ll DIArray> {
     if let ty::Adt(def, substs) = ty.kind {
-        if !substs.types().next().is_none() {
+        if substs.types().next().is_some() {
             let generics = cx.tcx.generics_of(def.did);
             let names = get_parameter_names(cx, generics);
             let template_params: Vec<_> = substs

--- a/src/librustc_codegen_ssa/mir/debuginfo.rs
+++ b/src/librustc_codegen_ssa/mir/debuginfo.rs
@@ -48,7 +48,7 @@ pub struct DebugScope<D> {
 
 impl<D> DebugScope<D> {
     pub fn is_valid(&self) -> bool {
-        !self.scope_metadata.is_none()
+        self.scope_metadata.is_some()
     }
 }
 
@@ -304,7 +304,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     ) -> Option<IndexVec<mir::Local, Vec<PerLocalVarDebugInfo<'tcx, Bx::DIVariable>>>> {
         let full_debug_info = self.cx.sess().opts.debuginfo == DebugInfo::Full;
 
-        if !(full_debug_info || !self.cx.sess().fewer_names()) {
+        if !full_debug_info && self.cx.sess().fewer_names() {
             return None;
         }
 

--- a/src/librustc_error_codes/error_codes/E0374.md
+++ b/src/librustc_error_codes/error_codes/E0374.md
@@ -1,9 +1,5 @@
-A struct without a field containing an unsized type cannot implement
-`CoerceUnsized`. An [unsized type][1] is any type that the compiler
-doesn't know the length or alignment of at compile time. Any struct
-containing an unsized type is also unsized.
-
-[1]: https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait
+`CoerceUnsized` was implemented on a struct which does not contain a field with
+an unsized type.
 
 Example of erroneous code:
 
@@ -19,6 +15,12 @@ struct Foo<T: ?Sized> {
 impl<T, U> CoerceUnsized<Foo<U>> for Foo<T>
     where T: CoerceUnsized<U> {}
 ```
+
+An [unsized type][1] is any type where the compiler does not know the length or
+alignment of at compile time. Any struct containing an unsized type is also
+unsized.
+
+[1]: https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait
 
 `CoerceUnsized` is used to coerce one struct containing an unsized type
 into another struct containing a different unsized type. If the struct

--- a/src/librustc_error_codes/error_codes/E0375.md
+++ b/src/librustc_error_codes/error_codes/E0375.md
@@ -1,12 +1,7 @@
-A struct with more than one field containing an unsized type cannot implement
-`CoerceUnsized`. This only occurs when you are trying to coerce one of the
-types in your struct to another type in the struct. In this case we try to
-impl `CoerceUnsized` from `T` to `U` which are both types that the struct
-takes. An [unsized type][1] is any type that the compiler doesn't know the
-length or alignment of at compile time. Any struct containing an unsized type
-is also unsized.
+`CoerceUnsized` was implemented on a struct which contains more than one field
+with an unsized type.
 
-Example of erroneous code:
+Erroneous code example:
 
 ```compile_fail,E0375
 #![feature(coerce_unsized)]
@@ -21,6 +16,14 @@ struct Foo<T: ?Sized, U: ?Sized> {
 // error: Struct `Foo` has more than one unsized field.
 impl<T, U> CoerceUnsized<Foo<U, T>> for Foo<T, U> {}
 ```
+
+A struct with more than one field containing an unsized type cannot implement
+`CoerceUnsized`. This only occurs when you are trying to coerce one of the
+types in your struct to another type in the struct. In this case we try to
+impl `CoerceUnsized` from `T` to `U` which are both types that the struct
+takes. An [unsized type][1] is any type that the compiler doesn't know the
+length or alignment of at compile time. Any struct containing an unsized type
+is also unsized.
 
 `CoerceUnsized` only allows for coercion from a structure with a single
 unsized type field to another struct with a single unsized type field.

--- a/src/librustc_error_codes/error_codes/E0376.md
+++ b/src/librustc_error_codes/error_codes/E0376.md
@@ -1,14 +1,6 @@
-The type you are trying to impl `CoerceUnsized` for is not a struct.
-`CoerceUnsized` can only be implemented for a struct. Unsized types are
-already able to be coerced without an implementation of `CoerceUnsized`
-whereas a struct containing an unsized type needs to know the unsized type
-field it's containing is able to be coerced. An [unsized type][1]
-is any type that the compiler doesn't know the length or alignment of at
-compile time. Any struct containing an unsized type is also unsized.
+`CoerceUnsized` was implemented on something that isn't a struct.
 
-[1]: https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait
-
-Example of erroneous code:
+Erroneous code example:
 
 ```compile_fail,E0376
 #![feature(coerce_unsized)]
@@ -21,6 +13,15 @@ struct Foo<T: ?Sized> {
 // error: The type `U` is not a struct
 impl<T, U> CoerceUnsized<U> for Foo<T> {}
 ```
+
+`CoerceUnsized` can only be implemented for a struct. Unsized types are
+already able to be coerced without an implementation of `CoerceUnsized`
+whereas a struct containing an unsized type needs to know the unsized type
+field it's containing is able to be coerced. An [unsized type][1]
+is any type that the compiler doesn't know the length or alignment of at
+compile time. Any struct containing an unsized type is also unsized.
+
+[1]: https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait
 
 The `CoerceUnsized` trait takes a struct type. Make sure the type you are
 providing to `CoerceUnsized` is a struct with only the last field containing an

--- a/src/librustc_infer/infer/freshen.rs
+++ b/src/librustc_infer/infer/freshen.rs
@@ -143,9 +143,9 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TypeFreshener<'a, 'tcx> {
     }
 
     fn fold_ty(&mut self, t: Ty<'tcx>) -> Ty<'tcx> {
-        if !t.needs_infer()
-            && !t.has_erasable_regions()
-            && !(t.has_closure_types() && self.infcx.in_progress_tables.is_some())
+        if !(t.needs_infer()
+            || t.has_erasable_regions()
+            || (t.has_closure_types() && self.infcx.in_progress_tables.is_some()))
         {
             return t;
         }

--- a/src/librustc_infer/infer/mod.rs
+++ b/src/librustc_infer/infer/mod.rs
@@ -1484,7 +1484,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
 
         // Even if the type may have no inference variables, during
         // type-checking closure types are in local tables only.
-        if !self.in_progress_tables.is_some() || !ty.has_closure_types() {
+        if self.in_progress_tables.is_none() || !ty.has_closure_types() {
             if !(param_env, ty).has_local_value() {
                 return ty.is_copy_modulo_regions(self.tcx, param_env, span);
             }

--- a/src/librustc_passes/stability.rs
+++ b/src/librustc_passes/stability.rs
@@ -551,7 +551,7 @@ impl Visitor<'tcx> for Checker<'tcx> {
                     .emit();
                 } else {
                     let param_env = self.tcx.param_env(def_id);
-                    if !can_type_implement_copy(self.tcx, param_env, ty).is_ok() {
+                    if can_type_implement_copy(self.tcx, param_env, ty).is_err() {
                         feature_err(
                             &self.tcx.sess.parse_sess,
                             sym::untagged_unions,

--- a/src/librustc_resolve/imports.rs
+++ b/src/librustc_resolve/imports.rs
@@ -313,9 +313,9 @@ impl<'a> Resolver<'a> {
                             }
                         }
 
-                        if !self.is_accessible_from(binding.vis, parent_scope.module) &&
+                        if !(self.is_accessible_from(binding.vis, parent_scope.module) ||
                        // Remove this together with `PUB_USE_OF_PRIVATE_EXTERN_CRATE`
-                       !(self.last_import_segment && binding.is_extern_crate())
+                       (self.last_import_segment && binding.is_extern_crate()))
                         {
                             self.privacy_errors.push(PrivacyError {
                                 ident,

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1313,7 +1313,8 @@ impl Context {
                          <p>Version {}</p>\
                      </div>\
                      <a id='all-types' href='index.html'><p>Back to index</p></a>",
-                crate_name, version
+                crate_name,
+                Escape(version),
             )
         } else {
             String::new()
@@ -3974,7 +3975,7 @@ fn print_sidebar(cx: &Context, it: &clean::Item, buffer: &mut Buffer) {
                 "<div class='block version'>\
                     <p>Version {}</p>\
                     </div>",
-                version
+                Escape(version)
             );
         }
     }

--- a/src/libstd/net/parser.rs
+++ b/src/libstd/net/parser.rs
@@ -206,7 +206,7 @@ impl<'a> Parser<'a> {
         }
 
         // read `::` if previous code parsed less than 8 groups
-        if !self.read_given_char(':').is_some() || !self.read_given_char(':').is_some() {
+        if self.read_given_char(':').is_none() || self.read_given_char(':').is_none() {
             return None;
         }
 

--- a/src/test/rustdoc/crate-version-escape.rs
+++ b/src/test/rustdoc/crate-version-escape.rs
@@ -1,0 +1,6 @@
+// compile-flags: --crate-version=<script>alert("hi")</script> -Z unstable-options
+
+#![crate_name = "foo"]
+
+// @has 'foo/index.html' '//div[@class="block version"]/p' 'Version <script>alert("hi")</script>'
+// @has 'foo/all.html' '//div[@class="block version"]/p' 'Version <script>alert("hi")</script>'


### PR DESCRIPTION
Successful merges:

 - #69504 (Use assert_ne in hash tests)
 - #69554 (Cleanup e0374)
 - #69568 (Clarify explanation of Vec<T> 'fn resize')
 - #69569 (simplify boolean expressions)
 - #69577 (Clean up E0375 explanation)
 - #69598 (rustdoc: HTML escape crate version)
 - #69607 (Clean up E0376 explanation)

Failed merges:


r? @ghost