### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -664,6 +664,10 @@ class RustBuild(object):
         if self.clean and os.path.exists(build_dir):
             shutil.rmtree(build_dir)
         env = os.environ.copy()
+        # `CARGO_BUILD_TARGET` breaks bootstrap build.
+        # See also: <https://github.com/rust-lang/rust/issues/70208>.
+        if "CARGO_BUILD_TARGET" in env:
+            del env["CARGO_BUILD_TARGET"]
         env["RUSTC_BOOTSTRAP"] = '1'
         env["CARGO_TARGET_DIR"] = build_dir
         env["RUSTC"] = self.rustc()

--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -735,14 +735,14 @@ impl<T: Clone> ToOwned for [T] {
     fn clone_into(&self, target: &mut Vec<T>) {
         // drop anything in target that will not be overwritten
         target.truncate(self.len());
-        let len = target.len();
-
-        // reuse the contained values' allocations/resources.
-        target.clone_from_slice(&self[..len]);
 
         // target.len <= self.len due to the truncate above, so the
-        // slice here is always in-bounds.
-        target.extend_from_slice(&self[len..]);
+        // slices here are always in-bounds.
+        let (init, tail) = self.split_at(target.len());
+
+        // reuse the contained values' allocations/resources.
+        target.clone_from_slice(init);
+        target.extend_from_slice(tail);
     }
 }
 

--- a/src/librustc/ty/instance.rs
+++ b/src/librustc/ty/instance.rs
@@ -406,10 +406,6 @@ impl<'tcx> Instance<'tcx> {
             | InstanceDef::VtableShim(..) => Some(self.substs),
         }
     }
