### PR TITLE
Expand: nix all fatal errors

### DIFF
--- a/src/librustc_builtin_macros/test.rs
+++ b/src/librustc_builtin_macros/test.rs
@@ -74,16 +74,16 @@ pub fn expand_test_or_bench(
         return vec![];
     }
 
-    let item = if let Annotatable::Item(i) = item {
-        i
-    } else {
-        cx.parse_sess
-            .span_diagnostic
-            .span_fatal(
-                item.span(),
+    let item = match item {
+        Annotatable::Item(i) => i,
+        other => {
+            cx.struct_span_err(
+                other.span(),
                 "`#[test]` attribute is only allowed on non associated functions",
             )
-            .raise();
+            .emit();
+            return vec![other];
+        }
     };
 
     if let ast::ItemKind::MacCall(_) = item.kind {

--- a/src/librustc_expand/base.rs
+++ b/src/librustc_expand/base.rs
@@ -1168,6 +1168,18 @@ pub fn check_zero_tts(cx: &ExtCtxt<'_>, sp: Span, tts: TokenStream, name: &str) 
     }
 }
 
+/// Parse an expression. On error, emit it, advancing to `Eof`, and return `None`.
+fn parse_expr(p: &mut parser::Parser<'_>) -> Option<P<ast::Expr>> {
+    match p.parse_expr() {
+        Ok(e) => return Some(e),
+        Err(mut err) => err.emit(),
+    }
+    while p.token != token::Eof {
+        p.bump();
+    }
+    None
+}
+
 /// Interpreting `tts` as a comma-separated sequence of expressions,
 /// expect exactly one string literal, or emit an error and return `None`.
 pub fn get_single_str_from_tts(
@@ -1181,7 +1193,7 @@ pub fn get_single_str_from_tts(
         cx.span_err(sp, &format!("{} takes 1 argument", name));
         return None;
     }
-    let ret = panictry!(p.parse_expr());
+    let ret = parse_expr(&mut p)?;
     let _ = p.eat(&token::Comma);
 
     if p.token != token::Eof {
@@ -1190,8 +1202,8 @@ pub fn get_single_str_from_tts(
     expr_to_string(cx, ret, "argument must be a string literal").map(|(s, _)| s.to_string())
 }
 
-/// Extracts comma-separated expressions from `tts`. If there is a
-/// parsing error, emit a non-fatal error and return `None`.
+/// Extracts comma-separated expressions from `tts`.
+/// On error, emit it, and return `None`.
 pub fn get_exprs_from_tts(
     cx: &mut ExtCtxt<'_>,
     sp: Span,
@@ -1200,7 +1212,7 @@ pub fn get_exprs_from_tts(
     let mut p = cx.new_parser_from_tts(tts);
     let mut es = Vec::new();
     while p.token != token::Eof {
-        let expr = panictry!(p.parse_expr());
+        let expr = parse_expr(&mut p)?;
 
         // Perform eager expansion on the expression.
         // We want to be able to handle e.g., `concat!("foo", "bar")`.

--- a/src/librustc_expand/base.rs
+++ b/src/librustc_expand/base.rs
@@ -10,7 +10,7 @@ use rustc_ast::visit::{AssocCtxt, Visitor};
 use rustc_attr::{self as attr, Deprecation, HasAttrs, Stability};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync::{self, Lrc};
-use rustc_errors::{DiagnosticBuilder, DiagnosticId, ErrorReported};
+use rustc_errors::{DiagnosticBuilder, ErrorReported};
 use rustc_parse::{self, parser, MACRO_ARGUMENTS};
 use rustc_session::parse::ParseSess;
 use rustc_span::edition::Edition;
@@ -1025,9 +1025,6 @@ impl<'a> ExtCtxt<'a> {
     /// the macro expansion phase).
     pub fn span_err<S: Into<MultiSpan>>(&self, sp: S, msg: &str) {
         self.parse_sess.span_diagnostic.span_err(sp, msg);
-    }
-    pub fn span_err_with_code<S: Into<MultiSpan>>(&self, sp: S, msg: &str, code: DiagnosticId) {
-        self.parse_sess.span_diagnostic.span_err_with_code(sp, msg, code);
     }
     pub fn span_warn<S: Into<MultiSpan>>(&self, sp: S, msg: &str) {
         self.parse_sess.span_diagnostic.span_warn(sp, msg);

--- a/src/librustc_expand/base.rs
+++ b/src/librustc_expand/base.rs
@@ -1020,9 +1020,6 @@ impl<'a> ExtCtxt<'a> {
     pub fn struct_span_err<S: Into<MultiSpan>>(&self, sp: S, msg: &str) -> DiagnosticBuilder<'a> {
         self.parse_sess.span_diagnostic.struct_span_err(sp, msg)
     }
-    pub fn struct_span_fatal<S: Into<MultiSpan>>(&self, sp: S, msg: &str) -> DiagnosticBuilder<'a> {
-        self.parse_sess.span_diagnostic.struct_span_fatal(sp, msg)
-    }
 
     /// Emit `msg` attached to `sp`, and stop compilation immediately.
     ///

--- a/src/librustc_expand/base.rs
+++ b/src/librustc_expand/base.rs
@@ -10,7 +10,7 @@ use rustc_ast::visit::{AssocCtxt, Visitor};
 use rustc_attr::{self as attr, Deprecation, HasAttrs, Stability};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync::{self, Lrc};
-use rustc_errors::{DiagnosticBuilder, DiagnosticId};
+use rustc_errors::{DiagnosticBuilder, DiagnosticId, ErrorReported};
 use rustc_parse::{self, parser, MACRO_ARGUMENTS};
 use rustc_session::parse::ParseSess;
 use rustc_span::edition::Edition;
@@ -296,16 +296,26 @@ where
 }
 
 pub trait ProcMacro {
-    fn expand<'cx>(&self, ecx: &'cx mut ExtCtxt<'_>, span: Span, ts: TokenStream) -> TokenStream;
+    fn expand<'cx>(
+        &self,
+        ecx: &'cx mut ExtCtxt<'_>,
+        span: Span,
+        ts: TokenStream,
+    ) -> Result<TokenStream, ErrorReported>;
 }
 
 impl<F> ProcMacro for F
 where
     F: Fn(TokenStream) -> TokenStream,
 {
-    fn expand<'cx>(&self, _ecx: &'cx mut ExtCtxt<'_>, _span: Span, ts: TokenStream) -> TokenStream {
+    fn expand<'cx>(
+        &self,
+        _ecx: &'cx mut ExtCtxt<'_>,
+        _span: Span,
+        ts: TokenStream,
+    ) -> Result<TokenStream, ErrorReported> {
         // FIXME setup implicit context in TLS before calling self.
-        (*self)(ts)
+        Ok((*self)(ts))
     }
 }
 

--- a/src/librustc_expand/base.rs
+++ b/src/librustc_expand/base.rs
@@ -1014,9 +1014,6 @@ impl<'a> ExtCtxt<'a> {
         self.current_expansion.id.expansion_cause()
     }
 
-    pub fn struct_span_warn<S: Into<MultiSpan>>(&self, sp: S, msg: &str) -> DiagnosticBuilder<'a> {
-        self.parse_sess.span_diagnostic.struct_span_warn(sp, msg)
-    }
     pub fn struct_span_err<S: Into<MultiSpan>>(&self, sp: S, msg: &str) -> DiagnosticBuilder<'a> {
         self.parse_sess.span_diagnostic.struct_span_err(sp, msg)
     }

--- a/src/librustc_expand/base.rs
+++ b/src/librustc_expand/base.rs
@@ -326,7 +326,7 @@ pub trait AttrProcMacro {
         span: Span,
         annotation: TokenStream,
         annotated: TokenStream,
-    ) -> TokenStream;
+    ) -> Result<TokenStream, ErrorReported>;
 }
 
 impl<F> AttrProcMacro for F
@@ -339,9 +339,9 @@ where
         _span: Span,
         annotation: TokenStream,
         annotated: TokenStream,
-    ) -> TokenStream {
+    ) -> Result<TokenStream, ErrorReported> {
         // FIXME setup implicit context in TLS before calling self.
-        (*self)(annotation, annotated)
+        Ok((*self)(annotation, annotated))
     }
 }
 

