### PR TITLE
Compile address sanitizer test with debuginfo

### DIFF
--- a/src/test/ui/sanitize/address.rs
+++ b/src/test/ui/sanitize/address.rs
@@ -1,16 +1,15 @@
 // needs-sanitizer-support
 // only-x86_64
 //
-// compile-flags: -Z sanitizer=address -O
+// compile-flags: -Z sanitizer=address -O -g
 //
 // run-fail
 // error-pattern: AddressSanitizer: stack-buffer-overflow
-// error-pattern: 'xs' <== Memory access at offset
+// error-pattern: 'xs' (line 15) <== Memory access at offset
 
 #![feature(test)]
 
 use std::hint::black_box;
-use std::mem;
 
 fn main() {
     let xs = [0, 1, 2, 3];


### PR DESCRIPTION
This makes error-pattern to match regardless of current
configuration of `rust.debuginfo-level-tests` in `config.toml`.