### PR TITLE
[stable] Release 1.42.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -71,7 +71,15 @@ Compatibility Notes
 -------------------
 - [`Error::description` has been deprecated, and its use will now produce a
   warning.][66919] It's recommended to use `Display`/`to_string` instead.
+- [`use $crate;` inside macros is now a hard error.][37390] The compiler
+  emitted forward compatibility warnings since Rust 1.14.0.
+- [As previously announced, this release reduces the level of support for
+  32-bit Apple targets to tier 3.][apple-32bit-drop]. This means that the
+  source code is still available to build, but the targets are no longer tested
+  and no release binary is distributed by the Rust project. Please refer to the
+  linked blog post for more information.
 
+[37390]: https://github.com/rust-lang/rust/issues/37390/
 [68253]: https://github.com/rust-lang/rust/pull/68253/
 [68348]: https://github.com/rust-lang/rust/pull/68348/
 [67935]: https://github.com/rust-lang/rust/pull/67935/

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -43,7 +43,7 @@ fi
 #
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
-export RUST_RELEASE_CHANNEL=beta
+export RUST_RELEASE_CHANNEL=stable
 
 # Always set the release channel for bootstrap; this is normally not important (i.e., only dist
 # builds would seem to matter) but in practice bootstrap wants to know whether we're targeting

