### PR TITLE
ci: workaround for repo.msys2.org being offline

### DIFF
--- a/src/ci/azure-pipelines/steps/run.yml
+++ b/src/ci/azure-pipelines/steps/run.yml
@@ -67,16 +67,20 @@ steps:
   displayName: "Disable git automatic line ending conversion (on C:/)"
   condition: and(succeeded(), not(variables.SKIP_JOB))
 
-- bash: src/ci/scripts/install-msys2.sh
-  displayName: Install msys2
-  condition: and(succeeded(), not(variables.SKIP_JOB))
-
-- bash: src/ci/scripts/install-msys2-packages.sh
-  displayName: Install msys2 packages
-  condition: and(succeeded(), not(variables.SKIP_JOB))
-
-- bash: src/ci/scripts/install-mingw.sh
-  displayName: Install MinGW
+# FIXME(69831): workaround for repo.msys2.org being offline
+#- bash: src/ci/scripts/install-msys2.sh
+#  displayName: Install msys2
+#  condition: and(succeeded(), not(variables.SKIP_JOB))
+#
+#- bash: src/ci/scripts/install-msys2-packages.sh
+#  displayName: Install msys2 packages
+#  condition: and(succeeded(), not(variables.SKIP_JOB))
+#
+#- bash: src/ci/scripts/install-mingw.sh
+#  displayName: Install MinGW
+#  condition: and(succeeded(), not(variables.SKIP_JOB))
+- bash: src/ci/scripts/install-msys2-workaround.sh
+  displayName: Install msys2 and MinGW (temporary workaround)
   condition: and(succeeded(), not(variables.SKIP_JOB))
 
 - bash: src/ci/scripts/install-ninja.sh

--- a/src/ci/azure-pipelines/try.yml
+++ b/src/ci/azure-pipelines/try.yml
@@ -6,17 +6,131 @@ variables:
 - group: prod-credentials
 
 jobs:
-- job: Linux
+- job: Windows
   timeoutInMinutes: 600
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: 'vs2017-win2016'
   steps:
   - template: steps/run.yml
   strategy:
     matrix:
-      dist-x86_64-linux: {}
-      dist-x86_64-linux-alt:
-        IMAGE: dist-x86_64-linux
+      # 32/64 bit MSVC tests
+      x86_64-msvc-1:
+        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-profiler
+        SCRIPT: make ci-subset-1
+        # FIXME(#59637)
+        NO_DEBUG_ASSERTIONS: 1
+        NO_LLVM_ASSERTIONS: 1
+      x86_64-msvc-2:
+        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-profiler
+        SCRIPT: make ci-subset-2
+      i686-msvc-1:
+        RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc
+        SCRIPT: make ci-subset-1
+        # FIXME(#59637)
+        NO_DEBUG_ASSERTIONS: 1
+        NO_LLVM_ASSERTIONS: 1
+      i686-msvc-2:
+        RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc
+        SCRIPT: make ci-subset-2
+        # FIXME(#59637)
+        NO_DEBUG_ASSERTIONS: 1
+        NO_LLVM_ASSERTIONS: 1
+      # MSVC aux tests
+      x86_64-msvc-aux:
+        RUST_CHECK_TARGET: check-aux EXCLUDE_CARGO=1
+        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc
+      x86_64-msvc-cargo:
+        SCRIPT: python x.py test src/tools/cargotest src/tools/cargo
+        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc
+        VCVARS_BAT: vcvars64.bat
+        # FIXME(#59637)
+        NO_DEBUG_ASSERTIONS: 1
+        NO_LLVM_ASSERTIONS: 1
+      # MSVC tools tests
+      x86_64-msvc-tools:
+        SCRIPT: src/ci/docker/x86_64-gnu-tools/checktools.sh x.py
+        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --save-toolstates=/tmp/toolstate/toolstates.json
+
+      # 32/64-bit MinGW builds.
+      #
+      # We are using MinGW with posix threads since LLVM does not compile with
+      # the win32 threads version due to missing support for C++'s std::thread.
+      #
+      # Instead of relying on the MinGW version installed on appveryor we download
+      # and install one ourselves so we won't be surprised by changes to appveyor's
+      # build image.
+      #
+      # Finally, note that the downloads below are all in the `rust-lang-ci` S3
+      # bucket, but they cleraly didn't originate there! The downloads originally
+      # came from the mingw-w64 SourceForge download site. Unfortunately
+      # SourceForge is notoriously flaky, so we mirror it on our own infrastructure.
+      i686-mingw-1:
+        RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
+        SCRIPT: make ci-mingw-subset-1
+        CUSTOM_MINGW: 1
+        # FIXME(#59637)
+        NO_DEBUG_ASSERTIONS: 1
+        NO_LLVM_ASSERTIONS: 1
+      i686-mingw-2:
+        RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
+        SCRIPT: make ci-mingw-subset-2
+        CUSTOM_MINGW: 1
+      x86_64-mingw-1:
+        SCRIPT: make ci-mingw-subset-1
+        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu
+        CUSTOM_MINGW: 1
+        # FIXME(#59637)
+        NO_DEBUG_ASSERTIONS: 1
+        NO_LLVM_ASSERTIONS: 1
+      x86_64-mingw-2:
+        SCRIPT: make ci-mingw-subset-2
+        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu
+        CUSTOM_MINGW: 1
+
+      # 32/64 bit MSVC and GNU deployment
+      dist-x86_64-msvc:
+        RUST_CONFIGURE_ARGS: >-
+          --build=x86_64-pc-windows-msvc
+          --target=x86_64-pc-windows-msvc,aarch64-pc-windows-msvc
+          --enable-full-tools
+          --enable-profiler
+        SCRIPT: python x.py dist
+        DIST_REQUIRE_ALL_TOOLS: 1
+      dist-i686-msvc:
+        RUST_CONFIGURE_ARGS: >-
+          --build=i686-pc-windows-msvc
+          --target=i586-pc-windows-msvc
+          --enable-full-tools
+          --enable-profiler
+        SCRIPT: python x.py dist
+        DIST_REQUIRE_ALL_TOOLS: 1
+      dist-i686-mingw:
+        RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu --enable-full-tools --enable-profiler
+        SCRIPT: python x.py dist
+        CUSTOM_MINGW: 1
+        DIST_REQUIRE_ALL_TOOLS: 1
+      dist-x86_64-mingw:
+        SCRIPT: python x.py dist
+        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu --enable-full-tools --enable-profiler
+        CUSTOM_MINGW: 1
+        DIST_REQUIRE_ALL_TOOLS: 1
+
+      # "alternate" deployment, see .travis.yml for more info
+      dist-x86_64-msvc-alt:
+        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-extended --enable-profiler
+        SCRIPT: python x.py dist
+#- job: Linux
+#  timeoutInMinutes: 600
+#  pool:
+#    vmImage: ubuntu-16.04
+#  steps:
+#  - template: steps/run.yml
+#  strategy:
+#    matrix:
+#      dist-x86_64-linux: {}
+#      dist-x86_64-linux-alt:
+#        IMAGE: dist-x86_64-linux
 
 # The macOS and Windows builds here are currently disabled due to them not being
 # overly necessary on `try` builds. We also don't actually have anything that

