### PR TITLE
resolve, inconsistent binding mode: tweak wording

### DIFF
--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -249,8 +249,7 @@ impl<'a> Resolver<'a> {
                     self.session,
                     span,
                     E0409,
-                    "variable `{}` is bound in inconsistent \
-                                ways within the same match arm",
+                    "variable `{}` is bound inconsistently across alternatives separated by `|`",
                     variable_name
                 );
                 err.span_label(span, "bound in different ways");

--- a/src/test/ui/mismatched_types/E0409.stderr
+++ b/src/test/ui/mismatched_types/E0409.stderr
@@ -1,4 +1,4 @@
-error[E0409]: variable `y` is bound in inconsistent ways within the same match arm
+error[E0409]: variable `y` is bound inconsistently across alternatives separated by `|`
   --> $DIR/E0409.rs:5:23
    |
 LL |         (0, ref y) | (y, 0) => {}

--- a/src/test/ui/or-patterns/inconsistent-modes.rs
+++ b/src/test/ui/or-patterns/inconsistent-modes.rs
@@ -5,22 +5,22 @@
 fn main() {
     // One level:
     let Ok(a) | Err(ref a): Result<&u8, u8> = Ok(&0);
-    //~^ ERROR variable `a` is bound in inconsistent ways
+    //~^ ERROR variable `a` is bound inconsistently
     let Ok(ref mut a) | Err(a): Result<u8, &mut u8> = Ok(0);
-    //~^ ERROR variable `a` is bound in inconsistent ways
+    //~^ ERROR variable `a` is bound inconsistently
     let Ok(ref a) | Err(ref mut a): Result<&u8, &mut u8> = Ok(&0);
-    //~^ ERROR variable `a` is bound in inconsistent ways
+    //~^ ERROR variable `a` is bound inconsistently
     //~| ERROR mismatched types
     let Ok((ref a, b)) | Err((ref mut a, ref b)) = Ok((0, &0));
-    //~^ ERROR variable `a` is bound in inconsistent ways
-    //~| ERROR variable `b` is bound in inconsistent ways
+    //~^ ERROR variable `a` is bound inconsistently
+    //~| ERROR variable `b` is bound inconsistently
     //~| ERROR mismatched types
 
     // Two levels:
     let Ok(Ok(a) | Err(a)) | Err(ref a) = Err(0);
-    //~^ ERROR variable `a` is bound in inconsistent ways
+    //~^ ERROR variable `a` is bound inconsistently
 
     // Three levels:
-    let Ok([ Ok((Ok(ref a) | Err(a),)) | Err(a) ]) | Err(a) = Err(&1);
-    //~^ ERROR variable `a` is bound in inconsistent ways
+    let Ok([Ok((Ok(ref a) | Err(a),)) | Err(a)]) | Err(a) = Err(&1);
+    //~^ ERROR variable `a` is bound inconsistently
 }

--- a/src/test/ui/or-patterns/inconsistent-modes.stderr
+++ b/src/test/ui/or-patterns/inconsistent-modes.stderr
@@ -1,4 +1,4 @@
-error[E0409]: variable `a` is bound in inconsistent ways within the same match arm
+error[E0409]: variable `a` is bound inconsistently across alternatives separated by `|`
   --> $DIR/inconsistent-modes.rs:7:25
    |
 LL |     let Ok(a) | Err(ref a): Result<&u8, u8> = Ok(&0);
@@ -6,7 +6,7 @@ LL |     let Ok(a) | Err(ref a): Result<&u8, u8> = Ok(&0);
    |            |
    |            first binding
 
-error[E0409]: variable `a` is bound in inconsistent ways within the same match arm
+error[E0409]: variable `a` is bound inconsistently across alternatives separated by `|`
   --> $DIR/inconsistent-modes.rs:9:29
    |
 LL |     let Ok(ref mut a) | Err(a): Result<u8, &mut u8> = Ok(0);
