### PR TITLE
Add a test for out-of-line module passed through a proc macro

### DIFF
--- a/src/test/ui/proc-macro/out-of-line-mod.rs
+++ b/src/test/ui/proc-macro/out-of-line-mod.rs
@@ -1,0 +1,13 @@
+// Out-of-line module is found on the filesystem if passed through a proc macro (issue #58818).
+
+// check-pass
+// aux-build:test-macros.rs
+
+#[macro_use]
+extern crate test_macros;
+
+mod outer {
+    identity! { mod inner; }
+}
+
+fn main() {}


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/58818.