### PR TITLE
more clippy fixes

### DIFF
--- a/src/libcore/hint.rs
+++ b/src/libcore/hint.rs
@@ -114,6 +114,6 @@ pub fn black_box<T>(dummy: T) -> T {
     // more than we want, but it's so far good enough.
     unsafe {
         asm!("" : : "r"(&dummy));
-        return dummy;
+        dummy
     }
 }

--- a/src/librustc/lint.rs
+++ b/src/librustc/lint.rs
@@ -85,7 +85,7 @@ impl LintLevelSets {
             level = cmp::min(*driver_level, level);
         }
 
-        return (level, src);
+        (level, src)
     }
 
     pub fn get_lint_id_level(

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -467,7 +467,7 @@ impl<'tcx> ScopeTree {
         }
 
         debug!("temporary_scope({:?}) = None", expr_id);
-        return None;
+        None
     }
 
     /// Returns the lifetime of the variable `id`.
@@ -498,7 +498,7 @@ impl<'tcx> ScopeTree {
 
         debug!("is_subscope_of({:?}, {:?})=true", subscope, superscope);
 
-        return true;
+        true
     }
 
     /// Returns the ID of the innermost containing body.

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1447,11 +1447,11 @@ impl<'tcx> TyCtxt<'tcx> {
             _ => return None,
         };
 
-        return Some(FreeRegionInfo {
+        Some(FreeRegionInfo {
             def_id: suitable_region_binding_scope,
             boundregion: bound_region,
             is_impl_item,
-        });
+        })
     }
 
     pub fn return_type_impl_trait(&self, scope_def_id: DefId) -> Option<(Ty<'tcx>, Span)> {

--- a/src/librustc/ty/relate.rs
+++ b/src/librustc/ty/relate.rs
@@ -440,7 +440,7 @@ pub fn super_relate_tys<R: TypeRelation<'tcx>>(
                         (Some(sz_a_val), Some(sz_b_val)) => Err(TypeError::FixedArraySize(
                             expected_found(relation, &sz_a_val, &sz_b_val),
                         )),
-                        _ => return Err(err),
+                        _ => Err(err),
                     }
                 }
             }

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1612,7 +1612,7 @@ impl<'tcx> PolyExistentialProjection<'tcx> {
     }
 
     pub fn item_def_id(&self) -> DefId {
-        return self.skip_binder().item_def_id;
+        self.skip_binder().item_def_id
     }
 }
 
@@ -2000,8 +2000,8 @@ impl<'tcx> TyS<'tcx> {
     #[inline]
     pub fn is_unsafe_ptr(&self) -> bool {
         match self.kind {
-            RawPtr(_) => return true,
-            _ => return false,
+            RawPtr(_) => true,
+            _ => false,
         }
     }
 

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -524,7 +524,7 @@ impl<'a, 'tcx> TypeFolder<'tcx> for SubstFolder<'a, 'tcx> {
             self.root_ty = None;
         }
 
-        return t1;
+        t1
     }
 
     fn fold_const(&mut self, c: &'tcx ty::Const<'tcx>) -> &'tcx ty::Const<'tcx> {

--- a/src/librustc_builtin_macros/deriving/decodable.rs
+++ b/src/librustc_builtin_macros/deriving/decodable.rs
@@ -87,7 +87,7 @@ fn decodable_substructure(
     let blkarg = cx.ident_of("_d", trait_span);
     let blkdecoder = cx.expr_ident(trait_span, blkarg);
 
-    return match *substr.fields {
+    match *substr.fields {
         StaticStruct(_, ref summary) => {
             let nfields = match *summary {
                 Unnamed(ref fields, _) => fields.len(),
@@ -178,7 +178,7 @@ fn decodable_substructure(
             )
         }
         _ => cx.bug("expected StaticEnum or StaticStruct in derive(Decodable)"),
-    };
+    }
 }
 
 /// Creates a decoder for a single enum variant/struct:

--- a/src/librustc_builtin_macros/deriving/default.rs
+++ b/src/librustc_builtin_macros/deriving/default.rs
@@ -53,7 +53,7 @@ fn default_substructure(
     let default_ident = cx.std_path(&[kw::Default, sym::Default, kw::Default]);
     let default_call = |span| cx.expr_call_global(span, default_ident.clone(), Vec::new());
 
-    return match *substr.fields {
+    match *substr.fields {
         StaticStruct(_, ref summary) => match *summary {
             Unnamed(ref fields, is_tuple) => {
                 if !is_tuple {
@@ -83,5 +83,5 @@ fn default_substructure(
             DummyResult::raw_expr(trait_span, true)
         }
         _ => cx.span_bug(trait_span, "method in `derive(Default)`"),
-    };
+    }
 }

--- a/src/librustc_builtin_macros/deriving/encodable.rs
+++ b/src/librustc_builtin_macros/deriving/encodable.rs
@@ -173,7 +173,7 @@ fn encodable_substructure(
         ],
     ));
 
-    return match *substr.fields {
+    match *substr.fields {
         Struct(_, ref fields) => {
             let emit_struct_field = cx.ident_of("emit_struct_field", trait_span);
             let mut stmts = Vec::new();
@@ -283,5 +283,5 @@ fn encodable_substructure(
         }
 
         _ => cx.bug("expected Struct or EnumMatching in derive(Encodable)"),
-    };
+    }
 }

--- a/src/librustc_builtin_macros/deriving/generic/mod.rs
+++ b/src/librustc_builtin_macros/deriving/generic/mod.rs
@@ -489,7 +489,6 @@ impl<'a> TraitDef<'a> {
                 // set earlier; see
                 // librustc_expand/expand.rs:MacroExpander::fully_expand_fragment()
                 // librustc_expand/base.rs:Annotatable::derive_allowed()
-                return;
             }
         }
     }

--- a/src/librustc_builtin_macros/format_foreign.rs
+++ b/src/librustc_builtin_macros/format_foreign.rs
@@ -359,7 +359,7 @@ pub mod printf {
         //
         // Note: `move` used to capture copies of the cursors as they are *now*.
         let fallback = move || {
-            return Some((
+            Some((
                 Substitution::Format(Format {
                     span: start.slice_between(next).unwrap(),
                     parameter: None,
@@ -371,7 +371,7 @@ pub mod printf {
                     position: InnerSpan::new(start.at, next.at),
                 }),
                 next.slice_after(),
-            ));
+            ))
         };
 
         // Next parsing state.

--- a/src/librustc_codegen_llvm/back/archive.rs
+++ b/src/librustc_codegen_llvm/back/archive.rs
@@ -146,7 +146,7 @@ impl<'a> ArchiveBuilder<'a> for LlvmArchiveBuilder<'a> {
             }
 
             // ok, don't skip this
-            return false;
+            false
         })
     }
 