@@ -14,25 +14,25 @@ LL |     let Ok(ref mut a) | Err(a): Result<u8, &mut u8> = Ok(0);
    |                    |
    |                    first binding
 
-error[E0409]: variable `a` is bound in inconsistent ways within the same match arm
+error[E0409]: variable `a` is bound inconsistently across alternatives separated by `|`
   --> $DIR/inconsistent-modes.rs:11:33
    |
 LL |     let Ok(ref a) | Err(ref mut a): Result<&u8, &mut u8> = Ok(&0);
    |                - first binding  ^ bound in different ways
 
-error[E0409]: variable `a` is bound in inconsistent ways within the same match arm
+error[E0409]: variable `a` is bound inconsistently across alternatives separated by `|`
   --> $DIR/inconsistent-modes.rs:14:39
    |
 LL |     let Ok((ref a, b)) | Err((ref mut a, ref b)) = Ok((0, &0));
    |                 - first binding       ^ bound in different ways
 
-error[E0409]: variable `b` is bound in inconsistent ways within the same match arm
+error[E0409]: variable `b` is bound inconsistently across alternatives separated by `|`
   --> $DIR/inconsistent-modes.rs:14:46
    |
 LL |     let Ok((ref a, b)) | Err((ref mut a, ref b)) = Ok((0, &0));
    |                    - first binding           ^ bound in different ways
 
-error[E0409]: variable `a` is bound in inconsistent ways within the same match arm
+error[E0409]: variable `a` is bound inconsistently across alternatives separated by `|`
   --> $DIR/inconsistent-modes.rs:20:38
    |
 LL |     let Ok(Ok(a) | Err(a)) | Err(ref a) = Err(0);
@@ -40,13 +40,13 @@ LL |     let Ok(Ok(a) | Err(a)) | Err(ref a) = Err(0);
    |                        |
    |                        first binding
 
-error[E0409]: variable `a` is bound in inconsistent ways within the same match arm
-  --> $DIR/inconsistent-modes.rs:24:34
+error[E0409]: variable `a` is bound inconsistently across alternatives separated by `|`
+  --> $DIR/inconsistent-modes.rs:24:33
    |
-LL |     let Ok([ Ok((Ok(ref a) | Err(a),)) | Err(a) ]) | Err(a) = Err(&1);
-   |                         -        ^ bound in different ways
-   |                         |
-   |                         first binding
+LL |     let Ok([Ok((Ok(ref a) | Err(a),)) | Err(a)]) | Err(a) = Err(&1);
+   |                        -        ^ bound in different ways
+   |                        |
+   |                        first binding
 
 error[E0308]: mismatched types
   --> $DIR/inconsistent-modes.rs:11:25

--- a/src/test/ui/resolve/resolve-inconsistent-binding-mode.rs
+++ b/src/test/ui/resolve/resolve-inconsistent-binding-mode.rs
@@ -1,39 +1,40 @@
 enum Opts {
-    A(isize), B(isize), C(isize)
+    A(isize),
+    B(isize),
+    C(isize),
 }
 
 fn matcher1(x: Opts) {
     match x {
-      Opts::A(ref i) | Opts::B(i) => {}
-      //~^ ERROR variable `i` is bound in inconsistent ways within the same match arm
-      //~^^ ERROR mismatched types
-      Opts::C(_) => {}
+        Opts::A(ref i) | Opts::B(i) => {}
+        //~^ ERROR variable `i` is bound inconsistently
+        //~^^ ERROR mismatched types
+        Opts::C(_) => {}
     }
 }
 
 fn matcher2(x: Opts) {
     match x {
-      Opts::A(ref i) | Opts::B(i) => {}
-      //~^ ERROR variable `i` is bound in inconsistent ways within the same match arm
-      //~^^ ERROR mismatched types
-      Opts::C(_) => {}
+        Opts::A(ref i) | Opts::B(i) => {}
+        //~^ ERROR variable `i` is bound inconsistently
+        //~^^ ERROR mismatched types
+        Opts::C(_) => {}
     }
 }
 
 fn matcher4(x: Opts) {
     match x {
-      Opts::A(ref mut i) | Opts::B(ref i) => {}
-      //~^ ERROR variable `i` is bound in inconsistent ways within the same match arm
-      //~^^ ERROR mismatched types
-      Opts::C(_) => {}
+        Opts::A(ref mut i) | Opts::B(ref i) => {}
+        //~^ ERROR variable `i` is bound inconsistently
+        //~^^ ERROR mismatched types
+        Opts::C(_) => {}
     }
 }
 
