### PR TITLE
Smaller and more correct generator codegen

### DIFF
--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -997,14 +997,14 @@ fn can_return<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'tcx>) -> bool {
         return false;
     }
 
-    // If there's no return terminator the function also won't return.
+    // If there's a return terminator the function may return.
     for block in body.basic_blocks() {
         if let TerminatorKind::Return = block.terminator().kind {
             return true;
         }
     }
 
-    // Otherwise we assume that the function may return.
+    // Otherwise the function can't return.
     false
 }
 

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -1099,17 +1099,17 @@ fn create_generator_resume_function<'tcx>(
     // Panic when resumed on the returned or poisoned state
     let generator_kind = body.generator_kind.unwrap();
 
-    if can_return {
-        cases.insert(
-            1,
-            (RETURNED, insert_panic_block(tcx, body, ResumedAfterReturn(generator_kind))),
-        );
-    }
-
     if can_unwind {
         cases.insert(
             1,
             (POISONED, insert_panic_block(tcx, body, ResumedAfterPanic(generator_kind))),
+        );
+    }
+
+    if can_return {
+        cases.insert(
+            1,
+            (RETURNED, insert_panic_block(tcx, body, ResumedAfterReturn(generator_kind))),
         );
     }
 

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -1108,7 +1108,7 @@ fn create_generator_resume_function<'tcx>(
 
     if can_unwind {
         cases.insert(
-            2,
+            1,
             (POISONED, insert_panic_block(tcx, body, ResumedAfterPanic(generator_kind))),
         );
     }

--- a/src/test/mir-opt/generator-tiny.rs
+++ b/src/test/mir-opt/generator-tiny.rs
@@ -1,0 +1,34 @@
+//! Tests that generators that cannot return or unwind don't have unnecessary
+//! panic branches.
+
+// compile-flags: -Zno-landing-pads
+
+#![feature(generators, generator_trait)]
+
+struct HasDrop;
+
+impl Drop for HasDrop {
+    fn drop(&mut self) {}
+}
+
+fn callee() {}
+
+fn main() {
+    let _gen = |_x: u8| {
+        let _d = HasDrop;
+        loop {
+            yield;
+            callee();
+        }
+    };
+}
+
+// END RUST SOURCE
+
+// START rustc.main-{{closure}}.generator_resume.0.mir
+// bb0: {
+//     ...
+//     switchInt(move _11) -> [0u32: bb1, 3u32: bb5, otherwise: bb6];
+// }
+// ...
+// END rustc.main-{{closure}}.generator_resume.0.mir


### PR DESCRIPTION
This removes unnecessary panicking branches in the resume function when the generator can not return or unwind, respectively.

Closes https://github.com/rust-lang/rust/issues/66100

It also addresses the correctness concerns wrt poisoning on unwind. These are not currently a soundness issue because any operation *inside* a generator that could possibly unwind will result in a cleanup path for dropping it, ultimately reaching a `Resume` terminator, which we already handled correctly. Future MIR optimizations might optimize that out, though.

r? @Zoxc