### PR TITLE
expand_include: set `.directory` to dir of included file.

### DIFF
--- a/src/test/ui/macros/issue-69838-dir/bar.rs
+++ b/src/test/ui/macros/issue-69838-dir/bar.rs
@@ -1,0 +1,3 @@
+// ignore-test -- this is an auxiliary file as part of another test.
+
+pub fn i_am_in_bar() {}

--- a/src/test/ui/macros/issue-69838-dir/included.rs
+++ b/src/test/ui/macros/issue-69838-dir/included.rs
@@ -1,0 +1,3 @@
+// ignore-test -- this is an auxiliary file as part of another test.
+
+pub mod bar;

--- a/src/test/ui/macros/issue-69838-mods-relative-to-included-path.rs
+++ b/src/test/ui/macros/issue-69838-mods-relative-to-included-path.rs
@@ -1,0 +1,7 @@
+// check-pass
+
+include!("issue-69838-dir/included.rs");
+
+fn main() {
+    bar::i_am_in_bar();
+}


### PR DESCRIPTION
Resolves the regression noted in https://github.com/rust-lang/rust/pull/69838/#discussion_r395217057.

r? @petrochenkov 
cc @eddyb @Mark-Simulacrum 