-
 fn matcher5(x: Opts) {
     match x {
-      Opts::A(ref i) | Opts::B(ref i) => {}
-      Opts::C(_) => {}
+        Opts::A(ref i) | Opts::B(ref i) => {}
+        Opts::C(_) => {}
     }
 }
 

--- a/src/test/ui/resolve/resolve-inconsistent-binding-mode.stderr
+++ b/src/test/ui/resolve/resolve-inconsistent-binding-mode.stderr
@@ -1,58 +1,58 @@
-error[E0409]: variable `i` is bound in inconsistent ways within the same match arm
-  --> $DIR/resolve-inconsistent-binding-mode.rs:7:32
+error[E0409]: variable `i` is bound inconsistently across alternatives separated by `|`
+  --> $DIR/resolve-inconsistent-binding-mode.rs:9:34
    |
-LL |       Opts::A(ref i) | Opts::B(i) => {}
-   |                   -            ^ bound in different ways
-   |                   |
-   |                   first binding
+LL |         Opts::A(ref i) | Opts::B(i) => {}
+   |                     -            ^ bound in different ways
+   |                     |
+   |                     first binding
 
-error[E0409]: variable `i` is bound in inconsistent ways within the same match arm
-  --> $DIR/resolve-inconsistent-binding-mode.rs:16:32
+error[E0409]: variable `i` is bound inconsistently across alternatives separated by `|`
+  --> $DIR/resolve-inconsistent-binding-mode.rs:18:34
    |
-LL |       Opts::A(ref i) | Opts::B(i) => {}
-   |                   -            ^ bound in different ways
-   |                   |
-   |                   first binding
+LL |         Opts::A(ref i) | Opts::B(i) => {}
+   |                     -            ^ bound in different ways
+   |                     |
+   |                     first binding
 
-error[E0409]: variable `i` is bound in inconsistent ways within the same match arm
-  --> $DIR/resolve-inconsistent-binding-mode.rs:25:40
+error[E0409]: variable `i` is bound inconsistently across alternatives separated by `|`
+  --> $DIR/resolve-inconsistent-binding-mode.rs:27:42
    |
-LL |       Opts::A(ref mut i) | Opts::B(ref i) => {}
-   |                       - first binding  ^ bound in different ways
+LL |         Opts::A(ref mut i) | Opts::B(ref i) => {}
+   |                         - first binding  ^ bound in different ways
 
 error[E0308]: mismatched types
