### PR TITLE
miri engine: fix treatment of abort intrinsic

### DIFF
--- a/src/test/ui/consts/const-eval/validate_uninhabited_zsts.stderr
+++ b/src/test/ui/consts/const-eval/validate_uninhabited_zsts.stderr
@@ -4,7 +4,7 @@ warning: any use of this value will cause an error
 LL |     unsafe { std::mem::transmute(()) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^
    |              |
-   |              entering unreachable code
+   |              transmuting to uninhabited type
    |              inside call to `foo` at $DIR/validate_uninhabited_zsts.rs:14:26
 ...
 LL | const FOO: [Empty; 3] = [foo(); 3];


### PR DESCRIPTION
I screwed up in https://github.com/rust-lang/rust/pull/69830 and added `abort` to the wrong block of intrinsics, namely the one that actually has a return place. So that branch was never actually reached.

r? @oli-obk 