### PR TITLE
rustc_infer: remove InferCtxt::closure_sig as the FnSig is always shallowly known.

### DIFF
--- a/src/librustc/ty/print/pretty.rs
+++ b/src/librustc/ty/print/pretty.rs
@@ -681,9 +681,9 @@ pub trait PrettyPrinter<'tcx>:
 
                 if self.tcx().sess.verbose() {
                     p!(write(
-                        " closure_kind_ty={:?} closure_sig_ty={:?}",
+                        " closure_kind_ty={:?} closure_sig_as_fn_ptr_ty={:?}",
                         substs.as_closure().kind_ty(did, self.tcx()),
-                        substs.as_closure().sig_ty(did, self.tcx())
+                        substs.as_closure().sig_as_fn_ptr_ty(did, self.tcx())
                     ));
                 }
 

--- a/src/librustc_infer/infer/mod.rs
+++ b/src/librustc_infer/infer/mod.rs
@@ -1486,16 +1486,6 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         closure_kind_ty.to_opt_closure_kind()
     }
 
-    /// Obtains the signature of a closure. For closures, unlike
-    /// `tcx.fn_sig(def_id)`, this method will work during the
-    /// type-checking of the enclosing function and return the closure
-    /// signature in its partially inferred state.
-    pub fn closure_sig(&self, def_id: DefId, substs: SubstsRef<'tcx>) -> ty::PolyFnSig<'tcx> {
-        let closure_sig_ty = substs.as_closure().sig_ty(def_id, self.tcx);
-        let closure_sig_ty = self.shallow_resolve(closure_sig_ty);
-        closure_sig_ty.fn_sig(self.tcx)
-    }
-
     /// Clears the selection, evaluation, and projection caches. This is useful when
     /// repeatedly attempting to select an `Obligation` while changing only
     /// its `ParamEnv`, since `FulfillmentContext` doesn't use probing.

--- a/src/librustc_mir/borrow_check/diagnostics/conflict_errors.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/conflict_errors.rs
@@ -1684,7 +1684,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                                 // case it ends up being assigned into the return place.
                                 annotated_closure = self.annotate_fn_sig(
                                     *def_id,
-                                    self.infcx.closure_sig(*def_id, *substs),
+                                    substs.as_closure().sig(*def_id, self.infcx.tcx),
                                 );
                                 debug!(
                                     "annotate_argument_and_return_for_borrow: \

--- a/src/librustc_mir/borrow_check/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/type_check/mod.rs
@@ -2083,9 +2083,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
 
                     CastKind::Pointer(PointerCast::ClosureFnPointer(unsafety)) => {
                         let sig = match op.ty(*body, tcx).kind {
-                            ty::Closure(def_id, substs) => {
-                                substs.as_closure().sig_ty(def_id, tcx).fn_sig(tcx)
-                            }
+                            ty::Closure(def_id, substs) => substs.as_closure().sig(def_id, tcx),
                             _ => bug!(),
                         };
                         let ty_fn_ptr_from = tcx.coerce_closure_fn_ty(sig, *unsafety);

--- a/src/librustc_mir/borrow_check/universal_regions.rs
+++ b/src/librustc_mir/borrow_check/universal_regions.rs
@@ -580,7 +580,7 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
         match defining_ty {
             DefiningTy::Closure(def_id, substs) => {
                 assert_eq!(self.mir_def_id, def_id);
-                let closure_sig = substs.as_closure().sig_ty(def_id, tcx).fn_sig(tcx);
+                let closure_sig = substs.as_closure().sig(def_id, tcx);
                 let inputs_and_output = closure_sig.inputs_and_output();
                 let closure_ty = tcx.closure_env_ty(def_id, substs).unwrap();
                 ty::Binder::fuse(closure_ty, inputs_and_output, |closure_ty, inputs_and_output| {

--- a/src/librustc_trait_selection/opaque_types.rs
+++ b/src/librustc_trait_selection/opaque_types.rs
@@ -724,7 +724,7 @@ where
                     upvar_ty.visit_with(self);
                 }
 
-                substs.as_closure().sig_ty(def_id, self.tcx).visit_with(self);
+                substs.as_closure().sig_as_fn_ptr_ty(def_id, self.tcx).visit_with(self);
             }
 
             ty::Generator(def_id, ref substs, _) => {

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -368,7 +368,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         let self_ty = trait_ref.self_ty();
         let (def_id, output_ty, callable) = match self_ty.kind {
             ty::Closure(def_id, substs) => {
-                (def_id, self.closure_sig(def_id, substs).output(), "closure")
+                (def_id, substs.as_closure().sig(def_id, self.tcx).output(), "closure")
             }
             ty::FnDef(def_id, _) => (def_id, self_ty.fn_sig(self.tcx).output(), "function"),
             _ => return,

--- a/src/librustc_trait_selection/traits/project.rs
+++ b/src/librustc_trait_selection/traits/project.rs
@@ -1311,9 +1311,7 @@ fn confirm_closure_candidate<'cx, 'tcx>(
     vtable: VtableClosureData<'tcx, PredicateObligation<'tcx>>,
 ) -> Progress<'tcx> {
     let tcx = selcx.tcx();
-    let infcx = selcx.infcx();
-    let closure_sig_ty = vtable.substs.as_closure().sig_ty(vtable.closure_def_id, tcx);
-    let closure_sig = infcx.shallow_resolve(closure_sig_ty).fn_sig(tcx);
+    let closure_sig = vtable.substs.as_closure().sig(vtable.closure_def_id, tcx);
     let Normalized { value: closure_sig, obligations } = normalize_with_depth(
         selcx,
         obligation.param_env,

--- a/src/librustc_trait_selection/traits/select.rs
+++ b/src/librustc_trait_selection/traits/select.rs
@@ -3349,9 +3349,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             "closure_trait_ref_unnormalized(obligation={:?}, closure_def_id={:?}, substs={:?})",
             obligation, closure_def_id, substs,
         );
-        let closure_type = self.infcx.closure_sig(closure_def_id, substs);
+        let closure_sig = substs.as_closure().sig(closure_def_id, self.tcx());
 
-        debug!("closure_trait_ref_unnormalized: closure_type = {:?}", closure_type);
+        debug!("closure_trait_ref_unnormalized: closure_sig = {:?}", closure_sig);
 
         // (1) Feels icky to skip the binder here, but OTOH we know
         // that the self-type is an unboxed closure type and hence is
@@ -3362,7 +3362,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             self.tcx(),
             obligation.predicate.def_id(),
             obligation.predicate.skip_binder().self_ty(), // (1)
-            closure_type,
+            closure_sig,
             util::TupleArgumentsFlag::No,
         )
         .map_bound(|(trait_ref, _)| trait_ref)

--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -105,12 +105,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // haven't yet decided on whether the closure is fn vs
                 // fnmut vs fnonce. If so, we have to defer further processing.
                 if self.closure_kind(def_id, substs).is_none() {
-                    let closure_ty = self.closure_sig(def_id, substs);
-                    let fn_sig = self
+                    let closure_sig = substs.as_closure().sig(def_id, self.tcx);
+                    let closure_sig = self
                         .replace_bound_vars_with_fresh_vars(
                             call_expr.span,
                             infer::FnCall,
-                            &closure_ty,
+                            &closure_sig,
                         )
                         .0;
                     let adjustments = autoderef.adjust_steps(self, Needs::None);
@@ -121,12 +121,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             callee_expr,
                             adjusted_ty,
                             adjustments,
-                            fn_sig,
+                            fn_sig: closure_sig,
                             closure_def_id: def_id,
                             closure_substs: substs,
                         },
                     );
-                    return Some(CallStep::DeferredClosure(fn_sig));
+                    return Some(CallStep::DeferredClosure(closure_sig));
                 }
             }
 

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -749,9 +749,9 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
                 //     `fn(arg0,arg1,...) -> _`
                 // or
                 //     `unsafe fn(arg0,arg1,...) -> _`
-                let sig = self.closure_sig(def_id_a, substs_a);
+                let closure_sig = substs_a.as_closure().sig(def_id_a, self.tcx);
                 let unsafety = fn_ty.unsafety();
-                let pointer_ty = self.tcx.coerce_closure_fn_ty(sig, unsafety);
+                let pointer_ty = self.tcx.coerce_closure_fn_ty(closure_sig, unsafety);
                 debug!("coerce_closure_to_fn(a={:?}, b={:?}, pty={:?})", a, b, pointer_ty);
                 self.unify_and(
                     pointer_ty,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4839,18 +4839,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let hir = self.tcx.hir();
         let (def_id, sig) = match found.kind {
             ty::FnDef(def_id, _) => (def_id, found.fn_sig(self.tcx)),
-            ty::Closure(def_id, substs) => {
-                // We don't use `closure_sig` to account for malformed closures like
-                // `|_: [_; continue]| {}` and instead we don't suggest anything.
-                let closure_sig_ty = substs.as_closure().sig_ty(def_id, self.tcx);
-                (
-                    def_id,
-                    match closure_sig_ty.kind {
-                        ty::FnPtr(sig) => sig,
-                        _ => return false,
-                    },
-                )
-            }
+            ty::Closure(def_id, substs) => (def_id, substs.as_closure().sig(def_id, self.tcx)),
             _ => return false,
         };
 

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1527,16 +1527,13 @@ fn fn_sig(tcx: TyCtxt<'_>, def_id: DefId) -> ty::PolyFnSig<'_> {
             // argument. In any case they are embedded within the
             // closure type as part of the `ClosureSubsts`.
             //
-            // To get
-            // the signature of a closure, you should use the
-            // `closure_sig` method on the `ClosureSubsts`:
+            // To get the signature of a closure, you should use the
+            // `sig` method on the `ClosureSubsts`:
             //
-            //    closure_substs.sig(def_id, tcx)
-            //
-            // or, inside of an inference context, you can use
-            //
-            //    infcx.closure_sig(def_id, closure_substs)
-            bug!("to get the signature of a closure, use `closure_sig()` not `fn_sig()`");
+            //    substs.as_closure().sig(def_id, tcx)
+            bug!(
+                "to get the signature of a closure, use `substs.as_closure().sig()` not `fn_sig()`",
+            );
         }
 
         x => {


### PR DESCRIPTION
That is, `ClosureSubsts` is always created (in `rustc_typeck::check::closure`) with a `FnSig`, as the number of inputs is known, even if they might all have inference types.
The only useful thing `InferCtxt::closure_sig` was doing is resolving an inference variable used just to get the `ty::FnPtr` containing that `FnSig` into `ClosureSubsts`.

The ideal way to solve this would be to add a constructor for `ClosureSubsts`, that combines the parent `Substs`, the closure kind, the signature, and capture types together, but for now I've went with resolving the inference types just after unifying them with the real types.

r? @nikomatsakis