### PR TITLE
ci: bump webrender in cargotest

### DIFF
--- a/src/tools/cargotest/main.rs
+++ b/src/tools/cargotest/main.rs
@@ -61,7 +61,7 @@ const TEST_REPOS: &'static [Test] = &[
     Test {
         name: "webrender",
         repo: "https://github.com/servo/webrender",
-        sha: "a3d6e6894c5a601fa547c6273eb963ca1321c2bb",
+        sha: "6f23331299bf47e7e4683b815d10320770e14e21",
         lock: None,
         packages: &[],
     },


### PR DESCRIPTION
This bumps the commit of webrender we test to include a fix for a spurious failure we encountered in CI. See #69895 for more context on the spurious failure.

The commit we're interested in including is https://github.com/servo/webrender/pull/3881/commits/07439c54a8176cb40dee84387976255720e1346c. Thanks again @jrmuizel for the quick response on this!

r? @Mark-Simulacrum 