--- a/src/librustc_codegen_llvm/back/bytecode.rs
+++ b/src/librustc_codegen_llvm/back/bytecode.rs
@@ -83,7 +83,7 @@ pub fn encode(identifier: &str, bytecode: &[u8]) -> Vec<u8> {
         encoded.push(0);
     }
 
-    return encoded;
+    encoded
 }
 
 pub struct DecodedBytecode<'a> {
@@ -132,7 +132,7 @@ impl<'a> DecodedBytecode<'a> {
     pub fn bytecode(&self) -> Vec<u8> {
         let mut data = Vec::new();
         DeflateDecoder::new(self.encoded_bytecode).read_to_end(&mut data).unwrap();
-        return data;
+        data
     }
 
     pub fn identifier(&self) -> &'a str {

--- a/src/librustc_codegen_llvm/common.rs
+++ b/src/librustc_codegen_llvm/common.rs
@@ -96,15 +96,11 @@ impl BackendTypes for CodegenCx<'ll, 'tcx> {
 
 impl CodegenCx<'ll, 'tcx> {
     pub fn const_array(&self, ty: &'ll Type, elts: &[&'ll Value]) -> &'ll Value {
-        unsafe {
-            return llvm::LLVMConstArray(ty, elts.as_ptr(), elts.len() as c_uint);
-        }
+        unsafe { llvm::LLVMConstArray(ty, elts.as_ptr(), elts.len() as c_uint) }
     }
 
     pub fn const_vector(&self, elts: &[&'ll Value]) -> &'ll Value {
-        unsafe {
-            return llvm::LLVMConstVector(elts.as_ptr(), elts.len() as c_uint);
-        }
+        unsafe { llvm::LLVMConstVector(elts.as_ptr(), elts.len() as c_uint) }
     }
 
     pub fn const_bytes(&self, bytes: &[u8]) -> &'ll Value {
@@ -330,7 +326,7 @@ pub fn val_ty(v: &Value) -> &Type {
 pub fn bytes_in_context(llcx: &'ll llvm::Context, bytes: &[u8]) -> &'ll Value {
     unsafe {
         let ptr = bytes.as_ptr() as *const c_char;
-        return llvm::LLVMConstStringInContext(llcx, ptr, bytes.len() as c_uint, True);
+        llvm::LLVMConstStringInContext(llcx, ptr, bytes.len() as c_uint, True)
     }
 }
 

--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -800,7 +800,7 @@ impl CodegenCx<'b, 'tcx> {
             ifn!("llvm.dbg.declare", fn(self.type_metadata(), self.type_metadata()) -> void);
             ifn!("llvm.dbg.value", fn(self.type_metadata(), t_i64, self.type_metadata()) -> void);
         }
-        return None;
+        None
     }
 }
 

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -203,7 +203,7 @@ impl TypeMap<'ll, 'tcx> {
         let key = self.unique_id_interner.intern(&unique_type_id);
         self.type_to_unique_id.insert(type_, UniqueTypeId(key));
 
-        return UniqueTypeId(key);
+        UniqueTypeId(key)
     }
 
     /// Gets the `UniqueTypeId` for an enum variant. Enum variants are not really
@@ -314,7 +314,7 @@ impl RecursiveTypeDescription<'ll, 'tcx> {
                     member_holding_stub,
                     member_descriptions,
                 );
-                return MetadataCreationResult::new(metadata_stub, true);
+                MetadataCreationResult::new(metadata_stub, true)
             }
         }
     }
@@ -364,7 +364,7 @@ fn fixed_vec_metadata(
         )
     };
 
-    return MetadataCreationResult::new(metadata, false);
+    MetadataCreationResult::new(metadata, false)
 }
 
 fn vec_slice_metadata(
@@ -445,7 +445,7 @@ fn subroutine_type_metadata(
 
     return_if_metadata_created_in_meantime!(cx, unique_type_id);
 
-    return MetadataCreationResult::new(
+    MetadataCreationResult::new(
         unsafe {
             llvm::LLVMRustDIBuilderCreateSubroutineType(
                 DIB(cx),
@@ -454,7 +454,7 @@ fn subroutine_type_metadata(
             )
         },
         false,
-    );
+    )
 }
 
 // FIXME(1563): This is all a bit of a hack because 'trait pointer' is an ill-
@@ -781,7 +781,7 @@ fn file_metadata_raw(
     let key = (file_name, directory);
 
     match debug_context(cx).created_files.borrow_mut().entry(key) {
-        Entry::Occupied(o) => return o.get(),
+        Entry::Occupied(o) => o.get(),
         Entry::Vacant(v) => {
             let (file_name, directory) = v.key();
             debug!("file_metadata: file_name: {:?}, directory: {:?}", file_name, directory);
@@ -831,7 +831,7 @@ fn basic_type_metadata(cx: &CodegenCx<'ll, 'tcx>, t: Ty<'tcx>) -> &'ll DIType {
         )
     };
 
-    return ty_metadata;
+    ty_metadata
 }
 
 fn foreign_type_metadata(
@@ -1273,11 +1273,11 @@ fn prepare_union_metadata(
 fn use_enum_fallback(cx: &CodegenCx<'_, '_>) -> bool {
     // On MSVC we have to use the fallback mode, because LLVM doesn't
     // lower variant parts to PDB.
-    return cx.sess().target.target.options.is_like_msvc
+    cx.sess().target.target.options.is_like_msvc
         // LLVM version 7 did not release with an important bug fix;
         // but the required patch is in the LLVM 8.  Rust LLVM reports
         // 8 as well.
-        || llvm_util::get_major_version() < 8;
+        || llvm_util::get_major_version() < 8
 }
 
 // FIXME(eddyb) maybe precompute this? Right now it's computed once
@@ -2075,7 +2075,7 @@ fn prepare_enum_metadata(
         }
     };
 
-    return create_and_register_recursive_type_forward_declaration(
+    create_and_register_recursive_type_forward_declaration(
         cx,
         enum_type,
         unique_type_id,
@@ -2088,7 +2088,7 @@ fn prepare_enum_metadata(
             containing_scope,
             span,
         }),
-    );
+    )
 }
 
 /// Creates debug information for a composite type, that is, anything that

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -444,7 +444,7 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
                 vec![]
             };
 
-            return create_DIArray(DIB(cx), &template_params[..]);
+            create_DIArray(DIB(cx), &template_params[..])
         }
 
         fn get_parameter_names(cx: &CodegenCx<'_, '_>, generics: &ty::Generics) -> Vec<Symbol> {

--- a/src/librustc_codegen_llvm/debuginfo/utils.rs
+++ b/src/librustc_codegen_llvm/debuginfo/utils.rs
@@ -24,9 +24,7 @@ pub fn is_node_local_to_unit(cx: &CodegenCx<'_, '_>, def_id: DefId) -> bool {
 
 #[allow(non_snake_case)]
 pub fn create_DIArray(builder: &DIBuilder<'ll>, arr: &[Option<&'ll DIDescriptor>]) -> &'ll DIArray {
-    return unsafe {
-        llvm::LLVMRustDIBuilderGetOrCreateArray(builder, arr.as_ptr(), arr.len() as u32)
-    };
+    unsafe { llvm::LLVMRustDIBuilderGetOrCreateArray(builder, arr.as_ptr(), arr.len() as u32) }
 }
 
 #[inline]

--- a/src/librustc_codegen_llvm/llvm/archive_ro.rs
+++ b/src/librustc_codegen_llvm/llvm/archive_ro.rs
@@ -27,13 +27,13 @@ impl ArchiveRO {
     /// If this archive is used with a mutable method, then an error will be
     /// raised.
     pub fn open(dst: &Path) -> Result<ArchiveRO, String> {
-        return unsafe {
+        unsafe {
             let s = path_to_c_string(dst);
             let ar = super::LLVMRustOpenArchive(s.as_ptr()).ok_or_else(|| {
                 super::last_error().unwrap_or_else(|| "failed to open archive".to_owned())
             })?;
             Ok(ArchiveRO { raw: ar })
-        };
+        }
     }
 
     pub fn iter(&self) -> Iter<'_> {

--- a/src/librustc_codegen_ssa/back/command.rs
+++ b/src/librustc_codegen_ssa/back/command.rs
@@ -119,7 +119,7 @@ impl Command {
         for k in &self.env_remove {
             ret.env_remove(k);
         }
-        return ret;
+        ret
     }
 
     // extensions

--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -852,7 +852,7 @@ impl CrateInfo {
             info.missing_lang_items.insert(cnum, missing);
         }
 
-        return info;
+        info
     }
 }
 
