### PR TITLE
 Maintain chain of derived obligations 

### DIFF
--- a/src/librustc_middle/traits/mod.rs
+++ b/src/librustc_middle/traits/mod.rs
@@ -191,6 +191,8 @@ pub enum ObligationCauseCode<'tcx> {
 
     ImplDerivedObligation(DerivedObligationCause<'tcx>),
 
+    DerivedObligation(DerivedObligationCause<'tcx>),
+
     /// Error derived when matching traits/impls; see ObligationCause for more details
     CompareImplMethodObligation {
         item_name: ast::Name,
@@ -263,7 +265,10 @@ impl ObligationCauseCode<'_> {
     // Return the base obligation, ignoring derived obligations.
     pub fn peel_derives(&self) -> &Self {
         let mut base_cause = self;
-        while let BuiltinDerivedObligation(cause) | ImplDerivedObligation(cause) = base_cause {
+        while let BuiltinDerivedObligation(cause)
+        | ImplDerivedObligation(cause)
+        | DerivedObligation(cause) = base_cause
+        {
             base_cause = &cause.parent_code;
         }
         base_cause

--- a/src/librustc_middle/traits/mod.rs
+++ b/src/librustc_middle/traits/mod.rs
@@ -257,8 +257,6 @@ pub enum ObligationCauseCode<'tcx> {
 
     /// #[feature(trivial_bounds)] is not enabled
     TrivialBound,
-
-    AssocTypeBound(Box<AssocTypeBoundData>),
 }
 
 impl ObligationCauseCode<'_> {
@@ -270,13 +268,6 @@ impl ObligationCauseCode<'_> {
         }
         base_cause
     }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct AssocTypeBoundData {
-    pub impl_span: Option<Span>,
-    pub original: Span,
-    pub bounds: Vec<Span>,
 }
 
 // `ObligationCauseCode` is used a lot. Make sure it doesn't unintentionally get bigger.

--- a/src/librustc_middle/traits/structural_impls.rs
+++ b/src/librustc_middle/traits/structural_impls.rs
@@ -501,7 +501,6 @@ impl<'a, 'tcx> Lift<'tcx> for traits::ObligationCauseCode<'a> {
             super::MethodReceiver => Some(super::MethodReceiver),
             super::BlockTailExpression(id) => Some(super::BlockTailExpression(id)),
             super::TrivialBound => Some(super::TrivialBound),
-            super::AssocTypeBound(ref data) => Some(super::AssocTypeBound(data.clone())),
         }
     }
 }

