### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -172,6 +172,9 @@ Mateusz Mikuła <matti@marinelayer.io> <mati865@gmail.com>
 Mateusz Mikuła <matti@marinelayer.io> <mati865@users.noreply.github.com>
 Matt Brubeck <mbrubeck@limpet.net> <mbrubeck@cs.hmc.edu>
 Matthew Auld <matthew.auld@intel.com>
+Matthew Kraai <kraai@ftbfs.org>
+Matthew Kraai <kraai@ftbfs.org> <matt.kraai@abbott.com>
+Matthew Kraai <kraai@ftbfs.org> <mkraai@its.jnj.com>
 Matthew McPherrin <matthew@mcpherrin.ca> <matt@mcpherrin.ca>
 Matthijs Hofstra <thiezz@gmail.com>
 Melody Horn <melody@boringcactus.com> <mathphreak@gmail.com>

--- a/src/librustc_ast/ast.rs
+++ b/src/librustc_ast/ast.rs
@@ -1446,7 +1446,7 @@ impl MacDelimiter {
 }
 
 /// Represents a macro definition.
-#[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
+#[derive(Clone, RustcEncodable, RustcDecodable, Debug, HashStable_Generic)]
 pub struct MacroDef {
     pub body: P<MacArgs>,
     /// `true` if macro was defined with `macro_rules`.

--- a/src/librustc_error_codes/error_codes.rs
+++ b/src/librustc_error_codes/error_codes.rs
@@ -380,6 +380,7 @@ E0689: include_str!("./error_codes/E0689.md"),
 E0690: include_str!("./error_codes/E0690.md"),
 E0691: include_str!("./error_codes/E0691.md"),
 E0692: include_str!("./error_codes/E0692.md"),
+E0693: include_str!("./error_codes/E0693.md"),
 E0695: include_str!("./error_codes/E0695.md"),
 E0697: include_str!("./error_codes/E0697.md"),
 E0698: include_str!("./error_codes/E0698.md"),
@@ -594,7 +595,6 @@ E0748: include_str!("./error_codes/E0748.md"),
     E0667, // `impl Trait` in projections
     E0687, // in-band lifetimes cannot be used in `fn`/`Fn` syntax
     E0688, // in-band lifetimes cannot be mixed with explicit lifetime binders
-    E0693, // incorrect `repr(align)` attribute format
 //  E0694, // an unknown tool name found in scoped attributes
     E0696, // `continue` pointing to a labeled block
 //  E0702, // replaced with a generic attribute input check

--- a/src/librustc_error_codes/error_codes/E0117.md
+++ b/src/librustc_error_codes/error_codes/E0117.md
@@ -1,4 +1,4 @@
-The `Drop` trait was implemented on a non-struct type.
+Only traits defined in the current crate can be implemented for arbitrary types.
 
 Erroneous code example:
 

--- a/src/librustc_error_codes/error_codes/E0693.md
+++ b/src/librustc_error_codes/error_codes/E0693.md
@@ -1,0 +1,19 @@
+`align` representation hint was incorrectly declared.
+
+Erroneous code examples:
+
+```compile_fail,E0693
+#[repr(align=8)] // error!
+struct Align8(i8);
+
+#[repr(align="8")] // error!
+struct Align8(i8);
+```
+
+This is a syntax error at the level of attribute declarations. The proper
+syntax for `align` representation hint is the following:
+
+```
+#[repr(align(8))] // ok!
+struct Align8(i8);
+```

--- a/src/librustc_hir/def.rs
+++ b/src/librustc_hir/def.rs
@@ -107,8 +107,7 @@ impl DefKind {
             DefKind::Union => "union",
             DefKind::Trait => "trait",
             DefKind::ForeignTy => "foreign type",
-            // FIXME: Update the description to "assoc fn"
-            DefKind::AssocFn => "method",
+            DefKind::AssocFn => "associated function",
             DefKind::Const => "constant",
             DefKind::AssocConst => "associated constant",
             DefKind::TyParam => "type parameter",
@@ -123,6 +122,7 @@ impl DefKind {
             DefKind::AssocTy
             | DefKind::AssocConst
             | DefKind::AssocOpaqueTy
+            | DefKind::AssocFn
             | DefKind::Enum
             | DefKind::OpaqueTy => "an",
             DefKind::Macro(macro_kind) => macro_kind.article(),

--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -13,7 +13,6 @@ use rustc_ast::ast::{AttrVec, Attribute, FloatTy, IntTy, Label, LitKind, StrStyl
 pub use rustc_ast::ast::{BorrowKind, ImplPolarity, IsAuto};
 pub use rustc_ast::ast::{CaptureBy, Movability, Mutability};
 use rustc_ast::node_id::NodeMap;
-use rustc_ast::tokenstream::TokenStream;
 use rustc_ast::util::parser::ExprPrecedence;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::sync::{par_for_each_in, Send, Sync};
@@ -722,13 +721,12 @@ impl Crate<'_> {
 /// Not parsed directly, but created on macro import or `macro_rules!` expansion.
 #[derive(RustcEncodable, RustcDecodable, Debug, HashStable_Generic)]
 pub struct MacroDef<'hir> {
-    pub name: Name,
+    pub ident: Ident,
     pub vis: Visibility<'hir>,
     pub attrs: &'hir [Attribute],
     pub hir_id: HirId,
     pub span: Span,
-    pub body: TokenStream,
-    pub legacy: bool,
+    pub ast: ast::MacroDef,
 }
 
 /// A block of statements `{ .. }`, which may have a label (in this case the

--- a/src/librustc_hir/intravisit.rs
+++ b/src/librustc_hir/intravisit.rs
@@ -445,7 +445,7 @@ pub fn walk_crate<'v, V: Visitor<'v>>(visitor: &mut V, krate: &'v Crate<'v>) {
 
 pub fn walk_macro_def<'v, V: Visitor<'v>>(visitor: &mut V, macro_def: &'v MacroDef<'v>) {
     visitor.visit_id(macro_def.hir_id);
-    visitor.visit_name(macro_def.span, macro_def.name);
+    visitor.visit_ident(macro_def.ident);
     walk_list!(visitor, visit_attribute, macro_def.attrs);
 }
 

--- a/src/librustc_metadata/rmeta/encoder.rs
+++ b/src/librustc_metadata/rmeta/encoder.rs
@@ -1236,10 +1236,7 @@ impl EncodeContext<'tcx> {
     /// Serialize the text of exported macros
     fn encode_info_for_macro_def(&mut self, macro_def: &hir::MacroDef<'_>) {
         let def_id = self.tcx.hir().local_def_id(macro_def.hir_id);
-        record!(self.per_def.kind[def_id] <- EntryKind::MacroDef(self.lazy(MacroDef {
-            body: macro_def.body.clone(),
-            legacy: macro_def.legacy,
-        })));
+        record!(self.per_def.kind[def_id] <- EntryKind::MacroDef(self.lazy(macro_def.ast.clone())));
         record!(self.per_def.visibility[def_id] <- ty::Visibility::Public);
         record!(self.per_def.span[def_id] <- macro_def.span);
         record!(self.per_def.attributes[def_id] <- macro_def.attrs);

--- a/src/librustc_metadata/rmeta/mod.rs
+++ b/src/librustc_metadata/rmeta/mod.rs
@@ -10,8 +10,7 @@ use rustc::mir;
 use rustc::session::config::SymbolManglingVersion;
 use rustc::session::CrateDisambiguator;
 use rustc::ty::{self, ReprOptions, Ty};
-use rustc_ast::ast;
-use rustc_ast::tokenstream::TokenStream;
+use rustc_ast::ast::{self, MacroDef};
 use rustc_attr as attr;
 use rustc_data_structures::svh::Svh;
 use rustc_data_structures::sync::MetadataRef;
@@ -321,12 +320,6 @@ struct RenderedConst(String);
 #[derive(RustcEncodable, RustcDecodable)]
 struct ModData {
     reexports: Lazy<[Export<hir::HirId>]>,
-}
-
-#[derive(RustcEncodable, RustcDecodable)]
-struct MacroDef {
-    body: TokenStream,
-    legacy: bool,
 }
 
 #[derive(RustcEncodable, RustcDecodable)]

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -920,7 +920,7 @@ impl Visitor<'tcx> for EmbargoVisitor<'tcx> {
     }
 
     fn visit_macro_def(&mut self, md: &'tcx hir::MacroDef<'tcx>) {
-        if attr::find_transparency(&md.attrs, md.legacy).0 != Transparency::Opaque {
+        if attr::find_transparency(&md.attrs, md.ast.legacy).0 != Transparency::Opaque {
             self.update(md.hir_id, Some(AccessLevel::Public));
             return;
         }

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -794,19 +794,6 @@ impl<'l, 'tcx> SaveContext<'l, 'tcx> {
             ExpnKind::Root | ExpnKind::AstPass(_) | ExpnKind::Desugaring(_) => return None,
         };
 
-        // If the callee is an imported macro from an external crate, need to get
-        // the source span and name from the session, as their spans are localized
-        // when read in, and no longer correspond to the source.
-        if let Some(mac) = self.tcx.sess.imported_macro_spans.borrow().get(&callee.def_site) {
-            let &(ref mac_name, mac_span) = mac;
-            let mac_span = self.span_from_span(mac_span);
-            return Some(MacroRef {
-                span: callsite_span,
-                qualname: mac_name.clone(), // FIXME: generate the real qualname
-                callee_span: mac_span,
-            });
-        }
-
         let callee_span = self.span_from_span(callee.def_site);
         Some(MacroRef {
             span: callsite_span,

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -103,11 +103,6 @@ pub struct Session {
     /// The maximum blocks a const expression can evaluate.
     pub const_eval_limit: Once<usize>,
 
-    /// Map from imported macro spans (which consist of
-    /// the localized span for the macro body) to the
-    /// macro name and definition span in the source crate.
-    pub imported_macro_spans: OneThread<RefCell<FxHashMap<Span, (String, Span)>>>,
-
     incr_comp_session: OneThread<RefCell<IncrCompSession>>,
     /// Used for incremental compilation tests. Will only be populated if
     /// `-Zquery-dep-graph` is specified.
@@ -1080,7 +1075,6 @@ fn build_session_(
         recursion_limit: Once::new(),
         type_length_limit: Once::new(),
         const_eval_limit: Once::new(),
-        imported_macro_spans: OneThread::new(RefCell::new(FxHashMap::default())),
         incr_comp_session: OneThread::new(RefCell::new(IncrCompSession::NotInitialized)),
         cgu_reuse_tracker,
         prof,

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -955,7 +955,7 @@ impl<'a, 'hir> intravisit::Visitor<'hir> for HirCollector<'a, 'hir> {
     }
 
     fn visit_macro_def(&mut self, macro_def: &'hir hir::MacroDef) {
-        self.visit_testable(macro_def.name.to_string(), &macro_def.attrs, |_| ());
+        self.visit_testable(macro_def.ident.to_string(), &macro_def.attrs, |_| ());
     }
 }
 

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -620,8 +620,8 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         def: &'tcx hir::MacroDef,
         renamed: Option<ast::Name>,
     ) -> Macro<'tcx> {
-        debug!("visit_local_macro: {}", def.name);
-        let tts = def.body.trees().collect::<Vec<_>>();
+        debug!("visit_local_macro: {}", def.ident);
+        let tts = def.ast.body.inner_tokens().trees().collect::<Vec<_>>();
         // Extract the spans of all matchers. They represent the "interface" of the macro.
         let matchers = tts.chunks(4).map(|arm| arm[0].span()).collect();
 
@@ -629,7 +629,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             hid: def.hir_id,
             def_id: self.cx.tcx.hir().local_def_id(def.hir_id),
             attrs: &def.attrs,
-            name: renamed.unwrap_or(def.name),
+            name: renamed.unwrap_or(def.ident.name),
             whence: def.span,
             matchers,
             imported_from: None,

--- a/src/test/ui/associated-item/associated-item-enum.stderr
+++ b/src/test/ui/associated-item/associated-item-enum.stderr
@@ -8,7 +8,7 @@ LL |     Enum::mispellable();
    |           ^^^^^^^^^^^
    |           |
    |           variant or associated item not found in `Enum`
-   |           help: there is a method with a similar name: `misspellable`
+   |           help: there is an associated function with a similar name: `misspellable`
 
 error[E0599]: no variant or associated item named `mispellable_trait` found for enum `Enum` in the current scope
   --> $DIR/associated-item-enum.rs:18:11

--- a/src/test/ui/async-await/issues/issue-62097.nll.stderr
+++ b/src/test/ui/async-await/issues/issue-62097.nll.stderr
@@ -16,13 +16,13 @@ help: to force the closure to take ownership of `self` (and any other referenced
 LL |         foo(move || self.bar()).await;
    |             ^^^^^^^
 
-error[E0521]: borrowed data escapes outside of method
+error[E0521]: borrowed data escapes outside of associated function
   --> $DIR/issue-62097.rs:13:9
    |
 LL |     pub async fn run_dummy_fn(&self) {
-   |                               ----- `self` is a reference that is only valid in the method body
+   |                               ----- `self` is a reference that is only valid in the associated function body
 LL |         foo(|| self.bar()).await;
-   |         ^^^^^^^^^^^^^^^^^^ `self` escapes the method body here
+   |         ^^^^^^^^^^^^^^^^^^ `self` escapes the associated function body here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/async-await/issues/issue-63388-1.nll.stderr
+++ b/src/test/ui/async-await/issues/issue-63388-1.nll.stderr
@@ -9,7 +9,7 @@ LL |       ) -> &dyn Foo
 LL | /     {
 LL | |         foo
 LL | |     }
-   | |_____^ method was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
+   | |_____^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
 
 error: aborting due to previous error
 

--- a/src/test/ui/auto-ref-slice-plus-ref.stderr
+++ b/src/test/ui/auto-ref-slice-plus-ref.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `test_mut` found for struct `std::vec::Vec<{intege
   --> $DIR/auto-ref-slice-plus-ref.rs:7:7
    |
 LL |     a.test_mut();
-   |       ^^^^^^^^ help: there is a method with a similar name: `get_mut`
+   |       ^^^^^^^^ help: there is an associated function with a similar name: `get_mut`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `MyIter` defines an item `test_mut`, perhaps you need to implement it

--- a/src/test/ui/block-result/issue-3563.stderr
+++ b/src/test/ui/block-result/issue-3563.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `b` found for reference `&Self` in the current sco
   --> $DIR/issue-3563.rs:3:17
    |
 LL |         || self.b()
-   |                 ^ help: there is a method with a similar name: `a`
+   |                 ^ help: there is an associated function with a similar name: `a`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0624.rs
+++ b/src/test/ui/error-codes/E0624.rs
@@ -8,5 +8,5 @@ mod inner {
 
 fn main() {
     let foo = inner::Foo;
-    foo.method(); //~ ERROR method `method` is private [E0624]
+    foo.method(); //~ ERROR associated function `method` is private [E0624]
 }

--- a/src/test/ui/error-codes/E0624.stderr
+++ b/src/test/ui/error-codes/E0624.stderr
@@ -1,4 +1,4 @@
-error[E0624]: method `method` is private
+error[E0624]: associated function `method` is private
   --> $DIR/E0624.rs:11:9
    |
 LL |     foo.method();

--- a/src/test/ui/explore-issue-38412.stderr
+++ b/src/test/ui/explore-issue-38412.stderr
@@ -79,19 +79,19 @@ LL |     r.unstable_undeclared();
    = note: see issue #38412 <https://github.com/rust-lang/rust/issues/38412> for more information
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
-error[E0624]: method `pub_crate` is private
+error[E0624]: associated function `pub_crate` is private
   --> $DIR/explore-issue-38412.rs:50:7
    |
 LL |     r.pub_crate();
    |       ^^^^^^^^^
 
-error[E0624]: method `pub_mod` is private
+error[E0624]: associated function `pub_mod` is private
   --> $DIR/explore-issue-38412.rs:51:7
    |
 LL |     r.pub_mod();
    |       ^^^^^^^
 
-error[E0624]: method `private` is private
+error[E0624]: associated function `private` is private
   --> $DIR/explore-issue-38412.rs:52:7
    |
 LL |     r.private();
@@ -115,19 +115,19 @@ LL |     t.unstable_undeclared();
    = note: see issue #38412 <https://github.com/rust-lang/rust/issues/38412> for more information
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
-error[E0624]: method `pub_crate` is private
+error[E0624]: associated function `pub_crate` is private
   --> $DIR/explore-issue-38412.rs:63:7
    |
 LL |     t.pub_crate();
    |       ^^^^^^^^^
 
-error[E0624]: method `pub_mod` is private
+error[E0624]: associated function `pub_mod` is private
   --> $DIR/explore-issue-38412.rs:64:7
    |
 LL |     t.pub_mod();
    |       ^^^^^^^
 
-error[E0624]: method `private` is private
+error[E0624]: associated function `private` is private
   --> $DIR/explore-issue-38412.rs:65:7
    |
 LL |     t.private();

--- a/src/test/ui/fn-in-pat.rs
+++ b/src/test/ui/fn-in-pat.rs
@@ -8,7 +8,7 @@ fn hof<F>(_: F) where F: FnMut(()) {}
 
 fn ice() {
     hof(|c| match c {
-        A::new() => (), //~ ERROR expected tuple struct or tuple variant, found method
+        A::new() => (), //~ ERROR expected tuple struct or tuple variant, found associated function
         _ => ()
     })
 }

--- a/src/test/ui/fn-in-pat.stderr
+++ b/src/test/ui/fn-in-pat.stderr
@@ -1,4 +1,4 @@
-error[E0164]: expected tuple struct or tuple variant, found method `A::new`
+error[E0164]: expected tuple struct or tuple variant, found associated function `A::new`
   --> $DIR/fn-in-pat.rs:11:9
    |
 LL |         A::new() => (),

--- a/src/test/ui/issues/issue-16683.nll.stderr
+++ b/src/test/ui/issues/issue-16683.nll.stderr
@@ -1,10 +1,10 @@
-error[E0521]: borrowed data escapes outside of method
+error[E0521]: borrowed data escapes outside of associated function
   --> $DIR/issue-16683.rs:4:9
    |
 LL |     fn b(&self) {
-   |          ----- `self` is a reference that is only valid in the method body
+   |          ----- `self` is a reference that is only valid in the associated function body
 LL |         self.a();
-   |         ^^^^^^^^ `self` escapes the method body here
+   |         ^^^^^^^^ `self` escapes the associated function body here
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17758.nll.stderr
+++ b/src/test/ui/issues/issue-17758.nll.stderr
@@ -1,10 +1,10 @@
-error[E0521]: borrowed data escapes outside of method
+error[E0521]: borrowed data escapes outside of associated function
   --> $DIR/issue-17758.rs:7:9
    |
 LL |     fn bar(&self) {
-   |            ----- `self` is a reference that is only valid in the method body
+   |            ----- `self` is a reference that is only valid in the associated function body
 LL |         self.foo();
-   |         ^^^^^^^^^^ `self` escapes the method body here
+   |         ^^^^^^^^^^ `self` escapes the associated function body here
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-21202.rs
+++ b/src/test/ui/issues/issue-21202.rs
@@ -8,7 +8,7 @@ mod B {
     use crate1::A::Foo;
     fn bar(f: Foo) {
         Foo::foo(&f);
-        //~^ ERROR: method `foo` is private
+        //~^ ERROR: associated function `foo` is private
     }
 }
 

--- a/src/test/ui/issues/issue-21202.stderr
+++ b/src/test/ui/issues/issue-21202.stderr
@@ -1,4 +1,4 @@
-error[E0624]: method `foo` is private
+error[E0624]: associated function `foo` is private
   --> $DIR/issue-21202.rs:10:9
    |
 LL |         Foo::foo(&f);

--- a/src/test/ui/issues/issue-28344.stderr
+++ b/src/test/ui/issues/issue-28344.stderr
@@ -11,7 +11,7 @@ LL |     let x: u8 = BitXor::bitor(0 as u8, 0 as u8);
    |                         ^^^^^
    |                         |
    |                         function or associated item not found in `dyn std::ops::BitXor<_>`
-   |                         help: there is a method with a similar name: `bitxor`
+   |                         help: there is an associated function with a similar name: `bitxor`
 
 error[E0191]: the value of the associated type `Output` (from trait `std::ops::BitXor`) must be specified
   --> $DIR/issue-28344.rs:8:13
@@ -26,7 +26,7 @@ LL |     let g = BitXor::bitor;
    |                     ^^^^^
    |                     |
    |                     function or associated item not found in `dyn std::ops::BitXor<_>`
-   |                     help: there is a method with a similar name: `bitxor`
+   |                     help: there is an associated function with a similar name: `bitxor`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/issues/issue-3763.rs
+++ b/src/test/ui/issues/issue-3763.rs
@@ -21,9 +21,9 @@ fn main() {
     let _woohoo = (Box::new(my_struct)).priv_field;
     //~^ ERROR field `priv_field` of struct `my_mod::MyStruct` is private
 
-    (&my_struct).happyfun();               //~ ERROR method `happyfun` is private
+    (&my_struct).happyfun();               //~ ERROR associated function `happyfun` is private
 
-    (Box::new(my_struct)).happyfun();          //~ ERROR method `happyfun` is private
+    (Box::new(my_struct)).happyfun();          //~ ERROR associated function `happyfun` is private
     let nope = my_struct.priv_field;
     //~^ ERROR field `priv_field` of struct `my_mod::MyStruct` is private
 }

--- a/src/test/ui/issues/issue-3763.stderr
+++ b/src/test/ui/issues/issue-3763.stderr
@@ -10,13 +10,13 @@ error[E0616]: field `priv_field` of struct `my_mod::MyStruct` is private
 LL |     let _woohoo = (Box::new(my_struct)).priv_field;
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0624]: method `happyfun` is private
+error[E0624]: associated function `happyfun` is private
   --> $DIR/issue-3763.rs:24:18
    |
 LL |     (&my_struct).happyfun();
    |                  ^^^^^^^^
 
-error[E0624]: method `happyfun` is private
+error[E0624]: associated function `happyfun` is private
   --> $DIR/issue-3763.rs:26:27
    |
 LL |     (Box::new(my_struct)).happyfun();

--- a/src/test/ui/issues/issue-50264-inner-deref-trait/option-as_deref.stderr
+++ b/src/test/ui/issues/issue-50264-inner-deref-trait/option-as_deref.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `as_deref` found for enum `std::option::Option<{in
   --> $DIR/option-as_deref.rs:2:29
    |
 LL |     let _result = &Some(42).as_deref();
-   |                             ^^^^^^^^ help: there is a method with a similar name: `as_ref`
+   |                             ^^^^^^^^ help: there is an associated function with a similar name: `as_ref`
    |
    = note: the method `as_deref` exists but the following trait bounds were not satisfied:
            `{integer}: std::ops::Deref`

--- a/src/test/ui/issues/issue-50264-inner-deref-trait/result-as_deref.stderr
+++ b/src/test/ui/issues/issue-50264-inner-deref-trait/result-as_deref.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `as_deref` found for enum `std::result::Result<{in
   --> $DIR/result-as_deref.rs:4:27
    |
 LL |     let _result = &Ok(42).as_deref();
-   |                           ^^^^^^^^ help: there is a method with a similar name: `as_ref`
+   |                           ^^^^^^^^ help: there is an associated function with a similar name: `as_ref`
    |
    = note: the method `as_deref` exists but the following trait bounds were not satisfied:
            `{integer}: std::ops::Deref`

--- a/src/test/ui/issues/issue-50264-inner-deref-trait/result-as_deref_err.stderr
+++ b/src/test/ui/issues/issue-50264-inner-deref-trait/result-as_deref_err.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `as_deref_err` found for enum `std::result::Result
   --> $DIR/result-as_deref_err.rs:4:28
    |
 LL |     let _result = &Err(41).as_deref_err();
-   |                            ^^^^^^^^^^^^ help: there is a method with a similar name: `as_deref_mut`
+   |                            ^^^^^^^^^^^^ help: there is an associated function with a similar name: `as_deref_mut`
    |
    = note: the method `as_deref_err` exists but the following trait bounds were not satisfied:
            `{integer}: std::ops::Deref`

--- a/src/test/ui/issues/issue-50264-inner-deref-trait/result-as_deref_mut.stderr
+++ b/src/test/ui/issues/issue-50264-inner-deref-trait/result-as_deref_mut.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `as_deref_mut` found for enum `std::result::Result
   --> $DIR/result-as_deref_mut.rs:4:31
    |
 LL |     let _result = &mut Ok(42).as_deref_mut();
-   |                               ^^^^^^^^^^^^ help: there is a method with a similar name: `as_deref_err`
+   |                               ^^^^^^^^^^^^ help: there is an associated function with a similar name: `as_deref_err`
    |
    = note: the method `as_deref_mut` exists but the following trait bounds were not satisfied:
            `{integer}: std::ops::DerefMut`

--- a/src/test/ui/issues/issue-50264-inner-deref-trait/result-as_deref_mut_err.stderr
+++ b/src/test/ui/issues/issue-50264-inner-deref-trait/result-as_deref_mut_err.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `as_deref_mut_err` found for enum `std::result::Re
   --> $DIR/result-as_deref_mut_err.rs:4:32
    |
 LL |     let _result = &mut Err(41).as_deref_mut_err();
-   |                                ^^^^^^^^^^^^^^^^ help: there is a method with a similar name: `as_deref_mut`
+   |                                ^^^^^^^^^^^^^^^^ help: there is an associated function with a similar name: `as_deref_mut`
    |
    = note: the method `as_deref_mut_err` exists but the following trait bounds were not satisfied:
            `{integer}: std::ops::DerefMut`

--- a/src/test/ui/issues/issue-53498.rs
+++ b/src/test/ui/issues/issue-53498.rs
@@ -13,5 +13,5 @@ pub mod test {
 }
 
 fn main() {
-    test::Foo::<test::B>::foo(); //~ ERROR method `foo` is private
+    test::Foo::<test::B>::foo(); //~ ERROR associated function `foo` is private
 }

--- a/src/test/ui/issues/issue-53498.stderr
+++ b/src/test/ui/issues/issue-53498.stderr
@@ -1,4 +1,4 @@
-error[E0624]: method `foo` is private
+error[E0624]: associated function `foo` is private
   --> $DIR/issue-53498.rs:16:5
    |
 LL |     test::Foo::<test::B>::foo();

--- a/src/test/ui/issues/issue-55587.stderr
+++ b/src/test/ui/issues/issue-55587.stderr
@@ -1,4 +1,4 @@
-error[E0164]: expected tuple struct or tuple variant, found method `Path::new`
+error[E0164]: expected tuple struct or tuple variant, found associated function `Path::new`
   --> $DIR/issue-55587.rs:4:9
    |
 LL |     let Path::new();

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl.nll.stderr
@@ -7,7 +7,7 @@ LL |     fn foo<'a>(x: &i32, y: &'a i32) -> &'a i32 {
    |            lifetime `'a` defined here
 LL | 
 LL |         if x > y { x } else { y }
-   |                    ^ method was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
+   |                    ^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.nll.stderr
@@ -7,7 +7,7 @@ LL |   fn foo<'a>(&self, x: &'a i32) -> &i32 {
    |          lifetime `'a` defined here
 LL | 
 LL |     x
-   |     ^ method was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
+   |     ^ associated function was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-self-is-anon.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-self-is-anon.nll.stderr
@@ -7,7 +7,7 @@ LL |     fn foo<'a>(&self, x: &'a Foo) -> &'a Foo {
    |            lifetime `'a` defined here
 LL | 
 LL |         if true { x } else { self }
-   |                              ^^^^ method was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
+   |                              ^^^^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.nll.stderr
@@ -6,7 +6,7 @@ LL |   fn foo<'a>(&self, x: &i32) -> &i32 {
    |              |
    |              let's call the lifetime of this reference `'2`
 LL |     x
-   |     ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |     ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-self-is-anon.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-self-is-anon.nll.stderr
@@ -6,7 +6,7 @@ LL |     fn foo<'a>(&self, x: &Foo) -> &Foo {
    |                |
    |                let's call the lifetime of this reference `'2`
 LL |         if true { x } else { self }
-   |                   ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |                   ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: aborting due to previous error
 

--- a/src/test/ui/match/match-fn-call.stderr
+++ b/src/test/ui/match/match-fn-call.stderr
@@ -1,4 +1,4 @@
-error[E0164]: expected tuple struct or tuple variant, found method `Path::new`
+error[E0164]: expected tuple struct or tuple variant, found associated function `Path::new`
   --> $DIR/match-fn-call.rs:6:9
    |
 LL |         Path::new("foo") => println!("foo"),
@@ -6,7 +6,7 @@ LL |         Path::new("foo") => println!("foo"),
    |
    = help: for more information, visit https://doc.rust-lang.org/book/ch18-00-patterns.html
 
-error[E0164]: expected tuple struct or tuple variant, found method `Path::new`
+error[E0164]: expected tuple struct or tuple variant, found associated function `Path::new`
   --> $DIR/match-fn-call.rs:8:9
    |
 LL |         Path::new("bar") => println!("bar"),

--- a/src/test/ui/methods/method-path-in-pattern.rs
+++ b/src/test/ui/methods/method-path-in-pattern.rs
@@ -13,20 +13,20 @@ impl MyTrait for Foo {}
 fn main() {
     match 0u32 {
         Foo::bar => {}
-        //~^ ERROR expected unit struct, unit variant or constant, found method `Foo::bar`
+        //~^ ERROR expected unit struct, unit variant or constant, found associated function
     }
     match 0u32 {
         <Foo>::bar => {}
-        //~^ ERROR expected unit struct, unit variant or constant, found method `Foo::bar`
+        //~^ ERROR expected unit struct, unit variant or constant, found associated function
     }
     match 0u32 {
         <Foo>::trait_bar => {}
-        //~^ ERROR expected unit struct, unit variant or constant, found method `Foo::trait_bar`
+        //~^ ERROR expected unit struct, unit variant or constant, found associated function
     }
     if let Foo::bar = 0u32 {}
-    //~^ ERROR expected unit struct, unit variant or constant, found method `Foo::bar`
+    //~^ ERROR expected unit struct, unit variant or constant, found associated function
     if let <Foo>::bar = 0u32 {}
-    //~^ ERROR expected unit struct, unit variant or constant, found method `Foo::bar`
+    //~^ ERROR expected unit struct, unit variant or constant, found associated function
     if let Foo::trait_bar = 0u32 {}
-    //~^ ERROR expected unit struct, unit variant or constant, found method `Foo::trait_bar`
+    //~^ ERROR expected unit struct, unit variant or constant, found associated function
 }

--- a/src/test/ui/methods/method-path-in-pattern.stderr
+++ b/src/test/ui/methods/method-path-in-pattern.stderr
@@ -1,34 +1,34 @@
-error[E0533]: expected unit struct, unit variant or constant, found method `Foo::bar`
+error[E0533]: expected unit struct, unit variant or constant, found associated function `Foo::bar`
   --> $DIR/method-path-in-pattern.rs:15:9
    |
 LL |         Foo::bar => {}
    |         ^^^^^^^^
 
-error[E0533]: expected unit struct, unit variant or constant, found method `Foo::bar`
+error[E0533]: expected unit struct, unit variant or constant, found associated function `Foo::bar`
   --> $DIR/method-path-in-pattern.rs:19:9
    |
 LL |         <Foo>::bar => {}
    |         ^^^^^^^^^^
 
-error[E0533]: expected unit struct, unit variant or constant, found method `Foo::trait_bar`
+error[E0533]: expected unit struct, unit variant or constant, found associated function `Foo::trait_bar`
   --> $DIR/method-path-in-pattern.rs:23:9
    |
 LL |         <Foo>::trait_bar => {}
    |         ^^^^^^^^^^^^^^^^
 
-error[E0533]: expected unit struct, unit variant or constant, found method `Foo::bar`
+error[E0533]: expected unit struct, unit variant or constant, found associated function `Foo::bar`
   --> $DIR/method-path-in-pattern.rs:26:12
    |
 LL |     if let Foo::bar = 0u32 {}
    |            ^^^^^^^^
 
-error[E0533]: expected unit struct, unit variant or constant, found method `Foo::bar`
+error[E0533]: expected unit struct, unit variant or constant, found associated function `Foo::bar`
   --> $DIR/method-path-in-pattern.rs:28:12
    |
 LL |     if let <Foo>::bar = 0u32 {}
    |            ^^^^^^^^^^
 
-error[E0533]: expected unit struct, unit variant or constant, found method `Foo::trait_bar`
+error[E0533]: expected unit struct, unit variant or constant, found associated function `Foo::trait_bar`
   --> $DIR/method-path-in-pattern.rs:30:12
    |
 LL |     if let Foo::trait_bar = 0u32 {}

--- a/src/test/ui/methods/method-resolvable-path-in-pattern.rs
+++ b/src/test/ui/methods/method-resolvable-path-in-pattern.rs
@@ -9,6 +9,6 @@ impl MyTrait for Foo {}
 fn main() {
     match 0u32 {
         <Foo as MyTrait>::trait_bar => {}
-        //~^ ERROR expected unit struct, unit variant or constant, found method `MyTrait::trait_bar`
+        //~^ ERROR expected unit struct, unit variant or constant, found associated function
     }
 }

--- a/src/test/ui/methods/method-resolvable-path-in-pattern.stderr
+++ b/src/test/ui/methods/method-resolvable-path-in-pattern.stderr
@@ -1,4 +1,4 @@
-error[E0532]: expected unit struct, unit variant or constant, found method `MyTrait::trait_bar`
+error[E0532]: expected unit struct, unit variant or constant, found associated function `MyTrait::trait_bar`
   --> $DIR/method-resolvable-path-in-pattern.rs:11:9
    |
 LL |         <Foo as MyTrait>::trait_bar => {}

--- a/src/test/ui/nll/outlives-suggestion-simple.rs
+++ b/src/test/ui/nll/outlives-suggestion-simple.rs
@@ -70,7 +70,7 @@ pub struct Foo2<'a> {
 impl<'a> Foo2<'a> {
     // should not produce outlives suggestions to name 'self
     fn get_bar(&self) -> Bar2 {
-        Bar2::new(&self) //~ERROR borrowed data escapes outside of method
+        Bar2::new(&self) //~ERROR borrowed data escapes outside of associated function
     }
 }
 

--- a/src/test/ui/nll/outlives-suggestion-simple.stderr
+++ b/src/test/ui/nll/outlives-suggestion-simple.stderr
@@ -93,16 +93,16 @@ LL |         self.x
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error[E0521]: borrowed data escapes outside of method
+error[E0521]: borrowed data escapes outside of associated function
   --> $DIR/outlives-suggestion-simple.rs:73:9
    |
 LL |     fn get_bar(&self) -> Bar2 {
    |                -----
    |                |
-   |                `self` declared here, outside of the method body
-   |                `self` is a reference that is only valid in the method body
+   |                `self` declared here, outside of the associated function body
+   |                `self` is a reference that is only valid in the associated function body
 LL |         Bar2::new(&self)
-   |         ^^^^^^^^^^^^^^^^ `self` escapes the method body here
+   |         ^^^^^^^^^^^^^^^^ `self` escapes the associated function body here
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/panic-while-printing.rs
+++ b/src/test/ui/panic-while-printing.rs
@@ -1,0 +1,23 @@
+// run-pass
+
+#![feature(set_stdio)]
+
+use std::fmt;
+use std::fmt::{Display, Formatter};
+use std::io::set_panic;
+
+pub struct A;
+
+impl Display for A {
+    fn fmt(&self, _f: &mut Formatter<'_>) -> fmt::Result {
+        panic!();
+    }
+}
+
+fn main() {
+    set_panic(Some(Box::new(Vec::new())));
+    assert!(std::panic::catch_unwind(|| {
+        eprintln!("{}", A);
+    })
+    .is_err());
+}

--- a/src/test/ui/privacy/privacy1.rs
+++ b/src/test/ui/privacy/privacy1.rs
@@ -74,7 +74,7 @@ mod bar {
         }
         self::baz::A;
         self::baz::A::foo();
-        self::baz::A::bar(); //~ ERROR: method `bar` is private
+        self::baz::A::bar(); //~ ERROR: associated function `bar` is private
         self::baz::A.foo2();
 
         // this used to cause an ICE in privacy traversal.
@@ -92,21 +92,21 @@ pub fn gpub() {}
 fn lol() {
     bar::A;
     bar::A::foo();
-    bar::A::bar(); //~ ERROR: method `bar` is private
+    bar::A::bar(); //~ ERROR: associated function `bar` is private
     bar::A.foo2();
 }
 
 mod foo {
     fn test() {
         ::bar::A::foo();
-        ::bar::A::bar();        //~ ERROR: method `bar` is private
+        ::bar::A::bar();        //~ ERROR: associated function `bar` is private
         ::bar::A.foo2();
         ::bar::baz::A::foo();   //~ ERROR: module `baz` is private
         ::bar::baz::A::bar();   //~ ERROR: module `baz` is private
-                                //~^ ERROR: method `bar` is private
+                                //~^ ERROR: associated function `bar` is private
         ::bar::baz::A.foo2();   //~ ERROR: module `baz` is private
         ::bar::baz::A.bar2();   //~ ERROR: module `baz` is private
-                                //~^ ERROR: method `bar2` is private
+                                //~^ ERROR: associated function `bar2` is private
 
         let _: isize =
         ::bar::B::foo();        //~ ERROR: trait `B` is private

--- a/src/test/ui/privacy/privacy1.stderr
+++ b/src/test/ui/privacy/privacy1.stderr
@@ -154,31 +154,31 @@ note: the trait `B` is defined here
 LL |     trait B {
    |     ^^^^^^^
 
-error[E0624]: method `bar` is private
+error[E0624]: associated function `bar` is private
   --> $DIR/privacy1.rs:77:9
    |
 LL |         self::baz::A::bar();
    |         ^^^^^^^^^^^^^^^^^
 
-error[E0624]: method `bar` is private
+error[E0624]: associated function `bar` is private
   --> $DIR/privacy1.rs:95:5
    |
 LL |     bar::A::bar();
    |     ^^^^^^^^^^^
 
-error[E0624]: method `bar` is private
+error[E0624]: associated function `bar` is private
   --> $DIR/privacy1.rs:102:9
    |
 LL |         ::bar::A::bar();
    |         ^^^^^^^^^^^^^
 
-error[E0624]: method `bar` is private
+error[E0624]: associated function `bar` is private
   --> $DIR/privacy1.rs:105:9
    |
 LL |         ::bar::baz::A::bar();
    |         ^^^^^^^^^^^^^^^^^^
 
-error[E0624]: method `bar2` is private
+error[E0624]: associated function `bar2` is private
   --> $DIR/privacy1.rs:108:23
    |
 LL |         ::bar::baz::A.bar2();

--- a/src/test/ui/privacy/private-impl-method.rs
+++ b/src/test/ui/privacy/private-impl-method.rs
@@ -17,5 +17,5 @@ fn f() {
 fn main() {
     let s = a::Foo { x: 1 };
     s.bar();
-    s.foo();    //~ ERROR method `foo` is private
+    s.foo();    //~ ERROR associated function `foo` is private
 }

--- a/src/test/ui/privacy/private-impl-method.stderr
+++ b/src/test/ui/privacy/private-impl-method.stderr
@@ -1,4 +1,4 @@
-error[E0624]: method `foo` is private
+error[E0624]: associated function `foo` is private
   --> $DIR/private-impl-method.rs:20:7
    |
 LL |     s.foo();

--- a/src/test/ui/privacy/private-method-cross-crate.rs
+++ b/src/test/ui/privacy/private-method-cross-crate.rs
@@ -4,5 +4,5 @@ use cci_class_5::kitties::cat;
 
 fn main() {
   let nyan : cat = cat(52, 99);
-  nyan.nap();   //~ ERROR method `nap` is private
+  nyan.nap();   //~ ERROR associated function `nap` is private
 }

--- a/src/test/ui/privacy/private-method-cross-crate.stderr
+++ b/src/test/ui/privacy/private-method-cross-crate.stderr
@@ -1,4 +1,4 @@
-error[E0624]: method `nap` is private
+error[E0624]: associated function `nap` is private
   --> $DIR/private-method-cross-crate.rs:7:8
    |
 LL |   nyan.nap();

--- a/src/test/ui/privacy/private-method-inherited.rs
+++ b/src/test/ui/privacy/private-method-inherited.rs
@@ -10,5 +10,5 @@ mod a {
 
 fn main() {
     let x = a::Foo;
-    x.f();  //~ ERROR method `f` is private
+    x.f();  //~ ERROR associated function `f` is private
 }

--- a/src/test/ui/privacy/private-method-inherited.stderr
+++ b/src/test/ui/privacy/private-method-inherited.stderr
@@ -1,4 +1,4 @@
-error[E0624]: method `f` is private
+error[E0624]: associated function `f` is private
   --> $DIR/private-method-inherited.rs:13:7
    |
 LL |     x.f();

--- a/src/test/ui/privacy/private-method.rs
+++ b/src/test/ui/privacy/private-method.rs
@@ -19,5 +19,5 @@ mod kitties {
 
 fn main() {
   let nyan : kitties::Cat = kitties::cat(52, 99);
-  nyan.nap(); //~ ERROR method `nap` is private
+  nyan.nap(); //~ ERROR associated function `nap` is private
 }

--- a/src/test/ui/privacy/private-method.stderr
+++ b/src/test/ui/privacy/private-method.stderr
@@ -1,4 +1,4 @@
-error[E0624]: method `nap` is private
+error[E0624]: associated function `nap` is private
   --> $DIR/private-method.rs:22:8
    |
 LL |   nyan.nap();

--- a/src/test/ui/privacy/restricted/test.stderr
+++ b/src/test/ui/privacy/restricted/test.stderr
@@ -52,13 +52,13 @@ error[E0616]: field `x` of struct `foo::bar::S` is private
 LL |     S::default().x;
    |     ^^^^^^^^^^^^^^
 
-error[E0624]: method `f` is private
+error[E0624]: associated function `f` is private
   --> $DIR/test.rs:32:18
    |
 LL |     S::default().f();
    |                  ^
 
-error[E0624]: method `g` is private
+error[E0624]: associated function `g` is private
   --> $DIR/test.rs:33:5
    |
 LL |     S::g();
@@ -76,13 +76,13 @@ error[E0616]: field `z` of struct `pub_restricted::Universe` is private
 LL |     let _ = u.z;
    |             ^^^
 
-error[E0624]: method `g` is private
+error[E0624]: associated function `g` is private
   --> $DIR/test.rs:45:7
    |
 LL |     u.g();
    |       ^
 
-error[E0624]: method `h` is private
+error[E0624]: associated function `h` is private
   --> $DIR/test.rs:46:7
    |
 LL |     u.h();

--- a/src/test/ui/qualified/qualified-path-params.rs
+++ b/src/test/ui/qualified/qualified-path-params.rs
@@ -18,7 +18,7 @@ impl S {
 fn main() {
     match 10 {
         <S as Tr>::A::f::<u8> => {}
-    //~^ ERROR expected unit struct, unit variant or constant, found method `<<S as Tr>::A>::f<u8>`
+    //~^ ERROR expected unit struct, unit variant or constant, found associated function
         0 ..= <S as Tr>::A::f::<u8> => {} //~ ERROR only char and numeric types are allowed in range
     }
 }

--- a/src/test/ui/qualified/qualified-path-params.stderr
+++ b/src/test/ui/qualified/qualified-path-params.stderr
@@ -1,4 +1,4 @@
-error[E0533]: expected unit struct, unit variant or constant, found method `<<S as Tr>::A>::f<u8>`
+error[E0533]: expected unit struct, unit variant or constant, found associated function `<<S as Tr>::A>::f<u8>`
   --> $DIR/qualified-path-params.rs:20:9
    |
 LL |         <S as Tr>::A::f::<u8> => {}

--- a/src/test/ui/repr/repr-align-assign.stderr
+++ b/src/test/ui/repr/repr-align-assign.stderr
@@ -24,3 +24,4 @@ LL | #[repr(align="8")]
 
 error: aborting due to 4 previous errors
 
+For more information about this error, try `rustc --explain E0693`.

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.nll.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.nll.stderr
@@ -2,7 +2,7 @@ error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:8:52
    |
 LL |     async fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
-   |                          -         -               ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |                          -         -               ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |                          |         |
    |                          |         let's call the lifetime of this reference `'1`
    |                          let's call the lifetime of this reference `'2`
@@ -11,7 +11,7 @@ error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:11:75
    |
 LL |     async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
-   |                          -          -                                     ^^^^^^^^^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |                          -          -                                     ^^^^^^^^^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |                          |          |
    |                          |          let's call the lifetime of this reference `'1`
    |                          let's call the lifetime of this reference `'2`
@@ -20,7 +20,7 @@ error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:17:64
    |
 LL |     async fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }
-   |                  --              -                             ^^^ method was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
+   |                  --              -                             ^^^ associated function was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
    |                  |               |
    |                  |               let's call the lifetime of this reference `'1`
    |                  lifetime `'a` defined here

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch.nll.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch.nll.stderr
@@ -2,7 +2,7 @@ error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:6:46
    |
 LL |     fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
-   |                    -         -               ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |                    -         -               ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |                    |         |
    |                    |         let's call the lifetime of this reference `'1`
    |                    let's call the lifetime of this reference `'2`
@@ -11,7 +11,7 @@ error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:8:69
    |
 LL |     fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
-   |                    -          -                                     ^^^^^^^^^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |                    -          -                                     ^^^^^^^^^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |                    |          |
    |                    |          let's call the lifetime of this reference `'1`
    |                    let's call the lifetime of this reference `'2`
@@ -20,7 +20,7 @@ error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:13:58
    |
 LL |     fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }
-   |            --  ---- has type `std::pin::Pin<&'1 Foo>`    ^^^ method was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
+   |            --  ---- has type `std::pin::Pin<&'1 Foo>`    ^^^ associated function was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
    |            |
    |            lifetime `'a` defined here
 

--- a/src/test/ui/self/elision/lt-ref-self-async.nll.stderr
+++ b/src/test/ui/self/elision/lt-ref-self-async.nll.stderr
@@ -6,7 +6,7 @@ LL |     async fn ref_self(&self, f: &u32) -> &u32 {
    |                       |
    |                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/lt-ref-self-async.rs:19:9
@@ -16,7 +16,7 @@ LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                             |
    |                             let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/lt-ref-self-async.rs:23:9
@@ -26,7 +26,7 @@ LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                                     |
    |                                     let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/lt-ref-self-async.rs:27:9
@@ -36,7 +36,7 @@ LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                                     |
    |                                     let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/lt-ref-self-async.rs:31:9
@@ -46,7 +46,7 @@ LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                             |
    |                                             let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/lt-ref-self-async.rs:35:9
@@ -56,7 +56,7 @@ LL |     async fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                         |
    |                                         let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/self/elision/lt-ref-self.nll.stderr
+++ b/src/test/ui/self/elision/lt-ref-self.nll.stderr
@@ -6,7 +6,7 @@ LL |     fn ref_self(&self, f: &u32) -> &u32 {
    |                 |
    |                 let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/lt-ref-self.rs:17:9
@@ -16,7 +16,7 @@ LL |     fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                       |
    |                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/lt-ref-self.rs:21:9
@@ -26,7 +26,7 @@ LL |     fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                               |
    |                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/lt-ref-self.rs:25:9
@@ -36,7 +36,7 @@ LL |     fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                               |
    |                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/lt-ref-self.rs:29:9
@@ -46,7 +46,7 @@ LL |     fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                       |
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/lt-ref-self.rs:33:9
@@ -56,7 +56,7 @@ LL |     fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                   |
    |                                   let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/self/elision/ref-mut-self-async.nll.stderr
+++ b/src/test/ui/self/elision/ref-mut-self-async.nll.stderr
@@ -6,7 +6,7 @@ LL |     async fn ref_self(&mut self, f: &u32) -> &u32 {
    |                       |
    |                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-self-async.rs:19:9
@@ -16,7 +16,7 @@ LL |     async fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
    |                             |
    |                             let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-self-async.rs:23:9
@@ -26,7 +26,7 @@ LL |     async fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
    |                                     |
    |                                     let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-self-async.rs:27:9
@@ -36,7 +36,7 @@ LL |     async fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
    |                                     |
    |                                     let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-self-async.rs:31:9
@@ -46,7 +46,7 @@ LL |     async fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
    |                                             |
    |                                             let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-self-async.rs:35:9
@@ -56,7 +56,7 @@ LL |     async fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 {
    |                                             |
    |                                             let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/self/elision/ref-mut-self.nll.stderr
+++ b/src/test/ui/self/elision/ref-mut-self.nll.stderr
@@ -6,7 +6,7 @@ LL |     fn ref_self(&mut self, f: &u32) -> &u32 {
    |                 |
    |                 let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-self.rs:17:9
@@ -16,7 +16,7 @@ LL |     fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
    |                       |
    |                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-self.rs:21:9
@@ -26,7 +26,7 @@ LL |     fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
    |                               |
    |                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-self.rs:25:9
@@ -36,7 +36,7 @@ LL |     fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
    |                               |
    |                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-self.rs:29:9
@@ -46,7 +46,7 @@ LL |     fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
    |                                       |
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-self.rs:33:9
@@ -56,7 +56,7 @@ LL |     fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 {
    |                                       |
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/self/elision/ref-mut-struct-async.nll.stderr
+++ b/src/test/ui/self/elision/ref-mut-struct-async.nll.stderr
@@ -6,7 +6,7 @@ LL |     async fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
    |                               |
    |                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-struct-async.rs:17:9
@@ -16,7 +16,7 @@ LL |     async fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
    |                                       |
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-struct-async.rs:21:9
@@ -26,7 +26,7 @@ LL |     async fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
    |                                       |
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-struct-async.rs:25:9
@@ -36,7 +36,7 @@ LL |     async fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u
    |                                               |
    |                                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-struct-async.rs:29:9
@@ -46,7 +46,7 @@ LL |     async fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u
    |                                               |
    |                                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/self/elision/ref-mut-struct.nll.stderr
+++ b/src/test/ui/self/elision/ref-mut-struct.nll.stderr
@@ -6,7 +6,7 @@ LL |     fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
    |                         |
    |                         let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-struct.rs:15:9
@@ -16,7 +16,7 @@ LL |     fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
    |                                 |
    |                                 let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-struct.rs:19:9
@@ -26,7 +26,7 @@ LL |     fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
    |                                 |
    |                                 let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-struct.rs:23:9
@@ -36,7 +36,7 @@ LL |     fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
    |                                         |
    |                                         let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-struct.rs:27:9
@@ -46,7 +46,7 @@ LL |     fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {
    |                                         |
    |                                         let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/self/elision/ref-self.nll.stderr
+++ b/src/test/ui/self/elision/ref-self.nll.stderr
@@ -6,7 +6,7 @@ LL |     fn ref_self(&self, f: &u32) -> &u32 {
    |                 |
    |                 let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-self.rs:27:9
@@ -16,7 +16,7 @@ LL |     fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                       |
    |                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-self.rs:31:9
@@ -26,7 +26,7 @@ LL |     fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                               |
    |                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-self.rs:35:9
@@ -36,7 +36,7 @@ LL |     fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                               |
    |                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-self.rs:39:9
@@ -46,7 +46,7 @@ LL |     fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                       |
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-self.rs:43:9
@@ -56,7 +56,7 @@ LL |     fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                       |
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-self.rs:47:9
@@ -66,7 +66,7 @@ LL |     fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {
    |                                      |
    |                                      let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/self/elision/ref-struct-async.nll.stderr
+++ b/src/test/ui/self/elision/ref-struct-async.nll.stderr
@@ -6,7 +6,7 @@ LL |     async fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |                               |
    |                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-struct-async.rs:17:9
@@ -16,7 +16,7 @@ LL |     async fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
    |                                       |
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-struct-async.rs:21:9
@@ -26,7 +26,7 @@ LL |     async fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
    |                                       |
    |                                       let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-struct-async.rs:25:9
@@ -36,7 +36,7 @@ LL |     async fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
    |                                               |
    |                                               let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-struct-async.rs:29:9
@@ -46,7 +46,7 @@ LL |     async fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {
    |                                           |
    |                                           let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/self/elision/ref-struct.nll.stderr
+++ b/src/test/ui/self/elision/ref-struct.nll.stderr
@@ -6,7 +6,7 @@ LL |     fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |                         |
    |                         let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-struct.rs:15:9
@@ -16,7 +16,7 @@ LL |     fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
    |                                 |
    |                                 let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-struct.rs:19:9
@@ -26,7 +26,7 @@ LL |     fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
    |                                 |
    |                                 let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-struct.rs:23:9
@@ -36,7 +36,7 @@ LL |     fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
    |                                         |
    |                                         let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/ref-struct.rs:27:9
@@ -46,7 +46,7 @@ LL |     fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {
    |                                     |
    |                                     let's call the lifetime of this reference `'2`
 LL |         f
-   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/span/type-annotations-needed-expr.stderr
+++ b/src/test/ui/span/type-annotations-needed-expr.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed
 LL |     let _ = (vec![1,2,3]).into_iter().sum() as f64;
    |                                       ^^^
    |                                       |
-   |                                       cannot infer type for type parameter `S` declared on the method `sum`
+   |                                       cannot infer type for type parameter `S` declared on the associated function `sum`
    |                                       help: consider specifying the type argument in the method call: `sum::<S>`
    |
    = note: type must be known at this point

--- a/src/test/ui/static/static-method-privacy.rs
+++ b/src/test/ui/static/static-method-privacy.rs
@@ -6,5 +6,5 @@ mod a {
 }
 
 fn main() {
-    let _ = a::S::new();    //~ ERROR method `new` is private
+    let _ = a::S::new();    //~ ERROR associated function `new` is private
 }

--- a/src/test/ui/static/static-method-privacy.stderr
+++ b/src/test/ui/static/static-method-privacy.stderr
@@ -1,4 +1,4 @@
-error[E0624]: method `new` is private
+error[E0624]: associated function `new` is private
   --> $DIR/static-method-privacy.rs:9:13
    |
 LL |     let _ = a::S::new();

--- a/src/test/ui/suggestions/suggest-methods.stderr
+++ b/src/test/ui/suggestions/suggest-methods.stderr
@@ -5,19 +5,19 @@ LL | struct Foo;
    | ----------- method `bat` not found for this
 ...
 LL |     f.bat(1.0);
-   |       ^^^ help: there is a method with a similar name: `bar`
+   |       ^^^ help: there is an associated function with a similar name: `bar`
 
 error[E0599]: no method named `is_emtpy` found for struct `std::string::String` in the current scope
   --> $DIR/suggest-methods.rs:21:15
    |
 LL |     let _ = s.is_emtpy();
-   |               ^^^^^^^^ help: there is a method with a similar name: `is_empty`
+   |               ^^^^^^^^ help: there is an associated function with a similar name: `is_empty`
 
 error[E0599]: no method named `count_eos` found for type `u32` in the current scope
   --> $DIR/suggest-methods.rs:25:19
    |
 LL |     let _ = 63u32.count_eos();
-   |                   ^^^^^^^^^ help: there is a method with a similar name: `count_zeros`
+   |                   ^^^^^^^^^ help: there is an associated function with a similar name: `count_zeros`
 
 error[E0599]: no method named `count_o` found for type `u32` in the current scope
   --> $DIR/suggest-methods.rs:28:19

--- a/src/test/ui/test-panic-while-printing.rs
+++ b/src/test/ui/test-panic-while-printing.rs
@@ -1,0 +1,23 @@
+// compile-flags:--test
+// run-pass
+
+use std::fmt;
+use std::fmt::{Display, Formatter};
+
+pub struct A(Vec<u32>);
+
+impl Display for A {
+    fn fmt(&self, _f: &mut Formatter<'_>) -> fmt::Result {
+        self.0[0];
+        Ok(())
+    }
+}
+
+#[test]
+fn main() {
+    let result = std::panic::catch_unwind(|| {
+        let a = A(vec![]);
+        eprintln!("{}", a);
+    });
+    assert!(result.is_err());
+}

--- a/src/test/ui/traits/trait-item-privacy.rs
+++ b/src/test/ui/traits/trait-item-privacy.rs
@@ -69,7 +69,7 @@ fn check_method() {
     S.c(); // OK
     // a, b, c are resolved as inherent items, their traits don't need to be in scope
     let c = &S as &dyn C;
-    c.a(); //~ ERROR method `a` is private
+    c.a(); //~ ERROR associated function `a` is private
     c.b(); // OK
     c.c(); // OK
 
@@ -81,7 +81,7 @@ fn check_method() {
     //~^ ERROR no function or associated item named `b` found
     S::c(&S); // OK
     // a, b, c are resolved as inherent items, their traits don't need to be in scope
-    C::a(&S); //~ ERROR method `a` is private
+    C::a(&S); //~ ERROR associated function `a` is private
     C::b(&S); // OK
     C::c(&S); // OK
 }

--- a/src/test/ui/traits/trait-item-privacy.stderr
+++ b/src/test/ui/traits/trait-item-privacy.stderr
@@ -36,7 +36,7 @@ help: the following trait is implemented but not in scope; perhaps add a `use` f
 LL | use method::B;
    |
 
-error[E0624]: method `a` is private
+error[E0624]: associated function `a` is private
   --> $DIR/trait-item-privacy.rs:72:7
    |
 LL |     c.a();
@@ -73,7 +73,7 @@ help: the following trait is implemented but not in scope; perhaps add a `use` f
 LL | use method::B;
    |
 
-error[E0624]: method `a` is private
+error[E0624]: associated function `a` is private
   --> $DIR/trait-item-privacy.rs:84:5
    |
 LL |     C::a(&S);

--- a/src/test/ui/traits/trait-method-private.stderr
+++ b/src/test/ui/traits/trait-method-private.stderr
@@ -1,4 +1,4 @@
-error[E0624]: method `method` is private
+error[E0624]: associated function `method` is private
   --> $DIR/trait-method-private.rs:19:9
    |
 LL |     foo.method();

--- a/src/test/ui/type-inference/or_else-multiple-type-params.stderr
+++ b/src/test/ui/type-inference/or_else-multiple-type-params.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed
 LL |         .or_else(|err| {
    |          ^^^^^^^
    |          |
-   |          cannot infer type for type parameter `F` declared on the method `or_else`
+   |          cannot infer type for type parameter `F` declared on the associated function `or_else`
    |          help: consider specifying the type arguments in the method call: `or_else::<F, O>`
 
 error: aborting due to previous error

--- a/src/test/ui/type-inference/sort_by_key.stderr
+++ b/src/test/ui/type-inference/sort_by_key.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed
 LL |     lst.sort_by_key(|&(v, _)| v.iter().sum());
    |         ^^^^^^^^^^^                    --- help: consider specifying the type argument in the method call: `sum::<S>`
    |         |
-   |         cannot infer type for type parameter `K` declared on the method `sort_by_key`
+   |         cannot infer type for type parameter `K` declared on the associated function `sort_by_key`
 
 error: aborting due to previous error
 

--- a/src/test/ui/ufcs/ufcs-partially-resolved.rs
+++ b/src/test/ui/ufcs/ufcs-partially-resolved.rs
@@ -49,8 +49,8 @@ fn main() {
     <u8 as Tr::Y>::NN; //~ ERROR cannot find method or associated constant `NN` in `Tr::Y`
     <u8 as E::Y>::NN; //~ ERROR failed to resolve: `Y` is a variant, not a module
 
-    let _: <u8 as Dr>::Z; //~ ERROR expected associated type, found method `Dr::Z`
+    let _: <u8 as Dr>::Z; //~ ERROR expected associated type, found associated function `Dr::Z`
     <u8 as Dr>::X; //~ ERROR expected method or associated constant, found associated type `Dr::X`
-    let _: <u8 as Dr>::Z::N; //~ ERROR expected associated type, found method `Dr::Z`
+    let _: <u8 as Dr>::Z::N; //~ ERROR expected associated type, found associated function `Dr::Z`
     <u8 as Dr>::X::N; //~ ERROR no associated item named `N` found for type `u16`
 }

--- a/src/test/ui/ufcs/ufcs-partially-resolved.stderr
+++ b/src/test/ui/ufcs/ufcs-partially-resolved.stderr
@@ -35,10 +35,10 @@ error[E0576]: cannot find method or associated constant `N` in trait `Tr`
   --> $DIR/ufcs-partially-resolved.rs:22:17
    |
 LL |     fn Y() {}
-   |     --------- similarly named method `Y` defined here
+   |     --------- similarly named associated function `Y` defined here
 ...
 LL |     <u8 as Tr>::N;
-   |                 ^ help: a method with a similar name exists: `Y`
+   |                 ^ help: an associated function with a similar name exists: `Y`
 
 error[E0576]: cannot find method or associated constant `N` in enum `E`
   --> $DIR/ufcs-partially-resolved.rs:23:16
@@ -166,7 +166,7 @@ error[E0576]: cannot find method or associated constant `NN` in `Tr::Y`
 LL |     <u8 as Tr::Y>::NN;
    |                    ^^ not found in `Tr::Y`
 
-error[E0575]: expected associated type, found method `Dr::Z`
+error[E0575]: expected associated type, found associated function `Dr::Z`
   --> $DIR/ufcs-partially-resolved.rs:52:12
    |
 LL |     type X = u16;
@@ -181,16 +181,16 @@ error[E0575]: expected method or associated constant, found associated type `Dr:
   --> $DIR/ufcs-partially-resolved.rs:53:5
    |
 LL |     fn Z() {}
-   |     --------- similarly named method `Z` defined here
+   |     --------- similarly named associated function `Z` defined here
 ...
 LL |     <u8 as Dr>::X;
    |     ^^^^^^^^^^^^-
    |                 |
-   |                 help: a method with a similar name exists: `Z`
+   |                 help: an associated function with a similar name exists: `Z`
    |
    = note: can't use a type alias as a constructor
 
-error[E0575]: expected associated type, found method `Dr::Z`
+error[E0575]: expected associated type, found associated function `Dr::Z`
   --> $DIR/ufcs-partially-resolved.rs:54:12
    |
 LL |     type X = u16;

--- a/src/test/ui/xc-private-method.rs
+++ b/src/test/ui/xc-private-method.rs
@@ -4,8 +4,8 @@ extern crate xc_private_method_lib;
 
 fn main() {
     let _ = xc_private_method_lib::Struct::static_meth_struct();
-    //~^ ERROR: method `static_meth_struct` is private
+    //~^ ERROR: associated function `static_meth_struct` is private
 
     let _ = xc_private_method_lib::Enum::static_meth_enum();
-    //~^ ERROR: method `static_meth_enum` is private
+    //~^ ERROR: associated function `static_meth_enum` is private
 }

--- a/src/test/ui/xc-private-method.stderr
+++ b/src/test/ui/xc-private-method.stderr
@@ -1,10 +1,10 @@
-error[E0624]: method `static_meth_struct` is private
+error[E0624]: associated function `static_meth_struct` is private
   --> $DIR/xc-private-method.rs:6:13
    |
 LL |     let _ = xc_private_method_lib::Struct::static_meth_struct();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0624]: method `static_meth_enum` is private
+error[E0624]: associated function `static_meth_enum` is private
   --> $DIR/xc-private-method.rs:9:13
    |
 LL |     let _ = xc_private_method_lib::Enum::static_meth_enum();

--- a/src/test/ui/xc-private-method2.rs
+++ b/src/test/ui/xc-private-method2.rs
@@ -4,8 +4,8 @@ extern crate xc_private_method_lib;
 
 fn main() {
     let _ = xc_private_method_lib::Struct{ x: 10 }.meth_struct();
-    //~^ ERROR method `meth_struct` is private
+    //~^ ERROR associated function `meth_struct` is private
 
     let _ = xc_private_method_lib::Enum::Variant1(20).meth_enum();
-    //~^ ERROR method `meth_enum` is private
+    //~^ ERROR associated function `meth_enum` is private
 }

--- a/src/test/ui/xc-private-method2.stderr
+++ b/src/test/ui/xc-private-method2.stderr
@@ -1,10 +1,10 @@
-error[E0624]: method `meth_struct` is private
+error[E0624]: associated function `meth_struct` is private
   --> $DIR/xc-private-method2.rs:6:52
    |
 LL |     let _ = xc_private_method_lib::Struct{ x: 10 }.meth_struct();
    |                                                    ^^^^^^^^^^^
 
-error[E0624]: method `meth_enum` is private
+error[E0624]: associated function `meth_enum` is private
   --> $DIR/xc-private-method2.rs:9:55
    |
 LL |     let _ = xc_private_method_lib::Enum::Variant1(20).meth_enum();


### PR DESCRIPTION
Successful merges:

 - #69471 (Remove `sip::Hasher::short_write`.)
 - #69498 (Change "method" to "associated function")
 - #69959 (std: Don't abort process when printing panics in tests)
 - #69987 (Add self to .mailmap)
 - #69988 (rustc_metadata: Remove `rmeta::MacroDef`)
 - #69991 (fix E0117 message out of sync)
 - #69993 (Add long error explanation for E0693)

Failed merges:


r? @ghost