### PR TITLE
Treat dependencies of proc-macro crates like normal dependencies

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -863,7 +863,7 @@ pub fn run_cargo(
             // to ignore it if it's a build script.
             if filename.starts_with(&host_root_dir) {
                 if crate_types.iter().any(|t| t == "proc-macro") {
-                    deps.push((filename.to_path_buf(), true));
+                    deps.push((filename.to_path_buf(), /* host_dep */ true));
                 }
 
                 let is_build_script = kind == &["custom_build"]
@@ -876,7 +876,7 @@ pub fn run_cargo(
                 // FIXME: Have Cargo explicitly indicate build-script vs proc-macro dependencies,
                 // instead of relying on this check.
                 if !is_build_script {
-                    deps.push((filename.to_path_buf(), false));
+                    deps.push((filename.to_path_buf(), /* host_dep */ true));
                 }
                 continue;
             }
@@ -945,8 +945,8 @@ pub fn run_cargo(
     deps.extend(additional_target_deps.into_iter().map(|d| (d, false)));
     deps.sort();
     let mut new_contents = Vec::new();
-    for (dep, proc_macro) in deps.iter() {
-        new_contents.extend(if *proc_macro { b"h" } else { b"t" });
+    for (dep, host_dep) in deps.iter() {
+        new_contents.extend(if *host_dep { b"h" } else { b"t" });
         new_contents.extend(dep.to_str().unwrap().as_bytes());
         new_contents.extend(b"\0");
     }

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -558,9 +558,10 @@ impl<'a> CrateLoader<'a> {
         dep_kind: DepKind,
     ) -> CrateNumMap {
         debug!("resolving deps of external crate");
-        if crate_root.is_proc_macro_crate() {
-            return CrateNumMap::new();
-        }
+
+        // Note that we need to resolve deps for proc-macro crates (just like normal crates)
+        // since we may need to decode `Span`s that reference the `CrateNums`
+        // of transitive dependencies
 
         // The map from crate numbers in the crate we're resolving to local crate numbers.
         // We map 0 and all other holes in the map to our parent crate. The "additional"


### PR DESCRIPTION
Split out from https://github.com/rust-lang/rust/pull/68941

Previously, we special-cased dependencies of proc-macro crates: we didn't load metadata for them, and we excluded them from the sysroot.

With https://github.com/rust-lang/rust/pull/68941, this will no longer work - we may need to deserialize `Span`s from proc-macro crates and their dependencies, which requires having metadata available.

This PR removes the special handling of proc-macro crates in `resolve_crate_deps`, and adjusts the sysroot generation in bootstrap to only exclude build scripts, not proc-macro dependencies.

I don't know of a way to write a test for this. However, the `ui-fulldeps` testsuite implicitly tests this, since it has several tests containing `extern crate rustc` (which ends up loading proc-macro dependencies from the sysroot).