### PR TITLE
Correct version that relaxed orphan rules

### DIFF
--- a/src/libcore/convert/mod.rs
+++ b/src/libcore/convert/mod.rs
@@ -229,7 +229,7 @@ pub trait AsMut<T: ?Sized> {
 ///
 /// # Implementing [`Into`] for conversions to external types in old versions of Rust
 ///
-/// Prior to Rust 1.40, if the destination type was not part of the current crate
+/// Prior to Rust 1.41, if the destination type was not part of the current crate
 /// then you couldn't implement [`From`] directly.
 /// For example, take this code:
 ///


### PR DESCRIPTION
Docs say
> Prior to Rust 1.40, if the destination type was not part of the current crate then you couldn't implement From directly

Version 1.41 of Rust introduced the change to the orphan rules - https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html#relaxed-restrictions-when-implementing-traits - so this should say
> Prior to Rust 1.41...