### PR TITLE
Increase verbosity when suggesting subtle code changes

### DIFF
--- a/src/librustc_infer/infer/error_reporting/need_type_info.rs
+++ b/src/librustc_infer/infer/error_reporting/need_type_info.rs
@@ -3,7 +3,7 @@ use crate::infer::InferCtxt;
 use rustc::hir::map::Map;
 use rustc::ty::print::Print;
 use rustc::ty::{self, DefIdTree, Infer, Ty, TyVar};
-use rustc_errors::{struct_span_err, Applicability, DiagnosticBuilder};
+use rustc_errors::{pluralize, struct_span_err, Applicability, DiagnosticBuilder};
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Namespace};
 use rustc_hir::intravisit::{self, NestedVisitorMap, Visitor};
@@ -462,24 +462,19 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         e: &Expr<'_>,
         err: &mut DiagnosticBuilder<'_>,
     ) {
-        if let (Ok(snippet), Some(tables), None) = (
-            self.tcx.sess.source_map().span_to_snippet(segment.ident.span),
-            self.in_progress_tables,
-            &segment.args,
-        ) {
+        if let (Some(tables), None) = (self.in_progress_tables, &segment.args) {
             let borrow = tables.borrow();
             if let Some((DefKind::AssocFn, did)) = borrow.type_dependent_def(e.hir_id) {
                 let generics = self.tcx.generics_of(did);
                 if !generics.params.is_empty() {
-                    err.span_suggestion(
-                        segment.ident.span,
+                    err.span_suggestion_verbose(
+                        segment.ident.span.shrink_to_hi(),
                         &format!(
                             "consider specifying the type argument{} in the method call",
-                            if generics.params.len() > 1 { "s" } else { "" },
+                            pluralize!(generics.params.len()),
                         ),
                         format!(
-                            "{}::<{}>",
-                            snippet,
+                            "::<{}>",
                             generics
                                 .params
                                 .iter()

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -952,7 +952,7 @@ impl<'a> Resolver<'a> {
         let descr = get_descr(binding);
         let mut err =
             struct_span_err!(self.session, ident.span, E0603, "{} `{}` is private", descr, ident);
-        err.span_label(ident.span, &format!("this {} is private", descr));
+        err.span_label(ident.span, &format!("private {}", descr));
         if let Some(span) = ctor_fields_span {
             err.span_label(span, "a constructor is private if any of the fields is private");
         }

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -506,10 +506,10 @@ impl<'a> LateResolutionVisitor<'a, '_, '_> {
 
         match (res, source) {
             (Res::Def(DefKind::Macro(MacroKind::Bang), _), _) => {
-                err.span_suggestion(
-                    span,
+                err.span_suggestion_verbose(
+                    span.shrink_to_hi(),
                     "use `!` to invoke the macro",
-                    format!("{}!", path_str),
+                    "!".to_string(),
                     Applicability::MaybeIncorrect,
                 );
                 if path_str == "try" && span.rust_2015() {

--- a/src/librustc_trait_selection/traits/error_reporting/mod.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/mod.rs
@@ -815,11 +815,11 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             // For example, if `expected_args_length` is 2, suggest `|_, _|`.
             if found_args.is_empty() && is_closure {
                 let underscores = vec!["_"; expected_args.len()].join(", ");
-                err.span_suggestion(
+                err.span_suggestion_verbose(
                     pipe_span,
                     &format!(
                         "consider changing the closure to take and ignore the expected argument{}",
-                        if expected_args.len() < 2 { "" } else { "s" }
+                        pluralize!(expected_args.len())
                     ),
                     format!("|{}|", underscores),
                     Applicability::MachineApplicable,
@@ -833,7 +833,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                         .map(|(name, _)| name.to_owned())
                         .collect::<Vec<String>>()
                         .join(", ");
-                    err.span_suggestion(
+                    err.span_suggestion_verbose(
                         found_span,
                         "change the closure to take multiple arguments instead of a single tuple",
                         format!("|{}|", sugg),
@@ -870,7 +870,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             String::new()
                         },
                     );
-                    err.span_suggestion(
+                    err.span_suggestion_verbose(
                         found_span,
                         "change the closure to accept a tuple instead of individual arguments",
                         sugg,
@@ -1420,15 +1420,14 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
                         //    |
                         //    = note: cannot resolve `_: Tt`
 
-                        err.span_suggestion(
-                            span,
+                        err.span_suggestion_verbose(
+                            span.shrink_to_hi(),
                             &format!(
                                 "consider specifying the type argument{} in the function call",
-                                if generics.params.len() > 1 { "s" } else { "" },
+                                pluralize!(generics.params.len()),
                             ),
                             format!(
-                                "{}::<{}>",
-                                snippet,
+                                "::<{}>",
                                 generics
                                     .params
                                     .iter()
@@ -1590,7 +1589,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
                             [] => (span.shrink_to_hi(), ":"),
                             [.., bound] => (bound.span().shrink_to_hi(), " + "),
                         };
-                        err.span_suggestion(
+                        err.span_suggestion_verbose(
                             span,
                             "consider relaxing the implicit `Sized` restriction",
                             format!("{} ?Sized", separator),

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -390,7 +390,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         }
         let hir = self.tcx.hir();
         // Get the name of the callable and the arguments to be used in the suggestion.
-        let snippet = match hir.get_if_local(def_id) {
+        let (snippet, sugg) = match hir.get_if_local(def_id) {
             Some(hir::Node::Expr(hir::Expr {
                 kind: hir::ExprKind::Closure(_, decl, _, span, ..),
                 ..
@@ -401,7 +401,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     None => return,
                 };
                 let args = decl.inputs.iter().map(|_| "_").collect::<Vec<_>>().join(", ");
-                format!("{}({})", name, args)
+                let sugg = format!("({})", args);
+                (format!("{}{}", name, sugg), sugg)
             }
             Some(hir::Node::Item(hir::Item {
                 ident,
@@ -422,7 +423,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     })
                     .collect::<Vec<_>>()
                     .join(", ");
-                format!("{}({})", ident, args)
+                let sugg = format!("({})", args);
+                (format!("{}{}", ident, sugg), sugg)
             }
             _ => return,
         };
@@ -431,10 +433,10 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             // an argument, the `obligation.cause.span` points at the expression
             // of the argument, so we can provide a suggestion. This is signaled
             // by `points_at_arg`. Otherwise, we give a more general note.
-            err.span_suggestion(
-                obligation.cause.span,
+            err.span_suggestion_verbose(
+                obligation.cause.span.shrink_to_hi(),
                 &msg,
-                snippet,
+                sugg,
                 Applicability::HasPlaceholders,
             );
         } else {
@@ -619,7 +621,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                         .source_map()
                         .span_take_while(span, |c| c.is_whitespace() || *c == '&');
                     if points_at_arg && mutability == hir::Mutability::Not && refs_number > 0 {
-                        err.span_suggestion(
+                        err.span_suggestion_verbose(
                             sp,
                             "consider changing this borrow's mutability",
                             "&mut ".to_string(),

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1452,8 +1452,13 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             .expect("missing associated type");
 
         if !assoc_ty.vis.is_accessible_from(def_scope, tcx) {
-            let msg = format!("associated type `{}` is private", binding.item_name);
-            tcx.sess.span_err(binding.span, &msg);
+            tcx.sess
+                .struct_span_err(
+                    binding.span,
+                    &format!("associated type `{}` is private", binding.item_name),
+                )
+                .span_label(binding.span, "private associated type")
+                .emit();
         }
         tcx.check_stability(assoc_ty.def_id, Some(hir_ref_id), binding.span);
 
@@ -2316,8 +2321,12 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 
         let kind = DefKind::AssocTy;
         if !item.vis.is_accessible_from(def_scope, tcx) {
-            let msg = format!("{} `{}` is private", kind.descr(item.def_id), assoc_ident);
-            tcx.sess.span_err(span, &msg);
+            let kind = kind.descr(item.def_id);
+            let msg = format!("{} `{}` is private", kind, assoc_ident);
+            tcx.sess
+                .struct_span_err(span, &msg)
+                .span_label(span, &format!("private {}", kind))
+                .emit();
         }
         tcx.check_stability(item.def_id, Some(hir_ref_id), span);
 

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -1583,13 +1583,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         };
         let mut err = struct_span_err!(
             self.tcx().sess,
-            expr.span,
+            field.span,
             E0616,
             "field `{}` of {} `{}` is private",
             field,
             kind_name,
             struct_path
         );
+        err.span_label(field.span, "private field");
         // Also check if an accessible method exists, which is often what is meant.
         if self.method_exists(field, expr_t, expr.hir_id, false) && !self.expr_in_place(expr.hir_id)
         {
@@ -1614,7 +1615,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             field,
             expr_t
         );
-
+        err.span_label(field.span, "method, not a field");
         if !self.expr_in_place(expr.hir_id) {
             self.suggest_method_call(
                 &mut err,

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -137,7 +137,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         self_ty: Ty<'tcx>,
         call_expr: &hir::Expr<'_>,
     ) {
-        let has_params = self
+        let params = self
             .probe_for_name(
                 method_name.span,
                 probe::Mode::MethodCall,
@@ -147,26 +147,20 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 call_expr.hir_id,
                 ProbeScope::TraitsInScope,
             )
-            .and_then(|pick| {
+            .map(|pick| {
                 let sig = self.tcx.fn_sig(pick.item.def_id);
-                Ok(sig.inputs().skip_binder().len() > 1)
-            });
+                sig.inputs().skip_binder().len().saturating_sub(1)
+            })
+            .unwrap_or(0);
 
         // Account for `foo.bar<T>`;
-        let sugg_span = method_name.span.with_hi(call_expr.span.hi());
-        let snippet = self
-            .tcx
-            .sess
-            .source_map()
-            .span_to_snippet(sugg_span)
-            .unwrap_or_else(|_| method_name.to_string());
-        let (suggestion, applicability) = if has_params.unwrap_or_default() {
-            (format!("{}(...)", snippet), Applicability::HasPlaceholders)
-        } else {
-            (format!("{}()", snippet), Applicability::MaybeIncorrect)
-        };
+        let sugg_span = call_expr.span.shrink_to_hi();
+        let (suggestion, applicability) = (
+            format!("({})", (0..params).map(|_| "_").collect::<Vec<_>>().join(", ")),
+            if params > 0 { Applicability::HasPlaceholders } else { Applicability::MaybeIncorrect },
+        );
 
-        err.span_suggestion(sugg_span, msg, suggestion, applicability);
+        err.span_suggestion_verbose(sugg_span, msg, suggestion, applicability);
     }
 
     /// Performs method lookup. If lookup is successful, it will return the callee

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -769,14 +769,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
 
             MethodError::PrivateMatch(kind, def_id, out_of_scope_traits) => {
+                let kind = kind.descr(def_id);
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
                     E0624,
                     "{} `{}` is private",
-                    kind.descr(def_id),
+                    kind,
                     item_name
                 );
+                err.span_label(span, &format!("private {}", kind));
                 self.suggest_valid_traits(&mut err, out_of_scope_traits);
                 err.emit();
             }

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -758,11 +758,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             MethodError::Ambiguity(sources) => {
                 let mut err = struct_span_err!(
                     self.sess(),
-                    span,
+                    item_name.span,
                     E0034,
                     "multiple applicable items in scope"
                 );
-                err.span_label(span, format!("multiple `{}` found", item_name));
+                err.span_label(item_name.span, format!("multiple `{}` found", item_name));
 
                 report_candidates(span, &mut err, sources, sugg_span);
                 err.emit();
@@ -772,13 +772,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let kind = kind.descr(def_id);
                 let mut err = struct_span_err!(
                     self.tcx.sess,
-                    span,
+                    item_name.span,
                     E0624,
                     "{} `{}` is private",
                     kind,
                     item_name
                 );
-                err.span_label(span, &format!("private {}", kind));
+                err.span_label(item_name.span, &format!("private {}", kind));
                 self.suggest_valid_traits(&mut err, out_of_scope_traits);
                 err.emit();
             }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4941,15 +4941,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
                 _ => {}
             }
-            if let Ok(code) = self.sess().source_map().span_to_snippet(expr.span) {
-                err.span_suggestion(
-                    expr.span,
-                    &format!("use parentheses to {}", msg),
-                    format!("{}({})", code, sugg_call),
-                    applicability,
-                );
-                return true;
-            }
+            err.span_suggestion_verbose(
+                expr.span.shrink_to_hi(),
+                &format!("use parentheses to {}", msg),
+                format!("({})", sugg_call),
+                applicability,
+            );
+            return true;
         }
         false
     }

--- a/src/librustc_typeck/check/pat.rs
+++ b/src/librustc_typeck/check/pat.rs
@@ -753,17 +753,21 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         res.descr(),
                     ),
                 );
-                let (msg, sugg) = match parent_pat {
-                    Some(Pat { kind: hir::PatKind::Struct(..), .. }) => (
-                        "bind the struct field to a different name instead",
-                        format!("{}: other_{}", ident, ident.as_str().to_lowercase()),
-                    ),
-                    _ => (
-                        "introduce a new binding instead",
-                        format!("other_{}", ident.as_str().to_lowercase()),
-                    ),
+                match parent_pat {
+                    Some(Pat { kind: hir::PatKind::Struct(..), .. }) => {
+                        e.span_suggestion_verbose(
+                            ident.span.shrink_to_hi(),
+                            "bind the struct field to a different name instead",
+                            format!(": other_{}", ident.as_str().to_lowercase()),
+                            Applicability::HasPlaceholders,
+                        );
+                    }
+                    _ => {
+                        let msg = "introduce a new binding instead";
+                        let sugg = format!("other_{}", ident.as_str().to_lowercase());
+                        e.span_suggestion(ident.span, msg, sugg, Applicability::HasPlaceholders);
+                    }
                 };
-                e.span_suggestion(ident.span, msg, sugg, Applicability::HasPlaceholders);
             }
         }
         e.emit();

--- a/src/test/ui/associated-const/associated-const-ambiguity-report.stderr
+++ b/src/test/ui/associated-const/associated-const-ambiguity-report.stderr
@@ -1,8 +1,8 @@
 error[E0034]: multiple applicable items in scope
-  --> $DIR/associated-const-ambiguity-report.rs:17:16
+  --> $DIR/associated-const-ambiguity-report.rs:17:23
    |
 LL | const X: i32 = <i32>::ID;
-   |                ^^^^^^^^^ multiple `ID` found
+   |                       ^^ multiple `ID` found
    |
 note: candidate #1 is defined in an impl of the trait `Foo` for the type `i32`
   --> $DIR/associated-const-ambiguity-report.rs:10:5

--- a/src/test/ui/associated-const/associated-const-private-impl.stderr
+++ b/src/test/ui/associated-const/associated-const-private-impl.stderr
@@ -2,7 +2,7 @@ error[E0624]: associated constant `ID` is private
   --> $DIR/associated-const-private-impl.rs:13:19
    |
 LL |     assert_eq!(1, bar1::Foo::ID);
-   |                   ^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^^^^ private associated constant
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-const/associated-const-private-impl.stderr
+++ b/src/test/ui/associated-const/associated-const-private-impl.stderr
@@ -1,8 +1,8 @@
 error[E0624]: associated constant `ID` is private
-  --> $DIR/associated-const-private-impl.rs:13:19
+  --> $DIR/associated-const-private-impl.rs:13:30
    |
 LL |     assert_eq!(1, bar1::Foo::ID);
-   |                   ^^^^^^^^^^^^^ private associated constant
+   |                              ^^ private associated constant
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0034.stderr
+++ b/src/test/ui/error-codes/E0034.stderr
@@ -1,8 +1,8 @@
 error[E0034]: multiple applicable items in scope
-  --> $DIR/E0034.rs:20:5
+  --> $DIR/E0034.rs:20:11
    |
 LL |     Test::foo()
-   |     ^^^^^^^^^ multiple `foo` found
+   |           ^^^ multiple `foo` found
    |
 note: candidate #1 is defined in an impl of the trait `Trait1` for the type `Test`
   --> $DIR/E0034.rs:12:5

--- a/src/test/ui/error-codes/E0451.stderr
+++ b/src/test/ui/error-codes/E0451.stderr
@@ -2,13 +2,13 @@ error[E0451]: field `b` of struct `bar::Foo` is private
   --> $DIR/E0451.rs:14:21
    |
 LL |     let bar::Foo{a, b} = foo;
-   |                     ^ field `b` is private
+   |                     ^ private field
 
 error[E0451]: field `b` of struct `bar::Foo` is private
   --> $DIR/E0451.rs:18:29
    |
 LL |     let f = bar::Foo{ a: 0, b: 0 };
-   |                             ^^^^ field `b` is private
+   |                             ^^^^ private field
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/error-codes/E0603.stderr
+++ b/src/test/ui/error-codes/E0603.stderr
@@ -2,7 +2,7 @@ error[E0603]: constant `PRIVATE` is private
   --> $DIR/E0603.rs:6:17
    |
 LL |     SomeModule::PRIVATE;
-   |                 ^^^^^^^ this constant is private
+   |                 ^^^^^^^ private constant
    |
 note: the constant `PRIVATE` is defined here
   --> $DIR/E0603.rs:2:5

--- a/src/test/ui/error-codes/E0615.stderr
+++ b/src/test/ui/error-codes/E0615.stderr
@@ -2,7 +2,12 @@ error[E0615]: attempted to take value of method `method` on type `Foo`
   --> $DIR/E0615.rs:11:7
    |
 LL |     f.method;
-   |       ^^^^^^ help: use parentheses to call the method: `method()`
+   |       ^^^^^^
+   |
+help: use parentheses to call the method
+   |
+LL |     f.method();
+   |             ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0615.stderr
+++ b/src/test/ui/error-codes/E0615.stderr
@@ -2,7 +2,7 @@ error[E0615]: attempted to take value of method `method` on type `Foo`
   --> $DIR/E0615.rs:11:7
    |
 LL |     f.method;
-   |       ^^^^^^
+   |       ^^^^^^ method, not a field
    |
 help: use parentheses to call the method
    |

--- a/src/test/ui/error-codes/E0616.stderr
+++ b/src/test/ui/error-codes/E0616.stderr
@@ -1,8 +1,8 @@
 error[E0616]: field `x` of struct `a::Foo` is private
-  --> $DIR/E0616.rs:13:5
+  --> $DIR/E0616.rs:13:7
    |
 LL |     f.x;
-   |     ^^^
+   |       ^ private field
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0624.stderr
+++ b/src/test/ui/error-codes/E0624.stderr
@@ -2,7 +2,7 @@ error[E0624]: associated function `method` is private
   --> $DIR/E0624.rs:11:9
    |
 LL |     foo.method();
-   |         ^^^^^^
+   |         ^^^^^^ private associated function
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/ex-E0611.stderr
+++ b/src/test/ui/error-codes/ex-E0611.stderr
@@ -1,8 +1,8 @@
 error[E0616]: field `0` of struct `a::Foo` is private
-  --> $DIR/ex-E0611.rs:11:4
+  --> $DIR/ex-E0611.rs:11:6
    |
 LL |    y.0;
-   |    ^^^
+   |      ^ private field
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-festival.stderr
+++ b/src/test/ui/error-festival.stderr
@@ -8,7 +8,7 @@ error[E0603]: constant `FOO` is private
   --> $DIR/error-festival.rs:22:10
    |
 LL |     foo::FOO;
-   |          ^^^ this constant is private
+   |          ^^^ private constant
    |
 note: the constant `FOO` is defined here
   --> $DIR/error-festival.rs:7:5

--- a/src/test/ui/explore-issue-38412.stderr
+++ b/src/test/ui/explore-issue-38412.stderr
@@ -83,19 +83,19 @@ error[E0624]: associated function `pub_crate` is private
   --> $DIR/explore-issue-38412.rs:50:7
    |
 LL |     r.pub_crate();
-   |       ^^^^^^^^^
+   |       ^^^^^^^^^ private associated function
 
 error[E0624]: associated function `pub_mod` is private
   --> $DIR/explore-issue-38412.rs:51:7
    |
 LL |     r.pub_mod();
-   |       ^^^^^^^
+   |       ^^^^^^^ private associated function
 
 error[E0624]: associated function `private` is private
   --> $DIR/explore-issue-38412.rs:52:7
    |
 LL |     r.private();
-   |       ^^^^^^^
+   |       ^^^^^^^ private associated function
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
   --> $DIR/explore-issue-38412.rs:57:7
@@ -119,19 +119,19 @@ error[E0624]: associated function `pub_crate` is private
   --> $DIR/explore-issue-38412.rs:63:7
    |
 LL |     t.pub_crate();
-   |       ^^^^^^^^^
+   |       ^^^^^^^^^ private associated function
 
 error[E0624]: associated function `pub_mod` is private
   --> $DIR/explore-issue-38412.rs:64:7
    |
 LL |     t.pub_mod();
-   |       ^^^^^^^
+   |       ^^^^^^^ private associated function
 
 error[E0624]: associated function `private` is private
   --> $DIR/explore-issue-38412.rs:65:7
    |
 LL |     t.private();
-   |       ^^^^^^^
+   |       ^^^^^^^ private associated function
 
 error: aborting due to 19 previous errors
 

--- a/src/test/ui/explore-issue-38412.stderr
+++ b/src/test/ui/explore-issue-38412.stderr
@@ -17,22 +17,22 @@ LL |     r.a_unstable_undeclared_pub;
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0616]: field `b_crate` of struct `pub_and_stability::Record` is private
-  --> $DIR/explore-issue-38412.rs:31:5
+  --> $DIR/explore-issue-38412.rs:31:7
    |
 LL |     r.b_crate;
-   |     ^^^^^^^^^
+   |       ^^^^^^^ private field
 
 error[E0616]: field `c_mod` of struct `pub_and_stability::Record` is private
-  --> $DIR/explore-issue-38412.rs:32:5
+  --> $DIR/explore-issue-38412.rs:32:7
    |
 LL |     r.c_mod;
-   |     ^^^^^^^
+   |       ^^^^^ private field
 
 error[E0616]: field `d_priv` of struct `pub_and_stability::Record` is private
-  --> $DIR/explore-issue-38412.rs:33:5
+  --> $DIR/explore-issue-38412.rs:33:7
    |
 LL |     r.d_priv;
-   |     ^^^^^^^^
+   |       ^^^^^^ private field
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
   --> $DIR/explore-issue-38412.rs:37:5
@@ -44,22 +44,22 @@ LL |     t.2;
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0616]: field `3` of struct `pub_and_stability::Tuple` is private
-  --> $DIR/explore-issue-38412.rs:38:5
+  --> $DIR/explore-issue-38412.rs:38:7
    |
 LL |     t.3;
-   |     ^^^
+   |       ^ private field
 
 error[E0616]: field `4` of struct `pub_and_stability::Tuple` is private
-  --> $DIR/explore-issue-38412.rs:39:5
+  --> $DIR/explore-issue-38412.rs:39:7
    |
 LL |     t.4;
-   |     ^^^
+   |       ^ private field
 
 error[E0616]: field `5` of struct `pub_and_stability::Tuple` is private
-  --> $DIR/explore-issue-38412.rs:40:5
+  --> $DIR/explore-issue-38412.rs:40:7
    |
 LL |     t.5;
-   |     ^^^
+   |       ^ private field
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
   --> $DIR/explore-issue-38412.rs:44:7

--- a/src/test/ui/export-import.stderr
+++ b/src/test/ui/export-import.stderr
@@ -2,7 +2,7 @@ error[E0603]: function `unexported` is private
   --> $DIR/export-import.rs:1:8
    |
 LL | use m::unexported;
-   |        ^^^^^^^^^^ this function is private
+   |        ^^^^^^^^^^ private function
    |
 note: the function `unexported` is defined here
   --> $DIR/export-import.rs:7:5

--- a/src/test/ui/export-tag-variant.stderr
+++ b/src/test/ui/export-tag-variant.stderr
@@ -2,7 +2,7 @@ error[E0603]: enum `Y` is private
   --> $DIR/export-tag-variant.rs:7:26
    |
 LL | fn main() { let z = foo::Y::Y1; }
-   |                          ^ this enum is private
+   |                          ^ private enum
    |
 note: the enum `Y` is defined here
   --> $DIR/export-tag-variant.rs:4:5

--- a/src/test/ui/export.stderr
+++ b/src/test/ui/export.stderr
@@ -26,7 +26,7 @@ error[E0603]: function `z` is private
   --> $DIR/export.rs:10:18
    |
 LL | fn main() { foo::z(10); }
-   |                  ^ this function is private
+   |                  ^ private function
    |
 note: the function `z` is defined here
   --> $DIR/export.rs:5:5

--- a/src/test/ui/extern/extern-crate-visibility.stderr
+++ b/src/test/ui/extern/extern-crate-visibility.stderr
@@ -2,7 +2,7 @@ error[E0603]: crate import `core` is private
   --> $DIR/extern-crate-visibility.rs:6:10
    |
 LL | use foo::core::cell;
-   |          ^^^^ this crate import is private
+   |          ^^^^ private crate import
    |
 note: the crate import `core` is defined here
   --> $DIR/extern-crate-visibility.rs:2:5
@@ -14,7 +14,7 @@ error[E0603]: crate import `core` is private
   --> $DIR/extern-crate-visibility.rs:9:10
    |
 LL |     foo::core::cell::Cell::new(0);
-   |          ^^^^ this crate import is private
+   |          ^^^^ private crate import
    |
 note: the crate import `core` is defined here
   --> $DIR/extern-crate-visibility.rs:2:5

--- a/src/test/ui/extern/extern-types-unsized.stderr
+++ b/src/test/ui/extern/extern-types-unsized.stderr
@@ -2,15 +2,17 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
   --> $DIR/extern-types-unsized.rs:22:20
    |
 LL | fn assert_sized<T>() { }
-   |    ------------ -- help: consider relaxing the implicit `Sized` restriction: `: ?Sized`
-   |                 |
-   |                 required by this bound in `assert_sized`
+   |    ------------ - required by this bound in `assert_sized`
 ...
 LL |     assert_sized::<A>();
    |                    ^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `A`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | fn assert_sized<T: ?Sized>() { }
+   |                  ^^^^^^^^
 
 error[E0277]: the size for values of type `A` cannot be known at compilation time
   --> $DIR/extern-types-unsized.rs:25:5

--- a/src/test/ui/functional-struct-update/functional-struct-update-respects-privacy.stderr
+++ b/src/test/ui/functional-struct-update/functional-struct-update-respects-privacy.stderr
@@ -2,7 +2,7 @@ error[E0451]: field `secret_uid` of struct `foo::S` is private
   --> $DIR/functional-struct-update-respects-privacy.rs:28:49
    |
 LL |     let s_2 = foo::S { b: format!("ess two"), ..s_1 }; // FRU ...
-   |                                                 ^^^ field `secret_uid` is private
+   |                                                 ^^^ private field
 
 error: aborting due to previous error
 

--- a/src/test/ui/hygiene/fields.stderr
+++ b/src/test/ui/hygiene/fields.stderr
@@ -2,7 +2,7 @@ error: type `foo::S` is private
   --> $DIR/fields.rs:15:17
    |
 LL |         let s = S { x: 0 };
-   |                 ^^^^^^^^^^
+   |                 ^^^^^^^^^^ private type
 ...
 LL |     let s = foo::m!(S, x);
    |             ------------- in this macro invocation
@@ -13,7 +13,7 @@ error: type `foo::S` is private
   --> $DIR/fields.rs:16:17
    |
 LL |         let _ = s.x;
-   |                 ^
+   |                 ^ private type
 ...
 LL |     let s = foo::m!(S, x);
    |             ------------- in this macro invocation
@@ -24,7 +24,7 @@ error: type `foo::T` is private
   --> $DIR/fields.rs:18:17
    |
 LL |         let t = T(0);
-   |                 ^^^^
+   |                 ^^^^ private type
 ...
 LL |     let s = foo::m!(S, x);
    |             ------------- in this macro invocation
@@ -35,7 +35,7 @@ error: type `foo::T` is private
   --> $DIR/fields.rs:19:17
    |
 LL |         let _ = t.0;
-   |                 ^
+   |                 ^ private type
 ...
 LL |     let s = foo::m!(S, x);
    |             ------------- in this macro invocation

--- a/src/test/ui/hygiene/impl_items.stderr
+++ b/src/test/ui/hygiene/impl_items.stderr
@@ -2,7 +2,7 @@ error: type `for<'r> fn(&'r foo::S) {foo::S::f}` is private
   --> $DIR/impl_items.rs:12:23
    |
 LL |         let _: () = S.f();
-   |                       ^
+   |                       ^ private type
 ...
 LL |     foo::m!();
    |     ---------- in this macro invocation

--- a/src/test/ui/hygiene/intercrate.stderr
+++ b/src/test/ui/hygiene/intercrate.stderr
@@ -2,7 +2,7 @@ error: type `fn() -> u32 {intercrate::foo::bar::f}` is private
   --> $DIR/intercrate.rs:10:16
    |
 LL |     assert_eq!(intercrate::foo::m!(), 1);
-   |                ^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^^ private type
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/hygiene/nested_macro_privacy.stderr
+++ b/src/test/ui/hygiene/nested_macro_privacy.stderr
@@ -1,8 +1,8 @@
 error[E0616]: field `i` of struct `foo::S` is private
-  --> $DIR/nested_macro_privacy.rs:15:5
+  --> $DIR/nested_macro_privacy.rs:15:18
    |
 LL |     S::default().i;
-   |     ^^^^^^^^^^^^^^
+   |                  ^ private field
 
 error: aborting due to previous error
 

--- a/src/test/ui/hygiene/privacy.stderr
+++ b/src/test/ui/hygiene/privacy.stderr
@@ -2,7 +2,7 @@ error[E0603]: function `f` is private
   --> $DIR/privacy.rs:16:14
    |
 LL |         foo::f()
-   |              ^ this function is private
+   |              ^ private function
    |
 note: the function `f` is defined here
   --> $DIR/privacy.rs:4:5

--- a/src/test/ui/hygiene/rustc-macro-transparency.stderr
+++ b/src/test/ui/hygiene/rustc-macro-transparency.stderr
@@ -8,13 +8,23 @@ error[E0423]: expected value, found macro `semitransparent`
   --> $DIR/rustc-macro-transparency.rs:29:5
    |
 LL |     semitransparent;
-   |     ^^^^^^^^^^^^^^^ help: use `!` to invoke the macro: `semitransparent!`
+   |     ^^^^^^^^^^^^^^^
+   |
+help: use `!` to invoke the macro
+   |
+LL |     semitransparent!;
+   |                    ^
 
 error[E0423]: expected value, found macro `opaque`
   --> $DIR/rustc-macro-transparency.rs:30:5
    |
 LL |     opaque;
-   |     ^^^^^^ help: use `!` to invoke the macro: `opaque!`
+   |     ^^^^^^
+   |
+help: use `!` to invoke the macro
+   |
+LL |     opaque!;
+   |           ^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/implicit-method-bind.stderr
+++ b/src/test/ui/implicit-method-bind.stderr
@@ -2,7 +2,12 @@ error[E0615]: attempted to take value of method `abs` on type `i32`
   --> $DIR/implicit-method-bind.rs:2:20
    |
 LL |     let _f = 10i32.abs;
-   |                    ^^^ help: use parentheses to call the method: `abs()`
+   |                    ^^^
+   |
+help: use parentheses to call the method
+   |
+LL |     let _f = 10i32.abs();
+   |                       ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/implicit-method-bind.stderr
+++ b/src/test/ui/implicit-method-bind.stderr
@@ -2,7 +2,7 @@ error[E0615]: attempted to take value of method `abs` on type `i32`
   --> $DIR/implicit-method-bind.rs:2:20
    |
 LL |     let _f = 10i32.abs;
-   |                    ^^^
+   |                    ^^^ method, not a field
    |
 help: use parentheses to call the method
    |

--- a/src/test/ui/import.stderr
+++ b/src/test/ui/import.stderr
@@ -17,7 +17,7 @@ error[E0603]: unresolved item import `foo` is private
   --> $DIR/import.rs:15:10
    |
 LL |     zed::foo();
-   |          ^^^ this unresolved item import is private
+   |          ^^^ private unresolved item import
    |
 note: the unresolved item import `foo` is defined here
   --> $DIR/import.rs:10:9

--- a/src/test/ui/imports/issue-55884-2.stderr
+++ b/src/test/ui/imports/issue-55884-2.stderr
@@ -2,7 +2,7 @@ error[E0603]: struct import `ParseOptions` is private
   --> $DIR/issue-55884-2.rs:12:17
    |
 LL | pub use parser::ParseOptions;
-   |                 ^^^^^^^^^^^^ this struct import is private
+   |                 ^^^^^^^^^^^^ private struct import
    |
 note: the struct import `ParseOptions` is defined here...
   --> $DIR/issue-55884-2.rs:9:9

--- a/src/test/ui/imports/reexports.stderr
+++ b/src/test/ui/imports/reexports.stderr
@@ -14,7 +14,7 @@ error[E0603]: module import `foo` is private
   --> $DIR/reexports.rs:33:15
    |
 LL |     use b::a::foo::S;
-   |               ^^^ this module import is private
+   |               ^^^ private module import
    |
 note: the module import `foo` is defined here...
   --> $DIR/reexports.rs:21:17
@@ -31,7 +31,7 @@ error[E0603]: module import `foo` is private
   --> $DIR/reexports.rs:34:15
    |
 LL |     use b::b::foo::S as T;
-   |               ^^^ this module import is private
+   |               ^^^ private module import
    |
 note: the module import `foo` is defined here...
   --> $DIR/reexports.rs:26:17

--- a/src/test/ui/imports/unresolved-imports-used.stderr
+++ b/src/test/ui/imports/unresolved-imports-used.stderr
@@ -38,7 +38,7 @@ error[E0603]: function `quz` is private
   --> $DIR/unresolved-imports-used.rs:9:10
    |
 LL | use qux::quz;
-   |          ^^^ this function is private
+   |          ^^^ private function
    |
 note: the function `quz` is defined here
   --> $DIR/unresolved-imports-used.rs:5:4

--- a/src/test/ui/issues/issue-10545.stderr
+++ b/src/test/ui/issues/issue-10545.stderr
@@ -2,7 +2,7 @@ error[E0603]: struct `S` is private
   --> $DIR/issue-10545.rs:6:14
    |
 LL | fn foo(_: a::S) {
-   |              ^ this struct is private
+   |              ^ private struct
    |
 note: the struct `S` is defined here
   --> $DIR/issue-10545.rs:2:5

--- a/src/test/ui/issues/issue-11593.stderr
+++ b/src/test/ui/issues/issue-11593.stderr
@@ -2,7 +2,7 @@ error[E0603]: trait `Foo` is private
   --> $DIR/issue-11593.rs:7:24
    |
 LL | impl private_trait_xc::Foo for Bar {}
-   |                        ^^^ this trait is private
+   |                        ^^^ private trait
    |
 note: the trait `Foo` is defined here
   --> $DIR/auxiliary/private-trait-xc.rs:1:1

--- a/src/test/ui/issues/issue-11680.stderr
+++ b/src/test/ui/issues/issue-11680.stderr
@@ -2,7 +2,7 @@ error[E0603]: enum `Foo` is private
   --> $DIR/issue-11680.rs:6:21
    |
 LL |     let _b = other::Foo::Bar(1);
-   |                     ^^^ this enum is private
+   |                     ^^^ private enum
    |
 note: the enum `Foo` is defined here
   --> $DIR/auxiliary/issue-11680.rs:1:1
@@ -14,7 +14,7 @@ error[E0603]: enum `Foo` is private
   --> $DIR/issue-11680.rs:9:27
    |
 LL |     let _b = other::test::Foo::Bar(1);
-   |                           ^^^ this enum is private
+   |                           ^^^ private enum
    |
 note: the enum `Foo` is defined here
   --> $DIR/auxiliary/issue-11680.rs:6:5

--- a/src/test/ui/issues/issue-13407.stderr
+++ b/src/test/ui/issues/issue-13407.stderr
@@ -2,7 +2,7 @@ error[E0603]: unit struct `C` is private
   --> $DIR/issue-13407.rs:6:8
    |
 LL |     A::C = 1;
-   |        ^ this unit struct is private
+   |        ^ private unit struct
    |
 note: the unit struct `C` is defined here
   --> $DIR/issue-13407.rs:2:5

--- a/src/test/ui/issues/issue-13641.stderr
+++ b/src/test/ui/issues/issue-13641.stderr
@@ -2,7 +2,7 @@ error[E0603]: struct `Foo` is private
   --> $DIR/issue-13641.rs:9:8
    |
 LL |     a::Foo::new();
-   |        ^^^ this struct is private
+   |        ^^^ private struct
    |
 note: the struct `Foo` is defined here
   --> $DIR/issue-13641.rs:2:5
@@ -14,7 +14,7 @@ error[E0603]: enum `Bar` is private
   --> $DIR/issue-13641.rs:11:8
    |
 LL |     a::Bar::new();
-   |        ^^^ this enum is private
+   |        ^^^ private enum
    |
 note: the enum `Bar` is defined here
   --> $DIR/issue-13641.rs:4:5

--- a/src/test/ui/issues/issue-13853-2.stderr
+++ b/src/test/ui/issues/issue-13853-2.stderr
@@ -2,7 +2,7 @@ error[E0615]: attempted to take value of method `get` on type `std::boxed::Box<(
   --> $DIR/issue-13853-2.rs:5:43
    |
 LL | fn foo(res : Box<dyn ResponseHook>) { res.get }
-   |                                           ^^^
+   |                                           ^^^ method, not a field
    |
 help: use parentheses to call the method
    |

--- a/src/test/ui/issues/issue-13853-2.stderr
+++ b/src/test/ui/issues/issue-13853-2.stderr
@@ -2,7 +2,12 @@ error[E0615]: attempted to take value of method `get` on type `std::boxed::Box<(
   --> $DIR/issue-13853-2.rs:5:43
    |
 LL | fn foo(res : Box<dyn ResponseHook>) { res.get }
-   |                                           ^^^ help: use parentheses to call the method: `get()`
+   |                                           ^^^
+   |
+help: use parentheses to call the method
+   |
+LL | fn foo(res : Box<dyn ResponseHook>) { res.get() }
+   |                                              ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-16725.stderr
+++ b/src/test/ui/issues/issue-16725.stderr
@@ -2,7 +2,7 @@ error[E0603]: function `bar` is private
   --> $DIR/issue-16725.rs:6:19
    |
 LL |     unsafe { foo::bar(); }
-   |                   ^^^ this function is private
+   |                   ^^^ private function
    |
 note: the function `bar` is defined here
   --> $DIR/auxiliary/issue-16725.rs:2:5

--- a/src/test/ui/issues/issue-17718-const-privacy.stderr
+++ b/src/test/ui/issues/issue-17718-const-privacy.stderr
@@ -2,7 +2,7 @@ error[E0603]: constant `B` is private
   --> $DIR/issue-17718-const-privacy.rs:5:8
    |
 LL | use a::B;
-   |        ^ this constant is private
+   |        ^ private constant
    |
 note: the constant `B` is defined here
   --> $DIR/issue-17718-const-privacy.rs:13:5
@@ -14,7 +14,7 @@ error[E0603]: constant `BAR` is private
   --> $DIR/issue-17718-const-privacy.rs:8:5
    |
 LL |     BAR,
-   |     ^^^ this constant is private
+   |     ^^^ private constant
    |
 note: the constant `BAR` is defined here
   --> $DIR/auxiliary/issue-17718-const-privacy.rs:4:1

--- a/src/test/ui/issues/issue-21202.stderr
+++ b/src/test/ui/issues/issue-21202.stderr
@@ -2,7 +2,7 @@ error[E0624]: associated function `foo` is private
   --> $DIR/issue-21202.rs:10:9
    |
 LL |         Foo::foo(&f);
-   |         ^^^^^^^^
+   |         ^^^^^^^^ private associated function
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-21202.stderr
+++ b/src/test/ui/issues/issue-21202.stderr
@@ -1,8 +1,8 @@
 error[E0624]: associated function `foo` is private
-  --> $DIR/issue-21202.rs:10:9
+  --> $DIR/issue-21202.rs:10:14
    |
 LL |         Foo::foo(&f);
-   |         ^^^^^^^^ private associated function
+   |              ^^^ private associated function
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-25386.rs
+++ b/src/test/ui/issues/issue-25386.rs
@@ -17,12 +17,12 @@ mod stuff {
 macro_rules! check_ptr_exist {
     ($var:expr, $member:ident) => (
         (*$var.c_object).$member.is_some()
-        //~^ ERROR field `name` of struct `stuff::CObj` is private
-        //~^^ ERROR field `c_object` of struct `stuff::Item` is private
+        //~^ ERROR field `c_object` of struct `stuff::Item` is private
     );
 }
 
 fn main() {
     let item = stuff::Item::new();
     println!("{}", check_ptr_exist!(item, name));
+    //~^ ERROR field `name` of struct `stuff::CObj` is private
 }

--- a/src/test/ui/issues/issue-25386.stderr
+++ b/src/test/ui/issues/issue-25386.stderr
@@ -1,8 +1,8 @@
 error[E0616]: field `c_object` of struct `stuff::Item` is private
-  --> $DIR/issue-25386.rs:19:11
+  --> $DIR/issue-25386.rs:19:16
    |
 LL |         (*$var.c_object).$member.is_some()
-   |           ^^^^^^^^^^^^^
+   |                ^^^^^^^^ private field
 ...
 LL |     println!("{}", check_ptr_exist!(item, name));
    |                    ---------------------------- in this macro invocation
@@ -10,15 +10,10 @@ LL |     println!("{}", check_ptr_exist!(item, name));
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0616]: field `name` of struct `stuff::CObj` is private
-  --> $DIR/issue-25386.rs:19:9
+  --> $DIR/issue-25386.rs:26:43
    |
-LL |         (*$var.c_object).$member.is_some()
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
-...
 LL |     println!("{}", check_ptr_exist!(item, name));
-   |                    ---------------------------- in this macro invocation
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   |                                           ^^^^ private field
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-26472.stderr
+++ b/src/test/ui/issues/issue-26472.stderr
@@ -1,8 +1,8 @@
 error[E0616]: field `len` of struct `sub::S` is private
-  --> $DIR/issue-26472.rs:11:13
+  --> $DIR/issue-26472.rs:11:15
    |
 LL |     let v = s.len;
-   |             ^^^^^
+   |               ^^^ private field
    |
 help: a method `len` also exists, call it with parentheses
    |
@@ -10,10 +10,10 @@ LL |     let v = s.len();
    |                  ^^
 
 error[E0616]: field `len` of struct `sub::S` is private
-  --> $DIR/issue-26472.rs:12:5
+  --> $DIR/issue-26472.rs:12:7
    |
 LL |     s.len = v;
-   |     ^^^^^
+   |       ^^^ private field
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-26472.stderr
+++ b/src/test/ui/issues/issue-26472.stderr
@@ -2,9 +2,12 @@ error[E0616]: field `len` of struct `sub::S` is private
   --> $DIR/issue-26472.rs:11:13
    |
 LL |     let v = s.len;
-   |             ^^---
-   |               |
-   |               help: a method `len` also exists, call it with parentheses: `len()`
+   |             ^^^^^
+   |
+help: a method `len` also exists, call it with parentheses
+   |
+LL |     let v = s.len();
+   |                  ^^
 
 error[E0616]: field `len` of struct `sub::S` is private
   --> $DIR/issue-26472.rs:12:5

--- a/src/test/ui/issues/issue-28388-2.stderr
+++ b/src/test/ui/issues/issue-28388-2.stderr
@@ -2,7 +2,7 @@ error[E0603]: module `n` is private
   --> $DIR/issue-28388-2.rs:7:8
    |
 LL | use m::n::{};
-   |        ^ this module is private
+   |        ^ private module
    |
 note: the module `n` is defined here
   --> $DIR/issue-28388-2.rs:4:5

--- a/src/test/ui/issues/issue-29161.stderr
+++ b/src/test/ui/issues/issue-29161.stderr
@@ -8,7 +8,7 @@ error[E0603]: struct `A` is private
   --> $DIR/issue-29161.rs:13:8
    |
 LL |     a::A::default();
-   |        ^ this struct is private
+   |        ^ private struct
    |
 note: the struct `A` is defined here
   --> $DIR/issue-29161.rs:2:5

--- a/src/test/ui/issues/issue-35241.stderr
+++ b/src/test/ui/issues/issue-35241.stderr
@@ -5,14 +5,16 @@ LL | struct Foo(u32);
    | ---------------- fn(u32) -> Foo {Foo} defined here
 LL | 
 LL | fn test() -> Foo { Foo }
-   |              ---   ^^^
-   |              |     |
-   |              |     expected struct `Foo`, found fn item
-   |              |     help: use parentheses to instantiate this tuple struct: `Foo(_)`
+   |              ---   ^^^ expected struct `Foo`, found fn item
+   |              |
    |              expected `Foo` because of return type
    |
    = note: expected struct `Foo`
              found fn item `fn(u32) -> Foo {Foo}`
+help: use parentheses to instantiate this tuple struct
+   |
+LL | fn test() -> Foo { Foo(_) }
+   |                       ^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-3763.stderr
+++ b/src/test/ui/issues/issue-3763.stderr
@@ -14,13 +14,13 @@ error[E0624]: associated function `happyfun` is private
   --> $DIR/issue-3763.rs:24:18
    |
 LL |     (&my_struct).happyfun();
-   |                  ^^^^^^^^
+   |                  ^^^^^^^^ private associated function
 
 error[E0624]: associated function `happyfun` is private
   --> $DIR/issue-3763.rs:26:27
    |
 LL |     (Box::new(my_struct)).happyfun();
-   |                           ^^^^^^^^
+   |                           ^^^^^^^^ private associated function
 
 error[E0616]: field `priv_field` of struct `my_mod::MyStruct` is private
   --> $DIR/issue-3763.rs:27:26

--- a/src/test/ui/issues/issue-3763.stderr
+++ b/src/test/ui/issues/issue-3763.stderr
@@ -1,14 +1,14 @@
 error[E0616]: field `priv_field` of struct `my_mod::MyStruct` is private
-  --> $DIR/issue-3763.rs:18:19
+  --> $DIR/issue-3763.rs:18:32
    |
 LL |     let _woohoo = (&my_struct).priv_field;
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^
+   |                                ^^^^^^^^^^ private field
 
 error[E0616]: field `priv_field` of struct `my_mod::MyStruct` is private
-  --> $DIR/issue-3763.rs:21:19
+  --> $DIR/issue-3763.rs:21:41
    |
 LL |     let _woohoo = (Box::new(my_struct)).priv_field;
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                         ^^^^^^^^^^ private field
 
 error[E0624]: associated function `happyfun` is private
   --> $DIR/issue-3763.rs:24:18
@@ -23,10 +23,10 @@ LL |     (Box::new(my_struct)).happyfun();
    |                           ^^^^^^^^
 
 error[E0616]: field `priv_field` of struct `my_mod::MyStruct` is private
-  --> $DIR/issue-3763.rs:27:16
+  --> $DIR/issue-3763.rs:27:26
    |
 LL |     let nope = my_struct.priv_field;
-   |                ^^^^^^^^^^^^^^^^^^^^
+   |                          ^^^^^^^^^^ private field
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/issues/issue-38857.stderr
+++ b/src/test/ui/issues/issue-38857.stderr
@@ -8,7 +8,7 @@ error[E0603]: module `sys` is private
   --> $DIR/issue-38857.rs:7:18
    |
 LL |     let a = std::sys::imp::process::process_common::StdioPipes { ..panic!() };
-   |                  ^^^ this module is private
+   |                  ^^^ private module
    |
 note: the module `sys` is defined here
   --> $SRC_DIR/libstd/lib.rs:LL:COL

--- a/src/test/ui/issues/issue-3993.stderr
+++ b/src/test/ui/issues/issue-3993.stderr
@@ -2,7 +2,7 @@ error[E0603]: function `fly` is private
   --> $DIR/issue-3993.rs:1:10
    |
 LL | use zoo::fly;
-   |          ^^^ this function is private
+   |          ^^^ private function
    |
 note: the function `fly` is defined here
   --> $DIR/issue-3993.rs:4:5

--- a/src/test/ui/issues/issue-53498.stderr
+++ b/src/test/ui/issues/issue-53498.stderr
@@ -1,8 +1,8 @@
 error[E0624]: associated function `foo` is private
-  --> $DIR/issue-53498.rs:16:5
+  --> $DIR/issue-53498.rs:16:27
    |
 LL |     test::Foo::<test::B>::foo();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ private associated function
+   |                           ^^^ private associated function
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-53498.stderr
+++ b/src/test/ui/issues/issue-53498.stderr
@@ -2,7 +2,7 @@ error[E0624]: associated function `foo` is private
   --> $DIR/issue-53498.rs:16:5
    |
 LL |     test::Foo::<test::B>::foo();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ private associated function
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-54062.stderr
+++ b/src/test/ui/issues/issue-54062.stderr
@@ -1,8 +1,8 @@
 error[E0616]: field `inner` of struct `std::sync::Mutex` is private
-  --> $DIR/issue-54062.rs:10:13
+  --> $DIR/issue-54062.rs:10:24
    |
 LL |     let _ = test.comps.inner.lock().unwrap();
-   |             ^^^^^^^^^^^^^^^^
+   |                        ^^^^^ private field
 
 error[E0599]: no method named `unwrap` found for struct `std::sys_common::mutex::MutexGuard<'_>` in the current scope
   --> $DIR/issue-54062.rs:10:37

--- a/src/test/ui/macros/macro-local-data-key-priv.stderr
+++ b/src/test/ui/macros/macro-local-data-key-priv.stderr
@@ -2,7 +2,7 @@ error[E0603]: constant `baz` is private
   --> $DIR/macro-local-data-key-priv.rs:8:10
    |
 LL |     bar::baz.with(|_| ());
-   |          ^^^ this constant is private
+   |          ^^^ private constant
    |
 note: the constant `baz` is defined here
   --> $DIR/macro-local-data-key-priv.rs:4:5

--- a/src/test/ui/methods/assign-to-method.stderr
+++ b/src/test/ui/methods/assign-to-method.stderr
@@ -2,7 +2,7 @@ error[E0615]: attempted to take value of method `speak` on type `Cat`
   --> $DIR/assign-to-method.rs:22:10
    |
 LL |     nyan.speak = || println!("meow");
-   |          ^^^^^
+   |          ^^^^^ method, not a field
    |
    = help: methods are immutable and cannot be assigned to
 
@@ -10,7 +10,7 @@ error[E0615]: attempted to take value of method `speak` on type `Cat`
   --> $DIR/assign-to-method.rs:23:10
    |
 LL |     nyan.speak += || println!("meow");
-   |          ^^^^^
+   |          ^^^^^ method, not a field
    |
    = help: methods are immutable and cannot be assigned to
 

--- a/src/test/ui/methods/method-ambig-two-traits-from-impls2.stderr
+++ b/src/test/ui/methods/method-ambig-two-traits-from-impls2.stderr
@@ -1,8 +1,8 @@
 error[E0034]: multiple applicable items in scope
-  --> $DIR/method-ambig-two-traits-from-impls2.rs:15:5
+  --> $DIR/method-ambig-two-traits-from-impls2.rs:15:9
    |
 LL |     AB::foo();
-   |     ^^^^^^^ multiple `foo` found
+   |         ^^^ multiple `foo` found
    |
 note: candidate #1 is defined in an impl of the trait `A` for the type `AB`
   --> $DIR/method-ambig-two-traits-from-impls2.rs:7:5

--- a/src/test/ui/methods/method-missing-call.stderr
+++ b/src/test/ui/methods/method-missing-call.stderr
@@ -2,13 +2,23 @@ error[E0615]: attempted to take value of method `get_x` on type `Point`
   --> $DIR/method-missing-call.rs:22:26
    |
 LL |                         .get_x;
-   |                          ^^^^^ help: use parentheses to call the method: `get_x()`
+   |                          ^^^^^
+   |
+help: use parentheses to call the method
+   |
+LL |                         .get_x();
+   |                               ^^
 
 error[E0615]: attempted to take value of method `filter_map` on type `std::iter::Filter<std::iter::Map<std::slice::Iter<'_, {integer}>, [closure@$DIR/method-missing-call.rs:27:20: 27:25]>, [closure@$DIR/method-missing-call.rs:28:23: 28:35]>`
   --> $DIR/method-missing-call.rs:29:16
    |
 LL |               .filter_map;
-   |                ^^^^^^^^^^ help: use parentheses to call the method: `filter_map(...)`
+   |                ^^^^^^^^^^
+   |
+help: use parentheses to call the method
+   |
+LL |               .filter_map(_);
+   |                          ^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/methods/method-missing-call.stderr
+++ b/src/test/ui/methods/method-missing-call.stderr
@@ -2,7 +2,7 @@ error[E0615]: attempted to take value of method `get_x` on type `Point`
   --> $DIR/method-missing-call.rs:22:26
    |
 LL |                         .get_x;
-   |                          ^^^^^
+   |                          ^^^^^ method, not a field
    |
 help: use parentheses to call the method
    |
@@ -13,7 +13,7 @@ error[E0615]: attempted to take value of method `filter_map` on type `std::iter:
   --> $DIR/method-missing-call.rs:29:16
    |
 LL |               .filter_map;
-   |                ^^^^^^^^^^
+   |                ^^^^^^^^^^ method, not a field
    |
 help: use parentheses to call the method
    |

--- a/src/test/ui/paren-span.stderr
+++ b/src/test/ui/paren-span.stderr
@@ -1,8 +1,8 @@
 error[E0616]: field `x` of struct `m::S` is private
-  --> $DIR/paren-span.rs:19:12
+  --> $DIR/paren-span.rs:19:14
    |
 LL |     paren!(s.x);
-   |            ^^^
+   |              ^ private field
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/macro/pub-item-macro.stderr
+++ b/src/test/ui/parser/macro/pub-item-macro.stderr
@@ -14,7 +14,7 @@ error[E0603]: static `x` is private
   --> $DIR/pub-item-macro.rs:20:23
    |
 LL |     let y: u32 = foo::x;
-   |                       ^ this static is private
+   |                       ^ private static
    |
 note: the static `x` is defined here
   --> $DIR/pub-item-macro.rs:5:9

--- a/src/test/ui/privacy/associated-item-privacy-inherent.stderr
+++ b/src/test/ui/privacy/associated-item-privacy-inherent.stderr
@@ -2,7 +2,7 @@ error: type `for<'r> fn(&'r priv_nominal::Pub) {priv_nominal::Pub::method}` is p
   --> $DIR/associated-item-privacy-inherent.rs:13:21
    |
 LL |         let value = Pub::method;
-   |                     ^^^^^^^^^^^
+   |                     ^^^^^^^^^^^ private type
 ...
 LL |     priv_nominal::mac!();
    |     --------------------- in this macro invocation
@@ -13,7 +13,7 @@ error: type `for<'r> fn(&'r priv_nominal::Pub) {priv_nominal::Pub::method}` is p
   --> $DIR/associated-item-privacy-inherent.rs:15:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private type
 ...
 LL |     priv_nominal::mac!();
    |     --------------------- in this macro invocation
@@ -24,7 +24,7 @@ error: type `for<'r> fn(&'r priv_nominal::Pub) {priv_nominal::Pub::method}` is p
   --> $DIR/associated-item-privacy-inherent.rs:17:13
    |
 LL |         Pub.method();
-   |             ^^^^^^
+   |             ^^^^^^ private type
 ...
 LL |     priv_nominal::mac!();
    |     --------------------- in this macro invocation
@@ -35,7 +35,7 @@ error: associated constant `CONST` is private
   --> $DIR/associated-item-privacy-inherent.rs:19:9
    |
 LL |         Pub::CONST;
-   |         ^^^^^^^^^^
+   |         ^^^^^^^^^^ private associated constant
 ...
 LL |     priv_nominal::mac!();
    |     --------------------- in this macro invocation
@@ -46,7 +46,7 @@ error: type `priv_signature::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:37:21
    |
 LL |         let value = Pub::method;
-   |                     ^^^^^^^^^^^
+   |                     ^^^^^^^^^^^ private type
 ...
 LL |     priv_signature::mac!();
    |     ----------------------- in this macro invocation
@@ -57,7 +57,7 @@ error: type `priv_signature::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:39:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private type
 ...
 LL |     priv_signature::mac!();
    |     ----------------------- in this macro invocation
@@ -68,7 +68,7 @@ error: type `priv_signature::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:41:13
    |
 LL |         Pub.method(loop {});
-   |             ^^^^^^
+   |             ^^^^^^ private type
 ...
 LL |     priv_signature::mac!();
    |     ----------------------- in this macro invocation
@@ -79,7 +79,7 @@ error: type `priv_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:57:21
    |
 LL |         let value = Pub::method::<Priv>;
-   |                     ^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_substs::mac!();
    |     -------------------- in this macro invocation
@@ -90,7 +90,7 @@ error: type `priv_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:59:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private type
 ...
 LL |     priv_substs::mac!();
    |     -------------------- in this macro invocation
@@ -101,7 +101,7 @@ error: type `priv_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:61:9
    |
 LL |         Pub.method::<Priv>();
-   |         ^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_substs::mac!();
    |     -------------------- in this macro invocation
@@ -112,7 +112,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:80:21
    |
 LL |         let value = <Pub>::method;
-   |                     ^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -123,7 +123,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:82:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -134,7 +134,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:84:21
    |
 LL |         let value = Pub::method;
-   |                     ^^^^^^^^^^^
+   |                     ^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -145,7 +145,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:86:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -156,7 +156,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:88:21
    |
 LL |         let value = <Pub>::static_method;
-   |                     ^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -167,7 +167,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:90:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -178,7 +178,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:92:21
    |
 LL |         let value = Pub::static_method;
-   |                     ^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -189,7 +189,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:94:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -200,7 +200,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:96:19
    |
 LL |         Pub(Priv).method();
-   |                   ^^^^^^
+   |                   ^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -211,7 +211,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:99:10
    |
 LL |         <Pub>::CONST;
-   |          ^^^
+   |          ^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -222,7 +222,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:101:9
    |
 LL |         Pub::CONST;
-   |         ^^^^^^^^^^
+   |         ^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation

--- a/src/test/ui/privacy/associated-item-privacy-trait.stderr
+++ b/src/test/ui/privacy/associated-item-privacy-trait.stderr
@@ -2,7 +2,7 @@ error: type `for<'r> fn(&'r priv_trait::Pub) {<priv_trait::Pub as priv_trait::Pr
   --> $DIR/associated-item-privacy-trait.rs:17:21
    |
 LL |         let value = <Pub as PrivTr>::method;
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
@@ -13,7 +13,7 @@ error: type `for<'r> fn(&'r priv_trait::Pub) {<priv_trait::Pub as priv_trait::Pr
   --> $DIR/associated-item-privacy-trait.rs:19:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private type
 ...
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
@@ -24,7 +24,7 @@ error: type `for<'r> fn(&'r Self) {<Self as priv_trait::PrivTr>::method}` is pri
   --> $DIR/associated-item-privacy-trait.rs:21:13
    |
 LL |         Pub.method();
-   |             ^^^^^^
+   |             ^^^^^^ private type
 ...
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
@@ -35,7 +35,7 @@ error: associated constant `PrivTr::CONST` is private
   --> $DIR/associated-item-privacy-trait.rs:23:9
    |
 LL |         <Pub as PrivTr>::CONST;
-   |         ^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^ private associated constant
 ...
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
@@ -46,7 +46,7 @@ error: associated type `PrivTr::AssocTy` is private
   --> $DIR/associated-item-privacy-trait.rs:25:16
    |
 LL |         let _: <Pub as PrivTr>::AssocTy;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^ private associated type
 ...
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
@@ -57,7 +57,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-trait.rs:27:34
    |
 LL |         pub type InSignatureTy = <Pub as PrivTr>::AssocTy;
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^ private trait
 ...
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
@@ -68,7 +68,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-trait.rs:29:34
    |
 LL |         pub trait InSignatureTr: PrivTr {}
-   |                                  ^^^^^^
+   |                                  ^^^^^^ private trait
 ...
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
@@ -79,7 +79,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-trait.rs:31:14
    |
 LL |         impl PrivTr for u8 {}
-   |              ^^^^^^
+   |              ^^^^^^ private trait
 ...
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
@@ -90,7 +90,7 @@ error: type `priv_signature::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:48:21
    |
 LL |         let value = <Pub as PubTr>::method;
-   |                     ^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_signature::mac!();
    |     ----------------------- in this macro invocation
@@ -101,7 +101,7 @@ error: type `priv_signature::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:50:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private type
 ...
 LL |     priv_signature::mac!();
    |     ----------------------- in this macro invocation
@@ -112,7 +112,7 @@ error: type `priv_signature::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:52:13
    |
 LL |         Pub.method(loop {});
-   |             ^^^^^^
+   |             ^^^^^^ private type
 ...
 LL |     priv_signature::mac!();
    |     ----------------------- in this macro invocation
@@ -123,7 +123,7 @@ error: type `priv_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:69:21
    |
 LL |         let value = <Pub as PubTr>::method::<Priv>;
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_substs::mac!();
    |     -------------------- in this macro invocation
@@ -134,7 +134,7 @@ error: type `priv_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:71:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private type
 ...
 LL |     priv_substs::mac!();
    |     -------------------- in this macro invocation
@@ -145,7 +145,7 @@ error: type `priv_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:73:9
    |
 LL |         Pub.method::<Priv>();
-   |         ^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_substs::mac!();
    |     -------------------- in this macro invocation
@@ -156,7 +156,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:93:21
    |
 LL |         let value = <Pub as PubTr>::method;
-   |                     ^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -167,7 +167,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:95:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -178,7 +178,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:97:21
    |
 LL |         let value = <Pub as PubTr<_>>::method;
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -189,7 +189,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:99:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -200,7 +200,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:101:9
    |
 LL |         Pub.method();
-   |         ^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -211,7 +211,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:104:21
    |
 LL |         let value = <Priv as PubTr<_>>::method;
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -222,7 +222,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:106:9
    |
 LL |         value;
-   |         ^^^^^
+   |         ^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -233,7 +233,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:108:9
    |
 LL |         Priv.method();
-   |         ^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -244,7 +244,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:111:9
    |
 LL |         <Pub as PubTr>::CONST;
-   |         ^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -255,7 +255,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:113:9
    |
 LL |         <Pub as PubTr<_>>::CONST;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -266,7 +266,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:115:9
    |
 LL |         <Priv as PubTr<_>>::CONST;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -277,7 +277,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:119:30
    |
 LL |         let _: <Pub as PubTr<_>>::AssocTy;
-   |                              ^
+   |                              ^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -288,7 +288,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:121:17
    |
 LL |         let _: <Priv as PubTr<_>>::AssocTy;
-   |                 ^^^^
+   |                 ^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -299,7 +299,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:124:35
    |
 LL |         pub type InSignatureTy1 = <Pub as PubTr>::AssocTy;
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -310,7 +310,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:126:35
    |
 LL |         pub type InSignatureTy2 = <Priv as PubTr<Pub>>::AssocTy;
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -321,7 +321,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:128:14
    |
 LL |         impl PubTr for u8 {}
-   |              ^^^^^
+   |              ^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation

--- a/src/test/ui/privacy/associated-item-privacy-type-binding.stderr
+++ b/src/test/ui/privacy/associated-item-privacy-type-binding.stderr
@@ -2,7 +2,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:11:13
    |
 LL |         let _: Box<dyn PubTr<AssocTy = u8>>;
-   |             ^
+   |             ^ private trait
 ...
 LL |     priv_trait::mac1!();
    |     -------------------- in this macro invocation
@@ -13,7 +13,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:11:16
    |
 LL |         let _: Box<dyn PubTr<AssocTy = u8>>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private trait
 ...
 LL |     priv_trait::mac1!();
    |     -------------------- in this macro invocation
@@ -24,7 +24,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:14:31
    |
 LL |         type InSignatureTy2 = Box<dyn PubTr<AssocTy = u8>>;
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private trait
 ...
 LL |     priv_trait::mac1!();
    |     -------------------- in this macro invocation
@@ -35,7 +35,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:16:31
    |
 LL |         trait InSignatureTr2: PubTr<AssocTy = u8> {}
-   |                               ^^^^^^^^^^^^^^^^^^^
+   |                               ^^^^^^^^^^^^^^^^^^^ private trait
 ...
 LL |     priv_trait::mac1!();
    |     -------------------- in this macro invocation
@@ -46,7 +46,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:20:13
    |
 LL |         let _: Box<dyn PrivTr<AssocTy = u8>>;
-   |             ^
+   |             ^ private trait
 ...
 LL |     priv_trait::mac2!();
    |     -------------------- in this macro invocation
@@ -57,7 +57,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:20:16
    |
 LL |         let _: Box<dyn PrivTr<AssocTy = u8>>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private trait
 ...
 LL |     priv_trait::mac2!();
    |     -------------------- in this macro invocation
@@ -68,7 +68,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:23:31
    |
 LL |         type InSignatureTy1 = Box<dyn PrivTr<AssocTy = u8>>;
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private trait
 ...
 LL |     priv_trait::mac2!();
    |     -------------------- in this macro invocation
@@ -79,7 +79,7 @@ error: trait `priv_trait::PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:25:31
    |
 LL |         trait InSignatureTr1: PrivTr<AssocTy = u8> {}
-   |                               ^^^^^^^^^^^^^^^^^^^^
+   |                               ^^^^^^^^^^^^^^^^^^^^ private trait
 ...
 LL |     priv_trait::mac2!();
    |     -------------------- in this macro invocation
@@ -90,7 +90,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:44:13
    |
 LL |         let _: Box<dyn PubTrWithParam<AssocTy = u8>>;
-   |             ^
+   |             ^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -101,7 +101,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:44:16
    |
 LL |         let _: Box<dyn PubTrWithParam<AssocTy = u8>>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -112,7 +112,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:47:13
    |
 LL |         let _: Box<dyn PubTr<AssocTy = u8>>;
-   |             ^
+   |             ^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -123,7 +123,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:47:16
    |
 LL |         let _: Box<dyn PubTr<AssocTy = u8>>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -134,7 +134,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:50:35
    |
 LL |         pub type InSignatureTy1 = Box<dyn PubTrWithParam<AssocTy = u8>>;
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -145,7 +145,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:52:35
    |
 LL |         pub type InSignatureTy2 = Box<dyn PubTr<AssocTy = u8>>;
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -156,7 +156,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:54:31
    |
 LL |         trait InSignatureTr1: PubTrWithParam<AssocTy = u8> {}
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
@@ -167,7 +167,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:56:31
    |
 LL |         trait InSignatureTr2: PubTr<AssocTy = u8> {}
-   |                               ^^^^^^^^^^^^^^^^^^^
+   |                               ^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation

--- a/src/test/ui/privacy/decl-macro.stderr
+++ b/src/test/ui/privacy/decl-macro.stderr
@@ -2,7 +2,7 @@ error[E0603]: macro `mac` is private
   --> $DIR/decl-macro.rs:8:8
    |
 LL |     m::mac!();
-   |        ^^^ this macro is private
+   |        ^^^ private macro
    |
 note: the macro `mac` is defined here
   --> $DIR/decl-macro.rs:4:5

--- a/src/test/ui/privacy/privacy-in-paths.stderr
+++ b/src/test/ui/privacy/privacy-in-paths.stderr
@@ -2,7 +2,7 @@ error[E0603]: module `bar` is private
   --> $DIR/privacy-in-paths.rs:24:16
    |
 LL |         ::foo::bar::baz::f();
-   |                ^^^ this module is private
+   |                ^^^ private module
    |
 note: the module `bar` is defined here
   --> $DIR/privacy-in-paths.rs:3:5
@@ -14,7 +14,7 @@ error[E0603]: module `bar` is private
   --> $DIR/privacy-in-paths.rs:25:16
    |
 LL |         ::foo::bar::S::f();
-   |                ^^^ this module is private
+   |                ^^^ private module
    |
 note: the module `bar` is defined here
   --> $DIR/privacy-in-paths.rs:3:5
@@ -26,7 +26,7 @@ error[E0603]: trait `T` is private
   --> $DIR/privacy-in-paths.rs:26:23
    |
 LL |         <() as ::foo::T>::Assoc::f();
-   |                       ^ this trait is private
+   |                       ^ private trait
    |
 note: the trait `T` is defined here
   --> $DIR/privacy-in-paths.rs:8:5

--- a/src/test/ui/privacy/privacy-ns2.stderr
+++ b/src/test/ui/privacy/privacy-ns2.stderr
@@ -58,7 +58,7 @@ error[E0603]: trait `Bar` is private
   --> $DIR/privacy-ns2.rs:63:15
    |
 LL |     use foo3::Bar;
-   |               ^^^ this trait is private
+   |               ^^^ private trait
    |
 note: the trait `Bar` is defined here
   --> $DIR/privacy-ns2.rs:55:5
@@ -70,7 +70,7 @@ error[E0603]: trait `Bar` is private
   --> $DIR/privacy-ns2.rs:67:15
    |
 LL |     use foo3::Bar;
-   |               ^^^ this trait is private
+   |               ^^^ private trait
    |
 note: the trait `Bar` is defined here
   --> $DIR/privacy-ns2.rs:55:5
@@ -82,7 +82,7 @@ error[E0603]: trait `Bar` is private
   --> $DIR/privacy-ns2.rs:74:16
    |
 LL |     use foo3::{Bar,Baz};
-   |                ^^^ this trait is private
+   |                ^^^ private trait
    |
 note: the trait `Bar` is defined here
   --> $DIR/privacy-ns2.rs:55:5

--- a/src/test/ui/privacy/privacy-ufcs.stderr
+++ b/src/test/ui/privacy/privacy-ufcs.stderr
@@ -2,7 +2,7 @@ error[E0603]: trait `Bar` is private
   --> $DIR/privacy-ufcs.rs:12:20
    |
 LL |     <i32 as ::foo::Bar>::baz();
-   |                    ^^^ this trait is private
+   |                    ^^^ private trait
    |
 note: the trait `Bar` is defined here
   --> $DIR/privacy-ufcs.rs:4:5

--- a/src/test/ui/privacy/privacy1.stderr
+++ b/src/test/ui/privacy/privacy1.stderr
@@ -155,28 +155,28 @@ LL |     trait B {
    |     ^^^^^^^
 
 error[E0624]: associated function `bar` is private
-  --> $DIR/privacy1.rs:77:9
+  --> $DIR/privacy1.rs:77:23
    |
 LL |         self::baz::A::bar();
-   |         ^^^^^^^^^^^^^^^^^ private associated function
+   |                       ^^^ private associated function
 
 error[E0624]: associated function `bar` is private
-  --> $DIR/privacy1.rs:95:5
+  --> $DIR/privacy1.rs:95:13
    |
 LL |     bar::A::bar();
-   |     ^^^^^^^^^^^ private associated function
+   |             ^^^ private associated function
 
 error[E0624]: associated function `bar` is private
-  --> $DIR/privacy1.rs:102:9
+  --> $DIR/privacy1.rs:102:19
    |
 LL |         ::bar::A::bar();
-   |         ^^^^^^^^^^^^^ private associated function
+   |                   ^^^ private associated function
 
 error[E0624]: associated function `bar` is private
-  --> $DIR/privacy1.rs:105:9
+  --> $DIR/privacy1.rs:105:24
    |
 LL |         ::bar::baz::A::bar();
-   |         ^^^^^^^^^^^^^^^^^^ private associated function
+   |                        ^^^ private associated function
 
 error[E0624]: associated function `bar2` is private
   --> $DIR/privacy1.rs:108:23

--- a/src/test/ui/privacy/privacy1.stderr
+++ b/src/test/ui/privacy/privacy1.stderr
@@ -2,7 +2,7 @@ error[E0603]: module `baz` is private
   --> $DIR/privacy1.rs:132:18
    |
 LL |         use bar::baz::{foo, bar};
-   |                  ^^^ this module is private
+   |                  ^^^ private module
    |
 note: the module `baz` is defined here
   --> $DIR/privacy1.rs:50:5
@@ -14,7 +14,7 @@ error[E0603]: module `baz` is private
   --> $DIR/privacy1.rs:132:18
    |
 LL |         use bar::baz::{foo, bar};
-   |                  ^^^ this module is private
+   |                  ^^^ private module
    |
 note: the module `baz` is defined here
   --> $DIR/privacy1.rs:50:5
@@ -26,7 +26,7 @@ error[E0603]: module `baz` is private
   --> $DIR/privacy1.rs:141:18
    |
 LL |         use bar::baz;
-   |                  ^^^ this module is private
+   |                  ^^^ private module
    |
 note: the module `baz` is defined here
   --> $DIR/privacy1.rs:50:5
@@ -38,7 +38,7 @@ error[E0603]: module `i` is private
   --> $DIR/privacy1.rs:165:20
    |
 LL |     use self::foo::i::A;
-   |                    ^ this module is private
+   |                    ^ private module
    |
 note: the module `i` is defined here
   --> $DIR/privacy1.rs:170:9
@@ -50,7 +50,7 @@ error[E0603]: module `baz` is private
   --> $DIR/privacy1.rs:104:16
    |
 LL |         ::bar::baz::A::foo();
-   |                ^^^ this module is private
+   |                ^^^ private module
    |
 note: the module `baz` is defined here
   --> $DIR/privacy1.rs:50:5
@@ -62,7 +62,7 @@ error[E0603]: module `baz` is private
   --> $DIR/privacy1.rs:105:16
    |
 LL |         ::bar::baz::A::bar();
-   |                ^^^ this module is private
+   |                ^^^ private module
    |
 note: the module `baz` is defined here
   --> $DIR/privacy1.rs:50:5
@@ -74,7 +74,7 @@ error[E0603]: module `baz` is private
   --> $DIR/privacy1.rs:107:16
    |
 LL |         ::bar::baz::A.foo2();
-   |                ^^^ this module is private
+   |                ^^^ private module
    |
 note: the module `baz` is defined here
   --> $DIR/privacy1.rs:50:5
@@ -86,7 +86,7 @@ error[E0603]: module `baz` is private
   --> $DIR/privacy1.rs:108:16
    |
 LL |         ::bar::baz::A.bar2();
-   |                ^^^ this module is private
+   |                ^^^ private module
    |
 note: the module `baz` is defined here
   --> $DIR/privacy1.rs:50:5
@@ -98,7 +98,7 @@ error[E0603]: trait `B` is private
   --> $DIR/privacy1.rs:112:16
    |
 LL |         ::bar::B::foo();
-   |                ^ this trait is private
+   |                ^ private trait
    |
 note: the trait `B` is defined here
   --> $DIR/privacy1.rs:40:5
@@ -110,7 +110,7 @@ error[E0603]: function `epriv` is private
   --> $DIR/privacy1.rs:118:20
    |
 LL |             ::bar::epriv();
-   |                    ^^^^^ this function is private
+   |                    ^^^^^ private function
    |
 note: the function `epriv` is defined here
   --> $DIR/privacy1.rs:65:9
@@ -122,7 +122,7 @@ error[E0603]: module `baz` is private
   --> $DIR/privacy1.rs:127:16
    |
 LL |         ::bar::baz::foo();
-   |                ^^^ this module is private
+   |                ^^^ private module
    |
 note: the module `baz` is defined here
   --> $DIR/privacy1.rs:50:5
@@ -134,7 +134,7 @@ error[E0603]: module `baz` is private
   --> $DIR/privacy1.rs:128:16
    |
 LL |         ::bar::baz::bar();
-   |                ^^^ this module is private
+   |                ^^^ private module
    |
 note: the module `baz` is defined here
   --> $DIR/privacy1.rs:50:5
@@ -146,7 +146,7 @@ error[E0603]: trait `B` is private
   --> $DIR/privacy1.rs:157:17
    |
 LL |     impl ::bar::B for f32 { fn foo() -> f32 { 1.0 } }
-   |                 ^ this trait is private
+   |                 ^ private trait
    |
 note: the trait `B` is defined here
   --> $DIR/privacy1.rs:40:5
@@ -158,31 +158,31 @@ error[E0624]: associated function `bar` is private
   --> $DIR/privacy1.rs:77:9
    |
 LL |         self::baz::A::bar();
-   |         ^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^ private associated function
 
 error[E0624]: associated function `bar` is private
   --> $DIR/privacy1.rs:95:5
    |
 LL |     bar::A::bar();
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^^^^ private associated function
 
 error[E0624]: associated function `bar` is private
   --> $DIR/privacy1.rs:102:9
    |
 LL |         ::bar::A::bar();
-   |         ^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^ private associated function
 
 error[E0624]: associated function `bar` is private
   --> $DIR/privacy1.rs:105:9
    |
 LL |         ::bar::baz::A::bar();
-   |         ^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^ private associated function
 
 error[E0624]: associated function `bar2` is private
   --> $DIR/privacy1.rs:108:23
    |
 LL |         ::bar::baz::A.bar2();
-   |                       ^^^^
+   |                       ^^^^ private associated function
 
 error: aborting due to 18 previous errors
 

--- a/src/test/ui/privacy/privacy2.stderr
+++ b/src/test/ui/privacy/privacy2.stderr
@@ -8,7 +8,7 @@ error[E0603]: function import `foo` is private
   --> $DIR/privacy2.rs:23:20
    |
 LL |     use bar::glob::foo;
-   |                    ^^^ this function import is private
+   |                    ^^^ private function import
    |
 note: the function import `foo` is defined here...
   --> $DIR/privacy2.rs:10:13

--- a/src/test/ui/privacy/privacy4.stderr
+++ b/src/test/ui/privacy/privacy4.stderr
@@ -2,7 +2,7 @@ error[E0603]: module `glob` is private
   --> $DIR/privacy4.rs:21:14
    |
 LL |     use bar::glob::gpriv;
-   |              ^^^^ this module is private
+   |              ^^^^ private module
    |
 note: the module `glob` is defined here
   --> $DIR/privacy4.rs:13:5

--- a/src/test/ui/privacy/privacy5.stderr
+++ b/src/test/ui/privacy/privacy5.stderr
@@ -5,7 +5,7 @@ LL |     pub struct A(());
    |                  -- a constructor is private if any of the fields is private
 ...
 LL |     let a = a::A(());
-   |                ^ this tuple struct constructor is private
+   |                ^ private tuple struct constructor
    |
 note: the tuple struct constructor `A` is defined here
   --> $DIR/privacy5.rs:6:5
@@ -20,7 +20,7 @@ LL |     pub struct B(isize);
    |                  ----- a constructor is private if any of the fields is private
 ...
 LL |     let b = a::B(2);
-   |                ^ this tuple struct constructor is private
+   |                ^ private tuple struct constructor
    |
 note: the tuple struct constructor `B` is defined here
   --> $DIR/privacy5.rs:7:5
@@ -35,7 +35,7 @@ LL |     pub struct C(pub isize, isize);
    |                  ---------------- a constructor is private if any of the fields is private
 ...
 LL |     let c = a::C(2, 3);
-   |                ^ this tuple struct constructor is private
+   |                ^ private tuple struct constructor
    |
 note: the tuple struct constructor `C` is defined here
   --> $DIR/privacy5.rs:8:5
@@ -50,7 +50,7 @@ LL |     pub struct A(());
    |                  -- a constructor is private if any of the fields is private
 ...
 LL |     let a::A(()) = a;
-   |            ^ this tuple struct constructor is private
+   |            ^ private tuple struct constructor
    |
 note: the tuple struct constructor `A` is defined here
   --> $DIR/privacy5.rs:6:5
@@ -65,7 +65,7 @@ LL |     pub struct A(());
    |                  -- a constructor is private if any of the fields is private
 ...
 LL |     let a::A(_) = a;
-   |            ^ this tuple struct constructor is private
+   |            ^ private tuple struct constructor
    |
 note: the tuple struct constructor `A` is defined here
   --> $DIR/privacy5.rs:6:5
@@ -80,7 +80,7 @@ LL |     pub struct A(());
    |                  -- a constructor is private if any of the fields is private
 ...
 LL |     match a { a::A(()) => {} }
-   |                  ^ this tuple struct constructor is private
+   |                  ^ private tuple struct constructor
    |
 note: the tuple struct constructor `A` is defined here
   --> $DIR/privacy5.rs:6:5
@@ -95,7 +95,7 @@ LL |     pub struct A(());
    |                  -- a constructor is private if any of the fields is private
 ...
 LL |     match a { a::A(_) => {} }
-   |                  ^ this tuple struct constructor is private
+   |                  ^ private tuple struct constructor
    |
 note: the tuple struct constructor `A` is defined here
   --> $DIR/privacy5.rs:6:5
@@ -110,7 +110,7 @@ LL |     pub struct B(isize);
    |                  ----- a constructor is private if any of the fields is private
 ...
 LL |     let a::B(_) = b;
-   |            ^ this tuple struct constructor is private
+   |            ^ private tuple struct constructor
    |
 note: the tuple struct constructor `B` is defined here
   --> $DIR/privacy5.rs:7:5
@@ -125,7 +125,7 @@ LL |     pub struct B(isize);
    |                  ----- a constructor is private if any of the fields is private
 ...
 LL |     let a::B(_b) = b;
-   |            ^ this tuple struct constructor is private
+   |            ^ private tuple struct constructor
    |
 note: the tuple struct constructor `B` is defined here
   --> $DIR/privacy5.rs:7:5
@@ -140,7 +140,7 @@ LL |     pub struct B(isize);
    |                  ----- a constructor is private if any of the fields is private
 ...
 LL |     match b { a::B(_) => {} }
-   |                  ^ this tuple struct constructor is private
+   |                  ^ private tuple struct constructor
    |
 note: the tuple struct constructor `B` is defined here
   --> $DIR/privacy5.rs:7:5
@@ -155,7 +155,7 @@ LL |     pub struct B(isize);
    |                  ----- a constructor is private if any of the fields is private
 ...
 LL |     match b { a::B(_b) => {} }
-   |                  ^ this tuple struct constructor is private
+   |                  ^ private tuple struct constructor
    |
 note: the tuple struct constructor `B` is defined here
   --> $DIR/privacy5.rs:7:5
@@ -170,7 +170,7 @@ LL |     pub struct B(isize);
    |                  ----- a constructor is private if any of the fields is private
 ...
 LL |     match b { a::B(1) => {} a::B(_) => {} }
-   |                  ^ this tuple struct constructor is private
+   |                  ^ private tuple struct constructor
    |
 note: the tuple struct constructor `B` is defined here
   --> $DIR/privacy5.rs:7:5
@@ -185,7 +185,7 @@ LL |     pub struct B(isize);
    |                  ----- a constructor is private if any of the fields is private
 ...
 LL |     match b { a::B(1) => {} a::B(_) => {} }
-   |                                ^ this tuple struct constructor is private
+   |                                ^ private tuple struct constructor
    |
 note: the tuple struct constructor `B` is defined here
   --> $DIR/privacy5.rs:7:5
@@ -200,7 +200,7 @@ LL |     pub struct C(pub isize, isize);
    |                  ---------------- a constructor is private if any of the fields is private
 ...
 LL |     let a::C(_, _) = c;
-   |            ^ this tuple struct constructor is private
+   |            ^ private tuple struct constructor
    |
 note: the tuple struct constructor `C` is defined here
   --> $DIR/privacy5.rs:8:5
@@ -215,7 +215,7 @@ LL |     pub struct C(pub isize, isize);
    |                  ---------------- a constructor is private if any of the fields is private
 ...
 LL |     let a::C(_a, _) = c;
-   |            ^ this tuple struct constructor is private
+   |            ^ private tuple struct constructor
    |
 note: the tuple struct constructor `C` is defined here
   --> $DIR/privacy5.rs:8:5
@@ -230,7 +230,7 @@ LL |     pub struct C(pub isize, isize);
    |                  ---------------- a constructor is private if any of the fields is private
 ...
 LL |     let a::C(_, _b) = c;
-   |            ^ this tuple struct constructor is private
+   |            ^ private tuple struct constructor
    |
 note: the tuple struct constructor `C` is defined here
   --> $DIR/privacy5.rs:8:5
@@ -245,7 +245,7 @@ LL |     pub struct C(pub isize, isize);
    |                  ---------------- a constructor is private if any of the fields is private
 ...
 LL |     let a::C(_a, _b) = c;
-   |            ^ this tuple struct constructor is private
+   |            ^ private tuple struct constructor
    |
 note: the tuple struct constructor `C` is defined here
   --> $DIR/privacy5.rs:8:5
@@ -260,7 +260,7 @@ LL |     pub struct C(pub isize, isize);
    |                  ---------------- a constructor is private if any of the fields is private
 ...
 LL |     match c { a::C(_, _) => {} }
-   |                  ^ this tuple struct constructor is private
+   |                  ^ private tuple struct constructor
    |
 note: the tuple struct constructor `C` is defined here
   --> $DIR/privacy5.rs:8:5
@@ -275,7 +275,7 @@ LL |     pub struct C(pub isize, isize);
    |                  ---------------- a constructor is private if any of the fields is private
 ...
 LL |     match c { a::C(_a, _) => {} }
-   |                  ^ this tuple struct constructor is private
+   |                  ^ private tuple struct constructor
    |
 note: the tuple struct constructor `C` is defined here
   --> $DIR/privacy5.rs:8:5
@@ -290,7 +290,7 @@ LL |     pub struct C(pub isize, isize);
    |                  ---------------- a constructor is private if any of the fields is private
 ...
 LL |     match c { a::C(_, _b) => {} }
-   |                  ^ this tuple struct constructor is private
+   |                  ^ private tuple struct constructor
    |
 note: the tuple struct constructor `C` is defined here
   --> $DIR/privacy5.rs:8:5
@@ -305,7 +305,7 @@ LL |     pub struct C(pub isize, isize);
    |                  ---------------- a constructor is private if any of the fields is private
 ...
 LL |     match c { a::C(_a, _b) => {} }
-   |                  ^ this tuple struct constructor is private
+   |                  ^ private tuple struct constructor
    |
 note: the tuple struct constructor `C` is defined here
   --> $DIR/privacy5.rs:8:5
@@ -320,7 +320,7 @@ LL |     pub struct A(());
    |                  -- a constructor is private if any of the fields is private
 ...
 LL |     let a2 = a::A;
-   |                 ^ this tuple struct constructor is private
+   |                 ^ private tuple struct constructor
    |
 note: the tuple struct constructor `A` is defined here
   --> $DIR/privacy5.rs:6:5
@@ -335,7 +335,7 @@ LL |     pub struct B(isize);
    |                  ----- a constructor is private if any of the fields is private
 ...
 LL |     let b2 = a::B;
-   |                 ^ this tuple struct constructor is private
+   |                 ^ private tuple struct constructor
    |
 note: the tuple struct constructor `B` is defined here
   --> $DIR/privacy5.rs:7:5
@@ -350,7 +350,7 @@ LL |     pub struct C(pub isize, isize);
    |                  ---------------- a constructor is private if any of the fields is private
 ...
 LL |     let c2 = a::C;
-   |                 ^ this tuple struct constructor is private
+   |                 ^ private tuple struct constructor
    |
 note: the tuple struct constructor `C` is defined here
   --> $DIR/privacy5.rs:8:5
@@ -362,7 +362,7 @@ error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:90:20
    |
 LL |     let a = other::A(());
-   |                    ^ this tuple struct constructor is private
+   |                    ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
@@ -379,7 +379,7 @@ error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:91:20
    |
 LL |     let b = other::B(2);
-   |                    ^ this tuple struct constructor is private
+   |                    ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
@@ -396,7 +396,7 @@ error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:92:20
    |
 LL |     let c = other::C(2, 3);
-   |                    ^ this tuple struct constructor is private
+   |                    ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
@@ -413,7 +413,7 @@ error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:95:16
    |
 LL |     let other::A(()) = a;
-   |                ^ this tuple struct constructor is private
+   |                ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
@@ -430,7 +430,7 @@ error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:96:16
    |
 LL |     let other::A(_) = a;
-   |                ^ this tuple struct constructor is private
+   |                ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
@@ -447,7 +447,7 @@ error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:97:22
    |
 LL |     match a { other::A(()) => {} }
-   |                      ^ this tuple struct constructor is private
+   |                      ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
@@ -464,7 +464,7 @@ error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:98:22
    |
 LL |     match a { other::A(_) => {} }
-   |                      ^ this tuple struct constructor is private
+   |                      ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
@@ -481,7 +481,7 @@ error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:100:16
    |
 LL |     let other::B(_) = b;
-   |                ^ this tuple struct constructor is private
+   |                ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
@@ -498,7 +498,7 @@ error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:101:16
    |
 LL |     let other::B(_b) = b;
-   |                ^ this tuple struct constructor is private
+   |                ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
@@ -515,7 +515,7 @@ error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:102:22
    |
 LL |     match b { other::B(_) => {} }
-   |                      ^ this tuple struct constructor is private
+   |                      ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
@@ -532,7 +532,7 @@ error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:103:22
    |
 LL |     match b { other::B(_b) => {} }
-   |                      ^ this tuple struct constructor is private
+   |                      ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
@@ -549,7 +549,7 @@ error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:104:22
    |
 LL |     match b { other::B(1) => {}
-   |                      ^ this tuple struct constructor is private
+   |                      ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
@@ -566,7 +566,7 @@ error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:105:16
    |
 LL |         other::B(_) => {} }
-   |                ^ this tuple struct constructor is private
+   |                ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
@@ -583,7 +583,7 @@ error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:107:16
    |
 LL |     let other::C(_, _) = c;
-   |                ^ this tuple struct constructor is private
+   |                ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
@@ -600,7 +600,7 @@ error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:108:16
    |
 LL |     let other::C(_a, _) = c;
-   |                ^ this tuple struct constructor is private
+   |                ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
@@ -617,7 +617,7 @@ error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:109:16
    |
 LL |     let other::C(_, _b) = c;
-   |                ^ this tuple struct constructor is private
+   |                ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
@@ -634,7 +634,7 @@ error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:110:16
    |
 LL |     let other::C(_a, _b) = c;
-   |                ^ this tuple struct constructor is private
+   |                ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
@@ -651,7 +651,7 @@ error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:111:22
    |
 LL |     match c { other::C(_, _) => {} }
-   |                      ^ this tuple struct constructor is private
+   |                      ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
@@ -668,7 +668,7 @@ error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:112:22
    |
 LL |     match c { other::C(_a, _) => {} }
-   |                      ^ this tuple struct constructor is private
+   |                      ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
@@ -685,7 +685,7 @@ error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:113:22
    |
 LL |     match c { other::C(_, _b) => {} }
-   |                      ^ this tuple struct constructor is private
+   |                      ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
@@ -702,7 +702,7 @@ error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:114:22
    |
 LL |     match c { other::C(_a, _b) => {} }
-   |                      ^ this tuple struct constructor is private
+   |                      ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
@@ -719,7 +719,7 @@ error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:122:21
    |
 LL |     let a2 = other::A;
-   |                     ^ this tuple struct constructor is private
+   |                     ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
@@ -736,7 +736,7 @@ error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:123:21
    |
 LL |     let b2 = other::B;
-   |                     ^ this tuple struct constructor is private
+   |                     ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
@@ -753,7 +753,7 @@ error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:124:21
    |
 LL |     let c2 = other::C;
-   |                     ^ this tuple struct constructor is private
+   |                     ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |

--- a/src/test/ui/privacy/private-impl-method.stderr
+++ b/src/test/ui/privacy/private-impl-method.stderr
@@ -2,7 +2,7 @@ error[E0624]: associated function `foo` is private
   --> $DIR/private-impl-method.rs:20:7
    |
 LL |     s.foo();
-   |       ^^^
+   |       ^^^ private associated function
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/private-in-public-non-principal-2.stderr
+++ b/src/test/ui/privacy/private-in-public-non-principal-2.stderr
@@ -2,7 +2,7 @@ error: trait `m::PrivNonPrincipal` is private
   --> $DIR/private-in-public-non-principal-2.rs:11:5
    |
 LL |     m::leak_dyn_nonprincipal();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ private trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/private-inferred-type-1.stderr
+++ b/src/test/ui/privacy/private-inferred-type-1.stderr
@@ -2,13 +2,13 @@ error: type `m::Priv` is private
   --> $DIR/private-inferred-type-1.rs:16:5
    |
 LL |     [].arr0_secret();
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type-1.rs:17:5
    |
 LL |     None.ty_param_secret();
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^ private type
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/privacy/private-inferred-type-2.stderr
+++ b/src/test/ui/privacy/private-inferred-type-2.stderr
@@ -2,19 +2,19 @@ error: type `m::Priv` is private
   --> $DIR/private-inferred-type-2.rs:16:5
    |
 LL |     m::Pub::get_priv;
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type-2.rs:17:5
    |
 LL |     m::Pub::static_method;
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^ private type
 
 error: type `ext::Priv` is private
   --> $DIR/private-inferred-type-2.rs:18:5
    |
 LL |     ext::Pub::static_method;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ private type
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/privacy/private-inferred-type-3.stderr
+++ b/src/test/ui/privacy/private-inferred-type-3.stderr
@@ -2,7 +2,7 @@ error: type `fn() {ext::priv_fn}` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^^ private type
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -10,7 +10,7 @@ error: static `PRIV_STATIC` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^^ private static
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -18,7 +18,7 @@ error: type `ext::PrivEnum` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^^ private type
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -26,7 +26,7 @@ error: type `fn() {<u8 as ext::PrivTrait>::method}` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^^ private type
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -34,7 +34,7 @@ error: type `fn(u8) -> ext::PrivTupleStruct {ext::PrivTupleStruct}` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^^ private type
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -42,7 +42,7 @@ error: type `fn(u8) -> ext::PubTupleStruct {ext::PubTupleStruct}` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^^ private type
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -50,7 +50,7 @@ error: type `for<'r> fn(&'r ext::Pub<u8>) {ext::Pub::<u8>::priv_method}` is priv
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^^ private type
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/privacy/private-inferred-type.stderr
+++ b/src/test/ui/privacy/private-inferred-type.stderr
@@ -20,97 +20,97 @@ error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:97:9
    |
 LL |     let _: m::Alias;
-   |         ^
+   |         ^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:97:12
    |
 LL |     let _: m::Alias;
-   |            ^^^^^^^^
+   |            ^^^^^^^^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:99:13
    |
 LL |     let _: <m::Alias as m::TraitWithAssocTy>::AssocTy;
-   |             ^^^^^^^^
+   |             ^^^^^^^^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:100:5
    |
 LL |     m::Alias {};
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^^^^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:101:5
    |
 LL |     m::Pub { 0: m::Alias {} };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:103:5
    |
 LL |     m::Pub::static_method;
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:104:5
    |
 LL |     m::Pub::INHERENT_ASSOC_CONST;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:105:5
    |
 LL |     m::Pub(0u8).method_with_substs::<m::Alias>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:106:17
    |
 LL |     m::Pub(0u8).method_with_priv_params(loop{});
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:107:5
    |
 LL |     <m::Alias as m::TraitWithAssocConst>::TRAIT_ASSOC_CONST;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:108:6
    |
 LL |     <m::Pub<m::Alias>>::INHERENT_ASSOC_CONST;
-   |      ^^^^^^^^^^^^^^^^
+   |      ^^^^^^^^^^^^^^^^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:109:5
    |
 LL |     <m::Pub<m::Alias>>::INHERENT_ASSOC_CONST_GENERIC_SELF;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:110:5
    |
 LL |     <m::Pub<m::Alias>>::static_method_generic_self;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:112:5
    |
 LL |     u8::pub_method;
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^ private type
 
 error: type `adjust::S2` is private
   --> $DIR/private-inferred-type.rs:114:5
    |
 LL |     adjust::S1.method_s3();
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^^ private type
 
 error: type `fn() {m::priv_fn}` is private
   --> $DIR/private-inferred-type.rs:39:9
    |
 LL |         priv_fn;
-   |         ^^^^^^^
+   |         ^^^^^^^ private type
 ...
 LL |     m::m!();
    |     -------- in this macro invocation
@@ -121,7 +121,7 @@ error: type `m::PrivEnum` is private
   --> $DIR/private-inferred-type.rs:41:9
    |
 LL |         PrivEnum::Variant;
-   |         ^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     m::m!();
    |     -------- in this macro invocation
@@ -132,7 +132,7 @@ error: type `fn() {<u8 as m::PrivTrait>::method}` is private
   --> $DIR/private-inferred-type.rs:43:9
    |
 LL |         <u8 as PrivTrait>::method;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     m::m!();
    |     -------- in this macro invocation
@@ -143,7 +143,7 @@ error: type `fn(u8) -> m::PrivTupleStruct {m::PrivTupleStruct}` is private
   --> $DIR/private-inferred-type.rs:45:9
    |
 LL |         PrivTupleStruct;
-   |         ^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^ private type
 ...
 LL |     m::m!();
    |     -------- in this macro invocation
@@ -154,7 +154,7 @@ error: type `fn(u8) -> m::PubTupleStruct {m::PubTupleStruct}` is private
   --> $DIR/private-inferred-type.rs:47:9
    |
 LL |         PubTupleStruct;
-   |         ^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^ private type
 ...
 LL |     m::m!();
    |     -------- in this macro invocation
@@ -165,7 +165,7 @@ error: type `for<'r> fn(&'r m::Pub<u8>) {m::Pub::<u8>::priv_method}` is private
   --> $DIR/private-inferred-type.rs:49:18
    |
 LL |         Pub(0u8).priv_method();
-   |                  ^^^^^^^^^^^
+   |                  ^^^^^^^^^^^ private type
 ...
 LL |     m::m!();
    |     -------- in this macro invocation
@@ -176,61 +176,61 @@ error: trait `m::Trait` is private
   --> $DIR/private-inferred-type.rs:118:5
    |
 LL |     m::leak_anon1();
-   |     ^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^ private trait
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:119:5
    |
 LL |     m::leak_anon2();
-   |     ^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:120:5
    |
 LL |     m::leak_anon3();
-   |     ^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^ private type
 
 error: trait `m::Trait` is private
   --> $DIR/private-inferred-type.rs:122:5
    |
 LL |     m::leak_dyn1();
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^ private trait
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:123:5
    |
 LL |     m::leak_dyn2();
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:124:5
    |
 LL |     m::leak_dyn3();
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:127:13
    |
 LL |     let a = m::Alias {};
-   |             ^^^^^^^^^^^
+   |             ^^^^^^^^^^^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:128:17
    |
 LL |     let mut b = a;
-   |                 ^
+   |                 ^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:129:9
    |
 LL |     b = a;
-   |         ^
+   |         ^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-inferred-type.rs:130:11
    |
 LL |     match a {
-   |           ^
+   |           ^ private type
 
 error: aborting due to 33 previous errors
 

--- a/src/test/ui/privacy/private-item-simple.stderr
+++ b/src/test/ui/privacy/private-item-simple.stderr
@@ -2,7 +2,7 @@ error[E0603]: function `f` is private
   --> $DIR/private-item-simple.rs:6:8
    |
 LL |     a::f();
-   |        ^ this function is private
+   |        ^ private function
    |
 note: the function `f` is defined here
   --> $DIR/private-item-simple.rs:2:5

--- a/src/test/ui/privacy/private-method-cross-crate.stderr
+++ b/src/test/ui/privacy/private-method-cross-crate.stderr
@@ -2,7 +2,7 @@ error[E0624]: associated function `nap` is private
   --> $DIR/private-method-cross-crate.rs:7:8
    |
 LL |   nyan.nap();
-   |        ^^^
+   |        ^^^ private associated function
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/private-method-inherited.stderr
+++ b/src/test/ui/privacy/private-method-inherited.stderr
@@ -2,7 +2,7 @@ error[E0624]: associated function `f` is private
   --> $DIR/private-method-inherited.rs:13:7
    |
 LL |     x.f();
-   |       ^
+   |       ^ private associated function
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/private-method.stderr
+++ b/src/test/ui/privacy/private-method.stderr
@@ -2,7 +2,7 @@ error[E0624]: associated function `nap` is private
   --> $DIR/private-method.rs:22:8
    |
 LL |   nyan.nap();
-   |        ^^^
+   |        ^^^ private associated function
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/private-struct-field-cross-crate.stderr
+++ b/src/test/ui/privacy/private-struct-field-cross-crate.stderr
@@ -1,8 +1,8 @@
 error[E0616]: field `meows` of struct `cci_class::kitties::cat` is private
-  --> $DIR/private-struct-field-cross-crate.rs:7:14
+  --> $DIR/private-struct-field-cross-crate.rs:7:19
    |
 LL |   assert_eq!(nyan.meows, 52);
-   |              ^^^^^^^^^^
+   |                   ^^^^^ private field
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/private-struct-field-ctor.stderr
+++ b/src/test/ui/privacy/private-struct-field-ctor.stderr
@@ -2,7 +2,7 @@ error[E0451]: field `x` of struct `a::Foo` is private
   --> $DIR/private-struct-field-ctor.rs:8:22
    |
 LL |     let s = a::Foo { x: 1 };
-   |                      ^^^^ field `x` is private
+   |                      ^^^^ private field
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/private-struct-field-pattern.stderr
+++ b/src/test/ui/privacy/private-struct-field-pattern.stderr
@@ -2,7 +2,7 @@ error[E0451]: field `x` of struct `a::Foo` is private
   --> $DIR/private-struct-field-pattern.rs:15:15
    |
 LL |         Foo { x: _ } => {}
-   |               ^^^^ field `x` is private
+   |               ^^^^ private field
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/private-struct-field.stderr
+++ b/src/test/ui/privacy/private-struct-field.stderr
@@ -1,8 +1,8 @@
 error[E0616]: field `meows` of struct `cat::Cat` is private
-  --> $DIR/private-struct-field.rs:13:16
+  --> $DIR/private-struct-field.rs:13:21
    |
 LL |     assert_eq!(nyan.meows, 52);
-   |                ^^^^^^^^^^
+   |                     ^^^^^ private field
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/private-type-in-interface.stderr
+++ b/src/test/ui/privacy/private-type-in-interface.stderr
@@ -2,55 +2,55 @@ error: type `m::Priv` is private
   --> $DIR/private-type-in-interface.rs:15:9
    |
 LL | fn f(_: m::Alias) {}
-   |         ^^^^^^^^
+   |         ^^^^^^^^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-type-in-interface.rs:15:6
    |
 LL | fn f(_: m::Alias) {}
-   |      ^
+   |      ^ private type
 
 error: type `ext::Priv` is private
   --> $DIR/private-type-in-interface.rs:17:13
    |
 LL | fn f_ext(_: ext::Alias) {}
-   |             ^^^^^^^^^^
+   |             ^^^^^^^^^^ private type
 
 error: type `ext::Priv` is private
   --> $DIR/private-type-in-interface.rs:17:10
    |
 LL | fn f_ext(_: ext::Alias) {}
-   |          ^
+   |          ^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-type-in-interface.rs:21:6
    |
 LL | impl m::Alias {}
-   |      ^^^^^^^^
+   |      ^^^^^^^^ private type
 
 error: type `ext::Priv` is private
   --> $DIR/private-type-in-interface.rs:22:14
    |
 LL | impl Tr1 for ext::Alias {}
-   |              ^^^^^^^^^^
+   |              ^^^^^^^^^^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-type-in-interface.rs:23:10
    |
 LL | type A = <m::Alias as m::Trait>::X;
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 
 error: type `m::Priv` is private
   --> $DIR/private-type-in-interface.rs:27:11
    |
 LL | fn g() -> impl Tr2<m::Alias> { 0 }
-   |           ^^^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^^^^^^^^ private type
 
 error: type `ext::Priv` is private
   --> $DIR/private-type-in-interface.rs:28:15
    |
 LL | fn g_ext() -> impl Tr2<ext::Alias> { 0 }
-   |               ^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^^^^^^^^^^^ private type
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/privacy/restricted/struct-literal-field.stderr
+++ b/src/test/ui/privacy/restricted/struct-literal-field.stderr
@@ -2,7 +2,7 @@ error[E0451]: field `x` of struct `foo::bar::S` is private
   --> $DIR/struct-literal-field.rs:18:9
    |
 LL |     S { x: 0 };
-   |         ^^^^ field `x` is private
+   |         ^^^^ private field
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/restricted/test.stderr
+++ b/src/test/ui/privacy/restricted/test.stderr
@@ -59,10 +59,10 @@ LL |     S::default().f();
    |                  ^ private associated function
 
 error[E0624]: associated function `g` is private
-  --> $DIR/test.rs:33:5
+  --> $DIR/test.rs:33:8
    |
 LL |     S::g();
-   |     ^^^^ private associated function
+   |        ^ private associated function
 
 error[E0616]: field `y` of struct `pub_restricted::Universe` is private
   --> $DIR/test.rs:42:15

--- a/src/test/ui/privacy/restricted/test.stderr
+++ b/src/test/ui/privacy/restricted/test.stderr
@@ -26,7 +26,7 @@ error[E0603]: struct `Crate` is private
   --> $DIR/test.rs:38:25
    |
 LL |     use pub_restricted::Crate;
-   |                         ^^^^^ this struct is private
+   |                         ^^^^^ private struct
    |
 note: the struct `Crate` is defined here
   --> $DIR/auxiliary/pub_restricted.rs:3:1
@@ -38,7 +38,7 @@ error[E0603]: function `f` is private
   --> $DIR/test.rs:30:19
    |
 LL |     use foo::bar::f;
-   |                   ^ this function is private
+   |                   ^ private function
    |
 note: the function `f` is defined here
   --> $DIR/test.rs:8:9
@@ -56,13 +56,13 @@ error[E0624]: associated function `f` is private
   --> $DIR/test.rs:32:18
    |
 LL |     S::default().f();
-   |                  ^
+   |                  ^ private associated function
 
 error[E0624]: associated function `g` is private
   --> $DIR/test.rs:33:5
    |
 LL |     S::g();
-   |     ^^^^
+   |     ^^^^ private associated function
 
 error[E0616]: field `y` of struct `pub_restricted::Universe` is private
   --> $DIR/test.rs:42:15
@@ -80,13 +80,13 @@ error[E0624]: associated function `g` is private
   --> $DIR/test.rs:45:7
    |
 LL |     u.g();
-   |       ^
+   |       ^ private associated function
 
 error[E0624]: associated function `h` is private
   --> $DIR/test.rs:46:7
    |
 LL |     u.h();
-   |       ^
+   |       ^ private associated function
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/privacy/restricted/test.stderr
+++ b/src/test/ui/privacy/restricted/test.stderr
@@ -47,10 +47,10 @@ LL |         pub(super) fn f() {}
    |         ^^^^^^^^^^^^^^^^^
 
 error[E0616]: field `x` of struct `foo::bar::S` is private
-  --> $DIR/test.rs:31:5
+  --> $DIR/test.rs:31:18
    |
 LL |     S::default().x;
-   |     ^^^^^^^^^^^^^^
+   |                  ^ private field
 
 error[E0624]: associated function `f` is private
   --> $DIR/test.rs:32:18
@@ -65,16 +65,16 @@ LL |     S::g();
    |     ^^^^
 
 error[E0616]: field `y` of struct `pub_restricted::Universe` is private
-  --> $DIR/test.rs:42:13
+  --> $DIR/test.rs:42:15
    |
 LL |     let _ = u.y;
-   |             ^^^
+   |               ^ private field
 
 error[E0616]: field `z` of struct `pub_restricted::Universe` is private
-  --> $DIR/test.rs:43:13
+  --> $DIR/test.rs:43:15
    |
 LL |     let _ = u.z;
-   |             ^^^
+   |               ^ private field
 
 error[E0624]: associated function `g` is private
   --> $DIR/test.rs:45:7

--- a/src/test/ui/privacy/union-field-privacy-1.stderr
+++ b/src/test/ui/privacy/union-field-privacy-1.stderr
@@ -2,13 +2,13 @@ error[E0451]: field `c` of union `m::U` is private
   --> $DIR/union-field-privacy-1.rs:12:20
    |
 LL |     let u = m::U { c: 0 };
-   |                    ^^^^ field `c` is private
+   |                    ^^^^ private field
 
 error[E0451]: field `c` of union `m::U` is private
   --> $DIR/union-field-privacy-1.rs:16:16
    |
 LL |     let m::U { c } = u;
-   |                ^ field `c` is private
+   |                ^ private field
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/privacy/union-field-privacy-2.stderr
+++ b/src/test/ui/privacy/union-field-privacy-2.stderr
@@ -1,8 +1,8 @@
 error[E0616]: field `c` of union `m::U` is private
-  --> $DIR/union-field-privacy-2.rs:14:13
+  --> $DIR/union-field-privacy-2.rs:14:15
    |
 LL |     let c = u.c;
-   |             ^^^
+   |               ^ private field
 
 error: aborting due to previous error
 

--- a/src/test/ui/proc-macro/disappearing-resolution.stderr
+++ b/src/test/ui/proc-macro/disappearing-resolution.stderr
@@ -8,7 +8,7 @@ error[E0603]: derive macro import `Empty` is private
   --> $DIR/disappearing-resolution.rs:11:8
    |
 LL | use m::Empty;
-   |        ^^^^^ this derive macro import is private
+   |        ^^^^^ private derive macro import
    |
 note: the derive macro import `Empty` is defined here
   --> $DIR/disappearing-resolution.rs:9:9

--- a/src/test/ui/proc-macro/issue-50493.stderr
+++ b/src/test/ui/proc-macro/issue-50493.stderr
@@ -8,7 +8,7 @@ error[E0616]: field `field` of struct `Restricted` is private
   --> $DIR/issue-50493.rs:6:10
    |
 LL | #[derive(Derive)]
-   |          ^^^^^^
+   |          ^^^^^^ private field
    |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -16,7 +16,7 @@ error[E0616]: field `field` of struct `Restricted` is private
   --> $DIR/issue-50493.rs:6:10
    |
 LL | #[derive(Derive)]
-   |          ^^^^^^
+   |          ^^^^^^ private field
    |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/question-mark-type-infer.stderr
+++ b/src/test/ui/question-mark-type-infer.stderr
@@ -2,12 +2,13 @@ error[E0284]: type annotations needed
   --> $DIR/question-mark-type-infer.rs:12:21
    |
 LL |     l.iter().map(f).collect()?
-   |                     ^^^^^^^
-   |                     |
-   |                     cannot infer type
-   |                     help: consider specifying the type argument in the method call: `collect::<B>`
+   |                     ^^^^^^^ cannot infer type
    |
    = note: cannot resolve `<_ as std::ops::Try>::Ok == _`
+help: consider specifying the type argument in the method call
+   |
+LL |     l.iter().map(f).collect::<B>()?
+   |                            ^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/reachable/unreachable-variant.stderr
+++ b/src/test/ui/reachable/unreachable-variant.stderr
@@ -2,7 +2,7 @@ error[E0603]: module `super_sekrit` is private
   --> $DIR/unreachable-variant.rs:6:21
    |
 LL |     let _x = other::super_sekrit::sooper_sekrit::baz;
-   |                     ^^^^^^^^^^^^ this module is private
+   |                     ^^^^^^^^^^^^ private module
    |
 note: the module `super_sekrit` is defined here
   --> $DIR/auxiliary/unreachable_variant.rs:1:1

--- a/src/test/ui/reify-intrinsic.stderr
+++ b/src/test/ui/reify-intrinsic.stderr
@@ -2,14 +2,16 @@ error[E0308]: cannot coerce intrinsics to function pointers
   --> $DIR/reify-intrinsic.rs:6:64
    |
 LL |     let _: unsafe extern "rust-intrinsic" fn(isize) -> usize = std::mem::transmute;
-   |            -------------------------------------------------   ^^^^^^^^^^^^^^^^^^^
-   |            |                                                   |
-   |            |                                                   cannot coerce intrinsics to function pointers
-   |            |                                                   help: use parentheses to call this function: `std::mem::transmute(...)`
+   |            -------------------------------------------------   ^^^^^^^^^^^^^^^^^^^ cannot coerce intrinsics to function pointers
+   |            |
    |            expected due to this
    |
    = note: expected fn pointer `unsafe extern "rust-intrinsic" fn(isize) -> usize`
                  found fn item `unsafe extern "rust-intrinsic" fn(_) -> _ {std::intrinsics::transmute::<_, _>}`
+help: use parentheses to call this function
+   |
+LL |     let _: unsafe extern "rust-intrinsic" fn(isize) -> usize = std::mem::transmute(...);
+   |                                                                                   ^^^^^
 
 error[E0606]: casting `unsafe extern "rust-intrinsic" fn(_) -> _ {std::intrinsics::transmute::<_, _>}` as `unsafe extern "rust-intrinsic" fn(isize) -> usize` is invalid
   --> $DIR/reify-intrinsic.rs:11:13

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -253,7 +253,7 @@ error[E0603]: enum `Z` is private
   --> $DIR/privacy-enum-ctor.rs:57:22
    |
 LL |     let _: Z = m::n::Z;
-   |                      ^ this enum is private
+   |                      ^ private enum
    |
 note: the enum `Z` is defined here
   --> $DIR/privacy-enum-ctor.rs:11:9
@@ -265,7 +265,7 @@ error[E0603]: enum `Z` is private
   --> $DIR/privacy-enum-ctor.rs:61:22
    |
 LL |     let _: Z = m::n::Z::Fn;
-   |                      ^ this enum is private
+   |                      ^ private enum
    |
 note: the enum `Z` is defined here
   --> $DIR/privacy-enum-ctor.rs:11:9
@@ -277,7 +277,7 @@ error[E0603]: enum `Z` is private
   --> $DIR/privacy-enum-ctor.rs:64:22
    |
 LL |     let _: Z = m::n::Z::Struct;
-   |                      ^ this enum is private
+   |                      ^ private enum
    |
 note: the enum `Z` is defined here
   --> $DIR/privacy-enum-ctor.rs:11:9
@@ -289,7 +289,7 @@ error[E0603]: enum `Z` is private
   --> $DIR/privacy-enum-ctor.rs:68:22
    |
 LL |     let _: Z = m::n::Z::Unit {};
-   |                      ^ this enum is private
+   |                      ^ private enum
    |
 note: the enum `Z` is defined here
   --> $DIR/privacy-enum-ctor.rs:11:9

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -304,14 +304,16 @@ LL |             Fn(u8),
    |             ------ fn(u8) -> m::n::Z {m::n::Z::Fn} defined here
 ...
 LL |         let _: Z = Z::Fn;
-   |                -   ^^^^^
-   |                |   |
-   |                |   expected enum `m::n::Z`, found fn item
-   |                |   help: use parentheses to instantiate this tuple variant: `Z::Fn(_)`
+   |                -   ^^^^^ expected enum `m::n::Z`, found fn item
+   |                |
    |                expected due to this
    |
    = note: expected enum `m::n::Z`
            found fn item `fn(u8) -> m::n::Z {m::n::Z::Fn}`
+help: use parentheses to instantiate this tuple variant
+   |
+LL |         let _: Z = Z::Fn(_);
+   |                         ^^^
 
 error[E0618]: expected function, found enum variant `Z::Unit`
   --> $DIR/privacy-enum-ctor.rs:31:17
@@ -336,14 +338,16 @@ LL |         Fn(u8),
    |         ------ fn(u8) -> m::E {m::E::Fn} defined here
 ...
 LL |     let _: E = m::E::Fn;
-   |            -   ^^^^^^^^
-   |            |   |
-   |            |   expected enum `m::E`, found fn item
-   |            |   help: use parentheses to instantiate this tuple variant: `m::E::Fn(_)`
+   |            -   ^^^^^^^^ expected enum `m::E`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected enum `m::E`
            found fn item `fn(u8) -> m::E {m::E::Fn}`
+help: use parentheses to instantiate this tuple variant
+   |
+LL |     let _: E = m::E::Fn(_);
+   |                        ^^^
 
 error[E0618]: expected function, found enum variant `m::E::Unit`
   --> $DIR/privacy-enum-ctor.rs:47:16
@@ -368,14 +372,16 @@ LL |         Fn(u8),
    |         ------ fn(u8) -> m::E {m::E::Fn} defined here
 ...
 LL |     let _: E = E::Fn;
-   |            -   ^^^^^
-   |            |   |
-   |            |   expected enum `m::E`, found fn item
-   |            |   help: use parentheses to instantiate this tuple variant: `E::Fn(_)`
+   |            -   ^^^^^ expected enum `m::E`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected enum `m::E`
            found fn item `fn(u8) -> m::E {m::E::Fn}`
+help: use parentheses to instantiate this tuple variant
+   |
+LL |     let _: E = E::Fn(_);
+   |                     ^^^
 
 error[E0618]: expected function, found enum variant `E::Unit`
   --> $DIR/privacy-enum-ctor.rs:55:16

--- a/src/test/ui/resolve/privacy-struct-ctor.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor.stderr
@@ -45,7 +45,7 @@ LL |         pub(in m) struct Z(pub(in m::n) u8);
    |                            --------------- a constructor is private if any of the fields is private
 ...
 LL |         n::Z;
-   |            ^ this tuple struct constructor is private
+   |            ^ private tuple struct constructor
    |
 note: the tuple struct constructor `Z` is defined here
   --> $DIR/privacy-struct-ctor.rs:12:9
@@ -60,7 +60,7 @@ LL |     pub struct S(u8);
    |                  -- a constructor is private if any of the fields is private
 ...
 LL |     m::S;
-   |        ^ this tuple struct constructor is private
+   |        ^ private tuple struct constructor
    |
 note: the tuple struct constructor `S` is defined here
   --> $DIR/privacy-struct-ctor.rs:6:5
@@ -75,7 +75,7 @@ LL |     pub struct S(u8);
    |                  -- a constructor is private if any of the fields is private
 ...
 LL |     let _: S = m::S(2);
-   |                   ^ this tuple struct constructor is private
+   |                   ^ private tuple struct constructor
    |
 note: the tuple struct constructor `S` is defined here
   --> $DIR/privacy-struct-ctor.rs:6:5
@@ -90,7 +90,7 @@ LL |         pub(in m) struct Z(pub(in m::n) u8);
    |                            --------------- a constructor is private if any of the fields is private
 ...
 LL |     m::n::Z;
-   |           ^ this tuple struct constructor is private
+   |           ^ private tuple struct constructor
    |
 note: the tuple struct constructor `Z` is defined here
   --> $DIR/privacy-struct-ctor.rs:12:9
@@ -102,7 +102,7 @@ error[E0603]: tuple struct constructor `S` is private
   --> $DIR/privacy-struct-ctor.rs:41:16
    |
 LL |     xcrate::m::S;
-   |                ^ this tuple struct constructor is private
+   |                ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy-struct-ctor.rs:2:18
    |
@@ -119,7 +119,7 @@ error[E0603]: tuple struct constructor `Z` is private
   --> $DIR/privacy-struct-ctor.rs:45:19
    |
 LL |     xcrate::m::n::Z;
-   |                   ^ this tuple struct constructor is private
+   |                   ^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/privacy-struct-ctor.rs:5:28
    |

--- a/src/test/ui/resolve/resolve-hint-macro.stderr
+++ b/src/test/ui/resolve/resolve-hint-macro.stderr
@@ -2,7 +2,12 @@ error[E0423]: expected function, found macro `assert`
   --> $DIR/resolve-hint-macro.rs:2:5
    |
 LL |     assert(true);
-   |     ^^^^^^ help: use `!` to invoke the macro: `assert!`
+   |     ^^^^^^
+   |
+help: use `!` to invoke the macro
+   |
+LL |     assert!(true);
+   |           ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2008-non-exhaustive/struct.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/struct.stderr
@@ -14,7 +14,7 @@ error[E0603]: tuple struct constructor `TupleStruct` is private
   --> $DIR/struct.rs:23:32
    |
 LL |     let ts_explicit = structs::TupleStruct(640, 480);
-   |                                ^^^^^^^^^^^ this tuple struct constructor is private
+   |                                ^^^^^^^^^^^ private tuple struct constructor
    | 
   ::: $DIR/auxiliary/structs.rs:11:24
    |
@@ -31,7 +31,7 @@ error[E0603]: unit struct `UnitStruct` is private
   --> $DIR/struct.rs:32:32
    |
 LL |     let us_explicit = structs::UnitStruct;
-   |                                ^^^^^^^^^^ this unit struct is private
+   |                                ^^^^^^^^^^ private unit struct
    |
 note: the unit struct `UnitStruct` is defined here
   --> $DIR/auxiliary/structs.rs:8:1

--- a/src/test/ui/rfc-2008-non-exhaustive/variant.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/variant.stderr
@@ -2,7 +2,7 @@ error[E0603]: tuple variant `Tuple` is private
   --> $DIR/variant.rs:11:48
    |
 LL |     let variant_tuple = NonExhaustiveVariants::Tuple(640);
-   |                                                ^^^^^ this tuple variant is private
+   |                                                ^^^^^ private tuple variant
    |
 note: the tuple variant `Tuple` is defined here
   --> $DIR/auxiliary/variants.rs:5:23
@@ -14,7 +14,7 @@ error[E0603]: unit variant `Unit` is private
   --> $DIR/variant.rs:14:47
    |
 LL |     let variant_unit = NonExhaustiveVariants::Unit;
-   |                                               ^^^^ this unit variant is private
+   |                                               ^^^^ private unit variant
    |
 note: the unit variant `Unit` is defined here
   --> $DIR/auxiliary/variants.rs:4:23
@@ -26,7 +26,7 @@ error[E0603]: unit variant `Unit` is private
   --> $DIR/variant.rs:18:32
    |
 LL |         NonExhaustiveVariants::Unit => "",
-   |                                ^^^^ this unit variant is private
+   |                                ^^^^ private unit variant
    |
 note: the unit variant `Unit` is defined here
   --> $DIR/auxiliary/variants.rs:4:23
@@ -38,7 +38,7 @@ error[E0603]: tuple variant `Tuple` is private
   --> $DIR/variant.rs:20:32
    |
 LL |         NonExhaustiveVariants::Tuple(fe_tpl) => "",
-   |                                ^^^^^ this tuple variant is private
+   |                                ^^^^^ private tuple variant
    |
 note: the tuple variant `Tuple` is defined here
   --> $DIR/auxiliary/variants.rs:5:23
@@ -50,7 +50,7 @@ error[E0603]: tuple variant `Tuple` is private
   --> $DIR/variant.rs:26:35
    |
 LL |     if let NonExhaustiveVariants::Tuple(fe_tpl) = variant_struct {
-   |                                   ^^^^^ this tuple variant is private
+   |                                   ^^^^^ private tuple variant
    |
 note: the tuple variant `Tuple` is defined here
   --> $DIR/auxiliary/variants.rs:5:23

--- a/src/test/ui/shadowed/shadowed-use-visibility.stderr
+++ b/src/test/ui/shadowed/shadowed-use-visibility.stderr
@@ -2,7 +2,7 @@ error[E0603]: module import `bar` is private
   --> $DIR/shadowed-use-visibility.rs:9:14
    |
 LL |     use foo::bar::f as g;
-   |              ^^^ this module import is private
+   |              ^^^ private module import
    |
 note: the module import `bar` is defined here...
   --> $DIR/shadowed-use-visibility.rs:4:9
@@ -19,7 +19,7 @@ error[E0603]: module import `f` is private
   --> $DIR/shadowed-use-visibility.rs:15:10
    |
 LL | use bar::f::f;
-   |          ^ this module import is private
+   |          ^ private module import
    |
 note: the module import `f` is defined here...
   --> $DIR/shadowed-use-visibility.rs:11:9

--- a/src/test/ui/span/type-annotations-needed-expr.stderr
+++ b/src/test/ui/span/type-annotations-needed-expr.stderr
@@ -2,12 +2,13 @@ error[E0282]: type annotations needed
   --> $DIR/type-annotations-needed-expr.rs:2:39
    |
 LL |     let _ = (vec![1,2,3]).into_iter().sum() as f64;
-   |                                       ^^^
-   |                                       |
-   |                                       cannot infer type for type parameter `S` declared on the associated function `sum`
-   |                                       help: consider specifying the type argument in the method call: `sum::<S>`
+   |                                       ^^^ cannot infer type for type parameter `S` declared on the associated function `sum`
    |
    = note: type must be known at this point
+help: consider specifying the type argument in the method call
+   |
+LL |     let _ = (vec![1,2,3]).into_iter().sum::<S>() as f64;
+   |                                          ^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/stability-in-private-module.stderr
+++ b/src/test/ui/stability-in-private-module.stderr
@@ -2,7 +2,7 @@ error[E0603]: module `thread_info` is private
   --> $DIR/stability-in-private-module.rs:7:26
    |
 LL |     let _ = std::thread::thread_info::current_thread();
-   |                          ^^^^^^^^^^^ this module is private
+   |                          ^^^^^^^^^^^ private module
    |
 note: the module `thread_info` is defined here
   --> $SRC_DIR/libstd/thread/mod.rs:LL:COL

--- a/src/test/ui/static/static-method-privacy.stderr
+++ b/src/test/ui/static/static-method-privacy.stderr
@@ -2,7 +2,7 @@ error[E0624]: associated function `new` is private
   --> $DIR/static-method-privacy.rs:9:13
    |
 LL |     let _ = a::S::new();
-   |             ^^^^^^^^^
+   |             ^^^^^^^^^ private associated function
 
 error: aborting due to previous error
 

--- a/src/test/ui/static/static-method-privacy.stderr
+++ b/src/test/ui/static/static-method-privacy.stderr
@@ -1,8 +1,8 @@
 error[E0624]: associated function `new` is private
-  --> $DIR/static-method-privacy.rs:9:13
+  --> $DIR/static-method-privacy.rs:9:19
    |
 LL |     let _ = a::S::new();
-   |             ^^^^^^^^^ private associated function
+   |                   ^^^ private associated function
 
 error: aborting due to previous error
 

--- a/src/test/ui/static/static-priv-by-default2.stderr
+++ b/src/test/ui/static/static-priv-by-default2.stderr
@@ -2,7 +2,7 @@ error[E0603]: static `private` is private
   --> $DIR/static-priv-by-default2.rs:15:30
    |
 LL |     use child::childs_child::private;
-   |                              ^^^^^^^ this static is private
+   |                              ^^^^^^^ private static
    |
 note: the static `private` is defined here
   --> $DIR/static-priv-by-default2.rs:7:9
@@ -14,7 +14,7 @@ error[E0603]: static `private` is private
   --> $DIR/static-priv-by-default2.rs:23:33
    |
 LL |     use static_priv_by_default::private;
-   |                                 ^^^^^^^ this static is private
+   |                                 ^^^^^^^ private static
    |
 note: the static `private` is defined here
   --> $DIR/auxiliary/static_priv_by_default.rs:3:1

--- a/src/test/ui/str/str-mut-idx.stderr
+++ b/src/test/ui/str/str-mut-idx.stderr
@@ -2,15 +2,17 @@ error[E0277]: the size for values of type `str` cannot be known at compilation t
   --> $DIR/str-mut-idx.rs:4:15
    |
 LL | fn bot<T>() -> T { loop {} }
-   |    --- -- help: consider relaxing the implicit `Sized` restriction: `: ?Sized`
-   |        |
-   |        required by this bound in `bot`
+   |    --- - required by this bound in `bot`
 ...
 LL |     s[1..2] = bot();
    |               ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | fn bot<T: ?Sized>() -> T { loop {} }
+   |         ^^^^^^^^
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/str-mut-idx.rs:4:5

--- a/src/test/ui/structs/struct-field-privacy.stderr
+++ b/src/test/ui/structs/struct-field-privacy.stderr
@@ -1,32 +1,32 @@
 error[E0616]: field `a` of struct `inner::A` is private
-  --> $DIR/struct-field-privacy.rs:23:5
+  --> $DIR/struct-field-privacy.rs:23:7
    |
 LL |     b.a;
-   |     ^^^
+   |       ^ private field
 
 error[E0616]: field `b` of struct `inner::B` is private
-  --> $DIR/struct-field-privacy.rs:26:5
+  --> $DIR/struct-field-privacy.rs:26:7
    |
 LL |     c.b;
-   |     ^^^
+   |       ^ private field
 
 error[E0616]: field `a` of struct `xc::A` is private
-  --> $DIR/struct-field-privacy.rs:28:5
+  --> $DIR/struct-field-privacy.rs:28:7
    |
 LL |     d.a;
-   |     ^^^
+   |       ^ private field
 
 error[E0616]: field `b` of struct `xc::B` is private
-  --> $DIR/struct-field-privacy.rs:32:5
+  --> $DIR/struct-field-privacy.rs:32:7
    |
 LL |     e.b;
-   |     ^^^
+   |       ^ private field
 
 error[E0616]: field `1` of struct `inner::Z` is private
-  --> $DIR/struct-field-privacy.rs:35:5
+  --> $DIR/struct-field-privacy.rs:35:7
    |
 LL |     z.1;
-   |     ^^^
+   |       ^ private field
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/structs/struct-variant-privacy-xc.stderr
+++ b/src/test/ui/structs/struct-variant-privacy-xc.stderr
@@ -2,7 +2,7 @@ error[E0603]: enum `Bar` is private
   --> $DIR/struct-variant-privacy-xc.rs:4:33
    |
 LL | fn f(b: struct_variant_privacy::Bar) {
-   |                                 ^^^ this enum is private
+   |                                 ^^^ private enum
    |
 note: the enum `Bar` is defined here
   --> $DIR/auxiliary/struct_variant_privacy.rs:1:1
@@ -14,7 +14,7 @@ error[E0603]: enum `Bar` is private
   --> $DIR/struct-variant-privacy-xc.rs:6:33
    |
 LL |         struct_variant_privacy::Bar::Baz { a: _a } => {}
-   |                                 ^^^ this enum is private
+   |                                 ^^^ private enum
    |
 note: the enum `Bar` is defined here
   --> $DIR/auxiliary/struct_variant_privacy.rs:1:1

--- a/src/test/ui/structs/struct-variant-privacy.stderr
+++ b/src/test/ui/structs/struct-variant-privacy.stderr
@@ -2,7 +2,7 @@ error[E0603]: enum `Bar` is private
   --> $DIR/struct-variant-privacy.rs:7:14
    |
 LL | fn f(b: foo::Bar) {
-   |              ^^^ this enum is private
+   |              ^^^ private enum
    |
 note: the enum `Bar` is defined here
   --> $DIR/struct-variant-privacy.rs:2:5
@@ -14,7 +14,7 @@ error[E0603]: enum `Bar` is private
   --> $DIR/struct-variant-privacy.rs:9:14
    |
 LL |         foo::Bar::Baz { a: _a } => {}
-   |              ^^^ this enum is private
+   |              ^^^ private enum
    |
 note: the enum `Bar` is defined here
   --> $DIR/struct-variant-privacy.rs:2:5

--- a/src/test/ui/substs-ppaux.normal.stderr
+++ b/src/test/ui/substs-ppaux.normal.stderr
@@ -5,14 +5,16 @@ LL |     fn bar<'a, T>() where T: 'a {}
    |     --------------------------- fn() {<i8 as Foo<'static, 'static, u8>>::bar::<'static, char>} defined here
 ...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
-   |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |            |    |
-   |            |    expected `()`, found fn item
-   |            |    help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>()`
+   |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected unit type `()`
                 found fn item `fn() {<i8 as Foo<'static, 'static, u8>>::bar::<'static, char>}`
+help: use parentheses to call this function
+   |
+LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>();
+   |                                                                         ^^
 
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:25:17
@@ -21,14 +23,16 @@ LL |     fn bar<'a, T>() where T: 'a {}
    |     --------------------------- fn() {<i8 as Foo<'static, 'static>>::bar::<'static, char>} defined here
 ...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
-   |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |            |    |
-   |            |    expected `()`, found fn item
-   |            |    help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>()`
+   |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected unit type `()`
                 found fn item `fn() {<i8 as Foo<'static, 'static>>::bar::<'static, char>}`
+help: use parentheses to call this function
+   |
+LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>();
+   |                                                                          ^^
 
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:33:17
@@ -37,14 +41,16 @@ LL |     fn baz() {}
    |     -------- fn() {<i8 as Foo<'static, 'static, u8>>::baz} defined here
 ...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
-   |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |            |    |
-   |            |    expected `()`, found fn item
-   |            |    help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u8>>::baz()`
+   |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected unit type `()`
                 found fn item `fn() {<i8 as Foo<'static, 'static, u8>>::baz}`
+help: use parentheses to call this function
+   |
+LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz();
+   |                                                        ^^
 
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:41:17
@@ -53,14 +59,16 @@ LL | fn foo<'z>() where &'z (): Sized {
    | -------------------------------- fn() {foo::<'static>} defined here
 ...
 LL |     let x: () = foo::<'static>;
-   |            --   ^^^^^^^^^^^^^^
-   |            |    |
-   |            |    expected `()`, found fn item
-   |            |    help: use parentheses to call this function: `foo::<'static>()`
+   |            --   ^^^^^^^^^^^^^^ expected `()`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected unit type `()`
                 found fn item `fn() {foo::<'static>}`
+help: use parentheses to call this function
+   |
+LL |     let x: () = foo::<'static>();
+   |                               ^^
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/substs-ppaux.rs:49:5

--- a/src/test/ui/substs-ppaux.verbose.stderr
+++ b/src/test/ui/substs-ppaux.verbose.stderr
@@ -5,14 +5,16 @@ LL |     fn bar<'a, T>() where T: 'a {}
    |     --------------------------- fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::bar::<ReStatic, char>} defined here
 ...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
-   |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |            |    |
-   |            |    expected `()`, found fn item
-   |            |    help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>()`
+   |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected unit type `()`
                 found fn item `fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::bar::<ReStatic, char>}`
+help: use parentheses to call this function
+   |
+LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>();
+   |                                                                         ^^
 
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:25:17
@@ -21,14 +23,16 @@ LL |     fn bar<'a, T>() where T: 'a {}
    |     --------------------------- fn() {<i8 as Foo<ReStatic, ReStatic>>::bar::<ReStatic, char>} defined here
 ...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
-   |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |            |    |
-   |            |    expected `()`, found fn item
-   |            |    help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>()`
+   |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected unit type `()`
                 found fn item `fn() {<i8 as Foo<ReStatic, ReStatic>>::bar::<ReStatic, char>}`
+help: use parentheses to call this function
+   |
+LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>();
+   |                                                                          ^^
 
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:33:17
@@ -37,14 +41,16 @@ LL |     fn baz() {}
    |     -------- fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::baz} defined here
 ...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
-   |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |            |    |
-   |            |    expected `()`, found fn item
-   |            |    help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u8>>::baz()`
+   |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected unit type `()`
                 found fn item `fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::baz}`
+help: use parentheses to call this function
+   |
+LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz();
+   |                                                        ^^
 
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:41:17
@@ -53,14 +59,16 @@ LL | fn foo<'z>() where &'z (): Sized {
    | -------------------------------- fn() {foo::<ReStatic>} defined here
 ...
 LL |     let x: () = foo::<'static>;
-   |            --   ^^^^^^^^^^^^^^
-   |            |    |
-   |            |    expected `()`, found fn item
-   |            |    help: use parentheses to call this function: `foo::<'static>()`
+   |            --   ^^^^^^^^^^^^^^ expected `()`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected unit type `()`
                 found fn item `fn() {foo::<ReStatic>}`
+help: use parentheses to call this function
+   |
+LL |     let x: () = foo::<'static>();
+   |                               ^^
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/substs-ppaux.rs:49:5

--- a/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -8,10 +8,12 @@ LL | fn bar(f: impl Future<Output=()>) {}
    |    ---         ----------------- required by this bound in `bar`
 ...
 LL |     bar(foo);
-   |         ^^^
-   |         |
-   |         the trait `std::future::Future` is not implemented for `fn() -> impl std::future::Future {foo}`
-   |         help: use parentheses to call the function: `foo()`
+   |         ^^^ the trait `std::future::Future` is not implemented for `fn() -> impl std::future::Future {foo}`
+   |
+help: use parentheses to call the function
+   |
+LL |     bar(foo());
+   |            ^^
 
 error[E0277]: the trait bound `[closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:11:25: 11:36]: std::future::Future` is not satisfied
   --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:12:9
@@ -22,10 +24,12 @@ LL | fn bar(f: impl Future<Output=()>) {}
 LL |     let async_closure = async || ();
    |                         -------- consider calling this closure
 LL |     bar(async_closure);
-   |         ^^^^^^^^^^^^^
-   |         |
-   |         the trait `std::future::Future` is not implemented for `[closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:11:25: 11:36]`
-   |         help: use parentheses to call the closure: `async_closure()`
+   |         ^^^^^^^^^^^^^ the trait `std::future::Future` is not implemented for `[closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:11:25: 11:36]`
+   |
+help: use parentheses to call the closure
+   |
+LL |     bar(async_closure());
+   |                      ^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/suggestions/const-in-struct-pat.stderr
+++ b/src/test/ui/suggestions/const-in-struct-pat.stderr
@@ -9,7 +9,11 @@ LL |     let Thing { foo } = t;
    |                 |
    |                 expected struct `std::string::String`, found struct `foo`
    |                 `foo` is interpreted as a unit struct, not a new binding
-   |                 help: bind the struct field to a different name instead: `foo: other_foo`
+   |
+help: bind the struct field to a different name instead
+   |
+LL |     let Thing { foo: other_foo } = t;
+   |                    ^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -8,10 +8,12 @@ LL | fn bar(f: impl T<O=()>) {}
    |    ---         ------- required by this bound in `bar`
 ...
 LL |     bar(foo);
-   |         ^^^
-   |         |
-   |         the trait `T` is not implemented for `fn() -> impl T {foo}`
-   |         help: use parentheses to call the function: `foo()`
+   |         ^^^ the trait `T` is not implemented for `fn() -> impl T {foo}`
+   |
+help: use parentheses to call the function
+   |
+LL |     bar(foo());
+   |            ^^
 
 error[E0277]: the trait bound `[closure@$DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:18:19: 18:23]: T` is not satisfied
   --> $DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:19:9
@@ -22,10 +24,12 @@ LL | fn bar(f: impl T<O=()>) {}
 LL |     let closure = || S;
    |                   -- consider calling this closure
 LL |     bar(closure);
-   |         ^^^^^^^
-   |         |
-   |         the trait `T` is not implemented for `[closure@$DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:18:19: 18:23]`
-   |         help: use parentheses to call the closure: `closure()`
+   |         ^^^^^^^ the trait `T` is not implemented for `[closure@$DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:18:19: 18:23]`
+   |
+help: use parentheses to call the closure
+   |
+LL |     bar(closure());
+   |                ^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -250,7 +250,7 @@ error[E0615]: attempted to take value of method `ban` on type `X`
   --> $DIR/fn-or-tuple-struct-without-args.rs:43:22
    |
 LL |     let _: usize = X.ban;
-   |                      ^^^
+   |                      ^^^ method, not a field
    |
 help: use parentheses to call the method
    |
@@ -261,7 +261,7 @@ error[E0615]: attempted to take value of method `bal` on type `X`
   --> $DIR/fn-or-tuple-struct-without-args.rs:44:22
    |
 LL |     let _: usize = X.bal;
-   |                      ^^^
+   |                      ^^^ method, not a field
    |
 help: use parentheses to call the method
    |

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -19,14 +19,16 @@ LL | fn foo(a: usize, b: usize) -> usize { a }
    | ----------------------------------- fn(usize, usize) -> usize {foo} defined here
 ...
 LL |     let _: usize = foo;
-   |            -----   ^^^
-   |            |       |
-   |            |       expected `usize`, found fn item
-   |            |       help: use parentheses to call this function: `foo(a, b)`
+   |            -----   ^^^ expected `usize`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected type `usize`
            found fn item `fn(usize, usize) -> usize {foo}`
+help: use parentheses to call this function
+   |
+LL |     let _: usize = foo(a, b);
+   |                       ^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:30:16
@@ -35,14 +37,16 @@ LL | struct S(usize, usize);
    | ----------------------- fn(usize, usize) -> S {S} defined here
 ...
 LL |     let _: S = S;
-   |            -   ^
-   |            |   |
-   |            |   expected struct `S`, found fn item
-   |            |   help: use parentheses to instantiate this tuple struct: `S(_, _)`
+   |            -   ^ expected struct `S`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected struct `S`
              found fn item `fn(usize, usize) -> S {S}`
+help: use parentheses to instantiate this tuple struct
+   |
+LL |     let _: S = S(_, _);
+   |                 ^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:31:20
@@ -51,14 +55,16 @@ LL | fn bar() -> usize { 42 }
    | ----------------- fn() -> usize {bar} defined here
 ...
 LL |     let _: usize = bar;
-   |            -----   ^^^
-   |            |       |
-   |            |       expected `usize`, found fn item
-   |            |       help: use parentheses to call this function: `bar()`
+   |            -----   ^^^ expected `usize`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected type `usize`
            found fn item `fn() -> usize {bar}`
+help: use parentheses to call this function
+   |
+LL |     let _: usize = bar();
+   |                       ^^
 
 error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:32:16
@@ -67,14 +73,16 @@ LL | struct V();
    | ----------- fn() -> V {V} defined here
 ...
 LL |     let _: V = V;
-   |            -   ^
-   |            |   |
-   |            |   expected struct `V`, found fn item
-   |            |   help: use parentheses to instantiate this tuple struct: `V()`
+   |            -   ^ expected struct `V`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected struct `V`
              found fn item `fn() -> V {V}`
+help: use parentheses to instantiate this tuple struct
+   |
+LL |     let _: V = V();
+   |                 ^^
 
 error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:33:20
@@ -83,14 +91,16 @@ LL |     fn baz(x: usize, y: usize) -> usize { x }
    |     ----------------------------------- fn(usize, usize) -> usize {<_ as T>::baz} defined here
 ...
 LL |     let _: usize = T::baz;
-   |            -----   ^^^^^^
-   |            |       |
-   |            |       expected `usize`, found fn item
-   |            |       help: use parentheses to call this function: `T::baz(x, y)`
+   |            -----   ^^^^^^ expected `usize`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected type `usize`
            found fn item `fn(usize, usize) -> usize {<_ as T>::baz}`
+help: use parentheses to call this function
+   |
+LL |     let _: usize = T::baz(x, y);
+   |                          ^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:34:20
@@ -99,14 +109,16 @@ LL |     fn bat(x: usize) -> usize { 42 }
    |     ------------------------- fn(usize) -> usize {<_ as T>::bat} defined here
 ...
 LL |     let _: usize = T::bat;
-   |            -----   ^^^^^^
-   |            |       |
-   |            |       expected `usize`, found fn item
-   |            |       help: use parentheses to call this function: `T::bat(x)`
+   |            -----   ^^^^^^ expected `usize`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected type `usize`
            found fn item `fn(usize) -> usize {<_ as T>::bat}`
+help: use parentheses to call this function
+   |
+LL |     let _: usize = T::bat(x);
+   |                          ^^^
 
 error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:35:16
@@ -115,14 +127,16 @@ LL |     A(usize),
    |     -------- fn(usize) -> E {E::A} defined here
 ...
 LL |     let _: E = E::A;
-   |            -   ^^^^
-   |            |   |
-   |            |   expected enum `E`, found fn item
-   |            |   help: use parentheses to instantiate this tuple variant: `E::A(_)`
+   |            -   ^^^^ expected enum `E`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected enum `E`
            found fn item `fn(usize) -> E {E::A}`
+help: use parentheses to instantiate this tuple variant
+   |
+LL |     let _: E = E::A(_);
+   |                    ^^^
 
 error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:37:20
@@ -131,14 +145,16 @@ LL |     fn baz(x: usize, y: usize) -> usize { x }
    |     ----------------------------------- fn(usize, usize) -> usize {<X as T>::baz} defined here
 ...
 LL |     let _: usize = X::baz;
-   |            -----   ^^^^^^
-   |            |       |
-   |            |       expected `usize`, found fn item
-   |            |       help: use parentheses to call this function: `X::baz(x, y)`
+   |            -----   ^^^^^^ expected `usize`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected type `usize`
            found fn item `fn(usize, usize) -> usize {<X as T>::baz}`
+help: use parentheses to call this function
+   |
+LL |     let _: usize = X::baz(x, y);
+   |                          ^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:38:20
@@ -147,14 +163,16 @@ LL |     fn bat(x: usize) -> usize { 42 }
    |     ------------------------- fn(usize) -> usize {<X as T>::bat} defined here
 ...
 LL |     let _: usize = X::bat;
-   |            -----   ^^^^^^
-   |            |       |
-   |            |       expected `usize`, found fn item
-   |            |       help: use parentheses to call this function: `X::bat(x)`
+   |            -----   ^^^^^^ expected `usize`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected type `usize`
            found fn item `fn(usize) -> usize {<X as T>::bat}`
+help: use parentheses to call this function
+   |
+LL |     let _: usize = X::bat(x);
+   |                          ^^^
 
 error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:39:20
@@ -163,14 +181,16 @@ LL |     fn bax(x: usize) -> usize { 42 }
    |     ------------------------- fn(usize) -> usize {<X as T>::bax} defined here
 ...
 LL |     let _: usize = X::bax;
-   |            -----   ^^^^^^
-   |            |       |
-   |            |       expected `usize`, found fn item
-   |            |       help: use parentheses to call this function: `X::bax(x)`
+   |            -----   ^^^^^^ expected `usize`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected type `usize`
            found fn item `fn(usize) -> usize {<X as T>::bax}`
+help: use parentheses to call this function
+   |
+LL |     let _: usize = X::bax(x);
+   |                          ^^^
 
 error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:40:20
@@ -179,14 +199,16 @@ LL |     fn bach(x: usize) -> usize;
    |     --------------------------- fn(usize) -> usize {<X as T>::bach} defined here
 ...
 LL |     let _: usize = X::bach;
-   |            -----   ^^^^^^^
-   |            |       |
-   |            |       expected `usize`, found fn item
-   |            |       help: use parentheses to call this function: `X::bach(x)`
+   |            -----   ^^^^^^^ expected `usize`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected type `usize`
            found fn item `fn(usize) -> usize {<X as T>::bach}`
+help: use parentheses to call this function
+   |
+LL |     let _: usize = X::bach(x);
+   |                           ^^^
 
 error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:41:20
@@ -195,14 +217,16 @@ LL |     fn ban(&self) -> usize { 42 }
    |     ---------------------- for<'r> fn(&'r X) -> usize {<X as T>::ban} defined here
 ...
 LL |     let _: usize = X::ban;
-   |            -----   ^^^^^^
-   |            |       |
-   |            |       expected `usize`, found fn item
-   |            |       help: use parentheses to call this function: `X::ban(_)`
+   |            -----   ^^^^^^ expected `usize`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected type `usize`
            found fn item `for<'r> fn(&'r X) -> usize {<X as T>::ban}`
+help: use parentheses to call this function
+   |
+LL |     let _: usize = X::ban(_);
+   |                          ^^^
 
 error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:42:20
@@ -211,26 +235,38 @@ LL |     fn bal(&self) -> usize;
    |     ----------------------- for<'r> fn(&'r X) -> usize {<X as T>::bal} defined here
 ...
 LL |     let _: usize = X::bal;
-   |            -----   ^^^^^^
-   |            |       |
-   |            |       expected `usize`, found fn item
-   |            |       help: use parentheses to call this function: `X::bal(_)`
+   |            -----   ^^^^^^ expected `usize`, found fn item
+   |            |
    |            expected due to this
    |
    = note: expected type `usize`
            found fn item `for<'r> fn(&'r X) -> usize {<X as T>::bal}`
+help: use parentheses to call this function
+   |
+LL |     let _: usize = X::bal(_);
+   |                          ^^^
 
 error[E0615]: attempted to take value of method `ban` on type `X`
   --> $DIR/fn-or-tuple-struct-without-args.rs:43:22
    |
 LL |     let _: usize = X.ban;
-   |                      ^^^ help: use parentheses to call the method: `ban()`
+   |                      ^^^
+   |
+help: use parentheses to call the method
+   |
+LL |     let _: usize = X.ban();
+   |                         ^^
 
 error[E0615]: attempted to take value of method `bal` on type `X`
   --> $DIR/fn-or-tuple-struct-without-args.rs:44:22
    |
 LL |     let _: usize = X.bal;
-   |                      ^^^ help: use parentheses to call the method: `bal()`
+   |                      ^^^
+   |
+help: use parentheses to call the method
+   |
+LL |     let _: usize = X.bal();
+   |                         ^^
 
 error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:46:20
@@ -238,14 +274,16 @@ error[E0308]: mismatched types
 LL |     let closure = || 42;
    |                   ----- the found closure
 LL |     let _: usize = closure;
-   |            -----   ^^^^^^^
-   |            |       |
-   |            |       expected `usize`, found closure
-   |            |       help: use parentheses to call this closure: `closure()`
+   |            -----   ^^^^^^^ expected `usize`, found closure
+   |            |
    |            expected due to this
    |
    = note: expected type `usize`
            found closure `[closure@$DIR/fn-or-tuple-struct-without-args.rs:45:19: 45:24]`
+help: use parentheses to call this closure
+   |
+LL |     let _: usize = closure();
+   |                           ^^
 
 error: aborting due to 17 previous errors
 

--- a/src/test/ui/suggestions/imm-ref-trait-object-literal.stderr
+++ b/src/test/ui/suggestions/imm-ref-trait-object-literal.stderr
@@ -5,13 +5,14 @@ LL | fn foo<X: Trait>(_: X) {}
    |    ---    ----- required by this bound in `foo`
 ...
 LL |   foo(&s);
-   |       -^
-   |       |
-   |       the trait `Trait` is not implemented for `&S`
-   |       help: consider changing this borrow's mutability: `&mut`
+   |       ^^ the trait `Trait` is not implemented for `&S`
    |
    = help: the following implementations were found:
              <&'a mut S as Trait>
+help: consider changing this borrow's mutability
+   |
+LL |   foo(&mut s);
+   |       ^^^^
 
 error[E0277]: the trait bound `S: Trait` is not satisfied
   --> $DIR/imm-ref-trait-object-literal.rs:13:7

--- a/src/test/ui/suggestions/method-missing-parentheses.stderr
+++ b/src/test/ui/suggestions/method-missing-parentheses.stderr
@@ -8,9 +8,12 @@ error[E0615]: attempted to take value of method `collect` on type `std::vec::Int
   --> $DIR/method-missing-parentheses.rs:2:32
    |
 LL |     let _ = vec![].into_iter().collect::<usize>;
-   |                                ^^^^^^^---------
-   |                                |
-   |                                help: use parentheses to call the method: `collect::<usize>()`
+   |                                ^^^^^^^
+   |
+help: use parentheses to call the method
+   |
+LL |     let _ = vec![].into_iter().collect::<usize>();
+   |                                                ^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/suggestions/method-missing-parentheses.stderr
+++ b/src/test/ui/suggestions/method-missing-parentheses.stderr
@@ -8,7 +8,7 @@ error[E0615]: attempted to take value of method `collect` on type `std::vec::Int
   --> $DIR/method-missing-parentheses.rs:2:32
    |
 LL |     let _ = vec![].into_iter().collect::<usize>;
-   |                                ^^^^^^^
+   |                                ^^^^^^^ method, not a field
    |
 help: use parentheses to call the method
    |

--- a/src/test/ui/traits/trait-item-privacy.stderr
+++ b/src/test/ui/traits/trait-item-privacy.stderr
@@ -74,10 +74,10 @@ LL | use method::B;
    |
 
 error[E0624]: associated function `a` is private
-  --> $DIR/trait-item-privacy.rs:84:5
+  --> $DIR/trait-item-privacy.rs:84:8
    |
 LL |     C::a(&S);
-   |     ^^^^ private associated function
+   |        ^ private associated function
 
 error[E0599]: no associated item named `A` found for struct `S` in the current scope
   --> $DIR/trait-item-privacy.rs:97:8
@@ -111,10 +111,10 @@ LL | use assoc_const::B;
    |
 
 error[E0624]: associated constant `A` is private
-  --> $DIR/trait-item-privacy.rs:101:5
+  --> $DIR/trait-item-privacy.rs:101:8
    |
 LL |     C::A;
-   |     ^^^^ private associated constant
+   |        ^ private associated constant
 
 error[E0038]: the trait `assoc_const::C` cannot be made into an object
   --> $DIR/trait-item-privacy.rs:101:5

--- a/src/test/ui/traits/trait-item-privacy.stderr
+++ b/src/test/ui/traits/trait-item-privacy.stderr
@@ -40,7 +40,7 @@ error[E0624]: associated function `a` is private
   --> $DIR/trait-item-privacy.rs:72:7
    |
 LL |     c.a();
-   |       ^
+   |       ^ private associated function
 
 error[E0599]: no function or associated item named `a` found for struct `S` in the current scope
   --> $DIR/trait-item-privacy.rs:78:8
@@ -77,7 +77,7 @@ error[E0624]: associated function `a` is private
   --> $DIR/trait-item-privacy.rs:84:5
    |
 LL |     C::a(&S);
-   |     ^^^^
+   |     ^^^^ private associated function
 
 error[E0599]: no associated item named `A` found for struct `S` in the current scope
   --> $DIR/trait-item-privacy.rs:97:8
@@ -114,7 +114,7 @@ error[E0624]: associated constant `A` is private
   --> $DIR/trait-item-privacy.rs:101:5
    |
 LL |     C::A;
-   |     ^^^^
+   |     ^^^^ private associated constant
 
 error[E0038]: the trait `assoc_const::C` cannot be made into an object
   --> $DIR/trait-item-privacy.rs:101:5
@@ -159,13 +159,13 @@ error: associated type `A` is private
   --> $DIR/trait-item-privacy.rs:119:12
    |
 LL |     let _: T::A;
-   |            ^^^^
+   |            ^^^^ private associated type
 
 error: associated type `A` is private
   --> $DIR/trait-item-privacy.rs:128:9
    |
 LL |         A = u8,
-   |         ^^^^^^
+   |         ^^^^^^ private associated type
 
 error: aborting due to 15 previous errors
 

--- a/src/test/ui/traits/trait-method-private.stderr
+++ b/src/test/ui/traits/trait-method-private.stderr
@@ -2,7 +2,7 @@ error[E0624]: associated function `method` is private
   --> $DIR/trait-method-private.rs:19:9
    |
 LL |     foo.method();
-   |         ^^^^^^
+   |         ^^^^^^ private associated function
    |
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:

--- a/src/test/ui/try-block/try-block-in-edition2015.stderr
+++ b/src/test/ui/try-block/try-block-in-edition2015.stderr
@@ -11,9 +11,13 @@ error[E0574]: expected struct, variant or union type, found macro `try`
   --> $DIR/try-block-in-edition2015.rs:4:33
    |
 LL |     let try_result: Option<_> = try {
-   |                                 ^^^ help: use `!` to invoke the macro: `try!`
+   |                                 ^^^
    |
    = note: if you want the `try` keyword, you need to be in the 2018 edition
+help: use `!` to invoke the macro
+   |
+LL |     let try_result: Option<_> = try! {
+   |                                    ^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/type-inference/or_else-multiple-type-params.stderr
+++ b/src/test/ui/type-inference/or_else-multiple-type-params.stderr
@@ -2,10 +2,12 @@ error[E0282]: type annotations needed
   --> $DIR/or_else-multiple-type-params.rs:7:10
    |
 LL |         .or_else(|err| {
-   |          ^^^^^^^
-   |          |
-   |          cannot infer type for type parameter `F` declared on the associated function `or_else`
-   |          help: consider specifying the type arguments in the method call: `or_else::<F, O>`
+   |          ^^^^^^^ cannot infer type for type parameter `F` declared on the associated function `or_else`
+   |
+help: consider specifying the type arguments in the method call
+   |
+LL |         .or_else::<F, O>(|err| {
+   |                 ^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-inference/sort_by_key.stderr
+++ b/src/test/ui/type-inference/sort_by_key.stderr
@@ -2,9 +2,12 @@ error[E0282]: type annotations needed
   --> $DIR/sort_by_key.rs:3:9
    |
 LL |     lst.sort_by_key(|&(v, _)| v.iter().sum());
-   |         ^^^^^^^^^^^                    --- help: consider specifying the type argument in the method call: `sum::<S>`
-   |         |
-   |         cannot infer type for type parameter `K` declared on the associated function `sort_by_key`
+   |         ^^^^^^^^^^^ cannot infer type for type parameter `K` declared on the associated function `sort_by_key`
+   |
+help: consider specifying the type argument in the method call
+   |
+LL |     lst.sort_by_key(|&(v, _)| v.iter().sum::<S>());
+   |                                           ^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/type-annotation-needed.stderr
+++ b/src/test/ui/type/type-annotation-needed.stderr
@@ -5,12 +5,13 @@ LL | fn foo<T: Into<String>>(x: i32) {}
    |    ---    ------------ required by this bound in `foo`
 ...
 LL |     foo(42);
-   |     ^^^
-   |     |
-   |     cannot infer type for type parameter `T` declared on the function `foo`
-   |     help: consider specifying the type argument in the function call: `foo::<T>`
+   |     ^^^ cannot infer type for type parameter `T` declared on the function `foo`
    |
    = note: cannot resolve `_: std::convert::Into<std::string::String>`
+help: consider specifying the type argument in the function call
+   |
+LL |     foo::<T>(42);
+   |        ^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/union/union-suggest-field.rs
+++ b/src/test/ui/union/union-suggest-field.rs
@@ -17,5 +17,5 @@ fn main() {
 
     let y = u.calculate; //~ ERROR attempted to take value of method `calculate` on type `U`
                          //~| HELP use parentheses to call the method
-                         //~| SUGGESTION calculate()
+                         //~| SUGGESTION ()
 }

--- a/src/test/ui/union/union-suggest-field.stderr
+++ b/src/test/ui/union/union-suggest-field.stderr
@@ -14,7 +14,7 @@ error[E0615]: attempted to take value of method `calculate` on type `U`
   --> $DIR/union-suggest-field.rs:18:15
    |
 LL |     let y = u.calculate;
-   |               ^^^^^^^^^
+   |               ^^^^^^^^^ method, not a field
    |
 help: use parentheses to call the method
    |

--- a/src/test/ui/union/union-suggest-field.stderr
+++ b/src/test/ui/union/union-suggest-field.stderr
@@ -14,7 +14,12 @@ error[E0615]: attempted to take value of method `calculate` on type `U`
   --> $DIR/union-suggest-field.rs:18:15
    |
 LL |     let y = u.calculate;
-   |               ^^^^^^^^^ help: use parentheses to call the method: `calculate()`
+   |               ^^^^^^^^^
+   |
+help: use parentheses to call the method
+   |
+LL |     let y = u.calculate();
+   |                        ^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/unsized3.stderr
+++ b/src/test/ui/unsized3.stderr
@@ -7,12 +7,14 @@ LL |     f2::<X>(x);
    |             ^ doesn't have a size known at compile-time
 ...
 LL | fn f2<X>(x: &X) {
-   |    -- -- help: consider relaxing the implicit `Sized` restriction: `: ?Sized`
-   |       |
-   |       required by this bound in `f2`
+   |    -- - required by this bound in `f2`
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | fn f2<X: ?Sized>(x: &X) {
+   |        ^^^^^^^^
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized3.rs:18:13
@@ -23,12 +25,14 @@ LL |     f4::<X>(x);
    |             ^ doesn't have a size known at compile-time
 ...
 LL | fn f4<X: T>(x: &X) {
-   |    -- -   - help: consider relaxing the implicit `Sized` restriction: `+  ?Sized`
-   |       |
-   |       required by this bound in `f4`
+   |    -- - required by this bound in `f4`
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | fn f4<X: T +  ?Sized>(x: &X) {
+   |            ^^^^^^^^^
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized3.rs:33:8

--- a/src/test/ui/use/use-from-trait-xc.stderr
+++ b/src/test/ui/use/use-from-trait-xc.stderr
@@ -44,7 +44,7 @@ error[E0603]: struct `Foo` is private
   --> $DIR/use-from-trait-xc.rs:14:24
    |
 LL | use use_from_trait_xc::Foo::new;
-   |                        ^^^ this struct is private
+   |                        ^^^ private struct
    |
 note: the struct `Foo` is defined here
   --> $DIR/auxiliary/use-from-trait-xc.rs:9:1
@@ -56,7 +56,7 @@ error[E0603]: struct `Foo` is private
   --> $DIR/use-from-trait-xc.rs:17:24
    |
 LL | use use_from_trait_xc::Foo::C;
-   |                        ^^^ this struct is private
+   |                        ^^^ private struct
    |
 note: the struct `Foo` is defined here
   --> $DIR/auxiliary/use-from-trait-xc.rs:9:1

--- a/src/test/ui/use/use-mod/use-mod-3.stderr
+++ b/src/test/ui/use/use-mod/use-mod-3.stderr
@@ -2,7 +2,7 @@ error[E0603]: module `bar` is private
   --> $DIR/use-mod-3.rs:1:10
    |
 LL | use foo::bar::{
-   |          ^^^ this module is private
+   |          ^^^ private module
    |
 note: the module `bar` is defined here
   --> $DIR/use-mod-3.rs:9:5
@@ -14,7 +14,7 @@ error[E0603]: module `bar` is private
   --> $DIR/use-mod-3.rs:4:10
    |
 LL | use foo::bar::{
-   |          ^^^ this module is private
+   |          ^^^ private module
    |
 note: the module `bar` is defined here
   --> $DIR/use-mod-3.rs:9:5

--- a/src/test/ui/xc-private-method.stderr
+++ b/src/test/ui/xc-private-method.stderr
@@ -1,14 +1,14 @@
 error[E0624]: associated function `static_meth_struct` is private
-  --> $DIR/xc-private-method.rs:6:13
+  --> $DIR/xc-private-method.rs:6:44
    |
 LL |     let _ = xc_private_method_lib::Struct::static_meth_struct();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private associated function
+   |                                            ^^^^^^^^^^^^^^^^^^ private associated function
 
 error[E0624]: associated function `static_meth_enum` is private
-  --> $DIR/xc-private-method.rs:9:13
+  --> $DIR/xc-private-method.rs:9:42
    |
 LL |     let _ = xc_private_method_lib::Enum::static_meth_enum();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private associated function
+   |                                          ^^^^^^^^^^^^^^^^ private associated function
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/xc-private-method.stderr
+++ b/src/test/ui/xc-private-method.stderr
@@ -2,13 +2,13 @@ error[E0624]: associated function `static_meth_struct` is private
   --> $DIR/xc-private-method.rs:6:13
    |
 LL |     let _ = xc_private_method_lib::Struct::static_meth_struct();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private associated function
 
 error[E0624]: associated function `static_meth_enum` is private
   --> $DIR/xc-private-method.rs:9:13
    |
 LL |     let _ = xc_private_method_lib::Enum::static_meth_enum();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private associated function
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/xc-private-method2.stderr
+++ b/src/test/ui/xc-private-method2.stderr
@@ -2,13 +2,13 @@ error[E0624]: associated function `meth_struct` is private
   --> $DIR/xc-private-method2.rs:6:52
    |
 LL |     let _ = xc_private_method_lib::Struct{ x: 10 }.meth_struct();
-   |                                                    ^^^^^^^^^^^
+   |                                                    ^^^^^^^^^^^ private associated function
 
 error[E0624]: associated function `meth_enum` is private
   --> $DIR/xc-private-method2.rs:9:55
    |
 LL |     let _ = xc_private_method_lib::Enum::Variant1(20).meth_enum();
-   |                                                       ^^^^^^^^^
+   |                                                       ^^^^^^^^^ private associated function
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/xcrate/xcrate-private-by-default.stderr
+++ b/src/test/ui/xcrate/xcrate-private-by-default.stderr
@@ -2,7 +2,7 @@ error[E0603]: static `j` is private
   --> $DIR/xcrate-private-by-default.rs:23:29
    |
 LL |     static_priv_by_default::j;
-   |                             ^ this static is private
+   |                             ^ private static
    |
 note: the static `j` is defined here
   --> $DIR/auxiliary/static_priv_by_default.rs:47:1
@@ -14,7 +14,7 @@ error[E0603]: function `k` is private
   --> $DIR/xcrate-private-by-default.rs:25:29
    |
 LL |     static_priv_by_default::k;
-   |                             ^ this function is private
+   |                             ^ private function
    |
 note: the function `k` is defined here
   --> $DIR/auxiliary/static_priv_by_default.rs:48:1
@@ -26,7 +26,7 @@ error[E0603]: unit struct `l` is private
   --> $DIR/xcrate-private-by-default.rs:27:29
    |
 LL |     static_priv_by_default::l;
-   |                             ^ this unit struct is private
+   |                             ^ private unit struct
    |
 note: the unit struct `l` is defined here
   --> $DIR/auxiliary/static_priv_by_default.rs:49:1
@@ -38,7 +38,7 @@ error[E0603]: enum `m` is private
   --> $DIR/xcrate-private-by-default.rs:29:35
    |
 LL |     foo::<static_priv_by_default::m>();
-   |                                   ^ this enum is private
+   |                                   ^ private enum
    |
 note: the enum `m` is defined here
   --> $DIR/auxiliary/static_priv_by_default.rs:50:1
@@ -50,7 +50,7 @@ error[E0603]: type alias `n` is private
   --> $DIR/xcrate-private-by-default.rs:31:35
    |
 LL |     foo::<static_priv_by_default::n>();
-   |                                   ^ this type alias is private
+   |                                   ^ private type alias
    |
 note: the type alias `n` is defined here
   --> $DIR/auxiliary/static_priv_by_default.rs:51:1
@@ -62,7 +62,7 @@ error[E0603]: module `foo` is private
   --> $DIR/xcrate-private-by-default.rs:35:29
    |
 LL |     static_priv_by_default::foo::a;
-   |                             ^^^ this module is private
+   |                             ^^^ private module
    |
 note: the module `foo` is defined here
   --> $DIR/auxiliary/static_priv_by_default.rs:12:1
@@ -74,7 +74,7 @@ error[E0603]: module `foo` is private
   --> $DIR/xcrate-private-by-default.rs:37:29
    |
 LL |     static_priv_by_default::foo::b;
-   |                             ^^^ this module is private
+   |                             ^^^ private module
    |
 note: the module `foo` is defined here
   --> $DIR/auxiliary/static_priv_by_default.rs:12:1
@@ -86,7 +86,7 @@ error[E0603]: module `foo` is private
   --> $DIR/xcrate-private-by-default.rs:39:29
    |
 LL |     static_priv_by_default::foo::c;
-   |                             ^^^ this module is private
+   |                             ^^^ private module
    |
 note: the module `foo` is defined here
   --> $DIR/auxiliary/static_priv_by_default.rs:12:1
@@ -98,7 +98,7 @@ error[E0603]: module `foo` is private
   --> $DIR/xcrate-private-by-default.rs:41:35
    |
 LL |     foo::<static_priv_by_default::foo::d>();
-   |                                   ^^^ this module is private
+   |                                   ^^^ private module
    |
 note: the module `foo` is defined here
   --> $DIR/auxiliary/static_priv_by_default.rs:12:1
@@ -110,7 +110,7 @@ error[E0603]: module `foo` is private
   --> $DIR/xcrate-private-by-default.rs:43:35
    |
 LL |     foo::<static_priv_by_default::foo::e>();
-   |                                   ^^^ this module is private
+   |                                   ^^^ private module
    |
 note: the module `foo` is defined here
   --> $DIR/auxiliary/static_priv_by_default.rs:12:1


### PR DESCRIPTION
Do not suggest changes that are actually quite small inline, to minimize the likelihood of confusion.

Fix #69243.