### PR TITLE
Tweak `suggest_constraining_type_param`

### DIFF
--- a/src/librustc_mir/borrow_check/diagnostics/conflict_errors.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/conflict_errors.rs
@@ -222,8 +222,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                             &mut err,
                             &param.name.as_str(),
                             "Copy",
-                            tcx.sess.source_map(),
-                            span,
                             None,
                         );
                     }

--- a/src/librustc_trait_selection/lib.rs
+++ b/src/librustc_trait_selection/lib.rs
@@ -15,6 +15,7 @@
 #![feature(drain_filter)]
 #![feature(in_band_lifetimes)]
 #![feature(crate_visibility_modifier)]
+#![feature(or_patterns)]
 #![recursion_limit = "512"] // For rustdoc
 
 #[macro_use]

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -195,8 +195,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     return;
                 }
 
-                hir::Node::Item(hir::Item { kind: hir::ItemKind::Fn(_, generics, _), .. })
-                | hir::Node::TraitItem(hir::TraitItem {
+                hir::Node::TraitItem(hir::TraitItem {
                     generics,
                     kind: hir::TraitItemKind::Fn(..),
                     ..
@@ -206,63 +205,31 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     kind: hir::ImplItemKind::Fn(..),
                     ..
                 })
-                | hir::Node::Item(hir::Item {
-                    kind: hir::ItemKind::Trait(_, _, generics, _, _),
-                    ..
-                })
-                | hir::Node::Item(hir::Item {
-                    kind: hir::ItemKind::Impl { generics, .. }, ..
-                }) if projection.is_some() => {
+                | hir::Node::Item(
+                    hir::Item { kind: hir::ItemKind::Fn(_, generics, _), .. }
+                    | hir::Item { kind: hir::ItemKind::Trait(_, _, generics, _, _), .. }
+                    | hir::Item { kind: hir::ItemKind::Impl { generics, .. }, .. },
+                ) if projection.is_some() => {
                     // Missing associated type bound.
                     suggest_restriction(&generics, "the associated type", err);
                     return;
                 }
 
-                hir::Node::Item(hir::Item {
-                    kind: hir::ItemKind::Struct(_, generics),
-                    span,
-                    ..
-                })
-                | hir::Node::Item(hir::Item {
-                    kind: hir::ItemKind::Enum(_, generics), span, ..
-                })
-                | hir::Node::Item(hir::Item {
-                    kind: hir::ItemKind::Union(_, generics),
-                    span,
-                    ..
-                })
-                | hir::Node::Item(hir::Item {
-                    kind: hir::ItemKind::Trait(_, _, generics, ..),
-                    span,
-                    ..
-                })
-                | hir::Node::Item(hir::Item {
-                    kind: hir::ItemKind::Impl { generics, .. },
-                    span,
-                    ..
-                })
-                | hir::Node::Item(hir::Item {
-                    kind: hir::ItemKind::Fn(_, generics, _),
-                    span,
-                    ..
-                })
-                | hir::Node::Item(hir::Item {
-                    kind: hir::ItemKind::TyAlias(_, generics),
-                    span,
-                    ..
-                })
-                | hir::Node::Item(hir::Item {
-                    kind: hir::ItemKind::TraitAlias(generics, _),
-                    span,
-                    ..
-                })
-                | hir::Node::Item(hir::Item {
-                    kind: hir::ItemKind::OpaqueTy(hir::OpaqueTy { generics, .. }),
-                    span,
-                    ..
-                })
-                | hir::Node::TraitItem(hir::TraitItem { generics, span, .. })
-                | hir::Node::ImplItem(hir::ImplItem { generics, span, .. })
+                hir::Node::Item(
+                    hir::Item { kind: hir::ItemKind::Struct(_, generics), .. }
+                    | hir::Item { kind: hir::ItemKind::Enum(_, generics), .. }
+                    | hir::Item { kind: hir::ItemKind::Union(_, generics), .. }
+                    | hir::Item { kind: hir::ItemKind::Trait(_, _, generics, ..), .. }
+                    | hir::Item { kind: hir::ItemKind::Impl { generics, .. }, .. }
+                    | hir::Item { kind: hir::ItemKind::Fn(_, generics, _), .. }
+                    | hir::Item { kind: hir::ItemKind::TyAlias(_, generics), .. }
+                    | hir::Item { kind: hir::ItemKind::TraitAlias(generics, _), .. }
+                    | hir::Item {
+                        kind: hir::ItemKind::OpaqueTy(hir::OpaqueTy { generics, .. }), ..
+                    },
+                )
+                | hir::Node::TraitItem(hir::TraitItem { generics, .. })
+                | hir::Node::ImplItem(hir::ImplItem { generics, .. })
                     if param_ty =>
                 {
                     // Missing generic type parameter bound.
@@ -274,8 +241,6 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                         &mut err,
                         &param_name,
                         &constraint,
-                        self.tcx.sess.source_map(),
-                        *span,
                         Some(trait_ref.def_id()),
                     ) {
                         return;

--- a/src/test/ui/associated-const/associated-const-type-parameter-arrays-2.stderr
+++ b/src/test/ui/associated-const/associated-const-type-parameter-arrays-2.stderr
@@ -7,11 +7,10 @@ LL |     const Y: usize;
 LL |     let _array = [4; <A as Foo>::Y];
    |                      ^^^^^^^^^^^^^ the trait `Foo` is not implemented for `A`
    |
-help: consider further restricting this bound with `+ Foo`
-  --> $DIR/associated-const-type-parameter-arrays-2.rs:15:16
+help: consider further restricting this bound
    |
-LL | pub fn test<A: Foo, B: Foo>() {
-   |                ^^^
+LL | pub fn test<A: Foo + Foo, B: Foo>() {
+   |                    ^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-const/associated-const-type-parameter-arrays.stderr
+++ b/src/test/ui/associated-const/associated-const-type-parameter-arrays.stderr
@@ -7,11 +7,10 @@ LL |     const Y: usize;
 LL |     let _array: [u32; <A as Foo>::Y];
    |                       ^^^^^^^^^^^^^ the trait `Foo` is not implemented for `A`
    |
-help: consider further restricting this bound with `+ Foo`
-  --> $DIR/associated-const-type-parameter-arrays.rs:15:16
+help: consider further restricting this bound
    |
-LL | pub fn test<A: Foo, B: Foo>() {
-   |                ^^^
+LL | pub fn test<A: Foo + Foo, B: Foo>() {
+   |                    ^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/associated-types-invalid-trait-ref-issue-18865.stderr
+++ b/src/test/ui/associated-types/associated-types-invalid-trait-ref-issue-18865.stderr
@@ -4,11 +4,10 @@ error[E0277]: the trait bound `T: Foo<usize>` is not satisfied
 LL |     let u: <T as Foo<usize>>::Bar = t.get_bar();
    |            ^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo<usize>` is not implemented for `T`
    |
-help: consider further restricting this bound with `+ Foo<usize>`
-  --> $DIR/associated-types-invalid-trait-ref-issue-18865.rs:9:8
+help: consider further restricting this bound
    |
-LL | fn f<T:Foo<isize>>(t: &T) {
-   |        ^^^^^^^^^^
+LL | fn f<T:Foo<isize> + Foo<usize>>(t: &T) {
+   |                   ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/associated-types-no-suitable-bound.stderr
+++ b/src/test/ui/associated-types/associated-types-no-suitable-bound.stderr
@@ -4,11 +4,10 @@ error[E0277]: the trait bound `T: Get` is not satisfied
 LL |     fn uhoh<T>(foo: <T as Get>::Value) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Get` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: Get`
-  --> $DIR/associated-types-no-suitable-bound.rs:11:13
+help: consider restricting type parameter `T`
    |
-LL |     fn uhoh<T>(foo: <T as Get>::Value) {}
-   |             ^
+LL |     fn uhoh<T: Get>(foo: <T as Get>::Value) {}
+   |              ^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/defaults-suitability.stderr
+++ b/src/test/ui/associated-types/defaults-suitability.stderr
@@ -23,12 +23,11 @@ LL | trait Foo<T> {
 LL |     type Bar: Clone = Vec<T>;
    |               ^^^^^ the trait `std::clone::Clone` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::clone::Clone`
-  --> $DIR/defaults-suitability.rs:32:11
-   |
-LL | trait Foo<T> {
-   |           ^
    = note: required because of the requirements on the impl of `std::clone::Clone` for `std::vec::Vec<T>`
+help: consider restricting type parameter `T`
+   |
+LL | trait Foo<T: std::clone::Clone> {
+   |            ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `(): Foo<Self>` is not satisfied
   --> $DIR/defaults-suitability.rs:39:17
@@ -119,11 +118,10 @@ LL | |     type Baz = T;
 LL | | }
    | |_- required by `Foo3`
    |
-help: consider restricting this type parameter with `where T: std::clone::Clone`
-  --> $DIR/defaults-suitability.rs:88:12
+help: consider further restricting type parameter `T`
    |
-LL | trait Foo3<T> where
-   |            ^
+LL |     Self::Baz: Clone, T: std::clone::Clone
+   |                     ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> $DIR/defaults-suitability.rs:27:5

--- a/src/test/ui/associated-types/defaults-unsound-62211-1.stderr
+++ b/src/test/ui/associated-types/defaults-unsound-62211-1.stderr
@@ -47,11 +47,10 @@ LL | impl<T> UncheckedCopy for T {}
    |
    = help: the trait `std::fmt::Display` is not implemented for `T`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-help: consider restricting this type parameter with `T: std::fmt::Display`
-  --> $DIR/defaults-unsound-62211-1.rs:41:6
+help: consider restricting type parameter `T`
    |
-LL | impl<T> UncheckedCopy for T {}
-   |      ^
+LL | impl<T: std::fmt::Display> UncheckedCopy for T {}
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `T: std::ops::Deref` is not satisfied
   --> $DIR/defaults-unsound-62211-1.rs:41:9
@@ -59,11 +58,10 @@ error[E0277]: the trait bound `T: std::ops::Deref` is not satisfied
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ the trait `std::ops::Deref` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::ops::Deref`
-  --> $DIR/defaults-unsound-62211-1.rs:41:6
+help: consider restricting type parameter `T`
    |
-LL | impl<T> UncheckedCopy for T {}
-   |      ^
+LL | impl<T: std::ops::Deref> UncheckedCopy for T {}
+   |       ^^^^^^^^^^^^^^^^^
 
 error[E0277]: cannot add-assign `&'static str` to `T`
   --> $DIR/defaults-unsound-62211-1.rs:41:9
@@ -72,11 +70,10 @@ LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ no implementation for `T += &'static str`
    |
    = help: the trait `std::ops::AddAssign<&'static str>` is not implemented for `T`
-help: consider restricting this type parameter with `T: std::ops::AddAssign<&'static str>`
-  --> $DIR/defaults-unsound-62211-1.rs:41:6
+help: consider restricting type parameter `T`
    |
-LL | impl<T> UncheckedCopy for T {}
-   |      ^
+LL | impl<T: std::ops::AddAssign<&'static str>> UncheckedCopy for T {}
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/defaults-unsound-62211-1.rs:41:9
@@ -84,11 +81,10 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::marker::Copy`
-  --> $DIR/defaults-unsound-62211-1.rs:41:6
+help: consider restricting type parameter `T`
    |
-LL | impl<T> UncheckedCopy for T {}
-   |      ^
+LL | impl<T: std::marker::Copy> UncheckedCopy for T {}
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/associated-types/defaults-unsound-62211-2.stderr
+++ b/src/test/ui/associated-types/defaults-unsound-62211-2.stderr
@@ -47,11 +47,10 @@ LL | impl<T> UncheckedCopy for T {}
    |
    = help: the trait `std::fmt::Display` is not implemented for `T`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-help: consider restricting this type parameter with `T: std::fmt::Display`
-  --> $DIR/defaults-unsound-62211-2.rs:41:6
+help: consider restricting type parameter `T`
    |
-LL | impl<T> UncheckedCopy for T {}
-   |      ^
+LL | impl<T: std::fmt::Display> UncheckedCopy for T {}
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `T: std::ops::Deref` is not satisfied
   --> $DIR/defaults-unsound-62211-2.rs:41:9
@@ -59,11 +58,10 @@ error[E0277]: the trait bound `T: std::ops::Deref` is not satisfied
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ the trait `std::ops::Deref` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::ops::Deref`
-  --> $DIR/defaults-unsound-62211-2.rs:41:6
+help: consider restricting type parameter `T`
    |
-LL | impl<T> UncheckedCopy for T {}
-   |      ^
+LL | impl<T: std::ops::Deref> UncheckedCopy for T {}
+   |       ^^^^^^^^^^^^^^^^^
 
 error[E0277]: cannot add-assign `&'static str` to `T`
   --> $DIR/defaults-unsound-62211-2.rs:41:9
@@ -72,11 +70,10 @@ LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ no implementation for `T += &'static str`
    |
    = help: the trait `std::ops::AddAssign<&'static str>` is not implemented for `T`
-help: consider restricting this type parameter with `T: std::ops::AddAssign<&'static str>`
-  --> $DIR/defaults-unsound-62211-2.rs:41:6
+help: consider restricting type parameter `T`
    |
-LL | impl<T> UncheckedCopy for T {}
-   |      ^
+LL | impl<T: std::ops::AddAssign<&'static str>> UncheckedCopy for T {}
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/defaults-unsound-62211-2.rs:41:9
@@ -84,11 +81,10 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
 LL | impl<T> UncheckedCopy for T {}
    |         ^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::marker::Copy`
-  --> $DIR/defaults-unsound-62211-2.rs:41:6
+help: consider restricting type parameter `T`
    |
-LL | impl<T> UncheckedCopy for T {}
-   |      ^
+LL | impl<T: std::marker::Copy> UncheckedCopy for T {}
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/bad/bad-method-typaram-kind.stderr
+++ b/src/test/ui/bad/bad-method-typaram-kind.stderr
@@ -5,11 +5,10 @@ LL |     1.bar::<T>();
    |       ^^^ `T` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `T`
-help: consider further restricting this bound with `+ std::marker::Send`
-  --> $DIR/bad-method-typaram-kind.rs:1:10
+help: consider further restricting this bound
    |
-LL | fn foo<T:'static>() {
-   |          ^^^^^^^
+LL | fn foo<T:'static + std::marker::Send>() {
+   |                  ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/binop/binop-consume-args.stderr
+++ b/src/test/ui/binop/binop-consume-args.stderr
@@ -8,11 +8,10 @@ LL |     lhs + rhs;
 LL |     drop(lhs);
    |          ^^^ value used here after move
    |
-help: consider further restricting this bound with `+ Copy`
-  --> $DIR/binop-consume-args.rs:5:11
+help: consider further restricting this bound
    |
-LL | fn add<A: Add<B, Output=()>, B>(lhs: A, rhs: B) {
-   |           ^^^^^^^^^^^^^^^^^
+LL | fn add<A: Add<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
+   |                             ^^^^^^
 
 error[E0382]: use of moved value: `rhs`
   --> $DIR/binop-consume-args.rs:8:10
@@ -25,11 +24,10 @@ LL |     drop(lhs);
 LL |     drop(rhs);
    |          ^^^ value used here after move
    |
-help: consider restricting this type parameter with `B: Copy`
-  --> $DIR/binop-consume-args.rs:5:30
+help: consider restricting type parameter `B`
    |
-LL | fn add<A: Add<B, Output=()>, B>(lhs: A, rhs: B) {
-   |                              ^
+LL | fn add<A: Add<B, Output=()>, B: Copy>(lhs: A, rhs: B) {
+   |                               ^^^^^^
 
 error[E0382]: use of moved value: `lhs`
   --> $DIR/binop-consume-args.rs:13:10
@@ -41,11 +39,10 @@ LL |     lhs - rhs;
 LL |     drop(lhs);
    |          ^^^ value used here after move
    |
-help: consider further restricting this bound with `+ Copy`
-  --> $DIR/binop-consume-args.rs:11:11
+help: consider further restricting this bound
    |
-LL | fn sub<A: Sub<B, Output=()>, B>(lhs: A, rhs: B) {
-   |           ^^^^^^^^^^^^^^^^^
+LL | fn sub<A: Sub<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
+   |                             ^^^^^^
 
 error[E0382]: use of moved value: `rhs`
   --> $DIR/binop-consume-args.rs:14:10
@@ -58,11 +55,10 @@ LL |     drop(lhs);
 LL |     drop(rhs);
    |          ^^^ value used here after move
    |
-help: consider restricting this type parameter with `B: Copy`
-  --> $DIR/binop-consume-args.rs:11:30
+help: consider restricting type parameter `B`
    |
-LL | fn sub<A: Sub<B, Output=()>, B>(lhs: A, rhs: B) {
-   |                              ^
+LL | fn sub<A: Sub<B, Output=()>, B: Copy>(lhs: A, rhs: B) {
+   |                               ^^^^^^
 
 error[E0382]: use of moved value: `lhs`
   --> $DIR/binop-consume-args.rs:19:10
@@ -74,11 +70,10 @@ LL |     lhs * rhs;
 LL |     drop(lhs);
    |          ^^^ value used here after move
    |
-help: consider further restricting this bound with `+ Copy`
-  --> $DIR/binop-consume-args.rs:17:11
+help: consider further restricting this bound
    |
-LL | fn mul<A: Mul<B, Output=()>, B>(lhs: A, rhs: B) {
-   |           ^^^^^^^^^^^^^^^^^
+LL | fn mul<A: Mul<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
+   |                             ^^^^^^
 
 error[E0382]: use of moved value: `rhs`
   --> $DIR/binop-consume-args.rs:20:10
@@ -91,11 +86,10 @@ LL |     drop(lhs);
 LL |     drop(rhs);
    |          ^^^ value used here after move
    |
-help: consider restricting this type parameter with `B: Copy`
-  --> $DIR/binop-consume-args.rs:17:30
+help: consider restricting type parameter `B`
    |
-LL | fn mul<A: Mul<B, Output=()>, B>(lhs: A, rhs: B) {
-   |                              ^
+LL | fn mul<A: Mul<B, Output=()>, B: Copy>(lhs: A, rhs: B) {
+   |                               ^^^^^^
 
 error[E0382]: use of moved value: `lhs`
   --> $DIR/binop-consume-args.rs:25:10
@@ -107,11 +101,10 @@ LL |     lhs / rhs;
 LL |     drop(lhs);
    |          ^^^ value used here after move
    |
-help: consider further restricting this bound with `+ Copy`
-  --> $DIR/binop-consume-args.rs:23:11
+help: consider further restricting this bound
    |
-LL | fn div<A: Div<B, Output=()>, B>(lhs: A, rhs: B) {
-   |           ^^^^^^^^^^^^^^^^^
+LL | fn div<A: Div<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
+   |                             ^^^^^^
 
 error[E0382]: use of moved value: `rhs`
   --> $DIR/binop-consume-args.rs:26:10
@@ -124,11 +117,10 @@ LL |     drop(lhs);
 LL |     drop(rhs);
    |          ^^^ value used here after move
    |
-help: consider restricting this type parameter with `B: Copy`
-  --> $DIR/binop-consume-args.rs:23:30
+help: consider restricting type parameter `B`
    |
-LL | fn div<A: Div<B, Output=()>, B>(lhs: A, rhs: B) {
-   |                              ^
+LL | fn div<A: Div<B, Output=()>, B: Copy>(lhs: A, rhs: B) {
+   |                               ^^^^^^
 
 error[E0382]: use of moved value: `lhs`
   --> $DIR/binop-consume-args.rs:31:10
@@ -140,11 +132,10 @@ LL |     lhs % rhs;
 LL |     drop(lhs);
    |          ^^^ value used here after move
    |
-help: consider further restricting this bound with `+ Copy`
-  --> $DIR/binop-consume-args.rs:29:11
+help: consider further restricting this bound
    |
-LL | fn rem<A: Rem<B, Output=()>, B>(lhs: A, rhs: B) {
-   |           ^^^^^^^^^^^^^^^^^
+LL | fn rem<A: Rem<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
+   |                             ^^^^^^
 
 error[E0382]: use of moved value: `rhs`
   --> $DIR/binop-consume-args.rs:32:10
@@ -157,11 +148,10 @@ LL |     drop(lhs);
 LL |     drop(rhs);
    |          ^^^ value used here after move
    |
-help: consider restricting this type parameter with `B: Copy`
-  --> $DIR/binop-consume-args.rs:29:30
+help: consider restricting type parameter `B`
    |
-LL | fn rem<A: Rem<B, Output=()>, B>(lhs: A, rhs: B) {
-   |                              ^
+LL | fn rem<A: Rem<B, Output=()>, B: Copy>(lhs: A, rhs: B) {
+   |                               ^^^^^^
 
 error[E0382]: use of moved value: `lhs`
   --> $DIR/binop-consume-args.rs:37:10
@@ -173,11 +163,10 @@ LL |     lhs & rhs;
 LL |     drop(lhs);
    |          ^^^ value used here after move
    |
-help: consider further restricting this bound with `+ Copy`
-  --> $DIR/binop-consume-args.rs:35:14
+help: consider further restricting this bound
    |
-LL | fn bitand<A: BitAnd<B, Output=()>, B>(lhs: A, rhs: B) {
-   |              ^^^^^^^^^^^^^^^^^^^^
+LL | fn bitand<A: BitAnd<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
+   |                                   ^^^^^^
 
 error[E0382]: use of moved value: `rhs`
   --> $DIR/binop-consume-args.rs:38:10
@@ -190,11 +179,10 @@ LL |     drop(lhs);
 LL |     drop(rhs);
    |          ^^^ value used here after move
    |
-help: consider restricting this type parameter with `B: Copy`
-  --> $DIR/binop-consume-args.rs:35:36
+help: consider restricting type parameter `B`
    |
-LL | fn bitand<A: BitAnd<B, Output=()>, B>(lhs: A, rhs: B) {
-   |                                    ^
+LL | fn bitand<A: BitAnd<B, Output=()>, B: Copy>(lhs: A, rhs: B) {
+   |                                     ^^^^^^
 
 error[E0382]: use of moved value: `lhs`
   --> $DIR/binop-consume-args.rs:43:10
@@ -206,11 +194,10 @@ LL |     lhs | rhs;
 LL |     drop(lhs);
    |          ^^^ value used here after move
    |
-help: consider further restricting this bound with `+ Copy`
-  --> $DIR/binop-consume-args.rs:41:13
+help: consider further restricting this bound
    |
-LL | fn bitor<A: BitOr<B, Output=()>, B>(lhs: A, rhs: B) {
-   |             ^^^^^^^^^^^^^^^^^^^
+LL | fn bitor<A: BitOr<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
+   |                                 ^^^^^^
 
 error[E0382]: use of moved value: `rhs`
   --> $DIR/binop-consume-args.rs:44:10
@@ -223,11 +210,10 @@ LL |     drop(lhs);
 LL |     drop(rhs);
    |          ^^^ value used here after move
    |
-help: consider restricting this type parameter with `B: Copy`
-  --> $DIR/binop-consume-args.rs:41:34
+help: consider restricting type parameter `B`
    |
-LL | fn bitor<A: BitOr<B, Output=()>, B>(lhs: A, rhs: B) {
-   |                                  ^
+LL | fn bitor<A: BitOr<B, Output=()>, B: Copy>(lhs: A, rhs: B) {
+   |                                   ^^^^^^
 
 error[E0382]: use of moved value: `lhs`
   --> $DIR/binop-consume-args.rs:49:10
@@ -239,11 +225,10 @@ LL |     lhs ^ rhs;
 LL |     drop(lhs);
    |          ^^^ value used here after move
    |
-help: consider further restricting this bound with `+ Copy`
-  --> $DIR/binop-consume-args.rs:47:14
+help: consider further restricting this bound
    |
-LL | fn bitxor<A: BitXor<B, Output=()>, B>(lhs: A, rhs: B) {
-   |              ^^^^^^^^^^^^^^^^^^^^
+LL | fn bitxor<A: BitXor<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
+   |                                   ^^^^^^
 
 error[E0382]: use of moved value: `rhs`
   --> $DIR/binop-consume-args.rs:50:10
@@ -256,11 +241,10 @@ LL |     drop(lhs);
 LL |     drop(rhs);
    |          ^^^ value used here after move
    |
-help: consider restricting this type parameter with `B: Copy`
-  --> $DIR/binop-consume-args.rs:47:36
+help: consider restricting type parameter `B`
    |
-LL | fn bitxor<A: BitXor<B, Output=()>, B>(lhs: A, rhs: B) {
-   |                                    ^
+LL | fn bitxor<A: BitXor<B, Output=()>, B: Copy>(lhs: A, rhs: B) {
+   |                                     ^^^^^^
 
 error[E0382]: use of moved value: `lhs`
   --> $DIR/binop-consume-args.rs:55:10
@@ -272,11 +256,10 @@ LL |     lhs << rhs;
 LL |     drop(lhs);
    |          ^^^ value used here after move
    |
-help: consider further restricting this bound with `+ Copy`
-  --> $DIR/binop-consume-args.rs:53:11
+help: consider further restricting this bound
    |
-LL | fn shl<A: Shl<B, Output=()>, B>(lhs: A, rhs: B) {
-   |           ^^^^^^^^^^^^^^^^^
+LL | fn shl<A: Shl<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
+   |                             ^^^^^^
 
 error[E0382]: use of moved value: `rhs`
   --> $DIR/binop-consume-args.rs:56:10
@@ -289,11 +272,10 @@ LL |     drop(lhs);
 LL |     drop(rhs);
    |          ^^^ value used here after move
    |
-help: consider restricting this type parameter with `B: Copy`
-  --> $DIR/binop-consume-args.rs:53:30
+help: consider restricting type parameter `B`
    |
-LL | fn shl<A: Shl<B, Output=()>, B>(lhs: A, rhs: B) {
-   |                              ^
+LL | fn shl<A: Shl<B, Output=()>, B: Copy>(lhs: A, rhs: B) {
+   |                               ^^^^^^
 
 error[E0382]: use of moved value: `lhs`
   --> $DIR/binop-consume-args.rs:61:10
@@ -305,11 +287,10 @@ LL |     lhs >> rhs;
 LL |     drop(lhs);
    |          ^^^ value used here after move
    |
-help: consider further restricting this bound with `+ Copy`
-  --> $DIR/binop-consume-args.rs:59:11
+help: consider further restricting this bound
    |
-LL | fn shr<A: Shr<B, Output=()>, B>(lhs: A, rhs: B) {
-   |           ^^^^^^^^^^^^^^^^^
+LL | fn shr<A: Shr<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
+   |                             ^^^^^^
 
 error[E0382]: use of moved value: `rhs`
   --> $DIR/binop-consume-args.rs:62:10
@@ -322,11 +303,10 @@ LL |     drop(lhs);
 LL |     drop(rhs);
    |          ^^^ value used here after move
    |
-help: consider restricting this type parameter with `B: Copy`
-  --> $DIR/binop-consume-args.rs:59:30
+help: consider restricting type parameter `B`
    |
-LL | fn shr<A: Shr<B, Output=()>, B>(lhs: A, rhs: B) {
-   |                              ^
+LL | fn shr<A: Shr<B, Output=()>, B: Copy>(lhs: A, rhs: B) {
+   |                               ^^^^^^
 
 error: aborting due to 20 previous errors
 

--- a/src/test/ui/binop/binop-move-semantics.stderr
+++ b/src/test/ui/binop/binop-move-semantics.stderr
@@ -9,11 +9,10 @@ LL |     +
 LL |     x;
    |     ^ value used here after move
    |
-help: consider further restricting this bound with `+ Copy`
-  --> $DIR/binop-move-semantics.rs:5:19
+help: consider further restricting this bound
    |
-LL | fn double_move<T: Add<Output=()>>(x: T) {
-   |                   ^^^^^^^^^^^^^^
+LL | fn double_move<T: Add<Output=()> + Copy>(x: T) {
+   |                                  ^^^^^^
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/binop-move-semantics.rs:14:5
@@ -26,11 +25,10 @@ LL |     +
 LL |     x.clone();
    |     ^ value borrowed here after move
    |
-help: consider further restricting this bound with `+ Copy`
-  --> $DIR/binop-move-semantics.rs:11:24
+help: consider further restricting this bound
    |
-LL | fn move_then_borrow<T: Add<Output=()> + Clone>(x: T) {
-   |                        ^^^^^^^^^^^^^^^^^^^^^^
+LL | fn move_then_borrow<T: Add<Output=()> + Clone + Copy>(x: T) {
+   |                                               ^^^^^^
 
 error[E0505]: cannot move out of `x` because it is borrowed
   --> $DIR/binop-move-semantics.rs:21:5

--- a/src/test/ui/borrowck/borrowck-unboxed-closures.stderr
+++ b/src/test/ui/borrowck/borrowck-unboxed-closures.stderr
@@ -26,11 +26,10 @@ LL |     f(1, 2);
 LL |     f(1, 2);
    |     ^ value used here after move
    |
-help: consider further restricting this bound with `+ Copy`
-  --> $DIR/borrowck-unboxed-closures.rs:10:8
+help: consider further restricting this bound
    |
-LL | fn c<F:FnOnce(isize, isize) -> isize>(f: F) {
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn c<F:FnOnce(isize, isize) -> isize + Copy>(f: F) {
+   |                                      ^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/bound-suggestions.fixed
+++ b/src/test/ui/bound-suggestions.fixed
@@ -13,7 +13,7 @@ fn test_no_bounds<T: std::fmt::Debug>(t: T) {
 }
 
 #[allow(dead_code)]
-fn test_one_bound<T: std::fmt::Debug +  Sized>(t: T) {
+fn test_one_bound<T: Sized + std::fmt::Debug>(t: T) {
     println!("{:?}", t);
     //~^ ERROR doesn't implement
 }
@@ -25,7 +25,7 @@ fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug, Y: std::fmt:
 }
 
 #[allow(dead_code)]
-fn test_one_bound_where<X>(x: X) where X: std::fmt::Debug + Sized {
+fn test_one_bound_where<X>(x: X) where X: Sized + std::fmt::Debug {
     println!("{:?}", x);
     //~^ ERROR doesn't implement
 }

--- a/src/test/ui/bound-suggestions.stderr
+++ b/src/test/ui/bound-suggestions.stderr
@@ -5,13 +5,12 @@ LL |     println!("{:?}", t);
    |                      ^ `impl Sized` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `impl Sized`
-help: consider further restricting this bound with `+ std::fmt::Debug`
-  --> $DIR/bound-suggestions.rs:4:17
-   |
-LL | fn test_impl(t: impl Sized) {
-   |                 ^^^^^^^^^^
    = note: required by `std::fmt::Debug::fmt`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider further restricting this bound
+   |
+LL | fn test_impl(t: impl Sized + std::fmt::Debug) {
+   |                            ^^^^^^^^^^^^^^^^^
 
 error[E0277]: `T` doesn't implement `std::fmt::Debug`
   --> $DIR/bound-suggestions.rs:11:22
@@ -20,13 +19,12 @@ LL |     println!("{:?}", t);
    |                      ^ `T` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `T`
-help: consider restricting this type parameter with `T: std::fmt::Debug`
-  --> $DIR/bound-suggestions.rs:10:19
-   |
-LL | fn test_no_bounds<T>(t: T) {
-   |                   ^
    = note: required by `std::fmt::Debug::fmt`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider restricting type parameter `T`
+   |
+LL | fn test_no_bounds<T: std::fmt::Debug>(t: T) {
+   |                    ^^^^^^^^^^^^^^^^^
 
 error[E0277]: `T` doesn't implement `std::fmt::Debug`
   --> $DIR/bound-suggestions.rs:17:22
@@ -35,13 +33,12 @@ LL |     println!("{:?}", t);
    |                      ^ `T` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `T`
-help: consider further restricting this bound with `+ std::fmt::Debug`
-  --> $DIR/bound-suggestions.rs:16:22
-   |
-LL | fn test_one_bound<T: Sized>(t: T) {
-   |                      ^^^^^
    = note: required by `std::fmt::Debug::fmt`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider further restricting this bound
+   |
+LL | fn test_one_bound<T: Sized + std::fmt::Debug>(t: T) {
+   |                            ^^^^^^^^^^^^^^^^^
 
 error[E0277]: `Y` doesn't implement `std::fmt::Debug`
   --> $DIR/bound-suggestions.rs:23:30
@@ -50,13 +47,12 @@ LL |     println!("{:?} {:?}", x, y);
    |                              ^ `Y` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `Y`
-help: consider restricting this type parameter with `where Y: std::fmt::Debug`
-  --> $DIR/bound-suggestions.rs:22:28
-   |
-LL | fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug {
-   |                            ^
    = note: required by `std::fmt::Debug::fmt`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider further restricting type parameter `Y`
+   |
+LL | fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug, Y: std::fmt::Debug {
+   |                                                                   ^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `X` doesn't implement `std::fmt::Debug`
   --> $DIR/bound-suggestions.rs:29:22
@@ -65,13 +61,12 @@ LL |     println!("{:?}", x);
    |                      ^ `X` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `X`
-help: consider further restricting this bound with `+ std::fmt::Debug`
-  --> $DIR/bound-suggestions.rs:28:40
-   |
-LL | fn test_one_bound_where<X>(x: X) where X: Sized {
-   |                                        ^^^^^^^^
    = note: required by `std::fmt::Debug::fmt`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider further restricting this bound
+   |
+LL | fn test_one_bound_where<X>(x: X) where X: Sized + std::fmt::Debug {
+   |                                                 ^^^^^^^^^^^^^^^^^
 
 error[E0277]: `X` doesn't implement `std::fmt::Debug`
   --> $DIR/bound-suggestions.rs:35:22
@@ -80,13 +75,12 @@ LL |     println!("{:?}", x);
    |                      ^ `X` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `X`
-help: consider further restricting this type parameter with `where X: std::fmt::Debug`
-  --> $DIR/bound-suggestions.rs:34:27
-   |
-LL | fn test_many_bounds_where<X>(x: X) where X: Sized, X: Sized {
-   |                           ^
    = note: required by `std::fmt::Debug::fmt`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider further restricting type parameter `X`
+   |
+LL | fn test_many_bounds_where<X>(x: X) where X: Sized, X: Sized, X: std::fmt::Debug {
+   |                                                            ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
@@ -5,12 +5,11 @@ LL | impl <T: Sync+'static> Foo for (T,) { }
    |                        ^^^ `T` cannot be sent between threads safely
    |
    = help: within `(T,)`, the trait `std::marker::Send` is not implemented for `T`
-help: consider further restricting this bound with `+ std::marker::Send`
-  --> $DIR/builtin-superkinds-double-superkind.rs:6:10
-   |
-LL | impl <T: Sync+'static> Foo for (T,) { }
-   |          ^^^^^^^^^^^^
    = note: required because it appears within the type `(T,)`
+help: consider further restricting this bound
+   |
+LL | impl <T: Sync+'static + std::marker::Send> Foo for (T,) { }
+   |                       ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `T` cannot be shared between threads safely
   --> $DIR/builtin-superkinds-double-superkind.rs:9:16
@@ -19,12 +18,11 @@ LL | impl <T: Send> Foo for (T,T) { }
    |                ^^^ `T` cannot be shared between threads safely
    |
    = help: within `(T, T)`, the trait `std::marker::Sync` is not implemented for `T`
-help: consider further restricting this bound with `+ std::marker::Sync`
-  --> $DIR/builtin-superkinds-double-superkind.rs:9:10
-   |
-LL | impl <T: Send> Foo for (T,T) { }
-   |          ^^^^
    = note: required because it appears within the type `(T, T)`
+help: consider further restricting this bound
+   |
+LL | impl <T: Send + std::marker::Sync> Foo for (T,T) { }
+   |               ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
@@ -5,12 +5,11 @@ LL | impl <T:Sync+'static> RequiresRequiresShareAndSend for X<T> { }
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `T` cannot be sent between threads safely
    |
    = help: within `X<T>`, the trait `std::marker::Send` is not implemented for `T`
-help: consider further restricting this bound with `+ std::marker::Send`
-  --> $DIR/builtin-superkinds-in-metadata.rs:13:9
-   |
-LL | impl <T:Sync+'static> RequiresRequiresShareAndSend for X<T> { }
-   |         ^^^^^^^^^^^^
    = note: required because it appears within the type `X<T>`
+help: consider further restricting this bound
+   |
+LL | impl <T:Sync+'static + std::marker::Send> RequiresRequiresShareAndSend for X<T> { }
+   |                      ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
@@ -5,11 +5,10 @@ LL | impl <T: Sync+'static> Foo for T { }
    |                        ^^^ `T` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `T`
-help: consider further restricting this bound with `+ std::marker::Send`
-  --> $DIR/builtin-superkinds-typaram-not-send.rs:5:10
+help: consider further restricting this bound
    |
-LL | impl <T: Sync+'static> Foo for T { }
-   |          ^^^^^^^^^^^^
+LL | impl <T: Sync+'static + std::marker::Send> Foo for T { }
+   |                       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
+++ b/src/test/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
@@ -8,11 +8,10 @@ LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static {
    |                      ^^^^ `F` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `F`
-help: consider further restricting this bound with `+ std::marker::Send`
-  --> $DIR/closure-bounds-cant-promote-superkind-in-struct.rs:5:33
+help: consider further restricting this bound
    |
-LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static {
-   |                                 ^^^^^^^^^^^^^^^^^^^^^
+LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static + std::marker::Send {
+   |                                                       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/closures/closure-bounds-subtype.stderr
+++ b/src/test/ui/closures/closure-bounds-subtype.stderr
@@ -8,11 +8,10 @@ LL |     take_const_owned(f);
    |                      ^ `F` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `F`
-help: consider further restricting this bound with `+ std::marker::Sync`
-  --> $DIR/closure-bounds-subtype.rs:11:30
+help: consider further restricting this bound
    |
-LL | fn give_owned<F>(f: F) where F: FnOnce() + Send {
-   |                              ^^^^^^^^^^^^^^^^^^
+LL | fn give_owned<F>(f: F) where F: FnOnce() + Send + std::marker::Sync {
+   |                                                 ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/closures/issue-67123.stderr
+++ b/src/test/ui/closures/issue-67123.stderr
@@ -6,12 +6,11 @@ LL |     || { t; t; };
    |          |
    |          value moved here
    |
-help: consider restricting this type parameter with `T: Copy`
-  --> $DIR/issue-67123.rs:1:8
-   |
-LL | fn foo<T>(t: T) {
-   |        ^
    = note: move occurs because `t` has type `T`, which does not implement the `Copy` trait
+help: consider restricting type parameter `T`
+   |
+LL | fn foo<T: Copy>(t: T) {
+   |         ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/issues/issue-61336-2.stderr
+++ b/src/test/ui/const-generics/issues/issue-61336-2.stderr
@@ -12,12 +12,11 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
 LL |     [x; { N }]
    |     ^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::marker::Copy`
-  --> $DIR/issue-61336-2.rs:8:6
-   |
-LL | fn g<T, const N: usize>(x: T) -> [T; N] {
-   |      ^
    = note: the `Copy` trait is required because the repeated element will be copied
+help: consider restricting type parameter `T`
+   |
+LL | fn g<T: std::marker::Copy, const N: usize>(x: T) -> [T; N] {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/issues/issue-61336.stderr
+++ b/src/test/ui/const-generics/issues/issue-61336.stderr
@@ -12,12 +12,11 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
 LL |     [x; N]
    |     ^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::marker::Copy`
-  --> $DIR/issue-61336.rs:8:6
-   |
-LL | fn g<T, const N: usize>(x: T) -> [T; N] {
-   |      ^
    = note: the `Copy` trait is required because the repeated element will be copied
+help: consider restricting type parameter `T`
+   |
+LL | fn g<T: std::marker::Copy, const N: usize>(x: T) -> [T; N] {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/impl_bounds.stderr
+++ b/src/test/ui/generic-associated-types/impl_bounds.stderr
@@ -34,13 +34,12 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
 LL |     type C where Self: Copy = String;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::marker::Copy`
-  --> $DIR/impl_bounds.rs:14:6
-   |
-LL | impl<T> Foo for Fooy<T> {
-   |      ^
    = note: required because of the requirements on the impl of `std::marker::Copy` for `Fooy<T>`
    = note: the requirement `Fooy<T>: std::marker::Copy` appears on the associated impl type but not on the corresponding associated trait type
+help: consider restricting type parameter `T`
+   |
+LL | impl<T: std::marker::Copy> Foo for Fooy<T> {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/hrtb/hrtb-higher-ranker-supertraits-transitive.stderr
+++ b/src/test/ui/hrtb/hrtb-higher-ranker-supertraits-transitive.stderr
@@ -9,11 +9,10 @@ LL |     where B : for<'ccx> Bar<'ccx>
 LL |     want_bar_for_any_ccx(b);
    |                          ^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
    |
-help: consider further restricting this bound with `+ for<'ccx> Bar<'ccx>`
-  --> $DIR/hrtb-higher-ranker-supertraits-transitive.rs:44:11
+help: consider further restricting this bound
    |
-LL |     where B : Qux
-   |           ^^^^^^^
+LL |     where B : Qux + for<'ccx> Bar<'ccx>
+   |                   ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/hrtb/hrtb-higher-ranker-supertraits.stderr
+++ b/src/test/ui/hrtb/hrtb-higher-ranker-supertraits.stderr
@@ -9,11 +9,10 @@ LL | fn want_foo_for_any_tcx<F>(f: &F)
 LL |     where F : for<'tcx> Foo<'tcx>
    |               ------------------- required by this bound in `want_foo_for_any_tcx`
    |
-help: consider further restricting this bound with `+ for<'tcx> Foo<'tcx>`
-  --> $DIR/hrtb-higher-ranker-supertraits.rs:15:11
+help: consider further restricting this bound
    |
-LL |     where F : Foo<'x>
-   |           ^^^^^^^^^^^
+LL |     where F : Foo<'x> + for<'tcx> Foo<'tcx>
+   |                       ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `for<'ccx> B: Bar<'ccx>` is not satisfied
   --> $DIR/hrtb-higher-ranker-supertraits.rs:35:26
@@ -26,11 +25,10 @@ LL | fn want_bar_for_any_ccx<B>(b: &B)
 LL |     where B : for<'ccx> Bar<'ccx>
    |               ------------------- required by this bound in `want_bar_for_any_ccx`
    |
-help: consider further restricting this bound with `+ for<'ccx> Bar<'ccx>`
-  --> $DIR/hrtb-higher-ranker-supertraits.rs:29:11
+help: consider further restricting this bound
    |
-LL |     where B : Bar<'x>
-   |           ^^^^^^^^^^^
+LL |     where B : Bar<'x> + for<'ccx> Bar<'ccx>
+   |                       ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/impl-trait/issue-55872-1.stderr
+++ b/src/test/ui/impl-trait/issue-55872-1.stderr
@@ -4,13 +4,12 @@ error[E0277]: the trait bound `S: std::marker::Copy` is not satisfied in `(S, T)
 LL |     type E = impl Copy;
    |     ^^^^^^^^^^^^^^^^^^^ within `(S, T)`, the trait `std::marker::Copy` is not implemented for `S`
    |
-help: consider further restricting this bound with `+ std::marker::Copy`
-  --> $DIR/issue-55872-1.rs:11:9
-   |
-LL | impl<S: Default> Bar for S {
-   |         ^^^^^^^
    = note: required because it appears within the type `(S, T)`
    = note: the return type of a function must have a statically known size
+help: consider further restricting this bound
+   |
+LL | impl<S: Default + std::marker::Copy> Bar for S {
+   |                 ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied in `(S, T)`
   --> $DIR/issue-55872-1.rs:12:5
@@ -18,13 +17,12 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied in `(S, T)
 LL |     type E = impl Copy;
    |     ^^^^^^^^^^^^^^^^^^^ within `(S, T)`, the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider further restricting this bound with `+ std::marker::Copy`
-  --> $DIR/issue-55872-1.rs:16:15
-   |
-LL |     fn foo<T: Default>() -> Self::E {
-   |               ^^^^^^^
    = note: required because it appears within the type `(S, T)`
    = note: the return type of a function must have a statically known size
+help: consider further restricting this bound
+   |
+LL |     fn foo<T: Default + std::marker::Copy>() -> Self::E {
+   |                       ^^^^^^^^^^^^^^^^^^^
 
 error: type parameter `T` is part of concrete type but not used in parameter list for the `impl Trait` type alias
   --> $DIR/issue-55872-1.rs:16:37

--- a/src/test/ui/issues/issue-21837.stderr
+++ b/src/test/ui/issues/issue-21837.stderr
@@ -7,11 +7,10 @@ LL | pub struct Foo<T: Bound>(T);
 LL | impl<T> Trait2 for Foo<T> {}
    |         ^^^^^^ the trait `Bound` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: Bound`
-  --> $DIR/issue-21837.rs:8:6
+help: consider restricting type parameter `T`
    |
-LL | impl<T> Trait2 for Foo<T> {}
-   |      ^
+LL | impl<T: Bound> Trait2 for Foo<T> {}
+   |       ^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-34721.fixed
+++ b/src/test/ui/issues/issue-34721.fixed
@@ -18,7 +18,7 @@ pub mod bar {
 mod baz {
     use bar;
     use Foo;
-    pub fn baz<T: Copy +  Foo>(x: T) -> T {
+    pub fn baz<T: Foo + Copy>(x: T) -> T {
         if 0 == 1 {
             bar::bar(x.zero())
         } else {

--- a/src/test/ui/issues/issue-34721.stderr
+++ b/src/test/ui/issues/issue-34721.stderr
@@ -13,11 +13,10 @@ LL |         };
 LL |         x.zero()
    |         ^ value used here after move
    |
-help: consider further restricting this bound with `+ Copy`
-  --> $DIR/issue-34721.rs:21:19
+help: consider further restricting this bound
    |
-LL |     pub fn baz<T: Foo>(x: T) -> T {
-   |                   ^^^
+LL |     pub fn baz<T: Foo + Copy>(x: T) -> T {
+   |                       ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-43784-associated-type.stderr
+++ b/src/test/ui/issues/issue-43784-associated-type.stderr
@@ -9,11 +9,10 @@ LL | impl<T> Complete for T {
 LL |     type Assoc = T;
    |     ^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::marker::Copy`
-  --> $DIR/issue-43784-associated-type.rs:13:6
+help: consider restricting type parameter `T`
    |
-LL | impl<T> Complete for T {
-   |      ^
+LL | impl<T: std::marker::Copy> Complete for T {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-43784-supertrait.stderr
+++ b/src/test/ui/issues/issue-43784-supertrait.stderr
@@ -4,11 +4,10 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
 LL | impl<T> Complete for T {}
    |         ^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::marker::Copy`
-  --> $DIR/issue-43784-supertrait.rs:8:6
+help: consider restricting type parameter `T`
    |
-LL | impl<T> Complete for T {}
-   |      ^
+LL | impl<T: std::marker::Copy> Complete for T {}
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/kindck/kindck-impl-type-params.nll.stderr
+++ b/src/test/ui/kindck/kindck-impl-type-params.nll.stderr
@@ -5,13 +5,12 @@ LL |     let a = &t as &dyn Gettable<T>;
    |             ^^ `T` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `T`
-help: consider restricting this type parameter with `T: std::marker::Send`
-  --> $DIR/kindck-impl-type-params.rs:16:6
-   |
-LL | fn f<T>(val: T) {
-   |      ^
    = note: required because of the requirements on the impl of `Gettable<T>` for `S<T>`
    = note: required for the cast to the object type `dyn Gettable<T>`
+help: consider restricting type parameter `T`
+   |
+LL | fn f<T: std::marker::Send>(val: T) {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/kindck-impl-type-params.rs:18:13
@@ -19,13 +18,12 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
 LL |     let a = &t as &dyn Gettable<T>;
    |             ^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::marker::Copy`
-  --> $DIR/kindck-impl-type-params.rs:16:6
-   |
-LL | fn f<T>(val: T) {
-   |      ^
    = note: required because of the requirements on the impl of `Gettable<T>` for `S<T>`
    = note: required for the cast to the object type `dyn Gettable<T>`
+help: consider restricting type parameter `T`
+   |
+LL | fn f<T: std::marker::Copy>(val: T) {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `T` cannot be sent between threads safely
   --> $DIR/kindck-impl-type-params.rs:25:31
@@ -34,13 +32,12 @@ LL |     let a: &dyn Gettable<T> = &t;
    |                               ^^ `T` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `T`
-help: consider restricting this type parameter with `T: std::marker::Send`
-  --> $DIR/kindck-impl-type-params.rs:23:6
-   |
-LL | fn g<T>(val: T) {
-   |      ^
    = note: required because of the requirements on the impl of `Gettable<T>` for `S<T>`
    = note: required for the cast to the object type `dyn Gettable<T>`
+help: consider restricting type parameter `T`
+   |
+LL | fn g<T: std::marker::Send>(val: T) {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/kindck-impl-type-params.rs:25:31
@@ -48,13 +45,12 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
 LL |     let a: &dyn Gettable<T> = &t;
    |                               ^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::marker::Copy`
-  --> $DIR/kindck-impl-type-params.rs:23:6
-   |
-LL | fn g<T>(val: T) {
-   |      ^
    = note: required because of the requirements on the impl of `Gettable<T>` for `S<T>`
    = note: required for the cast to the object type `dyn Gettable<T>`
+help: consider restricting type parameter `T`
+   |
+LL | fn g<T: std::marker::Copy>(val: T) {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
   --> $DIR/kindck-impl-type-params.rs:38:13

--- a/src/test/ui/kindck/kindck-impl-type-params.stderr
+++ b/src/test/ui/kindck/kindck-impl-type-params.stderr
@@ -5,13 +5,12 @@ LL |     let a = &t as &dyn Gettable<T>;
    |             ^^ `T` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `T`
-help: consider restricting this type parameter with `T: std::marker::Send`
-  --> $DIR/kindck-impl-type-params.rs:16:6
-   |
-LL | fn f<T>(val: T) {
-   |      ^
    = note: required because of the requirements on the impl of `Gettable<T>` for `S<T>`
    = note: required for the cast to the object type `dyn Gettable<T>`
+help: consider restricting type parameter `T`
+   |
+LL | fn f<T: std::marker::Send>(val: T) {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/kindck-impl-type-params.rs:18:13
@@ -19,13 +18,12 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
 LL |     let a = &t as &dyn Gettable<T>;
    |             ^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::marker::Copy`
-  --> $DIR/kindck-impl-type-params.rs:16:6
-   |
-LL | fn f<T>(val: T) {
-   |      ^
    = note: required because of the requirements on the impl of `Gettable<T>` for `S<T>`
    = note: required for the cast to the object type `dyn Gettable<T>`
+help: consider restricting type parameter `T`
+   |
+LL | fn f<T: std::marker::Copy>(val: T) {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `T` cannot be sent between threads safely
   --> $DIR/kindck-impl-type-params.rs:25:31
@@ -34,13 +32,12 @@ LL |     let a: &dyn Gettable<T> = &t;
    |                               ^^ `T` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `T`
-help: consider restricting this type parameter with `T: std::marker::Send`
-  --> $DIR/kindck-impl-type-params.rs:23:6
-   |
-LL | fn g<T>(val: T) {
-   |      ^
    = note: required because of the requirements on the impl of `Gettable<T>` for `S<T>`
    = note: required for the cast to the object type `dyn Gettable<T>`
+help: consider restricting type parameter `T`
+   |
+LL | fn g<T: std::marker::Send>(val: T) {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/kindck-impl-type-params.rs:25:31
@@ -48,13 +45,12 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
 LL |     let a: &dyn Gettable<T> = &t;
    |                               ^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::marker::Copy`
-  --> $DIR/kindck-impl-type-params.rs:23:6
-   |
-LL | fn g<T>(val: T) {
-   |      ^
    = note: required because of the requirements on the impl of `Gettable<T>` for `S<T>`
    = note: required for the cast to the object type `dyn Gettable<T>`
+help: consider restricting type parameter `T`
+   |
+LL | fn g<T: std::marker::Copy>(val: T) {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error[E0477]: the type `&'a isize` does not fulfill the required lifetime
   --> $DIR/kindck-impl-type-params.rs:32:13

--- a/src/test/ui/moves/moves-based-on-type-no-recursive-stack-closure.stderr
+++ b/src/test/ui/moves/moves-based-on-type-no-recursive-stack-closure.stderr
@@ -17,11 +17,10 @@ LL |     let mut r = R {c: Box::new(f)};
 LL |     f(&mut r, false)
    |     ^ value borrowed here after move
    |
-help: consider further restricting this bound with `+ Copy`
-  --> $DIR/moves-based-on-type-no-recursive-stack-closure.rs:30:35
+help: consider further restricting this bound
    |
-LL | fn conspirator<F>(mut f: F) where F: FnMut(&mut R, bool) {
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^
+LL | fn conspirator<F>(mut f: F) where F: FnMut(&mut R, bool) + Copy {
+   |                                                          ^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/once-cant-call-twice-on-heap.stderr
+++ b/src/test/ui/once-cant-call-twice-on-heap.stderr
@@ -8,11 +8,10 @@ LL |     blk();
 LL |     blk();
    |     ^^^ value used here after move
    |
-help: consider further restricting this bound with `+ Copy`
-  --> $DIR/once-cant-call-twice-on-heap.rs:7:10
+help: consider further restricting this bound
    |
-LL | fn foo<F:FnOnce()>(blk: F) {
-   |          ^^^^^^^^
+LL | fn foo<F:FnOnce() + Copy>(blk: F) {
+   |                   ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/phantom-oibit.stderr
+++ b/src/test/ui/phantom-oibit.stderr
@@ -8,14 +8,13 @@ LL |     is_zen(x)
    |            ^ `T` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `T`
-help: consider restricting this type parameter with `T: std::marker::Sync`
-  --> $DIR/phantom-oibit.rs:20:13
-   |
-LL | fn not_sync<T>(x: Guard<T>) {
-   |             ^
    = note: required because of the requirements on the impl of `Zen` for `&T`
    = note: required because it appears within the type `std::marker::PhantomData<&T>`
    = note: required because it appears within the type `Guard<'_, T>`
+help: consider restricting type parameter `T`
+   |
+LL | fn not_sync<T: std::marker::Sync>(x: Guard<T>) {
+   |              ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `T` cannot be shared between threads safely
   --> $DIR/phantom-oibit.rs:26:12
@@ -27,15 +26,14 @@ LL |     is_zen(x)
    |            ^ `T` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `T`
-help: consider restricting this type parameter with `T: std::marker::Sync`
-  --> $DIR/phantom-oibit.rs:25:20
-   |
-LL | fn nested_not_sync<T>(x: Nested<Guard<T>>) {
-   |                    ^
    = note: required because of the requirements on the impl of `Zen` for `&T`
    = note: required because it appears within the type `std::marker::PhantomData<&T>`
    = note: required because it appears within the type `Guard<'_, T>`
    = note: required because it appears within the type `Nested<Guard<'_, T>>`
+help: consider restricting type parameter `T`
+   |
+LL | fn nested_not_sync<T: std::marker::Sync>(x: Nested<Guard<T>>) {
+   |                     ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/specialization/defaultimpl/specialization-wfcheck.stderr
+++ b/src/test/ui/specialization/defaultimpl/specialization-wfcheck.stderr
@@ -4,11 +4,10 @@ error[E0277]: the trait bound `U: std::cmp::Eq` is not satisfied
 LL | default impl<U> Foo<'static, U> for () {}
    |                 ^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `U`
    |
-help: consider restricting this type parameter with `U: std::cmp::Eq`
-  --> $DIR/specialization-wfcheck.rs:7:14
+help: consider restricting type parameter `U`
    |
-LL | default impl<U> Foo<'static, U> for () {}
-   |              ^
+LL | default impl<U: std::cmp::Eq> Foo<'static, U> for () {}
+   |               ^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/restrict-type-argument.stderr
+++ b/src/test/ui/suggestions/restrict-type-argument.stderr
@@ -8,11 +8,10 @@ LL |     is_send(val);
    |             ^^^ `impl Sync` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `impl Sync`
-help: consider further restricting this bound with `+ std::marker::Send`
-  --> $DIR/restrict-type-argument.rs:3:23
+help: consider further restricting this bound
    |
-LL | fn use_impl_sync(val: impl Sync) {
-   |                       ^^^^^^^^^
+LL | fn use_impl_sync(val: impl Sync + std::marker::Send) {
+   |                                 ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:8:13
@@ -24,11 +23,10 @@ LL |     is_send(val);
    |             ^^^ `S` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `S`
-help: consider further restricting this bound with `+ std::marker::Send`
-  --> $DIR/restrict-type-argument.rs:7:31
+help: consider further restricting this bound
    |
-LL | fn use_where<S>(val: S) where S: Sync {
-   |                               ^^^^^^^
+LL | fn use_where<S>(val: S) where S: Sync + std::marker::Send {
+   |                                       ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:12:13
@@ -40,11 +38,10 @@ LL |     is_send(val);
    |             ^^^ `S` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `S`
-help: consider further restricting this bound with `+ std::marker::Send`
-  --> $DIR/restrict-type-argument.rs:11:17
+help: consider further restricting this bound
    |
-LL | fn use_bound<S: Sync>(val: S) {
-   |                 ^^^^
+LL | fn use_bound<S: Sync + std::marker::Send>(val: S) {
+   |                      ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:20:13
@@ -56,11 +53,10 @@ LL |     is_send(val);
    |             ^^^ `S` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `S`
-help: consider further restricting this bound with `+ std::marker::Send`
-  --> $DIR/restrict-type-argument.rs:18:5
+help: consider further restricting this bound
    |
-LL |     Sync
-   |     ^^^^
+LL |     Sync + std::marker::Send
+   |          ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:24:13
@@ -72,11 +68,10 @@ LL |     is_send(val);
    |             ^^^ `S` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `S`
-help: consider further restricting this bound with `+ std::marker::Send`
-  --> $DIR/restrict-type-argument.rs:23:47
+help: consider further restricting this bound
    |
-LL | fn use_bound_and_where<S: Sync>(val: S) where S: std::fmt::Debug {
-   |                                               ^^^^^^^^^^^^^^^^^^
+LL | fn use_bound_and_where<S: Sync>(val: S) where S: std::fmt::Debug + std::marker::Send {
+   |                                                                  ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:28:13
@@ -88,11 +83,10 @@ LL |     is_send(val);
    |             ^^^ `S` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `S`
-help: consider restricting this type parameter with `S: std::marker::Send`
-  --> $DIR/restrict-type-argument.rs:27:16
+help: consider restricting type parameter `S`
    |
-LL | fn use_unbound<S>(val: S) {
-   |                ^
+LL | fn use_unbound<S: std::marker::Send>(val: S) {
+   |                 ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/traits/trait-alias/trait-alias-wf.stderr
+++ b/src/test/ui/traits/trait-alias/trait-alias-wf.stderr
@@ -6,11 +6,10 @@ LL | trait A<T: Foo> {}
 LL | trait B<T> = A<T>;
    |              ^^^^ the trait `Foo` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: Foo`
-  --> $DIR/trait-alias-wf.rs:5:9
+help: consider restricting type parameter `T`
    |
-LL | trait B<T> = A<T>;
-   |         ^
+LL | trait B<T: Foo> = A<T>;
+   |          ^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums.stderr
@@ -7,11 +7,10 @@ LL | struct Foo<T:Trait> {
 LL | impl<T> Foo<T> {
    |         ^^^^^^ the trait `Trait` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: Trait`
-  --> $DIR/trait-bounds-on-structs-and-enums.rs:13:6
+help: consider restricting type parameter `T`
    |
-LL | impl<T> Foo<T> {
-   |      ^
+LL | impl<T: Trait> Foo<T> {
+   |       ^^^^^^^
 
 error[E0277]: the trait bound `isize: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:19:5
@@ -40,11 +39,10 @@ LL | struct Foo<T:Trait> {
 LL |     b: Foo<U>,
    |     ^^^^^^^^^ the trait `Trait` is not implemented for `U`
    |
-help: consider restricting this type parameter with `U: Trait`
-  --> $DIR/trait-bounds-on-structs-and-enums.rs:26:16
+help: consider restricting type parameter `U`
    |
-LL | struct Badness<U> {
-   |                ^
+LL | struct Badness<U: Trait> {
+   |                 ^^^^^^^
 
 error[E0277]: the trait bound `V: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:31:21
@@ -55,11 +53,10 @@ LL | enum Bar<T:Trait> {
 LL |     EvenMoreBadness(Bar<V>),
    |                     ^^^^^^ the trait `Trait` is not implemented for `V`
    |
-help: consider restricting this type parameter with `V: Trait`
-  --> $DIR/trait-bounds-on-structs-and-enums.rs:30:18
+help: consider restricting type parameter `V`
    |
-LL | enum MoreBadness<V> {
-   |                  ^
+LL | enum MoreBadness<V: Trait> {
+   |                   ^^^^^^^
 
 error[E0277]: the trait bound `i32: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:35:5

--- a/src/test/ui/traits/traits-repeated-supertrait-ambig.stderr
+++ b/src/test/ui/traits/traits-repeated-supertrait-ambig.stderr
@@ -10,11 +10,10 @@ error[E0277]: the trait bound `C: CompareTo<i32>` is not satisfied
 LL |     c.same_as(22)
    |       ^^^^^^^ the trait `CompareTo<i32>` is not implemented for `C`
    |
-help: consider further restricting this bound with `+ CompareTo<i32>`
-  --> $DIR/traits-repeated-supertrait-ambig.rs:29:17
+help: consider further restricting this bound
    |
-LL | fn with_trait<C:CompareToInts>(c: &C) -> bool {
-   |                 ^^^^^^^^^^^^^
+LL | fn with_trait<C:CompareToInts + CompareTo<i32>>(c: &C) -> bool {
+   |                               ^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `dyn CompareToInts: CompareTo<i32>` is not satisfied
   --> $DIR/traits-repeated-supertrait-ambig.rs:34:5
@@ -34,11 +33,10 @@ LL |     fn same_as(&self, t: T) -> bool;
 LL |     CompareTo::same_as(c, 22)
    |     ^^^^^^^^^^^^^^^^^^ the trait `CompareTo<i32>` is not implemented for `C`
    |
-help: consider further restricting this bound with `+ CompareTo<i32>`
-  --> $DIR/traits-repeated-supertrait-ambig.rs:37:17
+help: consider further restricting this bound
    |
-LL | fn with_ufcs2<C:CompareToInts>(c: &C) -> bool {
-   |                 ^^^^^^^^^^^^^
+LL | fn with_ufcs2<C:CompareToInts + CompareTo<i32>>(c: &C) -> bool {
+   |                               ^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `i64: CompareTo<i32>` is not satisfied
   --> $DIR/traits-repeated-supertrait-ambig.rs:42:23

--- a/src/test/ui/type-alias-impl-trait/bound_reduction2.stderr
+++ b/src/test/ui/type-alias-impl-trait/bound_reduction2.stderr
@@ -4,11 +4,10 @@ error[E0277]: the trait bound `T: TraitWithAssoc` is not satisfied
 LL | type Foo<V> = impl Trait<V>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TraitWithAssoc` is not implemented for `T`
    |
-help: consider further restricting this bound with `+ TraitWithAssoc`
-  --> $DIR/bound_reduction2.rs:18:21
+help: consider further restricting this bound
    |
-LL | fn foo_desugared<T: TraitWithAssoc>(_: T) -> Foo<T::Assoc> {
-   |                     ^^^^^^^^^^^^^^
+LL | fn foo_desugared<T: TraitWithAssoc + TraitWithAssoc>(_: T) -> Foo<T::Assoc> {
+   |                                    ^^^^^^^^^^^^^^^^
 
 error: defining opaque type use does not fully define opaque type: generic parameter `V` is specified as concrete type `<T as TraitWithAssoc>::Assoc`
   --> $DIR/bound_reduction2.rs:18:1

--- a/src/test/ui/type-alias-impl-trait/generic_underconstrained.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_underconstrained.stderr
@@ -10,12 +10,11 @@ error[E0277]: the trait bound `T: Trait` is not satisfied
 LL | type Underconstrained<T: Trait> = impl 'static;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: Trait`
-  --> $DIR/generic_underconstrained.rs:10:19
-   |
-LL | fn underconstrain<T>(_: T) -> Underconstrained<T> {
-   |                   ^
    = note: the return type of a function must have a statically known size
+help: consider restricting type parameter `T`
+   |
+LL | fn underconstrain<T: Trait>(_: T) -> Underconstrained<T> {
+   |                    ^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/type-alias-impl-trait/generic_underconstrained2.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_underconstrained2.stderr
@@ -20,12 +20,11 @@ LL |     5u32
    |     ---- this returned value is of type `u32`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `U`
-help: consider restricting this type parameter with `U: std::fmt::Debug`
-  --> $DIR/generic_underconstrained2.rs:10:21
-   |
-LL | fn underconstrained<U>(_: U) -> Underconstrained<U> {
-   |                     ^
    = note: the return type of a function must have a statically known size
+help: consider restricting type parameter `U`
+   |
+LL | fn underconstrained<U: std::fmt::Debug>(_: U) -> Underconstrained<U> {
+   |                      ^^^^^^^^^^^^^^^^^
 
 error[E0277]: `V` doesn't implement `std::fmt::Debug`
   --> $DIR/generic_underconstrained2.rs:14:1
@@ -37,12 +36,11 @@ LL |     5u32
    |     ---- this returned value is of type `u32`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `V`
-help: consider restricting this type parameter with `V: std::fmt::Debug`
-  --> $DIR/generic_underconstrained2.rs:19:25
-   |
-LL | fn underconstrained2<U, V>(_: U, _: V) -> Underconstrained2<V> {
-   |                         ^
    = note: the return type of a function must have a statically known size
+help: consider restricting type parameter `V`
+   |
+LL | fn underconstrained2<U, V: std::fmt::Debug>(_: U, _: V) -> Underconstrained2<V> {
+   |                          ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/type/type-check-defaults.stderr
+++ b/src/test/ui/type/type-check-defaults.stderr
@@ -54,11 +54,10 @@ LL | trait Super<T: Copy> { }
 LL | trait Base<T = String>: Super<T> { }
    |                         ^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::marker::Copy`
-  --> $DIR/type-check-defaults.rs:21:12
+help: consider further restricting type parameter `T`
    |
-LL | trait Base<T = String>: Super<T> { }
-   |            ^
+LL | trait Base<T = String>: Super<T>, T: std::marker::Copy { }
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: cannot add `u8` to `i32`
   --> $DIR/type-check-defaults.rs:24:66

--- a/src/test/ui/typeck/typeck-default-trait-impl-send-param.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-send-param.stderr
@@ -8,11 +8,10 @@ LL | fn is_send<T:Send>() {
    |    -------   ---- required by this bound in `is_send`
    |
    = help: the trait `std::marker::Send` is not implemented for `T`
-help: consider restricting this type parameter with `T: std::marker::Send`
-  --> $DIR/typeck-default-trait-impl-send-param.rs:4:8
+help: consider restricting type parameter `T`
    |
-LL | fn foo<T>() {
-   |        ^
+LL | fn foo<T: std::marker::Send>() {
+   |         ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/unop-move-semantics.stderr
+++ b/src/test/ui/unop-move-semantics.stderr
@@ -9,11 +9,10 @@ LL |
 LL |     x.clone();
    |     ^ value borrowed here after move
    |
-help: consider further restricting this bound with `+ Copy`
-  --> $DIR/unop-move-semantics.rs:5:24
+help: consider further restricting this bound
    |
-LL | fn move_then_borrow<T: Not<Output=T> + Clone>(x: T) {
-   |                        ^^^^^^^^^^^^^^^^^^^^^
+LL | fn move_then_borrow<T: Not<Output=T> + Clone + Copy>(x: T) {
+   |                                              ^^^^^^
 
 error[E0505]: cannot move out of `x` because it is borrowed
   --> $DIR/unop-move-semantics.rs:15:6

--- a/src/test/ui/wf/wf-enum-bound.stderr
+++ b/src/test/ui/wf/wf-enum-bound.stderr
@@ -7,11 +7,10 @@ LL | trait ExtraCopy<T:Copy> { }
 LL |     where T: ExtraCopy<U>
    |              ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`
    |
-help: consider restricting this type parameter with `where U: std::marker::Copy`
-  --> $DIR/wf-enum-bound.rs:9:17
+help: consider further restricting type parameter `U`
    |
-LL | enum SomeEnum<T,U>
-   |                 ^
+LL |     where T: ExtraCopy<U>, U: std::marker::Copy
+   |                          ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-enum-fields-struct-variant.stderr
+++ b/src/test/ui/wf/wf-enum-fields-struct-variant.stderr
@@ -7,11 +7,10 @@ LL | struct IsCopy<T:Copy> {
 LL |         f: IsCopy<A>
    |         ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `A`
    |
-help: consider restricting this type parameter with `A: std::marker::Copy`
-  --> $DIR/wf-enum-fields-struct-variant.rs:11:18
+help: consider restricting type parameter `A`
    |
-LL | enum AnotherEnum<A> {
-   |                  ^
+LL | enum AnotherEnum<A: std::marker::Copy> {
+   |                   ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-enum-fields.stderr
+++ b/src/test/ui/wf/wf-enum-fields.stderr
@@ -7,11 +7,10 @@ LL | struct IsCopy<T:Copy> {
 LL |     SomeVariant(IsCopy<A>)
    |                 ^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `A`
    |
-help: consider restricting this type parameter with `A: std::marker::Copy`
-  --> $DIR/wf-enum-fields.rs:11:15
+help: consider restricting type parameter `A`
    |
-LL | enum SomeEnum<A> {
-   |               ^
+LL | enum SomeEnum<A: std::marker::Copy> {
+   |                ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-fn-where-clause.stderr
@@ -7,11 +7,10 @@ LL |
 LL | fn foo<T,U>() where T: ExtraCopy<U>
    |                        ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`
    |
-help: consider restricting this type parameter with `where U: std::marker::Copy`
-  --> $DIR/wf-fn-where-clause.rs:8:10
+help: consider further restricting type parameter `U`
    |
-LL | fn foo<T,U>() where T: ExtraCopy<U>
-   |          ^
+LL | fn foo<T,U>() where T: ExtraCopy<U>, U: std::marker::Copy
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `(dyn std::marker::Copy + 'static)` cannot be known at compilation time
   --> $DIR/wf-fn-where-clause.rs:12:16

--- a/src/test/ui/wf/wf-impl-associated-type-trait.stderr
+++ b/src/test/ui/wf/wf-impl-associated-type-trait.stderr
@@ -7,11 +7,10 @@ LL | pub struct MySet<T:MyHash> {
 LL |     type Bar = MySet<T>;
    |     ^^^^^^^^^^^^^^^^^^^^ the trait `MyHash` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: MyHash`
-  --> $DIR/wf-impl-associated-type-trait.rs:16:6
+help: consider restricting type parameter `T`
    |
-LL | impl<T> Foo for T {
-   |      ^
+LL | impl<T: MyHash> Foo for T {
+   |       ^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-arg.stderr
+++ b/src/test/ui/wf/wf-in-fn-arg.stderr
@@ -7,11 +7,10 @@ LL | struct MustBeCopy<T:Copy> {
 LL | fn bar<T>(_: &MustBeCopy<T>)
    |              ^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::marker::Copy`
-  --> $DIR/wf-in-fn-arg.rs:10:8
+help: consider restricting type parameter `T`
    |
-LL | fn bar<T>(_: &MustBeCopy<T>)
-   |        ^
+LL | fn bar<T: std::marker::Copy>(_: &MustBeCopy<T>)
+   |         ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-ret.stderr
+++ b/src/test/ui/wf/wf-in-fn-ret.stderr
@@ -7,11 +7,10 @@ LL | struct MustBeCopy<T:Copy> {
 LL | fn bar<T>() -> MustBeCopy<T>
    |                ^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::marker::Copy`
-  --> $DIR/wf-in-fn-ret.rs:10:8
+help: consider restricting type parameter `T`
    |
-LL | fn bar<T>() -> MustBeCopy<T>
-   |        ^
+LL | fn bar<T: std::marker::Copy>() -> MustBeCopy<T>
+   |         ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-type-arg.stderr
+++ b/src/test/ui/wf/wf-in-fn-type-arg.stderr
@@ -7,11 +7,10 @@ LL | struct MustBeCopy<T:Copy> {
 LL |     x: fn(MustBeCopy<T>)
    |     ^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::marker::Copy`
-  --> $DIR/wf-in-fn-type-arg.rs:7:12
+help: consider restricting type parameter `T`
    |
-LL | struct Bar<T> {
-   |            ^
+LL | struct Bar<T: std::marker::Copy> {
+   |             ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-type-ret.stderr
+++ b/src/test/ui/wf/wf-in-fn-type-ret.stderr
@@ -7,11 +7,10 @@ LL | struct MustBeCopy<T:Copy> {
 LL |     x: fn() -> MustBeCopy<T>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::marker::Copy`
-  --> $DIR/wf-in-fn-type-ret.rs:7:12
+help: consider restricting type parameter `T`
    |
-LL | struct Foo<T> {
-   |            ^
+LL | struct Foo<T: std::marker::Copy> {
+   |             ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-in-fn-where-clause.stderr
@@ -7,11 +7,10 @@ LL | trait MustBeCopy<T:Copy> {
 LL |     where T: MustBeCopy<U>
    |              ^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`
    |
-help: consider restricting this type parameter with `where U: std::marker::Copy`
-  --> $DIR/wf-in-fn-where-clause.rs:9:10
+help: consider further restricting type parameter `U`
    |
-LL | fn bar<T,U>()
-   |          ^
+LL |     where T: MustBeCopy<U>, U: std::marker::Copy
+   |                           ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-obj-type-trait.stderr
+++ b/src/test/ui/wf/wf-in-obj-type-trait.stderr
@@ -7,11 +7,10 @@ LL | struct MustBeCopy<T:Copy> {
 LL |     x: dyn Object<MustBeCopy<T>>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::marker::Copy`
-  --> $DIR/wf-in-obj-type-trait.rs:9:12
+help: consider restricting type parameter `T`
    |
-LL | struct Bar<T> {
-   |            ^
+LL | struct Bar<T: std::marker::Copy> {
+   |             ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-inherent-impl-method-where-clause.stderr
+++ b/src/test/ui/wf/wf-inherent-impl-method-where-clause.stderr
@@ -7,11 +7,10 @@ LL | trait ExtraCopy<T:Copy> { }
 LL |     fn foo(self) where T: ExtraCopy<U>
    |                           ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`
    |
-help: consider restricting this type parameter with `U: std::marker::Copy`
-  --> $DIR/wf-inherent-impl-method-where-clause.rs:11:8
+help: consider restricting type parameter `U`
    |
-LL | impl<T,U> Foo<T,U> {
-   |        ^
+LL | impl<T,U: std::marker::Copy> Foo<T,U> {
+   |         ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-inherent-impl-where-clause.stderr
+++ b/src/test/ui/wf/wf-inherent-impl-where-clause.stderr
@@ -7,11 +7,10 @@ LL | trait ExtraCopy<T:Copy> { }
 LL | impl<T,U> Foo<T,U> where T: ExtraCopy<U>
    |                             ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`
    |
-help: consider restricting this type parameter with `where U: std::marker::Copy`
-  --> $DIR/wf-inherent-impl-where-clause.rs:11:8
+help: consider further restricting type parameter `U`
    |
-LL | impl<T,U> Foo<T,U> where T: ExtraCopy<U>
-   |        ^
+LL | impl<T,U> Foo<T,U> where T: ExtraCopy<U>, U: std::marker::Copy
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-struct-bound.stderr
+++ b/src/test/ui/wf/wf-struct-bound.stderr
@@ -7,11 +7,10 @@ LL | trait ExtraCopy<T:Copy> { }
 LL |     where T: ExtraCopy<U>
    |              ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`
    |
-help: consider restricting this type parameter with `where U: std::marker::Copy`
-  --> $DIR/wf-struct-bound.rs:9:21
+help: consider further restricting type parameter `U`
    |
-LL | struct SomeStruct<T,U>
-   |                     ^
+LL |     where T: ExtraCopy<U>, U: std::marker::Copy
+   |                          ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-struct-field.stderr
+++ b/src/test/ui/wf/wf-struct-field.stderr
@@ -7,11 +7,10 @@ LL | struct IsCopy<T:Copy> {
 LL |     data: IsCopy<A>
    |     ^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `A`
    |
-help: consider restricting this type parameter with `A: std::marker::Copy`
-  --> $DIR/wf-struct-field.rs:11:19
+help: consider restricting type parameter `A`
    |
-LL | struct SomeStruct<A> {
-   |                   ^
+LL | struct SomeStruct<A: std::marker::Copy> {
+   |                    ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-associated-type-bound.stderr
+++ b/src/test/ui/wf/wf-trait-associated-type-bound.stderr
@@ -7,11 +7,10 @@ LL | trait ExtraCopy<T:Copy> { }
 LL |     type Type1: ExtraCopy<T>;
    |                 ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::marker::Copy`
-  --> $DIR/wf-trait-associated-type-bound.rs:9:17
+help: consider restricting type parameter `T`
    |
-LL | trait SomeTrait<T> {
-   |                 ^
+LL | trait SomeTrait<T: std::marker::Copy> {
+   |                  ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-bound.stderr
+++ b/src/test/ui/wf/wf-trait-bound.stderr
@@ -7,11 +7,10 @@ LL | trait ExtraCopy<T:Copy> { }
 LL |     where T: ExtraCopy<U>
    |              ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `U`
    |
-help: consider restricting this type parameter with `where U: std::marker::Copy`
-  --> $DIR/wf-trait-bound.rs:9:19
+help: consider further restricting type parameter `U`
    |
-LL | trait SomeTrait<T,U>
-   |                   ^
+LL |     where T: ExtraCopy<U>, U: std::marker::Copy
+   |                          ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-superbound.stderr
+++ b/src/test/ui/wf/wf-trait-superbound.stderr
@@ -7,11 +7,10 @@ LL |
 LL | trait SomeTrait<T>: ExtraCopy<T> {
    |                     ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::marker::Copy`
-  --> $DIR/wf-trait-superbound.rs:9:17
+help: consider restricting type parameter `T`
    |
-LL | trait SomeTrait<T>: ExtraCopy<T> {
-   |                 ^
+LL | trait SomeTrait<T: std::marker::Copy>: ExtraCopy<T> {
+   |                  ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
+++ b/src/test/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
@@ -7,11 +7,10 @@ LL | fn require_copy<T: Copy>(x: T) {}
 LL |         require_copy(self.x);
    |                      ^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::marker::Copy`
-  --> $DIR/where-clause-constraints-are-local-for-inherent-impl.rs:6:6
+help: consider restricting type parameter `T`
    |
-LL | impl<T> Foo<T> {
-   |      ^
+LL | impl<T: std::marker::Copy> Foo<T> {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
+++ b/src/test/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
@@ -7,11 +7,10 @@ LL | fn require_copy<T: Copy>(x: T) {}
 LL |         require_copy(self.x);
    |                      ^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
-help: consider restricting this type parameter with `T: std::marker::Copy`
-  --> $DIR/where-clause-constraints-are-local-for-trait-impl.rs:11:6
+help: consider restricting type parameter `T`
    |
-LL | impl<T> Foo<T> for Bar<T> {
-   |      ^
+LL | impl<T: std::marker::Copy> Foo<T> for Bar<T> {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Some of the bound restriction structured suggestions were incorrect while others had subpar output.

The only issue left is a suggestion for an already present bound when dealing with `const`s that should be handled independently.

Fix #69983.