@@ -887,7 +887,7 @@ pub fn provide_both(providers: &mut Providers<'_>) {
                 }
             }
         }
-        return tcx.sess.opts.optimize;
+        tcx.sess.opts.optimize
     };
 
     providers.dllimport_foreign_items = |tcx, krate| {

--- a/src/librustc_data_structures/graph/dominators/mod.rs
+++ b/src/librustc_data_structures/graph/dominators/mod.rs
@@ -125,9 +125,9 @@ impl<'dom, Node: Idx> Iterator for Iter<'dom, Node> {
             } else {
                 self.node = Some(dom);
             }
-            return Some(node);
+            Some(node)
         } else {
-            return None;
+            None
         }
     }
 }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -752,7 +752,7 @@ impl RustcDefaultCalls {
                 PrintRequest::NativeStaticLibs => {}
             }
         }
-        return Compilation::Stop;
+        Compilation::Stop
     }
 }
 

--- a/src/librustc_incremental/assert_module_sources.rs
+++ b/src/librustc_incremental/assert_module_sources.rs
@@ -175,6 +175,6 @@ impl AssertModuleSource<'tcx> {
             return true;
         }
         debug!("check_config: no match found");
-        return false;
+        false
     }
 }

--- a/src/librustc_incremental/persist/save.rs
+++ b/src/librustc_incremental/persist/save.rs
@@ -132,7 +132,6 @@ where
         }
         Err(err) => {
             sess.err(&format!("failed to write dep-graph to `{}`: {}", path_buf.display(), err));
-            return;
         }
     }
 }

--- a/src/librustc_infer/infer/equate.rs
+++ b/src/librustc_infer/infer/equate.rs
@@ -136,7 +136,7 @@ impl TypeRelation<'tcx> for Equate<'combine, 'infcx, 'tcx> {
         } else {
             // Fast path for the common case.
             self.relate(a.skip_binder(), b.skip_binder())?;
-            return Ok(a.clone());
+            Ok(a.clone())
         }
     }
 }

--- a/src/librustc_infer/infer/error_reporting/nice_region_error/different_lifetimes.rs
+++ b/src/librustc_infer/infer/error_reporting/nice_region_error/different_lifetimes.rs
@@ -142,6 +142,6 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
             .span_label(span_2, String::new())
             .span_label(span, span_label)
             .emit();
-        return Some(ErrorReported);
+        Some(ErrorReported)
     }
 }

--- a/src/librustc_infer/infer/higher_ranked/mod.rs
+++ b/src/librustc_infer/infer/higher_ranked/mod.rs
@@ -30,7 +30,7 @@ impl<'a, 'tcx> CombineFields<'a, 'tcx> {
 
         let span = self.trace.cause.span;
 
-        return self.infcx.commit_if_ok(|snapshot| {
+        self.infcx.commit_if_ok(|snapshot| {
             // First, we instantiate each bound region in the supertype with a
             // fresh placeholder region.
             let (b_prime, placeholder_map) = self.infcx.replace_bound_vars_with_placeholders(b);
@@ -53,7 +53,7 @@ impl<'a, 'tcx> CombineFields<'a, 'tcx> {
             debug!("higher_ranked_sub: OK result={:?}", result);
 
             Ok(ty::Binder::bind(result))
-        });
+        })
     }
 }
 

--- a/src/librustc_infer/infer/lexical_region_resolve/mod.rs
+++ b/src/librustc_infer/infer/lexical_region_resolve/mod.rs
@@ -452,12 +452,10 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
                 debug!("Expanding value of {:?} from {:?} to {:?}", b_vid, cur_region, lub);
 
                 *b_data = VarValue::Value(lub);
-                return true;
+                true
             }
 
-            VarValue::ErrorValue => {
-                return false;
-            }
+            VarValue::ErrorValue => false,
         }
     }
 
@@ -804,7 +802,7 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
             }
         }
 
