### PR TITLE
Add regression test for TAIT lifetime inference (issue #55099)

### DIFF
--- a/src/test/ui/type-alias-impl-trait/issue-55099-lifetime-inference.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-55099-lifetime-inference.rs
@@ -1,0 +1,28 @@
+// check-pass
+// Regression test for issue #55099
+// Tests that we don't incorrectly consider a lifetime to part
+// of the concrete type
+
+#![feature(type_alias_impl_trait)]
+
+trait Future {
+}
+
+struct AndThen<F>(F);
+
+impl<F> Future for AndThen<F> {
+}
+
+struct Foo<'a> {
+    x: &'a mut (),
+}
+
+type F = impl Future;
+
+impl<'a> Foo<'a> {
+    fn reply(&mut self) -> F {
+        AndThen(|| ())
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #55099

The minimized reproducer in issue #55099 now compiles successfully.
This commit adds a regression test for it.