### PR TITLE
On mismatched delimiters, only point at empty blocks that are in the same line

### DIFF
--- a/src/test/ui/parser/mismatched-delim-brace-empty-block.stderr
+++ b/src/test/ui/parser/mismatched-delim-brace-empty-block.stderr
@@ -1,14 +1,8 @@
 error: unexpected closing delimiter: `}`
   --> $DIR/mismatched-delim-brace-empty-block.rs:5:1
    |
-LL |   fn main() {
-   |  ___________-
-LL | |
-LL | | }
-   | |_- this block is empty, you might have not meant to close it
-LL |       let _ = ();
-LL |   }
-   |   ^ unexpected closing delimiter
+LL | }
+   | ^ unexpected closing delimiter
 
 error: aborting due to previous error
 


### PR DESCRIPTION
We point at empty blocks when we have mismatched braces to detect cases where editors auto insert `}` after writing `{`. Gate this to only the case where the entire span is in the same line so we never point at explicitly empty blocks.