### PR TITLE
remove non-sysroot sources from rust-src component

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1002,8 +1002,6 @@ impl Step for Src {
             "src/tools/rustc-std-workspace-core",
             "src/tools/rustc-std-workspace-alloc",
             "src/tools/rustc-std-workspace-std",
-            "src/librustc",
-            "src/librustc_ast",
         ];
 
         copy_src_dirs(builder, &std_src_dirs[..], &[], &dst_src);


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/69592#discussion_r386238725: these were likely added in https://github.com/rust-lang/rust/pull/58269 for the sake of compiler plugins, but those are being entirely phased out, so there is no good reason to ship these sources.

OTOH, @eddyb [wrote](https://github.com/rust-lang/rust/pull/58269#issuecomment-463408918)

> Yeah, my question is why librustc_plugin specifically? Everything else makes sense.

So maybe there is some good reason to keep these? Then we should have a comment explaining that reason.

Cc @eddyb @taeguk @Mark-Simulacrum