### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue.md
@@ -39,8 +39,8 @@ for larger features an implementation could be broken up into multiple PRs.
 - [ ] Adjust documentation ([see instructions on rustc-dev-guide][doc-guide])
 - [ ] Stabilization PR ([see instructions on rustc-dev-guide][stabilization-guide])
 
-[stabilization-guide]: https://rust-lang.github.io/rustc-dev-guide/stabilization_guide.html#stabilization-pr
-[doc-guide]: https://rust-lang.github.io/rustc-dev-guide/stabilization_guide.html#documentation-prs
+[stabilization-guide]: https://rustc-dev-guide.rust-lang.org/stabilization_guide.html#stabilization-pr
+[doc-guide]: https://rustc-dev-guide.rust-lang.org/stabilization_guide.html#documentation-prs
 
 ### Unresolved Questions
 <!--

--- a/.github/ISSUE_TEMPLATE/tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue.md
@@ -36,11 +36,11 @@ for larger features an implementation could be broken up into multiple PRs.
 
 - [ ] Implement the RFC (cc @rust-lang/XXX -- can anyone write up mentoring
       instructions?)
-- [ ] Adjust documentation ([see instructions on rustc-guide][doc-guide])
-- [ ] Stabilization PR ([see instructions on rustc-guide][stabilization-guide])
+- [ ] Adjust documentation ([see instructions on rustc-dev-guide][doc-guide])
+- [ ] Stabilization PR ([see instructions on rustc-dev-guide][stabilization-guide])
 
-[stabilization-guide]: https://rust-lang.github.io/rustc-guide/stabilization_guide.html#stabilization-pr
-[doc-guide]: https://rust-lang.github.io/rustc-guide/stabilization_guide.html#documentation-prs
+[stabilization-guide]: https://rust-lang.github.io/rustc-dev-guide/stabilization_guide.html#stabilization-pr
+[doc-guide]: https://rust-lang.github.io/rustc-dev-guide/stabilization_guide.html#documentation-prs
 
 ### Unresolved Questions
 <!--

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -434,7 +434,7 @@ For people new to Rust, and just starting to contribute, or even for
 more seasoned developers, some useful places to look for information
 are:
 
-* The [rustc guide] contains information about how various parts of the compiler work and how to contribute to the compiler
+* The [rustc dev guide] contains information about how various parts of the compiler work and how to contribute to the compiler
 * [Rust Forge][rustforge] contains additional documentation, including write-ups of how to achieve common tasks
 * The [Rust Internals forum][rif], a place to ask questions and
   discuss Rust's internals
