### PR TITLE
Implement From<&mut str> for String

### DIFF
--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -2225,7 +2225,7 @@ impl From<&str> for String {
     }
 }
 
-#[stable(feature = "???", since = "1.43.0")]
+#[stable(feature = "from_mut_str_for_string", since = "1.44.0")]
 impl From<&mut str> for String {
     #[inline]
     fn from(s: &mut str) -> String {

--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -2227,6 +2227,9 @@ impl From<&str> for String {
 
 #[stable(feature = "from_mut_str_for_string", since = "1.44.0")]
 impl From<&mut str> for String {
+    /// Converts a `&mut str` into a `String`.
+    ///
+    /// The result is allocated on the heap.
     #[inline]
     fn from(s: &mut str) -> String {
         s.to_owned()

--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -2225,6 +2225,14 @@ impl From<&str> for String {
     }
 }
 
+#[stable(feature = "???", since = "1.43.0")]
+impl From<&mut str> for String {
+    #[inline]
+    fn from(s: &mut str) -> String {
+        s.to_owned()
+    }
+}
+
 #[stable(feature = "from_ref_string", since = "1.35.0")]
 impl From<&String> for String {
     #[inline]


### PR DESCRIPTION
I ran into this missing impl when trying to do `String::from` on the result returned from this API in the `uuid` crate:

https://docs.rs/uuid/0.8.1/uuid/adapter/struct.Hyphenated.html#method.encode_lower

I wasn't sure what to put in the stability annotation. I'd appreciate some help with that :)