--- a/src/librustc_expand/base.rs
+++ b/src/librustc_expand/base.rs
@@ -1169,7 +1169,7 @@ pub fn check_zero_tts(cx: &ExtCtxt<'_>, sp: Span, tts: TokenStream, name: &str) 
 }
 
 /// Parse an expression. On error, emit it, advancing to `Eof`, and return `None`.
-fn parse_expr(p: &mut parser::Parser<'_>) -> Option<P<ast::Expr>> {
+pub fn parse_expr(p: &mut parser::Parser<'_>) -> Option<P<ast::Expr>> {
     match p.parse_expr() {
         Ok(e) => return Some(e),
         Err(mut err) => err.emit(),

--- a/src/librustc_expand/base.rs
+++ b/src/librustc_expand/base.rs
@@ -1018,22 +1018,6 @@ impl<'a> ExtCtxt<'a> {
         self.parse_sess.span_diagnostic.struct_span_err(sp, msg)
     }
 
-    /// Emit `msg` attached to `sp`, and stop compilation immediately.
-    ///
-    /// `span_err` should be strongly preferred where-ever possible:
-    /// this should *only* be used when:
-    ///
-    /// - continuing has a high risk of flow-on errors (e.g., errors in
-    ///   declaring a macro would cause all uses of that macro to
-    ///   complain about "undefined macro"), or
-    /// - there is literally nothing else that can be done (however,
-    ///   in most cases one can construct a dummy expression/item to
-    ///   substitute; we never hit resolve/type-checking so the dummy
-    ///   value doesn't have to match anything)
-    pub fn span_fatal<S: Into<MultiSpan>>(&self, sp: S, msg: &str) -> ! {
-        self.parse_sess.span_diagnostic.span_fatal(sp, msg).raise();
-    }
-
     /// Emit `msg` attached to `sp`, without immediately stopping
     /// compilation.
     ///

--- a/src/librustc_expand/expand.rs
+++ b/src/librustc_expand/expand.rs
@@ -204,7 +204,7 @@ ast_fragments! {
 }
 
 impl AstFragmentKind {
-    fn dummy(self, span: Span) -> AstFragment {
+    crate fn dummy(self, span: Span) -> AstFragment {
         self.make_from(DummyResult::any(span)).expect("couldn't create a dummy AST fragment")
     }
 

--- a/src/librustc_expand/expand.rs
+++ b/src/librustc_expand/expand.rs
@@ -682,7 +682,10 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             InvocationKind::Bang { mac, .. } => match ext {
                 SyntaxExtensionKind::Bang(expander) => {
                     self.gate_proc_macro_expansion_kind(span, fragment_kind);
-                    let tok_result = expander.expand(self.cx, span, mac.args.inner_tokens());
+                    let tok_result = match expander.expand(self.cx, span, mac.args.inner_tokens()) {
+                        Err(_) => return ExpandResult::Ready(fragment_kind.dummy(span)),
+                        Ok(ts) => ts,
+                    };
                     self.parse_ast_fragment(tok_result, fragment_kind, &mac.path, span)
                 }
                 SyntaxExtensionKind::LegacyBang(expander) => {

--- a/src/librustc_expand/expand.rs
+++ b/src/librustc_expand/expand.rs
@@ -1145,6 +1145,8 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
             // macros are expanded before any lint passes so this warning has to be hardcoded
             if attr.has_name(sym::derive) {
                 self.cx
+                    .parse_sess()
+                    .span_diagnostic
                     .struct_span_warn(attr.span, "`#[derive]` does nothing on macro invocations")
                     .note("this may become a hard error in a future release")
                     .emit();

--- a/src/librustc_expand/expand.rs
+++ b/src/librustc_expand/expand.rs
@@ -712,8 +712,11 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                     if let MacArgs::Eq(..) = attr_item.args {
                         self.cx.span_err(span, "key-value macro attributes are not supported");
                     }
-                    let tok_result =
-                        expander.expand(self.cx, span, attr_item.args.inner_tokens(), tokens);
+                    let inner_tokens = attr_item.args.inner_tokens();
+                    let tok_result = match expander.expand(self.cx, span, inner_tokens, tokens) {
+                        Err(_) => return ExpandResult::Ready(fragment_kind.dummy(span)),
+                        Ok(ts) => ts,
+                    };
                     self.parse_ast_fragment(tok_result, fragment_kind, &attr_item.path, span)
                 }
                 SyntaxExtensionKind::LegacyAttr(expander) => {

--- a/src/librustc_expand/lib.rs
+++ b/src/librustc_expand/lib.rs
@@ -9,25 +9,6 @@
 
 extern crate proc_macro as pm;
 
-// A variant of 'try!' that panics on an Err. This is used as a crutch on the
-// way towards a non-panic!-prone parser. It should be used for fatal parsing
-// errors; eventually we plan to convert all code using panictry to just use
-// normal try.
-#[macro_export]
-macro_rules! panictry {
-    ($e:expr) => {{
-        use rustc_errors::FatalError;
-        use std::result::Result::{Err, Ok};
-        match $e {
-            Ok(e) => e,
-            Err(mut e) => {
-                e.emit();
-                FatalError.raise()
-            }
-        }
-    }};
-}
-
 mod placeholders;
 mod proc_macro_server;
 

--- a/src/librustc_expand/mbe/macro_rules.rs
+++ b/src/librustc_expand/mbe/macro_rules.rs
@@ -180,17 +180,12 @@ impl TTMacroExpander for MacroRulesMacroExpander {
     }
 }
 
-struct MacroRulesDummyExpander;
-
-impl TTMacroExpander for MacroRulesDummyExpander {
-    fn expand<'cx>(
-        &self,
-        _: &'cx mut ExtCtxt<'_>,
-        sp: Span,
-        _: TokenStream,
-    ) -> Box<dyn MacResult + 'cx> {
-        DummyResult::any(sp)
-    }
+fn macro_rules_dummy_expander<'cx>(
+    _: &'cx mut ExtCtxt<'_>,
+    span: Span,
+    _: TokenStream,
+) -> Box<dyn MacResult + 'cx> {
+    DummyResult::any(span)
 }
 
 fn trace_macros_note(cx_expansions: &mut FxHashMap<Span, Vec<String>>, sp: Span, message: String) {
@@ -443,14 +438,14 @@ pub fn compile_declarative_macro(
             let s = parse_failure_msg(&token);
             let sp = token.span.substitute_dummy(def.span);
             sess.span_diagnostic.struct_span_err(sp, &s).span_label(sp, msg).emit();
-            return mk_syn_ext(Box::new(MacroRulesDummyExpander));
+            return mk_syn_ext(Box::new(macro_rules_dummy_expander));
         }
         Error(sp, msg) => {
             sess.span_diagnostic.struct_span_err(sp.substitute_dummy(def.span), &msg).emit();
-            return mk_syn_ext(Box::new(MacroRulesDummyExpander));
+            return mk_syn_ext(Box::new(macro_rules_dummy_expander));
         }
         ErrorReported => {
-            return mk_syn_ext(Box::new(MacroRulesDummyExpander));
+            return mk_syn_ext(Box::new(macro_rules_dummy_expander));
         }
     };
 
@@ -513,16 +508,14 @@ pub fn compile_declarative_macro(
         None => {}
     }
 
-    let expander: Box<_> = Box::new(MacroRulesMacroExpander {
+    mk_syn_ext(Box::new(MacroRulesMacroExpander {
         name: def.ident,
         span: def.span,
         transparency,
         lhses,
         rhses,
         valid,
-    });
-
-    mk_syn_ext(expander)
+    }))
 }
 
 fn check_lhs_nt_follows(

--- a/src/librustc_expand/mbe/macro_rules.rs
+++ b/src/librustc_expand/mbe/macro_rules.rs
@@ -255,7 +255,13 @@ fn generic_extension<'cx>(
 
                 let rhs_spans = rhs.iter().map(|t| t.span()).collect::<Vec<_>>();
                 // rhs has holes ( `$id` and `$(...)` that need filled)
-                let mut tts = transcribe(cx, &named_matches, rhs, transparency);
+                let mut tts = match transcribe(cx, &named_matches, rhs, transparency) {
+                    Ok(tts) => tts,
+                    Err(mut err) => {
+                        err.emit();
+                        return DummyResult::any(arm_span);
+                    }
+                };
 
                 // Replace all the tokens for the corresponding positions in the macro, to maintain
                 // proper positions in error reporting, while maintaining the macro_backtrace.

--- a/src/librustc_expand/mbe/macro_rules.rs
+++ b/src/librustc_expand/mbe/macro_rules.rs
@@ -293,7 +293,11 @@ fn generic_extension<'cx>(
                 Some((ref best_token, _)) if best_token.span.lo() >= token.span.lo() => {}
                 _ => best_failure = Some((token, msg)),
             },
-            Error(err_sp, ref msg) => cx.span_fatal(err_sp.substitute_dummy(sp), &msg[..]),
+            Error(err_sp, ref msg) => {
+                let span = err_sp.substitute_dummy(sp);
+                cx.struct_span_err(span, &msg).emit();
+                return DummyResult::any(span);
+            }
         }
 
         // The matcher was not `Success(..)`ful.

--- a/src/librustc_expand/mbe/macro_rules.rs
+++ b/src/librustc_expand/mbe/macro_rules.rs
@@ -15,7 +15,7 @@ use rustc_ast_pretty::pprust;
 use rustc_attr::{self as attr, TransparencyError};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync::Lrc;
-use rustc_errors::{Applicability, DiagnosticBuilder, FatalError};
+use rustc_errors::{Applicability, DiagnosticBuilder};
 use rustc_feature::Features;
 use rustc_parse::parser::Parser;
 use rustc_session::parse::ParseSess;
@@ -177,6 +177,19 @@ impl TTMacroExpander for MacroRulesMacroExpander {
             &self.lhses,
             &self.rhses,
         )
+    }
+}
+
+struct MacroRulesDummyExpander;
+
+impl TTMacroExpander for MacroRulesDummyExpander {
+    fn expand<'cx>(
+        &self,
+        _: &'cx mut ExtCtxt<'_>,
+        sp: Span,
+        _: TokenStream,
+    ) -> Box<dyn MacResult + 'cx> {
+        DummyResult::any(sp)
     }
 }
 
