### PR TITLE
resolve: Avoid "self-confirming" import resolutions in one more case

### DIFF
--- a/src/test/ui/imports/issue-62767.rs
+++ b/src/test/ui/imports/issue-62767.rs
@@ -1,0 +1,15 @@
+// check-pass
+
+mod m {
+    pub enum Same {
+        Same,
+    }
+}
+
+use m::*;
+
+// The variant `Same` introduced by this import is not considered when resolving the prefix
+// `Same::` during import validation (issue #62767).
+use Same::Same;
+
+fn main() {}


### PR DESCRIPTION
So the idea behind "blacklisted bindings" is that we must ignore some name definitions during resolution because otherwise they cause infinite cycles.
E.g. import
```rust
use my_crate;
```
would refer to itself (on 2018 edition) without this blacklisting, because `use my_crate;` is the first name in scope when we are resolving `my_crate` here.

In this PR we are doing this blacklisting for the case
```rust
use same::same;
```
, namely blacklisting the second `same` when resolving the first `same`.
This was previously forgotten.

Fixes https://github.com/rust-lang/rust/issues/62767