### PR TITLE
miri: ICE on invalid terminators

### DIFF
--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -103,6 +103,10 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 self.write_scalar(location.ptr, dest)?;
             }
 
+            sym::abort => {
+                M::abort(self)?;
+            }
+
             sym::min_align_of
             | sym::pref_align_of
             | sym::needs_drop

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -171,7 +171,7 @@ pub trait Machine<'mir, 'tcx>: Sized {
     ) -> InterpResult<'tcx>;
 
     /// Called to evaluate `Abort` MIR terminator.
-    fn abort(_ecx: &mut InterpCx<'mir, 'tcx, Self>) -> InterpResult<'tcx> {
+    fn abort(_ecx: &mut InterpCx<'mir, 'tcx, Self>) -> InterpResult<'tcx, !> {
         throw_unsup_format!("aborting execution is not supported");
     }
 

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -170,6 +170,11 @@ pub trait Machine<'mir, 'tcx>: Sized {
         unwind: Option<mir::BasicBlock>,
     ) -> InterpResult<'tcx>;
 
+    /// Called to evaluate `Abort` MIR terminator.
+    fn abort(_ecx: &mut InterpCx<'mir, 'tcx, Self>) -> InterpResult<'tcx> {
+        throw_unsup_format!("aborting execution is not supported");
+    }
+
     /// Called for all binary operations where the LHS has pointer type.
     ///
     /// Returns a (value, overflowed) pair if the operation succeeded

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -99,6 +99,10 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 }
             }
 
+            Abort => {
+                M::abort(self)?;
+            }
+
             // When we encounter Resume, we've finished unwinding
             // cleanup for the current stack frame. We pop it in order
             // to continue unwinding the next frame
@@ -118,8 +122,9 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             | FalseEdges { .. }
             | FalseUnwind { .. }
             | Yield { .. }
-            | GeneratorDrop
-            | Abort => bug!("{:#?} should have been eliminated by MIR pass", terminator.kind),
+            | GeneratorDrop => {
+                bug!("{:#?} should have been eliminated by MIR pass", terminator.kind)
+            }
         }
 
         Ok(())

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -114,15 +114,12 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             Unreachable => throw_ub!(Unreachable),
 
             // These should never occur for MIR we actually run.
-            DropAndReplace { .. } | FalseEdges { .. } | FalseUnwind { .. } => {
-                bug!("{:#?} should have been eliminated by MIR pass", terminator.kind)
-            }
-
-            // These are not (yet) supported. It is unclear if they even can occur in
-            // MIR that we actually run.
-            Yield { .. } | GeneratorDrop | Abort => {
-                throw_unsup_format!("Unsupported terminator kind: {:#?}", terminator.kind)
-            }
+            DropAndReplace { .. }
+            | FalseEdges { .. }
+            | FalseUnwind { .. }
+            | Yield { .. }
+            | GeneratorDrop
+            | Abort => bug!("{:#?} should have been eliminated by MIR pass", terminator.kind),
         }
 
         Ok(())

--- a/src/librustc_span/symbol.rs
+++ b/src/librustc_span/symbol.rs
@@ -120,6 +120,7 @@ symbols! {
         abi_unadjusted,
         abi_vectorcall,
         abi_x86_interrupt,
+        abort,
         aborts,
         address,
         add_with_overflow,


### PR DESCRIPTION
We've run a lot of MIR in Miri (including some generators) and never seen these.

@tmandry is it correct that `Yield` and `GeneratorDrop` get lowered away?

@eddyb @oli-obk what's with this `Abort` that does not seem to ever actually exist? Codegen *does* seem to handle it, so I wonder why Miri can get away without that. In fact, codegen handles it twice:

https://github.com/rust-lang/rust/blob/1d5241c96208ca7d925442b1a5fa45ad18717a6f/src/librustc_codegen_ssa/mir/block.rs#L796

https://github.com/rust-lang/rust/blob/1d5241c96208ca7d925442b1a5fa45ad18717a6f/src/librustc_codegen_ssa/mir/mod.rs#L296