### PR TITLE
Vec::new is const stable in 1.39 not 1.32

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -317,7 +317,7 @@ impl<T> Vec<T> {
     /// let mut vec: Vec<i32> = Vec::new();
     /// ```
     #[inline]
-    #[rustc_const_stable(feature = "const_vec_new", since = "1.32.0")]
+    #[rustc_const_stable(feature = "const_vec_new", since = "1.39.0")]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const fn new() -> Vec<T> {
         Vec { buf: RawVec::NEW, len: 0 }


### PR DESCRIPTION
Changelog: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1390-2019-11-07

This really surprised me when a MSRV check for 1.35 failed with `Vec::new is not yet stable as a const fn` and the docs said that it was const stabilized in 1.32.