### PR TITLE
make `mem::discriminant` const

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1852,6 +1852,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is
     /// [`std::mem::discriminant`](../../std/mem/fn.discriminant.html)
+    #[rustc_const_unstable(feature = "const_discriminant", issue = "69821")]
     pub fn discriminant_value<T>(v: &T) -> u64;
 
     /// Rust's "try catch" construct which invokes the function pointer `f` with

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -72,6 +72,7 @@
 #![feature(concat_idents)]
 #![feature(const_ascii_ctype_on_intrinsics)]
 #![feature(const_alloc_layout)]
+#![feature(const_discriminant)]
 #![feature(const_if_match)]
 #![feature(const_loop)]
 #![feature(const_checked_int_methods)]

--- a/src/libcore/mem/mod.rs
+++ b/src/libcore/mem/mod.rs
@@ -864,6 +864,7 @@ impl<T> fmt::Debug for Discriminant<T> {
 /// assert_ne!(mem::discriminant(&Foo::B(3)), mem::discriminant(&Foo::C(3)));
 /// ```
 #[stable(feature = "discriminant_value", since = "1.21.0")]
-pub fn discriminant<T>(v: &T) -> Discriminant<T> {
+#[rustc_const_unstable(feature = "const_discriminant", issue = "69821")]
+pub const fn discriminant<T>(v: &T) -> Discriminant<T> {
     Discriminant(intrinsics::discriminant_value(v), PhantomData)
 }

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -216,6 +216,11 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 };
                 self.write_scalar(val, dest)?;
             }
+            sym::discriminant_value => {
+                let place = self.deref_operand(args[0])?;
+                let discr_val = self.read_discriminant(place.into())?.0;
+                self.write_scalar(Scalar::from_uint(discr_val, dest.layout.size), dest)?;
+            }
             sym::unchecked_shl
             | sym::unchecked_shr
             | sym::unchecked_add

--- a/src/librustc_span/symbol.rs
+++ b/src/librustc_span/symbol.rs
@@ -265,6 +265,7 @@ symbols! {
         derive,
         diagnostic,
         direct,
+        discriminant_value,
         doc,
         doc_alias,
         doc_cfg,

--- a/src/test/ui/consts/const_discriminant.rs
+++ b/src/test/ui/consts/const_discriminant.rs
@@ -1,5 +1,6 @@
 // run-pass
 #![feature(const_discriminant)]
+#![allow(dead_code)]
 
 use std::mem::{discriminant, Discriminant};
 

--- a/src/test/ui/consts/const_discriminant.rs
+++ b/src/test/ui/consts/const_discriminant.rs
@@ -3,6 +3,8 @@
 
 use std::mem::{discriminant, Discriminant};
 
+fn identity<T>(x: T) -> T { x }
+
 enum Test {
     A(u8),
     B,
@@ -15,8 +17,8 @@ const TEST_B: Discriminant<Test> = discriminant(&Test::B);
 
 fn main() {
     assert_eq!(TEST_A, TEST_A_OTHER);
-    assert_eq!(TEST_A, discriminant(&Test::A(17)));
-    assert_eq!(TEST_B, discriminant(&Test::B));
+    assert_eq!(TEST_A, discriminant(identity(&Test::A(17))));
+    assert_eq!(TEST_B, discriminant(identity(&Test::B)));
     assert_ne!(TEST_A, TEST_B);
-    assert_ne!(TEST_B, discriminant(&Test::C { a: 42, b: 7 }));
+    assert_ne!(TEST_B, discriminant(identity(&Test::C { a: 42, b: 7 })));
 }

--- a/src/test/ui/consts/const_discriminant.rs
+++ b/src/test/ui/consts/const_discriminant.rs
@@ -4,6 +4,9 @@
 
 use std::mem::{discriminant, Discriminant};
 
+// `discriminant(const_expr)` may get const-propagated.
+// As we want to check that const-eval is equal to ordinary exection,
+// we wrap `const_expr` with a function which is not const to prevent this.
 #[inline(never)]
 fn identity<T>(x: T) -> T { x }
 

--- a/src/test/ui/consts/const_discriminant.rs
+++ b/src/test/ui/consts/const_discriminant.rs
@@ -4,6 +4,7 @@
 
 use std::mem::{discriminant, Discriminant};
 
+#[inline(never)]
 fn identity<T>(x: T) -> T { x }
 
 enum Test {

--- a/src/test/ui/consts/const_discriminant.rs
+++ b/src/test/ui/consts/const_discriminant.rs
@@ -1,0 +1,22 @@
+// run-pass
+#![feature(const_discriminant)]
+
+use std::mem::{discriminant, Discriminant};
+
+enum Test {
+    A(u8),
+    B,
+    C { a: u8, b: u8 },
+}
+
+const TEST_A: Discriminant<Test> = discriminant(&Test::A(5));
+const TEST_A_OTHER: Discriminant<Test> = discriminant(&Test::A(17));
+const TEST_B: Discriminant<Test> = discriminant(&Test::B);
+
+fn main() {
+    assert_eq!(TEST_A, TEST_A_OTHER);
+    assert_eq!(TEST_A, discriminant(&Test::A(17)));
+    assert_eq!(TEST_B, discriminant(&Test::B));
+    assert_ne!(TEST_A, TEST_B);
+    assert_ne!(TEST_B, discriminant(&Test::C { a: 42, b: 7 }));
+}

--- a/src/test/ui/consts/const_discriminant.rs
+++ b/src/test/ui/consts/const_discriminant.rs
@@ -15,10 +15,21 @@ const TEST_A: Discriminant<Test> = discriminant(&Test::A(5));
 const TEST_A_OTHER: Discriminant<Test> = discriminant(&Test::A(17));
 const TEST_B: Discriminant<Test> = discriminant(&Test::B);
 
+enum Void {}
+
+enum SingleVariant {
+    V,
+    Never(Void),
+}
+
+const TEST_V: Discriminant<SingleVariant> = discriminant(&SingleVariant::V);
+
 fn main() {
     assert_eq!(TEST_A, TEST_A_OTHER);
     assert_eq!(TEST_A, discriminant(identity(&Test::A(17))));
     assert_eq!(TEST_B, discriminant(identity(&Test::B)));
     assert_ne!(TEST_A, TEST_B);
     assert_ne!(TEST_B, discriminant(identity(&Test::C { a: 42, b: 7 })));
+
+    assert_eq!(TEST_V, discriminant(identity(&SingleVariant::V)));
 }


### PR DESCRIPTION
implements #69821, which could be used as a tracking issue for `const_discriminant`.

Should this be added to the meta tracking issue #57563?
@Lokathor