-
-    pub fn is_vtable_shim(&self) -> bool {
-        if let InstanceDef::VtableShim(..) = self.def { true } else { false }
-    }
 }
 
 fn needs_fn_once_adapter_shim(

--- a/src/librustc_error_codes/error_codes.rs
+++ b/src/librustc_error_codes/error_codes.rs
@@ -118,6 +118,7 @@ E0220: include_str!("./error_codes/E0220.md"),
 E0221: include_str!("./error_codes/E0221.md"),
 E0222: include_str!("./error_codes/E0222.md"),
 E0223: include_str!("./error_codes/E0223.md"),
+E0224: include_str!("./error_codes/E0224.md"),
 E0225: include_str!("./error_codes/E0225.md"),
 E0229: include_str!("./error_codes/E0229.md"),
 E0230: include_str!("./error_codes/E0230.md"),
@@ -469,7 +470,6 @@ E0748: include_str!("./error_codes/E0748.md"),
 //  E0217, // ambiguous associated type, defined in multiple supertraits
 //  E0218, // no associated type defined
 //  E0219, // associated type defined in higher-ranked supertrait
-    E0224, // at least one non-builtin train is required for an object type
     E0226, // only a single explicit lifetime bound is permitted
     E0227, // ambiguous lifetime bound, explicit lifetime bound required
     E0228, // explicit lifetime bound required

--- a/src/librustc_error_codes/error_codes/E0224.md
+++ b/src/librustc_error_codes/error_codes/E0224.md
@@ -1,0 +1,15 @@
+A trait object was declaired with no traits.
+
+Erroneous code example:
+
+```compile_fail,E0224
+type Foo = dyn 'static +;
+```
+
+Rust does not currently support this.
+
+To solve ensure the the trait object has at least one trait:
+
+```
+type Foo = dyn 'static + Copy;
+```

--- a/src/librustc_symbol_mangling/legacy.rs
+++ b/src/librustc_symbol_mangling/legacy.rs
@@ -59,8 +59,12 @@ pub(super) fn mangle(
         .print_def_path(def_id, &[])
         .unwrap();
 
-    if instance.is_vtable_shim() {
+    if let ty::InstanceDef::VtableShim(..) = instance.def {
         let _ = printer.write_str("{{vtable-shim}}");
+    }
+
+    if let ty::InstanceDef::ReifyShim(..) = instance.def {
+        let _ = printer.write_str("{{reify-shim}}");
     }
 
     printer.path.finish(hash)
@@ -123,7 +127,8 @@ fn get_symbol_hash<'tcx>(
         }
 
         // We want to avoid accidental collision between different types of instances.
-        // Especially, VtableShim may overlap with its original instance without this.
+        // Especially, `VtableShim`s and `ReifyShim`s may overlap with their original
+        // instances without this.
         discriminant(&instance.def).hash_stable(&mut hcx, &mut hasher);
     });
 

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -88,7 +88,7 @@ pub trait Error: Debug + Display {
     /// fn main() {
     ///     match get_super_error() {
     ///         Err(e) => {
-    ///             println!("Error: {}", e.description());
+    ///             println!("Error: {}", e);
     ///             println!("Caused by: {}", e.source().unwrap());
     ///         }
     ///         _ => println!("No error"),

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -1329,6 +1329,12 @@ impl ToOwned for CStr {
     fn to_owned(&self) -> CString {
         CString { inner: self.to_bytes_with_nul().into() }
     }
+
+    fn clone_into(&self, target: &mut CString) {
+        let mut b = Vec::from(mem::take(&mut target.inner));
+        self.to_bytes_with_nul().clone_into(&mut b);
+        target.inner = b.into_boxed_slice();
+    }
 }
 
 #[stable(feature = "cstring_asref", since = "1.7.0")]
@@ -1508,6 +1514,17 @@ mod tests {
     fn boxed_default() {
         let boxed = <Box<CStr>>::default();
         assert_eq!(boxed.to_bytes_with_nul(), &[0]);
+    }
+
+    #[test]
+    fn test_c_str_clone_into() {
+        let mut c_string = CString::new("bonjour").unwrap();
+        let c_ptr = c_string.as_ptr();
+        let c_str = CStr::from_bytes_with_nul(b"hello\0").unwrap();
+        c_str.clone_into(&mut c_string);
+        assert_eq!(c_str, c_string.as_c_str());
+        // It shouldn't have needed to move its allocation
+        assert_eq!(c_ptr, c_string.as_ptr());
     }
 
     #[test]

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -952,8 +952,7 @@ impl ToOwned for OsStr {
         self.to_os_string()
     }
     fn clone_into(&self, target: &mut OsString) {
-        target.clear();
-        target.push(self);
+        self.inner.clone_into(&mut target.inner)
     }
 }
 

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -502,7 +502,7 @@ pub trait Read {
     /// how many bytes were read.
     ///
     /// This function does not provide any guarantees about whether it blocks
-    /// waiting for data, but if an object needs to block for a read but cannot
+    /// waiting for data, but if an object needs to block for a read and cannot,
     /// it will typically signal this via an [`Err`] return value.
     ///
     /// If the return value of this method is [`Ok(n)`], then it must be

--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -989,11 +989,26 @@ mod tests {
         // s has been moved into the tsa call
     }
 
-    // FIXME: figure out why this fails on openbsd and fix it
     #[test]
-    #[cfg(not(any(windows, target_os = "openbsd")))]
-    fn to_socket_addr_str_bad() {
-        assert!(tsa("1200::AB00:1234::2552:7777:1313:34300").is_err());
+    fn bind_udp_socket_bad() {
+        // rust-lang/rust#53957: This is a regression test for a parsing problem
+        // discovered as part of issue rust-lang/rust#23076, where we were
+        // incorrectly parsing invalid input and then that would result in a
+        // successful `UdpSocket` binding when we would expect failure.
+        //
+        // At one time, this test was written as a call to `tsa` with
+        // INPUT_23076. However, that structure yields an unreliable test,
+        // because it ends up passing junk input to the DNS server, and some DNS
+        // servers will respond with `Ok` to such input, with the ip address of
+        // the DNS server itself.
+        //
+        // This form of the test is more robust: even when the DNS server
+        // returns its own address, it is still an error to bind a UDP socket to
+        // a non-local address, and so we still get an error here in that case.
+
+        const INPUT_23076: &'static str = "1200::AB00:1234::2552:7777:1313:34300";
+
+        assert!(crate::net::UdpSocket::bind(INPUT_23076).is_err())
     }
 
     #[test]

--- a/src/libstd/sys/windows/os_str.rs
+++ b/src/libstd/sys/windows/os_str.rs
@@ -147,6 +147,10 @@ impl Slice {
         Buf { inner: buf }
     }
 
+    pub fn clone_into(&self, buf: &mut Buf) {
+        self.inner.clone_into(&mut buf.inner)
+    }
+
     #[inline]
     pub fn into_box(&self) -> Box<Slice> {
         unsafe { mem::transmute(self.inner.into_box()) }

--- a/src/libstd/sys_common/os_str_bytes.rs
+++ b/src/libstd/sys_common/os_str_bytes.rs
@@ -162,6 +162,10 @@ impl Slice {
         Buf { inner: self.inner.to_vec() }
     }
 
+    pub fn clone_into(&self, buf: &mut Buf) {
+        self.inner.clone_into(&mut buf.inner)
+    }
+
     #[inline]
     pub fn into_box(&self) -> Box<Slice> {
         let boxed: Box<[u8]> = self.inner.into();

--- a/src/libstd/sys_common/wtf8.rs
+++ b/src/libstd/sys_common/wtf8.rs
@@ -613,6 +613,10 @@ impl Wtf8 {
         }
     }
 
+    pub fn clone_into(&self, buf: &mut Wtf8Buf) {
+        self.bytes.clone_into(&mut buf.bytes)
+    }
+
     /// Boxes this `Wtf8`.
     #[inline]
     pub fn into_box(&self) -> Box<Wtf8> {

--- a/src/test/ui/parser/issue-68890-2.stderr
+++ b/src/test/ui/parser/issue-68890-2.stderr
@@ -20,3 +20,4 @@ LL | type X<'a> = (?'a) +;
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0224`.

--- a/src/test/ui/parser/macro/trait-object-macro-matcher.stderr
+++ b/src/test/ui/parser/macro/trait-object-macro-matcher.stderr
@@ -20,3 +20,4 @@ LL |     m!('static);
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0224`.

--- a/src/test/ui/traits/trait-alias/trait-alias-only-maybe-bound.stderr
+++ b/src/test/ui/traits/trait-alias/trait-alias-only-maybe-bound.stderr
@@ -12,3 +12,4 @@ LL | type _T1 = dyn _2;
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0224`.

--- a/src/test/ui/traits/trait-object-macro-matcher.stderr
+++ b/src/test/ui/traits/trait-object-macro-matcher.stderr
@@ -14,4 +14,5 @@ LL |     m!(dyn Copy + Send + 'static);
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0038`.
+Some errors have detailed explanations: E0038, E0224.
+For more information about an error, try `rustc --explain E0038`.

--- a/src/test/ui/traits/trait-object-vs-lifetime-2.stderr
+++ b/src/test/ui/traits/trait-object-vs-lifetime-2.stderr
@@ -6,3 +6,4 @@ LL |     dyn 'static +: 'static + Copy,
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0224`.

--- a/src/test/ui/traits/trait-object-vs-lifetime.stderr
+++ b/src/test/ui/traits/trait-object-vs-lifetime.stderr
@@ -32,5 +32,5 @@ LL |     let _: S<dyn 'static +, 'static>;
 
 error: aborting due to 5 previous errors
 
-Some errors have detailed explanations: E0107, E0747.
+Some errors have detailed explanations: E0107, E0224, E0747.
 For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/traits/wf-trait-object-only-maybe-bound.stderr
+++ b/src/test/ui/traits/wf-trait-object-only-maybe-bound.stderr
@@ -12,3 +12,4 @@ LL | type _0 = dyn ?Sized;
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0224`.


### PR DESCRIPTION
Successful merges:

 - #70003 (symbol_names: treat ReifyShim like VtableShim.)
 - #70197 (For issue 53957: revise unit test to focus on underlying bug of 23076.)
 - #70201 (Small tweaks in ToOwned::clone_into)
 - #70218 (Fix deprecated Error.description() usage in docs)
 - #70228 (Remove CARGO_BUILD_TARGET from bootstrap.py)
 - #70231 (Add explanation message for E0224)
 - #70232 (Tweak wording for std::io::Read::read function)

Failed merges:


r? @ghost