### PR TITLE
Update deprecation version to 1.42 for Error::description

### DIFF
--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -135,7 +135,7 @@ pub trait Error: Debug + Display {
     /// }
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_deprecated(since = "1.41.0", reason = "use the Display impl or to_string()")]
+    #[rustc_deprecated(since = "1.42.0", reason = "use the Display impl or to_string()")]
     fn description(&self) -> &str {
         "description() is deprecated; use Display"
     }


### PR DESCRIPTION
Error::description is deprecated as of version 1.42, as the commit was
not in the release for 1.41.

Fixes #69751