### PR TITLE
Rename rustc guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue.md
@@ -39,8 +39,8 @@ for larger features an implementation could be broken up into multiple PRs.
 - [ ] Adjust documentation ([see instructions on rustc-dev-guide][doc-guide])
 - [ ] Stabilization PR ([see instructions on rustc-dev-guide][stabilization-guide])
 
-[stabilization-guide]: https://rust-lang.github.io/rustc-dev-guide/stabilization_guide.html#stabilization-pr
-[doc-guide]: https://rust-lang.github.io/rustc-dev-guide/stabilization_guide.html#documentation-prs
+[stabilization-guide]: https://rustc-dev-guide.rust-lang.org/stabilization_guide.html#stabilization-pr
+[doc-guide]: https://rustc-dev-guide.rust-lang.org/stabilization_guide.html#documentation-prs
 
 ### Unresolved Questions
 <!--

--- a/.github/ISSUE_TEMPLATE/tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue.md
@@ -36,11 +36,11 @@ for larger features an implementation could be broken up into multiple PRs.
 
 - [ ] Implement the RFC (cc @rust-lang/XXX -- can anyone write up mentoring
       instructions?)
-- [ ] Adjust documentation ([see instructions on rustc-guide][doc-guide])
-- [ ] Stabilization PR ([see instructions on rustc-guide][stabilization-guide])
+- [ ] Adjust documentation ([see instructions on rustc-dev-guide][doc-guide])
+- [ ] Stabilization PR ([see instructions on rustc-dev-guide][stabilization-guide])
 
-[stabilization-guide]: https://rust-lang.github.io/rustc-guide/stabilization_guide.html#stabilization-pr
-[doc-guide]: https://rust-lang.github.io/rustc-guide/stabilization_guide.html#documentation-prs
+[stabilization-guide]: https://rust-lang.github.io/rustc-dev-guide/stabilization_guide.html#stabilization-pr
+[doc-guide]: https://rust-lang.github.io/rustc-dev-guide/stabilization_guide.html#documentation-prs
 
 ### Unresolved Questions
 <!--

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -434,7 +434,7 @@ For people new to Rust, and just starting to contribute, or even for
 more seasoned developers, some useful places to look for information
 are:
 
-* The [rustc guide] contains information about how various parts of the compiler work and how to contribute to the compiler
+* The [rustc dev guide] contains information about how various parts of the compiler work and how to contribute to the compiler
 * [Rust Forge][rustforge] contains additional documentation, including write-ups of how to achieve common tasks
 * The [Rust Internals forum][rif], a place to ask questions and
   discuss Rust's internals