-        return graph;
+        graph
     }
 
     fn collect_error_for_expanding_node(

--- a/src/librustc_infer/infer/nll_relate/mod.rs
+++ b/src/librustc_infer/infer/nll_relate/mod.rs
@@ -877,7 +877,7 @@ where
                     // If sub-roots are equal, then `for_vid` and
                     // `vid` are related via subtyping.
                     debug!("TypeGeneralizer::tys: occurs check failed");
-                    return Err(TypeError::Mismatch);
+                    Err(TypeError::Mismatch)
                 } else {
                     match variables.probe(vid) {
                         TypeVariableValue::Known { value: u } => {
@@ -898,7 +898,7 @@ where
 
                             let u = self.tcx().mk_ty_var(new_var_id);
                             debug!("generalize: replacing original vid={:?} with new={:?}", vid, u);
-                            return Ok(u);
+                            Ok(u)
                         }
                     }
                 }

--- a/src/librustc_infer/infer/region_constraints/mod.rs
+++ b/src/librustc_infer/infer/region_constraints/mod.rs
@@ -505,7 +505,7 @@ impl<'tcx> RegionConstraintCollector<'tcx> {
             self.undo_log.push(AddVar(vid));
         }
         debug!("created new region variable {:?} in {:?} with origin {:?}", vid, universe, origin);
-        return vid;
+        vid
     }
 
     /// Returns the universe for the given variable.

--- a/src/librustc_lexer/src/lib.rs
+++ b/src/librustc_lexer/src/lib.rs
@@ -527,10 +527,10 @@ impl Cursor<'_> {
         if self.first() == '\'' {
             self.bump();
             let kind = Char { terminated: true };
-            return Literal { kind, suffix_start: self.len_consumed() };
+            Literal { kind, suffix_start: self.len_consumed() }
+        } else {
+            Lifetime { starts_with_number }
         }
-
-        return Lifetime { starts_with_number };
     }
 
     fn single_quoted_string(&mut self) -> bool {

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -269,7 +269,7 @@ impl EarlyLintPass for UnsafeCode {
                 })
             }
 
-            _ => return,
+            _ => {}
         }
     }
 

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -273,7 +273,6 @@ fn lint_int_literal<'a, 'tcx>(
                     cx.sess()
                         .source_map()
                         .span_to_snippet(lit.span)
-                        .ok()
                         .expect("must get snippet from literal"),
                     t.name_str(),
                     min,
@@ -338,7 +337,6 @@ fn lint_uint_literal<'a, 'tcx>(
                     cx.sess()
                         .source_map()
                         .span_to_snippet(lit.span)
-                        .ok()
                         .expect("must get snippet from literal"),
                     t.name_str(),
                     min,

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -543,7 +543,7 @@ impl EarlyLintPass for UnusedParens {
             // Do not lint on `(..)` as that will result in the other arms being useless.
             Paren(_)
             // The other cases do not contain sub-patterns.
-            | Wild | Rest | Lit(..) | MacCall(..) | Range(..) | Ident(.., None) | Path(..) => return,
+            | Wild | Rest | Lit(..) | MacCall(..) | Range(..) | Ident(.., None) | Path(..) => {},
             // These are list-like patterns; parens can always be removed.
             TupleStruct(_, ps) | Tuple(ps) | Slice(ps) | Or(ps) => for p in ps {
                 self.check_unused_parens_pat(cx, p, false, false);

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -264,7 +264,7 @@ impl<'a> CrateLoader<'a> {
                 ret = Some(cnum);
             }
         });
-        return ret;
+        ret
     }
 
     fn verify_no_symbol_conflicts(&self, span: Span, root: &CrateRoot<'_>) {

--- a/src/librustc_metadata/foreign_modules.rs
+++ b/src/librustc_metadata/foreign_modules.rs
@@ -6,7 +6,7 @@ use rustc_hir::itemlikevisit::ItemLikeVisitor;
 crate fn collect(tcx: TyCtxt<'_>) -> Vec<ForeignModule> {
     let mut collector = Collector { tcx, modules: Vec::new() };
     tcx.hir().krate().visit_all_item_likes(&mut collector);
-    return collector.modules;
+    collector.modules
 }
 
 struct Collector<'tcx> {

--- a/src/librustc_metadata/link_args.rs
+++ b/src/librustc_metadata/link_args.rs
@@ -16,7 +16,7 @@ crate fn collect(tcx: TyCtxt<'_>) -> Vec<String> {
         }
     }
 
-    return collector.args;
+    collector.args
 }
 
 struct Collector {

--- a/src/librustc_metadata/locator.rs
+++ b/src/librustc_metadata/locator.rs
@@ -949,7 +949,7 @@ fn get_metadata_section(
     let start = Instant::now();
     let ret = get_metadata_section_imp(target, flavor, filename, loader);
     info!("reading {:?} => {:?}", filename.file_name().unwrap(), start.elapsed());
-    return ret;
+    ret
 }
 
 /// A trivial wrapper for `Mmap` that implements `StableDeref`.

--- a/src/librustc_metadata/native_libs.rs
+++ b/src/librustc_metadata/native_libs.rs
@@ -15,7 +15,7 @@ crate fn collect(tcx: TyCtxt<'_>) -> Vec<NativeLibrary> {
     let mut collector = Collector { tcx, libs: Vec::new() };
     tcx.hir().krate().visit_all_item_likes(&mut collector);
     collector.process_command_line();
-    return collector.libs;
+    collector.libs
 }
 
 crate fn relevant_lib(sess: &Session, lib: &NativeLibrary) -> bool {

--- a/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
+++ b/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
@@ -170,7 +170,7 @@ provide! { <'tcx> tcx, def_id, other, cdata,
             .iter()
             .filter_map(|&(exported_symbol, export_level)| {
                 if let ExportedSymbol::NonGeneric(def_id) = exported_symbol {
-                    return Some((def_id, export_level))
+                    Some((def_id, export_level))
                 } else {
                     None
                 }

--- a/src/librustc_mir/borrow_check/borrow_set.rs
+++ b/src/librustc_mir/borrow_check/borrow_set.rs
@@ -273,7 +273,7 @@ impl<'a, 'tcx> Visitor<'tcx> for GatherBorrows<'a, 'tcx> {
             assert_eq!(borrow_data.borrowed_place, *place);
         }
 
-        return self.super_rvalue(rvalue, location);
+        self.super_rvalue(rvalue, location)
     }
 }
 

--- a/src/librustc_mir/borrow_check/diagnostics/region_name.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/region_name.rs
@@ -500,7 +500,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
             }
         }
 
-        return None;
+        None
     }
 
     /// We've found an enum/struct/union type with the substitutions

