### PR TITLE
fix more clippy findings

### DIFF
--- a/src/libcore/str/pattern.rs
+++ b/src/libcore/str/pattern.rs
@@ -365,11 +365,7 @@ unsafe impl<'a> ReverseSearcher<'a> for CharSearcher<'a> {
         let haystack = self.haystack.as_bytes();
         loop {
             // get the haystack up to but not including the last character searched
-            let bytes = if let Some(slice) = haystack.get(self.finger..self.finger_back) {
-                slice
-            } else {
-                return None;
-            };
+            let bytes = haystack.get(self.finger..self.finger_back)?;
             // the last byte of the utf8 encoded needle
             // SAFETY: we have an invariant that `utf8_size < 5`
             let last_byte = unsafe { *self.utf8_encoded.get_unchecked(self.utf8_size - 1) };
@@ -575,11 +571,12 @@ macro_rules! pattern_methods {
 
         #[inline]
         fn is_suffix_of(self, haystack: &'a str) -> bool
-            where $t: ReverseSearcher<'a>
+        where
+            $t: ReverseSearcher<'a>,
         {
             ($pmap)(self).is_suffix_of(haystack)
         }
-    }
+    };
 }
 
 macro_rules! searcher_methods {
@@ -614,7 +611,7 @@ macro_rules! searcher_methods {
         fn next_reject_back(&mut self) -> Option<(usize, usize)> {
             self.0.next_reject_back()
         }
-    }
+    };
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -298,7 +298,7 @@ impl<'hir> Map<'hir> {
     }
 
     pub fn def_kind(&self, hir_id: HirId) -> Option<DefKind> {
-        let node = if let Some(node) = self.find(hir_id) { node } else { return None };
+        let node = self.find(hir_id)?;
 
         Some(match node {
             Node::Item(item) => match item.kind {

--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -346,12 +346,7 @@ impl<'tcx> TyCtxt<'tcx> {
         adt_did: DefId,
         validate: &mut dyn FnMut(Self, DefId) -> Result<(), ErrorReported>,
     ) -> Option<ty::Destructor> {
-        let drop_trait = if let Some(def_id) = self.lang_items().drop_trait() {
-            def_id
-        } else {
-            return None;
-        };
-
+        let drop_trait = self.lang_items().drop_trait()?;
         self.ensure().coherent_trait(drop_trait);
 
         let mut dtor_did = None;

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -1120,12 +1120,7 @@ fn extra_compiler_flags() -> Option<(Vec<String>, bool)> {
         return None;
     }
 
-    let matches = if let Some(matches) = handle_options(&args) {
-        matches
-    } else {
-        return None;
-    };
-
+    let matches = handle_options(&args)?;
     let mut result = Vec::new();
     let mut excluded_cargo_defaults = false;
     for flag in ICE_REPORT_COMPILER_FLAGS {

--- a/src/librustc_infer/traits/auto_trait.rs
+++ b/src/librustc_infer/traits/auto_trait.rs
@@ -113,7 +113,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
             return AutoTraitResult::ExplicitImpl;
         }
 
-        return tcx.infer_ctxt().enter(|mut infcx| {
+        return tcx.infer_ctxt().enter(|infcx| {
             let mut fresh_preds = FxHashSet::default();
 
             // Due to the way projections are handled by SelectionContext, we need to run
@@ -164,7 +164,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
 
             let (full_env, full_user_env) = self
                 .evaluate_predicates(
-                    &mut infcx,
+                    &infcx,
                     trait_did,
                     ty,
                     new_env,

--- a/src/librustc_infer/traits/specialize/mod.rs
+++ b/src/librustc_infer/traits/specialize/mod.rs
@@ -413,12 +413,7 @@ pub(super) fn specialization_graph_provider(
 fn to_pretty_impl_header(tcx: TyCtxt<'_>, impl_def_id: DefId) -> Option<String> {
     use std::fmt::Write;
 
-    let trait_ref = if let Some(tr) = tcx.impl_trait_ref(impl_def_id) {
-        tr
-    } else {
-        return None;
-    };
-
+    let trait_ref = tcx.impl_trait_ref(impl_def_id)?;
     let mut w = "impl".to_owned();
 
     let substs = InternalSubsts::identity_for_item(tcx, impl_def_id);

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -944,7 +944,7 @@ fn create_generator_drop_shim<'tcx>(
     // unrelated code from the resume part of the function
     simplify::remove_dead_blocks(&mut body);
 
-    dump_mir(tcx, None, "generator_drop", &0, source, &mut body, |_, _| Ok(()));
+    dump_mir(tcx, None, "generator_drop", &0, source, &body, |_, _| Ok(()));
 
     body
 }

--- a/src/librustc_mir/util/liveness.rs
+++ b/src/librustc_mir/util/liveness.rs
@@ -293,7 +293,7 @@ fn dump_matched_mir_node<'tcx>(
         writeln!(file, "// MIR local liveness analysis for `{}`", node_path)?;
         writeln!(file, "// source = {:?}", source)?;
         writeln!(file, "// pass_name = {}", pass_name)?;
-        writeln!(file, "")?;
+        writeln!(file)?;
         write_mir_fn(tcx, source, body, &mut file, result)?;
         Ok(())
     });
@@ -316,7 +316,7 @@ pub fn write_mir_fn<'tcx>(
         write_basic_block(tcx, block, body, &mut |_, _| Ok(()), w)?;
         print(w, "   ", &result.outs)?;
         if block.index() + 1 != body.basic_blocks().len() {
-            writeln!(w, "")?;
+            writeln!(w)?;
         }
     }
 

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -134,7 +134,7 @@ fn dump_matched_mir_node<'tcx, F>(
         if let Some(ref layout) = body.generator_layout {
             writeln!(file, "// generator_layout = {:?}", layout)?;
         }
-        writeln!(file, "")?;
+        writeln!(file)?;
         extra_data(PassWhere::BeforeCFG, &mut file)?;
         write_user_type_annotations(body, &mut file)?;
         write_mir_fn(tcx, source, body, &mut extra_data, &mut file)?;
@@ -242,13 +242,13 @@ pub fn write_mir_pretty<'tcx>(
             first = false;
         } else {
             // Put empty lines between all items
-            writeln!(w, "")?;
+            writeln!(w)?;
         }
 
         write_mir_fn(tcx, MirSource::item(def_id), body, &mut |_, _| Ok(()), w)?;
 
         for (i, body) in tcx.promoted_mir(def_id).iter_enumerated() {
-            writeln!(w, "")?;
+            writeln!(w)?;
             let src = MirSource { instance: ty::InstanceDef::Item(def_id), promoted: Some(i) };
             write_mir_fn(tcx, src, body, &mut |_, _| Ok(()), w)?;
         }
@@ -271,7 +271,7 @@ where
         extra_data(PassWhere::BeforeBlock(block), w)?;
         write_basic_block(tcx, block, body, extra_data, w)?;
         if block.index() + 1 != body.basic_blocks().len() {
-            writeln!(w, "")?;
+            writeln!(w)?;
         }
     }
 
@@ -529,7 +529,7 @@ pub fn write_mir_intro<'tcx>(
     write_scope_tree(tcx, body, &scope_tree, w, OUTERMOST_SOURCE_SCOPE, 1)?;
 
     // Add an empty line before the first block is printed.
-    writeln!(w, "")?;
+    writeln!(w)?;
 
     Ok(())
 }

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -1107,11 +1107,7 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
                 }
             };
 
-            match (
-                lifetime_names.len(),
-                lifetime_names.iter().next(),
-                snippet.as_ref().map(|s| s.as_str()),
-            ) {
+            match (lifetime_names.len(), lifetime_names.iter().next(), snippet.as_deref()) {
                 (1, Some(name), Some("&")) => {
                     suggest_existing(err, format!("&{} ", name));
                 }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2778,12 +2778,8 @@ impl<'a> Resolver<'a> {
             } else {
                 let crate_id = if !speculative {
                     self.crate_loader.process_path_extern(ident.name, ident.span)
-                } else if let Some(crate_id) =
-                    self.crate_loader.maybe_process_path_extern(ident.name, ident.span)
-                {
-                    crate_id
                 } else {
-                    return None;
+                    self.crate_loader.maybe_process_path_extern(ident.name, ident.span)?
                 };
                 let crate_root = self.get_module(DefId { krate: crate_id, index: CRATE_DEF_INDEX });
                 Some(

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -1167,11 +1167,7 @@ impl SourceFile {
         }
 
         let begin = {
-            let line = if let Some(line) = self.lines.get(line_number) {
-                line
-            } else {
-                return None;
-            };
+            let line = self.lines.get(line_number)?;
             let begin: BytePos = *line - self.start_pos;
             begin.to_usize()
         };

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -577,7 +577,7 @@ fn filter_non_trait_generics(trait_did: DefId, mut g: clean::Generics) -> clean:
                     name: ref _name,
                 },
             ref bounds,
-        } => !(*s == "Self" && did == trait_did) && !bounds.is_empty(),
+        } => !(bounds.is_empty() || *s == "Self" && did == trait_did),
         _ => true,
     });
     g

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -42,11 +42,7 @@ pub fn try_inline(
     attrs: Option<Attrs<'_>>,
     visited: &mut FxHashSet<DefId>,
 ) -> Option<Vec<clean::Item>> {
-    let did = if let Some(did) = res.opt_def_id() {
-        did
-    } else {
-        return None;
-    };
+    let did = res.opt_def_id()?;
     if did.is_local() {
         return None;
     }

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -844,11 +844,7 @@ pub fn plain_summary_line(md: &str) -> String {
         type Item = String;
 
         fn next(&mut self) -> Option<String> {
-            let next_event = self.inner.next();
-            if next_event.is_none() {
-                return None;
-            }
-            let next_event = next_event.unwrap();
+            let next_event = self.inner.next()?;
             let (ret, is_in) = match next_event {
                 Event::Start(Tag::Paragraph) => (None, 1),
                 Event::Start(Tag::Heading(_)) => (None, 1),

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -870,7 +870,7 @@ pub fn plain_summary_line(md: &str) -> String {
     }
     let mut s = String::with_capacity(md.len() * 3 / 2);
     let p = ParserWrapper { inner: Parser::new(md), is_in: 0, is_first: true };
-    p.into_iter().filter(|t| !t.is_empty()).for_each(|i| s.push_str(&i));
+    p.filter(|t| !t.is_empty()).for_each(|i| s.push_str(&i));
     s
 }
 

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -3401,10 +3401,8 @@ fn render_assoc_items(
         let deref_impl =
             traits.iter().find(|t| t.inner_impl().trait_.def_id() == c.deref_trait_did);
         if let Some(impl_) = deref_impl {
-            let has_deref_mut = traits
-                .iter()
-                .find(|t| t.inner_impl().trait_.def_id() == c.deref_mut_trait_did)
-                .is_some();
+            let has_deref_mut =
+                traits.iter().any(|t| t.inner_impl().trait_.def_id() == c.deref_mut_trait_did);
             render_deref_methods(w, cx, impl_, containing_item, has_deref_mut);
         }
 
@@ -3816,7 +3814,7 @@ fn render_impl(
     ) {
         for trait_item in &t.items {
             let n = trait_item.name.clone();
-            if i.items.iter().find(|m| m.name == n).is_some() {
+            if i.items.iter().any(|m| m.name == n) {
                 continue;
             }
             let did = i.trait_.as_ref().unwrap().def_id().unwrap();

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1542,7 +1542,7 @@ impl Context {
         }
 
         if self.shared.sort_modules_alphabetically {
-            for (_, items) in &mut map {
+            for items in map.values_mut() {
                 items.sort();
             }
         }

--- a/src/librustdoc/html/static_files.rs
+++ b/src/librustdoc/html/static_files.rs
@@ -8,106 +8,106 @@
 //! directly written to a `Write` handle.
 
 /// The file contents of the main `rustdoc.css` file, responsible for the core layout of the page.
-pub static RUSTDOC_CSS: &'static str = include_str!("static/rustdoc.css");
+pub static RUSTDOC_CSS: &str = include_str!("static/rustdoc.css");
 
 /// The file contents of `settings.css`, responsible for the items on the settings page.
-pub static SETTINGS_CSS: &'static str = include_str!("static/settings.css");
+pub static SETTINGS_CSS: &str = include_str!("static/settings.css");
 
 /// The file contents of the `noscript.css` file, used in case JS isn't supported or is disabled.
-pub static NOSCRIPT_CSS: &'static str = include_str!("static/noscript.css");
+pub static NOSCRIPT_CSS: &str = include_str!("static/noscript.css");
 
 /// The file contents of `normalize.css`, included to even out standard elements between browser
 /// implementations.
-pub static NORMALIZE_CSS: &'static str = include_str!("static/normalize.css");
+pub static NORMALIZE_CSS: &str = include_str!("static/normalize.css");
 
 /// The file contents of `main.js`, which contains the core JavaScript used on documentation pages,
 /// including search behavior and docblock folding, among others.
-pub static MAIN_JS: &'static str = include_str!("static/main.js");
+pub static MAIN_JS: &str = include_str!("static/main.js");
 
 /// The file contents of `settings.js`, which contains the JavaScript used to handle the settings
 /// page.
-pub static SETTINGS_JS: &'static str = include_str!("static/settings.js");
+pub static SETTINGS_JS: &str = include_str!("static/settings.js");
 
 /// The file contents of `storage.js`, which contains functionality related to browser Local
 /// Storage, used to store documentation settings.
-pub static STORAGE_JS: &'static str = include_str!("static/storage.js");
+pub static STORAGE_JS: &str = include_str!("static/storage.js");
 
 /// The file contents of `brush.svg`, the icon used for the theme-switch button.
-pub static BRUSH_SVG: &'static [u8] = include_bytes!("static/brush.svg");
+pub static BRUSH_SVG: &[u8] = include_bytes!("static/brush.svg");
 
 /// The file contents of `wheel.svg`, the icon used for the settings button.
-pub static WHEEL_SVG: &'static [u8] = include_bytes!("static/wheel.svg");
+pub static WHEEL_SVG: &[u8] = include_bytes!("static/wheel.svg");
 
 /// The file contents of `down-arrow.svg`, the icon used for the crate choice combobox.
-pub static DOWN_ARROW_SVG: &'static [u8] = include_bytes!("static/down-arrow.svg");
+pub static DOWN_ARROW_SVG: &[u8] = include_bytes!("static/down-arrow.svg");
 
 /// The contents of `COPYRIGHT.txt`, the license listing for files distributed with documentation
 /// output.
-pub static COPYRIGHT: &'static [u8] = include_bytes!("static/COPYRIGHT.txt");
+pub static COPYRIGHT: &[u8] = include_bytes!("static/COPYRIGHT.txt");
 
 /// The contents of `LICENSE-APACHE.txt`, the text of the Apache License, version 2.0.
-pub static LICENSE_APACHE: &'static [u8] = include_bytes!("static/LICENSE-APACHE.txt");
+pub static LICENSE_APACHE: &[u8] = include_bytes!("static/LICENSE-APACHE.txt");
 
 /// The contents of `LICENSE-MIT.txt`, the text of the MIT License.
-pub static LICENSE_MIT: &'static [u8] = include_bytes!("static/LICENSE-MIT.txt");
+pub static LICENSE_MIT: &[u8] = include_bytes!("static/LICENSE-MIT.txt");
 
 /// The contents of `rust-logo.png`, the default icon of the documentation.
-pub static RUST_LOGO: &'static [u8] = include_bytes!("static/rust-logo.png");
+pub static RUST_LOGO: &[u8] = include_bytes!("static/rust-logo.png");
 /// The contents of `favicon.ico`, the default favicon of the documentation.
-pub static RUST_FAVICON: &'static [u8] = include_bytes!("static/favicon.ico");
+pub static RUST_FAVICON: &[u8] = include_bytes!("static/favicon.ico");
 
 /// The built-in themes given to every documentation site.
 pub mod themes {
     /// The "light" theme, selected by default when no setting is available. Used as the basis for
     /// the `--check-theme` functionality.
-    pub static LIGHT: &'static str = include_str!("static/themes/light.css");
+    pub static LIGHT: &str = include_str!("static/themes/light.css");
 
     /// The "dark" theme.
-    pub static DARK: &'static str = include_str!("static/themes/dark.css");
+    pub static DARK: &str = include_str!("static/themes/dark.css");
 }
 
 /// Files related to the Fira Sans font.
 pub mod fira_sans {
     /// The file `FiraSans-Regular.woff`, the Regular variant of the Fira Sans font.
-    pub static REGULAR: &'static [u8] = include_bytes!("static/FiraSans-Regular.woff");
+    pub static REGULAR: &[u8] = include_bytes!("static/FiraSans-Regular.woff");
 
     /// The file `FiraSans-Medium.woff`, the Medium variant of the Fira Sans font.
-    pub static MEDIUM: &'static [u8] = include_bytes!("static/FiraSans-Medium.woff");
+    pub static MEDIUM: &[u8] = include_bytes!("static/FiraSans-Medium.woff");
 
     /// The file `FiraSans-LICENSE.txt`, the license text for the Fira Sans font.
-    pub static LICENSE: &'static [u8] = include_bytes!("static/FiraSans-LICENSE.txt");
+    pub static LICENSE: &[u8] = include_bytes!("static/FiraSans-LICENSE.txt");
 }
 
 /// Files related to the Source Serif Pro font.
 pub mod source_serif_pro {
     /// The file `SourceSerifPro-Regular.ttf.woff`, the Regular variant of the Source Serif Pro
     /// font.
-    pub static REGULAR: &'static [u8] = include_bytes!("static/SourceSerifPro-Regular.ttf.woff");
+    pub static REGULAR: &[u8] = include_bytes!("static/SourceSerifPro-Regular.ttf.woff");
 
     /// The file `SourceSerifPro-Bold.ttf.woff`, the Bold variant of the Source Serif Pro font.
-    pub static BOLD: &'static [u8] = include_bytes!("static/SourceSerifPro-Bold.ttf.woff");
+    pub static BOLD: &[u8] = include_bytes!("static/SourceSerifPro-Bold.ttf.woff");
 
     /// The file `SourceSerifPro-It.ttf.woff`, the Italic variant of the Source Serif Pro font.
-    pub static ITALIC: &'static [u8] = include_bytes!("static/SourceSerifPro-It.ttf.woff");
+    pub static ITALIC: &[u8] = include_bytes!("static/SourceSerifPro-It.ttf.woff");
 
     /// The file `SourceSerifPro-LICENSE.txt`, the license text for the Source Serif Pro font.
-    pub static LICENSE: &'static [u8] = include_bytes!("static/SourceSerifPro-LICENSE.md");
+    pub static LICENSE: &[u8] = include_bytes!("static/SourceSerifPro-LICENSE.md");
 }
 
 /// Files related to the Source Code Pro font.
 pub mod source_code_pro {
     /// The file `SourceCodePro-Regular.woff`, the Regular variant of the Source Code Pro font.
-    pub static REGULAR: &'static [u8] = include_bytes!("static/SourceCodePro-Regular.woff");
+    pub static REGULAR: &[u8] = include_bytes!("static/SourceCodePro-Regular.woff");
 
     /// The file `SourceCodePro-Semibold.woff`, the Semibold variant of the Source Code Pro font.
-    pub static SEMIBOLD: &'static [u8] = include_bytes!("static/SourceCodePro-Semibold.woff");
+    pub static SEMIBOLD: &[u8] = include_bytes!("static/SourceCodePro-Semibold.woff");
 
     /// The file `SourceCodePro-LICENSE.txt`, the license text of the Source Code Pro font.
-    pub static LICENSE: &'static [u8] = include_bytes!("static/SourceCodePro-LICENSE.txt");
+    pub static LICENSE: &[u8] = include_bytes!("static/SourceCodePro-LICENSE.txt");
 }
 
 /// Files related to the sidebar in rustdoc sources.
 pub mod sidebar {
     /// File script to handle sidebar.
-    pub static SOURCE_SCRIPT: &'static str = include_str!("static/source-script.js");
+    pub static SOURCE_SCRIPT: &str = include_str!("static/source-script.js");
 }

--- a/src/libstd/sys_common/backtrace.rs
+++ b/src/libstd/sys_common/backtrace.rs
@@ -70,7 +70,7 @@ unsafe fn _print_fmt(fmt: &mut fmt::Formatter<'_>, print_fmt: PrintFmt) -> fmt::
     let mut print_path = move |fmt: &mut fmt::Formatter<'_>, bows: BytesOrWideString<'_>| {
         output_filename(fmt, bows, print_fmt, cwd.as_ref())
     };
-    write!(fmt, "stack backtrace:\n")?;
+    writeln!(fmt, "stack backtrace:")?;
     let mut bt_fmt = BacktraceFmt::new(fmt, print_fmt, &mut print_path);
     bt_fmt.add_context()?;
     let mut idx = 0;

--- a/src/libstd/sys_common/process.rs
+++ b/src/libstd/sys_common/process.rs
@@ -47,7 +47,7 @@ impl CommandEnv {
             }
         }
         for (key, maybe_val) in self.vars.iter() {
-            if let &Some(ref val) = maybe_val {
+            if let Some(ref val) = maybe_val {
                 env::set_var(key, val);
             } else {
                 env::remove_var(key);

--- a/src/libstd/sys_common/wtf8.rs
+++ b/src/libstd/sys_common/wtf8.rs
@@ -603,8 +603,8 @@ impl Wtf8 {
         if len < 3 {
             return None;
         }
-        match &self.bytes[(len - 3)..] {
-            &[0xED, b2 @ 0xA0..=0xAF, b3] => Some(decode_surrogate(b2, b3)),
+        match self.bytes[(len - 3)..] {
+            [0xED, b2 @ 0xA0..=0xAF, b3] => Some(decode_surrogate(b2, b3)),
             _ => None,
         }
     }
@@ -615,8 +615,8 @@ impl Wtf8 {
         if len < 3 {
             return None;
         }
-        match &self.bytes[..3] {
-            &[0xED, b2 @ 0xB0..=0xBF, b3] => Some(decode_surrogate(b2, b3)),
+        match self.bytes[..3] {
+            [0xED, b2 @ 0xB0..=0xBF, b3] => Some(decode_surrogate(b2, b3)),
             _ => None,
         }
     }

--- a/src/libtest/console.rs
+++ b/src/libtest/console.rs
@@ -169,7 +169,7 @@ pub fn list_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Res
 
     if !quiet {
         if ntest != 0 || nbench != 0 {
-            writeln!(output, "")?;
+            writeln!(output)?;
         }
 
         writeln!(output, "{}, {}", plural(ntest, "test"), plural(nbench, "benchmark"))?;

--- a/src/libtest/formatters/mod.rs
+++ b/src/libtest/formatters/mod.rs
@@ -36,5 +36,5 @@ pub(crate) fn write_stderr_delimiter(test_output: &mut Vec<u8>, test_name: &Test
         Some(_) => test_output.push(b'\n'),
         None => (),
     }
-    write!(test_output, "---- {} stderr ----\n", test_name).unwrap();
+    writeln!(test_output, "---- {} stderr ----", test_name).unwrap();
 }

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -204,7 +204,7 @@ impl Stats for [f64] {
     }
 
     fn median(&self) -> f64 {
-        self.percentile(50 as f64)
+        self.percentile(50_f64)
     }
 
     fn var(&self) -> f64 {
@@ -230,7 +230,7 @@ impl Stats for [f64] {
     }
 
     fn std_dev_pct(&self) -> f64 {
-        let hundred = 100 as f64;
+        let hundred = 100_f64;
         (self.std_dev() / self.mean()) * hundred
     }
 
@@ -244,7 +244,7 @@ impl Stats for [f64] {
     }
 
     fn median_abs_dev_pct(&self) -> f64 {
-        let hundred = 100 as f64;
+        let hundred = 100_f64;
         (self.median_abs_dev() / self.median()) * hundred
     }
 
@@ -257,11 +257,11 @@ impl Stats for [f64] {
     fn quartiles(&self) -> (f64, f64, f64) {
         let mut tmp = self.to_vec();
         local_sort(&mut tmp);
-        let first = 25f64;
+        let first = 25_f64;
         let a = percentile_of_sorted(&tmp, first);
-        let second = 50f64;
+        let second = 50_f64;
         let b = percentile_of_sorted(&tmp, second);
-        let third = 75f64;
+        let third = 75_f64;
         let c = percentile_of_sorted(&tmp, third);
         (a, b, c)
     }
@@ -281,7 +281,7 @@ fn percentile_of_sorted(sorted_samples: &[f64], pct: f64) -> f64 {
     }
     let zero: f64 = 0.0;
     assert!(zero <= pct);
-    let hundred = 100f64;
+    let hundred = 100_f64;
     assert!(pct <= hundred);
     if pct == hundred {
         return sorted_samples[sorted_samples.len() - 1];
@@ -307,7 +307,7 @@ pub fn winsorize(samples: &mut [f64], pct: f64) {
     let mut tmp = samples.to_vec();
     local_sort(&mut tmp);
     let lo = percentile_of_sorted(&tmp, pct);
-    let hundred = 100 as f64;
+    let hundred = 100_f64;
     let hi = percentile_of_sorted(&tmp, hundred - pct);
     for samp in samples {
         if *samp > hi {

--- a/src/libtest/types.rs
+++ b/src/libtest/types.rs
@@ -59,10 +59,10 @@ impl TestName {
     }
 
     pub fn with_padding(&self, padding: NamePadding) -> TestName {
-        let name = match self {
-            &TestName::StaticTestName(name) => Cow::Borrowed(name),
-            &TestName::DynTestName(ref name) => Cow::Owned(name.clone()),
-            &TestName::AlignedTestName(ref name, _) => name.clone(),
+        let name = match *self {
+            TestName::StaticTestName(name) => Cow::Borrowed(name),
+            TestName::DynTestName(ref name) => Cow::Owned(name.clone()),
+            TestName::AlignedTestName(ref name, _) => name.clone(),
         };
 
         TestName::AlignedTestName(name, padding)


### PR DESCRIPTION
* reduce references on match patterns (clippy::match_ref_pats)
* Use writeln!(fmt, "word") instead of write!(fmt, "word\n") (clippy::write_with_newline)
* libtest: remove redundant argument to writeln!() (clippy::writeln_empty_string)
* remove unneeded mutable references (cippy::unnecessary_mut_passed)
* libtest: declare variables as floats instead of casting them (clippy::unnecessary_cast)
* rustdoc: remove redundant static lifetimes (clippy::redundant_static_lifetimes)
* call .as_deref() instead of .as_ref().map(Deref::deref) (clippy::option_as_ref_deref)
* iterate over a maps values directly. (clippy::for_kv_map)
* rustdoc: simplify boolean condition (clippy::nonminimal_bool)
* Use ?-operator in more places (clippy::question_mark, had some false negatives fixed recently)
* rustdoc: Use .any(p) instead of find(p).is_some(). (clippy::search_is_some)
* rustdoc: don't call into_iter() on iterator. (clippy::identity_conversion)