### PR TITLE
rustc: use LocalDefId instead of DefId in TypeckTables.

### DIFF
--- a/src/librustc_infer/infer/error_reporting/mod.rs
+++ b/src/librustc_infer/infer/error_reporting/mod.rs
@@ -1784,11 +1784,11 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         // suggest adding an explicit lifetime bound to it.
         let type_param_span = match (self.in_progress_tables, bound_kind) {
             (Some(ref table), GenericKind::Param(ref param)) => {
-                let table = table.borrow();
-                table.local_id_root.and_then(|did| {
-                    let generics = self.tcx.generics_of(did);
-                    // Account for the case where `did` corresponds to `Self`, which doesn't have
-                    // the expected type argument.
+                let table_owner = table.borrow().hir_owner;
+                table_owner.and_then(|table_owner| {
+                    let generics = self.tcx.generics_of(table_owner.to_def_id());
+                    // Account for the case where `param` corresponds to `Self`,
+                    // which doesn't have the expected type argument.
                     if !(generics.has_self && param.index == 0) {
                         let type_param = generics.type_param(param, self.tcx);
                         let hir = &self.tcx.hir();

--- a/src/librustc_infer/infer/mod.rs
+++ b/src/librustc_infer/infer/mod.rs
@@ -29,7 +29,7 @@ use rustc_data_structures::sync::Lrc;
 use rustc_data_structures::unify as ut;
 use rustc_errors::DiagnosticBuilder;
 use rustc_hir as hir;
-use rustc_hir::def_id::DefId;
+use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_session::config::BorrowckMode;
 use rustc_span::symbol::Symbol;
 use rustc_span::Span;
@@ -559,7 +559,7 @@ impl TyCtxtInferExt<'tcx> for TyCtxt<'tcx> {
 impl<'tcx> InferCtxtBuilder<'tcx> {
     /// Used only by `rustc_typeck` during body type-checking/inference,
     /// will initialize `in_progress_tables` with fresh `TypeckTables`.
-    pub fn with_fresh_in_progress_tables(mut self, table_owner: DefId) -> Self {
+    pub fn with_fresh_in_progress_tables(mut self, table_owner: LocalDefId) -> Self {
         self.fresh_tables = Some(RefCell::new(ty::TypeckTables::empty(Some(table_owner))));
         self
     }

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -1105,15 +1105,15 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         let generator_did_root = self.tcx.closure_base_def_id(generator_did);
         debug!(
             "maybe_note_obligation_cause_for_async_await: generator_did={:?} \
-             generator_did_root={:?} in_progress_tables.local_id_root={:?} span={:?}",
+             generator_did_root={:?} in_progress_tables.hir_owner={:?} span={:?}",
             generator_did,
             generator_did_root,
-            in_progress_tables.as_ref().map(|t| t.local_id_root),
+            in_progress_tables.as_ref().map(|t| t.hir_owner),
             span
         );
         let query_tables;
         let tables: &TypeckTables<'tcx> = match &in_progress_tables {
-            Some(t) if t.local_id_root == Some(generator_did_root) => t,
+            Some(t) if t.hir_owner.map(|owner| owner.to_def_id()) == Some(generator_did_root) => t,
             _ => {
                 query_tables = self.tcx.typeck_tables_of(generator_did);
                 &query_tables

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -213,7 +213,7 @@ fn compare_predicate_entailment<'tcx>(
     );
 
     tcx.infer_ctxt().enter(|infcx| {
-        let inh = Inherited::new(infcx, impl_m.def_id);
+        let inh = Inherited::new(infcx, impl_m.def_id.expect_local());
         let infcx = &inh.infcx;
 
         debug!("compare_impl_method: caller_bounds={:?}", param_env.caller_bounds);
@@ -950,7 +950,7 @@ crate fn compare_const_impl<'tcx>(
 
     tcx.infer_ctxt().enter(|infcx| {
         let param_env = tcx.param_env(impl_c.def_id);
-        let inh = Inherited::new(infcx, impl_c.def_id);
+        let inh = Inherited::new(infcx, impl_c.def_id.expect_local());
         let infcx = &inh.infcx;
 
         // The below is for the most part highly similar to the procedure
@@ -1130,7 +1130,7 @@ fn compare_type_predicate_entailment(
         normalize_cause.clone(),
     );
     tcx.infer_ctxt().enter(|infcx| {
-        let inh = Inherited::new(infcx, impl_ty.def_id);
+        let inh = Inherited::new(infcx, impl_ty.def_id.expect_local());
         let infcx = &inh.infcx;
 
         debug!("compare_type_predicate_entailment: caller_bounds={:?}", param_env.caller_bounds);

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -1018,9 +1018,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // Obtain the span for `param` and use it for a structured suggestion.
             let mut suggested = false;
             if let (Some(ref param), Some(ref table)) = (param_type, self.in_progress_tables) {
-                let table = table.borrow();
-                if let Some(did) = table.local_id_root {
-                    let generics = self.tcx.generics_of(did);
+                let table_owner = table.borrow().hir_owner;
+                if let Some(table_owner) = table_owner {
+                    let generics = self.tcx.generics_of(table_owner.to_def_id());
                     let type_param = generics.type_param(param, self.tcx);
                     let hir = &self.tcx.hir();
                     if let Some(id) = hir.as_local_hir_id(type_param.def_id) {

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -316,12 +316,12 @@ fn for_item<'tcx>(tcx: TyCtxt<'tcx>, item: &hir::Item<'_>) -> CheckWfFcxBuilder<
 }
 
 fn for_id(tcx: TyCtxt<'_>, id: hir::HirId, span: Span) -> CheckWfFcxBuilder<'_> {
-    let def_id = tcx.hir().local_def_id(id);
+    let def_id = tcx.hir().local_def_id(id).expect_local();
     CheckWfFcxBuilder {
         inherited: Inherited::build(tcx, def_id),
         id,
         span,
-        param_env: tcx.param_env(def_id),
+        param_env: tcx.param_env(def_id.to_def_id()),
     }
 }
 

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -111,7 +111,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
 
         WritebackCx {
             fcx,
-            tables: ty::TypeckTables::empty(Some(owner.to_def_id())),
+            tables: ty::TypeckTables::empty(Some(owner)),
             body,
             rustc_dump_user_substs,
         }
@@ -338,11 +338,11 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
 
     fn visit_closures(&mut self) {
         let fcx_tables = self.fcx.tables.borrow();
-        debug_assert_eq!(fcx_tables.local_id_root, self.tables.local_id_root);
-        let common_local_id_root = fcx_tables.local_id_root.unwrap();
+        assert_eq!(fcx_tables.hir_owner, self.tables.hir_owner);
+        let common_hir_owner = fcx_tables.hir_owner.unwrap();
 
         for (&id, &origin) in fcx_tables.closure_kind_origins().iter() {
-            let hir_id = hir::HirId { owner: common_local_id_root.expect_local(), local_id: id };
+            let hir_id = hir::HirId { owner: common_hir_owner, local_id: id };
             self.tables.closure_kind_origins_mut().insert(hir_id, origin);
         }
     }
@@ -350,7 +350,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
     fn visit_coercion_casts(&mut self) {
         let fcx_tables = self.fcx.tables.borrow();
         let fcx_coercion_casts = fcx_tables.coercion_casts();
-        debug_assert_eq!(fcx_tables.local_id_root, self.tables.local_id_root);
+        assert_eq!(fcx_tables.hir_owner, self.tables.hir_owner);
 
         for local_id in fcx_coercion_casts {
             self.tables.set_coercion_cast(*local_id);
@@ -359,12 +359,12 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
 
     fn visit_user_provided_tys(&mut self) {
         let fcx_tables = self.fcx.tables.borrow();
-        debug_assert_eq!(fcx_tables.local_id_root, self.tables.local_id_root);
-        let common_local_id_root = fcx_tables.local_id_root.unwrap();
+        assert_eq!(fcx_tables.hir_owner, self.tables.hir_owner);
+        let common_hir_owner = fcx_tables.hir_owner.unwrap();
 
         let mut errors_buffer = Vec::new();
         for (&local_id, c_ty) in fcx_tables.user_provided_types().iter() {
-            let hir_id = hir::HirId { owner: common_local_id_root.expect_local(), local_id };
+            let hir_id = hir::HirId { owner: common_hir_owner, local_id };
 
             if cfg!(debug_assertions) && c_ty.has_local_value() {
                 span_bug!(hir_id.to_span(self.fcx.tcx), "writeback: `{:?}` is a local value", c_ty);
@@ -397,7 +397,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
 
     fn visit_user_provided_sigs(&mut self) {
         let fcx_tables = self.fcx.tables.borrow();
-        debug_assert_eq!(fcx_tables.local_id_root, self.tables.local_id_root);
+        assert_eq!(fcx_tables.hir_owner, self.tables.hir_owner);
 
         for (&def_id, c_sig) in fcx_tables.user_provided_sigs.iter() {
             if cfg!(debug_assertions) && c_sig.has_local_value() {
@@ -414,7 +414,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
 
     fn visit_generator_interior_types(&mut self) {
         let fcx_tables = self.fcx.tables.borrow();
-        debug_assert_eq!(fcx_tables.local_id_root, self.tables.local_id_root);
+        assert_eq!(fcx_tables.hir_owner, self.tables.hir_owner);
         self.tables.generator_interior_types = fcx_tables.generator_interior_types.clone();
     }
 
@@ -553,11 +553,11 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
 
     fn visit_liberated_fn_sigs(&mut self) {
         let fcx_tables = self.fcx.tables.borrow();
-        debug_assert_eq!(fcx_tables.local_id_root, self.tables.local_id_root);
-        let common_local_id_root = fcx_tables.local_id_root.unwrap();
+        assert_eq!(fcx_tables.hir_owner, self.tables.hir_owner);
+        let common_hir_owner = fcx_tables.hir_owner.unwrap();
 
         for (&local_id, fn_sig) in fcx_tables.liberated_fn_sigs().iter() {
-            let hir_id = hir::HirId { owner: common_local_id_root.expect_local(), local_id };
+            let hir_id = hir::HirId { owner: common_hir_owner, local_id };
             let fn_sig = self.resolve(fn_sig, &hir_id);
             self.tables.liberated_fn_sigs_mut().insert(hir_id, fn_sig.clone());
         }
@@ -565,11 +565,11 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
 
     fn visit_fru_field_types(&mut self) {
         let fcx_tables = self.fcx.tables.borrow();
-        debug_assert_eq!(fcx_tables.local_id_root, self.tables.local_id_root);
-        let common_local_id_root = fcx_tables.local_id_root.unwrap();
+        assert_eq!(fcx_tables.hir_owner, self.tables.hir_owner);
+        let common_hir_owner = fcx_tables.hir_owner.unwrap();
 
         for (&local_id, ftys) in fcx_tables.fru_field_types().iter() {
-            let hir_id = hir::HirId { owner: common_local_id_root.expect_local(), local_id };
+            let hir_id = hir::HirId { owner: common_hir_owner, local_id };
             let ftys = self.resolve(ftys, &hir_id);
             self.tables.fru_field_types_mut().insert(hir_id, ftys);
         }


### PR DESCRIPTION
The logic in `TypeckTables`' implementation of `HashStable`, which created `DefId`s by combining a `CrateNum` from a `DefId` and a `DefIndex` from a `LocalDefId`, bothered me a bit.

I don't know how much this matters, but it works so might as well submit it.