--- a/src/librustc_mir/const_eval/machine.rs
+++ b/src/librustc_mir/const_eval/machine.rs
@@ -56,7 +56,7 @@ impl<'mir, 'tcx> InterpCx<'mir, 'tcx, CompileTimeInterpreter<'mir, 'tcx>> {
 
         self.return_to_block(ret.map(|r| r.1))?;
         self.dump_place(*dest);
-        return Ok(true);
+        Ok(true)
     }
 
     /// "Intercept" a function call to a panic-related function

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -122,7 +122,7 @@ pub(crate) fn has_rustc_mir_with(attrs: &[ast::Attribute], name: Symbol) -> Opti
             }
         }
     }
-    return None;
+    None
 }
 
 pub struct MoveDataParamEnv<'tcx> {
@@ -171,7 +171,7 @@ where
                     return None;
                 }
             }
-            return None;
+            None
         };
 
         let print_preflow_to = name_found(tcx.sess, attributes, sym::borrowck_graphviz_preflow);

--- a/src/librustc_mir/interpret/operator.rs
+++ b/src/librustc_mir/interpret/operator.rs
@@ -64,7 +64,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             Ge => l >= r,
             _ => bug!("Invalid operation on char: {:?}", bin_op),
         };
-        return (Scalar::from_bool(res), false, self.tcx.types.bool);
+        (Scalar::from_bool(res), false, self.tcx.types.bool)
     }
 
     fn binary_bool_op(
@@ -87,7 +87,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             BitXor => l ^ r,
             _ => bug!("Invalid operation on bool: {:?}", bin_op),
         };
-        return (Scalar::from_bool(res), false, self.tcx.types.bool);
+        (Scalar::from_bool(res), false, self.tcx.types.bool)
     }
 
     fn binary_float_op<F: Float + Into<Scalar<M::PointerTag>>>(
@@ -113,7 +113,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             Rem => ((l % r).value.into(), ty),
             _ => bug!("invalid float op: `{:?}`", bin_op),
         };
-        return (val, false, ty);
+        (val, false, ty)
     }
 
     fn binary_int_op(

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -212,9 +212,7 @@ impl<'tcx, Tag> MPlaceTy<'tcx, Tag> {
         if self.layout.is_unsized() {
             // We need to consult `meta` metadata
             match self.layout.ty.kind {
-                ty::Slice(..) | ty::Str => {
-                    return self.mplace.meta.unwrap_meta().to_machine_usize(cx);
-                }
+                ty::Slice(..) | ty::Str => self.mplace.meta.unwrap_meta().to_machine_usize(cx),
                 _ => bug!("len not supported on unsized type {:?}", self.layout.ty),
             }
         } else {

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -240,7 +240,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         match instance.def {
             ty::InstanceDef::Intrinsic(..) => {
                 assert!(caller_abi == Abi::RustIntrinsic || caller_abi == Abi::PlatformIntrinsic);
-                return M::call_intrinsic(self, span, instance, args, ret, unwind);
+                M::call_intrinsic(self, span, instance, args, ret, unwind)
             }
             ty::InstanceDef::VtableShim(..)
             | ty::InstanceDef::ReifyShim(..)

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -751,7 +751,7 @@ fn should_monomorphize_locally<'tcx>(tcx: TyCtxt<'tcx>, instance: &Instance<'tcx
         bug!("cannot create local mono-item for {:?}", def_id)
     }
 
-    return true;
+    true
 }
 
 /// For a given pair of source and target type that occur in an unsizing coercion,

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -483,7 +483,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
             err.span_label(source_info.span, format!("{:?}", panic));
             err.emit()
         });
-        return None;
+        None
     }
 
     fn check_unary_op(

--- a/src/librustc_mir_build/build/mod.rs
+++ b/src/librustc_mir_build/build/mod.rs
@@ -43,8 +43,7 @@ fn mir_build(tcx: TyCtxt<'_>, def_id: DefId) -> BodyAndCache<'_> {
             ..
         })
         | Node::TraitItem(hir::TraitItem {
-            kind:
-                hir::TraitItemKind::Fn(hir::FnSig { decl, .. }, hir::TraitFn::Provided(body_id)),
+            kind: hir::TraitItemKind::Fn(hir::FnSig { decl, .. }, hir::TraitFn::Provided(body_id)),
             ..
         }) => (*body_id, decl.output.span()),
         Node::Item(hir::Item { kind: hir::ItemKind::Static(ty, _, body_id), .. })
@@ -368,7 +367,7 @@ impl BlockContext {
             }
         }
 
-        return None;
+        None
     }
 
     /// Looks at the topmost frame on the BlockContext and reports

--- a/src/librustc_mir_build/hair/cx/block.rs
+++ b/src/librustc_mir_build/hair/cx/block.rs
@@ -98,7 +98,7 @@ fn mirror_stmts<'a, 'tcx>(
             }
         }
     }
-    return result;
+    result
 }
 
 crate fn to_expr_ref<'a, 'tcx>(

--- a/src/librustc_parse/lib.rs
+++ b/src/librustc_parse/lib.rs
@@ -320,7 +320,7 @@ pub fn nt_to_tokenstream(nt: &Nonterminal, sess: &ParseSess, span: Span) -> Toke
                 going with stringified version"
         );
     }
-    return tokens_for_real;
+    tokens_for_real
 }
 
 fn prepend_attrs(

--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -996,7 +996,7 @@ impl<'a> Parser<'a> {
                 let expr = self.mk_expr(lo.to(self.prev_token.span), ExprKind::Lit(literal), attrs);
                 self.maybe_recover_from_bad_qpath(expr, true)
             }
-            None => return Err(self.expected_expression_found()),
+            None => Err(self.expected_expression_found()),
         }
     }
 
@@ -1713,7 +1713,7 @@ impl<'a> Parser<'a> {
         }
         let hi = self.token.span;
         self.bump();
-        return Ok(self.mk_expr(lo.to(hi), ExprKind::Match(scrutinee, arms), attrs));
+        Ok(self.mk_expr(lo.to(hi), ExprKind::Match(scrutinee, arms), attrs))
     }
 
     pub(super) fn parse_arm(&mut self) -> PResult<'a, Arm> {

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -314,7 +314,7 @@ impl<'a> Parser<'a> {
                 " struct ".into(),
                 Applicability::MaybeIncorrect, // speculative
             );
-            return Err(err);
+            Err(err)
         } else if self.look_ahead(1, |t| *t == token::OpenDelim(token::Paren)) {
             let ident = self.parse_ident().unwrap();
             self.bump(); // `(`
@@ -362,7 +362,7 @@ impl<'a> Parser<'a> {
                     );
                 }
             }
