### PR TITLE
Limit maximum alignment in #[repr(align)] to 4K

### DIFF
--- a/src/librustc_attr/builtin.rs
+++ b/src/librustc_attr/builtin.rs
@@ -908,11 +908,12 @@ pub fn find_repr_attrs(sess: &ParseSess, attr: &Attribute) -> Vec<ReprAttr> {
                     let parse_alignment = |node: &ast::LitKind| -> Result<u32, &'static str> {
                         if let ast::LitKind::Int(literal, ast::LitIntType::Unsuffixed) = node {
                             if literal.is_power_of_two() {
-                                // rustc::ty::layout::Align restricts align to <= 2^29
-                                if *literal <= 1 << 29 {
+                                // Many targets don't support global variables
+                                // with alignment greater than the page size.
+                                if *literal <= 4096 {
                                     Ok(*literal as u32)
                                 } else {
-                                    Err("larger than 2^29")
+                                    Err("larger than 4096")
                                 }
                             } else {
                                 Err("not a power of two")

--- a/src/test/ui/repr/repr-align.rs
+++ b/src/test/ui/repr/repr-align.rs
@@ -8,11 +8,11 @@ struct S0(i32);
                    //~| ERROR: invalid `repr(align)` attribute: not a power of two
 struct S1(i32);
 
-#[repr(align(4294967296))] //~ ERROR: invalid `repr(align)` attribute: larger than 2^29
-                           //~| ERROR: invalid `repr(align)` attribute: larger than 2^29
+#[repr(align(4294967296))] //~ ERROR: invalid `repr(align)` attribute: larger than 4096
+                           //~| ERROR: invalid `repr(align)` attribute: larger than 4096
 struct S2(i32);
 
-#[repr(align(536870912))] // ok: this is the largest accepted alignment
+#[repr(align(4096))] // ok: this is the largest accepted alignment
 struct S3(i32);
 
 #[repr(align(16.0))] //~ ERROR: invalid `repr(align)` attribute: not an unsuffixed integer
@@ -23,11 +23,11 @@ enum E0 { A, B }
                    //~| ERROR: invalid `repr(align)` attribute: not a power of two
 enum E1 { A, B }
 
-#[repr(align(4294967296))] //~ ERROR: invalid `repr(align)` attribute: larger than 2^29
-                           //~| ERROR: invalid `repr(align)` attribute: larger than 2^29
+#[repr(align(4294967296))] //~ ERROR: invalid `repr(align)` attribute: larger than 4096
+                           //~| ERROR: invalid `repr(align)` attribute: larger than 4096
 enum E2 { A, B }
 
-#[repr(align(536870912))] // ok: this is the largest accepted alignment
+#[repr(align(4096))] // ok: this is the largest accepted alignment
 enum E3 { A, B }
 
 fn main() {}

--- a/src/test/ui/repr/repr-align.stderr
+++ b/src/test/ui/repr/repr-align.stderr
@@ -10,7 +10,7 @@ error[E0589]: invalid `repr(align)` attribute: not a power of two
 LL | #[repr(align(15))]
    |        ^^^^^^^^^
 
-error[E0589]: invalid `repr(align)` attribute: larger than 2^29
+error[E0589]: invalid `repr(align)` attribute: larger than 4096
   --> $DIR/repr-align.rs:11:8
    |
 LL | #[repr(align(4294967296))]
@@ -28,7 +28,7 @@ error[E0589]: invalid `repr(align)` attribute: not a power of two
 LL | #[repr(align(15))]
    |        ^^^^^^^^^
 
-error[E0589]: invalid `repr(align)` attribute: larger than 2^29
+error[E0589]: invalid `repr(align)` attribute: larger than 4096
   --> $DIR/repr-align.rs:26:8
    |
 LL | #[repr(align(4294967296))]
@@ -46,7 +46,7 @@ error[E0589]: invalid `repr(align)` attribute: not a power of two
 LL | #[repr(align(15))]
    |        ^^^^^^^^^
 
-error[E0589]: invalid `repr(align)` attribute: larger than 2^29
+error[E0589]: invalid `repr(align)` attribute: larger than 4096
   --> $DIR/repr-align.rs:11:8
    |
 LL | #[repr(align(4294967296))]
@@ -64,7 +64,7 @@ error[E0589]: invalid `repr(align)` attribute: not a power of two
 LL | #[repr(align(15))]
    |        ^^^^^^^^^
 
-error[E0589]: invalid `repr(align)` attribute: larger than 2^29
+error[E0589]: invalid `repr(align)` attribute: larger than 4096
   --> $DIR/repr-align.rs:26:8
    |
 LL | #[repr(align(4294967296))]

--- a/src/test/ui/structs-enums/align-struct.rs
+++ b/src/test/ui/structs-enums/align-struct.rs
@@ -67,9 +67,9 @@ struct AlignContainsPacked4C {
 
 // The align limit was originally smaller (2^15).
 // Check that it works with big numbers.
-#[repr(align(0x10000))]
+#[repr(align(0x1000))]
 struct AlignLarge {
-    stuff: [u8; 0x10000],
+    stuff: [u8; 0x1000],
 }
 
 union UnionContainsAlign {
@@ -233,13 +233,13 @@ pub fn main() {
     assert!(is_aligned_to(&a, 16));
 
     let mut large = box AlignLarge {
-        stuff: [0; 0x10000],
+        stuff: [0; 0x1000],
     };
     large.stuff[0] = 132;
     *large.stuff.last_mut().unwrap() = 102;
     assert_eq!(large.stuff[0], 132);
     assert_eq!(large.stuff.last(), Some(&102));
-    assert_eq!(mem::align_of::<AlignLarge>(), 0x10000);
-    assert_eq!(mem::align_of_val(&*large), 0x10000);
-    assert!(is_aligned_to(&*large, 0x10000));
+    assert_eq!(mem::align_of::<AlignLarge>(), 0x1000);
+    assert_eq!(mem::align_of_val(&*large), 0x1000);
+    assert!(is_aligned_to(&*large, 0x1000));
 }


### PR DESCRIPTION
Let's try this on crater to see the impact.

cc #70022 #70143 #70144 