### PR TITLE
[rustdoc] Improve visibility for code blocks warnings

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -12,7 +12,6 @@ use rustc_hir::Mutability;
 use rustc_metadata::creader::LoadedMacro;
 use rustc_mir::const_eval::is_min_const_fn;
 use rustc_span::hygiene::MacroKind;
-use rustc_span::symbol::sym;
 use rustc_span::Span;
 
 use crate::clean::{self, GetDefId, ToSource, TypeKind};

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1032,7 +1032,7 @@ h3 > .collapse-toggle, h4 > .collapse-toggle {
 
 .information {
 	position: absolute;
-	left: -20px;
+	left: -25px;
 	margin-top: 7px;
 	z-index: 1;
 }
@@ -1047,12 +1047,13 @@ h3 > .collapse-toggle, h4 > .collapse-toggle {
 	width: 120px;
 	display: none;
 	text-align: center;
-	padding: 5px 3px;
+	padding: 5px 3px 3px 3px;
 	border-radius: 6px;
 	margin-left: 5px;
 	top: -5px;
 	left: 105%;
 	z-index: 10;
+	font-size: 16px;
 }
 
 .tooltip:hover .tooltiptext {
@@ -1063,14 +1064,20 @@ h3 > .collapse-toggle, h4 > .collapse-toggle {
 	content: " ";
 	position: absolute;
 	top: 50%;
-	left: 11px;
+	left: 16px;
 	margin-top: -5px;
 	border-width: 5px;
 	border-style: solid;
 }
 
+.tooltip.compile_fail, .tooltip.ignore {
+	font-weight: bold;
+	font-size: 20px;
+}
+
 .tooltip .tooltiptext {
 	border: 1px solid;
+	font-weight: normal;
 }
 
 pre.rust {

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -254,7 +254,7 @@ a.test-arrow:hover{
 }
 
 pre.compile_fail {
-	border-left: 2px solid rgba(255,0,0,.6);
+	border-left: 2px solid rgba(255,0,0,.8);
 }
 
 pre.compile_fail:hover, .information:hover + pre.compile_fail {
@@ -270,7 +270,7 @@ pre.ignore:hover, .information:hover + pre.ignore {
 }
 
 .tooltip.compile_fail {
-	color: rgba(255,0,0,.6);
+	color: rgba(255,0,0,.8);
 }
 
 .information > .compile_fail:hover {
@@ -282,7 +282,7 @@ pre.ignore:hover, .information:hover + pre.ignore {
 }
 
 .information > .ignore:hover {
-	color: rgba(255,142,0,1);
+	color: #ff9200;
 }
 
 .search-failed a {
@@ -290,8 +290,9 @@ pre.ignore:hover, .information:hover + pre.ignore {
 }
 
 .tooltip .tooltiptext {
-	background-color: black;
+	background-color: #000;
 	color: #fff;
+	border-color: #000;
 }
 
 .tooltip .tooltiptext::after {

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -248,7 +248,7 @@ a.test-arrow:hover{
 }
 
 pre.compile_fail {
-	border-left: 2px solid rgba(255,0,0,.4);
+	border-left: 2px solid rgba(255,0,0,.5);
 }
 
 pre.compile_fail:hover, .information:hover + pre.compile_fail {
@@ -256,7 +256,7 @@ pre.compile_fail:hover, .information:hover + pre.compile_fail {
 }
 
 pre.ignore {
-	border-left: 2px solid rgba(255,142,0,.4);
+	border-left: 2px solid rgba(255,142,0,.6);
 }
 
 pre.ignore:hover, .information:hover + pre.ignore {
@@ -264,7 +264,7 @@ pre.ignore:hover, .information:hover + pre.ignore {
 }
 
 .tooltip.compile_fail {
-	color: rgba(255,0,0,.3);
+	color: rgba(255,0,0,.5);
 }
 
 .information > .compile_fail:hover {
@@ -272,11 +272,11 @@ pre.ignore:hover, .information:hover + pre.ignore {
 }
 
 .tooltip.ignore {
-	color: rgba(255,142,0,.3);
+	color: rgba(255,142,0,.6);
 }
 
 .information > .ignore:hover {
-	color: rgba(255,142,0,1);
+	color: #ff9200;
 }
 
 .search-failed a {
@@ -284,7 +284,7 @@ pre.ignore:hover, .information:hover + pre.ignore {
 }
 
 .tooltip .tooltiptext {
-	background-color: black;
+	background-color: #000;
 	color: #fff;
 }
 


### PR DESCRIPTION
It appeared that a lot of people didn't notice when a code block was meant to fail compilation or wasn't tested at all. The changes here make the colors less transparent and the icon bigger. So before it looked like this:

![old-light](https://user-images.githubusercontent.com/3050060/76687070-f1cdbb80-6620-11ea-9b73-0c787dc671f7.png)
![old-dark](https://user-images.githubusercontent.com/3050060/76687079-f4c8ac00-6620-11ea-90fb-e548329e01b4.png)

And now it looks like this:

![new-light](https://user-images.githubusercontent.com/3050060/76687092-fd20e700-6620-11ea-9ebb-2b6852f00899.png)
![new-dark](https://user-images.githubusercontent.com/3050060/76687091-fd20e700-6620-11ea-8fea-6854c8367b97.png)

cc @rust-lang/rustdoc 
r? @kinnison 

