### PR TITLE
Revised span-to-lines conversion to produce an empty vec on DUMMY_SP.

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -1574,7 +1574,7 @@ impl EmitterWriter {
                 .span_to_lines(parts[0].span)
                 .expect("span_to_lines failed when emitting suggestion");
 
-            assert!(!lines.lines.is_empty());
+            assert!(!lines.lines.is_empty() || parts[0].span.is_dummy());
 
             let line_start = sm.lookup_char_pos(parts[0].span.lo()).line;
             draw_col_separator_no_space(&mut buffer, 1, max_line_num_len + 1);

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -194,7 +194,7 @@ impl CodeSuggestion {
                 let bounding_span = Span::with_root_ctxt(lo, hi);
                 // The different spans might belong to different contexts, if so ignore suggestion.
                 let lines = sm.span_to_lines(bounding_span).ok()?;
-                assert!(!lines.lines.is_empty());
+                assert!(!lines.lines.is_empty() || bounding_span.is_dummy());
 
                 // We can't splice anything if the source is unavailable.
                 if !sm.ensure_source_file_source_present(lines.file.clone()) {
@@ -213,8 +213,8 @@ impl CodeSuggestion {
                 let sf = &lines.file;
                 let mut prev_hi = sm.lookup_char_pos(bounding_span.lo());
                 prev_hi.col = CharPos::from_usize(0);
-
-                let mut prev_line = sf.get_line(lines.lines[0].line_index);
+                let mut prev_line =
+                    lines.lines.get(0).and_then(|line0| sf.get_line(line0.line_index));
                 let mut buf = String::new();
 
                 for part in &substitution.parts {

--- a/src/librustc_span/source_map.rs
+++ b/src/librustc_span/source_map.rs
@@ -535,6 +535,10 @@ impl SourceMap {
         let (lo, hi) = self.is_valid_span(sp)?;
         assert!(hi.line >= lo.line);
 
+        if sp.is_dummy() {
+            return Ok(FileLines { file: lo.file, lines: Vec::new() });
+        }
+
         let mut lines = Vec::with_capacity(hi.line - lo.line + 1);
 
         // The span starts partway through the first line,
@@ -545,6 +549,9 @@ impl SourceMap {
         // and to the end of the line. Be careful because the line
         // numbers in Loc are 1-based, so we subtract 1 to get 0-based
         // lines.
+        //
+        // FIXME: now that we handle DUMMY_SP up above, we should consider
+        // aseerting the line numbers here are all indeed 1-based.
         let hi_line = hi.line.saturating_sub(1);
         for line_index in lo.line.saturating_sub(1)..hi_line {
             let line_len = lo.file.get_line(line_index).map(|s| s.chars().count()).unwrap_or(0);

--- a/src/librustc_span/source_map.rs
+++ b/src/librustc_span/source_map.rs
@@ -551,7 +551,7 @@ impl SourceMap {
         // lines.
         //
         // FIXME: now that we handle DUMMY_SP up above, we should consider
-        // aseerting the line numbers here are all indeed 1-based.
+        // asserting that the line numbers here are all indeed 1-based.
         let hi_line = hi.line.saturating_sub(1);
         for line_index in lo.line.saturating_sub(1)..hi_line {
             let line_len = lo.file.get_line(line_index).map(|s| s.chars().count()).unwrap_or(0);


### PR DESCRIPTION
This required revising some of the client code to stop relying on the returned set of lines being non-empty.

Fix #68808