-            return Err(err);
+            Err(err)
         } else if self.look_ahead(1, |t| *t == token::Lt) {
             let ident = self.parse_ident().unwrap();
             self.eat_to_tokens(&[&token::Gt]);
@@ -384,7 +384,7 @@ impl<'a> Parser<'a> {
                     Applicability::MachineApplicable,
                 );
             }
-            return Err(err);
+            Err(err)
         } else {
             Ok(())
         }
@@ -910,7 +910,7 @@ impl<'a> Parser<'a> {
         let span = self.sess.source_map().def_span(span);
         let msg = format!("{} is not supported in {}", kind.descr(), ctx);
         self.struct_span_err(span, &msg).emit();
-        return None;
+        None
     }
 
     fn error_on_foreign_const(&self, span: Span, ident: Ident) {

--- a/src/librustc_parse/parser/pat.rs
+++ b/src/librustc_parse/parser/pat.rs
@@ -918,7 +918,7 @@ impl<'a> Parser<'a> {
             }
             err.emit();
         }
-        return Ok((fields, etc));
+        Ok((fields, etc))
     }
 
     /// Recover on `...` as if it were `..` to avoid further errors.

--- a/src/librustc_parse/parser/stmt.rs
+++ b/src/librustc_parse/parser/stmt.rs
@@ -278,7 +278,7 @@ impl<'a> Parser<'a> {
             _ => {}
         }
         e.span_label(sp, "expected `{`");
-        return Err(e);
+        Err(e)
     }
 
     /// Parses a block. Inner attributes are allowed.

--- a/src/librustc_passes/liveness.rs
+++ b/src/librustc_passes/liveness.rs
@@ -864,7 +864,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
             first_merge,
             any_changed
         );
-        return any_changed;
+        any_changed
     }
 
     // Indicates that a local variable was *defined*; we know that no

--- a/src/librustc_passes/loops.rs
+++ b/src/librustc_passes/loops.rs
@@ -222,7 +222,7 @@ impl<'a, 'hir> CheckLoopVisitor<'a, 'hir> {
                 return true;
             }
         }
-        return false;
+        false
     }
     fn emit_unlabled_cf_in_while_condition(&mut self, span: Span, cf_type: &str) {
         struct_span_err!(

--- a/src/librustc_passes/reachable.rs
+++ b/src/librustc_passes/reachable.rs
@@ -30,9 +30,7 @@ fn item_might_be_inlined(tcx: TyCtxt<'tcx>, item: &hir::Item<'_>, attrs: Codegen
     }
 
     match item.kind {
-        hir::ItemKind::Fn(ref sig, ..) if sig.header.is_const() => {
-            return true;
-        }
+        hir::ItemKind::Fn(ref sig, ..) if sig.header.is_const() => true,
         hir::ItemKind::Impl { .. } | hir::ItemKind::Fn(..) => {
             let generics = tcx.generics_of(tcx.hir().local_def_id(item.hir_id));
             generics.requires_monomorphization(tcx)

--- a/src/librustc_passes/stability.rs
+++ b/src/librustc_passes/stability.rs
@@ -465,7 +465,7 @@ fn new_index(tcx: TyCtxt<'tcx>) -> Index<'tcx> {
             |v| intravisit::walk_crate(v, krate),
         );
     }
-    return index;
+    index
 }
 
 /// Cross-references the feature names of unstable APIs with enabled

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -1423,7 +1423,7 @@ impl<'a, 'tcx> ObsoleteVisiblePrivateTypesVisitor<'a, 'tcx> {
                 Some(_) | None => false,
             }
         } else {
-            return false;
+            false
         }
     }
 
@@ -1837,7 +1837,7 @@ impl SearchInterfaceForPrivateItemsVisitor<'tcx> {
             && self.tcx.is_private_dep(item_id.krate);
 
         log::debug!("leaks_private_dep(item_id={:?})={}", item_id, ret);
-        return ret;
+        ret
     }
 }
 

--- a/src/librustc_resolve/def_collector.rs
+++ b/src/librustc_resolve/def_collector.rs
@@ -200,7 +200,7 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
 
     fn visit_pat(&mut self, pat: &'a Pat) {
         match pat.kind {
-            PatKind::MacCall(..) => return self.visit_macro_invoc(pat.id),
+            PatKind::MacCall(..) => self.visit_macro_invoc(pat.id),
             _ => visit::walk_pat(self, pat),
         }
     }

--- a/src/librustc_resolve/imports.rs
+++ b/src/librustc_resolve/imports.rs
@@ -1108,7 +1108,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
                                     match binding.kind {
                                         // Never suggest the name that has binding error
                                         // i.e., the name that cannot be previously resolved
-                                        NameBindingKind::Res(Res::Err, _) => return None,
+                                        NameBindingKind::Res(Res::Err, _) => None,
                                         _ => Some(&i.name),
                                     }
                                 }

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -380,7 +380,7 @@ impl<'a> LateResolutionVisitor<'a, '_, '_> {
                 _ => (),
             }
         };
-        return has_self_arg;
+        has_self_arg
     }
 
     fn followed_by_brace(&self, span: Span) -> (bool, Option<(Span, String)>) {
@@ -430,7 +430,7 @@ impl<'a> LateResolutionVisitor<'a, '_, '_> {
                 break;
             }
         }
