### PR TITLE
submodules: update clippy from 329923ed to fdce47ba

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ version = "0.0.212"
 dependencies = [
  "cargo_metadata 0.9.0",
  "if_chain",
- "itertools 0.8.0",
+ "itertools 0.9.0",
  "lazy_static 1.4.0",
  "matches",
  "pulldown-cmark 0.7.0",
@@ -1600,6 +1600,15 @@ name = "itertools"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]


### PR DESCRIPTION
Changes:
````
add CR feedback
Improve documentation
Use `edition:2018` flag more widely
Update tests/ui/needless_doc_main.rs
Move links to the end of each chapter on adding_lints
Move links to the end of each chapter on CONTRIBUTING
Clean-up adding_lints.md
Clean-up CONTRIBUTING.md
needless_doc_main: only check rust code
Use `node_type_opt` over `node_type`
Fix doc
Fix ICE with trivial_bounds feature
clippy_lints: readme: don't mention crates.io since it is no longer used to publish clippy.
update rust-lang.github.io to rustc-dev-guide.rust-lang.org
Improve placeholder in map_unit_fn
Fix match single binding when in a let stmt
Improve error messages for {option,result}_map_unit_fn
Mention the setup instructions in CONTRIBUTING
redundant_pattern: take binding (ref, ref mut) into account in suggestion.
check_pat: delay creation of the "normal" vec until we reach the branch where is is actually needed
deps: bump itertools 0.8 -> 0.9
add lint on File::read_to_string and File::read_to_end
transition rustc-guide to rustc-dev-guide
Rename macro_use_import -> macro_use_imports
warn on macro_use attr
Fix deploy script for tag deploys
````


Fixes rust-lang#69957