@@ -448,7 +448,7 @@ are:
 * **Google!** ([search only in Rust Documentation][gsearchdocs] to find types, traits, etc. quickly)
 * Don't be afraid to ask! The Rust community is friendly and helpful.
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html
 [gdfrustc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/
 [gsearchdocs]: https://www.google.com/search?q=site:doc.rust-lang.org+your+query+here
 [rif]: http://internals.rust-lang.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,8 @@ can give you a good example of how a typical contribution would go.
 [rust-discord]: http://discord.gg/rust-lang
 [rust-zulip]: https://rust-lang.zulipchat.com
 [coc]: https://www.rust-lang.org/conduct.html
-[rustc-dev-guide]: https://rust-lang.github.io/rustc-dev-guide/
-[walkthrough]: https://rust-lang.github.io/rustc-dev-guide/walkthrough.html
+[rustc-dev-guide]: https://rustc-dev-guide.rust-lang.org/
+[walkthrough]: https://rustc-dev-guide.rust-lang.org/walkthrough.html
 
 ## Feature Requests
 [feature-requests]: #feature-requests
@@ -108,7 +108,7 @@ contributions to the compiler and the standard library. It also lists some
 really useful commands to the build system (`./x.py`), which could save you a
 lot of time.
 
-[rustcguidebuild]: https://rust-lang.github.io/rustc-dev-guide/building/how-to-build-and-run.html
+[rustcguidebuild]: https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html
 
 ## Pull Requests
 [pull-requests]: #pull-requests
@@ -448,7 +448,7 @@ are:
 * **Google!** ([search only in Rust Documentation][gsearchdocs] to find types, traits, etc. quickly)
 * Don't be afraid to ask! The Rust community is friendly and helpful.
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/about-this-guide.html
 [gdfrustc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/
 [gsearchdocs]: https://www.google.com/search?q=site:doc.rust-lang.org+your+query+here
 [rif]: http://internals.rust-lang.org
@@ -456,5 +456,5 @@ are:
 [rustforge]: https://forge.rust-lang.org/
 [tlgba]: http://tomlee.co/2014/04/a-more-detailed-tour-of-the-rust-compiler/
 [ro]: http://www.rustaceans.org/
-[rctd]: https://rust-lang.github.io/rustc-dev-guide/tests/intro.html
+[rctd]: https://rustc-dev-guide.rust-lang.org/tests/intro.html
 [cheatsheet]: https://buildbot2.rust-lang.org/homu/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ hop on the [Rust Discord server][rust-discord] or [Rust Zulip server][rust-zulip
 
 As a reminder, all contributors are expected to follow our [Code of Conduct][coc].
 
-The [rustc-guide] is your friend! It describes how the compiler works and how
+The [rustc-dev-guide] is your friend! It describes how the compiler works and how
 to contribute to it in more detail than this document.
 
 If this is your first time contributing, the [walkthrough] chapter of the guide
@@ -29,8 +29,8 @@ can give you a good example of how a typical contribution would go.
 [rust-discord]: http://discord.gg/rust-lang
 [rust-zulip]: https://rust-lang.zulipchat.com
 [coc]: https://www.rust-lang.org/conduct.html
-[rustc-guide]: https://rust-lang.github.io/rustc-guide/
-[walkthrough]: https://rust-lang.github.io/rustc-guide/walkthrough.html
+[rustc-dev-guide]: https://rust-lang.github.io/rustc-dev-guide/
+[walkthrough]: https://rust-lang.github.io/rustc-dev-guide/walkthrough.html
 
 ## Feature Requests
 [feature-requests]: #feature-requests
@@ -103,12 +103,12 @@ $ RUST_BACKTRACE=1 rustc ...
 ## The Build System
 
 For info on how to configure and build the compiler, please see [this
-chapter][rustcguidebuild] of the rustc-guide. This chapter contains info for
+chapter][rustcguidebuild] of the rustc-dev-guide. This chapter contains info for
 contributions to the compiler and the standard library. It also lists some
 really useful commands to the build system (`./x.py`), which could save you a
 lot of time.
 
-[rustcguidebuild]: https://rust-lang.github.io/rustc-guide/building/how-to-build-and-run.html
+[rustcguidebuild]: https://rust-lang.github.io/rustc-dev-guide/building/how-to-build-and-run.html
 
 ## Pull Requests
 [pull-requests]: #pull-requests
@@ -336,9 +336,9 @@ to check small fixes. For example, `rustdoc src/doc/reference.md` will render
 reference to `doc/reference.html`. The CSS might be messed up, but you can
 verify that the HTML is right.
 
-Additionally, contributions to the [rustc-guide] are always welcome. Contributions
+Additionally, contributions to the [rustc-dev-guide] are always welcome. Contributions
 can be made directly at [the
-rust-lang/rustc-guide](https://github.com/rust-lang/rustc-guide) repo. The issue
+rust-lang/rustc-dev-guide](https://github.com/rust-lang/rustc-dev-guide) repo. The issue
 tracker in that repo is also a great way to find things that need doing. There
 are issues for beginners and advanced compiler devs alike!
 
@@ -448,7 +448,7 @@ are:
 * **Google!** ([search only in Rust Documentation][gsearchdocs] to find types, traits, etc. quickly)
 * Don't be afraid to ask! The Rust community is friendly and helpful.
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/about-this-guide.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html
 [gdfrustc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/
 [gsearchdocs]: https://www.google.com/search?q=site:doc.rust-lang.org+your+query+here
 [rif]: http://internals.rust-lang.org
@@ -456,5 +456,5 @@ are:
 [rustforge]: https://forge.rust-lang.org/
 [tlgba]: http://tomlee.co/2014/04/a-more-detailed-tour-of-the-rust-compiler/
 [ro]: http://www.rustaceans.org/
-[rctd]: https://rust-lang.github.io/rustc-guide/tests/intro.html
+[rctd]: https://rust-lang.github.io/rustc-dev-guide/tests/intro.html
 [cheatsheet]: https://buildbot2.rust-lang.org/homu/

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Read ["Installation"] from [The Book].
 ## Installing from Source
 
 _Note: If you wish to contribute to the compiler, you should read [this
-chapter][rustcguidebuild] of the rustc-guide instead of this section._
+chapter][rustcguidebuild] of the rustc-dev-guide instead of this section._
 
 The Rust build system has a Python script called `x.py` to bootstrap building
 the compiler. More information about it may be found by running `./x.py --help`
 or reading the [rustc guide][rustcguidebuild].
 
-[rustcguidebuild]: https://rust-lang.github.io/rustc-guide/building/how-to-build-and-run.html
+[rustcguidebuild]: https://rust-lang.github.io/rustc-dev-guide/building/how-to-build-and-run.html
 
 ### Building on *nix
 1. Make sure you have installed the dependencies:
@@ -255,7 +255,7 @@ various parts of the compiler work.
 Also, you may find the [rustdocs for the compiler itself][rustdocs] useful.
 
 [rust-discord]: https://discord.gg/rust-lang
-[rustc guide]: https://rust-lang.github.io/rustc-guide/about-this-guide.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html
 [rustdocs]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/
 
 ## License

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The Rust build system has a Python script called `x.py` to bootstrap building
 the compiler. More information about it may be found by running `./x.py --help`
 or reading the [rustc dev guide][rustcguidebuild].
 
-[rustcguidebuild]: https://rust-lang.github.io/rustc-dev-guide/building/how-to-build-and-run.html
+[rustcguidebuild]: https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html
 
 ### Building on *nix
 1. Make sure you have installed the dependencies:
@@ -255,7 +255,7 @@ various parts of the compiler work.
 Also, you may find the [rustdocs for the compiler itself][rustdocs] useful.
 
 [rust-discord]: https://discord.gg/rust-lang
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/about-this-guide.html
 [rustdocs]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/
 
 ## License

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ chapter][rustcguidebuild] of the rustc-dev-guide instead of this section._
 
 The Rust build system has a Python script called `x.py` to bootstrap building
 the compiler. More information about it may be found by running `./x.py --help`
-or reading the [rustc guide][rustcguidebuild].
+or reading the [rustc dev guide][rustcguidebuild].
 
 [rustcguidebuild]: https://rust-lang.github.io/rustc-dev-guide/building/how-to-build-and-run.html
 
@@ -249,13 +249,13 @@ Most real-time collaboration happens in a variety of channels on the
 community, documentation, and all major contribution areas in the Rust ecosystem.
 A good place to ask for help would be the #help channel.
 
-The [rustc guide] might be a good place to start if you want to find out how
+The [rustc dev guide] might be a good place to start if you want to find out how
 various parts of the compiler work.
 
 Also, you may find the [rustdocs for the compiler itself][rustdocs] useful.
 
 [rust-discord]: https://discord.gg/rust-lang
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html
 [rustdocs]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/
 
 ## License

--- a/src/README.md
+++ b/src/README.md
@@ -5,4 +5,4 @@ This directory contains the source code of the rust project, including:
 
 For more information on how various parts of the compiler work, see the [rustc dev guide].
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/about-this-guide.html

--- a/src/README.md
+++ b/src/README.md
@@ -5,4 +5,4 @@ This directory contains the source code of the rust project, including:
 
 For more information on how various parts of the compiler work, see the [rustc guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/about-this-guide.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html

--- a/src/README.md
+++ b/src/README.md
@@ -3,6 +3,6 @@ This directory contains the source code of the rust project, including:
 - `libstd`
 - Various submodules for tools, like rustdoc, rls, etc.
 
-For more information on how various parts of the compiler work, see the [rustc guide].
+For more information on how various parts of the compiler work, see the [rustc dev guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/about-this-guide.html

--- a/src/bootstrap/toolstate.rs
+++ b/src/bootstrap/toolstate.rs
@@ -330,11 +330,11 @@ fn prepare_toolstate_config(token: &str) {
             Err(_) => false,
         };
         if !success {
-            panic!("git config key={} value={} successful (status: {:?})", key, value, status);
+            panic!("git config key={} value={} failed (status: {:?})", key, value, status);
         }
     }
 
-    // If changing anything here, then please check that src/ci/publish_toolstate.sh is up to date
+    // If changing anything here, then please check that `src/ci/publish_toolstate.sh` is up to date
     // as well.
     git_config("user.email", "7378925+rust-toolstate-update@users.noreply.github.com");
     git_config("user.name", "Rust Toolstate Update");
@@ -382,7 +382,9 @@ fn commit_toolstate_change(current_toolstate: &ToolstateData) {
     let message = format!("({} CI update)", OS.expect("linux/windows only"));
     let mut success = false;
     for _ in 1..=5 {
-        // Update the toolstate results (the new commit-to-toolstate mapping) in the toolstate repo.
+        // Upload the test results (the new commit-to-toolstate mapping) to the toolstate repo.
+        // This does *not* change the "current toolstate"; that only happens post-landing
+        // via `src/ci/docker/publish_toolstate.sh`.
         change_toolstate(&current_toolstate);
 
         // `git commit` failing means nothing to commit.

--- a/src/ci/publish_toolstate.sh
+++ b/src/ci/publish_toolstate.sh
@@ -23,7 +23,9 @@ GIT_COMMIT_MSG="$(git log --format=%s -n1 HEAD)"
 cd rust-toolstate
 FAILURE=1
 for RETRY_COUNT in 1 2 3 4 5; do
-    #  The purpose is to publish the new "current" toolstate in the toolstate repo.
+    # The purpose of this is to publish the new "current" toolstate in the toolstate repo.
+    # This happens post-landing, on master.
+    # (Publishing the per-commit test results happens pre-landing in src/bootstrap/toolstate.rs).
     "$(ciCheckoutPath)/src/tools/publish_toolstate.py" "$GIT_COMMIT" \
         "$GIT_COMMIT_MSG" \
         "$MESSAGE_FILE" \

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -120,7 +120,7 @@ Rust. It's also sometimes called "the 'nomicon."
 
 ## The `rustc` Contribution Guide
 
-[The `rustc` Guide](https://rust-lang.github.io/rustc-guide/) documents how
+[The `rustc` Guide](https://rust-lang.github.io/rustc-dev-guide/) documents how
 the compiler works and how to contribute to it. This is useful if you want to build
 or modify the Rust compiler from source (e.g. to target something non-standard).
 

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -120,7 +120,7 @@ Rust. It's also sometimes called "the 'nomicon."
 
 ## The `rustc` Contribution Guide
 
-[The `rustc` Guide](https://rust-lang.github.io/rustc-dev-guide/) documents how
+[The `rustc` Guide](https://rustc-dev-guide.rust-lang.org/) documents how
 the compiler works and how to contribute to it. This is useful if you want to build
 or modify the Rust compiler from source (e.g. to target something non-standard).
 

--- a/src/doc/rustc/src/contributing.md
+++ b/src/doc/rustc/src/contributing.md
@@ -8,5 +8,5 @@ more, you'll want to check that out.
 If you would like to contribute to _this_ book, you can find its source in the
 rustc source at [src/doc/rustc][rustc_book].
 
-[rustc_guide]: https://rust-lang.github.io/rustc-guide/
+[rustc_guide]: https://rust-lang.github.io/rustc-dev-guide/
 [rustc_book]: https://github.com/rust-lang/rust/tree/master/src/doc/rustc

--- a/src/doc/rustc/src/contributing.md
+++ b/src/doc/rustc/src/contributing.md
@@ -1,12 +1,12 @@
 # Contributing to rustc
 
 We'd love to have your help improving `rustc`! To that end, we've written [a
-whole book][rustc_guide] on its
+whole book][rustc_dev_guide] on its
 internals, how it works, and how to get started working on it. To learn
 more, you'll want to check that out.
 
 If you would like to contribute to _this_ book, you can find its source in the
 rustc source at [src/doc/rustc][rustc_book].
 
-[rustc_guide]: https://rust-lang.github.io/rustc-dev-guide/
+[rustc_dev_guide]: https://rust-lang.github.io/rustc-dev-guide/
 [rustc_book]: https://github.com/rust-lang/rust/tree/master/src/doc/rustc

--- a/src/doc/rustc/src/contributing.md
+++ b/src/doc/rustc/src/contributing.md
@@ -8,5 +8,5 @@ more, you'll want to check that out.
 If you would like to contribute to _this_ book, you can find its source in the
 rustc source at [src/doc/rustc][rustc_book].
 
-[rustc_dev_guide]: https://rust-lang.github.io/rustc-dev-guide/
+[rustc_dev_guide]: https://rustc-dev-guide.rust-lang.org/
 [rustc_book]: https://github.com/rust-lang/rust/tree/master/src/doc/rustc

--- a/src/liballoc/collections/mod.rs
+++ b/src/liballoc/collections/mod.rs
@@ -42,6 +42,7 @@ pub use linked_list::LinkedList;
 pub use vec_deque::VecDeque;
 
 use crate::alloc::{Layout, LayoutErr};
+use core::fmt::Display;
 
 /// The error type for `try_reserve` methods.
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -74,6 +75,22 @@ impl From<LayoutErr> for TryReserveError {
     #[inline]
     fn from(_: LayoutErr) -> Self {
         TryReserveError::CapacityOverflow
+    }
+}
+
+#[unstable(feature = "try_reserve", reason = "new API", issue = "48043")]
+impl Display for TryReserveError {
+    fn fmt(
+        &self,
+        fmt: &mut core::fmt::Formatter<'_>,
+    ) -> core::result::Result<(), core::fmt::Error> {
+        fmt.write_str("memory allocation failed")?;
+        fmt.write_str(match &self {
+            TryReserveError::CapacityOverflow => {
+                " because the computed capacity exceeded the collection's maximum"
+            }
+            TryReserveError::AllocError { .. } => " because the memory allocator returned a error",
+        })
     }
 }
 

--- a/src/liballoc/collections/mod.rs
+++ b/src/liballoc/collections/mod.rs
@@ -85,12 +85,15 @@ impl Display for TryReserveError {
         fmt: &mut core::fmt::Formatter<'_>,
     ) -> core::result::Result<(), core::fmt::Error> {
         fmt.write_str("memory allocation failed")?;
-        fmt.write_str(match &self {
+        let reason = match &self {
             TryReserveError::CapacityOverflow => {
                 " because the computed capacity exceeded the collection's maximum"
             }
-            TryReserveError::AllocError { .. } => " because the memory allocator returned a error",
-        })
+            TryReserveError::AllocError { .. } => {
+                " because the memory allocator returned a error"
+            }
+        };
+        fmt.write_str(reason)
     }
 }
 

--- a/src/liballoc/collections/mod.rs
+++ b/src/liballoc/collections/mod.rs
@@ -89,9 +89,7 @@ impl Display for TryReserveError {
             TryReserveError::CapacityOverflow => {
                 " because the computed capacity exceeded the collection's maximum"
             }
-            TryReserveError::AllocError { .. } => {
-                " because the memory allocator returned a error"
-            }
+            TryReserveError::AllocError { .. } => " because the memory allocator returned a error",
         };
         fmt.write_str(reason)
     }

--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -2,8 +2,6 @@ use crate::fmt::{Debug, Display, Formatter, LowerExp, Result, UpperExp};
 use crate::mem::MaybeUninit;
 use crate::num::flt2dec;
 
-// ignore-tidy-undocumented-unsafe
-
 // Don't inline this so callers don't use the stack space this function
 // requires unless they have to.
 #[inline(never)]
@@ -16,6 +14,7 @@ fn float_to_decimal_common_exact<T>(
 where
     T: flt2dec::DecodableFloat,
 {
+    // SAFETY: Possible undefined behavior, see FIXME(#53491)
     unsafe {
         let mut buf = MaybeUninit::<[u8; 1024]>::uninit(); // enough for f32 and f64
         let mut parts = MaybeUninit::<[flt2dec::Part<'_>; 4]>::uninit();
@@ -48,6 +47,7 @@ fn float_to_decimal_common_shortest<T>(
 where
     T: flt2dec::DecodableFloat,
 {
+    // SAFETY: Possible undefined behavior, see FIXME(#53491)
     unsafe {
         // enough for f32 and f64
         let mut buf = MaybeUninit::<[u8; flt2dec::MAX_SIG_DIGITS]>::uninit();
@@ -103,6 +103,7 @@ fn float_to_exponential_common_exact<T>(
 where
     T: flt2dec::DecodableFloat,
 {
+    // SAFETY: Possible undefined behavior, see FIXME(#53491)
     unsafe {
         let mut buf = MaybeUninit::<[u8; 1024]>::uninit(); // enough for f32 and f64
         let mut parts = MaybeUninit::<[flt2dec::Part<'_>; 6]>::uninit();
@@ -132,6 +133,7 @@ fn float_to_exponential_common_shortest<T>(
 where
     T: flt2dec::DecodableFloat,
 {
+    // SAFETY: Possible undefined behavior, see FIXME(#53491)
     unsafe {
         // enough for f32 and f64
         let mut buf = MaybeUninit::<[u8; flt2dec::MAX_SIG_DIGITS]>::uninit();

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1,7 +1,5 @@
 //! Utilities for formatting and printing strings.
 
-// ignore-tidy-undocumented-unsafe
-
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::cell::{Cell, Ref, RefCell, RefMut, UnsafeCell};
@@ -271,6 +269,14 @@ impl<'a> ArgumentV1<'a> {
     #[doc(hidden)]
     #[unstable(feature = "fmt_internals", reason = "internal to format_args!", issue = "none")]
     pub fn new<'b, T>(x: &'b T, f: fn(&T, &mut Formatter<'_>) -> Result) -> ArgumentV1<'b> {
+        // SAFETY: `mem::transmute(x)` is safe because
+        //     1. `&'b T` keeps the lifetime it originated with `'b`
+        //              (so as to not have an unbounded lifetime)
+        //     2. `&'b T` and `&'b Void` have the same memory layout
+        //              (when `T` is `Sized`, as it is here)
+        // `mem::transmute(f)` is safe since `fn(&T, &mut Formatter<'_>) -> Result`
+        // and `fn(&Void, &mut Formatter<'_>) -> Result` have the same ABI
+        // (as long as `T` is `Sized`)
         unsafe { ArgumentV1 { formatter: mem::transmute(f), value: mem::transmute(x) } }
     }
 
@@ -1389,6 +1395,14 @@ impl<'a> Formatter<'a> {
 
     fn write_formatted_parts(&mut self, formatted: &flt2dec::Formatted<'_>) -> Result {
         fn write_bytes(buf: &mut dyn Write, s: &[u8]) -> Result {
+            // SAFETY: This is used for `flt2dec::Part::Num` and `flt2dec::Part::Copy`.
+            // It's safe to use for `flt2dec::Part::Num` since every char `c` is between
+            // `b'0'` and `b'9'`, which means `s` is valid UTF-8.
+            // It's also probably safe in practice to use for `flt2dec::Part::Copy(buf)`
+            // since `buf` should be plain ASCII, but it's possible for someone to pass
+            // in a bad value for `buf` into `flt2dec::to_shortest_str` since it is a
+            // public function.
+            // FIXME: Determine whether this could result in UB.
             buf.write_str(unsafe { str::from_utf8_unchecked(s) })
         }
 

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -69,7 +69,7 @@ pub struct LexError {
 #[stable(feature = "proc_macro_lexerror_impls", since = "1.44.0")]
 impl fmt::Display for LexError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("lex error")
+        f.write_str("cannot parse string into token stream")
     }
 }
 

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -66,14 +66,14 @@ pub struct LexError {
     _inner: (),
 }
 
-#[stable(feature = "proc_macro_lib", since = "1.15.0")]
+#[stable(feature = "proc_macro_lexerror_impls", since = "1.44.0")]
 impl fmt::Display for LexError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("lex error")
     }
 }
 
-#[stable(feature = "proc_macro_lib", since = "1.15.0")]
+#[stable(feature = "proc_macro_lexerror_impls", since = "1.44.0")]
 impl error::Error for LexError {}
 
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -41,7 +41,7 @@ pub use diagnostic::{Diagnostic, Level, MultiSpan};
 use std::ops::{Bound, RangeBounds};
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::{fmt, iter, mem};
+use std::{error, fmt, iter, mem};
 
 /// The main type provided by this crate, representing an abstract stream of
 /// tokens, or, more specifically, a sequence of token trees.
@@ -65,6 +65,16 @@ impl !Sync for TokenStream {}
 pub struct LexError {
     _inner: (),
 }
+
+#[stable(feature = "proc_macro_lib", since = "1.15.0")]
+impl fmt::Display for LexError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("lex error")
+    }
+}
+
+#[stable(feature = "proc_macro_lib", since = "1.15.0")]
+impl error::Error for LexError {}
 
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 impl !Send for LexError {}

--- a/src/librustc/README.md
+++ b/src/librustc/README.md
@@ -1,3 +1,3 @@
 For more information about how rustc works, see the [rustc dev guide].
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/

--- a/src/librustc/README.md
+++ b/src/librustc/README.md
@@ -1,3 +1,3 @@
-For more information about how rustc works, see the [rustc guide].
+For more information about how rustc works, see the [rustc dev guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/

--- a/src/librustc/README.md
+++ b/src/librustc/README.md
@@ -1,3 +1,3 @@
 For more information about how rustc works, see the [rustc guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/

--- a/src/librustc/dep_graph/README.md
+++ b/src/librustc/dep_graph/README.md
@@ -1,4 +1,4 @@
 To learn more about how dependency tracking works in rustc, see the [rustc
 guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/query.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/query.html

--- a/src/librustc/dep_graph/README.md
+++ b/src/librustc/dep_graph/README.md
@@ -1,4 +1,4 @@
 To learn more about how dependency tracking works in rustc, see the [rustc
 guide].
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/query.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/query.html

--- a/src/librustc/dep_graph/README.md
+++ b/src/librustc/dep_graph/README.md
@@ -1,4 +1,4 @@
 To learn more about how dependency tracking works in rustc, see the [rustc
 guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/query.html
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/query.html

--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -194,7 +194,7 @@ impl DepGraph {
     /// - If you need 3+ arguments, use a tuple for the
     ///   `arg` parameter.
     ///
-    /// [rustc guide]: https://rust-lang.github.io/rustc-guide/incremental-compilation.html
+    /// [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/incremental-compilation.html
     pub fn with_task<'a, C, A, R>(
         &self,
         key: DepNode,

--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -174,7 +174,7 @@ impl DepGraph {
     /// what state they have access to. In particular, we want to
     /// prevent implicit 'leaks' of tracked state into the task (which
     /// could then be read without generating correct edges in the
-    /// dep-graph -- see the [rustc guide] for more details on
+    /// dep-graph -- see the [rustc dev guide] for more details on
     /// the dep-graph). To this end, the task function gets exactly two
     /// pieces of state: the context `cx` and an argument `arg`. Both
     /// of these bits of state must be of some type that implements
@@ -194,7 +194,7 @@ impl DepGraph {
     /// - If you need 3+ arguments, use a tuple for the
     ///   `arg` parameter.
     ///
-    /// [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/incremental-compilation.html
+    /// [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/incremental-compilation.html
     pub fn with_task<'a, C, A, R>(
         &self,
         key: DepNode,

--- a/src/librustc/dep_graph/graph.rs
+++ b/src/librustc/dep_graph/graph.rs
@@ -194,7 +194,7 @@ impl DepGraph {
     /// - If you need 3+ arguments, use a tuple for the
     ///   `arg` parameter.
     ///
-    /// [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/incremental-compilation.html
+    /// [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/incremental-compilation.html
     pub fn with_task<'a, C, A, R>(
         &self,
         key: DepNode,

--- a/src/librustc/hir/map/blocks.rs
+++ b/src/librustc/hir/map/blocks.rs
@@ -60,7 +60,7 @@ impl MaybeFnLike for hir::ImplItem<'_> {
 impl MaybeFnLike for hir::TraitItem<'_> {
     fn is_fn_like(&self) -> bool {
         match self.kind {
-            hir::TraitItemKind::Method(_, hir::TraitMethod::Provided(_)) => true,
+            hir::TraitItemKind::Fn(_, hir::TraitMethod::Provided(_)) => true,
             _ => false,
         }
     }
@@ -239,7 +239,7 @@ impl<'a> FnLikeNode<'a> {
                 _ => bug!("item FnLikeNode that is not fn-like"),
             },
             Node::TraitItem(ti) => match ti.kind {
-                hir::TraitItemKind::Method(ref sig, hir::TraitMethod::Provided(body)) => {
+                hir::TraitItemKind::Fn(ref sig, hir::TraitMethod::Provided(body)) => {
                     method(ti.hir_id, ti.ident, sig, None, body, ti.span, &ti.attrs)
                 }
                 _ => bug!("trait method FnLikeNode that is not fn-like"),

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -326,12 +326,12 @@ impl<'hir> Map<'hir> {
             },
             Node::TraitItem(item) => match item.kind {
                 TraitItemKind::Const(..) => DefKind::AssocConst,
-                TraitItemKind::Method(..) => DefKind::Method,
+                TraitItemKind::Method(..) => DefKind::AssocFn,
                 TraitItemKind::Type(..) => DefKind::AssocTy,
             },
             Node::ImplItem(item) => match item.kind {
                 ImplItemKind::Const(..) => DefKind::AssocConst,
-                ImplItemKind::Method(..) => DefKind::Method,
+                ImplItemKind::Method(..) => DefKind::AssocFn,
                 ImplItemKind::TyAlias(..) => DefKind::AssocTy,
                 ImplItemKind::OpaqueTy(..) => DefKind::AssocOpaqueTy,
             },

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -51,7 +51,7 @@ impl<'hir> Entry<'hir> {
             },
 
             Node::TraitItem(ref item) => match item.kind {
-                TraitItemKind::Method(ref sig, _) => Some(&sig.decl),
+                TraitItemKind::Fn(ref sig, _) => Some(&sig.decl),
                 _ => None,
             },
 
@@ -77,7 +77,7 @@ impl<'hir> Entry<'hir> {
             },
 
             Node::TraitItem(item) => match &item.kind {
-                TraitItemKind::Method(sig, _) => Some(sig),
+                TraitItemKind::Fn(sig, _) => Some(sig),
                 _ => None,
             },
 
@@ -101,7 +101,7 @@ impl<'hir> Entry<'hir> {
 
             Node::TraitItem(item) => match item.kind {
                 TraitItemKind::Const(_, Some(body))
-                | TraitItemKind::Method(_, TraitMethod::Provided(body)) => Some(body),
+                | TraitItemKind::Fn(_, TraitMethod::Provided(body)) => Some(body),
                 _ => None,
             },
 
@@ -326,7 +326,7 @@ impl<'hir> Map<'hir> {
             },
             Node::TraitItem(item) => match item.kind {
                 TraitItemKind::Const(..) => DefKind::AssocConst,
-                TraitItemKind::Method(..) => DefKind::AssocFn,
+                TraitItemKind::Fn(..) => DefKind::AssocFn,
                 TraitItemKind::Type(..) => DefKind::AssocTy,
             },
             Node::ImplItem(item) => match item.kind {
@@ -473,7 +473,7 @@ impl<'hir> Map<'hir> {
             | Node::AnonConst(_) => BodyOwnerKind::Const,
             Node::Ctor(..)
             | Node::Item(&Item { kind: ItemKind::Fn(..), .. })
-            | Node::TraitItem(&TraitItem { kind: TraitItemKind::Method(..), .. })
+            | Node::TraitItem(&TraitItem { kind: TraitItemKind::Fn(..), .. })
             | Node::ImplItem(&ImplItem { kind: ImplItemKind::Method(..), .. }) => BodyOwnerKind::Fn,
             Node::Item(&Item { kind: ItemKind::Static(_, m, _), .. }) => BodyOwnerKind::Static(m),
             Node::Expr(&Expr { kind: ExprKind::Closure(..), .. }) => BodyOwnerKind::Closure,
@@ -801,7 +801,7 @@ impl<'hir> Map<'hir> {
                     _ => false,
                 },
                 Node::TraitItem(ti) => match ti.kind {
-                    TraitItemKind::Method(..) => true,
+                    TraitItemKind::Fn(..) => true,
                     _ => false,
                 },
                 Node::ImplItem(ii) => match ii.kind {
@@ -1312,7 +1312,7 @@ fn hir_id_to_string(map: &Map<'_>, id: HirId, include_id: bool) -> String {
         Some(Node::TraitItem(ti)) => {
             let kind = match ti.kind {
                 TraitItemKind::Const(..) => "assoc constant",
-                TraitItemKind::Method(..) => "trait method",
+                TraitItemKind::Fn(..) => "trait method",
                 TraitItemKind::Type(..) => "assoc type",
             };
 

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1,6 +1,6 @@
 //! HIR datatypes. See the [rustc guide] for more info.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/hir.html
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
 
 pub mod exports;
 pub mod map;

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1,6 +1,6 @@
 //! HIR datatypes. See the [rustc dev guide] for more info.
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/hir.html
 
 pub mod exports;
 pub mod map;

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1,6 +1,6 @@
-//! HIR datatypes. See the [rustc guide] for more info.
+//! HIR datatypes. See the [rustc dev guide] for more info.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
 
 pub mod exports;
 pub mod map;

--- a/src/librustc/infer/canonical.rs
+++ b/src/librustc/infer/canonical.rs
@@ -19,7 +19,7 @@
 //! For a more detailed look at what is happening here, check
 //! out the [chapter in the rustc guide][c].
 //!
-//! [c]: https://rust-lang.github.io/rustc-guide/traits/canonicalization.html
+//! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 
 use crate::infer::MemberConstraint;
 use crate::ty::subst::GenericArg;

--- a/src/librustc/infer/canonical.rs
+++ b/src/librustc/infer/canonical.rs
@@ -17,7 +17,7 @@
 //! `instantiate_query_result` method.
 //!
 //! For a more detailed look at what is happening here, check
-//! out the [chapter in the rustc guide][c].
+//! out the [chapter in the rustc dev guide][c].
 //!
 //! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 

--- a/src/librustc/infer/canonical.rs
+++ b/src/librustc/infer/canonical.rs
@@ -19,7 +19,7 @@
 //! For a more detailed look at what is happening here, check
 //! out the [chapter in the rustc dev guide][c].
 //!
-//! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
+//! [c]: https://rustc-dev-guide.rust-lang.org/traits/canonicalization.html
 
 use crate::infer::MemberConstraint;
 use crate::ty::subst::GenericArg;

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! For more information about how rustc works, see the [rustc guide].
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/
 //!
 //! # Note
 //!

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! For more information about how rustc works, see the [rustc dev guide].
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/
 //!
 //! # Note
 //!

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -14,9 +14,9 @@
 //!   (or `tcx`), which is the central context during most of
 //!   compilation, containing the interners and other things.
 //!
-//! For more information about how rustc works, see the [rustc guide].
+//! For more information about how rustc works, see the [rustc dev guide].
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/
 //!
 //! # Note
 //!

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -4,7 +4,7 @@
 //! For more information about how MIR-based region-checking works,
 //! see the [rustc guide].
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/mir/borrowck.html
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/mir/borrowck.html
 
 use crate::ich::{NodeIdHashingMode, StableHashingContext};
 use crate::ty::{self, DefIdTree, TyCtxt};

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -2,9 +2,9 @@
 //! the parent links in the region hierarchy.
 //!
 //! For more information about how MIR-based region-checking works,
-//! see the [rustc guide].
+//! see the [rustc dev guide].
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/mir/borrowck.html
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/mir/borrowck.html
 
 use crate::ich::{NodeIdHashingMode, StableHashingContext};
 use crate::ty::{self, DefIdTree, TyCtxt};

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -4,7 +4,7 @@
 //! For more information about how MIR-based region-checking works,
 //! see the [rustc dev guide].
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/mir/borrowck.html
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/mir/borrowck.html
 
 use crate::ich::{NodeIdHashingMode, StableHashingContext};
 use crate::ty::{self, DefIdTree, TyCtxt};

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -250,7 +250,7 @@ pub enum EvalResult {
 fn skip_stability_check_due_to_privacy(tcx: TyCtxt<'_>, mut def_id: DefId) -> bool {
     // Check if `def_id` is a trait method.
     match tcx.def_kind(def_id) {
-        Some(DefKind::Method) | Some(DefKind::AssocTy) | Some(DefKind::AssocConst) => {
+        Some(DefKind::AssocFn) | Some(DefKind::AssocTy) | Some(DefKind::AssocConst) => {
             if let ty::TraitContainer(trait_def_id) = tcx.associated_item(def_id).container {
                 // Trait methods do not declare visibility (even
                 // for visibility info in cstore). Use containing

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1,6 +1,6 @@
-//! MIR datatypes and passes. See the [rustc guide] for more info.
+//! MIR datatypes and passes. See the [rustc dev guide] for more info.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/mir/index.html
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/mir/index.html
 
 use crate::mir::interpret::{GlobalAlloc, Scalar};
 use crate::mir::visit::MirVisitable;

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1,6 +1,6 @@
 //! MIR datatypes and passes. See the [rustc guide] for more info.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/mir/index.html
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/mir/index.html
 
 use crate::mir::interpret::{GlobalAlloc, Scalar};
 use crate::mir::visit::MirVisitable;

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1,6 +1,6 @@
 //! MIR datatypes and passes. See the [rustc dev guide] for more info.
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/mir/index.html
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/mir/index.html
 
 use crate::mir::interpret::{GlobalAlloc, Scalar};
 use crate::mir::visit::MirVisitable;

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -1,6 +1,6 @@
-//! Trait Resolution. See the [rustc guide] for more information on how this works.
+//! Trait Resolution. See the [rustc dev guide] for more information on how this works.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
 
 pub mod query;
 pub mod select;

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -1,6 +1,6 @@
 //! Trait Resolution. See the [rustc dev guide] for more information on how this works.
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/traits/resolution.html
 
 pub mod query;
 pub mod select;

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -1,6 +1,6 @@
 //! Trait Resolution. See the [rustc guide] for more information on how this works.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/traits/resolution.html
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
 
 pub mod query;
 pub mod select;

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -1,6 +1,6 @@
 //! Candidate selection. See the [rustc dev guide] for more information on how this works.
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#selection
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/traits/resolution.html#selection
 
 use self::EvaluationResult::*;
 

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -1,6 +1,6 @@
 //! Candidate selection. See the [rustc guide] for more information on how this works.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/traits/resolution.html#selection
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#selection
 
 use self::EvaluationResult::*;
 

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -1,6 +1,6 @@
-//! Candidate selection. See the [rustc guide] for more information on how this works.
+//! Candidate selection. See the [rustc dev guide] for more information on how this works.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#selection
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#selection
 
 use self::EvaluationResult::*;
 

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -611,7 +611,7 @@ impl<'tcx> TypeckTables<'tcx> {
         }
 
         match self.type_dependent_defs().get(expr.hir_id) {
-            Some(Ok((DefKind::Method, _))) => true,
+            Some(Ok((DefKind::AssocFn, _))) => true,
             _ => false,
         }
     }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -918,7 +918,7 @@ pub struct FreeRegionInfo {
 /// various **compiler queries** that have been performed. See the
 /// [rustc guide] for more details.
 ///
-/// [rustc guide]: https://rust-lang.github.io/rustc-guide/ty.html
+/// [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/ty.html
 #[derive(Copy, Clone)]
 #[rustc_diagnostic_item = "TyCtxt"]
 pub struct TyCtxt<'tcx> {

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -918,7 +918,7 @@ pub struct FreeRegionInfo {
 /// various **compiler queries** that have been performed. See the
 /// [rustc dev guide] for more details.
 ///
-/// [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/ty.html
+/// [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/ty.html
 #[derive(Copy, Clone)]
 #[rustc_diagnostic_item = "TyCtxt"]
 pub struct TyCtxt<'tcx> {

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -916,9 +916,9 @@ pub struct FreeRegionInfo {
 /// The central data structure of the compiler. It stores references
 /// to the various **arenas** and also houses the results of the
 /// various **compiler queries** that have been performed. See the
-/// [rustc guide] for more details.
+/// [rustc dev guide] for more details.
 ///
-/// [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/ty.html
+/// [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/ty.html
 #[derive(Copy, Clone)]
 #[rustc_diagnostic_item = "TyCtxt"]
 pub struct TyCtxt<'tcx> {

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -230,7 +230,7 @@ impl AssocItem {
     pub fn def_kind(&self) -> DefKind {
         match self.kind {
             AssocKind::Const => DefKind::AssocConst,
-            AssocKind::Method => DefKind::Method,
+            AssocKind::Method => DefKind::AssocFn,
             AssocKind::Type => DefKind::AssocTy,
             AssocKind::OpaqueTy => DefKind::AssocOpaqueTy,
         }
@@ -2872,7 +2872,7 @@ impl<'tcx> TyCtxt<'tcx> {
             }
         } else {
             match self.def_kind(def_id).expect("no def for `DefId`") {
-                DefKind::AssocConst | DefKind::Method | DefKind::AssocTy => true,
+                DefKind::AssocConst | DefKind::AssocFn | DefKind::AssocTy => true,
                 _ => false,
             }
         };
@@ -3051,7 +3051,7 @@ impl<'tcx> TyCtxt<'tcx> {
     /// `DefId` of the impl that the method belongs to; otherwise, returns `None`.
     pub fn impl_of_method(self, def_id: DefId) -> Option<DefId> {
         let item = if def_id.krate != LOCAL_CRATE {
-            if let Some(DefKind::Method) = self.def_kind(def_id) {
+            if let Some(DefKind::AssocFn) = self.def_kind(def_id) {
                 Some(self.associated_item(def_id))
             } else {
                 None

--- a/src/librustc/ty/query/README.md
+++ b/src/librustc/ty/query/README.md
@@ -1,3 +1,3 @@
 For more information about how the query system works, see the [rustc guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/query.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/query.html

--- a/src/librustc/ty/query/README.md
+++ b/src/librustc/ty/query/README.md
@@ -1,3 +1,3 @@
-For more information about how the query system works, see the [rustc guide].
+For more information about how the query system works, see the [rustc dev guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/query.html
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/query.html

--- a/src/librustc/ty/query/README.md
+++ b/src/librustc/ty/query/README.md
@@ -1,3 +1,3 @@
 For more information about how the query system works, see the [rustc dev guide].
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/query.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/query.html

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1396,11 +1396,11 @@ pub type Region<'tcx> = &'tcx RegionKind;
 /// the inference variable is supposed to satisfy the relation
 /// *for every value of the placeholder region*. To ensure that doesn't
 /// happen, you can use `leak_check`. This is more clearly explained
-/// by the [rustc guide].
+/// by the [rustc dev guide].
 ///
 /// [1]: http://smallcultfollowing.com/babysteps/blog/2013/10/29/intermingled-parameter-lists/
 /// [2]: http://smallcultfollowing.com/babysteps/blog/2013/11/04/intermingled-parameter-lists/
-/// [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/hrtb.html
+/// [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/hrtb.html
 #[derive(Clone, PartialEq, Eq, Hash, Copy, RustcEncodable, RustcDecodable, PartialOrd, Ord)]
 pub enum RegionKind {
     /// Region bound in a type or fn declaration which will be

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1400,7 +1400,7 @@ pub type Region<'tcx> = &'tcx RegionKind;
 ///
 /// [1]: http://smallcultfollowing.com/babysteps/blog/2013/10/29/intermingled-parameter-lists/
 /// [2]: http://smallcultfollowing.com/babysteps/blog/2013/11/04/intermingled-parameter-lists/
-/// [rustc guide]: https://rust-lang.github.io/rustc-guide/traits/hrtb.html
+/// [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/hrtb.html
 #[derive(Clone, PartialEq, Eq, Hash, Copy, RustcEncodable, RustcDecodable, PartialOrd, Ord)]
 pub enum RegionKind {
     /// Region bound in a type or fn declaration which will be

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1400,7 +1400,7 @@ pub type Region<'tcx> = &'tcx RegionKind;
 ///
 /// [1]: http://smallcultfollowing.com/babysteps/blog/2013/10/29/intermingled-parameter-lists/
 /// [2]: http://smallcultfollowing.com/babysteps/blog/2013/11/04/intermingled-parameter-lists/
-/// [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/hrtb.html
+/// [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/traits/hrtb.html
 #[derive(Clone, PartialEq, Eq, Hash, Copy, RustcEncodable, RustcDecodable, PartialOrd, Ord)]
 pub enum RegionKind {
     /// Region bound in a type or fn declaration which will be

--- a/src/librustc_ast/README.md
+++ b/src/librustc_ast/README.md
@@ -5,5 +5,5 @@ lexer, macro expander, and utilities for traversing ASTs.
 For more information about how these things work in rustc, see the
 rustc guide:
 
-- [Parsing](https://rust-lang.github.io/rustc-guide/the-parser.html)
-- [Macro Expansion](https://rust-lang.github.io/rustc-guide/macro-expansion.html)
+- [Parsing](https://rust-lang.github.io/rustc-dev-guide/the-parser.html)
+- [Macro Expansion](https://rust-lang.github.io/rustc-dev-guide/macro-expansion.html)

--- a/src/librustc_ast/README.md
+++ b/src/librustc_ast/README.md
@@ -3,7 +3,7 @@ The `rustc_ast` crate contains those things concerned purely with syntax
 lexer, macro expander, and utilities for traversing ASTs.
 
 For more information about how these things work in rustc, see the
-rustc guide:
+rustc dev guide:
 
 - [Parsing](https://rust-lang.github.io/rustc-dev-guide/the-parser.html)
 - [Macro Expansion](https://rust-lang.github.io/rustc-dev-guide/macro-expansion.html)

--- a/src/librustc_ast/README.md
+++ b/src/librustc_ast/README.md
@@ -5,5 +5,5 @@ lexer, macro expander, and utilities for traversing ASTs.
 For more information about how these things work in rustc, see the
 rustc dev guide:
 
-- [Parsing](https://rust-lang.github.io/rustc-dev-guide/the-parser.html)
-- [Macro Expansion](https://rust-lang.github.io/rustc-dev-guide/macro-expansion.html)
+- [Parsing](https://rustc-dev-guide.rust-lang.org/the-parser.html)
+- [Macro Expansion](https://rustc-dev-guide.rust-lang.org/macro-expansion.html)

--- a/src/librustc_ast/ast.rs
+++ b/src/librustc_ast/ast.rs
@@ -2117,14 +2117,14 @@ pub enum ImplPolarity {
     /// `impl Trait for Type`
     Positive,
     /// `impl !Trait for Type`
-    Negative,
+    Negative(Span),
 }
 
 impl fmt::Debug for ImplPolarity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             ImplPolarity::Positive => "positive".fmt(f),
-            ImplPolarity::Negative => "negative".fmt(f),
+            ImplPolarity::Negative(_) => "negative".fmt(f),
         }
     }
 }

--- a/src/librustc_ast_lowering/item.rs
+++ b/src/librustc_ast_lowering/item.rs
@@ -767,13 +767,13 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let names = self.lower_fn_params_to_names(&sig.decl);
                 let (generics, sig) =
                     self.lower_method_sig(generics, sig, trait_item_def_id, false, None);
-                (generics, hir::TraitItemKind::Method(sig, hir::TraitMethod::Required(names)))
+                (generics, hir::TraitItemKind::Fn(sig, hir::TraitMethod::Required(names)))
             }
             AssocItemKind::Fn(_, ref sig, ref generics, Some(ref body)) => {
                 let body_id = self.lower_fn_body_block(i.span, &sig.decl, Some(body));
                 let (generics, sig) =
                     self.lower_method_sig(generics, sig, trait_item_def_id, false, None);
-                (generics, hir::TraitItemKind::Method(sig, hir::TraitMethod::Provided(body_id)))
+                (generics, hir::TraitItemKind::Fn(sig, hir::TraitMethod::Provided(body_id)))
             }
             AssocItemKind::TyAlias(_, ref generics, ref bounds, ref default) => {
                 let ty = default.as_ref().map(|x| self.lower_ty(x, ImplTraitContext::disallowed()));

--- a/src/librustc_ast_lowering/path.rs
+++ b/src/librustc_ast_lowering/path.rs
@@ -75,7 +75,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                             ParenthesizedGenericArgs::Ok
                         }
                         // `a::b::Trait(Args)::TraitItem`
-                        Res::Def(DefKind::Method, _)
+                        Res::Def(DefKind::AssocFn, _)
                         | Res::Def(DefKind::AssocConst, _)
                         | Res::Def(DefKind::AssocTy, _)
                             if i + 2 == proj_start =>

--- a/src/librustc_ast_passes/ast_validation.rs
+++ b/src/librustc_ast_passes/ast_validation.rs
@@ -910,6 +910,12 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                             item.ident.span,
                             "auto trait cannot have generic parameters",
                         );
+                        err.span_suggestion_verbose(
+                            generics.span,
+                            "remove the parameters for the auto trait to be valid",
+                            String::new(),
+                            Applicability::MachineApplicable,
+                        );
                         err.emit();
                     }
                     if !bounds.is_empty() {
@@ -922,6 +928,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                             E0568,
                             "auto traits cannot have super traits"
                         );
+                        err.span_label(item.ident.span, "auto trait cannot have super traits");
                         if let Some(span) = last {
                             err.span_label(
                                 span,
@@ -931,8 +938,13 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                                     s = pluralize!(len)
                                 ),
                             );
+                            err.span_suggestion_verbose(
+                                generics.span.shrink_to_hi().to(span),
+                                "remove the super traits for the auto trait to be valid",
+                                String::new(),
+                                Applicability::MachineApplicable,
+                            );
                         }
-                        err.span_label(item.ident.span, "auto trait cannot have super traits");
                         err.emit();
                     }
                     if !trait_items.is_empty() {

--- a/src/librustc_ast_passes/ast_validation.rs
+++ b/src/librustc_ast_passes/ast_validation.rs
@@ -9,6 +9,7 @@
 use rustc_ast::ast::*;
 use rustc_ast::attr;
 use rustc_ast::expand::is_proc_macro_attr;
+use rustc_ast::ptr::P;
 use rustc_ast::visit::{self, AssocCtxt, FnCtxt, FnKind, Visitor};
 use rustc_ast::walk_list;
 use rustc_ast_pretty::pprust;
@@ -594,6 +595,54 @@ impl<'a> AstValidator<'a> {
             .span_label(ident.span, format!("`_` is not a valid name for this `{}` item", kind))
             .emit();
     }
+
+    fn deny_generic_params(&self, generics: &Generics, ident_span: Span) {
+        if !generics.params.is_empty() {
+            struct_span_err!(
+                self.session,
+                generics.span,
+                E0567,
+                "auto traits cannot have generic parameters"
+            )
+            .span_label(ident_span, "auto trait cannot have generic parameters")
+            .span_suggestion(
+                generics.span,
+                "remove the parameters",
+                String::new(),
+                Applicability::MachineApplicable,
+            )
+            .emit();
+        }
+    }
+
+    fn deny_super_traits(&self, bounds: &GenericBounds, ident_span: Span) {
+        if let [first @ last] | [first, .., last] = &bounds[..] {
+            let span = first.span().to(last.span());
+            struct_span_err!(self.session, span, E0568, "auto traits cannot have super traits")
+                .span_label(ident_span, "auto trait cannot have super traits")
+                .span_suggestion(
+                    span,
+                    "remove the super traits",
+                    String::new(),
+                    Applicability::MachineApplicable,
+                )
+                .emit();
+        }
+    }
+
+    fn deny_items(&self, trait_items: &[P<AssocItem>], ident_span: Span) {
+        if !trait_items.is_empty() {
+            let spans: Vec<_> = trait_items.iter().map(|i| i.ident.span).collect();
+            struct_span_err!(
+                self.session,
+                spans,
+                E0380,
+                "auto traits cannot have methods or associated items"
+            )
+            .span_label(ident_span, "auto trait cannot have items")
+            .emit();
+        }
+    }
 }
 
 fn validate_generic_param_order<'a>(
@@ -881,57 +930,9 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
             ItemKind::Trait(is_auto, _, ref generics, ref bounds, ref trait_items) => {
                 if is_auto == IsAuto::Yes {
                     // Auto traits cannot have generics, super traits nor contain items.
-                    if !generics.params.is_empty() {
-                        let mut err = struct_span_err!(
-                            self.session,
-                            generics.span,
-                            E0567,
-                            "auto traits cannot have generic parameters"
-                        );
-                        err.span_label(
-                            item.ident.span,
-                            "auto trait cannot have generic parameters",
-                        );
-                        err.span_suggestion(
-                            generics.span,
-                            "remove the parameters",
-                            String::new(),
-                            Applicability::MachineApplicable,
-                        );
-                        err.emit();
-                    }
-                    if !bounds.is_empty() {
-                        let span = match &bounds[..] {
-                            [] => unreachable!(),
-                            [single] => single.span(),
-                            [first, .., last] => first.span().to(last.span()),
-                        };
-                        let mut err = struct_span_err!(
-                            self.session,
-                            span,
-                            E0568,
-                            "auto traits cannot have super traits"
-                        );
-                        err.span_label(item.ident.span, "auto trait cannot have super traits");
-                        err.span_suggestion(
-                            span,
-                            "remove the super traits",
-                            String::new(),
-                            Applicability::MachineApplicable,
-                        );
-                        err.emit();
-                    }
-                    if !trait_items.is_empty() {
-                        let spans: Vec<_> = trait_items.iter().map(|i| i.ident.span).collect();
-                        struct_span_err!(
-                            self.session,
-                            spans,
-                            E0380,
-                            "auto traits cannot have methods or associated items"
-                        )
-                        .span_label(item.ident.span, "auto trait cannot have items")
-                        .emit();
-                    }
+                    self.deny_generic_params(generics, item.ident.span);
+                    self.deny_super_traits(bounds, item.ident.span);
+                    self.deny_items(trait_items, item.ident.span);
                 }
                 self.no_questions_in_bounds(bounds, "supertraits", true);
 

--- a/src/librustc_ast_passes/feature_gate.rs
+++ b/src/librustc_ast_passes/feature_gate.rs
@@ -338,14 +338,14 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 }
             }
 
-            ast::ItemKind::Impl { polarity, defaultness, .. } => {
-                if polarity == ast::ImplPolarity::Negative {
+            ast::ItemKind::Impl { polarity, defaultness, ref of_trait, .. } => {
+                if let ast::ImplPolarity::Negative(span) = polarity {
                     gate_feature_post!(
                         &self,
                         optin_builtin_traits,
-                        i.span,
+                        span.to(of_trait.as_ref().map(|t| t.path.span).unwrap_or(span)),
                         "negative trait bounds are not yet fully implemented; \
-                                        use marker types for now"
+                         use marker types for now"
                     );
                 }
 

--- a/src/librustc_ast_passes/lib.rs
+++ b/src/librustc_ast_passes/lib.rs
@@ -1,3 +1,4 @@
+#![feature(bindings_after_at)]
 //! The `rustc_ast_passes` crate contains passes which validate the AST in `syntax`
 //! parsed by `rustc_parse` and then lowered, after the passes in this crate,
 //! by `rustc_ast_lowering`.

--- a/src/librustc_ast_pretty/pprust.rs
+++ b/src/librustc_ast_pretty/pprust.rs
@@ -1175,7 +1175,7 @@ impl<'a> State<'a> {
                     self.s.space();
                 }
 
-                if polarity == ast::ImplPolarity::Negative {
+                if let ast::ImplPolarity::Negative(_) = polarity {
                     self.s.word("!");
                 }
 

--- a/src/librustc_codegen_llvm/README.md
+++ b/src/librustc_codegen_llvm/README.md
@@ -4,4 +4,4 @@ that runs towards the end of the compilation process.
 
 For more information about how codegen works, see the [rustc dev guide].
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/codegen.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/codegen.html

--- a/src/librustc_codegen_llvm/README.md
+++ b/src/librustc_codegen_llvm/README.md
@@ -2,6 +2,6 @@ The `codegen` crate contains the code to convert from MIR into LLVM IR,
 and then from LLVM IR into machine code. In general it contains code
 that runs towards the end of the compilation process.
 
-For more information about how codegen works, see the [rustc guide].
+For more information about how codegen works, see the [rustc dev guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/codegen.html
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/codegen.html

--- a/src/librustc_codegen_llvm/README.md
+++ b/src/librustc_codegen_llvm/README.md
@@ -4,4 +4,4 @@ that runs towards the end of the compilation process.
 
 For more information about how codegen works, see the [rustc guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/codegen.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/codegen.html

--- a/src/librustc_codegen_ssa/README.md
+++ b/src/librustc_codegen_ssa/README.md
@@ -1,3 +1,3 @@
-Please read the rustc-guide chapter on [Backend Agnostic Codegen][bac].
+Please read the rustc-dev-guide chapter on [Backend Agnostic Codegen][bac].
 
-[bac]: https://rust-lang.github.io/rustc-guide/codegen/backend-agnostic.html
+[bac]: https://rust-lang.github.io/rustc-dev-guide/codegen/backend-agnostic.html

--- a/src/librustc_codegen_ssa/README.md
+++ b/src/librustc_codegen_ssa/README.md
@@ -1,3 +1,3 @@
 Please read the rustc-dev-guide chapter on [Backend Agnostic Codegen][bac].
 
-[bac]: https://rust-lang.github.io/rustc-dev-guide/codegen/backend-agnostic.html
+[bac]: https://rustc-dev-guide.rust-lang.org/codegen/backend-agnostic.html

--- a/src/librustc_driver/README.md
+++ b/src/librustc_driver/README.md
@@ -5,6 +5,6 @@ not contain any of the "main logic" of the compiler (though it does
 have some code related to pretty printing or other minor compiler
 options).
 
-For more information about how the driver works, see the [rustc guide].
+For more information about how the driver works, see the [rustc dev guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/rustc-driver.html
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/rustc-driver.html

--- a/src/librustc_driver/README.md
+++ b/src/librustc_driver/README.md
@@ -7,4 +7,4 @@ options).
 
 For more information about how the driver works, see the [rustc guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/rustc-driver.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/rustc-driver.html

--- a/src/librustc_driver/README.md
+++ b/src/librustc_driver/README.md
@@ -7,4 +7,4 @@ options).
 
 For more information about how the driver works, see the [rustc dev guide].
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/rustc-driver.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/rustc-driver.html

--- a/src/librustc_hir/def.rs
+++ b/src/librustc_hir/def.rs
@@ -72,7 +72,7 @@ pub enum DefKind {
     Static,
     /// Refers to the struct or enum variant's constructor.
     Ctor(CtorOf, CtorKind),
-    Method,
+    AssocFn,
     AssocConst,
 
     // Macro namespace
@@ -107,7 +107,8 @@ impl DefKind {
             DefKind::Union => "union",
             DefKind::Trait => "trait",
             DefKind::ForeignTy => "foreign type",
-            DefKind::Method => "method",
+            // FIXME: Update the description to "assoc fn"
+            DefKind::AssocFn => "method",
             DefKind::Const => "constant",
             DefKind::AssocConst => "associated constant",
             DefKind::TyParam => "type parameter",
@@ -150,7 +151,7 @@ impl DefKind {
             | DefKind::ConstParam
             | DefKind::Static
             | DefKind::Ctor(..)
-            | DefKind::Method
+            | DefKind::AssocFn
             | DefKind::AssocConst => ns == Namespace::ValueNS,
 
             DefKind::Macro(..) => ns == Namespace::MacroNS,

--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -1863,8 +1863,8 @@ pub enum TraitMethod<'hir> {
 pub enum TraitItemKind<'hir> {
     /// An associated constant with an optional value (otherwise `impl`s must contain a value).
     Const(&'hir Ty<'hir>, Option<BodyId>),
-    /// A method with an optional body.
-    Method(FnSig<'hir>, TraitMethod<'hir>),
+    /// An associated function with an optional body.
+    Fn(FnSig<'hir>, TraitMethod<'hir>),
     /// An associated type with (possibly empty) bounds and optional concrete
     /// type.
     Type(GenericBounds<'hir>, Option<&'hir Ty<'hir>>),
@@ -2699,7 +2699,7 @@ impl Node<'_> {
 
     pub fn fn_decl(&self) -> Option<&FnDecl<'_>> {
         match self {
-            Node::TraitItem(TraitItem { kind: TraitItemKind::Method(fn_sig, _), .. })
+            Node::TraitItem(TraitItem { kind: TraitItemKind::Fn(fn_sig, _), .. })
             | Node::ImplItem(ImplItem { kind: ImplItemKind::Method(fn_sig, _), .. })
             | Node::Item(Item { kind: ItemKind::Fn(fn_sig, _, _), .. }) => Some(fn_sig.decl),
             Node::ForeignItem(ForeignItem { kind: ForeignItemKind::Fn(fn_decl, _, _), .. }) => {

--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -611,7 +611,7 @@ pub struct ModuleItems {
 ///
 /// For more details, see the [rustc guide].
 ///
-/// [rustc guide]: https://rust-lang.github.io/rustc-guide/hir.html
+/// [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
 #[derive(RustcEncodable, RustcDecodable, Debug)]
 pub struct Crate<'hir> {
     pub module: Mod<'hir>,

--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -611,7 +611,7 @@ pub struct ModuleItems {
 ///
 /// For more details, see the [rustc dev guide].
 ///
-/// [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
+/// [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/hir.html
 #[derive(RustcEncodable, RustcDecodable, Debug)]
 pub struct Crate<'hir> {
     pub module: Mod<'hir>,

--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -609,9 +609,9 @@ pub struct ModuleItems {
 /// The top-level data structure that stores the entire contents of
 /// the crate currently being compiled.
 ///
-/// For more details, see the [rustc guide].
+/// For more details, see the [rustc dev guide].
 ///
-/// [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
+/// [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
 #[derive(RustcEncodable, RustcDecodable, Debug)]
 pub struct Crate<'hir> {
     pub module: Mod<'hir>,

--- a/src/librustc_hir/intravisit.rs
+++ b/src/librustc_hir/intravisit.rs
@@ -911,14 +911,14 @@ pub fn walk_trait_item<'v, V: Visitor<'v>>(visitor: &mut V, trait_item: &'v Trai
             visitor.visit_ty(ty);
             walk_list!(visitor, visit_nested_body, default);
         }
-        TraitItemKind::Method(ref sig, TraitMethod::Required(param_names)) => {
+        TraitItemKind::Fn(ref sig, TraitMethod::Required(param_names)) => {
             visitor.visit_id(trait_item.hir_id);
             visitor.visit_fn_decl(&sig.decl);
             for &param_name in param_names {
                 visitor.visit_ident(param_name);
             }
         }
-        TraitItemKind::Method(ref sig, TraitMethod::Provided(body_id)) => {
+        TraitItemKind::Fn(ref sig, TraitMethod::Provided(body_id)) => {
             visitor.visit_fn(
                 FnKind::Method(trait_item.ident, sig, None, &trait_item.attrs),
                 &sig.decl,

--- a/src/librustc_hir/lib.rs
+++ b/src/librustc_hir/lib.rs
@@ -1,6 +1,6 @@
-//! HIR datatypes. See the [rustc guide] for more info.
+//! HIR datatypes. See the [rustc dev guide] for more info.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
 
 #![feature(crate_visibility_modifier)]
 #![feature(const_fn)] // For the unsizing cast on `&[]`

--- a/src/librustc_hir/lib.rs
+++ b/src/librustc_hir/lib.rs
@@ -1,6 +1,6 @@
 //! HIR datatypes. See the [rustc dev guide] for more info.
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/hir.html
 
 #![feature(crate_visibility_modifier)]
 #![feature(const_fn)] // For the unsizing cast on `&[]`

--- a/src/librustc_hir/lib.rs
+++ b/src/librustc_hir/lib.rs
@@ -1,6 +1,6 @@
 //! HIR datatypes. See the [rustc guide] for more info.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/hir.html
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/hir.html
 
 #![feature(crate_visibility_modifier)]
 #![feature(const_fn)] // For the unsizing cast on `&[]`

--- a/src/librustc_hir/print.rs
+++ b/src/librustc_hir/print.rs
@@ -886,13 +886,13 @@ impl<'a> State<'a> {
                     Spanned { span: rustc_span::DUMMY_SP, node: hir::VisibilityKind::Inherited };
                 self.print_associated_const(ti.ident, &ty, default, &vis);
             }
-            hir::TraitItemKind::Method(ref sig, hir::TraitMethod::Required(ref arg_names)) => {
+            hir::TraitItemKind::Fn(ref sig, hir::TraitMethod::Required(ref arg_names)) => {
                 let vis =
                     Spanned { span: rustc_span::DUMMY_SP, node: hir::VisibilityKind::Inherited };
                 self.print_method_sig(ti.ident, sig, &ti.generics, &vis, arg_names, None);
                 self.s.word(";");
             }
-            hir::TraitItemKind::Method(ref sig, hir::TraitMethod::Provided(body)) => {
+            hir::TraitItemKind::Fn(ref sig, hir::TraitMethod::Provided(body)) => {
                 let vis =
                     Spanned { span: rustc_span::DUMMY_SP, node: hir::VisibilityKind::Inherited };
                 self.head("");

--- a/src/librustc_hir/print.rs
+++ b/src/librustc_hir/print.rs
@@ -652,7 +652,7 @@ impl<'a> State<'a> {
                     self.word_nbsp("const");
                 }
 
-                if let hir::ImplPolarity::Negative = polarity {
+                if let hir::ImplPolarity::Negative(_) = polarity {
                     self.s.word("!");
                 }
 

--- a/src/librustc_hir/target.rs
+++ b/src/librustc_hir/target.rs
@@ -105,10 +105,10 @@ impl Target {
     pub fn from_trait_item(trait_item: &TraitItem<'_>) -> Target {
         match trait_item.kind {
             TraitItemKind::Const(..) => Target::AssocConst,
-            TraitItemKind::Method(_, hir::TraitMethod::Required(_)) => {
+            TraitItemKind::Fn(_, hir::TraitMethod::Required(_)) => {
                 Target::Method(MethodKind::Trait { body: false })
             }
-            TraitItemKind::Method(_, hir::TraitMethod::Provided(_)) => {
+            TraitItemKind::Fn(_, hir::TraitMethod::Provided(_)) => {
                 Target::Method(MethodKind::Trait { body: true })
             }
             TraitItemKind::Type(..) => Target::AssocTy,

--- a/src/librustc_incremental/persist/README.md
+++ b/src/librustc_incremental/persist/README.md
@@ -1,3 +1,3 @@
-For info on how the incremental compilation works, see the [rustc guide].
+For info on how the incremental compilation works, see the [rustc dev guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/query.html
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/query.html

--- a/src/librustc_incremental/persist/README.md
+++ b/src/librustc_incremental/persist/README.md
@@ -1,3 +1,3 @@
 For info on how the incremental compilation works, see the [rustc dev guide].
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/query.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/query.html

--- a/src/librustc_incremental/persist/README.md
+++ b/src/librustc_incremental/persist/README.md
@@ -1,3 +1,3 @@
 For info on how the incremental compilation works, see the [rustc guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/query.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/query.html

--- a/src/librustc_incremental/persist/dirty_clean.rs
+++ b/src/librustc_incremental/persist/dirty_clean.rs
@@ -328,7 +328,7 @@ impl DirtyCleanVisitor<'tcx> {
                 }
             }
             HirNode::TraitItem(item) => match item.kind {
-                TraitItemKind::Method(..) => ("Node::TraitItem", LABELS_FN_IN_TRAIT),
+                TraitItemKind::Fn(..) => ("Node::TraitItem", LABELS_FN_IN_TRAIT),
                 TraitItemKind::Const(..) => ("NodeTraitConst", LABELS_CONST_IN_TRAIT),
                 TraitItemKind::Type(..) => ("NodeTraitType", LABELS_CONST_IN_TRAIT),
             },

--- a/src/librustc_infer/infer/canonical/canonicalizer.rs
+++ b/src/librustc_infer/infer/canonical/canonicalizer.rs
@@ -1,7 +1,7 @@
 //! This module contains the "canonicalizer" itself.
 //!
 //! For an overview of what canonicalization is and how it fits into
-//! rustc, check out the [chapter in the rustc guide][c].
+//! rustc, check out the [chapter in the rustc dev guide][c].
 //!
 //! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 
@@ -33,7 +33,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
     /// with a mapping M that maps `'?0` to `'static`.
     ///
     /// To get a good understanding of what is happening here, check
-    /// out the [chapter in the rustc guide][c].
+    /// out the [chapter in the rustc dev guide][c].
     ///
     /// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html#canonicalizing-the-query
     pub fn canonicalize_query<V>(
@@ -77,7 +77,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
     /// reference to `'static` alone.
     ///
     /// To get a good understanding of what is happening here, check
-    /// out the [chapter in the rustc guide][c].
+    /// out the [chapter in the rustc dev guide][c].
     ///
     /// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html#canonicalizing-the-query-result
     pub fn canonicalize_response<V>(&self, value: &V) -> Canonicalized<'tcx, V>

--- a/src/librustc_infer/infer/canonical/canonicalizer.rs
+++ b/src/librustc_infer/infer/canonical/canonicalizer.rs
@@ -3,7 +3,7 @@
 //! For an overview of what canonicalization is and how it fits into
 //! rustc, check out the [chapter in the rustc dev guide][c].
 //!
-//! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
+//! [c]: https://rustc-dev-guide.rust-lang.org/traits/canonicalization.html
 
 use crate::infer::canonical::{
     Canonical, CanonicalTyVarKind, CanonicalVarInfo, CanonicalVarKind, Canonicalized,
@@ -35,7 +35,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
     /// To get a good understanding of what is happening here, check
     /// out the [chapter in the rustc dev guide][c].
     ///
-    /// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html#canonicalizing-the-query
+    /// [c]: https://rustc-dev-guide.rust-lang.org/traits/canonicalization.html#canonicalizing-the-query
     pub fn canonicalize_query<V>(
         &self,
         value: &V,
@@ -79,7 +79,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
     /// To get a good understanding of what is happening here, check
     /// out the [chapter in the rustc dev guide][c].
     ///
-    /// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html#canonicalizing-the-query-result
+    /// [c]: https://rustc-dev-guide.rust-lang.org/traits/canonicalization.html#canonicalizing-the-query-result
     pub fn canonicalize_response<V>(&self, value: &V) -> Canonicalized<'tcx, V>
     where
         V: TypeFoldable<'tcx>,

--- a/src/librustc_infer/infer/canonical/canonicalizer.rs
+++ b/src/librustc_infer/infer/canonical/canonicalizer.rs
@@ -3,7 +3,7 @@
 //! For an overview of what canonicalization is and how it fits into
 //! rustc, check out the [chapter in the rustc guide][c].
 //!
-//! [c]: https://rust-lang.github.io/rustc-guide/traits/canonicalization.html
+//! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 
 use crate::infer::canonical::{
     Canonical, CanonicalTyVarKind, CanonicalVarInfo, CanonicalVarKind, Canonicalized,
@@ -35,7 +35,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
     /// To get a good understanding of what is happening here, check
     /// out the [chapter in the rustc guide][c].
     ///
-    /// [c]: https://rust-lang.github.io/rustc-guide/traits/canonicalization.html#canonicalizing-the-query
+    /// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html#canonicalizing-the-query
     pub fn canonicalize_query<V>(
         &self,
         value: &V,
@@ -79,7 +79,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
     /// To get a good understanding of what is happening here, check
     /// out the [chapter in the rustc guide][c].
     ///
-    /// [c]: https://rust-lang.github.io/rustc-guide/traits/canonicalization.html#canonicalizing-the-query-result
+    /// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html#canonicalizing-the-query-result
     pub fn canonicalize_response<V>(&self, value: &V) -> Canonicalized<'tcx, V>
     where
         V: TypeFoldable<'tcx>,

--- a/src/librustc_infer/infer/canonical/mod.rs
+++ b/src/librustc_infer/infer/canonical/mod.rs
@@ -19,7 +19,7 @@
 //! For a more detailed look at what is happening here, check
 //! out the [chapter in the rustc guide][c].
 //!
-//! [c]: https://rust-lang.github.io/rustc-guide/traits/canonicalization.html
+//! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 
 use crate::infer::{ConstVariableOrigin, ConstVariableOriginKind};
 use crate::infer::{InferCtxt, RegionVariableOrigin, TypeVariableOrigin, TypeVariableOriginKind};

--- a/src/librustc_infer/infer/canonical/mod.rs
+++ b/src/librustc_infer/infer/canonical/mod.rs
@@ -17,7 +17,7 @@
 //! `instantiate_query_result` method.
 //!
 //! For a more detailed look at what is happening here, check
-//! out the [chapter in the rustc guide][c].
+//! out the [chapter in the rustc dev guide][c].
 //!
 //! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 

--- a/src/librustc_infer/infer/canonical/mod.rs
+++ b/src/librustc_infer/infer/canonical/mod.rs
@@ -19,7 +19,7 @@
 //! For a more detailed look at what is happening here, check
 //! out the [chapter in the rustc dev guide][c].
 //!
-//! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
+//! [c]: https://rustc-dev-guide.rust-lang.org/traits/canonicalization.html
 
 use crate::infer::{ConstVariableOrigin, ConstVariableOriginKind};
 use crate::infer::{InferCtxt, RegionVariableOrigin, TypeVariableOrigin, TypeVariableOriginKind};

--- a/src/librustc_infer/infer/canonical/query_response.rs
+++ b/src/librustc_infer/infer/canonical/query_response.rs
@@ -5,7 +5,7 @@
 //! For an overview of what canonicaliation is and how it fits into
 //! rustc, check out the [chapter in the rustc guide][c].
 //!
-//! [c]: https://rust-lang.github.io/rustc-guide/traits/canonicalization.html
+//! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 
 use crate::infer::canonical::substitute::{substitute_value, CanonicalExt};
 use crate::infer::canonical::{
@@ -197,7 +197,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
     /// To get a good understanding of what is happening here, check
     /// out the [chapter in the rustc guide][c].
     ///
-    /// [c]: https://rust-lang.github.io/rustc-guide/traits/canonicalization.html#processing-the-canonicalized-query-result
+    /// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html#processing-the-canonicalized-query-result
     pub fn instantiate_query_response_and_region_obligations<R>(
         &self,
         cause: &ObligationCause<'tcx>,

--- a/src/librustc_infer/infer/canonical/query_response.rs
+++ b/src/librustc_infer/infer/canonical/query_response.rs
@@ -3,7 +3,7 @@
 //! encode them therein.
 //!
 //! For an overview of what canonicaliation is and how it fits into
-//! rustc, check out the [chapter in the rustc guide][c].
+//! rustc, check out the [chapter in the rustc dev guide][c].
 //!
 //! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 
@@ -195,7 +195,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
     /// the query before applying this function.)
     ///
     /// To get a good understanding of what is happening here, check
-    /// out the [chapter in the rustc guide][c].
+    /// out the [chapter in the rustc dev guide][c].
     ///
     /// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html#processing-the-canonicalized-query-result
     pub fn instantiate_query_response_and_region_obligations<R>(

--- a/src/librustc_infer/infer/canonical/query_response.rs
+++ b/src/librustc_infer/infer/canonical/query_response.rs
@@ -5,7 +5,7 @@
 //! For an overview of what canonicaliation is and how it fits into
 //! rustc, check out the [chapter in the rustc dev guide][c].
 //!
-//! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
+//! [c]: https://rustc-dev-guide.rust-lang.org/traits/canonicalization.html
 
 use crate::infer::canonical::substitute::{substitute_value, CanonicalExt};
 use crate::infer::canonical::{
@@ -197,7 +197,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
     /// To get a good understanding of what is happening here, check
     /// out the [chapter in the rustc dev guide][c].
     ///
-    /// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html#processing-the-canonicalized-query-result
+    /// [c]: https://rustc-dev-guide.rust-lang.org/traits/canonicalization.html#processing-the-canonicalized-query-result
     pub fn instantiate_query_response_and_region_obligations<R>(
         &self,
         cause: &ObligationCause<'tcx>,

--- a/src/librustc_infer/infer/canonical/substitute.rs
+++ b/src/librustc_infer/infer/canonical/substitute.rs
@@ -4,7 +4,7 @@
 //! For an overview of what canonicalization is and how it fits into
 //! rustc, check out the [chapter in the rustc dev guide][c].
 //!
-//! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
+//! [c]: https://rustc-dev-guide.rust-lang.org/traits/canonicalization.html
 
 use crate::infer::canonical::{Canonical, CanonicalVarValues};
 use rustc::ty::fold::TypeFoldable;

--- a/src/librustc_infer/infer/canonical/substitute.rs
+++ b/src/librustc_infer/infer/canonical/substitute.rs
@@ -4,7 +4,7 @@
 //! For an overview of what canonicalization is and how it fits into
 //! rustc, check out the [chapter in the rustc guide][c].
 //!
-//! [c]: https://rust-lang.github.io/rustc-guide/traits/canonicalization.html
+//! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 
 use crate::infer::canonical::{Canonical, CanonicalVarValues};
 use rustc::ty::fold::TypeFoldable;

--- a/src/librustc_infer/infer/canonical/substitute.rs
+++ b/src/librustc_infer/infer/canonical/substitute.rs
@@ -2,7 +2,7 @@
 //! `Canonical<'tcx, T>`.
 //!
 //! For an overview of what canonicalization is and how it fits into
-//! rustc, check out the [chapter in the rustc guide][c].
+//! rustc, check out the [chapter in the rustc dev guide][c].
 //!
 //! [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 

--- a/src/librustc_infer/infer/error_reporting/mod.rs
+++ b/src/librustc_infer/infer/error_reporting/mod.rs
@@ -269,7 +269,7 @@ fn item_scope_tag(item: &hir::Item<'_>) -> &'static str {
 
 fn trait_item_scope_tag(item: &hir::TraitItem<'_>) -> &'static str {
     match item.kind {
-        hir::TraitItemKind::Method(..) => "method body",
+        hir::TraitItemKind::Fn(..) => "method body",
         hir::TraitItemKind::Const(..) | hir::TraitItemKind::Type(..) => "associated item",
     }
 }

--- a/src/librustc_infer/infer/error_reporting/need_type_info.rs
+++ b/src/librustc_infer/infer/error_reporting/need_type_info.rs
@@ -468,7 +468,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             &segment.args,
         ) {
             let borrow = tables.borrow();
-            if let Some((DefKind::Method, did)) = borrow.type_dependent_def(e.hir_id) {
+            if let Some((DefKind::AssocFn, did)) = borrow.type_dependent_def(e.hir_id) {
                 let generics = self.tcx.generics_of(did);
                 if !generics.params.is_empty() {
                     err.span_suggestion(

--- a/src/librustc_infer/infer/error_reporting/nice_region_error/find_anon_type.rs
+++ b/src/librustc_infer/infer/error_reporting/nice_region_error/find_anon_type.rs
@@ -33,7 +33,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
                 let fndecl = match self.tcx().hir().get(hir_id) {
                     Node::Item(&hir::Item { kind: hir::ItemKind::Fn(ref m, ..), .. })
                     | Node::TraitItem(&hir::TraitItem {
-                        kind: hir::TraitItemKind::Method(ref m, ..),
+                        kind: hir::TraitItemKind::Fn(ref m, ..),
                         ..
                     })
                     | Node::ImplItem(&hir::ImplItem {

--- a/src/librustc_infer/infer/higher_ranked/README.md
+++ b/src/librustc_infer/infer/higher_ranked/README.md
@@ -1,8 +1,8 @@
 To learn more about how Higher-ranked trait bounds work in the _old_ trait
-solver, see [this chapter][oldhrtb] of the rustc-guide.
+solver, see [this chapter][oldhrtb] of the rustc-dev-guide.
 
 To learn more about how they work in the _new_ trait solver, see [this
 chapter][newhrtb].
 
-[oldhrtb]: https://rust-lang.github.io/rustc-guide/traits/hrtb.html
-[newhrtb]: https://rust-lang.github.io/rustc-guide/borrow_check/region_inference.html#placeholders-and-universes
+[oldhrtb]: https://rust-lang.github.io/rustc-dev-guide/traits/hrtb.html
+[newhrtb]: https://rust-lang.github.io/rustc-dev-guide/borrow_check/region_inference.html#placeholders-and-universes

--- a/src/librustc_infer/infer/higher_ranked/README.md
+++ b/src/librustc_infer/infer/higher_ranked/README.md
@@ -4,5 +4,5 @@ solver, see [this chapter][oldhrtb] of the rustc-dev-guide.
 To learn more about how they work in the _new_ trait solver, see [this
 chapter][newhrtb].
 
-[oldhrtb]: https://rust-lang.github.io/rustc-dev-guide/traits/hrtb.html
-[newhrtb]: https://rust-lang.github.io/rustc-dev-guide/borrow_check/region_inference.html#placeholders-and-universes
+[oldhrtb]: https://rustc-dev-guide.rust-lang.org/traits/hrtb.html
+[newhrtb]: https://rustc-dev-guide.rust-lang.org/borrow_check/region_inference.html#placeholders-and-universes

--- a/src/librustc_infer/infer/higher_ranked/mod.rs
+++ b/src/librustc_infer/infer/higher_ranked/mod.rs
@@ -71,9 +71,9 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     /// needed (but is also permitted).
     ///
     /// For more information about how placeholders and HRTBs work, see
-    /// the [rustc guide].
+    /// the [rustc dev guide].
     ///
-    /// [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/hrtb.html
+    /// [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/hrtb.html
     pub fn replace_bound_vars_with_placeholders<T>(
         &self,
         binder: &ty::Binder<T>,

--- a/src/librustc_infer/infer/higher_ranked/mod.rs
+++ b/src/librustc_infer/infer/higher_ranked/mod.rs
@@ -73,7 +73,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     /// For more information about how placeholders and HRTBs work, see
     /// the [rustc guide].
     ///
-    /// [rustc guide]: https://rust-lang.github.io/rustc-guide/traits/hrtb.html
+    /// [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/hrtb.html
     pub fn replace_bound_vars_with_placeholders<T>(
         &self,
         binder: &ty::Binder<T>,

--- a/src/librustc_infer/infer/higher_ranked/mod.rs
+++ b/src/librustc_infer/infer/higher_ranked/mod.rs
@@ -73,7 +73,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     /// For more information about how placeholders and HRTBs work, see
     /// the [rustc dev guide].
     ///
-    /// [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/hrtb.html
+    /// [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/traits/hrtb.html
     pub fn replace_bound_vars_with_placeholders<T>(
         &self,
         binder: &ty::Binder<T>,

--- a/src/librustc_infer/infer/lexical_region_resolve/README.md
+++ b/src/librustc_infer/infer/lexical_region_resolve/README.md
@@ -2,6 +2,6 @@
 Lexical Region Resolution was removed in https://github.com/rust-lang/rust/pull/64790.
 
 Rust now uses Non-lexical lifetimes. For more info, please see the [borrowck
-chapter][bc] in the rustc-guide.
+chapter][bc] in the rustc-dev-guide.
 
-[bc]: https://rust-lang.github.io/rustc-guide/borrow_check/region_inference.html
+[bc]: https://rust-lang.github.io/rustc-dev-guide/borrow_check/region_inference.html

--- a/src/librustc_infer/infer/lexical_region_resolve/README.md
+++ b/src/librustc_infer/infer/lexical_region_resolve/README.md
@@ -4,4 +4,4 @@ Lexical Region Resolution was removed in https://github.com/rust-lang/rust/pull/
 Rust now uses Non-lexical lifetimes. For more info, please see the [borrowck
 chapter][bc] in the rustc-dev-guide.
 
-[bc]: https://rust-lang.github.io/rustc-dev-guide/borrow_check/region_inference.html
+[bc]: https://rustc-dev-guide.rust-lang.org/borrow_check/region_inference.html

--- a/src/librustc_infer/infer/region_constraints/README.md
+++ b/src/librustc_infer/infer/region_constraints/README.md
@@ -1,3 +1,3 @@
-For info on how the current borrowck works, see the [rustc guide].
+For info on how the current borrowck works, see the [rustc dev guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/borrow_check.html
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/borrow_check.html

--- a/src/librustc_infer/infer/region_constraints/README.md
+++ b/src/librustc_infer/infer/region_constraints/README.md
@@ -1,3 +1,3 @@
 For info on how the current borrowck works, see the [rustc dev guide].
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/borrow_check.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/borrow_check.html

--- a/src/librustc_infer/infer/region_constraints/README.md
+++ b/src/librustc_infer/infer/region_constraints/README.md
@@ -1,3 +1,3 @@
 For info on how the current borrowck works, see the [rustc guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/borrow_check.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/borrow_check.html

--- a/src/librustc_infer/lib.rs
+++ b/src/librustc_infer/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! For more information about how rustc works, see the [rustc guide].
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/
 //!
 //! # Note
 //!

--- a/src/librustc_infer/lib.rs
+++ b/src/librustc_infer/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! For more information about how rustc works, see the [rustc dev guide].
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/
 //!
 //! # Note
 //!

--- a/src/librustc_infer/lib.rs
+++ b/src/librustc_infer/lib.rs
@@ -5,9 +5,9 @@
 //!   this code handles low-level equality and subtyping operations. The
 //!   type check pass in the compiler is found in the `librustc_typeck` crate.
 //!
-//! For more information about how rustc works, see the [rustc guide].
+//! For more information about how rustc works, see the [rustc dev guide].
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/
 //!
 //! # Note
 //!

--- a/src/librustc_infer/traits/coherence.rs
+++ b/src/librustc_infer/traits/coherence.rs
@@ -1,5 +1,5 @@
-//! See Rustc Guide chapters on [trait-resolution] and [trait-specialization] for more info on how
-//! this works.
+//! See Rustc Dev Guide chapters on [trait-resolution] and [trait-specialization] for more info on
+//! how this works.
 //!
 //! [trait-resolution]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
 //! [trait-specialization]: https://rust-lang.github.io/rustc-dev-guide/traits/specialization.html

--- a/src/librustc_infer/traits/coherence.rs
+++ b/src/librustc_infer/traits/coherence.rs
@@ -1,8 +1,8 @@
 //! See Rustc Guide chapters on [trait-resolution] and [trait-specialization] for more info on how
 //! this works.
 //!
-//! [trait-resolution]: https://rust-lang.github.io/rustc-guide/traits/resolution.html
-//! [trait-specialization]: https://rust-lang.github.io/rustc-guide/traits/specialization.html
+//! [trait-resolution]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
+//! [trait-specialization]: https://rust-lang.github.io/rustc-dev-guide/traits/specialization.html
 
 use crate::infer::{CombinedSnapshot, InferOk, TyCtxtInferExt};
 use crate::traits::select::IntercrateAmbiguityCause;

--- a/src/librustc_infer/traits/coherence.rs
+++ b/src/librustc_infer/traits/coherence.rs
@@ -1,8 +1,8 @@
 //! See Rustc Dev Guide chapters on [trait-resolution] and [trait-specialization] for more info on
 //! how this works.
 //!
-//! [trait-resolution]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
-//! [trait-specialization]: https://rust-lang.github.io/rustc-dev-guide/traits/specialization.html
+//! [trait-resolution]: https://rustc-dev-guide.rust-lang.org/traits/resolution.html
+//! [trait-specialization]: https://rustc-dev-guide.rust-lang.org/traits/specialization.html
 
 use crate::infer::{CombinedSnapshot, InferOk, TyCtxtInferExt};
 use crate::traits::select::IntercrateAmbiguityCause;

--- a/src/librustc_infer/traits/error_reporting/on_unimplemented.rs
+++ b/src/librustc_infer/traits/error_reporting/on_unimplemented.rs
@@ -70,7 +70,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 })
             }
             hir::Node::TraitItem(hir::TraitItem {
-                kind: hir::TraitItemKind::Method(_, hir::TraitMethod::Provided(body_id)),
+                kind: hir::TraitItemKind::Fn(_, hir::TraitMethod::Provided(body_id)),
                 ..
             }) => self.describe_generator(*body_id).or_else(|| Some("a trait method")),
             hir::Node::ImplItem(hir::ImplItem {

--- a/src/librustc_infer/traits/error_reporting/suggestions.rs
+++ b/src/librustc_infer/traits/error_reporting/suggestions.rs
@@ -62,7 +62,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             match node {
                 hir::Node::TraitItem(hir::TraitItem {
                     generics,
-                    kind: hir::TraitItemKind::Method(..),
+                    kind: hir::TraitItemKind::Fn(..),
                     ..
                 }) if param_ty && self_ty == self.tcx.types.self_param => {
                     // Restricting `Self` for a single method.
@@ -73,7 +73,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 hir::Node::Item(hir::Item { kind: hir::ItemKind::Fn(_, generics, _), .. })
                 | hir::Node::TraitItem(hir::TraitItem {
                     generics,
-                    kind: hir::TraitItemKind::Method(..),
+                    kind: hir::TraitItemKind::Fn(..),
                     ..
                 })
                 | hir::Node::ImplItem(hir::ImplItem {
@@ -807,7 +807,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             })
             | Node::TraitItem(&hir::TraitItem {
                 span,
-                kind: hir::TraitItemKind::Method(ref sig, _),
+                kind: hir::TraitItemKind::Fn(ref sig, _),
                 ..
             }) => (
                 self.tcx.sess.source_map().def_span(span),

--- a/src/librustc_infer/traits/mod.rs
+++ b/src/librustc_infer/traits/mod.rs
@@ -1,6 +1,6 @@
 //! Trait Resolution. See the [rustc guide] for more information on how this works.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/traits/resolution.html
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
 
 #[allow(dead_code)]
 pub mod auto_trait;

--- a/src/librustc_infer/traits/mod.rs
+++ b/src/librustc_infer/traits/mod.rs
@@ -1,6 +1,6 @@
-//! Trait Resolution. See the [rustc guide] for more information on how this works.
+//! Trait Resolution. See the [rustc dev guide] for more information on how this works.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
 
 #[allow(dead_code)]
 pub mod auto_trait;

--- a/src/librustc_infer/traits/mod.rs
+++ b/src/librustc_infer/traits/mod.rs
@@ -1,6 +1,6 @@
 //! Trait Resolution. See the [rustc dev guide] for more information on how this works.
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/traits/resolution.html
 
 #[allow(dead_code)]
 pub mod auto_trait;

--- a/src/librustc_infer/traits/query/type_op/mod.rs
+++ b/src/librustc_infer/traits/query/type_op/mod.rs
@@ -44,7 +44,7 @@ pub trait TypeOp<'tcx>: Sized + fmt::Debug {
 /// first canonicalize the key and then invoke the query on the tcx,
 /// which produces the resulting query region constraints.
 ///
-/// [c]: https://rust-lang.github.io/rustc-guide/traits/canonicalization.html
+/// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
 pub trait QueryTypeOp<'tcx>: fmt::Debug + Sized + TypeFoldable<'tcx> + 'tcx {
     type QueryResponse: TypeFoldable<'tcx>;
 

--- a/src/librustc_infer/traits/query/type_op/mod.rs
+++ b/src/librustc_infer/traits/query/type_op/mod.rs
@@ -44,7 +44,7 @@ pub trait TypeOp<'tcx>: Sized + fmt::Debug {
 /// first canonicalize the key and then invoke the query on the tcx,
 /// which produces the resulting query region constraints.
 ///
-/// [c]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
+/// [c]: https://rustc-dev-guide.rust-lang.org/traits/canonicalization.html
 pub trait QueryTypeOp<'tcx>: fmt::Debug + Sized + TypeFoldable<'tcx> + 'tcx {
     type QueryResponse: TypeFoldable<'tcx>;
 

--- a/src/librustc_infer/traits/select.rs
+++ b/src/librustc_infer/traits/select.rs
@@ -1,8 +1,8 @@
 // ignore-tidy-filelength
 
-//! Candidate selection. See the [rustc guide] for more information on how this works.
+//! Candidate selection. See the [rustc dev guide] for more information on how this works.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#selection
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#selection
 
 use self::EvaluationResult::*;
 use self::SelectionCandidate::*;
@@ -931,9 +931,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     //
     // The selection process begins by examining all in-scope impls,
     // caller obligations, and so forth and assembling a list of
-    // candidates. See the [rustc guide] for more details.
+    // candidates. See the [rustc dev guide] for more details.
     //
-    // [rustc guide]:
+    // [rustc dev guide]:
     // https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#candidate-assembly
 
     fn candidate_from_obligation<'o>(
@@ -2447,9 +2447,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     //
     // Confirmation unifies the output type parameters of the trait
     // with the values found in the obligation, possibly yielding a
-    // type error.  See the [rustc guide] for more details.
+    // type error.  See the [rustc dev guide] for more details.
     //
-    // [rustc guide]:
+    // [rustc dev guide]:
     // https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#confirmation
 
     fn confirm_candidate(

--- a/src/librustc_infer/traits/select.rs
+++ b/src/librustc_infer/traits/select.rs
@@ -2,7 +2,7 @@
 
 //! Candidate selection. See the [rustc guide] for more information on how this works.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/traits/resolution.html#selection
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#selection
 
 use self::EvaluationResult::*;
 use self::SelectionCandidate::*;
@@ -934,7 +934,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     // candidates. See the [rustc guide] for more details.
     //
     // [rustc guide]:
-    // https://rust-lang.github.io/rustc-guide/traits/resolution.html#candidate-assembly
+    // https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#candidate-assembly
 
     fn candidate_from_obligation<'o>(
         &mut self,
@@ -2450,7 +2450,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     // type error.  See the [rustc guide] for more details.
     //
     // [rustc guide]:
-    // https://rust-lang.github.io/rustc-guide/traits/resolution.html#confirmation
+    // https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#confirmation
 
     fn confirm_candidate(
         &mut self,

--- a/src/librustc_infer/traits/select.rs
+++ b/src/librustc_infer/traits/select.rs
@@ -2,7 +2,7 @@
 
 //! Candidate selection. See the [rustc dev guide] for more information on how this works.
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#selection
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/traits/resolution.html#selection
 
 use self::EvaluationResult::*;
 use self::SelectionCandidate::*;
@@ -934,7 +934,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     // candidates. See the [rustc dev guide] for more details.
     //
     // [rustc dev guide]:
-    // https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#candidate-assembly
+    // https://rustc-dev-guide.rust-lang.org/traits/resolution.html#candidate-assembly
 
     fn candidate_from_obligation<'o>(
         &mut self,
@@ -2450,7 +2450,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     // type error.  See the [rustc dev guide] for more details.
     //
     // [rustc dev guide]:
-    // https://rust-lang.github.io/rustc-dev-guide/traits/resolution.html#confirmation
+    // https://rustc-dev-guide.rust-lang.org/traits/resolution.html#confirmation
 
     fn confirm_candidate(
         &mut self,

--- a/src/librustc_infer/traits/specialize/mod.rs
+++ b/src/librustc_infer/traits/specialize/mod.rs
@@ -7,7 +7,7 @@
 //! See the [rustc guide] for a bit more detail on how specialization
 //! fits together with the rest of the trait machinery.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/traits/specialization.html
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/specialization.html
 
 pub mod specialization_graph;
 use specialization_graph::GraphExt;

--- a/src/librustc_infer/traits/specialize/mod.rs
+++ b/src/librustc_infer/traits/specialize/mod.rs
@@ -4,10 +4,10 @@
 //! At the moment, this implementation support only the simple "chain" rule:
 //! If any two impls overlap, one must be a strict subset of the other.
 //!
-//! See the [rustc guide] for a bit more detail on how specialization
+//! See the [rustc dev guide] for a bit more detail on how specialization
 //! fits together with the rest of the trait machinery.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/traits/specialization.html
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/specialization.html
 
 pub mod specialization_graph;
 use specialization_graph::GraphExt;

--- a/src/librustc_infer/traits/specialize/mod.rs
+++ b/src/librustc_infer/traits/specialize/mod.rs
@@ -7,7 +7,7 @@
 //! See the [rustc dev guide] for a bit more detail on how specialization
 //! fits together with the rest of the trait machinery.
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/traits/specialization.html
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/traits/specialization.html
 
 pub mod specialization_graph;
 use specialization_graph::GraphExt;

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -465,7 +465,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingDoc {
 
         let desc = match trait_item.kind {
             hir::TraitItemKind::Const(..) => "an associated constant",
-            hir::TraitItemKind::Method(..) => "a trait method",
+            hir::TraitItemKind::Fn(..) => "a trait method",
             hir::TraitItemKind::Type(..) => "an associated type",
         };
 

--- a/src/librustc_lint/nonstandard_style.rs
+++ b/src/librustc_lint/nonstandard_style.rs
@@ -343,7 +343,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSnakeCase {
     }
 
     fn check_trait_item(&mut self, cx: &LateContext<'_, '_>, item: &hir::TraitItem<'_>) {
-        if let hir::TraitItemKind::Method(_, hir::TraitMethod::Required(pnames)) = item.kind {
+        if let hir::TraitItemKind::Fn(_, hir::TraitMethod::Required(pnames)) = item.kind {
             self.check_snake_case(cx, "trait method", &item.ident);
             for param_name in pnames {
                 self.check_snake_case(cx, "variable", param_name);

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -54,7 +54,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
                 match callee.kind {
                     hir::ExprKind::Path(ref qpath) => {
                         match cx.tables.qpath_res(qpath, callee.hir_id) {
-                            Res::Def(DefKind::Fn, def_id) | Res::Def(DefKind::Method, def_id) => {
+                            Res::Def(DefKind::Fn, def_id) | Res::Def(DefKind::AssocFn, def_id) => {
                                 Some(def_id)
                             }
                             // `Res::Local` if it was a closure, for which we

--- a/src/librustc_metadata/rmeta/decoder.rs
+++ b/src/librustc_metadata/rmeta/decoder.rs
@@ -504,7 +504,7 @@ impl EntryKind {
             EntryKind::Struct(_, _) => DefKind::Struct,
             EntryKind::Union(_, _) => DefKind::Union,
             EntryKind::Fn(_) | EntryKind::ForeignFn(_) => DefKind::Fn,
-            EntryKind::Method(_) => DefKind::Method,
+            EntryKind::Method(_) => DefKind::AssocFn,
             EntryKind::Type => DefKind::TyAlias,
             EntryKind::TypeParam => DefKind::TyParam,
             EntryKind::ConstParam => DefKind::ConstParam,

--- a/src/librustc_metadata/rmeta/encoder.rs
+++ b/src/librustc_metadata/rmeta/encoder.rs
@@ -805,7 +805,7 @@ impl EncodeContext<'tcx> {
                 )
             }
             ty::AssocKind::Method => {
-                let fn_data = if let hir::TraitItemKind::Method(m_sig, m) = &ast_item.kind {
+                let fn_data = if let hir::TraitItemKind::Fn(m_sig, m) = &ast_item.kind {
                     let param_names = match *m {
                         hir::TraitMethod::Required(ref names) => {
                             self.encode_fn_param_names(names)

--- a/src/librustc_mir/borrow_check/diagnostics/mutability_errors.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/mutability_errors.rs
@@ -478,7 +478,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                         }))
                         | Some(hir::Node::TraitItem(hir::TraitItem {
                             ident,
-                            kind: hir::TraitItemKind::Method(sig, _),
+                            kind: hir::TraitItemKind::Fn(sig, _),
                             ..
                         }))
                         | Some(hir::Node::ImplItem(hir::ImplItem {
@@ -520,7 +520,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                 hir::Node::Item(hir::Item { ident, kind: hir::ItemKind::Fn(sig, ..), .. })
                 | hir::Node::TraitItem(hir::TraitItem {
                     ident,
-                    kind: hir::TraitItemKind::Method(sig, _),
+                    kind: hir::TraitItemKind::Fn(sig, _),
                     ..
                 })
                 | hir::Node::ImplItem(hir::ImplItem {

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -103,6 +103,10 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 self.write_scalar(location.ptr, dest)?;
             }
 
+            sym::abort => {
+                M::abort(self)?;
+            }
+
             sym::min_align_of
             | sym::pref_align_of
             | sym::needs_drop

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -171,7 +171,7 @@ pub trait Machine<'mir, 'tcx>: Sized {
     ) -> InterpResult<'tcx>;
 
     /// Called to evaluate `Abort` MIR terminator.
-    fn abort(_ecx: &mut InterpCx<'mir, 'tcx, Self>) -> InterpResult<'tcx> {
+    fn abort(_ecx: &mut InterpCx<'mir, 'tcx, Self>) -> InterpResult<'tcx, !> {
         throw_unsup_format!("aborting execution is not supported");
     }
 

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -170,6 +170,11 @@ pub trait Machine<'mir, 'tcx>: Sized {
         unwind: Option<mir::BasicBlock>,
     ) -> InterpResult<'tcx>;
 
+    /// Called to evaluate `Abort` MIR terminator.
+    fn abort(_ecx: &mut InterpCx<'mir, 'tcx, Self>) -> InterpResult<'tcx> {
+        throw_unsup_format!("aborting execution is not supported");
+    }
+
     /// Called for all binary operations where the LHS has pointer type.
     ///
     /// Returns a (value, overflowed) pair if the operation succeeded

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -99,6 +99,10 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 }
             }
 
+            Abort => {
+                M::abort(self)?;
+            }
+
             // When we encounter Resume, we've finished unwinding
             // cleanup for the current stack frame. We pop it in order
             // to continue unwinding the next frame
@@ -118,8 +122,9 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             | FalseEdges { .. }
             | FalseUnwind { .. }
             | Yield { .. }
-            | GeneratorDrop
-            | Abort => bug!("{:#?} should have been eliminated by MIR pass", terminator.kind),
+            | GeneratorDrop => {
+                bug!("{:#?} should have been eliminated by MIR pass", terminator.kind)
+            }
         }
 
         Ok(())

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -114,15 +114,12 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             Unreachable => throw_ub!(Unreachable),
 
             // These should never occur for MIR we actually run.
-            DropAndReplace { .. } | FalseEdges { .. } | FalseUnwind { .. } => {
-                bug!("{:#?} should have been eliminated by MIR pass", terminator.kind)
-            }
-
-            // These are not (yet) supported. It is unclear if they even can occur in
-            // MIR that we actually run.
-            Yield { .. } | GeneratorDrop | Abort => {
-                throw_unsup_format!("Unsupported terminator kind: {:#?}", terminator.kind)
-            }
+            DropAndReplace { .. }
+            | FalseEdges { .. }
+            | FalseUnwind { .. }
+            | Yield { .. }
+            | GeneratorDrop
+            | Abort => bug!("{:#?} should have been eliminated by MIR pass", terminator.kind),
         }
 
         Ok(())

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -545,7 +545,7 @@ fn write_mir_sig(
     trace!("write_mir_sig: {:?}", src.instance);
     let kind = tcx.def_kind(src.def_id());
     let is_function = match kind {
-        Some(DefKind::Fn) | Some(DefKind::Method) | Some(DefKind::Ctor(..)) => true,
+        Some(DefKind::Fn) | Some(DefKind::AssocFn) | Some(DefKind::Ctor(..)) => true,
         _ => tcx.is_closure(src.def_id()),
     };
     match (kind, src.promoted) {

--- a/src/librustc_mir_build/build/mod.rs
+++ b/src/librustc_mir_build/build/mod.rs
@@ -44,7 +44,7 @@ fn mir_build(tcx: TyCtxt<'_>, def_id: DefId) -> BodyAndCache<'_> {
         })
         | Node::TraitItem(hir::TraitItem {
             kind:
-                hir::TraitItemKind::Method(hir::FnSig { decl, .. }, hir::TraitMethod::Provided(body_id)),
+                hir::TraitItemKind::Fn(hir::FnSig { decl, .. }, hir::TraitMethod::Provided(body_id)),
             ..
         }) => (*body_id, decl.output.span()),
         Node::Item(hir::Item { kind: hir::ItemKind::Static(ty, _, body_id), .. })

--- a/src/librustc_mir_build/hair/cx/expr.rs
+++ b/src/librustc_mir_build/hair/cx/expr.rs
@@ -600,7 +600,7 @@ fn user_substs_applied_to_res<'tcx>(
         // a tuple-struct or tuple-variant. This has the type of a
         // `Fn` but with the user-given substitutions.
         Res::Def(DefKind::Fn, _)
-        | Res::Def(DefKind::Method, _)
+        | Res::Def(DefKind::AssocFn, _)
         | Res::Def(DefKind::Ctor(_, CtorKind::Fn), _)
         | Res::Def(DefKind::Const, _)
         | Res::Def(DefKind::AssocConst, _) => {
@@ -703,7 +703,7 @@ fn convert_path_expr<'a, 'tcx>(
     match res {
         // A regular function, constructor function or a constant.
         Res::Def(DefKind::Fn, _)
-        | Res::Def(DefKind::Method, _)
+        | Res::Def(DefKind::AssocFn, _)
         | Res::Def(DefKind::Ctor(_, CtorKind::Fn), _)
         | Res::SelfCtor(..) => {
             let user_ty = user_substs_applied_to_res(cx, expr.hir_id, res);

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -373,6 +373,16 @@ impl<'a> Parser<'a> {
         self.token.is_keyword(kw::Async) && self.is_keyword_ahead(1, &[kw::Fn])
     }
 
+    fn parse_polarity(&mut self) -> ast::ImplPolarity {
+        // Disambiguate `impl !Trait for Type { ... }` and `impl ! { ... }` for the never type.
+        if self.check(&token::Not) && self.look_ahead(1, |t| t.can_begin_type()) {
+            self.bump(); // `!`
+            ast::ImplPolarity::Negative(self.prev_token.span)
+        } else {
+            ast::ImplPolarity::Positive
+        }
+    }
+
     /// Parses an implementation item.
     ///
     /// ```
@@ -411,13 +421,7 @@ impl<'a> Parser<'a> {
             self.sess.gated_spans.gate(sym::const_trait_impl, span);
         }
 
-        // Disambiguate `impl !Trait for Type { ... }` and `impl ! { ... }` for the never type.
-        let polarity = if self.check(&token::Not) && self.look_ahead(1, |t| t.can_begin_type()) {
-            self.bump(); // `!`
-            ast::ImplPolarity::Negative(self.prev_token.span)
-        } else {
-            ast::ImplPolarity::Positive
-        };
+        let polarity = self.parse_polarity();
 
         // Parse both types and traits as a type, then reinterpret if necessary.
         let err_path = |span| ast::Path::from_ident(Ident::new(kw::Invalid, span));

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -414,7 +414,7 @@ impl<'a> Parser<'a> {
         // Disambiguate `impl !Trait for Type { ... }` and `impl ! { ... }` for the never type.
         let polarity = if self.check(&token::Not) && self.look_ahead(1, |t| t.can_begin_type()) {
             self.bump(); // `!`
-            ast::ImplPolarity::Negative
+            ast::ImplPolarity::Negative(self.prev_token.span)
         } else {
             ast::ImplPolarity::Positive
         };

--- a/src/librustc_passes/dead.rs
+++ b/src/librustc_passes/dead.rs
@@ -391,7 +391,7 @@ impl<'v, 'k, 'tcx> ItemLikeVisitor<'v> for LifeSeeder<'k, 'tcx> {
                     let trait_item = self.krate.trait_item(trait_item_ref.id);
                     match trait_item.kind {
                         hir::TraitItemKind::Const(_, Some(_))
-                        | hir::TraitItemKind::Method(_, hir::TraitMethod::Provided(_)) => {
+                        | hir::TraitItemKind::Fn(_, hir::TraitMethod::Provided(_)) => {
                             if has_allow_dead_code_or_lang_attr(
                                 self.tcx,
                                 trait_item.hir_id,
@@ -682,11 +682,11 @@ impl Visitor<'tcx> for DeadVisitor<'tcx> {
     fn visit_trait_item(&mut self, trait_item: &'tcx hir::TraitItem<'tcx>) {
         match trait_item.kind {
             hir::TraitItemKind::Const(_, Some(body_id))
-            | hir::TraitItemKind::Method(_, hir::TraitMethod::Provided(body_id)) => {
+            | hir::TraitItemKind::Fn(_, hir::TraitMethod::Provided(body_id)) => {
                 self.visit_nested_body(body_id)
             }
             hir::TraitItemKind::Const(_, None)
-            | hir::TraitItemKind::Method(_, hir::TraitMethod::Required(_))
+            | hir::TraitItemKind::Fn(_, hir::TraitMethod::Required(_))
             | hir::TraitItemKind::Type(..) => {}
         }
     }

--- a/src/librustc_passes/reachable.rs
+++ b/src/librustc_passes/reachable.rs
@@ -162,8 +162,8 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
             },
             Some(Node::TraitItem(trait_method)) => match trait_method.kind {
                 hir::TraitItemKind::Const(_, ref default) => default.is_some(),
-                hir::TraitItemKind::Method(_, hir::TraitMethod::Provided(_)) => true,
-                hir::TraitItemKind::Method(_, hir::TraitMethod::Required(_))
+                hir::TraitItemKind::Fn(_, hir::TraitMethod::Provided(_)) => true,
+                hir::TraitItemKind::Fn(_, hir::TraitMethod::Required(_))
                 | hir::TraitItemKind::Type(..) => false,
             },
             Some(Node::ImplItem(impl_item)) => {
@@ -278,11 +278,11 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
             Node::TraitItem(trait_method) => {
                 match trait_method.kind {
                     hir::TraitItemKind::Const(_, None)
-                    | hir::TraitItemKind::Method(_, hir::TraitMethod::Required(_)) => {
+                    | hir::TraitItemKind::Fn(_, hir::TraitMethod::Required(_)) => {
                         // Keep going, nothing to get exported
                     }
                     hir::TraitItemKind::Const(_, Some(body_id))
-                    | hir::TraitItemKind::Method(_, hir::TraitMethod::Provided(body_id)) => {
+                    | hir::TraitItemKind::Fn(_, hir::TraitMethod::Provided(body_id)) => {
                         self.visit_nested_body(body_id);
                     }
                     hir::TraitItemKind::Type(..) => {}

--- a/src/librustc_passes/region.rs
+++ b/src/librustc_passes/region.rs
@@ -4,7 +4,7 @@
 //! For more information about how MIR-based region-checking works,
 //! see the [rustc dev guide].
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/borrow_check.html
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/borrow_check.html
 
 use rustc::hir::map::Map;
 use rustc::middle::region::*;

--- a/src/librustc_passes/region.rs
+++ b/src/librustc_passes/region.rs
@@ -4,7 +4,7 @@
 //! For more information about how MIR-based region-checking works,
 //! see the [rustc guide].
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/borrow_check.html
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/borrow_check.html
 
 use rustc::hir::map::Map;
 use rustc::middle::region::*;

--- a/src/librustc_passes/region.rs
+++ b/src/librustc_passes/region.rs
@@ -2,9 +2,9 @@
 //! the parent links in the region hierarchy.
 //!
 //! For more information about how MIR-based region-checking works,
-//! see the [rustc guide].
+//! see the [rustc dev guide].
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/borrow_check.html
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/borrow_check.html
 
 use rustc::hir::map::Map;
 use rustc::middle::region::*;

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -620,7 +620,7 @@ impl EmbargoVisitor<'tcx> {
             | DefKind::ForeignTy
             | DefKind::Fn
             | DefKind::OpaqueTy
-            | DefKind::Method
+            | DefKind::AssocFn
             | DefKind::Trait
             | DefKind::TyParam
             | DefKind::Variant => (),
@@ -1298,7 +1298,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypePrivacyVisitor<'a, 'tcx> {
             _ => None,
         };
         let def = def.filter(|(kind, _)| match kind {
-            DefKind::Method
+            DefKind::AssocFn
             | DefKind::AssocConst
             | DefKind::AssocTy
             | DefKind::AssocOpaqueTy

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -887,7 +887,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
             | Res::PrimTy(..)
             | Res::ToolMod => self.r.define(parent, ident, TypeNS, (res, vis, span, expansion)),
             Res::Def(DefKind::Fn, _)
-            | Res::Def(DefKind::Method, _)
+            | Res::Def(DefKind::AssocFn, _)
             | Res::Def(DefKind::Static, _)
             | Res::Def(DefKind::Const, _)
             | Res::Def(DefKind::AssocConst, _)
@@ -911,7 +911,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
                 let field_names = cstore.struct_field_names_untracked(def_id, self.r.session);
                 self.insert_field_names(def_id, field_names);
             }
-            Res::Def(DefKind::Method, def_id) => {
+            Res::Def(DefKind::AssocFn, def_id) => {
                 if cstore.associated_item_cloned_untracked(def_id).method_has_self_argument {
                     self.r.has_self.insert(def_id);
                 }
@@ -1257,7 +1257,7 @@ impl<'a, 'b> Visitor<'b> for BuildReducedGraphVisitor<'a, 'b> {
                 if sig.decl.has_self() {
                     self.r.has_self.insert(item_def_id);
                 }
-                (Res::Def(DefKind::Method, item_def_id), ValueNS)
+                (Res::Def(DefKind::AssocFn, item_def_id), ValueNS)
             }
             AssocItemKind::TyAlias(..) => (Res::Def(DefKind::AssocTy, item_def_id), TypeNS),
             AssocItemKind::Macro(_) => bug!(), // handled above

--- a/src/librustc_resolve/late.rs
+++ b/src/librustc_resolve/late.rs
@@ -266,7 +266,7 @@ impl<'a> PathSource<'a> {
                 | Res::Def(DefKind::Static, _)
                 | Res::Local(..)
                 | Res::Def(DefKind::Fn, _)
-                | Res::Def(DefKind::Method, _)
+                | Res::Def(DefKind::AssocFn, _)
                 | Res::Def(DefKind::AssocConst, _)
                 | Res::SelfCtor(..)
                 | Res::Def(DefKind::ConstParam, _) => true,
@@ -293,7 +293,7 @@ impl<'a> PathSource<'a> {
                 _ => false,
             },
             PathSource::TraitItem(ns) => match res {
-                Res::Def(DefKind::AssocConst, _) | Res::Def(DefKind::Method, _)
+                Res::Def(DefKind::AssocConst, _) | Res::Def(DefKind::AssocFn, _)
                     if ns == ValueNS =>
                 {
                     true

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -124,7 +124,7 @@ impl<'a> LateResolutionVisitor<'a, '_, '_> {
                             .unwrap_or(false)
                     }
                     Res::Def(DefKind::Ctor(..), _)
-                    | Res::Def(DefKind::Method, _)
+                    | Res::Def(DefKind::AssocFn, _)
                     | Res::Def(DefKind::Const, _)
                     | Res::Def(DefKind::AssocConst, _)
                     | Res::SelfCtor(_)

--- a/src/librustc_resolve/late/lifetimes.rs
+++ b/src/librustc_resolve/late/lifetimes.rs
@@ -713,7 +713,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
         use self::hir::TraitItemKind::*;
         self.missing_named_lifetime_spots.push((&trait_item.generics).into());
         match trait_item.kind {
-            Method(ref sig, _) => {
+            Fn(ref sig, _) => {
                 let tcx = self.tcx;
                 self.visit_early_late(
                     Some(tcx.hir().get_parent_item(trait_item.hir_id)),
@@ -1816,8 +1816,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                 match self.tcx.hir().get(fn_id) {
                     Node::Item(&hir::Item { kind: hir::ItemKind::Fn(..), .. })
                     | Node::TraitItem(&hir::TraitItem {
-                        kind: hir::TraitItemKind::Method(..),
-                        ..
+                        kind: hir::TraitItemKind::Fn(..), ..
                     })
                     | Node::ImplItem(&hir::ImplItem {
                         kind: hir::ImplItemKind::Method(..), ..
@@ -2093,9 +2092,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
             // `fn` definitions and methods.
             Node::Item(&hir::Item { kind: hir::ItemKind::Fn(.., body), .. }) => Some(body),
 
-            Node::TraitItem(&hir::TraitItem {
-                kind: hir::TraitItemKind::Method(_, ref m), ..
-            }) => {
+            Node::TraitItem(&hir::TraitItem { kind: hir::TraitItemKind::Fn(_, ref m), .. }) => {
                 if let hir::ItemKind::Trait(.., ref trait_items) =
                     self.tcx.hir().expect_item(self.tcx.hir().get_parent_item(parent)).kind
                 {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -742,7 +742,7 @@ impl<'a> NameBinding<'a> {
     fn is_importable(&self) -> bool {
         match self.res() {
             Res::Def(DefKind::AssocConst, _)
-            | Res::Def(DefKind::Method, _)
+            | Res::Def(DefKind::AssocFn, _)
             | Res::Def(DefKind::AssocTy, _) => false,
             _ => true,
         }

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -716,7 +716,7 @@ impl<'l, 'tcx> SaveContext<'l, 'tcx> {
             | Res::Def(HirDefKind::Ctor(..), _) => {
                 Some(Ref { kind: RefKind::Variable, span, ref_id: id_from_def_id(res.def_id()) })
             }
-            Res::Def(HirDefKind::Method, decl_id) => {
+            Res::Def(HirDefKind::AssocFn, decl_id) => {
                 let def_id = if decl_id.is_local() {
                     let ti = self.tcx.associated_item(decl_id);
 

--- a/src/librustc_save_analysis/sig.rs
+++ b/src/librustc_save_analysis/sig.rs
@@ -519,7 +519,7 @@ impl Sig for ast::Item {
                 text.push(' ');
 
                 let trait_sig = if let Some(ref t) = *of_trait {
-                    if polarity == ast::ImplPolarity::Negative {
+                    if let ast::ImplPolarity::Negative(_) = polarity {
                         text.push('!');
                     }
                     let trait_sig = t.path.make(offset + text.len(), id, scx)?;

--- a/src/librustc_span/symbol.rs
+++ b/src/librustc_span/symbol.rs
@@ -120,6 +120,7 @@ symbols! {
         abi_unadjusted,
         abi_vectorcall,
         abi_x86_interrupt,
+        abort,
         aborts,
         address,
         add_with_overflow,

--- a/src/librustc_target/README.md
+++ b/src/librustc_target/README.md
@@ -1,6 +1,6 @@
 `librustc_target` contains some very low-level details that are
 specific to different compilation targets and so forth.
 
-For more information about how rustc works, see the [rustc guide].
+For more information about how rustc works, see the [rustc dev guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/

--- a/src/librustc_target/README.md
+++ b/src/librustc_target/README.md
@@ -3,4 +3,4 @@ specific to different compilation targets and so forth.
 
 For more information about how rustc works, see the [rustc dev guide].
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/

--- a/src/librustc_target/README.md
+++ b/src/librustc_target/README.md
@@ -3,4 +3,4 @@ specific to different compilation targets and so forth.
 
 For more information about how rustc works, see the [rustc guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/

--- a/src/librustc_traits/lowering/environment.rs
+++ b/src/librustc_traits/lowering/environment.rs
@@ -185,7 +185,7 @@ crate fn environment(tcx: TyCtxt<'_>, def_id: DefId) -> Environment<'_> {
 
     let node_kind = match node {
         Node::TraitItem(item) => match item.kind {
-            TraitItemKind::Method(..) => NodeKind::Fn,
+            TraitItemKind::Fn(..) => NodeKind::Fn,
             _ => NodeKind::Other,
         },
 

--- a/src/librustc_traits/lowering/mod.rs
+++ b/src/librustc_traits/lowering/mod.rs
@@ -108,13 +108,13 @@ impl<'tcx> Lower<PolyDomainGoal<'tcx>> for ty::Predicate<'tcx> {
     }
 }
 
-/// Used for implied bounds related rules (see rustc guide).
+/// Used for implied bounds related rules (see rustc dev guide).
 trait IntoFromEnvGoal {
     /// Transforms an existing goal into a `FromEnv` goal.
     fn into_from_env_goal(self) -> Self;
 }
 
-/// Used for well-formedness related rules (see rustc guide).
+/// Used for well-formedness related rules (see rustc dev guide).
 trait IntoWellFormedGoal {
     /// Transforms an existing goal into a `WellFormed` goal.
     fn into_well_formed_goal(self) -> Self;
@@ -178,7 +178,7 @@ crate fn program_clauses_for(tcx: TyCtxt<'_>, def_id: DefId) -> Clauses<'_> {
 fn program_clauses_for_trait(tcx: TyCtxt<'_>, def_id: DefId) -> Clauses<'_> {
     // `trait Trait<P1..Pn> where WC { .. } // P0 == Self`
 
-    // Rule Implemented-From-Env (see rustc guide)
+    // Rule Implemented-From-Env (see rustc dev guide)
     //
     // ```
     // forall<Self, P1..Pn> {
@@ -282,7 +282,7 @@ fn program_clauses_for_impl(tcx: TyCtxt<'tcx>, def_id: DefId) -> Clauses<'tcx> {
         return List::empty();
     }
 
-    // Rule Implemented-From-Impl (see rustc guide)
+    // Rule Implemented-From-Impl (see rustc dev guide)
     //
     // `impl<P0..Pn> Trait<A1..An> for A0 where WC { .. }`
     //
@@ -501,7 +501,7 @@ pub fn program_clauses_for_associated_type_def(tcx: TyCtxt<'_>, item_id: DefId) 
 }
 
 pub fn program_clauses_for_associated_type_value(tcx: TyCtxt<'_>, item_id: DefId) -> Clauses<'_> {
-    // Rule Normalize-From-Impl (see rustc guide)
+    // Rule Normalize-From-Impl (see rustc dev guide)
     //
     // ```
     // impl<P0..Pn> Trait<A1..An> for A0 {

--- a/src/librustc_typeck/README.md
+++ b/src/librustc_typeck/README.md
@@ -1,5 +1,5 @@
 For high-level intro to how type checking works in rustc, see the
 [type checking] chapter of the [rustc guide].
 
-[type checking]: https://rust-lang.github.io/rustc-guide/type-checking.html
-[rustc guide]: https://rust-lang.github.io/rustc-guide/
+[type checking]: https://rust-lang.github.io/rustc-dev-guide/type-checking.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/

--- a/src/librustc_typeck/README.md
+++ b/src/librustc_typeck/README.md
@@ -1,5 +1,5 @@
 For high-level intro to how type checking works in rustc, see the
-[type checking] chapter of the [rustc guide].
+[type checking] chapter of the [rustc dev guide].
 
 [type checking]: https://rust-lang.github.io/rustc-dev-guide/type-checking.html
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/

--- a/src/librustc_typeck/README.md
+++ b/src/librustc_typeck/README.md
@@ -1,5 +1,5 @@
 For high-level intro to how type checking works in rustc, see the
 [type checking] chapter of the [rustc dev guide].
 
-[type checking]: https://rust-lang.github.io/rustc-dev-guide/type-checking.html
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/
+[type checking]: https://rustc-dev-guide.rust-lang.org/type-checking.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -2588,7 +2588,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             }
 
             // Case 4. Reference to a method or associated const.
-            DefKind::Method | DefKind::AssocConst => {
+            DefKind::AssocFn | DefKind::AssocConst => {
                 if segments.len() >= 2 {
                     let generics = tcx.generics_of(def_id);
                     path_segs.push(PathSeg(generics.parent.unwrap(), last - 1));

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -412,8 +412,8 @@ fn extract_spans_for_error_reporting<'a, 'tcx>(
         TypeError::Mutability => {
             if let Some(trait_m_hir_id) = tcx.hir().as_local_hir_id(trait_m.def_id) {
                 let trait_m_iter = match tcx.hir().expect_trait_item(trait_m_hir_id).kind {
-                    TraitItemKind::Method(ref trait_m_sig, _) => trait_m_sig.decl.inputs.iter(),
-                    _ => bug!("{:?} is not a TraitItemKind::Method", trait_m),
+                    TraitItemKind::Fn(ref trait_m_sig, _) => trait_m_sig.decl.inputs.iter(),
+                    _ => bug!("{:?} is not a TraitItemKind::Fn", trait_m),
                 };
 
                 impl_m_iter
@@ -440,10 +440,10 @@ fn extract_spans_for_error_reporting<'a, 'tcx>(
             if let Some(trait_m_hir_id) = tcx.hir().as_local_hir_id(trait_m.def_id) {
                 let (trait_m_output, trait_m_iter) =
                     match tcx.hir().expect_trait_item(trait_m_hir_id).kind {
-                        TraitItemKind::Method(ref trait_m_sig, _) => {
+                        TraitItemKind::Fn(ref trait_m_sig, _) => {
                             (&trait_m_sig.decl.output, trait_m_sig.decl.inputs.iter())
                         }
-                        _ => bug!("{:?} is not a TraitItemKind::Method", trait_m),
+                        _ => bug!("{:?} is not a TraitItemKind::Fn", trait_m),
                     };
 
                 let impl_iter = impl_sig.inputs().iter();
@@ -708,7 +708,7 @@ fn compare_number_of_method_arguments<'tcx>(
         let trait_m_hir_id = tcx.hir().as_local_hir_id(trait_m.def_id);
         let trait_span = if let Some(trait_id) = trait_m_hir_id {
             match tcx.hir().expect_trait_item(trait_id).kind {
-                TraitItemKind::Method(ref trait_m_sig, _) => {
+                TraitItemKind::Fn(ref trait_m_sig, _) => {
                     let pos = if trait_number_args > 0 { trait_number_args - 1 } else { 0 };
                     if let Some(arg) = trait_m_sig.decl.inputs.get(pos) {
                         Some(if pos == 0 {

--- a/src/librustc_typeck/check/generator_interior.rs
+++ b/src/librustc_typeck/check/generator_interior.rs
@@ -237,7 +237,7 @@ impl<'a, 'tcx> Visitor<'tcx> for InteriorVisitor<'a, 'tcx> {
                         // ZST in a temporary, so skip its type, just in case it
                         // can significantly complicate the generator type.
                         Res::Def(DefKind::Fn, _)
-                        | Res::Def(DefKind::Method, _)
+                        | Res::Def(DefKind::AssocFn, _)
                         | Res::Def(DefKind::Ctor(_, CtorKind::Fn), _) => {
                             // NOTE(eddyb) this assumes a path expression has
                             // no nested expressions to keep track of.

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -1,6 +1,6 @@
 //! Method lookup: the secret sauce of Rust. See the [rustc dev guide] for more information.
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/method-lookup.html
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/method-lookup.html
 
 mod confirm;
 pub mod probe;

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -1,6 +1,6 @@
 //! Method lookup: the secret sauce of Rust. See the [rustc guide] for more information.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/method-lookup.html
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/method-lookup.html
 
 mod confirm;
 pub mod probe;

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -1,6 +1,6 @@
-//! Method lookup: the secret sauce of Rust. See the [rustc guide] for more information.
+//! Method lookup: the secret sauce of Rust. See the [rustc dev guide] for more information.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/method-lookup.html
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/method-lookup.html
 
 mod confirm;
 pub mod probe;

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -930,7 +930,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             if let ty::AssocKind::Method = item.kind {
                                 let id = self.tcx.hir().as_local_hir_id(item.def_id);
                                 if let Some(hir::Node::TraitItem(hir::TraitItem {
-                                    kind: hir::TraitItemKind::Method(fn_sig, method),
+                                    kind: hir::TraitItemKind::Fn(fn_sig, method),
                                     ..
                                 })) = id.map(|id| self.tcx.hir().get(id))
                                 {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -811,7 +811,7 @@ fn primary_body_of(
         },
         Node::TraitItem(item) => match item.kind {
             hir::TraitItemKind::Const(ref ty, Some(body)) => Some((body, Some(ty), None, None)),
-            hir::TraitItemKind::Method(ref sig, hir::TraitMethod::Provided(body)) => {
+            hir::TraitItemKind::Fn(ref sig, hir::TraitMethod::Provided(body)) => {
                 Some((body, None, Some(&sig.header), Some(&sig.decl)))
             }
             _ => None,
@@ -1733,7 +1733,7 @@ pub fn check_item_type<'tcx>(tcx: TyCtxt<'tcx>, it: &'tcx hir::Item<'tcx>) {
 
             for item in items.iter() {
                 let item = tcx.hir().trait_item(item.id);
-                if let hir::TraitItemKind::Method(sig, _) = &item.kind {
+                if let hir::TraitItemKind::Fn(sig, _) = &item.kind {
                     let abi = sig.header.abi;
                     fn_maybe_err(tcx, item.ident.span, abi);
                 }
@@ -4769,7 +4769,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
             Node::TraitItem(&hir::TraitItem {
                 ident,
-                kind: hir::TraitItemKind::Method(ref sig, ..),
+                kind: hir::TraitItemKind::Fn(ref sig, ..),
                 ..
             }) => Some((&sig.decl, ident, true)),
             Node::ImplItem(&hir::ImplItem {
@@ -4863,7 +4863,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     ..
                 }))
                 | Some(Node::TraitItem(hir::TraitItem {
-                    kind: hir::TraitItemKind::Method(.., hir::TraitMethod::Provided(body_id)),
+                    kind: hir::TraitItemKind::Fn(.., hir::TraitMethod::Provided(body_id)),
                     ..
                 })) => {
                     let body = hir.body(*body_id);
@@ -4934,7 +4934,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         .join(", ")
                 }
                 Some(Node::TraitItem(hir::TraitItem {
-                    kind: hir::TraitItemKind::Method(.., hir::TraitMethod::Required(idents)),
+                    kind: hir::TraitItemKind::Fn(.., hir::TraitMethod::Required(idents)),
                     ..
                 })) => {
                     sugg_call = idents

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2976,7 +2976,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
     pub fn write_method_call(&self, hir_id: hir::HirId, method: MethodCallee<'tcx>) {
         debug!("write_method_call(hir_id={:?}, method={:?})", hir_id, method);
-        self.write_resolution(hir_id, Ok((DefKind::Method, method.def_id)));
+        self.write_resolution(hir_id, Ok((DefKind::AssocFn, method.def_id)));
         self.write_substs(hir_id, method.substs);
 
         // When the method is confirmed, the `method.substs` includes
@@ -5364,7 +5364,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     is_alias_variant_ctor = true;
                 }
             }
-            Res::Def(DefKind::Method, def_id) | Res::Def(DefKind::AssocConst, def_id) => {
+            Res::Def(DefKind::AssocFn, def_id) | Res::Def(DefKind::AssocConst, def_id) => {
                 let container = tcx.associated_item(def_id).container;
                 debug!("instantiate_value_path: def_id={:?} container={:?}", def_id, container);
                 match container {

--- a/src/librustc_typeck/check/pat.rs
+++ b/src/librustc_typeck/check/pat.rs
@@ -682,7 +682,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 self.set_tainted_by_errors();
                 return tcx.types.err;
             }
-            Res::Def(DefKind::Method, _)
+            Res::Def(DefKind::AssocFn, _)
             | Res::Def(DefKind::Ctor(_, CtorKind::Fictive), _)
             | Res::Def(DefKind::Ctor(_, CtorKind::Fn), _) => {
                 report_unexpected_variant_res(tcx, res, pat.span, qpath);
@@ -729,7 +729,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             );
             let mut err = struct_span_err!(tcx.sess, pat.span, E0164, "{}", msg);
             match (res, &pat.kind) {
-                (Res::Def(DefKind::Fn, _), _) | (Res::Def(DefKind::Method, _), _) => {
+                (Res::Def(DefKind::Fn, _), _) | (Res::Def(DefKind::AssocFn, _), _) => {
                     err.span_label(pat.span, "`fn` calls are not allowed in patterns");
                     err.help(
                         "for more information, visit \
@@ -766,7 +766,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 on_error();
                 return tcx.types.err;
             }
-            Res::Def(DefKind::AssocConst, _) | Res::Def(DefKind::Method, _) => {
+            Res::Def(DefKind::AssocConst, _) | Res::Def(DefKind::AssocFn, _) => {
                 report_unexpected_res(res);
                 return tcx.types.err;
             }

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -173,7 +173,7 @@ pub fn check_trait_item(tcx: TyCtxt<'_>, def_id: DefId) {
     let trait_item = tcx.hir().expect_trait_item(hir_id);
 
     let method_sig = match trait_item.kind {
-        hir::TraitItemKind::Method(ref sig, _) => Some(sig),
+        hir::TraitItemKind::Fn(ref sig, _) => Some(sig),
         _ => None,
     };
     check_object_unsafe_self_trait_by_name(tcx, &trait_item);
@@ -207,7 +207,7 @@ fn check_object_unsafe_self_trait_by_name(tcx: TyCtxt<'_>, item: &hir::TraitItem
         {
             trait_should_be_self.push(ty.span)
         }
-        hir::TraitItemKind::Method(sig, _) => {
+        hir::TraitItemKind::Fn(sig, _) => {
             for ty in sig.decl.inputs {
                 if could_be_self(trait_def_id, ty) {
                     trait_should_be_self.push(ty.span);

--- a/src/librustc_typeck/coherence/unsafety.rs
+++ b/src/librustc_typeck/coherence/unsafety.rs
@@ -69,11 +69,11 @@ impl UnsafetyChecker<'tcx> {
                     .emit();
                 }
 
-                (_, _, Unsafety::Unsafe, hir::ImplPolarity::Negative) => {
+                (_, _, Unsafety::Unsafe, hir::ImplPolarity::Negative(_)) => {
                     // Reported in AST validation
                     self.tcx.sess.delay_span_bug(item.span, "unsafe negative impl");
                 }
-                (_, _, Unsafety::Normal, hir::ImplPolarity::Negative)
+                (_, _, Unsafety::Normal, hir::ImplPolarity::Negative(_))
                 | (Unsafety::Unsafe, _, Unsafety::Unsafe, hir::ImplPolarity::Positive)
                 | (Unsafety::Normal, Some(_), Unsafety::Unsafe, hir::ImplPolarity::Positive)
                 | (Unsafety::Normal, None, Unsafety::Normal, _) => {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -715,7 +715,7 @@ fn convert_trait_item(tcx: TyCtxt<'_>, trait_item_id: hir::HirId) {
     tcx.generics_of(def_id);
 
     match trait_item.kind {
-        hir::TraitItemKind::Method(..) => {
+        hir::TraitItemKind::Fn(..) => {
             tcx.type_of(def_id);
             tcx.fn_sig(def_id);
         }
@@ -1121,7 +1121,7 @@ fn has_late_bound_regions<'tcx>(tcx: TyCtxt<'tcx>, node: Node<'tcx>) -> Option<S
 
     match node {
         Node::TraitItem(item) => match item.kind {
-            hir::TraitItemKind::Method(ref sig, _) => {
+            hir::TraitItemKind::Fn(ref sig, _) => {
                 has_late_bound_regions(tcx, &item.generics, &sig.decl)
             }
             _ => None,
@@ -1437,7 +1437,7 @@ fn fn_sig(tcx: TyCtxt<'_>, def_id: DefId) -> ty::PolyFnSig<'_> {
 
     match tcx.hir().get(hir_id) {
         TraitItem(hir::TraitItem {
-            kind: TraitItemKind::Method(sig, TraitMethod::Provided(_)),
+            kind: TraitItemKind::Fn(sig, TraitMethod::Provided(_)),
             ident,
             generics,
             ..
@@ -1474,7 +1474,7 @@ fn fn_sig(tcx: TyCtxt<'_>, def_id: DefId) -> ty::PolyFnSig<'_> {
         }
 
         TraitItem(hir::TraitItem {
-            kind: TraitItemKind::Method(FnSig { header, decl }, _),
+            kind: TraitItemKind::Fn(FnSig { header, decl }, _),
             ident,
             generics,
             ..

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1548,7 +1548,7 @@ fn impl_polarity(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ImplPolarity {
     let is_rustc_reservation = tcx.has_attr(def_id, sym::rustc_reservation_impl);
     let item = tcx.hir().expect_item(hir_id);
     match &item.kind {
-        hir::ItemKind::Impl { polarity: hir::ImplPolarity::Negative, .. } => {
+        hir::ItemKind::Impl { polarity: hir::ImplPolarity::Negative(_), .. } => {
             if is_rustc_reservation {
                 tcx.sess.span_err(item.span, "reservation impls can't be negative");
             }

--- a/src/librustc_typeck/collect/type_of.rs
+++ b/src/librustc_typeck/collect/type_of.rs
@@ -27,7 +27,7 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
 
     match tcx.hir().get(hir_id) {
         Node::TraitItem(item) => match item.kind {
-            TraitItemKind::Method(..) => {
+            TraitItemKind::Fn(..) => {
                 let substs = InternalSubsts::identity_for_item(tcx, def_id);
                 tcx.mk_fn_def(def_id, substs)
             }

--- a/src/librustc_typeck/constrained_generic_params.rs
+++ b/src/librustc_typeck/constrained_generic_params.rs
@@ -36,7 +36,7 @@ pub fn parameters_for_impl<'tcx>(
     vec.into_iter().collect()
 }
 
-/// If `include_projections` is false, returns the list of parameters that are
+/// If `include_nonconstraining` is false, returns the list of parameters that are
 /// constrained by `t` - i.e., the value of each parameter in the list is
 /// uniquely determined by `t` (see RFC 447). If it is true, return the list
 /// of parameters whose values are needed in order to constrain `ty` - these

--- a/src/librustc_typeck/mem_categorization.rs
+++ b/src/librustc_typeck/mem_categorization.rs
@@ -425,7 +425,7 @@ impl<'a, 'tcx> MemCategorizationContext<'a, 'tcx> {
             | Res::Def(DefKind::ConstParam, _)
             | Res::Def(DefKind::AssocConst, _)
             | Res::Def(DefKind::Fn, _)
-            | Res::Def(DefKind::Method, _)
+            | Res::Def(DefKind::AssocFn, _)
             | Res::SelfCtor(..) => Ok(self.cat_rvalue(hir_id, span, expr_ty)),
 
             Res::Def(DefKind::Static, _) => Ok(Place {

--- a/src/librustc_typeck/variance/constraints.rs
+++ b/src/librustc_typeck/variance/constraints.rs
@@ -105,7 +105,7 @@ impl<'a, 'tcx, 'v> ItemLikeVisitor<'v> for ConstraintContext<'a, 'tcx> {
     }
 
     fn visit_trait_item(&mut self, trait_item: &hir::TraitItem<'_>) {
-        if let hir::TraitItemKind::Method(..) = trait_item.kind {
+        if let hir::TraitItemKind::Fn(..) = trait_item.kind {
             self.visit_node_helper(trait_item.hir_id);
         }
     }

--- a/src/librustc_typeck/variance/mod.rs
+++ b/src/librustc_typeck/variance/mod.rs
@@ -1,7 +1,7 @@
 //! Module for inferring the variance of type and lifetime parameters. See the [rustc guide]
 //! chapter for more info.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/variance.html
+//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/variance.html
 
 use hir::Node;
 use rustc::ty::query::Providers;

--- a/src/librustc_typeck/variance/mod.rs
+++ b/src/librustc_typeck/variance/mod.rs
@@ -54,7 +54,7 @@ fn variances_of(tcx: TyCtxt<'_>, item_def_id: DefId) -> &[ty::Variance] {
         },
 
         Node::TraitItem(item) => match item.kind {
-            hir::TraitItemKind::Method(..) => {}
+            hir::TraitItemKind::Fn(..) => {}
 
             _ => unsupported(),
         },

--- a/src/librustc_typeck/variance/mod.rs
+++ b/src/librustc_typeck/variance/mod.rs
@@ -1,7 +1,7 @@
 //! Module for inferring the variance of type and lifetime parameters. See the [rustc dev guide]
 //! chapter for more info.
 //!
-//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/variance.html
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/variance.html
 
 use hir::Node;
 use rustc::ty::query::Providers;

--- a/src/librustc_typeck/variance/mod.rs
+++ b/src/librustc_typeck/variance/mod.rs
@@ -1,7 +1,7 @@
-//! Module for inferring the variance of type and lifetime parameters. See the [rustc guide]
+//! Module for inferring the variance of type and lifetime parameters. See the [rustc dev guide]
 //! chapter for more info.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-dev-guide/variance.html
+//! [rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/variance.html
 
 use hir::Node;
 use rustc::ty::query::Providers;

--- a/src/librustc_typeck/variance/terms.rs
+++ b/src/librustc_typeck/variance/terms.rs
@@ -77,8 +77,8 @@ pub fn determine_parameters_to_be_inferred<'a, 'tcx>(
 
     // See the following for a discussion on dep-graph management.
     //
-    // - https://rust-lang.github.io/rustc-guide/query.html
-    // - https://rust-lang.github.io/rustc-guide/variance.html
+    // - https://rust-lang.github.io/rustc-dev-guide/query.html
+    // - https://rust-lang.github.io/rustc-dev-guide/variance.html
     tcx.hir().krate().visit_all_item_likes(&mut terms_cx);
 
     terms_cx

--- a/src/librustc_typeck/variance/terms.rs
+++ b/src/librustc_typeck/variance/terms.rs
@@ -77,8 +77,8 @@ pub fn determine_parameters_to_be_inferred<'a, 'tcx>(
 
     // See the following for a discussion on dep-graph management.
     //
-    // - https://rust-lang.github.io/rustc-dev-guide/query.html
-    // - https://rust-lang.github.io/rustc-dev-guide/variance.html
+    // - https://rustc-dev-guide.rust-lang.org/query.html
+    // - https://rustc-dev-guide.rust-lang.org/variance.html
     tcx.hir().krate().visit_all_item_likes(&mut terms_cx);
 
     terms_cx

--- a/src/librustc_typeck/variance/terms.rs
+++ b/src/librustc_typeck/variance/terms.rs
@@ -164,7 +164,7 @@ impl<'a, 'tcx, 'v> ItemLikeVisitor<'v> for TermsContext<'a, 'tcx> {
     }
 
     fn visit_trait_item(&mut self, trait_item: &hir::TraitItem<'_>) {
-        if let hir::TraitItemKind::Method(..) = trait_item.kind {
+        if let hir::TraitItemKind::Fn(..) = trait_item.kind {
             self.add_inferreds_for_item(trait_item.hir_id);
         }
     }

--- a/src/librustdoc/README.md
+++ b/src/librustdoc/README.md
@@ -1,3 +1,3 @@
-For more information about how `librustdoc` works, see the [rustc guide].
+For more information about how `librustdoc` works, see the [rustc dev guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/rustdoc.html
+[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/rustdoc.html

--- a/src/librustdoc/README.md
+++ b/src/librustdoc/README.md
@@ -1,3 +1,3 @@
 For more information about how `librustdoc` works, see the [rustc dev guide].
 
-[rustc dev guide]: https://rust-lang.github.io/rustc-dev-guide/rustdoc.html
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/rustdoc.html

--- a/src/librustdoc/README.md
+++ b/src/librustdoc/README.md
@@ -1,3 +1,3 @@
 For more information about how `librustdoc` works, see the [rustc guide].
 
-[rustc guide]: https://rust-lang.github.io/rustc-guide/rustdoc.html
+[rustc guide]: https://rust-lang.github.io/rustc-dev-guide/rustdoc.html

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -12,7 +12,6 @@ use rustc_hir::Mutability;
 use rustc_metadata::creader::LoadedMacro;
 use rustc_mir::const_eval::is_min_const_fn;
 use rustc_span::hygiene::MacroKind;
-use rustc_span::symbol::sym;
 use rustc_span::Span;
 
 use crate::clean::{self, GetDefId, ToSource, TypeKind};

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1084,10 +1084,10 @@ impl Clean<Item> for hir::TraitItem<'_> {
             hir::TraitItemKind::Const(ref ty, default) => {
                 AssocConstItem(ty.clean(cx), default.map(|e| print_const_expr(cx, e)))
             }
-            hir::TraitItemKind::Method(ref sig, hir::TraitMethod::Provided(body)) => {
+            hir::TraitItemKind::Fn(ref sig, hir::TraitMethod::Provided(body)) => {
                 MethodItem((sig, &self.generics, body, None).clean(cx))
             }
-            hir::TraitItemKind::Method(ref sig, hir::TraitMethod::Required(ref names)) => {
+            hir::TraitItemKind::Fn(ref sig, hir::TraitMethod::Required(ref names)) => {
                 let (generics, decl) = enter_impl_trait(cx, || {
                     (self.generics.clean(cx), (&*sig.decl, &names[..]).clean(cx))
                 });

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -149,7 +149,7 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
                 // In case this is a trait item, skip the
                 // early return and try looking for the trait.
                 let value = match res {
-                    Res::Def(DefKind::Method, _) | Res::Def(DefKind::AssocConst, _) => true,
+                    Res::Def(DefKind::AssocFn, _) | Res::Def(DefKind::AssocConst, _) => true,
                     Res::Def(DefKind::AssocTy, _) => false,
                     Res::Def(DefKind::Variant, _) => {
                         return handle_variant(cx, res, extra_fragment);
@@ -813,7 +813,7 @@ fn ambiguity_error(
 
                     for (res, ns) in candidates {
                         let (action, mut suggestion) = match res {
-                            Res::Def(DefKind::Method, _) | Res::Def(DefKind::Fn, _) => {
+                            Res::Def(DefKind::AssocFn, _) | Res::Def(DefKind::Fn, _) => {
                                 ("add parentheses", format!("{}()", path_str))
                             }
                             Res::Def(DefKind::Macro(..), _) => {

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -552,6 +552,13 @@ impl Error for char::ParseCharError {
     }
 }
 
+#[unstable(feature = "try_reserve", reason = "new API", issue = "48043")]
+impl Error for alloc::collections::TryReserveError {
+    fn description(&self) -> &str {
+        "memory allocation failed"
+    }
+}
+
 // Copied from `any.rs`.
 impl dyn Error + 'static {
     /// Returns `true` if the boxed type is the same as `T`

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -553,11 +553,7 @@ impl Error for char::ParseCharError {
 }
 
 #[unstable(feature = "try_reserve", reason = "new API", issue = "48043")]
-impl Error for alloc::collections::TryReserveError {
-    fn description(&self) -> &str {
-        "memory allocation failed"
-    }
-}
+impl Error for alloc::collections::TryReserveError {}
 
 // Copied from `any.rs`.
 impl dyn Error + 'static {

--- a/src/test/COMPILER_TESTS.md
+++ b/src/test/COMPILER_TESTS.md
@@ -1,4 +1,4 @@
 # Compiler Test Documentation
 
 Documentation for the compiler testing framework can be found in
-[the rustc guide](https://rust-lang.github.io/rustc-guide/tests/intro.html).
+[the rustc guide](https://rust-lang.github.io/rustc-dev-guide/tests/intro.html).

--- a/src/test/COMPILER_TESTS.md
+++ b/src/test/COMPILER_TESTS.md
@@ -1,4 +1,4 @@
 # Compiler Test Documentation
 
 Documentation for the compiler testing framework can be found in
-[the rustc dev guide](https://rust-lang.github.io/rustc-dev-guide/tests/intro.html).
+[the rustc dev guide](https://rustc-dev-guide.rust-lang.org/tests/intro.html).

--- a/src/test/COMPILER_TESTS.md
+++ b/src/test/COMPILER_TESTS.md
@@ -1,4 +1,4 @@
 # Compiler Test Documentation
 
 Documentation for the compiler testing framework can be found in
-[the rustc guide](https://rust-lang.github.io/rustc-dev-guide/tests/intro.html).
+[the rustc dev guide](https://rust-lang.github.io/rustc-dev-guide/tests/intro.html).

--- a/src/test/ui/async-await/no-const-async.stderr
+++ b/src/test/ui/async-await/no-const-async.stderr
@@ -1,8 +1,8 @@
 error: functions cannot be both `const` and `async`
-  --> $DIR/no-const-async.rs:4:1
+  --> $DIR/no-const-async.rs:4:5
    |
 LL | pub const async fn x() {}
-   | ^^^^-----^-----^^^^^^^^^^
+   | ----^^^^^-^^^^^----------
    |     |     |
    |     |     `async` because of this
    |     `const` because of this

--- a/src/test/ui/auto-trait-validation.stderr
+++ b/src/test/ui/auto-trait-validation.stderr
@@ -5,6 +5,11 @@ LL | auto trait Generic<T> {}
    |            ------- ^ cannot have this generic parameter
    |            |
    |            auto trait cannot have generic parameters
+   |
+help: remove the parameters for the auto trait to be valid
+   |
+LL | auto trait Generic {}
+   |                  --
 
 error[E0568]: auto traits cannot have super traits
   --> $DIR/auto-trait-validation.rs:5:20
@@ -13,6 +18,11 @@ LL | auto trait Bound : Copy {}
    |            -----   ^^^^ cannot have this super trait
    |            |
    |            auto trait cannot have super traits
+   |
+help: remove the super traits for the auto trait to be valid
+   |
+LL | auto trait Bound {}
+   |                --
 
 error[E0380]: auto traits cannot have methods or associated items
   --> $DIR/auto-trait-validation.rs:7:25

--- a/src/test/ui/auto-trait-validation.stderr
+++ b/src/test/ui/auto-trait-validation.stderr
@@ -1,28 +1,18 @@
 error[E0567]: auto traits cannot have generic parameters
-  --> $DIR/auto-trait-validation.rs:3:20
+  --> $DIR/auto-trait-validation.rs:3:19
    |
 LL | auto trait Generic<T> {}
-   |            ------- ^ cannot have this generic parameter
+   |            -------^^^ help: remove the parameters
    |            |
    |            auto trait cannot have generic parameters
-   |
-help: remove the parameters for the auto trait to be valid
-   |
-LL | auto trait Generic {}
-   |                  --
 
 error[E0568]: auto traits cannot have super traits
   --> $DIR/auto-trait-validation.rs:5:20
    |
 LL | auto trait Bound : Copy {}
-   |            -----   ^^^^ cannot have this super trait
+   |            -----   ^^^^ help: remove the super traits
    |            |
    |            auto trait cannot have super traits
-   |
-help: remove the super traits for the auto trait to be valid
-   |
-LL | auto trait Bound {}
-   |                --
 
 error[E0380]: auto traits cannot have methods or associated items
   --> $DIR/auto-trait-validation.rs:7:25

--- a/src/test/ui/auto-trait-validation.stderr
+++ b/src/test/ui/auto-trait-validation.stderr
@@ -1,20 +1,26 @@
 error[E0567]: auto traits cannot have generic parameters
-  --> $DIR/auto-trait-validation.rs:3:1
+  --> $DIR/auto-trait-validation.rs:3:20
    |
 LL | auto trait Generic<T> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ------- ^ cannot have this generic parameter
+   |            |
+   |            auto trait cannot have generic parameters
 
 error[E0568]: auto traits cannot have super traits
-  --> $DIR/auto-trait-validation.rs:5:1
+  --> $DIR/auto-trait-validation.rs:5:20
    |
 LL | auto trait Bound : Copy {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            -----   ^^^^ cannot have this super trait
+   |            |
+   |            auto trait cannot have super traits
 
 error[E0380]: auto traits cannot have methods or associated items
-  --> $DIR/auto-trait-validation.rs:7:1
+  --> $DIR/auto-trait-validation.rs:7:25
    |
 LL | auto trait MyTrait { fn foo() {} }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            -------      ^^^
+   |            |
+   |            auto trait cannot have items
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/coherence/coherence-negative-impls-safe.stderr
+++ b/src/test/ui/coherence/coherence-negative-impls-safe.stderr
@@ -1,8 +1,8 @@
 error[E0198]: negative impls cannot be unsafe
-  --> $DIR/coherence-negative-impls-safe.rs:7:1
+  --> $DIR/coherence-negative-impls-safe.rs:7:13
    |
 LL | unsafe impl !Send for TestType {}
-   | ------^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ------      ^^^^^
    | |
    | unsafe because of this
 

--- a/src/test/ui/coherence/coherence-negative-impls-safe.stderr
+++ b/src/test/ui/coherence/coherence-negative-impls-safe.stderr
@@ -2,8 +2,9 @@ error[E0198]: negative impls cannot be unsafe
   --> $DIR/coherence-negative-impls-safe.rs:7:13
    |
 LL | unsafe impl !Send for TestType {}
-   | ------      ^^^^^
-   | |
+   | ------      -^^^^
+   | |           |
+   | |           negative because of this
    | unsafe because of this
 
 error: aborting due to previous error

--- a/src/test/ui/error-codes/E0197.stderr
+++ b/src/test/ui/error-codes/E0197.stderr
@@ -2,7 +2,7 @@ error[E0197]: inherent impls cannot be unsafe
   --> $DIR/E0197.rs:3:1
    |
 LL | unsafe impl Foo { }
-   | ------^^^^^^^^^^^^^
+   | ^^^^^^      ^^^ inherent impl for this type
    | |
    | unsafe because of this
 

--- a/src/test/ui/error-codes/E0197.stderr
+++ b/src/test/ui/error-codes/E0197.stderr
@@ -1,8 +1,8 @@
 error[E0197]: inherent impls cannot be unsafe
-  --> $DIR/E0197.rs:3:1
+  --> $DIR/E0197.rs:3:13
    |
 LL | unsafe impl Foo { }
-   | ^^^^^^      ^^^ inherent impl for this type
+   | ------      ^^^ inherent impl for this type
    | |
    | unsafe because of this
 

--- a/src/test/ui/error-codes/E0198.stderr
+++ b/src/test/ui/error-codes/E0198.stderr
@@ -1,8 +1,8 @@
 error[E0198]: negative impls cannot be unsafe
-  --> $DIR/E0198.rs:5:1
+  --> $DIR/E0198.rs:5:13
    |
 LL | unsafe impl !Send for Foo { }
-   | ------^^^^^^^^^^^^^^^^^^^^^^^
+   | ------      ^^^^^
    | |
    | unsafe because of this
 

--- a/src/test/ui/error-codes/E0198.stderr
+++ b/src/test/ui/error-codes/E0198.stderr
@@ -2,8 +2,9 @@ error[E0198]: negative impls cannot be unsafe
   --> $DIR/E0198.rs:5:13
    |
 LL | unsafe impl !Send for Foo { }
-   | ------      ^^^^^
-   | |
+   | ------      -^^^^
+   | |           |
+   | |           negative because of this
    | unsafe because of this
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-optin-builtin-traits.stderr
+++ b/src/test/ui/feature-gates/feature-gate-optin-builtin-traits.stderr
@@ -8,10 +8,10 @@ LL | auto trait AutoDummyTrait {}
    = help: add `#![feature(optin_builtin_traits)]` to the crate attributes to enable
 
 error[E0658]: negative trait bounds are not yet fully implemented; use marker types for now
-  --> $DIR/feature-gate-optin-builtin-traits.rs:9:1
+  --> $DIR/feature-gate-optin-builtin-traits.rs:9:6
    |
 LL | impl !AutoDummyTrait for DummyStruct {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |      ^^^^^^^^^^^^^^^
    |
    = note: see issue #13231 <https://github.com/rust-lang/rust/issues/13231> for more information
    = help: add `#![feature(optin_builtin_traits)]` to the crate attributes to enable

--- a/src/test/ui/issues/issue-23080-2.rs
+++ b/src/test/ui/issues/issue-23080-2.rs
@@ -3,8 +3,7 @@
 #![feature(optin_builtin_traits)]
 
 unsafe auto trait Trait {
-//~^ ERROR E0380
-    type Output;
+    type Output; //~ ERROR E0380
 }
 
 fn call_method<T: Trait>(x: T) {}

--- a/src/test/ui/issues/issue-23080-2.stderr
+++ b/src/test/ui/issues/issue-23080-2.stderr
@@ -1,11 +1,10 @@
 error[E0380]: auto traits cannot have methods or associated items
-  --> $DIR/issue-23080-2.rs:5:1
+  --> $DIR/issue-23080-2.rs:6:10
    |
-LL | / unsafe auto trait Trait {
-LL | |
-LL | |     type Output;
-LL | | }
-   | |_^
+LL | unsafe auto trait Trait {
+   |                   ----- auto trait cannot have items
+LL |     type Output;
+   |          ^^^^^^
 
 error[E0275]: overflow evaluating the requirement `<() as Trait>::Output`
    |

--- a/src/test/ui/issues/issue-23080.rs
+++ b/src/test/ui/issues/issue-23080.rs
@@ -1,8 +1,7 @@
 #![feature(optin_builtin_traits)]
 
 unsafe auto trait Trait {
-//~^ ERROR E0380
-    fn method(&self) {
+    fn method(&self) { //~ ERROR E0380
         println!("Hello");
     }
 }

--- a/src/test/ui/issues/issue-23080.stderr
+++ b/src/test/ui/issues/issue-23080.stderr
@@ -1,13 +1,10 @@
 error[E0380]: auto traits cannot have methods or associated items
-  --> $DIR/issue-23080.rs:3:1
+  --> $DIR/issue-23080.rs:4:8
    |
-LL | / unsafe auto trait Trait {
-LL | |
-LL | |     fn method(&self) {
-LL | |         println!("Hello");
-LL | |     }
-LL | | }
-   | |_^
+LL | unsafe auto trait Trait {
+   |                   ----- auto trait cannot have items
+LL |     fn method(&self) {
+   |        ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/fn-header-semantic-fail.stderr
+++ b/src/test/ui/parser/fn-header-semantic-fail.stderr
@@ -2,7 +2,7 @@ error: functions cannot be both `const` and `async`
   --> $DIR/fn-header-semantic-fail.rs:13:5
    |
 LL |     const async unsafe extern "C" fn ff5() {} // OK.
-   |     -----^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^-^^^^^------------------------------
    |     |     |
    |     |     `async` because of this
    |     `const` because of this
@@ -45,7 +45,7 @@ error: functions cannot be both `const` and `async`
   --> $DIR/fn-header-semantic-fail.rs:21:9
    |
 LL |         const async unsafe extern "C" fn ft5();
-   |         -----^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^-^^^^^----------------------------
    |         |     |
    |         |     `async` because of this
    |         `const` because of this
@@ -88,7 +88,7 @@ error: functions cannot be both `const` and `async`
   --> $DIR/fn-header-semantic-fail.rs:34:9
    |
 LL |         const async unsafe extern "C" fn ft5() {}
-   |         -----^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^-^^^^^------------------------------
    |         |     |
    |         |     `async` because of this
    |         `const` because of this
@@ -97,7 +97,7 @@ error: functions cannot be both `const` and `async`
   --> $DIR/fn-header-semantic-fail.rs:46:9
    |
 LL |         const async unsafe extern "C" fn fi5() {}
-   |         -----^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^-^^^^^------------------------------
    |         |     |
    |         |     `async` because of this
    |         `const` because of this
@@ -160,7 +160,7 @@ error: functions cannot be both `const` and `async`
   --> $DIR/fn-header-semantic-fail.rs:55:9
    |
 LL |         const async unsafe extern "C" fn fe5();
-   |         -----^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^-^^^^^----------------------------
    |         |     |
    |         |     `async` because of this
    |         `const` because of this

--- a/src/test/ui/rfc-2632-const-trait-impl/inherent-impl.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/inherent-impl.stderr
@@ -1,18 +1,18 @@
 error: inherent impls cannot be `const`
-  --> $DIR/inherent-impl.rs:9:6
+  --> $DIR/inherent-impl.rs:9:12
    |
 LL | impl const S {}
-   |      ^^^^^ ^ inherent impl for this type
+   |      ----- ^ inherent impl for this type
    |      |
    |      `const` because of this
    |
    = note: only trait implementations may be annotated with `const`
 
 error: inherent impls cannot be `const`
-  --> $DIR/inherent-impl.rs:12:6
+  --> $DIR/inherent-impl.rs:12:12
    |
 LL | impl const T {}
-   |      ^^^^^ ^ inherent impl for this type
+   |      ----- ^ inherent impl for this type
    |      |
    |      `const` because of this
    |

--- a/src/test/ui/rfc-2632-const-trait-impl/inherent-impl.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/inherent-impl.stderr
@@ -1,18 +1,18 @@
 error: inherent impls cannot be `const`
-  --> $DIR/inherent-impl.rs:9:1
+  --> $DIR/inherent-impl.rs:9:6
    |
 LL | impl const S {}
-   | ^^^^^-----^^^^^
+   |      ^^^^^ ^ inherent impl for this type
    |      |
    |      `const` because of this
    |
    = note: only trait implementations may be annotated with `const`
 
 error: inherent impls cannot be `const`
-  --> $DIR/inherent-impl.rs:12:1
+  --> $DIR/inherent-impl.rs:12:6
    |
 LL | impl const T {}
-   | ^^^^^-----^^^^^
+   |      ^^^^^ ^ inherent impl for this type
    |      |
    |      `const` because of this
    |

--- a/src/test/ui/specialization/defaultimpl/validation.stderr
+++ b/src/test/ui/specialization/defaultimpl/validation.stderr
@@ -2,7 +2,7 @@ error: inherent impls cannot be `default`
   --> $DIR/validation.rs:7:1
    |
 LL | default impl S {}
-   | -------^^^^^^^
+   | ^^^^^^^      ^ inherent impl for this type
    | |
    | `default` because of this
    |

--- a/src/test/ui/specialization/defaultimpl/validation.stderr
+++ b/src/test/ui/specialization/defaultimpl/validation.stderr
@@ -1,8 +1,8 @@
 error: inherent impls cannot be `default`
-  --> $DIR/validation.rs:7:1
+  --> $DIR/validation.rs:7:14
    |
 LL | default impl S {}
-   | ^^^^^^^      ^ inherent impl for this type
+   | -------      ^ inherent impl for this type
    | |
    | `default` because of this
    |

--- a/src/test/ui/syntax-trait-polarity-feature-gate.stderr
+++ b/src/test/ui/syntax-trait-polarity-feature-gate.stderr
@@ -1,8 +1,8 @@
 error[E0658]: negative trait bounds are not yet fully implemented; use marker types for now
-  --> $DIR/syntax-trait-polarity-feature-gate.rs:7:1
+  --> $DIR/syntax-trait-polarity-feature-gate.rs:7:6
    |
 LL | impl !Send for TestType {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |      ^^^^^
    |
    = note: see issue #13231 <https://github.com/rust-lang/rust/issues/13231> for more information
    = help: add `#![feature(optin_builtin_traits)]` to the crate attributes to enable

--- a/src/test/ui/syntax-trait-polarity.stderr
+++ b/src/test/ui/syntax-trait-polarity.stderr
@@ -1,28 +1,28 @@
 error: inherent impls cannot be negative
-  --> $DIR/syntax-trait-polarity.rs:7:1
+  --> $DIR/syntax-trait-polarity.rs:7:6
    |
 LL | impl !TestType {}
-   | ^^^^^^^^^^^^^^^^^
+   |      ^
 
 error[E0198]: negative impls cannot be unsafe
-  --> $DIR/syntax-trait-polarity.rs:12:1
+  --> $DIR/syntax-trait-polarity.rs:12:13
    |
 LL | unsafe impl !Send for TestType {}
-   | ------^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ------      ^^^^^
    | |
    | unsafe because of this
 
 error: inherent impls cannot be negative
-  --> $DIR/syntax-trait-polarity.rs:19:1
+  --> $DIR/syntax-trait-polarity.rs:19:9
    |
 LL | impl<T> !TestType2<T> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^
 
 error[E0198]: negative impls cannot be unsafe
-  --> $DIR/syntax-trait-polarity.rs:22:1
+  --> $DIR/syntax-trait-polarity.rs:22:16
    |
 LL | unsafe impl<T> !Send for TestType2<T> {}
-   | ------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ------         ^^^^^
    | |
    | unsafe because of this
 

--- a/src/test/ui/syntax-trait-polarity.stderr
+++ b/src/test/ui/syntax-trait-polarity.stderr
@@ -1,29 +1,35 @@
 error: inherent impls cannot be negative
-  --> $DIR/syntax-trait-polarity.rs:7:6
+  --> $DIR/syntax-trait-polarity.rs:7:7
    |
 LL | impl !TestType {}
-   |      ^
+   |      -^^^^^^^^ inherent impl for this type
+   |      |
+   |      negative because of this
 
 error[E0198]: negative impls cannot be unsafe
   --> $DIR/syntax-trait-polarity.rs:12:13
    |
 LL | unsafe impl !Send for TestType {}
-   | ------      ^^^^^
-   | |
+   | ------      -^^^^
+   | |           |
+   | |           negative because of this
    | unsafe because of this
 
 error: inherent impls cannot be negative
-  --> $DIR/syntax-trait-polarity.rs:19:9
+  --> $DIR/syntax-trait-polarity.rs:19:10
    |
 LL | impl<T> !TestType2<T> {}
-   |         ^
+   |         -^^^^^^^^^^^^ inherent impl for this type
+   |         |
+   |         negative because of this
 
 error[E0198]: negative impls cannot be unsafe
   --> $DIR/syntax-trait-polarity.rs:22:16
    |
 LL | unsafe impl<T> !Send for TestType2<T> {}
-   | ------         ^^^^^
-   | |
+   | ------         -^^^^
+   | |              |
+   | |              negative because of this
    | unsafe because of this
 
 error[E0192]: negative impls are only allowed for auto traits (e.g., `Send` and `Sync`)

--- a/src/test/ui/traits/trait-safety-inherent-impl.stderr
+++ b/src/test/ui/traits/trait-safety-inherent-impl.stderr
@@ -1,8 +1,8 @@
 error[E0197]: inherent impls cannot be unsafe
-  --> $DIR/trait-safety-inherent-impl.rs:5:1
+  --> $DIR/trait-safety-inherent-impl.rs:5:13
    |
 LL | unsafe impl SomeStruct {
-   | ^^^^^^      ^^^^^^^^^^ inherent impl for this type
+   | ------      ^^^^^^^^^^ inherent impl for this type
    | |
    | unsafe because of this
 

--- a/src/test/ui/traits/trait-safety-inherent-impl.stderr
+++ b/src/test/ui/traits/trait-safety-inherent-impl.stderr
@@ -1,14 +1,10 @@
 error[E0197]: inherent impls cannot be unsafe
   --> $DIR/trait-safety-inherent-impl.rs:5:1
    |
-LL |   unsafe impl SomeStruct {
-   |   ^-----
-   |   |
-   |  _unsafe because of this
+LL | unsafe impl SomeStruct {
+   | ^^^^^^      ^^^^^^^^^^ inherent impl for this type
    | |
-LL | |     fn foo(self) { }
-LL | | }
-   | |_^
+   | unsafe because of this
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/traits-inductive-overflow-supertrait-oibit.stderr
+++ b/src/test/ui/traits/traits-inductive-overflow-supertrait-oibit.stderr
@@ -1,8 +1,10 @@
 error[E0568]: auto traits cannot have super traits
-  --> $DIR/traits-inductive-overflow-supertrait-oibit.rs:7:1
+  --> $DIR/traits-inductive-overflow-supertrait-oibit.rs:7:19
    |
 LL | auto trait Magic: Copy {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            -----  ^^^^ cannot have this super trait
+   |            |
+   |            auto trait cannot have super traits
 
 error[E0277]: the trait bound `NoClone: std::marker::Copy` is not satisfied
   --> $DIR/traits-inductive-overflow-supertrait-oibit.rs:15:23

--- a/src/test/ui/traits/traits-inductive-overflow-supertrait-oibit.stderr
+++ b/src/test/ui/traits/traits-inductive-overflow-supertrait-oibit.stderr
@@ -5,6 +5,11 @@ LL | auto trait Magic: Copy {}
    |            -----  ^^^^ cannot have this super trait
    |            |
    |            auto trait cannot have super traits
+   |
+help: remove the super traits for the auto trait to be valid
+   |
+LL | auto trait Magic {}
+   |                --
 
 error[E0277]: the trait bound `NoClone: std::marker::Copy` is not satisfied
   --> $DIR/traits-inductive-overflow-supertrait-oibit.rs:15:23

--- a/src/test/ui/traits/traits-inductive-overflow-supertrait-oibit.stderr
+++ b/src/test/ui/traits/traits-inductive-overflow-supertrait-oibit.stderr
@@ -2,14 +2,9 @@ error[E0568]: auto traits cannot have super traits
   --> $DIR/traits-inductive-overflow-supertrait-oibit.rs:7:19
    |
 LL | auto trait Magic: Copy {}
-   |            -----  ^^^^ cannot have this super trait
+   |            -----  ^^^^ help: remove the super traits
    |            |
    |            auto trait cannot have super traits
-   |
-help: remove the super traits for the auto trait to be valid
-   |
-LL | auto trait Magic {}
-   |                --
 
 error[E0277]: the trait bound `NoClone: std::marker::Copy` is not satisfied
   --> $DIR/traits-inductive-overflow-supertrait-oibit.rs:15:23

--- a/src/test/ui/typeck/typeck-auto-trait-no-supertraits-2.stderr
+++ b/src/test/ui/typeck/typeck-auto-trait-no-supertraits-2.stderr
@@ -5,6 +5,11 @@ LL | auto trait Magic : Sized where Option<Self> : Magic {}
    |            -----   ^^^^^ cannot have this super trait
    |            |
    |            auto trait cannot have super traits
+   |
+help: remove the super traits for the auto trait to be valid
+   |
+LL | auto trait Magic where Option<Self> : Magic {}
+   |                --
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/typeck-auto-trait-no-supertraits-2.stderr
+++ b/src/test/ui/typeck/typeck-auto-trait-no-supertraits-2.stderr
@@ -2,14 +2,9 @@ error[E0568]: auto traits cannot have super traits
   --> $DIR/typeck-auto-trait-no-supertraits-2.rs:3:20
    |
 LL | auto trait Magic : Sized where Option<Self> : Magic {}
-   |            -----   ^^^^^ cannot have this super trait
+   |            -----   ^^^^^ help: remove the super traits
    |            |
    |            auto trait cannot have super traits
-   |
-help: remove the super traits for the auto trait to be valid
-   |
-LL | auto trait Magic where Option<Self> : Magic {}
-   |                --
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/typeck-auto-trait-no-supertraits-2.stderr
+++ b/src/test/ui/typeck/typeck-auto-trait-no-supertraits-2.stderr
@@ -1,8 +1,10 @@
 error[E0568]: auto traits cannot have super traits
-  --> $DIR/typeck-auto-trait-no-supertraits-2.rs:3:1
+  --> $DIR/typeck-auto-trait-no-supertraits-2.rs:3:20
    |
 LL | auto trait Magic : Sized where Option<Self> : Magic {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            -----   ^^^^^ cannot have this super trait
+   |            |
+   |            auto trait cannot have super traits
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/typeck-auto-trait-no-supertraits.stderr
+++ b/src/test/ui/typeck/typeck-auto-trait-no-supertraits.stderr
@@ -1,8 +1,10 @@
 error[E0568]: auto traits cannot have super traits
-  --> $DIR/typeck-auto-trait-no-supertraits.rs:27:1
+  --> $DIR/typeck-auto-trait-no-supertraits.rs:27:19
    |
 LL | auto trait Magic: Copy {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            -----  ^^^^ cannot have this super trait
+   |            |
+   |            auto trait cannot have super traits
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/typeck-auto-trait-no-supertraits.stderr
+++ b/src/test/ui/typeck/typeck-auto-trait-no-supertraits.stderr
@@ -2,14 +2,9 @@ error[E0568]: auto traits cannot have super traits
   --> $DIR/typeck-auto-trait-no-supertraits.rs:27:19
    |
 LL | auto trait Magic: Copy {}
-   |            -----  ^^^^ cannot have this super trait
+   |            -----  ^^^^ help: remove the super traits
    |            |
    |            auto trait cannot have super traits
-   |
-help: remove the super traits for the auto trait to be valid
-   |
-LL | auto trait Magic {}
-   |                --
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/typeck-auto-trait-no-supertraits.stderr
+++ b/src/test/ui/typeck/typeck-auto-trait-no-supertraits.stderr
@@ -5,6 +5,11 @@ LL | auto trait Magic: Copy {}
    |            -----  ^^^^ cannot have this super trait
    |            |
    |            auto trait cannot have super traits
+   |
+help: remove the super traits for the auto trait to be valid
+   |
+LL | auto trait Magic {}
+   |                --
 
 error: aborting due to previous error
 

--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# This script publishes the new "current" toolstate in the toolstate repo (not to be
-# confused with publishing the test results, which happens in
-# `src/ci/docker/x86_64-gnu-tools/checktools.sh`).
-# It is set as callback for `src/ci/docker/x86_64-gnu-tools/repo.sh` by the CI scripts
-# when a new commit lands on `master` (i.e., after it passed all checks on `auto`).
+# This script computes the new "current" toolstate for the toolstate repo (not to be
+# confused with publishing the test results, which happens in `src/bootstrap/toolstate.rs`).
+# It gets called from `src/ci/publish_toolstate.sh` when a new commit lands on `master`
+# (i.e., after it passed all checks on `auto`).
 
 from __future__ import print_function
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -17,7 +17,7 @@ Hey LLVM ICE-breakers! This bug has been identified as a good
 [instructions] for tackling these sorts of bugs. Maybe take a look?
 Thanks! <3
 
-[instructions]: https://rust-lang.github.io/rustc-dev-guide/ice-breaker/llvm.html
+[instructions]: https://rustc-dev-guide.rust-lang.org/ice-breaker/llvm.html
 """
 label = "ICEBreaker-LLVM"
 
@@ -28,6 +28,6 @@ Hey Cleanup Crew ICE-breakers! This bug has been identified as a good
 [instructions] for tackling these sorts of bugs. Maybe take a look?
 Thanks! <3
 
-[instructions]: https://rust-lang.github.io/rustc-dev-guide/ice-breaker/cleanup-crew.html
+[instructions]: https://rustc-dev-guide.rust-lang.org/ice-breaker/cleanup-crew.html
 """
 label = "ICEBreaker-Cleanup-Crew"

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -17,7 +17,7 @@ Hey LLVM ICE-breakers! This bug has been identified as a good
 [instructions] for tackling these sorts of bugs. Maybe take a look?
 Thanks! <3
 
-[instructions]: https://rust-lang.github.io/rustc-guide/ice-breaker/llvm.html
+[instructions]: https://rust-lang.github.io/rustc-dev-guide/ice-breaker/llvm.html
 """
 label = "ICEBreaker-LLVM"
 
@@ -28,6 +28,6 @@ Hey Cleanup Crew ICE-breakers! This bug has been identified as a good
 [instructions] for tackling these sorts of bugs. Maybe take a look?
 Thanks! <3
 
-[instructions]: https://rust-lang.github.io/rustc-guide/ice-breaker/cleanup-crew.html
+[instructions]: https://rust-lang.github.io/rustc-dev-guide/ice-breaker/cleanup-crew.html
 """
 label = "ICEBreaker-Cleanup-Crew"


### PR DESCRIPTION
Successful merges:

 - #68899 (Add Display and Error impls for proc_macro::LexError)
 - #69011 (Document unsafe blocks in core::fmt)
 - #69674 (Rename DefKind::Method and TraitItemKind::Method )
 - #69705 (Toolstate: remove redundant beta-week check.)
 - #69722 (Tweak output for invalid negative impl AST errors)
 - #69747 (Rename rustc guide)
 - #69792 (Implement Error for TryReserveError)
 - #69830 (miri: ICE on invalid terminators)
 - #69921 (rustdoc: remove unused import)
 - #69945 (update outdated comment)

Failed merges:


r? @ghost