### PR TITLE
more clippy cleanups

### DIFF
--- a/src/librustc/traits/structural_impls.rs
+++ b/src/librustc/traits/structural_impls.rs
@@ -415,9 +415,9 @@ impl<'a, 'tcx> Lift<'tcx> for traits::ObligationCauseCode<'a> {
             super::ReferenceOutlivesReferent(ty) => {
                 tcx.lift(&ty).map(super::ReferenceOutlivesReferent)
             }
-            super::ObjectTypeBound(ty, r) => tcx
-                .lift(&ty)
-                .and_then(|ty| tcx.lift(&r).and_then(|r| Some(super::ObjectTypeBound(ty, r)))),
+            super::ObjectTypeBound(ty, r) => {
+                tcx.lift(&ty).and_then(|ty| tcx.lift(&r).map(|r| super::ObjectTypeBound(ty, r)))
+            }
             super::ObjectCastObligation(ty) => tcx.lift(&ty).map(super::ObjectCastObligation),
             super::Coercion { source, target } => {
                 Some(super::Coercion { source: tcx.lift(&source)?, target: tcx.lift(&target)? })

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -725,7 +725,7 @@ pub(crate) unsafe fn codegen(
                         Err(_) => return 0,
                     };
 
-                    if let Err(_) = write!(cursor, "{:#}", demangled) {
+                    if write!(cursor, "{:#}", demangled).is_err() {
                         // Possible only if provided buffer is not big enough
                         return 0;
                     }

--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -174,7 +174,6 @@ pub unsafe fn create_module(
 
         let llvm_data_layout = llvm::LLVMGetDataLayout(llmod);
         let llvm_data_layout = str::from_utf8(CStr::from_ptr(llvm_data_layout).to_bytes())
-            .ok()
             .expect("got a non-UTF8 data-layout from LLVM");
 
         // Unfortunately LLVM target specs change over time, and right now we

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -1257,7 +1257,7 @@ fn start_executing_work<B: ExtraBackendMethods>(
                 if main_thread_worker_state == MainThreadWorkerState::Idle {
                     if !queue_full_enough(work_items.len(), running, max_workers) {
                         // The queue is not full enough, codegen more items:
-                        if let Err(_) = codegen_worker_send.send(Message::CodegenItem) {
+                        if codegen_worker_send.send(Message::CodegenItem).is_err() {
                             panic!("Could not send Message::CodegenItem to main thread")
                         }
                         main_thread_worker_state = MainThreadWorkerState::Codegenning;

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -163,7 +163,7 @@ impl CodeSuggestion {
                         None => buf.push_str(&line[lo..]),
                     }
                 }
-                if let None = hi_opt {
+                if hi_opt.is_none() {
                     buf.push('\n');
                 }
             }

--- a/src/librustc_errors/registry.rs
+++ b/src/librustc_errors/registry.rs
@@ -27,6 +27,6 @@ impl Registry {
         if !self.long_descriptions.contains_key(code) {
             return Err(InvalidErrorCode);
         }
-        Ok(self.long_descriptions.get(code).unwrap().clone())
+        Ok(*self.long_descriptions.get(code).unwrap())
     }
 }

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -426,7 +426,7 @@ pub(crate) fn check_attr_crate_type(attrs: &[ast::Attribute], lint_buffer: &mut 
     for a in attrs.iter() {
         if a.check_name(sym::crate_type) {
             if let Some(n) = a.value_str() {
-                if let Some(_) = categorize_crate_type(n) {
+                if categorize_crate_type(n).is_some() {
                     return;
                 }
 

--- a/src/librustc_lint/context.rs
+++ b/src/librustc_lint/context.rs
@@ -335,7 +335,7 @@ impl LintStore {
             lint_name.to_string()
         };
         // If the lint was scoped with `tool::` check if the tool lint exists
-        if let Some(_) = tool_name {
+        if tool_name.is_some() {
             match self.by_name.get(&complete_name) {
                 None => match self.lint_groups.get(&*complete_name) {
                     None => return CheckLintNameResult::Tool(Err((None, String::new()))),

--- a/src/librustc_mir/borrow_check/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/type_check/mod.rs
@@ -1905,7 +1905,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             // expressions evaluate through `as_temp` or `into` a return
             // slot or local, so to find all unsized rvalues it is enough
             // to check all temps, return slots and locals.
-            if let None = self.reported_errors.replace((ty, span)) {
+            if self.reported_errors.replace((ty, span)).is_none() {
                 let mut diag = struct_span_err!(
                     self.tcx().sess,
                     span,

--- a/src/librustc_mir/borrow_check/type_check/relate_tys.rs
+++ b/src/librustc_mir/borrow_check/type_check/relate_tys.rs
@@ -64,7 +64,7 @@ impl TypeRelatingDelegate<'tcx> for NllTypeRelatingDelegate<'_, '_, 'tcx> {
     }
 
     fn next_existential_region_var(&mut self, from_forall: bool) -> ty::Region<'tcx> {
-        if let Some(_) = &mut self.borrowck_context {
+        if self.borrowck_context.is_some() {
             let origin = NLLRegionVariableOrigin::Existential { from_forall };
             self.infcx.next_nll_region_var(origin)
         } else {

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -565,7 +565,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
 
         // # Function pointers
         // (both global from `alloc_map` and local from `extra_fn_ptr_map`)
-        if let Some(_) = self.get_fn_alloc(id) {
+        if self.get_fn_alloc(id).is_some() {
             return if let AllocCheck::Dereferenceable = liveness {
                 // The caller requested no function pointers.
                 throw_unsup!(DerefFunctionPointer)

--- a/src/librustc_parse/parser/attr.rs
+++ b/src/librustc_parse/parser/attr.rs
@@ -37,7 +37,7 @@ impl<'a> Parser<'a> {
                     let inner_parse_policy = InnerAttributeParsePolicy::NotPermitted {
                         reason: inner_error_reason,
                         saw_doc_comment: just_parsed_doc_comment,
-                        prev_attr_sp: attrs.last().and_then(|a| Some(a.span)),
+                        prev_attr_sp: attrs.last().map(|a| a.span),
                     };
                     let attr = self.parse_attribute_with_inner_parse_policy(inner_parse_policy)?;
                     attrs.push(attr);

--- a/src/librustc_passes/entry.rs
+++ b/src/librustc_passes/entry.rs
@@ -196,7 +196,7 @@ fn no_main_err(tcx: TyCtxt<'_>, visitor: &EntryContext<'_, '_>) {
     // The file may be empty, which leads to the diagnostic machinery not emitting this
     // note. This is a relatively simple way to detect that case and emit a span-less
     // note instead.
-    if let Ok(_) = tcx.sess.source_map().lookup_line(sp.lo()) {
+    if tcx.sess.source_map().lookup_line(sp.lo()).is_ok() {
         err.set_span(sp);
         err.span_label(sp, &note);
     } else {

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -1086,7 +1086,7 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
                     for param in params {
                         if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(param.span)
                         {
-                            if snippet.starts_with("&") && !snippet.starts_with("&'") {
+                            if snippet.starts_with('&') && !snippet.starts_with("&'") {
                                 introduce_suggestion
                                     .push((param.span, format!("&'a {}", &snippet[1..])));
                             } else if snippet.starts_with("&'_ ") {
@@ -1118,7 +1118,7 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
                 (1, Some(name), Some("'_")) => {
                     suggest_existing(err, name.to_string());
                 }
-                (1, Some(name), Some(snippet)) if !snippet.ends_with(">") => {
+                (1, Some(name), Some(snippet)) if !snippet.ends_with('>') => {
                     suggest_existing(err, format!("{}<{}>", snippet, name));
                 }
                 (0, _, Some("&")) => {
@@ -1127,7 +1127,7 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
                 (0, _, Some("'_")) => {
                     suggest_new(err, "'a");
                 }
-                (0, _, Some(snippet)) if !snippet.ends_with(">") => {
+                (0, _, Some(snippet)) if !snippet.ends_with('>') => {
                     suggest_new(err, &format!("{}<'a>", snippet));
                 }
                 _ => {

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -1551,21 +1551,18 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
 
             let method_names = pcx.candidate_method_names();
             pcx.allow_similar_names = false;
-            let applicable_close_candidates: Vec<ty::AssocItem> =
-                method_names
-                    .iter()
-                    .filter_map(|&method_name| {
-                        pcx.reset();
-                        pcx.method_name = Some(method_name);
-                        pcx.assemble_inherent_candidates();
-                        pcx.assemble_extension_candidates_for_traits_in_scope(hir::DUMMY_HIR_ID)
-                            .map_or(None, |_| {
-                                pcx.pick_core()
-                                    .and_then(|pick| pick.ok())
-                                    .and_then(|pick| Some(pick.item))
-                            })
-                    })
-                    .collect();
+            let applicable_close_candidates: Vec<ty::AssocItem> = method_names
+                .iter()
+                .filter_map(|&method_name| {
+                    pcx.reset();
+                    pcx.method_name = Some(method_name);
+                    pcx.assemble_inherent_candidates();
+                    pcx.assemble_extension_candidates_for_traits_in_scope(hir::DUMMY_HIR_ID)
+                        .map_or(None, |_| {
+                            pcx.pick_core().and_then(|pick| pick.ok()).map(|pick| pick.item)
+                        })
+                })
+                .collect();
 
             if applicable_close_candidates.is_empty() {
                 Ok(None)

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -121,9 +121,7 @@ pub fn external_generic_args(
     let args: Vec<_> = substs
         .iter()
         .filter_map(|kind| match kind.unpack() {
-            GenericArgKind::Lifetime(lt) => {
-                lt.clean(cx).and_then(|lt| Some(GenericArg::Lifetime(lt)))
-            }
+            GenericArgKind::Lifetime(lt) => lt.clean(cx).map(|lt| GenericArg::Lifetime(lt)),
             GenericArgKind::Type(_) if skip_self => {
                 skip_self = false;
                 None

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -296,7 +296,7 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for CodeBlocks<'_, 'a, I> {
                         ""
                     }
                 )),
-                playground_button.as_ref().map(String::as_str),
+                playground_button.as_deref(),
                 Some((s1.as_str(), s2)),
             ));
             Some(Event::Html(s.into()))
@@ -315,7 +315,7 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for CodeBlocks<'_, 'a, I> {
                         ""
                     }
                 )),
-                playground_button.as_ref().map(String::as_str),
+                playground_button.as_deref(),
                 None,
             ));
             Some(Event::Html(s.into()))


### PR DESCRIPTION
* Don't use .ok() before unwrapping via .expect() on a Result. 
* Use .map() to modify data inside Options instead of using .and_then(|x| Some(y))
* Use .as_deref() instead of .as_ref().map(Deref::deref)
* Don't use "if let" bindings to only check a value and not actually bind anything.
* Use single-char patter on {ends,starts}_with and remove clone on copy type.