### PR TITLE
Rename `syntax` in librustc_ast/README.md

### DIFF
--- a/src/librustc_ast/README.md
+++ b/src/librustc_ast/README.md
@@ -1,4 +1,4 @@
-The `syntax` crate contains those things concerned purely with syntax
+The `rustc_ast` crate contains those things concerned purely with syntax
 – that is, the AST ("abstract syntax tree"), parser, pretty-printer,
 lexer, macro expander, and utilities for traversing ASTs.
 


### PR DESCRIPTION
Related to e94d3b7.
r? @petrochenkov