### PR TITLE
Tweak output for invalid negative impl AST errors

### DIFF
--- a/src/librustc_ast/ast.rs
+++ b/src/librustc_ast/ast.rs
@@ -2117,14 +2117,14 @@ pub enum ImplPolarity {
     /// `impl Trait for Type`
     Positive,
     /// `impl !Trait for Type`
-    Negative,
+    Negative(Span),
 }
 
 impl fmt::Debug for ImplPolarity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             ImplPolarity::Positive => "positive".fmt(f),
-            ImplPolarity::Negative => "negative".fmt(f),
+            ImplPolarity::Negative(_) => "negative".fmt(f),
         }
     }
 }

--- a/src/librustc_ast_passes/ast_validation.rs
+++ b/src/librustc_ast_passes/ast_validation.rs
@@ -910,6 +910,12 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                             item.ident.span,
                             "auto trait cannot have generic parameters",
                         );
+                        err.span_suggestion_verbose(
+                            generics.span,
+                            "remove the parameters for the auto trait to be valid",
+                            String::new(),
+                            Applicability::MachineApplicable,
+                        );
                         err.emit();
                     }
                     if !bounds.is_empty() {
@@ -922,6 +928,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                             E0568,
                             "auto traits cannot have super traits"
                         );
+                        err.span_label(item.ident.span, "auto trait cannot have super traits");
                         if let Some(span) = last {
                             err.span_label(
                                 span,
@@ -931,8 +938,13 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                                     s = pluralize!(len)
                                 ),
                             );
+                            err.span_suggestion_verbose(
+                                generics.span.shrink_to_hi().to(span),
+                                "remove the super traits for the auto trait to be valid",
+                                String::new(),
+                                Applicability::MachineApplicable,
+                            );
                         }
-                        err.span_label(item.ident.span, "auto trait cannot have super traits");
                         err.emit();
                     }
                     if !trait_items.is_empty() {

--- a/src/librustc_ast_passes/ast_validation.rs
+++ b/src/librustc_ast_passes/ast_validation.rs
@@ -9,6 +9,7 @@
 use rustc_ast::ast::*;
 use rustc_ast::attr;
 use rustc_ast::expand::is_proc_macro_attr;
+use rustc_ast::ptr::P;
 use rustc_ast::visit::{self, AssocCtxt, FnCtxt, FnKind, Visitor};
 use rustc_ast::walk_list;
 use rustc_ast_pretty::pprust;
@@ -594,6 +595,54 @@ impl<'a> AstValidator<'a> {
             .span_label(ident.span, format!("`_` is not a valid name for this `{}` item", kind))
             .emit();
     }
+
+    fn deny_generic_params(&self, generics: &Generics, ident_span: Span) {
+        if !generics.params.is_empty() {
+            struct_span_err!(
+                self.session,
+                generics.span,
+                E0567,
+                "auto traits cannot have generic parameters"
+            )
+            .span_label(ident_span, "auto trait cannot have generic parameters")
+            .span_suggestion(
+                generics.span,
+                "remove the parameters",
+                String::new(),
+                Applicability::MachineApplicable,
+            )
+            .emit();
+        }
+    }
+
+    fn deny_super_traits(&self, bounds: &GenericBounds, ident_span: Span) {
+        if let [first @ last] | [first, .., last] = &bounds[..] {
+            let span = first.span().to(last.span());
+            struct_span_err!(self.session, span, E0568, "auto traits cannot have super traits")
+                .span_label(ident_span, "auto trait cannot have super traits")
+                .span_suggestion(
+                    span,
+                    "remove the super traits",
+                    String::new(),
+                    Applicability::MachineApplicable,
+                )
+                .emit();
+        }
+    }
+
+    fn deny_items(&self, trait_items: &[P<AssocItem>], ident_span: Span) {
+        if !trait_items.is_empty() {
+            let spans: Vec<_> = trait_items.iter().map(|i| i.ident.span).collect();
+            struct_span_err!(
+                self.session,
+                spans,
+                E0380,
+                "auto traits cannot have methods or associated items"
+            )
+            .span_label(ident_span, "auto trait cannot have items")
+            .emit();
+        }
+    }
 }
 
 fn validate_generic_param_order<'a>(