@@ -362,6 +375,18 @@ pub fn compile_declarative_macro(
     def: &ast::Item,
     edition: Edition,
 ) -> SyntaxExtension {
+    let mk_syn_ext = |expander| {
+        SyntaxExtension::new(
+            sess,
+            SyntaxExtensionKind::LegacyBang(expander),
+            def.span,
+            Vec::new(),
+            edition,
+            def.ident.name,
+            &def.attrs,
+        )
+    };
+
     let diag = &sess.span_diagnostic;
     let lhs_nm = ast::Ident::new(sym::lhs, def.span);
     let rhs_nm = ast::Ident::new(sym::rhs, def.span);
@@ -416,13 +441,12 @@ pub fn compile_declarative_macro(
         Failure(token, msg) => {
             let s = parse_failure_msg(&token);
             let sp = token.span.substitute_dummy(def.span);
-            let mut err = sess.span_diagnostic.struct_span_fatal(sp, &s);
-            err.span_label(sp, msg);
-            err.emit();
-            FatalError.raise();
+            sess.span_diagnostic.struct_span_err(sp, &s).span_label(sp, msg).emit();
+            return mk_syn_ext(Box::new(MacroRulesDummyExpander));
         }
-        Error(sp, s) => {
-            sess.span_diagnostic.span_fatal(sp.substitute_dummy(def.span), &s).raise();
+        Error(sp, msg) => {
+            sess.span_diagnostic.struct_span_err(sp.substitute_dummy(def.span), &msg).emit();
+            return mk_syn_ext(Box::new(MacroRulesDummyExpander));
         }
     };
 
@@ -494,15 +518,7 @@ pub fn compile_declarative_macro(
         valid,
     });
 
-    SyntaxExtension::new(
-        sess,
-        SyntaxExtensionKind::LegacyBang(expander),
-        def.span,
-        Vec::new(),
-        edition,
-        def.ident.name,
-        &def.attrs,
-    )
+    mk_syn_ext(expander)
 }
 
 fn check_lhs_nt_follows(

--- a/src/librustc_expand/mbe/macro_rules.rs
+++ b/src/librustc_expand/mbe/macro_rules.rs
@@ -83,41 +83,56 @@ fn suggest_slice_pat(e: &mut DiagnosticBuilder<'_>, site_span: Span, parser: &Pa
     );
 }
 
