### PR TITLE
Perform WF-check on `type`s with no type parameters

### DIFF
--- a/src/test/ui/conditional-compilation/cfg-generic-params.rs
+++ b/src/test/ui/conditional-compilation/cfg-generic-params.rs
@@ -7,9 +7,11 @@ type FnGood = for<#[cfg(yes)] 'a, #[cfg(no)] T> fn(); // OK
 type FnBad = for<#[cfg(no)] 'a, #[cfg(yes)] T> fn();
 //~^ ERROR only lifetime parameters can be used in this context
 
-type PolyGood = dyn for<#[cfg(yes)] 'a, #[cfg(no)] T> Copy; // OK
+type PolyGood = dyn for<#[cfg(yes)] 'a, #[cfg(no)] T> Copy;
+//~^ ERROR the trait `Copy` cannot be made into an object
 type PolyBad = dyn for<#[cfg(no)] 'a, #[cfg(yes)] T> Copy;
 //~^ ERROR only lifetime parameters can be used in this context
+//~| ERROR the trait `Copy` cannot be made into an object
 
 struct WhereGood where for<#[cfg(yes)] 'a, #[cfg(no)] T> u8: Copy; // OK
 struct WhereBad where for<#[cfg(no)] 'a, #[cfg(yes)] T> u8: Copy;
@@ -27,8 +29,10 @@ type FnYes = for<#[cfg_attr(yes, unknown)] 'a> fn();
 //~^ ERROR cannot find attribute `unknown` in this scope
 
 type PolyNo = dyn for<#[cfg_attr(no, unknown)] 'a> Copy; // OK
+//~^ ERROR the trait `Copy` cannot be made into an object
 type PolyYes = dyn for<#[cfg_attr(yes, unknown)] 'a> Copy;
 //~^ ERROR cannot find attribute `unknown` in this scope
+//~| ERROR the trait `Copy` cannot be made into an object
 
 struct WhereNo where for<#[cfg_attr(no, unknown)] 'a> u8: Copy; // OK
 struct WhereYes where for<#[cfg_attr(yes, unknown)] 'a> u8: Copy;

--- a/src/test/ui/conditional-compilation/cfg-generic-params.stderr
+++ b/src/test/ui/conditional-compilation/cfg-generic-params.stderr
@@ -5,46 +5,83 @@ LL | type FnBad = for<#[cfg(no)] 'a, #[cfg(yes)] T> fn();
    |                                             ^
 
 error: only lifetime parameters can be used in this context
-  --> $DIR/cfg-generic-params.rs:11:51
+  --> $DIR/cfg-generic-params.rs:12:51
    |
 LL | type PolyBad = dyn for<#[cfg(no)] 'a, #[cfg(yes)] T> Copy;
    |                                                   ^
 
 error: only lifetime parameters can be used in this context
-  --> $DIR/cfg-generic-params.rs:15:54
+  --> $DIR/cfg-generic-params.rs:17:54
    |
 LL | struct WhereBad where for<#[cfg(no)] 'a, #[cfg(yes)] T> u8: Copy;
    |                                                      ^
 
 error: cannot find attribute `unknown` in this scope
-  --> $DIR/cfg-generic-params.rs:19:29
+  --> $DIR/cfg-generic-params.rs:21:29
    |
 LL | fn f_lt_yes<#[cfg_attr(yes, unknown)] 'a>() {}
    |                             ^^^^^^^
 
 error: cannot find attribute `unknown` in this scope
-  --> $DIR/cfg-generic-params.rs:22:29
+  --> $DIR/cfg-generic-params.rs:24:29
    |
 LL | fn f_ty_yes<#[cfg_attr(yes, unknown)] T>() {}
    |                             ^^^^^^^
 
 error: cannot find attribute `unknown` in this scope
-  --> $DIR/cfg-generic-params.rs:26:34
+  --> $DIR/cfg-generic-params.rs:28:34
    |
 LL | type FnYes = for<#[cfg_attr(yes, unknown)] 'a> fn();
    |                                  ^^^^^^^
 
 error: cannot find attribute `unknown` in this scope
-  --> $DIR/cfg-generic-params.rs:30:40
+  --> $DIR/cfg-generic-params.rs:33:40
    |
 LL | type PolyYes = dyn for<#[cfg_attr(yes, unknown)] 'a> Copy;
    |                                        ^^^^^^^
 
 error: cannot find attribute `unknown` in this scope
-  --> $DIR/cfg-generic-params.rs:34:43
+  --> $DIR/cfg-generic-params.rs:38:43
    |
 LL | struct WhereYes where for<#[cfg_attr(yes, unknown)] 'a> u8: Copy;
    |                                           ^^^^^^^
 
-error: aborting due to 8 previous errors
+error[E0038]: the trait `Copy` cannot be made into an object
+  --> $DIR/cfg-generic-params.rs:10:17
+   |
+LL | type PolyGood = dyn for<#[cfg(yes)] 'a, #[cfg(no)] T> Copy;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Copy` cannot be made into an object
+   |
+   = note: the trait cannot be made into an object because it requires `Self: Sized`
+   = note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
 
