### PR TITLE
Small fixes in rustdoc book

### DIFF
--- a/src/doc/rustdoc/src/advanced-features.md
+++ b/src/doc/rustdoc/src/advanced-features.md
@@ -4,7 +4,7 @@ The features listed on this page fall outside the rest of the main categories.
 
 ## `#[cfg(doc)]`: Documenting platform-/feature-specific information
 
-For conditional compilation, Rustdoc treats your crate the same way the compiler does: Only things
+For conditional compilation, Rustdoc treats your crate the same way the compiler does. Only things
 from the host target are available (or from the given `--target` if present), and everything else is
 "filtered out" from the crate. This can cause problems if your crate is providing different things
 on different targets and you want your documentation to reflect all the available items you

--- a/src/doc/rustdoc/src/command-line-arguments.md
+++ b/src/doc/rustdoc/src/command-line-arguments.md
@@ -79,8 +79,8 @@ Rustdoc only supports HTML output, and so this flag is redundant today.
 Using this flag looks like this:
 
 ```bash
-$ rustdoc src/lib.rs -o target\\doc
-$ rustdoc src/lib.rs --output target\\doc
+$ rustdoc src/lib.rs -o target/doc
+$ rustdoc src/lib.rs --output target/doc
 ```
 
 By default, `rustdoc`'s output appears in a directory named `doc` in

--- a/src/doc/rustdoc/src/documentation-tests.md
+++ b/src/doc/rustdoc/src/documentation-tests.md
@@ -314,7 +314,7 @@ only shows the part you care about.
 `should_panic` tells `rustdoc` that the code should compile correctly, but
 not actually pass as a test.
 
-```text
+```rust
 /// ```no_run
 /// loop {
 ///     println!("Hello, world");

--- a/src/doc/rustdoc/src/what-is-rustdoc.md
+++ b/src/doc/rustdoc/src/what-is-rustdoc.md
@@ -78,8 +78,8 @@ $ cargo doc
 Internally, this calls out to `rustdoc` like this:
 
 ```bash
-$ rustdoc --crate-name docs srclib.rs -o <path>\docs\target\doc -L
-dependency=<path>docs\target\debug\deps
+$ rustdoc --crate-name docs src/lib.rs -o <path>/docs/target/doc -L
+dependency=<path>/docs/target/debug/deps
 ```
 
 You can see this with `cargo doc --verbose`.


### PR DESCRIPTION
I read the `rustdoc` book today and noticed some small typos/problems. Mainly:

 - `# fn foo() {}` was displayed when not needed because fenced block code type was `text` instead of `rust`;
 - two path separators were missing and some Windows-style separators were not consistent with the rest of them (mainly Linux-style).

Here are my proposed fixes. It is my first PR for the rust project. Don't hesitate to tell me if I am doing it wrong or if you need anything else.

Have a nice day!