### PR TITLE
Add `Layout::dangling()` to return a well-aligned `NonNull<u8>`

### DIFF
--- a/src/libcore/alloc.rs
+++ b/src/libcore/alloc.rs
@@ -140,6 +140,18 @@ impl Layout {
         unsafe { Layout::from_size_align_unchecked(size, align) }
     }
 
+    /// Creates a `NonNull` that is dangling, but well-aligned for this Layout.
+    ///
+    /// Note that the pointer value may potentially represent a valid pointer to
+    /// a `T`, which means this must not be used as a "not yet initialized"
+    /// sentinel value. Types that lazily allocate must track initialization by
+    /// some other means.
+    #[unstable(feature = "alloc_layout_extra", issue = "55724")]
+    pub const fn dangling(&self) -> NonNull<u8> {
+        // align is non-zero and a power of two
+        unsafe { NonNull::new_unchecked(self.align() as *mut u8) }
+    }
+
     /// Creates a layout describing the record that can hold a value
     /// of the same layout as `self`, but that also is aligned to
     /// alignment `align` (measured in bytes).

--- a/src/libcore/alloc.rs
+++ b/src/libcore/alloc.rs
@@ -142,8 +142,8 @@ impl Layout {
 
     /// Creates a `NonNull` that is dangling, but well-aligned for this Layout.
     ///
-    /// Note that the pointer value may potentially represent a valid pointer to
-    /// a `T`, which means this must not be used as a "not yet initialized"
+    /// Note that the pointer value may potentially represent a valid pointer,
+    /// which means this must not be used as a "not yet initialized"
     /// sentinel value. Types that lazily allocate must track initialization by
     /// some other means.
     #[unstable(feature = "alloc_layout_extra", issue = "55724")]

--- a/src/libcore/tests/alloc.rs
+++ b/src/libcore/tests/alloc.rs
@@ -1,10 +1,13 @@
 use core::alloc::Layout;
+use core::ptr::NonNull;
 
 #[test]
 fn const_unchecked_layout() {
     const SIZE: usize = 0x2000;
     const ALIGN: usize = 0x1000;
     const LAYOUT: Layout = unsafe { Layout::from_size_align_unchecked(SIZE, ALIGN) };
+    const DANGLING: NonNull<u8> = LAYOUT.dangling();
     assert_eq!(LAYOUT.size(), SIZE);
     assert_eq!(LAYOUT.align(), ALIGN);
+    assert_eq!(Some(DANGLING), NonNull::new(ALIGN as *mut u8));
 }

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -1,3 +1,4 @@
+#![feature(alloc_layout_extra)]
 #![feature(bool_to_option)]
 #![feature(bound_cloned)]
 #![feature(box_syntax)]


### PR DESCRIPTION
Adds a convenient function to `Layout` to create a `NonNull<u8>` out of a layout to be returned on ZST allocations.

This is the first item on the roadmap to support ZSTs in `AllocRef`: https://github.com/rust-lang/wg-allocators/issues/38#issuecomment-595861542 

r? @Amanieu