@@ -448,7 +448,7 @@ are:
 * **Google!** ([search only in Rust Documentation][gsearchdocs] to find types, traits, etc. quickly)
 * Don't be afraid to ask! The Rust community is friendly and helpful.
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html
 [gdfrustc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/
 [gsearchdocs]: https://www.google.com/search?q=site:doc.rust-lang.org+your+query+here
 [rif]: http://internals.rust-lang.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,8 @@ can give you a good example of how a typical contribution would go.
 [rust-discord]: http://discord.gg/rust-lang
 [rust-zulip]: https://rust-lang.zulipchat.com
 [coc]: https://www.rust-lang.org/conduct.html
-[rustc-dev-guide]: https://rust-lang.github.io/rustc-dev-guide/
-[walkthrough]: https://rust-lang.github.io/rustc-dev-guide/walkthrough.html
+[rustc-dev-guide]: https://rustc-dev-guide.rust-lang.org/
+[walkthrough]: https://rustc-dev-guide.rust-lang.org/walkthrough.html
 
 ## Feature Requests
 [feature-requests]: #feature-requests
@@ -108,7 +108,7 @@ contributions to the compiler and the standard library. It also lists some
 really useful commands to the build system (`./x.py`), which could save you a
 lot of time.
 
-[rustcguidebuild]: https://rust-lang.github.io/rustc-dev-guide/building/how-to-build-and-run.html
+[rustcguidebuild]: https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html
 
 ## Pull Requests
 [pull-requests]: #pull-requests
@@ -448,7 +448,7 @@ are:
 * **Google!** ([search only in Rust Documentation][gsearchdocs] to find types, traits, etc. quickly)
 * Don't be afraid to ask! The Rust community is friendly and helpful.
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/about-this-guide.html
 [gdfrustc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/
 [gsearchdocs]: https://www.google.com/search?q=site:doc.rust-lang.org+your+query+here
 [rif]: http://internals.rust-lang.org
@@ -456,5 +456,5 @@ are:
 [rustforge]: https://forge.rust-lang.org/
 [tlgba]: http://tomlee.co/2014/04/a-more-detailed-tour-of-the-rust-compiler/
 [ro]: http://www.rustaceans.org/
-[rctd]: https://rust-lang.github.io/rustc-dev-guide/tests/intro.html
+[rctd]: https://rustc-dev-guide.rust-lang.org/tests/intro.html
 [cheatsheet]: https://buildbot2.rust-lang.org/homu/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ hop on the [Rust Discord server][rust-discord] or [Rust Zulip server][rust-zulip
 
 As a reminder, all contributors are expected to follow our [Code of Conduct][coc].
 
-The [rustc-guide] is your friend! It describes how the compiler works and how
+The [rustc-dev-guide] is your friend! It describes how the compiler works and how
 to contribute to it in more detail than this document.
 
 If this is your first time contributing, the [walkthrough] chapter of the guide
@@ -29,8 +29,8 @@ can give you a good example of how a typical contribution would go.
 [rust-discord]: http://discord.gg/rust-lang
 [rust-zulip]: https://rust-lang.zulipchat.com
 [coc]: https://www.rust-lang.org/conduct.html
-[rustc-guide]: https://rust-lang.github.io/rustc-guide/
-[walkthrough]: https://rust-lang.github.io/rustc-guide/walkthrough.html
+[rustc-dev-guide]: https://rust-lang.github.io/rustc-dev-guide/
+[walkthrough]: https://rust-lang.github.io/rustc-dev-guide/walkthrough.html
 
 ## Feature Requests
 [feature-requests]: #feature-requests
@@ -103,12 +103,12 @@ $ RUST_BACKTRACE=1 rustc ...
 ## The Build System
 
 For info on how to configure and build the compiler, please see [this
-chapter][rustcguidebuild] of the rustc-guide. This chapter contains info for
+chapter][rustcguidebuild] of the rustc-dev-guide. This chapter contains info for
 contributions to the compiler and the standard library. It also lists some
 really useful commands to the build system (`./x.py`), which could save you a
 lot of time.
 
-[rustcguidebuild]: https://rust-lang.github.io/rustc-guide/building/how-to-build-and-run.html
+[rustcguidebuild]: https://rust-lang.github.io/rustc-dev-guide/building/how-to-build-and-run.html
 
 ## Pull Requests
 [pull-requests]: #pull-requests
@@ -336,9 +336,9 @@ to check small fixes. For example, `rustdoc src/doc/reference.md` will render
 reference to `doc/reference.html`. The CSS might be messed up, but you can
 verify that the HTML is right.
 
-Additionally, contributions to the [rustc-guide] are always welcome. Contributions
+Additionally, contributions to the [rustc-dev-guide] are always welcome. Contributions
 can be made directly at [the
-rust-lang/rustc-guide](https://github.com/rust-lang/rustc-guide) repo. The issue
+rust-lang/rustc-dev-guide](https://github.com/rust-lang/rustc-dev-guide) repo. The issue
 tracker in that repo is also a great way to find things that need doing. There
 are issues for beginners and advanced compiler devs alike!
 
@@ -448,7 +448,7 @@ are:
 * **Google!** ([search only in Rust Documentation][gsearchdocs] to find types, traits, etc. quickly)
 * Don't be afraid to ask! The Rust community is friendly and helpful.
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/about-this-guide.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html
 [gdfrustc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/
 [gsearchdocs]: https://www.google.com/search?q=site:doc.rust-lang.org+your+query+here
 [rif]: http://internals.rust-lang.org
@@ -456,5 +456,5 @@ are:
 [rustforge]: https://forge.rust-lang.org/
 [tlgba]: http://tomlee.co/2014/04/a-more-detailed-tour-of-the-rust-compiler/
 [ro]: http://www.rustaceans.org/
-[rctd]: https://rust-lang.github.io/rustc-guide/tests/intro.html
+[rctd]: https://rust-lang.github.io/rustc-dev-guide/tests/intro.html
 [cheatsheet]: https://buildbot2.rust-lang.org/homu/

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Read ["Installation"] from [The Book].
 ## Installing from Source
 
 _Note: If you wish to contribute to the compiler, you should read [this
-chapter][rustcguidebuild] of the rustc-guide instead of this section._
+chapter][rustcguidebuild] of the rustc-dev-guide instead of this section._
 
 The Rust build system has a Python script called `x.py` to bootstrap building
 the compiler. More information about it may be found by running `./x.py --help`
 or reading the [rustc guide][rustcguidebuild].
 
-[rustcguidebuild]: https://rust-lang.github.io/rustc-guide/building/how-to-build-and-run.html
+[rustcguidebuild]: https://rust-lang.github.io/rustc-dev-guide/building/how-to-build-and-run.html
 
 ### Building on *nix
 1. Make sure you have installed the dependencies:
@@ -255,7 +255,7 @@ various parts of the compiler work.
 Also, you may find the [rustdocs for the compiler itself][rustdocs] useful.
 
 [rust-discord]: https://discord.gg/rust-lang
-[rustc guide]: https://rust-lang.github.io/rustc-guide/about-this-guide.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html
 [rustdocs]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/
 
 ## License

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The Rust build system has a Python script called `x.py` to bootstrap building
 the compiler. More information about it may be found by running `./x.py --help`
 or reading the [rustc dev guide][rustcguidebuild].
 
-[rustcguidebuild]: https://rust-lang.github.io/rustc-dev-guide/building/how-to-build-and-run.html
+[rustcguidebuild]: https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html
 
 ### Building on *nix
 1. Make sure you have installed the dependencies:
@@ -255,7 +255,7 @@ various parts of the compiler work.
 Also, you may find the [rustdocs for the compiler itself][rustdocs] useful.
 
 [rust-discord]: https://discord.gg/rust-lang
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/about-this-guide.html
 [rustdocs]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/
 
 ## License

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ chapter][rustcguidebuild] of the rustc-dev-guide instead of this section._
 
 The Rust build system has a Python script called `x.py` to bootstrap building
 the compiler. More information about it may be found by running `./x.py --help`
-or reading the [rustc guide][rustcguidebuild].
+or reading the [rustc dev guide][rustcguidebuild].
 
 [rustcguidebuild]: https://rust-lang.github.io/rustc-dev-guide/building/how-to-build-and-run.html
 
@@ -249,13 +249,13 @@ Most real-time collaboration happens in a variety of channels on the
 community, documentation, and all major contribution areas in the Rust ecosystem.
 A good place to ask for help would be the #help channel.
 
-The [rustc guide] might be a good place to start if you want to find out how
+The [rustc dev guide] might be a good place to start if you want to find out how
 various parts of the compiler work.
 
 Also, you may find the [rustdocs for the compiler itself][rustdocs] useful.
 
 [rust-discord]: https://discord.gg/rust-lang
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html
 [rustdocs]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/
 
 ## License

--- a/src/README.md
+++ b/src/README.md
@@ -5,4 +5,4 @@ This directory contains the source code of the rust project, including:
 
 For more information on how various parts of the compiler work, see the [rustc dev guide].
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/about-this-guide.html

--- a/src/README.md
+++ b/src/README.md
@@ -5,4 +5,4 @@ This directory contains the source code of the rust project, including:
 
 For more information on how various parts of the compiler work, see the [rustc guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/about-this-guide.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html

--- a/src/README.md
+++ b/src/README.md
@@ -3,6 +3,6 @@ This directory contains the source code of the rust project, including:
 - `libstd`
 - Various submodules for tools, like rustdoc, rls, etc.
 
-For more information on how various parts of the compiler work, see the [rustc guide].
+For more information on how various parts of the compiler work, see the [rustc dev guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -120,7 +120,7 @@ Rust. It's also sometimes called "the 'nomicon."
 
 ## The `rustc` Contribution Guide
 
-[The `rustc` Guide](https://rust-lang.github.io/rustc-guide/) documents how
+[The `rustc` Guide](https://rust-lang.github.io/rustc-dev-guide/) documents how
 the compiler works and how to contribute to it. This is useful if you want to build
 or modify the Rust compiler from source (e.g. to target something non-standard).
 

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -120,7 +120,7 @@ Rust. It's also sometimes called "the 'nomicon."
 
 ## The `rustc` Contribution Guide
 
-[The `rustc` Guide](https://rust-lang.github.io/rustc-dev-guide/) documents how
+[The `rustc` Guide](https://rustc-dev-guide.rust-lang.org/) documents how
 the compiler works and how to contribute to it. This is useful if you want to build
 or modify the Rust compiler from source (e.g. to target something non-standard).
 

--- a/src/doc/rustc/src/contributing.md
+++ b/src/doc/rustc/src/contributing.md
@@ -8,5 +8,5 @@ more, you'll want to check that out.
 If you would like to contribute to _this_ book, you can find its source in the
 rustc source at [src/doc/rustc][rustc_book].
 
-[rustc_guide]: https://rust-lang.github.io/rustc-guide/
+[rustc_guide]: https://rust-lang.github.io/rustc-dev-guide/
 [rustc_book]: https://github.com/rust-lang/rust/tree/master/src/doc/rustc

--- a/src/doc/rustc/src/contributing.md
+++ b/src/doc/rustc/src/contributing.md
@@ -1,12 +1,12 @@
 # Contributing to rustc
 
 We'd love to have your help improving `rustc`! To that end, we've written [a
-whole book][rustc_guide] on its
+whole book][rustc_dev_guide] on its
 internals, how it works, and how to get started working on it. To learn
 more, you'll want to check that out.
 
 If you would like to contribute to _this_ book, you can find its source in the
 rustc source at [src/doc/rustc][rustc_book].
 
-[rustc_guide]: https://rust-lang.github.io/rustc-dev-guide/
+[rustc_dev_guide]: https://rust-lang.github.io/rustc-dev-guide/
 [rustc_book]: https://github.com/rust-lang/rust/tree/master/src/doc/rustc

--- a/src/doc/rustc/src/contributing.md
+++ b/src/doc/rustc/src/contributing.md
@@ -8,5 +8,5 @@ more, you'll want to check that out.
 If you would like to contribute to _this_ book, you can find its source in the
 rustc source at [src/doc/rustc][rustc_book].
 
-[rustc_dev_guide]: https://rust-lang.github.io/rustc-dev-guide/
+[rustc_dev_guide]: https://rustc-dev-guide.rust-lang.org/
 [rustc_book]: https://github.com/rust-lang/rust/tree/master/src/doc/rustc

--- a/src/librustc/README.md
+++ b/src/librustc/README.md
@@ -1,3 +1,3 @@
 For more information about how rustc works, see the [rustc dev guide].
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/

--- a/src/librustc/README.md
+++ b/src/librustc/README.md
@@ -1,3 +1,3 @@
-For more information about how rustc works, see the [rustc guide].
+For more information about how rustc works, see the [rustc dev guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/

--- a/src/librustc/README.md
+++ b/src/librustc/README.md
@@ -1,3 +1,3 @@
 For more information about how rustc works, see the [rustc guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/

--- a/src/librustc/dep_graph/README.md
+++ b/src/librustc/dep_graph/README.md
@@ -1,4 +1,4 @@
 To learn more about how dependency tracking works in rustc, see the [rustc
 guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/query.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/query.html

--- a/src/librustc/dep_graph/README.md
+++ b/src/librustc/dep_graph/README.md
@@ -1,4 +1,4 @@
 To learn more about how dependency tracking works in rustc, see the [rustc
 guide].
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/query.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/query.html

--- a/src/librustc/dep_graph/README.md
+++ b/src/librustc/dep_graph/README.md
@@ -1,4 +1,4 @@
 To learn more about how dependency tracking works in rustc, see the [rustc
 guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/query.html
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/query.html

--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -194,7 +194,7 @@ impl DepGraph {
     /// - If you need 3+ arguments, use a tuple for the
     ///   `arg` parameter.
     ///
-    /// [rustc guide]: https://rust-lang.github.io/rustc-guide/incremental-compilation.html
+    /// [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/incremental-compilation.html
     pub fn with_task<'a, C, A, R>(
         &self,
         key: DepNode,

--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -174,7 +174,7 @@ impl DepGraph {
     /// what state they have access to. In particular, we want to
     /// prevent implicit 'leaks' of tracked state into the task (which
     /// could then be read without generating correct edges in the
-    /// dep-graph -- see the [rustc guide] for more details on
+    /// dep-graph -- see the [rustc dev guide] for more details on
     /// the dep-graph). To this end, the task function gets exactly two
     /// pieces of state: the context `cx` and an argument `arg`. Both
     /// of these bits of state must be of some type that implements
@@ -194,7 +194,7 @@ impl DepGraph {
     /// - If you need 3+ arguments, use a tuple for the
     ///   `arg` parameter.
     ///
-    /// [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/incremental-compilation.html
+    /// [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/incremental-compilation.html
     pub fn with_task<'a, C, A, R>(
         &self,
         key: DepNode,

--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -194,7 +194,7 @@ impl DepGraph {
     /// - If you need 3+ arguments, use a tuple for the
     ///   `arg` parameter.
     ///
-    /// [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/incremental-compilation.html
+    /// [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/incremental-compilation.html
     pub fn with_task<'a, C, A, R>(
         &self,
         key: DepNode,

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1,6 +1,6 @@
 //! HIR datatypes. See the [rustc guide] for more info.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/hir.html
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
 
 pub mod exports;
 pub mod map;

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1,6 +1,6 @@
 //! HIR datatypes. See the [rustc dev guide] for more info.
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/hir.html
 
 pub mod exports;
 pub mod map;

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1,6 +1,6 @@
-//! HIR datatypes. See the [rustc guide] for more info.
+//! HIR datatypes. See the [rustc dev guide] for more info.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
 
 pub mod exports;
 pub mod map;

--- a/src/librustc/infer/canonical.rs
+++ b/src/librustc/infer/canonical.rs
@@ -19,7 +19,7 @@
 //! For a more detailed look at what is happening here, check
 //! out the [chapter in the rustc guide][c].
 //!
-//! [c]: https://rust-lang.github.io/rustc-guide/traits/canonicalization.html
+//! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 
 use crate::infer::MemberConstraint;
 use crate::ty::subst::GenericArg;

--- a/src/librustc/infer/canonical.rs
+++ b/src/librustc/infer/canonical.rs
@@ -17,7 +17,7 @@
 //! `instantiate_query_result` method.
 //!
 //! For a more detailed look at what is happening here, check
-//! out the [chapter in the rustc guide][c].
+//! out the [chapter in the rustc dev guide][c].
 //!
 //! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 

--- a/src/librustc/infer/canonical.rs
+++ b/src/librustc/infer/canonical.rs
@@ -19,7 +19,7 @@
 //! For a more detailed look at what is happening here, check
 //! out the [chapter in the rustc dev guide][c].
 //!
-//! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
+//! [c]: https://rustc-dev-guide.rust-lang.org/traits/canonicalization.html
 
 use crate::infer::MemberConstraint;
 use crate::ty::subst::GenericArg;

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! For more information about how rustc works, see the [rustc guide].
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/
 //!
 //! # Note
 //!

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! For more information about how rustc works, see the [rustc dev guide].
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/
 //!
 //! # Note
 //!

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -14,9 +14,9 @@
 //!   (or `tcx`), which is the central context during most of
 //!   compilation, containing the interners and other things.
 //!
-//! For more information about how rustc works, see the [rustc guide].
+//! For more information about how rustc works, see the [rustc dev guide].
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/
 //!
 //! # Note
 //!

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -4,7 +4,7 @@
 //! For more information about how MIR-based region-checking works,
 //! see the [rustc guide].
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/mir/borrowck.html
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/mir/borrowck.html
 
 use crate::ich::{NodeIdHashingMode, StableHashingContext};
 use crate::ty::{self, DefIdTree, TyCtxt};

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -2,9 +2,9 @@
 //! the parent links in the region hierarchy.
 //!
 //! For more information about how MIR-based region-checking works,
-//! see the [rustc guide].
+//! see the [rustc dev guide].
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/mir/borrowck.html
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/mir/borrowck.html
 
 use crate::ich::{NodeIdHashingMode, StableHashingContext};
 use crate::ty::{self, DefIdTree, TyCtxt};

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -4,7 +4,7 @@
 //! For more information about how MIR-based region-checking works,
 //! see the [rustc dev guide].
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/mir/borrowck.html
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/mir/borrowck.html
 
 use crate::ich::{NodeIdHashingMode, StableHashingContext};
 use crate::ty::{self, DefIdTree, TyCtxt};

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1,6 +1,6 @@
-//! MIR datatypes and passes. See the [rustc guide] for more info.
+//! MIR datatypes and passes. See the [rustc dev guide] for more info.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/mir/index.html
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/mir/index.html
 
 use crate::mir::interpret::{GlobalAlloc, Scalar};
 use crate::mir::visit::MirVisitable;

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1,6 +1,6 @@
 //! MIR datatypes and passes. See the [rustc guide] for more info.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/mir/index.html
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/mir/index.html
 
 use crate::mir::interpret::{GlobalAlloc, Scalar};
 use crate::mir::visit::MirVisitable;

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1,6 +1,6 @@
 //! MIR datatypes and passes. See the [rustc dev guide] for more info.
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/mir/index.html
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/mir/index.html
 
 use crate::mir::interpret::{GlobalAlloc, Scalar};
 use crate::mir::visit::MirVisitable;

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -1,6 +1,6 @@
-//! Trait Resolution. See the [rustc guide] for more information on how this works.
+//! Trait Resolution. See the [rustc dev guide] for more information on how this works.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
 
 pub mod query;
 pub mod select;

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -1,6 +1,6 @@
 //! Trait Resolution. See the [rustc dev guide] for more information on how this works.
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/traits/resolution.html
 
 pub mod query;
 pub mod select;

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -1,6 +1,6 @@
 //! Trait Resolution. See the [rustc guide] for more information on how this works.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/traits/resolution.html
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
 
 pub mod query;
 pub mod select;

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -1,6 +1,6 @@
 //! Candidate selection. See the [rustc dev guide] for more information on how this works.
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#selection
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/traits/resolution.html#selection
 
 use self::EvaluationResult::*;
 

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -1,6 +1,6 @@
 //! Candidate selection. See the [rustc guide] for more information on how this works.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/traits/resolution.html#selection
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#selection
 
 use self::EvaluationResult::*;
 

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -1,6 +1,6 @@
-//! Candidate selection. See the [rustc guide] for more information on how this works.
+//! Candidate selection. See the [rustc dev guide] for more information on how this works.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#selection
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#selection
 
 use self::EvaluationResult::*;
 

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -918,7 +918,7 @@ pub struct FreeRegionInfo {
 /// various **compiler queries** that have been performed. See the
 /// [rustc guide] for more details.
 ///
-/// [rustc guide]: https://rust-lang.github.io/rustc-guide/ty.html
+/// [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/ty.html
 #[derive(Copy, Clone)]
 #[rustc_diagnostic_item = "TyCtxt"]
 pub struct TyCtxt<'tcx> {

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -918,7 +918,7 @@ pub struct FreeRegionInfo {
 /// various **compiler queries** that have been performed. See the
 /// [rustc dev guide] for more details.
 ///
-/// [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/ty.html
+/// [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/ty.html
 #[derive(Copy, Clone)]
 #[rustc_diagnostic_item = "TyCtxt"]
 pub struct TyCtxt<'tcx> {

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -916,9 +916,9 @@ pub struct FreeRegionInfo {
 /// The central data structure of the compiler. It stores references
 /// to the various **arenas** and also houses the results of the
 /// various **compiler queries** that have been performed. See the
-/// [rustc guide] for more details.
+/// [rustc dev guide] for more details.
 ///
-/// [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/ty.html
+/// [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/ty.html
 #[derive(Copy, Clone)]
 #[rustc_diagnostic_item = "TyCtxt"]
 pub struct TyCtxt<'tcx> {

--- a/src/librustc/ty/query/README.md
+++ b/src/librustc/ty/query/README.md
@@ -1,3 +1,3 @@
 For more information about how the query system works, see the [rustc guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/query.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/query.html

--- a/src/librustc/ty/query/README.md
+++ b/src/librustc/ty/query/README.md
@@ -1,3 +1,3 @@
-For more information about how the query system works, see the [rustc guide].
+For more information about how the query system works, see the [rustc dev guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/query.html
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/query.html

--- a/src/librustc/ty/query/README.md
+++ b/src/librustc/ty/query/README.md
@@ -1,3 +1,3 @@
 For more information about how the query system works, see the [rustc dev guide].
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/query.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/query.html

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1396,11 +1396,11 @@ pub type Region<'tcx> = &'tcx RegionKind;
 /// the inference variable is supposed to satisfy the relation
 /// *for every value of the placeholder region*. To ensure that doesn't
 /// happen, you can use `leak_check`. This is more clearly explained
-/// by the [rustc guide].
+/// by the [rustc dev guide].
 ///
 /// [1]: http://smallcultfollowing.com/babysteps/blog/2013/10/29/intermingled-parameter-lists/
 /// [2]: http://smallcultfollowing.com/babysteps/blog/2013/11/04/intermingled-parameter-lists/
-/// [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/hrtb.html
+/// [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/hrtb.html
 #[derive(Clone, PartialEq, Eq, Hash, Copy, RustcEncodable, RustcDecodable, PartialOrd, Ord)]
 pub enum RegionKind {
     /// Region bound in a type or fn declaration which will be

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1400,7 +1400,7 @@ pub type Region<'tcx> = &'tcx RegionKind;
 ///
 /// [1]: http://smallcultfollowing.com/babysteps/blog/2013/10/29/intermingled-parameter-lists/
 /// [2]: http://smallcultfollowing.com/babysteps/blog/2013/11/04/intermingled-parameter-lists/
-/// [rustc guide]: https://rust-lang.github.io/rustc-guide/traits/hrtb.html
+/// [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/hrtb.html
 #[derive(Clone, PartialEq, Eq, Hash, Copy, RustcEncodable, RustcDecodable, PartialOrd, Ord)]
 pub enum RegionKind {
     /// Region bound in a type or fn declaration which will be

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1400,7 +1400,7 @@ pub type Region<'tcx> = &'tcx RegionKind;
 ///
 /// [1]: http://smallcultfollowing.com/babysteps/blog/2013/10/29/intermingled-parameter-lists/
 /// [2]: http://smallcultfollowing.com/babysteps/blog/2013/11/04/intermingled-parameter-lists/
-/// [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/hrtb.html
+/// [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/traits/hrtb.html
 #[derive(Clone, PartialEq, Eq, Hash, Copy, RustcEncodable, RustcDecodable, PartialOrd, Ord)]
 pub enum RegionKind {
     /// Region bound in a type or fn declaration which will be

--- a/src/librustc_ast/README.md
+++ b/src/librustc_ast/README.md
@@ -5,5 +5,5 @@ lexer, macro expander, and utilities for traversing ASTs.
 For more information about how these things work in rustc, see the
 rustc guide:
 
-- [Parsing](https://rust-lang.github.io/rustc-guide/the-parser.html)
-- [Macro Expansion](https://rust-lang.github.io/rustc-guide/macro-expansion.html)
+- [Parsing](https://rust-lang.github.io/rustc-dev-guide/the-parser.html)
+- [Macro Expansion](https://rust-lang.github.io/rustc-dev-guide/macro-expansion.html)

--- a/src/librustc_ast/README.md
+++ b/src/librustc_ast/README.md
@@ -3,7 +3,7 @@ The `rustc_ast` crate contains those things concerned purely with syntax
 lexer, macro expander, and utilities for traversing ASTs.
 
 For more information about how these things work in rustc, see the
-rustc guide:
+rustc dev guide:
 
 - [Parsing](https://rust-lang.github.io/rustc-dev-guide/the-parser.html)
 - [Macro Expansion](https://rust-lang.github.io/rustc-dev-guide/macro-expansion.html)

--- a/src/librustc_ast/README.md
+++ b/src/librustc_ast/README.md
@@ -5,5 +5,5 @@ lexer, macro expander, and utilities for traversing ASTs.
 For more information about how these things work in rustc, see the
 rustc dev guide:
 
-- [Parsing](https://rust-lang.github.io/rustc-dev-guide/the-parser.html)
-- [Macro Expansion](https://rust-lang.github.io/rustc-dev-guide/macro-expansion.html)
+- [Parsing](https://rustc-dev-guide.rust-lang.org/the-parser.html)
+- [Macro Expansion](https://rustc-dev-guide.rust-lang.org/macro-expansion.html)

--- a/src/librustc_codegen_llvm/README.md
+++ b/src/librustc_codegen_llvm/README.md
@@ -4,4 +4,4 @@ that runs towards the end of the compilation process.
 
 For more information about how codegen works, see the [rustc dev guide].
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/codegen.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/codegen.html

--- a/src/librustc_codegen_llvm/README.md
+++ b/src/librustc_codegen_llvm/README.md
@@ -2,6 +2,6 @@ The `codegen` crate contains the code to convert from MIR into LLVM IR,
 and then from LLVM IR into machine code. In general it contains code
 that runs towards the end of the compilation process.
 
-For more information about how codegen works, see the [rustc guide].
+For more information about how codegen works, see the [rustc dev guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/codegen.html
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/codegen.html

--- a/src/librustc_codegen_llvm/README.md
+++ b/src/librustc_codegen_llvm/README.md
@@ -4,4 +4,4 @@ that runs towards the end of the compilation process.
 
 For more information about how codegen works, see the [rustc guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/codegen.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/codegen.html

--- a/src/librustc_codegen_ssa/README.md
+++ b/src/librustc_codegen_ssa/README.md
@@ -1,3 +1,3 @@
-Please read the rustc-guide chapter on [Backend Agnostic Codegen][bac].
+Please read the rustc-dev-guide chapter on [Backend Agnostic Codegen][bac].
 
-[bac]: https://rust-lang.github.io/rustc-guide/codegen/backend-agnostic.html
+[bac]: https://rust-lang.github.io/rustc-dev-guide/codegen/backend-agnostic.html

--- a/src/librustc_codegen_ssa/README.md
+++ b/src/librustc_codegen_ssa/README.md
@@ -1,3 +1,3 @@
 Please read the rustc-dev-guide chapter on [Backend Agnostic Codegen][bac].
 
-[bac]: https://rust-lang.github.io/rustc-dev-guide/codegen/backend-agnostic.html
+[bac]: https://rustc-dev-guide.rust-lang.org/codegen/backend-agnostic.html

--- a/src/librustc_driver/README.md
+++ b/src/librustc_driver/README.md
@@ -5,6 +5,6 @@ not contain any of the "main logic" of the compiler (though it does
 have some code related to pretty printing or other minor compiler
 options).
 
-For more information about how the driver works, see the [rustc guide].
+For more information about how the driver works, see the [rustc dev guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/rustc-driver.html
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/rustc-driver.html

--- a/src/librustc_driver/README.md
+++ b/src/librustc_driver/README.md
@@ -7,4 +7,4 @@ options).
 
 For more information about how the driver works, see the [rustc guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/rustc-driver.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/rustc-driver.html

--- a/src/librustc_driver/README.md
+++ b/src/librustc_driver/README.md
@@ -7,4 +7,4 @@ options).
 
 For more information about how the driver works, see the [rustc dev guide].
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/rustc-driver.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/rustc-driver.html

--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -611,7 +611,7 @@ pub struct ModuleItems {
 ///
 /// For more details, see the [rustc guide].
 ///
-/// [rustc guide]: https://rust-lang.github.io/rustc-guide/hir.html
+/// [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
 #[derive(RustcEncodable, RustcDecodable, Debug)]
 pub struct Crate<'hir> {
     pub module: Mod<'hir>,

--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -611,7 +611,7 @@ pub struct ModuleItems {
 ///
 /// For more details, see the [rustc dev guide].
 ///
-/// [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
+/// [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/hir.html
 #[derive(RustcEncodable, RustcDecodable, Debug)]
 pub struct Crate<'hir> {
     pub module: Mod<'hir>,

--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -609,9 +609,9 @@ pub struct ModuleItems {
 /// The top-level data structure that stores the entire contents of
 /// the crate currently being compiled.
 ///
-/// For more details, see the [rustc guide].
+/// For more details, see the [rustc dev guide].
 ///
-/// [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
+/// [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
 #[derive(RustcEncodable, RustcDecodable, Debug)]
 pub struct Crate<'hir> {
     pub module: Mod<'hir>,

--- a/src/librustc_hir/lib.rs
+++ b/src/librustc_hir/lib.rs
@@ -1,6 +1,6 @@
-//! HIR datatypes. See the [rustc guide] for more info.
+//! HIR datatypes. See the [rustc dev guide] for more info.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
 
 #![feature(crate_visibility_modifier)]
 #![feature(const_fn)] // For the unsizing cast on `&[]`

--- a/src/librustc_hir/lib.rs
+++ b/src/librustc_hir/lib.rs
@@ -1,6 +1,6 @@
 //! HIR datatypes. See the [rustc dev guide] for more info.
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/hir.html
 
 #![feature(crate_visibility_modifier)]
 #![feature(const_fn)] // For the unsizing cast on `&[]`

--- a/src/librustc_hir/lib.rs
+++ b/src/librustc_hir/lib.rs
@@ -1,6 +1,6 @@
 //! HIR datatypes. See the [rustc guide] for more info.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/hir.html
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
 
 #![feature(crate_visibility_modifier)]
 #![feature(const_fn)] // For the unsizing cast on `&[]`

--- a/src/librustc_incremental/persist/README.md
+++ b/src/librustc_incremental/persist/README.md
@@ -1,3 +1,3 @@
-For info on how the incremental compilation works, see the [rustc guide].
+For info on how the incremental compilation works, see the [rustc dev guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/query.html
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/query.html

--- a/src/librustc_incremental/persist/README.md
+++ b/src/librustc_incremental/persist/README.md
@@ -1,3 +1,3 @@
 For info on how the incremental compilation works, see the [rustc dev guide].
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/query.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/query.html

--- a/src/librustc_incremental/persist/README.md
+++ b/src/librustc_incremental/persist/README.md
@@ -1,3 +1,3 @@
 For info on how the incremental compilation works, see the [rustc guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/query.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/query.html

--- a/src/librustc_infer/infer/canonical/canonicalizer.rs
+++ b/src/librustc_infer/infer/canonical/canonicalizer.rs
@@ -1,7 +1,7 @@
 //! This module contains the "canonicalizer" itself.
 //!
 //! For an overview of what canonicalization is and how it fits into
-//! rustc, check out the [chapter in the rustc guide][c].
+//! rustc, check out the [chapter in the rustc dev guide][c].
 //!
 //! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 
@@ -33,7 +33,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
     /// with a mapping M that maps `'?0` to `'static`.
     ///
     /// To get a good understanding of what is happening here, check
-    /// out the [chapter in the rustc guide][c].
+    /// out the [chapter in the rustc dev guide][c].
     ///
     /// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html#canonicalizing-the-query
     pub fn canonicalize_query<V>(
@@ -77,7 +77,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
     /// reference to `'static` alone.
     ///
     /// To get a good understanding of what is happening here, check
-    /// out the [chapter in the rustc guide][c].
+    /// out the [chapter in the rustc dev guide][c].
     ///
     /// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html#canonicalizing-the-query-result
     pub fn canonicalize_response<V>(&self, value: &V) -> Canonicalized<'tcx, V>

--- a/src/librustc_infer/infer/canonical/canonicalizer.rs
+++ b/src/librustc_infer/infer/canonical/canonicalizer.rs
@@ -3,7 +3,7 @@
 //! For an overview of what canonicalization is and how it fits into
 //! rustc, check out the [chapter in the rustc dev guide][c].
 //!
-//! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
+//! [c]: https://rustc-dev-guide.rust-lang.org/traits/canonicalization.html
 
 use crate::infer::canonical::{
     Canonical, CanonicalTyVarKind, CanonicalVarInfo, CanonicalVarKind, Canonicalized,
@@ -35,7 +35,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
     /// To get a good understanding of what is happening here, check
     /// out the [chapter in the rustc dev guide][c].
     ///
-    /// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html#canonicalizing-the-query
+    /// [c]: https://rustc-dev-guide.rust-lang.org/traits/canonicalization.html#canonicalizing-the-query
     pub fn canonicalize_query<V>(
         &self,
         value: &V,
@@ -79,7 +79,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
     /// To get a good understanding of what is happening here, check
     /// out the [chapter in the rustc dev guide][c].
     ///
-    /// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html#canonicalizing-the-query-result
+    /// [c]: https://rustc-dev-guide.rust-lang.org/traits/canonicalization.html#canonicalizing-the-query-result
     pub fn canonicalize_response<V>(&self, value: &V) -> Canonicalized<'tcx, V>
     where
         V: TypeFoldable<'tcx>,

--- a/src/librustc_infer/infer/canonical/canonicalizer.rs
+++ b/src/librustc_infer/infer/canonical/canonicalizer.rs
@@ -3,7 +3,7 @@
 //! For an overview of what canonicalization is and how it fits into
 //! rustc, check out the [chapter in the rustc guide][c].
 //!
-//! [c]: https://rust-lang.github.io/rustc-guide/traits/canonicalization.html
+//! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 
 use crate::infer::canonical::{
     Canonical, CanonicalTyVarKind, CanonicalVarInfo, CanonicalVarKind, Canonicalized,
@@ -35,7 +35,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
     /// To get a good understanding of what is happening here, check
     /// out the [chapter in the rustc guide][c].
     ///
-    /// [c]: https://rust-lang.github.io/rustc-guide/traits/canonicalization.html#canonicalizing-the-query
+    /// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html#canonicalizing-the-query
     pub fn canonicalize_query<V>(
         &self,
         value: &V,
@@ -79,7 +79,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
     /// To get a good understanding of what is happening here, check
     /// out the [chapter in the rustc guide][c].
     ///
-    /// [c]: https://rust-lang.github.io/rustc-guide/traits/canonicalization.html#canonicalizing-the-query-result
+    /// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html#canonicalizing-the-query-result
     pub fn canonicalize_response<V>(&self, value: &V) -> Canonicalized<'tcx, V>
     where
         V: TypeFoldable<'tcx>,

--- a/src/librustc_infer/infer/canonical/mod.rs
+++ b/src/librustc_infer/infer/canonical/mod.rs
@@ -19,7 +19,7 @@
 //! For a more detailed look at what is happening here, check
 //! out the [chapter in the rustc guide][c].
 //!
-//! [c]: https://rust-lang.github.io/rustc-guide/traits/canonicalization.html
+//! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 
 use crate::infer::{ConstVariableOrigin, ConstVariableOriginKind};
 use crate::infer::{InferCtxt, RegionVariableOrigin, TypeVariableOrigin, TypeVariableOriginKind};

--- a/src/librustc_infer/infer/canonical/mod.rs
+++ b/src/librustc_infer/infer/canonical/mod.rs
@@ -17,7 +17,7 @@
 //! `instantiate_query_result` method.
 //!
 //! For a more detailed look at what is happening here, check
-//! out the [chapter in the rustc guide][c].
+//! out the [chapter in the rustc dev guide][c].
 //!
 //! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 

--- a/src/librustc_infer/infer/canonical/mod.rs
+++ b/src/librustc_infer/infer/canonical/mod.rs
@@ -19,7 +19,7 @@
 //! For a more detailed look at what is happening here, check
 //! out the [chapter in the rustc dev guide][c].
 //!
-//! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
+//! [c]: https://rustc-dev-guide.rust-lang.org/traits/canonicalization.html
 
 use crate::infer::{ConstVariableOrigin, ConstVariableOriginKind};
 use crate::infer::{InferCtxt, RegionVariableOrigin, TypeVariableOrigin, TypeVariableOriginKind};

--- a/src/librustc_infer/infer/canonical/query_response.rs
+++ b/src/librustc_infer/infer/canonical/query_response.rs
@@ -5,7 +5,7 @@
 //! For an overview of what canonicaliation is and how it fits into
 //! rustc, check out the [chapter in the rustc guide][c].
 //!
-//! [c]: https://rust-lang.github.io/rustc-guide/traits/canonicalization.html
+//! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 
 use crate::infer::canonical::substitute::{substitute_value, CanonicalExt};
 use crate::infer::canonical::{
@@ -197,7 +197,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
     /// To get a good understanding of what is happening here, check
     /// out the [chapter in the rustc guide][c].
     ///
-    /// [c]: https://rust-lang.github.io/rustc-guide/traits/canonicalization.html#processing-the-canonicalized-query-result
+    /// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html#processing-the-canonicalized-query-result
     pub fn instantiate_query_response_and_region_obligations<R>(
         &self,
         cause: &ObligationCause<'tcx>,

--- a/src/librustc_infer/infer/canonical/query_response.rs
+++ b/src/librustc_infer/infer/canonical/query_response.rs
@@ -3,7 +3,7 @@
 //! encode them therein.
 //!
 //! For an overview of what canonicaliation is and how it fits into
-//! rustc, check out the [chapter in the rustc guide][c].
+//! rustc, check out the [chapter in the rustc dev guide][c].
 //!
 //! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 
@@ -195,7 +195,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
     /// the query before applying this function.)
     ///
     /// To get a good understanding of what is happening here, check
-    /// out the [chapter in the rustc guide][c].
+    /// out the [chapter in the rustc dev guide][c].
     ///
     /// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html#processing-the-canonicalized-query-result
     pub fn instantiate_query_response_and_region_obligations<R>(

--- a/src/librustc_infer/infer/canonical/query_response.rs
+++ b/src/librustc_infer/infer/canonical/query_response.rs
@@ -5,7 +5,7 @@
 //! For an overview of what canonicaliation is and how it fits into
 //! rustc, check out the [chapter in the rustc dev guide][c].
 //!
-//! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
+//! [c]: https://rustc-dev-guide.rust-lang.org/traits/canonicalization.html
 
 use crate::infer::canonical::substitute::{substitute_value, CanonicalExt};
 use crate::infer::canonical::{
@@ -197,7 +197,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
     /// To get a good understanding of what is happening here, check
     /// out the [chapter in the rustc dev guide][c].
     ///
-    /// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html#processing-the-canonicalized-query-result
+    /// [c]: https://rustc-dev-guide.rust-lang.org/traits/canonicalization.html#processing-the-canonicalized-query-result
     pub fn instantiate_query_response_and_region_obligations<R>(
         &self,
         cause: &ObligationCause<'tcx>,

--- a/src/librustc_infer/infer/canonical/substitute.rs
+++ b/src/librustc_infer/infer/canonical/substitute.rs
@@ -4,7 +4,7 @@
 //! For an overview of what canonicalization is and how it fits into
 //! rustc, check out the [chapter in the rustc dev guide][c].
 //!
-//! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
+//! [c]: https://rustc-dev-guide.rust-lang.org/traits/canonicalization.html
 
 use crate::infer::canonical::{Canonical, CanonicalVarValues};
 use rustc::ty::fold::TypeFoldable;

--- a/src/librustc_infer/infer/canonical/substitute.rs
+++ b/src/librustc_infer/infer/canonical/substitute.rs
@@ -4,7 +4,7 @@
 //! For an overview of what canonicalization is and how it fits into
 //! rustc, check out the [chapter in the rustc guide][c].
 //!
-//! [c]: https://rust-lang.github.io/rustc-guide/traits/canonicalization.html
+//! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 
 use crate::infer::canonical::{Canonical, CanonicalVarValues};
 use rustc::ty::fold::TypeFoldable;

--- a/src/librustc_infer/infer/canonical/substitute.rs
+++ b/src/librustc_infer/infer/canonical/substitute.rs
@@ -2,7 +2,7 @@
 //! `Canonical<'tcx, T>`.
 //!
 //! For an overview of what canonicalization is and how it fits into
-//! rustc, check out the [chapter in the rustc guide][c].
+//! rustc, check out the [chapter in the rustc dev guide][c].
 //!
 //! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 

--- a/src/librustc_infer/infer/higher_ranked/README.md
+++ b/src/librustc_infer/infer/higher_ranked/README.md
@@ -1,8 +1,8 @@
 To learn more about how Higher-ranked trait bounds work in the _old_ trait
-solver, see [this chapter][oldhrtb] of the rustc-guide.
+solver, see [this chapter][oldhrtb] of the rustc-dev-guide.
 
 To learn more about how they work in the _new_ trait solver, see [this
 chapter][newhrtb].
 
-[oldhrtb]: https://rust-lang.github.io/rustc-guide/traits/hrtb.html
-[newhrtb]: https://rust-lang.github.io/rustc-guide/borrow_check/region_inference.html#placeholders-and-universes
+[oldhrtb]: https://rust-lang.github.io/rustc-dev-guide/traits/hrtb.html
+[newhrtb]: https://rust-lang.github.io/rustc-dev-guide/borrow_check/region_inference.html#placeholders-and-universes

--- a/src/librustc_infer/infer/higher_ranked/README.md
+++ b/src/librustc_infer/infer/higher_ranked/README.md
@@ -4,5 +4,5 @@ solver, see [this chapter][oldhrtb] of the rustc-dev-guide.
 To learn more about how they work in the _new_ trait solver, see [this
 chapter][newhrtb].
 
-[oldhrtb]: https://rust-lang.github.io/rustc-dev-guide/traits/hrtb.html
-[newhrtb]: https://rust-lang.github.io/rustc-dev-guide/borrow_check/region_inference.html#placeholders-and-universes
+[oldhrtb]: https://rustc-dev-guide.rust-lang.org/traits/hrtb.html
+[newhrtb]: https://rustc-dev-guide.rust-lang.org/borrow_check/region_inference.html#placeholders-and-universes

--- a/src/librustc_infer/infer/higher_ranked/mod.rs
+++ b/src/librustc_infer/infer/higher_ranked/mod.rs
@@ -71,9 +71,9 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     /// needed (but is also permitted).
     ///
     /// For more information about how placeholders and HRTBs work, see
-    /// the [rustc guide].
+    /// the [rustc dev guide].
     ///
-    /// [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/hrtb.html
+    /// [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/hrtb.html
     pub fn replace_bound_vars_with_placeholders<T>(
         &self,
         binder: &ty::Binder<T>,

--- a/src/librustc_infer/infer/higher_ranked/mod.rs
+++ b/src/librustc_infer/infer/higher_ranked/mod.rs
@@ -73,7 +73,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     /// For more information about how placeholders and HRTBs work, see
     /// the [rustc guide].
     ///
-    /// [rustc guide]: https://rust-lang.github.io/rustc-guide/traits/hrtb.html
+    /// [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/hrtb.html
     pub fn replace_bound_vars_with_placeholders<T>(
         &self,
         binder: &ty::Binder<T>,

--- a/src/librustc_infer/infer/higher_ranked/mod.rs
+++ b/src/librustc_infer/infer/higher_ranked/mod.rs
@@ -73,7 +73,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     /// For more information about how placeholders and HRTBs work, see
     /// the [rustc dev guide].
     ///
-    /// [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/hrtb.html
+    /// [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/traits/hrtb.html
     pub fn replace_bound_vars_with_placeholders<T>(
         &self,
         binder: &ty::Binder<T>,

--- a/src/librustc_infer/infer/lexical_region_resolve/README.md
+++ b/src/librustc_infer/infer/lexical_region_resolve/README.md
@@ -2,6 +2,6 @@
 Lexical Region Resolution was removed in https://github.com/rust-lang/rust/pull/64790.
 
 Rust now uses Non-lexical lifetimes. For more info, please see the [borrowck
-chapter][bc] in the rustc-guide.
+chapter][bc] in the rustc-dev-guide.
 
-[bc]: https://rust-lang.github.io/rustc-guide/borrow_check/region_inference.html
+[bc]: https://rust-lang.github.io/rustc-dev-guide/borrow_check/region_inference.html

--- a/src/librustc_infer/infer/lexical_region_resolve/README.md
+++ b/src/librustc_infer/infer/lexical_region_resolve/README.md
@@ -4,4 +4,4 @@ Lexical Region Resolution was removed in https://github.com/rust-lang/rust/pull/
 Rust now uses Non-lexical lifetimes. For more info, please see the [borrowck
 chapter][bc] in the rustc-dev-guide.
 
-[bc]: https://rust-lang.github.io/rustc-dev-guide/borrow_check/region_inference.html
+[bc]: https://rustc-dev-guide.rust-lang.org/borrow_check/region_inference.html

--- a/src/librustc_infer/infer/region_constraints/README.md
+++ b/src/librustc_infer/infer/region_constraints/README.md
@@ -1,3 +1,3 @@
-For info on how the current borrowck works, see the [rustc guide].
+For info on how the current borrowck works, see the [rustc dev guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/borrow_check.html
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/borrow_check.html

--- a/src/librustc_infer/infer/region_constraints/README.md
+++ b/src/librustc_infer/infer/region_constraints/README.md
@@ -1,3 +1,3 @@
 For info on how the current borrowck works, see the [rustc dev guide].
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/borrow_check.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/borrow_check.html

--- a/src/librustc_infer/infer/region_constraints/README.md
+++ b/src/librustc_infer/infer/region_constraints/README.md
@@ -1,3 +1,3 @@
 For info on how the current borrowck works, see the [rustc guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/borrow_check.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/borrow_check.html

--- a/src/librustc_infer/lib.rs
+++ b/src/librustc_infer/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! For more information about how rustc works, see the [rustc guide].
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/
 //!
 //! # Note
 //!

--- a/src/librustc_infer/lib.rs
+++ b/src/librustc_infer/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! For more information about how rustc works, see the [rustc dev guide].
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/
 //!
 //! # Note
 //!

--- a/src/librustc_infer/lib.rs
+++ b/src/librustc_infer/lib.rs
@@ -5,9 +5,9 @@
 //!   this code handles low-level equality and subtyping operations. The
 //!   type check pass in the compiler is found in the `librustc_typeck` crate.
 //!
-//! For more information about how rustc works, see the [rustc guide].
+//! For more information about how rustc works, see the [rustc dev guide].
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/
 //!
 //! # Note
 //!

--- a/src/librustc_infer/traits/coherence.rs
+++ b/src/librustc_infer/traits/coherence.rs
@@ -1,5 +1,5 @@
-//! See Rustc Guide chapters on [trait-resolution] and [trait-specialization] for more info on how
-//! this works.
+//! See Rustc Dev Guide chapters on [trait-resolution] and [trait-specialization] for more info on
+//! how this works.
 //!
 //! [trait-resolution]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
 //! [trait-specialization]: https://rust-lang.github.io/rustc-dev-guide/traits/specialization.html

--- a/src/librustc_infer/traits/coherence.rs
+++ b/src/librustc_infer/traits/coherence.rs
@@ -1,8 +1,8 @@
 //! See Rustc Guide chapters on [trait-resolution] and [trait-specialization] for more info on how
 //! this works.
 //!
-//! [trait-resolution]: https://rust-lang.github.io/rustc-guide/traits/resolution.html
-//! [trait-specialization]: https://rust-lang.github.io/rustc-guide/traits/specialization.html
+//! [trait-resolution]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
+//! [trait-specialization]: https://rust-lang.github.io/rustc-dev-guide/traits/specialization.html
 
 use crate::infer::{CombinedSnapshot, InferOk, TyCtxtInferExt};
 use crate::traits::select::IntercrateAmbiguityCause;

--- a/src/librustc_infer/traits/coherence.rs
+++ b/src/librustc_infer/traits/coherence.rs
@@ -1,8 +1,8 @@
 //! See Rustc Dev Guide chapters on [trait-resolution] and [trait-specialization] for more info on
 //! how this works.
 //!
-//! [trait-resolution]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
-//! [trait-specialization]: https://rust-lang.github.io/rustc-dev-guide/traits/specialization.html
+//! [trait-resolution]: https://rustc-dev-guide.rust-lang.org/traits/resolution.html
+//! [trait-specialization]: https://rustc-dev-guide.rust-lang.org/traits/specialization.html
 
 use crate::infer::{CombinedSnapshot, InferOk, TyCtxtInferExt};
 use crate::traits::select::IntercrateAmbiguityCause;

--- a/src/librustc_infer/traits/mod.rs
+++ b/src/librustc_infer/traits/mod.rs
@@ -1,6 +1,6 @@
 //! Trait Resolution. See the [rustc guide] for more information on how this works.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/traits/resolution.html
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
 
 #[allow(dead_code)]
 pub mod auto_trait;

--- a/src/librustc_infer/traits/mod.rs
+++ b/src/librustc_infer/traits/mod.rs
@@ -1,6 +1,6 @@
-//! Trait Resolution. See the [rustc guide] for more information on how this works.
+//! Trait Resolution. See the [rustc dev guide] for more information on how this works.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
 
 #[allow(dead_code)]
 pub mod auto_trait;

--- a/src/librustc_infer/traits/mod.rs
+++ b/src/librustc_infer/traits/mod.rs
@@ -1,6 +1,6 @@
 //! Trait Resolution. See the [rustc dev guide] for more information on how this works.
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/traits/resolution.html
 
 #[allow(dead_code)]
 pub mod auto_trait;

--- a/src/librustc_infer/traits/query/type_op/mod.rs
+++ b/src/librustc_infer/traits/query/type_op/mod.rs
@@ -44,7 +44,7 @@ pub trait TypeOp<'tcx>: Sized + fmt::Debug {
 /// first canonicalize the key and then invoke the query on the tcx,
 /// which produces the resulting query region constraints.
 ///
-/// [c]: https://rust-lang.github.io/rustc-guide/traits/canonicalization.html
+/// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 pub trait QueryTypeOp<'tcx>: fmt::Debug + Sized + TypeFoldable<'tcx> + 'tcx {
     type QueryResponse: TypeFoldable<'tcx>;
 

--- a/src/librustc_infer/traits/query/type_op/mod.rs
+++ b/src/librustc_infer/traits/query/type_op/mod.rs
@@ -44,7 +44,7 @@ pub trait TypeOp<'tcx>: Sized + fmt::Debug {
 /// first canonicalize the key and then invoke the query on the tcx,
 /// which produces the resulting query region constraints.
 ///
-/// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
+/// [c]: https://rustc-dev-guide.rust-lang.org/traits/canonicalization.html
 pub trait QueryTypeOp<'tcx>: fmt::Debug + Sized + TypeFoldable<'tcx> + 'tcx {
     type QueryResponse: TypeFoldable<'tcx>;
 

--- a/src/librustc_infer/traits/select.rs
+++ b/src/librustc_infer/traits/select.rs
@@ -1,8 +1,8 @@
 // ignore-tidy-filelength
 
-//! Candidate selection. See the [rustc guide] for more information on how this works.
+//! Candidate selection. See the [rustc dev guide] for more information on how this works.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#selection
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#selection
 
 use self::EvaluationResult::*;
 use self::SelectionCandidate::*;
@@ -931,9 +931,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     //
     // The selection process begins by examining all in-scope impls,
     // caller obligations, and so forth and assembling a list of
-    // candidates. See the [rustc guide] for more details.
+    // candidates. See the [rustc dev guide] for more details.
     //
-    // [rustc guide]:
+    // [rustc dev guide]:
     // https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#candidate-assembly
 
     fn candidate_from_obligation<'o>(
@@ -2447,9 +2447,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     //
     // Confirmation unifies the output type parameters of the trait
     // with the values found in the obligation, possibly yielding a
-    // type error.  See the [rustc guide] for more details.
+    // type error.  See the [rustc dev guide] for more details.
     //
-    // [rustc guide]:
+    // [rustc dev guide]:
     // https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#confirmation
 
     fn confirm_candidate(

--- a/src/librustc_infer/traits/select.rs
+++ b/src/librustc_infer/traits/select.rs
@@ -2,7 +2,7 @@
 
 //! Candidate selection. See the [rustc guide] for more information on how this works.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/traits/resolution.html#selection
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#selection
 
 use self::EvaluationResult::*;
 use self::SelectionCandidate::*;
@@ -934,7 +934,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     // candidates. See the [rustc guide] for more details.
     //
     // [rustc guide]:
-    // https://rust-lang.github.io/rustc-guide/traits/resolution.html#candidate-assembly
+    // https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#candidate-assembly
 
     fn candidate_from_obligation<'o>(
         &mut self,
@@ -2450,7 +2450,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     // type error.  See the [rustc guide] for more details.
     //
     // [rustc guide]:
-    // https://rust-lang.github.io/rustc-guide/traits/resolution.html#confirmation
+    // https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#confirmation
 
     fn confirm_candidate(
         &mut self,

--- a/src/librustc_infer/traits/select.rs
+++ b/src/librustc_infer/traits/select.rs
@@ -2,7 +2,7 @@
 
 //! Candidate selection. See the [rustc dev guide] for more information on how this works.
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#selection
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/traits/resolution.html#selection
 
 use self::EvaluationResult::*;
 use self::SelectionCandidate::*;
@@ -934,7 +934,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     // candidates. See the [rustc dev guide] for more details.
     //
     // [rustc dev guide]:
-    // https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#candidate-assembly
+    // https://rustc-dev-guide.rust-lang.org/traits/resolution.html#candidate-assembly
 
     fn candidate_from_obligation<'o>(
         &mut self,
@@ -2450,7 +2450,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     // type error.  See the [rustc dev guide] for more details.
     //
     // [rustc dev guide]:
-    // https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#confirmation
+    // https://rustc-dev-guide.rust-lang.org/traits/resolution.html#confirmation
 
     fn confirm_candidate(
         &mut self,

--- a/src/librustc_infer/traits/specialize/mod.rs
+++ b/src/librustc_infer/traits/specialize/mod.rs
@@ -7,7 +7,7 @@
 //! See the [rustc guide] for a bit more detail on how specialization
 //! fits together with the rest of the trait machinery.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/traits/specialization.html
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/specialization.html
 
 pub mod specialization_graph;
 use specialization_graph::GraphExt;

--- a/src/librustc_infer/traits/specialize/mod.rs
+++ b/src/librustc_infer/traits/specialize/mod.rs
@@ -4,10 +4,10 @@
 //! At the moment, this implementation support only the simple "chain" rule:
 //! If any two impls overlap, one must be a strict subset of the other.
 //!
-//! See the [rustc guide] for a bit more detail on how specialization
+//! See the [rustc dev guide] for a bit more detail on how specialization
 //! fits together with the rest of the trait machinery.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/specialization.html
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/specialization.html
 
 pub mod specialization_graph;
 use specialization_graph::GraphExt;

--- a/src/librustc_infer/traits/specialize/mod.rs
+++ b/src/librustc_infer/traits/specialize/mod.rs
@@ -7,7 +7,7 @@
 //! See the [rustc dev guide] for a bit more detail on how specialization
 //! fits together with the rest of the trait machinery.
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/specialization.html
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/traits/specialization.html
 
 pub mod specialization_graph;
 use specialization_graph::GraphExt;

--- a/src/librustc_passes/region.rs
+++ b/src/librustc_passes/region.rs
@@ -4,7 +4,7 @@
 //! For more information about how MIR-based region-checking works,
 //! see the [rustc dev guide].
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/borrow_check.html
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/borrow_check.html
 
 use rustc::hir::map::Map;
 use rustc::middle::region::*;

--- a/src/librustc_passes/region.rs
+++ b/src/librustc_passes/region.rs
@@ -4,7 +4,7 @@
 //! For more information about how MIR-based region-checking works,
 //! see the [rustc guide].
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/borrow_check.html
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/borrow_check.html
 
 use rustc::hir::map::Map;
 use rustc::middle::region::*;

--- a/src/librustc_passes/region.rs
+++ b/src/librustc_passes/region.rs
@@ -2,9 +2,9 @@
 //! the parent links in the region hierarchy.
 //!
 //! For more information about how MIR-based region-checking works,
-//! see the [rustc guide].
+//! see the [rustc dev guide].
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/borrow_check.html
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/borrow_check.html
 
 use rustc::hir::map::Map;
 use rustc::middle::region::*;

--- a/src/librustc_target/README.md
+++ b/src/librustc_target/README.md
@@ -1,6 +1,6 @@
 `librustc_target` contains some very low-level details that are
 specific to different compilation targets and so forth.
 
-For more information about how rustc works, see the [rustc guide].
+For more information about how rustc works, see the [rustc dev guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/

--- a/src/librustc_target/README.md
+++ b/src/librustc_target/README.md
@@ -3,4 +3,4 @@ specific to different compilation targets and so forth.
 
 For more information about how rustc works, see the [rustc dev guide].
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/

--- a/src/librustc_target/README.md
+++ b/src/librustc_target/README.md
@@ -3,4 +3,4 @@ specific to different compilation targets and so forth.
 
 For more information about how rustc works, see the [rustc guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/

--- a/src/librustc_traits/lowering/mod.rs
+++ b/src/librustc_traits/lowering/mod.rs
@@ -108,13 +108,13 @@ impl<'tcx> Lower<PolyDomainGoal<'tcx>> for ty::Predicate<'tcx> {
     }
 }
 
-/// Used for implied bounds related rules (see rustc guide).
+/// Used for implied bounds related rules (see rustc dev guide).
 trait IntoFromEnvGoal {
     /// Transforms an existing goal into a `FromEnv` goal.
     fn into_from_env_goal(self) -> Self;
 }
 
-/// Used for well-formedness related rules (see rustc guide).
+/// Used for well-formedness related rules (see rustc dev guide).
 trait IntoWellFormedGoal {
     /// Transforms an existing goal into a `WellFormed` goal.
     fn into_well_formed_goal(self) -> Self;
@@ -178,7 +178,7 @@ crate fn program_clauses_for(tcx: TyCtxt<'_>, def_id: DefId) -> Clauses<'_> {
 fn program_clauses_for_trait(tcx: TyCtxt<'_>, def_id: DefId) -> Clauses<'_> {
     // `trait Trait<P1..Pn> where WC { .. } // P0 == Self`
 
-    // Rule Implemented-From-Env (see rustc guide)
+    // Rule Implemented-From-Env (see rustc dev guide)
     //
     // ```
     // forall<Self, P1..Pn> {
@@ -282,7 +282,7 @@ fn program_clauses_for_impl(tcx: TyCtxt<'tcx>, def_id: DefId) -> Clauses<'tcx> {
         return List::empty();
     }
 
-    // Rule Implemented-From-Impl (see rustc guide)
+    // Rule Implemented-From-Impl (see rustc dev guide)
     //
     // `impl<P0..Pn> Trait<A1..An> for A0 where WC { .. }`
     //
@@ -501,7 +501,7 @@ pub fn program_clauses_for_associated_type_def(tcx: TyCtxt<'_>, item_id: DefId) 
 }
 
 pub fn program_clauses_for_associated_type_value(tcx: TyCtxt<'_>, item_id: DefId) -> Clauses<'_> {
-    // Rule Normalize-From-Impl (see rustc guide)
+    // Rule Normalize-From-Impl (see rustc dev guide)
     //
     // ```
     // impl<P0..Pn> Trait<A1..An> for A0 {

--- a/src/librustc_typeck/README.md
+++ b/src/librustc_typeck/README.md
@@ -1,5 +1,5 @@
 For high-level intro to how type checking works in rustc, see the
 [type checking] chapter of the [rustc guide].
 
-[type checking]: https://rust-lang.github.io/rustc-guide/type-checking.html
-[rustc guide]: https://rust-lang.github.io/rustc-guide/
+[type checking]: https://rust-lang.github.io/rustc-dev-guide/type-checking.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/

--- a/src/librustc_typeck/README.md
+++ b/src/librustc_typeck/README.md
@@ -1,5 +1,5 @@
 For high-level intro to how type checking works in rustc, see the
-[type checking] chapter of the [rustc guide].
+[type checking] chapter of the [rustc dev guide].
 
 [type checking]: https://rust-lang.github.io/rustc-dev-guide/type-checking.html
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/

--- a/src/librustc_typeck/README.md
+++ b/src/librustc_typeck/README.md
@@ -1,5 +1,5 @@
 For high-level intro to how type checking works in rustc, see the
 [type checking] chapter of the [rustc dev guide].
 
-[type checking]: https://rust-lang.github.io/rustc-dev-guide/type-checking.html
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/
+[type checking]: https://rustc-dev-guide.rust-lang.org/type-checking.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -1,6 +1,6 @@
 //! Method lookup: the secret sauce of Rust. See the [rustc dev guide] for more information.
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/method-lookup.html
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/method-lookup.html
 
 mod confirm;
 pub mod probe;

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -1,6 +1,6 @@
 //! Method lookup: the secret sauce of Rust. See the [rustc guide] for more information.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/method-lookup.html
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/method-lookup.html
 
 mod confirm;
 pub mod probe;

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -1,6 +1,6 @@
-//! Method lookup: the secret sauce of Rust. See the [rustc guide] for more information.
+//! Method lookup: the secret sauce of Rust. See the [rustc dev guide] for more information.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/method-lookup.html
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/method-lookup.html
 
 mod confirm;
 pub mod probe;

--- a/src/librustc_typeck/variance/mod.rs
+++ b/src/librustc_typeck/variance/mod.rs
@@ -1,7 +1,7 @@
 //! Module for inferring the variance of type and lifetime parameters. See the [rustc guide]
 //! chapter for more info.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/variance.html
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/variance.html
 
 use hir::Node;
 use rustc::ty::query::Providers;

--- a/src/librustc_typeck/variance/mod.rs
+++ b/src/librustc_typeck/variance/mod.rs
@@ -1,7 +1,7 @@
 //! Module for inferring the variance of type and lifetime parameters. See the [rustc dev guide]
 //! chapter for more info.
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/variance.html
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/variance.html
 
 use hir::Node;
 use rustc::ty::query::Providers;

--- a/src/librustc_typeck/variance/mod.rs
+++ b/src/librustc_typeck/variance/mod.rs
@@ -1,7 +1,7 @@
-//! Module for inferring the variance of type and lifetime parameters. See the [rustc guide]
+//! Module for inferring the variance of type and lifetime parameters. See the [rustc dev guide]
 //! chapter for more info.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/variance.html
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/variance.html
 
 use hir::Node;
 use rustc::ty::query::Providers;

--- a/src/librustc_typeck/variance/terms.rs
+++ b/src/librustc_typeck/variance/terms.rs
@@ -77,8 +77,8 @@ pub fn determine_parameters_to_be_inferred<'a, 'tcx>(
 
     // See the following for a discussion on dep-graph management.
     //
-    // - https://rust-lang.github.io/rustc-guide/query.html
-    // - https://rust-lang.github.io/rustc-guide/variance.html
+    // - https://rust-lang.github.io/rustc-dev-guide/query.html
+    // - https://rust-lang.github.io/rustc-dev-guide/variance.html
     tcx.hir().krate().visit_all_item_likes(&mut terms_cx);
 
     terms_cx

--- a/src/librustc_typeck/variance/terms.rs
+++ b/src/librustc_typeck/variance/terms.rs
@@ -77,8 +77,8 @@ pub fn determine_parameters_to_be_inferred<'a, 'tcx>(
 
     // See the following for a discussion on dep-graph management.
     //
-    // - https://rust-lang.github.io/rustc-dev-guide/query.html
-    // - https://rust-lang.github.io/rustc-dev-guide/variance.html
+    // - https://rustc-dev-guide.rust-lang.org/query.html
+    // - https://rustc-dev-guide.rust-lang.org/variance.html
     tcx.hir().krate().visit_all_item_likes(&mut terms_cx);
 
     terms_cx

--- a/src/librustdoc/README.md
+++ b/src/librustdoc/README.md
@@ -1,3 +1,3 @@
-For more information about how `librustdoc` works, see the [rustc guide].
+For more information about how `librustdoc` works, see the [rustc dev guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/rustdoc.html
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/rustdoc.html

--- a/src/librustdoc/README.md
+++ b/src/librustdoc/README.md
@@ -1,3 +1,3 @@
 For more information about how `librustdoc` works, see the [rustc dev guide].
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/rustdoc.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/rustdoc.html

--- a/src/librustdoc/README.md
+++ b/src/librustdoc/README.md
@@ -1,3 +1,3 @@
 For more information about how `librustdoc` works, see the [rustc guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/rustdoc.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/rustdoc.html

--- a/src/test/COMPILER_TESTS.md
+++ b/src/test/COMPILER_TESTS.md
@@ -1,4 +1,4 @@
 # Compiler Test Documentation
 
 Documentation for the compiler testing framework can be found in
-[the rustc guide](https://rust-lang.github.io/rustc-guide/tests/intro.html).
+[the rustc guide](https://rust-lang.github.io/rustc-dev-guide/tests/intro.html).

--- a/src/test/COMPILER_TESTS.md
+++ b/src/test/COMPILER_TESTS.md
@@ -1,4 +1,4 @@
 # Compiler Test Documentation
 
 Documentation for the compiler testing framework can be found in
-[the rustc dev guide](https://rust-lang.github.io/rustc-dev-guide/tests/intro.html).
+[the rustc dev guide](https://rustc-dev-guide.rust-lang.org/tests/intro.html).

--- a/src/test/COMPILER_TESTS.md
+++ b/src/test/COMPILER_TESTS.md
@@ -1,4 +1,4 @@
 # Compiler Test Documentation
 
 Documentation for the compiler testing framework can be found in
-[the rustc guide](https://rust-lang.github.io/rustc-dev-guide/tests/intro.html).
+[the rustc dev guide](https://rust-lang.github.io/rustc-dev-guide/tests/intro.html).

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -17,7 +17,7 @@ Hey LLVM ICE-breakers! This bug has been identified as a good
 [instructions] for tackling these sorts of bugs. Maybe take a look?
 Thanks! <3
 
-[instructions]: https://rust-lang.github.io/rustc-dev-guide/ice-breaker/llvm.html
+[instructions]: https://rustc-dev-guide.rust-lang.org/ice-breaker/llvm.html
 """
 label = "ICEBreaker-LLVM"
 
@@ -28,6 +28,6 @@ Hey Cleanup Crew ICE-breakers! This bug has been identified as a good
 [instructions] for tackling these sorts of bugs. Maybe take a look?
 Thanks! <3
 
-[instructions]: https://rust-lang.github.io/rustc-dev-guide/ice-breaker/cleanup-crew.html
+[instructions]: https://rustc-dev-guide.rust-lang.org/ice-breaker/cleanup-crew.html
 """
 label = "ICEBreaker-Cleanup-Crew"

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -17,7 +17,7 @@ Hey LLVM ICE-breakers! This bug has been identified as a good
 [instructions] for tackling these sorts of bugs. Maybe take a look?
 Thanks! <3
 
-[instructions]: https://rust-lang.github.io/rustc-guide/ice-breaker/llvm.html
+[instructions]: https://rust-lang.github.io/rustc-dev-guide/ice-breaker/llvm.html
 """
 label = "ICEBreaker-LLVM"
 
@@ -28,6 +28,6 @@ Hey Cleanup Crew ICE-breakers! This bug has been identified as a good
 [instructions] for tackling these sorts of bugs. Maybe take a look?
 Thanks! <3
 
-[instructions]: https://rust-lang.github.io/rustc-guide/ice-breaker/cleanup-crew.html
+[instructions]: https://rust-lang.github.io/rustc-dev-guide/ice-breaker/cleanup-crew.html
 """
 label = "ICEBreaker-Cleanup-Crew"


### PR DESCRIPTION
This is in preparation for https://github.com/rust-lang/rustc-guide/issues/470
Needs to be merged after we actually rename the guide.

Have used this to rename:

`git grep -l 'rustc_guide' | xargs sed -i 's/rustc_guide/rustc_dev_guide/g'`
`git grep -l 'rustc-guide' | xargs sed -i 's/rustc-guide/rustc-dev-guide/g'`
`git grep -l 'rustc guide' | xargs sed -i 's/rustc guide/rustc dev guide/g'`