### PR TITLE
traits/fulfill: allow `stalled_on` to track `ty::Const::Infer(_)` (unused yet).

### DIFF
--- a/src/librustc_trait_selection/traits/fulfill.rs
+++ b/src/librustc_trait_selection/traits/fulfill.rs
@@ -73,6 +73,9 @@ pub struct FulfillmentContext<'tcx> {
 #[derive(Clone, Debug)]
 pub struct PendingPredicateObligation<'tcx> {
     pub obligation: PredicateObligation<'tcx>,
+    // FIXME(eddyb) look into whether this could be a `SmallVec`.
+    // Judging by the comment in `process_obligation`, the 1-element case
+    // is common so this could be a `SmallVec<[TyOrConstInferVar<'tcx>; 1]>`.
     pub stalled_on: Vec<TyOrConstInferVar<'tcx>>,
 }
 
@@ -538,6 +541,8 @@ fn trait_ref_type_vars<'a, 'tcx>(
         // FIXME(eddyb) walk over `GenericArg` to support const infer vars.
         .input_types()
         .map(|ty| selcx.infcx().resolve_vars_if_possible(&ty))
+        // FIXME(eddyb) try using `maybe_walk` to skip *all* subtrees that
+        // don't contain inference variables, not just the outermost level.
         // FIXME(eddyb) use `has_infer_types_or_const`.
         .filter(|ty| ty.has_infer_types())
         .flat_map(|ty| ty.walk())

--- a/src/librustc_trait_selection/traits/fulfill.rs
+++ b/src/librustc_trait_selection/traits/fulfill.rs
@@ -1,4 +1,4 @@
-use crate::infer::{InferCtxt, ShallowResolver};
+use crate::infer::InferCtxt;
 use rustc::ty::error::ExpectedFound;
 use rustc::ty::{self, ToPolyTraitRef, Ty, TypeFoldable};
 use rustc_data_structures::obligation_forest::ProcessResult;
@@ -267,7 +267,7 @@ impl<'a, 'b, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'tcx> {
             // code is so hot. 1 and 0 dominate; 2+ is fairly rare.
             1 => {
                 let infer = pending_obligation.stalled_on[0];
-                ShallowResolver::new(self.selcx.infcx()).shallow_resolve_changed(infer)
+                self.selcx.infcx().infer_ty_changed(infer)
             }
             0 => {
                 // In this case we haven't changed, but wish to make a change.
@@ -278,7 +278,7 @@ impl<'a, 'b, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'tcx> {
                 // form was a perf win. See #64545 for details.
                 (|| {
                     for &infer in &pending_obligation.stalled_on {
-                        if ShallowResolver::new(self.selcx.infcx()).shallow_resolve_changed(infer) {
+                        if self.selcx.infcx().infer_ty_changed(infer) {
                             return true;
                         }
                     }


### PR DESCRIPTION
This PR addresses the representation side of #70180, but only *actually collects* `ty::Infer`s via `Ty::walk` into `stalled_on` (collecting `ty::ConstKind::Infer`s requires #70164).

However, it should be enough to handle #70107's needs (WF obligations are stalled only on the outermost type/const being an inference variable, no `walk`-ing is involved).

This is my second attempt, see #70181 for the previous one, which unacceptably regressed perf.

r? @nikomatsakis cc @nnethercote 