-        return (followed_by_brace, closing_brace);
+        (followed_by_brace, closing_brace)
     }
 
     /// Provides context-dependent help for errors reported by the `smart_resolve_path_fragment`

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -83,7 +83,7 @@ fn sub_namespace_match(candidate: Option<MacroKind>, requirement: Option<MacroKi
 // line-breaks and is slow.
 fn fast_print_path(path: &ast::Path) -> Symbol {
     if path.segments.len() == 1 {
-        return path.segments[0].ident.name;
+        path.segments[0].ident.name
     } else {
         let mut path_str = String::with_capacity(64);
         for (i, segment) in path.segments.iter().enumerate() {

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -534,7 +534,7 @@ impl<'l, 'tcx> SaveContext<'l, 'tcx> {
                         let variant = &def.non_enum_variant();
                         filter!(self.span_utils, ident.span);
                         let span = self.span_from_span(ident.span);
-                        return Some(Data::RefData(Ref {
+                        Some(Data::RefData(Ref {
                             kind: RefKind::Variable,
                             span,
                             ref_id: self
@@ -542,7 +542,7 @@ impl<'l, 'tcx> SaveContext<'l, 'tcx> {
                                 .find_field_index(ident, variant)
                                 .map(|index| id_from_def_id(variant.fields[index].did))
                                 .unwrap_or_else(|| null_id()),
-                        }));
+                        }))
                     }
                     ty::Tuple(..) => None,
                     _ => {

--- a/src/librustc_session/config.rs
+++ b/src/librustc_session/config.rs
@@ -1140,7 +1140,7 @@ pub fn parse_error_format(
         _ => {}
     }
 
-    return error_format;
+    error_format
 }
 
 fn parse_crate_edition(matches: &getopts::Matches) -> Edition {

--- a/src/librustc_span/caching_source_map_view.rs
+++ b/src/librustc_span/caching_source_map_view.rs
@@ -99,10 +99,6 @@ impl<'sm> CachingSourceMapView<'sm> {
         cache_entry.line_end = line_bounds.1;
         cache_entry.time_stamp = self.time_stamp;
 
-        return Some((
-            cache_entry.file.clone(),
-            cache_entry.line_number,
-            pos - cache_entry.line_start,
-        ));
+        Some((cache_entry.file.clone(), cache_entry.line_number, pos - cache_entry.line_start))
     }
 }

--- a/src/librustc_span/source_map.rs
+++ b/src/librustc_span/source_map.rs
@@ -368,7 +368,7 @@ impl SourceMap {
 
     // If there is a doctest offset, applies it to the line.
     pub fn doctest_offset_line(&self, file: &FileName, orig: usize) -> usize {
-        return match file {
+        match file {
             FileName::DocTest(_, offset) => {
                 return if *offset >= 0 {
                     orig + *offset as usize
@@ -377,7 +377,7 @@ impl SourceMap {
                 };
             }
             _ => orig,
-        };
+        }
     }
 
     /// Looks up source information about a `BytePos`.
@@ -569,10 +569,10 @@ impl SourceMap {
         let local_end = self.lookup_byte_offset(sp.hi());
 
         if local_begin.sf.start_pos != local_end.sf.start_pos {
-            return Err(SpanSnippetError::DistinctSources(DistinctSources {
+            Err(SpanSnippetError::DistinctSources(DistinctSources {
                 begin: (local_begin.sf.name.clone(), local_begin.sf.start_pos),
                 end: (local_end.sf.name.clone(), local_end.sf.start_pos),
-            }));
+            }))
         } else {
             self.ensure_source_file_source_present(local_begin.sf.clone());
 
@@ -590,13 +590,11 @@ impl SourceMap {
             }
 
             if let Some(ref src) = local_begin.sf.src {
-                return extract_source(src, start_index, end_index);
+                extract_source(src, start_index, end_index)
             } else if let Some(src) = local_begin.sf.external_src.borrow().get_source() {
-                return extract_source(src, start_index, end_index);
+                extract_source(src, start_index, end_index)
             } else {
-                return Err(SpanSnippetError::SourceNotAvailable {
-                    filename: local_begin.sf.name.clone(),
-                });
+                Err(SpanSnippetError::SourceNotAvailable { filename: local_begin.sf.name.clone() })
             }
         }
     }

--- a/src/librustc_trait_selection/traits/auto_trait.rs
+++ b/src/librustc_trait_selection/traits/auto_trait.rs
@@ -113,7 +113,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
             return AutoTraitResult::ExplicitImpl;
         }
 
-        return tcx.infer_ctxt().enter(|infcx| {
+        tcx.infer_ctxt().enter(|infcx| {
             let mut fresh_preds = FxHashSet::default();
 
             // Due to the way projections are handled by SelectionContext, we need to run
@@ -219,8 +219,8 @@ impl<'tcx> AutoTraitFinder<'tcx> {
 
             let info = AutoTraitInfo { full_user_env, region_data, vid_to_region };
 
-            return AutoTraitResult::PositiveImpl(auto_trait_callback(&infcx, info));
-        });
+            AutoTraitResult::PositiveImpl(auto_trait_callback(&infcx, info))
+        })
     }
 }
 
@@ -384,7 +384,7 @@ impl AutoTraitFinder<'tcx> {
             ty, trait_did, new_env, final_user_env
         );
 
-        return Some((new_env, final_user_env));
+        Some((new_env, final_user_env))
     }
 
     /// This method is designed to work around the following issue:
@@ -492,7 +492,7 @@ impl AutoTraitFinder<'tcx> {
                 }
                 _ => {}
             }
-            return true;
+            true
         });
 
         if should_add_new {
@@ -591,15 +591,15 @@ impl AutoTraitFinder<'tcx> {
     }
 
     fn is_param_no_infer(&self, substs: SubstsRef<'_>) -> bool {
-        return self.is_of_param(substs.type_at(0)) && !substs.types().any(|t| t.has_infer_types());
+        self.is_of_param(substs.type_at(0)) && !substs.types().any(|t| t.has_infer_types())
     }
 
     pub fn is_of_param(&self, ty: Ty<'_>) -> bool {
-        return match ty.kind {
+        match ty.kind {
             ty::Param(_) => true,
             ty::Projection(p) => self.is_of_param(p.self_ty()),
             _ => false,
-        };
+        }
     }
 
     fn is_self_referential_projection(&self, p: ty::PolyProjectionPredicate<'_>) -> bool {
@@ -804,7 +804,7 @@ impl AutoTraitFinder<'tcx> {
                 _ => panic!("Unexpected predicate {:?} {:?}", ty, predicate),
             };
         }
-        return true;
+        true
     }
 
     pub fn clean_pred(

--- a/src/librustc_trait_selection/traits/coherence.rs
+++ b/src/librustc_trait_selection/traits/coherence.rs
@@ -221,10 +221,10 @@ pub fn trait_ref_is_knowable<'tcx>(
     // we are an owner.
     if orphan_check_trait_ref(tcx, trait_ref, InCrate::Local).is_ok() {
         debug!("trait_ref_is_knowable: orphan check passed");
-        return None;
+        None
     } else {
         debug!("trait_ref_is_knowable: nonlocal, nonfundamental, unowned");
-        return Some(Conflict::Upstream);
+        Some(Conflict::Upstream)
     }
 }
 

