### PR TITLE
Add self to .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -172,6 +172,9 @@ Mateusz Mikuła <matti@marinelayer.io> <mati865@gmail.com>
 Mateusz Mikuła <matti@marinelayer.io> <mati865@users.noreply.github.com>
 Matt Brubeck <mbrubeck@limpet.net> <mbrubeck@cs.hmc.edu>
 Matthew Auld <matthew.auld@intel.com>
+Matthew Kraai <kraai@ftbfs.org>
+Matthew Kraai <kraai@ftbfs.org> <matt.kraai@abbott.com>
+Matthew Kraai <kraai@ftbfs.org> <mkraai@its.jnj.com>
 Matthew McPherrin <matthew@mcpherrin.ca> <matt@mcpherrin.ca>
 Matthijs Hofstra <thiezz@gmail.com>
 Melody Horn <melody@boringcactus.com> <mathphreak@gmail.com>


### PR DESCRIPTION
The variants are only used for [rust-lang/rust-clippy](https://github.com/rust-lang/rust-clippy), but it seems like <https://thanks.rust-lang.org/> only uses this `.mailmap`.