### PR TITLE
unix: Don't override existing SIGSEGV/BUS handlers

### DIFF
--- a/src/test/ui/sanitize/badfree.rs
+++ b/src/test/ui/sanitize/badfree.rs
@@ -1,0 +1,19 @@
+// needs-sanitizer-support
+// only-x86_64
+//
+// compile-flags: -Z sanitizer=address -O
+//
+// run-fail
+// error-pattern: AddressSanitizer: SEGV
+
+use std::ffi::c_void;
+
+extern "C" {
+    fn free(ptr: *mut c_void);
+}
+
+fn main() {
+    unsafe {
+        free(1 as *mut c_void);
+    }
+}


### PR DESCRIPTION
Although `stack_overflow::init` runs very early in the process, even
before `main`, there may already be signal handlers installed for things
like the address sanitizer. In that case, just leave it alone, and don't
bother trying to allocate our own signal stacks either.

Fixes #69524.