+fn emit_frag_parse_err(
+    mut e: DiagnosticBuilder<'_>,
+    parser: &Parser<'_>,
+    site_span: Span,
+    macro_ident: ast::Ident,
+    arm_span: Span,
+    kind: AstFragmentKind,
+) {
+    if parser.token == token::Eof && e.message().ends_with(", found `<eof>`") {
+        if !e.span.is_dummy() {
+            // early end of macro arm (#52866)
+            e.replace_span_with(parser.sess.source_map().next_point(parser.token.span));
+        }
+        let msg = &e.message[0];
+        e.message[0] = (
+            format!(
+                "macro expansion ends with an incomplete expression: {}",
+                msg.0.replace(", found `<eof>`", ""),
+            ),
+            msg.1,
+        );
+    }
+    if e.span.is_dummy() {
+        // Get around lack of span in error (#30128)
+        e.replace_span_with(site_span);
+        if !parser.sess.source_map().is_imported(arm_span) {
+            e.span_label(arm_span, "in this macro arm");
+        }
+    } else if parser.sess.source_map().is_imported(parser.token.span) {
+        e.span_label(site_span, "in this macro invocation");
+    }
+    match kind {
+        AstFragmentKind::Pat if macro_ident.name == sym::vec => {
+            suggest_slice_pat(&mut e, site_span, parser);
+        }
+        _ => annotate_err_with_kind(&mut e, kind, site_span),
+    };
+    e.emit();
+}
+
 impl<'a> ParserAnyMacro<'a> {
     crate fn make(mut self: Box<ParserAnyMacro<'a>>, kind: AstFragmentKind) -> AstFragment {
         let ParserAnyMacro { site_span, macro_ident, ref mut parser, arm_span } = *self;
-        let fragment = panictry!(parse_ast_fragment(parser, kind).map_err(|mut e| {
-            if parser.token == token::Eof && e.message().ends_with(", found `<eof>`") {
-                if !e.span.is_dummy() {
-                    // early end of macro arm (#52866)
-                    e.replace_span_with(parser.sess.source_map().next_point(parser.token.span));
-                }
-                let msg = &e.message[0];
-                e.message[0] = (
-                    format!(
-                        "macro expansion ends with an incomplete expression: {}",
-                        msg.0.replace(", found `<eof>`", ""),
-                    ),
-                    msg.1,
-                );
+        let fragment = match parse_ast_fragment(parser, kind) {
+            Ok(f) => f,
+            Err(err) => {
+                emit_frag_parse_err(err, parser, site_span, macro_ident, arm_span, kind);
+                return kind.dummy(site_span);
             }
-            if e.span.is_dummy() {
-                // Get around lack of span in error (#30128)
-                e.replace_span_with(site_span);
-                if !parser.sess.source_map().is_imported(arm_span) {
-                    e.span_label(arm_span, "in this macro arm");
-                }
-            } else if parser.sess.source_map().is_imported(parser.token.span) {
-                e.span_label(site_span, "in this macro invocation");
-            }
-            match kind {
-                AstFragmentKind::Pat if macro_ident.name == sym::vec => {
-                    suggest_slice_pat(&mut e, site_span, parser);
-                }
-                _ => annotate_err_with_kind(&mut e, kind, site_span),
-            };
-            e
-        }));
+        };
 
         // We allow semicolons at the end of expressions -- e.g., the semicolon in
         // `macro_rules! m { () => { panic!(); } }` isn't parsed by `.parse_expr()`,

--- a/src/test/ui/editions/edition-keywords-2018-2015-parsing.rs
+++ b/src/test/ui/editions/edition-keywords-2018-2015-parsing.rs
@@ -1,6 +1,8 @@
 // edition:2018
 // aux-build:edition-kw-macro-2015.rs
 
+#![feature(async_closure)]
+
 fn main() {}
 
 #[macro_use]
@@ -19,8 +21,10 @@ pub fn check_async() {
     r#async = consumes_async_raw!(async); //~ ERROR no rules expected the token `async`
     r#async = consumes_async_raw!(r#async); // OK
 
-    if passes_ident!(async) == 1 {} //~ ERROR async closures are unstable
+    if passes_ident!(async) == 1 {}
     if passes_ident!(r#async) == 1 {} // OK
     module::async(); //~ ERROR expected identifier, found keyword `async`
     module::r#async(); // OK
+
+    let _recovery_witness: () = 0; //~ ERROR mismatched types
 }

--- a/src/test/ui/editions/edition-keywords-2018-2015-parsing.rs
+++ b/src/test/ui/editions/edition-keywords-2018-2015-parsing.rs
@@ -1,8 +1,14 @@
 // edition:2018
 // aux-build:edition-kw-macro-2015.rs
 
+fn main() {}
+
 #[macro_use]
 extern crate edition_kw_macro_2015;
+
+mod module {
+    pub fn r#async() {}
+}
 
 pub fn check_async() {
     let mut async = 1; //~ ERROR expected identifier, found keyword `async`
@@ -13,7 +19,7 @@ pub fn check_async() {
     r#async = consumes_async_raw!(async); //~ ERROR no rules expected the token `async`
     r#async = consumes_async_raw!(r#async); // OK
 
-    if passes_ident!(async) == 1 {}
+    if passes_ident!(async) == 1 {} //~ ERROR async closures are unstable
     if passes_ident!(r#async) == 1 {} // OK
     module::async(); //~ ERROR expected identifier, found keyword `async`
     module::r#async(); // OK

--- a/src/test/ui/editions/edition-keywords-2018-2015-parsing.stderr
+++ b/src/test/ui/editions/edition-keywords-2018-2015-parsing.stderr
@@ -1,5 +1,5 @@
 error: expected identifier, found keyword `async`
-  --> $DIR/edition-keywords-2018-2015-parsing.rs:14:13
+  --> $DIR/edition-keywords-2018-2015-parsing.rs:16:13
    |
 LL |     let mut async = 1;
    |             ^^^^^ expected identifier, found keyword
@@ -10,7 +10,7 @@ LL |     let mut r#async = 1;
    |             ^^^^^^^
 
 error: expected identifier, found keyword `async`
-  --> $DIR/edition-keywords-2018-2015-parsing.rs:24:13
+  --> $DIR/edition-keywords-2018-2015-parsing.rs:26:13
    |
 LL |     module::async();
    |             ^^^^^ expected identifier, found keyword
@@ -21,13 +21,13 @@ LL |     module::r#async();
    |             ^^^^^^^
 
 error: no rules expected the token `r#async`
-  --> $DIR/edition-keywords-2018-2015-parsing.rs:18:31
+  --> $DIR/edition-keywords-2018-2015-parsing.rs:20:31
    |
 LL |     r#async = consumes_async!(r#async);
    |                               ^^^^^^^ no rules expected this token in macro call
 
 error: no rules expected the token `async`
-  --> $DIR/edition-keywords-2018-2015-parsing.rs:19:35
+  --> $DIR/edition-keywords-2018-2015-parsing.rs:21:35
    |
 LL |     r#async = consumes_async_raw!(async);
    |                                   ^^^^^ no rules expected this token in macro call
@@ -38,20 +38,19 @@ error: macro expansion ends with an incomplete expression: expected one of `move
 LL |     ($i: ident) => ($i)
    |                       ^ expected one of `move`, `|`, or `||`
    | 
-  ::: $DIR/edition-keywords-2018-2015-parsing.rs:22:8
+  ::: $DIR/edition-keywords-2018-2015-parsing.rs:24:8
    |
 LL |     if passes_ident!(async) == 1 {}
    |        -------------------- in this macro invocation
 
-error[E0658]: async closures are unstable
-  --> $DIR/edition-keywords-2018-2015-parsing.rs:22:22
+error[E0308]: mismatched types
+  --> $DIR/edition-keywords-2018-2015-parsing.rs:29:33
    |
-LL |     if passes_ident!(async) == 1 {}
-   |                      ^^^^^
-   |
-   = note: see issue #62290 <https://github.com/rust-lang/rust/issues/62290> for more information
-   = help: add `#![feature(async_closure)]` to the crate attributes to enable
+LL |     let _recovery_witness: () = 0;
+   |                            --   ^ expected `()`, found integer
+   |                            |
+   |                            expected due to this
 
 error: aborting due to 6 previous errors
 
-For more information about this error, try `rustc --explain E0658`.
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/editions/edition-keywords-2018-2015-parsing.stderr
+++ b/src/test/ui/editions/edition-keywords-2018-2015-parsing.stderr
@@ -1,5 +1,5 @@
 error: expected identifier, found keyword `async`
-  --> $DIR/edition-keywords-2018-2015-parsing.rs:8:13
+  --> $DIR/edition-keywords-2018-2015-parsing.rs:14:13
    |
 LL |     let mut async = 1;
    |             ^^^^^ expected identifier, found keyword
@@ -10,7 +10,7 @@ LL |     let mut r#async = 1;
    |             ^^^^^^^
 
 error: expected identifier, found keyword `async`
-  --> $DIR/edition-keywords-2018-2015-parsing.rs:18:13
+  --> $DIR/edition-keywords-2018-2015-parsing.rs:24:13
    |
 LL |     module::async();
    |             ^^^^^ expected identifier, found keyword
@@ -21,13 +21,13 @@ LL |     module::r#async();
    |             ^^^^^^^
 
 error: no rules expected the token `r#async`
-  --> $DIR/edition-keywords-2018-2015-parsing.rs:12:31
+  --> $DIR/edition-keywords-2018-2015-parsing.rs:18:31
    |
 LL |     r#async = consumes_async!(r#async);
    |                               ^^^^^^^ no rules expected this token in macro call
 
 error: no rules expected the token `async`
-  --> $DIR/edition-keywords-2018-2015-parsing.rs:13:35
+  --> $DIR/edition-keywords-2018-2015-parsing.rs:19:35
    |
 LL |     r#async = consumes_async_raw!(async);
    |                                   ^^^^^ no rules expected this token in macro call
@@ -38,10 +38,20 @@ error: macro expansion ends with an incomplete expression: expected one of `move
 LL |     ($i: ident) => ($i)
    |                       ^ expected one of `move`, `|`, or `||`
    | 
-  ::: $DIR/edition-keywords-2018-2015-parsing.rs:16:8
+  ::: $DIR/edition-keywords-2018-2015-parsing.rs:22:8
    |
 LL |     if passes_ident!(async) == 1 {}
    |        -------------------- in this macro invocation
 
-error: aborting due to 5 previous errors
+error[E0658]: async closures are unstable
+  --> $DIR/edition-keywords-2018-2015-parsing.rs:22:22
+   |
+LL |     if passes_ident!(async) == 1 {}
+   |                      ^^^^^
+   |
+   = note: see issue #62290 <https://github.com/rust-lang/rust/issues/62290> for more information
+   = help: add `#![feature(async_closure)]` to the crate attributes to enable
 
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/editions/edition-keywords-2018-2018-parsing.rs
+++ b/src/test/ui/editions/edition-keywords-2018-2018-parsing.rs
@@ -1,6 +1,8 @@
 // edition:2018
 // aux-build:edition-kw-macro-2018.rs
 
+#![feature(async_closure)]
+
 fn main() {}
 
 #[macro_use]
@@ -19,8 +21,10 @@ pub fn check_async() {
     r#async = consumes_async_raw!(async); //~ ERROR no rules expected the token `async`
     r#async = consumes_async_raw!(r#async); // OK
 
-    if passes_ident!(async) == 1 {} //~ ERROR async closures are unstable
+    if passes_ident!(async) == 1 {}
     if passes_ident!(r#async) == 1 {} // OK
     module::async(); //~ ERROR expected identifier, found keyword `async`
     module::r#async(); // OK
+
+    let _recovery_witness: () = 0; //~ ERROR mismatched types
 }

--- a/src/test/ui/editions/edition-keywords-2018-2018-parsing.rs
+++ b/src/test/ui/editions/edition-keywords-2018-2018-parsing.rs
@@ -1,8 +1,14 @@
 // edition:2018
 // aux-build:edition-kw-macro-2018.rs
 
+fn main() {}
+
 #[macro_use]
 extern crate edition_kw_macro_2018;
+
+mod module {
+    pub fn r#async() {}
+}
 
 pub fn check_async() {
     let mut async = 1; //~ ERROR expected identifier, found keyword `async`
@@ -13,7 +19,7 @@ pub fn check_async() {
     r#async = consumes_async_raw!(async); //~ ERROR no rules expected the token `async`
     r#async = consumes_async_raw!(r#async); // OK
 
-    if passes_ident!(async) == 1 {}
+    if passes_ident!(async) == 1 {} //~ ERROR async closures are unstable
     if passes_ident!(r#async) == 1 {} // OK
     module::async(); //~ ERROR expected identifier, found keyword `async`
     module::r#async(); // OK

--- a/src/test/ui/editions/edition-keywords-2018-2018-parsing.stderr
+++ b/src/test/ui/editions/edition-keywords-2018-2018-parsing.stderr
@@ -1,5 +1,5 @@
 error: expected identifier, found keyword `async`
-  --> $DIR/edition-keywords-2018-2018-parsing.rs:14:13
+  --> $DIR/edition-keywords-2018-2018-parsing.rs:16:13
    |
 LL |     let mut async = 1;
    |             ^^^^^ expected identifier, found keyword
@@ -10,7 +10,7 @@ LL |     let mut r#async = 1;
    |             ^^^^^^^
 
 error: expected identifier, found keyword `async`
-  --> $DIR/edition-keywords-2018-2018-parsing.rs:24:13
+  --> $DIR/edition-keywords-2018-2018-parsing.rs:26:13
    |
 LL |     module::async();
    |             ^^^^^ expected identifier, found keyword
@@ -21,13 +21,13 @@ LL |     module::r#async();
    |             ^^^^^^^
 
 error: no rules expected the token `r#async`
-  --> $DIR/edition-keywords-2018-2018-parsing.rs:18:31
+  --> $DIR/edition-keywords-2018-2018-parsing.rs:20:31
    |
 LL |     r#async = consumes_async!(r#async);
    |                               ^^^^^^^ no rules expected this token in macro call
 
 error: no rules expected the token `async`
-  --> $DIR/edition-keywords-2018-2018-parsing.rs:19:35
+  --> $DIR/edition-keywords-2018-2018-parsing.rs:21:35
    |
 LL |     r#async = consumes_async_raw!(async);
    |                                   ^^^^^ no rules expected this token in macro call
@@ -38,20 +38,19 @@ error: macro expansion ends with an incomplete expression: expected one of `move
 LL |     ($i: ident) => ($i)
    |                       ^ expected one of `move`, `|`, or `||`
    | 
-  ::: $DIR/edition-keywords-2018-2018-parsing.rs:22:8
+  ::: $DIR/edition-keywords-2018-2018-parsing.rs:24:8
    |
 LL |     if passes_ident!(async) == 1 {}
    |        -------------------- in this macro invocation
 
-error[E0658]: async closures are unstable
-  --> $DIR/edition-keywords-2018-2018-parsing.rs:22:22
+error[E0308]: mismatched types
+  --> $DIR/edition-keywords-2018-2018-parsing.rs:29:33
    |
-LL |     if passes_ident!(async) == 1 {}
-   |                      ^^^^^
-   |
-   = note: see issue #62290 <https://github.com/rust-lang/rust/issues/62290> for more information
-   = help: add `#![feature(async_closure)]` to the crate attributes to enable
+LL |     let _recovery_witness: () = 0;
+   |                            --   ^ expected `()`, found integer
+   |                            |
+   |                            expected due to this
 
 error: aborting due to 6 previous errors
 
-For more information about this error, try `rustc --explain E0658`.
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/editions/edition-keywords-2018-2018-parsing.stderr
+++ b/src/test/ui/editions/edition-keywords-2018-2018-parsing.stderr
@@ -1,5 +1,5 @@
 error: expected identifier, found keyword `async`
-  --> $DIR/edition-keywords-2018-2018-parsing.rs:8:13
+  --> $DIR/edition-keywords-2018-2018-parsing.rs:14:13
    |
 LL |     let mut async = 1;
    |             ^^^^^ expected identifier, found keyword
@@ -10,7 +10,7 @@ LL |     let mut r#async = 1;
    |             ^^^^^^^
 
 error: expected identifier, found keyword `async`
-  --> $DIR/edition-keywords-2018-2018-parsing.rs:18:13
+  --> $DIR/edition-keywords-2018-2018-parsing.rs:24:13
    |
 LL |     module::async();
    |             ^^^^^ expected identifier, found keyword
@@ -21,13 +21,13 @@ LL |     module::r#async();
    |             ^^^^^^^
 
 error: no rules expected the token `r#async`
-  --> $DIR/edition-keywords-2018-2018-parsing.rs:12:31
+  --> $DIR/edition-keywords-2018-2018-parsing.rs:18:31
    |
 LL |     r#async = consumes_async!(r#async);
    |                               ^^^^^^^ no rules expected this token in macro call
 
 error: no rules expected the token `async`
-  --> $DIR/edition-keywords-2018-2018-parsing.rs:13:35
+  --> $DIR/edition-keywords-2018-2018-parsing.rs:19:35
    |
 LL |     r#async = consumes_async_raw!(async);
    |                                   ^^^^^ no rules expected this token in macro call
@@ -38,10 +38,20 @@ error: macro expansion ends with an incomplete expression: expected one of `move
 LL |     ($i: ident) => ($i)
    |                       ^ expected one of `move`, `|`, or `||`
    | 
-  ::: $DIR/edition-keywords-2018-2018-parsing.rs:16:8
+  ::: $DIR/edition-keywords-2018-2018-parsing.rs:22:8
    |
 LL |     if passes_ident!(async) == 1 {}
    |        -------------------- in this macro invocation
 
-error: aborting due to 5 previous errors
+error[E0658]: async closures are unstable
+  --> $DIR/edition-keywords-2018-2018-parsing.rs:22:22
+   |
+LL |     if passes_ident!(async) == 1 {}
+   |                      ^^^^^
+   |
+   = note: see issue #62290 <https://github.com/rust-lang/rust/issues/62290> for more information
+   = help: add `#![feature(async_closure)]` to the crate attributes to enable
 
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/macros/issue-61033-1.rs
+++ b/src/test/ui/macros/issue-61033-1.rs
@@ -1,9 +1,10 @@
 // Regression test for issue #61033.
 
 macro_rules! test1 {
-    ($x:ident, $($tt:tt)*) => { $($tt)+ } //~ERROR this must repeat at least once
+    ($x:ident, $($tt:tt)*) => { $($tt)+ } //~ ERROR this must repeat at least once
 }
 
 fn main() {
     test1!(x,);
+    let _recovery_witness: () = 0; //~ ERROR mismatched types
 }

--- a/src/test/ui/macros/issue-61033-1.stderr
+++ b/src/test/ui/macros/issue-61033-1.stderr
@@ -4,5 +4,14 @@ error: this must repeat at least once
 LL |     ($x:ident, $($tt:tt)*) => { $($tt)+ }
    |                                  ^^^^^
 
-error: aborting due to previous error
+error[E0308]: mismatched types
+  --> $DIR/issue-61033-1.rs:9:33
+   |
+LL |     let _recovery_witness: () = 0;
+   |                            --   ^ expected `()`, found integer
+   |                            |
+   |                            expected due to this
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/macros/issue-61033-2.rs
+++ b/src/test/ui/macros/issue-61033-2.rs
@@ -5,7 +5,9 @@ macro_rules! test2 {
         $(* $id1:ident)*
         $(+ $id2:ident)*
     ) => {
-        $( //~ERROR meta-variable `id1` repeats 2 times
+        $(
+        //~^ ERROR meta-variable `id1` repeats 2 times
+        //~| ERROR meta-variable `id1` repeats 2 times
             $id1 + $id2 // $id1 and $id2 may repeat different numbers of times
         )*
     }
@@ -15,5 +17,9 @@ fn main() {
     test2! {
         * a * b
         + a + b + c
+    }
+    test2! {
+        * a * b
+        + a + b + c + d
     }
 }

--- a/src/test/ui/macros/issue-61033-2.stderr
+++ b/src/test/ui/macros/issue-61033-2.stderr
@@ -3,9 +3,22 @@ error: meta-variable `id1` repeats 2 times, but `id2` repeats 3 times
    |
 LL |           $(
    |  __________^
+LL | |
+LL | |
 LL | |             $id1 + $id2 // $id1 and $id2 may repeat different numbers of times
 LL | |         )*
    | |_________^
 
-error: aborting due to previous error
+error: meta-variable `id1` repeats 2 times, but `id2` repeats 4 times
+  --> $DIR/issue-61033-2.rs:8:10
+   |
+LL |           $(
+   |  __________^
+LL | |
+LL | |
+LL | |             $id1 + $id2 // $id1 and $id2 may repeat different numbers of times
+LL | |         )*
+   | |_________^
+
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/macros/local-ambiguity-multiple-parsing-options.rs
+++ b/src/test/ui/macros/local-ambiguity-multiple-parsing-options.rs
@@ -1,0 +1,8 @@
+fn main() {}
+
+macro_rules! ambiguity {
+    ($($i:ident)* $j:ident) => {};
+}
+
+ambiguity!(error); //~ ERROR local ambiguity
+ambiguity!(error); //~ ERROR local ambiguity

--- a/src/test/ui/macros/local-ambiguity-multiple-parsing-options.stderr
+++ b/src/test/ui/macros/local-ambiguity-multiple-parsing-options.stderr
@@ -1,0 +1,14 @@
+error: local ambiguity: multiple parsing options: built-in NTs ident ('i') or ident ('j').
+  --> $DIR/local-ambiguity-multiple-parsing-options.rs:7:12
+   |
+LL | ambiguity!(error);
+   |            ^^^^^
+
+error: local ambiguity: multiple parsing options: built-in NTs ident ('i') or ident ('j').
+  --> $DIR/local-ambiguity-multiple-parsing-options.rs:8:12
+   |
+LL | ambiguity!(error);
+   |            ^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/macros/macro-context.rs
+++ b/src/test/ui/macros/macro-context.rs
@@ -4,6 +4,8 @@ macro_rules! m {
                             //~| ERROR macro expansion ignores token `typeof`
                             //~| ERROR macro expansion ignores token `;`
                             //~| ERROR macro expansion ignores token `;`
+                            //~| ERROR cannot find type `i` in this scope
+                            //~| ERROR cannot find value `i` in this scope
 }
 
 fn main() {

--- a/src/test/ui/macros/macro-context.stderr
+++ b/src/test/ui/macros/macro-context.stderr
@@ -42,5 +42,29 @@ LL |     m!();
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 4 previous errors
+error[E0412]: cannot find type `i` in this scope
+  --> $DIR/macro-context.rs:3:13
+   |
+LL |     () => ( i ; typeof );
+   |             ^ help: a builtin type with a similar name exists: `i8`
+...
+LL |     let a: m!();
+   |            ---- in this macro invocation
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error[E0425]: cannot find value `i` in this scope
+  --> $DIR/macro-context.rs:3:13
+   |
+LL |     () => ( i ; typeof );
+   |             ^ help: a local variable with a similar name exists: `a`
+...
+LL |     let i = m!();
+   |             ---- in this macro invocation
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0412, E0425.
+For more information about an error, try `rustc --explain E0412`.

--- a/src/test/ui/macros/macro-match-nonterminal.rs
+++ b/src/test/ui/macros/macro-match-nonterminal.rs
@@ -1,4 +1,11 @@
-macro_rules! test { ($a, $b) => (()); } //~ ERROR missing fragment
+macro_rules! test {
+    ($a, $b) => {
+        //~^ ERROR missing fragment
+        //~| ERROR missing fragment
+        //~| WARN this was previously accepted
+        ()
+    };
+}
 
 fn main() {
     test!()

--- a/src/test/ui/macros/macro-match-nonterminal.stderr
+++ b/src/test/ui/macros/macro-match-nonterminal.stderr
@@ -1,8 +1,18 @@
 error: missing fragment specifier
-  --> $DIR/macro-match-nonterminal.rs:1:24
+  --> $DIR/macro-match-nonterminal.rs:2:8
    |
-LL | macro_rules! test { ($a, $b) => (()); }
-   |                        ^
+LL |     ($a, $b) => {
+   |        ^
 
-error: aborting due to previous error
+error: missing fragment specifier
+  --> $DIR/macro-match-nonterminal.rs:2:10
+   |
+LL |     ($a, $b) => {
+   |          ^^
+   |
+   = note: `#[deny(missing_fragment_specifier)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #40107 <https://github.com/rust-lang/rust/issues/40107>
+
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/macros/trace_faulty_macros.rs
+++ b/src/test/ui/macros/trace_faulty_macros.rs
@@ -1,6 +1,6 @@
 // compile-flags: -Z trace-macros
 
-#![recursion_limit="4"]
+#![recursion_limit = "4"]
 
 macro_rules! my_faulty_macro {
     () => {
@@ -24,9 +24,7 @@ macro_rules! my_recursive_macro {
 }
 
 macro_rules! my_macro {
-    () => {
-
-    };
+    () => {};
 }
 
 fn main() {
@@ -39,7 +37,7 @@ fn main() {
 }
 
 #[my_macro]
-fn use_bang_macro_as_attr(){}
+fn use_bang_macro_as_attr() {}
 
-#[derive(Debug)]
-fn use_derive_macro_as_attr(){}
+#[derive(Debug)] //~ ERROR `derive` may only be applied to structs
+fn use_derive_macro_as_attr() {}

--- a/src/test/ui/macros/trace_faulty_macros.stderr
+++ b/src/test/ui/macros/trace_faulty_macros.stderr
@@ -13,7 +13,7 @@ LL |     my_faulty_macro!();
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: trace_macro
-  --> $DIR/trace_faulty_macros.rs:33:5
+  --> $DIR/trace_faulty_macros.rs:31:5
    |
 LL |     my_faulty_macro!();
    |     ^^^^^^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ LL |     my_recursive_macro!();
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: trace_macro
-  --> $DIR/trace_faulty_macros.rs:34:5
+  --> $DIR/trace_faulty_macros.rs:32:5
    |
 LL |     my_recursive_macro!();
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -60,5 +60,22 @@ LL |     let a = pat_macro!();
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 3 previous errors
+error: `derive` may only be applied to structs, enums and unions
+  --> $DIR/trace_faulty_macros.rs:42:1
+   |
+LL | #[derive(Debug)]
+   | ^^^^^^^^^^^^^^^^
+
+note: trace_macro
+  --> $DIR/trace_faulty_macros.rs:36:13
+   |
+LL |     let a = pat_macro!();
+   |             ^^^^^^^^^^^^
+   |
+   = note: expanding `pat_macro! {  }`
+   = note: to `pat_macro ! (A { a : a, b : 0, c : _, .. }) ;`
+   = note: expanding `pat_macro! { A { a : a, b : 0, c : _, .. } }`
+   = note: to `A { a: a, b: 0, c: _, .. }`
+
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/parser/issue-62894.rs
+++ b/src/test/ui/parser/issue-62894.rs
@@ -1,3 +1,8 @@
+// FIXME: missing sysroot spans (#53081)
+// ignore-i586-unknown-linux-gnu
+// ignore-i586-unknown-linux-musl
+// ignore-i686-unknown-linux-musl
+
 // Regression test for #62894, shouldn't crash.
 // error-pattern: this file contains an unclosed delimiter
 // error-pattern: expected one of `(`, `[`, or `{`, found keyword `fn`

--- a/src/test/ui/parser/issue-62894.stderr
+++ b/src/test/ui/parser/issue-62894.stderr
@@ -42,6 +42,11 @@ LL | fn f() { assert_eq!(f(), (), assert_eq!(assert_eq!
 LL | 
 LL | fn main() {}
    | ^^ unexpected token
+   | 
+  ::: $SRC_DIR/libcore/macros/mod.rs:LL:COL
+   |
+LL |     ($left:expr, $right:expr) => ({
+   |      ---------- while parsing argument for this `expr` macro fragment
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/parser/issue-62894.stderr
+++ b/src/test/ui/parser/issue-62894.stderr
@@ -1,5 +1,5 @@
 error: this file contains an unclosed delimiter
-  --> $DIR/issue-62894.rs:7:14
+  --> $DIR/issue-62894.rs:12:14
    |
 LL | fn f() { assert_eq!(f(), (), assert_eq!(assert_eq!
    |        -           -                   - unclosed delimiter
@@ -11,7 +11,7 @@ LL | fn main() {}
    |              ^
 
 error: this file contains an unclosed delimiter
-  --> $DIR/issue-62894.rs:7:14
+  --> $DIR/issue-62894.rs:12:14
    |
 LL | fn f() { assert_eq!(f(), (), assert_eq!(assert_eq!
    |        -           -                   - unclosed delimiter
@@ -23,7 +23,7 @@ LL | fn main() {}
    |              ^
 
 error: this file contains an unclosed delimiter
-  --> $DIR/issue-62894.rs:7:14
+  --> $DIR/issue-62894.rs:12:14
    |
 LL | fn f() { assert_eq!(f(), (), assert_eq!(assert_eq!
    |        -           -                   - unclosed delimiter
@@ -35,7 +35,7 @@ LL | fn main() {}
    |              ^
 
 error: expected one of `(`, `[`, or `{`, found keyword `fn`
-  --> $DIR/issue-62894.rs:7:1
+  --> $DIR/issue-62894.rs:12:1
    |
 LL | fn f() { assert_eq!(f(), (), assert_eq!(assert_eq!
    |                                                   - expected one of `(`, `[`, or `{`

--- a/src/test/ui/parser/macro/issue-33569.rs
+++ b/src/test/ui/parser/macro/issue-33569.rs
@@ -1,5 +1,3 @@
-fn main() {}
-
 macro_rules! foo {
     { $+ } => { //~ ERROR expected identifier, found `+`
                 //~^ ERROR missing fragment specifier
@@ -8,3 +6,5 @@ macro_rules! foo {
 }
 
 foo!();
+
+fn main() {}

--- a/src/test/ui/parser/macro/issue-33569.rs
+++ b/src/test/ui/parser/macro/issue-33569.rs
@@ -1,3 +1,5 @@
+fn main() {}
+
 macro_rules! foo {
     { $+ } => { //~ ERROR expected identifier, found `+`
                 //~^ ERROR missing fragment specifier

--- a/src/test/ui/parser/macro/issue-33569.stderr
+++ b/src/test/ui/parser/macro/issue-33569.stderr
@@ -1,17 +1,17 @@
 error: expected identifier, found `+`
-  --> $DIR/issue-33569.rs:2:8
+  --> $DIR/issue-33569.rs:4:8
    |
 LL |     { $+ } => {
    |        ^
 
 error: expected one of: `*`, `+`, or `?`
-  --> $DIR/issue-33569.rs:4:13
+  --> $DIR/issue-33569.rs:6:13
    |
 LL |         $(x)(y)
    |             ^^^
 
 error: missing fragment specifier
-  --> $DIR/issue-33569.rs:2:8
+  --> $DIR/issue-33569.rs:4:8
    |
 LL |     { $+ } => {
    |        ^

--- a/src/test/ui/parser/macro/issue-33569.stderr
+++ b/src/test/ui/parser/macro/issue-33569.stderr
@@ -1,17 +1,17 @@
 error: expected identifier, found `+`
-  --> $DIR/issue-33569.rs:4:8
+  --> $DIR/issue-33569.rs:2:8
    |
 LL |     { $+ } => {
    |        ^
 
 error: expected one of: `*`, `+`, or `?`
-  --> $DIR/issue-33569.rs:6:13
+  --> $DIR/issue-33569.rs:4:13
    |
 LL |         $(x)(y)
    |             ^^^
 
 error: missing fragment specifier
-  --> $DIR/issue-33569.rs:4:8
+  --> $DIR/issue-33569.rs:2:8
    |
 LL |     { $+ } => {
    |        ^

--- a/src/test/ui/parser/macro/macro-repeat.rs
+++ b/src/test/ui/parser/macro/macro-repeat.rs
@@ -1,9 +1,12 @@
 macro_rules! mac {
-    ( $($v:tt)* ) => (
-        $v  //~ ERROR still repeating at this depth
-    )
+    ( $($v:tt)* ) => {
+        $v
+        //~^ ERROR still repeating at this depth
+        //~| ERROR still repeating at this depth
+    };
 }
 
 fn main() {
     mac!(0);
+    mac!(1);
 }

--- a/src/test/ui/parser/macro/macro-repeat.stderr
+++ b/src/test/ui/parser/macro/macro-repeat.stderr
@@ -4,5 +4,11 @@ error: variable 'v' is still repeating at this depth
 LL |         $v
    |         ^^
 
-error: aborting due to previous error
+error: variable 'v' is still repeating at this depth
+  --> $DIR/macro-repeat.rs:3:9
+   |
+LL |         $v
+   |         ^^
+
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/nt-parsing-has-recovery.rs
+++ b/src/test/ui/parser/nt-parsing-has-recovery.rs
@@ -1,0 +1,10 @@
+macro_rules! foo {
+    ($e:expr) => {}
+}
+
+foo!(1 + @); //~ ERROR expected expression, found `@`
+foo!(1 + @); //~ ERROR expected expression, found `@`
+
+fn main() {
+    let _recovery_witness: () = 0; //~ ERROR mismatched types
+}

--- a/src/test/ui/parser/nt-parsing-has-recovery.stderr
+++ b/src/test/ui/parser/nt-parsing-has-recovery.stderr
@@ -1,0 +1,29 @@
+error: expected expression, found `@`
+  --> $DIR/nt-parsing-has-recovery.rs:5:10
+   |
+LL |     ($e:expr) => {}
+   |      ------- while parsing argument for this `expr` macro fragment
+...
+LL | foo!(1 + @);
+   |          ^ expected expression
+
+error: expected expression, found `@`
+  --> $DIR/nt-parsing-has-recovery.rs:6:10
+   |
+LL |     ($e:expr) => {}
+   |      ------- while parsing argument for this `expr` macro fragment
+...
+LL | foo!(1 + @);
+   |          ^ expected expression
+
+error[E0308]: mismatched types
+  --> $DIR/nt-parsing-has-recovery.rs:9:33
+   |
+LL |     let _recovery_witness: () = 0;
+   |                            --   ^ expected `()`, found integer
+   |                            |
+   |                            expected due to this
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/proc-macro/derive-bad.rs
+++ b/src/test/ui/proc-macro/derive-bad.rs
@@ -3,11 +3,9 @@
 #[macro_use]
 extern crate derive_bad;
 
-#[derive(
-    A
-)]
-//~^^ ERROR proc-macro derive produced unparseable tokens
+#[derive(A)]
+//~^ ERROR proc-macro derive produced unparseable tokens
 //~| ERROR expected `:`, found `}`
-struct A;
+struct A; //~ ERROR the name `A` is defined multiple times
 
 fn main() {}

--- a/src/test/ui/proc-macro/derive-bad.stderr
+++ b/src/test/ui/proc-macro/derive-bad.stderr
@@ -1,16 +1,28 @@
 error: expected `:`, found `}`
-  --> $DIR/derive-bad.rs:7:5
+  --> $DIR/derive-bad.rs:6:10
    |
-LL |     A
-   |     ^ expected `:`
+LL | #[derive(A)]
+   |          ^ expected `:`
    |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: proc-macro derive produced unparseable tokens
-  --> $DIR/derive-bad.rs:7:5
+  --> $DIR/derive-bad.rs:6:10
    |
-LL |     A
-   |     ^
+LL | #[derive(A)]
+   |          ^
 
-error: aborting due to 2 previous errors
+error[E0428]: the name `A` is defined multiple times
+  --> $DIR/derive-bad.rs:9:1
+   |
+LL | #[derive(A)]
+   |          - previous definition of the type `A` here
+...
+LL | struct A;
+   | ^^^^^^^^^ `A` redefined here
+   |
+   = note: `A` must be defined only once in the type namespace of this module
 
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0428`.

--- a/src/test/ui/proc-macro/invalid-punct-ident-1.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-1.rs
@@ -14,3 +14,5 @@
 extern crate invalid_punct_ident;
 
 invalid_punct!(); //~ ERROR proc macro panicked
+
+fn main() {}

--- a/src/test/ui/proc-macro/invalid-punct-ident-2.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-2.rs
@@ -14,3 +14,5 @@
 extern crate invalid_punct_ident;
 
 invalid_ident!(); //~ ERROR proc macro panicked
+
+fn main() {}

--- a/src/test/ui/proc-macro/invalid-punct-ident-3.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-3.rs
@@ -14,3 +14,5 @@
 extern crate invalid_punct_ident;
 
 invalid_raw_ident!(); //~ ERROR proc macro panicked
+
+fn main() {}

--- a/src/test/ui/proc-macro/invalid-punct-ident-4.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-4.rs
@@ -1,7 +1,10 @@
 // aux-build:invalid-punct-ident.rs
 
-#[macro_use]
+// We use `main` not found below as a witness for error recovery in proc macro expansion.
+
+#[macro_use] //~ ERROR `main` function not found
 extern crate invalid_punct_ident;
 
-lexer_failure!(); //~ ERROR proc macro panicked
-                  //~| ERROR unexpected closing delimiter: `)`
+lexer_failure!();
+//~^ ERROR proc macro panicked
+//~| ERROR unexpected closing delimiter: `)`

--- a/src/test/ui/proc-macro/invalid-punct-ident-4.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-4.rs
@@ -1,10 +1,12 @@
 // aux-build:invalid-punct-ident.rs
 
-// We use `main` not found below as a witness for error recovery in proc macro expansion.
-
-#[macro_use] //~ ERROR `main` function not found
+#[macro_use]
 extern crate invalid_punct_ident;
 
 lexer_failure!();
 //~^ ERROR proc macro panicked
 //~| ERROR unexpected closing delimiter: `)`
+
+fn main() {
+    let _recovery_witness: () = 0; //~ ERROR mismatched types
+}

--- a/src/test/ui/proc-macro/invalid-punct-ident-4.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-4.stderr
@@ -1,5 +1,5 @@
 error: unexpected closing delimiter: `)`
-  --> $DIR/invalid-punct-ident-4.rs:8:1
+  --> $DIR/invalid-punct-ident-4.rs:6:1
    |
 LL | lexer_failure!();
    | ^^^^^^^^^^^^^^^^^ unexpected closing delimiter
@@ -7,20 +7,19 @@ LL | lexer_failure!();
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: proc macro panicked
-  --> $DIR/invalid-punct-ident-4.rs:8:1
+  --> $DIR/invalid-punct-ident-4.rs:6:1
    |
 LL | lexer_failure!();
    | ^^^^^^^^^^^^^^^^^
 
-error[E0601]: `main` function not found in crate `invalid_punct_ident_4`
-  --> $DIR/invalid-punct-ident-4.rs:5:1
+error[E0308]: mismatched types
+  --> $DIR/invalid-punct-ident-4.rs:11:33
    |
-LL | / #[macro_use]
-LL | | extern crate invalid_punct_ident;
-LL | |
-LL | | lexer_failure!();
-   | |_________________^ consider adding a `main` function to `$DIR/invalid-punct-ident-4.rs`
+LL |     let _recovery_witness: () = 0;
+   |                            --   ^ expected `()`, found integer
+   |                            |
+   |                            expected due to this
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0601`.
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/proc-macro/invalid-punct-ident-4.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-4.stderr
@@ -1,5 +1,5 @@
 error: unexpected closing delimiter: `)`
-  --> $DIR/invalid-punct-ident-4.rs:6:1
+  --> $DIR/invalid-punct-ident-4.rs:8:1
    |
 LL | lexer_failure!();
    | ^^^^^^^^^^^^^^^^^ unexpected closing delimiter
@@ -7,10 +7,20 @@ LL | lexer_failure!();
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: proc macro panicked
-  --> $DIR/invalid-punct-ident-4.rs:6:1
+  --> $DIR/invalid-punct-ident-4.rs:8:1
    |
 LL | lexer_failure!();
    | ^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0601]: `main` function not found in crate `invalid_punct_ident_4`
+  --> $DIR/invalid-punct-ident-4.rs:5:1
+   |
+LL | / #[macro_use]
+LL | | extern crate invalid_punct_ident;
+LL | |
+LL | | lexer_failure!();
+   | |_________________^ consider adding a `main` function to `$DIR/invalid-punct-ident-4.rs`
 
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0601`.

--- a/src/test/ui/proc-macro/issue-36935.rs
+++ b/src/test/ui/proc-macro/issue-36935.rs
@@ -5,6 +5,7 @@ extern crate test_macros;
 
 #[derive(Identity, Panic)] //~ ERROR proc-macro derive panicked
 struct Baz {
+    //~^ ERROR the name `Baz` is defined multiple times
     a: i32,
     b: i32,
 }

--- a/src/test/ui/proc-macro/issue-36935.stderr
+++ b/src/test/ui/proc-macro/issue-36935.stderr
@@ -6,5 +6,17 @@ LL | #[derive(Identity, Panic)]
    |
    = help: message: panic-derive
 
-error: aborting due to previous error
+error[E0428]: the name `Baz` is defined multiple times
+  --> $DIR/issue-36935.rs:7:1
+   |
+LL | struct Baz {
+   | ^^^^^^^^^^
+   | |
+   | `Baz` redefined here
+   | previous definition of the type `Baz` here
+   |
+   = note: `Baz` must be defined only once in the type namespace of this module
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0428`.

--- a/src/test/ui/span/transitive-dep-span.rs
+++ b/src/test/ui/span/transitive-dep-span.rs
@@ -11,3 +11,5 @@
 extern crate transitive_dep_two;
 
 transitive_dep_two::parse_error!(); //~ ERROR expected one of
+
+fn main() {}

--- a/src/test/ui/test-attrs/test-attr-non-associated-functions.rs
+++ b/src/test/ui/test-attrs/test-attr-non-associated-functions.rs
@@ -6,7 +6,13 @@ struct A {}
 
 impl A {
     #[test]
-    fn new() -> A { //~ ERROR `#[test]` attribute is only allowed on non associated functions
+    fn new() -> A {
+        //~^ ERROR `#[test]` attribute is only allowed on non associated functions
+        A {}
+    }
+    #[test]
+    fn recovery_witness() -> A {
+        //~^ ERROR `#[test]` attribute is only allowed on non associated functions
         A {}
     }
 }

--- a/src/test/ui/test-attrs/test-attr-non-associated-functions.stderr
+++ b/src/test/ui/test-attrs/test-attr-non-associated-functions.stderr
@@ -2,9 +2,19 @@ error: `#[test]` attribute is only allowed on non associated functions
   --> $DIR/test-attr-non-associated-functions.rs:9:5
    |
 LL | /     fn new() -> A {
+LL | |
 LL | |         A {}
 LL | |     }
    | |_____^
 
-error: aborting due to previous error
+error: `#[test]` attribute is only allowed on non associated functions
+  --> $DIR/test-attr-non-associated-functions.rs:14:5
+   |
+LL | /     fn recovery_witness() -> A {
+LL | |
+LL | |         A {}
+LL | |     }
+   | |_____^
+
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/type/ascription/issue-47666.rs
+++ b/src/test/ui/type/ascription/issue-47666.rs
@@ -1,5 +1,7 @@
 fn main() {
     let _ = Option:Some(vec![0, 1]); //~ ERROR expected type, found
+    //~^ ERROR expected value, found enum `Option`
+    //~| ERROR expected type, found variant `Some`
 }
 
 // This case isn't currently being handled gracefully due to the macro invocation.

--- a/src/test/ui/type/ascription/issue-47666.stderr
+++ b/src/test/ui/type/ascription/issue-47666.stderr
@@ -13,5 +13,35 @@ LL |     let _ = Option:Some(vec![0, 1]);
    = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to previous error
+error[E0423]: expected value, found enum `Option`
+  --> $DIR/issue-47666.rs:2:13
+   |
+LL |     let _ = Option:Some(vec![0, 1]);
+   |             ^^^^^^
+   |
+help: try using one of the enum's variants
+   |
+LL |     let _ = std::option::Option::None:Some(vec![0, 1]);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = std::option::Option::Some:Some(vec![0, 1]);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error[E0573]: expected type, found variant `Some`
+  --> $DIR/issue-47666.rs:2:20
+   |
+LL |     let _ = Option:Some(vec![0, 1]);
+   |                    ^^^^^^^^^^^^^^^^ not a type
+   |
+help: try using the variant's enum
+   |
+LL |     let _ = Option:std::option::Option;
+   |                    ^^^^^^^^^^^^^^^^^^^
+help: maybe you meant to write a path separator here
+   |
+LL |     let _ = Option::Some(vec![0, 1]);
+   |                   ^^
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0423, E0573.
+For more information about an error, try `rustc --explain E0423`.


### PR DESCRIPTION
Basically, we go after all `.span_fatal` / `FatalError.raise()` and similar things and remove them one by one until there are no fatal errors left.

r? @petrochenkov 