### PR TITLE
Build dist-android with --enable-profiler

### DIFF
--- a/src/ci/docker/dist-android/Dockerfile
+++ b/src/ci/docker/dist-android/Dockerfile
@@ -23,6 +23,7 @@ ENV TARGETS=$TARGETS,x86_64-linux-android
 
 ENV RUST_CONFIGURE_ARGS \
       --enable-extended \
+      --enable-profiler \
       --arm-linux-androideabi-ndk=/android/ndk/arm-14 \
       --armv7-linux-androideabi-ndk=/android/ndk/arm-14 \
       --thumbv7neon-linux-androideabi-ndk=/android/ndk/arm-14 \

--- a/src/libprofiler_builtins/build.rs
+++ b/src/libprofiler_builtins/build.rs
@@ -41,7 +41,6 @@ fn main() {
         cfg.flag("-fno-builtin");
         cfg.flag("-fvisibility=hidden");
         cfg.flag("-fomit-frame-pointer");
-        cfg.flag("-ffreestanding");
         cfg.define("VISIBILITY_HIDDEN", None);
         if !target.contains("windows") {
             cfg.define("COMPILER_RT_HAS_UNAME", Some("1"));


### PR DESCRIPTION
This will make the runtime available to enable PGO for Rust code in Firefox on Android.

r? @michaelwoerister