### PR TITLE
Store `Ident` in `DefPathData` instead of `Symbol`

### DIFF
--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -211,7 +211,7 @@ impl DefPath {
         let mut s = String::with_capacity(self.data.len() * 16);
 
         for component in &self.data {
-            write!(s, "::{}[{}]", component.data.as_ident(), component.disambiguator).unwrap();
+            write!(s, "::{}[{}]", component.data.as_ident().name, component.disambiguator).unwrap();
         }
 
         s
@@ -230,9 +230,10 @@ impl DefPath {
 
         for component in &self.data {
             if component.disambiguator == 0 {
-                write!(s, "::{}", component.data.as_ident()).unwrap();
+                write!(s, "::{}", component.data.as_ident().name).unwrap();
             } else {
-                write!(s, "{}[{}]", component.data.as_ident(), component.disambiguator).unwrap();
+                write!(s, "{}[{}]", component.data.as_ident().name, component.disambiguator)
+                    .unwrap();
             }
         }
 
@@ -250,9 +251,10 @@ impl DefPath {
             opt_delimiter.map(|d| s.push(d));
             opt_delimiter = Some('-');
             if component.disambiguator == 0 {
-                write!(s, "{}", component.data.as_ident()).unwrap();
+                write!(s, "{}", component.data.as_ident().name).unwrap();
             } else {
-                write!(s, "{}[{}]", component.data.as_ident(), component.disambiguator).unwrap();
+                write!(s, "{}[{}]", component.data.as_ident().name, component.disambiguator)
+                    .unwrap();
             }
         }
         s
@@ -568,6 +570,6 @@ impl DefPathData {
     }
 
     pub fn to_string(&self) -> String {
-        self.as_ident().to_string()
+        self.as_ident().name.to_string()
     }
 }

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -541,7 +541,7 @@ impl DefPathData {
             ValueNs(name) => ValueNs(Ident::with_dummy_span(name.name)),
             MacroNs(name) => MacroNs(Ident::with_dummy_span(name.name)),
             LifetimeNs(name) => LifetimeNs(Ident::with_dummy_span(name.name)),
-            _ => *self,
+            CrateRoot | Misc | Impl | ClosureExpr | Ctor | AnonConst | ImplTrait => *self,
         }
     }
 

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -64,9 +64,10 @@ pub struct FrameInfo<'tcx> {
 impl<'tcx> fmt::Display for FrameInfo<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         ty::tls::with(|tcx| {
-            if tcx.def_key(self.instance.def_id()).disambiguated_data.data
-                == DefPathData::ClosureExpr
-            {
+            if matches!(
+                tcx.def_key(self.instance.def_id()).disambiguated_data.data,
+                DefPathData::ClosureExpr
+            ) {
                 write!(f, "inside call to closure")?;
             } else {
                 write!(f, "inside call to `{}`", self.instance)?;

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2996,9 +2996,16 @@ impl<'tcx> TyCtxt<'tcx> {
                 hir_map::DefPathData::Ctor => {
                     self.item_name(DefId { krate: id.krate, index: def_key.parent.unwrap() })
                 }
-                _ => def_key.disambiguated_data.data.get_opt_name().unwrap_or_else(|| {
-                    bug!("item_name: no name for {:?}", self.def_path(id));
-                }),
+                _ => {
+                    def_key
+                        .disambiguated_data
+                        .data
+                        .get_opt_name()
+                        .unwrap_or_else(|| {
+                            bug!("item_name: no name for {:?}", self.def_path(id));
+                        })
+                        .name
+                }
             }
         }
     }

--- a/src/librustc/ty/print/obsolete.rs
+++ b/src/librustc/ty/print/obsolete.rs
@@ -186,9 +186,9 @@ impl DefPathBasedNames<'tcx> {
         // foo::bar::ItemName::
         for part in self.tcx.def_path(def_id).data {
             if self.omit_disambiguators {
-                write!(output, "{}::", part.data.as_symbol()).unwrap();
+                write!(output, "{}::", part.data.as_ident()).unwrap();
             } else {
-                write!(output, "{}[{}]::", part.data.as_symbol(), part.disambiguator).unwrap();
+                write!(output, "{}[{}]::", part.data.as_ident(), part.disambiguator).unwrap();
             }
         }
 

--- a/src/librustc/ty/print/obsolete.rs
+++ b/src/librustc/ty/print/obsolete.rs
@@ -186,9 +186,9 @@ impl DefPathBasedNames<'tcx> {
         // foo::bar::ItemName::
         for part in self.tcx.def_path(def_id).data {
             if self.omit_disambiguators {
-                write!(output, "{}::", part.data.as_ident()).unwrap();
+                write!(output, "{}::", part.data.as_ident().name).unwrap();
             } else {
-                write!(output, "{}[{}]::", part.data.as_ident(), part.disambiguator).unwrap();
+                write!(output, "{}[{}]::", part.data.as_ident().name, part.disambiguator).unwrap();
             }
         }
 

--- a/src/librustc/ty/print/pretty.rs
+++ b/src/librustc/ty/print/pretty.rs
@@ -13,7 +13,7 @@ use rustc_apfloat::ieee::{Double, Single};
 use rustc_apfloat::Float;
 use rustc_ast::ast;
 use rustc_attr::{SignedInt, UnsignedInt};
-use rustc_span::symbol::{kw, Symbol};
+use rustc_span::symbol::{kw, Ident, Symbol};
 use rustc_target::spec::abi::Abi;
 
 use std::cell::Cell;