@@ -881,57 +930,9 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
             ItemKind::Trait(is_auto, _, ref generics, ref bounds, ref trait_items) => {
                 if is_auto == IsAuto::Yes {
                     // Auto traits cannot have generics, super traits nor contain items.
-                    if !generics.params.is_empty() {
-                        let mut err = struct_span_err!(
-                            self.session,
-                            generics.span,
-                            E0567,
-                            "auto traits cannot have generic parameters"
-                        );
-                        err.span_label(
-                            item.ident.span,
-                            "auto trait cannot have generic parameters",
-                        );
-                        err.span_suggestion(
-                            generics.span,
-                            "remove the parameters",
-                            String::new(),
-                            Applicability::MachineApplicable,
-                        );
-                        err.emit();
-                    }
-                    if !bounds.is_empty() {
-                        let span = match &bounds[..] {
-                            [] => unreachable!(),
-                            [single] => single.span(),
-                            [first, .., last] => first.span().to(last.span()),
-                        };
-                        let mut err = struct_span_err!(
-                            self.session,
-                            span,
-                            E0568,
-                            "auto traits cannot have super traits"
-                        );
-                        err.span_label(item.ident.span, "auto trait cannot have super traits");
-                        err.span_suggestion(
-                            span,
-                            "remove the super traits",
-                            String::new(),
-                            Applicability::MachineApplicable,
-                        );
-                        err.emit();
-                    }
-                    if !trait_items.is_empty() {
-                        let spans: Vec<_> = trait_items.iter().map(|i| i.ident.span).collect();
-                        struct_span_err!(
-                            self.session,
-                            spans,
-                            E0380,
-                            "auto traits cannot have methods or associated items"
-                        )
-                        .span_label(item.ident.span, "auto trait cannot have items")
-                        .emit();
-                    }
+                    self.deny_generic_params(generics, item.ident.span);
+                    self.deny_super_traits(bounds, item.ident.span);
+                    self.deny_items(trait_items, item.ident.span);
                 }
                 self.no_questions_in_bounds(bounds, "supertraits", true);
 

--- a/src/librustc_ast_passes/feature_gate.rs
+++ b/src/librustc_ast_passes/feature_gate.rs
@@ -338,14 +338,14 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 }
             }
 
