### PR TITLE
test(bindings_after_at): add dynamic drop tests for bindings_after_at

### DIFF
--- a/src/test/ui/drop/dynamic-drop.rs
+++ b/src/test/ui/drop/dynamic-drop.rs
@@ -3,6 +3,7 @@
 
 #![feature(generators, generator_trait, untagged_unions)]
 #![feature(move_ref_pattern)]
+#![feature(bindings_after_at)]
 
 #![allow(unused_assignments)]
 #![allow(unused_variables)]
@@ -291,6 +292,44 @@ fn subslice_mixed_min_lengths(a: &Allocator, c: i32) {
     }
 }
 
+fn bindings_after_at_dynamic_init_move(a: &Allocator, c: bool) {
+    let foo = if c { Some(a.alloc()) } else { None };
+    let _x;
+
+    if let bar @ Some(_) = foo {
+        _x = bar;
+    }
+}
+
+fn bindings_after_at_dynamic_init_ref(a: &Allocator, c: bool) {
+    let foo = if c { Some(a.alloc()) } else { None };
+    let _x;
+
+    if let bar @ Some(_baz) = &foo {
+        _x = bar;
+    }
+}
+
+fn bindings_after_at_dynamic_drop_move(a: &Allocator, c: bool) {
+    let foo = if c { Some(a.alloc()) } else { None };
+
+    if let bar @ Some(_) = foo {
+        bar
+    } else {
+        None
+    };
+}
+
+fn bindings_after_at_dynamic_drop_ref(a: &Allocator, c: bool) {
+    let foo = if c { Some(a.alloc()) } else { None };
+
+    if let bar @ Some(_baz) = &foo {
+        bar
+    } else {
+        &None
+    };
+}
+
 fn move_ref_pattern(a: &Allocator) {
     let mut tup = (a.alloc(), a.alloc(), a.alloc(), a.alloc());
     let (ref _a, ref mut _b, _c, mut _d) = tup;
@@ -470,6 +509,15 @@ fn main() {
     run_test(|a| panic_after_init(a));
     run_test(|a| panic_after_init_temp(a));
     run_test(|a| panic_after_init_by_loop(a));
+
+    run_test(|a| bindings_after_at_dynamic_init_move(a, true));
+    run_test(|a| bindings_after_at_dynamic_init_move(a, false));
+    run_test(|a| bindings_after_at_dynamic_init_ref(a, true));
+    run_test(|a| bindings_after_at_dynamic_init_ref(a, false));
+    run_test(|a| bindings_after_at_dynamic_drop_move(a, true));
+    run_test(|a| bindings_after_at_dynamic_drop_move(a, false));
+    run_test(|a| bindings_after_at_dynamic_drop_ref(a, true));
+    run_test(|a| bindings_after_at_dynamic_drop_ref(a, false));
 
     run_test_nopanic(|a| union1(a));
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/67523.
Working towards https://github.com/rust-lang/rust/issues/65490.