### PR TITLE
add #[rustc_layout(debug)]

### DIFF
--- a/src/librustc_passes/layout_test.rs
+++ b/src/librustc_passes/layout_test.rs
@@ -81,6 +81,13 @@ impl LayoutTest<'tcx> {
                             );
                         }
 
+                        sym::debug => {
+                            self.tcx.sess.span_err(
+                                item.span,
+                                &format!("layout debugging: {:#?}", *ty_layout),
+                            );
+                        }
+
                         name => {
                             self.tcx.sess.span_err(
                                 meta_item.span(),

--- a/src/librustc_passes/layout_test.rs
+++ b/src/librustc_passes/layout_test.rs
@@ -17,15 +17,15 @@ use rustc_span::symbol::sym;
 pub fn test_layout(tcx: TyCtxt<'_>) {
     if tcx.features().rustc_attrs {
         // if the `rustc_attrs` feature is not enabled, don't bother testing layout
-        tcx.hir().krate().visit_all_item_likes(&mut VarianceTest { tcx });
+        tcx.hir().krate().visit_all_item_likes(&mut LayoutTest { tcx });
     }
 }
 
-struct VarianceTest<'tcx> {
+struct LayoutTest<'tcx> {
     tcx: TyCtxt<'tcx>,
 }
 
-impl ItemLikeVisitor<'tcx> for VarianceTest<'tcx> {
+impl ItemLikeVisitor<'tcx> for LayoutTest<'tcx> {
     fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
         let item_def_id = self.tcx.hir().local_def_id(item.hir_id);
 
@@ -42,7 +42,7 @@ impl ItemLikeVisitor<'tcx> for VarianceTest<'tcx> {
     fn visit_impl_item(&mut self, _: &'tcx hir::ImplItem<'tcx>) {}
 }
 
-impl VarianceTest<'tcx> {
+impl LayoutTest<'tcx> {
     fn dump_layout_of(&self, item_def_id: DefId, item: &hir::Item<'tcx>, attr: &Attribute) {
         let tcx = self.tcx;
         let param_env = self.tcx.param_env(item_def_id);

--- a/src/librustc_passes/layout_test.rs
+++ b/src/librustc_passes/layout_test.rs
@@ -29,12 +29,18 @@ impl ItemLikeVisitor<'tcx> for LayoutTest<'tcx> {
     fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
         let item_def_id = self.tcx.hir().local_def_id(item.hir_id);
 
-        if let ItemKind::TyAlias(..) = item.kind {
-            for attr in self.tcx.get_attrs(item_def_id).iter() {
-                if attr.check_name(sym::rustc_layout) {
-                    self.dump_layout_of(item_def_id, item, attr);
+        match item.kind {
+            ItemKind::TyAlias(..) |
+            ItemKind::Enum(..) |
+            ItemKind::Struct(..) |
+            ItemKind::Union(..) => {
+                for attr in self.tcx.get_attrs(item_def_id).iter() {
+                    if attr.check_name(sym::rustc_layout) {
+                        self.dump_layout_of(item_def_id, item, attr);
+                    }
                 }
             }
+            _ => {}
         }
     }
 

--- a/src/librustc_passes/layout_test.rs
+++ b/src/librustc_passes/layout_test.rs
@@ -30,10 +30,10 @@ impl ItemLikeVisitor<'tcx> for LayoutTest<'tcx> {
         let item_def_id = self.tcx.hir().local_def_id(item.hir_id);
 
         match item.kind {
-            ItemKind::TyAlias(..) |
-            ItemKind::Enum(..) |
-            ItemKind::Struct(..) |
-            ItemKind::Union(..) => {
+            ItemKind::TyAlias(..)
+            | ItemKind::Enum(..)
+            | ItemKind::Struct(..)
+            | ItemKind::Union(..) => {
                 for attr in self.tcx.get_attrs(item_def_id).iter() {
                     if attr.check_name(sym::rustc_layout) {
                         self.dump_layout_of(item_def_id, item, attr);

--- a/src/librustc_span/symbol.rs
+++ b/src/librustc_span/symbol.rs
@@ -253,6 +253,7 @@ symbols! {
         debug_trait,
         declare_lint_pass,
         decl_macro,
+        debug,
         Debug,
         Decodable,
         Default,

--- a/src/test/ui/layout/debug.rs
+++ b/src/test/ui/layout/debug.rs
@@ -1,0 +1,7 @@
+#![feature(never_type, rustc_attrs)]
+#![crate_type = "lib"]
+
+enum E { Foo, Bar(!, i32, i32) }
+
+#[rustc_layout(debug)]
+type Test = E; //~ ERROR: layout debugging

--- a/src/test/ui/layout/debug.rs
+++ b/src/test/ui/layout/debug.rs
@@ -1,3 +1,4 @@
+// normalize-stderr-test "pref: Align \{\n *pow2: [1-3],\n *\}" -> "pref: $$PREF_ALIGN"
 #![feature(never_type, rustc_attrs)]
 #![crate_type = "lib"]
 

--- a/src/test/ui/layout/debug.rs
+++ b/src/test/ui/layout/debug.rs
@@ -1,7 +1,14 @@
 #![feature(never_type, rustc_attrs)]
 #![crate_type = "lib"]
 
-enum E { Foo, Bar(!, i32, i32) }
+#[rustc_layout(debug)]
+enum E { Foo, Bar(!, i32, i32) } //~ ERROR: layout debugging
 
 #[rustc_layout(debug)]
-type Test = E; //~ ERROR: layout debugging
+struct S { f1: i32, f2: (), f3: i32 } //~ ERROR: layout debugging
+
+#[rustc_layout(debug)]
+union U { f1: (i32, i32), f3: i32 } //~ ERROR: layout debugging
+
+#[rustc_layout(debug)]
+type Test = Result<i32, i32>; //~ ERROR: layout debugging

--- a/src/test/ui/layout/debug.stderr
+++ b/src/test/ui/layout/debug.stderr
@@ -111,10 +111,225 @@ error: layout debugging: LayoutDetails {
         raw: 12,
     },
 }
-  --> $DIR/debug.rs:7:1
+  --> $DIR/debug.rs:5:1
    |
-LL | type Test = E;
-   | ^^^^^^^^^^^^^^
+LL | enum E { Foo, Bar(!, i32, i32) }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: layout debugging: LayoutDetails {
+    fields: Arbitrary {
+        offsets: [
+            Size {
+                raw: 0,
+            },
+            Size {
+                raw: 0,
+            },
+            Size {
+                raw: 4,
+            },
+        ],
+        memory_index: [
+            1,
+            0,
+            2,
+        ],
+    },
+    variants: Single {
+        index: 0,
+    },
+    abi: ScalarPair(
+        Scalar {
+            value: Int(
+                I32,
+                true,
+            ),
+            valid_range: 0..=4294967295,
+        },
+        Scalar {
+            value: Int(
+                I32,
+                true,
+            ),
+            valid_range: 0..=4294967295,
+        },
+    ),
+    largest_niche: None,
+    align: AbiAndPrefAlign {
+        abi: Align {
+            pow2: 2,
+        },
+        pref: Align {
+            pow2: 3,
+        },
+    },
+    size: Size {
+        raw: 8,
+    },
+}
+  --> $DIR/debug.rs:8:1
+   |
+LL | struct S { f1: i32, f2: (), f3: i32 }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: layout debugging: LayoutDetails {
+    fields: Union(
+        2,
+    ),
+    variants: Single {
+        index: 0,
+    },
+    abi: Aggregate {
+        sized: true,
+    },
+    largest_niche: None,
+    align: AbiAndPrefAlign {
+        abi: Align {
+            pow2: 2,
+        },
+        pref: Align {
+            pow2: 3,
+        },
+    },
+    size: Size {
+        raw: 8,
+    },
+}
+  --> $DIR/debug.rs:11:1
+   |
+LL | union U { f1: (i32, i32), f3: i32 }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: layout debugging: LayoutDetails {
+    fields: Arbitrary {
+        offsets: [
+            Size {
+                raw: 0,
+            },
+        ],
+        memory_index: [
+            0,
+        ],
+    },
+    variants: Multiple {
+        discr: Scalar {
+            value: Int(
+                I32,
+                false,
+            ),
+            valid_range: 0..=1,
+        },
+        discr_kind: Tag,
+        discr_index: 0,
+        variants: [
+            LayoutDetails {
+                fields: Arbitrary {
+                    offsets: [
+                        Size {
+                            raw: 4,
+                        },
+                    ],
+                    memory_index: [
+                        0,
+                    ],
+                },
+                variants: Single {
+                    index: 0,
+                },
+                abi: Aggregate {
+                    sized: true,
+                },
+                largest_niche: None,
+                align: AbiAndPrefAlign {
+                    abi: Align {
+                        pow2: 2,
+                    },
+                    pref: Align {
+                        pow2: 3,
+                    },
+                },
+                size: Size {
+                    raw: 8,
+                },
+            },
+            LayoutDetails {
+                fields: Arbitrary {
+                    offsets: [
+                        Size {
+                            raw: 4,
+                        },
+                    ],
+                    memory_index: [
+                        0,
+                    ],
+                },
+                variants: Single {
+                    index: 1,
+                },
+                abi: Aggregate {
+                    sized: true,
+                },
+                largest_niche: None,
+                align: AbiAndPrefAlign {
+                    abi: Align {
+                        pow2: 2,
+                    },
+                    pref: Align {
+                        pow2: 3,
+                    },
+                },
+                size: Size {
+                    raw: 8,
+                },
+            },
+        ],
+    },
+    abi: ScalarPair(
+        Scalar {
+            value: Int(
+                I32,
+                false,
+            ),
+            valid_range: 0..=1,
+        },
+        Scalar {
+            value: Int(
+                I32,
+                true,
+            ),
+            valid_range: 0..=4294967295,
+        },
+    ),
+    largest_niche: Some(
+        Niche {
+            offset: Size {
+                raw: 0,
+            },
+            scalar: Scalar {
+                value: Int(
+                    I32,
+                    false,
+                ),
+                valid_range: 0..=1,
+            },
+        },
+    ),
+    align: AbiAndPrefAlign {
+        abi: Align {
+            pow2: 2,
+        },
+        pref: Align {
+            pow2: 3,
+        },
+    },
+    size: Size {
+        raw: 8,
+    },
+}
+  --> $DIR/debug.rs:14:1
+   |
+LL | type Test = Result<i32, i32>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/layout/debug.stderr
+++ b/src/test/ui/layout/debug.stderr
@@ -1,0 +1,120 @@
+error: layout debugging: LayoutDetails {
+    fields: Arbitrary {
+        offsets: [
+            Size {
+                raw: 0,
+            },
+        ],
+        memory_index: [
+            0,
+        ],
+    },
+    variants: Multiple {
+        discr: Scalar {
+            value: Int(
+                I32,
+                false,
+            ),
+            valid_range: 0..=0,
+        },
+        discr_kind: Tag,
+        discr_index: 0,
+        variants: [
+            LayoutDetails {
+                fields: Arbitrary {
+                    offsets: [],
+                    memory_index: [],
+                },
+                variants: Single {
+                    index: 0,
+                },
+                abi: Aggregate {
+                    sized: true,
+                },
+                largest_niche: None,
+                align: AbiAndPrefAlign {
+                    abi: Align {
+                        pow2: 0,
+                    },
+                    pref: Align {
+                        pow2: 3,
+                    },
+                },
+                size: Size {
+                    raw: 4,
+                },
+            },
+            LayoutDetails {
+                fields: Arbitrary {
+                    offsets: [
+                        Size {
+                            raw: 4,
+                        },
+                        Size {
+                            raw: 4,
+                        },
+                        Size {
+                            raw: 8,
+                        },
+                    ],
+                    memory_index: [
+                        0,
+                        1,
+                        2,
+                    ],
+                },
+                variants: Single {
+                    index: 1,
+                },
+                abi: Uninhabited,
+                largest_niche: None,
+                align: AbiAndPrefAlign {
+                    abi: Align {
+                        pow2: 2,
+                    },
+                    pref: Align {
+                        pow2: 3,
+                    },
+                },
+                size: Size {
+                    raw: 12,
+                },
+            },
+        ],
+    },
+    abi: Aggregate {
+        sized: true,
+    },
+    largest_niche: Some(
+        Niche {
+            offset: Size {
+                raw: 0,
+            },
+            scalar: Scalar {
+                value: Int(
+                    I32,
+                    false,
+                ),
+                valid_range: 0..=0,
+            },
+        },
+    ),
+    align: AbiAndPrefAlign {
+        abi: Align {
+            pow2: 2,
+        },
+        pref: Align {
+            pow2: 3,
+        },
+    },
+    size: Size {
+        raw: 12,
+    },
+}
+  --> $DIR/debug.rs:7:1
+   |
+LL | type Test = E;
+   | ^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/layout/debug.stderr
+++ b/src/test/ui/layout/debug.stderr
@@ -36,9 +36,7 @@ error: layout debugging: LayoutDetails {
                     abi: Align {
                         pow2: 0,
                     },
-                    pref: Align {
-                        pow2: 3,
-                    },
+                    pref: $PREF_ALIGN,
                 },
                 size: Size {
                     raw: 4,
@@ -72,9 +70,7 @@ error: layout debugging: LayoutDetails {
                     abi: Align {
                         pow2: 2,
                     },
-                    pref: Align {
-                        pow2: 3,
-                    },
+                    pref: $PREF_ALIGN,
                 },
                 size: Size {
                     raw: 12,
@@ -103,15 +99,13 @@ error: layout debugging: LayoutDetails {
         abi: Align {
             pow2: 2,
         },
-        pref: Align {
-            pow2: 3,
-        },
+        pref: $PREF_ALIGN,
     },
     size: Size {
         raw: 12,
     },
 }
-  --> $DIR/debug.rs:5:1
+  --> $DIR/debug.rs:6:1
    |
 LL | enum E { Foo, Bar(!, i32, i32) }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -159,15 +153,13 @@ error: layout debugging: LayoutDetails {
         abi: Align {
             pow2: 2,
         },
-        pref: Align {
-            pow2: 3,
-        },
+        pref: $PREF_ALIGN,
     },
     size: Size {
         raw: 8,
     },
 }
-  --> $DIR/debug.rs:8:1
+  --> $DIR/debug.rs:9:1
    |
 LL | struct S { f1: i32, f2: (), f3: i32 }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -187,15 +179,13 @@ error: layout debugging: LayoutDetails {
         abi: Align {
             pow2: 2,
         },
-        pref: Align {
-            pow2: 3,
-        },
+        pref: $PREF_ALIGN,
     },
     size: Size {
         raw: 8,
     },
 }
-  --> $DIR/debug.rs:11:1
+  --> $DIR/debug.rs:12:1
    |
 LL | union U { f1: (i32, i32), f3: i32 }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -244,9 +234,7 @@ error: layout debugging: LayoutDetails {
                     abi: Align {
                         pow2: 2,
                     },
-                    pref: Align {
-                        pow2: 3,
-                    },
+                    pref: $PREF_ALIGN,
                 },
                 size: Size {
                     raw: 8,
@@ -274,9 +262,7 @@ error: layout debugging: LayoutDetails {
                     abi: Align {
                         pow2: 2,
                     },
-                    pref: Align {
-                        pow2: 3,
-                    },
+                    pref: $PREF_ALIGN,
                 },
                 size: Size {
                     raw: 8,
@@ -318,15 +304,13 @@ error: layout debugging: LayoutDetails {
         abi: Align {
             pow2: 2,
         },
-        pref: Align {
-            pow2: 3,
-        },
+        pref: $PREF_ALIGN,
     },
     size: Size {
         raw: 8,
     },
 }
-  --> $DIR/debug.rs:14:1
+  --> $DIR/debug.rs:15:1
    |
 LL | type Test = Result<i32, i32>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
@eddyb recently told me about the `#[rustc_layout]` attribute, and I think it would be very useful if it could be used to print all the layout information Rust has about a type. When working with layouts (e.g. in Miri), it is often not clear how certain surface language features get represented internally. I have some awful hacks locally to be able to dump this debug information; with this attribute I could get it on the playground which is so much better. :)