### PR TITLE
Fix oudated comment for NamedRegionMap

### DIFF
--- a/src/librustc_resolve/late/lifetimes.rs
+++ b/src/librustc_resolve/late/lifetimes.rs
@@ -133,7 +133,7 @@ impl RegionExt for Region {
 /// that it corresponds to.
 ///
 /// FIXME. This struct gets converted to a `ResolveLifetimes` for
-/// actual use. It has the same data, but indexed by `DefIndex`.  This
+/// actual use. It has the same data, but indexed by `LocalDefId`.  This
 /// is silly.
 #[derive(Default)]
 struct NamedRegionMap {


### PR DESCRIPTION
`ResolveLifetimes` uses a `LocalDefId` since #66131.