### PR TITLE
Update issue reference for impl_trait_in_bindings feature

### DIFF
--- a/src/doc/unstable-book/src/language-features/impl-trait-in-bindings.md
+++ b/src/doc/unstable-book/src/language-features/impl-trait-in-bindings.md
@@ -1,8 +1,8 @@
 # `impl_trait_in_bindings`
 
-The tracking issue for this feature is: [#34511]
+The tracking issue for this feature is: [#63065]
 
-[#34511]: https://github.com/rust-lang/rust/issues/34511
+[#63065]: https://github.com/rust-lang/rust/issues/63065
 
 ------------------------
 


### PR DESCRIPTION
The existing issue #34511 has been closed and replaced by meta-issue #63066.

The concrete part of the new meta-issue for this feature should be #63065.