### PR TITLE
Use query to determine whether function needs const checking

### DIFF
--- a/src/librustc_mir/const_eval/fn_queries.rs
+++ b/src/librustc_mir/const_eval/fn_queries.rs
@@ -99,8 +99,16 @@ fn is_const_fn_raw(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
 
     let node = tcx.hir().get(hir_id);
 
-    if let Some(whitelisted) = is_const_intrinsic(tcx, def_id) {
-        whitelisted
+    if let hir::Node::ForeignItem(hir::ForeignItem { kind: hir::ForeignItemKind::Fn(..), .. }) =
+        node
+    {
+        // Intrinsics use `rustc_const_{un,}stable` attributes to indicate constness. All other
+        // foreign items cannot be evaluated at compile-time.
+        if let Abi::RustIntrinsic | Abi::PlatformIntrinsic = tcx.hir().get_foreign_abi(hir_id) {
+            tcx.lookup_const_stability(def_id).is_some()
+        } else {
+            false
+        }
     } else if let Some(fn_like) = FnLikeNode::from_node(node) {
         if fn_like.constness() == hir::Constness::Const {
             return true;
@@ -113,21 +121,6 @@ fn is_const_fn_raw(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
         true
     } else {
         false
-    }
-}
-
-/// Const evaluability whitelist is here to check evaluability at the
-/// top level beforehand.
-fn is_const_intrinsic(tcx: TyCtxt<'_>, def_id: DefId) -> Option<bool> {
-    if tcx.is_closure(def_id) {
-        return None;
-    }
-
-    match tcx.fn_sig(def_id).abi() {
-        Abi::RustIntrinsic | Abi::PlatformIntrinsic => {
-            Some(tcx.lookup_const_stability(def_id).is_some())
-        }
-        _ => None,
     }
 }
 

--- a/src/librustc_passes/check_const.rs
+++ b/src/librustc_passes/check_const.rs
@@ -74,16 +74,16 @@ enum ConstKind {
 }
 
 impl ConstKind {
-    fn for_body(body: &hir::Body<'_>, hir_map: Map<'_>) -> Option<Self> {
-        let is_const_fn = |id| hir_map.fn_sig_by_hir_id(id).unwrap().header.is_const();
-
-        let owner = hir_map.body_owner(body.id());
-        let const_kind = match hir_map.body_owner_kind(owner) {
+    fn for_body(body: &hir::Body<'_>, tcx: TyCtxt<'_>) -> Option<Self> {
+        let owner = tcx.hir().body_owner(body.id());
+        let const_kind = match tcx.hir().body_owner_kind(owner) {
             hir::BodyOwnerKind::Const => Self::Const,
             hir::BodyOwnerKind::Static(Mutability::Mut) => Self::StaticMut,
             hir::BodyOwnerKind::Static(Mutability::Not) => Self::Static,
 
-            hir::BodyOwnerKind::Fn if is_const_fn(owner) => Self::ConstFn,
+            hir::BodyOwnerKind::Fn if tcx.is_const_fn_raw(tcx.hir().local_def_id(owner)) => {
+                Self::ConstFn
+            }
             hir::BodyOwnerKind::Fn | hir::BodyOwnerKind::Closure => return None,
         };
 
@@ -211,7 +211,7 @@ impl<'tcx> Visitor<'tcx> for CheckConstVisitor<'tcx> {
     }
 
     fn visit_body(&mut self, body: &'tcx hir::Body<'tcx>) {
-        let kind = ConstKind::for_body(body, self.tcx.hir());
+        let kind = ConstKind::for_body(body, self.tcx);
         self.recurse_into(kind, |this| intravisit::walk_body(this, body));
     }
 

--- a/src/test/ui/rfc-2632-const-trait-impl/hir-const-check.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/hir-const-check.rs
@@ -1,0 +1,16 @@
+// Regression test for #69615.
+
+#![feature(const_trait_impl, const_fn)]
+#![allow(incomplete_features)]
+
+pub trait MyTrait {
+    fn method(&self);
+}
+
+impl const MyTrait for () {
+    fn method(&self) {
+        match *self {} //~ ERROR `match` is not allowed in a `const fn`
+    }
+}
+
+fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/hir-const-check.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/hir-const-check.stderr
@@ -1,0 +1,12 @@
+error[E0658]: `match` is not allowed in a `const fn`
+  --> $DIR/hir-const-check.rs:12:9
+   |
+LL |         match *self {}
+   |         ^^^^^^^^^^^^^^
+   |
+   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
+   = help: add `#![feature(const_if_match)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Resolves #69615.

The HIR const-checker was checking the `constness` of a function's `fn_sig` to determine whether a function needed const-checking. Now that const trait impls are a thing, this is no longer enough. All code should use the `is_const_fn_raw` query instead, which takes the constness of the impl block into account.

r? @oli-obk