### PR TITLE
Fixed a typo

### DIFF
--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -407,7 +407,7 @@ impl String {
     ///
     /// assert_eq!(s.capacity(), cap);
     ///
-    /// // ...but this may make the vector reallocate
+    /// // ...but this may make the string reallocate
     /// s.push('a');
     /// ```
     #[inline]


### PR DESCRIPTION
"vector" was used instead of "string". I think this is a typo?