### PR TITLE
reduce test size for Miri

### DIFF
--- a/src/liballoc/tests/slice.rs
+++ b/src/liballoc/tests/slice.rs
@@ -1733,9 +1733,9 @@ fn panic_safe() {
     let moduli = &[5, 20, 50];
 
     #[cfg(miri)]
-    let lens = 1..13;
+    let lens = 1..10;
     #[cfg(miri)]
-    let moduli = &[10];
+    let moduli = &[5];
 
     for len in lens {
         for &modulus in moduli {


### PR DESCRIPTION
The larger sizes take quite a while, and there is probably little point in repeating this quite so often.