### PR TITLE
can_begin_literal_maybe_minus: `true` on `"-"? lit` NTs.

### DIFF
--- a/src/librustc_ast/util/literal.rs
+++ b/src/librustc_ast/util/literal.rs
@@ -189,7 +189,7 @@ impl Lit {
 
     /// Converts arbitrary token into an AST literal.
     ///
-    /// Keep this in sync with `Token::can_begin_literal_or_bool`.
+    /// Keep this in sync with `Token::can_begin_literal_or_bool` excluding unary negation.
     pub fn from_token(token: &Token) -> Result<Lit, LitError> {
         let lit = match token.uninterpolate().kind {
             token::Ident(name, false) if name.is_bool_lit() => {

--- a/src/librustc_expand/mbe/macro_parser.rs
+++ b/src/librustc_expand/mbe/macro_parser.rs
@@ -778,7 +778,7 @@ fn may_begin_with(token: &Token, name: Name) -> bool {
         }
         sym::ty => token.can_begin_type(),
         sym::ident => get_macro_ident(token).is_some(),
-        sym::literal => token.can_begin_literal_or_bool(),
+        sym::literal => token.can_begin_literal_maybe_minus(),
         sym::vis => match token.kind {
             // The follow-set of :vis + "priv" keyword + interpolated
             token::Comma | token::Ident(..) | token::Interpolated(_) => true,

--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -1374,6 +1374,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Matches `'-' lit | lit` (cf. `ast_validation::AstValidator::check_expr_within_pat`).
+    /// Keep this in sync with `Token::can_begin_literal_maybe_minus`.
     pub fn parse_literal_maybe_minus(&mut self) -> PResult<'a, P<Expr>> {
         maybe_whole_expr!(self);
 

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -1509,7 +1509,7 @@ impl<'a> Parser<'a> {
                 })
             // `extern ABI fn`
             || self.check_keyword(kw::Extern)
-                && self.look_ahead(1, |t| t.can_begin_literal_or_bool())
+                && self.look_ahead(1, |t| t.can_begin_literal_maybe_minus())
                 && self.look_ahead(2, |t| t.is_keyword(kw::Fn))
     }
 

--- a/src/librustc_parse/parser/pat.rs
+++ b/src/librustc_parse/parser/pat.rs
@@ -696,7 +696,7 @@ impl<'a> Parser<'a> {
         self.look_ahead(dist, |t| {
             t.is_path_start() // e.g. `MY_CONST`;
                 || t.kind == token::Dot // e.g. `.5` for recovery;
-                || t.can_begin_literal_or_bool() // e.g. `42`.
+                || t.can_begin_literal_maybe_minus() // e.g. `42`.
                 || t.is_whole_expr()
         })
     }

--- a/src/test/ui/parser/extern-abi-from-mac-literal-frag.rs
+++ b/src/test/ui/parser/extern-abi-from-mac-literal-frag.rs
@@ -1,7 +1,7 @@
 // check-pass
 
 // In this test we check that the parser accepts an ABI string when it
-// comes from a macro `literal` fragment as opposed to a hardcoded string.
+// comes from a macro `literal` or `expr` fragment as opposed to a hardcoded string.
 
 fn main() {}
 
@@ -17,10 +17,30 @@ macro_rules! abi_from_lit_frag {
     }
 }
 
+macro_rules! abi_from_expr_frag {
+    ($abi:expr) => {
+        extern $abi {
+            fn _import();
+        }
+
+        extern $abi fn _export() {}
+
+        type _PTR = extern $abi fn();
+    };
+}
+
 mod rust {
     abi_from_lit_frag!("Rust");
 }
 
 mod c {
     abi_from_lit_frag!("C");
+}
+
+mod rust_expr {
+    abi_from_expr_frag!("Rust");
+}
+
+mod c_expr {
+    abi_from_expr_frag!("C");
 }

--- a/src/test/ui/parser/issue-70050-ntliteral-accepts-negated-lit.rs
+++ b/src/test/ui/parser/issue-70050-ntliteral-accepts-negated-lit.rs
@@ -1,0 +1,16 @@
+// check-pass
+
+macro_rules! foo {
+    ($a:literal) => {
+        bar!($a)
+    };
+}
+
+macro_rules! bar {
+    ($b:literal) => {};
+}
+
+fn main() {
+    foo!(-2);
+    bar!(-2);
+}


### PR DESCRIPTION
Make `can_begin_literal_or_bool` (renamed to `can_begin_literal_maybe_minus`) accept `NtLiteral(e) | NtExpr(e)` where `e` is either a literal or a negated literal.

Fixes https://github.com/rust-lang/rust/issues/70050.

r? @petrochenkov 