### PR TITLE
Tweak chained operators diagnostic

### DIFF
--- a/src/test/ui/did_you_mean/issue-40396.stderr
+++ b/src/test/ui/did_you_mean/issue-40396.stderr
@@ -2,16 +2,8 @@ error: comparison operators cannot be chained
   --> $DIR/issue-40396.rs:2:20
    |
 LL |     (0..13).collect<Vec<i32>>();
-   |                    ^^^^^
+   |                    ^   ^
    |
-help: split the comparison into two...
-   |
-LL |     (0..13).collect < Vec && Vec <i32>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: ...or parenthesize one of the comparisons
-   |
-LL |     ((0..13).collect < Vec) <i32>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 help: use `::<...>` instead of `<...>` to specify type arguments
    |
 LL |     (0..13).collect::<Vec<i32>>();
@@ -21,7 +13,7 @@ error: comparison operators cannot be chained
   --> $DIR/issue-40396.rs:4:8
    |
 LL |     Vec<i32>::new();
-   |        ^^^^^
+   |        ^   ^
    |
 help: use `::<...>` instead of `<...>` to specify type arguments
    |
@@ -32,16 +24,8 @@ error: comparison operators cannot be chained
   --> $DIR/issue-40396.rs:6:20
    |
 LL |     (0..13).collect<Vec<i32>();
-   |                    ^^^^^
+   |                    ^   ^
    |
-help: split the comparison into two...
-   |
-LL |     (0..13).collect < Vec && Vec <i32>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: ...or parenthesize one of the comparisons
-   |
-LL |     ((0..13).collect < Vec) <i32>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 help: use `::<...>` instead of `<...>` to specify type arguments
    |
 LL |     (0..13).collect::<Vec<i32>();

--- a/src/test/ui/parser/chained-comparison-suggestion.rs
+++ b/src/test/ui/parser/chained-comparison-suggestion.rs
@@ -37,4 +37,17 @@ fn comp8() {
     //~^ ERROR mismatched types
 }
 
+fn comp9() {
+    1 == 2 < 3; //~ ERROR comparison operators cannot be chained
+}
+
+fn comp10() {
+    1 > 2 == false; //~ ERROR comparison operators cannot be chained
+}
+
+fn comp11() {
+    1 == 2 == 3; //~ ERROR comparison operators cannot be chained
+    //~^ ERROR mismatched types
+}
+
 fn main() {}

--- a/src/test/ui/parser/chained-comparison-suggestion.stderr
+++ b/src/test/ui/parser/chained-comparison-suggestion.stderr
@@ -2,127 +2,122 @@ error: comparison operators cannot be chained
   --> $DIR/chained-comparison-suggestion.rs:4:7
    |
 LL |     1 < 2 <= 3;
-   |       ^^^^^^
+   |       ^   ^^
    |
-help: split the comparison into two...
+help: split the comparison into two
    |
 LL |     1 < 2 && 2 <= 3;
-   |     ^^^^^^^^^^^^^
-help: ...or parenthesize one of the comparisons
-   |
-LL |     (1 < 2) <= 3;
-   |     ^^^^^^^^^^
+   |           ^^^^
 
 error: comparison operators cannot be chained
   --> $DIR/chained-comparison-suggestion.rs:9:7
    |
 LL |     1 < 2 < 3;
-   |       ^^^^^
+   |       ^   ^
    |
-   = help: use `::<...>` instead of `<...>` to specify type arguments
-   = help: or use `(...)` if you meant to specify fn arguments
-help: split the comparison into two...
+help: split the comparison into two
    |
 LL |     1 < 2 && 2 < 3;
-   |     ^^^^^^^^^^^^
-help: ...or parenthesize one of the comparisons
-   |
-LL |     (1 < 2) < 3;
-   |     ^^^^^^^^^
+   |           ^^^^
 
 error: comparison operators cannot be chained
   --> $DIR/chained-comparison-suggestion.rs:13:7
    |
 LL |     1 <= 2 < 3;
-   |       ^^^^^^
+   |       ^^   ^
    |
-help: split the comparison into two...
+help: split the comparison into two
    |
 LL |     1 <= 2 && 2 < 3;
-   |     ^^^^^^^^^^^^^
-help: ...or parenthesize one of the comparisons
-   |
-LL |     (1 <= 2) < 3;
-   |     ^^^^^^^^^^
+   |            ^^^^
 
 error: comparison operators cannot be chained
   --> $DIR/chained-comparison-suggestion.rs:18:7
    |
 LL |     1 <= 2 <= 3;
