### PR TITLE
Fix broken macos codegen test

### DIFF
--- a/src/test/codegen/issue-44056-macos-tls-align.rs
+++ b/src/test/codegen/issue-44056-macos-tls-align.rs
@@ -6,12 +6,12 @@
 #![crate_type = "rlib"]
 #![feature(thread_local)]
 
-// CHECK: @STATIC_VAR_1 = thread_local local_unnamed_addr global <{ [32 x i8] }> zeroinitializer, section "__DATA,__thread_bss", align 4
+// CHECK: @STATIC_VAR_1 = thread_local global <{ [32 x i8] }> zeroinitializer, section "__DATA,__thread_bss", align 4
 #[no_mangle]
 #[thread_local]
 static mut STATIC_VAR_1: [u32; 8] = [0; 8];
 
-// CHECK: @STATIC_VAR_2 = thread_local local_unnamed_addr global <{ [32 x i8] }> <{{[^>]*}}>, section "__DATA,__thread_data", align 4
+// CHECK: @STATIC_VAR_2 = thread_local global <{ [32 x i8] }> <{{[^>]*}}>, section "__DATA,__thread_data", align 4
 #[no_mangle]
 #[thread_local]
 static mut STATIC_VAR_2: [u32; 8] = [4; 8];


### PR DESCRIPTION
I was receiving this output for a broken test on Mac OS. Let me know if this test isn't breaking on other Macs
```
---- [codegen] codegen/issue-44056-macos-tls-align.rs stdout ----

error: verification with 'FileCheck' failed
status: exit code: 1
command: "/Users/matthewkuo/projects/open-source/rust/build/x86_64-apple-darwin/llvm/build/bin/FileCheck" "--input-file" "/Users/matthewkuo/projects/open-source/rust/build/x86_64-apple-darwin/test/codegen/issue-44056-macos-tls-align/issue-44056-macos-tls-align.ll" "/Users/matthewkuo/projects/open-source/rust/src/test/codegen/issue-44056-macos-tls-align.rs"
stdout:
------------------------------------------

------------------------------------------
stderr:
------------------------------------------
/Users/matthewkuo/projects/open-source/rust/src/test/codegen/issue-44056-macos-tls-align.rs:9:11: error: CHECK: expected string not found in input
// CHECK: @STATIC_VAR_1 = thread_local local_unnamed_addr global <{ [32 x i8] }> zeroinitializer, section "__DATA,__thread_bss", align 4
          ^
/Users/matthewkuo/projects/open-source/rust/build/x86_64-apple-darwin/test/codegen/issue-44056-macos-tls-align/issue-44056-macos-tls-align.ll:1:1: note: scanning from here
; ModuleID = 'issue_44056_macos_tls_align.3a1fbbbh-cgu.0'
^
/Users/matthewkuo/projects/open-source/rust/build/x86_64-apple-darwin/test/codegen/issue-44056-macos-tls-align/issue-44056-macos-tls-align.ll:14:1: note: possible intended match here
@STATIC_VAR_1 = thread_local global <{ [32 x i8] }> zeroinitializer, section "__DATA,__thread_bss", align 4
^

------------------------------------------



failures:
    [codegen] codegen/issue-44056-macos-tls-align.rs
```