### PR TITLE
Use `PredicateObligation`s instead of `Predicate`s

### DIFF
--- a/src/librustc_infer/infer/outlives/verify.rs
+++ b/src/librustc_infer/infer/outlives/verify.rs
@@ -296,7 +296,10 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
         let identity_proj = tcx.mk_projection(assoc_item_def_id, identity_substs);
         self.collect_outlives_from_predicate_list(
             move |ty| ty == identity_proj,
-            traits::elaborate_predicates(tcx, trait_predicates),
+            traits::elaborate_predicates(tcx, trait_predicates)
+                .into_iter()
+                .map(|o| o.predicate)
+                .collect::<Vec<_>>(),
         )
         .map(|b| b.1)
     }

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -126,7 +126,7 @@ impl<'tcx> MirPass<'tcx> for ConstProp {
             .collect();
         if !traits::normalize_and_test_predicates(
             tcx,
-            traits::elaborate_predicates(tcx, predicates).collect(),
+            traits::elaborate_predicates(tcx, predicates).map(|o| o.predicate).collect(),
         ) {
             trace!("ConstProp skipped for {:?}: found unsatisfiable predicates", source.def_id());
             return;

--- a/src/librustc_trait_selection/opaque_types.rs
+++ b/src/librustc_trait_selection/opaque_types.rs
@@ -1255,8 +1255,8 @@ crate fn required_region_bounds(
     assert!(!erased_self_ty.has_escaping_bound_vars());
 
     traits::elaborate_predicates(tcx, predicates)
-        .filter_map(|predicate| {
-            match predicate {
+        .filter_map(|obligation| {
+            match obligation.predicate {
                 ty::Predicate::Projection(..)
                 | ty::Predicate::Trait(..)
                 | ty::Predicate::Subtype(..)

--- a/src/librustc_trait_selection/traits/auto_trait.rs
+++ b/src/librustc_trait_selection/traits/auto_trait.rs
@@ -366,7 +366,8 @@ impl AutoTraitFinder<'tcx> {
 
             computed_preds.extend(user_computed_preds.iter().cloned());
             let normalized_preds =
-                elaborate_predicates(tcx, computed_preds.iter().cloned().collect());
+                elaborate_predicates(tcx, computed_preds.iter().cloned().collect())
+                    .map(|o| o.predicate);
             new_env =
                 ty::ParamEnv::new(tcx.mk_predicates(normalized_preds), param_env.reveal, None);
         }

--- a/src/librustc_trait_selection/traits/error_reporting/mod.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/mod.rs
@@ -1387,7 +1387,9 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
                     (self.tcx.sess.source_map().span_to_snippet(span), &obligation.cause.code)
                 {
                     let generics = self.tcx.generics_of(*def_id);
-                    if generics.params.iter().filter(|p| p.name.as_str() != "Self").next().is_some() && !snippet.ends_with('>') {
+                    if generics.params.iter().filter(|p| p.name.as_str() != "Self").next().is_some()
+                        && !snippet.ends_with('>')
+                    {
                         // FIXME: To avoid spurious suggestions in functions where type arguments
                         // where already supplied, we check the snippet to make sure it doesn't
                         // end with a turbofish. Ideally we would have access to a `PathSegment`
@@ -1405,7 +1407,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
                         //    |                        `Tt::const_val::<[i8; 123]>::<T>`
                         // ...
                         // LL |     const fn const_val<T: Sized>() -> usize {
-                        //    |              --------- - required by this bound in `Tt::const_val`
+                        //    |                        - required by this bound in `Tt::const_val`
                         //    |
                         //    = note: cannot satisfy `_: Tt`
 

--- a/src/librustc_trait_selection/traits/error_reporting/mod.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/mod.rs
@@ -976,8 +976,8 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
             }
         };
 
-        for implication in super::elaborate_predicates(self.tcx, vec![*cond]) {
-            if let ty::Predicate::Trait(implication, _) = implication {
+        for obligation in super::elaborate_predicates(self.tcx, vec![*cond]) {
+            if let ty::Predicate::Trait(implication, _) = obligation.predicate {
                 let error = error.to_poly_trait_ref();
                 let implication = implication.to_poly_trait_ref();
                 // FIXME: I'm just not taking associated types at all here.
@@ -1387,7 +1387,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
                     (self.tcx.sess.source_map().span_to_snippet(span), &obligation.cause.code)
                 {
                     let generics = self.tcx.generics_of(*def_id);
-                    if !generics.params.is_empty() && !snippet.ends_with('>') {
+                    if generics.params.iter().filter(|p| p.name.as_str() != "Self").next().is_some() && !snippet.ends_with('>') {
                         // FIXME: To avoid spurious suggestions in functions where type arguments
                         // where already supplied, we check the snippet to make sure it doesn't
                         // end with a turbofish. Ideally we would have access to a `PathSegment`

--- a/src/librustc_trait_selection/traits/error_reporting/on_unimplemented.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/on_unimplemented.rs
@@ -142,7 +142,9 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             }
         }
 
-        if let ObligationCauseCode::ItemObligation(item) = obligation.cause.code {
+        if let ObligationCauseCode::ItemObligation(item)
+        | ObligationCauseCode::BindingObligation(item, _) = obligation.cause.code
+        {
             // FIXME: maybe also have some way of handling methods
             // from other traits? That would require name resolution,
             // which we might want to be some sort of hygienic.

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -1345,7 +1345,6 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             ObligationCauseCode::ItemObligation(item_def_id) => {
                 let item_name = tcx.def_path_str(item_def_id);
                 let msg = format!("required by `{}`", item_name);
-
                 if let Some(sp) = tcx.hir().span_if_local(item_def_id) {
                     let sp = tcx.sess.source_map().guess_head_span(sp);
                     err.span_label(sp, &msg);
@@ -1357,7 +1356,9 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 let item_name = tcx.def_path_str(item_def_id);
                 let msg = format!("required by this bound in `{}`", item_name);
                 if let Some(ident) = tcx.opt_item_name(item_def_id) {
-                    err.span_label(ident.span, "");
+                    if !ident.span.overlaps(span) {
+                        err.span_label(ident.span, "");
+                    }
                 }
                 if span != DUMMY_SP {
                     err.span_label(span, &msg);

--- a/src/librustc_trait_selection/traits/mod.rs
+++ b/src/librustc_trait_selection/traits/mod.rs
@@ -297,7 +297,9 @@ pub fn normalize_param_env_or_error<'tcx>(
     );
 
     let mut predicates: Vec<_> =
-        util::elaborate_predicates(tcx, unnormalized_env.caller_bounds.to_vec()).collect();
+        util::elaborate_predicates(tcx, unnormalized_env.caller_bounds.to_vec())
+            .map(|obligation| obligation.predicate)
+            .collect();
 
     debug!("normalize_param_env_or_error: elaborated-predicates={:?}", predicates);
 

--- a/src/librustc_trait_selection/traits/object_safety.rs
+++ b/src/librustc_trait_selection/traits/object_safety.rs
@@ -298,7 +298,7 @@ fn generics_require_sized_self(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
     // Search for a predicate like `Self : Sized` amongst the trait bounds.
     let predicates = tcx.predicates_of(def_id);
     let predicates = predicates.instantiate_identity(tcx).predicates;
-    elaborate_predicates(tcx, predicates).any(|predicate| match predicate {
+    elaborate_predicates(tcx, predicates).any(|obligation| match obligation.predicate {
         ty::Predicate::Trait(ref trait_pred, _) => {
             trait_pred.def_id() == sized_def_id && trait_pred.skip_binder().self_ty().is_param(0)
         }

--- a/src/librustc_trait_selection/traits/project.rs
+++ b/src/librustc_trait_selection/traits/project.rs
@@ -900,7 +900,7 @@ fn assemble_candidates_from_trait_def<'cx, 'tcx>(
     // If so, extract what we know from the trait and try to come up with a good answer.
     let trait_predicates = tcx.predicates_of(def_id);
     let bounds = trait_predicates.instantiate(tcx, substs);
-    let bounds = elaborate_predicates(tcx, bounds.predicates);
+    let bounds = elaborate_predicates(tcx, bounds.predicates).map(|o| o.predicate);
     assemble_candidates_from_predicates(
         selcx,
         obligation,
@@ -1162,7 +1162,7 @@ fn confirm_object_candidate<'cx, 'tcx>(
 
         // select only those projections that are actually projecting an
         // item with the correct name
-        let env_predicates = env_predicates.filter_map(|p| match p {
+        let env_predicates = env_predicates.filter_map(|o| match o.predicate {
             ty::Predicate::Projection(data) => {
                 if data.projection_def_id() == obligation.predicate.item_def_id {
                     Some(data)

--- a/src/librustc_trait_selection/traits/wf.rs
+++ b/src/librustc_trait_selection/traits/wf.rs
@@ -312,19 +312,18 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
         let item = self.item;
 
         if let Elaborate::All = elaborate {
-            let predicates = obligations.iter().map(|obligation| obligation.predicate).collect();
-            let implied_obligations = traits::elaborate_predicates(tcx, predicates);
-            let implied_obligations = implied_obligations.map(|pred| {
+            let implied_obligations = traits::util::elaborate_obligations(tcx, obligations.clone());
+            let implied_obligations = implied_obligations.map(|obligation| {
                 let mut cause = cause.clone();
                 extend_cause_with_original_assoc_item_obligation(
                     tcx,
                     trait_ref,
                     item,
                     &mut cause,
-                    &pred,
+                    &obligation.predicate,
                     tcx.associated_items(trait_ref.def_id).in_definition_order().copied(),
                 );
-                traits::Obligation::new(cause, param_env, pred)
+                traits::Obligation::new(cause, param_env, obligation.predicate)
             });
             self.out.extend(implied_obligations);
         }
@@ -613,11 +612,14 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
         substs: SubstsRef<'tcx>,
     ) -> Vec<traits::PredicateObligation<'tcx>> {
         let predicates = self.infcx.tcx.predicates_of(def_id).instantiate(self.infcx.tcx, substs);
-        let cause = self.cause(traits::ItemObligation(def_id));
         predicates
             .predicates
             .into_iter()
-            .map(|pred| traits::Obligation::new(cause.clone(), self.param_env, pred))
+            .zip(predicates.spans.into_iter())
+            .map(|(pred, span)| {
+                let cause = self.cause(traits::BindingObligation(def_id, span));
+                traits::Obligation::new(cause, self.param_env, pred)
+            })
             .filter(|pred| !pred.has_escaping_bound_vars())
             .collect()
     }

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1601,12 +1601,12 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         for (base_trait_ref, span, constness) in regular_traits_refs_spans {
             assert_eq!(constness, Constness::NotConst);
 
-            for trait_ref in traits::elaborate_trait_ref(tcx, base_trait_ref) {
+            for obligation in traits::elaborate_trait_ref(tcx, base_trait_ref) {
                 debug!(
                     "conv_object_ty_poly_trait_ref: observing object predicate `{:?}`",
-                    trait_ref
+                    obligation.predicate
                 );
-                match trait_ref {
+                match obligation.predicate {
                     ty::Predicate::Trait(pred, _) => {
                         associated_types.entry(span).or_default().extend(
                             tcx.associated_items(pred.def_id())

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -573,13 +573,15 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
         };
 
         traits::elaborate_predicates(self.tcx, predicates.predicates.clone())
-            .filter_map(|predicate| match predicate {
+            .filter_map(|obligation| match obligation.predicate {
                 ty::Predicate::Trait(trait_pred, _) if trait_pred.def_id() == sized_def_id => {
                     let span = predicates
                         .predicates
                         .iter()
                         .zip(predicates.spans.iter())
-                        .filter_map(|(p, span)| if *p == predicate { Some(*span) } else { None })
+                        .filter_map(
+                            |(p, span)| if *p == obligation.predicate { Some(*span) } else { None },
+                        )
                         .next()
                         .unwrap_or(rustc_span::DUMMY_SP);
                     Some((trait_pred, span))

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -1226,7 +1226,8 @@ fn check_false_global_bounds(fcx: &FnCtxt<'_, '_>, span: Span, id: hir::HirId) {
     // Check elaborated bounds.
     let implied_obligations = traits::elaborate_predicates(fcx.tcx, predicates);
 
-    for pred in implied_obligations {
+    for obligation in implied_obligations {
+        let pred = obligation.predicate;
         // Match the existing behavior.
         if pred.is_global() && !pred.has_late_bound_regions() {
             let pred = fcx.normalize_associated_types_in(span, &pred);

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1650,7 +1650,7 @@ fn predicates_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::GenericPredicates<'_> {
         // prove that the trait applies to the types that were
         // used, and adding the predicate into this list ensures
         // that this is done.
-        let span = tcx.def_span(def_id);
+        let span = tcx.sess.source_map().guess_head_span(tcx.def_span(def_id));
         result.predicates =
             tcx.arena.alloc_from_iter(result.predicates.iter().copied().chain(std::iter::once((
                 ty::TraitRef::identity(tcx, def_id).without_const().to_predicate(),

--- a/src/librustc_typeck/impl_wf_check/min_specialization.rs
+++ b/src/librustc_typeck/impl_wf_check/min_specialization.rs
@@ -348,7 +348,10 @@ fn check_predicates<'tcx>(
                 .extend(obligations.into_iter().map(|obligation| obligation.predicate))
         }
     }
-    impl2_predicates.predicates.extend(traits::elaborate_predicates(tcx, always_applicable_traits));
+    impl2_predicates.predicates.extend(
+        traits::elaborate_predicates(tcx, always_applicable_traits)
+            .map(|obligation| obligation.predicate),
+    );
 
     for predicate in impl1_predicates.predicates {
         if !impl2_predicates.predicates.contains(&predicate) {

--- a/src/test/ui/anonymous-higher-ranked-lifetime.stderr
+++ b/src/test/ui/anonymous-higher-ranked-lifetime.stderr
@@ -7,7 +7,7 @@ LL |     f1(|_: (), _: ()| {});
    |     expected signature of `for<'r, 's> fn(&'r (), &'s ()) -> _`
 ...
 LL | fn f1<F>(_: F) where F: Fn(&(), &()) {}
-   |    --                   ------------ required by this bound in `f1`
+   |                         ------------ required by this bound in `f1`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:3:5
@@ -18,7 +18,7 @@ LL |     f2(|_: (), _: ()| {});
    |     expected signature of `for<'a, 'r> fn(&'a (), &'r ()) -> _`
 ...
 LL | fn f2<F>(_: F) where F: for<'a> Fn(&'a (), &()) {}
-   |    --                   ----------------------- required by this bound in `f2`
+   |                         ----------------------- required by this bound in `f2`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:4:5
@@ -29,7 +29,7 @@ LL |     f3(|_: (), _: ()| {});
    |     expected signature of `for<'r> fn(&(), &'r ()) -> _`
 ...
 LL | fn f3<'a, F>(_: F) where F: Fn(&'a (), &()) {}
-   |    --                       --------------- required by this bound in `f3`
+   |                             --------------- required by this bound in `f3`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:5:5
@@ -40,7 +40,7 @@ LL |     f4(|_: (), _: ()| {});
    |     expected signature of `for<'s, 'r> fn(&'s (), &'r ()) -> _`
 ...
 LL | fn f4<F>(_: F) where F: for<'r> Fn(&(), &'r ()) {}
-   |    --                   ----------------------- required by this bound in `f4`
+   |                         ----------------------- required by this bound in `f4`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:6:5
@@ -51,7 +51,7 @@ LL |     f5(|_: (), _: ()| {});
    |     expected signature of `for<'r> fn(&'r (), &'r ()) -> _`
 ...
 LL | fn f5<F>(_: F) where F: for<'r> Fn(&'r (), &'r ()) {}
-   |    --                   -------------------------- required by this bound in `f5`
+   |                         -------------------------- required by this bound in `f5`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:7:5
@@ -62,7 +62,7 @@ LL |     g1(|_: (), _: ()| {});
    |     expected signature of `for<'r> fn(&'r (), std::boxed::Box<(dyn for<'s> std::ops::Fn(&'s ()) + 'static)>) -> _`
 ...
 LL | fn g1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>) {}
-   |    --                   ------------------------- required by this bound in `g1`
+   |                         ------------------------- required by this bound in `g1`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:8:5
@@ -73,7 +73,7 @@ LL |     g2(|_: (), _: ()| {});
    |     expected signature of `for<'r> fn(&'r (), for<'s> fn(&'s ())) -> _`
 ...
 LL | fn g2<F>(_: F) where F: Fn(&(), fn(&())) {}
-   |    --                   ---------------- required by this bound in `g2`
+   |                         ---------------- required by this bound in `g2`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:9:5
@@ -84,7 +84,7 @@ LL |     g3(|_: (), _: ()| {});
    |     expected signature of `for<'s> fn(&'s (), std::boxed::Box<(dyn for<'r> std::ops::Fn(&'r ()) + 'static)>) -> _`
 ...
 LL | fn g3<F>(_: F) where F: for<'s> Fn(&'s (), Box<dyn Fn(&())>) {}
-   |    --                   ------------------------------------ required by this bound in `g3`
+   |                         ------------------------------------ required by this bound in `g3`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:10:5
@@ -95,7 +95,7 @@ LL |     g4(|_: (), _: ()| {});
    |     expected signature of `for<'s> fn(&'s (), for<'r> fn(&'r ())) -> _`
 ...
 LL | fn g4<F>(_: F) where F: Fn(&(), for<'r> fn(&'r ())) {}
-   |    --                   --------------------------- required by this bound in `g4`
+   |                         --------------------------- required by this bound in `g4`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:11:5
@@ -106,7 +106,7 @@ LL |     h1(|_: (), _: (), _: (), _: ()| {});
    |     expected signature of `for<'r, 's> fn(&'r (), std::boxed::Box<(dyn for<'t0> std::ops::Fn(&'t0 ()) + 'static)>, &'s (), for<'t0, 't1> fn(&'t0 (), &'t1 ())) -> _`
 ...
 LL | fn h1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>, &(), fn(&(), &())) {}
-   |    --                   -------------------------------------------- required by this bound in `h1`
+   |                         -------------------------------------------- required by this bound in `h1`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:12:5
@@ -117,7 +117,7 @@ LL |     h2(|_: (), _: (), _: (), _: ()| {});
    |     expected signature of `for<'r, 't0> fn(&'r (), std::boxed::Box<(dyn for<'s> std::ops::Fn(&'s ()) + 'static)>, &'t0 (), for<'s, 't1> fn(&'s (), &'t1 ())) -> _`
 ...
 LL | fn h2<F>(_: F) where F: for<'t0> Fn(&(), Box<dyn Fn(&())>, &'t0 (), fn(&(), &())) {}
-   |    --                   --------------------------------------------------------- required by this bound in `h2`
+   |                         --------------------------------------------------------- required by this bound in `h2`
 
 error: aborting due to 11 previous errors
 

--- a/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
+++ b/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
@@ -20,7 +20,10 @@ error[E0277]: `<<T as Case1>::C as std::iter::Iterator>::Item` cannot be sent be
   --> $DIR/bad-bounds-on-assoc-in-trait.rs:36:20
    |
 LL | trait Case1 {
-   | ----------- required by `Case1`
+   |       -----
+LL |     type C: Clone + Iterator<Item:
+LL |         Send + Iterator<Item:
+   |         ---- required by this bound in `Case1`
 ...
 LL | fn assume_case1<T: Case1>() {
    |                    ^^^^^   - help: consider further restricting the associated type: `where <<T as Case1>::C as std::iter::Iterator>::Item: std::marker::Send`
@@ -33,7 +36,10 @@ error[E0277]: `<<T as Case1>::C as std::iter::Iterator>::Item` cannot be shared 
   --> $DIR/bad-bounds-on-assoc-in-trait.rs:36:20
    |
 LL | trait Case1 {
-   | ----------- required by `Case1`
+   |       -----
+...
+LL |         > + Sync>;
+   |             ---- required by this bound in `Case1`
 ...
 LL | fn assume_case1<T: Case1>() {
    |                    ^^^^^   - help: consider further restricting the associated type: `where <<T as Case1>::C as std::iter::Iterator>::Item: std::marker::Sync`
@@ -46,7 +52,10 @@ error[E0277]: `<_ as Lam<&'a u8>>::App` doesn't implement `std::fmt::Debug`
   --> $DIR/bad-bounds-on-assoc-in-trait.rs:36:20
    |
 LL | trait Case1 {
-   | ----------- required by `Case1`
+   |       -----
+...
+LL |                 Debug
+   |                 ----- required by this bound in `Case1`
 ...
 LL | fn assume_case1<T: Case1>() {
    |                    ^^^^^ `<_ as Lam<&'a u8>>::App` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`

--- a/src/test/ui/associated-types/associated-types-binding-to-type-defined-in-supertrait.stderr
+++ b/src/test/ui/associated-types/associated-types-binding-to-type-defined-in-supertrait.stderr
@@ -2,7 +2,7 @@ error[E0271]: type mismatch resolving `<ModelT as Vehicle>::Color == Blue`
   --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:31:10
    |
 LL | fn blue_car<C:Car<Color=Blue>>(c: C) {
-   |    --------       ---------- required by this bound in `blue_car`
+   |                   ---------- required by this bound in `blue_car`
 ...
 LL | fn b() { blue_car(ModelT); }
    |          ^^^^^^^^ expected struct `Blue`, found struct `Black`
@@ -11,7 +11,7 @@ error[E0271]: type mismatch resolving `<ModelU as Vehicle>::Color == Black`
   --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:32:10
    |
 LL | fn black_car<C:Car<Color=Black>>(c: C) {
-   |    ---------       ----------- required by this bound in `black_car`
+   |                    ----------- required by this bound in `black_car`
 ...
 LL | fn c() { black_car(ModelU); }
    |          ^^^^^^^^^ expected struct `Black`, found struct `Blue`

--- a/src/test/ui/associated-types/associated-types-eq-3.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-3.stderr
@@ -15,7 +15,7 @@ error[E0271]: type mismatch resolving `<isize as Foo>::A == Bar`
   --> $DIR/associated-types-eq-3.rs:38:5
    |
 LL | fn foo1<I: Foo<A=Bar>>(x: I) {
-   |    ----        ----- required by this bound in `foo1`
+   |                ----- required by this bound in `foo1`
 ...
 LL |     foo1(a);
    |     ^^^^ expected struct `Bar`, found `usize`

--- a/src/test/ui/associated-types/associated-types-issue-20346.stderr
+++ b/src/test/ui/associated-types/associated-types-issue-20346.stderr
@@ -2,7 +2,7 @@ error[E0271]: type mismatch resolving `<Adapter<I> as Iterator>::Item == std::op
   --> $DIR/associated-types-issue-20346.rs:34:5
    |
 LL | fn is_iterator_of<A, I: Iterator<Item=A>>(_: &I) {}
-   |    --------------                ------ required by this bound in `is_iterator_of`
+   |                                  ------ required by this bound in `is_iterator_of`
 ...
 LL | fn test_adapter<T, I: Iterator<Item=Option<T>>>(it: I) {
    |                 - this type parameter

--- a/src/test/ui/associated-types/associated-types-multiple-types-one-trait.stderr
+++ b/src/test/ui/associated-types/associated-types-multiple-types-one-trait.stderr
@@ -5,7 +5,7 @@ LL |     want_y(t);
    |     ^^^^^^ expected `i32`, found associated type
 ...
 LL | fn want_y<T:Foo<Y=i32>>(t: &T) { }
-   |    ------       ----- required by this bound in `want_y`
+   |                 ----- required by this bound in `want_y`
    |
    = note:         expected type `i32`
            found associated type `<T as Foo>::Y`
@@ -19,7 +19,7 @@ LL |     want_x(t);
    |     ^^^^^^ expected `u32`, found associated type
 ...
 LL | fn want_x<T:Foo<X=u32>>(t: &T) { }
-   |    ------       ----- required by this bound in `want_x`
+   |                 ----- required by this bound in `want_x`
    |
    = note:         expected type `u32`
            found associated type `<T as Foo>::X`

--- a/src/test/ui/associated-types/associated-types-overridden-binding.stderr
+++ b/src/test/ui/associated-types/associated-types-overridden-binding.stderr
@@ -2,7 +2,7 @@ error[E0284]: type annotations needed
   --> $DIR/associated-types-overridden-binding.rs:4:12
    |
 LL | trait Foo: Iterator<Item = i32> {}
-   | ------------------------------- required by `Foo`
+   |       ---           ---------- required by this bound in `Foo`
 LL | trait Bar: Foo<Item = u32> {}
    |            ^^^^^^^^^^^^^^^ cannot infer type for type parameter `Self`
    |
@@ -12,7 +12,7 @@ error[E0284]: type annotations needed
   --> $DIR/associated-types-overridden-binding.rs:7:21
    |
 LL | trait I32Iterator = Iterator<Item = i32>;
-   | ----------------------------------------- required by `I32Iterator`
+   |       -----------            ---------- required by this bound in `I32Iterator`
 LL | trait U32Iterator = I32Iterator<Item = u32>;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `Self`
    |

--- a/src/test/ui/associated-types/associated-types-overridden-binding.stderr
+++ b/src/test/ui/associated-types/associated-types-overridden-binding.stderr
@@ -2,7 +2,7 @@ error[E0284]: type annotations needed
   --> $DIR/associated-types-overridden-binding.rs:4:12
    |
 LL | trait Foo: Iterator<Item = i32> {}
-   |       ---           ---------- required by this bound in `Foo`
+   |                     ---------- required by this bound in `Foo`
 LL | trait Bar: Foo<Item = u32> {}
    |            ^^^^^^^^^^^^^^^ cannot infer type for type parameter `Self`
    |
@@ -12,7 +12,7 @@ error[E0284]: type annotations needed
   --> $DIR/associated-types-overridden-binding.rs:7:21
    |
 LL | trait I32Iterator = Iterator<Item = i32>;
-   |       -----------            ---------- required by this bound in `I32Iterator`
+   |                              ---------- required by this bound in `I32Iterator`
 LL | trait U32Iterator = I32Iterator<Item = u32>;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `Self`
    |

--- a/src/test/ui/associated-types/associated-types-path-2.stderr
+++ b/src/test/ui/associated-types/associated-types-path-2.stderr
@@ -13,7 +13,7 @@ error[E0277]: the trait bound `u32: Foo` is not satisfied
   --> $DIR/associated-types-path-2.rs:29:5
    |
 LL | pub fn f1<T: Foo>(a: T, x: T::A) {}
-   |        --    --- required by this bound in `f1`
+   |              --- required by this bound in `f1`
 ...
 LL |     f1(2u32, 4u32);
    |     ^^ the trait `Foo` is not implemented for `u32`
@@ -28,7 +28,7 @@ error[E0277]: the trait bound `u32: Foo` is not satisfied
   --> $DIR/associated-types-path-2.rs:35:5
    |
 LL | pub fn f1<T: Foo>(a: T, x: T::A) {}
-   |        --    --- required by this bound in `f1`
+   |              --- required by this bound in `f1`
 ...
 LL |     f1(2u32, 4i32);
    |     ^^ the trait `Foo` is not implemented for `u32`

--- a/src/test/ui/associated-types/defaults-suitability.stderr
+++ b/src/test/ui/associated-types/defaults-suitability.stderr
@@ -128,10 +128,14 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |
 LL |     type Ty = Vec<[u8]>;
    |     ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   | 
+  ::: $SRC_DIR/liballoc/vec.rs:LL:COL
+   |
+LL | pub struct Vec<T> {
+   |                - required by this bound in `std::vec::Vec`
    |
    = help: the trait `std::marker::Sized` is not implemented for `[u8]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required by `std::vec::Vec`
 
 error: aborting due to 11 previous errors
 

--- a/src/test/ui/async-await/async-fn-nonsend.stderr
+++ b/src/test/ui/async-await/async-fn-nonsend.stderr
@@ -2,7 +2,7 @@ error: future cannot be sent between threads safely
   --> $DIR/async-fn-nonsend.rs:49:5
    |
 LL | fn assert_send(_: impl Send) {}
-   |    -----------         ---- required by this bound in `assert_send`
+   |                        ---- required by this bound in `assert_send`
 ...
 LL |     assert_send(local_dropped_before_await());
    |     ^^^^^^^^^^^ future returned by `local_dropped_before_await` is not `Send`
@@ -23,7 +23,7 @@ error: future cannot be sent between threads safely
   --> $DIR/async-fn-nonsend.rs:51:5
    |
 LL | fn assert_send(_: impl Send) {}
-   |    -----------         ---- required by this bound in `assert_send`
+   |                        ---- required by this bound in `assert_send`
 ...
 LL |     assert_send(non_send_temporary_in_match());
    |     ^^^^^^^^^^^ future returned by `non_send_temporary_in_match` is not `Send`
@@ -44,7 +44,7 @@ error: future cannot be sent between threads safely
   --> $DIR/async-fn-nonsend.rs:53:5
    |
 LL | fn assert_send(_: impl Send) {}
-   |    -----------         ---- required by this bound in `assert_send`
+   |                        ---- required by this bound in `assert_send`
 ...
 LL |     assert_send(non_sync_with_method_call());
    |     ^^^^^^^^^^^ future returned by `non_sync_with_method_call` is not `Send`

--- a/src/test/ui/async-await/issue-64130-1-sync.stderr
+++ b/src/test/ui/async-await/issue-64130-1-sync.stderr
@@ -2,7 +2,7 @@ error: future cannot be shared between threads safely
   --> $DIR/issue-64130-1-sync.rs:21:5
    |
 LL | fn is_sync<T: Sync>(t: T) { }
-   |    -------    ---- required by this bound in `is_sync`
+   |               ---- required by this bound in `is_sync`
 ...
 LL |     is_sync(bar());
    |     ^^^^^^^ future returned by `bar` is not `Sync`

--- a/src/test/ui/async-await/issue-64130-2-send.stderr
+++ b/src/test/ui/async-await/issue-64130-2-send.stderr
@@ -2,7 +2,7 @@ error: future cannot be sent between threads safely
   --> $DIR/issue-64130-2-send.rs:21:5
    |
 LL | fn is_send<T: Send>(t: T) { }
-   |    -------    ---- required by this bound in `is_send`
+   |               ---- required by this bound in `is_send`
 ...
 LL |     is_send(bar());
    |     ^^^^^^^ future returned by `bar` is not `Send`

--- a/src/test/ui/async-await/issue-64130-3-other.stderr
+++ b/src/test/ui/async-await/issue-64130-3-other.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Foo: Qux` is not satisfied in `impl std::future::
   --> $DIR/issue-64130-3-other.rs:24:5
    |
 LL | fn is_qux<T: Qux>(t: T) { }
-   |    ------    --- required by this bound in `is_qux`
+   |              --- required by this bound in `is_qux`
 LL | 
 LL | async fn bar() {
    |                - within this `impl std::future::Future`

--- a/src/test/ui/async-await/issue-64130-non-send-future-diags.stderr
+++ b/src/test/ui/async-await/issue-64130-non-send-future-diags.stderr
@@ -2,7 +2,7 @@ error: future cannot be sent between threads safely
   --> $DIR/issue-64130-non-send-future-diags.rs:21:5
    |
 LL | fn is_send<T: Send>(t: T) { }
-   |    -------    ---- required by this bound in `is_send`
+   |               ---- required by this bound in `is_send`
 ...
 LL |     is_send(foo());
    |     ^^^^^^^ future returned by `foo` is not `Send`

--- a/src/test/ui/async-await/issue-67252-unnamed-future.stderr
+++ b/src/test/ui/async-await/issue-67252-unnamed-future.stderr
@@ -2,7 +2,7 @@ error: future cannot be sent between threads safely
   --> $DIR/issue-67252-unnamed-future.rs:18:5
    |
 LL | fn spawn<T: Send>(_: T) {}
-   |    -----    ---- required by this bound in `spawn`
+   |             ---- required by this bound in `spawn`
 ...
 LL |     spawn(async {
    |     ^^^^^ future is not `Send`

--- a/src/test/ui/async-await/issues/issue-65436-raw-ptr-not-send.stderr
+++ b/src/test/ui/async-await/issues/issue-65436-raw-ptr-not-send.stderr
@@ -2,7 +2,7 @@ error: future cannot be sent between threads safely
   --> $DIR/issue-65436-raw-ptr-not-send.rs:12:5
    |
 LL | fn assert_send<T: Send>(_: T) {}
-   |    -----------    ---- required by this bound in `assert_send`
+   |                   ---- required by this bound in `assert_send`
 ...
 LL |     assert_send(async {
    |     ^^^^^^^^^^^ future returned by `main` is not `Send`

--- a/src/test/ui/bad/bad-sized.stderr
+++ b/src/test/ui/bad/bad-sized.stderr
@@ -14,10 +14,14 @@ error[E0277]: the size for values of type `dyn Trait` cannot be known at compila
    |
 LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
    |            ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   | 
+  ::: $SRC_DIR/liballoc/vec.rs:LL:COL
+   |
+LL | pub struct Vec<T> {
+   |                - required by this bound in `std::vec::Vec`
    |
    = help: the trait `std::marker::Sized` is not implemented for `dyn Trait`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required by `std::vec::Vec`
 
 error[E0277]: the size for values of type `dyn Trait` cannot be known at compilation time
   --> $DIR/bad-sized.rs:4:37

--- a/src/test/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
+++ b/src/test/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
@@ -2,7 +2,7 @@ error[E0277]: `F` cannot be sent between threads safely
   --> $DIR/closure-bounds-cant-promote-superkind-in-struct.rs:5:22
    |
 LL | struct X<F> where F: FnOnce() + 'static + Send {
-   | ---------------------------------------------- required by `X`
+   |        -                                  ---- required by this bound in `X`
 ...
 LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static {
    |                      ^^^^ `F` cannot be sent between threads safely

--- a/src/test/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
+++ b/src/test/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
@@ -2,7 +2,7 @@ error[E0277]: `F` cannot be sent between threads safely
   --> $DIR/closure-bounds-cant-promote-superkind-in-struct.rs:5:22
    |
 LL | struct X<F> where F: FnOnce() + 'static + Send {
-   |        -                                  ---- required by this bound in `X`
+   |                                           ---- required by this bound in `X`
 ...
 LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static {
    |                      ^^^^ `F` cannot be sent between threads safely

--- a/src/test/ui/closures/closure-bounds-subtype.stderr
+++ b/src/test/ui/closures/closure-bounds-subtype.stderr
@@ -2,7 +2,7 @@ error[E0277]: `F` cannot be shared between threads safely
   --> $DIR/closure-bounds-subtype.rs:13:22
    |
 LL | fn take_const_owned<F>(_: F) where F: FnOnce() + Sync + Send {
-   |    ----------------                              ---- required by this bound in `take_const_owned`
+   |                                                  ---- required by this bound in `take_const_owned`
 ...
 LL |     take_const_owned(f);
    |                      ^ `F` cannot be shared between threads safely

--- a/src/test/ui/coherence/coherence-unsafe-trait-object-impl.stderr
+++ b/src/test/ui/coherence/coherence-unsafe-trait-object-impl.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `&dyn Trait: Trait` is not satisfied
   --> $DIR/coherence-unsafe-trait-object-impl.rs:15:13
    |
 LL | fn takes_t<S: Trait>(s: S) {
-   |    -------    ----- required by this bound in `takes_t`
+   |               ----- required by this bound in `takes_t`
 ...
 LL |     takes_t(t);
    |             ^ the trait `Trait` is not implemented for `&dyn Trait`

--- a/src/test/ui/consts/too_generic_eval_ice.stderr
+++ b/src/test/ui/consts/too_generic_eval_ice.stderr
@@ -15,7 +15,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
   --> $DIR/too_generic_eval_ice.rs:7:13
    |
 LL | pub struct Foo<A, B>(A, B);
-   | --------------------------- required by `Foo`
+   |            --- - required by this bound in `Foo`
 LL | 
 LL | impl<A, B> Foo<A, B> {
    |      - this type parameter needs to be `std::marker::Sized`
@@ -30,7 +30,7 @@ error[E0277]: the size for values of type `B` cannot be known at compilation tim
   --> $DIR/too_generic_eval_ice.rs:7:13
    |
 LL | pub struct Foo<A, B>(A, B);
-   | --------------------------- required by `Foo`
+   |            ---    - required by this bound in `Foo`
 LL | 
 LL | impl<A, B> Foo<A, B> {
    |         - this type parameter needs to be `std::marker::Sized`

--- a/src/test/ui/consts/too_generic_eval_ice.stderr
+++ b/src/test/ui/consts/too_generic_eval_ice.stderr
@@ -15,7 +15,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
   --> $DIR/too_generic_eval_ice.rs:7:13
    |
 LL | pub struct Foo<A, B>(A, B);
-   |            --- - required by this bound in `Foo`
+   |                - required by this bound in `Foo`
 LL | 
 LL | impl<A, B> Foo<A, B> {
    |      - this type parameter needs to be `std::marker::Sized`
@@ -30,7 +30,7 @@ error[E0277]: the size for values of type `B` cannot be known at compilation tim
   --> $DIR/too_generic_eval_ice.rs:7:13
    |
 LL | pub struct Foo<A, B>(A, B);
-   |            ---    - required by this bound in `Foo`
+   |                   - required by this bound in `Foo`
 LL | 
 LL | impl<A, B> Foo<A, B> {
    |         - this type parameter needs to be `std::marker::Sized`

--- a/src/test/ui/derives/derives-span-Eq-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Eq-enum-struct-variant.stderr
@@ -3,8 +3,12 @@ error[E0277]: the trait bound `Error: std::cmp::Eq` is not satisfied
    |
 LL |      x: Error
    |      ^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `Error`
+   | 
+  ::: $SRC_DIR/libcore/cmp.rs:LL:COL
    |
-   = note: required by `std::cmp::AssertParamIsEq`
+LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
+   |                               -- required by this bound in `std::cmp::AssertParamIsEq`
+   |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Eq-enum.stderr
+++ b/src/test/ui/derives/derives-span-Eq-enum.stderr
@@ -3,8 +3,12 @@ error[E0277]: the trait bound `Error: std::cmp::Eq` is not satisfied
    |
 LL |      Error
    |      ^^^^^ the trait `std::cmp::Eq` is not implemented for `Error`
+   | 
+  ::: $SRC_DIR/libcore/cmp.rs:LL:COL
    |
-   = note: required by `std::cmp::AssertParamIsEq`
+LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
+   |                               -- required by this bound in `std::cmp::AssertParamIsEq`
+   |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Eq-struct.stderr
+++ b/src/test/ui/derives/derives-span-Eq-struct.stderr
@@ -3,8 +3,12 @@ error[E0277]: the trait bound `Error: std::cmp::Eq` is not satisfied
    |
 LL |     x: Error
    |     ^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `Error`
+   | 
+  ::: $SRC_DIR/libcore/cmp.rs:LL:COL
    |
-   = note: required by `std::cmp::AssertParamIsEq`
+LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
+   |                               -- required by this bound in `std::cmp::AssertParamIsEq`
+   |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Eq-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Eq-tuple-struct.stderr
@@ -3,8 +3,12 @@ error[E0277]: the trait bound `Error: std::cmp::Eq` is not satisfied
    |
 LL |     Error
    |     ^^^^^ the trait `std::cmp::Eq` is not implemented for `Error`
+   | 
+  ::: $SRC_DIR/libcore/cmp.rs:LL:COL
    |
-   = note: required by `std::cmp::AssertParamIsEq`
+LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
+   |                               -- required by this bound in `std::cmp::AssertParamIsEq`
+   |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/deriving-copyclone.stderr
+++ b/src/test/ui/derives/deriving-copyclone.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `C: std::marker::Copy` is not satisfied
   --> $DIR/deriving-copyclone.rs:31:13
    |
 LL | fn is_copy<T: Copy>(_: T) {}
-   |    -------    ---- required by this bound in `is_copy`
+   |               ---- required by this bound in `is_copy`
 ...
 LL |     is_copy(B { a: 1, b: C });
    |             ^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ error[E0277]: the trait bound `C: std::clone::Clone` is not satisfied
   --> $DIR/deriving-copyclone.rs:32:14
    |
 LL | fn is_clone<T: Clone>(_: T) {}
-   |    --------    ----- required by this bound in `is_clone`
+   |                ----- required by this bound in `is_clone`
 ...
 LL |     is_clone(B { a: 1, b: C });
    |              ^^^^^^^^^^^^^^^^
@@ -30,7 +30,7 @@ error[E0277]: the trait bound `D: std::marker::Copy` is not satisfied
   --> $DIR/deriving-copyclone.rs:35:13
    |
 LL | fn is_copy<T: Copy>(_: T) {}
-   |    -------    ---- required by this bound in `is_copy`
+   |               ---- required by this bound in `is_copy`
 ...
 LL |     is_copy(B { a: 1, b: D });
    |             ^^^^^^^^^^^^^^^^

--- a/src/test/ui/did_you_mean/recursion_limit.stderr
+++ b/src/test/ui/did_you_mean/recursion_limit.stderr
@@ -2,7 +2,7 @@ error[E0275]: overflow evaluating the requirement `J: std::marker::Send`
   --> $DIR/recursion_limit.rs:34:5
    |
 LL | fn is_send<T:Send>() { }
-   |    -------   ---- required by this bound in `is_send`
+   |              ---- required by this bound in `is_send`
 ...
 LL |     is_send::<A>();
    |     ^^^^^^^^^^^^

--- a/src/test/ui/error-codes/E0271.stderr
+++ b/src/test/ui/error-codes/E0271.stderr
@@ -2,7 +2,7 @@ error[E0271]: type mismatch resolving `<i8 as Trait>::AssociatedType == u32`
   --> $DIR/E0271.rs:10:5
    |
 LL | fn foo<T>(t: T) where T: Trait<AssociatedType=u32> {
-   |    ---                         ------------------ required by this bound in `foo`
+   |                                ------------------ required by this bound in `foo`
 ...
 LL |     foo(3_i8);
    |     ^^^ expected `u32`, found `&str`

--- a/src/test/ui/error-codes/E0275.stderr
+++ b/src/test/ui/error-codes/E0275.stderr
@@ -2,7 +2,7 @@ error[E0275]: overflow evaluating the requirement `Bar<Bar<Bar<Bar<Bar<Bar<Bar<B
   --> $DIR/E0275.rs:5:33
    |
 LL | trait Foo {}
-   | --------- required by `Foo`
+   | --------- required by this bound in `Foo`
 ...
 LL | impl<T> Foo for T where Bar<T>: Foo {}
    |                                 ^^^

--- a/src/test/ui/error-codes/E0277-2.stderr
+++ b/src/test/ui/error-codes/E0277-2.stderr
@@ -2,7 +2,7 @@ error[E0277]: `*const u8` cannot be sent between threads safely
   --> $DIR/E0277-2.rs:16:5
    |
 LL | fn is_send<T: Send>() { }
-   |    -------    ---- required by this bound in `is_send`
+   |               ---- required by this bound in `is_send`
 ...
 LL |     is_send::<Foo>();
    |     ^^^^^^^^^^^^^^ `*const u8` cannot be sent between threads safely

--- a/src/test/ui/error-codes/E0277.stderr
+++ b/src/test/ui/error-codes/E0277.stderr
@@ -14,7 +14,7 @@ error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/E0277.rs:17:15
    |
 LL | fn some_func<T: Foo>(foo: T) {
-   |    ---------    --- required by this bound in `some_func`
+   |                 --- required by this bound in `some_func`
 ...
 LL |     some_func(5i32);
    |               ^^^^ the trait `Foo` is not implemented for `i32`

--- a/src/test/ui/error-should-say-copy-not-pod.stderr
+++ b/src/test/ui/error-should-say-copy-not-pod.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not sa
   --> $DIR/error-should-say-copy-not-pod.rs:6:17
    |
 LL | fn check_bound<T:Copy>(_: T) {}
-   |    -----------   ---- required by this bound in `check_bound`
+   |                  ---- required by this bound in `check_bound`
 ...
 LL |     check_bound("nocopy".to_string());
    |                 ^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`

--- a/src/test/ui/extern/extern-types-not-sync-send.stderr
+++ b/src/test/ui/extern/extern-types-not-sync-send.stderr
@@ -2,7 +2,7 @@ error[E0277]: `A` cannot be shared between threads safely
   --> $DIR/extern-types-not-sync-send.rs:13:19
    |
 LL | fn assert_sync<T: ?Sized + Sync>() { }
-   |    -----------             ---- required by this bound in `assert_sync`
+   |                            ---- required by this bound in `assert_sync`
 ...
 LL |     assert_sync::<A>();
    |                   ^ `A` cannot be shared between threads safely
@@ -13,7 +13,7 @@ error[E0277]: `A` cannot be sent between threads safely
   --> $DIR/extern-types-not-sync-send.rs:16:19
    |
 LL | fn assert_send<T: ?Sized + Send>() { }
-   |    -----------             ---- required by this bound in `assert_send`
+   |                            ---- required by this bound in `assert_send`
 ...
 LL |     assert_send::<A>();
    |                   ^ `A` cannot be sent between threads safely

--- a/src/test/ui/extern/extern-types-unsized.stderr
+++ b/src/test/ui/extern/extern-types-unsized.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
   --> $DIR/extern-types-unsized.rs:22:20
    |
 LL | fn assert_sized<T>() { }
-   |    ------------ - required by this bound in `assert_sized`
+   |                 - required by this bound in `assert_sized`
 ...
 LL |     assert_sized::<A>();
    |                    ^ doesn't have a size known at compile-time
@@ -18,7 +18,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
   --> $DIR/extern-types-unsized.rs:25:5
    |
 LL | fn assert_sized<T>() { }
-   |    ------------ - required by this bound in `assert_sized`
+   |                 - required by this bound in `assert_sized`
 ...
 LL |     assert_sized::<Foo>();
    |     ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -31,7 +31,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
   --> $DIR/extern-types-unsized.rs:28:5
    |
 LL | fn assert_sized<T>() { }
-   |    ------------ - required by this bound in `assert_sized`
+   |                 - required by this bound in `assert_sized`
 ...
 LL |     assert_sized::<Bar<A>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -44,7 +44,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
   --> $DIR/extern-types-unsized.rs:31:5
    |
 LL | fn assert_sized<T>() { }
-   |    ------------ - required by this bound in `assert_sized`
+   |                 - required by this bound in `assert_sized`
 ...
 LL |     assert_sized::<Bar<Bar<A>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/extern/extern-wrong-value-type.stderr
+++ b/src/test/ui/extern/extern-wrong-value-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: expected a `std::ops::Fn<()>` closure, found `extern "C" fn() {f}`
   --> $DIR/extern-wrong-value-type.rs:9:11
    |
 LL | fn is_fn<F>(_: F) where F: Fn() {}
-   |    -----                   ---- required by this bound in `is_fn`
+   |                            ---- required by this bound in `is_fn`
 ...
 LL |     is_fn(f);
    |           ^ expected an `Fn<()>` closure, found `extern "C" fn() {f}`

--- a/src/test/ui/fmt/send-sync.stderr
+++ b/src/test/ui/fmt/send-sync.stderr
@@ -2,7 +2,7 @@ error[E0277]: `core::fmt::Opaque` cannot be shared between threads safely
   --> $DIR/send-sync.rs:8:5
    |
 LL | fn send<T: Send>(_: T) {}
-   |    ----    ---- required by this bound in `send`
+   |            ---- required by this bound in `send`
 ...
 LL |     send(format_args!("{:?}", c));
    |     ^^^^ `core::fmt::Opaque` cannot be shared between threads safely
@@ -18,7 +18,7 @@ error[E0277]: `core::fmt::Opaque` cannot be shared between threads safely
   --> $DIR/send-sync.rs:9:5
    |
 LL | fn sync<T: Sync>(_: T) {}
-   |    ----    ---- required by this bound in `sync`
+   |            ---- required by this bound in `sync`
 ...
 LL |     sync(format_args!("{:?}", c));
    |     ^^^^ `core::fmt::Opaque` cannot be shared between threads safely

--- a/src/test/ui/fn/fn-trait-formatting.stderr
+++ b/src/test/ui/fn/fn-trait-formatting.stderr
@@ -35,7 +35,7 @@ error[E0277]: expected a `std::ops::Fn<(isize,)>` closure, found `{integer}`
   --> $DIR/fn-trait-formatting.rs:19:14
    |
 LL | fn needs_fn<F>(x: F) where F: Fn(isize) -> isize {}
-   |    --------                   ------------------ required by this bound in `needs_fn`
+   |                               ------------------ required by this bound in `needs_fn`
 ...
 LL |     needs_fn(1);
    |              ^ expected an `Fn<(isize,)>` closure, found `{integer}`

--- a/src/test/ui/generator/not-send-sync.stderr
+++ b/src/test/ui/generator/not-send-sync.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::cell::Cell<i32>` cannot be shared between threads safely
   --> $DIR/not-send-sync.rs:16:5
    |
 LL |     fn assert_send<T: Send>(_: T) {}
-   |        -----------    ---- required by this bound in `main::assert_send`
+   |                       ---- required by this bound in `main::assert_send`
 ...
 LL |     assert_send(|| {
    |     ^^^^^^^^^^^ `std::cell::Cell<i32>` cannot be shared between threads safely
@@ -15,7 +15,7 @@ error: future cannot be shared between threads safely
   --> $DIR/not-send-sync.rs:9:5
    |
 LL |     fn assert_sync<T: Sync>(_: T) {}
-   |        -----------    ---- required by this bound in `main::assert_sync`
+   |                       ---- required by this bound in `main::assert_sync`
 ...
 LL |     assert_sync(|| {
    |     ^^^^^^^^^^^ future returned by `main` is not `Sync`

--- a/src/test/ui/generator/resume-arg-late-bound.stderr
+++ b/src/test/ui/generator/resume-arg-late-bound.stderr
@@ -2,7 +2,7 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/resume-arg-late-bound.rs:15:10
    |
 LL | fn test(a: impl for<'a> Generator<&'a mut bool>) {}
-   |    ----         ------------------------------- required by this bound in `test`
+   |                 ------------------------------- required by this bound in `test`
 ...
 LL |     test(gen);
    |          ^^^

--- a/src/test/ui/generator/static-not-unpin.stderr
+++ b/src/test/ui/generator/static-not-unpin.stderr
@@ -2,7 +2,7 @@ error[E0277]: `[static generator@$DIR/static-not-unpin.rs:11:25: 13:6 _]` cannot
   --> $DIR/static-not-unpin.rs:14:18
    |
 LL | fn assert_unpin<T: Unpin>(_: T) {
-   |    ------------    ----- required by this bound in `assert_unpin`
+   |                    ----- required by this bound in `assert_unpin`
 ...
 LL |     assert_unpin(generator);
    |                  ^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `[static generator@$DIR/static-not-unpin.rs:11:25: 13:6 _]`

--- a/src/test/ui/generic-associated-types/issue-62326-parameter-out-of-range.stderr
+++ b/src/test/ui/generic-associated-types/issue-62326-parameter-out-of-range.stderr
@@ -2,9 +2,9 @@ error[E0280]: the requirement `for<'a> <Self as Iterator>::Item<'a>: 'a` is not 
   --> $DIR/issue-62326-parameter-out-of-range.rs:7:20
    |
 LL | trait Iterator {
-   | -------------- required by `Iterator`
+   |       --------
 LL |     type Item<'a>: 'a;
-   |                    ^^
+   |                    ^^ required by this bound in `Iterator`
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/iterable.stderr
+++ b/src/test/ui/generic-associated-types/iterable.stderr
@@ -38,7 +38,10 @@ error[E0271]: type mismatch resolving `for<'a> <<std::vec::Vec<T> as Iterable>::
   --> $DIR/iterable.rs:19:30
    |
 LL | trait Iterable {
-   | -------------- required by `Iterable`
+   |       --------
+LL |     type Item<'a> where Self: 'a;
+LL |     type Iter<'a>: Iterator<Item = Self::Item<'a>> where Self: 'a;
+   |                             --------------------- required by this bound in `Iterable`
 ...
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'a> {
    |                              ^^^^^^^^^^^^^^ expected associated type, found reference
@@ -52,7 +55,10 @@ error[E0271]: type mismatch resolving `for<'a> <<[T] as Iterable>::Iter<'a> as s
   --> $DIR/iterable.rs:31:30
    |
 LL | trait Iterable {
-   | -------------- required by `Iterable`
+   |       --------
+LL |     type Item<'a> where Self: 'a;
+LL |     type Iter<'a>: Iterator<Item = Self::Item<'a>> where Self: 'a;
+   |                             --------------------- required by this bound in `Iterable`
 ...
 LL |     fn iter<'a>(&'a self) -> Self::Iter<'a> {
    |                              ^^^^^^^^^^^^^^ expected associated type, found reference

--- a/src/test/ui/hrtb/issue-46989.stderr
+++ b/src/test/ui/hrtb/issue-46989.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `for<'r> fn(&'r i32): Foo` is not satisfied
   --> $DIR/issue-46989.rs:40:18
    |
 LL | fn assert_foo<T: Foo>() {}
-   |    ----------    --- required by this bound in `assert_foo`
+   |                  --- required by this bound in `assert_foo`
 ...
 LL |     assert_foo::<fn(&i32)>();
    |                  ^^^^^^^^ the trait `Foo` is not implemented for `for<'r> fn(&'r i32)`

--- a/src/test/ui/impl-trait/auto-trait-leak.stderr
+++ b/src/test/ui/impl-trait/auto-trait-leak.stderr
@@ -258,7 +258,7 @@ error[E0277]: `std::rc::Rc<std::string::String>` cannot be sent between threads 
   --> $DIR/auto-trait-leak.rs:16:5
    |
 LL | fn send<T: Send>(_: T) {}
-   |    ----    ---- required by this bound in `send`
+   |            ---- required by this bound in `send`
 ...
 LL |     send(cycle2().clone());
    |     ^^^^ `std::rc::Rc<std::string::String>` cannot be sent between threads safely

--- a/src/test/ui/impl-trait/auto-trait-leak2.stderr
+++ b/src/test/ui/impl-trait/auto-trait-leak2.stderr
@@ -5,7 +5,7 @@ LL | fn before() -> impl Fn(i32) {
    |                ------------ within this `impl std::ops::Fn<(i32,)>`
 ...
 LL | fn send<T: Send>(_: T) {}
-   |    ----    ---- required by this bound in `send`
+   |            ---- required by this bound in `send`
 ...
 LL |     send(before());
    |     ^^^^ `std::rc::Rc<std::cell::Cell<i32>>` cannot be sent between threads safely
@@ -18,7 +18,7 @@ error[E0277]: `std::rc::Rc<std::cell::Cell<i32>>` cannot be sent between threads
   --> $DIR/auto-trait-leak2.rs:16:5
    |
 LL | fn send<T: Send>(_: T) {}
-   |    ----    ---- required by this bound in `send`
+   |            ---- required by this bound in `send`
 ...
 LL |     send(after());
    |     ^^^^ `std::rc::Rc<std::cell::Cell<i32>>` cannot be sent between threads safely

--- a/src/test/ui/issues/issue-18919.rs
+++ b/src/test/ui/issues/issue-18919.rs
@@ -4,4 +4,9 @@ fn ho_func(f: Option<FuncType>) {
     //~^ ERROR the size for values of type
 }
 
+enum Option<T> {
+    Some(T),
+    None,
+}
+
 fn main() {}

--- a/src/test/ui/issues/issue-18919.stderr
+++ b/src/test/ui/issues/issue-18919.stderr
@@ -5,7 +5,7 @@ LL | fn ho_func(f: Option<FuncType>) {
    |               ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
 ...
 LL | enum Option<T> {
-   |      ------ - required by this bound in `Option`
+   |             - required by this bound in `Option`
    |
    = help: the trait `std::marker::Sized` is not implemented for `dyn for<'r> std::ops::Fn(&'r isize) -> isize`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>

--- a/src/test/ui/issues/issue-18919.stderr
+++ b/src/test/ui/issues/issue-18919.stderr
@@ -3,10 +3,12 @@ error[E0277]: the size for values of type `dyn for<'r> std::ops::Fn(&'r isize) -
    |
 LL | fn ho_func(f: Option<FuncType>) {
    |               ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+...
+LL | enum Option<T> {
+   |      ------ - required by this bound in `Option`
    |
    = help: the trait `std::marker::Sized` is not implemented for `dyn for<'r> std::ops::Fn(&'r isize) -> isize`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required by `std::option::Option`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-1920-1.stderr
+++ b/src/test/ui/issues/issue-1920-1.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `foo::issue_1920::S: std::clone::Clone` is not sat
   --> $DIR/issue-1920-1.rs:12:20
    |
 LL | fn assert_clone<T>() where T : Clone { }
-   |    ------------                ----- required by this bound in `assert_clone`
+   |                                ----- required by this bound in `assert_clone`
 ...
 LL |     assert_clone::<foo::issue_1920::S>();
    |                    ^^^^^^^^^^^^^^^^^^ the trait `std::clone::Clone` is not implemented for `foo::issue_1920::S`

--- a/src/test/ui/issues/issue-1920-2.stderr
+++ b/src/test/ui/issues/issue-1920-2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `bar::S: std::clone::Clone` is not satisfied
   --> $DIR/issue-1920-2.rs:10:20
    |
 LL | fn assert_clone<T>() where T : Clone { }
-   |    ------------                ----- required by this bound in `assert_clone`
+   |                                ----- required by this bound in `assert_clone`
 ...
 LL |     assert_clone::<bar::S>();
    |                    ^^^^^^ the trait `std::clone::Clone` is not implemented for `bar::S`

--- a/src/test/ui/issues/issue-1920-3.stderr
+++ b/src/test/ui/issues/issue-1920-3.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `issue_1920::S: std::clone::Clone` is not satisfie
   --> $DIR/issue-1920-3.rs:14:20
    |
 LL | fn assert_clone<T>() where T : Clone { }
-   |    ------------                ----- required by this bound in `assert_clone`
+   |                                ----- required by this bound in `assert_clone`
 ...
 LL |     assert_clone::<foo::issue_1920::S>();
    |                    ^^^^^^^^^^^^^^^^^^ the trait `std::clone::Clone` is not implemented for `issue_1920::S`

--- a/src/test/ui/issues/issue-20005.stderr
+++ b/src/test/ui/issues/issue-20005.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
   --> $DIR/issue-20005.rs:10:49
    |
 LL | trait From<Src> {
-   |       ---- --- required by this bound in `From`
+   |            --- required by this bound in `From`
 ...
 LL |     ) -> <Dst as From<Self>>::Result where Dst: From<Self> {
    |                                                 ^^^^^^^^^^- help: consider further restricting `Self`: `, Self: std::marker::Sized`

--- a/src/test/ui/issues/issue-20005.stderr
+++ b/src/test/ui/issues/issue-20005.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
   --> $DIR/issue-20005.rs:10:49
    |
 LL | trait From<Src> {
-   | --------------- required by `From`
+   |       ---- --- required by this bound in `From`
 ...
 LL |     ) -> <Dst as From<Self>>::Result where Dst: From<Self> {
    |                                                 ^^^^^^^^^^- help: consider further restricting `Self`: `, Self: std::marker::Sized`

--- a/src/test/ui/issues/issue-20413.stderr
+++ b/src/test/ui/issues/issue-20413.stderr
@@ -10,7 +10,7 @@ error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<N
   --> $DIR/issue-20413.rs:8:36
    |
 LL | trait Foo {
-   | --------- required by `Foo`
+   | --------- required by this bound in `Foo`
 ...
 LL | impl<T> Foo for T where NoData<T>: Foo {
    |                                    ^^^
@@ -148,7 +148,7 @@ error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<N
   --> $DIR/issue-20413.rs:8:36
    |
 LL | trait Foo {
-   | --------- required by `Foo`
+   | --------- required by this bound in `Foo`
 ...
 LL | impl<T> Foo for T where NoData<T>: Foo {
    |                                    ^^^

--- a/src/test/ui/issues/issue-20433.stderr
+++ b/src/test/ui/issues/issue-20433.stderr
@@ -3,10 +3,14 @@ error[E0277]: the size for values of type `[i32]` cannot be known at compilation
    |
 LL |     fn iceman(c: Vec<[i32]>) {}
    |                  ^^^^^^^^^^ doesn't have a size known at compile-time
+   | 
+  ::: $SRC_DIR/liballoc/vec.rs:LL:COL
+   |
+LL | pub struct Vec<T> {
+   |                - required by this bound in `std::vec::Vec`
    |
    = help: the trait `std::marker::Sized` is not implemented for `[i32]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required by `std::vec::Vec`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-21763.stderr
+++ b/src/test/ui/issues/issue-21763.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::rc::Rc<()>` cannot be sent between threads safely
   --> $DIR/issue-21763.rs:9:5
    |
 LL | fn foo<T: Send>() {}
-   |    ---    ---- required by this bound in `foo`
+   |           ---- required by this bound in `foo`
 ...
 LL |     foo::<HashMap<Rc<()>, Rc<()>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::rc::Rc<()>` cannot be sent between threads safely

--- a/src/test/ui/issues/issue-21837.stderr
+++ b/src/test/ui/issues/issue-21837.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: Bound` is not satisfied
   --> $DIR/issue-21837.rs:8:9
    |
 LL | pub struct Foo<T: Bound>(T);
-   | ---------------------------- required by `Foo`
+   |            ---    ----- required by this bound in `Foo`
 ...
 LL | impl<T> Trait2 for Foo<T> {}
    |         ^^^^^^ the trait `Bound` is not implemented for `T`

--- a/src/test/ui/issues/issue-21837.stderr
+++ b/src/test/ui/issues/issue-21837.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: Bound` is not satisfied
   --> $DIR/issue-21837.rs:8:9
    |
 LL | pub struct Foo<T: Bound>(T);
-   |            ---    ----- required by this bound in `Foo`
+   |                   ----- required by this bound in `Foo`
 ...
 LL | impl<T> Trait2 for Foo<T> {}
    |         ^^^^^^ the trait `Bound` is not implemented for `T`

--- a/src/test/ui/issues/issue-21974.stderr
+++ b/src/test/ui/issues/issue-21974.stderr
@@ -2,7 +2,7 @@ error[E0283]: type annotations needed
   --> $DIR/issue-21974.rs:11:19
    |
 LL | trait Foo {
-   | --------- required by `Foo`
+   | --------- required by this bound in `Foo`
 ...
 LL |     where &'a T : Foo,
    |                   ^^^ cannot infer type for reference `&'a T`

--- a/src/test/ui/issues/issue-23281.rs
+++ b/src/test/ui/issues/issue-23281.rs
@@ -5,4 +5,8 @@ impl Struct {
     //~^ ERROR the size for values of type
 }
 
+struct Vec<T> {
+    t: T,
+}
+
 fn main() {}

--- a/src/test/ui/issues/issue-23281.stderr
+++ b/src/test/ui/issues/issue-23281.stderr
@@ -3,10 +3,12 @@ error[E0277]: the size for values of type `(dyn std::ops::Fn() + 'static)` canno
    |
 LL |     pub fn function(funs: Vec<dyn Fn() -> ()>) {}
    |                           ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+...
+LL | struct Vec<T> {
+   |        --- - required by this bound in `Vec`
    |
    = help: the trait `std::marker::Sized` is not implemented for `(dyn std::ops::Fn() + 'static)`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required by `std::vec::Vec`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-23281.stderr
+++ b/src/test/ui/issues/issue-23281.stderr
@@ -5,7 +5,7 @@ LL |     pub fn function(funs: Vec<dyn Fn() -> ()>) {}
    |                           ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
 ...
 LL | struct Vec<T> {
-   |        --- - required by this bound in `Vec`
+   |            - required by this bound in `Vec`
    |
    = help: the trait `std::marker::Sized` is not implemented for `(dyn std::ops::Fn() + 'static)`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>

--- a/src/test/ui/issues/issue-24204.stderr
+++ b/src/test/ui/issues/issue-24204.stderr
@@ -2,7 +2,9 @@ error[E0271]: type mismatch resolving `<<T as Trait>::A as MultiDispatch<i32>>::
   --> $DIR/issue-24204.rs:14:12
    |
 LL | trait Trait: Sized {
-   | ------------------ required by `Trait`
+   |       -----
+LL |     type A: MultiDispatch<Self::B, O = Self>;
+   |                                    -------- required by this bound in `Trait`
 ...
 LL | fn test<T: Trait<B=i32>>(b: i32) -> T where T::A: MultiDispatch<i32> { T::new(b) }
    |            ^^^^^^^^^^^^ expected type parameter `T`, found associated type

--- a/src/test/ui/issues/issue-24424.stderr
+++ b/src/test/ui/issues/issue-24424.stderr
@@ -2,7 +2,7 @@ error[E0283]: type annotations needed
   --> $DIR/issue-24424.rs:4:57
    |
 LL | trait Trait0<'l0>  {}
-   | ----------------- required by `Trait0`
+   | ----------------- required by this bound in `Trait0`
 LL | 
 LL | impl <'l0, 'l1, T0> Trait1<'l0, T0> for bool where T0 : Trait0<'l0>, T0 : Trait0<'l1> {}
    |                                                         ^^^^^^^^^^^ cannot infer type for type parameter `T0`

--- a/src/test/ui/issues/issue-25076.stderr
+++ b/src/test/ui/issues/issue-25076.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `(): InOut<_>` is not satisfied
   --> $DIR/issue-25076.rs:10:20
    |
 LL | fn do_fold<B, F: InOut<B, Out=B>>(init: B, f: F) {}
-   |    -------       --------------- required by this bound in `do_fold`
+   |                  --------------- required by this bound in `do_fold`
 ...
 LL |     do_fold(bot(), ());
    |                    ^^ the trait `InOut<_>` is not implemented for `()`

--- a/src/test/ui/issues/issue-32963.stderr
+++ b/src/test/ui/issues/issue-32963.stderr
@@ -24,7 +24,7 @@ error[E0277]: the trait bound `dyn Misc: std::marker::Copy` is not satisfied
   --> $DIR/issue-32963.rs:8:5
    |
 LL | fn size_of_copy<T: Copy+?Sized>() -> usize { mem::size_of::<T>() }
-   |    ------------    ---- required by this bound in `size_of_copy`
+   |                    ---- required by this bound in `size_of_copy`
 ...
 LL |     size_of_copy::<dyn Misc + Copy>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `dyn Misc`

--- a/src/test/ui/issues/issue-40827.stderr
+++ b/src/test/ui/issues/issue-40827.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::rc::Rc<Foo>` cannot be sent between threads safely
   --> $DIR/issue-40827.rs:14:5
    |
 LL | fn f<T: Send>(_: T) {}
-   |    -    ---- required by this bound in `f`
+   |         ---- required by this bound in `f`
 ...
 LL |     f(Foo(Arc::new(Bar::B(None))));
    |     ^ `std::rc::Rc<Foo>` cannot be sent between threads safely
@@ -16,7 +16,7 @@ error[E0277]: `std::rc::Rc<Foo>` cannot be shared between threads safely
   --> $DIR/issue-40827.rs:14:5
    |
 LL | fn f<T: Send>(_: T) {}
-   |    -    ---- required by this bound in `f`
+   |         ---- required by this bound in `f`
 ...
 LL |     f(Foo(Arc::new(Bar::B(None))));
    |     ^ `std::rc::Rc<Foo>` cannot be shared between threads safely

--- a/src/test/ui/issues/issue-54954.stderr
+++ b/src/test/ui/issues/issue-54954.stderr
@@ -11,7 +11,7 @@ LL | const ARR_LEN: usize = Tt::const_val::<[i8; 123]>();
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
 ...
 LL |     const fn const_val<T: Sized>() -> usize {
-   |              --------- - required by this bound in `Tt::const_val`
+   |                        - required by this bound in `Tt::const_val`
    |
    = note: cannot satisfy `_: Tt`
 

--- a/src/test/ui/iterators/bound.stderr
+++ b/src/test/ui/iterators/bound.stderr
@@ -2,7 +2,7 @@ error[E0277]: `u8` is not an iterator
   --> $DIR/bound.rs:2:10
    |
 LL | struct S<I: Iterator>(I);
-   | ------------------------- required by `S`
+   |        -    -------- required by this bound in `S`
 LL | struct T(S<u8>);
    |          ^^^^^ `u8` is not an iterator
    |

--- a/src/test/ui/iterators/bound.stderr
+++ b/src/test/ui/iterators/bound.stderr
@@ -2,7 +2,7 @@ error[E0277]: `u8` is not an iterator
   --> $DIR/bound.rs:2:10
    |
 LL | struct S<I: Iterator>(I);
-   |        -    -------- required by this bound in `S`
+   |             -------- required by this bound in `S`
 LL | struct T(S<u8>);
    |          ^^^^^ `u8` is not an iterator
    |

--- a/src/test/ui/kindck/kindck-copy.stderr
+++ b/src/test/ui/kindck/kindck-copy.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `&'static mut isize: std::marker::Copy` is not sat
   --> $DIR/kindck-copy.rs:27:19
    |
 LL | fn assert_copy<T:Copy>() { }
-   |    -----------   ---- required by this bound in `assert_copy`
+   |                  ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<&'static mut isize>();
    |                   ^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `&'static mut isize`
@@ -14,7 +14,7 @@ error[E0277]: the trait bound `&'a mut isize: std::marker::Copy` is not satisfie
   --> $DIR/kindck-copy.rs:28:19
    |
 LL | fn assert_copy<T:Copy>() { }
-   |    -----------   ---- required by this bound in `assert_copy`
+   |                  ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<&'a mut isize>();
    |                   ^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `&'a mut isize`
@@ -26,7 +26,7 @@ error[E0277]: the trait bound `std::boxed::Box<isize>: std::marker::Copy` is not
   --> $DIR/kindck-copy.rs:31:19
    |
 LL | fn assert_copy<T:Copy>() { }
-   |    -----------   ---- required by this bound in `assert_copy`
+   |                  ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<Box<isize>>();
    |                   ^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<isize>`
@@ -35,7 +35,7 @@ error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not sa
   --> $DIR/kindck-copy.rs:32:19
    |
 LL | fn assert_copy<T:Copy>() { }
-   |    -----------   ---- required by this bound in `assert_copy`
+   |                  ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<String>();
    |                   ^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
@@ -44,7 +44,7 @@ error[E0277]: the trait bound `std::vec::Vec<isize>: std::marker::Copy` is not s
   --> $DIR/kindck-copy.rs:33:19
    |
 LL | fn assert_copy<T:Copy>() { }
-   |    -----------   ---- required by this bound in `assert_copy`
+   |                  ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<Vec<isize> >();
    |                   ^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::vec::Vec<isize>`
@@ -53,7 +53,7 @@ error[E0277]: the trait bound `std::boxed::Box<&'a mut isize>: std::marker::Copy
   --> $DIR/kindck-copy.rs:34:19
    |
 LL | fn assert_copy<T:Copy>() { }
-   |    -----------   ---- required by this bound in `assert_copy`
+   |                  ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<Box<&'a mut isize>>();
    |                   ^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<&'a mut isize>`
@@ -62,7 +62,7 @@ error[E0277]: the trait bound `std::boxed::Box<dyn Dummy>: std::marker::Copy` is
   --> $DIR/kindck-copy.rs:42:5
    |
 LL | fn assert_copy<T:Copy>() { }
-   |    -----------   ---- required by this bound in `assert_copy`
+   |                  ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<Box<dyn Dummy>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<dyn Dummy>`
@@ -71,7 +71,7 @@ error[E0277]: the trait bound `std::boxed::Box<dyn Dummy + std::marker::Send>: s
   --> $DIR/kindck-copy.rs:43:5
    |
 LL | fn assert_copy<T:Copy>() { }
-   |    -----------   ---- required by this bound in `assert_copy`
+   |                  ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<Box<dyn Dummy + Send>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<dyn Dummy + std::marker::Send>`
@@ -80,7 +80,7 @@ error[E0277]: the trait bound `&'a mut (dyn Dummy + std::marker::Send + 'a): std
   --> $DIR/kindck-copy.rs:46:19
    |
 LL | fn assert_copy<T:Copy>() { }
-   |    -----------   ---- required by this bound in `assert_copy`
+   |                  ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<&'a mut (dyn Dummy + Send)>();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `&'a mut (dyn Dummy + std::marker::Send + 'a)`
@@ -89,7 +89,7 @@ error[E0277]: the trait bound `MyNoncopyStruct: std::marker::Copy` is not satisf
   --> $DIR/kindck-copy.rs:64:19
    |
 LL | fn assert_copy<T:Copy>() { }
-   |    -----------   ---- required by this bound in `assert_copy`
+   |                  ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<MyNoncopyStruct>();
    |                   ^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `MyNoncopyStruct`
@@ -98,7 +98,7 @@ error[E0277]: the trait bound `std::rc::Rc<isize>: std::marker::Copy` is not sat
   --> $DIR/kindck-copy.rs:67:19
    |
 LL | fn assert_copy<T:Copy>() { }
-   |    -----------   ---- required by this bound in `assert_copy`
+   |                  ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<Rc<isize>>();
    |                   ^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::rc::Rc<isize>`

--- a/src/test/ui/kindck/kindck-impl-type-params-2.stderr
+++ b/src/test/ui/kindck/kindck-impl-type-params-2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `std::boxed::Box<{integer}>: Foo` is not satisfied
   --> $DIR/kindck-impl-type-params-2.rs:13:16
    |
 LL | fn take_param<T:Foo>(foo: &T) { }
-   |    ----------   --- required by this bound in `take_param`
+   |                 --- required by this bound in `take_param`
 ...
 LL |     take_param(&x);
    |                ^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<{integer}>`

--- a/src/test/ui/kindck/kindck-inherited-copy-bound.curr.stderr
+++ b/src/test/ui/kindck/kindck-inherited-copy-bound.curr.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `std::boxed::Box<{integer}>: Foo` is not satisfied
   --> $DIR/kindck-inherited-copy-bound.rs:21:16
    |
 LL | fn take_param<T:Foo>(foo: &T) { }
-   |    ----------   --- required by this bound in `take_param`
+   |                 --- required by this bound in `take_param`
 ...
 LL |     take_param(&x);
    |                ^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<{integer}>`

--- a/src/test/ui/kindck/kindck-inherited-copy-bound.object_safe_for_dispatch.stderr
+++ b/src/test/ui/kindck/kindck-inherited-copy-bound.object_safe_for_dispatch.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `std::boxed::Box<{integer}>: Foo` is not satisfied
   --> $DIR/kindck-inherited-copy-bound.rs:21:16
    |
 LL | fn take_param<T:Foo>(foo: &T) { }
-   |    ----------   --- required by this bound in `take_param`
+   |                 --- required by this bound in `take_param`
 ...
 LL |     take_param(&x);
    |                ^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<{integer}>`

--- a/src/test/ui/kindck/kindck-nonsendable-1.stderr
+++ b/src/test/ui/kindck/kindck-nonsendable-1.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::rc::Rc<usize>` cannot be sent between threads safely
   --> $DIR/kindck-nonsendable-1.rs:9:5
    |
 LL | fn bar<F:FnOnce() + Send>(_: F) { }
-   |    ---              ---- required by this bound in `bar`
+   |                     ---- required by this bound in `bar`
 ...
 LL |     bar(move|| foo(x));
    |     ^^^ ------------- within this `[closure@$DIR/kindck-nonsendable-1.rs:9:9: 9:22 x:std::rc::Rc<usize>]`

--- a/src/test/ui/kindck/kindck-send-object.stderr
+++ b/src/test/ui/kindck/kindck-send-object.stderr
@@ -2,7 +2,7 @@ error[E0277]: `(dyn Dummy + 'static)` cannot be shared between threads safely
   --> $DIR/kindck-send-object.rs:12:5
    |
 LL | fn assert_send<T:Send>() { }
-   |    -----------   ---- required by this bound in `assert_send`
+   |                  ---- required by this bound in `assert_send`
 ...
 LL |     assert_send::<&'static (dyn Dummy + 'static)>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'static)` cannot be shared between threads safely
@@ -14,7 +14,7 @@ error[E0277]: `dyn Dummy` cannot be sent between threads safely
   --> $DIR/kindck-send-object.rs:17:5
    |
 LL | fn assert_send<T:Send>() { }
-   |    -----------   ---- required by this bound in `assert_send`
+   |                  ---- required by this bound in `assert_send`
 ...
 LL |     assert_send::<Box<dyn Dummy>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn Dummy` cannot be sent between threads safely

--- a/src/test/ui/kindck/kindck-send-object1.nll.stderr
+++ b/src/test/ui/kindck/kindck-send-object1.nll.stderr
@@ -2,7 +2,7 @@ error[E0277]: `(dyn Dummy + 'a)` cannot be shared between threads safely
   --> $DIR/kindck-send-object1.rs:10:5
    |
 LL | fn assert_send<T:Send+'static>() { }
-   |    -----------   ---- required by this bound in `assert_send`
+   |                  ---- required by this bound in `assert_send`
 ...
 LL |     assert_send::<&'a dyn Dummy>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be shared between threads safely
@@ -14,7 +14,7 @@ error[E0277]: `(dyn Dummy + 'a)` cannot be sent between threads safely
   --> $DIR/kindck-send-object1.rs:29:5
    |
 LL | fn assert_send<T:Send+'static>() { }
-   |    -----------   ---- required by this bound in `assert_send`
+   |                  ---- required by this bound in `assert_send`
 ...
 LL |     assert_send::<Box<dyn Dummy + 'a>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be sent between threads safely

--- a/src/test/ui/kindck/kindck-send-object1.stderr
+++ b/src/test/ui/kindck/kindck-send-object1.stderr
@@ -2,7 +2,7 @@ error[E0277]: `(dyn Dummy + 'a)` cannot be shared between threads safely
   --> $DIR/kindck-send-object1.rs:10:5
    |
 LL | fn assert_send<T:Send+'static>() { }
-   |    -----------   ---- required by this bound in `assert_send`
+   |                  ---- required by this bound in `assert_send`
 ...
 LL |     assert_send::<&'a dyn Dummy>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be shared between threads safely
@@ -22,7 +22,7 @@ error[E0277]: `(dyn Dummy + 'a)` cannot be sent between threads safely
   --> $DIR/kindck-send-object1.rs:29:5
    |
 LL | fn assert_send<T:Send+'static>() { }
-   |    -----------   ---- required by this bound in `assert_send`
+   |                  ---- required by this bound in `assert_send`
 ...
 LL |     assert_send::<Box<dyn Dummy + 'a>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be sent between threads safely

--- a/src/test/ui/kindck/kindck-send-object2.stderr
+++ b/src/test/ui/kindck/kindck-send-object2.stderr
@@ -2,7 +2,7 @@ error[E0277]: `(dyn Dummy + 'static)` cannot be shared between threads safely
   --> $DIR/kindck-send-object2.rs:7:5
    |
 LL | fn assert_send<T:Send>() { }
-   |    -----------   ---- required by this bound in `assert_send`
+   |                  ---- required by this bound in `assert_send`
 ...
 LL |     assert_send::<&'static dyn Dummy>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'static)` cannot be shared between threads safely
@@ -14,7 +14,7 @@ error[E0277]: `dyn Dummy` cannot be sent between threads safely
   --> $DIR/kindck-send-object2.rs:12:5
    |
 LL | fn assert_send<T:Send>() { }
-   |    -----------   ---- required by this bound in `assert_send`
+   |                  ---- required by this bound in `assert_send`
 ...
 LL |     assert_send::<Box<dyn Dummy>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn Dummy` cannot be sent between threads safely

--- a/src/test/ui/kindck/kindck-send-owned.stderr
+++ b/src/test/ui/kindck/kindck-send-owned.stderr
@@ -2,7 +2,7 @@ error[E0277]: `*mut u8` cannot be sent between threads safely
   --> $DIR/kindck-send-owned.rs:12:5
    |
 LL | fn assert_send<T:Send>() { }
-   |    -----------   ---- required by this bound in `assert_send`
+   |                  ---- required by this bound in `assert_send`
 ...
 LL |     assert_send::<Box<*mut u8>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*mut u8` cannot be sent between threads safely

--- a/src/test/ui/kindck/kindck-send-unsafe.stderr
+++ b/src/test/ui/kindck/kindck-send-unsafe.stderr
@@ -2,7 +2,7 @@ error[E0277]: `*mut &'a isize` cannot be sent between threads safely
   --> $DIR/kindck-send-unsafe.rs:6:19
    |
 LL | fn assert_send<T:Send>() { }
-   |    -----------   ---- required by this bound in `assert_send`
+   |                  ---- required by this bound in `assert_send`
 ...
 LL |     assert_send::<*mut &'a isize>();
    |                   ^^^^^^^^^^^^^^ `*mut &'a isize` cannot be sent between threads safely

--- a/src/test/ui/marker_trait_attr/overlap-marker-trait.stderr
+++ b/src/test/ui/marker_trait_attr/overlap-marker-trait.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `NotDebugOrDisplay: Marker` is not satisfied
   --> $DIR/overlap-marker-trait.rs:27:17
    |
 LL | fn is_marker<T: Marker>() { }
-   |    ---------    ------ required by this bound in `is_marker`
+   |                 ------ required by this bound in `is_marker`
 ...
 LL |     is_marker::<NotDebugOrDisplay>();
    |                 ^^^^^^^^^^^^^^^^^ the trait `Marker` is not implemented for `NotDebugOrDisplay`

--- a/src/test/ui/mismatched_types/E0631.stderr
+++ b/src/test/ui/mismatched_types/E0631.stderr
@@ -2,7 +2,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/E0631.rs:7:5
    |
 LL | fn foo<F: Fn(usize)>(_: F) {}
-   |    ---    --------- required by this bound in `foo`
+   |           --------- required by this bound in `foo`
 ...
 LL |     foo(|_: isize| {});
    |     ^^^ ---------- found signature of `fn(isize) -> _`
@@ -13,7 +13,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/E0631.rs:8:5
    |
 LL | fn bar<F: Fn<usize>>(_: F) {}
-   |    ---    --------- required by this bound in `bar`
+   |           --------- required by this bound in `bar`
 ...
 LL |     bar(|_: isize| {});
    |     ^^^ ---------- found signature of `fn(isize) -> _`
@@ -24,7 +24,7 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/E0631.rs:9:9
    |
 LL | fn foo<F: Fn(usize)>(_: F) {}
-   |    ---    --------- required by this bound in `foo`
+   |           --------- required by this bound in `foo`
 ...
 LL |     fn f(_: u64) {}
    |     ------------ found signature of `fn(u64) -> _`
@@ -36,7 +36,7 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/E0631.rs:10:9
    |
 LL | fn bar<F: Fn<usize>>(_: F) {}
-   |    ---    --------- required by this bound in `bar`
+   |           --------- required by this bound in `bar`
 LL | fn main() {
 LL |     fn f(_: u64) {}
    |     ------------ found signature of `fn(u64) -> _`

--- a/src/test/ui/mismatched_types/closure-arg-count.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-count.stderr
@@ -49,7 +49,7 @@ error[E0593]: closure is expected to take 1 argument, but it takes 0 arguments
   --> $DIR/closure-arg-count.rs:13:5
    |
 LL | fn f<F: Fn<usize>>(_: F) {}
-   |    -    --------- required by this bound in `f`
+   |         --------- required by this bound in `f`
 ...
 LL |     f(|| panic!());
    |     ^ -- takes 0 arguments
@@ -65,7 +65,7 @@ error[E0593]: closure is expected to take 1 argument, but it takes 0 arguments
   --> $DIR/closure-arg-count.rs:15:5
    |
 LL | fn f<F: Fn<usize>>(_: F) {}
-   |    -    --------- required by this bound in `f`
+   |         --------- required by this bound in `f`
 ...
 LL |     f(  move    || panic!());
    |     ^   ---------- takes 0 arguments
@@ -150,7 +150,7 @@ LL |     call(Foo);
    |          ^^^ expected function that takes 0 arguments
 ...
 LL | fn call<F, R>(_: F) where F: FnOnce() -> R {}
-   |    ----                      ------------- required by this bound in `call`
+   |                              ------------- required by this bound in `call`
 LL | struct Foo(u8);
    | --------------- takes 1 argument
 

--- a/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
@@ -26,7 +26,7 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/closure-arg-type-mismatch.rs:10:9
    |
 LL | fn baz<F: Fn(*mut &u32)>(_: F) {}
-   |    ---    ------------- required by this bound in `baz`
+   |           ------------- required by this bound in `baz`
 LL | fn _test<'a>(f: fn(*mut &'a u32)) {
 LL |     baz(f);
    |         ^
@@ -38,7 +38,7 @@ error[E0271]: type mismatch resolving `for<'r> <fn(*mut &'a u32) as std::ops::Fn
   --> $DIR/closure-arg-type-mismatch.rs:10:5
    |
 LL | fn baz<F: Fn(*mut &u32)>(_: F) {}
-   |    ---    ------------- required by this bound in `baz`
+   |           ------------- required by this bound in `baz`
 LL | fn _test<'a>(f: fn(*mut &'a u32)) {
 LL |     baz(f);
    |     ^^^ expected bound lifetime parameter, found concrete lifetime

--- a/src/test/ui/mismatched_types/closure-mismatch.stderr
+++ b/src/test/ui/mismatched_types/closure-mismatch.stderr
@@ -2,7 +2,7 @@ error[E0271]: type mismatch resolving `for<'r> <[closure@$DIR/closure-mismatch.r
   --> $DIR/closure-mismatch.rs:8:5
    |
 LL | fn baz<T: Foo>(_: T) {}
-   |    ---    --- required by this bound in `baz`
+   |           --- required by this bound in `baz`
 ...
 LL |     baz(|_| ());
    |     ^^^ expected bound lifetime parameter, found concrete lifetime
@@ -13,7 +13,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/closure-mismatch.rs:8:5
    |
 LL | fn baz<T: Foo>(_: T) {}
-   |    ---    --- required by this bound in `baz`
+   |           --- required by this bound in `baz`
 ...
 LL |     baz(|_| ());
    |     ^^^ ------ found signature of `fn(_) -> _`

--- a/src/test/ui/mismatched_types/fn-variance-1.stderr
+++ b/src/test/ui/mismatched_types/fn-variance-1.stderr
@@ -5,7 +5,7 @@ LL | fn takes_mut(x: &mut isize) { }
    | --------------------------- found signature of `for<'r> fn(&'r mut isize) -> _`
 LL | 
 LL | fn apply<T, F>(t: T, f: F) where F: FnOnce(T) {
-   |    -----                            --------- required by this bound in `apply`
+   |                                     --------- required by this bound in `apply`
 ...
 LL |     apply(&3, takes_mut);
    |               ^^^^^^^^^ expected signature of `fn(&{integer}) -> _`
@@ -17,7 +17,7 @@ LL | fn takes_imm(x: &isize) { }
    | ----------------------- found signature of `for<'r> fn(&'r isize) -> _`
 ...
 LL | fn apply<T, F>(t: T, f: F) where F: FnOnce(T) {
-   |    -----                            --------- required by this bound in `apply`
+   |                                     --------- required by this bound in `apply`
 ...
 LL |     apply(&mut 3, takes_imm);
    |                   ^^^^^^^^^ expected signature of `fn(&mut {integer}) -> _`

--- a/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.rs
+++ b/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.rs
@@ -6,7 +6,6 @@ fn to_fn_mut<A,F:FnMut<A>>(f: F) -> F { f }
 
 fn call_it<F:FnMut(isize,isize)->isize>(y: isize, mut f: F) -> isize {
 //~^ NOTE required by this bound in `call_it`
-//~| NOTE
     f(2, y)
 }
 

--- a/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
+++ b/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
@@ -1,8 +1,8 @@
 error[E0631]: type mismatch in closure arguments
-  --> $DIR/unboxed-closures-vtable-mismatch.rs:16:24
+  --> $DIR/unboxed-closures-vtable-mismatch.rs:15:24
    |
 LL | fn call_it<F:FnMut(isize,isize)->isize>(y: isize, mut f: F) -> isize {
-   |    -------   ------------------------- required by this bound in `call_it`
+   |              ------------------------- required by this bound in `call_it`
 ...
 LL |     let f = to_fn_mut(|x: usize, y: isize| -> isize { (x as isize) + y });
    |                       ----------------------------- found signature of `fn(usize, isize) -> _`

--- a/src/test/ui/mut/mutable-enum-indirect.stderr
+++ b/src/test/ui/mut/mutable-enum-indirect.stderr
@@ -2,7 +2,7 @@ error[E0277]: `NoSync` cannot be shared between threads safely
   --> $DIR/mutable-enum-indirect.rs:17:5
    |
 LL | fn bar<T: Sync>(_: T) {}
-   |    ---    ---- required by this bound in `bar`
+   |           ---- required by this bound in `bar`
 ...
 LL |     bar(&x);
    |     ^^^ `NoSync` cannot be shared between threads safely

--- a/src/test/ui/mutexguard-sync.stderr
+++ b/src/test/ui/mutexguard-sync.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::cell::Cell<i32>` cannot be shared between threads safely
   --> $DIR/mutexguard-sync.rs:11:15
    |
 LL | fn test_sync<T: Sync>(_t: T) {}
-   |    ---------    ---- required by this bound in `test_sync`
+   |                 ---- required by this bound in `test_sync`
 ...
 LL |     test_sync(guard);
    |               ^^^^^ `std::cell::Cell<i32>` cannot be shared between threads safely

--- a/src/test/ui/namespace/namespace-mix.stderr
+++ b/src/test/ui/namespace/namespace-mix.stderr
@@ -90,7 +90,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:33:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(m1::S{});
    |           ^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -99,7 +99,7 @@ error[E0277]: the trait bound `c::S: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:35:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(m2::S{});
    |           ^^^^^^^ the trait `Impossible` is not implemented for `c::S`
@@ -108,7 +108,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:36:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(m2::S);
    |           ^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -117,7 +117,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:39:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xm1::S{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -126,7 +126,7 @@ error[E0277]: the trait bound `namespace_mix::c::S: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:41:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xm2::S{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::S`
@@ -135,7 +135,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:42:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xm2::S);
    |           ^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -144,7 +144,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:55:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(m3::TS{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -153,7 +153,7 @@ error[E0277]: the trait bound `fn() -> c::TS {c::TS}: Impossible` is not satisfi
   --> $DIR/namespace-mix.rs:56:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(m3::TS);
    |           ^^^^^^ the trait `Impossible` is not implemented for `fn() -> c::TS {c::TS}`
@@ -162,7 +162,7 @@ error[E0277]: the trait bound `c::TS: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:57:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(m4::TS{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::TS`
@@ -171,7 +171,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:58:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(m4::TS);
    |           ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -180,7 +180,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:61:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xm3::TS{});
    |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -189,7 +189,7 @@ error[E0277]: the trait bound `fn() -> namespace_mix::c::TS {namespace_mix::c::T
   --> $DIR/namespace-mix.rs:62:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xm3::TS);
    |           ^^^^^^^ the trait `Impossible` is not implemented for `fn() -> namespace_mix::c::TS {namespace_mix::c::TS}`
@@ -198,7 +198,7 @@ error[E0277]: the trait bound `namespace_mix::c::TS: Impossible` is not satisfie
   --> $DIR/namespace-mix.rs:63:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xm4::TS{});
    |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::TS`
@@ -207,7 +207,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:64:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xm4::TS);
    |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -216,7 +216,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:77:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(m5::US{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -225,7 +225,7 @@ error[E0277]: the trait bound `c::US: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:78:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(m5::US);
    |           ^^^^^^ the trait `Impossible` is not implemented for `c::US`
@@ -234,7 +234,7 @@ error[E0277]: the trait bound `c::US: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:79:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(m6::US{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::US`
@@ -243,7 +243,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:80:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(m6::US);
    |           ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -252,7 +252,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:83:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xm5::US{});
    |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -261,7 +261,7 @@ error[E0277]: the trait bound `namespace_mix::c::US: Impossible` is not satisfie
   --> $DIR/namespace-mix.rs:84:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xm5::US);
    |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::US`
@@ -270,7 +270,7 @@ error[E0277]: the trait bound `namespace_mix::c::US: Impossible` is not satisfie
   --> $DIR/namespace-mix.rs:85:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xm6::US{});
    |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::US`
@@ -279,7 +279,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:86:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xm6::US);
    |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -288,7 +288,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:99:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(m7::V{});
    |           ^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -297,7 +297,7 @@ error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:101:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(m8::V{});
    |           ^^^^^^^ the trait `Impossible` is not implemented for `c::E`
@@ -306,7 +306,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:102:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(m8::V);
    |           ^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -315,7 +315,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:105:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xm7::V{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -324,7 +324,7 @@ error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:107:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xm8::V{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
@@ -333,7 +333,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:108:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xm8::V);
    |           ^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -342,7 +342,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:121:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(m9::TV{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -351,7 +351,7 @@ error[E0277]: the trait bound `fn() -> c::E {c::E::TV}: Impossible` is not satis
   --> $DIR/namespace-mix.rs:122:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(m9::TV);
    |           ^^^^^^ the trait `Impossible` is not implemented for `fn() -> c::E {c::E::TV}`
@@ -360,7 +360,7 @@ error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:123:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(mA::TV{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::E`
@@ -369,7 +369,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:124:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(mA::TV);
    |           ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -378,7 +378,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:127:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xm9::TV{});
    |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -387,7 +387,7 @@ error[E0277]: the trait bound `fn() -> namespace_mix::c::E {namespace_mix::xm7::
   --> $DIR/namespace-mix.rs:128:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xm9::TV);
    |           ^^^^^^^ the trait `Impossible` is not implemented for `fn() -> namespace_mix::c::E {namespace_mix::xm7::TV}`
@@ -396,7 +396,7 @@ error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:129:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xmA::TV{});
    |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
@@ -405,7 +405,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:130:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xmA::TV);
    |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -414,7 +414,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:143:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(mB::UV{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -423,7 +423,7 @@ error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:144:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(mB::UV);
    |           ^^^^^^ the trait `Impossible` is not implemented for `c::E`
@@ -432,7 +432,7 @@ error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:145:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(mC::UV{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::E`
@@ -441,7 +441,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:146:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(mC::UV);
    |           ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -450,7 +450,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:149:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xmB::UV{});
    |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -459,7 +459,7 @@ error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:150:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xmB::UV);
    |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
@@ -468,7 +468,7 @@ error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:151:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xmC::UV{});
    |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
@@ -477,7 +477,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:152:11
    |
 LL | fn check<T: Impossible>(_: T) {}
-   |    -----    ---------- required by this bound in `check`
+   |             ---------- required by this bound in `check`
 ...
 LL |     check(xmC::UV);
    |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`

--- a/src/test/ui/never_type/defaulted-never-note.rs
+++ b/src/test/ui/never_type/defaulted-never-note.rs
@@ -20,7 +20,6 @@ impl ImplementedForUnitButNotNever for () {}
 
 fn foo<T: ImplementedForUnitButNotNever>(_t: T) {}
 //~^ NOTE required by this bound in `foo`
-//~| NOTE
 
 fn smeg() {
     let _x = return;

--- a/src/test/ui/never_type/defaulted-never-note.stderr
+++ b/src/test/ui/never_type/defaulted-never-note.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `!: ImplementedForUnitButNotNever` is not satisfied
-  --> $DIR/defaulted-never-note.rs:27:5
+  --> $DIR/defaulted-never-note.rs:26:5
    |
 LL | fn foo<T: ImplementedForUnitButNotNever>(_t: T) {}
-   |    ---    ----------------------------- required by this bound in `foo`
+   |           ----------------------------- required by this bound in `foo`
 ...
 LL |     foo(_x);
    |     ^^^ the trait `ImplementedForUnitButNotNever` is not implemented for `!`

--- a/src/test/ui/no_send-enum.stderr
+++ b/src/test/ui/no_send-enum.stderr
@@ -2,7 +2,7 @@ error[E0277]: `NoSend` cannot be sent between threads safely
   --> $DIR/no_send-enum.rs:16:5
    |
 LL | fn bar<T: Send>(_: T) {}
-   |    ---    ---- required by this bound in `bar`
+   |           ---- required by this bound in `bar`
 ...
 LL |     bar(x);
    |     ^^^ `NoSend` cannot be sent between threads safely

--- a/src/test/ui/no_send-rc.stderr
+++ b/src/test/ui/no_send-rc.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::rc::Rc<{integer}>` cannot be sent between threads safely
   --> $DIR/no_send-rc.rs:7:9
    |
 LL | fn bar<T: Send>(_: T) {}
-   |    ---    ---- required by this bound in `bar`
+   |           ---- required by this bound in `bar`
 ...
 LL |     bar(x);
    |         ^ `std::rc::Rc<{integer}>` cannot be sent between threads safely

--- a/src/test/ui/no_send-struct.stderr
+++ b/src/test/ui/no_send-struct.stderr
@@ -2,7 +2,7 @@ error[E0277]: `Foo` cannot be sent between threads safely
   --> $DIR/no_send-struct.rs:15:9
    |
 LL | fn bar<T: Send>(_: T) {}
-   |    ---    ---- required by this bound in `bar`
+   |           ---- required by this bound in `bar`
 ...
 LL |     bar(x);
    |         ^ `Foo` cannot be sent between threads safely

--- a/src/test/ui/no_share-enum.stderr
+++ b/src/test/ui/no_share-enum.stderr
@@ -2,7 +2,7 @@ error[E0277]: `NoSync` cannot be shared between threads safely
   --> $DIR/no_share-enum.rs:14:5
    |
 LL | fn bar<T: Sync>(_: T) {}
-   |    ---    ---- required by this bound in `bar`
+   |           ---- required by this bound in `bar`
 ...
 LL |     bar(x);
    |     ^^^ `NoSync` cannot be shared between threads safely

--- a/src/test/ui/no_share-struct.stderr
+++ b/src/test/ui/no_share-struct.stderr
@@ -2,7 +2,7 @@ error[E0277]: `Foo` cannot be shared between threads safely
   --> $DIR/no_share-struct.rs:12:9
    |
 LL | fn bar<T: Sync>(_: T) {}
-   |    ---    ---- required by this bound in `bar`
+   |           ---- required by this bound in `bar`
 ...
 LL |     bar(x);
    |         ^ `Foo` cannot be shared between threads safely

--- a/src/test/ui/not-panic/not-panic-safe-2.stderr
+++ b/src/test/ui/not-panic/not-panic-safe-2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the type `std::cell::UnsafeCell<i32>` may contain interior mutabil
   --> $DIR/not-panic-safe-2.rs:10:5
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   |    ------    ---------- required by this bound in `assert`
+   |              ---------- required by this bound in `assert`
 ...
 LL |     assert::<Rc<RefCell<i32>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
@@ -15,7 +15,7 @@ error[E0277]: the type `std::cell::UnsafeCell<isize>` may contain interior mutab
   --> $DIR/not-panic-safe-2.rs:10:5
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   |    ------    ---------- required by this bound in `assert`
+   |              ---------- required by this bound in `assert`
 ...
 LL |     assert::<Rc<RefCell<i32>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary

--- a/src/test/ui/not-panic/not-panic-safe-3.stderr
+++ b/src/test/ui/not-panic/not-panic-safe-3.stderr
@@ -2,7 +2,7 @@ error[E0277]: the type `std::cell::UnsafeCell<i32>` may contain interior mutabil
   --> $DIR/not-panic-safe-3.rs:10:5
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   |    ------    ---------- required by this bound in `assert`
+   |              ---------- required by this bound in `assert`
 ...
 LL |     assert::<Arc<RefCell<i32>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
@@ -15,7 +15,7 @@ error[E0277]: the type `std::cell::UnsafeCell<isize>` may contain interior mutab
   --> $DIR/not-panic-safe-3.rs:10:5
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   |    ------    ---------- required by this bound in `assert`
+   |              ---------- required by this bound in `assert`
 ...
 LL |     assert::<Arc<RefCell<i32>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary

--- a/src/test/ui/not-panic/not-panic-safe-4.stderr
+++ b/src/test/ui/not-panic/not-panic-safe-4.stderr
@@ -2,7 +2,7 @@ error[E0277]: the type `std::cell::UnsafeCell<i32>` may contain interior mutabil
   --> $DIR/not-panic-safe-4.rs:9:5
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   |    ------    ---------- required by this bound in `assert`
+   |              ---------- required by this bound in `assert`
 ...
 LL |     assert::<&RefCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
@@ -15,7 +15,7 @@ error[E0277]: the type `std::cell::UnsafeCell<isize>` may contain interior mutab
   --> $DIR/not-panic-safe-4.rs:9:5
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   |    ------    ---------- required by this bound in `assert`
+   |              ---------- required by this bound in `assert`
 ...
 LL |     assert::<&RefCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary

--- a/src/test/ui/not-panic/not-panic-safe-5.stderr
+++ b/src/test/ui/not-panic/not-panic-safe-5.stderr
@@ -2,7 +2,7 @@ error[E0277]: the type `std::cell::UnsafeCell<i32>` may contain interior mutabil
   --> $DIR/not-panic-safe-5.rs:9:5
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   |    ------    ---------- required by this bound in `assert`
+   |              ---------- required by this bound in `assert`
 ...
 LL |     assert::<*const UnsafeCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary

--- a/src/test/ui/not-panic/not-panic-safe-6.stderr
+++ b/src/test/ui/not-panic/not-panic-safe-6.stderr
@@ -2,7 +2,7 @@ error[E0277]: the type `std::cell::UnsafeCell<i32>` may contain interior mutabil
   --> $DIR/not-panic-safe-6.rs:9:5
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   |    ------    ---------- required by this bound in `assert`
+   |              ---------- required by this bound in `assert`
 ...
 LL |     assert::<*mut RefCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
@@ -15,7 +15,7 @@ error[E0277]: the type `std::cell::UnsafeCell<isize>` may contain interior mutab
   --> $DIR/not-panic-safe-6.rs:9:5
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   |    ------    ---------- required by this bound in `assert`
+   |              ---------- required by this bound in `assert`
 ...
 LL |     assert::<*mut RefCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary

--- a/src/test/ui/not-panic/not-panic-safe.stderr
+++ b/src/test/ui/not-panic/not-panic-safe.stderr
@@ -2,7 +2,7 @@ error[E0277]: the type `&mut i32` may not be safely transferred across an unwind
   --> $DIR/not-panic-safe.rs:9:5
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   |    ------    ---------- required by this bound in `assert`
+   |              ---------- required by this bound in `assert`
 ...
 LL |     assert::<&mut i32>();
    |     ^^^^^^^^^^^^^^^^^^ `&mut i32` may not be safely transferred across an unwind boundary

--- a/src/test/ui/not-sync.stderr
+++ b/src/test/ui/not-sync.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::cell::Cell<i32>` cannot be shared between threads safely
   --> $DIR/not-sync.rs:8:12
    |
 LL | fn test<T: Sync>() {}
-   |    ----    ---- required by this bound in `test`
+   |            ---- required by this bound in `test`
 ...
 LL |     test::<Cell<i32>>();
    |            ^^^^^^^^^ `std::cell::Cell<i32>` cannot be shared between threads safely
@@ -13,7 +13,7 @@ error[E0277]: `std::cell::RefCell<i32>` cannot be shared between threads safely
   --> $DIR/not-sync.rs:10:12
    |
 LL | fn test<T: Sync>() {}
-   |    ----    ---- required by this bound in `test`
+   |            ---- required by this bound in `test`
 ...
 LL |     test::<RefCell<i32>>();
    |            ^^^^^^^^^^^^ `std::cell::RefCell<i32>` cannot be shared between threads safely
@@ -24,7 +24,7 @@ error[E0277]: `std::rc::Rc<i32>` cannot be shared between threads safely
   --> $DIR/not-sync.rs:13:12
    |
 LL | fn test<T: Sync>() {}
-   |    ----    ---- required by this bound in `test`
+   |            ---- required by this bound in `test`
 ...
 LL |     test::<Rc<i32>>();
    |            ^^^^^^^ `std::rc::Rc<i32>` cannot be shared between threads safely
@@ -35,7 +35,7 @@ error[E0277]: `std::rc::Weak<i32>` cannot be shared between threads safely
   --> $DIR/not-sync.rs:15:12
    |
 LL | fn test<T: Sync>() {}
-   |    ----    ---- required by this bound in `test`
+   |            ---- required by this bound in `test`
 ...
 LL |     test::<Weak<i32>>();
    |            ^^^^^^^^^ `std::rc::Weak<i32>` cannot be shared between threads safely
@@ -46,7 +46,7 @@ error[E0277]: `std::sync::mpsc::Receiver<i32>` cannot be shared between threads 
   --> $DIR/not-sync.rs:18:12
    |
 LL | fn test<T: Sync>() {}
-   |    ----    ---- required by this bound in `test`
+   |            ---- required by this bound in `test`
 ...
 LL |     test::<Receiver<i32>>();
    |            ^^^^^^^^^^^^^ `std::sync::mpsc::Receiver<i32>` cannot be shared between threads safely
@@ -57,7 +57,7 @@ error[E0277]: `std::sync::mpsc::Sender<i32>` cannot be shared between threads sa
   --> $DIR/not-sync.rs:20:12
    |
 LL | fn test<T: Sync>() {}
-   |    ----    ---- required by this bound in `test`
+   |            ---- required by this bound in `test`
 ...
 LL |     test::<Sender<i32>>();
    |            ^^^^^^^^^^^ `std::sync::mpsc::Sender<i32>` cannot be shared between threads safely

--- a/src/test/ui/object-does-not-impl-trait.stderr
+++ b/src/test/ui/object-does-not-impl-trait.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `std::boxed::Box<dyn Foo>: Foo` is not satisfied
   --> $DIR/object-does-not-impl-trait.rs:6:44
    |
 LL | fn take_foo<F:Foo>(f: F) {}
-   |    --------   --- required by this bound in `take_foo`
+   |               --- required by this bound in `take_foo`
 LL | fn take_object(f: Box<dyn Foo>) { take_foo(f); }
    |                                            ^ the trait `Foo` is not implemented for `std::boxed::Box<dyn Foo>`
 

--- a/src/test/ui/on-unimplemented/enclosing-scope.stderr
+++ b/src/test/ui/on-unimplemented/enclosing-scope.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Foo: Trait` is not satisfied
   --> $DIR/enclosing-scope.rs:14:11
    |
 LL |   fn f<T: Trait>(x: T) {}
-   |      -    ----- required by this bound in `f`
+   |           ----- required by this bound in `f`
 ...
 LL |       let x = || {
    |  _____________-
@@ -18,7 +18,7 @@ error[E0277]: the trait bound `Foo: Trait` is not satisfied
   --> $DIR/enclosing-scope.rs:16:15
    |
 LL |   fn f<T: Trait>(x: T) {}
-   |      -    ----- required by this bound in `f`
+   |           ----- required by this bound in `f`
 ...
 LL |           let y = || {
    |  _________________-
@@ -31,7 +31,7 @@ error[E0277]: the trait bound `Foo: Trait` is not satisfied
   --> $DIR/enclosing-scope.rs:22:15
    |
 LL |   fn f<T: Trait>(x: T) {}
-   |      -    ----- required by this bound in `f`
+   |           ----- required by this bound in `f`
 LL | 
 LL | / fn main() {
 LL | |     let x = || {
@@ -49,7 +49,7 @@ error[E0277]: the trait bound `Foo: Trait` is not satisfied
   --> $DIR/enclosing-scope.rs:26:7
    |
 LL |   fn f<T: Trait>(x: T) {}
-   |      -    ----- required by this bound in `f`
+   |           ----- required by this bound in `f`
 LL | 
 LL | / fn main() {
 LL | |     let x = || {

--- a/src/test/ui/on-unimplemented/on-trait.stderr
+++ b/src/test/ui/on-unimplemented/on-trait.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `std::option::Option<std::vec::Vec<u8>>: MyFromIte
   --> $DIR/on-trait.rs:28:30
    |
 LL | fn collect<A, I: Iterator<Item=A>, B: MyFromIterator<A>>(it: I) -> B {
-   |    -------                            ----------------- required by this bound in `collect`
+   |                                       ----------------- required by this bound in `collect`
 ...
 LL |     let y: Option<Vec<u8>> = collect(x.iter()); // this should give approximately the same error for x.iter().collect()
    |                              ^^^^^^^ a collection of type `std::option::Option<std::vec::Vec<u8>>` cannot be built from an iterator over elements of type `&u8`
@@ -13,7 +13,7 @@ error[E0277]: the trait bound `std::string::String: Bar::Foo<u8, _, u32>` is not
   --> $DIR/on-trait.rs:31:21
    |
 LL | fn foobar<U: Clone, T: Foo<u8, U, u32>>() -> T {
-   |    ------              --------------- required by this bound in `foobar`
+   |                        --------------- required by this bound in `foobar`
 ...
 LL |     let x: String = foobar();
    |                     ^^^^^^ test error `std::string::String` with `u8` `_` `u32` in `Bar::Foo`

--- a/src/test/ui/phantom-oibit.stderr
+++ b/src/test/ui/phantom-oibit.stderr
@@ -2,7 +2,7 @@ error[E0277]: `T` cannot be shared between threads safely
   --> $DIR/phantom-oibit.rs:21:12
    |
 LL | fn is_zen<T: Zen>(_: T) {}
-   |    ------    --- required by this bound in `is_zen`
+   |              --- required by this bound in `is_zen`
 ...
 LL |     is_zen(x)
    |            ^ `T` cannot be shared between threads safely
@@ -20,7 +20,7 @@ error[E0277]: `T` cannot be shared between threads safely
   --> $DIR/phantom-oibit.rs:26:12
    |
 LL | fn is_zen<T: Zen>(_: T) {}
-   |    ------    --- required by this bound in `is_zen`
+   |              --- required by this bound in `is_zen`
 ...
 LL |     is_zen(x)
    |            ^ `T` cannot be shared between threads safely

--- a/src/test/ui/recursion/recursive-requirements.stderr
+++ b/src/test/ui/recursion/recursive-requirements.stderr
@@ -2,7 +2,7 @@ error[E0277]: `*const Bar` cannot be shared between threads safely
   --> $DIR/recursive-requirements.rs:16:12
    |
 LL | struct AssertSync<T: Sync>(PhantomData<T>);
-   | ------------------------------------------- required by `AssertSync`
+   |        ----------    ---- required by this bound in `AssertSync`
 ...
 LL |     let _: AssertSync<Foo> = unimplemented!();
    |            ^^^^^^^^^^^^^^^ `*const Bar` cannot be shared between threads safely
@@ -14,7 +14,7 @@ error[E0277]: `*const Foo` cannot be shared between threads safely
   --> $DIR/recursive-requirements.rs:16:12
    |
 LL | struct AssertSync<T: Sync>(PhantomData<T>);
-   | ------------------------------------------- required by `AssertSync`
+   |        ----------    ---- required by this bound in `AssertSync`
 ...
 LL |     let _: AssertSync<Foo> = unimplemented!();
    |            ^^^^^^^^^^^^^^^ `*const Foo` cannot be shared between threads safely

--- a/src/test/ui/recursion/recursive-requirements.stderr
+++ b/src/test/ui/recursion/recursive-requirements.stderr
@@ -2,7 +2,7 @@ error[E0277]: `*const Bar` cannot be shared between threads safely
   --> $DIR/recursive-requirements.rs:16:12
    |
 LL | struct AssertSync<T: Sync>(PhantomData<T>);
-   |        ----------    ---- required by this bound in `AssertSync`
+   |                      ---- required by this bound in `AssertSync`
 ...
 LL |     let _: AssertSync<Foo> = unimplemented!();
    |            ^^^^^^^^^^^^^^^ `*const Bar` cannot be shared between threads safely
@@ -14,7 +14,7 @@ error[E0277]: `*const Foo` cannot be shared between threads safely
   --> $DIR/recursive-requirements.rs:16:12
    |
 LL | struct AssertSync<T: Sync>(PhantomData<T>);
-   |        ----------    ---- required by this bound in `AssertSync`
+   |                      ---- required by this bound in `AssertSync`
 ...
 LL |     let _: AssertSync<Foo> = unimplemented!();
    |            ^^^^^^^^^^^^^^^ `*const Foo` cannot be shared between threads safely

--- a/src/test/ui/str/str-mut-idx.stderr
+++ b/src/test/ui/str/str-mut-idx.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `str` cannot be known at compilation t
   --> $DIR/str-mut-idx.rs:4:15
    |
 LL | fn bot<T>() -> T { loop {} }
-   |    --- - required by this bound in `bot`
+   |        - required by this bound in `bot`
 ...
 LL |     s[1..2] = bot();
    |               ^^^ doesn't have a size known at compile-time

--- a/src/test/ui/substs-ppaux.normal.stderr
+++ b/src/test/ui/substs-ppaux.normal.stderr
@@ -74,7 +74,7 @@ error[E0277]: the size for values of type `str` cannot be known at compilation t
   --> $DIR/substs-ppaux.rs:49:5
    |
 LL |     fn bar<'a, T>() where T: 'a {}
-   |        ---                   -- required by this bound in `Foo::bar`
+   |                              -- required by this bound in `Foo::bar`
 ...
 LL |     <str as Foo<u8>>::bar;
    |     ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/substs-ppaux.verbose.stderr
+++ b/src/test/ui/substs-ppaux.verbose.stderr
@@ -74,7 +74,7 @@ error[E0277]: the size for values of type `str` cannot be known at compilation t
   --> $DIR/substs-ppaux.rs:49:5
    |
 LL |     fn bar<'a, T>() where T: 'a {}
-   |        ---                   -- required by this bound in `Foo::bar`
+   |                              -- required by this bound in `Foo::bar`
 ...
 LL |     <str as Foo<u8>>::bar;
    |     ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -5,7 +5,7 @@ LL | async fn foo() {}
    |          --- consider calling this function
 LL | 
 LL | fn bar(f: impl Future<Output=()>) {}
-   |    ---         ----------------- required by this bound in `bar`
+   |                ----------------- required by this bound in `bar`
 ...
 LL |     bar(foo);
    |         ^^^ the trait `std::future::Future` is not implemented for `fn() -> impl std::future::Future {foo}`
@@ -19,7 +19,7 @@ error[E0277]: the trait bound `[closure@$DIR/async-fn-ctor-passed-as-arg-where-i
   --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:12:9
    |
 LL | fn bar(f: impl Future<Output=()>) {}
-   |    ---         ----------------- required by this bound in `bar`
+   |                ----------------- required by this bound in `bar`
 ...
 LL |     let async_closure = async || ();
    |                         -------- consider calling this closure

--- a/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -5,7 +5,7 @@ LL | fn foo() -> impl T<O=()> { S }
    |    --- consider calling this function
 LL | 
 LL | fn bar(f: impl T<O=()>) {}
-   |    ---         ------- required by this bound in `bar`
+   |                ------- required by this bound in `bar`
 ...
 LL |     bar(foo);
    |         ^^^ the trait `T` is not implemented for `fn() -> impl T {foo}`
@@ -19,7 +19,7 @@ error[E0277]: the trait bound `[closure@$DIR/fn-ctor-passed-as-arg-where-it-shou
   --> $DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:19:9
    |
 LL | fn bar(f: impl T<O=()>) {}
-   |    ---         ------- required by this bound in `bar`
+   |                ------- required by this bound in `bar`
 ...
 LL |     let closure = || S;
    |                   -- consider calling this closure

--- a/src/test/ui/suggestions/imm-ref-trait-object-literal.stderr
+++ b/src/test/ui/suggestions/imm-ref-trait-object-literal.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `&S: Trait` is not satisfied
   --> $DIR/imm-ref-trait-object-literal.rs:12:7
    |
 LL | fn foo<X: Trait>(_: X) {}
-   |    ---    ----- required by this bound in `foo`
+   |           ----- required by this bound in `foo`
 ...
 LL |   foo(&s);
    |       ^^ the trait `Trait` is not implemented for `&S`
@@ -18,7 +18,7 @@ error[E0277]: the trait bound `S: Trait` is not satisfied
   --> $DIR/imm-ref-trait-object-literal.rs:13:7
    |
 LL | fn foo<X: Trait>(_: X) {}
-   |    ---    ----- required by this bound in `foo`
+   |           ----- required by this bound in `foo`
 ...
 LL |   foo(s);
    |       ^ the trait `Trait` is not implemented for `S`

--- a/src/test/ui/suggestions/into-str.stderr
+++ b/src/test/ui/suggestions/into-str.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `&str: std::convert::From<std::string::String>` is
   --> $DIR/into-str.rs:4:5
    |
 LL | fn foo<'a, T>(_t: T) where T: Into<&'a str> {}
-   |    ---                        ------------- required by this bound in `foo`
+   |                               ------------- required by this bound in `foo`
 ...
 LL |     foo(String::new());
    |     ^^^ the trait `std::convert::From<std::string::String>` is not implemented for `&str`

--- a/src/test/ui/suggestions/missing-assoc-type-bound-restriction.stderr
+++ b/src/test/ui/suggestions/missing-assoc-type-bound-restriction.stderr
@@ -2,7 +2,10 @@ error[E0277]: the trait bound `<T as Parent>::Assoc: Child<A>` is not satisfied
   --> $DIR/missing-assoc-type-bound-restriction.rs:17:19
    |
 LL | trait Parent {
-   | ------------ required by `Parent`
+   |       ------
+LL |     type Ty;
+LL |     type Assoc: Child<Self::Ty>;
+   |                 --------------- required by this bound in `Parent`
 ...
 LL | impl<A, T: Parent<Ty = A>> Parent for ParentWrapper<T> {
    |                   ^^^^^^                              - help: consider further restricting the associated type: `where <T as Parent>::Assoc: Child<A>`
@@ -29,7 +32,10 @@ error[E0277]: the trait bound `<T as Parent>::Assoc: Child<A>` is not satisfied
   --> $DIR/missing-assoc-type-bound-restriction.rs:20:5
    |
 LL | trait Parent {
-   | ------------ required by `Parent`
+   |       ------
+LL |     type Ty;
+LL |     type Assoc: Child<Self::Ty>;
+   |                 --------------- required by this bound in `Parent`
 ...
 LL | impl<A, T: Parent<Ty = A>> Parent for ParentWrapper<T> {
    |                                                       - help: consider further restricting the associated type: `where <T as Parent>::Assoc: Child<A>`

--- a/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
+++ b/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
@@ -12,18 +12,26 @@ error[E0277]: the trait bound `&dyn std::io::Write: std::io::Write` is not satis
    |
 LL |     let fp = BufWriter::new(fp);
    |              ^^^^^^^^^^^^^^ the trait `std::io::Write` is not implemented for `&dyn std::io::Write`
+   | 
+  ::: $SRC_DIR/libstd/io/buffered.rs:LL:COL
+   |
+LL | pub struct BufWriter<W: Write> {
+   |                         ----- required by this bound in `std::io::BufWriter`
    |
    = note: `std::io::Write` is implemented for `&mut dyn std::io::Write`, but not for `&dyn std::io::Write`
-   = note: required by `std::io::BufWriter`
 
 error[E0277]: the trait bound `&dyn std::io::Write: std::io::Write` is not satisfied
   --> $DIR/mut-borrow-needed-by-trait.rs:17:14
    |
 LL |     let fp = BufWriter::new(fp);
    |              ^^^^^^^^^^^^^^^^^^ the trait `std::io::Write` is not implemented for `&dyn std::io::Write`
+   | 
+  ::: $SRC_DIR/libstd/io/buffered.rs:LL:COL
+   |
+LL | pub struct BufWriter<W: Write> {
+   |                         ----- required by this bound in `std::io::BufWriter`
    |
    = note: `std::io::Write` is implemented for `&mut dyn std::io::Write`, but not for `&dyn std::io::Write`
-   = note: required by `std::io::BufWriter`
 
 error[E0599]: no method named `write_fmt` found for struct `std::io::BufWriter<&dyn std::io::Write>` in the current scope
   --> $DIR/mut-borrow-needed-by-trait.rs:22:5

--- a/src/test/ui/suggestions/restrict-type-argument.stderr
+++ b/src/test/ui/suggestions/restrict-type-argument.stderr
@@ -2,7 +2,7 @@ error[E0277]: `impl Sync` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:4:13
    |
 LL | fn is_send<T: Send>(val: T) {}
-   |    -------    ---- required by this bound in `is_send`
+   |               ---- required by this bound in `is_send`
 ...
 LL |     is_send(val);
    |             ^^^ `impl Sync` cannot be sent between threads safely
@@ -17,7 +17,7 @@ error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:8:13
    |
 LL | fn is_send<T: Send>(val: T) {}
-   |    -------    ---- required by this bound in `is_send`
+   |               ---- required by this bound in `is_send`
 ...
 LL |     is_send(val);
    |             ^^^ `S` cannot be sent between threads safely
@@ -32,7 +32,7 @@ error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:12:13
    |
 LL | fn is_send<T: Send>(val: T) {}
-   |    -------    ---- required by this bound in `is_send`
+   |               ---- required by this bound in `is_send`
 ...
 LL |     is_send(val);
    |             ^^^ `S` cannot be sent between threads safely
@@ -47,7 +47,7 @@ error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:20:13
    |
 LL | fn is_send<T: Send>(val: T) {}
-   |    -------    ---- required by this bound in `is_send`
+   |               ---- required by this bound in `is_send`
 ...
 LL |     is_send(val);
    |             ^^^ `S` cannot be sent between threads safely
@@ -62,7 +62,7 @@ error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:24:13
    |
 LL | fn is_send<T: Send>(val: T) {}
-   |    -------    ---- required by this bound in `is_send`
+   |               ---- required by this bound in `is_send`
 ...
 LL |     is_send(val);
    |             ^^^ `S` cannot be sent between threads safely
@@ -77,7 +77,7 @@ error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:28:13
    |
 LL | fn is_send<T: Send>(val: T) {}
-   |    -------    ---- required by this bound in `is_send`
+   |               ---- required by this bound in `is_send`
 ...
 LL |     is_send(val);
    |             ^^^ `S` cannot be sent between threads safely

--- a/src/test/ui/traits/negative-impls/negated-auto-traits-error.stderr
+++ b/src/test/ui/traits/negative-impls/negated-auto-traits-error.stderr
@@ -13,7 +13,7 @@ error[E0277]: `dummy::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:23:5
    |
 LL | struct Outer<T: Send>(T);
-   | ------------------------- required by `Outer`
+   |        -----    ---- required by this bound in `Outer`
 ...
 LL |     Outer(TestType);
    |     ^^^^^^^^^^^^^^^ `dummy::TestType` cannot be sent between threads safely

--- a/src/test/ui/traits/negative-impls/negated-auto-traits-error.stderr
+++ b/src/test/ui/traits/negative-impls/negated-auto-traits-error.stderr
@@ -13,7 +13,7 @@ error[E0277]: `dummy::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:23:5
    |
 LL | struct Outer<T: Send>(T);
-   |        -----    ---- required by this bound in `Outer`
+   |                 ---- required by this bound in `Outer`
 ...
 LL |     Outer(TestType);
    |     ^^^^^^^^^^^^^^^ `dummy::TestType` cannot be sent between threads safely
@@ -24,7 +24,7 @@ error[E0277]: `dummy1b::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:32:13
    |
 LL | fn is_send<T: Send>(_: T) {}
-   |    -------    ---- required by this bound in `is_send`
+   |               ---- required by this bound in `is_send`
 ...
 LL |     is_send(TestType);
    |             ^^^^^^^^ `dummy1b::TestType` cannot be sent between threads safely
@@ -35,7 +35,7 @@ error[E0277]: `dummy1c::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:40:13
    |
 LL | fn is_send<T: Send>(_: T) {}
-   |    -------    ---- required by this bound in `is_send`
+   |               ---- required by this bound in `is_send`
 ...
 LL |     is_send((8, TestType));
    |             ^^^^^^^^^^^^^ `dummy1c::TestType` cannot be sent between threads safely
@@ -47,7 +47,7 @@ error[E0277]: `dummy2::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:48:13
    |
 LL | fn is_send<T: Send>(_: T) {}
-   |    -------    ---- required by this bound in `is_send`
+   |               ---- required by this bound in `is_send`
 ...
 LL |     is_send(Box::new(TestType));
    |             ^^^^^^^^^^^^^^^^^^
@@ -63,7 +63,7 @@ error[E0277]: `dummy3::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:56:13
    |
 LL | fn is_send<T: Send>(_: T) {}
-   |    -------    ---- required by this bound in `is_send`
+   |               ---- required by this bound in `is_send`
 ...
 LL |     is_send(Box::new(Outer2(TestType)));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ `dummy3::TestType` cannot be sent between threads safely
@@ -77,7 +77,7 @@ error[E0277]: `main::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:66:13
    |
 LL | fn is_sync<T: Sync>(_: T) {}
-   |    -------    ---- required by this bound in `is_sync`
+   |               ---- required by this bound in `is_sync`
 ...
 LL |     is_sync(Outer2(TestType));
    |             ^^^^^^^^^^^^^^^^

--- a/src/test/ui/traits/trait-alias/trait-alias-cross-crate.stderr
+++ b/src/test/ui/traits/trait-alias/trait-alias-cross-crate.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::rc::Rc<u32>` cannot be sent between threads safely
   --> $DIR/trait-alias-cross-crate.rs:14:17
    |
 LL | fn use_alias<T: SendSync>() {}
-   |    ---------    -------- required by this bound in `use_alias`
+   |                 -------- required by this bound in `use_alias`
 ...
 LL |     use_alias::<Rc<u32>>();
    |                 ^^^^^^^ `std::rc::Rc<u32>` cannot be sent between threads safely
@@ -13,7 +13,7 @@ error[E0277]: `std::rc::Rc<u32>` cannot be shared between threads safely
   --> $DIR/trait-alias-cross-crate.rs:14:17
    |
 LL | fn use_alias<T: SendSync>() {}
-   |    ---------    -------- required by this bound in `use_alias`
+   |                 -------- required by this bound in `use_alias`
 ...
 LL |     use_alias::<Rc<u32>>();
    |                 ^^^^^^^ `std::rc::Rc<u32>` cannot be shared between threads safely

--- a/src/test/ui/traits/trait-alias/trait-alias-wf.stderr
+++ b/src/test/ui/traits/trait-alias/trait-alias-wf.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: Foo` is not satisfied
   --> $DIR/trait-alias-wf.rs:5:14
    |
 LL | trait A<T: Foo> {}
-   | --------------- required by `A`
+   |       -    --- required by this bound in `A`
 LL | trait B<T> = A<T>;
    |              ^^^^ the trait `Foo` is not implemented for `T`
    |

--- a/src/test/ui/traits/trait-alias/trait-alias-wf.stderr
+++ b/src/test/ui/traits/trait-alias/trait-alias-wf.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: Foo` is not satisfied
   --> $DIR/trait-alias-wf.rs:5:14
    |
 LL | trait A<T: Foo> {}
-   |       -    --- required by this bound in `A`
+   |            --- required by this bound in `A`
 LL | trait B<T> = A<T>;
    |              ^^^^ the trait `Foo` is not implemented for `T`
    |

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-in-fns.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-in-fns.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `u32: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-in-fns.rs:13:15
    |
 LL | struct Foo<T:Trait> {
-   | ------------------- required by `Foo`
+   |        ---   ----- required by this bound in `Foo`
 ...
 LL | fn explode(x: Foo<u32>) {}
    |               ^^^^^^^^ the trait `Trait` is not implemented for `u32`
@@ -11,7 +11,7 @@ error[E0277]: the trait bound `f32: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-in-fns.rs:16:14
    |
 LL | enum Bar<T:Trait> {
-   | ----------------- required by `Bar`
+   |      ---   ----- required by this bound in `Bar`
 ...
 LL | fn kaboom(y: Bar<f32>) {}
    |              ^^^^^^^^ the trait `Trait` is not implemented for `f32`

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-in-fns.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-in-fns.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `u32: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-in-fns.rs:13:15
    |
 LL | struct Foo<T:Trait> {
-   |        ---   ----- required by this bound in `Foo`
+   |              ----- required by this bound in `Foo`
 ...
 LL | fn explode(x: Foo<u32>) {}
    |               ^^^^^^^^ the trait `Trait` is not implemented for `u32`
@@ -11,7 +11,7 @@ error[E0277]: the trait bound `f32: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-in-fns.rs:16:14
    |
 LL | enum Bar<T:Trait> {
-   |      ---   ----- required by this bound in `Bar`
+   |            ----- required by this bound in `Bar`
 ...
 LL | fn kaboom(y: Bar<f32>) {}
    |              ^^^^^^^^ the trait `Trait` is not implemented for `f32`

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-in-impls.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-in-impls.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `u16: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-in-impls.rs:20:6
    |
 LL | struct Foo<T:Trait> {
-   | ------------------- required by `Foo`
+   |        ---   ----- required by this bound in `Foo`
 ...
 LL | impl PolyTrait<Foo<u16>> for Struct {
    |      ^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `u16`

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-in-impls.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-in-impls.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `u16: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-in-impls.rs:20:6
    |
 LL | struct Foo<T:Trait> {
-   |        ---   ----- required by this bound in `Foo`
+   |              ----- required by this bound in `Foo`
 ...
 LL | impl PolyTrait<Foo<u16>> for Struct {
    |      ^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `u16`

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-locals.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-locals.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `usize: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-locals.rs:15:14
    |
 LL | struct Foo<T:Trait> {
-   | ------------------- required by `Foo`
+   |        ---   ----- required by this bound in `Foo`
 ...
 LL |     let baz: Foo<usize> = loop { };
    |              ^^^^^^^^^^ the trait `Trait` is not implemented for `usize`

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-locals.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-locals.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `usize: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-locals.rs:15:14
    |
 LL | struct Foo<T:Trait> {
-   |        ---   ----- required by this bound in `Foo`
+   |              ----- required by this bound in `Foo`
 ...
 LL |     let baz: Foo<usize> = loop { };
    |              ^^^^^^^^^^ the trait `Trait` is not implemented for `usize`

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-static.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-static.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `usize: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-static.rs:9:11
    |
 LL | struct Foo<T:Trait> {
-   |        ---   ----- required by this bound in `Foo`
+   |              ----- required by this bound in `Foo`
 ...
 LL | static X: Foo<usize> = Foo {
    |           ^^^^^^^^^^ the trait `Trait` is not implemented for `usize`

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-static.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-static.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `usize: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-static.rs:9:11
    |
 LL | struct Foo<T:Trait> {
-   | ------------------- required by `Foo`
+   |        ---   ----- required by this bound in `Foo`
 ...
 LL | static X: Foo<usize> = Foo {
    |           ^^^^^^^^^^ the trait `Trait` is not implemented for `usize`

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-xc.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-xc.stderr
@@ -3,16 +3,22 @@ error[E0277]: the trait bound `usize: trait_bounds_on_structs_and_enums_xc::Trai
    |
 LL | fn explode(x: Foo<usize>) {}
    |               ^^^^^^^^^^ the trait `trait_bounds_on_structs_and_enums_xc::Trait` is not implemented for `usize`
+   | 
+  ::: $DIR/auxiliary/trait_bounds_on_structs_and_enums_xc.rs:5:18
    |
-   = note: required by `trait_bounds_on_structs_and_enums_xc::Foo`
+LL | pub struct Foo<T:Trait> {
+   |                  ----- required by this bound in `trait_bounds_on_structs_and_enums_xc::Foo`
 
 error[E0277]: the trait bound `f32: trait_bounds_on_structs_and_enums_xc::Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-xc.rs:10:14
    |
 LL | fn kaboom(y: Bar<f32>) {}
    |              ^^^^^^^^ the trait `trait_bounds_on_structs_and_enums_xc::Trait` is not implemented for `f32`
+   | 
+  ::: $DIR/auxiliary/trait_bounds_on_structs_and_enums_xc.rs:9:16
    |
-   = note: required by `trait_bounds_on_structs_and_enums_xc::Bar`
+LL | pub enum Bar<T:Trait> {
+   |                ----- required by this bound in `trait_bounds_on_structs_and_enums_xc::Bar`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-xc1.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-xc1.stderr
@@ -3,8 +3,11 @@ error[E0277]: the trait bound `f64: trait_bounds_on_structs_and_enums_xc::Trait`
    |
 LL |     let bar: Bar<f64> = return;
    |              ^^^^^^^^ the trait `trait_bounds_on_structs_and_enums_xc::Trait` is not implemented for `f64`
+   | 
+  ::: $DIR/auxiliary/trait_bounds_on_structs_and_enums_xc.rs:9:16
    |
-   = note: required by `trait_bounds_on_structs_and_enums_xc::Bar`
+LL | pub enum Bar<T:Trait> {
+   |                ----- required by this bound in `trait_bounds_on_structs_and_enums_xc::Bar`
 
 error[E0277]: the trait bound `{integer}: trait_bounds_on_structs_and_enums_xc::Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-xc1.rs:8:15

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:13:9
    |
 LL | struct Foo<T:Trait> {
-   |        ---   ----- required by this bound in `Foo`
+   |              ----- required by this bound in `Foo`
 ...
 LL | impl<T> Foo<T> {
    |         ^^^^^^ the trait `Trait` is not implemented for `T`
@@ -16,7 +16,7 @@ error[E0277]: the trait bound `isize: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:19:5
    |
 LL | struct Foo<T:Trait> {
-   |        ---   ----- required by this bound in `Foo`
+   |              ----- required by this bound in `Foo`
 ...
 LL |     a: Foo<isize>,
    |     ^^^^^^^^^^^^^ the trait `Trait` is not implemented for `isize`
@@ -25,7 +25,7 @@ error[E0277]: the trait bound `usize: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:23:10
    |
 LL | enum Bar<T:Trait> {
-   |      ---   ----- required by this bound in `Bar`
+   |            ----- required by this bound in `Bar`
 ...
 LL |     Quux(Bar<usize>),
    |          ^^^^^^^^^^ the trait `Trait` is not implemented for `usize`
@@ -34,7 +34,7 @@ error[E0277]: the trait bound `U: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:27:5
    |
 LL | struct Foo<T:Trait> {
-   |        ---   ----- required by this bound in `Foo`
+   |              ----- required by this bound in `Foo`
 ...
 LL |     b: Foo<U>,
    |     ^^^^^^^^^ the trait `Trait` is not implemented for `U`
@@ -48,7 +48,7 @@ error[E0277]: the trait bound `V: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:31:21
    |
 LL | enum Bar<T:Trait> {
-   |      ---   ----- required by this bound in `Bar`
+   |            ----- required by this bound in `Bar`
 ...
 LL |     EvenMoreBadness(Bar<V>),
    |                     ^^^^^^ the trait `Trait` is not implemented for `V`
@@ -62,7 +62,7 @@ error[E0277]: the trait bound `i32: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:35:5
    |
 LL | struct Foo<T:Trait> {
-   |        ---   ----- required by this bound in `Foo`
+   |              ----- required by this bound in `Foo`
 ...
 LL |     Foo<i32>,
    |     ^^^^^^^^ the trait `Trait` is not implemented for `i32`
@@ -71,7 +71,7 @@ error[E0277]: the trait bound `u8: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:39:22
    |
 LL | enum Bar<T:Trait> {
-   |      ---   ----- required by this bound in `Bar`
+   |            ----- required by this bound in `Bar`
 ...
 LL |     DictionaryLike { field: Bar<u8> },
    |                      ^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `u8`

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:13:9
    |
 LL | struct Foo<T:Trait> {
-   | ------------------- required by `Foo`
+   |        ---   ----- required by this bound in `Foo`
 ...
 LL | impl<T> Foo<T> {
    |         ^^^^^^ the trait `Trait` is not implemented for `T`
@@ -16,7 +16,7 @@ error[E0277]: the trait bound `isize: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:19:5
    |
 LL | struct Foo<T:Trait> {
-   | ------------------- required by `Foo`
+   |        ---   ----- required by this bound in `Foo`
 ...
 LL |     a: Foo<isize>,
    |     ^^^^^^^^^^^^^ the trait `Trait` is not implemented for `isize`
@@ -25,7 +25,7 @@ error[E0277]: the trait bound `usize: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:23:10
    |
 LL | enum Bar<T:Trait> {
-   | ----------------- required by `Bar`
+   |      ---   ----- required by this bound in `Bar`
 ...
 LL |     Quux(Bar<usize>),
    |          ^^^^^^^^^^ the trait `Trait` is not implemented for `usize`
@@ -34,7 +34,7 @@ error[E0277]: the trait bound `U: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:27:5
    |
 LL | struct Foo<T:Trait> {
-   | ------------------- required by `Foo`
+   |        ---   ----- required by this bound in `Foo`
 ...
 LL |     b: Foo<U>,
    |     ^^^^^^^^^ the trait `Trait` is not implemented for `U`
@@ -48,7 +48,7 @@ error[E0277]: the trait bound `V: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:31:21
    |
 LL | enum Bar<T:Trait> {
-   | ----------------- required by `Bar`
+   |      ---   ----- required by this bound in `Bar`
 ...
 LL |     EvenMoreBadness(Bar<V>),
    |                     ^^^^^^ the trait `Trait` is not implemented for `V`
@@ -62,7 +62,7 @@ error[E0277]: the trait bound `i32: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:35:5
    |
 LL | struct Foo<T:Trait> {
-   | ------------------- required by `Foo`
+   |        ---   ----- required by this bound in `Foo`
 ...
 LL |     Foo<i32>,
    |     ^^^^^^^^ the trait `Trait` is not implemented for `i32`
@@ -71,7 +71,7 @@ error[E0277]: the trait bound `u8: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:39:22
    |
 LL | enum Bar<T:Trait> {
-   | ----------------- required by `Bar`
+   |      ---   ----- required by this bound in `Bar`
 ...
 LL |     DictionaryLike { field: Bar<u8> },
    |                      ^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `u8`

--- a/src/test/ui/traits/traits-inductive-overflow-simultaneous.stderr
+++ b/src/test/ui/traits/traits-inductive-overflow-simultaneous.stderr
@@ -2,7 +2,7 @@ error[E0275]: overflow evaluating the requirement `{integer}: Tweedledum`
   --> $DIR/traits-inductive-overflow-simultaneous.rs:18:5
    |
 LL | fn is_ee<T: Combo>(t: T) {
-   |    -----    ----- required by this bound in `is_ee`
+   |             ----- required by this bound in `is_ee`
 ...
 LL |     is_ee(4);
    |     ^^^^^

--- a/src/test/ui/traits/traits-inductive-overflow-supertrait-oibit.stderr
+++ b/src/test/ui/traits/traits-inductive-overflow-supertrait-oibit.stderr
@@ -10,7 +10,7 @@ error[E0277]: the trait bound `NoClone: std::marker::Copy` is not satisfied
   --> $DIR/traits-inductive-overflow-supertrait-oibit.rs:16:23
    |
 LL | fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
-   |    ----    ----- required by this bound in `copy`
+   |            ----- required by this bound in `copy`
 ...
 LL |     let (a, b) = copy(NoClone);
    |                       ^^^^^^^ the trait `std::marker::Copy` is not implemented for `NoClone`

--- a/src/test/ui/traits/traits-inductive-overflow-supertrait.stderr
+++ b/src/test/ui/traits/traits-inductive-overflow-supertrait.stderr
@@ -2,7 +2,7 @@ error[E0275]: overflow evaluating the requirement `NoClone: Magic`
   --> $DIR/traits-inductive-overflow-supertrait.rs:13:18
    |
 LL | fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
-   |    ----    ----- required by this bound in `copy`
+   |            ----- required by this bound in `copy`
 ...
 LL |     let (a, b) = copy(NoClone);
    |                  ^^^^

--- a/src/test/ui/traits/traits-inductive-overflow-two-traits.stderr
+++ b/src/test/ui/traits/traits-inductive-overflow-two-traits.stderr
@@ -2,7 +2,7 @@ error[E0275]: overflow evaluating the requirement `*mut (): Magic`
   --> $DIR/traits-inductive-overflow-two-traits.rs:19:5
    |
 LL | fn wizard<T: Magic>() { check::<<T as Magic>::X>(); }
-   |    ------    ----- required by this bound in `wizard`
+   |              ----- required by this bound in `wizard`
 ...
 LL |     wizard::<*mut ()>();
    |     ^^^^^^^^^^^^^^^^^

--- a/src/test/ui/trivial-bounds/trivial-bounds-leak.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-leak.stderr
@@ -37,7 +37,7 @@ LL |     generic_function(5i32);
    |                      ^^^^ the trait `Foo` is not implemented for `i32`
 ...
 LL | fn generic_function<T: Foo>(t: T) {}
-   |    ----------------    --- required by this bound in `generic_function`
+   |                        --- required by this bound in `generic_function`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/try-operator-on-main.stderr
+++ b/src/test/ui/try-operator-on-main.stderr
@@ -30,7 +30,7 @@ LL |     try_trait_generic::<()>();
    |                         ^^ the trait `std::ops::Try` is not implemented for `()`
 ...
 LL | fn try_trait_generic<T: Try>() -> T {
-   |    -----------------    --- required by this bound in `try_trait_generic`
+   |                         --- required by this bound in `try_trait_generic`
 
 error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
   --> $DIR/try-operator-on-main.rs:22:5

--- a/src/test/ui/type/type-annotation-needed.rs
+++ b/src/test/ui/type/type-annotation-needed.rs
@@ -1,6 +1,5 @@
 fn foo<T: Into<String>>(x: i32) {}
 //~^ NOTE required by
-//~| NOTE
 
 fn main() {
     foo(42);

--- a/src/test/ui/type/type-annotation-needed.stderr
+++ b/src/test/ui/type/type-annotation-needed.stderr
@@ -1,8 +1,8 @@
 error[E0283]: type annotations needed
-  --> $DIR/type-annotation-needed.rs:6:5
+  --> $DIR/type-annotation-needed.rs:5:5
    |
 LL | fn foo<T: Into<String>>(x: i32) {}
-   |    ---    ------------ required by this bound in `foo`
+   |           ------------ required by this bound in `foo`
 ...
 LL |     foo(42);
    |     ^^^ cannot infer type for type parameter `T` declared on the function `foo`

--- a/src/test/ui/type/type-check-defaults.stderr
+++ b/src/test/ui/type/type-check-defaults.stderr
@@ -2,7 +2,7 @@ error[E0277]: a value of type `i32` cannot be built from an iterator over elemen
   --> $DIR/type-check-defaults.rs:6:19
    |
 LL | struct Foo<T, U: FromIterator<T>>(T, U);
-   | ---------------------------------------- required by `Foo`
+   |        ---       --------------- required by this bound in `Foo`
 LL | struct WellFormed<Z = Foo<i32, i32>>(Z);
    |                   ^ value of type `i32` cannot be built from `std::iter::Iterator<Item=i32>`
    |
@@ -12,7 +12,7 @@ error[E0277]: a value of type `i32` cannot be built from an iterator over elemen
   --> $DIR/type-check-defaults.rs:8:27
    |
 LL | struct Foo<T, U: FromIterator<T>>(T, U);
-   | ---------------------------------------- required by `Foo`
+   |        ---       --------------- required by this bound in `Foo`
 ...
 LL | struct WellFormedNoBounds<Z:?Sized = Foo<i32, i32>>(Z);
    |                           ^ value of type `i32` cannot be built from `std::iter::Iterator<Item=i32>`
@@ -50,7 +50,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/type-check-defaults.rs:21:25
    |
 LL | trait Super<T: Copy> { }
-   | -------------------- required by `Super`
+   |       -----    ---- required by this bound in `Super`
 LL | trait Base<T = String>: Super<T> { }
    |                         ^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |

--- a/src/test/ui/type/type-check-defaults.stderr
+++ b/src/test/ui/type/type-check-defaults.stderr
@@ -2,7 +2,7 @@ error[E0277]: a value of type `i32` cannot be built from an iterator over elemen
   --> $DIR/type-check-defaults.rs:6:19
    |
 LL | struct Foo<T, U: FromIterator<T>>(T, U);
-   |        ---       --------------- required by this bound in `Foo`
+   |                  --------------- required by this bound in `Foo`
 LL | struct WellFormed<Z = Foo<i32, i32>>(Z);
    |                   ^ value of type `i32` cannot be built from `std::iter::Iterator<Item=i32>`
    |
@@ -12,7 +12,7 @@ error[E0277]: a value of type `i32` cannot be built from an iterator over elemen
   --> $DIR/type-check-defaults.rs:8:27
    |
 LL | struct Foo<T, U: FromIterator<T>>(T, U);
-   |        ---       --------------- required by this bound in `Foo`
+   |                  --------------- required by this bound in `Foo`
 ...
 LL | struct WellFormedNoBounds<Z:?Sized = Foo<i32, i32>>(Z);
    |                           ^ value of type `i32` cannot be built from `std::iter::Iterator<Item=i32>`
@@ -50,7 +50,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/type-check-defaults.rs:21:25
    |
 LL | trait Super<T: Copy> { }
-   |       -----    ---- required by this bound in `Super`
+   |                ---- required by this bound in `Super`
 LL | trait Base<T = String>: Super<T> { }
    |                         ^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |

--- a/src/test/ui/type/type-check/issue-40294.stderr
+++ b/src/test/ui/type/type-check/issue-40294.stderr
@@ -2,7 +2,7 @@ error[E0283]: type annotations needed
   --> $DIR/issue-40294.rs:6:19
    |
 LL | trait Foo: Sized {
-   | ---------------- required by `Foo`
+   | ---------------- required by this bound in `Foo`
 ...
 LL |     where &'a T : Foo,
    |                   ^^^ cannot infer type for reference `&'a T`

--- a/src/test/ui/typeck/typeck-default-trait-impl-assoc-type.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-assoc-type.stderr
@@ -7,7 +7,7 @@ LL |     is_send::<T::AssocType>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ `<T as Trait>::AssocType` cannot be sent between threads safely
 ...
 LL | fn is_send<T:Send>() {
-   |    -------   ---- required by this bound in `is_send`
+   |              ---- required by this bound in `is_send`
    |
    = help: the trait `std::marker::Send` is not implemented for `<T as Trait>::AssocType`
 

--- a/src/test/ui/typeck/typeck-default-trait-impl-constituent-types-2.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-constituent-types-2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `MyS2: MyTrait` is not satisfied in `(MyS2, MyS)`
   --> $DIR/typeck-default-trait-impl-constituent-types-2.rs:17:5
    |
 LL | fn is_mytrait<T: MyTrait>() {}
-   |    ----------    ------- required by this bound in `is_mytrait`
+   |                  ------- required by this bound in `is_mytrait`
 ...
 LL |     is_mytrait::<(MyS2, MyS)>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ within `(MyS2, MyS)`, the trait `MyTrait` is not implemented for `MyS2`

--- a/src/test/ui/typeck/typeck-default-trait-impl-constituent-types.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-constituent-types.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `MyS2: MyTrait` is not satisfied
   --> $DIR/typeck-default-trait-impl-constituent-types.rs:21:18
    |
 LL | fn is_mytrait<T: MyTrait>() {}
-   |    ----------    ------- required by this bound in `is_mytrait`
+   |                  ------- required by this bound in `is_mytrait`
 ...
 LL |     is_mytrait::<MyS2>();
    |                  ^^^^ the trait `MyTrait` is not implemented for `MyS2`

--- a/src/test/ui/typeck/typeck-default-trait-impl-negation-send.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-negation-send.stderr
@@ -2,7 +2,7 @@ error[E0277]: `MyNotSendable` cannot be sent between threads safely
   --> $DIR/typeck-default-trait-impl-negation-send.rs:19:15
    |
 LL | fn is_send<T: Send>() {}
-   |    -------    ---- required by this bound in `is_send`
+   |               ---- required by this bound in `is_send`
 ...
 LL |     is_send::<MyNotSendable>();
    |               ^^^^^^^^^^^^^ `MyNotSendable` cannot be sent between threads safely

--- a/src/test/ui/typeck/typeck-default-trait-impl-negation-sync.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-negation-sync.stderr
@@ -2,7 +2,7 @@ error[E0277]: `MyNotSync` cannot be shared between threads safely
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:33:15
    |
 LL | fn is_sync<T: Sync>() {}
-   |    -------    ---- required by this bound in `is_sync`
+   |               ---- required by this bound in `is_sync`
 ...
 LL |     is_sync::<MyNotSync>();
    |               ^^^^^^^^^ `MyNotSync` cannot be shared between threads safely
@@ -13,7 +13,7 @@ error[E0277]: `std::cell::UnsafeCell<u8>` cannot be shared between threads safel
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:36:5
    |
 LL | fn is_sync<T: Sync>() {}
-   |    -------    ---- required by this bound in `is_sync`
+   |               ---- required by this bound in `is_sync`
 ...
 LL |     is_sync::<MyTypeWUnsafe>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<u8>` cannot be shared between threads safely
@@ -25,7 +25,7 @@ error[E0277]: `Managed` cannot be shared between threads safely
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:39:5
    |
 LL | fn is_sync<T: Sync>() {}
-   |    -------    ---- required by this bound in `is_sync`
+   |               ---- required by this bound in `is_sync`
 ...
 LL |     is_sync::<MyTypeManaged>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ `Managed` cannot be shared between threads safely

--- a/src/test/ui/typeck/typeck-default-trait-impl-negation.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-negation.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `ThisImplsUnsafeTrait: MyTrait` is not satisfied
   --> $DIR/typeck-default-trait-impl-negation.rs:22:19
    |
 LL | fn is_my_trait<T: MyTrait>() {}
-   |    -----------    ------- required by this bound in `is_my_trait`
+   |                   ------- required by this bound in `is_my_trait`
 ...
 LL |     is_my_trait::<ThisImplsUnsafeTrait>();
    |                   ^^^^^^^^^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `ThisImplsUnsafeTrait`
@@ -14,7 +14,7 @@ error[E0277]: the trait bound `ThisImplsTrait: MyUnsafeTrait` is not satisfied
   --> $DIR/typeck-default-trait-impl-negation.rs:25:26
    |
 LL | fn is_my_unsafe_trait<T: MyUnsafeTrait>() {}
-   |    ------------------    ------------- required by this bound in `is_my_unsafe_trait`
+   |                          ------------- required by this bound in `is_my_unsafe_trait`
 ...
 LL |     is_my_unsafe_trait::<ThisImplsTrait>();
    |                          ^^^^^^^^^^^^^^ the trait `MyUnsafeTrait` is not implemented for `ThisImplsTrait`

--- a/src/test/ui/typeck/typeck-default-trait-impl-precedence.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-precedence.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `u32: Signed` is not satisfied
   --> $DIR/typeck-default-trait-impl-precedence.rs:19:5
    |
 LL | fn is_defaulted<T:Defaulted>() { }
-   |    ------------   --------- required by this bound in `is_defaulted`
+   |                   --------- required by this bound in `is_defaulted`
 ...
 LL |     is_defaulted::<&'static u32>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Signed` is not implemented for `u32`

--- a/src/test/ui/typeck/typeck-default-trait-impl-send-param.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-send-param.stderr
@@ -5,7 +5,7 @@ LL |     is_send::<T>()
    |               ^ `T` cannot be sent between threads safely
 ...
 LL | fn is_send<T:Send>() {
-   |    -------   ---- required by this bound in `is_send`
+   |              ---- required by this bound in `is_send`
    |
    = help: the trait `std::marker::Send` is not implemented for `T`
 help: consider restricting type parameter `T`

--- a/src/test/ui/typeck/typeck-unsafe-always-share.stderr
+++ b/src/test/ui/typeck/typeck-unsafe-always-share.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::cell::UnsafeCell<MySync<{integer}>>` cannot be shared betwee
   --> $DIR/typeck-unsafe-always-share.rs:19:10
    |
 LL | fn test<T: Sync>(s: T) {}
-   |    ----    ---- required by this bound in `test`
+   |            ---- required by this bound in `test`
 ...
 LL |     test(us);
    |          ^^ `std::cell::UnsafeCell<MySync<{integer}>>` cannot be shared between threads safely
@@ -13,7 +13,7 @@ error[E0277]: `std::cell::UnsafeCell<NoSync>` cannot be shared between threads s
   --> $DIR/typeck-unsafe-always-share.rs:23:10
    |
 LL | fn test<T: Sync>(s: T) {}
-   |    ----    ---- required by this bound in `test`
+   |            ---- required by this bound in `test`
 ...
 LL |     test(uns);
    |          ^^^ `std::cell::UnsafeCell<NoSync>` cannot be shared between threads safely
@@ -24,7 +24,7 @@ error[E0277]: `std::cell::UnsafeCell<NoSync>` cannot be shared between threads s
   --> $DIR/typeck-unsafe-always-share.rs:27:5
    |
 LL | fn test<T: Sync>(s: T) {}
-   |    ----    ---- required by this bound in `test`
+   |            ---- required by this bound in `test`
 ...
 LL |     test(ms);
    |     ^^^^ `std::cell::UnsafeCell<NoSync>` cannot be shared between threads safely
@@ -36,7 +36,7 @@ error[E0277]: `NoSync` cannot be shared between threads safely
   --> $DIR/typeck-unsafe-always-share.rs:30:10
    |
 LL | fn test<T: Sync>(s: T) {}
-   |    ----    ---- required by this bound in `test`
+   |            ---- required by this bound in `test`
 ...
 LL |     test(NoSync);
    |          ^^^^^^ `NoSync` cannot be shared between threads safely

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-default.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-default.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `dyn Foo<(isize,), isize, Output = ()>: Eq<dyn Foo
   --> $DIR/unboxed-closure-sugar-default.rs:21:5
    |
 LL | fn eq<A: ?Sized,B: ?Sized>() where A : Eq<B> { }
-   |    --                                  ----- required by this bound in `eq`
+   |                                        ----- required by this bound in `eq`
 ...
 LL |     eq::<dyn Foo<(isize,), isize, Output=()>, dyn Foo(isize)>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Eq<dyn Foo<(isize,), Output = ()>>` is not implemented for `dyn Foo<(isize,), isize, Output = ()>`

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-equiv.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-equiv.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `dyn Foo<(char,), Output = ()>: Eq<dyn Foo<(), Out
   --> $DIR/unboxed-closure-sugar-equiv.rs:43:5
    |
 LL |   fn eq<A: ?Sized,B: ?Sized +Eq<A>>() { }
-   |      --                      ----- required by this bound in `eq`
+   |                              ----- required by this bound in `eq`
 ...
 LL | /     eq::< dyn Foo<(),Output=()>,
 LL | |           dyn Foo(char)                                               >();

--- a/src/test/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
@@ -2,7 +2,7 @@ error[E0277]: expected a `std::ops::Fn<(isize,)>` closure, found `S`
   --> $DIR/unboxed-closures-fnmut-as-fn.rs:28:21
    |
 LL | fn call_it<F:Fn(isize)->isize>(f: &F, x: isize) -> isize {
-   |    -------   ---------------- required by this bound in `call_it`
+   |              ---------------- required by this bound in `call_it`
 ...
 LL |     let x = call_it(&S, 22);
    |                     ^^ expected an `Fn<(isize,)>` closure, found `S`

--- a/src/test/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
@@ -2,7 +2,7 @@ error[E0277]: expected a `std::ops::Fn<(&isize,)>` closure, found `for<'r> unsaf
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:12:21
    |
 LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
-   |    -------   ----------------- required by this bound in `call_it`
+   |              ----------------- required by this bound in `call_it`
 ...
 LL |     let x = call_it(&square, 22);
    |                     ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
@@ -13,7 +13,7 @@ error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> u
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:12:21
    |
 LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
-   |    -------               ----- required by this bound in `call_it`
+   |                          ----- required by this bound in `call_it`
 ...
 LL |     let x = call_it(&square, 22);
    |                     ^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
@@ -24,7 +24,7 @@ error[E0277]: expected a `std::ops::FnMut<(&isize,)>` closure, found `for<'r> un
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:18:25
    |
 LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
-   |    -----------   -------------------- required by this bound in `call_it_mut`
+   |                  -------------------- required by this bound in `call_it_mut`
 ...
 LL |     let y = call_it_mut(&mut square, 22);
    |                         ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
@@ -35,7 +35,7 @@ error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> u
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:18:25
    |
 LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
-   |    -----------                  ----- required by this bound in `call_it_mut`
+   |                                 ----- required by this bound in `call_it_mut`
 ...
 LL |     let y = call_it_mut(&mut square, 22);
    |                         ^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
@@ -46,7 +46,7 @@ error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> u
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:24:26
    |
 LL | fn call_it_once<F:FnOnce(&isize)->isize>(_: F, _: isize) -> isize { 0 }
-   |    ------------                   ----- required by this bound in `call_it_once`
+   |                                   ----- required by this bound in `call_it_once`
 ...
 LL |     let z = call_it_once(square, 22);
    |                          ^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`

--- a/src/test/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
@@ -2,7 +2,7 @@ error[E0277]: expected a `std::ops::Fn<(&isize,)>` closure, found `for<'r> exter
   --> $DIR/unboxed-closures-wrong-abi.rs:12:21
    |
 LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
-   |    -------   ----------------- required by this bound in `call_it`
+   |              ----------------- required by this bound in `call_it`
 ...
 LL |     let x = call_it(&square, 22);
    |                     ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
@@ -13,7 +13,7 @@ error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> e
   --> $DIR/unboxed-closures-wrong-abi.rs:12:21
    |
 LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
-   |    -------               ----- required by this bound in `call_it`
+   |                          ----- required by this bound in `call_it`
 ...
 LL |     let x = call_it(&square, 22);
    |                     ^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
@@ -24,7 +24,7 @@ error[E0277]: expected a `std::ops::FnMut<(&isize,)>` closure, found `for<'r> ex
   --> $DIR/unboxed-closures-wrong-abi.rs:18:25
    |
 LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
-   |    -----------   -------------------- required by this bound in `call_it_mut`
+   |                  -------------------- required by this bound in `call_it_mut`
 ...
 LL |     let y = call_it_mut(&mut square, 22);
    |                         ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
@@ -35,7 +35,7 @@ error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> e
   --> $DIR/unboxed-closures-wrong-abi.rs:18:25
    |
 LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
-   |    -----------                  ----- required by this bound in `call_it_mut`
+   |                                 ----- required by this bound in `call_it_mut`
 ...
 LL |     let y = call_it_mut(&mut square, 22);
    |                         ^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
@@ -46,7 +46,7 @@ error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> e
   --> $DIR/unboxed-closures-wrong-abi.rs:24:26
    |
 LL | fn call_it_once<F:FnOnce(&isize)->isize>(_: F, _: isize) -> isize { 0 }
-   |    ------------                   ----- required by this bound in `call_it_once`
+   |                                   ----- required by this bound in `call_it_once`
 ...
 LL |     let z = call_it_once(square, 22);
    |                          ^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`

--- a/src/test/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
@@ -2,7 +2,7 @@ error[E0277]: expected a `std::ops::Fn<(&isize,)>` closure, found `unsafe fn(isi
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:13:21
    |
 LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
-   |    -------   ----------------- required by this bound in `call_it`
+   |              ----------------- required by this bound in `call_it`
 ...
 LL |     let x = call_it(&square, 22);
    |                     ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
@@ -13,7 +13,7 @@ error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `unsafe fn
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:13:21
    |
 LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
-   |    -------               ----- required by this bound in `call_it`
+   |                          ----- required by this bound in `call_it`
 ...
 LL |     let x = call_it(&square, 22);
    |                     ^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
@@ -24,7 +24,7 @@ error[E0277]: expected a `std::ops::FnMut<(&isize,)>` closure, found `unsafe fn(
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:19:25
    |
 LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
-   |    -----------   -------------------- required by this bound in `call_it_mut`
+   |                  -------------------- required by this bound in `call_it_mut`
 ...
 LL |     let y = call_it_mut(&mut square, 22);
    |                         ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
@@ -35,7 +35,7 @@ error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `unsafe fn
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:19:25
    |
 LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
-   |    -----------                  ----- required by this bound in `call_it_mut`
+   |                                 ----- required by this bound in `call_it_mut`
 ...
 LL |     let y = call_it_mut(&mut square, 22);
    |                         ^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
@@ -46,7 +46,7 @@ error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `unsafe fn
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:25:26
    |
 LL | fn call_it_once<F:FnOnce(&isize)->isize>(_: F, _: isize) -> isize { 0 }
-   |    ------------                   ----- required by this bound in `call_it_once`
+   |                                   ----- required by this bound in `call_it_once`
 ...
 LL |     let z = call_it_once(square, 22);
    |                          ^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`

--- a/src/test/ui/union/union-derive-clone.stderr
+++ b/src/test/ui/union/union-derive-clone.stderr
@@ -3,8 +3,12 @@ error[E0277]: the trait bound `U1: std::marker::Copy` is not satisfied
    |
 LL | #[derive(Clone)]
    |          ^^^^^ the trait `std::marker::Copy` is not implemented for `U1`
+   | 
+  ::: $SRC_DIR/libcore/clone.rs:LL:COL
    |
-   = note: required by `std::clone::AssertParamIsCopy`
+LL | pub struct AssertParamIsCopy<T: Copy + ?Sized> {
+   |                                 ---- required by this bound in `std::clone::AssertParamIsCopy`
+   |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no method named `clone` found for union `U5<CloneNoCopy>` in the current scope

--- a/src/test/ui/union/union-derive-eq.stderr
+++ b/src/test/ui/union/union-derive-eq.stderr
@@ -3,8 +3,12 @@ error[E0277]: the trait bound `PartialEqNotEq: std::cmp::Eq` is not satisfied
    |
 LL |     a: PartialEqNotEq,
    |     ^^^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `PartialEqNotEq`
+   | 
+  ::: $SRC_DIR/libcore/cmp.rs:LL:COL
    |
-   = note: required by `std::cmp::AssertParamIsEq`
+LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
+   |                               -- required by this bound in `std::cmp::AssertParamIsEq`
+   |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/unsized/unsized-bare-typaram.stderr
+++ b/src/test/ui/unsized/unsized-bare-typaram.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/unsized-bare-typaram.rs:2:29
    |
 LL | fn bar<T: Sized>() { }
-   |    --- - required by this bound in `bar`
+   |        - required by this bound in `bar`
 LL | fn foo<T: ?Sized>() { bar::<T>() }
    |        -                    ^ doesn't have a size known at compile-time
    |        |

--- a/src/test/ui/unsized/unsized-enum.stderr
+++ b/src/test/ui/unsized/unsized-enum.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/unsized-enum.rs:6:36
    |
 LL | enum Foo<U> { FooSome(U), FooNone }
-   | ----------- required by `Foo`
+   |      --- - required by this bound in `Foo`
 LL | fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
 LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |         -                          ^^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/unsized/unsized-enum.stderr
+++ b/src/test/ui/unsized/unsized-enum.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/unsized-enum.rs:6:36
    |
 LL | enum Foo<U> { FooSome(U), FooNone }
-   |      --- - required by this bound in `Foo`
+   |          - required by this bound in `Foo`
 LL | fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
 LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |         -                          ^^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/unsized/unsized-inherent-impl-self-type.stderr
+++ b/src/test/ui/unsized/unsized-inherent-impl-self-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized-inherent-impl-self-type.rs:7:17
    |
 LL | struct S5<Y>(Y);
-   |        -- - required by this bound in `S5`
+   |           - required by this bound in `S5`
 LL | 
 LL | impl<X: ?Sized> S5<X> {
    |      -          ^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/unsized/unsized-inherent-impl-self-type.stderr
+++ b/src/test/ui/unsized/unsized-inherent-impl-self-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized-inherent-impl-self-type.rs:7:17
    |
 LL | struct S5<Y>(Y);
-   | ---------------- required by `S5`
+   |        -- - required by this bound in `S5`
 LL | 
 LL | impl<X: ?Sized> S5<X> {
    |      -          ^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/unsized/unsized-struct.stderr
+++ b/src/test/ui/unsized/unsized-struct.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/unsized-struct.rs:6:36
    |
 LL | struct Foo<T> { data: T }
-   | ------------- required by `Foo`
+   |        --- - required by this bound in `Foo`
 LL | fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
 LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |         -                          ^^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/unsized/unsized-struct.stderr
+++ b/src/test/ui/unsized/unsized-struct.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/unsized-struct.rs:6:36
    |
 LL | struct Foo<T> { data: T }
-   |        --- - required by this bound in `Foo`
+   |            - required by this bound in `Foo`
 LL | fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
 LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |         -                          ^^^^^^ doesn't have a size known at compile-time
@@ -16,7 +16,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/unsized-struct.rs:13:24
    |
 LL | fn is_sized<T:Sized>() { }
-   |    -------- - required by this bound in `is_sized`
+   |             - required by this bound in `is_sized`
 ...
 LL | fn bar2<T: ?Sized>() { is_sized::<Bar<T>>() }
    |         -              ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/unsized/unsized-trait-impl-self-type.stderr
+++ b/src/test/ui/unsized/unsized-trait-impl-self-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized-trait-impl-self-type.rs:10:17
    |
 LL | struct S5<Y>(Y);
-   |        -- - required by this bound in `S5`
+   |           - required by this bound in `S5`
 LL | 
 LL | impl<X: ?Sized> T3<X> for S5<X> {
    |      -          ^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/unsized/unsized-trait-impl-self-type.stderr
+++ b/src/test/ui/unsized/unsized-trait-impl-self-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized-trait-impl-self-type.rs:10:17
    |
 LL | struct S5<Y>(Y);
-   | ---------------- required by `S5`
+   |        -- - required by this bound in `S5`
 LL | 
 LL | impl<X: ?Sized> T3<X> for S5<X> {
    |      -          ^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/unsized3.stderr
+++ b/src/test/ui/unsized3.stderr
@@ -7,7 +7,7 @@ LL |     f2::<X>(x);
    |             ^ doesn't have a size known at compile-time
 ...
 LL | fn f2<X>(x: &X) {
-   |    -- - required by this bound in `f2`
+   |       - required by this bound in `f2`
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
@@ -25,7 +25,7 @@ LL |     f4::<X>(x);
    |             ^ doesn't have a size known at compile-time
 ...
 LL | fn f4<X: T>(x: &X) {
-   |    -- - required by this bound in `f4`
+   |       - required by this bound in `f4`
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
@@ -38,7 +38,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:33:8
    |
 LL | fn f5<Y>(x: &Y) {}
-   |    -- - required by this bound in `f5`
+   |       - required by this bound in `f5`
 ...
 LL | fn f8<X: ?Sized>(x1: &S<X>, x2: &S<X>) {
    |       - this type parameter needs to be `std::marker::Sized`
@@ -80,7 +80,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:45:8
    |
 LL | fn f5<Y>(x: &Y) {}
-   |    -- - required by this bound in `f5`
+   |       - required by this bound in `f5`
 ...
 LL | fn f10<X: ?Sized>(x1: Box<S<X>>) {
    |        - this type parameter needs to be `std::marker::Sized`

--- a/src/test/ui/wf/wf-const-type.stderr
+++ b/src/test/ui/wf/wf-const-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `NotCopy: std::marker::Copy` is not satisfied
   --> $DIR/wf-const-type.rs:10:12
    |
 LL | struct IsCopy<T:Copy> { t: T }
-   |        ------   ---- required by this bound in `IsCopy`
+   |                 ---- required by this bound in `IsCopy`
 ...
 LL | const FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
    |            ^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `NotCopy`

--- a/src/test/ui/wf/wf-const-type.stderr
+++ b/src/test/ui/wf/wf-const-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `NotCopy: std::marker::Copy` is not satisfied
   --> $DIR/wf-const-type.rs:10:12
    |
 LL | struct IsCopy<T:Copy> { t: T }
-   | --------------------- required by `IsCopy`
+   |        ------   ---- required by this bound in `IsCopy`
 ...
 LL | const FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
    |            ^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `NotCopy`

--- a/src/test/ui/wf/wf-enum-bound.stderr
+++ b/src/test/ui/wf/wf-enum-bound.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-enum-bound.rs:10:14
    |
 LL | trait ExtraCopy<T:Copy> { }
-   | ----------------------- required by `ExtraCopy`
+   |       ---------   ---- required by this bound in `ExtraCopy`
 ...
 LL |     where T: ExtraCopy<U>
    |              ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`

--- a/src/test/ui/wf/wf-enum-bound.stderr
+++ b/src/test/ui/wf/wf-enum-bound.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-enum-bound.rs:10:14
    |
 LL | trait ExtraCopy<T:Copy> { }
-   |       ---------   ---- required by this bound in `ExtraCopy`
+   |                   ---- required by this bound in `ExtraCopy`
 ...
 LL |     where T: ExtraCopy<U>
    |              ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`

--- a/src/test/ui/wf/wf-enum-fields-struct-variant.stderr
+++ b/src/test/ui/wf/wf-enum-fields-struct-variant.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `A: std::marker::Copy` is not satisfied
   --> $DIR/wf-enum-fields-struct-variant.rs:13:9
    |
 LL | struct IsCopy<T:Copy> {
-   |        ------   ---- required by this bound in `IsCopy`
+   |                 ---- required by this bound in `IsCopy`
 ...
 LL |         f: IsCopy<A>
    |         ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `A`

--- a/src/test/ui/wf/wf-enum-fields-struct-variant.stderr
+++ b/src/test/ui/wf/wf-enum-fields-struct-variant.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `A: std::marker::Copy` is not satisfied
   --> $DIR/wf-enum-fields-struct-variant.rs:13:9
    |
 LL | struct IsCopy<T:Copy> {
-   | --------------------- required by `IsCopy`
+   |        ------   ---- required by this bound in `IsCopy`
 ...
 LL |         f: IsCopy<A>
    |         ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `A`

--- a/src/test/ui/wf/wf-enum-fields.stderr
+++ b/src/test/ui/wf/wf-enum-fields.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `A: std::marker::Copy` is not satisfied
   --> $DIR/wf-enum-fields.rs:12:17
    |
 LL | struct IsCopy<T:Copy> {
-   | --------------------- required by `IsCopy`
+   |        ------   ---- required by this bound in `IsCopy`
 ...
 LL |     SomeVariant(IsCopy<A>)
    |                 ^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `A`

--- a/src/test/ui/wf/wf-enum-fields.stderr
+++ b/src/test/ui/wf/wf-enum-fields.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `A: std::marker::Copy` is not satisfied
   --> $DIR/wf-enum-fields.rs:12:17
    |
 LL | struct IsCopy<T:Copy> {
-   |        ------   ---- required by this bound in `IsCopy`
+   |                 ---- required by this bound in `IsCopy`
 ...
 LL |     SomeVariant(IsCopy<A>)
    |                 ^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `A`

--- a/src/test/ui/wf/wf-fn-where-clause.rs
+++ b/src/test/ui/wf/wf-fn-where-clause.rs
@@ -13,5 +13,8 @@ fn bar() where Vec<dyn Copy>:, {}
 //~^ ERROR E0277
 //~| ERROR E0038
 
+struct Vec<T> {
+    t: T,
+}
 
 fn main() { }

--- a/src/test/ui/wf/wf-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-fn-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-fn-where-clause.rs:8:24
    |
 LL | trait ExtraCopy<T:Copy> { }
-   | ----------------------- required by `ExtraCopy`
+   |       ---------   ---- required by this bound in `ExtraCopy`
 LL | 
 LL | fn foo<T,U>() where T: ExtraCopy<U>
    |                        ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`
@@ -17,10 +17,12 @@ error[E0277]: the size for values of type `(dyn std::marker::Copy + 'static)` ca
    |
 LL | fn bar() where Vec<dyn Copy>:, {}
    |                ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+...
+LL | struct Vec<T> {
+   |        --- - required by this bound in `Vec`
    |
    = help: the trait `std::marker::Sized` is not implemented for `(dyn std::marker::Copy + 'static)`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required by `std::vec::Vec`
 
 error[E0038]: the trait `std::marker::Copy` cannot be made into an object
   --> $DIR/wf-fn-where-clause.rs:12:16

--- a/src/test/ui/wf/wf-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-fn-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-fn-where-clause.rs:8:24
    |
 LL | trait ExtraCopy<T:Copy> { }
-   |       ---------   ---- required by this bound in `ExtraCopy`
+   |                   ---- required by this bound in `ExtraCopy`
 LL | 
 LL | fn foo<T,U>() where T: ExtraCopy<U>
    |                        ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`
@@ -19,7 +19,7 @@ LL | fn bar() where Vec<dyn Copy>:, {}
    |                ^^^^^^^^^^^^^ doesn't have a size known at compile-time
 ...
 LL | struct Vec<T> {
-   |        --- - required by this bound in `Vec`
+   |            - required by this bound in `Vec`
    |
    = help: the trait `std::marker::Sized` is not implemented for `(dyn std::marker::Copy + 'static)`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>

--- a/src/test/ui/wf/wf-impl-associated-type-trait.stderr
+++ b/src/test/ui/wf/wf-impl-associated-type-trait.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: MyHash` is not satisfied
   --> $DIR/wf-impl-associated-type-trait.rs:17:5
    |
 LL | pub struct MySet<T:MyHash> {
-   | -------------------------- required by `MySet`
+   |            -----   ------ required by this bound in `MySet`
 ...
 LL |     type Bar = MySet<T>;
    |     ^^^^^^^^^^^^^^^^^^^^ the trait `MyHash` is not implemented for `T`

--- a/src/test/ui/wf/wf-impl-associated-type-trait.stderr
+++ b/src/test/ui/wf/wf-impl-associated-type-trait.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: MyHash` is not satisfied
   --> $DIR/wf-impl-associated-type-trait.rs:17:5
    |
 LL | pub struct MySet<T:MyHash> {
-   |            -----   ------ required by this bound in `MySet`
+   |                    ------ required by this bound in `MySet`
 ...
 LL |     type Bar = MySet<T>;
    |     ^^^^^^^^^^^^^^^^^^^^ the trait `MyHash` is not implemented for `T`

--- a/src/test/ui/wf/wf-in-fn-arg.stderr
+++ b/src/test/ui/wf/wf-in-fn-arg.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-fn-arg.rs:10:14
    |
 LL | struct MustBeCopy<T:Copy> {
-   | ------------------------- required by `MustBeCopy`
+   |        ----------   ---- required by this bound in `MustBeCopy`
 ...
 LL | fn bar<T>(_: &MustBeCopy<T>)
    |              ^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/wf/wf-in-fn-arg.stderr
+++ b/src/test/ui/wf/wf-in-fn-arg.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-fn-arg.rs:10:14
    |
 LL | struct MustBeCopy<T:Copy> {
-   |        ----------   ---- required by this bound in `MustBeCopy`
+   |                     ---- required by this bound in `MustBeCopy`
 ...
 LL | fn bar<T>(_: &MustBeCopy<T>)
    |              ^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/wf/wf-in-fn-ret.stderr
+++ b/src/test/ui/wf/wf-in-fn-ret.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-fn-ret.rs:10:16
    |
 LL | struct MustBeCopy<T:Copy> {
-   |        ----------   ---- required by this bound in `MustBeCopy`
+   |                     ---- required by this bound in `MustBeCopy`
 ...
 LL | fn bar<T>() -> MustBeCopy<T>
    |                ^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/wf/wf-in-fn-ret.stderr
+++ b/src/test/ui/wf/wf-in-fn-ret.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-fn-ret.rs:10:16
    |
 LL | struct MustBeCopy<T:Copy> {
-   | ------------------------- required by `MustBeCopy`
+   |        ----------   ---- required by this bound in `MustBeCopy`
 ...
 LL | fn bar<T>() -> MustBeCopy<T>
    |                ^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/wf/wf-in-fn-type-arg.stderr
+++ b/src/test/ui/wf/wf-in-fn-type-arg.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-fn-type-arg.rs:9:5
    |
 LL | struct MustBeCopy<T:Copy> {
-   |        ----------   ---- required by this bound in `MustBeCopy`
+   |                     ---- required by this bound in `MustBeCopy`
 ...
 LL |     x: fn(MustBeCopy<T>)
    |     ^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/wf/wf-in-fn-type-arg.stderr
+++ b/src/test/ui/wf/wf-in-fn-type-arg.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-fn-type-arg.rs:9:5
    |
 LL | struct MustBeCopy<T:Copy> {
-   | ------------------------- required by `MustBeCopy`
+   |        ----------   ---- required by this bound in `MustBeCopy`
 ...
 LL |     x: fn(MustBeCopy<T>)
    |     ^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/wf/wf-in-fn-type-ret.stderr
+++ b/src/test/ui/wf/wf-in-fn-type-ret.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-fn-type-ret.rs:9:5
    |
 LL | struct MustBeCopy<T:Copy> {
-   | ------------------------- required by `MustBeCopy`
+   |        ----------   ---- required by this bound in `MustBeCopy`
 ...
 LL |     x: fn() -> MustBeCopy<T>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/wf/wf-in-fn-type-ret.stderr
+++ b/src/test/ui/wf/wf-in-fn-type-ret.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-fn-type-ret.rs:9:5
    |
 LL | struct MustBeCopy<T:Copy> {
-   |        ----------   ---- required by this bound in `MustBeCopy`
+   |                     ---- required by this bound in `MustBeCopy`
 ...
 LL |     x: fn() -> MustBeCopy<T>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/wf/wf-in-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-in-fn-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-fn-where-clause.rs:10:14
    |
 LL | trait MustBeCopy<T:Copy> {
-   | ------------------------ required by `MustBeCopy`
+   |       ----------   ---- required by this bound in `MustBeCopy`
 ...
 LL |     where T: MustBeCopy<U>
    |              ^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`

--- a/src/test/ui/wf/wf-in-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-in-fn-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-fn-where-clause.rs:10:14
    |
 LL | trait MustBeCopy<T:Copy> {
-   |       ----------   ---- required by this bound in `MustBeCopy`
+   |                    ---- required by this bound in `MustBeCopy`
 ...
 LL |     where T: MustBeCopy<U>
    |              ^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`

--- a/src/test/ui/wf/wf-in-obj-type-trait.stderr
+++ b/src/test/ui/wf/wf-in-obj-type-trait.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-obj-type-trait.rs:11:5
    |
 LL | struct MustBeCopy<T:Copy> {
-   |        ----------   ---- required by this bound in `MustBeCopy`
+   |                     ---- required by this bound in `MustBeCopy`
 ...
 LL |     x: dyn Object<MustBeCopy<T>>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/wf/wf-in-obj-type-trait.stderr
+++ b/src/test/ui/wf/wf-in-obj-type-trait.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-obj-type-trait.rs:11:5
    |
 LL | struct MustBeCopy<T:Copy> {
-   | ------------------------- required by `MustBeCopy`
+   |        ----------   ---- required by this bound in `MustBeCopy`
 ...
 LL |     x: dyn Object<MustBeCopy<T>>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/wf/wf-inherent-impl-method-where-clause.stderr
+++ b/src/test/ui/wf/wf-inherent-impl-method-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-inherent-impl-method-where-clause.rs:12:27
    |
 LL | trait ExtraCopy<T:Copy> { }
-   |       ---------   ---- required by this bound in `ExtraCopy`
+   |                   ---- required by this bound in `ExtraCopy`
 ...
 LL |     fn foo(self) where T: ExtraCopy<U>
    |                           ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`

--- a/src/test/ui/wf/wf-inherent-impl-method-where-clause.stderr
+++ b/src/test/ui/wf/wf-inherent-impl-method-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-inherent-impl-method-where-clause.rs:12:27
    |
 LL | trait ExtraCopy<T:Copy> { }
-   | ----------------------- required by `ExtraCopy`
+   |       ---------   ---- required by this bound in `ExtraCopy`
 ...
 LL |     fn foo(self) where T: ExtraCopy<U>
    |                           ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`

--- a/src/test/ui/wf/wf-inherent-impl-where-clause.stderr
+++ b/src/test/ui/wf/wf-inherent-impl-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-inherent-impl-where-clause.rs:11:29
    |
 LL | trait ExtraCopy<T:Copy> { }
-   |       ---------   ---- required by this bound in `ExtraCopy`
+   |                   ---- required by this bound in `ExtraCopy`
 ...
 LL | impl<T,U> Foo<T,U> where T: ExtraCopy<U>
    |                             ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`

--- a/src/test/ui/wf/wf-inherent-impl-where-clause.stderr
+++ b/src/test/ui/wf/wf-inherent-impl-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-inherent-impl-where-clause.rs:11:29
    |
 LL | trait ExtraCopy<T:Copy> { }
-   | ----------------------- required by `ExtraCopy`
+   |       ---------   ---- required by this bound in `ExtraCopy`
 ...
 LL | impl<T,U> Foo<T,U> where T: ExtraCopy<U>
    |                             ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`

--- a/src/test/ui/wf/wf-static-type.stderr
+++ b/src/test/ui/wf/wf-static-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `NotCopy: std::marker::Copy` is not satisfied
   --> $DIR/wf-static-type.rs:10:13
    |
 LL | struct IsCopy<T:Copy> { t: T }
-   | --------------------- required by `IsCopy`
+   |        ------   ---- required by this bound in `IsCopy`
 ...
 LL | static FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
    |             ^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `NotCopy`

--- a/src/test/ui/wf/wf-static-type.stderr
+++ b/src/test/ui/wf/wf-static-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `NotCopy: std::marker::Copy` is not satisfied
   --> $DIR/wf-static-type.rs:10:13
    |
 LL | struct IsCopy<T:Copy> { t: T }
-   |        ------   ---- required by this bound in `IsCopy`
+   |                 ---- required by this bound in `IsCopy`
 ...
 LL | static FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
    |             ^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `NotCopy`

--- a/src/test/ui/wf/wf-struct-bound.stderr
+++ b/src/test/ui/wf/wf-struct-bound.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-struct-bound.rs:10:14
    |
 LL | trait ExtraCopy<T:Copy> { }
-   | ----------------------- required by `ExtraCopy`
+   |       ---------   ---- required by this bound in `ExtraCopy`
 ...
 LL |     where T: ExtraCopy<U>
    |              ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`

--- a/src/test/ui/wf/wf-struct-bound.stderr
+++ b/src/test/ui/wf/wf-struct-bound.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-struct-bound.rs:10:14
    |
 LL | trait ExtraCopy<T:Copy> { }
-   |       ---------   ---- required by this bound in `ExtraCopy`
+   |                   ---- required by this bound in `ExtraCopy`
 ...
 LL |     where T: ExtraCopy<U>
    |              ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`

--- a/src/test/ui/wf/wf-struct-field.stderr
+++ b/src/test/ui/wf/wf-struct-field.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `A: std::marker::Copy` is not satisfied
   --> $DIR/wf-struct-field.rs:12:5
    |
 LL | struct IsCopy<T:Copy> {
-   |        ------   ---- required by this bound in `IsCopy`
+   |                 ---- required by this bound in `IsCopy`
 ...
 LL |     data: IsCopy<A>
    |     ^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `A`

--- a/src/test/ui/wf/wf-struct-field.stderr
+++ b/src/test/ui/wf/wf-struct-field.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `A: std::marker::Copy` is not satisfied
   --> $DIR/wf-struct-field.rs:12:5
    |
 LL | struct IsCopy<T:Copy> {
-   | --------------------- required by `IsCopy`
+   |        ------   ---- required by this bound in `IsCopy`
 ...
 LL |     data: IsCopy<A>
    |     ^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `A`

--- a/src/test/ui/wf/wf-trait-associated-type-bound.stderr
+++ b/src/test/ui/wf/wf-trait-associated-type-bound.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-trait-associated-type-bound.rs:10:17
    |
 LL | trait ExtraCopy<T:Copy> { }
-   | ----------------------- required by `ExtraCopy`
+   |       ---------   ---- required by this bound in `ExtraCopy`
 ...
 LL |     type Type1: ExtraCopy<T>;
    |                 ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/wf/wf-trait-associated-type-bound.stderr
+++ b/src/test/ui/wf/wf-trait-associated-type-bound.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-trait-associated-type-bound.rs:10:17
    |
 LL | trait ExtraCopy<T:Copy> { }
-   |       ---------   ---- required by this bound in `ExtraCopy`
+   |                   ---- required by this bound in `ExtraCopy`
 ...
 LL |     type Type1: ExtraCopy<T>;
    |                 ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/wf/wf-trait-associated-type-trait.stderr
+++ b/src/test/ui/wf/wf-trait-associated-type-trait.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `<Self as SomeTrait>::Type1: std::marker::Copy` is
   --> $DIR/wf-trait-associated-type-trait.rs:11:5
    |
 LL | struct IsCopy<T:Copy> { x: T }
-   | --------------------- required by `IsCopy`
+   |        ------   ---- required by this bound in `IsCopy`
 LL | 
 LL | trait SomeTrait {
    |                - help: consider further restricting the associated type: `where <Self as SomeTrait>::Type1: std::marker::Copy`

--- a/src/test/ui/wf/wf-trait-associated-type-trait.stderr
+++ b/src/test/ui/wf/wf-trait-associated-type-trait.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `<Self as SomeTrait>::Type1: std::marker::Copy` is
   --> $DIR/wf-trait-associated-type-trait.rs:11:5
    |
 LL | struct IsCopy<T:Copy> { x: T }
-   |        ------   ---- required by this bound in `IsCopy`
+   |                 ---- required by this bound in `IsCopy`
 LL | 
 LL | trait SomeTrait {
    |                - help: consider further restricting the associated type: `where <Self as SomeTrait>::Type1: std::marker::Copy`

--- a/src/test/ui/wf/wf-trait-bound.stderr
+++ b/src/test/ui/wf/wf-trait-bound.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-trait-bound.rs:10:14
    |
 LL | trait ExtraCopy<T:Copy> { }
-   | ----------------------- required by `ExtraCopy`
+   |       ---------   ---- required by this bound in `ExtraCopy`
 ...
 LL |     where T: ExtraCopy<U>
    |              ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`

--- a/src/test/ui/wf/wf-trait-bound.stderr
+++ b/src/test/ui/wf/wf-trait-bound.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-trait-bound.rs:10:14
    |
 LL | trait ExtraCopy<T:Copy> { }
-   |       ---------   ---- required by this bound in `ExtraCopy`
+   |                   ---- required by this bound in `ExtraCopy`
 ...
 LL |     where T: ExtraCopy<U>
    |              ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`

--- a/src/test/ui/wf/wf-trait-default-fn-arg.stderr
+++ b/src/test/ui/wf/wf-trait-default-fn-arg.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-default-fn-arg.rs:11:22
    |
 LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   | ----------------------- required by `Bar`
+   |        ---   -- required by this bound in `Bar`
 ...
 LL |     fn bar(&self, x: &Bar<Self>) {
    |                      ^^^^^^^^^^ - help: consider further restricting `Self`: `where Self: std::cmp::Eq`

--- a/src/test/ui/wf/wf-trait-default-fn-arg.stderr
+++ b/src/test/ui/wf/wf-trait-default-fn-arg.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-default-fn-arg.rs:11:22
    |
 LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   |        ---   -- required by this bound in `Bar`
+   |              -- required by this bound in `Bar`
 ...
 LL |     fn bar(&self, x: &Bar<Self>) {
    |                      ^^^^^^^^^^ - help: consider further restricting `Self`: `where Self: std::cmp::Eq`

--- a/src/test/ui/wf/wf-trait-default-fn-ret.stderr
+++ b/src/test/ui/wf/wf-trait-default-fn-ret.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-default-fn-ret.rs:11:22
    |
 LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   | ----------------------- required by `Bar`
+   |        ---   -- required by this bound in `Bar`
 ...
 LL |     fn bar(&self) -> Bar<Self> {
    |                      ^^^^^^^^^- help: consider further restricting `Self`: `where Self: std::cmp::Eq`

--- a/src/test/ui/wf/wf-trait-default-fn-ret.stderr
+++ b/src/test/ui/wf/wf-trait-default-fn-ret.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-default-fn-ret.rs:11:22
    |
 LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   |        ---   -- required by this bound in `Bar`
+   |              -- required by this bound in `Bar`
 ...
 LL |     fn bar(&self) -> Bar<Self> {
    |                      ^^^^^^^^^- help: consider further restricting `Self`: `where Self: std::cmp::Eq`

--- a/src/test/ui/wf/wf-trait-default-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-trait-default-fn-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-default-fn-where-clause.rs:11:31
    |
 LL | trait Bar<T:Eq+?Sized> { }
-   | ---------------------- required by `Bar`
+   |       ---   -- required by this bound in `Bar`
 ...
 LL |     fn bar<A>(&self) where A: Bar<Self> {
    |                               ^^^^^^^^^- help: consider further restricting `Self`: `, Self: std::cmp::Eq`

--- a/src/test/ui/wf/wf-trait-default-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-trait-default-fn-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-default-fn-where-clause.rs:11:31
    |
 LL | trait Bar<T:Eq+?Sized> { }
-   |       ---   -- required by this bound in `Bar`
+   |             -- required by this bound in `Bar`
 ...
 LL |     fn bar<A>(&self) where A: Bar<Self> {
    |                               ^^^^^^^^^- help: consider further restricting `Self`: `, Self: std::cmp::Eq`

--- a/src/test/ui/wf/wf-trait-fn-arg.stderr
+++ b/src/test/ui/wf/wf-trait-fn-arg.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-fn-arg.rs:10:22
    |
 LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   | ----------------------- required by `Bar`
+   |        ---   -- required by this bound in `Bar`
 ...
 LL |     fn bar(&self, x: &Bar<Self>);
    |                      ^^^^^^^^^^ - help: consider further restricting `Self`: `where Self: std::cmp::Eq`

--- a/src/test/ui/wf/wf-trait-fn-arg.stderr
+++ b/src/test/ui/wf/wf-trait-fn-arg.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-fn-arg.rs:10:22
    |
 LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   |        ---   -- required by this bound in `Bar`
+   |              -- required by this bound in `Bar`
 ...
 LL |     fn bar(&self, x: &Bar<Self>);
    |                      ^^^^^^^^^^ - help: consider further restricting `Self`: `where Self: std::cmp::Eq`

--- a/src/test/ui/wf/wf-trait-fn-ret.stderr
+++ b/src/test/ui/wf/wf-trait-fn-ret.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-fn-ret.rs:10:22
    |
 LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   |        ---   -- required by this bound in `Bar`
+   |              -- required by this bound in `Bar`
 ...
 LL |     fn bar(&self) -> &Bar<Self>;
    |                      ^^^^^^^^^^- help: consider further restricting `Self`: `where Self: std::cmp::Eq`

--- a/src/test/ui/wf/wf-trait-fn-ret.stderr
+++ b/src/test/ui/wf/wf-trait-fn-ret.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-fn-ret.rs:10:22
    |
 LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   | ----------------------- required by `Bar`
+   |        ---   -- required by this bound in `Bar`
 ...
 LL |     fn bar(&self) -> &Bar<Self>;
    |                      ^^^^^^^^^^- help: consider further restricting `Self`: `where Self: std::cmp::Eq`

--- a/src/test/ui/wf/wf-trait-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-trait-fn-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-fn-where-clause.rs:10:49
    |
 LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   | ----------------------- required by `Bar`
+   |        ---   -- required by this bound in `Bar`
 ...
 LL |     fn bar(&self) where Self: Sized, Bar<Self>: Copy;
    |                                                 ^^^^- help: consider further restricting `Self`: `, Self: std::cmp::Eq`

--- a/src/test/ui/wf/wf-trait-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-trait-fn-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-fn-where-clause.rs:10:49
    |
 LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   |        ---   -- required by this bound in `Bar`
+   |              -- required by this bound in `Bar`
 ...
 LL |     fn bar(&self) where Self: Sized, Bar<Self>: Copy;
    |                                                 ^^^^- help: consider further restricting `Self`: `, Self: std::cmp::Eq`

--- a/src/test/ui/wf/wf-trait-superbound.stderr
+++ b/src/test/ui/wf/wf-trait-superbound.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-trait-superbound.rs:9:21
    |
 LL | trait ExtraCopy<T:Copy> { }
-   |       ---------   ---- required by this bound in `ExtraCopy`
+   |                   ---- required by this bound in `ExtraCopy`
 LL | 
 LL | trait SomeTrait<T>: ExtraCopy<T> {
    |                     ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/wf/wf-trait-superbound.stderr
+++ b/src/test/ui/wf/wf-trait-superbound.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-trait-superbound.rs:9:21
    |
 LL | trait ExtraCopy<T:Copy> { }
-   | ----------------------- required by `ExtraCopy`
+   |       ---------   ---- required by this bound in `ExtraCopy`
 LL | 
 LL | trait SomeTrait<T>: ExtraCopy<T> {
    |                     ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
+++ b/src/test/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/where-clause-constraints-are-local-for-inherent-impl.rs:13:22
    |
 LL | fn require_copy<T: Copy>(x: T) {}
-   |    ------------    ---- required by this bound in `require_copy`
+   |                    ---- required by this bound in `require_copy`
 ...
 LL |         require_copy(self.x);
    |                      ^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
+++ b/src/test/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/where-clause-constraints-are-local-for-trait-impl.rs:18:22
    |
 LL | fn require_copy<T: Copy>(x: T) {}
-   |    ------------    ---- required by this bound in `require_copy`
+   |                    ---- required by this bound in `require_copy`
 ...
 LL |         require_copy(self.x);
    |                      ^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/where-clauses/where-clauses-unsatisfied.stderr
+++ b/src/test/ui/where-clauses/where-clauses-unsatisfied.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Struct: std::cmp::Eq` is not satisfied
   --> $DIR/where-clauses-unsatisfied.rs:6:10
    |
 LL | fn equal<T>(a: &T, b: &T) -> bool where T : Eq { a == b }
-   |    -----                                    -- required by this bound in `equal`
+   |                                             -- required by this bound in `equal`
 ...
 LL |     drop(equal(&Struct, &Struct))
    |          ^^^^^ the trait `std::cmp::Eq` is not implemented for `Struct`


### PR DESCRIPTION
Keep more information about trait binding failures. Use more specific spans by pointing at bindings that introduce obligations.

Subset of #69709.

r? @eddyb 