### PR TITLE
rustdoc: remove unused import

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -12,7 +12,6 @@ use rustc_hir::Mutability;
 use rustc_metadata::creader::LoadedMacro;
 use rustc_mir::const_eval::is_min_const_fn;
 use rustc_span::hygiene::MacroKind;
-use rustc_span::symbol::sym;
 use rustc_span::Span;
 
 use crate::clean::{self, GetDefId, ToSource, TypeKind};


### PR DESCRIPTION
```
    Checking rustdoc v0.0.0 (/home/matthias/vcs/github/rust/src/librustdoc)
warning: unused import: `rustc_span::symbol::sym`
  --> src/librustdoc/clean/inline.rs:15:5
   |
15 | use rustc_span::symbol::sym;
   |     ^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
```