### PR TITLE
Use `pprust` to print attributes in rustdoc

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -44,7 +44,6 @@ use std::sync::Arc;
 
 use rustc::middle::privacy::AccessLevels;
 use rustc::middle::stability;
-use rustc_ast::ast;
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::flock;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
@@ -3152,6 +3151,7 @@ fn render_attributes(w: &mut Buffer, it: &clean::Item, top: bool) {
             continue;
         }
 
+        // FIXME: this currently renders too many spaces as in: `#[repr(C, align (8))]`.
         attrs.push_str(&pprust::attribute_to_string(&attr));
     }
     if !attrs.is_empty() {

--- a/src/test/rustdoc/attributes.rs
+++ b/src/test/rustdoc/attributes.rs
@@ -15,3 +15,7 @@ pub extern "C" fn g() {}
 pub enum Foo {
     Bar,
 }
+
+// @has foo/struct.Repr.html '//*[@class="docblock attributes top-attr"]' '#[repr(C, align (8))]'
+#[repr(C, align(8))]
+pub struct Repr;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/69559.

I'm not sure what the original motivation was for the `render_attribute`, so I may be missing something, but replacing it with `pprust::attribute_to_string` seems to give the intended output (modulo some spacing idiosyncrasies).

r? @GuillaumeGomez 