### PR TITLE
Do not ICE when matching an uninhabited enum's field

### DIFF
--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -410,6 +410,12 @@ where
                 stride * field
             }
             layout::FieldPlacement::Union(count) => {
+                // This is a narrow bug-fix for rust-lang/rust#69191: if we are
+                // trying to access absent field of uninhabited variant, then
+                // signal UB (but don't ICE the compiler).
+                if field >= count as u64 && base.layout.abi == layout::Abi::Uninhabited {
+                    throw_ub!(Unreachable);
+                }
                 assert!(
                     field < count as u64,
                     "Tried to access field {} of union {:#?} with {} fields",

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -413,6 +413,8 @@ where
                 // This is a narrow bug-fix for rust-lang/rust#69191: if we are
                 // trying to access absent field of uninhabited variant, then
                 // signal UB (but don't ICE the compiler).
+                // FIXME temporary hack to work around incoherence between
+                // layout computation and MIR building
                 if field >= count as u64 && base.layout.abi == layout::Abi::Uninhabited {
                     throw_ub!(Unreachable);
                 }

--- a/src/test/ui/consts/issue-69191-ice-on-uninhabited-enum-field.rs
+++ b/src/test/ui/consts/issue-69191-ice-on-uninhabited-enum-field.rs
@@ -5,18 +5,78 @@
 
 pub enum Void {}
 
-enum UninhabitedUnivariant { _Variant(Void), }
+enum UninhabitedUnivariant {
+    _Variant(Void),
+}
+
+enum UninhabitedMultivariant2 {
+    _Variant(Void),
+    _Warriont(Void),
+}
+
+enum UninhabitedMultivariant3 {
+    _Variant(Void),
+    _Warriont(Void),
+    _Worrynot(Void),
+}
 
 #[repr(C)]
-enum UninhabitedUnivariantC { _Variant(Void), }
+enum UninhabitedUnivariantC {
+    _Variant(Void),
+}
 
 #[repr(i32)]
-enum UninhabitedUnivariant32 { _Variant(Void), }
+enum UninhabitedUnivariant32 {
+    _Variant(Void),
+}
 
 fn main() {
     let _seed: UninhabitedUnivariant = None.unwrap();
     match _seed {
         UninhabitedUnivariant::_Variant(_x) => {}
+    }
+
+    let _seed: UninhabitedMultivariant2 = None.unwrap();
+    match _seed {
+        UninhabitedMultivariant2::_Variant(_x) => {}
+        UninhabitedMultivariant2::_Warriont(_x) => {}
+    }
+
+    let _seed: UninhabitedMultivariant2 = None.unwrap();
+    match _seed {
+        UninhabitedMultivariant2::_Variant(_x) => {}
+        _ => {}
+    }
+
+    let _seed: UninhabitedMultivariant2 = None.unwrap();
+    match _seed {
+        UninhabitedMultivariant2::_Warriont(_x) => {}
+        _ => {}
+    }
+
+    let _seed: UninhabitedMultivariant3 = None.unwrap();
+    match _seed {
+        UninhabitedMultivariant3::_Variant(_x) => {}
+        UninhabitedMultivariant3::_Warriont(_x) => {}
+        UninhabitedMultivariant3::_Worrynot(_x) => {}
+    }
+
+    let _seed: UninhabitedMultivariant3 = None.unwrap();
+    match _seed {
+        UninhabitedMultivariant3::_Variant(_x) => {}
+        _ => {}
+    }
+
+    let _seed: UninhabitedMultivariant3 = None.unwrap();
+    match _seed {
+        UninhabitedMultivariant3::_Warriont(_x) => {}
+        _ => {}
+    }
+
+    let _seed: UninhabitedMultivariant3 = None.unwrap();
+    match _seed {
+        UninhabitedMultivariant3::_Worrynot(_x) => {}
+        _ => {}
     }
 
     let _seed: UninhabitedUnivariantC = None.unwrap();

--- a/src/test/ui/consts/issue-69191-ice-on-uninhabited-enum-field.rs
+++ b/src/test/ui/consts/issue-69191-ice-on-uninhabited-enum-field.rs
@@ -1,0 +1,31 @@
+// build-pass
+//
+// (this is deliberately *not* check-pass; I have confirmed that the bug in
+// question does not replicate when one uses `cargo check` alone.)
+
+pub enum Void {}
+
+enum UninhabitedUnivariant { _Variant(Void), }
+
+#[repr(C)]
+enum UninhabitedUnivariantC { _Variant(Void), }
+
+#[repr(i32)]
+enum UninhabitedUnivariant32 { _Variant(Void), }
+
+fn main() {
+    let _seed: UninhabitedUnivariant = None.unwrap();
+    match _seed {
+        UninhabitedUnivariant::_Variant(_x) => {}
+    }
+
+    let _seed: UninhabitedUnivariantC = None.unwrap();
+    match _seed {
+        UninhabitedUnivariantC::_Variant(_x) => {}
+    }
+
+    let _seed: UninhabitedUnivariant32 = None.unwrap();
+    match _seed {
+        UninhabitedUnivariant32::_Variant(_x) => {}
+    }
+}


### PR DESCRIPTION
Fix #69191