### PR TITLE
Invoke OptimizerLastEPCallbacks in PreLinkThinLTO

### DIFF
--- a/src/test/codegen/sanitizer-recover.rs
+++ b/src/test/codegen/sanitizer-recover.rs
@@ -14,8 +14,8 @@
 //[MSAN-RECOVER-LTO] compile-flags: -Zsanitizer=memory  -Zsanitizer-recover=memory -C lto=fat
 //
 // MSAN-NOT:         @__msan_keep_going
-// MSAN-RECOVER:     @__msan_keep_going = weak_odr {{.*}} constant i32 1
-// MSAN-RECOVER-LTO: @__msan_keep_going = weak_odr {{.*}} constant i32 1
+// MSAN-RECOVER:     @__msan_keep_going = weak_odr {{.*}}constant i32 1
+// MSAN-RECOVER-LTO: @__msan_keep_going = weak_odr {{.*}}constant i32 1
 
 // ASAN-LABEL: define i32 @penguin(
 // ASAN:         call void @__asan_report_load4(i64 %0)

--- a/src/test/ui/sanitize/new-llvm-pass-manager-thin-lto.rs
+++ b/src/test/ui/sanitize/new-llvm-pass-manager-thin-lto.rs
@@ -1,0 +1,27 @@
+// Regression test for sanitizer function instrumentation passes not
+// being run when compiling with new LLVM pass manager and ThinLTO.
+// Note: The issue occured only on non-zero opt-level.
+//
+// min-llvm-version 9.0
+// needs-sanitizer-support
+// only-x86_64
+//
+// no-prefer-dynamic
+// revisions: opt0 opt1
+// compile-flags: -Znew-llvm-pass-manager=yes -Zsanitizer=address -Clto=thin
+//[opt0]compile-flags: -Copt-level=0
+//[opt1]compile-flags: -Copt-level=1
+// run-fail
+// error-pattern: ERROR: AddressSanitizer: stack-use-after-scope
+
+static mut P: *mut usize = std::ptr::null_mut();
+
+fn main() {
+    unsafe {
+        {
+            let mut x = 0;
+            P = &mut x;
+        }
+        std::ptr::write_volatile(P, 123);
+    }
+}

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -110,6 +110,24 @@ fn no_system_llvm() {
 }
 
 #[test]
+fn llvm_version() {
+    let mut config = config();
+
+    config.llvm_version = Some("8.1.2-rust".to_owned());
+    assert!(parse_rs(&config, "// min-llvm-version 9.0").ignore);
+
+    config.llvm_version = Some("9.0.1-rust-1.43.0-dev".to_owned());
+    assert!(parse_rs(&config, "// min-llvm-version 9.2").ignore);
+
+    config.llvm_version = Some("9.3.1-rust-1.43.0-dev".to_owned());
+    assert!(!parse_rs(&config, "// min-llvm-version 9.2").ignore);
+
+    // FIXME.
+    // config.llvm_version = Some("10.0.0-rust".to_owned());
+    // assert!(!parse_rs(&config, "// min-llvm-version 9.0").ignore);
+}
+
+#[test]
 fn ignore_target() {
     let mut config = config();
     config.target = "x86_64-unknown-linux-gnu".to_owned();


### PR DESCRIPTION
The default ThinLTO pre-link pipeline does not include optimizer last
extension points. Thus, when using the new LLVM pass manager & ThinLTO
& sanitizers on any opt-level different from zero, the sanitizer
function passes would be omitted from the pipeline.

Add optimizer last extensions points manually to the pipeline, but guard
registration with stage check in the case this behaviour changes in the
future.