### PR TITLE
cleanup more iterator usages (and other things)

### DIFF
--- a/src/liballoc/collections/btree/node.rs
+++ b/src/liballoc/collections/btree/node.rs
@@ -1191,7 +1191,7 @@ impl<'a, K, V> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, marker::
         let right_len = right_node.len();
 
         // necessary for correctness, but in a private module
-        assert!(left_len + right_len + 1 <= CAPACITY);
+        assert!(left_len + right_len < CAPACITY);
 
         unsafe {
             ptr::write(

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -189,7 +189,7 @@ impl<'tcx> Body<'tcx> {
     ) -> Self {
         // We need `arg_count` locals, and one for the return place.
         assert!(
-            local_decls.len() >= arg_count + 1,
+            local_decls.len() > arg_count,
             "expected at least {} locals, got {}",
             arg_count + 1,
             local_decls.len()

--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -186,7 +186,7 @@ pub fn get_linker(sess: &Session, linker: &Path, flavor: LinkerFlavor) -> (PathB
     if flavor == LinkerFlavor::Msvc && t.target_vendor == "uwp" {
         if let Some(ref tool) = msvc_tool {
             let original_path = tool.path();
-            if let Some(ref root_lib_path) = original_path.ancestors().skip(4).next() {
+            if let Some(ref root_lib_path) = original_path.ancestors().nth(4) {
                 let arch = match t.arch.as_str() {
                     "x86_64" => Some("x64".to_string()),
                     "x86" => Some("x86".to_string()),

--- a/src/librustc_expand/mbe/transcribe.rs
+++ b/src/librustc_expand/mbe/transcribe.rs
@@ -119,9 +119,9 @@ pub(super) fn transcribe(
         let tree = if let Some(tree) = stack.last_mut().unwrap().next() {
             // If it still has a TokenTree we have not looked at yet, use that tree.
             tree
-        }
-        // The else-case never produces a value for `tree` (it `continue`s or `return`s).
-        else {
+        } else {
+            // This else-case never produces a value for `tree` (it `continue`s or `return`s).
+
             // Otherwise, if we have just reached the end of a sequence and we can keep repeating,
             // go back to the beginning of the sequence.
             if let Frame::Sequence { idx, sep, .. } = stack.last_mut().unwrap() {

--- a/src/librustc_infer/traits/error_reporting/suggestions.rs
+++ b/src/librustc_infer/traits/error_reporting/suggestions.rs
@@ -401,9 +401,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(span) {
             let refs_number =
                 snippet.chars().filter(|c| !c.is_whitespace()).take_while(|c| *c == '&').count();
-            if let Some('\'') =
-                snippet.chars().filter(|c| !c.is_whitespace()).skip(refs_number).next()
-            {
+            if let Some('\'') = snippet.chars().filter(|c| !c.is_whitespace()).nth(refs_number) {
                 // Do not suggest removal of borrow from type arguments.
                 return;
             }
@@ -464,9 +462,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(span) {
             let refs_number =
                 snippet.chars().filter(|c| !c.is_whitespace()).take_while(|c| *c == '&').count();
-            if let Some('\'') =
-                snippet.chars().filter(|c| !c.is_whitespace()).skip(refs_number).next()
-            {
+            if let Some('\'') = snippet.chars().filter(|c| !c.is_whitespace()).nth(refs_number) {
                 // Do not suggest removal of borrow from type arguments.
                 return;
             }

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -824,11 +824,8 @@ fn find_vtable_types_for_unsizing<'tcx>(
         (&ty::Adt(source_adt_def, source_substs), &ty::Adt(target_adt_def, target_substs)) => {
             assert_eq!(source_adt_def, target_adt_def);
 
-            let kind = monomorphize::custom_coerce_unsize_info(tcx, source_ty, target_ty);
-
-            let coerce_index = match kind {
-                CustomCoerceUnsized::Struct(i) => i,
-            };
+            let CustomCoerceUnsized::Struct(coerce_index) =
+                monomorphize::custom_coerce_unsize_info(tcx, source_ty, target_ty);
 
             let source_fields = &source_adt_def.non_enum_variant().fields;
             let target_fields = &target_adt_def.non_enum_variant().fields;

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -236,8 +236,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     //
                     // FIXME? Other potential candidate methods: `as_ref` and
                     // `as_mut`?
-                    .find(|a| a.check_name(sym::rustc_conversion_suggestion))
-                    .is_some()
+                    .any(|a| a.check_name(sym::rustc_conversion_suggestion))
         });
 
         methods

--- a/src/librustc_typeck/coherence/inherent_impls_overlap.rs
+++ b/src/librustc_typeck/coherence/inherent_impls_overlap.rs
@@ -23,14 +23,11 @@ impl InherentOverlapChecker<'tcx> {
         let impl_items2 = self.tcx.associated_items(impl2);
 
         for item1 in impl_items1.in_definition_order() {
-            let collision = impl_items2
-                .filter_by_name_unhygienic(item1.ident.name)
-                .find(|item2| {
-                    // Symbols and namespace match, compare hygienically.
-                    item1.kind.namespace() == item2.kind.namespace()
-                        && item1.ident.modern() == item2.ident.modern()
-                })
-                .is_some();
+            let collision = impl_items2.filter_by_name_unhygienic(item1.ident.name).any(|item2| {
+                // Symbols and namespace match, compare hygienically.
+                item1.kind.namespace() == item2.kind.namespace()
+                    && item1.ident.modern() == item2.ident.modern()
+            });
 
             if collision {
                 return true;


### PR DESCRIPTION
* Improve weird formatting by moving comment inside else-code block.
* Use .any(x) instead of .find(x).is_some() on iterators.
* Use .nth(x) instead of .skip(x).next() on iterators.
* Simplify conditions like  x + 1 <= y   to   x < y
* Use let instead of match to get value of enum with single variant.