--- a/src/librustc_expand/expand.rs
+++ b/src/librustc_expand/expand.rs
@@ -435,14 +435,13 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                         _ => unreachable!(),
                     };
                     if !item.derive_allowed() {
-                        let attr = attr::find_by_name(item.attrs(), sym::derive)
-                            .expect("`derive` attribute should exist");
-                        let span = attr.span;
+                        let attr = attr::find_by_name(item.attrs(), sym::derive);
+                        let span = attr.map_or(item.span(), |attr| attr.span);
                         let mut err = self.cx.struct_span_err(
                             span,
                             "`derive` may only be applied to structs, enums and unions",
                         );
-                        if let ast::AttrStyle::Inner = attr.style {
+                        if let Some(ast::Attribute { style: ast::AttrStyle::Inner, .. }) = attr {
                             let trait_list = derives
                                 .iter()
                                 .map(|t| pprust::path_to_string(t))

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -410,6 +410,12 @@ where
                 stride * field
             }
             layout::FieldPlacement::Union(count) => {
+                // This is a narrow bug-fix for rust-lang/rust#69191: if we are
+                // trying to access absent field of uninhabited variant, then
+                // signal UB (but don't ICE the compiler).
+                if field >= count as u64 && base.layout.abi == layout::Abi::Uninhabited {
+                    throw_ub!(Unreachable);
+                }
                 assert!(
                     field < count as u64,
                     "Tried to access field {} of union {:#?} with {} fields",

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -413,6 +413,8 @@ where
                 // This is a narrow bug-fix for rust-lang/rust#69191: if we are
                 // trying to access absent field of uninhabited variant, then
                 // signal UB (but don't ICE the compiler).
+                // FIXME temporary hack to work around incoherence between
+                // layout computation and MIR building
                 if field >= count as u64 && base.layout.abi == layout::Abi::Uninhabited {
                     throw_ub!(Unreachable);
                 }

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1895,21 +1895,23 @@ function getSearchElement() {
         var implementors = document.getElementById("implementors-list");
         var synthetic_implementors = document.getElementById("synthetic-implementors-list");
 
-        // This `inlined_types` variable is used to avoid having the same implementation showing
-        // up twice. For example "String" in the "Sync" doc page.
-        //
-        // By the way, this is only used by and useful for traits implemented automatically (like
-        // "Send" and "Sync").
-        var inlined_types = new Set();
-        onEachLazy(synthetic_implementors.getElementsByClassName("impl"), function(el) {
-            var aliases = el.getAttribute("aliases");
-            if (!aliases) {
-                return;
-            }
-            aliases.split(",").forEach(function(alias) {
-                inlined_types.add(alias);
+        if (synthetic_implementors) {
+            // This `inlined_types` variable is used to avoid having the same implementation
+            // showing up twice. For example "String" in the "Sync" doc page.
+            //
+            // By the way, this is only used by and useful for traits implemented automatically
+            // (like "Send" and "Sync").
+            var inlined_types = new Set();
+            onEachLazy(synthetic_implementors.getElementsByClassName("impl"), function(el) {
+                var aliases = el.getAttribute("aliases");
+                if (!aliases) {
+                    return;
+                }
+                aliases.split(",").forEach(function(alias) {
+                    inlined_types.add(alias);
+                });
             });
-        });
+        }
 
         var libs = Object.getOwnPropertyNames(imp);
         var llength = libs.length;

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -135,7 +135,7 @@ pub trait Error: Debug + Display {
     /// }
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_deprecated(since = "1.41.0", reason = "use the Display impl or to_string()")]
+    #[rustc_deprecated(since = "1.42.0", reason = "use the Display impl or to_string()")]
     fn description(&self) -> &str {
         "description() is deprecated; use Display"
     }

--- a/src/test/ui/consts/issue-69191-ice-on-uninhabited-enum-field.rs
+++ b/src/test/ui/consts/issue-69191-ice-on-uninhabited-enum-field.rs
@@ -5,18 +5,78 @@
 
 pub enum Void {}
 
-enum UninhabitedUnivariant { _Variant(Void), }
+enum UninhabitedUnivariant {
+    _Variant(Void),
+}
+
+enum UninhabitedMultivariant2 {
+    _Variant(Void),
+    _Warriont(Void),
+}
+
+enum UninhabitedMultivariant3 {
+    _Variant(Void),
+    _Warriont(Void),
+    _Worrynot(Void),
+}
 
 #[repr(C)]
-enum UninhabitedUnivariantC { _Variant(Void), }
+enum UninhabitedUnivariantC {
+    _Variant(Void),
+}
 
 #[repr(i32)]
-enum UninhabitedUnivariant32 { _Variant(Void), }
+enum UninhabitedUnivariant32 {
+    _Variant(Void),
+}
 
 fn main() {
     let _seed: UninhabitedUnivariant = None.unwrap();
     match _seed {
         UninhabitedUnivariant::_Variant(_x) => {}
+    }
+
+    let _seed: UninhabitedMultivariant2 = None.unwrap();
+    match _seed {
+        UninhabitedMultivariant2::_Variant(_x) => {}
+        UninhabitedMultivariant2::_Warriont(_x) => {}
+    }
+
+    let _seed: UninhabitedMultivariant2 = None.unwrap();
+    match _seed {
+        UninhabitedMultivariant2::_Variant(_x) => {}
+        _ => {}
+    }
+
+    let _seed: UninhabitedMultivariant2 = None.unwrap();
+    match _seed {
+        UninhabitedMultivariant2::_Warriont(_x) => {}
+        _ => {}
+    }
+
+    let _seed: UninhabitedMultivariant3 = None.unwrap();
+    match _seed {
+        UninhabitedMultivariant3::_Variant(_x) => {}
+        UninhabitedMultivariant3::_Warriont(_x) => {}
+        UninhabitedMultivariant3::_Worrynot(_x) => {}
+    }
+
+    let _seed: UninhabitedMultivariant3 = None.unwrap();
+    match _seed {
+        UninhabitedMultivariant3::_Variant(_x) => {}
+        _ => {}
+    }
+
+    let _seed: UninhabitedMultivariant3 = None.unwrap();
+    match _seed {
+        UninhabitedMultivariant3::_Warriont(_x) => {}
+        _ => {}
+    }
+
+    let _seed: UninhabitedMultivariant3 = None.unwrap();
+    match _seed {
+        UninhabitedMultivariant3::_Worrynot(_x) => {}
+        _ => {}
     }
 
     let _seed: UninhabitedUnivariantC = None.unwrap();

--- a/src/test/ui/consts/issue-69191-ice-on-uninhabited-enum-field.rs
+++ b/src/test/ui/consts/issue-69191-ice-on-uninhabited-enum-field.rs
@@ -1,0 +1,31 @@
+// build-pass
+//
+// (this is deliberately *not* check-pass; I have confirmed that the bug in
+// question does not replicate when one uses `cargo check` alone.)
+
+pub enum Void {}
+
+enum UninhabitedUnivariant { _Variant(Void), }
+
+#[repr(C)]
+enum UninhabitedUnivariantC { _Variant(Void), }
+
+#[repr(i32)]
+enum UninhabitedUnivariant32 { _Variant(Void), }
+
+fn main() {
+    let _seed: UninhabitedUnivariant = None.unwrap();
+    match _seed {
+        UninhabitedUnivariant::_Variant(_x) => {}
+    }
+
+    let _seed: UninhabitedUnivariantC = None.unwrap();
+    match _seed {
+        UninhabitedUnivariantC::_Variant(_x) => {}
+    }
+
+    let _seed: UninhabitedUnivariant32 = None.unwrap();
+    match _seed {
+        UninhabitedUnivariant32::_Variant(_x) => {}
+    }
+}

--- a/src/test/ui/malformed/issue-69341-malformed-derive-inert.rs
+++ b/src/test/ui/malformed/issue-69341-malformed-derive-inert.rs
@@ -1,0 +1,10 @@
+fn main() {}
+
+struct CLI {
+    #[derive(parse())]
+    //~^ ERROR traits in `#[derive(...)]` don't accept arguments
+    //~| ERROR cannot find derive macro `parse` in this scope
+    //~| ERROR cannot find derive macro `parse` in this scope
+    path: (),
+    //~^ ERROR `derive` may only be applied to structs, enums and unions
+}

--- a/src/test/ui/malformed/issue-69341-malformed-derive-inert.stderr
+++ b/src/test/ui/malformed/issue-69341-malformed-derive-inert.stderr
@@ -1,0 +1,26 @@
+error: traits in `#[derive(...)]` don't accept arguments
+  --> $DIR/issue-69341-malformed-derive-inert.rs:4:19
+   |
+LL |     #[derive(parse())]
+   |                   ^^ help: remove the arguments
+
+error: `derive` may only be applied to structs, enums and unions
+  --> $DIR/issue-69341-malformed-derive-inert.rs:8:5
+   |
+LL |     path: (),
+   |     ^^^^^^^^
+
+error: cannot find derive macro `parse` in this scope
+  --> $DIR/issue-69341-malformed-derive-inert.rs:4:14
+   |
+LL |     #[derive(parse())]
+   |              ^^^^^
+
+error: cannot find derive macro `parse` in this scope
+  --> $DIR/issue-69341-malformed-derive-inert.rs:4:14
+   |
+LL |     #[derive(parse())]
+   |              ^^^^^
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
This PR prepares the release artifacts of Rust 1.42.0, and cherry-picks the following PRs:

* https://github.com/rust-lang/rust/pull/69754: Update deprecation version to 1.42 for Error::description
* https://github.com/rust-lang/rust/pull/69753: Do not ICE when matching an uninhabited enum's field
* https://github.com/rust-lang/rust/pull/69522 / https://github.com/rust-lang/rust/pull/69853: error_derive_forbidden_on_non_adt: be more graceful
* https://github.com/rust-lang/rust/pull/68598:  Fix null synthetic_implementors error

In addition, the release notes are updated to include the remaining compatibility notes.

r? @Centril 