### PR TITLE
ci: use python from the correct path

### DIFF
--- a/src/ci/scripts/install-msys2-packages.sh
+++ b/src/ci/scripts/install-msys2-packages.sh
@@ -13,6 +13,7 @@ if isWindows; then
     # one way or another. The msys interpreters seem to have weird path conversions
     # baked in which break LLVM's build system one way or another, so let's use the
     # native version which keeps everything as native as possible.
-    cp C:/Python27amd64/python.exe C:/Python27amd64/python2.7.exe
-    ciCommandAddPath "C:\\Python27amd64"
+    python_home="C:/hostedtoolcache/windows/Python/2.7.17/x64"
+    cp "${python_home}/python.exe" "${python_home}/python2.7.exe"
+    ciCommandAddPath "C:\\hostedtoolcache\\windows\\Python\\2.7.17\\x64"
 fi


### PR DESCRIPTION
Apparently the old path we were using for Python 2 on Windows was not documented, and eventually got removed. This switches our CI to use the correct path.

See https://github.com/rust-lang/rust/pull/70112#issuecomment-600760786 for the actual failure.