### PR TITLE
Add `FromIterator` impl `for [T; N]`

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -192,7 +192,6 @@ impl<T: fmt::Debug, const N: usize> fmt::Debug for [T; N] {
 
 /// Return Error of the FromIterator impl for array
 #[unstable(feature = "array_from_iter_impl", issue = "none")]
-#[derive(Debug)]
 pub struct FillError<T, const N: usize>
 where
     [MaybeUninit<T>; N]: LengthAtMost32,
@@ -215,6 +214,19 @@ where
             ),
             f,
         )
+    }
+}
+
+#[unstable(feature = "array_from_iter_impl", issue = "none")]
+impl<T: fmt::Debug, const N: usize> fmt::Debug for FillError<T, N>
+where
+    [MaybeUninit<T>; N]: LengthAtMost32,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FillError")
+            .field("array", &self.as_slice())
+            .field("len", &self.len())
+            .finish()
     }
 }
 

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -192,36 +192,23 @@ impl<T: fmt::Debug, const N: usize> fmt::Debug for [T; N] {
 
 /// Return Error of the FromIterator impl for array
 #[unstable(feature = "array_from_iter_impl", issue = "none")]
-pub struct FillError<T, const N: usize>
-where
-    [MaybeUninit<T>; N]: LengthAtMost32,
-{
+pub struct FillError<T, const N: usize> {
     array: [MaybeUninit<T>; N],
     len: usize,
 }
 
 #[unstable(feature = "array_from_iter_impl", issue = "none")]
-impl<T, const N: usize> fmt::Display for FillError<T, N>
-where
-    [MaybeUninit<T>; N]: LengthAtMost32,
-{
+impl<T, const N: usize> fmt::Display for FillError<T, N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(
-            &format_args!(
-                "The iterator only returned {} items, but {} where needed",
-                self.len(),
-                N
-            ),
+            &format_args!("The iterator only returned {} items, but {} were needed", self.len(), N),
             f,
         )
     }
 }
 
 #[unstable(feature = "array_from_iter_impl", issue = "none")]
-impl<T: fmt::Debug, const N: usize> fmt::Debug for FillError<T, N>
-where
-    [MaybeUninit<T>; N]: LengthAtMost32,
-{
+impl<T: fmt::Debug, const N: usize> fmt::Debug for FillError<T, N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FillError")
             .field("array", &self.as_slice())
@@ -231,10 +218,7 @@ where
 }
 
 #[unstable(feature = "array_from_iter_impl", issue = "none")]
-impl<T, const N: usize> Drop for FillError<T, N>
-where
-    [MaybeUninit<T>; N]: LengthAtMost32,
-{
+impl<T, const N: usize> Drop for FillError<T, N> {
     fn drop(&mut self) {
         // SAFETY: This is safe: `as_mut_slice` returns exactly the sub-slice
         // of elements that have been initialized and need to be droped
@@ -243,10 +227,7 @@ where
 }
 
 #[unstable(feature = "array_from_iter_impl", issue = "none")]
-impl<T, const N: usize> FillError<T, N>
-where
-    [MaybeUninit<T>; N]: LengthAtMost32,
-{
+impl<T, const N: usize> FillError<T, N> {
     fn new() -> Self {
         Self { array: MaybeUninit::uninit_array(), len: 0 }
     }
@@ -299,11 +280,7 @@ where
 }
 
 #[unstable(feature = "array_from_iter_impl", issue = "none")]
-impl<T, const N: usize> FromIterator<T> for Result<[T; N], FillError<T, N>>
-where
-    [T; N]: LengthAtMost32,
-    [MaybeUninit<T>; N]: LengthAtMost32,
-{
+impl<T, const N: usize> FromIterator<T> for Result<[T; N], FillError<T, N>> {
     #[inline]
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         FillError::<T, N>::new().fill(iter)

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -201,14 +201,15 @@ where
         let mut array: [MaybeUninit<T>; N] = MaybeUninit::uninit_array();
         
         for i in 0..N {
-            let value = iter.next().unwrap_or_else(|| {
+            if let Some(value) = iter.next() {
+                array[i].write(value);
+            } else {
                 // Drop already writen elements
                 for elem in &mut array[0..i] {
                     unsafe { crate::ptr::drop_in_place(elem.as_mut_ptr()); }
                 }
                 panic!("Iterator is to short");
-            });
-            array[i].write(value);
+            } 
         }
         
         // FIXME: actually use `mem::transmute` here, once it

--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -378,37 +378,7 @@ fn cell_allows_array_cycle() {
 #[test]
 fn array_collects() {
     let v = vec![1, 2, 3, 4, 5];
-    let a: [i32; 5] = v
-        .clone()
-        .into_iter()
-        .collect::<Result<[i32; 5], core::array::FillError<i32, 5>>>()
-        .unwrap();
+    let a: [i32; 5] = v.clone().into_iter().collect::<Result<[i32; 5], _>>().unwrap();
 
     assert_eq!(v[..], a[..]);
-}
-
-#[test]
-fn array_collect_drop_on_panic() {
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Arc;
-
-    #[derive(Clone)]
-    struct Foo(Arc<AtomicUsize>);
-
-    // count the number of eleemts that got dropped
-    impl Drop for Foo {
-        fn drop(&mut self) {
-            self.0.fetch_add(1, Ordering::SeqCst);
-        }
-    }
-
-    let i = Arc::new(AtomicUsize::new(0));
-    let foo = Foo(i.clone());
-
-    std::panic::catch_unwind(move || {
-        let _a: [Foo; 5] = from_iter(vec![foo.clone(), foo.clone(), foo.clone(), foo]);
-    })
-    .unwrap_err();
-
-    assert_eq!(i.load(Ordering::SeqCst), 4);
 }

--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -378,7 +378,11 @@ fn cell_allows_array_cycle() {
 #[test]
 fn array_collects() {
     let v = vec![1, 2, 3, 4, 5];
-    let a: [i32; 5] = v.clone().into_iter().collect().unwrap();
+    let a: [i32; 5] = v
+        .clone()
+        .into_iter()
+        .collect::<Result<[i32; 5], core::array::FillError<i32, 5>>>()
+        .unwrap();
 
     assert_eq!(v[..], a[..]);
 }

--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -378,7 +378,7 @@ fn cell_allows_array_cycle() {
 #[test]
 fn array_collects() {
     let v = vec![1, 2, 3, 4, 5];
-    let a: [i32; 5] = v.clone().into_iter().collect();
+    let a: [i32; 5] = v.clone().into_iter().collect().unwrap();
 
     assert_eq!(v[..], a[..]);
 }

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -60,6 +60,7 @@
 #![feature(unsafe_block_in_unsafe_fn)]
 #![feature(int_bits_const)]
 #![deny(unsafe_op_in_unsafe_fn)]
+#![feature(array_from_iter_impl)]
 
 extern crate test;
 

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -492,7 +492,7 @@ mod prim_pointer {}
 /// Arrays of *any* size implement the following traits if the element type allows it:
 ///
 /// - [`Debug`]
-/// - [`FromIterator`]
+/// - [`iter::FromIterator`]
 /// - [`IntoIterator`] (implemented for `&[T; N]` and `&mut [T; N]`)
 /// - [`PartialEq`], [`PartialOrd`], [`Eq`], [`Ord`]
 /// - [`Hash`]

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -492,6 +492,7 @@ mod prim_pointer {}
 /// Arrays of *any* size implement the following traits if the element type allows it:
 ///
 /// - [`Debug`]
+/// - [`FromIterator`]
 /// - [`IntoIterator`] (implemented for `&[T; N]` and `&mut [T; N]`)
 /// - [`PartialEq`], [`PartialOrd`], [`Eq`], [`Ord`]
 /// - [`Hash`]


### PR DESCRIPTION
This PR adds this impl:
```rust
impl<T, const N: usize> FromIterator for [T; N]
where
    [T; N]: LengthAtMost32
```

I think this in conjunction with #65819 would be really useful when working with arrays.

There was a previews (#29693) PR which got closed due to concerns which I feel can be avoided by using new language features like const generics and MaybeUninit.