### PR TITLE
Fix sequence of Type and Trait in optin-builtin-traits in Unstable Book

### DIFF
--- a/src/doc/unstable-book/src/language-features/optin-builtin-traits.md
+++ b/src/doc/unstable-book/src/language-features/optin-builtin-traits.md
@@ -16,7 +16,7 @@ has explicitly opted out via a negative impl.
 [`Sync`]: https://doc.rust-lang.org/std/marker/trait.Sync.html
 
 ```rust,ignore
-impl !Type for Trait
+impl !Trait for Type
 ```
 
 Example:


### PR DESCRIPTION
A simple fix in docs - the sequence of words in basic example of negative trait implementation was reversed.