### PR TITLE
do not 'return' in 'throw_' macros

### DIFF
--- a/src/librustc/mir/interpret/mod.rs
+++ b/src/librustc/mir/interpret/mod.rs
@@ -49,7 +49,7 @@ macro_rules! err_exhaust {
 // In the `throw_*` macros, avoid `return` to make them work with `try {}`.
 #[macro_export]
 macro_rules! throw_unsup {
-    ($($tt:tt)*) => { Err(err_unsup!($($tt)*))? };
+    ($($tt:tt)*) => { Err::<!, _>(err_unsup!($($tt)*))? };
 }
 
 #[macro_export]
@@ -59,12 +59,12 @@ macro_rules! throw_unsup_format {
 
 #[macro_export]
 macro_rules! throw_inval {
-    ($($tt:tt)*) => { Err(err_inval!($($tt)*))? };
+    ($($tt:tt)*) => { Err::<!, _>(err_inval!($($tt)*))? };
 }
 
 #[macro_export]
 macro_rules! throw_ub {
-    ($($tt:tt)*) => { Err(err_ub!($($tt)*))? };
+    ($($tt:tt)*) => { Err::<!, _>(err_ub!($($tt)*))? };
 }
 
 #[macro_export]
@@ -74,13 +74,13 @@ macro_rules! throw_ub_format {
 
 #[macro_export]
 macro_rules! throw_exhaust {
-    ($($tt:tt)*) => { Err(err_exhaust!($($tt)*))? };
+    ($($tt:tt)*) => { Err::<!, _>(err_exhaust!($($tt)*))? };
 }
 
 #[macro_export]
 macro_rules! throw_machine_stop {
     ($($tt:tt)*) => {
-        Err($crate::mir::interpret::InterpError::MachineStop(Box::new($($tt)*)))?
+        Err::<!, _>($crate::mir::interpret::InterpError::MachineStop(Box::new($($tt)*)))?
     };
 }
 

--- a/src/librustc/mir/interpret/mod.rs
+++ b/src/librustc/mir/interpret/mod.rs
@@ -46,9 +46,10 @@ macro_rules! err_exhaust {
     };
 }
 
+// In the `throw_*` macros, avoid `return` to make them work with `try {}`.
 #[macro_export]
 macro_rules! throw_unsup {
-    ($($tt:tt)*) => { return Err(err_unsup!($($tt)*).into()) };
+    ($($tt:tt)*) => { Err(err_unsup!($($tt)*))? };
 }
 
 #[macro_export]
@@ -58,12 +59,12 @@ macro_rules! throw_unsup_format {
 
 #[macro_export]
 macro_rules! throw_inval {
-    ($($tt:tt)*) => { return Err(err_inval!($($tt)*).into()) };
+    ($($tt:tt)*) => { Err(err_inval!($($tt)*))? };
 }
 
 #[macro_export]
 macro_rules! throw_ub {
-    ($($tt:tt)*) => { return Err(err_ub!($($tt)*).into()) };
+    ($($tt:tt)*) => { Err(err_ub!($($tt)*))? };
 }
 
 #[macro_export]
@@ -73,13 +74,13 @@ macro_rules! throw_ub_format {
 
 #[macro_export]
 macro_rules! throw_exhaust {
-    ($($tt:tt)*) => { return Err(err_exhaust!($($tt)*).into()) };
+    ($($tt:tt)*) => { Err(err_exhaust!($($tt)*))? };
 }
 
 #[macro_export]
 macro_rules! throw_machine_stop {
     ($($tt:tt)*) => {
-        return Err($crate::mir::interpret::InterpError::MachineStop(Box::new($($tt)*)).into())
+        Err($crate::mir::interpret::InterpError::MachineStop(Box::new($($tt)*)))?
     };
 }
 

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -171,7 +171,7 @@ pub trait Machine<'mir, 'tcx>: Sized {
 
     /// Called to evaluate `Abort` MIR terminator.
     fn abort(_ecx: &mut InterpCx<'mir, 'tcx, Self>) -> InterpResult<'tcx, !> {
-        throw_unsup_format!("aborting execution is not supported");
+        throw_unsup_format!("aborting execution is not supported")
     }
 
     /// Called for all binary operations where the LHS has pointer type.

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -192,7 +192,7 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for ConstPropMachine {
         _ret: Option<(PlaceTy<'tcx>, BasicBlock)>,
         _unwind: Option<BasicBlock>,
     ) -> InterpResult<'tcx> {
-        throw_unsup!(ConstPropUnsupported("calling intrinsics isn't supported in ConstProp"));
+        throw_unsup!(ConstPropUnsupported("calling intrinsics isn't supported in ConstProp"))
     }
 
     fn assert_panic(
@@ -200,11 +200,11 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for ConstPropMachine {
         _msg: &rustc::mir::AssertMessage<'tcx>,
         _unwind: Option<rustc::mir::BasicBlock>,
     ) -> InterpResult<'tcx> {
-        bug!("panics terminators are not evaluated in ConstProp");
+        bug!("panics terminators are not evaluated in ConstProp")
     }
 
     fn ptr_to_int(_mem: &Memory<'mir, 'tcx, Self>, _ptr: Pointer) -> InterpResult<'tcx, u64> {
-        throw_unsup!(ConstPropUnsupported("ptr-to-int casts aren't supported in ConstProp"));
+        throw_unsup!(ConstPropUnsupported("ptr-to-int casts aren't supported in ConstProp"))
     }
 
     fn binary_ptr_op(
@@ -217,7 +217,7 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for ConstPropMachine {
         throw_unsup!(ConstPropUnsupported(
             "pointer arithmetic or comparisons aren't supported \
             in ConstProp"
-        ));
+        ))
     }
 
     #[inline(always)]
@@ -240,7 +240,7 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for ConstPropMachine {
         _ecx: &mut InterpCx<'mir, 'tcx, Self>,
         _dest: PlaceTy<'tcx>,
     ) -> InterpResult<'tcx> {
-        throw_unsup!(ConstPropUnsupported("can't const prop `box` keyword"));
+        throw_unsup!(ConstPropUnsupported("can't const prop `box` keyword"))
     }
 
     fn access_local(


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/69839 we turned a closure into a `try` block, but it turns out that does not work with our `throw_` macros, which `return` so they skip the `try`.

Here we fix that. For some reason that means we also have to remove some `;`.

r? @oli-obk 