### PR TITLE
Tidy: fix running rustfmt twice

### DIFF
--- a/src/bootstrap/format.rs
+++ b/src/bootstrap/format.rs
@@ -37,6 +37,9 @@ struct RustfmtConfig {
 }
 
 pub fn format(build: &Build, check: bool) {
+    if build.config.dry_run {
+        return;
+    }
     let mut builder = ignore::types::TypesBuilder::new();
     builder.add_defaults();
     builder.select("rust");


### PR DESCRIPTION
`./x.py test tidy` runs rustfmt twice. This is because `Build::build` runs `execute_cli` twice (once dry, once not). This can be quite slow (and prints a bunch of things twice).

I'm not sure if this is really the best place to check the dry_run status.
