### PR TITLE
Add `set_status` for `std::process::Child`

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1525,7 +1525,7 @@ impl Child {
     ///
     /// [`wait`]: #method.wait
     /// [`wait_with_output`]: #method.wait_with_output
-    #[stable(feature = "child_set_status", since = "1.43.0")]
+    #[stable(feature = "child_set_status", since = "1.44.0")]
     pub unsafe fn set_status(&mut self, status: ExitStatus) {
         self.handle.set_status(status.0);
     }

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1496,12 +1496,6 @@ impl Child {
     /// equivalent function on another platform. It will cause future calls to
     /// [`wait`] and [`wait_with_output`] to use this exit status.
     ///
-    /// # Safety
-    ///
-    /// This function is unsafe because it does not check that the process
-    /// exited. If this function is given wrong information, it will continue
-    /// to use that wrong information in potentially unexpected ways.
-    ///
     /// # Examples
     ///
     /// ```
@@ -1518,7 +1512,7 @@ impl Child {
     /// #     child.wait().unwrap()
     /// # }
     /// let status = external_wait(&mut child);
-    /// unsafe { child.set_status(status) }
+    /// child.set_status(status);
     ///
     /// assert_eq!(status, child.wait().expect("failed to wait on child"));
     /// ```
@@ -1526,7 +1520,7 @@ impl Child {
     /// [`wait`]: #method.wait
     /// [`wait_with_output`]: #method.wait_with_output
     #[stable(feature = "child_set_status", since = "1.44.0")]
-    pub unsafe fn set_status(&mut self, status: ExitStatus) {
+    pub fn set_status(&mut self, status: ExitStatus) {
         self.handle.set_status(status.0);
     }
 }

--- a/src/libstd/sys/cloudabi/shims/process.rs
+++ b/src/libstd/sys/cloudabi/shims/process.rs
@@ -146,4 +146,6 @@ impl Process {
     pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
         match self.0 {}
     }
+
+    pub fn set_status(&mut self, _: ExitStatus) {}
 }

--- a/src/libstd/sys/hermit/process.rs
+++ b/src/libstd/sys/hermit/process.rs
@@ -146,4 +146,6 @@ impl Process {
     pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
         match self.0 {}
     }
+
+    pub fn set_status(&mut self, _: ExitStatus) {}
 }

--- a/src/libstd/sys/sgx/process.rs
+++ b/src/libstd/sys/sgx/process.rs
@@ -146,4 +146,6 @@ impl Process {
     pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
         match self.0 {}
     }
+
+    pub fn set_status(&mut self, _: ExitStatus) {}
 }

--- a/src/libstd/sys/unix/process/process_fuchsia.rs
+++ b/src/libstd/sys/unix/process/process_fuchsia.rs
@@ -32,7 +32,7 @@ impl Command {
 
         let process_handle = unsafe { self.do_exec(theirs, envp.as_ref())? };
 
-        Ok((Process { handle: Handle::new(process_handle) }, ours))
+        Ok((Process { handle: Handle::new(process_handle), status: None }, ours))
     }
 
     pub fn exec(&mut self, default: Stdio) -> io::Error {

--- a/src/libstd/sys/unix/process/process_unix.rs
+++ b/src/libstd/sys/unix/process/process_unix.rs
@@ -436,8 +436,8 @@ impl Process {
         }
         let mut status = 0 as c_int;
         cvt_r(|| unsafe { libc::waitpid(self.pid, &mut status, 0) })?;
-        self.status = Some(ExitStatus::new(status));
-        Ok(ExitStatus::new(status))
+        self.set_status(ExitStatus(status));
+        Ok(ExitStatus(status))
     }
 
     pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
@@ -446,12 +446,14 @@ impl Process {
         }
         let mut status = 0 as c_int;
         let pid = cvt(unsafe { libc::waitpid(self.pid, &mut status, libc::WNOHANG) })?;
-        if pid == 0 {
-            Ok(None)
-        } else {
-            self.status = Some(ExitStatus::new(status));
-            Ok(Some(ExitStatus::new(status)))
+        if pid != 0 {
+            self.set_status(ExitStatus(status));
         }
+        Ok(self.status)
+    }
+
+    pub fn set_status(&mut self, status: ExitStatus) {
+        self.status = Some(status);
     }
 }
 
@@ -460,10 +462,6 @@ impl Process {
 pub struct ExitStatus(c_int);
 
 impl ExitStatus {
-    pub fn new(status: c_int) -> ExitStatus {
-        ExitStatus(status)
-    }
-
     fn exited(&self) -> bool {
         unsafe { libc::WIFEXITED(self.0) }
     }

--- a/src/libstd/sys/vxworks/process/process_common.rs
+++ b/src/libstd/sys/vxworks/process/process_common.rs
@@ -344,10 +344,6 @@ impl fmt::Debug for Command {
 pub struct ExitStatus(c_int);
 
 impl ExitStatus {
-    pub fn new(status: c_int) -> ExitStatus {
-        ExitStatus(status)
-    }
-
     fn exited(&self) -> bool {
         /*unsafe*/
         { libc::WIFEXITED(self.0) }

--- a/src/libstd/sys/vxworks/process/process_vxworks.rs
+++ b/src/libstd/sys/vxworks/process/process_vxworks.rs
@@ -149,8 +149,8 @@ impl Process {
         }
         let mut status = 0 as c_int;
         cvt_r(|| unsafe { libc::waitpid(self.pid, &mut status, 0) })?;
-        self.status = Some(ExitStatus::new(status));
-        Ok(ExitStatus::new(status))
+        self.set_status(ExitStatus(status));
+        Ok(ExitStatus(status))
     }
 
     pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
@@ -159,11 +159,13 @@ impl Process {
         }
         let mut status = 0 as c_int;
         let pid = cvt(unsafe { libc::waitpid(self.pid, &mut status, libc::WNOHANG) })?;
-        if pid == 0 {
-            Ok(None)
-        } else {
-            self.status = Some(ExitStatus::new(status));
-            Ok(Some(ExitStatus::new(status)))
+        if pid != 0 {
+            self.set_status(ExitStatus(status));
         }
+        Ok(self.status)
+    }
+
+    pub fn set_status(&mut self, status: ExitStatus) {
+        self.status = Some(status);
     }
 }

--- a/src/libstd/sys/wasi/process.rs
+++ b/src/libstd/sys/wasi/process.rs
@@ -146,4 +146,6 @@ impl Process {
     pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
         match self.0 {}
     }
+
+    pub fn set_status(&mut self, _: ExitStatus) {}
 }

--- a/src/libstd/sys/wasm/process.rs
+++ b/src/libstd/sys/wasm/process.rs
@@ -146,4 +146,6 @@ impl Process {
     pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
         match self.0 {}
     }
+
+    pub fn set_status(&mut self, _: ExitStatus) {}
 }

--- a/src/libstd/sys/windows/process.rs
+++ b/src/libstd/sys/windows/process.rs
@@ -220,7 +220,7 @@ impl Command {
         // around to be able to close it later.
         drop(Handle::new(pi.hThread));
 
-        Ok((Process { handle: Handle::new(pi.hProcess) }, pipes))
+        Ok((Process { handle: Handle::new(pi.hProcess), status: None }, pipes))
     }
 }
 


### PR DESCRIPTION
Closes #39188

Are tests other than the doctest needed? Any good test would need to be very platform-specific.

I also removed `ExitStatus::new`, since it was only used for some platforms and could be replaced with constructing the struct directly.