### PR TITLE
Fixing broken references to char primitive methods in str module

### DIFF
--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -4315,7 +4315,7 @@ impl str {
     /// Note: only extended grapheme codepoints that begin the string will be
     /// escaped.
     ///
-    /// [`char::escape_debug`]: ../std/primitive.char.html#method.escape_debug
+    /// [`char::escape_debug`]: ../../std/primitive.char.html#method.escape_debug
     ///
     /// # Examples
     ///
@@ -4361,7 +4361,7 @@ impl str {
 
     /// Return an iterator that escapes each char in `self` with [`char::escape_default`].
     ///
-    /// [`char::escape_default`]: ../std/primitive.char.html#method.escape_default
+    /// [`char::escape_default`]: ../../std/primitive.char.html#method.escape_default
     ///
     /// # Examples
     ///
@@ -4399,7 +4399,7 @@ impl str {
 
     /// Return an iterator that escapes each char in `self` with [`char::escape_unicode`].
     ///
-    /// [`char::escape_unicode`]: ../std/primitive.char.html#method.escape_unicode
+    /// [`char::escape_unicode`]: ../../std/primitive.char.html#method.escape_unicode
     ///
     /// # Examples
     ///


### PR DESCRIPTION
The links in [`string` module][string-module] to methods in [`char` module][char-module] are broken for [#method.escape_debug][escape-debug], [#method.escape_default][escape-default] and [#method.escape_unicode][escape-unicode].

r? @steveklabnik

[escape-debug]: https://doc.rust-lang.org/std/string/struct.String.html#method.escape_debug
[escape-default]: https://doc.rust-lang.org/std/string/struct.String.html#method.escape_default
[escape-unicode]: https://doc.rust-lang.org/std/string/struct.String.html#method.escape_unicode
[char-module]: https://doc.rust-lang.org/std/primitive.char.html
[string-module]: https://doc.rust-lang.org/std/string/struct.String.html