### PR TITLE
[PERF][WIP] Use `unchecked_add` in `Layout::repeat`

### DIFF
--- a/src/libcore/alloc.rs
+++ b/src/libcore/alloc.rs
@@ -239,7 +239,9 @@ impl Layout {
         // > `size`, when rounded up to the nearest multiple of `align`,
         // > must not overflow (i.e., the rounded value must be less than
         // > `usize::MAX`)
-        let padded_size = self.size() + self.padding_needed_for(self.align());
+        let padded_size = unsafe {
+            crate::intrinsics::unchecked_add(self.size(), self.padding_needed_for(self.align()))
+        };
         let alloc_size = padded_size.checked_mul(n).ok_or(LayoutErr { private: () })?;
 
         unsafe {


### PR DESCRIPTION
#69635 (a rollup) caused a [small performance regression](https://perf.rust-lang.org/compare.html?start=c839a7b4c26e58319b0c40448dd423facff34cd0&end=18c275b423f9f13c0e404ae3804967d2ab66337c&stat=instructions:u). Nothing in that rollup jumps out at me, but #69544 alters some code that is pretty hot, so let's mess with that.

r? @ghost (just for a perf run)
