### PR TITLE
Implement Error for TryReserveError

### DIFF
--- a/src/liballoc/collections/mod.rs
+++ b/src/liballoc/collections/mod.rs
@@ -42,6 +42,7 @@ pub use linked_list::LinkedList;
 pub use vec_deque::VecDeque;
 
 use crate::alloc::{Layout, LayoutErr};
+use core::fmt::Display;
 
 /// The error type for `try_reserve` methods.
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -74,6 +75,22 @@ impl From<LayoutErr> for TryReserveError {
     #[inline]
     fn from(_: LayoutErr) -> Self {
         TryReserveError::CapacityOverflow
+    }
+}
+
+#[unstable(feature = "try_reserve", reason = "new API", issue = "48043")]
+impl Display for TryReserveError {
+    fn fmt(
+        &self,
+        fmt: &mut core::fmt::Formatter<'_>,
+    ) -> core::result::Result<(), core::fmt::Error> {
+        fmt.write_str("memory allocation failed")?;
+        fmt.write_str(match &self {
+            TryReserveError::CapacityOverflow => {
+                " because the computed capacity exceeded the collection's maximum"
+            }
+            TryReserveError::AllocError { .. } => " because the memory allocator returned a error",
+        })
     }
 }
 

--- a/src/liballoc/collections/mod.rs
+++ b/src/liballoc/collections/mod.rs
@@ -85,12 +85,15 @@ impl Display for TryReserveError {
         fmt: &mut core::fmt::Formatter<'_>,
     ) -> core::result::Result<(), core::fmt::Error> {
         fmt.write_str("memory allocation failed")?;
-        fmt.write_str(match &self {
+        let reason = match &self {
             TryReserveError::CapacityOverflow => {
                 " because the computed capacity exceeded the collection's maximum"
             }
-            TryReserveError::AllocError { .. } => " because the memory allocator returned a error",
-        })
+            TryReserveError::AllocError { .. } => {
+                " because the memory allocator returned a error"
+            }
+        };
+        fmt.write_str(reason)
     }
 }
 

--- a/src/liballoc/collections/mod.rs
+++ b/src/liballoc/collections/mod.rs
@@ -89,9 +89,7 @@ impl Display for TryReserveError {
             TryReserveError::CapacityOverflow => {
                 " because the computed capacity exceeded the collection's maximum"
             }
-            TryReserveError::AllocError { .. } => {
-                " because the memory allocator returned a error"
-            }
+            TryReserveError::AllocError { .. } => " because the memory allocator returned a error",
         };
         fmt.write_str(reason)
     }

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -552,6 +552,13 @@ impl Error for char::ParseCharError {
     }
 }
 
+#[unstable(feature = "try_reserve", reason = "new API", issue = "48043")]
+impl Error for alloc::collections::TryReserveError {
+    fn description(&self) -> &str {
+        "memory allocation failed"
+    }
+}
+
 // Copied from `any.rs`.
 impl dyn Error + 'static {
     /// Returns `true` if the boxed type is the same as `T`

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -553,11 +553,7 @@ impl Error for char::ParseCharError {
 }
 
 #[unstable(feature = "try_reserve", reason = "new API", issue = "48043")]
-impl Error for alloc::collections::TryReserveError {
-    fn description(&self) -> &str {
-        "memory allocation failed"
-    }
-}
+impl Error for alloc::collections::TryReserveError {}
 
 // Copied from `any.rs`.
 impl dyn Error + 'static {


### PR DESCRIPTION
I noticed that the Error trait wasn't implemented for TryReserveError. (#48043)  

Not sure if the error messages and code style are 100% correct, it's my first time contributing to the Rust std.  
