### PR TITLE
Allow inner lint attributes on block expressions

### DIFF
--- a/src/librustc_ast/attr/mod.rs
+++ b/src/librustc_ast/attr/mod.rs
@@ -177,6 +177,15 @@ impl Attribute {
         matches
     }
 
+    /// Checks if the attribute is a lint attribute (`allow`, `warn`, `deny`, or `forbid`).
+    pub fn is_lint(&self) -> bool {
+        if let Some(ident) = self.ident().map(Ident::as_str) {
+            ident == "allow" || ident == "warn" || ident == "deny" || ident == "forbid"
+        } else {
+            false
+        }
+    }
+
     /// For a single-segment attribute, returns its name; otherwise, returns `None`.
     pub fn ident(&self) -> Option<Ident> {
         match self.kind {

--- a/src/librustc_parse/config.rs
+++ b/src/librustc_parse/config.rs
@@ -9,7 +9,7 @@
 //! [#64197]: https://github.com/rust-lang/rust/issues/64197
 
 use crate::{parse_in, validate_attr};
-use rustc_ast::ast::{self, AttrItem, Attribute, MetaItem};
+use rustc_ast::ast::{self, AttrItem, AttrStyle, Attribute, MetaItem};
 use rustc_ast::attr::HasAttrs;
 use rustc_ast::mut_visit::*;
 use rustc_ast::ptr::P;
@@ -389,7 +389,9 @@ impl<'a> StripUnconfigured<'a> {
 
     /// If attributes are not allowed on expressions, emit an error for `attr`
     pub fn maybe_emit_expr_attr_err(&self, attr: &Attribute) {
-        if !self.features.map(|features| features.stmt_expr_attributes).unwrap_or(true) {
+        if !self.features.map(|features| features.stmt_expr_attributes).unwrap_or(true)
+            && !(attr.is_lint() && attr.style == AttrStyle::Inner)
+        {
             let mut err = feature_err(
                 self.sess,
                 sym::stmt_expr_attributes,

--- a/src/test/ui/lint-expr-stmt-attrs-for-early-lints.rs
+++ b/src/test/ui/lint-expr-stmt-attrs-for-early-lints.rs
@@ -1,6 +1,5 @@
 // run-pass
 
-#![feature(stmt_expr_attributes)]
 #![deny(unused_parens)]
 
 // Tests that lint attributes on statements/expressions are
@@ -11,4 +10,9 @@ fn main() {
     {
         let _ = (9);
     }
+
+    let _ = {
+        #![allow(unused_parens)]
+        let _ = (9);
+    };
 }

--- a/src/test/ui/stmt_expr_attrs_no_feature.rs
+++ b/src/test/ui/stmt_expr_attrs_no_feature.rs
@@ -16,6 +16,17 @@ fn main() {
 
     }
 
+    let _ = {
+        // inner lint attributes are allowed on blocks
+        #![allow(unused_variables)]
+        #![warn(unused_variables)]
+        #![deny(unused_variables)]
+        #![forbid(unused_variables)]
+        #![rustc_dummy] //~ ERROR attributes on expressions are experimental
+    };
+
+    let _ = #[allow(unused_variables)] {}; //~ ERROR attributes on expressions are experimental
+
     #[rustc_dummy]
     5;
 

--- a/src/test/ui/stmt_expr_attrs_no_feature.stderr
+++ b/src/test/ui/stmt_expr_attrs_no_feature.stderr
@@ -8,7 +8,25 @@ LL |     #[rustfmt::skip]
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/stmt_expr_attrs_no_feature.rs:95:18
+  --> $DIR/stmt_expr_attrs_no_feature.rs:25:9
+   |
+LL |         #![rustc_dummy]
+   |         ^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/stmt_expr_attrs_no_feature.rs:28:13
+   |
+LL |     let _ = #[allow(unused_variables)] {};
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/stmt_expr_attrs_no_feature.rs:106:18
    |
 LL |     fn y(a: [u8; #[rustc_dummy] 5]);
    |                  ^^^^^^^^^^^^^^
@@ -17,7 +35,7 @@ LL |     fn y(a: [u8; #[rustc_dummy] 5]);
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/stmt_expr_attrs_no_feature.rs:102:19
+  --> $DIR/stmt_expr_attrs_no_feature.rs:113:19
    |
 LL |     const Y: u8 = #[rustc_dummy] 5;
    |                   ^^^^^^^^^^^^^^
@@ -26,7 +44,7 @@ LL |     const Y: u8 = #[rustc_dummy] 5;
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/stmt_expr_attrs_no_feature.rs:108:19
+  --> $DIR/stmt_expr_attrs_no_feature.rs:119:19
    |
 LL |     const Y: [u8; #[rustc_dummy] 5];
    |                   ^^^^^^^^^^^^^^
@@ -35,7 +53,7 @@ LL |     const Y: [u8; #[rustc_dummy] 5];
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/stmt_expr_attrs_no_feature.rs:114:18
+  --> $DIR/stmt_expr_attrs_no_feature.rs:125:18
    |
 LL |     field2: [u8; #[rustc_dummy] 5]
    |                  ^^^^^^^^^^^^^^
@@ -44,7 +62,7 @@ LL |     field2: [u8; #[rustc_dummy] 5]
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/stmt_expr_attrs_no_feature.rs:119:10
+  --> $DIR/stmt_expr_attrs_no_feature.rs:130:10
    |
 LL |     [u8; #[rustc_dummy] 5]
    |          ^^^^^^^^^^^^^^
@@ -53,7 +71,7 @@ LL |     [u8; #[rustc_dummy] 5]
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/stmt_expr_attrs_no_feature.rs:125:14
+  --> $DIR/stmt_expr_attrs_no_feature.rs:136:14
    |
 LL |         [u8; #[rustc_dummy] 5]
    |              ^^^^^^^^^^^^^^
@@ -62,7 +80,7 @@ LL |         [u8; #[rustc_dummy] 5]
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/stmt_expr_attrs_no_feature.rs:130:22
+  --> $DIR/stmt_expr_attrs_no_feature.rs:141:22
    |
 LL |         field2: [u8; #[rustc_dummy] 5]
    |                      ^^^^^^^^^^^^^^
@@ -71,7 +89,7 @@ LL |         field2: [u8; #[rustc_dummy] 5]
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/stmt_expr_attrs_no_feature.rs:138:14
+  --> $DIR/stmt_expr_attrs_no_feature.rs:149:14
    |
 LL |         6 => #[rustc_dummy] (),
    |              ^^^^^^^^^^^^^^
@@ -79,6 +97,6 @@ LL |         6 => #[rustc_dummy] (),
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
-error: aborting due to 9 previous errors
+error: aborting due to 11 previous errors
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
follow-up to #69675.

This pull request allows lint attributes on blocks like this:
```rust
fn main() {
    let _ = {
        #![allow(unused_variables)]
        let x = ();
    };
}
```

I think this should be fine, because attributes are already allowed on blocks, if they are the tail expression of another block:
```rust
// this compiles on stable
fn main() {
    let _ = {{
        #![allow(unused_variables)]
        let x = ();
    }};
}
```

This pull request does not allow outer attributes on blocks or inner attributes that are not lint attributes:
```rust
fn main() {
    let _ = #[allow(unused_variables)] {}; // error

    let _ = {
        #![cfg(TRUE)] // error
    };
}
```