### PR TITLE
Allow obtaining &mut OsStr

### DIFF
--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -379,6 +379,14 @@ impl ops::Index<ops::RangeFull> for OsString {
     }
 }
 
+#[stable(feature = "mut_osstr", since = "1.44.0")]
+impl ops::IndexMut<ops::RangeFull> for OsString {
+    #[inline]
+    fn index_mut(&mut self, _index: ops::RangeFull) -> &mut OsStr {
+        OsStr::from_inner_mut(self.inner.as_mut_slice())
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl ops::Deref for OsString {
     type Target = OsStr;
@@ -386,6 +394,14 @@ impl ops::Deref for OsString {
     #[inline]
     fn deref(&self) -> &OsStr {
         &self[..]
+    }
+}
+
+#[stable(feature = "mut_osstr", since = "1.44.0")]
+impl ops::DerefMut for OsString {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut OsStr {
+        &mut self[..]
     }
 }
 
@@ -510,6 +526,11 @@ impl OsStr {
     #[inline]
     fn from_inner(inner: &Slice) -> &OsStr {
         unsafe { &*(inner as *const Slice as *const OsStr) }
+    }
+
+    #[inline]
+    fn from_inner_mut(inner: &mut Slice) -> &mut OsStr {
+        unsafe { &mut *(inner as *mut Slice as *mut OsStr) }
     }
 
     /// Yields a [`&str`] slice if the `OsStr` is valid Unicode.

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -534,6 +534,8 @@ impl OsStr {
     fn from_inner_mut(inner: &mut Slice) -> &mut OsStr {
         // Safety: OsStr is just a wrapper of Slice,
         // therefore converting &mut Slice to &mut OsStr is safe.
+        // Any method that mutates OsStr must be careful not to
+        // break platform-specific encoding, in particular Wtf8 on Windows.
         unsafe { &mut *(inner as *mut Slice as *mut OsStr) }
     }
 

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -525,11 +525,15 @@ impl OsStr {
 
     #[inline]
     fn from_inner(inner: &Slice) -> &OsStr {
+        // Safety: OsStr is just a wrapper of Slice,
+        // therefore converting &Slice to &OsStr is safe.
         unsafe { &*(inner as *const Slice as *const OsStr) }
     }
 
     #[inline]
     fn from_inner_mut(inner: &mut Slice) -> &mut OsStr {
+        // Safety: OsStr is just a wrapper of Slice,
+        // therefore converting &mut Slice to &mut OsStr is safe.
         unsafe { &mut *(inner as *mut Slice as *mut OsStr) }
     }
 

--- a/src/libstd/sys/windows/os_str.rs
+++ b/src/libstd/sys/windows/os_str.rs
@@ -83,7 +83,6 @@ impl Buf {
         unsafe { mem::transmute(self.inner.as_slice()) }
     }
 
-    #[inline]
     pub fn as_mut_slice(&mut self) -> &mut Slice {
         // Safety: Slice is just a wrapper for Wtf8,
         // and as_slice returns &Wtf8. Therefore,

--- a/src/libstd/sys/windows/os_str.rs
+++ b/src/libstd/sys/windows/os_str.rs
@@ -87,6 +87,8 @@ impl Buf {
         // Safety: Slice is just a wrapper for Wtf8,
         // and self.inner.as_mut_slice() returns &mut Wtf8.
         // Therefore, transmuting &mut Wtf8 to &mut Slice is safe.
+        // Additionally, care should be taken to ensure the slice
+        // is always valid Wtf8.
         unsafe { mem::transmute(self.inner.as_mut_slice()) }
     }
 

--- a/src/libstd/sys/windows/os_str.rs
+++ b/src/libstd/sys/windows/os_str.rs
@@ -80,6 +80,11 @@ impl Buf {
         unsafe { mem::transmute(self.inner.as_slice()) }
     }
 
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut Slice {
+        unsafe { mem::transmute(self.inner.as_mut_slice()) }
+    }
+
     pub fn into_string(self) -> Result<String, Buf> {
         self.inner.into_string().map_err(|buf| Buf { inner: buf })
     }

--- a/src/libstd/sys/windows/os_str.rs
+++ b/src/libstd/sys/windows/os_str.rs
@@ -78,15 +78,15 @@ impl Buf {
 
     pub fn as_slice(&self) -> &Slice {
         // Safety: Slice is just a wrapper for Wtf8,
-        // and as_slice returns &Wtf8. Therefore,
-        // transmuting &Wtf8 to &Slice is safe.
+        // and self.inner.as_slice() returns &Wtf8.
+        // Therefore, transmuting &Wtf8 to &Slice is safe.
         unsafe { mem::transmute(self.inner.as_slice()) }
     }
 
     pub fn as_mut_slice(&mut self) -> &mut Slice {
         // Safety: Slice is just a wrapper for Wtf8,
-        // and as_mut_slice returns &mut Wtf8. Therefore,
-        // transmuting &mut Wtf8 to &mut Slice is safe.
+        // and self.inner.as_mut_slice() returns &mut Wtf8.
+        // Therefore, transmuting &mut Wtf8 to &mut Slice is safe.
         unsafe { mem::transmute(self.inner.as_mut_slice()) }
     }
 

--- a/src/libstd/sys/windows/os_str.rs
+++ b/src/libstd/sys/windows/os_str.rs
@@ -79,14 +79,14 @@ impl Buf {
     pub fn as_slice(&self) -> &Slice {
         // Safety: Slice is just a wrapper for Wtf8,
         // and as_slice returns &Wtf8. Therefore,
-        // transmute &Wtf8 to &Slice is safe.
+        // transmuting &Wtf8 to &Slice is safe.
         unsafe { mem::transmute(self.inner.as_slice()) }
     }
 
     pub fn as_mut_slice(&mut self) -> &mut Slice {
         // Safety: Slice is just a wrapper for Wtf8,
-        // and as_slice returns &Wtf8. Therefore,
-        // transmute &mut Wtf8 to &mut Slice is safe.
+        // and as_mut_slice returns &mut Wtf8. Therefore,
+        // transmuting &mut Wtf8 to &mut Slice is safe.
         unsafe { mem::transmute(self.inner.as_mut_slice()) }
     }
 

--- a/src/libstd/sys/windows/os_str.rs
+++ b/src/libstd/sys/windows/os_str.rs
@@ -77,11 +77,17 @@ impl Buf {
     }
 
     pub fn as_slice(&self) -> &Slice {
+        // Safety: Slice is just a wrapper for Wtf8,
+        // and as_slice returns &Wtf8. Therefore,
+        // transmute &Wtf8 to &Slice is safe.
         unsafe { mem::transmute(self.inner.as_slice()) }
     }
 
     #[inline]
     pub fn as_mut_slice(&mut self) -> &mut Slice {
+        // Safety: Slice is just a wrapper for Wtf8,
+        // and as_slice returns &Wtf8. Therefore,
+        // transmute &mut Wtf8 to &mut Slice is safe.
         unsafe { mem::transmute(self.inner.as_mut_slice()) }
     }
 

--- a/src/libstd/sys_common/os_str_bytes.rs
+++ b/src/libstd/sys_common/os_str_bytes.rs
@@ -106,11 +106,17 @@ impl Buf {
 
     #[inline]
     pub fn as_slice(&self) -> &Slice {
+        // Safety: Slice just wraps [u8],
+        // and &*self.inner is &[u8], therefore
+        // transmuting &[u8] to &Slice is safe.
         unsafe { mem::transmute(&*self.inner) }
     }
 
     #[inline]
     pub fn as_mut_slice(&mut self) -> &mut Slice {
+        // Safety: Slice just wraps [u8],
+        // and &mut *self.inner is &mut [u8], therefore
+        // transmuting &mut [u8] to &mut Slice is safe.
         unsafe { mem::transmute(&mut *self.inner) }
     }
 

--- a/src/libstd/sys_common/os_str_bytes.rs
+++ b/src/libstd/sys_common/os_str_bytes.rs
@@ -109,6 +109,11 @@ impl Buf {
         unsafe { mem::transmute(&*self.inner) }
     }
 
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut Slice {
+        unsafe { mem::transmute(&mut *self.inner) }
+    }
+
     pub fn into_string(self) -> Result<String, Buf> {
         String::from_utf8(self.inner).map_err(|p| Buf { inner: p.into_bytes() })
     }


### PR DESCRIPTION
```rust
impl DerefMut for OsString {...}              // type Target = OsStr
impl IndexMut<RangeFull> for OsString {...}   // type Output = OsStr
```

---

This change is pulled out of #69937 per @dtolnay 

This implements `DerefMut for OsString` to allow obtaining a `&mut OsStr`. This also implements `IndexMut for OsString`, which is used by `DerefMut`. This pattern is the same as is used by `Deref`.

This is necessary to for methods like `make_ascii_lowercase` which need to mutate the underlying value.