### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/src/liballoc/collections/linked_list.rs
+++ b/src/liballoc/collections/linked_list.rs
@@ -1427,7 +1427,7 @@ impl<'a, T> CursorMut<'a, T> {
     /// `CursorMut`, which means it cannot outlive the `CursorMut` and that the
     /// `CursorMut` is frozen for the lifetime of the `Cursor`.
     #[unstable(feature = "linked_list_cursors", issue = "58533")]
-    pub fn as_cursor<'cm>(&'cm self) -> Cursor<'cm, T> {
+    pub fn as_cursor(&self) -> Cursor<'_, T> {
         Cursor { list: self.list, current: self.current, index: self.index }
     }
 }

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1005,17 +1005,23 @@ extern "rust-intrinsic" {
 
     /// A guard for unsafe functions that cannot ever be executed if `T` is uninhabited:
     /// This will statically either panic, or do nothing.
+    #[cfg(bootstrap)]
     pub fn panic_if_uninhabited<T>();
+
+    /// A guard for unsafe functions that cannot ever be executed if `T` is uninhabited:
+    /// This will statically either panic, or do nothing.
+    #[cfg(not(bootstrap))]
+    pub fn assert_inhabited<T>();
 
     /// A guard for unsafe functions that cannot ever be executed if `T` does not permit
     /// zero-initialization: This will statically either panic, or do nothing.
     #[cfg(not(bootstrap))]
-    pub fn panic_if_zero_invalid<T>();
+    pub fn assert_zero_valid<T>();
 
     /// A guard for unsafe functions that cannot ever be executed if `T` has invalid
     /// bit patterns: This will statically either panic, or do nothing.
     #[cfg(not(bootstrap))]
-    pub fn panic_if_any_invalid<T>();
+    pub fn assert_uninit_valid<T>();
 
     /// Gets a reference to a static `Location` indicating where it was called.
     #[rustc_const_unstable(feature = "const_caller_location", issue = "47809")]

--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -495,7 +495,10 @@ impl<T> MaybeUninit<T> {
     #[inline(always)]
     #[rustc_diagnostic_item = "assume_init"]
     pub unsafe fn assume_init(self) -> T {
+        #[cfg(bootstrap)]
         intrinsics::panic_if_uninhabited::<T>();
+        #[cfg(not(bootstrap))]
+        intrinsics::assert_inhabited::<T>();
         ManuallyDrop::into_inner(self.value)
     }
 
@@ -559,7 +562,10 @@ impl<T> MaybeUninit<T> {
     #[unstable(feature = "maybe_uninit_extra", issue = "63567")]
     #[inline(always)]
     pub unsafe fn read(&self) -> T {
+        #[cfg(bootstrap)]
         intrinsics::panic_if_uninhabited::<T>();
+        #[cfg(not(bootstrap))]
+        intrinsics::assert_inhabited::<T>();
         self.as_ptr().read()
     }
 
@@ -621,7 +627,10 @@ impl<T> MaybeUninit<T> {
     #[unstable(feature = "maybe_uninit_ref", issue = "63568")]
     #[inline(always)]
     pub unsafe fn get_ref(&self) -> &T {
+        #[cfg(bootstrap)]
         intrinsics::panic_if_uninhabited::<T>();
+        #[cfg(not(bootstrap))]
+        intrinsics::assert_inhabited::<T>();
         &*self.value
     }
 
@@ -739,7 +748,10 @@ impl<T> MaybeUninit<T> {
     #[unstable(feature = "maybe_uninit_ref", issue = "63568")]
     #[inline(always)]
     pub unsafe fn get_mut(&mut self) -> &mut T {
+        #[cfg(bootstrap)]
         intrinsics::panic_if_uninhabited::<T>();
+        #[cfg(not(bootstrap))]
+        intrinsics::assert_inhabited::<T>();
         &mut *self.value
     }
 

--- a/src/libcore/mem/mod.rs
+++ b/src/libcore/mem/mod.rs
@@ -497,7 +497,7 @@ pub const fn needs_drop<T>() -> bool {
 #[rustc_diagnostic_item = "mem_zeroed"]
 pub unsafe fn zeroed<T>() -> T {
     #[cfg(not(bootstrap))]
-    intrinsics::panic_if_zero_invalid::<T>();
+    intrinsics::assert_zero_valid::<T>();
     #[cfg(bootstrap)]
     intrinsics::panic_if_uninhabited::<T>();
     intrinsics::init()
@@ -533,7 +533,7 @@ pub unsafe fn zeroed<T>() -> T {
 #[rustc_diagnostic_item = "mem_uninitialized"]
 pub unsafe fn uninitialized<T>() -> T {
     #[cfg(not(bootstrap))]
-    intrinsics::panic_if_any_invalid::<T>();
+    intrinsics::assert_uninit_valid::<T>();
     #[cfg(bootstrap)]
     intrinsics::panic_if_uninhabited::<T>();
     intrinsics::uninit()

--- a/src/libcore/str/pattern.rs
+++ b/src/libcore/str/pattern.rs
@@ -365,11 +365,7 @@ unsafe impl<'a> ReverseSearcher<'a> for CharSearcher<'a> {
         let haystack = self.haystack.as_bytes();
         loop {
             // get the haystack up to but not including the last character searched
-            let bytes = if let Some(slice) = haystack.get(self.finger..self.finger_back) {
-                slice
-            } else {
-                return None;
-            };
+            let bytes = haystack.get(self.finger..self.finger_back)?;
             // the last byte of the utf8 encoded needle
             // SAFETY: we have an invariant that `utf8_size < 5`
             let last_byte = unsafe { *self.utf8_encoded.get_unchecked(self.utf8_size - 1) };
@@ -575,11 +571,12 @@ macro_rules! pattern_methods {
 
         #[inline]
         fn is_suffix_of(self, haystack: &'a str) -> bool
-            where $t: ReverseSearcher<'a>
+        where
+            $t: ReverseSearcher<'a>,
         {
             ($pmap)(self).is_suffix_of(haystack)
         }
-    }
+    };
 }
 
 macro_rules! searcher_methods {
@@ -614,7 +611,7 @@ macro_rules! searcher_methods {
         fn next_reject_back(&mut self) -> Option<(usize, usize)> {
             self.0.next_reject_back()
         }
-    }
+    };
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -179,7 +179,7 @@ macro_rules! define_dep_nodes {
             $(
                 #[inline(always)]
                 #[allow(unreachable_code, non_snake_case)]
-                pub fn $variant<'tcx>(_tcx: TyCtxt<'tcx>, $(arg: $tuple_arg_ty)*) -> DepNode {
+                pub fn $variant(_tcx: TyCtxt<'_>, $(arg: $tuple_arg_ty)*) -> DepNode {
                     // tuple args
                     $({
                         erase!($tuple_arg_ty);

--- a/src/librustc/hir/map/collector.rs
+++ b/src/librustc/hir/map/collector.rs
@@ -340,7 +340,7 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
     /// deep walking so that we walk nested items in the context of
     /// their outer items.
 
-    fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, Self::Map> {
+    fn nested_visit_map(&mut self) -> NestedVisitorMap<'_, Self::Map> {
         panic!("`visit_nested_xxx` must be manually implemented in this visitor");
     }
 

--- a/src/librustc/hir/map/hir_id_validator.rs
+++ b/src/librustc/hir/map/hir_id_validator.rs
@@ -135,7 +135,7 @@ impl<'a, 'hir> HirIdValidator<'a, 'hir> {
 impl<'a, 'hir> intravisit::Visitor<'hir> for HirIdValidator<'a, 'hir> {
     type Map = Map<'hir>;
 
-    fn nested_visit_map<'this>(&'this mut self) -> intravisit::NestedVisitorMap<'this, Self::Map> {
+    fn nested_visit_map(&mut self) -> intravisit::NestedVisitorMap<'_, Self::Map> {
         intravisit::NestedVisitorMap::OnlyBodies(self.hir_map)
     }
 

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -298,7 +298,7 @@ impl<'hir> Map<'hir> {
     }
 
     pub fn def_kind(&self, hir_id: HirId) -> Option<DefKind> {
-        let node = if let Some(node) = self.find(hir_id) { node } else { return None };
+        let node = self.find(hir_id)?;
 
         Some(match node {
             Node::Item(item) => match item.kind {

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -403,7 +403,7 @@ pub enum ClearCrossCrate<T> {
 }
 
 impl<T> ClearCrossCrate<T> {
-    pub fn as_ref(&'a self) -> ClearCrossCrate<&'a T> {
+    pub fn as_ref(&self) -> ClearCrossCrate<&T> {
         match self {
             ClearCrossCrate::Clear => ClearCrossCrate::Clear,
             ClearCrossCrate::Set(v) => ClearCrossCrate::Set(v),
@@ -2503,7 +2503,7 @@ impl UserTypeProjection {
 
     pub(crate) fn variant(
         mut self,
-        adt_def: &'tcx AdtDef,
+        adt_def: &AdtDef,
         variant_index: VariantIdx,
         field: Field,
     ) -> Self {

--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -346,12 +346,7 @@ impl<'tcx> TyCtxt<'tcx> {
         adt_did: DefId,
         validate: &mut dyn FnMut(Self, DefId) -> Result<(), ErrorReported>,
     ) -> Option<ty::Destructor> {
-        let drop_trait = if let Some(def_id) = self.lang_items().drop_trait() {
-            def_id
-        } else {
-            return None;
-        };
-
+        let drop_trait = self.lang_items().drop_trait()?;
         self.ensure().coherent_trait(drop_trait);
 
         let mut dtor_did = None;

--- a/src/librustc_codegen_llvm/common.rs
+++ b/src/librustc_codegen_llvm/common.rs
@@ -320,7 +320,7 @@ impl ConstMethods<'tcx> for CodegenCx<'ll, 'tcx> {
     }
 }
 
-pub fn val_ty(v: &'ll Value) -> &'ll Type {
+pub fn val_ty(v: &Value) -> &Type {
     unsafe { llvm::LLVMTypeOf(v) }
 }
 
@@ -342,6 +342,6 @@ fn hi_lo_to_u128(lo: u64, hi: u64) -> u128 {
     ((hi as u128) << 64) | (lo as u128)
 }
 
-fn try_as_const_integral(v: &'ll Value) -> Option<&'ll ConstantInt> {
+fn try_as_const_integral(v: &Value) -> Option<&ConstantInt> {
     unsafe { llvm::LLVMIsAConstantInt(v) }
 }

--- a/src/librustc_codegen_llvm/llvm/mod.rs
+++ b/src/librustc_codegen_llvm/llvm/mod.rs
@@ -185,12 +185,12 @@ impl Drop for SectionIter<'a> {
     }
 }
 
-pub fn mk_section_iter(llof: &'a ffi::ObjectFile) -> SectionIter<'a> {
+pub fn mk_section_iter(llof: &ffi::ObjectFile) -> SectionIter<'_> {
     unsafe { SectionIter { llsi: LLVMGetSections(llof) } }
 }
 
 /// Safe wrapper around `LLVMGetParam`, because segfaults are no fun.
-pub fn get_param(llfn: &'a Value, index: c_uint) -> &'a Value {
+pub fn get_param(llfn: &Value, index: c_uint) -> &Value {
     unsafe {
         assert!(
             index < LLVMCountParams(llfn),
@@ -203,7 +203,7 @@ pub fn get_param(llfn: &'a Value, index: c_uint) -> &'a Value {
 }
 
 /// Safe wrapper for `LLVMGetValueName2` into a byte slice
-pub fn get_value_name(value: &'a Value) -> &'a [u8] {
+pub fn get_value_name(value: &Value) -> &[u8] {
     unsafe {
         let mut len = 0;
         let data = LLVMGetValueName2(value, &mut len);

--- a/src/librustc_codegen_llvm/type_.rs
+++ b/src/librustc_codegen_llvm/type_.rs
@@ -240,7 +240,7 @@ impl Type {
         unsafe { llvm::LLVMIntTypeInContext(llcx, num_bits as c_uint) }
     }
 
-    pub fn i8p_llcx(llcx: &'ll llvm::Context) -> &'ll Type {
+    pub fn i8p_llcx(llcx: &llvm::Context) -> &Type {
         Type::i8_llcx(llcx).ptr_to()
     }
 

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -449,7 +449,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         destination: &Option<(mir::Place<'tcx>, mir::BasicBlock)>,
         cleanup: Option<mir::BasicBlock>,
     ) -> bool {
-        // Emit a panic or a no-op for `panic_if_uninhabited`.
+        // Emit a panic or a no-op for `assert_*` intrinsics.
         // These are intrinsics that compile to panics so that we can get a message
         // which mentions the offending type, even from a const context.
         #[derive(Debug, PartialEq)]
@@ -460,9 +460,9 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         };
         let panic_intrinsic = intrinsic.and_then(|i| match i {
             // FIXME: Move to symbols instead of strings.
-            "panic_if_uninhabited" => Some(PanicIntrinsic::IfUninhabited),
-            "panic_if_zero_invalid" => Some(PanicIntrinsic::IfZeroInvalid),
-            "panic_if_any_invalid" => Some(PanicIntrinsic::IfAnyInvalid),
+            "assert_inhabited" => Some(PanicIntrinsic::IfUninhabited),
+            "assert_zero_valid" => Some(PanicIntrinsic::IfZeroInvalid),
+            "assert_uninit_valid" => Some(PanicIntrinsic::IfAnyInvalid),
             _ => None,
         });
         if let Some(intrinsic) = panic_intrinsic {

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -453,34 +453,34 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         // These are intrinsics that compile to panics so that we can get a message
         // which mentions the offending type, even from a const context.
         #[derive(Debug, PartialEq)]
-        enum PanicIntrinsic {
-            IfUninhabited,
-            IfZeroInvalid,
-            IfAnyInvalid,
+        enum AssertIntrinsic {
+            Inhabited,
+            ZeroValid,
+            UninitValid,
         };
         let panic_intrinsic = intrinsic.and_then(|i| match i {
             // FIXME: Move to symbols instead of strings.
-            "assert_inhabited" => Some(PanicIntrinsic::IfUninhabited),
-            "assert_zero_valid" => Some(PanicIntrinsic::IfZeroInvalid),
-            "assert_uninit_valid" => Some(PanicIntrinsic::IfAnyInvalid),
+            "assert_inhabited" => Some(AssertIntrinsic::Inhabited),
+            "assert_zero_valid" => Some(AssertIntrinsic::ZeroValid),
+            "assert_uninit_valid" => Some(AssertIntrinsic::UninitValid),
             _ => None,
         });
         if let Some(intrinsic) = panic_intrinsic {
-            use PanicIntrinsic::*;
+            use AssertIntrinsic::*;
             let ty = instance.unwrap().substs.type_at(0);
             let layout = bx.layout_of(ty);
             let do_panic = match intrinsic {
-                IfUninhabited => layout.abi.is_uninhabited(),
+                Inhabited => layout.abi.is_uninhabited(),
                 // We unwrap as the error type is `!`.
-                IfZeroInvalid => !layout.might_permit_raw_init(bx, /*zero:*/ true).unwrap(),
+                ZeroValid => !layout.might_permit_raw_init(bx, /*zero:*/ true).unwrap(),
                 // We unwrap as the error type is `!`.
-                IfAnyInvalid => !layout.might_permit_raw_init(bx, /*zero:*/ false).unwrap(),
+                UninitValid => !layout.might_permit_raw_init(bx, /*zero:*/ false).unwrap(),
             };
             if do_panic {
                 let msg_str = if layout.abi.is_uninhabited() {
                     // Use this error even for the other intrinsics as it is more precise.
                     format!("attempted to instantiate uninhabited type `{}`", ty)
-                } else if intrinsic == IfZeroInvalid {
+                } else if intrinsic == ZeroValid {
                     format!("attempted to zero-initialize type `{}`, which is invalid", ty)
                 } else {
                     format!("attempted to leave type `{}` uninitialized, which is invalid", ty)

--- a/src/librustc_data_structures/graph/scc/mod.rs
+++ b/src/librustc_data_structures/graph/scc/mod.rs
@@ -97,7 +97,7 @@ impl<N: Idx, S: Idx> GraphSuccessors<'graph> for Sccs<N, S> {
 }
 
 impl<N: Idx, S: Idx> WithSuccessors for Sccs<N, S> {
-    fn successors<'graph>(&'graph self, node: S) -> <Self as GraphSuccessors<'graph>>::Iter {
+    fn successors(&self, node: S) -> <Self as GraphSuccessors<'_>>::Iter {
         self.successors(node).iter().cloned()
     }
 }

--- a/src/librustc_data_structures/graph/vec_graph/mod.rs
+++ b/src/librustc_data_structures/graph/vec_graph/mod.rs
@@ -101,7 +101,7 @@ impl<N: Idx> GraphSuccessors<'graph> for VecGraph<N> {
 }
 
 impl<N: Idx> WithSuccessors for VecGraph<N> {
-    fn successors<'graph>(&'graph self, node: N) -> <Self as GraphSuccessors<'graph>>::Iter {
+    fn successors(&self, node: N) -> <Self as GraphSuccessors<'_>>::Iter {
         self.successors(node).iter().cloned()
     }
 }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -1120,12 +1120,7 @@ fn extra_compiler_flags() -> Option<(Vec<String>, bool)> {
         return None;
     }
 
-    let matches = if let Some(matches) = handle_options(&args) {
-        matches
-    } else {
-        return None;
-    };
-
+    let matches = handle_options(&args)?;
     let mut result = Vec::new();
     let mut excluded_cargo_defaults = false;
     for flag in ICE_REPORT_COMPILER_FLAGS {

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -96,7 +96,7 @@ trait PrinterSupport: pprust::PpAnn {
     ///
     /// (Rust does not yet support upcasting from a trait object to
     /// an object for one of its super-traits.)
-    fn pp_ann<'a>(&'a self) -> &'a dyn pprust::PpAnn;
+    fn pp_ann(&self) -> &dyn pprust::PpAnn;
 }
 
 trait HirPrinterSupport<'hir>: pprust_hir::PpAnn {
@@ -106,13 +106,13 @@ trait HirPrinterSupport<'hir>: pprust_hir::PpAnn {
 
     /// Provides a uniform interface for re-extracting a reference to an
     /// `hir_map::Map` from a value that now owns it.
-    fn hir_map<'a>(&'a self) -> Option<&'a hir_map::Map<'hir>>;
+    fn hir_map(&self) -> Option<&hir_map::Map<'hir>>;
 
     /// Produces the pretty-print annotation object.
     ///
     /// (Rust does not yet support upcasting from a trait object to
     /// an object for one of its super-traits.)
-    fn pp_ann<'a>(&'a self) -> &'a dyn pprust_hir::PpAnn;
+    fn pp_ann(&self) -> &dyn pprust_hir::PpAnn;
 
     /// Computes an user-readable representation of a path, if possible.
     fn node_path(&self, id: hir::HirId) -> Option<String> {
@@ -132,7 +132,7 @@ impl<'hir> PrinterSupport for NoAnn<'hir> {
         self.sess
     }
 
-    fn pp_ann<'a>(&'a self) -> &'a dyn pprust::PpAnn {
+    fn pp_ann(&self) -> &dyn pprust::PpAnn {
         self
     }
 }
@@ -142,11 +142,11 @@ impl<'hir> HirPrinterSupport<'hir> for NoAnn<'hir> {
         self.sess
     }
 
-    fn hir_map<'a>(&'a self) -> Option<&'a hir_map::Map<'hir>> {
+    fn hir_map(&self) -> Option<&hir_map::Map<'hir>> {
         self.tcx.map(|tcx| *tcx.hir())
     }
 
-    fn pp_ann<'a>(&'a self) -> &'a dyn pprust_hir::PpAnn {
+    fn pp_ann(&self) -> &dyn pprust_hir::PpAnn {
         self
     }
 }
@@ -170,7 +170,7 @@ impl<'hir> PrinterSupport for IdentifiedAnnotation<'hir> {
         self.sess
     }
 
-    fn pp_ann<'a>(&'a self) -> &'a dyn pprust::PpAnn {
+    fn pp_ann(&self) -> &dyn pprust::PpAnn {
         self
     }
 }
@@ -216,11 +216,11 @@ impl<'hir> HirPrinterSupport<'hir> for IdentifiedAnnotation<'hir> {
         self.sess
     }
 
-    fn hir_map<'a>(&'a self) -> Option<&'a hir_map::Map<'hir>> {
+    fn hir_map(&self) -> Option<&hir_map::Map<'hir>> {
         self.tcx.map(|tcx| *tcx.hir())
     }
 
-    fn pp_ann<'a>(&'a self) -> &'a dyn pprust_hir::PpAnn {
+    fn pp_ann(&self) -> &dyn pprust_hir::PpAnn {
         self
     }
 }
@@ -315,11 +315,11 @@ impl<'b, 'tcx> HirPrinterSupport<'tcx> for TypedAnnotation<'b, 'tcx> {
         &self.tcx.sess
     }
 
-    fn hir_map<'a>(&'a self) -> Option<&'a hir_map::Map<'tcx>> {
+    fn hir_map(&self) -> Option<&hir_map::Map<'tcx>> {
         Some(&self.tcx.hir())
     }
 
-    fn pp_ann<'a>(&'a self) -> &'a dyn pprust_hir::PpAnn {
+    fn pp_ann(&self) -> &dyn pprust_hir::PpAnn {
         self
     }
 

--- a/src/librustc_error_codes/error_codes/E0412.md
+++ b/src/librustc_error_codes/error_codes/E0412.md
@@ -1,4 +1,4 @@
-The type name used is not in scope.
+A used type name is not in scope.
 
 Erroneous code examples:
 

--- a/src/librustc_error_codes/error_codes/E0422.md
+++ b/src/librustc_error_codes/error_codes/E0422.md
@@ -1,4 +1,5 @@
-You are trying to use an identifier that is either undefined or not a struct.
+An identifier that is neither defined nor a struct was used.
+
 Erroneous code example:
 
 ```compile_fail,E0422

--- a/src/librustc_error_codes/error_codes/E0423.md
+++ b/src/librustc_error_codes/error_codes/E0423.md
@@ -1,8 +1,7 @@
 An identifier was used like a function name or a value was expected and the
 identifier exists but it belongs to a different namespace.
 
-For (an erroneous) example, here a `struct` variant name were used as a
-function:
+Erroneous code example:
 
 ```compile_fail,E0423
 struct Foo { a: bool };

--- a/src/librustc_error_codes/error_codes/E0434.md
+++ b/src/librustc_error_codes/error_codes/E0434.md
@@ -1,6 +1,4 @@
-This error indicates that a variable usage inside an inner function is invalid
-because the variable comes from a dynamic environment. Inner functions do not
-have access to their containing environment.
+A variable used inside an inner function comes from a dynamic environment.
 
 Erroneous code example:
 
@@ -14,8 +12,8 @@ fn foo() {
 }
 ```
 
-Functions do not capture local variables. To fix this error, you can replace the
-function with a closure:
+Inner functions do not have access to their containing environment. To fix this
+error, you can replace the function with a closure:
 
 ```
 fn foo() {
@@ -26,7 +24,7 @@ fn foo() {
 }
 ```
 
-or replace the captured variable with a constant or a static item:
+Or replace the captured variable with a constant or a static item:
 
 ```
 fn foo() {

--- a/src/librustc_hir/intravisit.rs
+++ b/src/librustc_hir/intravisit.rs
@@ -284,7 +284,7 @@ pub trait Visitor<'v>: Sized {
     /// If you use this, you probably don't want to process the
     /// contents of nested item-like things, since the outer loop will
     /// visit them as well.
-    fn as_deep_visitor<'s>(&'s mut self) -> DeepVisitor<'s, Self> {
+    fn as_deep_visitor(&mut self) -> DeepVisitor<'_, Self> {
         DeepVisitor::new(self)
     }
 

--- a/src/librustc_incremental/assert_dep_graph.rs
+++ b/src/librustc_incremental/assert_dep_graph.rs
@@ -162,7 +162,7 @@ impl IfThisChanged<'tcx> {
 impl Visitor<'tcx> for IfThisChanged<'tcx> {
     type Map = Map<'tcx>;
 
-    fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, Self::Map> {
+    fn nested_visit_map(&mut self) -> NestedVisitorMap<'_, Self::Map> {
         NestedVisitorMap::OnlyBodies(&self.tcx.hir())
     }
 

--- a/src/librustc_incremental/persist/dirty_clean.rs
+++ b/src/librustc_incremental/persist/dirty_clean.rs
@@ -548,7 +548,7 @@ impl FindAllAttrs<'tcx> {
 impl intravisit::Visitor<'tcx> for FindAllAttrs<'tcx> {
     type Map = Map<'tcx>;
 
-    fn nested_visit_map<'this>(&'this mut self) -> intravisit::NestedVisitorMap<'this, Self::Map> {
+    fn nested_visit_map(&mut self) -> intravisit::NestedVisitorMap<'_, Self::Map> {
         intravisit::NestedVisitorMap::All(&self.tcx.hir())
     }
 

--- a/src/librustc_infer/infer/error_reporting/need_type_info.rs
+++ b/src/librustc_infer/infer/error_reporting/need_type_info.rs
@@ -69,7 +69,7 @@ impl<'a, 'tcx> FindLocalByTypeVisitor<'a, 'tcx> {
 impl<'a, 'tcx> Visitor<'tcx> for FindLocalByTypeVisitor<'a, 'tcx> {
     type Map = Map<'tcx>;
 
-    fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, Self::Map> {
+    fn nested_visit_map(&mut self) -> NestedVisitorMap<'_, Self::Map> {
         NestedVisitorMap::OnlyBodies(&self.hir_map)
     }
 

--- a/src/librustc_infer/infer/error_reporting/nice_region_error/find_anon_type.rs
+++ b/src/librustc_infer/infer/error_reporting/nice_region_error/find_anon_type.rs
@@ -93,7 +93,7 @@ struct FindNestedTypeVisitor<'tcx> {
 impl Visitor<'tcx> for FindNestedTypeVisitor<'tcx> {
     type Map = Map<'tcx>;
 
-    fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, Self::Map> {
+    fn nested_visit_map(&mut self) -> NestedVisitorMap<'_, Self::Map> {
         NestedVisitorMap::OnlyBodies(&self.tcx.hir())
     }
 

--- a/src/librustc_infer/traits/auto_trait.rs
+++ b/src/librustc_infer/traits/auto_trait.rs
@@ -113,7 +113,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
             return AutoTraitResult::ExplicitImpl;
         }
 
-        return tcx.infer_ctxt().enter(|mut infcx| {
+        return tcx.infer_ctxt().enter(|infcx| {
             let mut fresh_preds = FxHashSet::default();
 
             // Due to the way projections are handled by SelectionContext, we need to run
@@ -164,7 +164,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
 
             let (full_env, full_user_env) = self
                 .evaluate_predicates(
-                    &mut infcx,
+                    &infcx,
                     trait_did,
                     ty,
                     new_env,

--- a/src/librustc_infer/traits/coherence.rs
+++ b/src/librustc_infer/traits/coherence.rs
@@ -451,7 +451,7 @@ fn def_id_is_local(def_id: DefId, in_crate: InCrate) -> bool {
     }
 }
 
-fn ty_is_non_local_constructor<'tcx>(ty: Ty<'tcx>, in_crate: InCrate) -> Option<Ty<'tcx>> {
+fn ty_is_non_local_constructor(ty: Ty<'_>, in_crate: InCrate) -> Option<Ty<'_>> {
     debug!("ty_is_non_local_constructor({:?})", ty);
 
     match ty.kind {

--- a/src/librustc_infer/traits/specialize/mod.rs
+++ b/src/librustc_infer/traits/specialize/mod.rs
@@ -413,12 +413,7 @@ pub(super) fn specialization_graph_provider(
 fn to_pretty_impl_header(tcx: TyCtxt<'_>, impl_def_id: DefId) -> Option<String> {
     use std::fmt::Write;
 
-    let trait_ref = if let Some(tr) = tcx.impl_trait_ref(impl_def_id) {
-        tr
-    } else {
-        return None;
-    };
-
+    let trait_ref = tcx.impl_trait_ref(impl_def_id)?;
     let mut w = "impl".to_owned();
 
     let substs = InternalSubsts::identity_for_item(tcx, impl_def_id);

--- a/src/librustc_lint/late.rs
+++ b/src/librustc_lint/late.rs
@@ -33,7 +33,7 @@ use std::slice;
 
 /// Extract the `LintStore` from the query context.
 /// This function exists because we've erased `LintStore` as `dyn Any` in the context.
-crate fn unerased_lint_store<'tcx>(tcx: TyCtxt<'tcx>) -> &'tcx LintStore {
+crate fn unerased_lint_store(tcx: TyCtxt<'_>) -> &LintStore {
     let store: &dyn Any = &*tcx.lint_store;
     store.downcast_ref().unwrap()
 }
@@ -99,7 +99,7 @@ impl<'a, 'tcx, T: LateLintPass<'a, 'tcx>> hir_visit::Visitor<'tcx>
     /// Because lints are scoped lexically, we want to walk nested
     /// items in the context of the outer item, so enable
     /// deep-walking.
-    fn nested_visit_map<'this>(&'this mut self) -> hir_visit::NestedVisitorMap<'this, Self::Map> {
+    fn nested_visit_map(&mut self) -> hir_visit::NestedVisitorMap<'_, Self::Map> {
         hir_visit::NestedVisitorMap::All(&self.context.tcx.hir())
     }
 

--- a/src/librustc_lint/levels.rs
+++ b/src/librustc_lint/levels.rs
@@ -438,7 +438,7 @@ impl LintLevelMapBuilder<'_, '_> {
 impl<'tcx> intravisit::Visitor<'tcx> for LintLevelMapBuilder<'_, 'tcx> {
     type Map = Map<'tcx>;
 
-    fn nested_visit_map<'this>(&'this mut self) -> intravisit::NestedVisitorMap<'this, Self::Map> {
+    fn nested_visit_map(&mut self) -> intravisit::NestedVisitorMap<'_, Self::Map> {
         intravisit::NestedVisitorMap::All(&self.tcx.hir())
     }
 

--- a/src/librustc_mir/const_eval/mod.rs
+++ b/src/librustc_mir/const_eval/mod.rs
@@ -43,7 +43,7 @@ pub(crate) fn const_field<'tcx>(
     op_to_const(&ecx, field)
 }
 
-pub(crate) fn const_caller_location<'tcx>(
+pub(crate) fn const_caller_location(
     tcx: TyCtxt<'tcx>,
     (file, line, col): (Symbol, u32, u32),
 ) -> ConstValue<'tcx> {

--- a/src/librustc_mir/transform/add_retag.rs
+++ b/src/librustc_mir/transform/add_retag.rs
@@ -34,7 +34,7 @@ fn is_stable(place: PlaceRef<'_>) -> bool {
 }
 
 /// Determine whether this type may be a reference (or box), and thus needs retagging.
-fn may_be_reference<'tcx>(ty: Ty<'tcx>) -> bool {
+fn may_be_reference(ty: Ty<'tcx>) -> bool {
     match ty.kind {
         // Primitive types that are not references
         ty::Bool

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -453,7 +453,7 @@ struct UnusedUnsafeVisitor<'a> {
 impl<'a, 'tcx> intravisit::Visitor<'tcx> for UnusedUnsafeVisitor<'a> {
     type Map = Map<'tcx>;
 
-    fn nested_visit_map<'this>(&'this mut self) -> intravisit::NestedVisitorMap<'this, Self::Map> {
+    fn nested_visit_map(&mut self) -> intravisit::NestedVisitorMap<'_, Self::Map> {
         intravisit::NestedVisitorMap::None
     }
 

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -944,7 +944,7 @@ fn create_generator_drop_shim<'tcx>(
     // unrelated code from the resume part of the function
     simplify::remove_dead_blocks(&mut body);
 
-    dump_mir(tcx, None, "generator_drop", &0, source, &mut body, |_, _| Ok(()));
+    dump_mir(tcx, None, "generator_drop", &0, source, &body, |_, _| Ok(()));
 
     body
 }

--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -87,7 +87,7 @@ fn mir_keys(tcx: TyCtxt<'_>, krate: CrateNum) -> &DefIdSet {
             intravisit::walk_struct_def(self, v)
         }
         type Map = Map<'tcx>;
-        fn nested_visit_map<'b>(&'b mut self) -> NestedVisitorMap<'b, Self::Map> {
+        fn nested_visit_map(&mut self) -> NestedVisitorMap<'_, Self::Map> {
             NestedVisitorMap::None
         }
     }

--- a/src/librustc_mir/util/liveness.rs
+++ b/src/librustc_mir/util/liveness.rs
@@ -293,7 +293,7 @@ fn dump_matched_mir_node<'tcx>(
         writeln!(file, "// MIR local liveness analysis for `{}`", node_path)?;
         writeln!(file, "// source = {:?}", source)?;
         writeln!(file, "// pass_name = {}", pass_name)?;
-        writeln!(file, "")?;
+        writeln!(file)?;
         write_mir_fn(tcx, source, body, &mut file, result)?;
         Ok(())
     });
@@ -316,7 +316,7 @@ pub fn write_mir_fn<'tcx>(
         write_basic_block(tcx, block, body, &mut |_, _| Ok(()), w)?;
         print(w, "   ", &result.outs)?;
         if block.index() + 1 != body.basic_blocks().len() {
-            writeln!(w, "")?;
+            writeln!(w)?;
         }
     }
 

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -134,7 +134,7 @@ fn dump_matched_mir_node<'tcx, F>(
         if let Some(ref layout) = body.generator_layout {
             writeln!(file, "// generator_layout = {:?}", layout)?;
         }
-        writeln!(file, "")?;
+        writeln!(file)?;
         extra_data(PassWhere::BeforeCFG, &mut file)?;
         write_user_type_annotations(body, &mut file)?;
         write_mir_fn(tcx, source, body, &mut extra_data, &mut file)?;
@@ -242,13 +242,13 @@ pub fn write_mir_pretty<'tcx>(
             first = false;
         } else {
             // Put empty lines between all items
-            writeln!(w, "")?;
+            writeln!(w)?;
         }
 
         write_mir_fn(tcx, MirSource::item(def_id), body, &mut |_, _| Ok(()), w)?;
 
         for (i, body) in tcx.promoted_mir(def_id).iter_enumerated() {
-            writeln!(w, "")?;
+            writeln!(w)?;
             let src = MirSource { instance: ty::InstanceDef::Item(def_id), promoted: Some(i) };
             write_mir_fn(tcx, src, body, &mut |_, _| Ok(()), w)?;
         }
@@ -271,7 +271,7 @@ where
         extra_data(PassWhere::BeforeBlock(block), w)?;
         write_basic_block(tcx, block, body, extra_data, w)?;
         if block.index() + 1 != body.basic_blocks().len() {
-            writeln!(w, "")?;
+            writeln!(w)?;
         }
     }
 
@@ -529,7 +529,7 @@ pub fn write_mir_intro<'tcx>(
     write_scope_tree(tcx, body, &scope_tree, w, OUTERMOST_SOURCE_SCOPE, 1)?;
 
     // Add an empty line before the first block is printed.
-    writeln!(w, "")?;
+    writeln!(w)?;
 
     Ok(())
 }

--- a/src/librustc_parse/lib.rs
+++ b/src/librustc_parse/lib.rs
@@ -271,11 +271,11 @@ pub fn stream_to_parser<'a>(
 /// The main usage of this function is outside of rustc, for those who uses
 /// librustc_ast as a library. Please do not remove this function while refactoring
 /// just because it is not used in rustc codebase!
-pub fn stream_to_parser_with_base_dir<'a>(
-    sess: &'a ParseSess,
+pub fn stream_to_parser_with_base_dir(
+    sess: &ParseSess,
     stream: TokenStream,
     base_dir: Directory,
-) -> Parser<'a> {
+) -> Parser<'_> {
     Parser::new(sess, stream, Some(base_dir), true, false, None)
 }
 

--- a/src/librustc_passes/check_attr.rs
+++ b/src/librustc_passes/check_attr.rs
@@ -418,7 +418,7 @@ impl CheckAttrVisitor<'tcx> {
 impl Visitor<'tcx> for CheckAttrVisitor<'tcx> {
     type Map = Map<'tcx>;
 
-    fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, Self::Map> {
+    fn nested_visit_map(&mut self) -> NestedVisitorMap<'_, Self::Map> {
         NestedVisitorMap::OnlyBodies(&self.tcx.hir())
     }
 

--- a/src/librustc_passes/lang_items.rs
+++ b/src/librustc_passes/lang_items.rs
@@ -143,7 +143,7 @@ impl LanguageItemCollector<'tcx> {
 }
 
 /// Traverses and collects all the lang items in all crates.
-fn collect<'tcx>(tcx: TyCtxt<'tcx>) -> LanguageItems {
+fn collect(tcx: TyCtxt<'_>) -> LanguageItems {
     // Initialize the collector.
     let mut collector = LanguageItemCollector::new(tcx);
 

--- a/src/librustc_passes/upvars.rs
+++ b/src/librustc_passes/upvars.rs
@@ -46,7 +46,7 @@ struct LocalCollector {
 impl Visitor<'tcx> for LocalCollector {
     type Map = Map<'tcx>;
 
-    fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, Self::Map> {
+    fn nested_visit_map(&mut self) -> NestedVisitorMap<'_, Self::Map> {
         NestedVisitorMap::None
     }
 
@@ -75,7 +75,7 @@ impl CaptureCollector<'_, '_> {
 impl Visitor<'tcx> for CaptureCollector<'a, 'tcx> {
     type Map = Map<'tcx>;
 
-    fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, Self::Map> {
+    fn nested_visit_map(&mut self) -> NestedVisitorMap<'_, Self::Map> {
         NestedVisitorMap::None
     }
 

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -1107,11 +1107,7 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
                 }
             };
 
-            match (
-                lifetime_names.len(),
-                lifetime_names.iter().next(),
-                snippet.as_ref().map(|s| s.as_str()),
-            ) {
+            match (lifetime_names.len(), lifetime_names.iter().next(), snippet.as_deref()) {
                 (1, Some(name), Some("&")) => {
                     suggest_existing(err, format!("&{} ", name));
                 }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2778,12 +2778,8 @@ impl<'a> Resolver<'a> {
             } else {
                 let crate_id = if !speculative {
                     self.crate_loader.process_path_extern(ident.name, ident.span)
-                } else if let Some(crate_id) =
-                    self.crate_loader.maybe_process_path_extern(ident.name, ident.span)
-                {
-                    crate_id
                 } else {
-                    return None;
+                    self.crate_loader.maybe_process_path_extern(ident.name, ident.span)?
                 };
                 let crate_root = self.get_module(DefId { krate: crate_id, index: CRATE_DEF_INDEX });
                 Some(

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -1167,11 +1167,7 @@ impl SourceFile {
         }
 
         let begin = {
-            let line = if let Some(line) = self.lines.get(line_number) {
-                line
-            } else {
-                return None;
-            };
+            let line = self.lines.get(line_number)?;
             let begin: BytePos = *line - self.start_pos;
             begin.to_usize()
         };

--- a/src/librustc_traits/lowering/mod.rs
+++ b/src/librustc_traits/lowering/mod.rs
@@ -603,7 +603,7 @@ impl ClauseDumper<'tcx> {
 impl Visitor<'tcx> for ClauseDumper<'tcx> {
     type Map = Map<'tcx>;
 
-    fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, Self::Map> {
+    fn nested_visit_map(&mut self) -> NestedVisitorMap<'_, Self::Map> {
         NestedVisitorMap::OnlyBodies(&self.tcx.hir())
     }
 

--- a/src/librustc_ty/ty.rs
+++ b/src/librustc_ty/ty.rs
@@ -210,7 +210,7 @@ fn associated_item_def_ids(tcx: TyCtxt<'_>, def_id: DefId) -> &[DefId] {
     }
 }
 
-fn associated_items<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> &'tcx ty::AssociatedItems {
+fn associated_items(tcx: TyCtxt<'_>, def_id: DefId) -> &ty::AssociatedItems {
     let items = tcx.associated_item_def_ids(def_id).iter().map(|did| tcx.associated_item(*did));
     tcx.arena.alloc(ty::AssociatedItems::new(items))
 }

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -111,7 +111,7 @@ fn identity(_: Ty<'_>) -> Vec<Adjustment<'_>> {
     vec![]
 }
 
-fn simple<'tcx>(kind: Adjust<'tcx>) -> impl FnOnce(Ty<'tcx>) -> Vec<Adjustment<'tcx>> {
+fn simple(kind: Adjust<'tcx>) -> impl FnOnce(Ty<'tcx>) -> Vec<Adjustment<'tcx>> {
     move |target| vec![Adjustment { kind, target }]
 }
 

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -147,7 +147,7 @@ pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem<'_>) {
             ),
             "rustc_peek" => (1, vec![param(0)], param(0)),
             "caller_location" => (0, vec![], tcx.caller_location_ty()),
-            "panic_if_uninhabited" | "panic_if_zero_invalid" | "panic_if_any_invalid" => {
+            "assert_inhabited" | "assert_zero_valid" | "assert_uninit_valid" => {
                 (1, Vec::new(), tcx.mk_unit())
             }
             "init" => (1, Vec::new(), param(0)),

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -860,7 +860,7 @@ enum Op {
 }
 
 /// Dereferences a single level of immutable referencing.
-fn deref_ty_if_possible<'tcx>(ty: Ty<'tcx>) -> Ty<'tcx> {
+fn deref_ty_if_possible(ty: Ty<'tcx>) -> Ty<'tcx> {
     match ty.kind {
         ty::Ref(_, ty, hir::Mutability::Not) => ty,
         _ => ty,

--- a/src/librustc_typeck/coherence/builtin.rs
+++ b/src/librustc_typeck/coherence/builtin.rs
@@ -322,7 +322,7 @@ fn visit_implementation_of_dispatch_from_dyn(tcx: TyCtxt<'_>, impl_did: DefId) {
     }
 }
 
-pub fn coerce_unsized_info<'tcx>(tcx: TyCtxt<'tcx>, impl_did: DefId) -> CoerceUnsizedInfo {
+pub fn coerce_unsized_info(tcx: TyCtxt<'tcx>, impl_did: DefId) -> CoerceUnsizedInfo {
     debug!("compute_coerce_unsized_info(impl_did={:?})", impl_did);
     let coerce_unsized_trait = tcx.lang_items().coerce_unsized_trait().unwrap();
 

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -577,7 +577,7 @@ fn filter_non_trait_generics(trait_did: DefId, mut g: clean::Generics) -> clean:
                     name: ref _name,
                 },
             ref bounds,
-        } => !(*s == "Self" && did == trait_did) && !bounds.is_empty(),
+        } => !(bounds.is_empty() || *s == "Self" && did == trait_did),
         _ => true,
     });
     g

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -42,11 +42,7 @@ pub fn try_inline(
     attrs: Option<Attrs<'_>>,
     visited: &mut FxHashSet<DefId>,
 ) -> Option<Vec<clean::Item>> {
-    let did = if let Some(did) = res.opt_def_id() {
-        did
-    } else {
-        return None;
-    };
+    let did = res.opt_def_id()?;
     if did.is_local() {
         return None;
     }

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -844,11 +844,7 @@ pub fn plain_summary_line(md: &str) -> String {
         type Item = String;
 
         fn next(&mut self) -> Option<String> {
-            let next_event = self.inner.next();
-            if next_event.is_none() {
-                return None;
-            }
-            let next_event = next_event.unwrap();
+            let next_event = self.inner.next()?;
             let (ret, is_in) = match next_event {
                 Event::Start(Tag::Paragraph) => (None, 1),
                 Event::Start(Tag::Heading(_)) => (None, 1),

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -870,7 +870,7 @@ pub fn plain_summary_line(md: &str) -> String {
     }
     let mut s = String::with_capacity(md.len() * 3 / 2);
     let p = ParserWrapper { inner: Parser::new(md), is_in: 0, is_first: true };
-    p.into_iter().filter(|t| !t.is_empty()).for_each(|i| s.push_str(&i));
+    p.filter(|t| !t.is_empty()).for_each(|i| s.push_str(&i));
     s
 }
 

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -3401,10 +3401,8 @@ fn render_assoc_items(
         let deref_impl =
             traits.iter().find(|t| t.inner_impl().trait_.def_id() == c.deref_trait_did);
         if let Some(impl_) = deref_impl {
-            let has_deref_mut = traits
-                .iter()
-                .find(|t| t.inner_impl().trait_.def_id() == c.deref_mut_trait_did)
-                .is_some();
+            let has_deref_mut =
+                traits.iter().any(|t| t.inner_impl().trait_.def_id() == c.deref_mut_trait_did);
             render_deref_methods(w, cx, impl_, containing_item, has_deref_mut);
         }
 
@@ -3816,7 +3814,7 @@ fn render_impl(
     ) {
         for trait_item in &t.items {
             let n = trait_item.name.clone();
-            if i.items.iter().find(|m| m.name == n).is_some() {
+            if i.items.iter().any(|m| m.name == n) {
                 continue;
             }
             let did = i.trait_.as_ref().unwrap().def_id().unwrap();

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1542,7 +1542,7 @@ impl Context {
         }
 
         if self.shared.sort_modules_alphabetically {
-            for (_, items) in &mut map {
+            for items in map.values_mut() {
                 items.sort();
             }
         }

--- a/src/librustdoc/html/static_files.rs
+++ b/src/librustdoc/html/static_files.rs
@@ -8,106 +8,106 @@
 //! directly written to a `Write` handle.
 
 /// The file contents of the main `rustdoc.css` file, responsible for the core layout of the page.
-pub static RUSTDOC_CSS: &'static str = include_str!("static/rustdoc.css");
+pub static RUSTDOC_CSS: &str = include_str!("static/rustdoc.css");
 
 /// The file contents of `settings.css`, responsible for the items on the settings page.
-pub static SETTINGS_CSS: &'static str = include_str!("static/settings.css");
+pub static SETTINGS_CSS: &str = include_str!("static/settings.css");
 
 /// The file contents of the `noscript.css` file, used in case JS isn't supported or is disabled.
-pub static NOSCRIPT_CSS: &'static str = include_str!("static/noscript.css");
+pub static NOSCRIPT_CSS: &str = include_str!("static/noscript.css");
 
 /// The file contents of `normalize.css`, included to even out standard elements between browser
 /// implementations.
-pub static NORMALIZE_CSS: &'static str = include_str!("static/normalize.css");
+pub static NORMALIZE_CSS: &str = include_str!("static/normalize.css");
 
 /// The file contents of `main.js`, which contains the core JavaScript used on documentation pages,
 /// including search behavior and docblock folding, among others.
-pub static MAIN_JS: &'static str = include_str!("static/main.js");
+pub static MAIN_JS: &str = include_str!("static/main.js");
 
 /// The file contents of `settings.js`, which contains the JavaScript used to handle the settings
 /// page.
-pub static SETTINGS_JS: &'static str = include_str!("static/settings.js");
+pub static SETTINGS_JS: &str = include_str!("static/settings.js");
 
 /// The file contents of `storage.js`, which contains functionality related to browser Local
 /// Storage, used to store documentation settings.
-pub static STORAGE_JS: &'static str = include_str!("static/storage.js");
+pub static STORAGE_JS: &str = include_str!("static/storage.js");
 
 /// The file contents of `brush.svg`, the icon used for the theme-switch button.
-pub static BRUSH_SVG: &'static [u8] = include_bytes!("static/brush.svg");
+pub static BRUSH_SVG: &[u8] = include_bytes!("static/brush.svg");
 
 /// The file contents of `wheel.svg`, the icon used for the settings button.
-pub static WHEEL_SVG: &'static [u8] = include_bytes!("static/wheel.svg");
+pub static WHEEL_SVG: &[u8] = include_bytes!("static/wheel.svg");
 
 /// The file contents of `down-arrow.svg`, the icon used for the crate choice combobox.
-pub static DOWN_ARROW_SVG: &'static [u8] = include_bytes!("static/down-arrow.svg");
+pub static DOWN_ARROW_SVG: &[u8] = include_bytes!("static/down-arrow.svg");
 
 /// The contents of `COPYRIGHT.txt`, the license listing for files distributed with documentation
 /// output.
-pub static COPYRIGHT: &'static [u8] = include_bytes!("static/COPYRIGHT.txt");
+pub static COPYRIGHT: &[u8] = include_bytes!("static/COPYRIGHT.txt");
 
 /// The contents of `LICENSE-APACHE.txt`, the text of the Apache License, version 2.0.
-pub static LICENSE_APACHE: &'static [u8] = include_bytes!("static/LICENSE-APACHE.txt");
+pub static LICENSE_APACHE: &[u8] = include_bytes!("static/LICENSE-APACHE.txt");
 
 /// The contents of `LICENSE-MIT.txt`, the text of the MIT License.
-pub static LICENSE_MIT: &'static [u8] = include_bytes!("static/LICENSE-MIT.txt");
+pub static LICENSE_MIT: &[u8] = include_bytes!("static/LICENSE-MIT.txt");
 
 /// The contents of `rust-logo.png`, the default icon of the documentation.
-pub static RUST_LOGO: &'static [u8] = include_bytes!("static/rust-logo.png");
+pub static RUST_LOGO: &[u8] = include_bytes!("static/rust-logo.png");
 /// The contents of `favicon.ico`, the default favicon of the documentation.
-pub static RUST_FAVICON: &'static [u8] = include_bytes!("static/favicon.ico");
+pub static RUST_FAVICON: &[u8] = include_bytes!("static/favicon.ico");
 
 /// The built-in themes given to every documentation site.
 pub mod themes {
     /// The "light" theme, selected by default when no setting is available. Used as the basis for
     /// the `--check-theme` functionality.
-    pub static LIGHT: &'static str = include_str!("static/themes/light.css");
+    pub static LIGHT: &str = include_str!("static/themes/light.css");
 
     /// The "dark" theme.
-    pub static DARK: &'static str = include_str!("static/themes/dark.css");
+    pub static DARK: &str = include_str!("static/themes/dark.css");
 }
 
 /// Files related to the Fira Sans font.
 pub mod fira_sans {
     /// The file `FiraSans-Regular.woff`, the Regular variant of the Fira Sans font.
-    pub static REGULAR: &'static [u8] = include_bytes!("static/FiraSans-Regular.woff");
+    pub static REGULAR: &[u8] = include_bytes!("static/FiraSans-Regular.woff");
 
     /// The file `FiraSans-Medium.woff`, the Medium variant of the Fira Sans font.
-    pub static MEDIUM: &'static [u8] = include_bytes!("static/FiraSans-Medium.woff");
+    pub static MEDIUM: &[u8] = include_bytes!("static/FiraSans-Medium.woff");
 
     /// The file `FiraSans-LICENSE.txt`, the license text for the Fira Sans font.
-    pub static LICENSE: &'static [u8] = include_bytes!("static/FiraSans-LICENSE.txt");
+    pub static LICENSE: &[u8] = include_bytes!("static/FiraSans-LICENSE.txt");
 }
 
 /// Files related to the Source Serif Pro font.
 pub mod source_serif_pro {
     /// The file `SourceSerifPro-Regular.ttf.woff`, the Regular variant of the Source Serif Pro
     /// font.
-    pub static REGULAR: &'static [u8] = include_bytes!("static/SourceSerifPro-Regular.ttf.woff");
+    pub static REGULAR: &[u8] = include_bytes!("static/SourceSerifPro-Regular.ttf.woff");
 
     /// The file `SourceSerifPro-Bold.ttf.woff`, the Bold variant of the Source Serif Pro font.
-    pub static BOLD: &'static [u8] = include_bytes!("static/SourceSerifPro-Bold.ttf.woff");
+    pub static BOLD: &[u8] = include_bytes!("static/SourceSerifPro-Bold.ttf.woff");
 
     /// The file `SourceSerifPro-It.ttf.woff`, the Italic variant of the Source Serif Pro font.
-    pub static ITALIC: &'static [u8] = include_bytes!("static/SourceSerifPro-It.ttf.woff");
+    pub static ITALIC: &[u8] = include_bytes!("static/SourceSerifPro-It.ttf.woff");
 
     /// The file `SourceSerifPro-LICENSE.txt`, the license text for the Source Serif Pro font.
-    pub static LICENSE: &'static [u8] = include_bytes!("static/SourceSerifPro-LICENSE.md");
+    pub static LICENSE: &[u8] = include_bytes!("static/SourceSerifPro-LICENSE.md");
 }
 
 /// Files related to the Source Code Pro font.
 pub mod source_code_pro {
     /// The file `SourceCodePro-Regular.woff`, the Regular variant of the Source Code Pro font.
-    pub static REGULAR: &'static [u8] = include_bytes!("static/SourceCodePro-Regular.woff");
+    pub static REGULAR: &[u8] = include_bytes!("static/SourceCodePro-Regular.woff");
 
     /// The file `SourceCodePro-Semibold.woff`, the Semibold variant of the Source Code Pro font.
-    pub static SEMIBOLD: &'static [u8] = include_bytes!("static/SourceCodePro-Semibold.woff");
+    pub static SEMIBOLD: &[u8] = include_bytes!("static/SourceCodePro-Semibold.woff");
 
     /// The file `SourceCodePro-LICENSE.txt`, the license text of the Source Code Pro font.
-    pub static LICENSE: &'static [u8] = include_bytes!("static/SourceCodePro-LICENSE.txt");
+    pub static LICENSE: &[u8] = include_bytes!("static/SourceCodePro-LICENSE.txt");
 }
 
 /// Files related to the sidebar in rustdoc sources.
 pub mod sidebar {
     /// File script to handle sidebar.
-    pub static SOURCE_SCRIPT: &'static str = include_str!("static/source-script.js");
+    pub static SOURCE_SCRIPT: &str = include_str!("static/source-script.js");
 }

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1051,6 +1051,7 @@ impl<'a> DerefMut for IoSliceMut<'a> {
 /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
 /// Windows.
 #[stable(feature = "iovec", since = "1.36.0")]
+#[derive(Copy, Clone)]
 #[repr(transparent)]
 pub struct IoSlice<'a>(sys::io::IoSlice<'a>);
 

--- a/src/libstd/keyword_docs.rs
+++ b/src/libstd/keyword_docs.rs
@@ -925,9 +925,15 @@ mod mut_keyword {}
 //
 /// Make an item visible to others.
 ///
-/// The documentation for this keyword is [not yet complete]. Pull requests welcome!
+/// The keyword `pub` makes any module, function, or data structure accessible from inside
+/// of external modules. The `pub` keyword may also be used in a `use` declaration to re-export
+/// an identifier from a namespace.
 ///
-/// [not yet complete]: https://github.com/rust-lang/rust/issues/34601
+/// For more information on the `pub` keyword, please see the visibility section
+/// of the [reference] and for some examples, see [Rust by Example].
+///
+/// [reference]:../reference/visibility-and-privacy.html?highlight=pub#visibility-and-privacy
+/// [Rust by Example]:../rust-by-example/mod/visibility.html
 mod pub_keyword {}
 
 #[doc(keyword = "ref")]

--- a/src/libstd/sys/cloudabi/io.rs
+++ b/src/libstd/sys/cloudabi/io.rs
@@ -1,5 +1,6 @@
 use crate::mem;
 
+#[derive(Copy, Clone)]
 pub struct IoSlice<'a>(&'a [u8]);
 
 impl<'a> IoSlice<'a> {

--- a/src/libstd/sys/hermit/io.rs
+++ b/src/libstd/sys/hermit/io.rs
@@ -1,5 +1,6 @@
 use crate::mem;
 
+#[derive(Copy, Clone)]
 pub struct IoSlice<'a>(&'a [u8]);
 
 impl<'a> IoSlice<'a> {

--- a/src/libstd/sys/sgx/io.rs
+++ b/src/libstd/sys/sgx/io.rs
@@ -1,5 +1,6 @@
 use crate::mem;
 
+#[derive(Copy, Clone)]
 pub struct IoSlice<'a>(&'a [u8]);
 
 impl<'a> IoSlice<'a> {

--- a/src/libstd/sys/unix/io.rs
+++ b/src/libstd/sys/unix/io.rs
@@ -3,6 +3,7 @@ use crate::slice;
 
 use libc::{c_void, iovec};
 
+#[derive(Copy, Clone)]
 #[repr(transparent)]
 pub struct IoSlice<'a> {
     vec: iovec,

--- a/src/libstd/sys/vxworks/io.rs
+++ b/src/libstd/sys/vxworks/io.rs
@@ -3,6 +3,7 @@ use crate::slice;
 
 use libc::{c_void, iovec};
 
+#[derive(Copy, Clone)]
 #[repr(transparent)]
 pub struct IoSlice<'a> {
     vec: iovec,

--- a/src/libstd/sys/wasi/io.rs
+++ b/src/libstd/sys/wasi/io.rs
@@ -1,6 +1,7 @@
 use crate::marker::PhantomData;
 use crate::slice;
 
+#[derive(Copy, Clone)]
 #[repr(transparent)]
 pub struct IoSlice<'a> {
     vec: wasi::Ciovec,

--- a/src/libstd/sys/wasm/io.rs
+++ b/src/libstd/sys/wasm/io.rs
@@ -1,5 +1,6 @@
 use crate::mem;
 
+#[derive(Copy, Clone)]
 pub struct IoSlice<'a>(&'a [u8]);
 
 impl<'a> IoSlice<'a> {

--- a/src/libstd/sys/windows/c.rs
+++ b/src/libstd/sys/windows/c.rs
@@ -295,6 +295,7 @@ pub struct WSADATA {
     pub szSystemStatus: [u8; WSASYS_STATUS_LEN + 1],
 }
 
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct WSABUF {
     pub len: ULONG,

--- a/src/libstd/sys/windows/io.rs
+++ b/src/libstd/sys/windows/io.rs
@@ -2,6 +2,7 @@ use crate::marker::PhantomData;
 use crate::slice;
 use crate::sys::c;
 
+#[derive(Copy, Clone)]
 #[repr(transparent)]
 pub struct IoSlice<'a> {
     vec: c::WSABUF,

--- a/src/libstd/sys_common/backtrace.rs
+++ b/src/libstd/sys_common/backtrace.rs
@@ -70,7 +70,7 @@ unsafe fn _print_fmt(fmt: &mut fmt::Formatter<'_>, print_fmt: PrintFmt) -> fmt::
     let mut print_path = move |fmt: &mut fmt::Formatter<'_>, bows: BytesOrWideString<'_>| {
         output_filename(fmt, bows, print_fmt, cwd.as_ref())
     };
-    write!(fmt, "stack backtrace:\n")?;
+    writeln!(fmt, "stack backtrace:")?;
     let mut bt_fmt = BacktraceFmt::new(fmt, print_fmt, &mut print_path);
     bt_fmt.add_context()?;
     let mut idx = 0;

--- a/src/libstd/sys_common/process.rs
+++ b/src/libstd/sys_common/process.rs
@@ -47,7 +47,7 @@ impl CommandEnv {
             }
         }
         for (key, maybe_val) in self.vars.iter() {
-            if let &Some(ref val) = maybe_val {
+            if let Some(ref val) = maybe_val {
                 env::set_var(key, val);
             } else {
                 env::remove_var(key);

--- a/src/libstd/sys_common/wtf8.rs
+++ b/src/libstd/sys_common/wtf8.rs
@@ -603,8 +603,8 @@ impl Wtf8 {
         if len < 3 {
             return None;
         }
-        match &self.bytes[(len - 3)..] {
-            &[0xED, b2 @ 0xA0..=0xAF, b3] => Some(decode_surrogate(b2, b3)),
+        match self.bytes[(len - 3)..] {
+            [0xED, b2 @ 0xA0..=0xAF, b3] => Some(decode_surrogate(b2, b3)),
             _ => None,
         }
     }
@@ -615,8 +615,8 @@ impl Wtf8 {
         if len < 3 {
             return None;
         }
-        match &self.bytes[..3] {
-            &[0xED, b2 @ 0xB0..=0xBF, b3] => Some(decode_surrogate(b2, b3)),
+        match self.bytes[..3] {
+            [0xED, b2 @ 0xB0..=0xBF, b3] => Some(decode_surrogate(b2, b3)),
             _ => None,
         }
     }

--- a/src/libtest/console.rs
+++ b/src/libtest/console.rs
@@ -169,7 +169,7 @@ pub fn list_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Res
 
     if !quiet {
         if ntest != 0 || nbench != 0 {
-            writeln!(output, "")?;
+            writeln!(output)?;
         }
 
         writeln!(output, "{}, {}", plural(ntest, "test"), plural(nbench, "benchmark"))?;

--- a/src/libtest/formatters/mod.rs
+++ b/src/libtest/formatters/mod.rs
@@ -36,5 +36,5 @@ pub(crate) fn write_stderr_delimiter(test_output: &mut Vec<u8>, test_name: &Test
         Some(_) => test_output.push(b'\n'),
         None => (),
     }
-    write!(test_output, "---- {} stderr ----\n", test_name).unwrap();
+    writeln!(test_output, "---- {} stderr ----", test_name).unwrap();
 }

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -204,7 +204,7 @@ impl Stats for [f64] {
     }
 
     fn median(&self) -> f64 {
-        self.percentile(50 as f64)
+        self.percentile(50_f64)
     }
 
     fn var(&self) -> f64 {
@@ -230,7 +230,7 @@ impl Stats for [f64] {
     }
 
     fn std_dev_pct(&self) -> f64 {
-        let hundred = 100 as f64;
+        let hundred = 100_f64;
         (self.std_dev() / self.mean()) * hundred
     }
 
@@ -244,7 +244,7 @@ impl Stats for [f64] {
     }
 
     fn median_abs_dev_pct(&self) -> f64 {
-        let hundred = 100 as f64;
+        let hundred = 100_f64;
         (self.median_abs_dev() / self.median()) * hundred
     }
 
@@ -257,11 +257,11 @@ impl Stats for [f64] {
     fn quartiles(&self) -> (f64, f64, f64) {
         let mut tmp = self.to_vec();
         local_sort(&mut tmp);
-        let first = 25f64;
+        let first = 25_f64;
         let a = percentile_of_sorted(&tmp, first);
-        let second = 50f64;
+        let second = 50_f64;
         let b = percentile_of_sorted(&tmp, second);
-        let third = 75f64;
+        let third = 75_f64;
         let c = percentile_of_sorted(&tmp, third);
         (a, b, c)
     }
@@ -281,7 +281,7 @@ fn percentile_of_sorted(sorted_samples: &[f64], pct: f64) -> f64 {
     }
     let zero: f64 = 0.0;
     assert!(zero <= pct);
-    let hundred = 100f64;
+    let hundred = 100_f64;
     assert!(pct <= hundred);
     if pct == hundred {
         return sorted_samples[sorted_samples.len() - 1];
@@ -307,7 +307,7 @@ pub fn winsorize(samples: &mut [f64], pct: f64) {
     let mut tmp = samples.to_vec();
     local_sort(&mut tmp);
     let lo = percentile_of_sorted(&tmp, pct);
-    let hundred = 100 as f64;
+    let hundred = 100_f64;
     let hi = percentile_of_sorted(&tmp, hundred - pct);
     for samp in samples {
         if *samp > hi {

--- a/src/libtest/types.rs
+++ b/src/libtest/types.rs
@@ -59,10 +59,10 @@ impl TestName {
     }
 
     pub fn with_padding(&self, padding: NamePadding) -> TestName {
-        let name = match self {
-            &TestName::StaticTestName(name) => Cow::Borrowed(name),
-            &TestName::DynTestName(ref name) => Cow::Owned(name.clone()),
-            &TestName::AlignedTestName(ref name, _) => name.clone(),
+        let name = match *self {
+            TestName::StaticTestName(name) => Cow::Borrowed(name),
+            TestName::DynTestName(ref name) => Cow::Owned(name.clone()),
+            TestName::AlignedTestName(ref name, _) => name.clone(),
         };
 
         TestName::AlignedTestName(name, padding)

--- a/src/test/ui/asm/issue-69092.rs
+++ b/src/test/ui/asm/issue-69092.rs
@@ -1,0 +1,10 @@
+// build-fail
+// ignore-emscripten no asm! support
+// Regression test for #69092
+
+#![feature(asm)]
+
+fn main() {
+    unsafe { asm!(".ascii \"Xen\0\""); }
+    //~^ ERROR: <inline asm>:1:9: error: expected string in '.ascii' directive
+}

--- a/src/test/ui/asm/issue-69092.stderr
+++ b/src/test/ui/asm/issue-69092.stderr
@@ -1,0 +1,11 @@
+error: <inline asm>:1:9: error: expected string in '.ascii' directive
+        .ascii "Xen
+               ^
+
+  --> $DIR/issue-69092.rs:8:14
+   |
+LL |     unsafe { asm!(".ascii \"Xen\0\""); }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/const-generics/issues/issue-62504.rs
+++ b/src/test/ui/const-generics/issues/issue-62504.rs
@@ -1,0 +1,25 @@
+// Regression test for #62504
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+trait HasSize {
+    const SIZE: usize;
+}
+
+impl<const X: usize> HasSize for ArrayHolder<{ X }> {
+    const SIZE: usize = X;
+}
+
+struct ArrayHolder<const X: usize>([u32; X]);
+
+impl<const X: usize> ArrayHolder<{ X }> {
+    pub const fn new() -> Self {
+        ArrayHolder([0; Self::SIZE])
+        //~^ ERROR: array lengths can't depend on generic parameters
+    }
+}
+
+fn main() {
+    let mut array = ArrayHolder::new();
+}

--- a/src/test/ui/const-generics/issues/issue-62504.stderr
+++ b/src/test/ui/const-generics/issues/issue-62504.stderr
@@ -1,0 +1,8 @@
+error: array lengths can't depend on generic parameters
+  --> $DIR/issue-62504.rs:18:25
+   |
+LL |         ArrayHolder([0; Self::SIZE])
+   |                         ^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/const-generics/issues/issue-67739.rs
+++ b/src/test/ui/const-generics/issues/issue-67739.rs
@@ -1,0 +1,18 @@
+// Regression test for #67739
+
+#![allow(incomplete_features)]
+#![feature(const_generics)]
+
+use std::mem;
+
+pub trait Trait {
+    type Associated: Sized;
+
+    fn associated_size(&self) -> usize {
+        [0u8; mem::size_of::<Self::Associated>()];
+        //~^ ERROR: array lengths can't depend on generic parameters
+        0
+    }
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-67739.stderr
+++ b/src/test/ui/const-generics/issues/issue-67739.stderr
@@ -1,0 +1,8 @@
+error: array lengths can't depend on generic parameters
+  --> $DIR/issue-67739.rs:12:15
+   |
+LL |         [0u8; mem::size_of::<Self::Associated>()];
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/consts/const-eval/const_prop_errors.rs
+++ b/src/test/ui/consts/const-eval/const_prop_errors.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 pub trait Foo {
     fn foo(self) -> u32;

--- a/src/test/ui/consts/const-eval/const_signed_pat.rs
+++ b/src/test/ui/consts/const-eval/const_signed_pat.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 fn main() {
     const MIN: i8 = -5;

--- a/src/test/ui/consts/const-eval/double_check.rs
+++ b/src/test/ui/consts/const-eval/double_check.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 enum Foo {
     A = 5,

--- a/src/test/ui/consts/const-eval/double_promotion.rs
+++ b/src/test/ui/consts/const-eval/double_promotion.rs
@@ -1,4 +1,4 @@
-// build-pass
+// check-pass
 
 #![feature(const_fn, rustc_attrs)]
 

--- a/src/test/ui/consts/const-eval/double_promotion.rs
+++ b/src/test/ui/consts/const-eval/double_promotion.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// build-pass
 
 #![feature(const_fn, rustc_attrs)]
 

--- a/src/test/ui/consts/const-eval/duration_conversion.rs
+++ b/src/test/ui/consts/const-eval/duration_conversion.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 use std::time::Duration;
 

--- a/src/test/ui/consts/const-eval/extern_fat_pointer.rs
+++ b/src/test/ui/consts/const-eval/extern_fat_pointer.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(extern_types)]
 

--- a/src/test/ui/consts/const-eval/ice-generic-assoc-const.rs
+++ b/src/test/ui/consts/const-eval/ice-generic-assoc-const.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 pub trait Nullable {
     const NULL: Self;

--- a/src/test/ui/consts/const-eval/ice-packed.rs
+++ b/src/test/ui/consts/const-eval/ice-packed.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// build-pass
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(packed)]
 pub struct Num(u64);

--- a/src/test/ui/consts/const-eval/ice-packed.rs
+++ b/src/test/ui/consts/const-eval/ice-packed.rs
@@ -1,4 +1,7 @@
-// build-pass
+// Regression test for #50356: Compiler panic when using repr(packed)
+// associated constant in a match arm
+
+// check-pass
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(packed)]
 pub struct Num(u64);

--- a/src/test/ui/consts/const-eval/issue-47971.rs
+++ b/src/test/ui/consts/const-eval/issue-47971.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 struct S(pub &'static u32, pub u32);
 

--- a/src/test/ui/consts/const-eval/issue-50706.rs
+++ b/src/test/ui/consts/const-eval/issue-50706.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 pub struct Stats;
 

--- a/src/test/ui/consts/const-eval/issue-51300.rs
+++ b/src/test/ui/consts/const-eval/issue-51300.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// build-pass
 // https://github.com/rust-lang/rust/issues/51300
 
 #[derive(PartialEq, Eq, Clone, Copy)]

--- a/src/test/ui/consts/const-eval/issue-51300.rs
+++ b/src/test/ui/consts/const-eval/issue-51300.rs
@@ -1,4 +1,4 @@
-// build-pass
+// check-pass
 // https://github.com/rust-lang/rust/issues/51300
 
 #[derive(PartialEq, Eq, Clone, Copy)]

--- a/src/test/ui/consts/const-eval/issue-53157.rs
+++ b/src/test/ui/consts/const-eval/issue-53157.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 macro_rules! m {
     () => {{

--- a/src/test/ui/consts/const-eval/issue-53401.rs
+++ b/src/test/ui/consts/const-eval/issue-53401.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 pub const STATIC_TRAIT: &dyn Test = &();
 

--- a/src/test/ui/consts/const-eval/issue-55541.rs
+++ b/src/test/ui/consts/const-eval/issue-55541.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 // Test that we can handle newtypes wrapping extern types
 

--- a/src/test/ui/consts/const-eval/no_lint_for_statically_known_error.rs
+++ b/src/test/ui/consts/const-eval/no_lint_for_statically_known_error.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 // if `X` were used instead of `x`, `X - 10` would result in a lint.
 // This file should never produce a lint, no matter how the const

--- a/src/test/ui/consts/const-eval/promote_mutable_zst_mir_borrowck.rs
+++ b/src/test/ui/consts/const-eval/promote_mutable_zst_mir_borrowck.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 pub fn main() {
     let y: &'static mut [u8; 0] = &mut [];

--- a/src/test/ui/consts/const-eval/pub_const_err.rs
+++ b/src/test/ui/consts/const-eval/pub_const_err.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![warn(const_err)]
 
 #![crate_type = "lib"]

--- a/src/test/ui/consts/const-eval/pub_const_err_bin.rs
+++ b/src/test/ui/consts/const-eval/pub_const_err_bin.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![warn(const_err)]
 
 pub const Z: u32 = 0 - 1;

--- a/src/test/ui/consts/const-eval/simple_with_undef.rs
+++ b/src/test/ui/consts/const-eval/simple_with_undef.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 const PARSE_BOOL: Option<&'static str> = None;
 static FOO: (Option<&str>, u32) = (PARSE_BOOL, 42);

--- a/src/test/ui/consts/const-eval/zst_operand_eval.rs
+++ b/src/test/ui/consts/const-eval/zst_operand_eval.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 static ASSERT: () = [()][!(std::mem::size_of::<u32>() == 4) as usize];
 

--- a/src/test/ui/macros/issue-58490.rs
+++ b/src/test/ui/macros/issue-58490.rs
@@ -1,0 +1,26 @@
+// Regression test for #58490
+
+macro_rules! a {
+    ( @1 $i:item ) => {
+        a! { @2 $i }
+    };
+    ( @2 $i:item ) => {
+        $i
+    };
+}
+mod b {
+    a! {
+        @1
+        #[macro_export]
+        macro_rules! b { () => () }
+    }
+    #[macro_export]
+    macro_rules! b { () => () }
+    //~^ ERROR: the name `b` is defined multiple times
+}
+mod c {
+    #[allow(unused_imports)]
+    use crate::b;
+}
+
+fn main() {}

--- a/src/test/ui/macros/issue-58490.stderr
+++ b/src/test/ui/macros/issue-58490.stderr
@@ -1,0 +1,14 @@
+error[E0428]: the name `b` is defined multiple times
+  --> $DIR/issue-58490.rs:18:5
+   |
+LL |         macro_rules! b { () => () }
+   |         -------------- previous definition of the macro `b` here
+...
+LL |     macro_rules! b { () => () }
+   |     ^^^^^^^^^^^^^^ `b` redefined here
+   |
+   = note: `b` must be defined only once in the macro namespace of this module
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0428`.

--- a/src/test/ui/mir/issue-60390.rs
+++ b/src/test/ui/mir/issue-60390.rs
@@ -1,0 +1,8 @@
+// check-pass
+// compile-flags: --emit=mir,link
+// Regression test for #60390, this ICE requires `--emit=mir` flag.
+
+fn main() {
+    enum Inner { Member(u32) };
+    Inner::Member(0);
+}

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -11,6 +11,7 @@ allow-unauthenticated = [
 [assign]
 
 [ping.icebreakers-llvm]
+alias = ["llvm"]
 message = """\
 Hey LLVM ICE-breakers! This bug has been identified as a good
 "LLVM ICE-breaking candidate". In case it's useful, here are some
@@ -22,6 +23,7 @@ Thanks! <3
 label = "ICEBreaker-LLVM"
 
 [ping.icebreakers-cleanup-crew]
+alias = ["cleanup", "shrink", "reduce", "bisect"]
 message = """\
 Hey Cleanup Crew ICE-breakers! This bug has been identified as a good
 "Cleanup ICE-breaking candidate". In case it's useful, here are some

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -11,7 +11,7 @@ allow-unauthenticated = [
 [assign]
 
 [ping.icebreakers-llvm]
-alias = ["llvm"]
+alias = ["llvm", "llvms"]
 message = """\
 Hey LLVM ICE-breakers! This bug has been identified as a good
 "LLVM ICE-breaking candidate". In case it's useful, here are some
@@ -23,7 +23,7 @@ Thanks! <3
 label = "ICEBreaker-LLVM"
 
 [ping.icebreakers-cleanup-crew]
-alias = ["cleanup", "shrink", "reduce", "bisect"]
+alias = ["cleanup", "cleanups", "shrink", "reduce", "bisect"]
 message = """\
 Hey Cleanup Crew ICE-breakers! This bug has been identified as a good
 "Cleanup ICE-breaking candidate". In case it's useful, here are some


### PR DESCRIPTION
Successful merges:

 - #69403 (Implement `Copy` for `IoSlice`)
 - #69460 (Move some `build-pass` tests to `check-pass`)
 - #69723 (Added doc on keyword Pub.)
 - #69802 (fix more clippy findings)
 - #69809 (remove lifetimes that can be elided (clippy::needless_lifetimes))
 - #69917 (Cleanup E0412 and E0422)
 - #69947 (Clean up E0423 explanation)
 - #69949 (triagebot.toml: add ping aliases)
 - #69954 (rename panic_if_ intrinsics to assert_)
 - #69966 (Add more regression tests)
 - #69974 (Clean up E0434 explanation)

Failed merges:


r? @ghost