### PR TITLE
use "gcc" instead of "cc" on *-sun-solaris systems when linking

### DIFF
--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -841,6 +841,12 @@ pub fn linker_and_flavor(sess: &Session) -> (PathBuf, LinkerFlavor) {
                     }
                     LinkerFlavor::Gcc => {
                         if cfg!(target_os = "solaris") {
+                            // On historical Solaris systems, "cc" may have
+                            // been Sun Studio, which is not flag-compatible
+                            // with "gcc".  This history casts a long shadow,
+                            // and many modern illumos distributions today
+                            // ship GCC as "gcc" without also making it
+                            // available as "cc".
                             "gcc"
                         } else {
                             "cc"

--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -839,7 +839,13 @@ pub fn linker_and_flavor(sess: &Session) -> (PathBuf, LinkerFlavor) {
                             "emcc"
                         }
                     }
-                    LinkerFlavor::Gcc => "cc",
+                    LinkerFlavor::Gcc => {
+                        if cfg!(target_os = "solaris") {
+                            "gcc"
+                        } else {
+                            "cc"
+                        }
+                    }
                     LinkerFlavor::Ld => "ld",
                     LinkerFlavor::Msvc => "link.exe",
                     LinkerFlavor::Lld(_) => "lld",


### PR DESCRIPTION
On illumos and Solaris systems, Rust will use GCC as the link editor.
Rust does this by invoking "cc", which on many (Linux and perhaps BSD)
systems is generally either GCC or a GCC-compatible front-end.  On
historical Solaris systems, "cc" was often the Sun Studio compiler.
This history casts a long shadow, and as such, even most modern
illumos-based operating systems tend to install GCC as "gcc", without
also making it available as "cc".

We should invoke GCC as "gcc" on such systems to ensure we get the right
compiler driver.