### PR TITLE
Implement AsMut<String> for String

### DIFF
--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -2209,6 +2209,14 @@ impl AsMut<str> for String {
     }
 }
 
+#[stable(feature = "string_as_mut", since = "1.43.0")]
+impl AsMut<String> for String {
+    #[inline]
+    fn as_mut(&mut self) -> &mut String {
+        self
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl AsRef<[u8]> for String {
     #[inline]


### PR DESCRIPTION
Related to #68741 and #68742.

There's a parallel implementation of [`AsMut<[T]> for Vec<T>`][slice] and [`AsMut<Vec<T>> for Vec<T>`][vec], so I thought we might want to do the same for `String`?

EDIT: actually, would it make more sense to just write the following global implementations?

```rust
impl<T: ?Sized> AsRef<T> for T {
    fn as_ref(&self) -> &T {
        self
    }
}

impl<T: ?Sized> AsMut<T> for T {
    fn as_mut(&mut self) -> &mut T {
        self
    }
}
```

Similarly to what the [`Borrow` and `BorrowMut` traits][borrow] do? This is my first time contributing, so I'm not sure if this would require an issue or RFC--please let me know if there's a more appropriate place to suggest this.

[slice]: https://github.com/rust-lang/rust/blob/2b0cfa5b4c5099f45ca540ee1c7d8c1ecd5267d2/src/liballoc/vec.rs#L2369-L2374
[vec]: https://github.com/rust-lang/rust/blob/2b0cfa5b4c5099f45ca540ee1c7d8c1ecd5267d2/src/liballoc/vec.rs#L2355-L2360
[borrow]: https://github.com/rust-lang/rust/blob/2b0cfa5b4c5099f45ca540ee1c7d8c1ecd5267d2/src/libcore/borrow.rs#L212-L224