+error[E0038]: the trait `Copy` cannot be made into an object
+  --> $DIR/cfg-generic-params.rs:12:16
+   |
+LL | type PolyBad = dyn for<#[cfg(no)] 'a, #[cfg(yes)] T> Copy;
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Copy` cannot be made into an object
+   |
+   = note: the trait cannot be made into an object because it requires `Self: Sized`
+   = note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+
+error[E0038]: the trait `Copy` cannot be made into an object
+  --> $DIR/cfg-generic-params.rs:31:15
+   |
+LL | type PolyNo = dyn for<#[cfg_attr(no, unknown)] 'a> Copy; // OK
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Copy` cannot be made into an object
+   |
+   = note: the trait cannot be made into an object because it requires `Self: Sized`
+   = note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+
+error[E0038]: the trait `Copy` cannot be made into an object
+  --> $DIR/cfg-generic-params.rs:33:16
+   |
+LL | type PolyYes = dyn for<#[cfg_attr(yes, unknown)] 'a> Copy;
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Copy` cannot be made into an object
+   |
+   = note: the trait cannot be made into an object because it requires `Self: Sized`
+   = note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+
+error: aborting due to 12 previous errors
+
+For more information about this error, try `rustc --explain E0038`.

--- a/src/test/ui/consts/const-eval/pub_const_err.rs
+++ b/src/test/ui/consts/const-eval/pub_const_err.rs
@@ -7,4 +7,5 @@ pub const Z: u32 = 0 - 1;
 //~^ WARN any use of this value will cause an error
 //~| WARN this was previously accepted by the compiler but is being phased out
 
-pub type Foo = [i32; 0 - 1];
+//pub type Foo = [i32; 0 - 1];
+//^ evaluation of constant value failed

--- a/src/test/ui/consts/const-eval/pub_const_err_bin.rs
+++ b/src/test/ui/consts/const-eval/pub_const_err_bin.rs
@@ -5,6 +5,7 @@ pub const Z: u32 = 0 - 1;
 //~^ WARN any use of this value will cause an error
 //~| WARN this was previously accepted by the compiler but is being phased out
 
-pub type Foo = [i32; 0 - 1];
+// pub type Foo = [i32; 0 - 1];
+//^ evaluation of constant value failed
 
 fn main() {}

--- a/src/test/ui/consts/const_let_assign3.rs
+++ b/src/test/ui/consts/const_let_assign3.rs
@@ -17,13 +17,6 @@ const FOO: S = {
     s
 };
 
-type Array = [u32; {
-    let mut x = 2;
-    let y = &mut x; //~ ERROR mutable reference
-    *y = 42;
-    *y
-}];
-
 fn main() {
     assert_eq!(FOO.state, 3);
 }

--- a/src/test/ui/consts/const_let_assign3.stderr
+++ b/src/test/ui/consts/const_let_assign3.stderr
@@ -16,15 +16,6 @@ LL |     s.foo(3);
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
-error[E0658]: mutable references are not allowed in constants
-  --> $DIR/const_let_assign3.rs:22:13
-   |
-LL |     let y = &mut x;
-   |             ^^^^^^
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/consts/const_let_assign4.rs
+++ b/src/test/ui/consts/const_let_assign4.rs
@@ -1,0 +1,31 @@
+#![feature(const_fn)]
+
+struct S {
+    state: u32,
+}
+
+impl S {
+    const fn foo(&mut self, x: u32) {
+        self.state = x;
+    }
+}
+
+const FOO: S = {
+    let mut s = S { state: 42 };
+    s.foo(3);
+    s
+};
+// The `impl` and `const` would error out if the following `type` was correct.
+// See `const_let_assignment3.rs`.
+
+type Array = [u32; {
+    let mut x = 2;
+    let y = &mut x;
+    //~^ ERROR mutable references are not allowed in constants
+    *y = 42;
+    *y
+}];
+
+fn main() {
+    assert_eq!(FOO.state, 3);
+}

--- a/src/test/ui/consts/const_let_assign4.stderr
+++ b/src/test/ui/consts/const_let_assign4.stderr
@@ -1,0 +1,12 @@
+error[E0658]: mutable references are not allowed in constants
+  --> $DIR/const_let_assign4.rs:23:13
+   |
+LL |     let y = &mut x;
+   |             ^^^^^^
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gates/feature-gate-trivial_bounds.rs
+++ b/src/test/ui/feature-gates/feature-gate-trivial_bounds.rs
@@ -15,7 +15,7 @@ trait T where i32: Foo {} //~ ERROR
 
 union U where i32: Foo { f: i32 } //~ ERROR
 
-type Y where i32: Foo = (); // OK - bound is ignored
+type Y where i32: Foo = (); //~ ERROR
 
 impl Foo for () where i32: Foo { //~ ERROR
     fn test(&self) {

--- a/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
+++ b/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
@@ -35,6 +35,15 @@ LL | union U where i32: Foo { f: i32 }
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
+  --> $DIR/feature-gate-trivial_bounds.rs:18:25
+   |
+LL | type Y where i32: Foo = ();
+   |                         ^^ the trait `Foo` is not implemented for `i32`
+   |
+   = help: see issue #48214
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+
+error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/feature-gate-trivial_bounds.rs:20:1
    |
 LL | / impl Foo for () where i32: Foo {
@@ -123,6 +132,6 @@ LL | | }
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
-error: aborting due to 11 previous errors
+error: aborting due to 12 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/hygiene/assoc_ty_bindings.rs
+++ b/src/test/ui/hygiene/assoc_ty_bindings.rs
@@ -5,10 +5,10 @@
 
 trait Base {
     type AssocTy;
-    fn f();
+    fn f(&self);
 }
 trait Derived: Base {
-    fn g();
+    fn g(&self);
 }
 
 macro mac() {
@@ -17,12 +17,12 @@ macro mac() {
 
     impl Base for u8 {
         type AssocTy = u8;
-        fn f() {
+        fn f(&self) {
             let _: Self::AssocTy;
         }
     }
     impl Derived for u8 {
-        fn g() {
+        fn g(&self) {
             let _: Self::AssocTy;
         }
     }

--- a/src/test/ui/resolve/issue-3907-2.rs
+++ b/src/test/ui/resolve/issue-3907-2.rs
@@ -2,13 +2,12 @@
 
 extern crate issue_3907;
 
-type Foo = dyn issue_3907::Foo + 'static;
+type Foo = dyn issue_3907::Foo + 'static; //~ ERROR E0038
 
 struct S {
     name: isize
 }
 
-fn bar(_x: Foo) {}
-//~^ ERROR E0038
+fn bar(_x: Foo) {} //~ ERROR E0038
 
 fn main() {}

--- a/src/test/ui/resolve/issue-3907-2.stderr
+++ b/src/test/ui/resolve/issue-3907-2.stderr
@@ -1,4 +1,16 @@
 error[E0038]: the trait `issue_3907::Foo` cannot be made into an object
+  --> $DIR/issue-3907-2.rs:5:12
+   |
+LL | type Foo = dyn issue_3907::Foo + 'static;
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `issue_3907::Foo` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/auxiliary/issue-3907.rs:2:8
+   |
+LL |     fn bar();
+   |        ^^^ the trait cannot be made into an object because associated function `bar` has no `self` parameter
+
+error[E0038]: the trait `issue_3907::Foo` cannot be made into an object
   --> $DIR/issue-3907-2.rs:11:12
    |
 LL | fn bar(_x: Foo) {}
@@ -10,6 +22,6 @@ note: for a trait to be "object safe" it needs to allow building a vtable to all
 LL |     fn bar();
    |        ^^^ the trait cannot be made into an object because associated function `bar` has no `self` parameter
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/src/test/ui/structs/struct-path-alias-bounds.rs
+++ b/src/test/ui/structs/struct-path-alias-bounds.rs
@@ -3,9 +3,8 @@
 struct S<T: Clone> { a: T }
 
 struct NoClone;
-type A = S<NoClone>;
+type A = S<NoClone>; //~ ERROR the trait bound `NoClone: Clone` is not satisfied
 
 fn main() {
     let s = A { a: NoClone };
-    //~^ ERROR the trait bound `NoClone: Clone` is not satisfied
 }

--- a/src/test/ui/structs/struct-path-alias-bounds.stderr
+++ b/src/test/ui/structs/struct-path-alias-bounds.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `NoClone: Clone` is not satisfied
-  --> $DIR/struct-path-alias-bounds.rs:9:13
+  --> $DIR/struct-path-alias-bounds.rs:6:10
    |
 LL | struct S<T: Clone> { a: T }
-   | ------------------ required by `S`
+   |             ----- required by this bound in `S`
 ...
-LL |     let s = A { a: NoClone };
-   |             ^ the trait `Clone` is not implemented for `NoClone`
+LL | type A = S<NoClone>;
+   |          ^^^^^^^^^^ the trait `Clone` is not implemented for `NoClone`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
- Start performing a WF-check on `type`s without type parameters to verify that they will be able to be constructed.
- Do *not* perform a `Sized` check, as `type T = dyn Trait;` should be allowed.
- Do *not* WF-check `type`s with type parameters because we currently lint *against* `type T<X: Trait> = K<X>;` because we do not propagate `X: Trait`, which means that we currently allow `type T<X> = <X as Trait>::Foo;`, which would be rejected if we WF-checked it because it would need to be written as `type T<X: Trait> = <X as Trait>::Foo;` to be correct.

   Instead, we simply don't check it at definition and only do so at use like we do currently. In the future, the alternatives would be to either automatically backpropagate the `X: Trait` obligation when WF-checking the `type` or (my preferred solution) properly propagate the explicit `X: Trait` obligation to the uses, which would likely be a breaking change.

Fixes #60980 by using a more appropriate span for the error.