--- a/src/ci/scripts/install-msys2-workaround.sh
+++ b/src/ci/scripts/install-msys2-workaround.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Downloads and "installs" msys2 and MinGW by downloading and extracting a
+# pre-installed copy from our mirrors. This is a workaround for repo.msys2.org
+# being offline, and it should be reverted as soon as it gets live again.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
+
+WORKAROUND_TARBALL_DATE="2020-03-08"
+MINGW_ARCHIVE_32="i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z"
+MINGW_ARCHIVE_64="x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z"
+
+if isWindows; then
+    case "${CI_JOB_NAME}" in
+        *i686*)
+            bits=32
+            arch=i686
+            mingw_archive="${MINGW_ARCHIVE_32}"
+            ;;
+        *x86_64*)
+            bits=64
+            arch=x86_64
+            mingw_archive="${MINGW_ARCHIVE_64}"
+            ;;
+        *)
+            echo "src/ci/scripts/install-mingw.sh can't detect the builder's architecture"
+            echo "please tweak it to recognize the builder named '${CI_JOB_NAME}'"
+            exit 1
+            ;;
+    esac
+
+    if [[ "${CUSTOM_MINGW-0}" -ne 1 ]]; then
+        curl -o msys2.7z "${MIRRORS_BASE}/${WORKAROUND_TARBALL_DATE}-msys2-msvc-${arch}.7z"
+        7z x -y msys2.7z > /dev/null
+
+        ciCommandAddPath "$(ciCheckoutPath)/msys2/mingw${bits}/bin"
+    else
+        mingw_dir="mingw${bits}"
+
+        curl -o mingw-base.7z "${MIRRORS_BASE}/${WORKAROUND_TARBALL_DATE}-msys2-mingw-base.7z"
+        7z x -y mingw-base.7z > /dev/null
+        curl -o mingw.7z "${MIRRORS_BASE}/${mingw_archive}"
+        7z x -y mingw.7z > /dev/null
+        curl -o "${mingw_dir}/bin/gdborig.exe" "${MIRRORS_BASE}/2017-04-20-${bits}bit-gdborig.exe"
+        ciCommandAddPath "$(pwd)/${mingw_dir}/bin"
+    fi
+
+    mkdir -p "$(ciCheckoutPath)/msys2/home/${USERNAME}"
+    ciCommandAddPath "$(ciCheckoutPath)/msys2/usr/bin"
+
+    # Make sure we use the native python interpreter instead of some msys equivalent
+    # one way or another. The msys interpreters seem to have weird path conversions
+    # baked in which break LLVM's build system one way or another, so let's use the
+    # native version which keeps everything as native as possible.
+    cp C:/Python27amd64/python.exe C:/Python27amd64/python2.7.exe
+    ciCommandAddPath "C:\\Python27amd64"
+fi


### PR DESCRIPTION
This PR switches CI to download a pre-installed, vendored copy of msys2 and MinGW, instead of installing it on the fly. This is intended to be a workaround for repo.msys2.org being offline (see https://github.com/msys2/MSYS2-packages/issues/1884), and it should be reverted as soon as it gets back online.