### PR TITLE
Maintain predicate obligation chain for more detailed diagnostics

### DIFF
--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -138,7 +138,7 @@ pub enum ObligationCauseCode<'tcx> {
 
     /// In an impl of trait `X` for type `Y`, type `Y` must
     /// also implement all supertraits of `X`.
-    ItemObligation(DefId),
+    ItemObligation(DefId, Option<Span>),
 
     /// Like `ItemObligation`, but with extra detail on the source of the obligation.
     BindingObligation(DefId, Span),
@@ -192,6 +192,8 @@ pub enum ObligationCauseCode<'tcx> {
     BuiltinDerivedObligation(DerivedObligationCause<'tcx>),
 
     ImplDerivedObligation(DerivedObligationCause<'tcx>),
+
+    DerivedCauseCode(Box<ObligationCauseCode<'tcx>>),
 
     /// Error derived when matching traits/impls; see ObligationCause for more details
     CompareImplMethodObligation {

--- a/src/librustc/traits/structural_impls.rs
+++ b/src/librustc/traits/structural_impls.rs
@@ -410,7 +410,7 @@ impl<'a, 'tcx> Lift<'tcx> for traits::ObligationCauseCode<'a> {
             super::SliceOrArrayElem => Some(super::SliceOrArrayElem),
             super::TupleElem => Some(super::TupleElem),
             super::ProjectionWf(proj) => tcx.lift(&proj).map(super::ProjectionWf),
-            super::ItemObligation(def_id) => Some(super::ItemObligation(def_id)),
+            super::ItemObligation(def_id, span) => Some(super::ItemObligation(def_id, span)),
             super::BindingObligation(def_id, span) => Some(super::BindingObligation(def_id, span)),
             super::ReferenceOutlivesReferent(ty) => {
                 tcx.lift(&ty).map(super::ReferenceOutlivesReferent)
@@ -442,6 +442,7 @@ impl<'a, 'tcx> Lift<'tcx> for traits::ObligationCauseCode<'a> {
             super::ImplDerivedObligation(ref cause) => {
                 tcx.lift(cause).map(super::ImplDerivedObligation)
             }
+            super::DerivedCauseCode(ref x) => tcx.lift(&**x).map(|x| x),
             super::CompareImplMethodObligation {
                 item_name,
                 impl_item_def_id,

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1933,6 +1933,14 @@ impl<'tcx> TyS<'tcx> {
     }
 
     #[inline]
+    pub fn is_some_param(&self) -> bool {
+        match self.kind {
+            ty::Param(_) => true,
+            _ => false,
+        }
+    }
+
+    #[inline]
     pub fn is_slice(&self) -> bool {
         match self.kind {
             RawPtr(TypeAndMut { ty, .. }) | Ref(_, ty, _) => match ty.kind {

--- a/src/librustc_infer/infer/error_reporting/nice_region_error/placeholder_error.rs
+++ b/src/librustc_infer/infer/error_reporting/nice_region_error/placeholder_error.rs
@@ -222,7 +222,7 @@ impl NiceRegionError<'me, 'tcx> {
             format!("trait `{}` defined here", self.tcx().def_path_str(trait_def_id)),
         );
 
-        let leading_ellipsis = if let ObligationCauseCode::ItemObligation(def_id) = cause.code {
+        let leading_ellipsis = if let ObligationCauseCode::ItemObligation(def_id, _) = cause.code {
             err.span_label(span, "doesn't satisfy where-clause");
             err.span_label(
                 self.tcx().def_span(def_id),

--- a/src/librustc_infer/infer/opaque_types/mod.rs
+++ b/src/librustc_infer/infer/opaque_types/mod.rs
@@ -1295,8 +1295,8 @@ crate fn required_region_bounds(
     assert!(!erased_self_ty.has_escaping_bound_vars());
 
     traits::elaborate_predicates(tcx, predicates)
-        .filter_map(|predicate| {
-            match predicate {
+        .filter_map(|obligation| {
+            match obligation.predicate {
                 ty::Predicate::Projection(..)
                 | ty::Predicate::Trait(..)
                 | ty::Predicate::Subtype(..)

--- a/src/librustc_infer/infer/outlives/verify.rs
+++ b/src/librustc_infer/infer/outlives/verify.rs
@@ -290,7 +290,10 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
         let identity_proj = tcx.mk_projection(assoc_item_def_id, identity_substs);
         self.collect_outlives_from_predicate_list(
             move |ty| ty == identity_proj,
-            traits::elaborate_predicates(tcx, trait_predicates),
+            traits::elaborate_predicates(tcx, trait_predicates)
+                .into_iter()
+                .map(|o| o.predicate)
+                .collect::<Vec<_>>(),
         )
         .map(|b| b.1)
     }

--- a/src/librustc_infer/traits/auto_trait.rs
+++ b/src/librustc_infer/traits/auto_trait.rs
@@ -368,7 +368,8 @@ impl AutoTraitFinder<'tcx> {
 
             computed_preds.extend(user_computed_preds.iter().cloned());
             let normalized_preds =
-                elaborate_predicates(tcx, computed_preds.iter().cloned().collect());
+                elaborate_predicates(tcx, computed_preds.iter().cloned().collect())
+                    .map(|o| o.predicate);
             new_env =
                 ty::ParamEnv::new(tcx.mk_predicates(normalized_preds), param_env.reveal, None);
         }

--- a/src/librustc_infer/traits/error_reporting/mod.rs
+++ b/src/librustc_infer/traits/error_reporting/mod.rs
@@ -133,8 +133,8 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             }
         };
 
-        for implication in super::elaborate_predicates(self.tcx, vec![*cond]) {
-            if let ty::Predicate::Trait(implication, _) = implication {
+        for obligation in super::elaborate_predicates(self.tcx, vec![*cond]) {
+            if let ty::Predicate::Trait(implication, _) = obligation.predicate {
                 let error = error.to_poly_trait_ref();
                 let implication = implication.to_poly_trait_ref();
                 // FIXME: I'm just not taking associated types at all here.
@@ -233,7 +233,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 );
 
                 let is_normalized_ty_expected = match &obligation.cause.code {
-                    ObligationCauseCode::ItemObligation(_)
+                    ObligationCauseCode::ItemObligation(..)
                     | ObligationCauseCode::BindingObligation(_, _)
                     | ObligationCauseCode::ObjectCastObligation(_) => false,
                     _ => true,
@@ -423,7 +423,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
 
         self.note_obligation_cause_code(
             &mut err,
-            &obligation.predicate,
+            Some(&obligation.predicate),
             &obligation.cause.code,
             &mut vec![],
         );
@@ -1164,7 +1164,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 }
                 let mut err = self.need_type_info_err(body_id, span, self_ty, ErrorCode::E0283);
                 err.note(&format!("cannot resolve `{}`", predicate));
-                if let ObligationCauseCode::ItemObligation(def_id) = obligation.cause.code {
+                if let ObligationCauseCode::ItemObligation(def_id, _) = obligation.cause.code {
                     self.suggest_fully_qualified_path(&mut err, def_id, span, trait_ref.def_id());
                 } else if let (
                     Ok(ref snippet),
@@ -1333,7 +1333,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         if !self.maybe_note_obligation_cause_for_async_await(err, obligation) {
             self.note_obligation_cause_code(
                 err,
-                &obligation.predicate,
+                Some(&obligation.predicate),
                 &obligation.cause.code,
                 &mut vec![],
             );

--- a/src/librustc_infer/traits/error_reporting/on_unimplemented.rs
+++ b/src/librustc_infer/traits/error_reporting/on_unimplemented.rs
@@ -126,7 +126,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             }
         }
 
-        if let ObligationCauseCode::ItemObligation(item) = obligation.cause.code {
+        if let ObligationCauseCode::ItemObligation(item, _) = obligation.cause.code {
             // FIXME: maybe also have some way of handling methods
             // from other traits? That would require name resolution,
             // which we might want to be some sort of hygienic.

--- a/src/librustc_infer/traits/mod.rs
+++ b/src/librustc_infer/traits/mod.rs
@@ -64,7 +64,9 @@ pub use self::specialize::{specialization_graph, translate_substs, OverlapError}
 pub use self::structural_match::search_for_structural_match_violation;
 pub use self::structural_match::type_marked_structural;
 pub use self::structural_match::NonStructuralMatchTy;
-pub use self::util::{elaborate_predicates, elaborate_trait_ref, elaborate_trait_refs};
+pub use self::util::{
+    elaborate_obligations, elaborate_predicates, elaborate_trait_ref, elaborate_trait_refs,
+};
 pub use self::util::{expand_trait_aliases, TraitAliasExpander};
 pub use self::util::{
     get_vtable_index_of_object_method, impl_is_default, impl_item_is_final,
@@ -361,7 +363,9 @@ pub fn normalize_param_env_or_error<'tcx>(
     );
 
     let mut predicates: Vec<_> =
-        util::elaborate_predicates(tcx, unnormalized_env.caller_bounds.to_vec()).collect();
+        util::elaborate_predicates(tcx, unnormalized_env.caller_bounds.to_vec())
+            .map(|o| o.predicate)
+            .collect();
 
     debug!("normalize_param_env_or_error: elaborated-predicates={:?}", predicates);
 

--- a/src/librustc_infer/traits/object_safety.rs
+++ b/src/librustc_infer/traits/object_safety.rs
@@ -302,7 +302,7 @@ fn generics_require_sized_self(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
     // Search for a predicate like `Self : Sized` amongst the trait bounds.
     let predicates = tcx.predicates_of(def_id);
     let predicates = predicates.instantiate_identity(tcx).predicates;
-    elaborate_predicates(tcx, predicates).any(|predicate| match predicate {
+    elaborate_predicates(tcx, predicates).any(|obligation| match obligation.predicate {
         ty::Predicate::Trait(ref trait_pred, _) => {
             trait_pred.def_id() == sized_def_id && trait_pred.skip_binder().self_ty().is_param(0)
         }

--- a/src/librustc_infer/traits/project.rs
+++ b/src/librustc_infer/traits/project.rs
@@ -893,7 +893,7 @@ fn assemble_candidates_from_param_env<'cx, 'tcx>(
 ///
 /// ```
 /// trait Foo {
-///     type FooT : Bar<BarT=i32>
+///     type FooT: Bar<BarT=i32>
 /// }
 /// ```
 ///
@@ -923,7 +923,7 @@ fn assemble_candidates_from_trait_def<'cx, 'tcx>(
     // If so, extract what we know from the trait and try to come up with a good answer.
     let trait_predicates = tcx.predicates_of(def_id);
     let bounds = trait_predicates.instantiate(tcx, substs);
-    let bounds = elaborate_predicates(tcx, bounds.predicates);
+    let bounds = elaborate_predicates(tcx, bounds.predicates).map(|o| o.predicate);
     assemble_candidates_from_predicates(
         selcx,
         obligation,
@@ -1212,7 +1212,7 @@ fn confirm_object_candidate<'cx, 'tcx>(
 
         // select only those projections that are actually projecting an
         // item with the correct name
-        let env_predicates = env_predicates.filter_map(|p| match p {
+        let env_predicates = env_predicates.filter_map(|o| match o.predicate {
             ty::Predicate::Projection(data) => {
                 if data.projection_def_id() == obligation.predicate.item_def_id {
                     Some(data)

--- a/src/librustc_infer/traits/util.rs
+++ b/src/librustc_infer/traits/util.rs
@@ -92,7 +92,7 @@ impl<T: AsRef<ty::Predicate<'tcx>>> Extend<T> for PredicateSet<'tcx> {
 /// holds as well. Similarly, if we have `trait Foo: 'static`, and we know that
 /// `T: Foo`, then we know that `T: 'static`.
 pub struct Elaborator<'tcx> {
-    stack: Vec<ty::Predicate<'tcx>>,
+    stack: Vec<PredicateObligation<'tcx>>,
     visited: PredicateSet<'tcx>,
 }
 
@@ -117,7 +117,29 @@ pub fn elaborate_predicates<'tcx>(
 ) -> Elaborator<'tcx> {
     let mut visited = PredicateSet::new(tcx);
     predicates.retain(|pred| visited.insert(pred));
-    Elaborator { stack: predicates, visited }
+    let obligations: Vec<_> =
+        predicates.into_iter().map(|predicate| predicate_obligation(predicate, None)).collect();
+    elaborate_obligations(tcx, obligations)
+}
+
+pub fn elaborate_obligations<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    mut obligations: Vec<PredicateObligation<'tcx>>,
+) -> Elaborator<'tcx> {
+    let mut visited = PredicateSet::new(tcx);
+    obligations.retain(|obligation| visited.insert(&obligation.predicate));
+    Elaborator { stack: obligations, visited }
+}
+
+fn predicate_obligation<'tcx>(
+    predicate: ty::Predicate<'tcx>,
+    span: Option<Span>,
+) -> PredicateObligation<'tcx> {
+    let mut cause = ObligationCause::dummy();
+    if let Some(span) = span {
+        cause.span = span;
+    }
+    Obligation { cause, param_env: ty::ParamEnv::empty(), recursion_depth: 0, predicate }
 }
 
 impl Elaborator<'tcx> {
@@ -125,27 +147,30 @@ impl Elaborator<'tcx> {
         FilterToTraits::new(self)
     }
 
-    fn elaborate(&mut self, predicate: &ty::Predicate<'tcx>) {
+    fn elaborate(&mut self, obligation: &PredicateObligation<'tcx>) {
         let tcx = self.visited.tcx;
-        match *predicate {
+        match obligation.predicate {
             ty::Predicate::Trait(ref data, _) => {
                 // Get predicates declared on the trait.
                 let predicates = tcx.super_predicates_of(data.def_id());
 
-                let predicates = predicates
-                    .predicates
-                    .iter()
-                    .map(|(pred, _)| pred.subst_supertrait(tcx, &data.to_poly_trait_ref()));
-                debug!("super_predicates: data={:?} predicates={:?}", data, predicates.clone());
+                let obligations = predicates.predicates.iter().map(|(pred, span)| {
+                    predicate_obligation(
+                        pred.subst_supertrait(tcx, &data.to_poly_trait_ref()),
+                        Some(*span),
+                    )
+                });
+                debug!("super_predicates: data={:?} predicates={:?}", data, &obligations);
 
                 // Only keep those bounds that we haven't already seen.
                 // This is necessary to prevent infinite recursion in some
                 // cases. One common case is when people define
                 // `trait Sized: Sized { }` rather than `trait Sized { }`.
                 let visited = &mut self.visited;
-                let predicates = predicates.filter(|pred| visited.insert(pred));
+                let obligations =
+                    obligations.filter(|obligation| visited.insert(&obligation.predicate));
 
-                self.stack.extend(predicates);
+                self.stack.extend(obligations);
             }
             ty::Predicate::WellFormed(..) => {
                 // Currently, we do not elaborate WF predicates,
@@ -226,7 +251,8 @@ impl Elaborator<'tcx> {
                                 None
                             }
                         })
-                        .filter(|p| visited.insert(p)),
+                        .filter(|p| visited.insert(p))
+                        .map(|p| predicate_obligation(p, None)),
                 );
             }
         }
@@ -234,17 +260,17 @@ impl Elaborator<'tcx> {
 }
 
 impl Iterator for Elaborator<'tcx> {
-    type Item = ty::Predicate<'tcx>;
+    type Item = PredicateObligation<'tcx>;
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.stack.len(), None)
     }
 
-    fn next(&mut self) -> Option<ty::Predicate<'tcx>> {
+    fn next(&mut self) -> Option<Self::Item> {
         // Extract next item from top-most stack frame, if any.
-        if let Some(pred) = self.stack.pop() {
-            self.elaborate(&pred);
-            Some(pred)
+        if let Some(obligation) = self.stack.pop() {
+            self.elaborate(&obligation);
+            Some(obligation)
         } else {
             None
         }
@@ -463,12 +489,12 @@ impl<I> FilterToTraits<I> {
     }
 }
 
-impl<'tcx, I: Iterator<Item = ty::Predicate<'tcx>>> Iterator for FilterToTraits<I> {
+impl<'tcx, I: Iterator<Item = PredicateObligation<'tcx>>> Iterator for FilterToTraits<I> {
     type Item = ty::PolyTraitRef<'tcx>;
 
     fn next(&mut self) -> Option<ty::PolyTraitRef<'tcx>> {
-        while let Some(pred) = self.base_iterator.next() {
-            if let ty::Predicate::Trait(data, _) = pred {
+        while let Some(obligation) = self.base_iterator.next() {
+            if let ty::Predicate::Trait(data, _) = obligation.predicate {
                 return Some(data.to_poly_trait_ref());
             }
         }

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -110,7 +110,7 @@ impl<'tcx> MirPass<'tcx> for ConstProp {
             .collect();
         if !traits::normalize_and_test_predicates(
             tcx,
-            traits::elaborate_predicates(tcx, predicates).collect(),
+            traits::elaborate_predicates(tcx, predicates).map(|o| o.predicate).collect(),
         ) {
             trace!("ConstProp skipped for {:?}: found unsatisfiable predicates", source.def_id());
             return;

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1605,12 +1605,12 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         for (base_trait_ref, span, constness) in regular_traits_refs_spans {
             assert_eq!(constness, Constness::NotConst);
 
-            for trait_ref in traits::elaborate_trait_ref(tcx, base_trait_ref) {
+            for obligation in traits::elaborate_trait_ref(tcx, base_trait_ref) {
                 debug!(
                     "conv_object_ty_poly_trait_ref: observing object predicate `{:?}`",
-                    trait_ref
+                    obligation.predicate
                 );
-                match trait_ref {
+                match obligation.predicate {
                     ty::Predicate::Trait(pred, _) => {
                         associated_types.entry(span).or_default().extend(
                             tcx.associated_items(pred.def_id())

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -574,13 +574,15 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
         };
 
         traits::elaborate_predicates(self.tcx, predicates.predicates.clone())
-            .filter_map(|predicate| match predicate {
+            .filter_map(|obligation| match obligation.predicate {
                 ty::Predicate::Trait(trait_pred, _) if trait_pred.def_id() == sized_def_id => {
                     let span = predicates
                         .predicates
                         .iter()
                         .zip(predicates.spans.iter())
-                        .filter_map(|(p, span)| if *p == predicate { Some(*span) } else { None })
+                        .filter_map(
+                            |(p, span)| if *p == obligation.predicate { Some(*span) } else { None },
+                        )
                         .next()
                         .unwrap_or(rustc_span::DUMMY_SP);
                     Some((trait_pred, span))

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4330,8 +4330,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             // Check bounds on type arguments used in the path.
             let (bounds, _) = self.instantiate_bounds(path_span, did, substs);
-            let cause =
-                traits::ObligationCause::new(path_span, self.body_id, traits::ItemObligation(did));
+            let cause = traits::ObligationCause::new(
+                path_span,
+                self.body_id,
+                traits::ItemObligation(did, None),
+            );
             self.add_obligations_for_parameters(cause, &bounds);
 
             Some((variant, ty))
@@ -5610,7 +5613,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let (bounds, spans) = self.instantiate_bounds(span, def_id, &substs);
 
         for (i, mut obligation) in traits::predicates_for_generics(
-            traits::ObligationCause::new(span, self.body_id, traits::ItemObligation(def_id)),
+            traits::ObligationCause::new(span, self.body_id, traits::ItemObligation(def_id, None)),
             self.param_env,
             &bounds,
         )

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -519,7 +519,7 @@ fn check_associated_type_defaults(fcx: &FnCtxt<'_, '_>, trait_def_id: DefId) {
             let cause = traits::ObligationCause::new(
                 span,
                 fcx.body_id,
-                traits::ItemObligation(trait_def_id),
+                traits::ItemObligation(trait_def_id, None),
             );
             let obligation = traits::Obligation::new(cause, fcx.param_env, pred);
 
@@ -754,7 +754,7 @@ fn check_where_clauses<'tcx, 'fcx>(
             // to be *true* but merely *well-formed*.
             let pred = fcx.normalize_associated_types_in(sp, &pred);
             let cause =
-                traits::ObligationCause::new(sp, fcx.body_id, traits::ItemObligation(def_id));
+                traits::ObligationCause::new(sp, fcx.body_id, traits::ItemObligation(def_id, None));
             traits::Obligation::new(cause, fcx.param_env, pred)
         });
 
@@ -1219,7 +1219,8 @@ fn check_false_global_bounds(fcx: &FnCtxt<'_, '_>, span: Span, id: hir::HirId) {
     // Check elaborated bounds.
     let implied_obligations = traits::elaborate_predicates(fcx.tcx, predicates);
 
-    for pred in implied_obligations {
+    for obligation in implied_obligations {
+        let pred = obligation.predicate;
         // Match the existing behavior.
         if pred.is_global() && !pred.has_late_bound_regions() {
             let pred = fcx.normalize_associated_types_in(span, &pred);

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1632,7 +1632,7 @@ fn predicates_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::GenericPredicates<'_> {
         // prove that the trait applies to the types that were
         // used, and adding the predicate into this list ensures
         // that this is done.
-        let span = tcx.def_span(def_id);
+        let span = tcx.sess.source_map().def_span(tcx.def_span(def_id));
         result.predicates =
             tcx.arena.alloc_from_iter(result.predicates.iter().copied().chain(std::iter::once((
                 ty::TraitRef::identity(tcx, def_id).without_const().to_predicate(),

--- a/src/librustc_typeck/collect/type_of.rs
+++ b/src/librustc_typeck/collect/type_of.rs
@@ -440,17 +440,13 @@ fn find_opaque_ty_constraints(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
                         _ => None,
                     })
                     .collect();
-                let is_param = |ty: Ty<'_>| match ty.kind {
-                    ty::Param(_) => true,
-                    _ => false,
-                };
                 let bad_substs: Vec<_> = substs
                     .iter()
                     .enumerate()
                     .filter_map(|(i, k)| {
                         if let GenericArgKind::Type(ty) = k.unpack() { Some((i, ty)) } else { None }
                     })
-                    .filter(|(_, ty)| !is_param(ty))
+                    .filter(|(_, ty)| !ty.is_some_param())
                     .collect();
                 if !bad_substs.is_empty() {
                     let identity_substs = InternalSubsts::identity_for_item(self.tcx, self.def_id);

--- a/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
+++ b/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
@@ -1,6 +1,12 @@
 error[E0277]: `<L1 as Lam<&'a u8>>::App` doesn't implement `std::fmt::Debug`
   --> $DIR/bad-bounds-on-assoc-in-trait.rs:31:6
    |
+LL | trait Case1 {
+   | ----------- required by `Case1`
+...
+LL |                 Debug
+   |                 ----- required by `Case1` here
+...
 LL | impl Case1 for S1 {
    |      ^^^^^ `<L1 as Lam<&'a u8>>::App` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
@@ -21,6 +27,9 @@ error[E0277]: `<<T as Case1>::C as std::iter::Iterator>::Item` cannot be sent be
    |
 LL | trait Case1 {
    | ----------- required by `Case1`
+LL |     type C: Clone + Iterator<Item:
+LL |         Send + Iterator<Item:
+   |         ---- required by `Case1` here
 ...
 LL | fn assume_case1<T: Case1>() {
    |                    ^^^^^   - help: consider further restricting the associated type: `where <<T as Case1>::C as std::iter::Iterator>::Item: std::marker::Send`
@@ -35,6 +44,9 @@ error[E0277]: `<<T as Case1>::C as std::iter::Iterator>::Item` cannot be shared 
 LL | trait Case1 {
    | ----------- required by `Case1`
 ...
+LL |         > + Sync>;
+   |             ---- required by `Case1` here
+...
 LL | fn assume_case1<T: Case1>() {
    |                    ^^^^^   - help: consider further restricting the associated type: `where <<T as Case1>::C as std::iter::Iterator>::Item: std::marker::Sync`
    |                    |
@@ -47,6 +59,9 @@ error[E0277]: `<_ as Lam<&'a u8>>::App` doesn't implement `std::fmt::Debug`
    |
 LL | trait Case1 {
    | ----------- required by `Case1`
+...
+LL |                 Debug
+   |                 ----- required by `Case1` here
 ...
 LL | fn assume_case1<T: Case1>() {
    |                    ^^^^^ `<_ as Lam<&'a u8>>::App` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`

--- a/src/test/ui/associated-types/associated-types-overridden-binding.stderr
+++ b/src/test/ui/associated-types/associated-types-overridden-binding.stderr
@@ -2,7 +2,7 @@ error[E0284]: type annotations needed
   --> $DIR/associated-types-overridden-binding.rs:4:12
    |
 LL | trait Foo: Iterator<Item = i32> {}
-   | ------------------------------- required by `Foo`
+   |                     ---------- required by `Foo` here
 LL | trait Bar: Foo<Item = u32> {}
    |            ^^^^^^^^^^^^^^^ cannot infer type for type parameter `Self`
    |
@@ -12,7 +12,7 @@ error[E0284]: type annotations needed
   --> $DIR/associated-types-overridden-binding.rs:7:21
    |
 LL | trait I32Iterator = Iterator<Item = i32>;
-   | ----------------------------------------- required by `I32Iterator`
+   |                              ---------- required by `I32Iterator` here
 LL | trait U32Iterator = I32Iterator<Item = u32>;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `Self`
    |

--- a/src/test/ui/associated-types/defaults-suitability.rs
+++ b/src/test/ui/associated-types/defaults-suitability.rs
@@ -1,3 +1,8 @@
+// FIXME: missing sysroot spans (#53081)
+// ignore-i586-unknown-linux-gnu
+// ignore-i586-unknown-linux-musl
+// ignore-i686-unknown-linux-musl
+
 //! Checks that associated type defaults are properly validated.
 //!
 //! This means:

--- a/src/test/ui/associated-types/defaults-suitability.stderr
+++ b/src/test/ui/associated-types/defaults-suitability.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `NotClone: std::clone::Clone` is not satisfied
-  --> $DIR/defaults-suitability.rs:15:14
+  --> $DIR/defaults-suitability.rs:20:14
    |
 LL | trait Tr {
    | -------- required by `Tr`
@@ -7,7 +7,7 @@ LL |     type Ty: Clone = NotClone;
    |              ^^^^^ the trait `std::clone::Clone` is not implemented for `NotClone`
 
 error[E0277]: the trait bound `NotClone: std::clone::Clone` is not satisfied
-  --> $DIR/defaults-suitability.rs:20:27
+  --> $DIR/defaults-suitability.rs:25:27
    |
 LL | trait Tr2 where Self::Ty: Clone {
    | --------------------------^^^^^
@@ -16,7 +16,7 @@ LL | trait Tr2 where Self::Ty: Clone {
    | required by `Tr2`
 
 error[E0277]: the trait bound `T: std::clone::Clone` is not satisfied
-  --> $DIR/defaults-suitability.rs:33:15
+  --> $DIR/defaults-suitability.rs:38:15
    |
 LL | trait Foo<T> {
    | ------------ required by `Foo`
@@ -24,14 +24,14 @@ LL |     type Bar: Clone = Vec<T>;
    |               ^^^^^ the trait `std::clone::Clone` is not implemented for `T`
    |
 help: consider restricting this type parameter with `T: std::clone::Clone`
-  --> $DIR/defaults-suitability.rs:32:11
+  --> $DIR/defaults-suitability.rs:37:11
    |
 LL | trait Foo<T> {
    |           ^
    = note: required because of the requirements on the impl of `std::clone::Clone` for `std::vec::Vec<T>`
 
 error[E0277]: the trait bound `(): Foo<Self>` is not satisfied
-  --> $DIR/defaults-suitability.rs:39:17
+  --> $DIR/defaults-suitability.rs:44:17
    |
 LL | trait Bar: Sized {
    | ---------------- required by `Bar`
@@ -40,7 +40,7 @@ LL |     type Assoc: Foo<Self> = ();
    |                 ^^^^^^^^^ the trait `Foo<Self>` is not implemented for `()`
 
 error[E0277]: the trait bound `NotClone: IsU8<NotClone>` is not satisfied
-  --> $DIR/defaults-suitability.rs:59:18
+  --> $DIR/defaults-suitability.rs:64:18
    |
 LL | / trait D where
 LL | |     Vec<Self::Assoc>: Clone,
@@ -53,7 +53,7 @@ LL | | }
    | |_- required by `D`
 
 error[E0277]: the trait bound `bool: IsU8<NotClone>` is not satisfied
-  --> $DIR/defaults-suitability.rs:61:11
+  --> $DIR/defaults-suitability.rs:66:11
    |
 LL | / trait D where
 LL | |     Vec<Self::Assoc>: Clone,
@@ -68,7 +68,7 @@ LL | | }
    | |_- required by `D`
 
 error[E0277]: the trait bound `NotClone: std::clone::Clone` is not satisfied
-  --> $DIR/defaults-suitability.rs:57:23
+  --> $DIR/defaults-suitability.rs:62:23
    |
 LL | / trait D where
 LL | |     Vec<Self::Assoc>: Clone,
@@ -83,7 +83,7 @@ LL | | }
    = note: required because of the requirements on the impl of `std::clone::Clone` for `std::vec::Vec<NotClone>`
 
 error[E0277]: the trait bound `<Self as Foo2<T>>::Baz: std::clone::Clone` is not satisfied
-  --> $DIR/defaults-suitability.rs:72:15
+  --> $DIR/defaults-suitability.rs:77:15
    |
 LL | trait Foo2<T> {
    | -------------- help: consider further restricting the associated type: `where <Self as Foo2<T>>::Baz: std::clone::Clone`
@@ -95,7 +95,7 @@ LL |     type Bar: Clone = Vec<Self::Baz>;
    = note: required because of the requirements on the impl of `std::clone::Clone` for `std::vec::Vec<<Self as Foo2<T>>::Baz>`
 
 error[E0277]: the trait bound `<Self as Foo25<T>>::Baz: std::clone::Clone` is not satisfied
-  --> $DIR/defaults-suitability.rs:81:15
+  --> $DIR/defaults-suitability.rs:86:15
    |
 LL | trait Foo25<T: Clone> {
    | ---------------------- help: consider further restricting the associated type: `where <Self as Foo25<T>>::Baz: std::clone::Clone`
@@ -107,7 +107,7 @@ LL |     type Bar: Clone = Vec<Self::Baz>;
    = note: required because of the requirements on the impl of `std::clone::Clone` for `std::vec::Vec<<Self as Foo25<T>>::Baz>`
 
 error[E0277]: the trait bound `T: std::clone::Clone` is not satisfied
-  --> $DIR/defaults-suitability.rs:90:16
+  --> $DIR/defaults-suitability.rs:95:16
    |
 LL | / trait Foo3<T> where
 LL | |     Self::Bar: Clone,
@@ -120,20 +120,24 @@ LL | | }
    | |_- required by `Foo3`
    |
 help: consider restricting this type parameter with `where T: std::clone::Clone`
-  --> $DIR/defaults-suitability.rs:88:12
+  --> $DIR/defaults-suitability.rs:93:12
    |
 LL | trait Foo3<T> where
    |            ^
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/defaults-suitability.rs:27:5
+  --> $DIR/defaults-suitability.rs:32:5
    |
 LL |     type Ty = Vec<[u8]>;
    |     ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   | 
+  ::: $SRC_DIR/liballoc/vec.rs:LL:COL
+   |
+LL | pub struct Vec<T> {
+   |                - required by `std::vec::Vec` here
    |
    = help: the trait `std::marker::Sized` is not implemented for `[u8]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required by `std::vec::Vec`
 
 error: aborting due to 11 previous errors
 

--- a/src/test/ui/associated-types/defaults-unsound-62211-1.stderr
+++ b/src/test/ui/associated-types/defaults-unsound-62211-1.stderr
@@ -42,6 +42,12 @@ LL |     + Display = Self;
 error[E0277]: `T` doesn't implement `std::fmt::Display`
   --> $DIR/defaults-unsound-62211-1.rs:41:9
    |
+LL | trait UncheckedCopy: Sized {
+   | -------------------------- required by `UncheckedCopy`
+...
+LL |     + Display = Self;
+   |       ------- required by `UncheckedCopy` here
+...
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ `T` cannot be formatted with the default formatter
    |
@@ -56,6 +62,12 @@ LL | impl<T> UncheckedCopy for T {}
 error[E0277]: the trait bound `T: std::ops::Deref` is not satisfied
   --> $DIR/defaults-unsound-62211-1.rs:41:9
    |
+LL | trait UncheckedCopy: Sized {
+   | -------------------------- required by `UncheckedCopy`
+...
+LL |     + Deref<Target = str>
+   |       ------------------- required by `UncheckedCopy` here
+...
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ the trait `std::ops::Deref` is not implemented for `T`
    |
@@ -68,6 +80,12 @@ LL | impl<T> UncheckedCopy for T {}
 error[E0277]: cannot add-assign `&'static str` to `T`
   --> $DIR/defaults-unsound-62211-1.rs:41:9
    |
+LL | trait UncheckedCopy: Sized {
+   | -------------------------- required by `UncheckedCopy`
+...
+LL |     + AddAssign<&'static str>
+   |       ----------------------- required by `UncheckedCopy` here
+...
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ no implementation for `T += &'static str`
    |
@@ -81,6 +99,12 @@ LL | impl<T> UncheckedCopy for T {}
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/defaults-unsound-62211-1.rs:41:9
    |
+LL | trait UncheckedCopy: Sized {
+   | -------------------------- required by `UncheckedCopy`
+...
+LL |     type Output: Copy
+   |                  ---- required by `UncheckedCopy` here
+...
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |

--- a/src/test/ui/associated-types/defaults-unsound-62211-2.stderr
+++ b/src/test/ui/associated-types/defaults-unsound-62211-2.stderr
@@ -42,6 +42,12 @@ LL |     + Display = Self;
 error[E0277]: `T` doesn't implement `std::fmt::Display`
   --> $DIR/defaults-unsound-62211-2.rs:41:9
    |
+LL | trait UncheckedCopy: Sized {
+   | -------------------------- required by `UncheckedCopy`
+...
+LL |     + Display = Self;
+   |       ------- required by `UncheckedCopy` here
+...
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ `T` cannot be formatted with the default formatter
    |
@@ -56,6 +62,12 @@ LL | impl<T> UncheckedCopy for T {}
 error[E0277]: the trait bound `T: std::ops::Deref` is not satisfied
   --> $DIR/defaults-unsound-62211-2.rs:41:9
    |
+LL | trait UncheckedCopy: Sized {
+   | -------------------------- required by `UncheckedCopy`
+...
+LL |     + Deref<Target = str>
+   |       ------------------- required by `UncheckedCopy` here
+...
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ the trait `std::ops::Deref` is not implemented for `T`
    |
@@ -68,6 +80,12 @@ LL | impl<T> UncheckedCopy for T {}
 error[E0277]: cannot add-assign `&'static str` to `T`
   --> $DIR/defaults-unsound-62211-2.rs:41:9
    |
+LL | trait UncheckedCopy: Sized {
+   | -------------------------- required by `UncheckedCopy`
+...
+LL |     + AddAssign<&'static str>
+   |       ----------------------- required by `UncheckedCopy` here
+...
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ no implementation for `T += &'static str`
    |
@@ -81,6 +99,12 @@ LL | impl<T> UncheckedCopy for T {}
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/defaults-unsound-62211-2.rs:41:9
    |
+LL | trait UncheckedCopy: Sized {
+   | -------------------------- required by `UncheckedCopy`
+...
+LL |     type Output: Copy
+   |                  ---- required by `UncheckedCopy` here
+...
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |

--- a/src/test/ui/associated-types/issue-43924.stderr
+++ b/src/test/ui/associated-types/issue-43924.stderr
@@ -9,12 +9,22 @@ LL |     type Out: Default + ToString + ?Sized = dyn ToString;
 error[E0277]: the trait bound `(dyn std::string::ToString + 'static): std::default::Default` is not satisfied
   --> $DIR/issue-43924.rs:10:6
    |
+LL | trait Foo<T: Default + ToString> {
+   | -------------------------------- required by `Foo`
+LL |     type Out: Default + ToString + ?Sized = dyn ToString;
+   |               ------- required by `Foo` here
+...
 LL | impl Foo<u32> for () {}
    |      ^^^^^^^^ the trait `std::default::Default` is not implemented for `(dyn std::string::ToString + 'static)`
 
 error[E0277]: the trait bound `(dyn std::string::ToString + 'static): std::default::Default` is not satisfied
   --> $DIR/issue-43924.rs:11:6
    |
+LL | trait Foo<T: Default + ToString> {
+   | -------------------------------- required by `Foo`
+LL |     type Out: Default + ToString + ?Sized = dyn ToString;
+   |               ------- required by `Foo` here
+...
 LL | impl Foo<u64> for () {}
    |      ^^^^^^^^ the trait `std::default::Default` is not implemented for `(dyn std::string::ToString + 'static)`
 

--- a/src/test/ui/associated-types/issue-65774-1.stderr
+++ b/src/test/ui/associated-types/issue-65774-1.stderr
@@ -9,6 +9,11 @@ LL |     type MpuConfig: MyDisplay = T;
 error[E0277]: the trait bound `T: MyDisplay` is not satisfied
   --> $DIR/issue-65774-1.rs:16:6
    |
+LL | trait MPU {
+   | --------- required by `MPU`
+LL |     type MpuConfig: MyDisplay = T;
+   |                     --------- required by `MPU` here
+...
 LL | impl MPU for S { }
    |      ^^^ the trait `MyDisplay` is not implemented for `T`
 

--- a/src/test/ui/associated-types/issue-65774-2.stderr
+++ b/src/test/ui/associated-types/issue-65774-2.stderr
@@ -9,6 +9,11 @@ LL |     type MpuConfig: MyDisplay = T;
 error[E0277]: the trait bound `T: MyDisplay` is not satisfied
   --> $DIR/issue-65774-2.rs:16:6
    |
+LL | trait MPU {
+   | --------- required by `MPU`
+LL |     type MpuConfig: MyDisplay = T;
+   |                     --------- required by `MPU` here
+...
 LL | impl MPU for S { }
    |      ^^^ the trait `MyDisplay` is not implemented for `T`
 

--- a/src/test/ui/bad/bad-sized.rs
+++ b/src/test/ui/bad/bad-sized.rs
@@ -1,3 +1,8 @@
+// FIXME: missing sysroot spans (#53081)
+// ignore-i586-unknown-linux-gnu
+// ignore-i586-unknown-linux-musl
+// ignore-i686-unknown-linux-musl
+
 trait Trait {}
 
 pub fn main() {

--- a/src/test/ui/bad/bad-sized.stderr
+++ b/src/test/ui/bad/bad-sized.stderr
@@ -1,5 +1,5 @@
 error[E0225]: only auto traits can be used as additional traits in a trait object
-  --> $DIR/bad-sized.rs:4:28
+  --> $DIR/bad-sized.rs:9:28
    |
 LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
    |                    -----   ^^^^^
@@ -10,17 +10,21 @@ LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
    |                    trait alias used in trait object type (first use)
 
 error[E0277]: the size for values of type `dyn Trait` cannot be known at compilation time
-  --> $DIR/bad-sized.rs:4:12
+  --> $DIR/bad-sized.rs:9:12
    |
 LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
    |            ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   | 
+  ::: $SRC_DIR/liballoc/vec.rs:LL:COL
+   |
+LL | pub struct Vec<T> {
+   |                - required by `std::vec::Vec` here
    |
    = help: the trait `std::marker::Sized` is not implemented for `dyn Trait`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required by `std::vec::Vec`
 
 error[E0277]: the size for values of type `dyn Trait` cannot be known at compilation time
-  --> $DIR/bad-sized.rs:4:37
+  --> $DIR/bad-sized.rs:9:37
    |
 LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
    |                                     ^^^^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
@@ -1,6 +1,9 @@
 error[E0277]: `T` cannot be sent between threads safely
   --> $DIR/builtin-superkinds-double-superkind.rs:6:24
    |
+LL | trait Foo : Send+Sync { }
+   |             ---- required by `Foo` here
+LL | 
 LL | impl <T: Sync+'static> Foo for (T,) { }
    |                        ^^^ `T` cannot be sent between threads safely
    |
@@ -15,6 +18,9 @@ LL | impl <T: Sync+'static> Foo for (T,) { }
 error[E0277]: `T` cannot be shared between threads safely
   --> $DIR/builtin-superkinds-double-superkind.rs:9:16
    |
+LL | trait Foo : Send+Sync { }
+   |                  ---- required by `Foo` here
+...
 LL | impl <T: Send> Foo for (T,T) { }
    |                ^^^ `T` cannot be shared between threads safely
    |

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
@@ -3,6 +3,11 @@ error[E0277]: `T` cannot be sent between threads safely
    |
 LL | impl <T:Sync+'static> RequiresRequiresShareAndSend for X<T> { }
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `T` cannot be sent between threads safely
+   | 
+  ::: $DIR/auxiliary/trait_superkinds_in_metadata.rs:7:58
+   |
+LL | pub trait RequiresRequiresShareAndSend : RequiresShare + Send { }
+   |                                                          ---- required by `trait_superkinds_in_metadata::RequiresRequiresShareAndSend` here
    |
    = help: within `X<T>`, the trait `std::marker::Send` is not implemented for `T`
 help: consider further restricting this bound with `+ std::marker::Send`

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-simple.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-simple.stderr
@@ -1,6 +1,9 @@
 error[E0277]: `std::rc::Rc<i8>` cannot be sent between threads safely
   --> $DIR/builtin-superkinds-simple.rs:6:6
    |
+LL | trait Foo : Send { }
+   |             ---- required by `Foo` here
+LL | 
 LL | impl Foo for std::rc::Rc<i8> { }
    |      ^^^ `std::rc::Rc<i8>` cannot be sent between threads safely
    |

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
@@ -1,6 +1,9 @@
 error[E0277]: `T` cannot be sent between threads safely
   --> $DIR/builtin-superkinds-typaram-not-send.rs:5:24
    |
+LL | trait Foo : Send { }
+   |             ---- required by `Foo` here
+LL | 
 LL | impl <T: Sync+'static> Foo for T { }
    |                        ^^^ `T` cannot be sent between threads safely
    |

--- a/src/test/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
+++ b/src/test/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
@@ -2,7 +2,7 @@ error[E0277]: `F` cannot be sent between threads safely
   --> $DIR/closure-bounds-cant-promote-superkind-in-struct.rs:5:22
    |
 LL | struct X<F> where F: FnOnce() + 'static + Send {
-   | ---------------------------------------------- required by `X`
+   |                                           ---- required by `X` here
 ...
 LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static {
    |                      ^^^^ `F` cannot be sent between threads safely

--- a/src/test/ui/consts/too_generic_eval_ice.stderr
+++ b/src/test/ui/consts/too_generic_eval_ice.stderr
@@ -15,7 +15,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
   --> $DIR/too_generic_eval_ice.rs:7:13
    |
 LL | pub struct Foo<A, B>(A, B);
-   | --------------------------- required by `Foo`
+   |                - required by `Foo` here
 LL | 
 LL | impl<A, B> Foo<A, B> {
    |      - this type parameter needs to be `std::marker::Sized`
@@ -30,7 +30,7 @@ error[E0277]: the size for values of type `B` cannot be known at compilation tim
   --> $DIR/too_generic_eval_ice.rs:7:13
    |
 LL | pub struct Foo<A, B>(A, B);
-   | --------------------------- required by `Foo`
+   |                   - required by `Foo` here
 LL | 
 LL | impl<A, B> Foo<A, B> {
    |         - this type parameter needs to be `std::marker::Sized`

--- a/src/test/ui/consts/too_generic_eval_ice.stderr
+++ b/src/test/ui/consts/too_generic_eval_ice.stderr
@@ -23,7 +23,7 @@ LL | impl<A, B> Foo<A, B> {
 LL |         [5; Self::HOST_SIZE] == [6; 0]
    |             ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `A`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
 
 error[E0277]: the size for values of type `B` cannot be known at compilation time
@@ -38,7 +38,7 @@ LL | impl<A, B> Foo<A, B> {
 LL |         [5; Self::HOST_SIZE] == [6; 0]
    |             ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `B`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/derives/derives-span-Eq-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Eq-enum-struct-variant.stderr
@@ -3,8 +3,12 @@ error[E0277]: the trait bound `Error: std::cmp::Eq` is not satisfied
    |
 LL |      x: Error
    |      ^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `Error`
+   | 
+  ::: $SRC_DIR/libcore/cmp.rs:LL:COL
    |
-   = note: required by `std::cmp::AssertParamIsEq`
+LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
+   |                               -- required by `std::cmp::AssertParamIsEq` here
+   |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Eq-enum.stderr
+++ b/src/test/ui/derives/derives-span-Eq-enum.stderr
@@ -3,8 +3,12 @@ error[E0277]: the trait bound `Error: std::cmp::Eq` is not satisfied
    |
 LL |      Error
    |      ^^^^^ the trait `std::cmp::Eq` is not implemented for `Error`
+   | 
+  ::: $SRC_DIR/libcore/cmp.rs:LL:COL
    |
-   = note: required by `std::cmp::AssertParamIsEq`
+LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
+   |                               -- required by `std::cmp::AssertParamIsEq` here
+   |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Eq-struct.stderr
+++ b/src/test/ui/derives/derives-span-Eq-struct.stderr
@@ -3,8 +3,12 @@ error[E0277]: the trait bound `Error: std::cmp::Eq` is not satisfied
    |
 LL |     x: Error
    |     ^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `Error`
+   | 
+  ::: $SRC_DIR/libcore/cmp.rs:LL:COL
    |
-   = note: required by `std::cmp::AssertParamIsEq`
+LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
+   |                               -- required by `std::cmp::AssertParamIsEq` here
+   |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Eq-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Eq-tuple-struct.stderr
@@ -3,8 +3,12 @@ error[E0277]: the trait bound `Error: std::cmp::Eq` is not satisfied
    |
 LL |     Error
    |     ^^^^^ the trait `std::cmp::Eq` is not implemented for `Error`
+   | 
+  ::: $SRC_DIR/libcore/cmp.rs:LL:COL
    |
-   = note: required by `std::cmp::AssertParamIsEq`
+LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
+   |                               -- required by `std::cmp::AssertParamIsEq` here
+   |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/dst/dst-object-from-unsized-type.stderr
+++ b/src/test/ui/dst/dst-object-from-unsized-type.stderr
@@ -6,7 +6,7 @@ LL | fn test1<T: ?Sized + Foo>(t: &T) {
 LL |     let u: &dyn Foo = t;
    |                       ^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `T`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: required for the cast to the object type `dyn Foo`
 
@@ -18,7 +18,7 @@ LL | fn test2<T: ?Sized + Foo>(t: &T) {
 LL |     let v: &dyn Foo = t as &dyn Foo;
    |                       ^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `T`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: required for the cast to the object type `dyn Foo`
 

--- a/src/test/ui/dst/dst-sized-trait-param.stderr
+++ b/src/test/ui/dst/dst-sized-trait-param.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the size for values of type `[isize]` cannot be known at compilation time
   --> $DIR/dst-sized-trait-param.rs:7:6
    |
+LL | trait Foo<T> : Sized { fn take(self, x: &T) { } } // Note: T is sized
+   |           - required by `Foo` here
+LL | 
 LL | impl Foo<[isize]> for usize { }
    |      ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
@@ -10,6 +13,9 @@ LL | impl Foo<[isize]> for usize { }
 error[E0277]: the size for values of type `[usize]` cannot be known at compilation time
   --> $DIR/dst-sized-trait-param.rs:10:6
    |
+LL | trait Foo<T> : Sized { fn take(self, x: &T) { } } // Note: T is sized
+   |                ----- required by `Foo` here
+...
 LL | impl Foo<isize> for [usize] { }
    |      ^^^^^^^^^^ doesn't have a size known at compile-time
    |

--- a/src/test/ui/error-codes/E0275.stderr
+++ b/src/test/ui/error-codes/E0275.stderr
@@ -2,7 +2,7 @@ error[E0275]: overflow evaluating the requirement `Bar<Bar<Bar<Bar<Bar<Bar<Bar<B
   --> $DIR/E0275.rs:5:33
    |
 LL | trait Foo {}
-   | --------- required by `Foo`
+   | --------- required by `Foo` here
 ...
 LL | impl<T> Foo for T where Bar<T>: Foo {}
    |                                 ^^^

--- a/src/test/ui/generic-associated-types/construct_with_other_type.stderr
+++ b/src/test/ui/generic-associated-types/construct_with_other_type.stderr
@@ -1,6 +1,12 @@
 error[E0271]: type mismatch resolving `for<'a> <<T as Baz>::Baa<'a> as std::ops::Deref>::Target == <<T as Baz>::Quux<'a> as Foo>::Bar<'a, 'static>`
   --> $DIR/construct_with_other_type.rs:19:9
    |
+LL | trait Baz {
+   | --------- required by `Baz`
+...
+LL |     type Baa<'a>: Deref<Target = <Self::Quux<'a> as Foo>::Bar<'a, 'static>>  where Self: 'a;
+   |                         -------------------------------------------------- required by `Baz` here
+...
 LL | impl<T> Baz for T where T: Foo {
    |         ^^^ expected type parameter `T`, found associated type
    |

--- a/src/test/ui/generic-associated-types/issue-62326-parameter-out-of-range.stderr
+++ b/src/test/ui/generic-associated-types/issue-62326-parameter-out-of-range.stderr
@@ -4,7 +4,7 @@ error[E0280]: the requirement `for<'a> <Self as Iterator>::Item<'a>: 'a` is not 
 LL | trait Iterator {
    | -------------- required by `Iterator`
 LL |     type Item<'a>: 'a;
-   |                    ^^
+   |                    ^^ required by `Iterator` here
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/iterable.stderr
+++ b/src/test/ui/generic-associated-types/iterable.stderr
@@ -29,6 +29,9 @@ error[E0271]: type mismatch resolving `for<'a> <<std::vec::Vec<T> as Iterable>::
    |
 LL | trait Iterable {
    | -------------- required by `Iterable`
+LL |     type Item<'a> where Self: 'a;
+LL |     type Iter<'a>: Iterator<Item = Self::Item<'a>> where Self: 'a;
+   |                             --------------------- required by `Iterable` here
 ...
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'a> {
    |                              ^^^^^^^^^^^^^^ expected associated type, found reference
@@ -43,6 +46,9 @@ error[E0271]: type mismatch resolving `for<'a> <<[T] as Iterable>::Iter<'a> as s
    |
 LL | trait Iterable {
    | -------------- required by `Iterable`
+LL |     type Item<'a> where Self: 'a;
+LL |     type Iter<'a>: Iterator<Item = Self::Item<'a>> where Self: 'a;
+   |                             --------------------- required by `Iterable` here
 ...
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'a> {
    |                              ^^^^^^^^^^^^^^ expected associated type, found reference

--- a/src/test/ui/generics/issue-61631-default-type-param-can-reference-self-in-trait.stderr
+++ b/src/test/ui/generics/issue-61631-default-type-param-can-reference-self-in-trait.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the size for values of type `[()]` cannot be known at compilation time
   --> $DIR/issue-61631-default-type-param-can-reference-self-in-trait.rs:19:6
    |
+LL | trait Tsized<P: Sized = [Self]> {}
+   |              - required by `Tsized` here
+LL | 
 LL | impl Tsized for () {}
    |      ^^^^^^ doesn't have a size known at compile-time
    |

--- a/src/test/ui/impl-bounds-checking.stderr
+++ b/src/test/ui/impl-bounds-checking.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `isize: Clone2` is not satisfied
   --> $DIR/impl-bounds-checking.rs:10:6
    |
+LL | trait Getter<T: Clone2> {
+   |                 ------ required by `Getter` here
+...
 LL | impl Getter<isize> for isize {
    |      ^^^^^^^^^^^^^ the trait `Clone2` is not implemented for `isize`
 

--- a/src/test/ui/issues/issue-10412.stderr
+++ b/src/test/ui/issues/issue-10412.stderr
@@ -49,6 +49,9 @@ LL | impl<'self> Serializable<str> for &'self str {
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/issue-10412.rs:6:13
    |
+LL | trait Serializable<'self, T> {
+   |                           - required by `Serializable` here
+...
 LL | impl<'self> Serializable<str> for &'self str {
    |             ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |

--- a/src/test/ui/issues/issue-18919.rs
+++ b/src/test/ui/issues/issue-18919.rs
@@ -4,4 +4,9 @@ fn ho_func(f: Option<FuncType>) {
     //~^ ERROR the size for values of type
 }
 
+enum Option<T> {
+    Some(T),
+    None,
+}
+
 fn main() {}

--- a/src/test/ui/issues/issue-18919.stderr
+++ b/src/test/ui/issues/issue-18919.stderr
@@ -3,10 +3,12 @@ error[E0277]: the size for values of type `dyn for<'r> std::ops::Fn(&'r isize) -
    |
 LL | fn ho_func(f: Option<FuncType>) {
    |               ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+...
+LL | enum Option<T> {
+   |             - required by `Option` here
    |
    = help: the trait `std::marker::Sized` is not implemented for `dyn for<'r> std::ops::Fn(&'r isize) -> isize`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required by `std::option::Option`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-20005.stderr
+++ b/src/test/ui/issues/issue-20005.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
   --> $DIR/issue-20005.rs:10:49
    |
 LL | trait From<Src> {
-   | --------------- required by `From`
+   |            --- required by `From` here
 ...
 LL |     ) -> <Dst as From<Self>>::Result where Dst: From<Self> {
    |                                                 ^^^^^^^^^^- help: consider further restricting `Self`: `, Self: std::marker::Sized`

--- a/src/test/ui/issues/issue-20413.stderr
+++ b/src/test/ui/issues/issue-20413.stderr
@@ -10,7 +10,7 @@ error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<N
   --> $DIR/issue-20413.rs:8:36
    |
 LL | trait Foo {
-   | --------- required by `Foo`
+   | --------- required by `Foo` here
 ...
 LL | impl<T> Foo for T where NoData<T>: Foo {
    |                                    ^^^
@@ -148,7 +148,7 @@ error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<N
   --> $DIR/issue-20413.rs:8:36
    |
 LL | trait Foo {
-   | --------- required by `Foo`
+   | --------- required by `Foo` here
 ...
 LL | impl<T> Foo for T where NoData<T>: Foo {
    |                                    ^^^

--- a/src/test/ui/issues/issue-20433.stderr
+++ b/src/test/ui/issues/issue-20433.stderr
@@ -3,10 +3,14 @@ error[E0277]: the size for values of type `[i32]` cannot be known at compilation
    |
 LL |     fn iceman(c: Vec<[i32]>) {}
    |                  ^^^^^^^^^^ doesn't have a size known at compile-time
+   | 
+  ::: $SRC_DIR/liballoc/vec.rs:LL:COL
+   |
+LL | pub struct Vec<T> {
+   |                - required by `std::vec::Vec` here
    |
    = help: the trait `std::marker::Sized` is not implemented for `[i32]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required by `std::vec::Vec`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-21837.stderr
+++ b/src/test/ui/issues/issue-21837.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: Bound` is not satisfied
   --> $DIR/issue-21837.rs:8:9
    |
 LL | pub struct Foo<T: Bound>(T);
-   | ---------------------------- required by `Foo`
+   |                   ----- required by `Foo` here
 ...
 LL | impl<T> Trait2 for Foo<T> {}
    |         ^^^^^^ the trait `Bound` is not implemented for `T`

--- a/src/test/ui/issues/issue-21974.stderr
+++ b/src/test/ui/issues/issue-21974.stderr
@@ -2,7 +2,7 @@ error[E0283]: type annotations needed
   --> $DIR/issue-21974.rs:11:19
    |
 LL | trait Foo {
-   | --------- required by `Foo`
+   | --------- required by `Foo` here
 ...
 LL |     where &'a T : Foo,
    |                   ^^^ cannot infer type for reference `&'a T`

--- a/src/test/ui/issues/issue-23281.rs
+++ b/src/test/ui/issues/issue-23281.rs
@@ -5,4 +5,8 @@ impl Struct {
     //~^ ERROR the size for values of type
 }
 
+struct Vec<T> {
+    t: T,
+}
+
 fn main() {}

--- a/src/test/ui/issues/issue-23281.stderr
+++ b/src/test/ui/issues/issue-23281.stderr
@@ -3,10 +3,12 @@ error[E0277]: the size for values of type `(dyn std::ops::Fn() + 'static)` canno
    |
 LL |     pub fn function(funs: Vec<dyn Fn() -> ()>) {}
    |                           ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+...
+LL | struct Vec<T> {
+   |            - required by `Vec` here
    |
    = help: the trait `std::marker::Sized` is not implemented for `(dyn std::ops::Fn() + 'static)`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required by `std::vec::Vec`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-24204.stderr
+++ b/src/test/ui/issues/issue-24204.stderr
@@ -3,6 +3,8 @@ error[E0271]: type mismatch resolving `<<T as Trait>::A as MultiDispatch<i32>>::
    |
 LL | trait Trait: Sized {
    | ------------------ required by `Trait`
+LL |     type A: MultiDispatch<Self::B, O = Self>;
+   |                                    -------- required by `Trait` here
 ...
 LL | fn test<T: Trait<B=i32>>(b: i32) -> T where T::A: MultiDispatch<i32> { T::new(b) }
    |            ^^^^^^^^^^^^ expected type parameter `T`, found associated type

--- a/src/test/ui/issues/issue-24424.stderr
+++ b/src/test/ui/issues/issue-24424.stderr
@@ -2,7 +2,7 @@ error[E0283]: type annotations needed
   --> $DIR/issue-24424.rs:4:57
    |
 LL | trait Trait0<'l0>  {}
-   | ----------------- required by `Trait0`
+   | ----------------- required by `Trait0` here
 LL | 
 LL | impl <'l0, 'l1, T0> Trait1<'l0, T0> for bool where T0 : Trait0<'l0>, T0 : Trait0<'l1> {}
    |                                                         ^^^^^^^^^^^ cannot infer type for type parameter `T0`

--- a/src/test/ui/issues/issue-27060-2.stderr
+++ b/src/test/ui/issues/issue-27060-2.stderr
@@ -6,7 +6,7 @@ LL | pub struct Bad<T: ?Sized> {
 LL |     data: T,
    |     ^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `T`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: the last field of a packed struct may only have a dynamically sized type if it does not need drop to be run
 

--- a/src/test/ui/iterators/bound.stderr
+++ b/src/test/ui/iterators/bound.stderr
@@ -2,7 +2,7 @@ error[E0277]: `u8` is not an iterator
   --> $DIR/bound.rs:2:10
    |
 LL | struct S<I: Iterator>(I);
-   | ------------------------- required by `S`
+   |             -------- required by `S` here
 LL | struct T(S<u8>);
    |          ^^^^^ `u8` is not an iterator
    |

--- a/src/test/ui/malformed/malformed-derive-entry.rs
+++ b/src/test/ui/malformed/malformed-derive-entry.rs
@@ -1,3 +1,8 @@
+// FIXME: missing sysroot spans (#53081)
+// ignore-i586-unknown-linux-gnu
+// ignore-i586-unknown-linux-musl
+// ignore-i686-unknown-linux-musl
+
 #[derive(Copy(Bad))]
 //~^ ERROR traits in `#[derive(...)]` don't accept arguments
 //~| ERROR the trait bound

--- a/src/test/ui/malformed/malformed-derive-entry.stderr
+++ b/src/test/ui/malformed/malformed-derive-entry.stderr
@@ -1,34 +1,44 @@
 error: traits in `#[derive(...)]` don't accept arguments
-  --> $DIR/malformed-derive-entry.rs:1:14
+  --> $DIR/malformed-derive-entry.rs:6:14
    |
 LL | #[derive(Copy(Bad))]
    |              ^^^^^ help: remove the arguments
 
 error: traits in `#[derive(...)]` don't accept values
-  --> $DIR/malformed-derive-entry.rs:6:14
+  --> $DIR/malformed-derive-entry.rs:11:14
    |
 LL | #[derive(Copy="bad")]
    |              ^^^^^^ help: remove the value
 
 error: malformed `derive` attribute input
-  --> $DIR/malformed-derive-entry.rs:11:1
+  --> $DIR/malformed-derive-entry.rs:16:1
    |
 LL | #[derive]
    | ^^^^^^^^^ help: missing traits to be derived: `#[derive(Trait1, Trait2, ...)]`
 
 error[E0277]: the trait bound `Test1: std::clone::Clone` is not satisfied
-  --> $DIR/malformed-derive-entry.rs:1:10
+  --> $DIR/malformed-derive-entry.rs:6:10
    |
 LL | #[derive(Copy(Bad))]
    |          ^^^^ the trait `std::clone::Clone` is not implemented for `Test1`
+   | 
+  ::: $SRC_DIR/libcore/marker.rs:LL:COL
+   |
+LL | pub trait Copy: Clone {
+   |                 ----- required by `std::marker::Copy` here
    |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Test2: std::clone::Clone` is not satisfied
-  --> $DIR/malformed-derive-entry.rs:6:10
+  --> $DIR/malformed-derive-entry.rs:11:10
    |
 LL | #[derive(Copy="bad")]
    |          ^^^^ the trait `std::clone::Clone` is not implemented for `Test2`
+   | 
+  ::: $SRC_DIR/libcore/marker.rs:LL:COL
+   |
+LL | pub trait Copy: Clone {
+   |                 ----- required by `std::marker::Copy` here
    |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/recursion/recursive-requirements.stderr
+++ b/src/test/ui/recursion/recursive-requirements.stderr
@@ -2,7 +2,7 @@ error[E0277]: `*const Bar` cannot be shared between threads safely
   --> $DIR/recursive-requirements.rs:16:12
    |
 LL | struct AssertSync<T: Sync>(PhantomData<T>);
-   | ------------------------------------------- required by `AssertSync`
+   |                      ---- required by `AssertSync` here
 ...
 LL |     let _: AssertSync<Foo> = unimplemented!();
    |            ^^^^^^^^^^^^^^^ `*const Bar` cannot be shared between threads safely
@@ -14,7 +14,7 @@ error[E0277]: `*const Foo` cannot be shared between threads safely
   --> $DIR/recursive-requirements.rs:16:12
    |
 LL | struct AssertSync<T: Sync>(PhantomData<T>);
-   | ------------------------------------------- required by `AssertSync`
+   |                      ---- required by `AssertSync` here
 ...
 LL |     let _: AssertSync<Foo> = unimplemented!();
    |            ^^^^^^^^^^^^^^^ `*const Foo` cannot be shared between threads safely

--- a/src/test/ui/specialization/defaultimpl/specialization-wfcheck.stderr
+++ b/src/test/ui/specialization/defaultimpl/specialization-wfcheck.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `U: std::cmp::Eq` is not satisfied
   --> $DIR/specialization-wfcheck.rs:7:17
    |
+LL | trait Foo<'a, T: Eq + 'a> { }
+   |                  -- required by `Foo` here
+LL | 
 LL | default impl<U> Foo<'static, U> for () {}
    |                 ^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `U`
    |

--- a/src/test/ui/suggestions/missing-assoc-type-bound-restriction.stderr
+++ b/src/test/ui/suggestions/missing-assoc-type-bound-restriction.stderr
@@ -3,6 +3,9 @@ error[E0277]: the trait bound `<T as Parent>::Assoc: Child<A>` is not satisfied
    |
 LL | trait Parent {
    | ------------ required by `Parent`
+LL |     type Ty;
+LL |     type Assoc: Child<Self::Ty>;
+   |                 --------------- required by `Parent` here
 ...
 LL | impl<A, T: Parent<Ty = A>> Parent for ParentWrapper<T> {
    |                   ^^^^^^                              - help: consider further restricting the associated type: `where <T as Parent>::Assoc: Child<A>`
@@ -30,6 +33,9 @@ error[E0277]: the trait bound `<T as Parent>::Assoc: Child<A>` is not satisfied
    |
 LL | trait Parent {
    | ------------ required by `Parent`
+LL |     type Ty;
+LL |     type Assoc: Child<Self::Ty>;
+   |                 --------------- required by `Parent` here
 ...
 LL | impl<A, T: Parent<Ty = A>> Parent for ParentWrapper<T> {
    |                                                       - help: consider further restricting the associated type: `where <T as Parent>::Assoc: Child<A>`

--- a/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
+++ b/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
@@ -12,18 +12,26 @@ error[E0277]: the trait bound `&dyn std::io::Write: std::io::Write` is not satis
    |
 LL |     let fp = BufWriter::new(fp);
    |              ^^^^^^^^^^^^^^ the trait `std::io::Write` is not implemented for `&dyn std::io::Write`
+   | 
+  ::: $SRC_DIR/libstd/io/buffered.rs:LL:COL
+   |
+LL | pub struct BufWriter<W: Write> {
+   |                         ----- required by `std::io::BufWriter` here
    |
    = note: `std::io::Write` is implemented for `&mut dyn std::io::Write`, but not for `&dyn std::io::Write`
-   = note: required by `std::io::BufWriter`
 
 error[E0277]: the trait bound `&dyn std::io::Write: std::io::Write` is not satisfied
   --> $DIR/mut-borrow-needed-by-trait.rs:21:14
    |
 LL |     let fp = BufWriter::new(fp);
    |              ^^^^^^^^^^^^^^^^^^ the trait `std::io::Write` is not implemented for `&dyn std::io::Write`
+   | 
+  ::: $SRC_DIR/libstd/io/buffered.rs:LL:COL
+   |
+LL | pub struct BufWriter<W: Write> {
+   |                         ----- required by `std::io::BufWriter` here
    |
    = note: `std::io::Write` is implemented for `&mut dyn std::io::Write`, but not for `&dyn std::io::Write`
-   = note: required by `std::io::BufWriter`
 
 error[E0599]: no method named `write_fmt` found for struct `std::io::BufWriter<&dyn std::io::Write>` in the current scope
   --> $DIR/mut-borrow-needed-by-trait.rs:26:5

--- a/src/test/ui/traits/trait-alias/trait-alias-wf.stderr
+++ b/src/test/ui/traits/trait-alias/trait-alias-wf.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: Foo` is not satisfied
   --> $DIR/trait-alias-wf.rs:5:14
    |
 LL | trait A<T: Foo> {}
-   | --------------- required by `A`
+   |            --- required by `A` here
 LL | trait B<T> = A<T>;
    |              ^^^^ the trait `Foo` is not implemented for `T`
    |

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-in-fns.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-in-fns.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `u32: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-in-fns.rs:13:15
    |
 LL | struct Foo<T:Trait> {
-   | ------------------- required by `Foo`
+   |              ----- required by `Foo` here
 ...
 LL | fn explode(x: Foo<u32>) {}
    |               ^^^^^^^^ the trait `Trait` is not implemented for `u32`
@@ -11,7 +11,7 @@ error[E0277]: the trait bound `f32: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-in-fns.rs:16:14
    |
 LL | enum Bar<T:Trait> {
-   | ----------------- required by `Bar`
+   |            ----- required by `Bar` here
 ...
 LL | fn kaboom(y: Bar<f32>) {}
    |              ^^^^^^^^ the trait `Trait` is not implemented for `f32`

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-in-impls.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-in-impls.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `u16: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-in-impls.rs:20:6
    |
 LL | struct Foo<T:Trait> {
-   | ------------------- required by `Foo`
+   |              ----- required by `Foo` here
 ...
 LL | impl PolyTrait<Foo<u16>> for Struct {
    |      ^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `u16`

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-locals.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-locals.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `usize: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-locals.rs:15:14
    |
 LL | struct Foo<T:Trait> {
-   | ------------------- required by `Foo`
+   |              ----- required by `Foo` here
 ...
 LL |     let baz: Foo<usize> = loop { };
    |              ^^^^^^^^^^ the trait `Trait` is not implemented for `usize`

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-static.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-static.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `usize: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-static.rs:9:11
    |
 LL | struct Foo<T:Trait> {
-   | ------------------- required by `Foo`
+   |              ----- required by `Foo` here
 ...
 LL | static X: Foo<usize> = Foo {
    |           ^^^^^^^^^^ the trait `Trait` is not implemented for `usize`

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-xc.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-xc.stderr
@@ -3,16 +3,22 @@ error[E0277]: the trait bound `usize: trait_bounds_on_structs_and_enums_xc::Trai
    |
 LL | fn explode(x: Foo<usize>) {}
    |               ^^^^^^^^^^ the trait `trait_bounds_on_structs_and_enums_xc::Trait` is not implemented for `usize`
+   | 
+  ::: $DIR/auxiliary/trait_bounds_on_structs_and_enums_xc.rs:5:18
    |
-   = note: required by `trait_bounds_on_structs_and_enums_xc::Foo`
+LL | pub struct Foo<T:Trait> {
+   |                  ----- required by `trait_bounds_on_structs_and_enums_xc::Foo` here
 
 error[E0277]: the trait bound `f32: trait_bounds_on_structs_and_enums_xc::Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-xc.rs:10:14
    |
 LL | fn kaboom(y: Bar<f32>) {}
    |              ^^^^^^^^ the trait `trait_bounds_on_structs_and_enums_xc::Trait` is not implemented for `f32`
+   | 
+  ::: $DIR/auxiliary/trait_bounds_on_structs_and_enums_xc.rs:9:16
    |
-   = note: required by `trait_bounds_on_structs_and_enums_xc::Bar`
+LL | pub enum Bar<T:Trait> {
+   |                ----- required by `trait_bounds_on_structs_and_enums_xc::Bar` here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-xc1.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-xc1.stderr
@@ -3,8 +3,11 @@ error[E0277]: the trait bound `f64: trait_bounds_on_structs_and_enums_xc::Trait`
    |
 LL |     let bar: Bar<f64> = return;
    |              ^^^^^^^^ the trait `trait_bounds_on_structs_and_enums_xc::Trait` is not implemented for `f64`
+   | 
+  ::: $DIR/auxiliary/trait_bounds_on_structs_and_enums_xc.rs:9:16
    |
-   = note: required by `trait_bounds_on_structs_and_enums_xc::Bar`
+LL | pub enum Bar<T:Trait> {
+   |                ----- required by `trait_bounds_on_structs_and_enums_xc::Bar` here
 
 error[E0277]: the trait bound `{integer}: trait_bounds_on_structs_and_enums_xc::Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-xc1.rs:8:15

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:13:9
    |
 LL | struct Foo<T:Trait> {
-   | ------------------- required by `Foo`
+   |              ----- required by `Foo` here
 ...
 LL | impl<T> Foo<T> {
    |         ^^^^^^ the trait `Trait` is not implemented for `T`
@@ -17,7 +17,7 @@ error[E0277]: the trait bound `isize: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:19:5
    |
 LL | struct Foo<T:Trait> {
-   | ------------------- required by `Foo`
+   |              ----- required by `Foo` here
 ...
 LL |     a: Foo<isize>,
    |     ^^^^^^^^^^^^^ the trait `Trait` is not implemented for `isize`
@@ -26,7 +26,7 @@ error[E0277]: the trait bound `usize: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:23:10
    |
 LL | enum Bar<T:Trait> {
-   | ----------------- required by `Bar`
+   |            ----- required by `Bar` here
 ...
 LL |     Quux(Bar<usize>),
    |          ^^^^^^^^^^ the trait `Trait` is not implemented for `usize`
@@ -35,7 +35,7 @@ error[E0277]: the trait bound `U: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:27:5
    |
 LL | struct Foo<T:Trait> {
-   | ------------------- required by `Foo`
+   |              ----- required by `Foo` here
 ...
 LL |     b: Foo<U>,
    |     ^^^^^^^^^ the trait `Trait` is not implemented for `U`
@@ -50,7 +50,7 @@ error[E0277]: the trait bound `V: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:31:21
    |
 LL | enum Bar<T:Trait> {
-   | ----------------- required by `Bar`
+   |            ----- required by `Bar` here
 ...
 LL |     EvenMoreBadness(Bar<V>),
    |                     ^^^^^^ the trait `Trait` is not implemented for `V`
@@ -65,7 +65,7 @@ error[E0277]: the trait bound `i32: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:35:5
    |
 LL | struct Foo<T:Trait> {
-   | ------------------- required by `Foo`
+   |              ----- required by `Foo` here
 ...
 LL |     Foo<i32>,
    |     ^^^^^^^^ the trait `Trait` is not implemented for `i32`
@@ -74,7 +74,7 @@ error[E0277]: the trait bound `u8: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:39:22
    |
 LL | enum Bar<T:Trait> {
-   | ----------------- required by `Bar`
+   |            ----- required by `Bar` here
 ...
 LL |     DictionaryLike { field: Bar<u8> },
    |                      ^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `u8`

--- a/src/test/ui/traits/trait-suggest-where-clause.stderr
+++ b/src/test/ui/traits/trait-suggest-where-clause.stderr
@@ -12,7 +12,7 @@ LL |     mem::size_of::<U>();
 LL | pub const fn size_of<T>() -> usize {
    |                      - required by this bound in `std::mem::size_of`
    |
-   = help: the trait `std::marker::Sized` is not implemented for `U`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
 
 error[E0277]: the size for values of type `U` cannot be known at compilation time
@@ -29,7 +29,7 @@ LL |     mem::size_of::<Misc<U>>();
 LL | pub const fn size_of<T>() -> usize {
    |                      - required by this bound in `std::mem::size_of`
    |
-   = help: within `Misc<U>`, the trait `std::marker::Sized` is not implemented for `U`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: required because it appears within the type `Misc<U>`
 

--- a/src/test/ui/traits/traits-assoc-type-in-supertrait-bad.stderr
+++ b/src/test/ui/traits/traits-assoc-type-in-supertrait-bad.stderr
@@ -1,6 +1,9 @@
 error[E0271]: type mismatch resolving `<std::vec::IntoIter<i32> as std::iter::Iterator>::Item == u32`
   --> $DIR/traits-assoc-type-in-supertrait-bad.rs:11:6
    |
+LL | pub trait Foo: Iterator<Item=<Self as Foo>::Key> {
+   |                         ----------------------- required by `Foo` here
+...
 LL | impl Foo for IntoIter<i32> {
    |      ^^^ expected `i32`, found `u32`
 

--- a/src/test/ui/traits/traits-negative-impls.stderr
+++ b/src/test/ui/traits/traits-negative-impls.stderr
@@ -13,7 +13,7 @@ error[E0277]: `dummy::TestType` cannot be sent between threads safely
   --> $DIR/traits-negative-impls.rs:23:5
    |
 LL | struct Outer<T: Send>(T);
-   | ------------------------- required by `Outer`
+   |                 ---- required by `Outer` here
 ...
 LL |     Outer(TestType);
    |     ^^^^^^^^^^^^^^^ `dummy::TestType` cannot be sent between threads safely

--- a/src/test/ui/type/type-check-defaults.stderr
+++ b/src/test/ui/type/type-check-defaults.stderr
@@ -2,7 +2,7 @@ error[E0277]: a value of type `i32` cannot be built from an iterator over elemen
   --> $DIR/type-check-defaults.rs:6:19
    |
 LL | struct Foo<T, U: FromIterator<T>>(T, U);
-   | ---------------------------------------- required by `Foo`
+   |                  --------------- required by `Foo` here
 LL | struct WellFormed<Z = Foo<i32, i32>>(Z);
    |                   ^ value of type `i32` cannot be built from `std::iter::Iterator<Item=i32>`
    |
@@ -12,7 +12,7 @@ error[E0277]: a value of type `i32` cannot be built from an iterator over elemen
   --> $DIR/type-check-defaults.rs:8:27
    |
 LL | struct Foo<T, U: FromIterator<T>>(T, U);
-   | ---------------------------------------- required by `Foo`
+   |                  --------------- required by `Foo` here
 ...
 LL | struct WellFormedNoBounds<Z:?Sized = Foo<i32, i32>>(Z);
    |                           ^ value of type `i32` cannot be built from `std::iter::Iterator<Item=i32>`
@@ -50,7 +50,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/type-check-defaults.rs:21:25
    |
 LL | trait Super<T: Copy> { }
-   | -------------------- required by `Super`
+   |                ---- required by `Super` here
 LL | trait Base<T = String>: Super<T> { }
    |                         ^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |

--- a/src/test/ui/type/type-check/issue-40294.stderr
+++ b/src/test/ui/type/type-check/issue-40294.stderr
@@ -2,7 +2,7 @@ error[E0283]: type annotations needed
   --> $DIR/issue-40294.rs:6:19
    |
 LL | trait Foo: Sized {
-   | ---------------- required by `Foo`
+   | ---------------- required by `Foo` here
 ...
 LL |     where &'a T : Foo,
    |                   ^^^ cannot infer type for reference `&'a T`

--- a/src/test/ui/union/union-derive-clone.rs
+++ b/src/test/ui/union/union-derive-clone.rs
@@ -1,3 +1,8 @@
+// FIXME: missing sysroot spans (#53081)
+// ignore-i586-unknown-linux-gnu
+// ignore-i586-unknown-linux-musl
+// ignore-i686-unknown-linux-musl
+
 #![feature(untagged_unions)]
 
 use std::mem::ManuallyDrop;

--- a/src/test/ui/union/union-derive-clone.stderr
+++ b/src/test/ui/union/union-derive-clone.stderr
@@ -1,14 +1,18 @@
 error[E0277]: the trait bound `U1: std::marker::Copy` is not satisfied
-  --> $DIR/union-derive-clone.rs:5:10
+  --> $DIR/union-derive-clone.rs:10:10
    |
 LL | #[derive(Clone)]
    |          ^^^^^ the trait `std::marker::Copy` is not implemented for `U1`
+   | 
+  ::: $SRC_DIR/libcore/clone.rs:LL:COL
    |
-   = note: required by `std::clone::AssertParamIsCopy`
+LL | pub struct AssertParamIsCopy<T: Copy + ?Sized> {
+   |                                 ---- required by `std::clone::AssertParamIsCopy` here
+   |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no method named `clone` found for union `U5<CloneNoCopy>` in the current scope
-  --> $DIR/union-derive-clone.rs:37:15
+  --> $DIR/union-derive-clone.rs:42:15
    |
 LL | union U5<T> {
    | -----------

--- a/src/test/ui/union/union-derive-eq.rs
+++ b/src/test/ui/union/union-derive-eq.rs
@@ -1,3 +1,8 @@
+// FIXME: missing sysroot spans (#53081)
+// ignore-i586-unknown-linux-gnu
+// ignore-i586-unknown-linux-musl
+// ignore-i686-unknown-linux-musl
+
 #![feature(untagged_unions)]
 
 #[derive(Eq)] // OK

--- a/src/test/ui/union/union-derive-eq.stderr
+++ b/src/test/ui/union/union-derive-eq.stderr
@@ -1,10 +1,14 @@
 error[E0277]: the trait bound `PartialEqNotEq: std::cmp::Eq` is not satisfied
-  --> $DIR/union-derive-eq.rs:15:5
+  --> $DIR/union-derive-eq.rs:20:5
    |
 LL |     a: PartialEqNotEq,
    |     ^^^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `PartialEqNotEq`
+   | 
+  ::: $SRC_DIR/libcore/cmp.rs:LL:COL
    |
-   = note: required by `std::cmp::AssertParamIsEq`
+LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
+   |                               -- required by `std::cmp::AssertParamIsEq` here
+   |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/union/union-sized-field.stderr
+++ b/src/test/ui/union/union-sized-field.stderr
@@ -6,7 +6,7 @@ LL | union Foo<T: ?Sized> {
 LL |     value: T,
    |     ^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `T`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: no field of a union may have a dynamically sized type
 
@@ -18,7 +18,7 @@ LL | struct Foo2<T: ?Sized> {
 LL |     value: T,
    |     ^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `T`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: only the last field of a struct may have a dynamically sized type
 
@@ -30,7 +30,7 @@ LL | enum Foo3<T: ?Sized> {
 LL |     Value(T),
    |           ^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `T`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: no field of an enum variant may have a dynamically sized type
 

--- a/src/test/ui/unsized/unsized-bare-typaram.stderr
+++ b/src/test/ui/unsized/unsized-bare-typaram.stderr
@@ -8,7 +8,7 @@ LL | fn foo<T: ?Sized>() { bar::<T>() }
    |        |
    |        this type parameter needs to be `std::marker::Sized`
    |
-   = help: the trait `std::marker::Sized` is not implemented for `T`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
 
 error: aborting due to previous error

--- a/src/test/ui/unsized/unsized-enum.stderr
+++ b/src/test/ui/unsized/unsized-enum.stderr
@@ -9,7 +9,7 @@ LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |         |
    |         this type parameter needs to be `std::marker::Sized`
    |
-   = help: the trait `std::marker::Sized` is not implemented for `T`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
 
 error: aborting due to previous error

--- a/src/test/ui/unsized/unsized-enum.stderr
+++ b/src/test/ui/unsized/unsized-enum.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/unsized-enum.rs:6:36
    |
 LL | enum Foo<U> { FooSome(U), FooNone }
-   | ----------- required by `Foo`
+   |          - required by `Foo` here
 LL | fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
 LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |         -                          ^^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/unsized/unsized-enum2.stderr
+++ b/src/test/ui/unsized/unsized-enum2.stderr
@@ -7,7 +7,7 @@ LL |     // parameter
 LL |     VA(W),
    |        ^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `W`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: no field of an enum variant may have a dynamically sized type
 
@@ -20,7 +20,7 @@ LL | enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
 LL |     VB{x: X},
    |        ^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: no field of an enum variant may have a dynamically sized type
 
@@ -33,7 +33,7 @@ LL | enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
 LL |     VC(isize, Y),
    |               ^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `Y`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: no field of an enum variant may have a dynamically sized type
 
@@ -46,7 +46,7 @@ LL | enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
 LL |     VD{u: isize, x: Z},
    |                  ^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `Z`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: no field of an enum variant may have a dynamically sized type
 

--- a/src/test/ui/unsized/unsized-inherent-impl-self-type.stderr
+++ b/src/test/ui/unsized/unsized-inherent-impl-self-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized-inherent-impl-self-type.rs:7:17
    |
 LL | struct S5<Y>(Y);
-   | ---------------- required by `S5`
+   |           - required by `S5` here
 LL | 
 LL | impl<X: ?Sized> S5<X> {
    |      -          ^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/unsized/unsized-inherent-impl-self-type.stderr
+++ b/src/test/ui/unsized/unsized-inherent-impl-self-type.stderr
@@ -9,7 +9,7 @@ LL | impl<X: ?Sized> S5<X> {
    |      |
    |      this type parameter needs to be `std::marker::Sized`
    |
-   = help: the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
 
 error: aborting due to previous error

--- a/src/test/ui/unsized/unsized-struct.stderr
+++ b/src/test/ui/unsized/unsized-struct.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/unsized-struct.rs:6:36
    |
 LL | struct Foo<T> { data: T }
-   | ------------- required by `Foo`
+   |            - required by `Foo` here
 LL | fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
 LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |         -                          ^^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/unsized/unsized-struct.stderr
+++ b/src/test/ui/unsized/unsized-struct.stderr
@@ -9,7 +9,7 @@ LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |         |
    |         this type parameter needs to be `std::marker::Sized`
    |
-   = help: the trait `std::marker::Sized` is not implemented for `T`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
@@ -23,7 +23,7 @@ LL | fn bar2<T: ?Sized>() { is_sized::<Bar<T>>() }
    |         |
    |         this type parameter needs to be `std::marker::Sized`
    |
-   = help: within `Bar<T>`, the trait `std::marker::Sized` is not implemented for `T`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: required because it appears within the type `Bar<T>`
 

--- a/src/test/ui/unsized/unsized-trait-impl-self-type.stderr
+++ b/src/test/ui/unsized/unsized-trait-impl-self-type.stderr
@@ -9,7 +9,7 @@ LL | impl<X: ?Sized> T3<X> for S5<X> {
    |      |
    |      this type parameter needs to be `std::marker::Sized`
    |
-   = help: the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
 
 error: aborting due to previous error

--- a/src/test/ui/unsized/unsized-trait-impl-self-type.stderr
+++ b/src/test/ui/unsized/unsized-trait-impl-self-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized-trait-impl-self-type.rs:10:17
    |
 LL | struct S5<Y>(Y);
-   | ---------------- required by `S5`
+   |           - required by `S5` here
 LL | 
 LL | impl<X: ?Sized> T3<X> for S5<X> {
    |      -          ^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/unsized/unsized-trait-impl-trait-arg.stderr
+++ b/src/test/ui/unsized/unsized-trait-impl-trait-arg.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized-trait-impl-trait-arg.rs:8:17
    |
+LL | trait T2<Z> {
+   |          - required by `T2` here
+...
 LL | impl<X: ?Sized> T2<X> for S4<X> {
    |      -          ^^^^^ doesn't have a size known at compile-time
    |      |

--- a/src/test/ui/unsized/unsized-trait-impl-trait-arg.stderr
+++ b/src/test/ui/unsized/unsized-trait-impl-trait-arg.stderr
@@ -9,7 +9,7 @@ LL | impl<X: ?Sized> T2<X> for S4<X> {
    |      |
    |      this type parameter needs to be `std::marker::Sized`
    |
-   = help: the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
 
 error: aborting due to previous error

--- a/src/test/ui/unsized3.stderr
+++ b/src/test/ui/unsized3.stderr
@@ -11,7 +11,7 @@ LL | fn f2<X>(x: &X) {
    |       |
    |       required by this bound in `f2`
    |
-   = help: the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
@@ -27,7 +27,7 @@ LL | fn f4<X: T>(x: &X) {
    |       |
    |       required by this bound in `f4`
    |
-   = help: the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
@@ -41,7 +41,7 @@ LL | fn f8<X: ?Sized>(x1: &S<X>, x2: &S<X>) {
 LL |     f5(x1);
    |        ^^ doesn't have a size known at compile-time
    |
-   = help: within `S<X>`, the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: required because it appears within the type `S<X>`
 
@@ -53,7 +53,7 @@ LL | fn f9<X: ?Sized>(x1: Box<S<X>>) {
 LL |     f5(&(*x1, 34));
    |        ^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `S<X>`, the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: required because it appears within the type `S<X>`
    = note: only the last element of a tuple may have a dynamically sized type
@@ -66,7 +66,7 @@ LL | fn f10<X: ?Sized>(x1: Box<S<X>>) {
 LL |     f5(&(32, *x1));
    |         ^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `({integer}, S<X>)`, the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: required because it appears within the type `S<X>`
    = note: required because it appears within the type `({integer}, S<X>)`
@@ -83,7 +83,7 @@ LL | fn f10<X: ?Sized>(x1: Box<S<X>>) {
 LL |     f5(&(32, *x1));
    |        ^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `({integer}, S<X>)`, the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: required because it appears within the type `S<X>`
    = note: required because it appears within the type `({integer}, S<X>)`

--- a/src/test/ui/unsized5.stderr
+++ b/src/test/ui/unsized5.stderr
@@ -6,7 +6,7 @@ LL | struct S1<X: ?Sized> {
 LL |     f1: X,
    |     ^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: only the last field of a struct may have a dynamically sized type
 
@@ -19,7 +19,7 @@ LL |     f: isize,
 LL |     g: X,
    |     ^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: only the last field of a struct may have a dynamically sized type
 
@@ -51,7 +51,7 @@ LL | enum E<X: ?Sized> {
 LL |     V1(X, isize),
    |        ^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: no field of an enum variant may have a dynamically sized type
 
@@ -63,7 +63,7 @@ LL | enum F<X: ?Sized> {
 LL |     V2{f1: X, f: isize},
    |        ^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: no field of an enum variant may have a dynamically sized type
 

--- a/src/test/ui/unsized6.stderr
+++ b/src/test/ui/unsized6.stderr
@@ -7,7 +7,7 @@ LL | fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
 LL |     let y: Y;
    |         ^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `Y`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
@@ -21,7 +21,7 @@ LL |     let _: W; // <-- this is OK, no bindings created, no initializer.
 LL |     let _: (isize, (X, isize));
    |            ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: only the last element of a tuple may have a dynamically sized type
 
@@ -34,7 +34,7 @@ LL | fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
 LL |     let y: (isize, (Z, usize));
    |            ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `Z`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: only the last element of a tuple may have a dynamically sized type
 
@@ -46,7 +46,7 @@ LL | fn f2<X: ?Sized, Y: ?Sized>(x: &X) {
 LL |     let y: X;
    |         ^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
@@ -60,7 +60,7 @@ LL | fn f2<X: ?Sized, Y: ?Sized>(x: &X) {
 LL |     let y: (isize, (Y, isize));
    |            ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `Y`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: only the last element of a tuple may have a dynamically sized type
 
@@ -72,7 +72,7 @@ LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
 LL |     let y: X = *x1;
    |         ^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
@@ -86,7 +86,7 @@ LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
 LL |     let y = *x2;
    |         ^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
@@ -100,7 +100,7 @@ LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
 LL |     let (y, z) = (*x3, 4);
    |          ^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
@@ -113,7 +113,7 @@ LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
 LL |     let y: X = *x1;
    |         ^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
@@ -127,7 +127,7 @@ LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
 LL |     let y = *x2;
    |         ^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
@@ -141,7 +141,7 @@ LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
 LL |     let (y, z) = (*x3, 4);
    |          ^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
@@ -154,7 +154,7 @@ LL | fn g1<X: ?Sized>(x: X) {}
    |       |
    |       this type parameter needs to be `std::marker::Sized`
    |
-   = help: the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
@@ -167,7 +167,7 @@ LL | fn g2<X: ?Sized + T>(x: X) {}
    |       |
    |       this type parameter needs to be `std::marker::Sized`
    |
-   = help: the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature

--- a/src/test/ui/unsized7.stderr
+++ b/src/test/ui/unsized7.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized7.rs:12:21
    |
+LL | trait T1<Z: T> {
+   |          - required by `T1` here
+...
 LL | impl<X: ?Sized + T> T1<X> for S3<X> {
    |      -              ^^^^^ doesn't have a size known at compile-time
    |      |

--- a/src/test/ui/unsized7.stderr
+++ b/src/test/ui/unsized7.stderr
@@ -9,7 +9,7 @@ LL | impl<X: ?Sized + T> T1<X> for S3<X> {
    |      |
    |      this type parameter needs to be `std::marker::Sized`
    |
-   = help: the trait `std::marker::Sized` is not implemented for `X`
+   = help: type parameters have an implicit `Sized` requirement by default
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
 
 error: aborting due to previous error

--- a/src/test/ui/wf/wf-const-type.stderr
+++ b/src/test/ui/wf/wf-const-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `NotCopy: std::marker::Copy` is not satisfied
   --> $DIR/wf-const-type.rs:10:12
    |
 LL | struct IsCopy<T:Copy> { t: T }
-   | --------------------- required by `IsCopy`
+   |                 ---- required by `IsCopy` here
 ...
 LL | const FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
    |            ^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `NotCopy`

--- a/src/test/ui/wf/wf-enum-bound.stderr
+++ b/src/test/ui/wf/wf-enum-bound.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-enum-bound.rs:10:14
    |
 LL | trait ExtraCopy<T:Copy> { }
-   | ----------------------- required by `ExtraCopy`
+   |                   ---- required by `ExtraCopy` here
 ...
 LL |     where T: ExtraCopy<U>
    |              ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`

--- a/src/test/ui/wf/wf-enum-fields-struct-variant.stderr
+++ b/src/test/ui/wf/wf-enum-fields-struct-variant.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `A: std::marker::Copy` is not satisfied
   --> $DIR/wf-enum-fields-struct-variant.rs:13:9
    |
 LL | struct IsCopy<T:Copy> {
-   | --------------------- required by `IsCopy`
+   |                 ---- required by `IsCopy` here
 ...
 LL |         f: IsCopy<A>
    |         ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `A`

--- a/src/test/ui/wf/wf-enum-fields.stderr
+++ b/src/test/ui/wf/wf-enum-fields.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `A: std::marker::Copy` is not satisfied
   --> $DIR/wf-enum-fields.rs:12:17
    |
 LL | struct IsCopy<T:Copy> {
-   | --------------------- required by `IsCopy`
+   |                 ---- required by `IsCopy` here
 ...
 LL |     SomeVariant(IsCopy<A>)
    |                 ^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `A`

--- a/src/test/ui/wf/wf-fn-where-clause.rs
+++ b/src/test/ui/wf/wf-fn-where-clause.rs
@@ -13,5 +13,8 @@ fn bar() where Vec<dyn Copy>:, {}
 //~^ ERROR E0277
 //~| ERROR E0038
 
+struct Vec<T> {
+    t: T,
+}
 
 fn main() { }

--- a/src/test/ui/wf/wf-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-fn-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-fn-where-clause.rs:8:24
    |
 LL | trait ExtraCopy<T:Copy> { }
-   | ----------------------- required by `ExtraCopy`
+   |                   ---- required by `ExtraCopy` here
 LL | 
 LL | fn foo<T,U>() where T: ExtraCopy<U>
    |                        ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`
@@ -18,10 +18,12 @@ error[E0277]: the size for values of type `(dyn std::marker::Copy + 'static)` ca
    |
 LL | fn bar() where Vec<dyn Copy>:, {}
    |                ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+...
+LL | struct Vec<T> {
+   |            - required by `Vec` here
    |
    = help: the trait `std::marker::Sized` is not implemented for `(dyn std::marker::Copy + 'static)`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required by `std::vec::Vec`
 
 error[E0038]: the trait `std::marker::Copy` cannot be made into an object
   --> $DIR/wf-fn-where-clause.rs:12:16

--- a/src/test/ui/wf/wf-impl-associated-type-trait.stderr
+++ b/src/test/ui/wf/wf-impl-associated-type-trait.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: MyHash` is not satisfied
   --> $DIR/wf-impl-associated-type-trait.rs:17:5
    |
 LL | pub struct MySet<T:MyHash> {
-   | -------------------------- required by `MySet`
+   |                    ------ required by `MySet` here
 ...
 LL |     type Bar = MySet<T>;
    |     ^^^^^^^^^^^^^^^^^^^^ the trait `MyHash` is not implemented for `T`

--- a/src/test/ui/wf/wf-in-fn-arg.stderr
+++ b/src/test/ui/wf/wf-in-fn-arg.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-fn-arg.rs:10:14
    |
 LL | struct MustBeCopy<T:Copy> {
-   | ------------------------- required by `MustBeCopy`
+   |                     ---- required by `MustBeCopy` here
 ...
 LL | fn bar<T>(_: &MustBeCopy<T>)
    |              ^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/wf/wf-in-fn-ret.stderr
+++ b/src/test/ui/wf/wf-in-fn-ret.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-fn-ret.rs:10:16
    |
 LL | struct MustBeCopy<T:Copy> {
-   | ------------------------- required by `MustBeCopy`
+   |                     ---- required by `MustBeCopy` here
 ...
 LL | fn bar<T>() -> MustBeCopy<T>
    |                ^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/wf/wf-in-fn-type-arg.stderr
+++ b/src/test/ui/wf/wf-in-fn-type-arg.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-fn-type-arg.rs:9:5
    |
 LL | struct MustBeCopy<T:Copy> {
-   | ------------------------- required by `MustBeCopy`
+   |                     ---- required by `MustBeCopy` here
 ...
 LL |     x: fn(MustBeCopy<T>)
    |     ^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/wf/wf-in-fn-type-ret.stderr
+++ b/src/test/ui/wf/wf-in-fn-type-ret.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-fn-type-ret.rs:9:5
    |
 LL | struct MustBeCopy<T:Copy> {
-   | ------------------------- required by `MustBeCopy`
+   |                     ---- required by `MustBeCopy` here
 ...
 LL |     x: fn() -> MustBeCopy<T>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/wf/wf-in-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-in-fn-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-fn-where-clause.rs:10:14
    |
 LL | trait MustBeCopy<T:Copy> {
-   | ------------------------ required by `MustBeCopy`
+   |                    ---- required by `MustBeCopy` here
 ...
 LL |     where T: MustBeCopy<U>
    |              ^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`

--- a/src/test/ui/wf/wf-in-obj-type-trait.stderr
+++ b/src/test/ui/wf/wf-in-obj-type-trait.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-obj-type-trait.rs:11:5
    |
 LL | struct MustBeCopy<T:Copy> {
-   | ------------------------- required by `MustBeCopy`
+   |                     ---- required by `MustBeCopy` here
 ...
 LL |     x: dyn Object<MustBeCopy<T>>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/wf/wf-inherent-impl-method-where-clause.stderr
+++ b/src/test/ui/wf/wf-inherent-impl-method-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-inherent-impl-method-where-clause.rs:12:27
    |
 LL | trait ExtraCopy<T:Copy> { }
-   | ----------------------- required by `ExtraCopy`
+   |                   ---- required by `ExtraCopy` here
 ...
 LL |     fn foo(self) where T: ExtraCopy<U>
    |                           ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`

--- a/src/test/ui/wf/wf-inherent-impl-where-clause.stderr
+++ b/src/test/ui/wf/wf-inherent-impl-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-inherent-impl-where-clause.rs:11:29
    |
 LL | trait ExtraCopy<T:Copy> { }
-   | ----------------------- required by `ExtraCopy`
+   |                   ---- required by `ExtraCopy` here
 ...
 LL | impl<T,U> Foo<T,U> where T: ExtraCopy<U>
    |                             ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`

--- a/src/test/ui/wf/wf-static-type.stderr
+++ b/src/test/ui/wf/wf-static-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `NotCopy: std::marker::Copy` is not satisfied
   --> $DIR/wf-static-type.rs:10:13
    |
 LL | struct IsCopy<T:Copy> { t: T }
-   | --------------------- required by `IsCopy`
+   |                 ---- required by `IsCopy` here
 ...
 LL | static FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
    |             ^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `NotCopy`

--- a/src/test/ui/wf/wf-struct-bound.stderr
+++ b/src/test/ui/wf/wf-struct-bound.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-struct-bound.rs:10:14
    |
 LL | trait ExtraCopy<T:Copy> { }
-   | ----------------------- required by `ExtraCopy`
+   |                   ---- required by `ExtraCopy` here
 ...
 LL |     where T: ExtraCopy<U>
    |              ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`

--- a/src/test/ui/wf/wf-struct-field.stderr
+++ b/src/test/ui/wf/wf-struct-field.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `A: std::marker::Copy` is not satisfied
   --> $DIR/wf-struct-field.rs:12:5
    |
 LL | struct IsCopy<T:Copy> {
-   | --------------------- required by `IsCopy`
+   |                 ---- required by `IsCopy` here
 ...
 LL |     data: IsCopy<A>
    |     ^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `A`

--- a/src/test/ui/wf/wf-trait-associated-type-bound.stderr
+++ b/src/test/ui/wf/wf-trait-associated-type-bound.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-trait-associated-type-bound.rs:10:17
    |
 LL | trait ExtraCopy<T:Copy> { }
-   | ----------------------- required by `ExtraCopy`
+   |                   ---- required by `ExtraCopy` here
 ...
 LL |     type Type1: ExtraCopy<T>;
    |                 ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/wf/wf-trait-associated-type-trait.stderr
+++ b/src/test/ui/wf/wf-trait-associated-type-trait.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `<Self as SomeTrait>::Type1: std::marker::Copy` is
   --> $DIR/wf-trait-associated-type-trait.rs:11:5
    |
 LL | struct IsCopy<T:Copy> { x: T }
-   | --------------------- required by `IsCopy`
+   |                 ---- required by `IsCopy` here
 LL | 
 LL | trait SomeTrait {
    |                - help: consider further restricting the associated type: `where <Self as SomeTrait>::Type1: std::marker::Copy`

--- a/src/test/ui/wf/wf-trait-bound.stderr
+++ b/src/test/ui/wf/wf-trait-bound.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-trait-bound.rs:10:14
    |
 LL | trait ExtraCopy<T:Copy> { }
-   | ----------------------- required by `ExtraCopy`
+   |                   ---- required by `ExtraCopy` here
 ...
 LL |     where T: ExtraCopy<U>
    |              ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`

--- a/src/test/ui/wf/wf-trait-default-fn-arg.stderr
+++ b/src/test/ui/wf/wf-trait-default-fn-arg.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-default-fn-arg.rs:11:22
    |
 LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   | ----------------------- required by `Bar`
+   |              -- required by `Bar` here
 ...
 LL |     fn bar(&self, x: &Bar<Self>) {
    |                      ^^^^^^^^^^ - help: consider further restricting `Self`: `where Self: std::cmp::Eq`

--- a/src/test/ui/wf/wf-trait-default-fn-ret.stderr
+++ b/src/test/ui/wf/wf-trait-default-fn-ret.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-default-fn-ret.rs:11:22
    |
 LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   | ----------------------- required by `Bar`
+   |              -- required by `Bar` here
 ...
 LL |     fn bar(&self) -> Bar<Self> {
    |                      ^^^^^^^^^- help: consider further restricting `Self`: `where Self: std::cmp::Eq`

--- a/src/test/ui/wf/wf-trait-default-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-trait-default-fn-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-default-fn-where-clause.rs:11:31
    |
 LL | trait Bar<T:Eq+?Sized> { }
-   | ---------------------- required by `Bar`
+   |             -- required by `Bar` here
 ...
 LL |     fn bar<A>(&self) where A: Bar<Self> {
    |                               ^^^^^^^^^- help: consider further restricting `Self`: `, Self: std::cmp::Eq`

--- a/src/test/ui/wf/wf-trait-fn-arg.stderr
+++ b/src/test/ui/wf/wf-trait-fn-arg.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-fn-arg.rs:10:22
    |
 LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   | ----------------------- required by `Bar`
+   |              -- required by `Bar` here
 ...
 LL |     fn bar(&self, x: &Bar<Self>);
    |                      ^^^^^^^^^^ - help: consider further restricting `Self`: `where Self: std::cmp::Eq`

--- a/src/test/ui/wf/wf-trait-fn-ret.stderr
+++ b/src/test/ui/wf/wf-trait-fn-ret.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-fn-ret.rs:10:22
    |
 LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   | ----------------------- required by `Bar`
+   |              -- required by `Bar` here
 ...
 LL |     fn bar(&self) -> &Bar<Self>;
    |                      ^^^^^^^^^^- help: consider further restricting `Self`: `where Self: std::cmp::Eq`

--- a/src/test/ui/wf/wf-trait-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-trait-fn-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-fn-where-clause.rs:10:49
    |
 LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   | ----------------------- required by `Bar`
+   |              -- required by `Bar` here
 ...
 LL |     fn bar(&self) where Self: Sized, Bar<Self>: Copy;
    |                                                 ^^^^- help: consider further restricting `Self`: `, Self: std::cmp::Eq`

--- a/src/test/ui/wf/wf-trait-superbound.stderr
+++ b/src/test/ui/wf/wf-trait-superbound.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-trait-superbound.rs:9:21
    |
 LL | trait ExtraCopy<T:Copy> { }
-   | ----------------------- required by `ExtraCopy`
+   |                   ---- required by `ExtraCopy` here
 LL | 
 LL | trait SomeTrait<T>: ExtraCopy<T> {
    |                     ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`


### PR DESCRIPTION
Keep obligations around instead of just predicates as much as possible, to maintain extra context, including chains of obligations.
Use more specific spans by pointing at bindings that introduce obligations.
Mention implicit `T: Sized` bound in E0277 errors.

Fix #27964.