### PR TITLE
Add Node.js to PR CI image

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -607,7 +607,6 @@ impl Step for RustdocTheme {
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct RustdocJSStd {
-    pub host: Interned<String>,
     pub target: Interned<String>,
 }
 
@@ -621,13 +620,16 @@ impl Step for RustdocJSStd {
     }
 
     fn make_run(run: RunConfig<'_>) {
-        run.builder.ensure(RustdocJSStd { host: run.host, target: run.target });
+        run.builder.ensure(RustdocJSStd { target: run.target });
     }
 
     fn run(self, builder: &Builder<'_>) {
         if let Some(ref nodejs) = builder.config.nodejs {
             let mut command = Command::new(nodejs);
-            command.args(&["src/tools/rustdoc-js-std/tester.js", &*self.host]);
+            command
+                .arg(builder.src.join("src/tools/rustdoc-js-std/tester.js"))
+                .arg(builder.doc_out(self.target))
+                .arg(builder.src.join("src/test/rustdoc-js-std"));
             builder.ensure(crate::doc::Std { target: self.target, stage: builder.top_stage });
             builder.run(&mut command);
         } else {

--- a/src/ci/docker/x86_64-gnu-llvm-7/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-llvm-7/Dockerfile
@@ -16,7 +16,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libssl-dev \
   pkg-config \
   zlib1g-dev \
-  xz-utils
+  xz-utils \
+  nodejs
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2779,7 +2779,7 @@ impl<'test> TestCx<'test> {
                 Command::new(&nodejs)
                     .arg(root.join("src/tools/rustdoc-js/tester.js"))
                     .arg(out_dir.parent().expect("no parent"))
-                    .arg(&self.testpaths.file.file_stem().expect("couldn't get file stem")),
+                    .arg(self.testpaths.file.with_extension("js")),
             );
             if !res.status.success() {
                 self.fatal_proc_rec("rustdoc-js test failed!", &res);

--- a/src/tools/rustdoc-js-std/tester.js
+++ b/src/tools/rustdoc-js-std/tester.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
-
-const TEST_FOLDER = 'src/test/rustdoc-js-std/';
+const path = require('path');
 
 function getNextStep(content, pos, stop) {
     while (pos < content.length && content[pos] !== stop &&
@@ -246,17 +245,16 @@ function readFileMatching(dir, name, extension) {
 }
 
 function main(argv) {
-    if (argv.length !== 3) {
-        console.error("Expected toolchain to check as argument (for example \
-                       'x86_64-apple-darwin')");
+    if (argv.length !== 4) {
+        console.error("USAGE: node tester.js STD_DOCS TEST_FOLDER");
         return 1;
     }
-    var toolchain = argv[2];
+    var std_docs = argv[2];
+    var test_folder = argv[3];
 
-    var mainJs = readFileMatching("build/" + toolchain + "/doc/", "main", ".js");
-    var ALIASES = readFileMatching("build/" + toolchain + "/doc/", "aliases", ".js");
-    var searchIndex = readFileMatching("build/" + toolchain + "/doc/",
-                                       "search-index", ".js").split("\n");
+    var mainJs = readFileMatching(std_docs, "main", ".js");
+    var ALIASES = readFileMatching(std_docs, "aliases", ".js");
+    var searchIndex = readFileMatching(std_docs, "search-index", ".js").split("\n");
     if (searchIndex[searchIndex.length - 1].length === 0) {
         searchIndex.pop();
     }
@@ -287,8 +285,8 @@ function main(argv) {
 
     var errors = 0;
 
-    fs.readdirSync(TEST_FOLDER).forEach(function(file) {
-        var loadedFile = loadContent(readFile(TEST_FOLDER + file) +
+    fs.readdirSync(test_folder).forEach(function(file) {
+        var loadedFile = loadContent(readFile(path.join(test_folder, file)) +
                                'exports.QUERY = QUERY;exports.EXPECTED = EXPECTED;');
         const expected = loadedFile.EXPECTED;
         const query = loadedFile.QUERY;

--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
+const path = require('path');
 const { spawnSync } = require('child_process');
-
-const TEST_FOLDER = 'src/test/rustdoc-js/';
 
 function getNextStep(content, pos, stop) {
     while (pos < content.length && content[pos] !== stop &&
@@ -266,10 +265,11 @@ function main(argv) {
     var errors = 0;
 
     for (var j = 3; j < argv.length; ++j) {
-        const test_name = argv[j];
+        const test_file = argv[j];
+        const test_name = path.basename(test_file, ".js");
 
         process.stdout.write('Checking "' + test_name + '" ... ');
-        if (!fs.existsSync(TEST_FOLDER + test_name + ".js")) {
+        if (!fs.existsSync(test_file)) {
             errors += 1;
             console.error("FAILED");
             console.error("==> Missing '" + test_name + ".js' file...");
@@ -279,7 +279,7 @@ function main(argv) {
         const test_out_folder = out_folder + test_name;
 
         var [loaded, index] = load_files(test_out_folder, test_name);
-        var loadedFile = loadContent(readFile(TEST_FOLDER + test_name + ".js") +
+        var loadedFile = loadContent(readFile(test_file) +
                                'exports.QUERY = QUERY;exports.EXPECTED = EXPECTED;');
         const expected = loadedFile.EXPECTED;
         const query = loadedFile.QUERY;


### PR DESCRIPTION
This should allow the `rustdoc-js` and `rustdoc-js-std` test suites to run automatically on PRs.