### PR TITLE
remove unused imports

### DIFF
--- a/src/libpanic_unwind/hermit.rs
+++ b/src/libpanic_unwind/hermit.rs
@@ -4,7 +4,6 @@
 
 use alloc::boxed::Box;
 use core::any::Any;
-use core::ptr;
 
 pub unsafe fn cleanup(_ptr: *mut u8) -> Box<dyn Any + Send> {
     extern "C" {


### PR DESCRIPTION
patch is required to avoid compiler errors by building src/libpanic_unwind/hermit.rs