### PR TITLE
test(pattern): add tests for combinations of pattern features

### DIFF
--- a/src/test/ui/or-patterns/box-patterns.rs
+++ b/src/test/ui/or-patterns/box-patterns.rs
@@ -1,0 +1,37 @@
+// Test or-patterns with box-patterns
+
+// run-pass
+
+#![feature(or_patterns)]
+#![feature(box_patterns)]
+
+#[derive(Debug, PartialEq)]
+enum MatchArm {
+    Arm(usize),
+    Wild,
+}
+
+#[derive(Debug)]
+enum Test {
+    Foo,
+    Bar,
+    Baz,
+    Qux,
+}
+
+fn test(x: Option<Box<Test>>) -> MatchArm {
+    match x {
+        Some(box Test::Foo | box Test::Bar) => MatchArm::Arm(0),
+        Some(box Test::Baz) => MatchArm::Arm(1),
+        Some(_) => MatchArm::Arm(2),
+        _ => MatchArm::Wild,
+    }
+}
+
+fn main() {
+    assert_eq!(test(Some(Box::new(Test::Foo))), MatchArm::Arm(0));
+    assert_eq!(test(Some(Box::new(Test::Bar))), MatchArm::Arm(0));
+    assert_eq!(test(Some(Box::new(Test::Baz))), MatchArm::Arm(1));
+    assert_eq!(test(Some(Box::new(Test::Qux))), MatchArm::Arm(2));
+    assert_eq!(test(None), MatchArm::Wild);
+}

