### PR TITLE
miri engine: turn error sanity checks into assertions

### DIFF
--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -825,11 +825,10 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         // Run it.
         match visitor.visit_value(op) {
             Ok(()) => Ok(()),
+            // We should only get validation errors here. Avoid other errors as
+            // those do not show *where* in the value the issue lies.
             Err(err) if matches!(err.kind, err_ub!(ValidationFailure { .. })) => Err(err),
-            Err(err) if cfg!(debug_assertions) => {
-                bug!("Unexpected error during validation: {}", err)
-            }
-            Err(err) => Err(err),
+            Err(err) => bug!("Unexpected error during validation: {}", err),
         }
     }
 

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -404,8 +404,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
                 // Some errors shouldn't come up because creating them causes
                 // an allocation, which we should avoid. When that happens,
                 // dedicated error variants should be introduced instead.
-                // Only test this in debug builds though to avoid disruptions.
-                debug_assert!(
+                assert!(
                     !error.kind.allocates(),
                     "const-prop encountered allocating error: {}",
                     error


### PR DESCRIPTION
We had these as debug assertions so far to make sure our test suite is clean, but really these are conditions that should never arise and also @eddyb told me to turn non-performance-critical debug assertions into full assertions so here we go. ;)

I propose that we do a check-only crater run to make sure this does not actually happen in practice.

r? @oli-obk 