### PR TITLE
Add an optional abort message to MIR

### DIFF
--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -88,7 +88,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let (dest, ret) = match ret {
             None => match intrinsic_name {
                 sym::transmute => throw_ub_format!("transmuting to uninhabited type"),
-                sym::abort => M::abort(self)?,
+                sym::abort => M::abort(self, None)?,
                 // Unsupported diverging intrinsic.
                 _ => return Ok(false),
             },

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -170,7 +170,7 @@ pub trait Machine<'mir, 'tcx>: Sized {
     ) -> InterpResult<'tcx>;
 
     /// Called to evaluate `Abort` MIR terminator.
-    fn abort(_ecx: &mut InterpCx<'mir, 'tcx, Self>) -> InterpResult<'tcx, !> {
+    fn abort(_ecx: &mut InterpCx<'mir, 'tcx, Self>, _msg: Option<String>) -> InterpResult<'tcx, !> {
         throw_unsup_format!("aborting execution is not supported");
     }
 

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -100,7 +100,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
 
             Abort => {
-                M::abort(self)?;
+                M::abort(self, None)?;
             }
 
             // When we encounter Resume, we've finished unwinding


### PR DESCRIPTION
Hi,
This is needed to enable possible error reporting when the program is aborted in const eval.
required for https://github.com/rust-lang/miri/issues/1222
r? @RalfJung 