-   |       ^^^^^^^
+   |       ^^   ^^
    |
-help: split the comparison into two...
+help: split the comparison into two
    |
 LL |     1 <= 2 && 2 <= 3;
-   |     ^^^^^^^^^^^^^^
-help: ...or parenthesize one of the comparisons
-   |
-LL |     (1 <= 2) <= 3;
-   |     ^^^^^^^^^^^
+   |            ^^^^
 
 error: comparison operators cannot be chained
   --> $DIR/chained-comparison-suggestion.rs:23:7
    |
 LL |     1 > 2 >= 3;
-   |       ^^^^^^
+   |       ^   ^^
    |
-help: split the comparison into two...
+help: split the comparison into two
    |
 LL |     1 > 2 && 2 >= 3;
-   |     ^^^^^^^^^^^^^
-help: ...or parenthesize one of the comparisons
-   |
-LL |     (1 > 2) >= 3;
-   |     ^^^^^^^^^^
+   |           ^^^^
 
 error: comparison operators cannot be chained
   --> $DIR/chained-comparison-suggestion.rs:28:7
    |
 LL |     1 > 2 > 3;
-   |       ^^^^^
+   |       ^   ^
    |
-   = help: use `::<...>` instead of `<...>` to specify type arguments
-   = help: or use `(...)` if you meant to specify fn arguments
-help: split the comparison into two...
+help: split the comparison into two
    |
 LL |     1 > 2 && 2 > 3;
-   |     ^^^^^^^^^^^^
-help: ...or parenthesize one of the comparisons
-   |
-LL |     (1 > 2) > 3;
-   |     ^^^^^^^^^
+   |           ^^^^
 
 error: comparison operators cannot be chained
   --> $DIR/chained-comparison-suggestion.rs:32:7
    |
 LL |     1 >= 2 > 3;
-   |       ^^^^^^
+   |       ^^   ^
    |
-   = help: use `::<...>` instead of `<...>` to specify type arguments
-   = help: or use `(...)` if you meant to specify fn arguments
-help: split the comparison into two...
+help: split the comparison into two
    |
 LL |     1 >= 2 && 2 > 3;
-   |     ^^^^^^^^^^^^^
-help: ...or parenthesize one of the comparisons
-   |
-LL |     (1 >= 2) > 3;
-   |     ^^^^^^^^^^
+   |            ^^^^
 
 error: comparison operators cannot be chained
   --> $DIR/chained-comparison-suggestion.rs:36:7
    |
 LL |     1 >= 2 >= 3;
-   |       ^^^^^^^
+   |       ^^   ^^
    |
-help: split the comparison into two...
+help: split the comparison into two
    |
 LL |     1 >= 2 && 2 >= 3;
-   |     ^^^^^^^^^^^^^^
-help: ...or parenthesize one of the comparisons
+   |            ^^^^
+
+error: comparison operators cannot be chained
+  --> $DIR/chained-comparison-suggestion.rs:41:7
    |
-LL |     (1 >= 2) >= 3;
-   |     ^^^^^^^^^^^
+LL |     1 == 2 < 3;
+   |       ^^   ^
+   |
+help: parenthesize the comparison
+   |
+LL |     1 == (2 < 3);
+   |          ^     ^
+
+error: comparison operators cannot be chained
+  --> $DIR/chained-comparison-suggestion.rs:45:7
+   |
+LL |     1 > 2 == false;
+   |       ^   ^^
+   |
+help: parenthesize the comparison
+   |
+LL |     (1 > 2) == false;
+   |     ^     ^
+
+error: comparison operators cannot be chained
+  --> $DIR/chained-comparison-suggestion.rs:49:7
+   |
+LL |     1 == 2 == 3;
+   |       ^^   ^^
+   |
+help: split the comparison into two
+   |
+LL |     1 == 2 && 2 == 3;
+   |            ^^^^
 
 error[E0308]: mismatched types
   --> $DIR/chained-comparison-suggestion.rs:4:14
@@ -154,6 +149,12 @@ error[E0308]: mismatched types
 LL |     1 >= 2 >= 3;
    |               ^ expected `bool`, found integer
 
