### PR TITLE
Return NonZeroU64 from ThreadId::as_u64.

### DIFF
--- a/src/librustc_data_structures/profiling.rs
+++ b/src/librustc_data_structures/profiling.rs
@@ -345,7 +345,7 @@ impl SelfProfilerRef {
     ) {
         drop(self.exec(event_filter, |profiler| {
             let event_id = StringId::new_virtual(query_invocation_id.0);
-            let thread_id = std::thread::current().id().as_u64() as u32;
+            let thread_id = std::thread::current().id().as_u64().get() as u32;
 
             profiler.profiler.record_instant_event(
                 event_kind(profiler),
@@ -522,7 +522,7 @@ impl<'a> TimingGuard<'a> {
         event_kind: StringId,
         event_id: EventId,
     ) -> TimingGuard<'a> {
-        let thread_id = std::thread::current().id().as_u64() as u32;
+        let thread_id = std::thread::current().id().as_u64().get() as u32;
         let raw_profiler = &profiler.profiler;
         let timing_guard =
             raw_profiler.start_recording_interval_event(event_kind, event_id, thread_id);

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -1082,8 +1082,8 @@ impl ThreadId {
     /// it is not guaranteed which values new threads will return, and this may
     /// change across Rust versions.
     #[unstable(feature = "thread_id_value", issue = "67939")]
-    pub fn as_u64(&self) -> u64 {
-        self.0.get()
+    pub fn as_u64(&self) -> NonZeroU64 {
+        self.0
     }
 }
 


### PR DESCRIPTION
As discussed in #67939, this allows turning Option<ThreadId> into Option<NonZeroU64> which
can then be stored inside an AtomicU64.