### PR TITLE
submodules: update clippy from 8485d40a to d556bb73

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,6 @@ dependencies = [
  "clippy_lints",
  "compiletest_rs",
  "derive-new",
- "git2",
  "lazy_static 1.4.0",
  "regex",
  "rustc-workspace-hack",


### PR DESCRIPTION
Changes:
````
    rustup https://github.com/rust-lang/rust/pull/68944
    rustup https://github.com/rust-lang/rust/pull/69589/
    Rustup to rust-lang/rust#69076
    Don't convert Path to lossy str
    Use `into_path`
    Use pattern matching instead of manually checking condition
    Fix typo
    Remove git2 dependency.
    Document that wildcard_imports doesn't warn about `use ...::prelude::*;`
    Change changelog formatting
    Update changelog_update doc to reflect the actual ordering of the changelog
    Update CHANGELOG.md
````

Fixes #70007