### PR TITLE
symbol_names: treat ReifyShim like VtableShim.

### DIFF
--- a/src/librustc/ty/instance.rs
+++ b/src/librustc/ty/instance.rs
@@ -406,10 +406,6 @@ impl<'tcx> Instance<'tcx> {
             | InstanceDef::VtableShim(..) => Some(self.substs),
         }
     }
-
-    pub fn is_vtable_shim(&self) -> bool {
-        if let InstanceDef::VtableShim(..) = self.def { true } else { false }
-    }
 }
 
 fn needs_fn_once_adapter_shim(

--- a/src/librustc_symbol_mangling/legacy.rs
+++ b/src/librustc_symbol_mangling/legacy.rs
@@ -59,8 +59,12 @@ pub(super) fn mangle(
         .print_def_path(def_id, &[])
         .unwrap();
 
-    if instance.is_vtable_shim() {
+    if let ty::InstanceDef::VtableShim(..) = instance.def {
         let _ = printer.write_str("{{vtable-shim}}");
+    }
+
+    if let ty::InstanceDef::ReifyShim(..) = instance.def {
+        let _ = printer.write_str("{{reify-shim}}");
     }
 
     printer.path.finish(hash)
@@ -123,7 +127,8 @@ fn get_symbol_hash<'tcx>(
         }
 
         // We want to avoid accidental collision between different types of instances.
-        // Especially, VtableShim may overlap with its original instance without this.
+        // Especially, `VtableShim`s and `ReifyShim`s may overlap with their original
+        // instances without this.
         discriminant(&instance.def).hash_stable(&mut hcx, &mut hasher);
     });
 


### PR DESCRIPTION
Without this, the `#[track_caller]` tests don't pass with `-Zsymbol-mangling-version=v0`, because there is a symbol name collision between the `ReifyShim` and the original definition.

cc @anp