-            ast::ItemKind::Impl { polarity, defaultness, .. } => {
-                if polarity == ast::ImplPolarity::Negative {
+            ast::ItemKind::Impl { polarity, defaultness, ref of_trait, .. } => {
+                if let ast::ImplPolarity::Negative(span) = polarity {
                     gate_feature_post!(
                         &self,
                         optin_builtin_traits,
-                        i.span,
+                        span.to(of_trait.as_ref().map(|t| t.path.span).unwrap_or(span)),
                         "negative trait bounds are not yet fully implemented; \
-                                        use marker types for now"
+                         use marker types for now"
                     );
                 }
 

--- a/src/librustc_ast_passes/lib.rs
+++ b/src/librustc_ast_passes/lib.rs
@@ -1,3 +1,4 @@
+#![feature(bindings_after_at)]
 //! The `rustc_ast_passes` crate contains passes which validate the AST in `syntax`
 //! parsed by `rustc_parse` and then lowered, after the passes in this crate,
 //! by `rustc_ast_lowering`.

--- a/src/librustc_ast_pretty/pprust.rs
+++ b/src/librustc_ast_pretty/pprust.rs
@@ -1175,7 +1175,7 @@ impl<'a> State<'a> {
                     self.s.space();
                 }
 
-                if polarity == ast::ImplPolarity::Negative {
+                if let ast::ImplPolarity::Negative(_) = polarity {
                     self.s.word("!");
                 }
 

--- a/src/librustc_hir/print.rs
+++ b/src/librustc_hir/print.rs
@@ -652,7 +652,7 @@ impl<'a> State<'a> {
                     self.word_nbsp("const");
                 }
 
-                if let hir::ImplPolarity::Negative = polarity {
+                if let hir::ImplPolarity::Negative(_) = polarity {
                     self.s.word("!");
                 }
 

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -373,6 +373,16 @@ impl<'a> Parser<'a> {
         self.token.is_keyword(kw::Async) && self.is_keyword_ahead(1, &[kw::Fn])
     }
 
+    fn parse_polarity(&mut self) -> ast::ImplPolarity {
+        // Disambiguate `impl !Trait for Type { ... }` and `impl ! { ... }` for the never type.
+        if self.check(&token::Not) && self.look_ahead(1, |t| t.can_begin_type()) {
+            self.bump(); // `!`
+            ast::ImplPolarity::Negative(self.prev_token.span)
+        } else {
+            ast::ImplPolarity::Positive
+        }
+    }
+
     /// Parses an implementation item.
     ///
     /// ```
@@ -411,13 +421,7 @@ impl<'a> Parser<'a> {
             self.sess.gated_spans.gate(sym::const_trait_impl, span);
         }
 
-        // Disambiguate `impl !Trait for Type { ... }` and `impl ! { ... }` for the never type.
-        let polarity = if self.check(&token::Not) && self.look_ahead(1, |t| t.can_begin_type()) {
-            self.bump(); // `!`
-            ast::ImplPolarity::Negative(self.prev_token.span)
-        } else {
-            ast::ImplPolarity::Positive
-        };
+        let polarity = self.parse_polarity();
 
         // Parse both types and traits as a type, then reinterpret if necessary.
         let err_path = |span| ast::Path::from_ident(Ident::new(kw::Invalid, span));

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -414,7 +414,7 @@ impl<'a> Parser<'a> {
         // Disambiguate `impl !Trait for Type { ... }` and `impl ! { ... }` for the never type.
         let polarity = if self.check(&token::Not) && self.look_ahead(1, |t| t.can_begin_type()) {
             self.bump(); // `!`
-            ast::ImplPolarity::Negative
+            ast::ImplPolarity::Negative(self.prev_token.span)
         } else {
             ast::ImplPolarity::Positive
         };

--- a/src/librustc_save_analysis/sig.rs
+++ b/src/librustc_save_analysis/sig.rs
@@ -519,7 +519,7 @@ impl Sig for ast::Item {
                 text.push(' ');
 
                 let trait_sig = if let Some(ref t) = *of_trait {
-                    if polarity == ast::ImplPolarity::Negative {
+                    if let ast::ImplPolarity::Negative(_) = polarity {
                         text.push('!');
                     }
                     let trait_sig = t.path.make(offset + text.len(), id, scx)?;

--- a/src/librustc_typeck/coherence/unsafety.rs
+++ b/src/librustc_typeck/coherence/unsafety.rs
@@ -69,11 +69,11 @@ impl UnsafetyChecker<'tcx> {
                     .emit();
                 }
 
-                (_, _, Unsafety::Unsafe, hir::ImplPolarity::Negative) => {
+                (_, _, Unsafety::Unsafe, hir::ImplPolarity::Negative(_)) => {
                     // Reported in AST validation
                     self.tcx.sess.delay_span_bug(item.span, "unsafe negative impl");
                 }
-                (_, _, Unsafety::Normal, hir::ImplPolarity::Negative)
+                (_, _, Unsafety::Normal, hir::ImplPolarity::Negative(_))
                 | (Unsafety::Unsafe, _, Unsafety::Unsafe, hir::ImplPolarity::Positive)
                 | (Unsafety::Normal, Some(_), Unsafety::Unsafe, hir::ImplPolarity::Positive)
                 | (Unsafety::Normal, None, Unsafety::Normal, _) => {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1548,7 +1548,7 @@ fn impl_polarity(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ImplPolarity {
     let is_rustc_reservation = tcx.has_attr(def_id, sym::rustc_reservation_impl);
     let item = tcx.hir().expect_item(hir_id);
     match &item.kind {
-        hir::ItemKind::Impl { polarity: hir::ImplPolarity::Negative, .. } => {
+        hir::ItemKind::Impl { polarity: hir::ImplPolarity::Negative(_), .. } => {
             if is_rustc_reservation {
                 tcx.sess.span_err(item.span, "reservation impls can't be negative");
             }

--- a/src/test/ui/async-await/no-const-async.stderr
+++ b/src/test/ui/async-await/no-const-async.stderr
@@ -1,8 +1,8 @@
 error: functions cannot be both `const` and `async`
-  --> $DIR/no-const-async.rs:4:1
+  --> $DIR/no-const-async.rs:4:5
    |
 LL | pub const async fn x() {}
-   | ^^^^-----^-----^^^^^^^^^^
+   | ----^^^^^-^^^^^----------
    |     |     |
    |     |     `async` because of this
    |     `const` because of this

--- a/src/test/ui/auto-trait-validation.stderr
+++ b/src/test/ui/auto-trait-validation.stderr
@@ -5,6 +5,11 @@ LL | auto trait Generic<T> {}
    |            ------- ^ cannot have this generic parameter
    |            |
    |            auto trait cannot have generic parameters
+   |
+help: remove the parameters for the auto trait to be valid
+   |
+LL | auto trait Generic {}
+   |                  --
 
 error[E0568]: auto traits cannot have super traits
   --> $DIR/auto-trait-validation.rs:5:20
@@ -13,6 +18,11 @@ LL | auto trait Bound : Copy {}
    |            -----   ^^^^ cannot have this super trait
    |            |
    |            auto trait cannot have super traits
+   |
+help: remove the super traits for the auto trait to be valid
+   |
+LL | auto trait Bound {}
+   |                --
 
 error[E0380]: auto traits cannot have methods or associated items
   --> $DIR/auto-trait-validation.rs:7:25

--- a/src/test/ui/auto-trait-validation.stderr
+++ b/src/test/ui/auto-trait-validation.stderr
@@ -1,28 +1,18 @@
 error[E0567]: auto traits cannot have generic parameters
-  --> $DIR/auto-trait-validation.rs:3:20
+  --> $DIR/auto-trait-validation.rs:3:19
    |
 LL | auto trait Generic<T> {}
-   |            ------- ^ cannot have this generic parameter
+   |            -------^^^ help: remove the parameters
    |            |
    |            auto trait cannot have generic parameters
-   |
-help: remove the parameters for the auto trait to be valid
-   |
-LL | auto trait Generic {}
-   |                  --
 
 error[E0568]: auto traits cannot have super traits
   --> $DIR/auto-trait-validation.rs:5:20
    |
 LL | auto trait Bound : Copy {}
-   |            -----   ^^^^ cannot have this super trait
+   |            -----   ^^^^ help: remove the super traits
    |            |
    |            auto trait cannot have super traits
-   |
-help: remove the super traits for the auto trait to be valid
-   |
-LL | auto trait Bound {}
-   |                --
 
 error[E0380]: auto traits cannot have methods or associated items
   --> $DIR/auto-trait-validation.rs:7:25

--- a/src/test/ui/auto-trait-validation.stderr
+++ b/src/test/ui/auto-trait-validation.stderr
@@ -1,20 +1,26 @@
 error[E0567]: auto traits cannot have generic parameters
-  --> $DIR/auto-trait-validation.rs:3:1
+  --> $DIR/auto-trait-validation.rs:3:20
    |
 LL | auto trait Generic<T> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ------- ^ cannot have this generic parameter
+   |            |
+   |            auto trait cannot have generic parameters
 
 error[E0568]: auto traits cannot have super traits
-  --> $DIR/auto-trait-validation.rs:5:1
+  --> $DIR/auto-trait-validation.rs:5:20
    |
 LL | auto trait Bound : Copy {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            -----   ^^^^ cannot have this super trait
+   |            |
+   |            auto trait cannot have super traits
 
 error[E0380]: auto traits cannot have methods or associated items
-  --> $DIR/auto-trait-validation.rs:7:1
+  --> $DIR/auto-trait-validation.rs:7:25
    |
 LL | auto trait MyTrait { fn foo() {} }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            -------      ^^^
+   |            |
+   |            auto trait cannot have items
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/coherence/coherence-negative-impls-safe.stderr
+++ b/src/test/ui/coherence/coherence-negative-impls-safe.stderr
@@ -1,8 +1,8 @@
 error[E0198]: negative impls cannot be unsafe
-  --> $DIR/coherence-negative-impls-safe.rs:7:1
+  --> $DIR/coherence-negative-impls-safe.rs:7:13
    |
 LL | unsafe impl !Send for TestType {}
-   | ------^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ------      ^^^^^
    | |
    | unsafe because of this
 

--- a/src/test/ui/coherence/coherence-negative-impls-safe.stderr
+++ b/src/test/ui/coherence/coherence-negative-impls-safe.stderr
@@ -2,8 +2,9 @@ error[E0198]: negative impls cannot be unsafe
   --> $DIR/coherence-negative-impls-safe.rs:7:13
    |
 LL | unsafe impl !Send for TestType {}
-   | ------      ^^^^^
-   | |
+   | ------      -^^^^
+   | |           |
+   | |           negative because of this
    | unsafe because of this
 
 error: aborting due to previous error

--- a/src/test/ui/error-codes/E0197.stderr
+++ b/src/test/ui/error-codes/E0197.stderr
@@ -2,7 +2,7 @@ error[E0197]: inherent impls cannot be unsafe
   --> $DIR/E0197.rs:3:1
    |
 LL | unsafe impl Foo { }
-   | ------^^^^^^^^^^^^^
+   | ^^^^^^      ^^^ inherent impl for this type
    | |
    | unsafe because of this
 

--- a/src/test/ui/error-codes/E0197.stderr
+++ b/src/test/ui/error-codes/E0197.stderr
@@ -1,8 +1,8 @@
 error[E0197]: inherent impls cannot be unsafe
-  --> $DIR/E0197.rs:3:1
+  --> $DIR/E0197.rs:3:13
    |
 LL | unsafe impl Foo { }
-   | ^^^^^^      ^^^ inherent impl for this type
+   | ------      ^^^ inherent impl for this type
    | |
    | unsafe because of this
 

--- a/src/test/ui/error-codes/E0198.stderr
+++ b/src/test/ui/error-codes/E0198.stderr
@@ -1,8 +1,8 @@
 error[E0198]: negative impls cannot be unsafe
-  --> $DIR/E0198.rs:5:1
+  --> $DIR/E0198.rs:5:13
    |
 LL | unsafe impl !Send for Foo { }
-   | ------^^^^^^^^^^^^^^^^^^^^^^^
+   | ------      ^^^^^
    | |
    | unsafe because of this
 

--- a/src/test/ui/error-codes/E0198.stderr
+++ b/src/test/ui/error-codes/E0198.stderr
@@ -2,8 +2,9 @@ error[E0198]: negative impls cannot be unsafe
   --> $DIR/E0198.rs:5:13
    |
 LL | unsafe impl !Send for Foo { }
-   | ------      ^^^^^
-   | |
+   | ------      -^^^^
+   | |           |
+   | |           negative because of this
    | unsafe because of this
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-optin-builtin-traits.stderr
+++ b/src/test/ui/feature-gates/feature-gate-optin-builtin-traits.stderr
@@ -8,10 +8,10 @@ LL | auto trait AutoDummyTrait {}
    = help: add `#![feature(optin_builtin_traits)]` to the crate attributes to enable
 
 error[E0658]: negative trait bounds are not yet fully implemented; use marker types for now
-  --> $DIR/feature-gate-optin-builtin-traits.rs:9:1
+  --> $DIR/feature-gate-optin-builtin-traits.rs:9:6
    |
 LL | impl !AutoDummyTrait for DummyStruct {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |      ^^^^^^^^^^^^^^^
    |
    = note: see issue #13231 <https://github.com/rust-lang/rust/issues/13231> for more information
    = help: add `#![feature(optin_builtin_traits)]` to the crate attributes to enable

--- a/src/test/ui/issues/issue-23080-2.rs
+++ b/src/test/ui/issues/issue-23080-2.rs
@@ -3,8 +3,7 @@
 #![feature(optin_builtin_traits)]
 
 unsafe auto trait Trait {
-//~^ ERROR E0380
-    type Output;
+    type Output; //~ ERROR E0380
 }
 
 fn call_method<T: Trait>(x: T) {}

--- a/src/test/ui/issues/issue-23080-2.stderr
+++ b/src/test/ui/issues/issue-23080-2.stderr
@@ -1,11 +1,10 @@
 error[E0380]: auto traits cannot have methods or associated items
-  --> $DIR/issue-23080-2.rs:5:1
+  --> $DIR/issue-23080-2.rs:6:10
    |
-LL | / unsafe auto trait Trait {
-LL | |
-LL | |     type Output;
-LL | | }
-   | |_^
+LL | unsafe auto trait Trait {
+   |                   ----- auto trait cannot have items
+LL |     type Output;
+   |          ^^^^^^
 
 error[E0275]: overflow evaluating the requirement `<() as Trait>::Output`
    |

--- a/src/test/ui/issues/issue-23080.rs
+++ b/src/test/ui/issues/issue-23080.rs
@@ -1,8 +1,7 @@
 #![feature(optin_builtin_traits)]
 
 unsafe auto trait Trait {
-//~^ ERROR E0380
-    fn method(&self) {
+    fn method(&self) { //~ ERROR E0380
         println!("Hello");
     }
 }

--- a/src/test/ui/issues/issue-23080.stderr
+++ b/src/test/ui/issues/issue-23080.stderr
@@ -1,13 +1,10 @@
 error[E0380]: auto traits cannot have methods or associated items
-  --> $DIR/issue-23080.rs:3:1
+  --> $DIR/issue-23080.rs:4:8
    |
-LL | / unsafe auto trait Trait {
-LL | |
-LL | |     fn method(&self) {
-LL | |         println!("Hello");
-LL | |     }
-LL | | }
-   | |_^
+LL | unsafe auto trait Trait {
+   |                   ----- auto trait cannot have items
+LL |     fn method(&self) {
+   |        ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/fn-header-semantic-fail.stderr
+++ b/src/test/ui/parser/fn-header-semantic-fail.stderr
@@ -2,7 +2,7 @@ error: functions cannot be both `const` and `async`
   --> $DIR/fn-header-semantic-fail.rs:13:5
    |
 LL |     const async unsafe extern "C" fn ff5() {} // OK.
-   |     -----^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^-^^^^^------------------------------
    |     |     |
    |     |     `async` because of this
    |     `const` because of this
@@ -45,7 +45,7 @@ error: functions cannot be both `const` and `async`
   --> $DIR/fn-header-semantic-fail.rs:21:9
    |
 LL |         const async unsafe extern "C" fn ft5();
-   |         -----^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^-^^^^^----------------------------
    |         |     |
    |         |     `async` because of this
    |         `const` because of this
@@ -88,7 +88,7 @@ error: functions cannot be both `const` and `async`
   --> $DIR/fn-header-semantic-fail.rs:34:9
    |
 LL |         const async unsafe extern "C" fn ft5() {}
-   |         -----^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^-^^^^^------------------------------
    |         |     |
    |         |     `async` because of this
    |         `const` because of this
@@ -97,7 +97,7 @@ error: functions cannot be both `const` and `async`
   --> $DIR/fn-header-semantic-fail.rs:46:9
    |
 LL |         const async unsafe extern "C" fn fi5() {}
-   |         -----^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^-^^^^^------------------------------
    |         |     |
    |         |     `async` because of this
    |         `const` because of this
@@ -160,7 +160,7 @@ error: functions cannot be both `const` and `async`
   --> $DIR/fn-header-semantic-fail.rs:55:9
    |
 LL |         const async unsafe extern "C" fn fe5();
-   |         -----^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^-^^^^^----------------------------
    |         |     |
    |         |     `async` because of this
    |         `const` because of this

--- a/src/test/ui/rfc-2632-const-trait-impl/inherent-impl.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/inherent-impl.stderr
@@ -1,18 +1,18 @@
 error: inherent impls cannot be `const`
-  --> $DIR/inherent-impl.rs:9:6
+  --> $DIR/inherent-impl.rs:9:12
    |
 LL | impl const S {}
-   |      ^^^^^ ^ inherent impl for this type
+   |      ----- ^ inherent impl for this type
    |      |
    |      `const` because of this
    |
    = note: only trait implementations may be annotated with `const`
 
 error: inherent impls cannot be `const`
-  --> $DIR/inherent-impl.rs:12:6
+  --> $DIR/inherent-impl.rs:12:12
    |
 LL | impl const T {}
-   |      ^^^^^ ^ inherent impl for this type
+   |      ----- ^ inherent impl for this type
    |      |
    |      `const` because of this
    |

--- a/src/test/ui/rfc-2632-const-trait-impl/inherent-impl.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/inherent-impl.stderr
@@ -1,18 +1,18 @@
 error: inherent impls cannot be `const`
-  --> $DIR/inherent-impl.rs:9:1
+  --> $DIR/inherent-impl.rs:9:6
    |
 LL | impl const S {}
-   | ^^^^^-----^^^^^
+   |      ^^^^^ ^ inherent impl for this type
    |      |
    |      `const` because of this
    |
    = note: only trait implementations may be annotated with `const`
 
 error: inherent impls cannot be `const`
-  --> $DIR/inherent-impl.rs:12:1
+  --> $DIR/inherent-impl.rs:12:6
    |
 LL | impl const T {}
-   | ^^^^^-----^^^^^
+   |      ^^^^^ ^ inherent impl for this type
    |      |
    |      `const` because of this
    |

--- a/src/test/ui/specialization/defaultimpl/validation.stderr
+++ b/src/test/ui/specialization/defaultimpl/validation.stderr
@@ -2,7 +2,7 @@ error: inherent impls cannot be `default`
   --> $DIR/validation.rs:7:1
    |
 LL | default impl S {}
-   | -------^^^^^^^
+   | ^^^^^^^      ^ inherent impl for this type
    | |
    | `default` because of this
    |

--- a/src/test/ui/specialization/defaultimpl/validation.stderr
+++ b/src/test/ui/specialization/defaultimpl/validation.stderr
@@ -1,8 +1,8 @@
 error: inherent impls cannot be `default`
-  --> $DIR/validation.rs:7:1
+  --> $DIR/validation.rs:7:14
    |
 LL | default impl S {}
-   | ^^^^^^^      ^ inherent impl for this type
+   | -------      ^ inherent impl for this type
    | |
    | `default` because of this
    |

--- a/src/test/ui/syntax-trait-polarity-feature-gate.stderr
+++ b/src/test/ui/syntax-trait-polarity-feature-gate.stderr
@@ -1,8 +1,8 @@
 error[E0658]: negative trait bounds are not yet fully implemented; use marker types for now
-  --> $DIR/syntax-trait-polarity-feature-gate.rs:7:1
+  --> $DIR/syntax-trait-polarity-feature-gate.rs:7:6
    |
 LL | impl !Send for TestType {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |      ^^^^^
    |
    = note: see issue #13231 <https://github.com/rust-lang/rust/issues/13231> for more information
    = help: add `#![feature(optin_builtin_traits)]` to the crate attributes to enable

--- a/src/test/ui/syntax-trait-polarity.stderr
+++ b/src/test/ui/syntax-trait-polarity.stderr
@@ -1,28 +1,28 @@
 error: inherent impls cannot be negative
-  --> $DIR/syntax-trait-polarity.rs:7:1
+  --> $DIR/syntax-trait-polarity.rs:7:6
    |
 LL | impl !TestType {}
-   | ^^^^^^^^^^^^^^^^^
+   |      ^
 
 error[E0198]: negative impls cannot be unsafe
-  --> $DIR/syntax-trait-polarity.rs:12:1
+  --> $DIR/syntax-trait-polarity.rs:12:13
    |
 LL | unsafe impl !Send for TestType {}
-   | ------^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ------      ^^^^^
    | |
    | unsafe because of this
 
 error: inherent impls cannot be negative
-  --> $DIR/syntax-trait-polarity.rs:19:1
+  --> $DIR/syntax-trait-polarity.rs:19:9
    |
 LL | impl<T> !TestType2<T> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^
 
 error[E0198]: negative impls cannot be unsafe
-  --> $DIR/syntax-trait-polarity.rs:22:1
+  --> $DIR/syntax-trait-polarity.rs:22:16
    |
 LL | unsafe impl<T> !Send for TestType2<T> {}
-   | ------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ------         ^^^^^
    | |
    | unsafe because of this
 

--- a/src/test/ui/syntax-trait-polarity.stderr
+++ b/src/test/ui/syntax-trait-polarity.stderr
@@ -1,29 +1,35 @@
 error: inherent impls cannot be negative
-  --> $DIR/syntax-trait-polarity.rs:7:6
+  --> $DIR/syntax-trait-polarity.rs:7:7
    |
 LL | impl !TestType {}
-   |      ^
+   |      -^^^^^^^^ inherent impl for this type
+   |      |
+   |      negative because of this
 
 error[E0198]: negative impls cannot be unsafe
   --> $DIR/syntax-trait-polarity.rs:12:13
    |
 LL | unsafe impl !Send for TestType {}
-   | ------      ^^^^^
-   | |
+   | ------      -^^^^
+   | |           |
+   | |           negative because of this
    | unsafe because of this
 
 error: inherent impls cannot be negative
-  --> $DIR/syntax-trait-polarity.rs:19:9
+  --> $DIR/syntax-trait-polarity.rs:19:10
    |
 LL | impl<T> !TestType2<T> {}
-   |         ^
+   |         -^^^^^^^^^^^^ inherent impl for this type
+   |         |
+   |         negative because of this
 
 error[E0198]: negative impls cannot be unsafe
   --> $DIR/syntax-trait-polarity.rs:22:16
    |
 LL | unsafe impl<T> !Send for TestType2<T> {}
-   | ------         ^^^^^
-   | |
+   | ------         -^^^^
+   | |              |
+   | |              negative because of this
    | unsafe because of this
 
 error[E0192]: negative impls are only allowed for auto traits (e.g., `Send` and `Sync`)

--- a/src/test/ui/traits/trait-safety-inherent-impl.stderr
+++ b/src/test/ui/traits/trait-safety-inherent-impl.stderr
@@ -1,8 +1,8 @@
 error[E0197]: inherent impls cannot be unsafe
-  --> $DIR/trait-safety-inherent-impl.rs:5:1
+  --> $DIR/trait-safety-inherent-impl.rs:5:13
    |
 LL | unsafe impl SomeStruct {
-   | ^^^^^^      ^^^^^^^^^^ inherent impl for this type
+   | ------      ^^^^^^^^^^ inherent impl for this type
    | |
    | unsafe because of this
 

--- a/src/test/ui/traits/trait-safety-inherent-impl.stderr
+++ b/src/test/ui/traits/trait-safety-inherent-impl.stderr
@@ -1,14 +1,10 @@
 error[E0197]: inherent impls cannot be unsafe
   --> $DIR/trait-safety-inherent-impl.rs:5:1
    |
-LL |   unsafe impl SomeStruct {
-   |   ^-----
-   |   |
-   |  _unsafe because of this
+LL | unsafe impl SomeStruct {
+   | ^^^^^^      ^^^^^^^^^^ inherent impl for this type
    | |
-LL | |     fn foo(self) { }
-LL | | }
-   | |_^
+   | unsafe because of this
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/traits-inductive-overflow-supertrait-oibit.stderr
+++ b/src/test/ui/traits/traits-inductive-overflow-supertrait-oibit.stderr
@@ -1,8 +1,10 @@
 error[E0568]: auto traits cannot have super traits
-  --> $DIR/traits-inductive-overflow-supertrait-oibit.rs:7:1
+  --> $DIR/traits-inductive-overflow-supertrait-oibit.rs:7:19
    |
 LL | auto trait Magic: Copy {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            -----  ^^^^ cannot have this super trait
+   |            |
+   |            auto trait cannot have super traits
 
 error[E0277]: the trait bound `NoClone: std::marker::Copy` is not satisfied
   --> $DIR/traits-inductive-overflow-supertrait-oibit.rs:15:23

--- a/src/test/ui/traits/traits-inductive-overflow-supertrait-oibit.stderr
+++ b/src/test/ui/traits/traits-inductive-overflow-supertrait-oibit.stderr
@@ -5,6 +5,11 @@ LL | auto trait Magic: Copy {}
    |            -----  ^^^^ cannot have this super trait
    |            |
    |            auto trait cannot have super traits
+   |
+help: remove the super traits for the auto trait to be valid
+   |
+LL | auto trait Magic {}
+   |                --
 
 error[E0277]: the trait bound `NoClone: std::marker::Copy` is not satisfied
   --> $DIR/traits-inductive-overflow-supertrait-oibit.rs:15:23

--- a/src/test/ui/traits/traits-inductive-overflow-supertrait-oibit.stderr
+++ b/src/test/ui/traits/traits-inductive-overflow-supertrait-oibit.stderr
@@ -2,14 +2,9 @@ error[E0568]: auto traits cannot have super traits
   --> $DIR/traits-inductive-overflow-supertrait-oibit.rs:7:19
    |
 LL | auto trait Magic: Copy {}
-   |            -----  ^^^^ cannot have this super trait
+   |            -----  ^^^^ help: remove the super traits
    |            |
    |            auto trait cannot have super traits
-   |
-help: remove the super traits for the auto trait to be valid
-   |
-LL | auto trait Magic {}
-   |                --
 
 error[E0277]: the trait bound `NoClone: std::marker::Copy` is not satisfied
   --> $DIR/traits-inductive-overflow-supertrait-oibit.rs:15:23

--- a/src/test/ui/typeck/typeck-auto-trait-no-supertraits-2.stderr
+++ b/src/test/ui/typeck/typeck-auto-trait-no-supertraits-2.stderr
@@ -5,6 +5,11 @@ LL | auto trait Magic : Sized where Option<Self> : Magic {}
    |            -----   ^^^^^ cannot have this super trait
    |            |
    |            auto trait cannot have super traits
+   |
+help: remove the super traits for the auto trait to be valid
+   |
+LL | auto trait Magic where Option<Self> : Magic {}
+   |                --
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/typeck-auto-trait-no-supertraits-2.stderr
+++ b/src/test/ui/typeck/typeck-auto-trait-no-supertraits-2.stderr
@@ -2,14 +2,9 @@ error[E0568]: auto traits cannot have super traits
   --> $DIR/typeck-auto-trait-no-supertraits-2.rs:3:20
    |
 LL | auto trait Magic : Sized where Option<Self> : Magic {}
-   |            -----   ^^^^^ cannot have this super trait
+   |            -----   ^^^^^ help: remove the super traits
    |            |
    |            auto trait cannot have super traits
-   |
-help: remove the super traits for the auto trait to be valid
-   |
-LL | auto trait Magic where Option<Self> : Magic {}
-   |                --
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/typeck-auto-trait-no-supertraits-2.stderr
+++ b/src/test/ui/typeck/typeck-auto-trait-no-supertraits-2.stderr
@@ -1,8 +1,10 @@
 error[E0568]: auto traits cannot have super traits
-  --> $DIR/typeck-auto-trait-no-supertraits-2.rs:3:1
+  --> $DIR/typeck-auto-trait-no-supertraits-2.rs:3:20
    |
 LL | auto trait Magic : Sized where Option<Self> : Magic {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            -----   ^^^^^ cannot have this super trait
+   |            |
+   |            auto trait cannot have super traits
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/typeck-auto-trait-no-supertraits.stderr
+++ b/src/test/ui/typeck/typeck-auto-trait-no-supertraits.stderr
@@ -1,8 +1,10 @@
 error[E0568]: auto traits cannot have super traits
-  --> $DIR/typeck-auto-trait-no-supertraits.rs:27:1
+  --> $DIR/typeck-auto-trait-no-supertraits.rs:27:19
    |
 LL | auto trait Magic: Copy {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            -----  ^^^^ cannot have this super trait
+   |            |
+   |            auto trait cannot have super traits
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/typeck-auto-trait-no-supertraits.stderr
+++ b/src/test/ui/typeck/typeck-auto-trait-no-supertraits.stderr
@@ -2,14 +2,9 @@ error[E0568]: auto traits cannot have super traits
   --> $DIR/typeck-auto-trait-no-supertraits.rs:27:19
    |
 LL | auto trait Magic: Copy {}
-   |            -----  ^^^^ cannot have this super trait
+   |            -----  ^^^^ help: remove the super traits
    |            |
    |            auto trait cannot have super traits
-   |
-help: remove the super traits for the auto trait to be valid
-   |
-LL | auto trait Magic {}
-   |                --
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/typeck-auto-trait-no-supertraits.stderr
+++ b/src/test/ui/typeck/typeck-auto-trait-no-supertraits.stderr
@@ -5,6 +5,11 @@ LL | auto trait Magic: Copy {}
    |            -----  ^^^^ cannot have this super trait
    |            |
    |            auto trait cannot have super traits
+   |
+help: remove the super traits for the auto trait to be valid
+   |
+LL | auto trait Magic {}
+   |                --
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Use more accurate spans for negative `impl` errors.

r? @Centril 