-error: aborting due to 13 previous errors
+error[E0308]: mismatched types
+  --> $DIR/chained-comparison-suggestion.rs:49:15
+   |
+LL |     1 == 2 == 3;
+   |               ^ expected `bool`, found integer
+
+error: aborting due to 17 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/parser/require-parens-for-chained-comparison.rs
+++ b/src/test/ui/parser/require-parens-for-chained-comparison.rs
@@ -4,11 +4,11 @@ struct X;
 fn main() {
     false == false == false;
     //~^ ERROR comparison operators cannot be chained
+    //~| HELP split the comparison into two
 
     false == 0 < 2;
     //~^ ERROR comparison operators cannot be chained
-    //~| ERROR mismatched types
-    //~| ERROR mismatched types
+    //~| HELP parenthesize the comparison
 
     f<X>();
     //~^ ERROR comparison operators cannot be chained
@@ -16,8 +16,6 @@ fn main() {
 
     f<Result<Option<X>, Option<Option<X>>>(1, 2);
     //~^ ERROR comparison operators cannot be chained
-    //~| HELP split the comparison into two...
-    //~| ...or parenthesize one of the comparisons
     //~| HELP use `::<...>` instead of `<...>` to specify type arguments
 
     use std::convert::identity;

--- a/src/test/ui/parser/require-parens-for-chained-comparison.stderr
+++ b/src/test/ui/parser/require-parens-for-chained-comparison.stderr
@@ -2,19 +2,29 @@ error: comparison operators cannot be chained
   --> $DIR/require-parens-for-chained-comparison.rs:5:11
    |
 LL |     false == false == false;
-   |           ^^^^^^^^^^^
+   |           ^^       ^^
+   |
+help: split the comparison into two
+   |
+LL |     false == false && false == false;
+   |                    ^^^^^^^^
 
 error: comparison operators cannot be chained
-  --> $DIR/require-parens-for-chained-comparison.rs:8:11
+  --> $DIR/require-parens-for-chained-comparison.rs:9:11
    |
 LL |     false == 0 < 2;
-   |           ^^^^^^
+   |           ^^   ^
+   |
+help: parenthesize the comparison
+   |
+LL |     false == (0 < 2);
+   |              ^     ^
 
 error: comparison operators cannot be chained
   --> $DIR/require-parens-for-chained-comparison.rs:13:6
    |
 LL |     f<X>();
-   |      ^^^
+   |      ^ ^
    |
 help: use `::<...>` instead of `<...>` to specify type arguments
    |
@@ -25,42 +35,21 @@ error: comparison operators cannot be chained
   --> $DIR/require-parens-for-chained-comparison.rs:17:6
    |
 LL |     f<Result<Option<X>, Option<Option<X>>>(1, 2);
-   |      ^^^^^^^^
+   |      ^      ^
    |
-help: split the comparison into two...
-   |
-LL |     f < Result && Result <Option<X>, Option<Option<X>>>(1, 2);
-   |     ^^^^^^^^^^^^^^^^^^^^^^
-help: ...or parenthesize one of the comparisons
-   |
-LL |     (f < Result) <Option<X>, Option<Option<X>>>(1, 2);
-   |     ^^^^^^^^^^^^^^
 help: use `::<...>` instead of `<...>` to specify type arguments
    |
 LL |     f::<Result<Option<X>, Option<Option<X>>>(1, 2);
    |      ^^
 
 error: comparison operators cannot be chained
-  --> $DIR/require-parens-for-chained-comparison.rs:24:21
+  --> $DIR/require-parens-for-chained-comparison.rs:22:21
    |
 LL |     let _ = identity<u8>;
-   |                     ^^^^
+   |                     ^  ^
    |
    = help: use `::<...>` instead of `<...>` to specify type arguments
    = help: or use `(...)` if you meant to specify fn arguments
 
-error[E0308]: mismatched types
-  --> $DIR/require-parens-for-chained-comparison.rs:8:14
-   |
-LL |     false == 0 < 2;
-   |              ^ expected `bool`, found integer
+error: aborting due to 5 previous errors
 
-error[E0308]: mismatched types
-  --> $DIR/require-parens-for-chained-comparison.rs:8:18
-   |
-LL |     false == 0 < 2;
-   |                  ^ expected `bool`, found integer
-
-error: aborting due to 7 previous errors
-
-For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Use more selective spans
Improve suggestion output
Be more selective when displaying suggestions
Silence some knock-down type errors

r? @Centril 