### PR TITLE
Also run UnusedBrokenConst on associated consts.

### DIFF
--- a/src/librustc/mir/interpret/queries.rs
+++ b/src/librustc/mir/interpret/queries.rs
@@ -1,9 +1,9 @@
 use super::{ConstEvalResult, ErrorHandled, GlobalId};
 
 use crate::mir;
+use crate::ty::fold::TypeFoldable;
 use crate::ty::subst::{InternalSubsts, SubstsRef};
 use crate::ty::{self, TyCtxt};
-use crate::ty::fold::TypeFoldable;
 use rustc_hir::def_id::DefId;
 use rustc_span::Span;
 

--- a/src/librustc/mir/interpret/queries.rs
+++ b/src/librustc/mir/interpret/queries.rs
@@ -9,7 +9,7 @@ use rustc_span::Span;
 impl<'tcx> TyCtxt<'tcx> {
     /// Evaluates a constant without providing any substitutions. This is useful to evaluate consts
     /// that can't take any generic arguments like statics, const items or enum discriminants. If a
-    /// generic parameter is used within the constant `ErrorHandled::ToGeneric` will be returned.
+    /// generic parameter is used within the constant `ErrorHandled::TooGeneric` will be returned.
     pub fn const_eval_poly(self, def_id: DefId) -> ConstEvalResult<'tcx> {
         // In some situations def_id will have substitutions within scope, but they aren't allowed
         // to be used. So we can't use `Instance::mono`, instead we feed unresolved substitutions

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -47,7 +47,7 @@ use rustc_trait_selection::traits::misc::can_type_implement_copy;
 
 use crate::nonstandard_style::{method_context, MethodLateContext};
 
-use log::debug;
+use log::{debug, trace};
 use std::fmt::Write;
 
 // hardwired lints from librustc
@@ -1181,11 +1181,14 @@ fn check_const(cx: &LateContext<'_, '_>, body_id: hir::BodyId) {
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedBrokenConst {
     fn check_item(&mut self, cx: &LateContext<'_, '_>, it: &hir::Item<'_>) {
+        trace!("UnusedBrokenConst: check_item(_, _, {:?}", it);
         match it.kind {
             hir::ItemKind::Const(_, body_id) => {
+                trace!("UnusedBrokenConst: checking {:?}", body_id);
                 check_const(cx, body_id);
             }
             hir::ItemKind::Static(_, _, body_id) => {
+                trace!("UnusedBrokenConst: checking {:?}", body_id);
                 check_const(cx, body_id);
             }
             _ => {}

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1183,15 +1183,18 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedBrokenConst {
     fn check_item(&mut self, cx: &LateContext<'_, '_>, it: &hir::Item<'_>) {
         trace!("UnusedBrokenConst: check_item(_, _, {:?}", it);
         match it.kind {
-            hir::ItemKind::Const(_, body_id) => {
-                trace!("UnusedBrokenConst: checking {:?}", body_id);
-                check_const(cx, body_id);
-            }
-            hir::ItemKind::Static(_, _, body_id) => {
+            hir::ItemKind::Const(_, body_id) | hir::ItemKind::Static(_, _, body_id) => {
                 trace!("UnusedBrokenConst: checking {:?}", body_id);
                 check_const(cx, body_id);
             }
             _ => {}
+        }
+    }
+    fn check_impl_item(&mut self, cx: &LateContext<'_, '_>, it: &hir::ImplItem<'_>) {
+        trace!("UnusedBrokenConst: check_impl_item(_, _, it = {:?})", it);
+        if let hir::ImplItemKind::Const(_, body_id) = it.kind {
+            trace!("UnusedBrokenConst: checking {:?}", body_id);
+            check_const(cx, body_id);
         }
     }
 }

--- a/src/librustc_mir/const_eval/eval_queries.rs
+++ b/src/librustc_mir/const_eval/eval_queries.rs
@@ -255,7 +255,11 @@ pub fn const_eval_validated_provider<'tcx>(
     }
 
     tcx.const_eval_raw(key).and_then(|val| {
-        trace!("const_eval_raw succeeded. val.alloc_id = {:?}. val.ty = {:?}", val.alloc_id, val.ty);
+        trace!(
+            "const_eval_raw succeeded. val.alloc_id = {:?}. val.ty = {:?}",
+            val.alloc_id,
+            val.ty
+        );
         validate_and_turn_into_const(tcx, val, key)
     })
 }
@@ -277,7 +281,9 @@ pub fn const_eval_raw_provider<'tcx>(
         key.param_env.reveal = Reveal::UserFacing;
         match tcx.const_eval_raw(key) {
             // try again with reveal all as requested
-            Err(ErrorHandled::TooGeneric) => { trace!("const_eval_raw: retrying with RevealAll"); }
+            Err(ErrorHandled::TooGeneric) => {
+                trace!("const_eval_raw: retrying with RevealAll");
+            }
             // deduplicate calls
             other => return other,
         }

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -206,13 +206,11 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> LayoutOf for InterpCx<'mir, 'tcx, M> {
 
     #[inline]
     fn layout_of(&self, ty: Ty<'tcx>) -> Self::TyLayout {
-        self.tcx
-            .layout_of(self.param_env.and(ty))
-            .map_err(|layout| {
-                let result = err_inval!(Layout(layout)).into();
-                trace!("layout_of: returning error: {:?}", result);
-                result
-            })
+        self.tcx.layout_of(self.param_env.and(ty)).map_err(|layout| {
+            let result = err_inval!(Layout(layout)).into();
+            trace!("layout_of: returning error: {:?}", result);
+            result
+        })
     }
 }
 

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -208,7 +208,11 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> LayoutOf for InterpCx<'mir, 'tcx, M> {
     fn layout_of(&self, ty: Ty<'tcx>) -> Self::TyLayout {
         self.tcx
             .layout_of(self.param_env.and(ty))
-            .map_err(|layout| err_inval!(Layout(layout)).into())
+            .map_err(|layout| {
+                let result = err_inval!(Layout(layout)).into();
+                trace!("layout_of: returning error: {:?}", result);
+                result
+            })
     }
 }
 

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -1134,6 +1134,7 @@ where
     ) -> InterpResult<'tcx, MPlaceTy<'tcx, M::PointerTag>> {
         // This must be an allocation in `tcx`
         assert!(self.tcx.alloc_map.lock().get(raw.alloc_id).is_some());
+        trace!("raw_const_to_mplace: raw.ty = {:?}", raw.ty);
         let ptr = self.tag_global_base_pointer(Pointer::from(raw.alloc_id));
         let layout = self.layout_of(raw.ty)?;
         Ok(MPlaceTy::from_aligned_ptr(ptr, layout))

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -305,7 +305,9 @@ where
     ) -> InterpResult<'tcx, MPlaceTy<'tcx, M::PointerTag>> {
         let pointee_type =
             val.layout.ty.builtin_deref(true).expect("`ref_to_mplace` called on non-ptr type").ty;
-        let layout = self.layout_of(pointee_type)?;
+        let layout = self.layout_of(pointee_type);
+        debug!("ref_to_mplace: layout_of(pointee_type = {:?}) = {:?}", pointee_type, layout);
+        let layout = layout?;
         let (ptr, meta) = match *val {
             Immediate::Scalar(ptr) => (ptr.not_undef()?, MemPlaceMeta::None),
             Immediate::ScalarPair(ptr, meta) => {

--- a/src/test/ui/associated-const/lints-used-unused.rs
+++ b/src/test/ui/associated-const/lints-used-unused.rs
@@ -1,0 +1,27 @@
+// Tests that associated constants are checked whether they are used or not.
+//
+// revisions: used unused
+// compile-flags: -Copt-level=2 --emit link
+
+#![cfg_attr(unused, allow(dead_code))]
+#![deny(arithmetic_overflow)]
+
+pub trait Foo {
+    const N: i32;
+}
+
+struct S;
+
+impl Foo for S {
+    const N: i32 = 1 << 42;
+    //~^ ERROR this arithmetic operation will overflow
+}
+
+impl<T: Foo> Foo for Vec<T> {
+    const N: i32 = --T::N + (-i32::MIN); //~ ERROR this arithmetic operation will overflow
+}
+
+fn main() {
+    #[cfg(used)]
+    let _ = S::N; //[used]~ ERROR erroneous constant used
+}

--- a/src/test/ui/associated-const/lints-used-unused.rs
+++ b/src/test/ui/associated-const/lints-used-unused.rs
@@ -23,5 +23,5 @@ impl<T: Foo> Foo for Vec<T> {
 
 fn main() {
     #[cfg(used)]
-    let _ = S::N; //[used]~ ERROR erroneous constant used
+    let _ = S::N; // FIXME: "erroneous constant used" -- awaiting #67176
 }

--- a/src/test/ui/associated-const/lints-used-unused.rs
+++ b/src/test/ui/associated-const/lints-used-unused.rs
@@ -15,10 +15,12 @@ struct S;
 impl Foo for S {
     const N: i32 = 1 << 42;
     //~^ ERROR this arithmetic operation will overflow
+    //~| ERROR any use of this value will cause an error
 }
 
 impl<T: Foo> Foo for Vec<T> {
-    const N: i32 = --T::N + (-i32::MIN); //~ ERROR this arithmetic operation will overflow
+    const N: i32 = --T::N + (-i32::MIN);
+    //~^ ERROR this arithmetic operation will overflow
 }
 
 fn main() {

--- a/src/test/ui/associated-const/lints-used-unused.unused.stderr
+++ b/src/test/ui/associated-const/lints-used-unused.unused.stderr
@@ -20,5 +20,11 @@ LL |     const N: i32 = 1 << 42;
    |
    = note: `#[deny(const_err)]` on by default
 
-error: aborting due to 2 previous errors
+error: this arithmetic operation will overflow
+  --> $DIR/lints-used-unused.rs:22:29
+   |
+LL |     const N: i32 = --T::N + (-i32::MIN);
+   |                             ^^^^^^^^^^^ attempt to negate with overflow
+
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/associated-const/lints-used-unused.unused.stderr
+++ b/src/test/ui/associated-const/lints-used-unused.unused.stderr
@@ -1,0 +1,24 @@
+error: this arithmetic operation will overflow
+  --> $DIR/lints-used-unused.rs:16:20
+   |
+LL |     const N: i32 = 1 << 42;
+   |                    ^^^^^^^ attempt to shift left with overflow
+   |
+note: the lint level is defined here
+  --> $DIR/lints-used-unused.rs:7:9
+   |
+LL | #![deny(arithmetic_overflow)]
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: any use of this value will cause an error
+  --> $DIR/lints-used-unused.rs:16:20
+   |
+LL |     const N: i32 = 1 << 42;
+   |     ---------------^^^^^^^-
+   |                    |
+   |                    attempt to shift left with overflow
+   |
+   = note: `#[deny(const_err)]` on by default
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/associated-const/lints-used-unused.used.stderr
+++ b/src/test/ui/associated-const/lints-used-unused.used.stderr
@@ -20,5 +20,11 @@ LL |     const N: i32 = 1 << 42;
    |
    = note: `#[deny(const_err)]` on by default
 
-error: aborting due to 2 previous errors
+error: this arithmetic operation will overflow
+  --> $DIR/lints-used-unused.rs:22:29
+   |
+LL |     const N: i32 = --T::N + (-i32::MIN);
+   |                             ^^^^^^^^^^^ attempt to negate with overflow
+
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/associated-const/lints-used-unused.used.stderr
+++ b/src/test/ui/associated-const/lints-used-unused.used.stderr
@@ -1,0 +1,24 @@
+error: this arithmetic operation will overflow
+  --> $DIR/lints-used-unused.rs:16:20
+   |
+LL |     const N: i32 = 1 << 42;
+   |                    ^^^^^^^ attempt to shift left with overflow
+   |
+note: the lint level is defined here
+  --> $DIR/lints-used-unused.rs:7:9
+   |
+LL | #![deny(arithmetic_overflow)]
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: any use of this value will cause an error
+  --> $DIR/lints-used-unused.rs:16:20
+   |
+LL |     const N: i32 = 1 << 42;
+   |     ---------------^^^^^^^-
+   |                    |
+   |                    attempt to shift left with overflow
+   |
+   = note: `#[deny(const_err)]` on by default
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/consts/issue-69020.noopt.stderr
+++ b/src/test/ui/consts/issue-69020.noopt.stderr
@@ -6,11 +6,29 @@ LL |     const NEG: i32 = -i32::MIN + T::NEG;
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
 
+error: any use of this value will cause an error
+  --> $DIR/issue-69020.rs:21:22
+   |
+LL |     const NEG: i32 = -i32::MIN + T::NEG;
+   |     -----------------^^^^^^^^^----------
+   |                      |
+   |                      attempt to negate with overflow
+   |
+   = note: `#[deny(const_err)]` on by default
+
 error: this arithmetic operation will overflow
   --> $DIR/issue-69020.rs:23:22
    |
 LL |     const ADD: i32 = (i32::MAX+1) + T::ADD;
    |                      ^^^^^^^^^^^^ attempt to add with overflow
+
+error: any use of this value will cause an error
+  --> $DIR/issue-69020.rs:23:22
+   |
+LL |     const ADD: i32 = (i32::MAX+1) + T::ADD;
+   |     -----------------^^^^^^^^^^^^----------
+   |                      |
+   |                      attempt to add with overflow
 
 error: this operation will panic at runtime
   --> $DIR/issue-69020.rs:25:22
@@ -20,11 +38,27 @@ LL |     const DIV: i32 = (1/0) + T::DIV;
    |
    = note: `#[deny(unconditional_panic)]` on by default
 
+error: any use of this value will cause an error
+  --> $DIR/issue-69020.rs:25:22
+   |
+LL |     const DIV: i32 = (1/0) + T::DIV;
+   |     -----------------^^^^^----------
+   |                      |
+   |                      attempt to divide by zero
+
 error: this operation will panic at runtime
   --> $DIR/issue-69020.rs:27:22
    |
 LL |     const OOB: i32 = [1][1] + T::OOB;
    |                      ^^^^^^ index out of bounds: the len is 1 but the index is 1
 
-error: aborting due to 4 previous errors
+error: any use of this value will cause an error
+  --> $DIR/issue-69020.rs:27:22
+   |
+LL |     const OOB: i32 = [1][1] + T::OOB;
+   |     -----------------^^^^^^----------
+   |                      |
+   |                      index out of bounds: the len is 1 but the index is 1
+
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/consts/issue-69020.noopt.stderr
+++ b/src/test/ui/consts/issue-69020.noopt.stderr
@@ -17,13 +17,13 @@ LL |     const NEG: i32 = -i32::MIN + T::NEG;
    = note: `#[deny(const_err)]` on by default
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-69020.rs:23:22
+  --> $DIR/issue-69020.rs:24:22
    |
 LL |     const ADD: i32 = (i32::MAX+1) + T::ADD;
    |                      ^^^^^^^^^^^^ attempt to add with overflow
 
 error: any use of this value will cause an error
-  --> $DIR/issue-69020.rs:23:22
+  --> $DIR/issue-69020.rs:24:22
    |
 LL |     const ADD: i32 = (i32::MAX+1) + T::ADD;
    |     -----------------^^^^^^^^^^^^----------
@@ -31,7 +31,7 @@ LL |     const ADD: i32 = (i32::MAX+1) + T::ADD;
    |                      attempt to add with overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-69020.rs:25:22
+  --> $DIR/issue-69020.rs:27:22
    |
 LL |     const DIV: i32 = (1/0) + T::DIV;
    |                      ^^^^^ attempt to divide by zero
@@ -39,7 +39,7 @@ LL |     const DIV: i32 = (1/0) + T::DIV;
    = note: `#[deny(unconditional_panic)]` on by default
 
 error: any use of this value will cause an error
-  --> $DIR/issue-69020.rs:25:22
+  --> $DIR/issue-69020.rs:27:22
    |
 LL |     const DIV: i32 = (1/0) + T::DIV;
    |     -----------------^^^^^----------
@@ -47,13 +47,13 @@ LL |     const DIV: i32 = (1/0) + T::DIV;
    |                      attempt to divide by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-69020.rs:27:22
+  --> $DIR/issue-69020.rs:30:22
    |
 LL |     const OOB: i32 = [1][1] + T::OOB;
    |                      ^^^^^^ index out of bounds: the len is 1 but the index is 1
 
 error: any use of this value will cause an error
-  --> $DIR/issue-69020.rs:27:22
+  --> $DIR/issue-69020.rs:30:22
    |
 LL |     const OOB: i32 = [1][1] + T::OOB;
    |     -----------------^^^^^^----------

--- a/src/test/ui/consts/issue-69020.opt.stderr
+++ b/src/test/ui/consts/issue-69020.opt.stderr
@@ -6,11 +6,29 @@ LL |     const NEG: i32 = -i32::MIN + T::NEG;
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
 
+error: any use of this value will cause an error
+  --> $DIR/issue-69020.rs:21:22
+   |
+LL |     const NEG: i32 = -i32::MIN + T::NEG;
+   |     -----------------^^^^^^^^^----------
+   |                      |
+   |                      attempt to negate with overflow
+   |
+   = note: `#[deny(const_err)]` on by default
+
 error: this arithmetic operation will overflow
   --> $DIR/issue-69020.rs:23:22
    |
 LL |     const ADD: i32 = (i32::MAX+1) + T::ADD;
    |                      ^^^^^^^^^^^^ attempt to add with overflow
+
+error: any use of this value will cause an error
+  --> $DIR/issue-69020.rs:23:22
+   |
+LL |     const ADD: i32 = (i32::MAX+1) + T::ADD;
+   |     -----------------^^^^^^^^^^^^----------
+   |                      |
+   |                      attempt to add with overflow
 
 error: this operation will panic at runtime
   --> $DIR/issue-69020.rs:25:22
@@ -20,11 +38,27 @@ LL |     const DIV: i32 = (1/0) + T::DIV;
    |
    = note: `#[deny(unconditional_panic)]` on by default
 
+error: any use of this value will cause an error
+  --> $DIR/issue-69020.rs:25:22
+   |
+LL |     const DIV: i32 = (1/0) + T::DIV;
+   |     -----------------^^^^^----------
+   |                      |
+   |                      attempt to divide by zero
+
 error: this operation will panic at runtime
   --> $DIR/issue-69020.rs:27:22
    |
 LL |     const OOB: i32 = [1][1] + T::OOB;
    |                      ^^^^^^ index out of bounds: the len is 1 but the index is 1
 
-error: aborting due to 4 previous errors
+error: any use of this value will cause an error
+  --> $DIR/issue-69020.rs:27:22
+   |
+LL |     const OOB: i32 = [1][1] + T::OOB;
+   |     -----------------^^^^^^----------
+   |                      |
+   |                      index out of bounds: the len is 1 but the index is 1
+
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/consts/issue-69020.opt.stderr
+++ b/src/test/ui/consts/issue-69020.opt.stderr
@@ -17,13 +17,13 @@ LL |     const NEG: i32 = -i32::MIN + T::NEG;
    = note: `#[deny(const_err)]` on by default
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-69020.rs:23:22
+  --> $DIR/issue-69020.rs:24:22
    |
 LL |     const ADD: i32 = (i32::MAX+1) + T::ADD;
    |                      ^^^^^^^^^^^^ attempt to add with overflow
 
 error: any use of this value will cause an error
-  --> $DIR/issue-69020.rs:23:22
+  --> $DIR/issue-69020.rs:24:22
    |
 LL |     const ADD: i32 = (i32::MAX+1) + T::ADD;
    |     -----------------^^^^^^^^^^^^----------
@@ -31,7 +31,7 @@ LL |     const ADD: i32 = (i32::MAX+1) + T::ADD;
    |                      attempt to add with overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-69020.rs:25:22
+  --> $DIR/issue-69020.rs:27:22
    |
 LL |     const DIV: i32 = (1/0) + T::DIV;
    |                      ^^^^^ attempt to divide by zero
@@ -39,7 +39,7 @@ LL |     const DIV: i32 = (1/0) + T::DIV;
    = note: `#[deny(unconditional_panic)]` on by default
 
 error: any use of this value will cause an error
-  --> $DIR/issue-69020.rs:25:22
+  --> $DIR/issue-69020.rs:27:22
    |
 LL |     const DIV: i32 = (1/0) + T::DIV;
    |     -----------------^^^^^----------
@@ -47,13 +47,13 @@ LL |     const DIV: i32 = (1/0) + T::DIV;
    |                      attempt to divide by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-69020.rs:27:22
+  --> $DIR/issue-69020.rs:30:22
    |
 LL |     const OOB: i32 = [1][1] + T::OOB;
    |                      ^^^^^^ index out of bounds: the len is 1 but the index is 1
 
 error: any use of this value will cause an error
-  --> $DIR/issue-69020.rs:27:22
+  --> $DIR/issue-69020.rs:30:22
    |
 LL |     const OOB: i32 = [1][1] + T::OOB;
    |     -----------------^^^^^^----------

--- a/src/test/ui/consts/issue-69020.opt_with_overflow_checks.stderr
+++ b/src/test/ui/consts/issue-69020.opt_with_overflow_checks.stderr
@@ -6,11 +6,29 @@ LL |     const NEG: i32 = -i32::MIN + T::NEG;
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
 
+error: any use of this value will cause an error
+  --> $DIR/issue-69020.rs:21:22
+   |
+LL |     const NEG: i32 = -i32::MIN + T::NEG;
+   |     -----------------^^^^^^^^^----------
+   |                      |
+   |                      attempt to negate with overflow
+   |
+   = note: `#[deny(const_err)]` on by default
+
 error: this arithmetic operation will overflow
   --> $DIR/issue-69020.rs:23:22
    |
 LL |     const ADD: i32 = (i32::MAX+1) + T::ADD;
    |                      ^^^^^^^^^^^^ attempt to add with overflow
+
+error: any use of this value will cause an error
+  --> $DIR/issue-69020.rs:23:22
+   |
+LL |     const ADD: i32 = (i32::MAX+1) + T::ADD;
+   |     -----------------^^^^^^^^^^^^----------
+   |                      |
+   |                      attempt to add with overflow
 
 error: this operation will panic at runtime
   --> $DIR/issue-69020.rs:25:22
@@ -20,11 +38,27 @@ LL |     const DIV: i32 = (1/0) + T::DIV;
    |
    = note: `#[deny(unconditional_panic)]` on by default
 
+error: any use of this value will cause an error
+  --> $DIR/issue-69020.rs:25:22
+   |
+LL |     const DIV: i32 = (1/0) + T::DIV;
+   |     -----------------^^^^^----------
+   |                      |
+   |                      attempt to divide by zero
+
 error: this operation will panic at runtime
   --> $DIR/issue-69020.rs:27:22
    |
 LL |     const OOB: i32 = [1][1] + T::OOB;
    |                      ^^^^^^ index out of bounds: the len is 1 but the index is 1
 
-error: aborting due to 4 previous errors
+error: any use of this value will cause an error
+  --> $DIR/issue-69020.rs:27:22
+   |
+LL |     const OOB: i32 = [1][1] + T::OOB;
+   |     -----------------^^^^^^----------
+   |                      |
+   |                      index out of bounds: the len is 1 but the index is 1
+
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/consts/issue-69020.opt_with_overflow_checks.stderr
+++ b/src/test/ui/consts/issue-69020.opt_with_overflow_checks.stderr
@@ -17,13 +17,13 @@ LL |     const NEG: i32 = -i32::MIN + T::NEG;
    = note: `#[deny(const_err)]` on by default
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-69020.rs:23:22
+  --> $DIR/issue-69020.rs:24:22
    |
 LL |     const ADD: i32 = (i32::MAX+1) + T::ADD;
    |                      ^^^^^^^^^^^^ attempt to add with overflow
 
 error: any use of this value will cause an error
-  --> $DIR/issue-69020.rs:23:22
+  --> $DIR/issue-69020.rs:24:22
    |
 LL |     const ADD: i32 = (i32::MAX+1) + T::ADD;
    |     -----------------^^^^^^^^^^^^----------
@@ -31,7 +31,7 @@ LL |     const ADD: i32 = (i32::MAX+1) + T::ADD;
    |                      attempt to add with overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-69020.rs:25:22
+  --> $DIR/issue-69020.rs:27:22
    |
 LL |     const DIV: i32 = (1/0) + T::DIV;
    |                      ^^^^^ attempt to divide by zero
@@ -39,7 +39,7 @@ LL |     const DIV: i32 = (1/0) + T::DIV;
    = note: `#[deny(unconditional_panic)]` on by default
 
 error: any use of this value will cause an error
-  --> $DIR/issue-69020.rs:25:22
+  --> $DIR/issue-69020.rs:27:22
    |
 LL |     const DIV: i32 = (1/0) + T::DIV;
    |     -----------------^^^^^----------
@@ -47,13 +47,13 @@ LL |     const DIV: i32 = (1/0) + T::DIV;
    |                      attempt to divide by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-69020.rs:27:22
+  --> $DIR/issue-69020.rs:30:22
    |
 LL |     const OOB: i32 = [1][1] + T::OOB;
    |                      ^^^^^^ index out of bounds: the len is 1 but the index is 1
 
 error: any use of this value will cause an error
-  --> $DIR/issue-69020.rs:27:22
+  --> $DIR/issue-69020.rs:30:22
    |
 LL |     const OOB: i32 = [1][1] + T::OOB;
    |     -----------------^^^^^^----------

--- a/src/test/ui/consts/issue-69020.rs
+++ b/src/test/ui/consts/issue-69020.rs
@@ -20,10 +20,14 @@ pub trait Foo {
 impl<T: Foo> Foo for Vec<T> {
     const NEG: i32 = -i32::MIN + T::NEG;
     //~^ ERROR arithmetic operation will overflow
+    //~| ERROR any use of this value will cause an error
     const ADD: i32 = (i32::MAX+1) + T::ADD;
     //~^ ERROR arithmetic operation will overflow
+    //~| ERROR any use of this value will cause an error
     const DIV: i32 = (1/0) + T::DIV;
     //~^ ERROR operation will panic
+    //~| ERROR any use of this value will cause an error
     const OOB: i32 = [1][1] + T::OOB;
     //~^ ERROR operation will panic
+    //~| ERROR any use of this value will cause an error
 }

--- a/src/test/ui/lint/lint-exceeding-bitshifts.rs
+++ b/src/test/ui/lint/lint-exceeding-bitshifts.rs
@@ -15,7 +15,7 @@ pub trait Foo {
 }
 
 impl<T: Foo> Foo for Vec<T> {
-    const N: i32 = T::N << 42; // FIXME this should warn
+    const N: i32 = T::N << 42; // ERROR: arithmetic operation will overflow
 }
 
 pub fn foo(x: i32) {


### PR DESCRIPTION
Fixes #69021.

Changes UnusedBrokenConst to also run on associated consts (when previously, it only ran on consts). Previously, if an associated const was unused, we would not end up linting the value, because `const_prop` (where `check_{unary, binary}_op` are run) would never reach the value.

r? @RalfJung