-  --> $DIR/resolve-inconsistent-binding-mode.rs:7:32
+  --> $DIR/resolve-inconsistent-binding-mode.rs:9:34
    |
 LL |     match x {
    |           - this expression has type `Opts`
-LL |       Opts::A(ref i) | Opts::B(i) => {}
-   |               -----            ^ expected `&isize`, found `isize`
-   |               |
-   |               first introduced with type `&isize` here
+LL |         Opts::A(ref i) | Opts::B(i) => {}
+   |                 -----            ^ expected `&isize`, found `isize`
+   |                 |
+   |                 first introduced with type `&isize` here
    |
    = note: in the same arm, a binding must have the same type in all alternatives
 
 error[E0308]: mismatched types
-  --> $DIR/resolve-inconsistent-binding-mode.rs:16:32
+  --> $DIR/resolve-inconsistent-binding-mode.rs:18:34
    |
 LL |     match x {
    |           - this expression has type `Opts`
-LL |       Opts::A(ref i) | Opts::B(i) => {}
-   |               -----            ^ expected `&isize`, found `isize`
-   |               |
-   |               first introduced with type `&isize` here
+LL |         Opts::A(ref i) | Opts::B(i) => {}
+   |                 -----            ^ expected `&isize`, found `isize`
+   |                 |
+   |                 first introduced with type `&isize` here
    |
    = note: in the same arm, a binding must have the same type in all alternatives
 
 error[E0308]: mismatched types
-  --> $DIR/resolve-inconsistent-binding-mode.rs:25:36
+  --> $DIR/resolve-inconsistent-binding-mode.rs:27:38
    |
 LL |     match x {
    |           - this expression has type `Opts`
-LL |       Opts::A(ref mut i) | Opts::B(ref i) => {}
-   |               ---------            ^^^^^ types differ in mutability
-   |               |
-   |               first introduced with type `&mut isize` here
+LL |         Opts::A(ref mut i) | Opts::B(ref i) => {}
+   |                 ---------            ^^^^^ types differ in mutability
+   |                 |
+   |                 first introduced with type `&mut isize` here
    |
    = note: expected type `&mut isize`
               found type `&isize`

--- a/src/test/ui/resolve/resolve-inconsistent-names.rs
+++ b/src/test/ui/resolve/resolve-inconsistent-names.rs
@@ -19,7 +19,7 @@ fn main() {
         (A, B) | (ref B, c) | (c, A) => ()
         //~^ ERROR variable `A` is not bound in all patterns
         //~| ERROR variable `B` is not bound in all patterns
-        //~| ERROR variable `B` is bound in inconsistent ways
+        //~| ERROR variable `B` is bound inconsistently
         //~| ERROR mismatched types
         //~| ERROR variable `c` is not bound in all patterns
         //~| HELP consider making the path in the pattern qualified: `?::A`

--- a/src/test/ui/resolve/resolve-inconsistent-names.stderr
+++ b/src/test/ui/resolve/resolve-inconsistent-names.stderr
@@ -47,7 +47,7 @@ LL |         (A, B) | (ref B, c) | (c, A) => ()
    |         |                variable not in all patterns
    |         pattern doesn't bind `c`
 
-error[E0409]: variable `B` is bound in inconsistent ways within the same match arm
+error[E0409]: variable `B` is bound inconsistently across alternatives separated by `|`
   --> $DIR/resolve-inconsistent-names.rs:19:23
    |
 LL |         (A, B) | (ref B, c) | (c, A) => ()

--- a/src/test/ui/rfc-2005-default-binding-mode/issue-44912-or.rs
+++ b/src/test/ui/rfc-2005-default-binding-mode/issue-44912-or.rs
@@ -4,7 +4,7 @@ pub fn main() {
     let x = &Some((3, 3));
     let _: &i32 = match x {
         Some((x, 3)) | &Some((ref x, 5)) => x,
-        //~^ ERROR is bound in inconsistent ways
+        //~^ ERROR is bound inconsistently
         _ => &5i32,
     };
 }

--- a/src/test/ui/rfc-2005-default-binding-mode/issue-44912-or.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/issue-44912-or.stderr
@@ -1,4 +1,4 @@
-error[E0409]: variable `x` is bound in inconsistent ways within the same match arm
+error[E0409]: variable `x` is bound inconsistently across alternatives separated by `|`
   --> $DIR/issue-44912-or.rs:6:35
    |
 LL |         Some((x, 3)) | &Some((ref x, 5)) => x,


### PR DESCRIPTION
Now that we can have e.g. `let Ok(x) | Err(x) = res;`, it's no longer appropriate to refer to "the same *match arm*", so let's tweak the wording.

r? @estebank 