--- a/src/librustc_middle/traits/structural_impls.rs
+++ b/src/librustc_middle/traits/structural_impls.rs
@@ -456,6 +456,7 @@ impl<'a, 'tcx> Lift<'tcx> for traits::ObligationCauseCode<'a> {
             super::ImplDerivedObligation(ref cause) => {
                 tcx.lift(cause).map(super::ImplDerivedObligation)
             }
+            super::DerivedObligation(ref cause) => tcx.lift(cause).map(super::DerivedObligation),
             super::CompareImplMethodObligation {
                 item_name,
                 impl_item_def_id,

--- a/src/librustc_trait_selection/traits/error_reporting/on_unimplemented.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/on_unimplemented.rs
@@ -134,7 +134,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
 
         match obligation.cause.code {
             ObligationCauseCode::BuiltinDerivedObligation(..)
-            | ObligationCauseCode::ImplDerivedObligation(..) => {}
+            | ObligationCauseCode::ImplDerivedObligation(..)
+            | ObligationCauseCode::DerivedObligation(..) => {}
             _ => {
                 // this is a "direct", user-specified, rather than derived,
                 // obligation.

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -1684,15 +1684,6 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     err.help("add `#![feature(trivial_bounds)]` to the crate attributes to enable");
                 }
             }
-            ObligationCauseCode::AssocTypeBound(ref data) => {
-                err.span_label(data.original, "associated type defined here");
-                if let Some(sp) = data.impl_span {
-                    err.span_label(sp, "in this `impl` item");
-                }
-                for sp in &data.bounds {
-                    err.span_label(*sp, "restricted in this bound");
-                }
-            }
         }
     }
 

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -1135,7 +1135,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         while let Some(code) = next_code {
             debug!("maybe_note_obligation_cause_for_async_await: code={:?}", code);
             match code {
-                ObligationCauseCode::BuiltinDerivedObligation(derived_obligation)
+                ObligationCauseCode::DerivedObligation(derived_obligation)
+                | ObligationCauseCode::BuiltinDerivedObligation(derived_obligation)
                 | ObligationCauseCode::ImplDerivedObligation(derived_obligation) => {
                     let ty = derived_obligation.parent_trait_ref.self_ty();
                     debug!(
@@ -1653,6 +1654,16 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     parent_trait_ref.print_only_trait_path(),
                     parent_trait_ref.skip_binder().self_ty()
                 ));
+                let parent_predicate = parent_trait_ref.without_const().to_predicate();
+                self.note_obligation_cause_code(
+                    err,
+                    &parent_predicate,
+                    &data.parent_code,
+                    obligated_types,
+                );
+            }
+            ObligationCauseCode::DerivedObligation(ref data) => {
+                let parent_trait_ref = self.resolve_vars_if_possible(&data.parent_trait_ref);
                 let parent_predicate = parent_trait_ref.without_const().to_predicate();
                 self.note_obligation_cause_code(
                     err,

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -1532,14 +1532,14 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 let item_name = tcx.def_path_str(item_def_id);
                 let msg = format!("required by this bound in `{}`", item_name);
                 if let Some(ident) = tcx.opt_item_name(item_def_id) {
-                    let sm = self.tcx.sess.source_map();
+                    let sm = tcx.sess.source_map();
                     let same_line =
                         match (sm.lookup_line(ident.span.hi()), sm.lookup_line(span.lo())) {
                             (Ok(l), Ok(r)) => l.line == r.line,
                             _ => true,
                         };
                     if !ident.span.overlaps(span) && !same_line {
-                        err.span_label(ident.span, "");
+                        err.span_label(ident.span, "required by a bound in this");
                     }
                 }
                 if span != DUMMY_SP {

--- a/src/librustc_trait_selection/traits/wf.rs
+++ b/src/librustc_trait_selection/traits/wf.rs
@@ -1,12 +1,11 @@
 use crate::infer::InferCtxt;
 use crate::opaque_types::required_region_bounds;
-use crate::traits::{self, AssocTypeBoundData};
+use crate::traits;
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_hir::lang_items;
 use rustc_middle::ty::subst::{GenericArgKind, SubstsRef};
 use rustc_middle::ty::{self, ToPredicate, Ty, TyCtxt, TypeFoldable, WithConstness};
-use rustc_span::symbol::{kw, Ident};
 use rustc_span::Span;
 use std::rc::Rc;
 
@@ -143,137 +142,57 @@ fn extend_cause_with_original_assoc_item_obligation<'tcx>(
     pred: &ty::Predicate<'_>,
     mut trait_assoc_items: impl Iterator<Item = ty::AssocItem>,
 ) {
-    let trait_item =
-        tcx.hir().as_local_hir_id(trait_ref.def_id).and_then(|trait_id| tcx.hir().find(trait_id));
-    let (trait_name, trait_generics) = match trait_item {
-        Some(hir::Node::Item(hir::Item {
-            ident,
-            kind: hir::ItemKind::Trait(.., generics, _, _),
-            ..
-        }))
-        | Some(hir::Node::Item(hir::Item {
-            ident,
-            kind: hir::ItemKind::TraitAlias(generics, _),
-            ..
-        })) => (Some(ident), Some(generics)),
-        _ => (None, None),
+    debug!(
+        "extended_cause_with_original_assoc_item_obligation {:?} {:?} {:?} {:?}",
+        trait_ref, item, cause, pred
+    );
+    let items = match item {
+        Some(hir::Item { kind: hir::ItemKind::Impl { items, .. }, .. }) => items,
+        _ => return,
     };
-
-    let item_span = item.map(|i| tcx.sess.source_map().guess_head_span(i.span));
+    let fix_span =
+        |impl_item_ref: &hir::ImplItemRef<'_>| match tcx.hir().impl_item(impl_item_ref.id).kind {
+            hir::ImplItemKind::Const(ty, _) | hir::ImplItemKind::TyAlias(ty) => ty.span,
+            _ => impl_item_ref.span,
+        };
     match pred {
         ty::Predicate::Projection(proj) => {
             // The obligation comes not from the current `impl` nor the `trait` being
             // implemented, but rather from a "second order" obligation, like in
-            // `src/test/ui/associated-types/point-at-type-on-obligation-failure.rs`:
-            //
-            //   error[E0271]: type mismatch resolving `<Foo2 as Bar2>::Ok == ()`
-            //     --> $DIR/point-at-type-on-obligation-failure.rs:13:5
-            //      |
-            //   LL |     type Ok;
-            //      |          -- associated type defined here
-            //   ...
-            //   LL | impl Bar for Foo {
-            //      | ---------------- in this `impl` item
-            //   LL |     type Ok = ();
-            //      |     ^^^^^^^^^^^^^ expected `u32`, found `()`
-            //      |
-            //      = note: expected type `u32`
-            //                 found type `()`
-            //
-            // FIXME: we would want to point a span to all places that contributed to this
-            // obligation. In the case above, it should be closer to:
-            //
-            //   error[E0271]: type mismatch resolving `<Foo2 as Bar2>::Ok == ()`
-            //     --> $DIR/point-at-type-on-obligation-failure.rs:13:5
-            //      |
-            //   LL |     type Ok;
-            //      |          -- associated type defined here
-            //   LL |     type Sibling: Bar2<Ok=Self::Ok>;
-            //      |     -------------------------------- obligation set here
-            //   ...
-            //   LL | impl Bar for Foo {
-            //      | ---------------- in this `impl` item
-            //   LL |     type Ok = ();
-            //      |     ^^^^^^^^^^^^^ expected `u32`, found `()`
-            //   ...
-            //   LL | impl Bar2 for Foo2 {
-            //      | ---------------- in this `impl` item
-            //   LL |     type Ok = u32;
-            //      |     -------------- obligation set here
-            //      |
-            //      = note: expected type `u32`
-            //                 found type `()`
-            if let Some(hir::ItemKind::Impl { items, .. }) = item.map(|i| &i.kind) {
-                let trait_assoc_item = tcx.associated_item(proj.projection_def_id());
-                if let Some(impl_item) =
-                    items.iter().find(|item| item.ident == trait_assoc_item.ident)
-                {
-                    cause.span = impl_item.span;
-                    cause.code = traits::AssocTypeBound(Box::new(AssocTypeBoundData {
-                        impl_span: item_span,
-                        original: trait_assoc_item.ident.span,
-                        bounds: vec![],
-                    }));
+            // `src/test/ui/associated-types/point-at-type-on-obligation-failure.rs`.
+            let trait_assoc_item = tcx.associated_item(proj.projection_def_id());
+            if let Some(impl_item_span) =
+                items.iter().find(|item| item.ident == trait_assoc_item.ident).map(fix_span)
+            {
+                cause.span = impl_item_span;
+            } else {
+                let kind = &proj.ty().skip_binder().kind;
+                if let ty::Projection(projection_ty) = kind {
+                    // This happens when an associated type has a projection coming from another
+                    // associated type. See `traits-assoc-type-in-supertrait-bad.rs`.
+                    let trait_assoc_item = tcx.associated_item(projection_ty.item_def_id);
+                    if let Some(impl_item_span) =
+                        items.iter().find(|item| item.ident == trait_assoc_item.ident).map(fix_span)
+                    {
+                        cause.span = impl_item_span;
+                    }
                 }
             }
         }
-        ty::Predicate::Trait(proj, _) => {
-            // An associated item obligation born out of the `trait` failed to be met.
-            // Point at the `impl` that failed the obligation, the associated item that
-            // needed to meet the obligation, and the definition of that associated item,
-            // which should hold the obligation in most cases. An example can be seen in
-            // `src/test/ui/associated-types/point-at-type-on-obligation-failure-2.rs`:
-            //
-            //   error[E0277]: the trait bound `bool: Bar` is not satisfied
-            //     --> $DIR/point-at-type-on-obligation-failure-2.rs:8:5
-            //      |
-            //   LL |     type Assoc: Bar;
-            //      |          ----- associated type defined here
-            //   ...
-            //   LL | impl Foo for () {
-            //      | --------------- in this `impl` item
-            //   LL |     type Assoc = bool;
-            //      |     ^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `bool`
-            //
-            // If the obligation comes from the where clause in the `trait`, we point at it:
-            //
-            //   error[E0277]: the trait bound `bool: Bar` is not satisfied
-            //     --> $DIR/point-at-type-on-obligation-failure-2.rs:8:5
-            //      |
-            //      | trait Foo where <Self as Foo>>::Assoc: Bar {
-            //      |                 -------------------------- restricted in this bound
-            //   LL |     type Assoc;
-            //      |          ----- associated type defined here
-            //   ...
-            //   LL | impl Foo for () {
-            //      | --------------- in this `impl` item
-            //   LL |     type Assoc = bool;
-            //      |     ^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `bool`
-            if let (
-                ty::Projection(ty::ProjectionTy { item_def_id, .. }),
-                Some(hir::ItemKind::Impl { items, .. }),
-            ) = (&proj.skip_binder().self_ty().kind, item.map(|i| &i.kind))
+        ty::Predicate::Trait(pred, _) => {
+            // An associated item obligation born out of the `trait` failed to be met. An example
+            // can be seen in `ui/associated-types/point-at-type-on-obligation-failure-2.rs`.
+            debug!("extended_cause_with_original_assoc_item_obligation trait proj {:?}", pred);
+            if let ty::Projection(ty::ProjectionTy { item_def_id, .. }) =
+                &pred.skip_binder().self_ty().kind
             {
-                if let Some((impl_item, trait_assoc_item)) = trait_assoc_items
+                if let Some(impl_item_span) = trait_assoc_items
                     .find(|i| i.def_id == *item_def_id)
                     .and_then(|trait_assoc_item| {
-                        items
-                            .iter()
-                            .find(|i| i.ident == trait_assoc_item.ident)
-                            .map(|impl_item| (impl_item, trait_assoc_item))
+                        items.iter().find(|i| i.ident == trait_assoc_item.ident).map(fix_span)
                     })
                 {
-                    let bounds = trait_generics
-                        .map(|generics| {
-                            get_generic_bound_spans(&generics, trait_name, trait_assoc_item.ident)
-                        })
-                        .unwrap_or_else(Vec::new);
-                    cause.span = impl_item.span;
-                    cause.code = traits::AssocTypeBound(Box::new(AssocTypeBoundData {
-                        impl_span: item_span,
-                        original: trait_assoc_item.ident.span,
-                        bounds,
-                    }));
+                    cause.span = impl_item_span;
                 }
             }
         }
@@ -307,6 +226,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
         let tcx = self.infcx.tcx;
         let obligations = self.nominal_obligations(trait_ref.def_id, trait_ref.substs);
 
+        debug!("compute_trait_ref obligations {:?}", obligations);
         let cause = self.cause(traits::MiscObligation);
         let param_env = self.param_env;
 
@@ -315,16 +235,16 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
         if let Elaborate::All = elaborate {
             let implied_obligations = traits::util::elaborate_obligations(tcx, obligations.clone());
             let implied_obligations = implied_obligations.map(|obligation| {
+                debug!("compute_trait_ref implied_obligation {:?}", obligation);
+                debug!("compute_trait_ref implied_obligation cause {:?}", obligation.cause);
                 let mut cause = cause.clone();
-                let parent_trait_ref = obligation
-                    .predicate
-                    .to_opt_poly_trait_ref()
-                    .unwrap_or_else(|| ty::Binder::dummy(*trait_ref));
-                let derived_cause = traits::DerivedObligationCause {
-                    parent_trait_ref,
-                    parent_code: Rc::new(obligation.cause.code.clone()),
-                };
-                cause.code = traits::ObligationCauseCode::ImplDerivedObligation(derived_cause);
+                if let Some(parent_trait_ref) = obligation.predicate.to_opt_poly_trait_ref() {
+                    let derived_cause = traits::DerivedObligationCause {
+                        parent_trait_ref,
+                        parent_code: Rc::new(obligation.cause.code.clone()),
+                    };
+                    cause.code = traits::ObligationCauseCode::ImplDerivedObligation(derived_cause);
+                }
                 extend_cause_with_original_assoc_item_obligation(
                     tcx,
                     trait_ref,
@@ -333,6 +253,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
                     &obligation.predicate,
                     tcx.associated_items(trait_ref.def_id).in_definition_order().copied(),
                 );
+                debug!("compute_trait_ref new cause {:?}", cause);
                 traits::Obligation::new(cause, param_env, obligation.predicate)
             });
             self.out.extend(implied_obligations);
@@ -718,54 +639,4 @@ pub fn object_region_bounds<'tcx>(
         .collect();
 
     required_region_bounds(tcx, open_ty, predicates)
-}
-
-/// Find the span of a generic bound affecting an associated type.
-fn get_generic_bound_spans(
-    generics: &hir::Generics<'_>,
-    trait_name: Option<&Ident>,
-    assoc_item_name: Ident,
-) -> Vec<Span> {
-    let mut bounds = vec![];
-    for clause in generics.where_clause.predicates.iter() {
-        if let hir::WherePredicate::BoundPredicate(pred) = clause {
-            match &pred.bounded_ty.kind {
-                hir::TyKind::Path(hir::QPath::Resolved(Some(ty), path)) => {
-                    let mut s = path.segments.iter();
-                    if let (a, Some(b), None) = (s.next(), s.next(), s.next()) {
-                        if a.map(|s| &s.ident) == trait_name
-                            && b.ident == assoc_item_name
-                            && is_self_path(&ty.kind)
-                        {
-                            // `<Self as Foo>::Bar`
-                            bounds.push(pred.span);
-                        }
-                    }
-                }
-                hir::TyKind::Path(hir::QPath::TypeRelative(ty, segment)) => {
-                    if segment.ident == assoc_item_name {
-                        if is_self_path(&ty.kind) {
-                            // `Self::Bar`
-                            bounds.push(pred.span);
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
-    bounds
-}
-
-fn is_self_path(kind: &hir::TyKind<'_>) -> bool {
-    if let hir::TyKind::Path(hir::QPath::Resolved(None, path)) = kind {
-        let mut s = path.segments.iter();
-        if let (Some(segment), None) = (s.next(), s.next()) {
-            if segment.ident.name == kw::SelfUpper {
-                // `type(Self)`
-                return true;
-            }
-        }
-    }
-    false
 }

--- a/src/librustc_trait_selection/traits/wf.rs
+++ b/src/librustc_trait_selection/traits/wf.rs
@@ -243,7 +243,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
                         parent_trait_ref,
                         parent_code: Rc::new(obligation.cause.code.clone()),
                     };
-                    cause.code = traits::ObligationCauseCode::ImplDerivedObligation(derived_cause);
+                    cause.code = traits::ObligationCauseCode::DerivedObligation(derived_cause);
                 }
                 extend_cause_with_original_assoc_item_obligation(
                     tcx,

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1045,7 +1045,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 bounds,
                 speculative,
                 &mut dup_bindings,
-                span,
+                binding.span,
             );
             // Okay to ignore `Err` because of `ErrorReported` (see above).
         }

--- a/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
+++ b/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
@@ -1,10 +1,17 @@
 error[E0277]: `<L1 as Lam<&'a u8>>::App` doesn't implement `std::fmt::Debug`
   --> $DIR/bad-bounds-on-assoc-in-trait.rs:31:6
    |
+LL | trait Case1 {
+   |       -----
+...
+LL |                 Debug
+   |                 ----- required by this bound in `Case1`
+...
 LL | impl Case1 for S1 {
    |      ^^^^^ `<L1 as Lam<&'a u8>>::App` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
    = help: the trait `for<'a> std::fmt::Debug` is not implemented for `<L1 as Lam<&'a u8>>::App`
+   = note: required because of the requirements on the impl of `for<'a> std::fmt::Debug` for `<<<<S1 as Case1>::C as std::iter::Iterator>::Item as std::iter::Iterator>::Item as Lam<&'a u8>>::App`
 
 error[E0277]: `<<T as Case1>::C as std::iter::Iterator>::Item` is not an iterator
   --> $DIR/bad-bounds-on-assoc-in-trait.rs:36:20

--- a/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
+++ b/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
@@ -11,7 +11,6 @@ LL | impl Case1 for S1 {
    |      ^^^^^ `<L1 as Lam<&'a u8>>::App` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
    = help: the trait `for<'a> std::fmt::Debug` is not implemented for `<L1 as Lam<&'a u8>>::App`
-   = note: required because of the requirements on the impl of `for<'a> std::fmt::Debug` for `<<<<S1 as Case1>::C as std::iter::Iterator>::Item as std::iter::Iterator>::Item as Lam<&'a u8>>::App`
 
 error[E0277]: `<<T as Case1>::C as std::iter::Iterator>::Item` is not an iterator
   --> $DIR/bad-bounds-on-assoc-in-trait.rs:36:20

--- a/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
+++ b/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
@@ -2,7 +2,7 @@ error[E0277]: `<L1 as Lam<&'a u8>>::App` doesn't implement `std::fmt::Debug`
   --> $DIR/bad-bounds-on-assoc-in-trait.rs:31:6
    |
 LL | trait Case1 {
-   |       -----
+   |       ----- required by a bound in this
 ...
 LL |                 Debug
    |                 ----- required by this bound in `Case1`
@@ -26,7 +26,7 @@ error[E0277]: `<<T as Case1>::C as std::iter::Iterator>::Item` cannot be sent be
   --> $DIR/bad-bounds-on-assoc-in-trait.rs:36:20
    |
 LL | trait Case1 {
-   |       -----
+   |       ----- required by a bound in this
 LL |     type C: Clone + Iterator<Item:
 LL |         Send + Iterator<Item:
    |         ---- required by this bound in `Case1`
@@ -42,7 +42,7 @@ error[E0277]: `<<T as Case1>::C as std::iter::Iterator>::Item` cannot be shared 
   --> $DIR/bad-bounds-on-assoc-in-trait.rs:36:20
    |
 LL | trait Case1 {
-   |       -----
+   |       ----- required by a bound in this
 ...
 LL |         > + Sync>;
    |             ---- required by this bound in `Case1`
@@ -58,7 +58,7 @@ error[E0277]: `<_ as Lam<&'a u8>>::App` doesn't implement `std::fmt::Debug`
   --> $DIR/bad-bounds-on-assoc-in-trait.rs:36:20
    |
 LL | trait Case1 {
-   |       -----
+   |       ----- required by a bound in this
 ...
 LL |                 Debug
    |                 ----- required by this bound in `Case1`

--- a/src/test/ui/associated-type/associated-type-projection-from-multiple-supertraits.stderr
+++ b/src/test/ui/associated-type/associated-type-projection-from-multiple-supertraits.stderr
@@ -28,7 +28,7 @@ LL | fn dent<C:BoxCar>(c: C, color: <C as Vehicle>::Color) {
    |                                ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0222]: ambiguous associated type `Color` in bounds of `BoxCar`
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:30
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:37
    |
 LL |     type Color;
    |     ----------- ambiguous `Color` from `Vehicle`
@@ -37,7 +37,7 @@ LL |     type Color;
    |     ----------- ambiguous `Color` from `Box`
 ...
 LL | fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
-   |                              ^^^^^^^^^^^^^^^^^^^ ambiguous associated type `Color`
+   |                                     ^^^^^^^^^^^ ambiguous associated type `Color`
    |
    = help: consider introducing a new type parameter `T` and adding `where` constraints:
                where

--- a/src/test/ui/associated-types/associated-types-eq-hr.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-hr.stderr
@@ -2,7 +2,7 @@ error[E0271]: type mismatch resolving `for<'x> <UintStruct as TheTrait<&'x isize
   --> $DIR/associated-types-eq-hr.rs:82:5
    |
 LL | fn foo<T>()
-   |    ---
+   |    --- required by a bound in this
 LL |     where T : for<'x> TheTrait<&'x isize, A = &'x isize>
    |                                           ------------- required by this bound in `foo`
 ...
@@ -16,7 +16,7 @@ error[E0271]: type mismatch resolving `for<'x> <IntStruct as TheTrait<&'x isize>
   --> $DIR/associated-types-eq-hr.rs:86:5
    |
 LL | fn bar<T>()
-   |    ---
+   |    --- required by a bound in this
 LL |     where T : for<'x> TheTrait<&'x isize, A = &'x usize>
    |                                           ------------- required by this bound in `bar`
 ...
@@ -30,7 +30,7 @@ error[E0277]: the trait bound `for<'x, 'y> Tuple: TheTrait<(&'x isize, &'y isize
   --> $DIR/associated-types-eq-hr.rs:91:17
    |
 LL | fn tuple_one<T>()
-   |    ---------
+   |    --------- required by a bound in this
 LL |     where T : for<'x,'y> TheTrait<(&'x isize, &'y isize), A = &'x isize>
    |               ---------------------------------------------------------- required by this bound in `tuple_one`
 ...
@@ -44,7 +44,7 @@ error[E0271]: type mismatch resolving `for<'x, 'y> <Tuple as TheTrait<(&'x isize
   --> $DIR/associated-types-eq-hr.rs:91:5
    |
 LL | fn tuple_one<T>()
-   |    ---------
+   |    --------- required by a bound in this
 LL |     where T : for<'x,'y> TheTrait<(&'x isize, &'y isize), A = &'x isize>
    |                                                           ------------- required by this bound in `tuple_one`
 ...
@@ -55,7 +55,7 @@ error[E0277]: the trait bound `for<'x, 'y> Tuple: TheTrait<(&'x isize, &'y isize
   --> $DIR/associated-types-eq-hr.rs:97:17
    |
 LL | fn tuple_two<T>()
-   |    ---------
+   |    --------- required by a bound in this
 LL |     where T : for<'x,'y> TheTrait<(&'x isize, &'y isize), A = &'y isize>
    |               ---------------------------------------------------------- required by this bound in `tuple_two`
 ...
@@ -69,7 +69,7 @@ error[E0271]: type mismatch resolving `for<'x, 'y> <Tuple as TheTrait<(&'x isize
   --> $DIR/associated-types-eq-hr.rs:97:5
    |
 LL | fn tuple_two<T>()
-   |    ---------
+   |    --------- required by a bound in this
 LL |     where T : for<'x,'y> TheTrait<(&'x isize, &'y isize), A = &'y isize>
    |                                                           ------------- required by this bound in `tuple_two`
 ...
@@ -80,7 +80,7 @@ error[E0277]: the trait bound `for<'x, 'y> Tuple: TheTrait<(&'x isize, &'y isize
   --> $DIR/associated-types-eq-hr.rs:107:18
    |
 LL | fn tuple_four<T>()
-   |    ----------
+   |    ---------- required by a bound in this
 LL |     where T : for<'x,'y> TheTrait<(&'x isize, &'y isize)>
    |               ------------------------------------------- required by this bound in `tuple_four`
 ...

--- a/src/test/ui/associated-types/defaults-unsound-62211-1.stderr
+++ b/src/test/ui/associated-types/defaults-unsound-62211-1.stderr
@@ -43,7 +43,7 @@ error[E0277]: `T` doesn't implement `std::fmt::Display`
   --> $DIR/defaults-unsound-62211-1.rs:41:9
    |
 LL | trait UncheckedCopy: Sized {
-   |       -------------
+   |       ------------- required by a bound in this
 ...
 LL |     + Display = Self;
    |       ------- required by this bound in `UncheckedCopy`
@@ -62,7 +62,7 @@ error[E0277]: the trait bound `T: std::ops::Deref` is not satisfied
   --> $DIR/defaults-unsound-62211-1.rs:41:9
    |
 LL | trait UncheckedCopy: Sized {
-   |       -------------
+   |       ------------- required by a bound in this
 ...
 LL |     + Deref<Target = str>
    |       ------------------- required by this bound in `UncheckedCopy`
@@ -79,7 +79,7 @@ error[E0277]: cannot add-assign `&'static str` to `T`
   --> $DIR/defaults-unsound-62211-1.rs:41:9
    |
 LL | trait UncheckedCopy: Sized {
-   |       -------------
+   |       ------------- required by a bound in this
 ...
 LL |     + AddAssign<&'static str>
    |       ----------------------- required by this bound in `UncheckedCopy`
@@ -97,7 +97,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/defaults-unsound-62211-1.rs:41:9
    |
 LL | trait UncheckedCopy: Sized {
-   |       -------------
+   |       ------------- required by a bound in this
 ...
 LL |     type Output: Copy
    |                  ---- required by this bound in `UncheckedCopy`

--- a/src/test/ui/associated-types/defaults-unsound-62211-1.stderr
+++ b/src/test/ui/associated-types/defaults-unsound-62211-1.stderr
@@ -42,11 +42,18 @@ LL |     + Display = Self;
 error[E0277]: `T` doesn't implement `std::fmt::Display`
   --> $DIR/defaults-unsound-62211-1.rs:41:9
    |
+LL | trait UncheckedCopy: Sized {
+   |       -------------
+...
+LL |     + Display = Self;
+   |       ------- required by this bound in `UncheckedCopy`
+...
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ `T` cannot be formatted with the default formatter
    |
    = help: the trait `std::fmt::Display` is not implemented for `T`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+   = note: required because of the requirements on the impl of `std::fmt::Display` for `<T as UncheckedCopy>::Output`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::fmt::Display> UncheckedCopy for T {}
@@ -55,9 +62,16 @@ LL | impl<T: std::fmt::Display> UncheckedCopy for T {}
 error[E0277]: the trait bound `T: std::ops::Deref` is not satisfied
   --> $DIR/defaults-unsound-62211-1.rs:41:9
    |
+LL | trait UncheckedCopy: Sized {
+   |       -------------
+...
+LL |     + Deref<Target = str>
+   |       ------------------- required by this bound in `UncheckedCopy`
+...
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ the trait `std::ops::Deref` is not implemented for `T`
    |
+   = note: required because of the requirements on the impl of `std::ops::Deref` for `<T as UncheckedCopy>::Output`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::ops::Deref> UncheckedCopy for T {}
@@ -66,10 +80,17 @@ LL | impl<T: std::ops::Deref> UncheckedCopy for T {}
 error[E0277]: cannot add-assign `&'static str` to `T`
   --> $DIR/defaults-unsound-62211-1.rs:41:9
    |
+LL | trait UncheckedCopy: Sized {
+   |       -------------
+...
+LL |     + AddAssign<&'static str>
+   |       ----------------------- required by this bound in `UncheckedCopy`
+...
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ no implementation for `T += &'static str`
    |
    = help: the trait `std::ops::AddAssign<&'static str>` is not implemented for `T`
+   = note: required because of the requirements on the impl of `std::ops::AddAssign<&'static str>` for `<T as UncheckedCopy>::Output`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::ops::AddAssign<&'static str>> UncheckedCopy for T {}
@@ -78,9 +99,16 @@ LL | impl<T: std::ops::AddAssign<&'static str>> UncheckedCopy for T {}
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/defaults-unsound-62211-1.rs:41:9
    |
+LL | trait UncheckedCopy: Sized {
+   |       -------------
+...
+LL |     type Output: Copy
+   |                  ---- required by this bound in `UncheckedCopy`
+...
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
+   = note: required because of the requirements on the impl of `std::marker::Copy` for `<T as UncheckedCopy>::Output`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::marker::Copy> UncheckedCopy for T {}

--- a/src/test/ui/associated-types/defaults-unsound-62211-1.stderr
+++ b/src/test/ui/associated-types/defaults-unsound-62211-1.stderr
@@ -53,7 +53,6 @@ LL | impl<T> UncheckedCopy for T {}
    |
    = help: the trait `std::fmt::Display` is not implemented for `T`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: required because of the requirements on the impl of `std::fmt::Display` for `<T as UncheckedCopy>::Output`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::fmt::Display> UncheckedCopy for T {}
@@ -71,7 +70,6 @@ LL |     + Deref<Target = str>
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ the trait `std::ops::Deref` is not implemented for `T`
    |
-   = note: required because of the requirements on the impl of `std::ops::Deref` for `<T as UncheckedCopy>::Output`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::ops::Deref> UncheckedCopy for T {}
@@ -90,7 +88,6 @@ LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ no implementation for `T += &'static str`
    |
    = help: the trait `std::ops::AddAssign<&'static str>` is not implemented for `T`
-   = note: required because of the requirements on the impl of `std::ops::AddAssign<&'static str>` for `<T as UncheckedCopy>::Output`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::ops::AddAssign<&'static str>> UncheckedCopy for T {}
@@ -108,7 +105,6 @@ LL |     type Output: Copy
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-   = note: required because of the requirements on the impl of `std::marker::Copy` for `<T as UncheckedCopy>::Output`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::marker::Copy> UncheckedCopy for T {}

--- a/src/test/ui/associated-types/defaults-unsound-62211-2.stderr
+++ b/src/test/ui/associated-types/defaults-unsound-62211-2.stderr
@@ -43,7 +43,7 @@ error[E0277]: `T` doesn't implement `std::fmt::Display`
   --> $DIR/defaults-unsound-62211-2.rs:41:9
    |
 LL | trait UncheckedCopy: Sized {
-   |       -------------
+   |       ------------- required by a bound in this
 ...
 LL |     + Display = Self;
    |       ------- required by this bound in `UncheckedCopy`
@@ -62,7 +62,7 @@ error[E0277]: the trait bound `T: std::ops::Deref` is not satisfied
   --> $DIR/defaults-unsound-62211-2.rs:41:9
    |
 LL | trait UncheckedCopy: Sized {
-   |       -------------
+   |       ------------- required by a bound in this
 ...
 LL |     + Deref<Target = str>
    |       ------------------- required by this bound in `UncheckedCopy`
@@ -79,7 +79,7 @@ error[E0277]: cannot add-assign `&'static str` to `T`
   --> $DIR/defaults-unsound-62211-2.rs:41:9
    |
 LL | trait UncheckedCopy: Sized {
-   |       -------------
+   |       ------------- required by a bound in this
 ...
 LL |     + AddAssign<&'static str>
    |       ----------------------- required by this bound in `UncheckedCopy`
@@ -97,7 +97,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/defaults-unsound-62211-2.rs:41:9
    |
 LL | trait UncheckedCopy: Sized {
-   |       -------------
+   |       ------------- required by a bound in this
 ...
 LL |     type Output: Copy
    |                  ---- required by this bound in `UncheckedCopy`

--- a/src/test/ui/associated-types/defaults-unsound-62211-2.stderr
+++ b/src/test/ui/associated-types/defaults-unsound-62211-2.stderr
@@ -53,7 +53,6 @@ LL | impl<T> UncheckedCopy for T {}
    |
    = help: the trait `std::fmt::Display` is not implemented for `T`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: required because of the requirements on the impl of `std::fmt::Display` for `<T as UncheckedCopy>::Output`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::fmt::Display> UncheckedCopy for T {}
@@ -71,7 +70,6 @@ LL |     + Deref<Target = str>
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ the trait `std::ops::Deref` is not implemented for `T`
    |
-   = note: required because of the requirements on the impl of `std::ops::Deref` for `<T as UncheckedCopy>::Output`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::ops::Deref> UncheckedCopy for T {}
@@ -90,7 +88,6 @@ LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ no implementation for `T += &'static str`
    |
    = help: the trait `std::ops::AddAssign<&'static str>` is not implemented for `T`
-   = note: required because of the requirements on the impl of `std::ops::AddAssign<&'static str>` for `<T as UncheckedCopy>::Output`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::ops::AddAssign<&'static str>> UncheckedCopy for T {}
@@ -108,7 +105,6 @@ LL |     type Output: Copy
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-   = note: required because of the requirements on the impl of `std::marker::Copy` for `<T as UncheckedCopy>::Output`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::marker::Copy> UncheckedCopy for T {}

--- a/src/test/ui/associated-types/defaults-unsound-62211-2.stderr
+++ b/src/test/ui/associated-types/defaults-unsound-62211-2.stderr
@@ -42,11 +42,18 @@ LL |     + Display = Self;
 error[E0277]: `T` doesn't implement `std::fmt::Display`
   --> $DIR/defaults-unsound-62211-2.rs:41:9
    |
+LL | trait UncheckedCopy: Sized {
+   |       -------------
+...
+LL |     + Display = Self;
+   |       ------- required by this bound in `UncheckedCopy`
+...
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ `T` cannot be formatted with the default formatter
    |
    = help: the trait `std::fmt::Display` is not implemented for `T`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+   = note: required because of the requirements on the impl of `std::fmt::Display` for `<T as UncheckedCopy>::Output`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::fmt::Display> UncheckedCopy for T {}
@@ -55,9 +62,16 @@ LL | impl<T: std::fmt::Display> UncheckedCopy for T {}
 error[E0277]: the trait bound `T: std::ops::Deref` is not satisfied
   --> $DIR/defaults-unsound-62211-2.rs:41:9
    |
+LL | trait UncheckedCopy: Sized {
+   |       -------------
+...
+LL |     + Deref<Target = str>
+   |       ------------------- required by this bound in `UncheckedCopy`
+...
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ the trait `std::ops::Deref` is not implemented for `T`
    |
+   = note: required because of the requirements on the impl of `std::ops::Deref` for `<T as UncheckedCopy>::Output`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::ops::Deref> UncheckedCopy for T {}
@@ -66,10 +80,17 @@ LL | impl<T: std::ops::Deref> UncheckedCopy for T {}
 error[E0277]: cannot add-assign `&'static str` to `T`
   --> $DIR/defaults-unsound-62211-2.rs:41:9
    |
+LL | trait UncheckedCopy: Sized {
+   |       -------------
+...
+LL |     + AddAssign<&'static str>
+   |       ----------------------- required by this bound in `UncheckedCopy`
+...
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ no implementation for `T += &'static str`
    |
    = help: the trait `std::ops::AddAssign<&'static str>` is not implemented for `T`
+   = note: required because of the requirements on the impl of `std::ops::AddAssign<&'static str>` for `<T as UncheckedCopy>::Output`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::ops::AddAssign<&'static str>> UncheckedCopy for T {}
@@ -78,9 +99,16 @@ LL | impl<T: std::ops::AddAssign<&'static str>> UncheckedCopy for T {}
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/defaults-unsound-62211-2.rs:41:9
    |
+LL | trait UncheckedCopy: Sized {
+   |       -------------
+...
+LL |     type Output: Copy
+   |                  ---- required by this bound in `UncheckedCopy`
+...
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
+   = note: required because of the requirements on the impl of `std::marker::Copy` for `<T as UncheckedCopy>::Output`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::marker::Copy> UncheckedCopy for T {}

--- a/src/test/ui/associated-types/higher-ranked-projection.bad.stderr
+++ b/src/test/ui/associated-types/higher-ranked-projection.bad.stderr
@@ -2,7 +2,7 @@ error[E0271]: type mismatch resolving `for<'a> <&'a _ as Mirror>::Image == _`
   --> $DIR/higher-ranked-projection.rs:25:5
    |
 LL | fn foo<U, T>(_t: T)
-   |    ---
+   |    --- required by a bound in this
 LL |     where for<'a> &'a T: Mirror<Image=U>
    |                                 ------- required by this bound in `foo`
 ...

--- a/src/test/ui/associated-types/issue-43924.stderr
+++ b/src/test/ui/associated-types/issue-43924.stderr
@@ -9,14 +9,28 @@ LL |     type Out: Default + ToString + ?Sized = dyn ToString;
 error[E0277]: the trait bound `(dyn std::string::ToString + 'static): std::default::Default` is not satisfied
   --> $DIR/issue-43924.rs:10:6
    |
+LL | trait Foo<T: Default + ToString> {
+   |       ---
+LL |     type Out: Default + ToString + ?Sized = dyn ToString;
+   |               ------- required by this bound in `Foo`
+...
 LL | impl Foo<u32> for () {}
    |      ^^^^^^^^ the trait `std::default::Default` is not implemented for `(dyn std::string::ToString + 'static)`
+   |
+   = note: required because of the requirements on the impl of `std::default::Default` for `<() as Foo<u32>>::Out`
 
 error[E0277]: the trait bound `(dyn std::string::ToString + 'static): std::default::Default` is not satisfied
   --> $DIR/issue-43924.rs:11:6
    |
+LL | trait Foo<T: Default + ToString> {
+   |       ---
+LL |     type Out: Default + ToString + ?Sized = dyn ToString;
+   |               ------- required by this bound in `Foo`
+...
 LL | impl Foo<u64> for () {}
    |      ^^^^^^^^ the trait `std::default::Default` is not implemented for `(dyn std::string::ToString + 'static)`
+   |
+   = note: required because of the requirements on the impl of `std::default::Default` for `<() as Foo<u64>>::Out`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/associated-types/issue-43924.stderr
+++ b/src/test/ui/associated-types/issue-43924.stderr
@@ -16,8 +16,6 @@ LL |     type Out: Default + ToString + ?Sized = dyn ToString;
 ...
 LL | impl Foo<u32> for () {}
    |      ^^^^^^^^ the trait `std::default::Default` is not implemented for `(dyn std::string::ToString + 'static)`
-   |
-   = note: required because of the requirements on the impl of `std::default::Default` for `<() as Foo<u32>>::Out`
 
 error[E0277]: the trait bound `(dyn std::string::ToString + 'static): std::default::Default` is not satisfied
   --> $DIR/issue-43924.rs:11:6
@@ -29,8 +27,6 @@ LL |     type Out: Default + ToString + ?Sized = dyn ToString;
 ...
 LL | impl Foo<u64> for () {}
    |      ^^^^^^^^ the trait `std::default::Default` is not implemented for `(dyn std::string::ToString + 'static)`
-   |
-   = note: required because of the requirements on the impl of `std::default::Default` for `<() as Foo<u64>>::Out`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/associated-types/issue-43924.stderr
+++ b/src/test/ui/associated-types/issue-43924.stderr
@@ -10,7 +10,7 @@ error[E0277]: the trait bound `(dyn std::string::ToString + 'static): std::defau
   --> $DIR/issue-43924.rs:10:6
    |
 LL | trait Foo<T: Default + ToString> {
-   |       ---
+   |       --- required by a bound in this
 LL |     type Out: Default + ToString + ?Sized = dyn ToString;
    |               ------- required by this bound in `Foo`
 ...
@@ -21,7 +21,7 @@ error[E0277]: the trait bound `(dyn std::string::ToString + 'static): std::defau
   --> $DIR/issue-43924.rs:11:6
    |
 LL | trait Foo<T: Default + ToString> {
-   |       ---
+   |       --- required by a bound in this
 LL |     type Out: Default + ToString + ?Sized = dyn ToString;
    |               ------- required by this bound in `Foo`
 ...

--- a/src/test/ui/associated-types/issue-65774-1.stderr
+++ b/src/test/ui/associated-types/issue-65774-1.stderr
@@ -16,8 +16,6 @@ LL |     type MpuConfig: MyDisplay = T;
 ...
 LL | impl MPU for S { }
    |      ^^^ the trait `MyDisplay` is not implemented for `T`
-   |
-   = note: required because of the requirements on the impl of `MyDisplay` for `<S as MPU>::MpuConfig`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-types/issue-65774-1.stderr
+++ b/src/test/ui/associated-types/issue-65774-1.stderr
@@ -10,7 +10,7 @@ error[E0277]: the trait bound `T: MyDisplay` is not satisfied
   --> $DIR/issue-65774-1.rs:16:6
    |
 LL | trait MPU {
-   |       ---
+   |       --- required by a bound in this
 LL |     type MpuConfig: MyDisplay = T;
    |                     --------- required by this bound in `MPU`
 ...

--- a/src/test/ui/associated-types/issue-65774-1.stderr
+++ b/src/test/ui/associated-types/issue-65774-1.stderr
@@ -9,8 +9,15 @@ LL |     type MpuConfig: MyDisplay = T;
 error[E0277]: the trait bound `T: MyDisplay` is not satisfied
   --> $DIR/issue-65774-1.rs:16:6
    |
+LL | trait MPU {
+   |       ---
+LL |     type MpuConfig: MyDisplay = T;
+   |                     --------- required by this bound in `MPU`
+...
 LL | impl MPU for S { }
    |      ^^^ the trait `MyDisplay` is not implemented for `T`
+   |
+   = note: required because of the requirements on the impl of `MyDisplay` for `<S as MPU>::MpuConfig`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-types/issue-65774-2.stderr
+++ b/src/test/ui/associated-types/issue-65774-2.stderr
@@ -16,8 +16,6 @@ LL |     type MpuConfig: MyDisplay = T;
 ...
 LL | impl MPU for S { }
    |      ^^^ the trait `MyDisplay` is not implemented for `T`
-   |
-   = note: required because of the requirements on the impl of `MyDisplay` for `<S as MPU>::MpuConfig`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-types/issue-65774-2.stderr
+++ b/src/test/ui/associated-types/issue-65774-2.stderr
@@ -10,7 +10,7 @@ error[E0277]: the trait bound `T: MyDisplay` is not satisfied
   --> $DIR/issue-65774-2.rs:16:6
    |
 LL | trait MPU {
-   |       ---
+   |       --- required by a bound in this
 LL |     type MpuConfig: MyDisplay = T;
    |                     --------- required by this bound in `MPU`
 ...

--- a/src/test/ui/associated-types/issue-65774-2.stderr
+++ b/src/test/ui/associated-types/issue-65774-2.stderr
@@ -9,8 +9,15 @@ LL |     type MpuConfig: MyDisplay = T;
 error[E0277]: the trait bound `T: MyDisplay` is not satisfied
   --> $DIR/issue-65774-2.rs:16:6
    |
+LL | trait MPU {
+   |       ---
+LL |     type MpuConfig: MyDisplay = T;
+   |                     --------- required by this bound in `MPU`
+...
 LL | impl MPU for S { }
    |      ^^^ the trait `MyDisplay` is not implemented for `T`
+   |
+   = note: required because of the requirements on the impl of `MyDisplay` for `<S as MPU>::MpuConfig`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-types/point-at-type-on-obligation-failure-2.stderr
+++ b/src/test/ui/associated-types/point-at-type-on-obligation-failure-2.stderr
@@ -8,8 +8,6 @@ LL |     type Assoc: Bar;
 ...
 LL |     type Assoc = bool;
    |                  ^^^^ the trait `Bar` is not implemented for `bool`
-   |
-   = note: required because of the requirements on the impl of `Bar` for `<() as Foo>::Assoc`
 
 error[E0277]: the trait bound `bool: Bar` is not satisfied
   --> $DIR/point-at-type-on-obligation-failure-2.rs:16:18
@@ -19,8 +17,6 @@ LL | trait Baz where Self::Assoc: Bar {
 ...
 LL |     type Assoc = bool;
    |                  ^^^^ the trait `Bar` is not implemented for `bool`
-   |
-   = note: required because of the requirements on the impl of `Bar` for `<() as Baz>::Assoc`
 
 error[E0277]: the trait bound `bool: Bar` is not satisfied
   --> $DIR/point-at-type-on-obligation-failure-2.rs:24:18
@@ -30,8 +26,6 @@ LL | trait Bat where <Self as Bat>::Assoc: Bar {
 ...
 LL |     type Assoc = bool;
    |                  ^^^^ the trait `Bar` is not implemented for `bool`
-   |
-   = note: required because of the requirements on the impl of `Bar` for `<() as Bat>::Assoc`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/associated-types/point-at-type-on-obligation-failure-2.stderr
+++ b/src/test/ui/associated-types/point-at-type-on-obligation-failure-2.stderr
@@ -1,39 +1,37 @@
 error[E0277]: the trait bound `bool: Bar` is not satisfied
-  --> $DIR/point-at-type-on-obligation-failure-2.rs:8:5
+  --> $DIR/point-at-type-on-obligation-failure-2.rs:8:18
    |
+LL | trait Foo {
+   |       ---
 LL |     type Assoc: Bar;
-   |          ----- associated type defined here
+   |                 --- required by this bound in `Foo`
 ...
-LL | impl Foo for () {
-   | --------------- in this `impl` item
 LL |     type Assoc = bool;
-   |     ^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `bool`
+   |                  ^^^^ the trait `Bar` is not implemented for `bool`
+   |
+   = note: required because of the requirements on the impl of `Bar` for `<() as Foo>::Assoc`
 
 error[E0277]: the trait bound `bool: Bar` is not satisfied
-  --> $DIR/point-at-type-on-obligation-failure-2.rs:16:5
+  --> $DIR/point-at-type-on-obligation-failure-2.rs:16:18
    |
 LL | trait Baz where Self::Assoc: Bar {
-   |                 ---------------- restricted in this bound
-LL |     type Assoc;
-   |          ----- associated type defined here
+   |                              --- required by this bound in `Baz`
 ...
-LL | impl Baz for () {
-   | --------------- in this `impl` item
 LL |     type Assoc = bool;
-   |     ^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `bool`
+   |                  ^^^^ the trait `Bar` is not implemented for `bool`
+   |
+   = note: required because of the requirements on the impl of `Bar` for `<() as Baz>::Assoc`
 
 error[E0277]: the trait bound `bool: Bar` is not satisfied
-  --> $DIR/point-at-type-on-obligation-failure-2.rs:24:5
+  --> $DIR/point-at-type-on-obligation-failure-2.rs:24:18
    |
 LL | trait Bat where <Self as Bat>::Assoc: Bar {
-   |                 ------------------------- restricted in this bound
-LL |     type Assoc;
-   |          ----- associated type defined here
+   |                                       --- required by this bound in `Bat`
 ...
-LL | impl Bat for () {
-   | --------------- in this `impl` item
 LL |     type Assoc = bool;
-   |     ^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `bool`
+   |                  ^^^^ the trait `Bar` is not implemented for `bool`
+   |
+   = note: required because of the requirements on the impl of `Bar` for `<() as Bat>::Assoc`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/associated-types/point-at-type-on-obligation-failure-2.stderr
+++ b/src/test/ui/associated-types/point-at-type-on-obligation-failure-2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `bool: Bar` is not satisfied
   --> $DIR/point-at-type-on-obligation-failure-2.rs:8:18
    |
 LL | trait Foo {
-   |       ---
+   |       --- required by a bound in this
 LL |     type Assoc: Bar;
    |                 --- required by this bound in `Foo`
 ...

--- a/src/test/ui/associated-types/point-at-type-on-obligation-failure.stderr
+++ b/src/test/ui/associated-types/point-at-type-on-obligation-failure.stderr
@@ -1,13 +1,8 @@
 error[E0271]: type mismatch resolving `<Foo2 as Bar2>::Ok == ()`
-  --> $DIR/point-at-type-on-obligation-failure.rs:13:5
+  --> $DIR/point-at-type-on-obligation-failure.rs:13:15
    |
-LL |     type Ok;
-   |          -- associated type defined here
-...
-LL | impl Bar for Foo {
-   | ---------------- in this `impl` item
 LL |     type Ok = ();
-   |     ^^^^^^^^^^^^^ expected `u32`, found `()`
+   |               ^^ expected `u32`, found `()`
 
 error: aborting due to previous error
 

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
@@ -1,11 +1,15 @@
 error[E0277]: `T` cannot be sent between threads safely
   --> $DIR/builtin-superkinds-double-superkind.rs:6:24
    |
+LL | trait Foo : Send+Sync { }
+   |             ---- required by this bound in `Foo`
+LL | 
 LL | impl <T: Sync+'static> Foo for (T,) { }
    |                        ^^^ `T` cannot be sent between threads safely
    |
    = help: within `(T,)`, the trait `std::marker::Send` is not implemented for `T`
    = note: required because it appears within the type `(T,)`
+   = note: required because of the requirements on the impl of `std::marker::Send` for `(T,)`
 help: consider further restricting this bound
    |
 LL | impl <T: Sync+'static + std::marker::Send> Foo for (T,) { }
@@ -14,11 +18,15 @@ LL | impl <T: Sync+'static + std::marker::Send> Foo for (T,) { }
 error[E0277]: `T` cannot be shared between threads safely
   --> $DIR/builtin-superkinds-double-superkind.rs:9:16
    |
+LL | trait Foo : Send+Sync { }
+   |                  ---- required by this bound in `Foo`
+...
 LL | impl <T: Send> Foo for (T,T) { }
    |                ^^^ `T` cannot be shared between threads safely
    |
    = help: within `(T, T)`, the trait `std::marker::Sync` is not implemented for `T`
    = note: required because it appears within the type `(T, T)`
+   = note: required because of the requirements on the impl of `std::marker::Sync` for `(T, T)`
 help: consider further restricting this bound
    |
 LL | impl <T: Send + std::marker::Sync> Foo for (T,T) { }

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
@@ -9,7 +9,6 @@ LL | impl <T: Sync+'static> Foo for (T,) { }
    |
    = help: within `(T,)`, the trait `std::marker::Send` is not implemented for `T`
    = note: required because it appears within the type `(T,)`
-   = note: required because of the requirements on the impl of `std::marker::Send` for `(T,)`
 help: consider further restricting this bound
    |
 LL | impl <T: Sync+'static + std::marker::Send> Foo for (T,) { }
@@ -26,7 +25,6 @@ LL | impl <T: Send> Foo for (T,T) { }
    |
    = help: within `(T, T)`, the trait `std::marker::Sync` is not implemented for `T`
    = note: required because it appears within the type `(T, T)`
-   = note: required because of the requirements on the impl of `std::marker::Sync` for `(T, T)`
 help: consider further restricting this bound
    |
 LL | impl <T: Send + std::marker::Sync> Foo for (T,T) { }

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
@@ -11,7 +11,6 @@ LL | pub trait RequiresRequiresShareAndSend : RequiresShare + Send { }
    |
    = help: within `X<T>`, the trait `std::marker::Send` is not implemented for `T`
    = note: required because it appears within the type `X<T>`
-   = note: required because of the requirements on the impl of `std::marker::Send` for `X<T>`
 help: consider further restricting this bound
    |
 LL | impl <T:Sync+'static + std::marker::Send> RequiresRequiresShareAndSend for X<T> { }

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
@@ -3,9 +3,15 @@ error[E0277]: `T` cannot be sent between threads safely
    |
 LL | impl <T:Sync+'static> RequiresRequiresShareAndSend for X<T> { }
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `T` cannot be sent between threads safely
+   | 
+  ::: $DIR/auxiliary/trait_superkinds_in_metadata.rs:7:58
+   |
+LL | pub trait RequiresRequiresShareAndSend : RequiresShare + Send { }
+   |                                                          ---- required by this bound in `trait_superkinds_in_metadata::RequiresRequiresShareAndSend`
    |
    = help: within `X<T>`, the trait `std::marker::Send` is not implemented for `T`
    = note: required because it appears within the type `X<T>`
+   = note: required because of the requirements on the impl of `std::marker::Send` for `X<T>`
 help: consider further restricting this bound
    |
 LL | impl <T:Sync+'static + std::marker::Send> RequiresRequiresShareAndSend for X<T> { }

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-simple.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-simple.stderr
@@ -8,7 +8,6 @@ LL | impl Foo for std::rc::Rc<i8> { }
    |      ^^^ `std::rc::Rc<i8>` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `std::rc::Rc<i8>`
-   = note: required because of the requirements on the impl of `std::marker::Send` for `std::rc::Rc<i8>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-simple.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-simple.stderr
@@ -1,10 +1,14 @@
 error[E0277]: `std::rc::Rc<i8>` cannot be sent between threads safely
   --> $DIR/builtin-superkinds-simple.rs:6:6
    |
+LL | trait Foo : Send { }
+   |             ---- required by this bound in `Foo`
+LL | 
 LL | impl Foo for std::rc::Rc<i8> { }
    |      ^^^ `std::rc::Rc<i8>` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `std::rc::Rc<i8>`
+   = note: required because of the requirements on the impl of `std::marker::Send` for `std::rc::Rc<i8>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
@@ -1,10 +1,14 @@
 error[E0277]: `T` cannot be sent between threads safely
   --> $DIR/builtin-superkinds-typaram-not-send.rs:5:24
    |
+LL | trait Foo : Send { }
+   |             ---- required by this bound in `Foo`
+LL | 
 LL | impl <T: Sync+'static> Foo for T { }
    |                        ^^^ `T` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `T`
+   = note: required because of the requirements on the impl of `std::marker::Send` for `T`
 help: consider further restricting this bound
    |
 LL | impl <T: Sync+'static + std::marker::Send> Foo for T { }

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
@@ -8,7 +8,6 @@ LL | impl <T: Sync+'static> Foo for T { }
    |                        ^^^ `T` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `T`
-   = note: required because of the requirements on the impl of `std::marker::Send` for `T`
 help: consider further restricting this bound
    |
 LL | impl <T: Sync+'static + std::marker::Send> Foo for T { }

--- a/src/test/ui/closure-expected-type/expect-fn-supply-fn.nll.stderr
+++ b/src/test/ui/closure-expected-type/expect-fn-supply-fn.nll.stderr
@@ -2,7 +2,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-fn-supply-fn.rs:30:5
    |
 LL | fn with_closure_expecting_fn_with_free_region<F>(_: F)
-   |    ------------------------------------------
+   |    ------------------------------------------ required by a bound in this
 LL |     where F: for<'a> FnOnce(fn(&'a u32), &i32)
    |                      ------------------------- required by this bound in `with_closure_expecting_fn_with_free_region`
 ...
@@ -15,7 +15,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-fn-supply-fn.rs:37:5
    |
 LL | fn with_closure_expecting_fn_with_bound_region<F>(_: F)
-   |    -------------------------------------------
+   |    ------------------------------------------- required by a bound in this
 LL |     where F: FnOnce(fn(&u32), &i32)
    |              ---------------------- required by this bound in `with_closure_expecting_fn_with_bound_region`
 ...
@@ -28,7 +28,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-fn-supply-fn.rs:46:5
    |
 LL | fn with_closure_expecting_fn_with_bound_region<F>(_: F)
-   |    -------------------------------------------
+   |    ------------------------------------------- required by a bound in this
 LL |     where F: FnOnce(fn(&u32), &i32)
    |              ---------------------- required by this bound in `with_closure_expecting_fn_with_bound_region`
 ...

--- a/src/test/ui/closure-expected-type/expect-fn-supply-fn.stderr
+++ b/src/test/ui/closure-expected-type/expect-fn-supply-fn.stderr
@@ -40,7 +40,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-fn-supply-fn.rs:30:5
    |
 LL | fn with_closure_expecting_fn_with_free_region<F>(_: F)
-   |    ------------------------------------------
+   |    ------------------------------------------ required by a bound in this
 LL |     where F: for<'a> FnOnce(fn(&'a u32), &i32)
    |                      ------------------------- required by this bound in `with_closure_expecting_fn_with_free_region`
 ...
@@ -53,7 +53,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-fn-supply-fn.rs:37:5
    |
 LL | fn with_closure_expecting_fn_with_bound_region<F>(_: F)
-   |    -------------------------------------------
+   |    ------------------------------------------- required by a bound in this
 LL |     where F: FnOnce(fn(&u32), &i32)
    |              ---------------------- required by this bound in `with_closure_expecting_fn_with_bound_region`
 ...
@@ -66,7 +66,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-fn-supply-fn.rs:46:5
    |
 LL | fn with_closure_expecting_fn_with_bound_region<F>(_: F)
-   |    -------------------------------------------
+   |    ------------------------------------------- required by a bound in this
 LL |     where F: FnOnce(fn(&u32), &i32)
    |              ---------------------- required by this bound in `with_closure_expecting_fn_with_bound_region`
 ...

--- a/src/test/ui/closure-expected-type/expect-infer-var-appearing-twice.stderr
+++ b/src/test/ui/closure-expected-type/expect-infer-var-appearing-twice.stderr
@@ -2,7 +2,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-infer-var-appearing-twice.rs:14:5
    |
 LL | fn with_closure<F, A>(_: F)
-   |    ------------
+   |    ------------ required by a bound in this
 LL |     where F: FnOnce(A, A)
    |              ------------ required by this bound in `with_closure`
 ...

--- a/src/test/ui/dst/dst-sized-trait-param.stderr
+++ b/src/test/ui/dst/dst-sized-trait-param.stderr
@@ -1,20 +1,28 @@
 error[E0277]: the size for values of type `[isize]` cannot be known at compilation time
   --> $DIR/dst-sized-trait-param.rs:7:6
    |
+LL | trait Foo<T> : Sized { fn take(self, x: &T) { } } // Note: T is sized
+   |           - required by this bound in `Foo`
+LL | 
 LL | impl Foo<[isize]> for usize { }
    |      ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[isize]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+   = note: required because of the requirements on the impl of `std::marker::Sized` for `[isize]`
 
 error[E0277]: the size for values of type `[usize]` cannot be known at compilation time
   --> $DIR/dst-sized-trait-param.rs:10:6
    |
+LL | trait Foo<T> : Sized { fn take(self, x: &T) { } } // Note: T is sized
+   |                ----- required by this bound in `Foo`
+...
 LL | impl Foo<isize> for [usize] { }
    |      ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[usize]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+   = note: required because of the requirements on the impl of `std::marker::Sized` for `[usize]`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/dst/dst-sized-trait-param.stderr
+++ b/src/test/ui/dst/dst-sized-trait-param.stderr
@@ -9,7 +9,6 @@ LL | impl Foo<[isize]> for usize { }
    |
    = help: the trait `std::marker::Sized` is not implemented for `[isize]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required because of the requirements on the impl of `std::marker::Sized` for `[isize]`
 
 error[E0277]: the size for values of type `[usize]` cannot be known at compilation time
   --> $DIR/dst-sized-trait-param.rs:10:6
@@ -22,7 +21,6 @@ LL | impl Foo<isize> for [usize] { }
    |
    = help: the trait `std::marker::Sized` is not implemented for `[usize]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required because of the requirements on the impl of `std::marker::Sized` for `[usize]`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generator/generator-yielding-or-returning-itself.stderr
+++ b/src/test/ui/generator/generator-yielding-or-returning-itself.stderr
@@ -2,7 +2,7 @@ error[E0271]: type mismatch resolving `<[generator@$DIR/generator-yielding-or-re
   --> $DIR/generator-yielding-or-returning-itself.rs:15:5
    |
 LL | pub fn want_cyclic_generator_return<T>(_: T)
-   |        ----------------------------
+   |        ---------------------------- required by a bound in this
 LL |     where T: Generator<Yield = (), Return = T>
    |                                    ---------- required by this bound in `want_cyclic_generator_return`
 ...
@@ -18,7 +18,7 @@ error[E0271]: type mismatch resolving `<[generator@$DIR/generator-yielding-or-re
   --> $DIR/generator-yielding-or-returning-itself.rs:28:5
    |
 LL | pub fn want_cyclic_generator_yield<T>(_: T)
-   |        ---------------------------
+   |        --------------------------- required by a bound in this
 LL |     where T: Generator<Yield = T, Return = ()>
    |                        --------- required by this bound in `want_cyclic_generator_yield`
 ...

--- a/src/test/ui/generic-associated-types/construct_with_other_type.stderr
+++ b/src/test/ui/generic-associated-types/construct_with_other_type.stderr
@@ -1,19 +1,12 @@
 error[E0271]: type mismatch resolving `for<'a> <<T as Baz>::Baa<'a> as std::ops::Deref>::Target == <<T as Baz>::Quux<'a> as Foo>::Bar<'a, 'static>`
   --> $DIR/construct_with_other_type.rs:19:9
    |
-LL | trait Baz {
-   |       ---
-...
-LL |     type Baa<'a>: Deref<Target = <Self::Quux<'a> as Foo>::Bar<'a, 'static>>  where Self: 'a;
-   |                         -------------------------------------------------- required by this bound in `Baz`
-...
 LL | impl<T> Baz for T where T: Foo {
    |         ^^^ expected type parameter `T`, found associated type
    |
    = note: expected associated type `<T as Foo>::Bar<'_, 'static>`
               found associated type `<<T as Baz>::Quux<'_> as Foo>::Bar<'_, 'static>`
    = note: you might be missing a type parameter or trait bound
-   = note: required because of the requirements on the impl of `Baz` for `T`
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/construct_with_other_type.stderr
+++ b/src/test/ui/generic-associated-types/construct_with_other_type.stderr
@@ -1,12 +1,19 @@
 error[E0271]: type mismatch resolving `for<'a> <<T as Baz>::Baa<'a> as std::ops::Deref>::Target == <<T as Baz>::Quux<'a> as Foo>::Bar<'a, 'static>`
   --> $DIR/construct_with_other_type.rs:19:9
    |
+LL | trait Baz {
+   |       ---
+...
+LL |     type Baa<'a>: Deref<Target = <Self::Quux<'a> as Foo>::Bar<'a, 'static>>  where Self: 'a;
+   |                         -------------------------------------------------- required by this bound in `Baz`
+...
 LL | impl<T> Baz for T where T: Foo {
    |         ^^^ expected type parameter `T`, found associated type
    |
    = note: expected associated type `<T as Foo>::Bar<'_, 'static>`
               found associated type `<<T as Baz>::Quux<'_> as Foo>::Bar<'_, 'static>`
    = note: you might be missing a type parameter or trait bound
+   = note: required because of the requirements on the impl of `Baz` for `T`
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/issue-62326-parameter-out-of-range.stderr
+++ b/src/test/ui/generic-associated-types/issue-62326-parameter-out-of-range.stderr
@@ -2,7 +2,7 @@ error[E0280]: the requirement `for<'a> <Self as Iterator>::Item<'a>: 'a` is not 
   --> $DIR/issue-62326-parameter-out-of-range.rs:7:20
    |
 LL | trait Iterator {
-   |       --------
+   |       -------- required by a bound in this
 LL |     type Item<'a>: 'a;
    |                    ^^ required by this bound in `Iterator`
 

--- a/src/test/ui/generic-associated-types/iterable.stderr
+++ b/src/test/ui/generic-associated-types/iterable.stderr
@@ -1,15 +1,8 @@
 error[E0271]: type mismatch resolving `for<'a> <<std::vec::Vec<T> as Iterable>::Iter<'a> as std::iter::Iterator>::Item == <std::vec::Vec<T> as Iterable>::Item<'a>`
-  --> $DIR/iterable.rs:15:5
+  --> $DIR/iterable.rs:15:33
    |
-LL | impl<T> Iterable for Vec<T> {
-   | --------------------------- in this `impl` item
 LL |     type Item<'a> where T: 'a = <std::slice::Iter<'a, T> as Iterator>::Item;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected reference, found associated type
-   | 
-  ::: $SRC_DIR/libcore/iter/traits/iterator.rs:LL:COL
-   |
-LL |     type Item;
-   |          ---- associated type defined here
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected reference, found associated type
    |
    = note:    expected reference `&T`
            found associated type `<std::vec::Vec<T> as Iterable>::Item<'_>`
@@ -17,17 +10,10 @@ LL |     type Item;
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
 
 error[E0271]: type mismatch resolving `for<'a> <<[T] as Iterable>::Iter<'a> as std::iter::Iterator>::Item == <[T] as Iterable>::Item<'a>`
-  --> $DIR/iterable.rs:27:5
+  --> $DIR/iterable.rs:27:33
    |
-LL | impl<T> Iterable for [T] {
-   | ------------------------ in this `impl` item
 LL |     type Item<'a> where T: 'a = <std::slice::Iter<'a, T> as Iterator>::Item;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected reference, found associated type
-   | 
-  ::: $SRC_DIR/libcore/iter/traits/iterator.rs:LL:COL
-   |
-LL |     type Item;
-   |          ---- associated type defined here
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected reference, found associated type
    |
    = note:    expected reference `&T`
            found associated type `<[T] as Iterable>::Item<'_>`

--- a/src/test/ui/generic-associated-types/iterable.stderr
+++ b/src/test/ui/generic-associated-types/iterable.stderr
@@ -24,7 +24,7 @@ error[E0271]: type mismatch resolving `for<'a> <<std::vec::Vec<T> as Iterable>::
   --> $DIR/iterable.rs:19:30
    |
 LL | trait Iterable {
-   |       --------
+   |       -------- required by a bound in this
 LL |     type Item<'a> where Self: 'a;
 LL |     type Iter<'a>: Iterator<Item = Self::Item<'a>> where Self: 'a;
    |                             --------------------- required by this bound in `Iterable`
@@ -41,7 +41,7 @@ error[E0271]: type mismatch resolving `for<'a> <<[T] as Iterable>::Iter<'a> as s
   --> $DIR/iterable.rs:31:30
    |
 LL | trait Iterable {
-   |       --------
+   |       -------- required by a bound in this
 LL |     type Item<'a> where Self: 'a;
 LL |     type Iter<'a>: Iterator<Item = Self::Item<'a>> where Self: 'a;
    |                             --------------------- required by this bound in `Iterable`

--- a/src/test/ui/generics/issue-61631-default-type-param-can-reference-self-in-trait.stderr
+++ b/src/test/ui/generics/issue-61631-default-type-param-can-reference-self-in-trait.stderr
@@ -1,11 +1,15 @@
 error[E0277]: the size for values of type `[()]` cannot be known at compilation time
   --> $DIR/issue-61631-default-type-param-can-reference-self-in-trait.rs:19:6
    |
+LL | trait Tsized<P: Sized = [Self]> {}
+   |              - required by this bound in `Tsized`
+LL | 
 LL | impl Tsized for () {}
    |      ^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[()]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+   = note: required because of the requirements on the impl of `std::marker::Sized` for `[()]`
 
 error: aborting due to previous error
 

--- a/src/test/ui/generics/issue-61631-default-type-param-can-reference-self-in-trait.stderr
+++ b/src/test/ui/generics/issue-61631-default-type-param-can-reference-self-in-trait.stderr
@@ -9,7 +9,6 @@ LL | impl Tsized for () {}
    |
    = help: the trait `std::marker::Sized` is not implemented for `[()]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required because of the requirements on the impl of `std::marker::Sized` for `[()]`
 
 error: aborting due to previous error
 

--- a/src/test/ui/hrtb/hrtb-conflate-regions.stderr
+++ b/src/test/ui/hrtb/hrtb-conflate-regions.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `for<'a, 'b> SomeStruct: Foo<(&'a isize, &'b isize
   --> $DIR/hrtb-conflate-regions.rs:27:22
    |
 LL | fn want_foo2<T>()
-   |    ---------
+   |    --------- required by a bound in this
 LL |     where T : for<'a,'b> Foo<(&'a isize, &'b isize)>
    |               -------------------------------------- required by this bound in `want_foo2`
 ...

--- a/src/test/ui/hrtb/hrtb-exists-forall-trait-contravariant.stderr
+++ b/src/test/ui/hrtb/hrtb-exists-forall-trait-contravariant.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `(): Trait<for<'b> fn(&'b u32)>` is not satisfied
   --> $DIR/hrtb-exists-forall-trait-contravariant.rs:34:11
    |
 LL | fn foo<T>()
-   |    ---
+   |    --- required by a bound in this
 LL | where
 LL |     T: Trait<for<'b> fn(&'b u32)>,
    |        -------------------------- required by this bound in `foo`

--- a/src/test/ui/hrtb/hrtb-exists-forall-trait-covariant.stderr
+++ b/src/test/ui/hrtb/hrtb-exists-forall-trait-covariant.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `(): Trait<for<'b> fn(fn(&'b u32))>` is not satisf
   --> $DIR/hrtb-exists-forall-trait-covariant.rs:36:11
    |
 LL | fn foo<T>()
-   |    ---
+   |    --- required by a bound in this
 LL | where
 LL |     T: Trait<for<'b> fn(fn(&'b u32))>,
    |        ------------------------------ required by this bound in `foo`

--- a/src/test/ui/hrtb/hrtb-exists-forall-trait-invariant.stderr
+++ b/src/test/ui/hrtb/hrtb-exists-forall-trait-invariant.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `(): Trait<for<'b> fn(std::cell::Cell<&'b u32>)>` 
   --> $DIR/hrtb-exists-forall-trait-invariant.rs:28:11
    |
 LL | fn foo<T>()
-   |    ---
+   |    --- required by a bound in this
 LL | where
 LL |     T: Trait<for<'b> fn(Cell<&'b u32>)>,
    |        -------------------------------- required by this bound in `foo`

--- a/src/test/ui/hrtb/hrtb-higher-ranker-supertraits-transitive.stderr
+++ b/src/test/ui/hrtb/hrtb-higher-ranker-supertraits-transitive.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `for<'ccx> B: Bar<'ccx>` is not satisfied
   --> $DIR/hrtb-higher-ranker-supertraits-transitive.rs:47:26
    |
 LL | fn want_bar_for_any_ccx<B>(b: &B)
-   |    --------------------
+   |    -------------------- required by a bound in this
 LL |     where B : for<'ccx> Bar<'ccx>
    |               ------------------- required by this bound in `want_bar_for_any_ccx`
 ...

--- a/src/test/ui/hrtb/hrtb-higher-ranker-supertraits.stderr
+++ b/src/test/ui/hrtb/hrtb-higher-ranker-supertraits.stderr
@@ -5,7 +5,7 @@ LL |     want_foo_for_any_tcx(f);
    |                          ^ the trait `for<'tcx> Foo<'tcx>` is not implemented for `F`
 ...
 LL | fn want_foo_for_any_tcx<F>(f: &F)
-   |    --------------------
+   |    -------------------- required by a bound in this
 LL |     where F : for<'tcx> Foo<'tcx>
    |               ------------------- required by this bound in `want_foo_for_any_tcx`
    |
@@ -21,7 +21,7 @@ LL |     want_bar_for_any_ccx(b);
    |                          ^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
 ...
 LL | fn want_bar_for_any_ccx<B>(b: &B)
-   |    --------------------
+   |    -------------------- required by a bound in this
 LL |     where B : for<'ccx> Bar<'ccx>
    |               ------------------- required by this bound in `want_bar_for_any_ccx`
    |

--- a/src/test/ui/hrtb/hrtb-just-for-static.stderr
+++ b/src/test/ui/hrtb/hrtb-just-for-static.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `for<'a> StaticInt: Foo<&'a isize>` is not satisfi
   --> $DIR/hrtb-just-for-static.rs:24:17
    |
 LL | fn want_hrtb<T>()
-   |    ---------
+   |    --------- required by a bound in this
 LL |     where T : for<'a> Foo<&'a isize>
    |               ---------------------- required by this bound in `want_hrtb`
 ...
@@ -16,7 +16,7 @@ error[E0277]: the trait bound `for<'a> &'a u32: Foo<&'a isize>` is not satisfied
   --> $DIR/hrtb-just-for-static.rs:30:17
    |
 LL | fn want_hrtb<T>()
-   |    ---------
+   |    --------- required by a bound in this
 LL |     where T : for<'a> Foo<&'a isize>
    |               ---------------------- required by this bound in `want_hrtb`
 ...

--- a/src/test/ui/impl-bounds-checking.stderr
+++ b/src/test/ui/impl-bounds-checking.stderr
@@ -6,8 +6,6 @@ LL | trait Getter<T: Clone2> {
 ...
 LL | impl Getter<isize> for isize {
    |      ^^^^^^^^^^^^^ the trait `Clone2` is not implemented for `isize`
-   |
-   = note: required because of the requirements on the impl of `Clone2` for `isize`
 
 error: aborting due to previous error
 

--- a/src/test/ui/impl-bounds-checking.stderr
+++ b/src/test/ui/impl-bounds-checking.stderr
@@ -1,8 +1,13 @@
 error[E0277]: the trait bound `isize: Clone2` is not satisfied
   --> $DIR/impl-bounds-checking.rs:10:6
    |
+LL | trait Getter<T: Clone2> {
+   |                 ------ required by this bound in `Getter`
+...
 LL | impl Getter<isize> for isize {
    |      ^^^^^^^^^^^^^ the trait `Clone2` is not implemented for `isize`
+   |
+   = note: required because of the requirements on the impl of `Clone2` for `isize`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-10412.stderr
+++ b/src/test/ui/issues/issue-10412.stderr
@@ -49,11 +49,15 @@ LL | impl<'self> Serializable<str> for &'self str {
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/issue-10412.rs:6:13
    |
+LL | trait Serializable<'self, T> {
+   |                           - required by this bound in `Serializable`
+...
 LL | impl<'self> Serializable<str> for &'self str {
    |             ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+   = note: required because of the requirements on the impl of `std::marker::Sized` for `str`
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/issues/issue-10412.stderr
+++ b/src/test/ui/issues/issue-10412.stderr
@@ -57,7 +57,6 @@ LL | impl<'self> Serializable<str> for &'self str {
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required because of the requirements on the impl of `std::marker::Sized` for `str`
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/issues/issue-24204.stderr
+++ b/src/test/ui/issues/issue-24204.stderr
@@ -2,7 +2,7 @@ error[E0271]: type mismatch resolving `<<T as Trait>::A as MultiDispatch<i32>>::
   --> $DIR/issue-24204.rs:14:12
    |
 LL | trait Trait: Sized {
-   |       -----
+   |       ----- required by a bound in this
 LL |     type A: MultiDispatch<Self::B, O = Self>;
    |                                    -------- required by this bound in `Trait`
 ...

--- a/src/test/ui/issues/issue-43623.stderr
+++ b/src/test/ui/issues/issue-43623.stderr
@@ -2,7 +2,7 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/issue-43623.rs:14:5
    |
 LL | pub fn break_me<T, F>(f: F)
-   |        --------
+   |        -------- required by a bound in this
 LL | where T: for<'b> Trait<'b>,
 LL |       F: for<'b> FnMut(<T as Trait<'b>>::Assoc) {
    |          -------------------------------------- required by this bound in `break_me`
@@ -16,7 +16,7 @@ error[E0271]: type mismatch resolving `for<'b> <fn(_) as std::ops::FnOnce<(<Type
   --> $DIR/issue-43623.rs:14:5
    |
 LL | pub fn break_me<T, F>(f: F)
-   |        --------
+   |        -------- required by a bound in this
 LL | where T: for<'b> Trait<'b>,
 LL |       F: for<'b> FnMut(<T as Trait<'b>>::Assoc) {
    |                  ------------------------------ required by this bound in `break_me`

--- a/src/test/ui/issues/issue-43784-associated-type.stderr
+++ b/src/test/ui/issues/issue-43784-associated-type.stderr
@@ -1,14 +1,10 @@
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
-  --> $DIR/issue-43784-associated-type.rs:14:5
+  --> $DIR/issue-43784-associated-type.rs:14:18
    |
-LL |     type Assoc: Partial<Self>;
-   |          ----- associated type defined here
-...
-LL | impl<T> Complete for T {
-   | ---------------------- in this `impl` item
 LL |     type Assoc = T;
-   |     ^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
+   |                  ^ the trait `std::marker::Copy` is not implemented for `T`
    |
+   = note: required because of the requirements on the impl of `std::marker::Copy` for `<T as Complete>::Assoc`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::marker::Copy> Complete for T {

--- a/src/test/ui/issues/issue-43784-associated-type.stderr
+++ b/src/test/ui/issues/issue-43784-associated-type.stderr
@@ -4,7 +4,6 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
 LL |     type Assoc = T;
    |                  ^ the trait `std::marker::Copy` is not implemented for `T`
    |
-   = note: required because of the requirements on the impl of `std::marker::Copy` for `<T as Complete>::Assoc`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::marker::Copy> Complete for T {

--- a/src/test/ui/issues/issue-43784-supertrait.stderr
+++ b/src/test/ui/issues/issue-43784-supertrait.stderr
@@ -4,6 +4,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
 LL | impl<T> Complete for T {}
    |         ^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
+   = note: required because of the requirements on the impl of `std::marker::Copy` for `T`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::marker::Copy> Complete for T {}

--- a/src/test/ui/issues/issue-43784-supertrait.stderr
+++ b/src/test/ui/issues/issue-43784-supertrait.stderr
@@ -4,7 +4,6 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
 LL | impl<T> Complete for T {}
    |         ^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-   = note: required because of the requirements on the impl of `std::marker::Copy` for `T`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::marker::Copy> Complete for T {}

--- a/src/test/ui/issues/issue-47706.stderr
+++ b/src/test/ui/issues/issue-47706.stderr
@@ -14,7 +14,7 @@ LL |     Bar(i32),
    |     -------- takes 1 argument
 ...
 LL | fn foo<F>(f: F)
-   |    ---
+   |    --- required by a bound in this
 LL | where
 LL |     F: Fn(),
    |        ---- required by this bound in `foo`

--- a/src/test/ui/issues/issue-60218.stderr
+++ b/src/test/ui/issues/issue-60218.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `for<'t> <std::iter::Map<<&'t _ as std::iter::Into
   --> $DIR/issue-60218.rs:18:5
    |
 LL | pub fn trigger_error<I, F>(iterable: I, functor: F)
-   |        -------------
+   |        ------------- required by a bound in this
 ...
 LL | for<'t> <Map<<&'t I as IntoIterator>::IntoIter, F> as Iterator>::Item: Foo,
    |                                                                        --- required by this bound in `trigger_error`

--- a/src/test/ui/issues/issue-60283.stderr
+++ b/src/test/ui/issues/issue-60283.stderr
@@ -2,7 +2,7 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/issue-60283.rs:14:13
    |
 LL | pub fn foo<T, F>(_: T, _: F)
-   |        ---
+   |        --- required by a bound in this
 LL | where T: for<'a> Trait<'a>,
 LL |       F: for<'a> FnMut(<T as Trait<'a>>::Item) {}
    |          ------------------------------------- required by this bound in `foo`
@@ -17,7 +17,7 @@ error[E0271]: type mismatch resolving `for<'a> <fn(_) {std::mem::drop::<_>} as s
   --> $DIR/issue-60283.rs:14:5
    |
 LL | pub fn foo<T, F>(_: T, _: F)
-   |        ---
+   |        --- required by a bound in this
 LL | where T: for<'a> Trait<'a>,
 LL |       F: for<'a> FnMut(<T as Trait<'a>>::Item) {}
    |                  ----------------------------- required by this bound in `foo`

--- a/src/test/ui/issues/issue-65673.stderr
+++ b/src/test/ui/issues/issue-65673.stderr
@@ -11,7 +11,6 @@ LL |     type Ctx = dyn Alias<T>;
    |
    = help: the trait `std::marker::Sized` is not implemented for `(dyn Trait + 'static)`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required because of the requirements on the impl of `std::marker::Sized` for `<T as WithType>::Ctx`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-65673.stderr
+++ b/src/test/ui/issues/issue-65673.stderr
@@ -1,16 +1,17 @@
 error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
-  --> $DIR/issue-65673.rs:9:5
+  --> $DIR/issue-65673.rs:9:16
    |
+LL | trait WithType {
+   |       --------
 LL |     type Ctx;
-   |          --- associated type defined here
+   |     --------- required by this bound in `WithType`
 ...
-LL | impl<T> WithType for T {
-   | ---------------------- in this `impl` item
 LL |     type Ctx = dyn Alias<T>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `(dyn Trait + 'static)`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+   = note: required because of the requirements on the impl of `std::marker::Sized` for `<T as WithType>::Ctx`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-65673.stderr
+++ b/src/test/ui/issues/issue-65673.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be know
   --> $DIR/issue-65673.rs:9:16
    |
 LL | trait WithType {
-   |       --------
+   |       -------- required by a bound in this
 LL |     type Ctx;
    |     --------- required by this bound in `WithType`
 ...

--- a/src/test/ui/malformed/malformed-derive-entry.stderr
+++ b/src/test/ui/malformed/malformed-derive-entry.stderr
@@ -27,7 +27,6 @@ LL | #[derive(Copy(Bad))]
 LL | pub trait Copy: Clone {
    |                 ----- required by this bound in `std::marker::Copy`
    |
-   = note: required because of the requirements on the impl of `std::clone::Clone` for `Test1`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Test2: std::clone::Clone` is not satisfied
@@ -41,7 +40,6 @@ LL | #[derive(Copy="bad")]
 LL | pub trait Copy: Clone {
    |                 ----- required by this bound in `std::marker::Copy`
    |
-   = note: required because of the requirements on the impl of `std::clone::Clone` for `Test2`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 5 previous errors

--- a/src/test/ui/malformed/malformed-derive-entry.stderr
+++ b/src/test/ui/malformed/malformed-derive-entry.stderr
@@ -21,7 +21,13 @@ error[E0277]: the trait bound `Test1: std::clone::Clone` is not satisfied
    |
 LL | #[derive(Copy(Bad))]
    |          ^^^^ the trait `std::clone::Clone` is not implemented for `Test1`
+   | 
+  ::: $SRC_DIR/libcore/marker.rs:LL:COL
    |
+LL | pub trait Copy: Clone {
+   |                 ----- required by this bound in `std::marker::Copy`
+   |
+   = note: required because of the requirements on the impl of `std::clone::Clone` for `Test1`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Test2: std::clone::Clone` is not satisfied
@@ -29,7 +35,13 @@ error[E0277]: the trait bound `Test2: std::clone::Clone` is not satisfied
    |
 LL | #[derive(Copy="bad")]
    |          ^^^^ the trait `std::clone::Clone` is not implemented for `Test2`
+   | 
+  ::: $SRC_DIR/libcore/marker.rs:LL:COL
    |
+LL | pub trait Copy: Clone {
+   |                 ----- required by this bound in `std::marker::Copy`
+   |
+   = note: required because of the requirements on the impl of `std::clone::Clone` for `Test2`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 5 previous errors

--- a/src/test/ui/specialization/defaultimpl/specialization-wfcheck.stderr
+++ b/src/test/ui/specialization/defaultimpl/specialization-wfcheck.stderr
@@ -1,9 +1,13 @@
 error[E0277]: the trait bound `U: std::cmp::Eq` is not satisfied
   --> $DIR/specialization-wfcheck.rs:7:17
    |
+LL | trait Foo<'a, T: Eq + 'a> { }
+   |                  -- required by this bound in `Foo`
+LL | 
 LL | default impl<U> Foo<'static, U> for () {}
    |                 ^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `U`
    |
+   = note: required because of the requirements on the impl of `std::cmp::Eq` for `U`
 help: consider restricting type parameter `U`
    |
 LL | default impl<U: std::cmp::Eq> Foo<'static, U> for () {}

--- a/src/test/ui/specialization/defaultimpl/specialization-wfcheck.stderr
+++ b/src/test/ui/specialization/defaultimpl/specialization-wfcheck.stderr
@@ -7,7 +7,6 @@ LL |
 LL | default impl<U> Foo<'static, U> for () {}
    |                 ^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `U`
    |
-   = note: required because of the requirements on the impl of `std::cmp::Eq` for `U`
 help: consider restricting type parameter `U`
    |
 LL | default impl<U: std::cmp::Eq> Foo<'static, U> for () {}

--- a/src/test/ui/suggestions/missing-assoc-type-bound-restriction.stderr
+++ b/src/test/ui/suggestions/missing-assoc-type-bound-restriction.stderr
@@ -28,7 +28,6 @@ LL |     type Assoc = ChildWrapper<T::Assoc>;
    |                  ^^^^^^^^^^^^^^^^^^^^^^ the trait `Child<A>` is not implemented for `<T as Parent>::Assoc`
    |
    = note: required because of the requirements on the impl of `Child<A>` for `ChildWrapper<<T as Parent>::Assoc>`
-   = note: required because of the requirements on the impl of `Child<<ParentWrapper<T> as Parent>::Ty>` for `<ParentWrapper<T> as Parent>::Assoc`
 
 error[E0277]: the trait bound `<T as Parent>::Assoc: Child<A>` is not satisfied
   --> $DIR/missing-assoc-type-bound-restriction.rs:20:5

--- a/src/test/ui/suggestions/missing-assoc-type-bound-restriction.stderr
+++ b/src/test/ui/suggestions/missing-assoc-type-bound-restriction.stderr
@@ -13,20 +13,22 @@ LL | impl<A, T: Parent<Ty = A>> Parent for ParentWrapper<T> {
    |                   the trait `Child<A>` is not implemented for `<T as Parent>::Assoc`
 
 error[E0277]: the trait bound `<T as Parent>::Assoc: Child<A>` is not satisfied
-  --> $DIR/missing-assoc-type-bound-restriction.rs:20:5
+  --> $DIR/missing-assoc-type-bound-restriction.rs:20:18
    |
+LL | trait Parent {
+   |       ------
+LL |     type Ty;
 LL |     type Assoc: Child<Self::Ty>;
-   |          ----- associated type defined here
+   |                 --------------- required by this bound in `Parent`
 ...
 LL | impl<A, T: Parent<Ty = A>> Parent for ParentWrapper<T> {
-   | ------------------------------------------------------- help: consider further restricting the associated type: `where <T as Parent>::Assoc: Child<A>`
-   | |
-   | in this `impl` item
+   |                                                       - help: consider further restricting the associated type: `where <T as Parent>::Assoc: Child<A>`
 ...
 LL |     type Assoc = ChildWrapper<T::Assoc>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Child<A>` is not implemented for `<T as Parent>::Assoc`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^ the trait `Child<A>` is not implemented for `<T as Parent>::Assoc`
    |
    = note: required because of the requirements on the impl of `Child<A>` for `ChildWrapper<<T as Parent>::Assoc>`
+   = note: required because of the requirements on the impl of `Child<<ParentWrapper<T> as Parent>::Ty>` for `<ParentWrapper<T> as Parent>::Assoc`
 
 error[E0277]: the trait bound `<T as Parent>::Assoc: Child<A>` is not satisfied
   --> $DIR/missing-assoc-type-bound-restriction.rs:20:5

--- a/src/test/ui/suggestions/missing-assoc-type-bound-restriction.stderr
+++ b/src/test/ui/suggestions/missing-assoc-type-bound-restriction.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `<T as Parent>::Assoc: Child<A>` is not satisfied
   --> $DIR/missing-assoc-type-bound-restriction.rs:17:19
    |
 LL | trait Parent {
-   |       ------
+   |       ------ required by a bound in this
 LL |     type Ty;
 LL |     type Assoc: Child<Self::Ty>;
    |                 --------------- required by this bound in `Parent`
@@ -16,7 +16,7 @@ error[E0277]: the trait bound `<T as Parent>::Assoc: Child<A>` is not satisfied
   --> $DIR/missing-assoc-type-bound-restriction.rs:20:18
    |
 LL | trait Parent {
-   |       ------
+   |       ------ required by a bound in this
 LL |     type Ty;
 LL |     type Assoc: Child<Self::Ty>;
    |                 --------------- required by this bound in `Parent`
@@ -33,7 +33,7 @@ error[E0277]: the trait bound `<T as Parent>::Assoc: Child<A>` is not satisfied
   --> $DIR/missing-assoc-type-bound-restriction.rs:20:5
    |
 LL | trait Parent {
-   |       ------
+   |       ------ required by a bound in this
 LL |     type Ty;
 LL |     type Assoc: Child<Self::Ty>;
    |                 --------------- required by this bound in `Parent`

--- a/src/test/ui/traits/cycle-cache-err-60010.stderr
+++ b/src/test/ui/traits/cycle-cache-err-60010.stderr
@@ -7,20 +7,21 @@ LL |     _parse: <ParseQuery as Query<RootDatabase>>::Data,
    = note: required because of the requirements on the impl of `Query<RootDatabase>` for `ParseQuery`
 
 error[E0275]: overflow evaluating the requirement `Runtime<RootDatabase>: std::panic::RefUnwindSafe`
-  --> $DIR/cycle-cache-err-60010.rs:31:5
+  --> $DIR/cycle-cache-err-60010.rs:31:20
    |
+LL | trait Database {
+   |       --------
 LL |     type Storage;
-   |          ------- associated type defined here
+   |     ------------- required by this bound in `Database`
 ...
-LL | impl Database for RootDatabase {
-   | ------------------------------ in this `impl` item
 LL |     type Storage = SalsaStorage;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^
    |
    = note: required because it appears within the type `RootDatabase`
    = note: required because of the requirements on the impl of `SourceDatabase` for `RootDatabase`
    = note: required because of the requirements on the impl of `Query<RootDatabase>` for `ParseQuery`
    = note: required because it appears within the type `SalsaStorage`
+   = note: required because of the requirements on the impl of `std::marker::Sized` for `<RootDatabase as Database>::Storage`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/cycle-cache-err-60010.stderr
+++ b/src/test/ui/traits/cycle-cache-err-60010.stderr
@@ -10,7 +10,7 @@ error[E0275]: overflow evaluating the requirement `Runtime<RootDatabase>: std::p
   --> $DIR/cycle-cache-err-60010.rs:31:20
    |
 LL | trait Database {
-   |       --------
+   |       -------- required by a bound in this
 LL |     type Storage;
    |     ------------- required by this bound in `Database`
 ...

--- a/src/test/ui/traits/cycle-cache-err-60010.stderr
+++ b/src/test/ui/traits/cycle-cache-err-60010.stderr
@@ -21,7 +21,6 @@ LL |     type Storage = SalsaStorage;
    = note: required because of the requirements on the impl of `SourceDatabase` for `RootDatabase`
    = note: required because of the requirements on the impl of `Query<RootDatabase>` for `ParseQuery`
    = note: required because it appears within the type `SalsaStorage`
-   = note: required because of the requirements on the impl of `std::marker::Sized` for `<RootDatabase as Database>::Storage`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/traits-assoc-type-in-supertrait-bad.rs
+++ b/src/test/ui/traits/traits-assoc-type-in-supertrait-bad.rs
@@ -8,8 +8,8 @@ pub trait Foo: Iterator<Item=<Self as Foo>::Key> {
     type Key;
 }
 
-impl Foo for IntoIter<i32> { //~ ERROR type mismatch
-    type Key = u32;
+impl Foo for IntoIter<i32> {
+    type Key = u32; //~ ERROR type mismatch
 }
 
 fn main() {

--- a/src/test/ui/traits/traits-assoc-type-in-supertrait-bad.stderr
+++ b/src/test/ui/traits/traits-assoc-type-in-supertrait-bad.stderr
@@ -1,8 +1,13 @@
 error[E0271]: type mismatch resolving `<std::vec::IntoIter<i32> as std::iter::Iterator>::Item == u32`
   --> $DIR/traits-assoc-type-in-supertrait-bad.rs:11:6
    |
+LL | pub trait Foo: Iterator<Item=<Self as Foo>::Key> {
+   |                         ----------------------- required by this bound in `Foo`
+...
 LL | impl Foo for IntoIter<i32> {
    |      ^^^ expected `i32`, found `u32`
+   |
+   = note: required because of the requirements on the impl of `Foo` for `std::vec::IntoIter<i32>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/traits-assoc-type-in-supertrait-bad.stderr
+++ b/src/test/ui/traits/traits-assoc-type-in-supertrait-bad.stderr
@@ -1,13 +1,8 @@
 error[E0271]: type mismatch resolving `<std::vec::IntoIter<i32> as std::iter::Iterator>::Item == u32`
-  --> $DIR/traits-assoc-type-in-supertrait-bad.rs:11:6
+  --> $DIR/traits-assoc-type-in-supertrait-bad.rs:12:16
    |
-LL | pub trait Foo: Iterator<Item=<Self as Foo>::Key> {
-   |                         ----------------------- required by this bound in `Foo`
-...
-LL | impl Foo for IntoIter<i32> {
-   |      ^^^ expected `i32`, found `u32`
-   |
-   = note: required because of the requirements on the impl of `Foo` for `std::vec::IntoIter<i32>`
+LL |     type Key = u32;
+   |                ^^^ expected `i32`, found `u32`
 
 error: aborting due to previous error
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-wrong-trait.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-wrong-trait.stderr
@@ -5,10 +5,10 @@ LL | fn f<F:Trait(isize) -> isize>(x: F) {}
    |        ^^^^^^^^^^^^ unexpected type argument
 
 error[E0220]: associated type `Output` not found for `Trait`
-  --> $DIR/unboxed-closure-sugar-wrong-trait.rs:5:8
+  --> $DIR/unboxed-closure-sugar-wrong-trait.rs:5:24
    |
 LL | fn f<F:Trait(isize) -> isize>(x: F) {}
-   |        ^^^^^^^^^^^^^^^^^^^^^ associated type `Output` not found
+   |                        ^^^^^ associated type `Output` not found
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/unsized/unsized-trait-impl-trait-arg.stderr
+++ b/src/test/ui/unsized/unsized-trait-impl-trait-arg.stderr
@@ -11,7 +11,6 @@ LL | impl<X: ?Sized> T2<X> for S4<X> {
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required because of the requirements on the impl of `std::marker::Sized` for `X`
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsized/unsized-trait-impl-trait-arg.stderr
+++ b/src/test/ui/unsized/unsized-trait-impl-trait-arg.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized-trait-impl-trait-arg.rs:8:17
    |
+LL | trait T2<Z> {
+   |          - required by this bound in `T2`
+...
 LL | impl<X: ?Sized> T2<X> for S4<X> {
    |      -          ^^^^^ doesn't have a size known at compile-time
    |      |
@@ -8,6 +11,7 @@ LL | impl<X: ?Sized> T2<X> for S4<X> {
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+   = note: required because of the requirements on the impl of `std::marker::Sized` for `X`
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsized7.stderr
+++ b/src/test/ui/unsized7.stderr
@@ -11,7 +11,6 @@ LL | impl<X: ?Sized + T> T1<X> for S3<X> {
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required because of the requirements on the impl of `std::marker::Sized` for `X`
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsized7.stderr
+++ b/src/test/ui/unsized7.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized7.rs:12:21
    |
+LL | trait T1<Z: T> {
+   |          - required by this bound in `T1`
+...
 LL | impl<X: ?Sized + T> T1<X> for S3<X> {
    |      -              ^^^^^ doesn't have a size known at compile-time
    |      |
@@ -8,6 +11,7 @@ LL | impl<X: ?Sized + T> T1<X> for S3<X> {
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+   = note: required because of the requirements on the impl of `std::marker::Sized` for `X`
 
 error: aborting due to previous error
 

--- a/src/test/ui/where-clauses/where-for-self-2.stderr
+++ b/src/test/ui/where-clauses/where-for-self-2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `for<'a> &'a _: Bar` is not satisfied
   --> $DIR/where-for-self-2.rs:21:5
    |
 LL | fn foo<T>(x: &T)
-   |    ---
+   |    --- required by a bound in this
 LL |     where for<'a> &'a T: Bar
    |                          --- required by this bound in `foo`
 ...


### PR DESCRIPTION
When evaluating the derived obligations from super traits, maintain a
reference to the original obligation in order to give more actionable
context in the output.

Continuation (and built on) #69745, subset of #69709.

r? @eddyb