### PR TITLE
Use `AllocRef` for ZSTs in `RawVec`

### DIFF
--- a/src/liballoc/raw_vec/tests.rs
+++ b/src/liballoc/raw_vec/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use core::ptr::NonNull;
 
 #[test]
 fn allocator_param() {


### PR DESCRIPTION
Moves the responsibility for handling ZSTs from `RawVec` to `AllocRef`. On the same occasion I have moved the logic for reserving and shrinking into the new methods `grow` and `shrink` to keep the logic in one place without changing the behavior.

Every grow/shrink operation now has three steps:
1. Calculate the new size, either by doubling the current capacity, calculate the amortized size, or use an exact size
2. Call `AllocRef`
3. Update `self.ptr` and `self.cap`

There are no more checks in `RawVec` needed for taking a different path for ZSTs.

---

This is the last item on the roadmap to support ZSTs in `AllocRef`: https://github.com/rust-lang/wg-allocators/issues/38#issuecomment-595861542 

Requires #69799 to land first, otherwise `Global` will be called with zero-sized layouts.

closes rust-lang/wg-allocators#38

r? @Amanieu