--- a/src/test/ui/or-patterns/slice-patterns.rs
+++ b/src/test/ui/or-patterns/slice-patterns.rs
@@ -20,8 +20,8 @@ enum Test {
 
 fn test(foo: &[Option<Test>]) -> MatchArm {
     match foo {
-        [.., Some(Test::Foo | Test::Qux)] => MatchArm::Arm(0),
-        [Some(Test::Foo), .., Some(Test::Bar | Test::Baz)] => MatchArm::Arm(1),
+        [.., Some(Test::Qux | Test::Foo)] => MatchArm::Arm(0),
+        [Some(Test::Foo), .., Some(Test::Baz | Test::Bar)] => MatchArm::Arm(1),
         [.., Some(Test::Bar | Test::Baz), _] => MatchArm::Arm(2),
         _ => MatchArm::Wild,
     }
@@ -35,8 +35,18 @@ fn main() {
         Some(Test::Qux),
     ];
 
+    // path 1a
     assert_eq!(test(&foo), MatchArm::Arm(0));
+    // path 1b
+    assert_eq!(test(&[Some(Test::Bar), Some(Test::Foo)]), MatchArm::Arm(0));
+    // path 2a
     assert_eq!(test(&foo[..3]), MatchArm::Arm(1));
+    // path 2b
+    assert_eq!(test(&[Some(Test::Foo), Some(Test::Foo), Some(Test::Bar)]), MatchArm::Arm(1));
+    // path 3a
     assert_eq!(test(&foo[1..3]), MatchArm::Arm(2));
+    // path 3b
+    assert_eq!(test(&[Some(Test::Bar), Some(Test::Baz), Some(Test::Baz), Some(Test::Bar)]), MatchArm::Arm(2));
+    // path 4
     assert_eq!(test(&foo[4..]), MatchArm::Wild);
 }

--- a/src/test/ui/or-patterns/slice-patterns.rs
+++ b/src/test/ui/or-patterns/slice-patterns.rs
@@ -1,0 +1,42 @@
+// Test or-patterns with slice-patterns
+
+// run-pass
+
+#![feature(or_patterns)]
+
+#[derive(Debug, PartialEq)]
+enum MatchArm {
+    Arm(usize),
+    Wild,
+}
+
+#[derive(Debug)]
+enum Test {
+    Foo,
+    Bar,
+    Baz,
+    Qux,
+}
+
+fn test(foo: &[Option<Test>]) -> MatchArm {
+    match foo {
+        [.., Some(Test::Foo | Test::Qux)] => MatchArm::Arm(0),
+        [Some(Test::Foo), .., Some(Test::Bar | Test::Baz)] => MatchArm::Arm(1),
+        [.., Some(Test::Bar | Test::Baz), _] => MatchArm::Arm(2),
+        _ => MatchArm::Wild,
+    }
+}
+
+fn main() {
+    let foo = vec![
+        Some(Test::Foo),
+        Some(Test::Bar),
+        Some(Test::Baz),
+        Some(Test::Qux),
+    ];
+
+    assert_eq!(test(&foo), MatchArm::Arm(0));
+    assert_eq!(test(&foo[..3]), MatchArm::Arm(1));
+    assert_eq!(test(&foo[1..3]), MatchArm::Arm(2));
+    assert_eq!(test(&foo[4..]), MatchArm::Wild);
+}

--- a/src/test/ui/or-patterns/slice-patterns.rs
+++ b/src/test/ui/or-patterns/slice-patterns.rs
@@ -46,7 +46,8 @@ fn main() {
     // path 3a
     assert_eq!(test(&foo[1..3]), MatchArm::Arm(2));
     // path 3b
-    assert_eq!(test(&[Some(Test::Bar), Some(Test::Baz), Some(Test::Baz), Some(Test::Bar)]), MatchArm::Arm(2));
+    assert_eq!(test(&[Some(Test::Bar), Some(Test::Baz), Some(Test::Baz), Some(Test::Bar)]),
+        MatchArm::Arm(2));
     // path 4
     assert_eq!(test(&foo[4..]), MatchArm::Wild);
 }

--- a/src/test/ui/pattern/bindings-after-at/box-patterns.rs
+++ b/src/test/ui/pattern/bindings-after-at/box-patterns.rs
@@ -1,0 +1,36 @@
+// Test bindings-after-at with box-patterns
+
+// run-pass
+
+#![feature(bindings_after_at)]
+#![feature(box_patterns)]
+
+#[derive(Debug, PartialEq)]
+enum MatchArm {
+    Arm(usize),
+    Wild,
+}
+
+fn test(x: Option<Box<i32>>) -> MatchArm {
+    match x {
+        ref bar @ Some(box n) if n > 0 => {
+            // bar is a &Option<Box<i32>>
+            assert_eq!(bar, &x);
+
+            MatchArm::Arm(0)
+        },
+        Some(ref bar @ box n) if n < 0 => {
+            // bar is a &Box<i32> here
+            assert_eq!(**bar, n);
+
+            MatchArm::Arm(1)
+        },
+        _ => MatchArm::Wild,
+    }
+}
+
+fn main() {
+    assert_eq!(test(Some(Box::new(2))), MatchArm::Arm(0));
+    assert_eq!(test(Some(Box::new(-1))), MatchArm::Arm(1));
+    assert_eq!(test(Some(Box::new(0))), MatchArm::Wild);
+}

--- a/src/test/ui/pattern/bindings-after-at/or-patterns-box-patterns.rs
+++ b/src/test/ui/pattern/bindings-after-at/or-patterns-box-patterns.rs
@@ -1,0 +1,45 @@
+// Test bindings-after-at with or-patterns and box-patterns
+
+// run-pass
+
+#![feature(bindings_after_at)]
+#![feature(or_patterns)]
+#![feature(box_patterns)]
+
+#[derive(Debug, PartialEq)]
+enum MatchArm {
+    Arm(usize),
+    Wild,
+}
+
+#[derive(Debug, PartialEq)]
+enum Test {
+    Foo,
+    Bar,
+    Baz,
+    Qux,
+}
+
+fn test(foo: Option<Box<Test>>) -> MatchArm {
+    match foo {
+        ref bar @ Some(box Test::Foo | box Test::Bar) => {
+            assert_eq!(bar, &foo);
+
+            MatchArm::Arm(0)
+        },
+        Some(ref bar @ box Test::Baz | ref bar @ box Test::Qux) => {
+            assert!(**bar == Test::Baz || **bar == Test::Qux);
+
+            MatchArm::Arm(1)
+        },
+        _ => MatchArm::Wild,
+    }
+}
+
+fn main() {
+    assert_eq!(test(Some(Box::new(Test::Foo))), MatchArm::Arm(0));
+    assert_eq!(test(Some(Box::new(Test::Bar))), MatchArm::Arm(0));
+    assert_eq!(test(Some(Box::new(Test::Baz))), MatchArm::Arm(1));
+    assert_eq!(test(Some(Box::new(Test::Qux))), MatchArm::Arm(1));
+    assert_eq!(test(None), MatchArm::Wild);
+}

--- a/src/test/ui/pattern/bindings-after-at/or-patterns-slice-patterns.rs
+++ b/src/test/ui/pattern/bindings-after-at/or-patterns-slice-patterns.rs
@@ -1,0 +1,43 @@
+// Test bindings-after-at with or-patterns and slice-patterns
+
+// run-pass
+
+#![feature(bindings_after_at)]
+#![feature(or_patterns)]
+
+#[derive(Debug, PartialEq)]
+enum MatchArm {
+    Arm(usize),
+    Wild,
+}
+
+#[derive(Debug, PartialEq)]
+enum Test {
+    Foo,
+    Bar,
+    Baz,
+    Qux,
+}
+
+fn test(foo: &[Option<Test>]) -> MatchArm {
+    match foo {
+        bar @ [Some(Test::Foo), .., Some(Test::Foo | Test::Qux)] => {
+            assert_eq!(bar, foo);
+
+            MatchArm::Arm(0)
+        },
+        [.., bar @ Some(Test::Bar | Test::Qux), _] => {
+            assert!(bar == &Some(Test::Bar) || bar == &Some(Test::Qux));
+
+            MatchArm::Arm(1)
+        },
+        _ => MatchArm::Wild,
+    }
+}
+
+fn main() {
+    let foo = vec![Some(Test::Foo), Some(Test::Bar), Some(Test::Baz), Some(Test::Qux)];
+    assert_eq!(test(&foo), MatchArm::Arm(0));
+    assert_eq!(test(&foo[..3]), MatchArm::Arm(1));
+    assert_eq!(test(&foo[1..2]), MatchArm::Wild);
+}

--- a/src/test/ui/pattern/bindings-after-at/or-patterns-slice-patterns.rs
+++ b/src/test/ui/pattern/bindings-after-at/or-patterns-slice-patterns.rs
@@ -21,7 +21,7 @@ enum Test {
 
 fn test(foo: &[Option<Test>]) -> MatchArm {
     match foo {
-        bar @ [Some(Test::Foo), .., Some(Test::Foo | Test::Qux)] => {
+        bar @ [Some(Test::Foo), .., Some(Test::Qux | Test::Foo)] => {
             assert_eq!(bar, foo);
 
             MatchArm::Arm(0)
@@ -36,8 +36,21 @@ fn test(foo: &[Option<Test>]) -> MatchArm {
 }
 
 fn main() {
-    let foo = vec![Some(Test::Foo), Some(Test::Bar), Some(Test::Baz), Some(Test::Qux)];
+    let foo = vec![
+        Some(Test::Foo),
+        Some(Test::Bar),
+        Some(Test::Baz),
+        Some(Test::Qux),
+    ];
+
+    // path 1a
     assert_eq!(test(&foo), MatchArm::Arm(0));
+    // path 1b
+    assert_eq!(test(&[Some(Test::Foo), Some(Test::Bar), Some(Test::Foo)]), MatchArm::Arm(0));
+    // path 2a
     assert_eq!(test(&foo[..3]), MatchArm::Arm(1));
+    // path 2b
+    assert_eq!(test(&[Some(Test::Bar), Some(Test::Qux), Some(Test::Baz)]), MatchArm::Arm(1));
+    // path 3
     assert_eq!(test(&foo[1..2]), MatchArm::Wild);
 }

--- a/src/test/ui/pattern/bindings-after-at/or-patterns.rs
+++ b/src/test/ui/pattern/bindings-after-at/or-patterns.rs
@@ -1,0 +1,40 @@
+// Test bindings-after-at with or-patterns
+
+// run-pass
+
+#![feature(bindings_after_at)]
+#![feature(or_patterns)]
+
+#[derive(Debug, PartialEq)]
+enum MatchArm {
+    Arm(usize),
+    Wild,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum Test {
+    Foo,
+    Bar,
+    Baz,
+    Qux,
+}
+
+fn test(foo: Option<Test>) -> MatchArm {
+    match foo {
+        bar @ Some(Test::Foo | Test::Bar) => {
+            assert!(bar == Some(Test::Foo) || bar == Some(Test::Bar));
+
+            MatchArm::Arm(0)
+        },
+        Some(_) => MatchArm::Arm(1),
+        _ => MatchArm::Wild,
+    }
+}
+
+fn main() {
+    assert_eq!(test(Some(Test::Foo)), MatchArm::Arm(0));
+    assert_eq!(test(Some(Test::Bar)), MatchArm::Arm(0));
+    assert_eq!(test(Some(Test::Baz)), MatchArm::Arm(1));
+    assert_eq!(test(Some(Test::Qux)), MatchArm::Arm(1));
+    assert_eq!(test(None), MatchArm::Wild);
+}

--- a/src/test/ui/pattern/bindings-after-at/slice-patterns.rs
+++ b/src/test/ui/pattern/bindings-after-at/slice-patterns.rs
@@ -1,0 +1,40 @@
+// Test bindings-after-at with slice-patterns
+
+// run-pass
+
+#![feature(bindings_after_at)]
+
+#[derive(Debug, PartialEq)]
+enum MatchArm {
+    Arm(usize),
+    Wild,
+}
+
+fn test(foo: &[i32]) -> MatchArm {
+    match foo {
+        [bar @ .., n] if n == &5 => {
+            for i in bar {
+                assert!(i < &5);
+            }
+
+            MatchArm::Arm(0)
+        },
+        bar @ [x0, .., xn] => {
+            assert_eq!(x0, &1);
+            assert_eq!(x0, &1);
+            assert_eq!(xn, &4);
+            assert_eq!(bar, &[1, 2, 3, 4]);
+
+            MatchArm::Arm(1)
+        },
+        _ => MatchArm::Wild,
+    }
+}
+
+fn main() {
+    let foo = vec![1, 2, 3, 4, 5];
+
+    assert_eq!(test(&foo), MatchArm::Arm(0));
+    assert_eq!(test(&foo[..4]), MatchArm::Arm(1));
+    assert_eq!(test(&foo[0..1]), MatchArm::Wild);
+}


### PR DESCRIPTION
Reference issue #67311

Tests combinations of the following pattern features:
- bindings_after_at
- or_patterns
- slice_patterns
- box_patterns

r? @Centril 