### PR TITLE
Enable blessing of mir opt tests

### DIFF
--- a/src/librustc_data_structures/sorted_map.rs
+++ b/src/librustc_data_structures/sorted_map.rs
@@ -110,13 +110,13 @@ impl<K: Ord, V> SortedMap<K, V> {
 
     /// Iterate over the keys, sorted
     #[inline]
-    pub fn keys(&self) -> impl Iterator<Item = &K> + ExactSizeIterator {
+    pub fn keys(&self) -> impl Iterator<Item = &K> + ExactSizeIterator + DoubleEndedIterator {
         self.data.iter().map(|&(ref k, _)| k)
     }
 
     /// Iterate over values, sorted by key
     #[inline]
-    pub fn values(&self) -> impl Iterator<Item = &V> + ExactSizeIterator {
+    pub fn values(&self) -> impl Iterator<Item = &V> + ExactSizeIterator + DoubleEndedIterator {
         self.data.iter().map(|&(_, ref v)| v)
     }
 

--- a/src/test/mir-opt/README.md
+++ b/src/test/mir-opt/README.md
@@ -1,6 +1,46 @@
 This folder contains tests for MIR optimizations.
 
-The test format is:
+There are two test formats. One allows specifying a pattern to look for in the MIR, which also
+permits leaving placeholders, but requires you to manually change the pattern if anything changes.
+The other emits MIR to extra files that you can automatically update by specifying `--bless` on
+the command line (just like `ui` tests updating `.stderr` files).
+
+# `--bless`able test format
+
+By default 32 bit and 64 bit targets use the same dump files, which can be problematic in the
+presence of pointers in constants or other bit width dependent things. In that case you can add
+
+```
+// EMIT_MIR_FOR_EACH_BIT_WIDTH
+```
+
+to your test, causing separate files to be generated for 32bit and 64bit systems.
+
+## Emit a diff of the mir for a specific optimization
+
+This is what you want most often when you want to see how an optimization changes the MIR.
+
+```
+// EMIT_MIR $file_name_of_some_mir_dump.diff
+```
+
+## Emit mir after a specific optimization
+
+Use this if you are just interested in the final state after an optimization.
+
+```
+// EMIT_MIR $file_name_of_some_mir_dump.after.mir
+```
+
+## Emit mir before a specific optimization
+
+This exists mainly for completeness and is rarely useful.
+
+```
+// EMIT_MIR $file_name_of_some_mir_dump.before.mir
+```
+
+# Inline test format
 
 ```
 (arbitrary rust code)

--- a/src/test/mir-opt/basic_assignment.rs
+++ b/src/test/mir-opt/basic_assignment.rs
@@ -1,5 +1,7 @@
 // this tests move up progration, which is not yet implemented
 
+// EMIT_MIR rustc.main.SimplifyCfg-initial.after.mir
+
 // Check codegen for assignments (`a = b`) where the left-hand-side is
 // not yet initialized. Assignments tend to be absent in simple code,
 // so subtle breakage in them can leave a quite hard-to-find trail of
@@ -13,40 +15,10 @@ fn main() {
     // assignment:
     nodrop_y = nodrop_x;
 
-    let drop_x : Option<Box<u32>> = None;
+    let drop_x: Option<Box<u32>> = None;
     let drop_y;
 
     // Since the type of `drop_y` has drop, we generate a `replace`
     // terminator:
     drop_y = drop_x;
 }
-
-// END RUST SOURCE
-// START rustc.main.SimplifyCfg-initial.after.mir
-//    bb0: {
-//        StorageLive(_1);
-//        _1 = const false;
-//        FakeRead(ForLet, _1);
-//        StorageLive(_2);
-//        StorageLive(_3);
-//        _3 = _1;
-//        _2 = move _3;
-//        StorageDead(_3);
-//        StorageLive(_4);
-//        _4 = std::option::Option::<std::boxed::Box<u32>>::None;
-//        FakeRead(ForLet, _4);
-//        AscribeUserType(_4, o, UserTypeProjection { base: UserType(1), projs: [] });
-//        StorageLive(_5);
-//        StorageLive(_6);
-//        _6 = move _4;
-//        replace(_5 <- move _6) -> [return: bb2, unwind: bb5];
-//    }
-//    ...
-//    bb2: {
-//        drop(_6) -> [return: bb6, unwind: bb4];
-//    }
-//    ...
-//    bb5 (cleanup): {
-//        drop(_6) -> bb4;
-//    }
-// END rustc.main.SimplifyCfg-initial.after.mir

--- a/src/test/mir-opt/basic_assignment/rustc.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/basic_assignment/rustc.main.SimplifyCfg-initial.after.mir
@@ -1,0 +1,90 @@
+// MIR for `main` after SimplifyCfg-initial
+
+| User Type Annotations
+| 0: Canonical { max_universe: U0, variables: [], value: Ty(std::option::Option<std::boxed::Box<u32>>) } at $DIR/basic_assignment.rs:18:17: 18:33
+| 1: Canonical { max_universe: U0, variables: [], value: Ty(std::option::Option<std::boxed::Box<u32>>) } at $DIR/basic_assignment.rs:18:17: 18:33
+|
+fn main() -> () {
+    let mut _0: ();                      // return place in scope 0 at $DIR/basic_assignment.rs:10:11: 10:11
+    let _1: bool;                        // in scope 0 at $DIR/basic_assignment.rs:11:9: 11:17
+    let mut _3: bool;                    // in scope 0 at $DIR/basic_assignment.rs:16:16: 16:24
+    let mut _6: std::option::Option<std::boxed::Box<u32>>; // in scope 0 at $DIR/basic_assignment.rs:23:14: 23:20
+    scope 1 {
+        debug nodrop_x => _1;            // in scope 1 at $DIR/basic_assignment.rs:11:9: 11:17
+        let _2: bool;                    // in scope 1 at $DIR/basic_assignment.rs:12:9: 12:17
+        scope 2 {
+            debug nodrop_y => _2;        // in scope 2 at $DIR/basic_assignment.rs:12:9: 12:17
+            let _4: std::option::Option<std::boxed::Box<u32>> as UserTypeProjection { base: UserType(0), projs: [] }; // in scope 2 at $DIR/basic_assignment.rs:18:9: 18:15
+            scope 3 {
+                debug drop_x => _4;      // in scope 3 at $DIR/basic_assignment.rs:18:9: 18:15
+                let _5: std::option::Option<std::boxed::Box<u32>>; // in scope 3 at $DIR/basic_assignment.rs:19:9: 19:15
+                scope 4 {
+                    debug drop_y => _5;  // in scope 4 at $DIR/basic_assignment.rs:19:9: 19:15
+                }
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/basic_assignment.rs:11:9: 11:17
+        _1 = const false;                // bb0[1]: scope 0 at $DIR/basic_assignment.rs:11:20: 11:25
+                                         // ty::Const
+                                         // + ty: bool
+                                         // + val: Value(Scalar(0x00))
+                                         // mir::Constant
+                                         // + span: $DIR/basic_assignment.rs:11:20: 11:25
+                                         // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
+        FakeRead(ForLet, _1);            // bb0[2]: scope 0 at $DIR/basic_assignment.rs:11:9: 11:17
+        StorageLive(_2);                 // bb0[3]: scope 1 at $DIR/basic_assignment.rs:12:9: 12:17
+        StorageLive(_3);                 // bb0[4]: scope 2 at $DIR/basic_assignment.rs:16:16: 16:24
+        _3 = _1;                         // bb0[5]: scope 2 at $DIR/basic_assignment.rs:16:16: 16:24
+        _2 = move _3;                    // bb0[6]: scope 2 at $DIR/basic_assignment.rs:16:5: 16:24
+        StorageDead(_3);                 // bb0[7]: scope 2 at $DIR/basic_assignment.rs:16:23: 16:24
+        StorageLive(_4);                 // bb0[8]: scope 2 at $DIR/basic_assignment.rs:18:9: 18:15
+        _4 = std::option::Option::<std::boxed::Box<u32>>::None; // bb0[9]: scope 2 at $DIR/basic_assignment.rs:18:36: 18:40
+        FakeRead(ForLet, _4);            // bb0[10]: scope 2 at $DIR/basic_assignment.rs:18:9: 18:15
+        AscribeUserType(_4, o, UserTypeProjection { base: UserType(1), projs: [] }); // bb0[11]: scope 2 at $DIR/basic_assignment.rs:18:17: 18:33
+        StorageLive(_5);                 // bb0[12]: scope 3 at $DIR/basic_assignment.rs:19:9: 19:15
+        StorageLive(_6);                 // bb0[13]: scope 4 at $DIR/basic_assignment.rs:23:14: 23:20
+        _6 = move _4;                    // bb0[14]: scope 4 at $DIR/basic_assignment.rs:23:14: 23:20
+        replace(_5 <- move _6) -> [return: bb2, unwind: bb5]; // bb0[15]: scope 4 at $DIR/basic_assignment.rs:23:5: 23:11
+    }
+
+    bb1 (cleanup): {
+        resume;                          // bb1[0]: scope 0 at $DIR/basic_assignment.rs:10:1: 24:2
+    }
+
+    bb2: {
+        drop(_6) -> [return: bb6, unwind: bb4]; // bb2[0]: scope 4 at $DIR/basic_assignment.rs:23:19: 23:20
+    }
+
+    bb3 (cleanup): {
+        drop(_4) -> bb1;                 // bb3[0]: scope 2 at $DIR/basic_assignment.rs:24:1: 24:2
+    }
+
+    bb4 (cleanup): {
+        drop(_5) -> bb3;                 // bb4[0]: scope 3 at $DIR/basic_assignment.rs:24:1: 24:2
+    }
+
+    bb5 (cleanup): {
+        drop(_6) -> bb4;                 // bb5[0]: scope 4 at $DIR/basic_assignment.rs:23:19: 23:20
+    }
+
+    bb6: {
+        StorageDead(_6);                 // bb6[0]: scope 4 at $DIR/basic_assignment.rs:23:19: 23:20
+        _0 = ();                         // bb6[1]: scope 0 at $DIR/basic_assignment.rs:10:11: 24:2
+        drop(_5) -> [return: bb7, unwind: bb3]; // bb6[2]: scope 3 at $DIR/basic_assignment.rs:24:1: 24:2
+    }
+
+    bb7: {
+        StorageDead(_5);                 // bb7[0]: scope 3 at $DIR/basic_assignment.rs:24:1: 24:2
+        drop(_4) -> [return: bb8, unwind: bb1]; // bb7[1]: scope 2 at $DIR/basic_assignment.rs:24:1: 24:2
+    }
+
+    bb8: {
+        StorageDead(_4);                 // bb8[0]: scope 2 at $DIR/basic_assignment.rs:24:1: 24:2
+        StorageDead(_2);                 // bb8[1]: scope 1 at $DIR/basic_assignment.rs:24:1: 24:2
+        StorageDead(_1);                 // bb8[2]: scope 0 at $DIR/basic_assignment.rs:24:1: 24:2
+        return;                          // bb8[3]: scope 0 at $DIR/basic_assignment.rs:24:2: 24:2
+    }
+}

--- a/src/test/mir-opt/const-promotion-extern-static.rs
+++ b/src/test/mir-opt/const-promotion-extern-static.rs
@@ -4,70 +4,12 @@ extern "C" {
 
 static Y: i32 = 42;
 
+// EMIT_MIR rustc.BAR.PromoteTemps.diff
+// EMIT_MIR rustc.BAR-promoted[0].ConstProp.after.mir
 static mut BAR: *const &i32 = [&Y].as_ptr();
 
+// EMIT_MIR rustc.FOO.PromoteTemps.diff
+// EMIT_MIR rustc.FOO-promoted[0].ConstProp.after.mir
 static mut FOO: *const &i32 = [unsafe { &X }].as_ptr();
 
 fn main() {}
-
-// END RUST SOURCE
-// START rustc.FOO.PromoteTemps.before.mir
-// bb0: {
-// ...
-//     _5 = const {alloc1+0: &i32};
-//     _4 = &(*_5);
-//     _3 = [move _4];
-//     _2 = &_3;
-//     _1 = move _2 as &[&i32] (Pointer(Unsize));
-//     _0 = const core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb2, unwind: bb1];
-// }
-// ...
-// bb2: {
-//     StorageDead(_5);
-//     StorageDead(_3);
-//     return;
-// }
-// END rustc.FOO.PromoteTemps.before.mir
-// START rustc.BAR.PromoteTemps.before.mir
-// bb0: {
-// ...
-//     _5 = const {alloc0+0: &i32};
-//     _4 = &(*_5);
-//     _3 = [move _4];
-//     _2 = &_3;
-//     _1 = move _2 as &[&i32] (Pointer(Unsize));
-//     _0 = const core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb2, unwind: bb1];
-// }
-// ...
-// bb2: {
-//     StorageDead(_5);
-//     StorageDead(_3);
-//     return;
-// }
-// END rustc.BAR.PromoteTemps.before.mir
-// START rustc.BAR.PromoteTemps.after.mir
-// bb0: {
-// ...
-//     _6 = const BAR::promoted[0];
-//     _2 = &(*_6);
-//     _1 = move _2 as &[&i32] (Pointer(Unsize));
-//     _0 = const core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb2, unwind: bb1];
-// }
-// ...
-// bb2: {
-//     return;
-// }
-// END rustc.BAR.PromoteTemps.after.mir
-// START rustc.FOO.PromoteTemps.after.mir
-// bb0: {
-// ...
-//     _6 = const FOO::promoted[0];
-//     _2 = &(*_6);
-//     _1 = move _2 as &[&i32] (Pointer(Unsize));
-//     _0 = const core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb2, unwind: bb1];
-// }
-// ...
-// bb2: {
-//     return;
-// }
-// END rustc.FOO.PromoteTemps.after.mir

--- a/src/test/mir-opt/const-promotion-extern-static/rustc.BAR-promoted[0].ConstProp.after.mir
+++ b/src/test/mir-opt/const-promotion-extern-static/rustc.BAR-promoted[0].ConstProp.after.mir
@@ -1,0 +1,26 @@
+// MIR for `BAR::promoted[0]` after ConstProp
+
+promoted[0] in BAR: &[&i32; 1] = {
+    let mut _0: &[&i32; 1];              // return place in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
+    let mut _1: [&i32; 1];               // in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
+    let mut _2: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
+    let mut _3: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
+
+    bb0: {
+        _3 = const {alloc0+0: &i32};     // bb0[0]: scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
+                                         // ty::Const
+                                         // + ty: &i32
+                                         // + val: Value(Scalar(alloc0+0))
+                                         // mir::Constant
+                                         // + span: $DIR/const-promotion-extern-static.rs:9:33: 9:34
+                                         // + literal: Const { ty: &i32, val: Value(Scalar(alloc0+0)) }
+        _2 = _3;                         // bb0[1]: scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
+        _1 = [move _2];                  // bb0[2]: scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
+        _0 = &_1;                        // bb0[3]: scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
+        return;                          // bb0[4]: scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
+    }
+}
+
+alloc0 (static: Y, size: 4, align: 4) {
+    2a 00 00 00                                     │ *...
+}

--- a/src/test/mir-opt/const-promotion-extern-static/rustc.BAR.PromoteTemps.diff
+++ b/src/test/mir-opt/const-promotion-extern-static/rustc.BAR.PromoteTemps.diff
@@ -1,0 +1,62 @@
+- // MIR for `BAR` before PromoteTemps
++ // MIR for `BAR` after PromoteTemps
+  
+  static mut BAR: *const &i32 = {
+      let mut _0: *const &i32;             // return place in scope 0 at $DIR/const-promotion-extern-static.rs:9:17: 9:28
+      let mut _1: &[&i32];                 // in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
+      let mut _2: &[&i32; 1];              // in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
+      let _3: [&i32; 1];                   // in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
+      let mut _4: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
+      let _5: &i32;                        // in scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
++     let mut _6: &[&i32; 1];              // in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
+  
+      bb0: {
+          StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
+          StorageLive(_2);                 // bb0[1]: scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
+-         StorageLive(_3);                 // bb0[2]: scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
+-         StorageLive(_4);                 // bb0[3]: scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
+-         StorageLive(_5);                 // bb0[4]: scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
+-         _5 = const {alloc0+0: &i32};     // bb0[5]: scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
++         _6 = const BAR::promoted[0];     // bb0[2]: scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
+                                           // ty::Const
+-                                          // + ty: &i32
+-                                          // + val: Value(Scalar(alloc0+0))
++                                          // + ty: &[&i32; 1]
++                                          // + val: Unevaluated(DefId(0:6 ~ const_promotion_extern_static[317d]::BAR[0]), [], Some(promoted[0]))
+                                           // mir::Constant
+-                                          // + span: $DIR/const-promotion-extern-static.rs:9:33: 9:34
+-                                          // + literal: Const { ty: &i32, val: Value(Scalar(alloc0+0)) }
+-         _4 = &(*_5);                     // bb0[6]: scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
+-         _3 = [move _4];                  // bb0[7]: scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
+-         _2 = &_3;                        // bb0[8]: scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
+-         _1 = move _2 as &[&i32] (Pointer(Unsize)); // bb0[9]: scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
+-         _0 = const core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb2, unwind: bb1]; // bb0[10]: scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
++                                          // + span: $DIR/const-promotion-extern-static.rs:9:31: 9:35
++                                          // + literal: Const { ty: &[&i32; 1], val: Unevaluated(DefId(0:6 ~ const_promotion_extern_static[317d]::BAR[0]), [], Some(promoted[0])) }
++         _2 = &(*_6);                     // bb0[3]: scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
++         _1 = move _2 as &[&i32] (Pointer(Unsize)); // bb0[4]: scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
++         _0 = const core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb2, unwind: bb1]; // bb0[5]: scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
+                                           // ty::Const
+                                           // + ty: for<'r> fn(&'r [&i32]) -> *const &i32 {core::slice::<impl [&i32]>::as_ptr}
+                                           // + val: Value(Scalar(<ZST>))
+                                           // mir::Constant
+                                           // + span: $DIR/const-promotion-extern-static.rs:9:36: 9:42
+                                           // + literal: Const { ty: for<'r> fn(&'r [&i32]) -> *const &i32 {core::slice::<impl [&i32]>::as_ptr}, val: Value(Scalar(<ZST>)) }
+      }
+  
+      bb1 (cleanup): {
+          resume;                          // bb1[0]: scope 0 at $DIR/const-promotion-extern-static.rs:9:1: 9:45
+      }
+  
+      bb2: {
+-         StorageDead(_5);                 // bb2[0]: scope 0 at $DIR/const-promotion-extern-static.rs:9:43: 9:44
+-         StorageDead(_3);                 // bb2[1]: scope 0 at $DIR/const-promotion-extern-static.rs:9:43: 9:44
+-         return;                          // bb2[2]: scope 0 at $DIR/const-promotion-extern-static.rs:9:1: 9:45
++         return;                          // bb2[0]: scope 0 at $DIR/const-promotion-extern-static.rs:9:1: 9:45
+      }
+- }
+- 
+- alloc0 (static: Y, size: 4, align: 4) {
+-     2a 00 00 00                                     │ *...
+  }
+  

--- a/src/test/mir-opt/const-promotion-extern-static/rustc.FOO-promoted[0].ConstProp.after.mir
+++ b/src/test/mir-opt/const-promotion-extern-static/rustc.FOO-promoted[0].ConstProp.after.mir
@@ -1,0 +1,26 @@
+// MIR for `FOO::promoted[0]` after ConstProp
+
+promoted[0] in FOO: &[&i32; 1] = {
+    let mut _0: &[&i32; 1];              // return place in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
+    let mut _1: [&i32; 1];               // in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
+    let mut _2: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:13:32: 13:45
+    let mut _3: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
+    scope 1 {
+    }
+
+    bb0: {
+        _3 = const {alloc2+0: &i32};     // bb0[0]: scope 0 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
+                                         // ty::Const
+                                         // + ty: &i32
+                                         // + val: Value(Scalar(alloc2+0))
+                                         // mir::Constant
+                                         // + span: $DIR/const-promotion-extern-static.rs:13:42: 13:43
+                                         // + literal: Const { ty: &i32, val: Value(Scalar(alloc2+0)) }
+        _2 = _3;                         // bb0[1]: scope 0 at $DIR/const-promotion-extern-static.rs:13:41: 13:43
+        _1 = [move _2];                  // bb0[2]: scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
+        _0 = &_1;                        // bb0[3]: scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
+        return;                          // bb0[4]: scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
+    }
+}
+
+alloc2 (extern static: X)

--- a/src/test/mir-opt/const-promotion-extern-static/rustc.FOO.PromoteTemps.diff
+++ b/src/test/mir-opt/const-promotion-extern-static/rustc.FOO.PromoteTemps.diff
@@ -1,0 +1,62 @@
+- // MIR for `FOO` before PromoteTemps
++ // MIR for `FOO` after PromoteTemps
+  
+  static mut FOO: *const &i32 = {
+      let mut _0: *const &i32;             // return place in scope 0 at $DIR/const-promotion-extern-static.rs:13:17: 13:28
+      let mut _1: &[&i32];                 // in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
+      let mut _2: &[&i32; 1];              // in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
+      let _3: [&i32; 1];                   // in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
+      let mut _4: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:13:32: 13:45
+      let _5: &i32;                        // in scope 0 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
++     let mut _6: &[&i32; 1];              // in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
+      scope 1 {
+      }
+  
+      bb0: {
+          StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
+          StorageLive(_2);                 // bb0[1]: scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
+-         StorageLive(_3);                 // bb0[2]: scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
+-         StorageLive(_4);                 // bb0[3]: scope 0 at $DIR/const-promotion-extern-static.rs:13:32: 13:45
+-         StorageLive(_5);                 // bb0[4]: scope 1 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
+-         _5 = const {alloc2+0: &i32};     // bb0[5]: scope 1 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
++         _6 = const FOO::promoted[0];     // bb0[2]: scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
+                                           // ty::Const
+-                                          // + ty: &i32
+-                                          // + val: Value(Scalar(alloc2+0))
++                                          // + ty: &[&i32; 1]
++                                          // + val: Unevaluated(DefId(0:7 ~ const_promotion_extern_static[317d]::FOO[0]), [], Some(promoted[0]))
+                                           // mir::Constant
+-                                          // + span: $DIR/const-promotion-extern-static.rs:13:42: 13:43
+-                                          // + literal: Const { ty: &i32, val: Value(Scalar(alloc2+0)) }
+-         _4 = &(*_5);                     // bb0[6]: scope 1 at $DIR/const-promotion-extern-static.rs:13:41: 13:43
+-         _3 = [move _4];                  // bb0[7]: scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
+-         _2 = &_3;                        // bb0[8]: scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
+-         _1 = move _2 as &[&i32] (Pointer(Unsize)); // bb0[9]: scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
+-         _0 = const core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb2, unwind: bb1]; // bb0[10]: scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
++                                          // + span: $DIR/const-promotion-extern-static.rs:13:31: 13:46
++                                          // + literal: Const { ty: &[&i32; 1], val: Unevaluated(DefId(0:7 ~ const_promotion_extern_static[317d]::FOO[0]), [], Some(promoted[0])) }
++         _2 = &(*_6);                     // bb0[3]: scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
++         _1 = move _2 as &[&i32] (Pointer(Unsize)); // bb0[4]: scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
++         _0 = const core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb2, unwind: bb1]; // bb0[5]: scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
+                                           // ty::Const
+                                           // + ty: for<'r> fn(&'r [&i32]) -> *const &i32 {core::slice::<impl [&i32]>::as_ptr}
+                                           // + val: Value(Scalar(<ZST>))
+                                           // mir::Constant
+                                           // + span: $DIR/const-promotion-extern-static.rs:13:47: 13:53
+                                           // + literal: Const { ty: for<'r> fn(&'r [&i32]) -> *const &i32 {core::slice::<impl [&i32]>::as_ptr}, val: Value(Scalar(<ZST>)) }
+      }
+  
+      bb1 (cleanup): {
+          resume;                          // bb1[0]: scope 0 at $DIR/const-promotion-extern-static.rs:13:1: 13:56
+      }
+  
+      bb2: {
+-         StorageDead(_5);                 // bb2[0]: scope 0 at $DIR/const-promotion-extern-static.rs:13:54: 13:55
+-         StorageDead(_3);                 // bb2[1]: scope 0 at $DIR/const-promotion-extern-static.rs:13:54: 13:55
+-         return;                          // bb2[2]: scope 0 at $DIR/const-promotion-extern-static.rs:13:1: 13:56
++         return;                          // bb2[0]: scope 0 at $DIR/const-promotion-extern-static.rs:13:1: 13:56
+      }
+  }
+- 
+- alloc2 (extern static: X)
+  

--- a/src/test/mir-opt/const_allocation.rs
+++ b/src/test/mir-opt/const_allocation.rs
@@ -1,0 +1,9 @@
+// EMIT_MIR_FOR_EACH_BIT_WIDTH
+
+static FOO: &[(Option<i32>, &[&str])] =
+    &[(None, &[]), (None, &["foo", "bar"]), (Some(42), &["meh", "mop", "möp"])];
+
+// EMIT_MIR rustc.main.ConstProp.after.mir
+fn main() {
+    FOO;
+}

--- a/src/test/mir-opt/const_allocation/32bit/rustc.main.ConstProp.after.mir
+++ b/src/test/mir-opt/const_allocation/32bit/rustc.main.ConstProp.after.mir
@@ -1,0 +1,65 @@
+// MIR for `main` after ConstProp
+
+fn main() -> () {
+    let mut _0: ();                      // return place in scope 0 at $DIR/const_allocation.rs:7:11: 7:11
+    let _1: &[(std::option::Option<i32>, &[&str])]; // in scope 0 at $DIR/const_allocation.rs:8:5: 8:8
+    let mut _2: &&[(std::option::Option<i32>, &[&str])]; // in scope 0 at $DIR/const_allocation.rs:8:5: 8:8
+
+    bb0: {
+        StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/const_allocation.rs:8:5: 8:8
+        StorageLive(_2);                 // bb0[1]: scope 0 at $DIR/const_allocation.rs:8:5: 8:8
+        _2 = const {alloc0+0: &&[(std::option::Option<i32>, &[&str])]}; // bb0[2]: scope 0 at $DIR/const_allocation.rs:8:5: 8:8
+                                         // ty::Const
+                                         // + ty: &&[(std::option::Option<i32>, &[&str])]
+                                         // + val: Value(Scalar(alloc0+0))
+                                         // mir::Constant
+                                         // + span: $DIR/const_allocation.rs:8:5: 8:8
+                                         // + literal: Const { ty: &&[(std::option::Option<i32>, &[&str])], val: Value(Scalar(alloc0+0)) }
+        _1 = (*_2);                      // bb0[3]: scope 0 at $DIR/const_allocation.rs:8:5: 8:8
+        StorageDead(_2);                 // bb0[4]: scope 0 at $DIR/const_allocation.rs:8:8: 8:9
+        StorageDead(_1);                 // bb0[5]: scope 0 at $DIR/const_allocation.rs:8:8: 8:9
+        _0 = ();                         // bb0[6]: scope 0 at $DIR/const_allocation.rs:7:11: 9:2
+        return;                          // bb0[7]: scope 0 at $DIR/const_allocation.rs:9:2: 9:2
+    }
+}
+
+alloc0 (static: FOO, size: 8, align: 4) {
+    ╾alloc17+0╼ 03 00 00 00                         │ ╾──╼....
+}
+
+alloc17 (size: 48, align: 4) {
+    0x00 │ 00 00 00 00 __ __ __ __ ╾alloc4+0─╼ 00 00 00 00 │ ....░░░░╾──╼....
+    0x10 │ 00 00 00 00 __ __ __ __ ╾alloc8+0─╼ 02 00 00 00 │ ....░░░░╾──╼....
+    0x20 │ 01 00 00 00 2a 00 00 00 ╾alloc13+0╼ 03 00 00 00 │ ....*...╾──╼....
+}
+
+alloc4 (size: 0, align: 4) {}
+
+alloc8 (size: 16, align: 4) {
+    ╾alloc7+0─╼ 03 00 00 00 ╾alloc9+0─╼ 03 00 00 00 │ ╾──╼....╾──╼....
+}
+
+alloc7 (size: 3, align: 1) {
+    66 6f 6f                                        │ foo
+}
+
+alloc9 (size: 3, align: 1) {
+    62 61 72                                        │ bar
+}
+
+alloc13 (size: 24, align: 4) {
+    0x00 │ ╾alloc12+0╼ 03 00 00 00 ╾alloc14+0╼ 03 00 00 00 │ ╾──╼....╾──╼....
+    0x10 │ ╾alloc15+0╼ 04 00 00 00                         │ ╾──╼....
+}
+
+alloc12 (size: 3, align: 1) {
+    6d 65 68                                        │ meh
+}
+
+alloc14 (size: 3, align: 1) {
+    6d 6f 70                                        │ mop
+}
+
+alloc15 (size: 4, align: 1) {
+    6d c3 b6 70                                     │ m..p
+}

--- a/src/test/mir-opt/const_allocation/64bit/rustc.main.ConstProp.after.mir
+++ b/src/test/mir-opt/const_allocation/64bit/rustc.main.ConstProp.after.mir
@@ -1,0 +1,69 @@
+// MIR for `main` after ConstProp
+
+fn main() -> () {
+    let mut _0: ();                      // return place in scope 0 at $DIR/const_allocation.rs:7:11: 7:11
+    let _1: &[(std::option::Option<i32>, &[&str])]; // in scope 0 at $DIR/const_allocation.rs:8:5: 8:8
+    let mut _2: &&[(std::option::Option<i32>, &[&str])]; // in scope 0 at $DIR/const_allocation.rs:8:5: 8:8
+
+    bb0: {
+        StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/const_allocation.rs:8:5: 8:8
+        StorageLive(_2);                 // bb0[1]: scope 0 at $DIR/const_allocation.rs:8:5: 8:8
+        _2 = const {alloc0+0: &&[(std::option::Option<i32>, &[&str])]}; // bb0[2]: scope 0 at $DIR/const_allocation.rs:8:5: 8:8
+                                         // ty::Const
+                                         // + ty: &&[(std::option::Option<i32>, &[&str])]
+                                         // + val: Value(Scalar(alloc0+0))
+                                         // mir::Constant
+                                         // + span: $DIR/const_allocation.rs:8:5: 8:8
+                                         // + literal: Const { ty: &&[(std::option::Option<i32>, &[&str])], val: Value(Scalar(alloc0+0)) }
+        _1 = (*_2);                      // bb0[3]: scope 0 at $DIR/const_allocation.rs:8:5: 8:8
+        StorageDead(_2);                 // bb0[4]: scope 0 at $DIR/const_allocation.rs:8:8: 8:9
+        StorageDead(_1);                 // bb0[5]: scope 0 at $DIR/const_allocation.rs:8:8: 8:9
+        _0 = ();                         // bb0[6]: scope 0 at $DIR/const_allocation.rs:7:11: 9:2
+        return;                          // bb0[7]: scope 0 at $DIR/const_allocation.rs:9:2: 9:2
+    }
+}
+
+alloc0 (static: FOO, size: 16, align: 8) {
+    ╾──────alloc17+0──────╼ 03 00 00 00 00 00 00 00 │ ╾──────╼........
+}
+
+alloc17 (size: 72, align: 8) {
+    0x00 │ 00 00 00 00 __ __ __ __ ╾──────alloc4+0───────╼ │ ....░░░░╾──────╼
+    0x10 │ 00 00 00 00 00 00 00 00 00 00 00 00 __ __ __ __ │ ............░░░░
+    0x20 │ ╾──────alloc8+0───────╼ 02 00 00 00 00 00 00 00 │ ╾──────╼........
+    0x30 │ 01 00 00 00 2a 00 00 00 ╾──────alloc13+0──────╼ │ ....*...╾──────╼
+    0x40 │ 03 00 00 00 00 00 00 00                         │ ........
+}
+
+alloc4 (size: 0, align: 8) {}
+
+alloc8 (size: 32, align: 8) {
+    0x00 │ ╾──────alloc7+0───────╼ 03 00 00 00 00 00 00 00 │ ╾──────╼........
+    0x10 │ ╾──────alloc9+0───────╼ 03 00 00 00 00 00 00 00 │ ╾──────╼........
+}
+
+alloc7 (size: 3, align: 1) {
+    66 6f 6f                                        │ foo
+}
+
+alloc9 (size: 3, align: 1) {
+    62 61 72                                        │ bar
+}
+
+alloc13 (size: 48, align: 8) {
+    0x00 │ ╾──────alloc12+0──────╼ 03 00 00 00 00 00 00 00 │ ╾──────╼........
+    0x10 │ ╾──────alloc14+0──────╼ 03 00 00 00 00 00 00 00 │ ╾──────╼........
+    0x20 │ ╾──────alloc15+0──────╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
+}
+
+alloc12 (size: 3, align: 1) {
+    6d 65 68                                        │ meh
+}
+
+alloc14 (size: 3, align: 1) {
+    6d 6f 70                                        │ mop
+}
+
+alloc15 (size: 4, align: 1) {
+    6d c3 b6 70                                     │ m..p
+}

--- a/src/test/mir-opt/const_allocation2.rs
+++ b/src/test/mir-opt/const_allocation2.rs
@@ -1,0 +1,11 @@
+// EMIT_MIR_FOR_EACH_BIT_WIDTH
+
+// EMIT_MIR rustc.main.ConstProp.after.mir
+fn main() {
+    FOO;
+}
+
+const BAR: [u8; 4] = [42, 69, 21, 111];
+
+static FOO: &[(Option<i32>, &[&u8])] =
+    &[(None, &[]), (None, &[&5, &6]), (Some(42), &[&BAR[3], &42, &BAR[2]])];

--- a/src/test/mir-opt/const_allocation2/32bit/rustc.main.ConstProp.after.mir
+++ b/src/test/mir-opt/const_allocation2/32bit/rustc.main.ConstProp.after.mir
@@ -1,0 +1,64 @@
+// MIR for `main` after ConstProp
+
+fn main() -> () {
+    let mut _0: ();                      // return place in scope 0 at $DIR/const_allocation2.rs:4:11: 4:11
+    let _1: &[(std::option::Option<i32>, &[&u8])]; // in scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
+    let mut _2: &&[(std::option::Option<i32>, &[&u8])]; // in scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
+
+    bb0: {
+        StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
+        StorageLive(_2);                 // bb0[1]: scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
+        _2 = const {alloc0+0: &&[(std::option::Option<i32>, &[&u8])]}; // bb0[2]: scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
+                                         // ty::Const
+                                         // + ty: &&[(std::option::Option<i32>, &[&u8])]
+                                         // + val: Value(Scalar(alloc0+0))
+                                         // mir::Constant
+                                         // + span: $DIR/const_allocation2.rs:5:5: 5:8
+                                         // + literal: Const { ty: &&[(std::option::Option<i32>, &[&u8])], val: Value(Scalar(alloc0+0)) }
+        _1 = (*_2);                      // bb0[3]: scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
+        StorageDead(_2);                 // bb0[4]: scope 0 at $DIR/const_allocation2.rs:5:8: 5:9
+        StorageDead(_1);                 // bb0[5]: scope 0 at $DIR/const_allocation2.rs:5:8: 5:9
+        _0 = ();                         // bb0[6]: scope 0 at $DIR/const_allocation2.rs:4:11: 6:2
+        return;                          // bb0[7]: scope 0 at $DIR/const_allocation2.rs:6:2: 6:2
+    }
+}
+
+alloc0 (static: FOO, size: 8, align: 4) {
+    ╾alloc24+0╼ 03 00 00 00                         │ ╾──╼....
+}
+
+alloc24 (size: 48, align: 4) {
+    0x00 │ 00 00 00 00 __ __ __ __ ╾alloc9+0─╼ 00 00 00 00 │ ....░░░░╾──╼....
+    0x10 │ 00 00 00 00 __ __ __ __ ╾alloc14+0╼ 02 00 00 00 │ ....░░░░╾──╼....
+    0x20 │ 01 00 00 00 2a 00 00 00 ╾alloc22+0╼ 03 00 00 00 │ ....*...╾──╼....
+}
+
+alloc9 (size: 0, align: 4) {}
+
+alloc14 (size: 8, align: 4) {
+    ╾alloc12+0╼ ╾alloc13+0╼                         │ ╾──╼╾──╼
+}
+
+alloc12 (size: 1, align: 1) {
+    05                                              │ .
+}
+
+alloc13 (size: 1, align: 1) {
+    06                                              │ .
+}
+
+alloc22 (size: 12, align: 4) {
+    ╾alloc18+3╼ ╾alloc19+0╼ ╾alloc21+2╼             │ ╾──╼╾──╼╾──╼
+}
+
+alloc18 (size: 4, align: 1) {
+    2a 45 15 6f                                     │ *E.o
+}
+
+alloc19 (size: 1, align: 1) {
+    2a                                              │ *
+}
+
+alloc21 (size: 4, align: 1) {
+    2a 45 15 6f                                     │ *E.o
+}

--- a/src/test/mir-opt/const_allocation2/64bit/rustc.main.ConstProp.after.mir
+++ b/src/test/mir-opt/const_allocation2/64bit/rustc.main.ConstProp.after.mir
@@ -1,0 +1,67 @@
+// MIR for `main` after ConstProp
+
+fn main() -> () {
+    let mut _0: ();                      // return place in scope 0 at $DIR/const_allocation2.rs:4:11: 4:11
+    let _1: &[(std::option::Option<i32>, &[&u8])]; // in scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
+    let mut _2: &&[(std::option::Option<i32>, &[&u8])]; // in scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
+
+    bb0: {
+        StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
+        StorageLive(_2);                 // bb0[1]: scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
+        _2 = const {alloc0+0: &&[(std::option::Option<i32>, &[&u8])]}; // bb0[2]: scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
+                                         // ty::Const
+                                         // + ty: &&[(std::option::Option<i32>, &[&u8])]
+                                         // + val: Value(Scalar(alloc0+0))
+                                         // mir::Constant
+                                         // + span: $DIR/const_allocation2.rs:5:5: 5:8
+                                         // + literal: Const { ty: &&[(std::option::Option<i32>, &[&u8])], val: Value(Scalar(alloc0+0)) }
+        _1 = (*_2);                      // bb0[3]: scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
+        StorageDead(_2);                 // bb0[4]: scope 0 at $DIR/const_allocation2.rs:5:8: 5:9
+        StorageDead(_1);                 // bb0[5]: scope 0 at $DIR/const_allocation2.rs:5:8: 5:9
+        _0 = ();                         // bb0[6]: scope 0 at $DIR/const_allocation2.rs:4:11: 6:2
+        return;                          // bb0[7]: scope 0 at $DIR/const_allocation2.rs:6:2: 6:2
+    }
+}
+
+alloc0 (static: FOO, size: 16, align: 8) {
+    ╾──────alloc24+0──────╼ 03 00 00 00 00 00 00 00 │ ╾──────╼........
+}
+
+alloc24 (size: 72, align: 8) {
+    0x00 │ 00 00 00 00 __ __ __ __ ╾──────alloc9+0───────╼ │ ....░░░░╾──────╼
+    0x10 │ 00 00 00 00 00 00 00 00 00 00 00 00 __ __ __ __ │ ............░░░░
+    0x20 │ ╾──────alloc14+0──────╼ 02 00 00 00 00 00 00 00 │ ╾──────╼........
+    0x30 │ 01 00 00 00 2a 00 00 00 ╾──────alloc22+0──────╼ │ ....*...╾──────╼
+    0x40 │ 03 00 00 00 00 00 00 00                         │ ........
+}
+
+alloc9 (size: 0, align: 8) {}
+
+alloc14 (size: 16, align: 8) {
+    ╾──────alloc12+0──────╼ ╾──────alloc13+0──────╼ │ ╾──────╼╾──────╼
+}
+
+alloc12 (size: 1, align: 1) {
+    05                                              │ .
+}
+
+alloc13 (size: 1, align: 1) {
+    06                                              │ .
+}
+
+alloc22 (size: 24, align: 8) {
+    0x00 │ ╾──────alloc18+3──────╼ ╾──────alloc19+0──────╼ │ ╾──────╼╾──────╼
+    0x10 │ ╾──────alloc21+2──────╼                         │ ╾──────╼
+}
+
+alloc18 (size: 4, align: 1) {
+    2a 45 15 6f                                     │ *E.o
+}
+
+alloc19 (size: 1, align: 1) {
+    2a                                              │ *
+}
+
+alloc21 (size: 4, align: 1) {
+    2a 45 15 6f                                     │ *E.o
+}

--- a/src/test/mir-opt/const_allocation3.rs
+++ b/src/test/mir-opt/const_allocation3.rs
@@ -1,0 +1,29 @@
+// EMIT_MIR_FOR_EACH_BIT_WIDTH
+
+// EMIT_MIR rustc.main.ConstProp.after.mir
+fn main() {
+    FOO;
+}
+
+#[repr(packed)]
+struct Packed {
+    a: [u8; 28],
+    b: &'static i32,
+    c: u32,
+    d: [u8; 102],
+    e: fn(),
+    f: u16,
+    g: &'static u8,
+    h: [u8; 20],
+}
+
+static FOO: &Packed = &Packed {
+    a: [0xAB; 28],
+    b: &42,
+    c: 0xABCD_EF01,
+    d: [0; 102],
+    e: main,
+    f: 0,
+    g: &[0; 100][99],
+    h: [0; 20],
+};

--- a/src/test/mir-opt/const_allocation3/32bit/rustc.main.ConstProp.after.mir
+++ b/src/test/mir-opt/const_allocation3/32bit/rustc.main.ConstProp.after.mir
@@ -1,0 +1,58 @@
+// MIR for `main` after ConstProp
+
+fn main() -> () {
+    let mut _0: ();                      // return place in scope 0 at $DIR/const_allocation3.rs:4:11: 4:11
+    let _1: &Packed;                     // in scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
+    let mut _2: &&Packed;                // in scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
+
+    bb0: {
+        StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
+        StorageLive(_2);                 // bb0[1]: scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
+        _2 = const {alloc0+0: &&Packed}; // bb0[2]: scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
+                                         // ty::Const
+                                         // + ty: &&Packed
+                                         // + val: Value(Scalar(alloc0+0))
+                                         // mir::Constant
+                                         // + span: $DIR/const_allocation3.rs:5:5: 5:8
+                                         // + literal: Const { ty: &&Packed, val: Value(Scalar(alloc0+0)) }
+        _1 = (*_2);                      // bb0[3]: scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
+        StorageDead(_2);                 // bb0[4]: scope 0 at $DIR/const_allocation3.rs:5:8: 5:9
+        StorageDead(_1);                 // bb0[5]: scope 0 at $DIR/const_allocation3.rs:5:8: 5:9
+        _0 = ();                         // bb0[6]: scope 0 at $DIR/const_allocation3.rs:4:11: 6:2
+        return;                          // bb0[7]: scope 0 at $DIR/const_allocation3.rs:6:2: 6:2
+    }
+}
+
+alloc0 (static: FOO, size: 4, align: 4) {
+    ╾alloc10+0╼                                     │ ╾──╼
+}
+
+alloc10 (size: 168, align: 1) {
+    0x00 │ ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab │ ................
+    0x10 │ ab ab ab ab ab ab ab ab ab ab ab ab ╾alloc5+0─╼ │ ............╾──╼
+    0x20 │ 01 ef cd ab 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x30 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x40 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x50 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x60 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x70 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x80 │ 00 00 00 00 00 00 00 00 00 00 ╾alloc7+0─╼ 00 00 │ ..........╾──╼..
+    0x90 │ ╾alloc8+99╼ 00 00 00 00 00 00 00 00 00 00 00 00 │ ╾──╼............
+    0xa0 │ 00 00 00 00 00 00 00 00                         │ ........
+}
+
+alloc5 (size: 4, align: 4) {
+    2a 00 00 00                                     │ *...
+}
+
+alloc7 (fn: main)
+
+alloc8 (size: 100, align: 1) {
+    0x00 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x10 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x20 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x30 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x40 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x50 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x60 │ 00 00 00 00                                     │ ....
+}

--- a/src/test/mir-opt/const_allocation3/64bit/rustc.main.ConstProp.after.mir
+++ b/src/test/mir-opt/const_allocation3/64bit/rustc.main.ConstProp.after.mir
@@ -1,0 +1,59 @@
+// MIR for `main` after ConstProp
+
+fn main() -> () {
+    let mut _0: ();                      // return place in scope 0 at $DIR/const_allocation3.rs:4:11: 4:11
+    let _1: &Packed;                     // in scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
+    let mut _2: &&Packed;                // in scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
+
+    bb0: {
+        StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
+        StorageLive(_2);                 // bb0[1]: scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
+        _2 = const {alloc0+0: &&Packed}; // bb0[2]: scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
+                                         // ty::Const
+                                         // + ty: &&Packed
+                                         // + val: Value(Scalar(alloc0+0))
+                                         // mir::Constant
+                                         // + span: $DIR/const_allocation3.rs:5:5: 5:8
+                                         // + literal: Const { ty: &&Packed, val: Value(Scalar(alloc0+0)) }
+        _1 = (*_2);                      // bb0[3]: scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
+        StorageDead(_2);                 // bb0[4]: scope 0 at $DIR/const_allocation3.rs:5:8: 5:9
+        StorageDead(_1);                 // bb0[5]: scope 0 at $DIR/const_allocation3.rs:5:8: 5:9
+        _0 = ();                         // bb0[6]: scope 0 at $DIR/const_allocation3.rs:4:11: 6:2
+        return;                          // bb0[7]: scope 0 at $DIR/const_allocation3.rs:6:2: 6:2
+    }
+}
+
+alloc0 (static: FOO, size: 8, align: 8) {
+    ╾──────alloc10+0──────╼                         │ ╾──────╼
+}
+
+alloc10 (size: 180, align: 1) {
+    0x00 │ ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab │ ................
+    0x10 │ ab ab ab ab ab ab ab ab ab ab ab ab ╾─alloc5+0─ │ ............╾───
+    0x20 │ ──────────╼ 01 ef cd ab 00 00 00 00 00 00 00 00 │ ───╼............
+    0x30 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x40 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x50 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x60 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x70 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x80 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ╾──── │ ..............╾─
+    0x90 │ ────alloc7+0────╼ 00 00 ╾──────alloc8+99──────╼ │ ─────╼..╾──────╼
+    0xa0 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0xb0 │ 00 00 00 00                                     │ ....
+}
+
+alloc5 (size: 4, align: 4) {
+    2a 00 00 00                                     │ *...
+}
+
+alloc7 (fn: main)
+
+alloc8 (size: 100, align: 1) {
+    0x00 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x10 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x20 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x30 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x40 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x50 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+    0x60 │ 00 00 00 00                                     │ ....
+}

--- a/src/test/mir-opt/const_prop/cast.rs
+++ b/src/test/mir-opt/const_prop/cast.rs
@@ -1,49 +1,7 @@
+// EMIT_MIR rustc.main.ConstProp.diff
+
 fn main() {
     let x = 42u8 as u32;
 
     let y = 42u32 as u8;
 }
-
-// END RUST SOURCE
-// START rustc.main.ConstProp.before.mir
-// let mut _0: ();
-// let _1: u32;
-// scope 1 {
-//   debug x => _1;
-//   let _2: u8;
-//   scope 2 {
-//     debug y => _2;
-//   }
-// }
-// bb0: {
-//   StorageLive(_1);
-//   _1 = const 42u8 as u32 (Misc);
-//   StorageLive(_2);
-//   _2 = const 42u32 as u8 (Misc);
-//   _0 = ();
-//   StorageDead(_2);
-//   StorageDead(_1);
-//   return;
-// }
-// END rustc.main.ConstProp.before.mir
-// START rustc.main.ConstProp.after.mir
-// let mut _0: ();
-// let _1: u32;
-// scope 1 {
-//   debug x => _1;
-//   let _2: u8;
-//   scope 2 {
-//     debug y => _2;
-//   }
-// }
-// bb0: {
-//   StorageLive(_1);
-//   _1 = const 42u32;
-//   StorageLive(_2);
-//   _2 = const 42u8;
-//   _0 = ();
-//   StorageDead(_2);
-//   StorageDead(_1);
-//   return;
-// }
-// END rustc.main.ConstProp.after.mir

--- a/src/test/mir-opt/const_prop/cast/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/cast/rustc.main.ConstProp.diff
@@ -1,0 +1,48 @@
+- // MIR for `main` before ConstProp
++ // MIR for `main` after ConstProp
+  
+  fn main() -> () {
+      let mut _0: ();                      // return place in scope 0 at $DIR/cast.rs:3:11: 3:11
+      let _1: u32;                         // in scope 0 at $DIR/cast.rs:4:9: 4:10
+      scope 1 {
+          debug x => _1;                   // in scope 1 at $DIR/cast.rs:4:9: 4:10
+          let _2: u8;                      // in scope 1 at $DIR/cast.rs:6:9: 6:10
+          scope 2 {
+              debug y => _2;               // in scope 2 at $DIR/cast.rs:6:9: 6:10
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/cast.rs:4:9: 4:10
+-         _1 = const 42u8 as u32 (Misc);   // bb0[1]: scope 0 at $DIR/cast.rs:4:13: 4:24
++         _1 = const 42u32;                // bb0[1]: scope 0 at $DIR/cast.rs:4:13: 4:24
+                                           // ty::Const
+-                                          // + ty: u8
+-                                          // + val: Value(Scalar(0x2a))
+-                                          // mir::Constant
+-                                          // + span: $DIR/cast.rs:4:13: 4:17
+-                                          // + literal: Const { ty: u8, val: Value(Scalar(0x2a)) }
+-         StorageLive(_2);                 // bb0[2]: scope 1 at $DIR/cast.rs:6:9: 6:10
+-         _2 = const 42u32 as u8 (Misc);   // bb0[3]: scope 1 at $DIR/cast.rs:6:13: 6:24
+-                                          // ty::Const
+                                           // + ty: u32
+                                           // + val: Value(Scalar(0x0000002a))
+                                           // mir::Constant
+-                                          // + span: $DIR/cast.rs:6:13: 6:18
++                                          // + span: $DIR/cast.rs:4:13: 4:24
+                                           // + literal: Const { ty: u32, val: Value(Scalar(0x0000002a)) }
++         StorageLive(_2);                 // bb0[2]: scope 1 at $DIR/cast.rs:6:9: 6:10
++         _2 = const 42u8;                 // bb0[3]: scope 1 at $DIR/cast.rs:6:13: 6:24
++                                          // ty::Const
++                                          // + ty: u8
++                                          // + val: Value(Scalar(0x2a))
++                                          // mir::Constant
++                                          // + span: $DIR/cast.rs:6:13: 6:24
++                                          // + literal: Const { ty: u8, val: Value(Scalar(0x2a)) }
+          _0 = ();                         // bb0[4]: scope 0 at $DIR/cast.rs:3:11: 7:2
+          StorageDead(_2);                 // bb0[5]: scope 1 at $DIR/cast.rs:7:1: 7:2
+          StorageDead(_1);                 // bb0[6]: scope 0 at $DIR/cast.rs:7:1: 7:2
+          return;                          // bb0[7]: scope 0 at $DIR/cast.rs:7:2: 7:2
+      }
+  }
+  

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -449,15 +449,8 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
 pub fn make_tests(config: &Config, tests: &mut Vec<test::TestDescAndFn>) {
     debug!("making tests from {:?}", config.src_base.display());
     let inputs = common_inputs_stamp(config);
-    collect_tests_from_dir(
-        config,
-        &config.src_base,
-        &config.src_base,
-        &PathBuf::new(),
-        &inputs,
-        tests,
-    )
-    .expect(&format!("Could not read tests from {}", config.src_base.display()));
+    collect_tests_from_dir(config, &config.src_base, &PathBuf::new(), &inputs, tests)
+        .expect(&format!("Could not read tests from {}", config.src_base.display()));
 }
 
 /// Returns a stamp constructed from input files common to all test cases.
@@ -494,7 +487,6 @@ fn common_inputs_stamp(config: &Config) -> Stamp {
 
 fn collect_tests_from_dir(
     config: &Config,
-    base: &Path,
     dir: &Path,
     relative_dir_path: &Path,
     inputs: &Stamp,
@@ -538,14 +530,7 @@ fn collect_tests_from_dir(
             let relative_file_path = relative_dir_path.join(file.file_name());
             if &file_name != "auxiliary" {
                 debug!("found directory: {:?}", file_path.display());
-                collect_tests_from_dir(
-                    config,
-                    base,
-                    &file_path,
-                    &relative_file_path,
-                    inputs,
-                    tests,
-                )?;
+                collect_tests_from_dir(config, &file_path, &relative_file_path, inputs, tests)?;
             }
         } else {
             debug!("found other file/directory: {:?}", file_path.display());


### PR DESCRIPTION
cc @rust-lang/wg-mir-opt 
cc @RalfJung 

Long overdue, but now you can finally just add a

```rust
// EMIT_MIR rustc.function_name.MirPassName.before.mir
```

(or `after.mir` since most of the time you want to know the MIR after a pass). A `--bless` invocation will automatically create the files for you.

I suggest we do this for all mir opt tests that have all of the MIR in their source anyway

If you use `rustc.function.MirPass.diff` you only get the diff that the MIR pass causes on the MIR.

Fixes #67865 