### PR TITLE
Allocate some query results on an arena

### DIFF
--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -26,7 +26,6 @@ use rustc_target::spec::{HasTargetSpec, Target};
 use std::cell::{Cell, RefCell};
 use std::ffi::CStr;
 use std::str;
-use std::sync::Arc;
 
 /// There is one `CodegenCx` per compilation unit. Each one has its own LLVM
 /// `llvm::Context` so that several compilation units may be optimized in parallel.
@@ -39,7 +38,7 @@ pub struct CodegenCx<'ll, 'tcx> {
 
     pub llmod: &'ll llvm::Module,
     pub llcx: &'ll llvm::Context,
-    pub codegen_unit: Arc<CodegenUnit<'tcx>>,
+    pub codegen_unit: &'tcx CodegenUnit<'tcx>,
 
     /// Cache instances of monomorphic and polymorphic items
     pub instances: RefCell<FxHashMap<Instance<'tcx>, &'ll Value>>,
@@ -232,7 +231,7 @@ pub unsafe fn create_module(
 impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
     crate fn new(
         tcx: TyCtxt<'tcx>,
-        codegen_unit: Arc<CodegenUnit<'tcx>>,
+        codegen_unit: &'tcx CodegenUnit<'tcx>,
         llvm_module: &'ll crate::ModuleLlvm,
     ) -> Self {
         // An interesting part of Windows which MSVC forces our hand on (and
@@ -402,8 +401,8 @@ impl MiscMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         self.check_overflow
     }
 
-    fn codegen_unit(&self) -> &Arc<CodegenUnit<'tcx>> {
-        &self.codegen_unit
+    fn codegen_unit(&self) -> &'tcx CodegenUnit<'tcx> {
+        self.codegen_unit
     }
 
     fn used_statics(&self) -> &RefCell<Vec<&'ll Value>> {

--- a/src/librustc_codegen_ssa/back/symbol_export.rs
+++ b/src/librustc_codegen_ssa/back/symbol_export.rs
@@ -1,5 +1,4 @@
 use std::collections::hash_map::Entry::*;
-use std::sync::Arc;
 
 use rustc_ast::expand::allocator::ALLOCATOR_METHODS;
 use rustc_data_structures::fingerprint::Fingerprint;
@@ -164,11 +163,11 @@ fn is_reachable_non_generic_provider_extern(tcx: TyCtxt<'_>, def_id: DefId) -> b
 fn exported_symbols_provider_local(
     tcx: TyCtxt<'_>,
     cnum: CrateNum,
-) -> Arc<Vec<(ExportedSymbol<'_>, SymbolExportLevel)>> {
+) -> &'tcx [(ExportedSymbol<'_>, SymbolExportLevel)] {
     assert_eq!(cnum, LOCAL_CRATE);
 
     if !tcx.sess.opts.output_types.should_codegen() {
-        return Arc::new(vec![]);
+        return &[];
     }
 
     let mut symbols: Vec<_> = tcx
@@ -274,7 +273,7 @@ fn exported_symbols_provider_local(
     // Sort so we get a stable incr. comp. hash.
     symbols.sort_by_cached_key(|s| s.0.symbol_name_for_local_instance(tcx));
 
-    Arc::new(symbols)
+    tcx.arena.alloc_from_iter(symbols)
 }
 
 fn upstream_monomorphizations_provider(

--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -533,7 +533,6 @@ pub fn codegen_crate<B: ExtraBackendMethods>(
     // Run the monomorphization collector and partition the collected items into
     // codegen units.
     let codegen_units = tcx.collect_and_partition_mono_items(LOCAL_CRATE).1;
-    let codegen_units = (*codegen_units).clone();
 
     // Force all codegen_unit queries so they are already either red or green
     // when compile_codegen_unit accesses them. We are not able to re-execute
@@ -541,7 +540,7 @@ pub fn codegen_crate<B: ExtraBackendMethods>(
     // lead to having to re-execute compile_codegen_unit, possibly
     // unnecessarily.
     if tcx.dep_graph.is_fully_enabled() {
-        for cgu in &codegen_units {
+        for cgu in codegen_units {
             tcx.codegen_unit(cgu.name());
         }
     }
@@ -603,7 +602,7 @@ pub fn codegen_crate<B: ExtraBackendMethods>(
     // We sort the codegen units by size. This way we can schedule work for LLVM
     // a bit more efficiently.
     let codegen_units = {
-        let mut codegen_units = codegen_units;
+        let mut codegen_units = codegen_units.iter().collect::<Vec<_>>();
         codegen_units.sort_by_cached_key(|cgu| cmp::Reverse(cgu.size_estimate()));
         codegen_units
     };

--- a/src/librustc_codegen_ssa/traits/misc.rs
+++ b/src/librustc_codegen_ssa/traits/misc.rs
@@ -4,7 +4,6 @@ use rustc_middle::mir::mono::CodegenUnit;
 use rustc_middle::ty::{self, Instance, Ty};
 use rustc_session::Session;
 use std::cell::RefCell;
-use std::sync::Arc;
 
 pub trait MiscMethods<'tcx>: BackendTypes {
     fn vtables(
@@ -15,7 +14,7 @@ pub trait MiscMethods<'tcx>: BackendTypes {
     fn get_fn_addr(&self, instance: Instance<'tcx>) -> Self::Value;
     fn eh_personality(&self) -> Self::Value;
     fn sess(&self) -> &Session;
-    fn codegen_unit(&self) -> &Arc<CodegenUnit<'tcx>>;
+    fn codegen_unit(&self) -> &'tcx CodegenUnit<'tcx>;
     fn used_statics(&self) -> &RefCell<Vec<Self::Value>>;
     fn set_frame_pointer_elimination(&self, llfn: Self::Function);
     fn apply_target_cpu_attr(&self, llfn: Self::Function);

--- a/src/librustc_infer/traits/error_reporting/mod.rs
+++ b/src/librustc_infer/traits/error_reporting/mod.rs
@@ -39,7 +39,7 @@ pub fn report_object_safety_error(
     tcx: TyCtxt<'tcx>,
     span: Span,
     trait_def_id: DefId,
-    violations: Vec<ObjectSafetyViolation>,
+    violations: &[ObjectSafetyViolation],
 ) -> DiagnosticBuilder<'tcx> {
     let trait_str = tcx.def_path_str(trait_def_id);
     let trait_span = tcx.hir().get_if_local(trait_def_id).and_then(|node| match node {

--- a/src/librustc_metadata/rmeta/decoder.rs
+++ b/src/librustc_metadata/rmeta/decoder.rs
@@ -1197,7 +1197,7 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
         }
     }
 
-    fn get_item_attrs(&self, node_id: DefIndex, sess: &Session) -> Lrc<[ast::Attribute]> {
+    fn get_item_attrs(&self, node_id: DefIndex, sess: &Session) -> Vec<ast::Attribute> {
         // The attributes for a tuple struct/variant are attached to the definition, not the ctor;
         // we assume that someone passing in a tuple struct ctor is actually wanting to
         // look at the definition
@@ -1208,15 +1208,13 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
             node_id
         };
 
-        Lrc::from(
-            self.root
-                .tables
-                .attributes
-                .get(self, item_id)
-                .unwrap_or(Lazy::empty())
-                .decode((self, sess))
-                .collect::<Vec<_>>(),
-        )
+        self.root
+            .tables
+            .attributes
+            .get(self, item_id)
+            .unwrap_or(Lazy::empty())
+            .decode((self, sess))
+            .collect::<Vec<_>>()
     }
 
     fn get_struct_field_names(&self, id: DefIndex, sess: &Session) -> Vec<Spanned<ast::Name>> {

--- a/src/librustc_metadata/rmeta/decoder.rs
+++ b/src/librustc_metadata/rmeta/decoder.rs
@@ -1331,13 +1331,13 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
         }
     }
 
-    fn get_fn_param_names(&self, id: DefIndex) -> Vec<ast::Name> {
+    fn get_fn_param_names(&self, tcx: TyCtxt<'tcx>, id: DefIndex) -> &'tcx [ast::Name] {
         let param_names = match self.kind(id) {
             EntryKind::Fn(data) | EntryKind::ForeignFn(data) => data.decode(self).param_names,
             EntryKind::AssocFn(data) => data.decode(self).fn_data.param_names,
             _ => Lazy::empty(),
         };
-        param_names.decode(self).collect()
+        tcx.arena.alloc_from_iter(param_names.decode(self))
     }
 
     fn exported_symbols(

--- a/src/librustc_metadata/rmeta/decoder.rs
+++ b/src/librustc_metadata/rmeta/decoder.rs
@@ -1343,13 +1343,13 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
     fn exported_symbols(
         &self,
         tcx: TyCtxt<'tcx>,
-    ) -> Vec<(ExportedSymbol<'tcx>, SymbolExportLevel)> {
+    ) -> &'tcx [(ExportedSymbol<'tcx>, SymbolExportLevel)] {
         if self.root.is_proc_macro_crate() {
             // If this crate is a custom derive crate, then we're not even going to
             // link those in so we skip those crates.
-            vec![]
+            &[]
         } else {
-            self.root.exported_symbols.decode((self, tcx)).collect()
+            tcx.arena.alloc_from_iter(self.root.exported_symbols.decode((self, tcx)))
         }
     }
 

--- a/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
+++ b/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
@@ -138,7 +138,9 @@ provide! { <'tcx> tcx, def_id, other, cdata,
     lookup_deprecation_entry => {
         cdata.get_deprecation(def_id.index).map(DeprecationEntry::external)
     }
-    item_attrs => { cdata.get_item_attrs(def_id.index, tcx.sess) }
+    item_attrs => { tcx.arena.alloc_from_iter(
+        cdata.get_item_attrs(def_id.index, tcx.sess).into_iter()
+    ) }
     // FIXME(#38501) We've skipped a `read` on the `hir_owner_nodes` of
     // a `fn` when encoding, so the dep-tracking wouldn't work.
     // This is only used by rustdoc anyway, which shouldn't have

--- a/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
+++ b/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
@@ -144,7 +144,7 @@ provide! { <'tcx> tcx, def_id, other, cdata,
     // a `fn` when encoding, so the dep-tracking wouldn't work.
     // This is only used by rustdoc anyway, which shouldn't have
     // incremental recompilation ever enabled.
-    fn_arg_names => { cdata.get_fn_param_names(def_id.index) }
+    fn_arg_names => { cdata.get_fn_param_names(tcx, def_id.index) }
     rendered_const => { cdata.get_rendered_const(def_id.index) }
     impl_parent => { cdata.get_parent_impl(def_id.index) }
     trait_of_item => { cdata.get_trait_of_item(def_id.index) }

--- a/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
+++ b/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
@@ -26,7 +26,6 @@ use rustc_span::symbol::Symbol;
 use rustc_data_structures::sync::Lrc;
 use smallvec::SmallVec;
 use std::any::Any;
-use std::sync::Arc;
 
 macro_rules! provide {
     (<$lt:tt> $tcx:ident, $def_id:ident, $other:ident, $cdata:ident,
@@ -239,7 +238,7 @@ provide! { <'tcx> tcx, def_id, other, cdata,
         // to block export of generics from dylibs, but we must fix
         // rust-lang/rust#65890 before we can do that robustly.
 
-        Arc::new(syms)
+        syms
     }
 }
 

--- a/src/librustc_middle/arena.rs
+++ b/src/librustc_middle/arena.rs
@@ -117,6 +117,7 @@ macro_rules! arena_types {
             [few] inferred_outlives_crate: rustc_middle::ty::CratePredicatesMap<'tcx>,
             [] upvars: rustc_data_structures::fx::FxIndexMap<rustc_hir::HirId, rustc_hir::Upvar>,
             [] object_safety_violations: rustc_middle::traits::ObjectSafetyViolation,
+            [] codegen_unit: rustc_middle::mir::mono::CodegenUnit<$tcx>,
 
             // Interned types
             [] tys: rustc_middle::ty::TyS<$tcx>,

--- a/src/librustc_middle/arena.rs
+++ b/src/librustc_middle/arena.rs
@@ -118,6 +118,9 @@ macro_rules! arena_types {
             [] upvars: rustc_data_structures::fx::FxIndexMap<rustc_hir::HirId, rustc_hir::Upvar>,
             [] object_safety_violations: rustc_middle::traits::ObjectSafetyViolation,
             [] codegen_unit: rustc_middle::mir::mono::CodegenUnit<$tcx>,
+            [] attribute: rustc_ast::ast::Attribute,
+            [] name_set: rustc_data_structures::fx::FxHashSet<rustc_ast::ast::Name>,
+            [] hir_id_set: rustc_hir::HirIdSet,
 
             // Interned types
             [] tys: rustc_middle::ty::TyS<$tcx>,

--- a/src/librustc_middle/arena.rs
+++ b/src/librustc_middle/arena.rs
@@ -116,6 +116,7 @@ macro_rules! arena_types {
             [few] crate_variances: rustc_middle::ty::CrateVariancesMap<'tcx>,
             [few] inferred_outlives_crate: rustc_middle::ty::CratePredicatesMap<'tcx>,
             [] upvars: rustc_data_structures::fx::FxIndexMap<rustc_hir::HirId, rustc_hir::Upvar>,
+            [] object_safety_violations: rustc_middle::traits::ObjectSafetyViolation,
 
             // Interned types
             [] tys: rustc_middle::ty::TyS<$tcx>,

--- a/src/librustc_middle/query/mod.rs
+++ b/src/librustc_middle/query/mod.rs
@@ -610,7 +610,7 @@ rustc_queries! {
     }
 
     Other {
-        query reachable_set(_: CrateNum) -> Lrc<HirIdSet> {
+        query reachable_set(_: CrateNum) -> &'tcx HirIdSet {
             desc { "reachability" }
         }
 
@@ -642,7 +642,7 @@ rustc_queries! {
         query lookup_stability(_: DefId) -> Option<&'tcx attr::Stability> {}
         query lookup_const_stability(_: DefId) -> Option<&'tcx attr::ConstStability> {}
         query lookup_deprecation_entry(_: DefId) -> Option<DeprecationEntry> {}
-        query item_attrs(_: DefId) -> Lrc<[ast::Attribute]> {}
+        query item_attrs(_: DefId) -> &'tcx [ast::Attribute] {}
     }
 
     Codegen {
@@ -1047,7 +1047,7 @@ rustc_queries! {
             desc { "looking up all possibly unused extern crates" }
         }
         query names_imported_by_glob_use(_: DefId)
-            -> Lrc<FxHashSet<ast::Name>> {
+            -> &'tcx FxHashSet<ast::Name> {
             eval_always
         }
 

--- a/src/librustc_middle/query/mod.rs
+++ b/src/librustc_middle/query/mod.rs
@@ -652,7 +652,7 @@ rustc_queries! {
     }
 
     Other {
-        query fn_arg_names(_: DefId) -> Vec<ast::Name> {}
+        query fn_arg_names(_: DefId) -> &'tcx [ast::Name] {}
         /// Gets the rendered value of the specified constant or associated constant.
         /// Used by rustdoc.
         query rendered_const(_: DefId) -> String {}
@@ -699,7 +699,7 @@ rustc_queries! {
             desc { |tcx| "building specialization graph of trait `{}`", tcx.def_path_str(key) }
             cache_on_disk_if { true }
         }
-        query object_safety_violations(key: DefId) -> Vec<traits::ObjectSafetyViolation> {
+        query object_safety_violations(key: DefId) -> &'tcx [traits::ObjectSafetyViolation] {
             desc { |tcx| "determine object safety of trait `{}`", tcx.def_path_str(key) }
         }
 

--- a/src/librustc_middle/query/mod.rs
+++ b/src/librustc_middle/query/mod.rs
@@ -1075,19 +1075,19 @@ rustc_queries! {
         ///   correspond to a publicly visible symbol in `cnum` machine code.
         /// - The `exported_symbols` sets of different crates do not intersect.
         query exported_symbols(_: CrateNum)
-            -> Arc<Vec<(ExportedSymbol<'tcx>, SymbolExportLevel)>> {
+            -> &'tcx [(ExportedSymbol<'tcx>, SymbolExportLevel)] {
             desc { "exported_symbols" }
         }
     }
 
     Codegen {
         query collect_and_partition_mono_items(_: CrateNum)
-            -> (Arc<DefIdSet>, Arc<Vec<Arc<CodegenUnit<'tcx>>>>) {
+            -> (&'tcx DefIdSet, &'tcx [CodegenUnit<'tcx>]) {
             eval_always
             desc { "collect_and_partition_mono_items" }
         }
         query is_codegened_item(_: DefId) -> bool {}
-        query codegen_unit(_: Symbol) -> Arc<CodegenUnit<'tcx>> {
+        query codegen_unit(_: Symbol) -> &'tcx CodegenUnit<'tcx> {
             desc { "codegen_unit" }
         }
         query backend_optimization_level(_: CrateNum) -> OptLevel {

--- a/src/librustc_middle/ty/context.rs
+++ b/src/librustc_middle/ty/context.rs
@@ -2721,7 +2721,7 @@ pub fn provide(providers: &mut ty::query::Providers<'_>) {
     };
     providers.names_imported_by_glob_use = |tcx, id| {
         assert_eq!(id.krate, LOCAL_CRATE);
-        Lrc::new(tcx.glob_map.get(&id).cloned().unwrap_or_default())
+        tcx.arena.alloc(tcx.glob_map.get(&id).cloned().unwrap_or_default())
     };
 
     providers.lookup_stability = |tcx, id| {

--- a/src/librustc_middle/ty/mod.rs
+++ b/src/librustc_middle/ty/mod.rs
@@ -29,7 +29,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_data_structures::sorted_map::SortedIndexMultiMap;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
-use rustc_data_structures::sync::{self, par_iter, Lrc, ParallelIterator};
+use rustc_data_structures::sync::{self, par_iter, ParallelIterator};
 use rustc_hir as hir;
 use rustc_hir::def::{CtorKind, CtorOf, DefKind, Namespace, Res};
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, LocalDefId, CRATE_DEF_INDEX};
@@ -2760,22 +2760,7 @@ impl BorrowKind {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum Attributes<'tcx> {
-    Owned(Lrc<[ast::Attribute]>),
-    Borrowed(&'tcx [ast::Attribute]),
-}
-
-impl<'tcx> ::std::ops::Deref for Attributes<'tcx> {
-    type Target = [ast::Attribute];
-
-    fn deref(&self) -> &[ast::Attribute] {
-        match self {
-            &Attributes::Owned(ref data) => &data,
-            &Attributes::Borrowed(data) => data,
-        }
-    }
-}
+pub type Attributes<'tcx> = &'tcx [ast::Attribute];
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ImplOverlapKind {
@@ -3011,9 +2996,9 @@ impl<'tcx> TyCtxt<'tcx> {
     /// Gets the attributes of a definition.
     pub fn get_attrs(self, did: DefId) -> Attributes<'tcx> {
         if let Some(id) = self.hir().as_local_hir_id(did) {
-            Attributes::Borrowed(self.hir().attrs(id))
+            self.hir().attrs(id)
         } else {
-            Attributes::Borrowed(self.item_attrs(did))
+            self.item_attrs(did)
         }
     }
 

--- a/src/librustc_middle/ty/mod.rs
+++ b/src/librustc_middle/ty/mod.rs
@@ -3013,7 +3013,7 @@ impl<'tcx> TyCtxt<'tcx> {
         if let Some(id) = self.hir().as_local_hir_id(did) {
             Attributes::Borrowed(self.hir().attrs(id))
         } else {
-            Attributes::Owned(self.item_attrs(did))
+            Attributes::Borrowed(self.item_attrs(did))
         }
     }
 

--- a/src/librustc_mir/monomorphize/partitioning.rs
+++ b/src/librustc_mir/monomorphize/partitioning.rs
@@ -94,7 +94,6 @@
 
 use std::cmp;
 use std::collections::hash_map::Entry;
-use std::sync::Arc;
 
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::sync;
@@ -883,7 +882,7 @@ where
 fn collect_and_partition_mono_items(
     tcx: TyCtxt<'_>,
     cnum: CrateNum,
-) -> (Arc<DefIdSet>, Arc<Vec<Arc<CodegenUnit<'_>>>>) {
+) -> (&'tcx DefIdSet, &'tcx [CodegenUnit<'_>]) {
     assert_eq!(cnum, LOCAL_CRATE);
 
     let collection_mode = match tcx.sess.opts.debugging_opts.print_mono_items {
@@ -921,10 +920,12 @@ fn collect_and_partition_mono_items(
     let (codegen_units, _) = tcx.sess.time("partition_and_assert_distinct_symbols", || {
         sync::join(
             || {
-                partition(tcx, items.iter().cloned(), tcx.sess.codegen_units(), &inlining_map)
-                    .into_iter()
-                    .map(Arc::new)
-                    .collect::<Vec<_>>()
+                &*tcx.arena.alloc_from_iter(partition(
+                    tcx,
+                    items.iter().cloned(),
+                    tcx.sess.codegen_units(),
+                    &inlining_map,
+                ))
             },
             || assert_symbols_are_distinct(tcx, items.iter()),
         )
@@ -942,7 +943,7 @@ fn collect_and_partition_mono_items(
     if tcx.sess.opts.debugging_opts.print_mono_items.is_some() {
         let mut item_to_cgus: FxHashMap<_, Vec<_>> = Default::default();
 
-        for cgu in &codegen_units {
+        for cgu in codegen_units {
             for (&mono_item, &linkage) in cgu.items() {
                 item_to_cgus.entry(mono_item).or_default().push((cgu.name(), linkage));
             }
@@ -990,7 +991,7 @@ fn collect_and_partition_mono_items(
         }
     }
 
-    (Arc::new(mono_items), Arc::new(codegen_units))
+    (tcx.arena.alloc(mono_items), codegen_units)
 }
 
 pub fn provide(providers: &mut Providers<'_>) {
@@ -1005,7 +1006,6 @@ pub fn provide(providers: &mut Providers<'_>) {
         let (_, all) = tcx.collect_and_partition_mono_items(LOCAL_CRATE);
         all.iter()
             .find(|cgu| cgu.name() == name)
-            .cloned()
             .unwrap_or_else(|| panic!("failed to find cgu with name {:?}", name))
     };
 }

--- a/src/librustc_passes/reachable.rs
+++ b/src/librustc_passes/reachable.rs
@@ -6,7 +6,6 @@
 // reachable as well.
 
 use rustc_data_structures::fx::FxHashSet;
-use rustc_data_structures::sync::Lrc;
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::LOCAL_CRATE;
@@ -375,7 +374,7 @@ impl<'a, 'tcx> ItemLikeVisitor<'tcx> for CollectPrivateImplItemsVisitor<'a, 'tcx
     }
 }
 
-fn reachable_set(tcx: TyCtxt<'_>, crate_num: CrateNum) -> Lrc<HirIdSet> {
+fn reachable_set<'tcx>(tcx: TyCtxt<'tcx>, crate_num: CrateNum) -> &'tcx HirIdSet {
     debug_assert!(crate_num == LOCAL_CRATE);
 
     let access_levels = &tcx.privacy_access_levels(LOCAL_CRATE);
@@ -421,7 +420,7 @@ fn reachable_set(tcx: TyCtxt<'_>, crate_num: CrateNum) -> Lrc<HirIdSet> {
     debug!("Inline reachability shows: {:?}", reachable_context.reachable_symbols);
 
     // Return the set of reachable symbols.
-    Lrc::new(reachable_context.reachable_symbols)
+    tcx.arena.alloc(reachable_context.reachable_symbols)
 }
 
 pub fn provide(providers: &mut Providers<'_>) {

--- a/src/librustc_trait_selection/traits/object_safety.rs
+++ b/src/librustc_trait_selection/traits/object_safety.rs
@@ -47,13 +47,17 @@ pub fn astconv_object_safety_violations(
     violations
 }
 
-fn object_safety_violations(tcx: TyCtxt<'_>, trait_def_id: DefId) -> Vec<ObjectSafetyViolation> {
+fn object_safety_violations(
+    tcx: TyCtxt<'tcx>,
+    trait_def_id: DefId,
+) -> &'tcx [ObjectSafetyViolation] {
     debug_assert!(tcx.generics_of(trait_def_id).has_self);
     debug!("object_safety_violations: {:?}", trait_def_id);
 
-    traits::supertrait_def_ids(tcx, trait_def_id)
-        .flat_map(|def_id| object_safety_violations_for_trait(tcx, def_id))
-        .collect()
+    tcx.arena.alloc_from_iter(
+        traits::supertrait_def_ids(tcx, trait_def_id)
+            .flat_map(|def_id| object_safety_violations_for_trait(tcx, def_id)),
+    )
 }
 
 /// We say a method is *vtable safe* if it can be invoked on a trait

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1582,7 +1582,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     tcx,
                     span,
                     item.trait_ref().def_id(),
-                    object_safety_violations,
+                    &object_safety_violations[..],
                 )
                 .emit();
                 return tcx.types.err;

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2178,13 +2178,9 @@ impl Clean<Vec<Item>> for doctree::ExternCrate<'_> {
 
             let res = Res::Def(DefKind::Mod, DefId { krate: self.cnum, index: CRATE_DEF_INDEX });
 
-            if let Some(items) = inline::try_inline(
-                cx,
-                res,
-                self.name,
-                Some(rustc_middle::ty::Attributes::Borrowed(self.attrs)),
-                &mut visited,
-            ) {
+            if let Some(items) =
+                inline::try_inline(cx, res, self.name, Some(self.attrs), &mut visited)
+            {
                 return items;
             }
         }
@@ -2245,13 +2241,9 @@ impl Clean<Vec<Item>> for doctree::Import<'_> {
             }
             if !denied {
                 let mut visited = FxHashSet::default();
-                if let Some(items) = inline::try_inline(
-                    cx,
-                    path.res,
-                    name,
-                    Some(rustc_middle::ty::Attributes::Borrowed(self.attrs)),
-                    &mut visited,
-                ) {
+                if let Some(items) =
+                    inline::try_inline(cx, path.res, name, Some(self.attrs), &mut visited)
+                {
                     return items;
                 }
             }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -973,10 +973,11 @@ impl<'tcx> Clean<FnDecl> for (DefId, ty::PolyFnSig<'tcx>) {
     fn clean(&self, cx: &DocContext<'_>) -> FnDecl {
         let (did, sig) = *self;
         let mut names = if cx.tcx.hir().as_local_hir_id(did).is_some() {
-            vec![].into_iter()
+            &[]
         } else {
-            cx.tcx.fn_arg_names(did).into_iter()
-        };
+            cx.tcx.fn_arg_names(did)
+        }
+        .iter();
 
         FnDecl {
             output: Return(sig.skip_binder().output().clean(cx)),

--- a/src/test/run-make-fulldeps/hotplug_codegen_backend/the_backend.rs
+++ b/src/test/run-make-fulldeps/hotplug_codegen_backend/the_backend.rs
@@ -26,7 +26,6 @@ use rustc_span::symbol::Symbol;
 use rustc_target::spec::Target;
 use std::any::Any;
 use std::path::Path;
-use std::sync::Arc;
 
 pub struct NoLlvmMetadataLoader;
 
@@ -57,7 +56,7 @@ impl CodegenBackend for TheBackend {
             tcx.arena.alloc(Default::default()) // Just a dummy
         };
         providers.is_reachable_non_generic = |_tcx, _defid| true;
-        providers.exported_symbols = |_tcx, _crate| Arc::new(Vec::new());
+        providers.exported_symbols = |_tcx, _crate| &[];
     }
 
     fn provide_extern(&self, providers: &mut Providers) {


### PR DESCRIPTION
This avoids a cloning few `Lrc` and `Vec`s in the queries.