@@ -402,12 +402,14 @@ pub trait PrettyPrinter<'tcx>:
                     .find(|child| child.res.def_id() == def_id)
                     .map(|child| child.ident.name);
                 if let Some(reexport) = reexport {
-                    *name = reexport;
+                    *name = Ident::with_dummy_span(reexport);
                 }
             }
             // Re-exported `extern crate` (#43189).
             DefPathData::CrateRoot => {
-                data = DefPathData::TypeNs(self.tcx().original_crate_name(def_id.krate));
+                data = DefPathData::TypeNs(Ident::with_dummy_span(
+                    self.tcx().original_crate_name(def_id.krate),
+                ));
             }
             _ => {}
         }
@@ -1401,7 +1403,7 @@ impl<F: fmt::Write> Printer<'tcx> for FmtPrinter<'_, 'tcx, F> {
 
         // FIXME(eddyb) `name` should never be empty, but it
         // currently is for `extern { ... }` "foreign modules".
-        let name = disambiguated_data.data.as_symbol().as_str();
+        let name = disambiguated_data.data.to_string();
         if !name.is_empty() {
             if !self.empty_path {
                 write!(self, "::")?;

--- a/src/librustc/ty/query/profiling_support.rs
+++ b/src/librustc/ty/query/profiling_support.rs
@@ -60,12 +60,12 @@ impl<'p, 'c, 'tcx> QueryKeyStringBuilder<'p, 'c, 'tcx> {
 
         match def_key.disambiguated_data.data {
             DefPathData::CrateRoot => {
-                name = self.tcx.original_crate_name(def_id.krate).as_str();
+                name = self.tcx.original_crate_name(def_id.krate).as_str().to_string();
                 dis = "";
                 end_index = 3;
             }
             other => {
-                name = other.as_symbol().as_str();
+                name = other.to_string();
                 if def_key.disambiguated_data.disambiguator == 0 {
                     dis = "";
                     end_index = 3;

--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -448,7 +448,7 @@ impl<'tcx> TyCtxt<'tcx> {
     /// those are not yet phased out). The parent of the closure's
     /// `DefId` will also be the context where it appears.
     pub fn is_closure(self, def_id: DefId) -> bool {
-        self.def_key(def_id).disambiguated_data.data == DefPathData::ClosureExpr
+        matches!(self.def_key(def_id).disambiguated_data.data, DefPathData::ClosureExpr)
     }
 
     /// Returns `true` if `def_id` refers to a trait (i.e., `trait Foo { ... }`).
@@ -465,7 +465,7 @@ impl<'tcx> TyCtxt<'tcx> {
     /// Returns `true` if this `DefId` refers to the implicit constructor for
     /// a tuple struct like `struct Foo(u32)`, and `false` otherwise.
     pub fn is_constructor(self, def_id: DefId) -> bool {
-        self.def_key(def_id).disambiguated_data.data == DefPathData::Ctor
+        matches!(self.def_key(def_id).disambiguated_data.data, DefPathData::Ctor)
     }
 
     /// Given the def-ID of a fn or closure, returns the def-ID of

--- a/src/librustc_ast_lowering/lib.rs
+++ b/src/librustc_ast_lowering/lib.rs
@@ -764,17 +764,21 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         // Get the name we'll use to make the def-path. Note
         // that collisions are ok here and this shouldn't
         // really show up for end-user.
-        let (str_name, kind) = match hir_name {
-            ParamName::Plain(ident) => (ident.name, hir::LifetimeParamKind::InBand),
-            ParamName::Fresh(_) => (kw::UnderscoreLifetime, hir::LifetimeParamKind::Elided),
-            ParamName::Error => (kw::UnderscoreLifetime, hir::LifetimeParamKind::Error),
+        let (name, kind) = match hir_name {
+            ParamName::Plain(ident) => (ident, hir::LifetimeParamKind::InBand),
+            ParamName::Fresh(_) => {
+                (Ident::with_dummy_span(kw::UnderscoreLifetime), hir::LifetimeParamKind::Elided)
+            }
+            ParamName::Error => {
+                (Ident::with_dummy_span(kw::UnderscoreLifetime), hir::LifetimeParamKind::Error)
+            }
         };
 
         // Add a definition for the in-band lifetime def.
         self.resolver.definitions().create_def_with_parent(
             parent_index,
             node_id,
-            DefPathData::LifetimeNs(str_name),
+            DefPathData::LifetimeNs(name),
             ExpnId::root(),
             span,
         );
@@ -1560,7 +1564,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     self.context.resolver.definitions().create_def_with_parent(
                         self.parent,
                         def_node_id,
-                        DefPathData::LifetimeNs(name.ident().name),
+                        DefPathData::LifetimeNs(name.ident()),
                         ExpnId::root(),
                         lifetime.span,
                     );

--- a/src/librustc_codegen_llvm/debuginfo/namespace.rs
+++ b/src/librustc_codegen_llvm/debuginfo/namespace.rs
@@ -29,7 +29,7 @@ pub fn item_namespace(cx: &CodegenCx<'ll, '_>, def_id: DefId) -> &'ll DIScope {
 
     let namespace_name = match def_key.disambiguated_data.data {
         DefPathData::CrateRoot => cx.tcx.crate_name(def_id.krate),
-        data => data.as_symbol(),
+        data => data.as_ident().name,
     };
     let namespace_name = namespace_name.as_str();
 

--- a/src/librustc_codegen_ssa/debuginfo/type_names.rs
+++ b/src/librustc_codegen_ssa/debuginfo/type_names.rs
@@ -217,7 +217,7 @@ pub fn push_debuginfo_type_name<'tcx>(
             output.push_str(&tcx.crate_name(def_id.krate).as_str());
             for path_element in tcx.def_path(def_id).data {
                 output.push_str("::");
-                output.push_str(&path_element.data.as_symbol().as_str());
+                output.push_str(&path_element.data.to_string());
             }
         } else {
             output.push_str(&tcx.item_name(def_id).as_str());

--- a/src/librustc_codegen_utils/symbol_names/legacy.rs
+++ b/src/librustc_codegen_utils/symbol_names/legacy.rs
@@ -315,7 +315,7 @@ impl Printer<'tcx> for SymbolPrinter<'tcx> {
             self.path.finalize_pending_component();
         }
 
-        self.write_str(&disambiguated_data.data.as_symbol().as_str())?;
+        self.write_str(&disambiguated_data.data.to_string())?;
         Ok(self)
     }
     fn path_generic_args(

--- a/src/librustc_infer/infer/error_reporting/mod.rs
+++ b/src/librustc_infer/infer/error_reporting/mod.rs
@@ -631,7 +631,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 disambiguated_data: &DisambiguatedDefPathData,
             ) -> Result<Self::Path, Self::Error> {
                 let mut path = print_prefix(self)?;
-                path.push(disambiguated_data.data.as_symbol().to_string());
+                path.push(disambiguated_data.data.to_string());
                 Ok(path)
             }
             fn path_generic_args(

--- a/src/librustc_lint/context.rs
+++ b/src/librustc_lint/context.rs
@@ -793,7 +793,7 @@ impl<'a, 'tcx> LateContext<'a, 'tcx> {
                     _ => {}
                 }
 
-                path.push(disambiguated_data.data.as_symbol());
+                path.push(disambiguated_data.data.as_ident().name);
                 Ok(path)
             }
 

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -14,7 +14,7 @@ use rustc_ast::ast;
 use rustc_ast::attr;
 use rustc_ast::expand::allocator::{global_allocator_spans, AllocatorKind};
 use rustc_data_structures::svh::Svh;
-use rustc_data_structures::sync::Lrc;
+use rustc_data_structures::sync::{Lrc, Once};
 use rustc_errors::struct_span_err;
 use rustc_expand::base::SyntaxExtension;
 use rustc_hir::def_id::{CrateNum, LOCAL_CRATE};
@@ -28,6 +28,19 @@ use log::{debug, info, log_enabled};
 use proc_macro::bridge::client::ProcMacro;
 use std::path::Path;
 use std::{cmp, fs};
+
+crate type SourceMapImportInfo = Once<Vec<ImportedSourceFile>>;
+
+/// Holds information about a rustc_span::SourceFile imported from another crate.
+/// See `imported_source_files()` for more information.
+crate struct ImportedSourceFile {
+    /// This SourceFile's byte-offset within the source_map of its original crate
+    pub original_start_pos: rustc_span::BytePos,
+    /// The end of this SourceFile within the source_map of its original crate
+    pub original_end_pos: rustc_span::BytePos,
+    /// The imported SourceFile's representation within the local source_map
+    pub translated_source_file: Lrc<rustc_span::SourceFile>,
+}
 
 #[derive(Clone)]
 pub struct CStore {

--- a/src/librustc_metadata/rmeta/decoder.rs
+++ b/src/librustc_metadata/rmeta/decoder.rs
@@ -1297,7 +1297,7 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
         // we assume that someone passing in a tuple struct ctor is actually wanting to
         // look at the definition
         let def_key = self.def_key(node_id);
-        let item_id = if def_key.disambiguated_data.data == DefPathData::Ctor {
+        let item_id = if matches!(def_key.disambiguated_data.data, DefPathData::Ctor) {
             def_key.parent.unwrap()
         } else {
             node_id

--- a/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
+++ b/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
@@ -20,8 +20,8 @@ use rustc_ast::expand::allocator::AllocatorKind;
 use rustc_data_structures::svh::Svh;
 use rustc_hir as hir;
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, CRATE_DEF_INDEX, LOCAL_CRATE};
-use rustc_span::source_map::{self, Span, Spanned};
-use rustc_span::symbol::Symbol;
+use rustc_span::source_map::{self, Span};
+use rustc_span::symbol::{Ident, Symbol};
 
 use rustc_data_structures::sync::Lrc;
 use smallvec::SmallVec;
@@ -386,7 +386,7 @@ pub fn provide(providers: &mut Providers<'_>) {
 }
 
 impl CStore {
-    pub fn struct_field_names_untracked(&self, def: DefId, sess: &Session) -> Vec<Spanned<Symbol>> {
+    pub fn struct_field_names_untracked(&self, def: DefId, sess: &Session) -> Vec<Ident> {
         self.get_crate_data(def.krate).get_struct_field_names(def.index, sess)
     }
 
@@ -425,7 +425,6 @@ impl CStore {
             .disambiguated_data
             .data
             .get_opt_name()
-            .map(ast::Ident::with_dummy_span) // FIXME: cross-crate hygiene
             .expect("no name in load_macro");
 
         LoadedMacro::MacroDef(

--- a/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
+++ b/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
@@ -23,7 +23,6 @@ use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, CRATE_DEF_INDEX, LOCAL_CRATE}
 use rustc_span::source_map::{self, Span, Spanned};
 use rustc_span::symbol::Symbol;
 
-use rustc_ast::ast::Name;
 use rustc_data_structures::sync::Lrc;
 use smallvec::SmallVec;
 use std::any::Any;
@@ -387,7 +386,7 @@ pub fn provide(providers: &mut Providers<'_>) {
 }
 
 impl CStore {
-    pub fn struct_field_names_untracked(&self, def: DefId, sess: &Session) -> Vec<Spanned<Name>> {
+    pub fn struct_field_names_untracked(&self, def: DefId, sess: &Session) -> Vec<Spanned<Symbol>> {
         self.get_crate_data(def.krate).get_struct_field_names(def.index, sess)
     }
 

--- a/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
+++ b/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
@@ -20,9 +20,10 @@ use rustc_ast::expand::allocator::AllocatorKind;
 use rustc_data_structures::svh::Svh;
 use rustc_hir as hir;
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, CRATE_DEF_INDEX, LOCAL_CRATE};
-use rustc_span::source_map::{self, Span};
-use rustc_span::symbol::{Ident, Symbol};
+use rustc_span::source_map::{self, Span, Spanned};
+use rustc_span::symbol::Symbol;
 
+use rustc_ast::ast::Name;
 use rustc_data_structures::sync::Lrc;
 use smallvec::SmallVec;
 use std::any::Any;
@@ -386,7 +387,7 @@ pub fn provide(providers: &mut Providers<'_>) {
 }
 
 impl CStore {
-    pub fn struct_field_names_untracked(&self, def: DefId, sess: &Session) -> Vec<Ident> {
+    pub fn struct_field_names_untracked(&self, def: DefId, sess: &Session) -> Vec<Spanned<Name>> {
         self.get_crate_data(def.krate).get_struct_field_names(def.index, sess)
     }
 

--- a/src/librustc_metadata/rmeta/encoder.rs
+++ b/src/librustc_metadata/rmeta/encoder.rs
@@ -28,7 +28,7 @@ use log::{debug, trace};
 use rustc_ast::ast;
 use rustc_ast::attr;
 use rustc_span::source_map::Spanned;
-use rustc_span::symbol::{kw, sym, Ident, Symbol};
+use rustc_span::symbol::{kw, sym, Symbol};
 use rustc_span::{self, FileName, SourceFile, Span};
 use std::hash::Hash;
 use std::num::NonZeroUsize;
@@ -183,13 +183,6 @@ impl<'tcx> SpecializedEncoder<Span> for EncodeContext<'tcx> {
         len.encode(self)
 
         // Don't encode the expansion context.
-    }
-}
-
-impl SpecializedEncoder<Ident> for EncodeContext<'tcx> {
-    fn specialized_encode(&mut self, ident: &Ident) -> Result<(), Self::Error> {
-        // FIXME(jseyfried): intercrate hygiene
-        ident.name.encode(self)
     }
 }
 

--- a/src/librustc_mir/interpret/intrinsics/type_name.rs
+++ b/src/librustc_mir/interpret/intrinsics/type_name.rs
@@ -136,7 +136,7 @@ impl<'tcx> Printer<'tcx> for AbsolutePathPrinter<'tcx> {
 
         self.path.push_str("::");
 
-        self.path.push_str(&disambiguated_data.data.as_symbol().as_str());
+        self.path.push_str(&disambiguated_data.data.to_string());
         Ok(self)
     }
 

--- a/src/librustc_mir/monomorphize/partitioning.rs
+++ b/src/librustc_mir/monomorphize/partitioning.rs
@@ -750,7 +750,7 @@ fn compute_codegen_unit_name(
     *cache.entry((cgu_def_id, volatile)).or_insert_with(|| {
         let def_path = tcx.def_path(cgu_def_id);
 
-        let components = def_path.data.iter().map(|part| part.data.as_symbol());
+        let components = def_path.data.iter().map(|part| part.data.as_ident());
 
         let volatile_suffix = volatile.then_some("volatile");
 

--- a/src/librustc_resolve/def_collector.rs
+++ b/src/librustc_resolve/def_collector.rs
@@ -192,7 +192,7 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
     fn visit_assoc_item(&mut self, i: &'a AssocItem, ctxt: visit::AssocCtxt) {
         let def_data = match &i.kind {
             AssocItemKind::Fn(..) | AssocItemKind::Const(..) => DefPathData::ValueNs(i.ident),
-            AssocItemKind::TyAlias(..) => DefPathData::TypeNs(i.ident.name),
+            AssocItemKind::TyAlias(..) => DefPathData::TypeNs(i.ident),
             AssocItemKind::MacCall(..) => return self.visit_macro_invoc(i.id),
         };
 

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -624,7 +624,7 @@ impl<'a> LateResolutionVisitor<'a, '_, '_> {
                             if let Some(field_names) = self.r.field_names.get(&did) {
                                 if field_names
                                     .iter()
-                                    .any(|&field_name| ident.name == field_name.node)
+                                    .any(|&field_name| ident.name == field_name.name)
                                 {
                                     return Some(AssocSuggestion::Field);
                                 }

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -624,7 +624,7 @@ impl<'a> LateResolutionVisitor<'a, '_, '_> {
                             if let Some(field_names) = self.r.field_names.get(&did) {
                                 if field_names
                                     .iter()
-                                    .any(|&field_name| ident.name == field_name.name)
+                                    .any(|&field_name| ident.name == field_name.node)
                                 {
                                     return Some(AssocSuggestion::Field);
                                 }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -58,6 +58,7 @@ use diagnostics::{ImportSuggestion, Suggestion};
 use imports::{Import, ImportKind, ImportResolver, NameResolution};
 use late::{HasGenericParams, PathSource, Rib, RibKind::*};
 use macros::{MacroRulesBinding, MacroRulesScope};
+use rustc_span::source_map::Spanned;
 
 type Res = def::Res<NodeId>;
 
@@ -834,7 +835,7 @@ pub struct Resolver<'a> {
 
     /// Names of fields of an item `DefId` accessible with dot syntax.
     /// Used for hints during error reporting.
-    field_names: FxHashMap<DefId, Vec<Ident>>,
+    field_names: FxHashMap<DefId, Vec<Spanned<Name>>>,
 
     /// All imports known to succeed or fail.
     determined_imports: Vec<&'a Import<'a>>,

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -45,7 +45,6 @@ use rustc_metadata::creader::{CStore, CrateLoader};
 use rustc_session::lint::{BuiltinLintDiagnostics, LintBuffer};
 use rustc_session::Session;
 use rustc_span::hygiene::{ExpnId, ExpnKind, MacroKind, SyntaxContext, Transparency};
-use rustc_span::source_map::Spanned;
 use rustc_span::symbol::{kw, sym};
 use rustc_span::{Span, DUMMY_SP};
 
@@ -835,7 +834,7 @@ pub struct Resolver<'a> {
 
     /// Names of fields of an item `DefId` accessible with dot syntax.
     /// Used for hints during error reporting.
-    field_names: FxHashMap<DefId, Vec<Spanned<Name>>>,
+    field_names: FxHashMap<DefId, Vec<Ident>>,
 
     /// All imports known to succeed or fail.
     determined_imports: Vec<&'a Import<'a>>,

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -45,6 +45,7 @@ use rustc_metadata::creader::{CStore, CrateLoader};
 use rustc_session::lint::{BuiltinLintDiagnostics, LintBuffer};
 use rustc_session::Session;
 use rustc_span::hygiene::{ExpnId, ExpnKind, MacroKind, SyntaxContext, Transparency};
+use rustc_span::source_map::Spanned;
 use rustc_span::symbol::{kw, sym};
 use rustc_span::{Span, DUMMY_SP};
 

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -45,7 +45,6 @@ use rustc_metadata::creader::{CStore, CrateLoader};
 use rustc_session::lint::{BuiltinLintDiagnostics, LintBuffer};
 use rustc_session::Session;
 use rustc_span::hygiene::{ExpnId, ExpnKind, MacroKind, SyntaxContext, Transparency};
-use rustc_span::source_map::Spanned;
 use rustc_span::symbol::{kw, sym};
 use rustc_span::{Span, DUMMY_SP};
 

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -1350,7 +1350,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         );
         match variant.ctor_kind {
             CtorKind::Fn => {
-                debug!("report_unknown_field: ident span={:?}", variant.ident.span);
                 err.span_label(variant.ident.span, format!("`{adt}` defined here", adt = ty));
                 err.span_label(field.ident.span, "field does not exist");
                 err.span_label(

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -1350,6 +1350,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         );
         match variant.ctor_kind {
             CtorKind::Fn => {
+                debug!("report_unknown_field: ident span={:?}", variant.ident.span);
                 err.span_label(variant.ident.span, format!("`{adt}` defined here", adt = ty));
                 err.span_label(field.ident.span, "field does not exist");
                 err.span_label(

--- a/src/test/rustdoc/auxiliary/raw-foreign.rs
+++ b/src/test/rustdoc/auxiliary/raw-foreign.rs
@@ -1,0 +1,6 @@
+pub mod r#try {
+    // @has raw_idents/try/struct.struct.html
+    pub struct r#struct;
+
+    pub trait r#trait {}
+}

--- a/src/test/rustdoc/raw_idents.rs
+++ b/src/test/rustdoc/raw_idents.rs
@@ -1,0 +1,14 @@
+// aux-build:raw-foreign.rs
+// build-aux-docs
+
+extern crate raw_foreign;
+
+// has 'raw_idents/trait.MyTrait.html' '//a[@href="../raw_foreign/try/trait.trait.html"]' 'trait'
+// has 'raw_idents/trait.MyTrait.html' '//a[@href="../raw_foreign/try/struct.struct.html"]' 'struct'
+pub trait MyTrait {
+    fn foo<T>() where T: raw_foreign::r#try::r#trait {}
+}
+
+impl MyTrait for raw_foreign::r#try::r#struct {
+    fn foo<T>() where T: raw_foreign::r#try::r#trait {}
+}

--- a/src/test/ui/consts/const-eval/feature-gate-const_panic.stderr
+++ b/src/test/ui/consts/const-eval/feature-gate-const_panic.stderr
@@ -1,4 +1,14 @@
 error[E0658]: panicking in constants is unstable
+  --> $DIR/feature-gate-const_panic.rs:6:15
+   |
+LL | const Y: () = unreachable!();
+   |               ^^^^^^^^^^^^^^
+   |
+   = note: see issue #51999 <https://github.com/rust-lang/rust/issues/51999> for more information
+   = help: add `#![feature(const_panic)]` to the crate attributes to enable
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0658]: panicking in constants is unstable
   --> $DIR/feature-gate-const_panic.rs:3:15
    |
 LL | const Z: () = panic!("cheese");
@@ -13,16 +23,6 @@ error[E0658]: panicking in constants is unstable
    |
 LL | const X: () = unimplemented!();
    |               ^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #51999 <https://github.com/rust-lang/rust/issues/51999> for more information
-   = help: add `#![feature(const_panic)]` to the crate attributes to enable
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0658]: panicking in constants is unstable
-  --> $DIR/feature-gate-const_panic.rs:6:15
-   |
-LL | const Y: () = unreachable!();
-   |               ^^^^^^^^^^^^^^
    |
    = note: see issue #51999 <https://github.com/rust-lang/rust/issues/51999> for more information
    = help: add `#![feature(const_panic)]` to the crate attributes to enable

--- a/src/test/ui/copy-a-resource.stderr
+++ b/src/test/ui/copy-a-resource.stderr
@@ -6,6 +6,14 @@ LL | struct Foo {
 ...
 LL |     let _y = x.clone();
    |                ^^^^^ method not found in `Foo`
+   | 
+  ::: $SRC_DIR/libcore/clone.rs:LL:COL
+   |
+LL |     fn clone(&self) -> Self;
+   |        -----
+   |        |
+   |        the method is available for `std::sync::Arc<Foo>` here
+   |        the method is available for `std::rc::Rc<Foo>` here
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `clone`, perhaps you need to implement it:

--- a/src/test/ui/derives/derive-assoc-type-not-impl.stderr
+++ b/src/test/ui/derives/derive-assoc-type-not-impl.stderr
@@ -12,6 +12,14 @@ LL | struct NotClone;
 ...
 LL |     Bar::<NotClone> { x: 1 }.clone();
    |                              ^^^^^ method not found in `Bar<NotClone>`
+   | 
+  ::: $SRC_DIR/libcore/clone.rs:LL:COL
+   |
+LL |     fn clone(&self) -> Self;
+   |        -----
+   |        |
+   |        the method is available for `std::sync::Arc<Bar<NotClone>>` here
+   |        the method is available for `std::rc::Rc<Bar<NotClone>>` here
    |
    = note: the method `clone` exists but the following trait bounds were not satisfied:
            `NotClone: std::clone::Clone`

--- a/src/test/ui/error-codes/E0004-2.stderr
+++ b/src/test/ui/error-codes/E0004-2.stderr
@@ -3,6 +3,14 @@ error[E0004]: non-exhaustive patterns: `None` and `Some(_)` not covered
    |
 LL |     match x { }
    |           ^ patterns `None` and `Some(_)` not covered
+   | 
+  ::: $SRC_DIR/libcore/option.rs:LL:COL
+   |
+LL |     None,
+   |     ---- not covered
+...
+LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ---- not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 

--- a/src/test/ui/error-codes/E0005.stderr
+++ b/src/test/ui/error-codes/E0005.stderr
@@ -3,6 +3,11 @@ error[E0005]: refutable pattern in local binding: `None` not covered
    |
 LL |     let Some(y) = x;
    |         ^^^^^^^ pattern `None` not covered
+   | 
+  ::: $SRC_DIR/libcore/option.rs:LL:COL
+   |
+LL |     None,
+   |     ---- not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html

--- a/src/test/ui/error-codes/E0297.stderr
+++ b/src/test/ui/error-codes/E0297.stderr
@@ -3,6 +3,11 @@ error[E0005]: refutable pattern in `for` loop binding: `None` not covered
    |
 LL |     for Some(x) in xs {}
    |         ^^^^^^^ pattern `None` not covered
+   | 
+  ::: $SRC_DIR/libcore/option.rs:LL:COL
+   |
+LL |     None,
+   |     ---- not covered
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-exhaustive-patterns.stderr
+++ b/src/test/ui/feature-gates/feature-gate-exhaustive-patterns.stderr
@@ -3,6 +3,11 @@ error[E0005]: refutable pattern in local binding: `Err(_)` not covered
    |
 LL |     let Ok(_x) = foo();
    |         ^^^^^^ pattern `Err(_)` not covered
+   | 
+  ::: $SRC_DIR/libcore/result.rs:LL:COL
+   |
+LL |     Err(#[stable(feature = "rust1", since = "1.0.0")] E),
+   |     --- not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html

--- a/src/test/ui/generic-associated-types/iterable.stderr
+++ b/src/test/ui/generic-associated-types/iterable.stderr
@@ -5,6 +5,11 @@ LL | impl<T> Iterable for Vec<T> {
    | --------------------------- in this `impl` item
 LL |     type Item<'a> where T: 'a = <std::slice::Iter<'a, T> as Iterator>::Item;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected reference, found associated type
+   | 
+  ::: $SRC_DIR/libcore/iter/traits/iterator.rs:LL:COL
+   |
+LL |     type Item;
+   |          ---- associated type defined here
    |
    = note:    expected reference `&T`
            found associated type `<std::vec::Vec<T> as Iterable>::Item<'_>`
@@ -18,6 +23,11 @@ LL | impl<T> Iterable for [T] {
    | ------------------------ in this `impl` item
 LL |     type Item<'a> where T: 'a = <std::slice::Iter<'a, T> as Iterator>::Item;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected reference, found associated type
+   | 
+  ::: $SRC_DIR/libcore/iter/traits/iterator.rs:LL:COL
+   |
+LL |     type Item;
+   |          ---- associated type defined here
    |
    = note:    expected reference `&T`
            found associated type `<[T] as Iterable>::Item<'_>`

--- a/src/test/ui/impl-trait/no-method-suggested-traits.stderr
+++ b/src/test/ui/impl-trait/no-method-suggested-traits.stderr
@@ -83,6 +83,16 @@ error[E0599]: no method named `method` found for struct `std::rc::Rc<&mut std::b
    |
 LL |     std::rc::Rc::new(&mut Box::new(&1i32)).method();
    |                                            ^^^^^^ method not found in `std::rc::Rc<&mut std::boxed::Box<&i32>>`
+   | 
+  ::: $DIR/auxiliary/no_method_suggested_traits.rs:8:12
+   |
+LL |         fn method(&self) {}
+   |            ------
+   |            |
+   |            the method is available for `std::boxed::Box<std::rc::Rc<&mut std::boxed::Box<&i32>>>` here
+   |            the method is available for `std::pin::Pin<std::rc::Rc<&mut std::boxed::Box<&i32>>>` here
+   |            the method is available for `std::sync::Arc<std::rc::Rc<&mut std::boxed::Box<&i32>>>` here
+   |            the method is available for `std::rc::Rc<std::rc::Rc<&mut std::boxed::Box<&i32>>>` here
    |
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:

--- a/src/test/ui/issues/issue-2823.stderr
+++ b/src/test/ui/issues/issue-2823.stderr
@@ -6,6 +6,14 @@ LL | struct C {
 ...
 LL |     let _d = c.clone();
    |                ^^^^^ method not found in `C`
+   | 
+  ::: $SRC_DIR/libcore/clone.rs:LL:COL
+   |
+LL |     fn clone(&self) -> Self;
+   |        -----
+   |        |
+   |        the method is available for `std::sync::Arc<C>` here
+   |        the method is available for `std::rc::Rc<C>` here
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `clone`, perhaps you need to implement it:

--- a/src/test/ui/issues/issue-69725.stderr
+++ b/src/test/ui/issues/issue-69725.stderr
@@ -8,6 +8,14 @@ LL |     let _ = Struct::<A>::new().clone();
    |
 LL | pub struct Struct<A>(A);
    | ------------------------ doesn't satisfy `issue_69725::Struct<A>: std::clone::Clone`
+   | 
+  ::: $SRC_DIR/libcore/clone.rs:LL:COL
+   |
+LL |     fn clone(&self) -> Self;
+   |        -----
+   |        |
+   |        the method is available for `std::sync::Arc<issue_69725::Struct<A>>` here
+   |        the method is available for `std::rc::Rc<issue_69725::Struct<A>>` here
    |
    = note: the method `clone` exists but the following trait bounds were not satisfied:
            `A: std::clone::Clone`

--- a/src/test/ui/non-copyable-void.stderr
+++ b/src/test/ui/non-copyable-void.stderr
@@ -3,6 +3,14 @@ error[E0599]: no method named `clone` found for enum `libc::c_void` in the curre
    |
 LL |         let _z = (*y).clone();
    |                       ^^^^^ method not found in `libc::c_void`
+   | 
+  ::: $SRC_DIR/libcore/clone.rs:LL:COL
+   |
+LL |     fn clone(&self) -> Self;
+   |        -----
+   |        |
+   |        the method is available for `std::sync::Arc<libc::c_void>` here
+   |        the method is available for `std::rc::Rc<libc::c_void>` here
 
 error: aborting due to previous error
 

--- a/src/test/ui/noncopyable-class.stderr
+++ b/src/test/ui/noncopyable-class.stderr
@@ -6,6 +6,14 @@ LL | struct Foo {
 ...
 LL |     let _y = x.clone();
    |                ^^^^^ method not found in `Foo`
+   | 
+  ::: $SRC_DIR/libcore/clone.rs:LL:COL
+   |
+LL |     fn clone(&self) -> Self;
+   |        -----
+   |        |
+   |        the method is available for `std::sync::Arc<Foo>` here
+   |        the method is available for `std::rc::Rc<Foo>` here
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `clone`, perhaps you need to implement it:

--- a/src/test/ui/pattern/usefulness/match-arm-statics-2.stderr
+++ b/src/test/ui/pattern/usefulness/match-arm-statics-2.stderr
@@ -11,6 +11,14 @@ error[E0004]: non-exhaustive patterns: `Some(Some(West))` not covered
    |
 LL |     match Some(Some(North)) {
    |           ^^^^^^^^^^^^^^^^^ pattern `Some(Some(West))` not covered
+   | 
+  ::: $SRC_DIR/libcore/option.rs:LL:COL
+   |
+LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ----
+   |     |
+   |     not covered
+   |     not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 

--- a/src/test/ui/pattern/usefulness/match-privately-empty.stderr
+++ b/src/test/ui/pattern/usefulness/match-privately-empty.stderr
@@ -3,6 +3,11 @@ error[E0004]: non-exhaustive patterns: `Some(Private { misc: true, .. })` not co
    |
 LL |     match private::DATA {
    |           ^^^^^^^^^^^^^ pattern `Some(Private { misc: true, .. })` not covered
+   | 
+  ::: $SRC_DIR/libcore/option.rs:LL:COL
+   |
+LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ---- not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 

--- a/src/test/ui/pattern/usefulness/non-exhaustive-match.stderr
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-match.stderr
@@ -25,6 +25,11 @@ error[E0004]: non-exhaustive patterns: `Some(_)` not covered
    |
 LL |     match Some(10) {
    |           ^^^^^^^^ pattern `Some(_)` not covered
+   | 
+  ::: $SRC_DIR/libcore/option.rs:LL:COL
+   |
+LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ---- not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 

--- a/src/test/ui/recursion/recursive-types-are-not-uninhabited.stderr
+++ b/src/test/ui/recursion/recursive-types-are-not-uninhabited.stderr
@@ -3,6 +3,11 @@ error[E0005]: refutable pattern in local binding: `Err(_)` not covered
    |
 LL |     let Ok(x) = res;
    |         ^^^^^ pattern `Err(_)` not covered
+   | 
+  ::: $SRC_DIR/libcore/result.rs:LL:COL
+   |
+LL |     Err(#[stable(feature = "rust1", since = "1.0.0")] E),
+   |     --- not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html

--- a/src/test/ui/resolve/issue-3907-2.stderr
+++ b/src/test/ui/resolve/issue-3907-2.stderr
@@ -3,8 +3,11 @@ error[E0038]: the trait `issue_3907::Foo` cannot be made into an object
    |
 LL | fn bar(_x: Foo) {}
    |            ^^^ the trait `issue_3907::Foo` cannot be made into an object
+   | 
+  ::: $DIR/auxiliary/issue-3907.rs:2:8
    |
-   = note: the trait cannot be made into an object because associated function `bar` has no `self` parameter
+LL |     fn bar();
+   |        --- the trait cannot be made into an object because associated function `bar` has no `self` parameter
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match.stderr
@@ -27,6 +27,13 @@ error[E0004]: non-exhaustive patterns: `Tuple(_)` and `Struct { .. }` not covere
    |
 LL |     match x {}
    |           ^ patterns `Tuple(_)` and `Struct { .. }` not covered
+   | 
+  ::: $DIR/auxiliary/uninhabited.rs:17:23
+   |
+LL |     #[non_exhaustive] Tuple(!),
+   |                       ----- not covered
+LL |     #[non_exhaustive] Struct { x: ! }
+   |                       ------ not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns.stderr
@@ -27,6 +27,13 @@ error[E0004]: non-exhaustive patterns: `Tuple(_)` and `Struct { .. }` not covere
    |
 LL |     match x {}
    |           ^ patterns `Tuple(_)` and `Struct { .. }` not covered
+   | 
+  ::: $DIR/auxiliary/uninhabited.rs:17:23
+   |
+LL |     #[non_exhaustive] Tuple(!),
+   |                       ----- not covered
+LL |     #[non_exhaustive] Struct { x: ! }
+   |                       ------ not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 

--- a/src/test/ui/uninhabited/uninhabited-matches-feature-gated.stderr
+++ b/src/test/ui/uninhabited/uninhabited-matches-feature-gated.stderr
@@ -3,6 +3,11 @@ error[E0004]: non-exhaustive patterns: `Err(_)` not covered
    |
 LL |     let _ = match x {
    |                   ^ pattern `Err(_)` not covered
+   | 
+  ::: $SRC_DIR/libcore/result.rs:LL:COL
+   |
+LL |     Err(#[stable(feature = "rust1", since = "1.0.0")] E),
+   |     --- not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
@@ -46,6 +51,11 @@ error[E0004]: non-exhaustive patterns: `Err(_)` not covered
    |
 LL |     let _ = match x {
    |                   ^ pattern `Err(_)` not covered
+   | 
+  ::: $SRC_DIR/libcore/result.rs:LL:COL
+   |
+LL |     Err(#[stable(feature = "rust1", since = "1.0.0")] E),
+   |     --- not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
@@ -54,6 +64,11 @@ error[E0005]: refutable pattern in local binding: `Err(_)` not covered
    |
 LL |     let Ok(x) = x;
    |         ^^^^^ pattern `Err(_)` not covered
+   | 
+  ::: $SRC_DIR/libcore/result.rs:LL:COL
+   |
+LL |     Err(#[stable(feature = "rust1", since = "1.0.0")] E),
+   |     --- not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html

--- a/src/test/ui/union/union-derive-clone.stderr
+++ b/src/test/ui/union/union-derive-clone.stderr
@@ -21,6 +21,14 @@ LL | struct CloneNoCopy;
 ...
 LL |     let w = u.clone();
    |               ^^^^^ method not found in `U5<CloneNoCopy>`
+   | 
+  ::: $SRC_DIR/libcore/clone.rs:LL:COL
+   |
+LL |     fn clone(&self) -> Self;
+   |        -----
+   |        |
+   |        the method is available for `std::sync::Arc<U5<CloneNoCopy>>` here
+   |        the method is available for `std::rc::Rc<U5<CloneNoCopy>>` here
    |
    = note: the method `clone` exists but the following trait bounds were not satisfied:
            `CloneNoCopy: std::marker::Copy`

--- a/src/test/ui/unique-object-noncopyable.stderr
+++ b/src/test/ui/unique-object-noncopyable.stderr
@@ -14,6 +14,14 @@ LL |     let _z = y.clone();
    |
 LL | pub struct Box<T: ?Sized>(Unique<T>);
    | ------------------------------------- doesn't satisfy `std::boxed::Box<dyn Foo>: std::clone::Clone`
+   | 
+  ::: $SRC_DIR/libcore/clone.rs:LL:COL
+   |
+LL |     fn clone(&self) -> Self;
+   |        -----
+   |        |
+   |        the method is available for `std::sync::Arc<std::boxed::Box<dyn Foo>>` here
+   |        the method is available for `std::rc::Rc<std::boxed::Box<dyn Foo>>` here
    |
    = note: the method `clone` exists but the following trait bounds were not satisfied:
            `dyn Foo: std::marker::Sized`

--- a/src/test/ui/unique-pinned-nocopy.stderr
+++ b/src/test/ui/unique-pinned-nocopy.stderr
@@ -11,6 +11,14 @@ LL |     let _j = i.clone();
    |
 LL | pub struct Box<T: ?Sized>(Unique<T>);
    | ------------------------------------- doesn't satisfy `std::boxed::Box<R>: std::clone::Clone`
+   | 
+  ::: $SRC_DIR/libcore/clone.rs:LL:COL
+   |
+LL |     fn clone(&self) -> Self;
+   |        -----
+   |        |
+   |        the method is available for `std::sync::Arc<std::boxed::Box<R>>` here
+   |        the method is available for `std::rc::Rc<std::boxed::Box<R>>` here
    |
    = note: the method `clone` exists but the following trait bounds were not satisfied:
            `R: std::clone::Clone`


### PR DESCRIPTION
This allows us to recover span information when emitting cross crate
errors. A number of test cases benefit from this change, since we were
previously not emitting messages due to invalid spans.

There are four main parts to this commit:

1. Adding `Ident` to `DefPathData`, and updating the affected code. This
mostly consists of mechanical changes.

2. Updating how we determine the disambiguator for a `DefPath`. Since
`DefPathData` now stores a `Span` (inside the `Ident`), we need to
make sure we ignore this span we determining if a path needs to be
disambiguated. This ensure that two paths with the same symbols but
different spans are considered equal (this can occur when a macro is
repeatedly expanded to a definition).

3. Ensuring that we are able to decode `Spans` when decoding the
`DefPathTable`. Since the `DefPathTable` is stored in `CrateMetadata`, we
must decode it before we have a `CrateMetadata` available. Since
decoding a `Span` requires access to several fields from
`CrateMetadata`, this commit adds a new struct `InitialCrateMetadata`,
which implements `Metadata` and stores all of the necessary fields.

4. The specialized metadata encoder/decoder impls for `Ident` are
removed. This causes us to fall back to the default encoder/decoder
implementations for `Ident`, which simply serializes and deserializes
the fields of `Ident`. This is strictly an improvement - we still don't
have any hygiene information, but we now have a non-dummy Span.

This should hopefully allow us to test PR #68941, since we will now use
cross-crate spans in more places.