--- a/src/librustc_trait_selection/traits/error_reporting/on_unimplemented.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/on_unimplemented.rs
@@ -111,11 +111,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             }),
             hir::Node::Expr(hir::Expr { .. }) => {
                 let parent_hid = hir.get_parent_node(hir_id);
-                if parent_hid != hir_id {
-                    return self.describe_enclosure(parent_hid);
-                } else {
-                    None
-                }
+                if parent_hid != hir_id { self.describe_enclosure(parent_hid) } else { None }
             }
             _ => None,
         }

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -351,7 +351,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             // Different to previous arm because one is `&hir::Local` and the other
             // is `P<hir::Local>`.
             Some(hir::Node::Local(local)) => get_name(err, &local.pat.kind),
-            _ => return None,
+            _ => None,
         }
     }
 

--- a/src/librustc_trait_selection/traits/query/normalize.rs
+++ b/src/librustc_trait_selection/traits/query/normalize.rs
@@ -169,12 +169,12 @@ impl<'cx, 'tcx> TypeFolder<'tcx> for QueryNormalizer<'cx, 'tcx> {
                                 debug!("QueryNormalizer: result = {:#?}", result);
                                 debug!("QueryNormalizer: obligations = {:#?}", obligations);
                                 self.obligations.extend(obligations);
-                                return result.normalized_ty;
+                                result.normalized_ty
                             }
 
                             Err(_) => {
                                 self.error = true;
-                                return ty;
+                                ty
                             }
                         }
                     }

--- a/src/librustc_trait_selection/traits/wf.rs
+++ b/src/librustc_trait_selection/traits/wf.rs
@@ -595,7 +595,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
         }
 
         // if we made it through that loop above, we made progress!
-        return true;
+        true
     }
 
     fn nominal_obligations(

--- a/src/librustc_traits/lowering/environment.rs
+++ b/src/librustc_traits/lowering/environment.rs
@@ -146,7 +146,7 @@ crate fn program_clauses_for_env<'tcx>(
 
     debug!("program_clauses_for_env: closure = {:#?}", closure);
 
-    return tcx.mk_clauses(closure.into_iter());
+    tcx.mk_clauses(closure.into_iter())
 }
 
 crate fn environment(tcx: TyCtxt<'_>, def_id: DefId) -> Environment<'_> {

--- a/src/librustc_ty/needs_drop.rs
+++ b/src/librustc_ty/needs_drop.rs
@@ -132,7 +132,7 @@ where
             }
         }
 
-        return None;
+        None
     }
 }
 

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -2128,7 +2128,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 return Err(ErrorReported);
             }
         }
-        return Ok(bound);
+        Ok(bound)
     }
 
     fn complain_about_assoc_type_not_found<I>(
@@ -2709,7 +2709,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             }
             Res::Err => {
                 self.set_tainted_by_errors();
-                return self.tcx().types.err;
+                self.tcx().types.err
             }
             _ => span_bug!(span, "unexpected resolution: {:?}", path.res),
         }
@@ -3047,7 +3047,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             )
             .emit();
         }
-        return Some(r);
+        Some(r)
     }
 }
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1580,7 +1580,7 @@ fn check_union_fields(tcx: TyCtxt<'_>, span: Span, item_def_id: DefId) -> bool {
     } else {
         span_bug!(span, "unions must be ty::Adt, but got {:?}", item_type.kind);
     }
-    return true;
+    true
 }
 
 /// Checks that an opaque type does not contain cycles and does not use `Self` or `T::Foo`
@@ -2313,7 +2313,7 @@ fn check_representable(tcx: TyCtxt<'_>, sp: Span, item_def_id: DefId) -> bool {
         }
         Representability::Representable | Representability::ContainsRecursive => (),
     }
-    return true;
+    true
 }
 
 pub fn check_simd(tcx: TyCtxt<'_>, sp: Span, def_id: DefId) {

--- a/src/librustc_typeck/coherence/inherent_impls.rs
+++ b/src/librustc_typeck/coherence/inherent_impls.rs
@@ -272,9 +272,7 @@ impl ItemLikeVisitor<'v> for InherentCollect<'tcx> {
                     item.span,
                 );
             }
-            ty::Error => {
-                return;
-            }
+            ty::Error => {}
             _ => {
                 struct_span_err!(
                     self.tcx.sess,
@@ -288,7 +286,6 @@ impl ItemLikeVisitor<'v> for InherentCollect<'tcx> {
                        to wrap it instead",
                 )
                 .emit();
-                return;
             }
         }
     }

--- a/src/librustc_typeck/collect/type_of.rs
+++ b/src/librustc_typeck/collect/type_of.rs
@@ -290,7 +290,7 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
                             DUMMY_SP,
                             &format!("unexpected const parent path {:?}", parent_node,),
                         );
-                        return tcx.types.err;
+                        tcx.types.err
                     }
                 }
 

--- a/src/librustc_typeck/impl_wf_check/min_specialization.rs
+++ b/src/librustc_typeck/impl_wf_check/min_specialization.rs
@@ -270,7 +270,7 @@ fn check_static_lifetimes<'tcx>(
     span: Span,
 ) {
     if tcx.any_free_region_meets(parent_substs, |r| *r == ty::ReStatic) {
-        tcx.sess.struct_span_err(span, &format!("cannot specialize on `'static` lifetime")).emit();
+        tcx.sess.struct_span_err(span, "cannot specialize on `'static` lifetime").emit();
     }
 }
 

--- a/src/librustdoc/passes/calculate_doc_coverage.rs
+++ b/src/librustdoc/passes/calculate_doc_coverage.rs
@@ -8,7 +8,6 @@ use rustc_ast::attr;
 use rustc_span::symbol::sym;
 use rustc_span::FileName;
 use serde::Serialize;
-use serde_json;
 
 use std::collections::BTreeMap;
 use std::ops;

--- a/src/libstd/backtrace.rs
+++ b/src/libstd/backtrace.rs
@@ -250,7 +250,7 @@ impl Backtrace {
             },
         };
         ENABLED.store(enabled as usize + 1, SeqCst);
-        return enabled;
+        enabled
     }
 
     /// Capture a stack backtrace of the current thread.

--- a/src/libstd/sys_common/backtrace.rs
+++ b/src/libstd/sys_common/backtrace.rs
@@ -28,7 +28,7 @@ pub fn lock() -> impl Drop {
 
     unsafe {
         LOCK.lock();
-        return Guard;
+        Guard
     }
 }
 


### PR DESCRIPTION
    * remove redundant returns (clippy::needless_return)
    * remove redundant import (clippy::single_component_path_imports)
    * remove redundant format!() call (clippy::useless_format)
    * don't use ok() before calling expect() (clippy::ok_expect)