### PR TITLE
Make it a bit easier to debug TyKind::Error errors

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -50,6 +50,7 @@
 #![feature(rustc_attrs)]
 #![feature(hash_raw_entry)]
 #![feature(int_error_matching)]
+#![feature(track_caller)]
 #![recursion_limit = "512"]
 
 #[macro_use]

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -30,7 +30,11 @@ pub enum StabilityLevel {
 
 impl StabilityLevel {
     pub fn from_attr_level(level: &attr::StabilityLevel) -> Self {
-        if level.is_stable() { Stable } else { Unstable }
+        if level.is_stable() {
+            Stable
+        } else {
+            Unstable
+        }
     }
 }
 
@@ -110,7 +114,11 @@ pub fn report_unstable(
     let span_key = msp.primary_span().and_then(|sp: Span| {
         if !sp.is_dummy() {
             let file = sm.lookup_char_pos(sp.lo()).file;
-            if file.is_imported() { None } else { Some(span) }
+            if file.is_imported() {
+                None
+            } else {
+                Some(span)
+            }
         } else {
             None
         }
@@ -227,7 +235,7 @@ fn late_report_deprecation(
         if let hir::Node::Expr(_) = tcx.hir().get(hir_id) {
             deprecation_suggestion(&mut diag, suggestion, span);
         }
-        diag.emit()
+        diag.emit();
     });
     if hir_id == hir::DUMMY_HIR_ID {
         span_bug!(span, "emitted a {} lint with dummy HIR id: {:?}", lint.name, def_id);
@@ -391,7 +399,7 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn check_stability(self, def_id: DefId, id: Option<HirId>, span: Span) {
         let soft_handler = |lint, span, msg: &_| {
             self.struct_span_lint_hir(lint, id.unwrap_or(hir::CRATE_HIR_ID), span, |lint| {
-                lint.build(msg).emit()
+                lint.build(msg).emit();
             })
         };
         match self.eval_stability(def_id, id, span) {

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -89,7 +89,9 @@ impl<'tcx> ConstEvalErr<'tcx> {
     }
 
     pub fn report_as_error(&self, tcx: TyCtxtAt<'tcx>, message: &str) -> ErrorHandled {
-        match self.struct_error(tcx, message, |mut e| e.emit()) {
+        match self.struct_error(tcx, message, |mut e| {
+            e.emit();
+        }) {
             Ok(_) => ErrorHandled::Reported,
             Err(x) => x,
         }

--- a/src/librustc/traits/query.rs
+++ b/src/librustc/traits/query.rs
@@ -221,7 +221,7 @@ pub fn trivial_dropck_outlives<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> bool {
         | ty::Ref(..)
         | ty::Str
         | ty::Foreign(..)
-        | ty::Error => true,
+        | ty::Error(..) => true,
 
         // [T; N] and [T] have same properties as T.
         ty::Array(ty, _) | ty::Slice(ty) => trivial_dropck_outlives(tcx, ty),

--- a/src/librustc/traits/specialization_graph.rs
+++ b/src/librustc/traits/specialization_graph.rs
@@ -32,12 +32,12 @@ pub struct Graph {
     pub children: DefIdMap<Children>,
 
     /// Whether an error was emitted while constructing the graph.
-    pub has_errored: bool,
+    pub error_reported: Option<ErrorReported>,
 }
 
 impl Graph {
     pub fn new() -> Graph {
-        Graph { parent: Default::default(), children: Default::default(), has_errored: false }
+        Graph { parent: Default::default(), children: Default::default(), error_reported: None }
     }
 
     /// The parent of a given impl, which is the `DefId` of the trait when the
@@ -191,8 +191,8 @@ pub fn ancestors(
     start_from_impl: DefId,
 ) -> Result<Ancestors<'tcx>, ErrorReported> {
     let specialization_graph = tcx.specialization_graph_of(trait_def_id);
-    if specialization_graph.has_errored {
-        Err(ErrorReported)
+    if let Some(error_reported) = specialization_graph.error_reported {
+        Err(error_reported)
     } else {
         Ok(Ancestors {
             trait_def_id,

--- a/src/librustc/ty/_match.rs
+++ b/src/librustc/ty/_match.rs
@@ -76,7 +76,7 @@ impl TypeRelation<'tcx> for Match<'tcx> {
                 Err(TypeError::Sorts(relate::expected_found(self, &a, &b)))
             }
 
-            (&ty::Error, _) | (_, &ty::Error) => Ok(self.tcx().types.err),
+            (&ty::Error(proof), _) | (_, &ty::Error(proof)) => Ok(self.tcx().err(proof)),
 
             _ => relate::super_relate_tys(self, a, b),
         }

--- a/src/librustc/ty/error.rs
+++ b/src/librustc/ty/error.rs
@@ -275,14 +275,14 @@ impl<'tcx> ty::TyS<'tcx> {
             ty::UnnormalizedProjection(_) => "non-normalized associated type".into(),
             ty::Param(p) => format!("type parameter `{}`", p).into(),
             ty::Opaque(..) => "opaque type".into(),
-            ty::Error => "type error".into(),
+            ty::Error(..) => "type error".into(),
         }
     }
 
     pub fn prefix_string(&self) -> Cow<'static, str> {
         match self.kind {
             ty::Infer(_)
-            | ty::Error
+            | ty::Error(..)
             | ty::Bool
             | ty::Char
             | ty::Int(_)

--- a/src/librustc/ty/fast_reject.rs
+++ b/src/librustc/ty/fast_reject.rs
@@ -105,7 +105,7 @@ pub fn simplify_type(
         }
         ty::Opaque(def_id, _) => Some(OpaqueSimplifiedType(def_id)),
         ty::Foreign(def_id) => Some(ForeignSimplifiedType(def_id)),
-        ty::Placeholder(..) | ty::Bound(..) | ty::Infer(_) | ty::Error => None,
+        ty::Placeholder(..) | ty::Bound(..) | ty::Infer(_) | ty::Error(..) => None,
     }
 }
 

--- a/src/librustc/ty/flags.rs
+++ b/src/librustc/ty/flags.rs
@@ -77,7 +77,7 @@ impl FlagComputation {
             // But doing so caused sporadic memory corruption, and
             // neither I (tjc) nor nmatsakis could figure out why,
             // so we're doing it this way.
-            &ty::Error => self.add_flags(TypeFlags::HAS_TY_ERR),
+            &ty::Error(..) => self.add_flags(TypeFlags::HAS_TY_ERR),
 
             &ty::Param(_) => {
                 self.add_flags(TypeFlags::HAS_TY_PARAM);

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -1249,7 +1249,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
             | ty::GeneratorWitness(..)
             | ty::Infer(_) => bug!("LayoutDetails::compute: unexpected type `{}`", ty),
 
-            ty::Param(_) | ty::Error => {
+            ty::Param(_) | ty::Error(..) => {
                 return Err(LayoutError::Unknown(ty));
             }
         })
@@ -2144,7 +2144,7 @@ where
             | ty::Opaque(..)
             | ty::Param(_)
             | ty::Infer(_)
-            | ty::Error => bug!("TyLayout::field_type: unexpected type `{}`", this.ty),
+            | ty::Error(..) => bug!("TyLayout::field_type: unexpected type `{}`", this.ty),
         })
     }
 

--- a/src/librustc/ty/outlives.rs
+++ b/src/librustc/ty/outlives.rs
@@ -147,7 +147,7 @@ fn compute_components(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, out: &mut SmallVec<[Compo
             ty::Dynamic(..) |       // OutlivesObject, OutlivesFragment (*)
             ty::Placeholder(..) |
             ty::Bound(..) |
-            ty::Error => {
+            ty::Error(..) => {
                 // (*) Bare functions and traits are both binders. In the
                 // RFC, this means we would add the bound regions to the
                 // "bound regions list".  In our representation, no such

--- a/src/librustc/ty/print/mod.rs
+++ b/src/librustc/ty/print/mod.rs
@@ -299,7 +299,7 @@ pub fn characteristic_def_id_of_type(ty: Ty<'_>) -> Option<DefId> {
         | ty::Opaque(..)
         | ty::Infer(_)
         | ty::Bound(..)
-        | ty::Error
+        | ty::Error(..)
         | ty::GeneratorWitness(..)
         | ty::Never
         | ty::Float(_) => None,

--- a/src/librustc/ty/print/obsolete.rs
+++ b/src/librustc/ty/print/obsolete.rs
@@ -144,7 +144,7 @@ impl DefPathBasedNames<'tcx> {
                 let substs = substs.truncate_to(self.tcx, generics);
                 self.push_generic_params(substs, iter::empty(), output, debug);
             }
-            ty::Error
+            ty::Error(..)
             | ty::Bound(..)
             | ty::Infer(_)
             | ty::Placeholder(..)

--- a/src/librustc/ty/print/pretty.rs
+++ b/src/librustc/ty/print/pretty.rs
@@ -530,7 +530,7 @@ pub trait PrettyPrinter<'tcx>:
                     p!(write("{}", infer_ty))
                 }
             }
-            ty::Error => p!(write("[type error]")),
+            ty::Error(..) => p!(write("[type error]")),
             ty::Param(ref param_ty) => p!(write("{}", param_ty)),
             ty::Bound(debruijn, bound_ty) => match bound_ty.kind {
                 ty::BoundTyKind::Anon => self.pretty_print_bound_var(debruijn, bound_ty.var)?,

--- a/src/librustc/ty/query/plumbing.rs
+++ b/src/librustc/ty/query/plumbing.rs
@@ -804,8 +804,8 @@ impl<'tcx> TyCtxt<'tcx> {
 
 macro_rules! handle_cycle_error {
     ([][$tcx: expr, $error:expr]) => {{
-        $tcx.report_cycle($error).emit();
-        Value::from_cycle_error($tcx)
+        let proof = $tcx.report_cycle($error).emit().proof();
+        Value::from_cycle_error($tcx, proof)
     }};
     ([fatal_cycle $($rest:tt)*][$tcx:expr, $error:expr]) => {{
         $tcx.report_cycle($error).emit();
@@ -813,8 +813,8 @@ macro_rules! handle_cycle_error {
         unreachable!()
     }};
     ([cycle_delay_bug $($rest:tt)*][$tcx:expr, $error:expr]) => {{
-        $tcx.report_cycle($error).delay_as_bug();
-        Value::from_cycle_error($tcx)
+        let proof = $tcx.report_cycle($error).delay_as_bug();
+        Value::from_cycle_error($tcx, proof)
     }};
     ([$other:ident $(($($other_args:tt)*))* $(, $($modifiers:tt)*)*][$($args:tt)*]) => {
         handle_cycle_error!([$($($modifiers)*)*][$($args)*])

--- a/src/librustc/ty/query/values.rs
+++ b/src/librustc/ty/query/values.rs
@@ -1,32 +1,33 @@
 use crate::ty::{self, AdtSizedConstraint, Ty, TyCtxt};
 
+use rustc_errors::ErrorProof;
 use rustc_span::symbol::Symbol;
 
 pub(super) trait Value<'tcx>: Sized {
-    fn from_cycle_error(tcx: TyCtxt<'tcx>) -> Self;
+    fn from_cycle_error(tcx: TyCtxt<'tcx>, proof: ErrorProof) -> Self;
 }
 
 impl<'tcx, T> Value<'tcx> for T {
-    default fn from_cycle_error(tcx: TyCtxt<'tcx>) -> T {
+    default fn from_cycle_error(tcx: TyCtxt<'tcx>, _: ErrorProof) -> T {
         tcx.sess.abort_if_errors();
         bug!("Value::from_cycle_error called without errors");
     }
 }
 
 impl<'tcx> Value<'tcx> for Ty<'tcx> {
-    fn from_cycle_error(tcx: TyCtxt<'tcx>) -> Ty<'tcx> {
-        tcx.types.err
+    fn from_cycle_error(tcx: TyCtxt<'tcx>, proof: ErrorProof) -> Ty<'tcx> {
+        tcx.err(proof)
     }
 }
 
 impl<'tcx> Value<'tcx> for ty::SymbolName {
-    fn from_cycle_error(_: TyCtxt<'tcx>) -> Self {
+    fn from_cycle_error(_: TyCtxt<'tcx>, _: ErrorProof) -> Self {
         ty::SymbolName { name: Symbol::intern("<error>") }
     }
 }
 
 impl<'tcx> Value<'tcx> for AdtSizedConstraint<'tcx> {
-    fn from_cycle_error(tcx: TyCtxt<'tcx>) -> Self {
-        AdtSizedConstraint(tcx.intern_type_list(&[tcx.types.err]))
+    fn from_cycle_error(tcx: TyCtxt<'tcx>, proof: ErrorProof) -> Self {
+        AdtSizedConstraint(tcx.intern_type_list(&[tcx.err(proof)]))
     }
 }

--- a/src/librustc/ty/relate.rs
+++ b/src/librustc/ty/relate.rs
@@ -354,7 +354,7 @@ pub fn super_relate_tys<R: TypeRelation<'tcx>>(
             bug!("bound types encountered in super_relate_tys")
         }
 
-        (&ty::Error, _) | (_, &ty::Error) => Ok(tcx.types.err),
+        (&ty::Error(proof), _) | (_, &ty::Error(proof)) => Ok(tcx.err(proof)),
 
         (&ty::Never, _)
         | (&ty::Char, _)

--- a/src/librustc/ty/structural_impls.rs
+++ b/src/librustc/ty/structural_impls.rs
@@ -900,7 +900,7 @@ impl<'tcx> TypeFoldable<'tcx> for Ty<'tcx> {
             | ty::Int(_)
             | ty::Uint(_)
             | ty::Float(_)
-            | ty::Error
+            | ty::Error(..)
             | ty::Infer(_)
             | ty::Param(..)
             | ty::Bound(..)
@@ -943,7 +943,7 @@ impl<'tcx> TypeFoldable<'tcx> for Ty<'tcx> {
             | ty::Int(_)
             | ty::Uint(_)
             | ty::Float(_)
-            | ty::Error
+            | ty::Error(..)
             | ty::Infer(_)
             | ty::Bound(..)
             | ty::Placeholder(..)

--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -176,7 +176,7 @@ impl<'tcx> TyCtxt<'tcx> {
         if let ty::Adt(def, substs) = ty.kind {
             for field in def.all_fields() {
                 let field_ty = field.ty(self, substs);
-                if let Error = field_ty.kind {
+                if let Error(..) = field_ty.kind {
                     return true;
                 }
             }
@@ -727,7 +727,7 @@ impl<'tcx> ty::TyS<'tcx> {
             | ty::Ref(..)
             | ty::RawPtr(_)
             | ty::FnDef(..)
-            | ty::Error
+            | ty::Error(..)
             | ty::FnPtr(_) => true,
             ty::Tuple(_) => self.tuple_fields().all(Self::is_trivially_freeze),
             ty::Slice(elem_ty) | ty::Array(elem_ty, _) => elem_ty.is_trivially_freeze(),
@@ -1050,7 +1050,7 @@ pub fn needs_drop_components(
         // Pessimistically assume that all generators will require destructors
         // as we don't know if a destructor is a noop or not until after the MIR
         // state transformation pass.
-        ty::Generator(..) | ty::Dynamic(..) | ty::Error => Err(AlwaysRequiresDrop),
+        ty::Generator(..) | ty::Dynamic(..) | ty::Error(..) => Err(AlwaysRequiresDrop),
 
         ty::Slice(ty) => needs_drop_components(ty, target_layout),
         ty::Array(elem_ty, size) => {

--- a/src/librustc/ty/walk.rs
+++ b/src/librustc/ty/walk.rs
@@ -76,7 +76,7 @@ fn push_subtypes<'tcx>(stack: &mut TypeWalkerStack<'tcx>, parent_ty: Ty<'tcx>) {
         | ty::Infer(_)
         | ty::Param(_)
         | ty::Never
-        | ty::Error
+        | ty::Error(..)
         | ty::Placeholder(..)
         | ty::Bound(..)
         | ty::Foreign(..) => {}

--- a/src/librustc_codegen_ssa/debuginfo/type_names.rs
+++ b/src/librustc_codegen_ssa/debuginfo/type_names.rs
@@ -195,7 +195,7 @@ pub fn push_debuginfo_type_name<'tcx>(
                 tcx.def_key(def_id).disambiguated_data.disambiguator
             ));
         }
-        ty::Error
+        ty::Error(..)
         | ty::Infer(_)
         | ty::Placeholder(..)
         | ty::UnnormalizedProjection(..)

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -38,6 +38,8 @@ mod snippet;
 mod styled_buffer;
 pub use snippet::Style;
 
+pub use diagnostic_builder::ErrorProof;
+
 pub type PResult<'a, T> = Result<T, DiagnosticBuilder<'a>>;
 
 // `PResult` is used a lot. Make sure it doesn't unintentionally get bigger.
@@ -971,13 +973,29 @@ impl Level {
 #[macro_export]
 macro_rules! pluralize {
     ($x:expr) => {
-        if $x != 1 { "s" } else { "" }
+        if $x != 1 {
+            "s"
+        } else {
+            ""
+        }
     };
 }
 
-// Useful type to use with `Result<>` indicate that an error has already
-// been reported to the user, so no need to continue checking.
+/// Useful type to use with `Result<>` indicate that an error has already
+/// been reported to the user, so no need to continue checking.
 #[derive(Clone, Copy, Debug, RustcEncodable, RustcDecodable, Hash, PartialEq, Eq)]
-pub struct ErrorReported;
+pub enum ErrorReported {
+    NonError,
+    Error(ErrorProof),
+}
 
 rustc_data_structures::impl_stable_hash_via_hash!(ErrorReported);
+
+impl ErrorReported {
+    pub fn proof(self) -> ErrorProof {
+        match self {
+            ErrorReported::NonError => panic!("No proof here"),
+            ErrorReported::Error(proof) => proof,
+        }
+    }
+}

--- a/src/librustc_infer/infer/canonical/canonicalizer.rs
+++ b/src/librustc_infer/infer/canonical/canonicalizer.rs
@@ -408,7 +408,7 @@ impl<'cx, 'tcx> TypeFolder<'tcx> for Canonicalizer<'cx, 'tcx> {
             | ty::Float(..)
             | ty::Adt(..)
             | ty::Str
-            | ty::Error
+            | ty::Error(..)
             | ty::Array(..)
             | ty::Slice(..)
             | ty::RawPtr(..)

--- a/src/librustc_infer/infer/canonical/mod.rs
+++ b/src/librustc_infer/infer/canonical/mod.rs
@@ -154,7 +154,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
                 self.tcx
                     .mk_const(ty::Const {
                         val: ty::ConstKind::Placeholder(placeholder_mapped),
-                        ty: self.tcx.types.err, // FIXME(const_generics)
+                        ty: self.tcx.err(), // FIXME(const_generics)
                     })
                     .into()
             }

--- a/src/librustc_infer/infer/error_reporting/nice_region_error/different_lifetimes.rs
+++ b/src/librustc_infer/infer/error_reporting/nice_region_error/different_lifetimes.rs
@@ -137,11 +137,12 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
             ),
         };
 
-        struct_span_err!(self.tcx().sess, span, E0623, "lifetime mismatch")
-            .span_label(span_1, main_label)
-            .span_label(span_2, String::new())
-            .span_label(span, span_label)
-            .emit();
-        Some(ErrorReported)
+        Some(
+            struct_span_err!(self.tcx().sess, span, E0623, "lifetime mismatch")
+                .span_label(span_1, main_label)
+                .span_label(span_2, String::new())
+                .span_label(span, span_label)
+                .emit(),
+        )
     }
 }

--- a/src/librustc_infer/infer/error_reporting/nice_region_error/mod.rs
+++ b/src/librustc_infer/infer/error_reporting/nice_region_error/mod.rs
@@ -53,10 +53,7 @@ impl<'cx, 'tcx> NiceRegionError<'cx, 'tcx> {
 
     pub fn try_report(&self) -> Option<ErrorReported> {
         self.try_report_from_nll()
-            .map(|mut diag| {
-                diag.emit();
-                ErrorReported
-            })
+            .map(|mut diag| diag.emit())
             .or_else(|| self.try_report_anon_anon_conflict())
             .or_else(|| self.try_report_outlives_closure())
             .or_else(|| self.try_report_static_impl_trait())

--- a/src/librustc_infer/infer/error_reporting/nice_region_error/outlives_closure.rs
+++ b/src/librustc_infer/infer/error_reporting/nice_region_error/outlives_closure.rs
@@ -105,8 +105,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
                                 "borrowed data cannot outlive this closure",
                             );
                         }
-                        err.emit();
-                        return Some(ErrorReported);
+                        return Some(err.emit());
                     }
                 }
             }

--- a/src/librustc_infer/infer/error_reporting/nice_region_error/static_impl_trait.rs
+++ b/src/librustc_infer/infer/error_reporting/nice_region_error/static_impl_trait.rs
@@ -64,8 +64,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
                             );
                         }
                     }
-                    err.emit();
-                    return Some(ErrorReported);
+                    Some(err.emit());
                 }
             }
         }

--- a/src/librustc_infer/infer/error_reporting/nice_region_error/trait_impl_difference.rs
+++ b/src/librustc_infer/infer/error_reporting/nice_region_error/trait_impl_difference.rs
@@ -31,13 +31,12 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
                         ) = (&sub_trace.values, &sup_trace.values, &sub_trace.cause.code)
                         {
                             if sup_expected_found == sub_expected_found {
-                                self.emit_err(
+                                return Some(self.emit_err(
                                     var_origin.span(),
                                     sub_expected_found.expected,
                                     sub_expected_found.found,
                                     self.tcx().def_span(*trait_item_def_id),
-                                );
-                                return Some(ErrorReported);
+                                ));
                             }
                         }
                     }
@@ -48,7 +47,13 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         None
     }
 
-    fn emit_err(&self, sp: Span, expected: Ty<'tcx>, found: Ty<'tcx>, impl_sp: Span) {
+    fn emit_err(
+        &self,
+        sp: Span,
+        expected: Ty<'tcx>,
+        found: Ty<'tcx>,
+        impl_sp: Span,
+    ) -> ErrorReported {
         let mut err = self
             .tcx()
             .sess
@@ -56,6 +61,6 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         err.note(&format!("expected `{:?}`\n   found `{:?}`", expected, found));
         err.span_label(sp, &format!("found {:?}", found));
         err.span_label(impl_sp, &format!("expected {:?}", expected));
-        err.emit();
+        err.emit()
     }
 }

--- a/src/librustc_infer/infer/freshen.rs
+++ b/src/librustc_infer/infer/freshen.rs
@@ -199,7 +199,7 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TypeFreshener<'a, 'tcx> {
             | ty::Float(..)
             | ty::Adt(..)
             | ty::Str
-            | ty::Error
+            | ty::Error(..)
             | ty::Array(..)
             | ty::Slice(..)
             | ty::RawPtr(..)

--- a/src/librustc_infer/infer/mod.rs
+++ b/src/librustc_infer/infer/mod.rs
@@ -1691,7 +1691,7 @@ impl<'tcx> TypeTrace<'tcx> {
     pub fn dummy(tcx: TyCtxt<'tcx>) -> TypeTrace<'tcx> {
         TypeTrace {
             cause: ObligationCause::dummy(),
-            values: Types(ExpectedFound { expected: tcx.types.err, found: tcx.types.err }),
+            values: Types(ExpectedFound { expected: tcx.err(), found: tcx.err() }),
         }
     }
 }

--- a/src/librustc_infer/infer/sub.rs
+++ b/src/librustc_infer/infer/sub.rs
@@ -117,9 +117,9 @@ impl TypeRelation<'tcx> for Sub<'combine, 'infcx, 'tcx> {
                 Ok(a)
             }
 
-            (&ty::Error, _) | (_, &ty::Error) => {
+            (&ty::Error(proof), _) | (_, &ty::Error(proof)) => {
                 infcx.set_tainted_by_errors();
-                Ok(self.tcx().types.err)
+                Ok(self.tcx().err(proof))
             }
 
             _ => {

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -283,7 +283,7 @@ impl<'a> CrateLoader<'a> {
                          will result in symbol conflicts between the two.",
                 root.name()
             )
-            .emit()
+            .emit();
         }
 
         // Check for conflicts with any crate loaded so far

--- a/src/librustc_metadata/native_libs.rs
+++ b/src/librustc_metadata/native_libs.rs
@@ -157,7 +157,9 @@ impl Collector<'tcx> {
         if lib.kind == cstore::NativeFramework && !is_osx {
             let msg = "native frameworks are only available on macOS targets";
             match span {
-                Some(span) => struct_span_err!(self.tcx.sess, span, E0455, "{}", msg).emit(),
+                Some(span) => {
+                    struct_span_err!(self.tcx.sess, span, E0455, "{}", msg).emit();
+                }
                 None => self.tcx.sess.err(msg),
             }
         }

--- a/src/librustc_mir/borrow_check/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/type_check/mod.rs
@@ -491,7 +491,7 @@ impl<'a, 'b, 'tcx> TypeVerifier<'a, 'b, 'tcx> {
             if place_ty.variant_index.is_none() {
                 if place_ty.ty.references_error() {
                     assert!(self.errors_reported);
-                    return PlaceTy::from_ty(self.tcx().types.err);
+                    return PlaceTy::from_ty(self.tcx().types.err());
                 }
             }
             place_ty = self.sanitize_projection(place_ty, elem, place, location)
@@ -721,7 +721,7 @@ impl<'a, 'b, 'tcx> TypeVerifier<'a, 'b, 'tcx> {
 
     fn error(&mut self) -> Ty<'tcx> {
         self.errors_reported = true;
-        self.tcx().types.err
+        self.tcx().types.err()
     }
 
     fn field_ty(

--- a/src/librustc_mir_build/build/mod.rs
+++ b/src/librustc_mir_build/build/mod.rs
@@ -688,7 +688,7 @@ fn construct_error<'a, 'tcx>(hir: Cx<'a, 'tcx>, body_id: hir::BodyId) -> Body<'t
     let tcx = hir.tcx();
     let owner_id = tcx.hir().body_owner(body_id);
     let span = tcx.hir().span(owner_id);
-    let ty = tcx.types.err;
+    let ty = tcx.types.err();
     let num_params = match hir.body_owner_kind {
         hir::BodyOwnerKind::Fn => tcx.hir().fn_decl_by_hir_id(owner_id).unwrap().inputs.len(),
         hir::BodyOwnerKind::Closure => {

--- a/src/librustc_mir_build/hair/pattern/_match.rs
+++ b/src/librustc_mir_build/hair/pattern/_match.rs
@@ -892,12 +892,12 @@ impl<'tcx> Constructor<'tcx> {
                                 match (is_visible, is_non_exhaustive, is_uninhabited) {
                                     // Treat all uninhabited types in non-exhaustive variants as
                                     // `TyErr`.
-                                    (_, true, true) => cx.tcx.types.err,
+                                    (_, true, true) => cx.tcx.types.err(),
                                     // Treat all non-visible fields as `TyErr`. They can't appear
                                     // in any other pattern from this match (because they are
                                     // private), so their type does not matter - but we don't want
                                     // to know they are uninhabited.
-                                    (false, ..) => cx.tcx.types.err,
+                                    (false, ..) => cx.tcx.types.err(),
                                     (true, ..) => {
                                         let ty = field.ty(cx.tcx, substs);
                                         match ty.kind {
@@ -908,7 +908,7 @@ impl<'tcx> Constructor<'tcx> {
                                                     .try_eval_usize(cx.tcx, cx.param_env)
                                                     .is_none() =>
                                             {
-                                                cx.tcx.types.err
+                                                cx.tcx.types.err()
                                             }
                                             _ => ty,
                                         }

--- a/src/librustc_parse/parser/ty.rs
+++ b/src/librustc_parse/parser/ty.rs
@@ -216,7 +216,7 @@ impl<'a> Parser<'a> {
         let lt_no_plus = self.check_lifetime() && !self.look_ahead(1, |t| t.is_like_plus());
         let bounds = self.parse_generic_bounds_common(allow_plus, None)?;
         if lt_no_plus {
-            self.struct_span_err(lo, "lifetime in trait object type must be followed by `+`").emit()
+            self.struct_span_err(lo, "lifetime in trait object type must be followed by `+`").emit();
         }
         Ok(TyKind::TraitObject(bounds, TraitObjectSyntax::None))
     }

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -851,7 +851,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
         let parent = self.parent_scope.module;
         let Export { ident, res, vis, span } = child;
         let expansion = ExpnId::root(); // FIXME(jseyfried) intercrate hygiene
-        // Record primary definitions.
+                                        // Record primary definitions.
         match res {
             Res::Def(kind @ DefKind::Mod, def_id)
             | Res::Def(kind @ DefKind::Enum, def_id)
@@ -957,8 +957,9 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
                             .emit();
                     }
                 }
-                let ill_formed =
-                    |span| struct_span_err!(self.r.session, span, E0466, "bad macro import").emit();
+                let ill_formed = |span| {
+                    struct_span_err!(self.r.session, span, E0466, "bad macro import").emit();
+                };
                 match attr.meta() {
                     Some(meta) => match meta.kind {
                         MetaItemKind::Word => {

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -454,7 +454,7 @@ impl<'a> Resolver<'a> {
                 self.session.struct_span_err(span, "visibility must resolve to a module")
             }
         }
-        .emit()
+        .emit();
     }
 
     /// Lookup typo candidate in scope for a macro or import.
@@ -1047,7 +1047,11 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
         path[0].ident.name = kw::SelfLower;
         let result = self.r.resolve_path(&path, None, parent_scope, false, span, CrateLint::No);
         debug!("make_missing_self_suggestion: path={:?} result={:?}", path, result);
-        if let PathResult::Module(..) = result { Some((path, Vec::new())) } else { None }
+        if let PathResult::Module(..) = result {
+            Some((path, Vec::new()))
+        } else {
+            None
+        }
     }
 
     /// Suggests a missing `crate::` if that resolves to an correct module.
@@ -1070,12 +1074,10 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
         if let PathResult::Module(..) = result {
             Some((
                 path,
-                vec![
-                    "`use` statements changed in Rust 2018; read more at \
+                vec!["`use` statements changed in Rust 2018; read more at \
                      <https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-\
                      clarity.html>"
-                        .to_string(),
-                ],
+                    .to_string()],
             ))
         } else {
             None
@@ -1099,7 +1101,11 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
         path[0].ident.name = kw::Super;
         let result = self.r.resolve_path(&path, None, parent_scope, false, span, CrateLint::No);
         debug!("make_missing_super_suggestion:  path={:?} result={:?}", path, result);
-        if let PathResult::Module(..) = result { Some((path, Vec::new())) } else { None }
+        if let PathResult::Module(..) = result {
+            Some((path, Vec::new()))
+        } else {
+            None
+        }
     }
 
     /// Suggests a missing external crate name if that resolves to an correct module.

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -513,7 +513,7 @@ impl<'l, 'tcx> SaveContext<'l, 'tcx> {
         let expr_hir_id = self.tcx.hir().node_to_hir_id(expr.id);
         let hir_node = self.tcx.hir().expect_expr(expr_hir_id);
         let ty = self.tables.expr_ty_adjusted_opt(&hir_node);
-        if ty.is_none() || ty.unwrap().kind == ty::Error {
+        if ty.is_none() || ty.unwrap().kind.is_err() {
             return None;
         }
         match expr.kind {

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -283,23 +283,13 @@ impl Session {
     pub fn abort_if_errors(&self) {
         self.diagnostic().abort_if_errors();
     }
-    pub fn compile_status(&self) -> Result<(), ErrorReported> {
+    pub fn compile_status(&self) -> Result<(), ()> {
         if self.has_errors() {
             self.diagnostic().emit_stashed_diagnostics();
-            Err(ErrorReported)
+            Err(())
         } else {
             Ok(())
         }
-    }
-    // FIXME(matthewjasper) Remove this method, it should never be needed.
-    pub fn track_errors<F, T>(&self, f: F) -> Result<T, ErrorReported>
-    where
-        F: FnOnce() -> T,
-    {
-        let old_count = self.err_count();
-        let result = f();
-        let errors = self.err_count() - old_count;
-        if errors == 0 { Ok(result) } else { Err(ErrorReported) }
     }
     pub fn span_warn<S: Into<MultiSpan>>(&self, sp: S, msg: &str) {
         self.diagnostic().span_warn(sp, msg)

--- a/src/librustc_symbol_mangling/v0.rs
+++ b/src/librustc_symbol_mangling/v0.rs
@@ -336,7 +336,7 @@ impl Printer<'tcx> for SymbolMangler<'tcx> {
             ty::Never => "z",
 
             // Placeholders (should be demangled as `_`).
-            ty::Param(_) | ty::Bound(..) | ty::Placeholder(_) | ty::Infer(_) | ty::Error => "p",
+            ty::Param(_) | ty::Bound(..) | ty::Placeholder(_) | ty::Infer(_) | ty::Error(..) => "p",
 
             _ => "",
         };
@@ -358,7 +358,7 @@ impl Printer<'tcx> for SymbolMangler<'tcx> {
             ty::Tuple(_) if ty.is_unit() => unreachable!(),
 
             // Placeholders, also handled as part of basic types.
-            ty::Param(_) | ty::Bound(..) | ty::Placeholder(_) | ty::Infer(_) | ty::Error => {
+            ty::Param(_) | ty::Bound(..) | ty::Placeholder(_) | ty::Infer(_) | ty::Error(..) => {
                 unreachable!()
             }
 

--- a/src/librustc_trait_selection/opaque_types.rs
+++ b/src/librustc_trait_selection/opaque_types.rs
@@ -950,7 +950,7 @@ impl TypeFolder<'tcx> for ReverseMapper<'tcx> {
                             )
                             .emit();
 
-                        self.tcx().types.err
+                        self.tcx().types.err()
                     }
                 }
             }
@@ -1011,7 +1011,7 @@ impl<'a, 'tcx> Instantiator<'a, 'tcx> {
             tcx,
             ty_op: |ty| {
                 if ty.references_error() {
-                    return tcx.types.err;
+                    return tcx.types.err();
                 } else if let ty::Opaque(def_id, substs) = ty.kind {
                     // Check that this is `impl Trait` type is
                     // declared by `parent_def_id` -- i.e., one whose

--- a/src/librustc_trait_selection/traits/project.rs
+++ b/src/librustc_trait_selection/traits/project.rs
@@ -772,7 +772,7 @@ struct Progress<'tcx> {
 
 impl<'tcx> Progress<'tcx> {
     fn error(tcx: TyCtxt<'tcx>) -> Self {
-        Progress { ty: tcx.types.err, obligations: vec![] }
+        Progress { ty: tcx.types.err(), obligations: vec![] }
     }
 
     fn with_addl_obligations(mut self, mut obligations: Vec<PredicateObligation<'tcx>>) -> Self {
@@ -1388,7 +1388,7 @@ fn confirm_param_env_candidate<'cx, 'tcx>(
             );
             debug!("confirm_param_env_candidate: {}", msg);
             infcx.tcx.sess.delay_span_bug(obligation.cause.span, &msg);
-            Progress { ty: infcx.tcx.types.err, obligations: vec![] }
+            Progress { ty: infcx.tcx.types.err(), obligations: vec![] }
         }
     }
 }
@@ -1407,7 +1407,7 @@ fn confirm_impl_candidate<'cx, 'tcx>(
     let param_env = obligation.param_env;
     let assoc_ty = match assoc_ty_def(selcx, impl_def_id, assoc_item_id) {
         Ok(assoc_ty) => assoc_ty,
-        Err(ErrorReported) => return Progress { ty: tcx.types.err, obligations: nested },
+        Err(ErrorReported) => return Progress { ty: tcx.types.err(), obligations: nested },
     };
 
     if !assoc_ty.item.defaultness.has_value() {
@@ -1419,7 +1419,7 @@ fn confirm_impl_candidate<'cx, 'tcx>(
             "confirm_impl_candidate: no associated type {:?} for {:?}",
             assoc_ty.item.ident, obligation.predicate
         );
-        return Progress { ty: tcx.types.err, obligations: nested };
+        return Progress { ty: tcx.types.err(), obligations: nested };
     }
     let substs = obligation.predicate.substs.rebase_onto(tcx, trait_def_id, substs);
     let substs = translate_substs(selcx.infcx(), param_env, impl_def_id, substs, assoc_ty.node);
@@ -1432,7 +1432,7 @@ fn confirm_impl_candidate<'cx, 'tcx>(
     if substs.len() != tcx.generics_of(assoc_ty.item.def_id).count() {
         tcx.sess
             .delay_span_bug(DUMMY_SP, "impl item and trait item have different parameter counts");
-        Progress { ty: tcx.types.err, obligations: nested }
+        Progress { ty: tcx.types.err(), obligations: nested }
     } else {
         Progress { ty: ty.subst(tcx, substs), obligations: nested }
     }

--- a/src/librustc_trait_selection/traits/select.rs
+++ b/src/librustc_trait_selection/traits/select.rs
@@ -3084,7 +3084,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 let params = substs_a
                     .iter()
                     .enumerate()
-                    .map(|(i, &k)| if ty_params.contains(i) { tcx.types.err.into() } else { k });
+                    .map(|(i, &k)| if ty_params.contains(i) { tcx.types.err().into() } else { k });
                 let substs = tcx.mk_substs(params);
                 for &ty in fields.split_last().unwrap().1 {
                     if ty.subst(tcx, substs).references_error() {

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -776,7 +776,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 (GenericParamDefKind::Type { .. }, GenericArg::Type(ty)) => {
                     if let (hir::TyKind::Infer, false) = (&ty.kind, self.allow_ty_infer()) {
                         inferred_params.push(ty.span);
-                        tcx.types.err.into()
+                        tcx.types.err().into()
                     } else {
                         self.ast_ty_to_ty(&ty).into()
                     }
@@ -801,7 +801,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                             // careful!
                             if default_needs_object_self(param) {
                                 missing_type_params.push(param.name.to_string());
-                                tcx.types.err.into()
+                                tcx.types.err().into()
                             } else {
                                 // This is a default type parameter.
                                 self.normalize_ty(
@@ -821,7 +821,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                             self.ty_infer(param, span).into()
                         } else {
                             // We've already errored above about the mismatch.
-                            tcx.types.err.into()
+                            tcx.types.err().into()
                         }
                     }
                     GenericParamDefKind::Const => {
@@ -1575,7 +1575,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 "at least one trait is required for an object type"
             )
             .emit();
-            return tcx.types.err;
+            return tcx.types.err();
         }
 
         // Check that there are no gross object safety violations;
@@ -1592,7 +1592,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     object_safety_violations,
                 )
                 .emit();
-                return tcx.types.err;
+                return tcx.types.err();
             }
         }
 
@@ -2396,7 +2396,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 &path_str,
                 item_segment.ident.name,
             );
-            return tcx.types.err;
+            return tcx.types.err();
         };
 
         debug!("qpath_to_ty: self_type={:?}", self_ty);
@@ -2709,7 +2709,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             }
             Res::Err => {
                 self.set_tainted_by_errors();
-                self.tcx().types.err
+                self.tcx().types.err()
             }
             _ => span_bug!(span, "unexpected resolution: {:?}", path.res),
         }
@@ -2764,7 +2764,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 };
                 self.associated_path_to_ty(ast_ty.hir_id, ast_ty.span, ty, res, segment, false)
                     .map(|(ty, _, _)| ty)
-                    .unwrap_or(tcx.types.err)
+                    .unwrap_or(tcx.types.err())
             }
             hir::TyKind::Array(ref ty, ref length) => {
                 let length = self.ast_const_to_const(length, tcx.types.usize);
@@ -2781,7 +2781,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 .span_label(ast_ty.span, "reserved keyword")
                 .emit();
 
-                tcx.types.err
+                tcx.types.err()
             }
             hir::TyKind::Infer => {
                 // Infer also appears as the type of arguments or return
@@ -2790,7 +2790,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 // handled specially and will not descend into this routine.
                 self.ty_infer(None, ast_ty.span)
             }
-            hir::TyKind::Err => tcx.types.err,
+            hir::TyKind::Err => tcx.types.err(),
         };
 
         debug!("ast_ty_to_ty: result_ty={:?}", result_ty);

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -105,7 +105,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 && i != 0
                 && self.if_fallback_coercion(expr.span, &arms[0].body, &mut coercion)
             {
-                tcx.types.err
+                tcx.types.err()
             } else {
                 // Only call this if this is not an `if` expr with an expected type and no `else`
                 // clause to avoid duplicated type errors. (#60254)

--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -358,7 +358,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 (
                     ty::Binder::bind(self.tcx.mk_fn_sig(
                         self.err_args(arg_exprs.len()).into_iter(),
-                        self.tcx.types.err,
+                        self.tcx.types.err(),
                         false,
                         hir::Unsafety::Normal,
                         abi::Abi::Rust,

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -180,7 +180,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let sig = object_type
                     .projection_bounds()
                     .filter_map(|pb| {
-                        let pb = pb.with_self_ty(self.tcx, self.tcx.types.err);
+                        let pb = pb.with_self_ty(self.tcx, self.tcx.types.err());
                         self.deduce_sig_from_projection(None, &pb)
                     })
                     .next();
@@ -712,7 +712,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let supplied_arguments = decl.inputs.iter().map(|a| {
             // Convert the types that the user supplied (if any), but ignore them.
             astconv.ast_ty_to_ty(a);
-            self.tcx.types.err
+            self.tcx.types.err()
         });
 
         if let hir::FnRetTy::Return(ref output) = decl.output {
@@ -721,7 +721,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let result = ty::Binder::bind(self.tcx.mk_fn_sig(
             supplied_arguments,
-            self.tcx.types.err,
+            self.tcx.types.err(),
             decl.c_variadic,
             hir::Unsafety::Normal,
             Abi::RustCall,

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -161,7 +161,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
 
         // Just ignore error types.
         if a.references_error() || b.references_error() {
-            return success(vec![], self.fcx.tcx.types.err, vec![]);
+            return success(vec![], self.fcx.tcx.types.err(), vec![]);
         }
 
         if a.is_never() {
@@ -820,7 +820,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let (adjustments, _) = self.register_infer_ok_obligations(ok);
         self.apply_adjustments(expr, adjustments);
-        Ok(if expr_ty.references_error() { self.tcx.types.err } else { target })
+        Ok(if expr_ty.references_error() { self.tcx.types.err() } else { target })
     }
 
     /// Same as `try_coerce()`, but without side-effects.
@@ -1137,7 +1137,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
         // If we see any error types, just propagate that error
         // upwards.
         if expression_ty.references_error() || self.merged_ty().references_error() {
-            self.final_ty = Some(fcx.tcx.types.err);
+            self.final_ty = Some(fcx.tcx.types.err());
             return;
         }
 
@@ -1294,7 +1294,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
 
                 err.emit_unless(assign_to_bool || unsized_return);
 
-                self.final_ty = Some(fcx.tcx.types.err);
+                self.final_ty = Some(fcx.tcx.types.err());
             }
         }
     }

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -245,7 +245,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     tcx.types.never
                 } else {
                     // There was an error; make type-check fail.
-                    tcx.types.err
+                    tcx.types.err()
                 }
             }
             ExprKind::Ret(ref expr_opt) => self.check_expr_return(expr_opt.as_deref(), expr),
@@ -281,7 +281,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ExprKind::Field(ref base, field) => self.check_field(expr, needs, &base, field),
             ExprKind::Index(ref base, ref idx) => self.check_expr_index(base, idx, needs, expr),
             ExprKind::Yield(ref value, ref src) => self.check_expr_yield(value, expr, src),
-            hir::ExprKind::Err => tcx.types.err,
+            hir::ExprKind::Err => tcx.types.err(),
         }
     }
 
@@ -357,7 +357,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             tcx.sess.parse_sess.expr_parentheses_needed(&mut err, *sp, None);
                         }
                         err.emit();
-                        oprnd_t = tcx.types.err;
+                        oprnd_t = tcx.types.err();
                     }
                 }
                 hir::UnOp::UnNot => {
@@ -407,7 +407,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let tm = ty::TypeAndMut { ty, mutbl };
         match kind {
-            _ if tm.ty.references_error() => self.tcx.types.err,
+            _ if tm.ty.references_error() => self.tcx.types.err(),
             hir::BorrowKind::Raw => {
                 self.check_named_place_expr(oprnd);
                 self.tcx.mk_ptr(tm)
@@ -473,11 +473,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let ty = match res {
             Res::Err => {
                 self.set_tainted_by_errors();
-                tcx.types.err
+                tcx.types.err()
             }
             Res::Def(DefKind::Ctor(_, CtorKind::Fictive), _) => {
                 report_unexpected_variant_res(tcx, res, expr.span, qpath);
-                tcx.types.err
+                tcx.types.err()
             }
             _ => self.instantiate_value_path(segs, opt_ty, res, expr.span, expr.hir_id).0,
         };
@@ -561,7 +561,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 expr.span,
                                 "break was outside loop, but no error was emitted",
                             );
-                            return tcx.types.err;
+                            return tcx.types.err();
                         }
                     }
                 };
@@ -569,7 +569,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // If the loop context is not a `loop { }`, then break with
                 // a value is illegal, and `opt_coerce_to` will be `None`.
                 // Just set expectation to error in that case.
-                let coerce_to = opt_coerce_to.unwrap_or(tcx.types.err);
+                let coerce_to = opt_coerce_to.unwrap_or(tcx.types.err());
 
                 // Recurse without `enclosing_breakables` borrowed.
                 e_ty = self.check_expr_with_hint(e, coerce_to);
@@ -593,7 +593,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         expr.span,
                         "break was outside loop, but no error was emitted",
                     );
-                    return tcx.types.err;
+                    return tcx.types.err();
                 }
             };
 
@@ -653,7 +653,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // We still need to assign a type to the inner expression to
             // prevent the ICE in #43162.
             if let Some(ref e) = expr_opt {
-                self.check_expr_with_hint(e, tcx.types.err);
+                self.check_expr_with_hint(e, tcx.types.err());
 
                 // ... except when we try to 'break rust;'.
                 // ICE this expression in particular (see #43162).
@@ -664,7 +664,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
             }
             // There was an error; make type-check fail.
-            tcx.types.err
+            tcx.types.err()
         }
     }
 
@@ -797,7 +797,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         self.require_type_is_sized(lhs_ty, lhs.span, traits::AssignmentLhsSized);
 
         if lhs_ty.references_error() || rhs_ty.references_error() {
-            self.tcx.types.err
+            self.tcx.types.err()
         } else {
             self.tcx.mk_unit()
         }
@@ -951,7 +951,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Eagerly check for some obvious errors.
         if t_expr.references_error() || t_cast.references_error() {
-            self.tcx.types.err
+            self.tcx.types.err()
         } else {
             // Defer other checks until we're done type checking.
             let mut deferred_cast_checks = self.deferred_cast_checks.borrow_mut();
@@ -960,7 +960,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     deferred_cast_checks.push(cast_check);
                     t_cast
                 }
-                Err(ErrorReported) => self.tcx.types.err,
+                Err(ErrorReported) => self.tcx.types.err(),
             }
         }
     }
@@ -1040,7 +1040,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         };
 
         if element_ty.references_error() {
-            return tcx.types.err;
+            return tcx.types.err();
         }
         match count {
             Ok(count) => tcx.mk_ty(ty::Array(t, count)),
@@ -1049,9 +1049,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     tcx.def_span(count_def_id),
                     "array lengths can't depend on generic parameters",
                 );
-                tcx.types.err
+                tcx.types.err()
             }
-            Err(ErrorHandled::Reported) => tcx.types.err,
+            Err(ErrorHandled::Reported) => tcx.types.err(),
         }
     }
 
@@ -1082,7 +1082,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         });
         let tuple = self.tcx.mk_tup(elt_ts_iter);
         if tuple.references_error() {
-            self.tcx.types.err
+            self.tcx.types.err()
         } else {
             self.require_type_is_sized(tuple, expr.span, traits::TupleInitializerSized);
             tuple
@@ -1103,7 +1103,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             variant_ty
         } else {
             self.check_struct_fields_on_error(fields, base_expr);
-            return self.tcx.types.err;
+            return self.tcx.types.err();
         };
 
         let path_span = match *qpath {
@@ -1244,7 +1244,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     self.report_unknown_field(adt_ty, variant, field, ast_fields, kind_name, span);
                 }
 
-                tcx.types.err
+                tcx.types.err()
             };
 
             // Make sure to give a type to the field even if there's
@@ -1530,7 +1530,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             .emit();
         }
 
-        self.tcx().types.err
+        self.tcx().types.err()
     }
 
     fn ban_nonexisting_field(
@@ -1796,7 +1796,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         }
                     }
                     err.emit();
-                    self.tcx.types.err
+                    self.tcx.types.err()
                 }
             }
         }

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -145,7 +145,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
                     rustc_span::DUMMY_SP,
                     &format!("failed autoderef {}", pick.autoderefs),
                 );
-                return self.tcx.types.err;
+                return self.tcx.types.err();
             }
         };
         assert_eq!(n, pick.autoderefs);

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -400,7 +400,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     .probe_instantiate_query_response(span, &orig_values, ty)
                     .unwrap_or_else(|_| span_bug!(span, "instantiating {:?} failed?", ty));
                 let ty = self.structurally_resolved_type(span, ty.value);
-                assert_eq!(ty, self.tcx.types.err);
+                assert_eq!(ty, self.tcx.types.err());
                 return Err(MethodError::NoMatch(NoMatchData::new(
                     Vec::new(),
                     Vec::new(),

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -972,7 +972,7 @@ fn diagnostic_only_typeck_tables_of<'tcx>(
     let fallback = move || {
         let span = tcx.hir().span(tcx.hir().as_local_hir_id(def_id).unwrap());
         tcx.sess.delay_span_bug(span, "diagnostic only typeck table used");
-        tcx.types.err
+        tcx.types.err()
     };
     typeck_tables_of_with_fallback(tcx, def_id, fallback)
 }
@@ -3305,7 +3305,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub fn node_ty(&self, id: hir::HirId) -> Ty<'tcx> {
         match self.tables.borrow().node_types().get(id) {
             Some(&t) => t,
-            None if self.is_tainted_by_errors() => self.tcx.types.err,
+            None if self.is_tainted_by_errors() => self.tcx.types.err(),
             None => {
                 bug!(
                     "no type for node {}: {} in fcx {}",
@@ -3420,7 +3420,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         assert!(ty.is_ty_infer());
         let fallback = match self.type_is_unconstrained_numeric(ty) {
-            _ if self.is_tainted_by_errors() => self.tcx().types.err,
+            _ if self.is_tainted_by_errors() => self.tcx().types.err(),
             UnconstrainedInt => self.tcx.types.i32,
             UnconstrainedFloat => self.tcx.types.f64,
             Neither if self.type_var_diverges(ty) => self.tcx.mk_diverging_default(),
@@ -3695,7 +3695,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 tuple_arguments,
                 None,
             );
-            return self.tcx.types.err;
+            return self.tcx.types.err();
         }
 
         let method = method.unwrap();
@@ -4079,7 +4079,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     fn err_args(&self, len: usize) -> Vec<Ty<'tcx>> {
-        vec![self.tcx.types.err; len]
+        vec![self.tcx.types.err(); len]
     }
 
     /// Given a vec of evaluated `FulfillmentError`s and an `fn` call argument expressions, we walk
@@ -4218,7 +4218,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 opt_ty.unwrap_or_else(|| self.next_float_var())
             }
             ast::LitKind::Bool(_) => tcx.types.bool,
-            ast::LitKind::Err(_) => tcx.types.err,
+            ast::LitKind::Err(_) => tcx.types.err(),
         }
     }
 
@@ -4376,7 +4376,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 };
                 let result =
                     AstConv::associated_path_to_ty(self, hir_id, path_span, ty, res, segment, true);
-                let ty = result.map(|(ty, _, _)| ty).unwrap_or(self.tcx().types.err);
+                let ty = result.map(|(ty, _, _)| ty).unwrap_or(self.tcx().types.err());
                 let result = result.map(|(_, kind, def_id)| (kind, def_id));
 
                 // Write back the new resolution.
@@ -4503,7 +4503,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         ty: Ty<'tcx>,
     ) {
         if ty.references_error() {
-            // Override the types everywhere with `types.err` to avoid knock on errors.
+            // Override the types everywhere with `types.err()` to avoid knock on errors.
             self.write_ty(local.hir_id, ty);
             self.write_ty(local.pat.hir_id, ty);
             let local_ty = LocalTy { decl_ty, revealed_ty: ty };
@@ -4723,7 +4723,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let mut ty = ctxt.coerce.unwrap().complete(self);
 
         if self.has_errors.get() || ty.references_error() {
-            ty = self.tcx.types.err
+            ty = self.tcx.types.err()
         }
 
         self.write_ty(blk.hir_id, ty);
@@ -5469,7 +5469,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                     err.emit();
 
-                    return (tcx.types.err, res);
+                    return (tcx.types.err(), res);
                 }
             }
         } else {
@@ -5651,8 +5651,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     .note("type must be known at this point")
                     .emit();
             }
-            self.demand_suptype(sp, self.tcx.types.err, ty);
-            self.tcx.types.err
+            self.demand_suptype(sp, self.tcx.types.err(), ty);
+            self.tcx.types.err()
         }
     }
 

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -471,7 +471,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         }
                     }
                 }
-                self.tcx.types.err
+                self.tcx.types.err()
             }
         };
 
@@ -705,7 +705,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                     err.emit();
                 }
-                self.tcx.types.err
+                self.tcx.types.err()
             }
         }
     }

--- a/src/librustc_typeck/check/pat.rs
+++ b/src/librustc_typeck/check/pat.rs
@@ -441,7 +441,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // There exists a side that didn't meet our criteria that the end-point
             // be of a numeric or char type, as checked in `calc_side` above.
             self.emit_err_pat_range(span, lhs, rhs);
-            return self.tcx.types.err;
+            return self.tcx.types.err();
         }
 
         // Now that we know the types can be unified we find the unified type
@@ -674,9 +674,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         } else {
             for field in fields {
                 let ti = TopInfo { parent_pat: Some(&pat), ..ti };
-                self.check_pat(&field.pat, self.tcx.types.err, def_bm, ti);
+                self.check_pat(&field.pat, self.tcx.types.err(), def_bm, ti);
             }
-            return self.tcx.types.err;
+            return self.tcx.types.err();
         };
 
         // Type-check the path.
@@ -686,7 +686,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         if self.check_struct_pat_fields(pat_ty, &pat, variant, fields, etc, def_bm, ti) {
             pat_ty
         } else {
-            self.tcx.types.err
+            self.tcx.types.err()
         }
     }
 
@@ -705,13 +705,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         match res {
             Res::Err => {
                 self.set_tainted_by_errors();
-                return tcx.types.err;
+                return tcx.types.err();
             }
             Res::Def(DefKind::AssocFn, _)
             | Res::Def(DefKind::Ctor(_, CtorKind::Fictive), _)
             | Res::Def(DefKind::Ctor(_, CtorKind::Fn), _) => {
                 report_unexpected_variant_res(tcx, res, pat.span, qpath);
-                return tcx.types.err;
+                return tcx.types.err();
             }
             Res::Def(DefKind::Ctor(_, CtorKind::Const), _)
             | Res::SelfCtor(..)
@@ -783,7 +783,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let on_error = || {
             let parent_pat = Some(pat);
             for pat in subpats {
-                self.check_pat(&pat, tcx.types.err, def_bm, TopInfo { parent_pat, ..ti });
+                self.check_pat(&pat, tcx.types.err(), def_bm, TopInfo { parent_pat, ..ti });
             }
         };
         let report_unexpected_res = |res: Res| {
@@ -814,7 +814,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         if res == Res::Err {
             self.set_tainted_by_errors();
             on_error();
-            return self.tcx.types.err;
+            return self.tcx.types.err();
         }
 
         // Type-check the path.
@@ -822,18 +822,18 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.instantiate_value_path(segments, opt_ty, res, pat.span, pat.hir_id);
         if !pat_ty.is_fn() {
             report_unexpected_res(res);
-            return tcx.types.err;
+            return tcx.types.err();
         }
 
         let variant = match res {
             Res::Err => {
                 self.set_tainted_by_errors();
                 on_error();
-                return tcx.types.err;
+                return tcx.types.err();
             }
             Res::Def(DefKind::AssocConst, _) | Res::Def(DefKind::AssocFn, _) => {
                 report_unexpected_res(res);
-                return tcx.types.err;
+                return tcx.types.err();
             }
             Res::Def(DefKind::Ctor(_, CtorKind::Fn), _) => tcx.expect_variant_res(res),
             _ => bug!("unexpected pattern resolution: {:?}", res),
@@ -866,7 +866,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // Pattern has wrong number of fields.
             self.e0023(pat.span, res, qpath, subpats, &variant.fields, expected, had_err);
             on_error();
-            return tcx.types.err;
+            return tcx.types.err();
         }
         pat_ty
     }
@@ -987,9 +987,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             err.emit();
             // Walk subpatterns with an expected type of `err` in this case to silence
             // further errors being emitted when using the bindings. #50333
-            let element_tys_iter = (0..max_len).map(|_| tcx.types.err);
+            let element_tys_iter = (0..max_len).map(|_| tcx.types.err());
             for (_, elem) in elements.iter().enumerate_and_adjust(max_len, ddpos) {
-                self.check_pat(elem, &tcx.types.err, def_bm, ti);
+                self.check_pat(elem, &tcx.types.err(), def_bm, ti);
             }
             tcx.mk_tup(element_tys_iter)
         } else {
@@ -1039,7 +1039,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 Occupied(occupied) => {
                     self.error_field_already_bound(span, field.ident, *occupied.get());
                     no_field_errors = false;
-                    tcx.types.err
+                    tcx.types.err()
                 }
                 Vacant(vacant) => {
                     vacant.insert(span);
@@ -1053,7 +1053,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         .unwrap_or_else(|| {
                             inexistent_fields.push(field.ident);
                             no_field_errors = false;
-                            tcx.types.err
+                            tcx.types.err()
                         })
                 }
             };
@@ -1252,7 +1252,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.demand_eqtype_pat(span, expected, box_ty, ti);
             (box_ty, inner_ty)
         } else {
-            (tcx.types.err, tcx.types.err)
+            (tcx.types.err(), tcx.types.err())
         };
         self.check_pat(&inner, inner_ty, def_bm, ti);
         box_ty
@@ -1298,7 +1298,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
             }
         } else {
-            (tcx.types.err, tcx.types.err)
+            (tcx.types.err(), tcx.types.err())
         };
         self.check_pat(&inner, inner_ty, def_bm, TopInfo { parent_pat: Some(&pat), ..ti });
         rptr_ty
@@ -1331,7 +1331,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         def_bm: BindingMode,
         ti: TopInfo<'tcx>,
     ) -> Ty<'tcx> {
-        let err = self.tcx.types.err;
+        let err = self.tcx.types.err();
         let expected = self.structurally_resolved_type(span, expected);
         let (inner_ty, slice_ty, expected) = match expected.kind {
             // An array, so we might have something like `let [a, b, c] = [0, 1, 2];`.

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -693,7 +693,7 @@ fn check_where_clauses<'tcx, 'fcx>(
                     }
                 }
                 // Mark unwanted params as error.
-                fcx.tcx.types.err.into()
+                fcx.tcx.types.err().into()
             }
 
             GenericParamDefKind::Const => {

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -202,7 +202,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                         e.span,
                         &format!("bad index {:?} for base: `{:?}`", index, base),
                     );
-                    self.fcx.tcx.types.err
+                    self.fcx.tcx.types.err()
                 });
                 let index_ty = self.fcx.resolve_vars_if_possible(&index_ty);
 
@@ -641,7 +641,7 @@ impl<'cx, 'tcx> TypeFolder<'tcx> for Resolver<'cx, 'tcx> {
             Err(_) => {
                 debug!("Resolver::fold_ty: input type `{:?}` not fully resolvable", t);
                 self.report_error(t);
-                self.tcx().types.err
+                self.tcx().types.err()
             }
         }
     }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -321,7 +321,7 @@ impl AstConv<'tcx> for ItemCtxt<'tcx> {
 
     fn ty_infer(&self, _: Option<&ty::GenericParamDef>, span: Span) -> Ty<'tcx> {
         self.tcx().sess.delay_span_bug(span, "bad placeholder type");
-        self.tcx().types.err
+        self.tcx().types.err()
     }
 
     fn ct_infer(
@@ -430,7 +430,7 @@ impl AstConv<'tcx> for ItemCtxt<'tcx> {
                 _ => {}
             }
             err.emit();
-            self.tcx().types.err
+            self.tcx().types.err()
         }
     }
 
@@ -1486,7 +1486,7 @@ fn fn_sig(tcx: TyCtxt<'_>, def_id: DefId) -> ty::PolyFnSig<'_> {
                     visitor.visit_ty(ty);
                     let mut diag = bad_placeholder_type(tcx, visitor.0);
                     let ret_ty = fn_sig.output();
-                    if ret_ty != tcx.types.err {
+                    if ret_ty != tcx.types.err() {
                         diag.span_suggestion(
                             ty.span,
                             "replace with the correct return type",
@@ -2045,7 +2045,7 @@ fn associated_item_predicates(
             // once they are handled by the trait system.
             ty::GenericParamDefKind::Type { .. } => {
                 unimplemented_error("type");
-                tcx.types.err.into()
+                tcx.types.err().into()
             }
             ty::GenericParamDefKind::Const => {
                 unimplemented_error("const");

--- a/src/librustc_typeck/collect/type_of.rs
+++ b/src/librustc_typeck/collect/type_of.rs
@@ -129,7 +129,7 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
                                 // Some error in the
                                 // owner fn prevented us from populating
                                 // the `concrete_opaque_types` table.
-                                tcx.types.err
+                                tcx.types.err()
                             } else {
                                 // We failed to resolve the opaque type or it
                                 // resolves to itself. Return the non-revealed
@@ -260,13 +260,13 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
                                 tcx.generics_of(tcx.parent(def_id).unwrap())
                             }
                             Res::Def(_, def_id) => tcx.generics_of(def_id),
-                            Res::Err => return tcx.types.err,
+                            Res::Err => return tcx.types.err(),
                             res => {
                                 tcx.sess.delay_span_bug(
                                     DUMMY_SP,
                                     &format!("unexpected const parent path def {:?}", res,),
                                 );
-                                return tcx.types.err;
+                                return tcx.types.err();
                             }
                         };
 
@@ -284,13 +284,13 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
                             .map(|param| tcx.type_of(param.def_id))
                             // This is no generic parameter associated with the arg. This is
                             // probably from an extra arg where one is not needed.
-                            .unwrap_or(tcx.types.err)
+                            .unwrap_or(tcx.types.err())
                     } else {
                         tcx.sess.delay_span_bug(
                             DUMMY_SP,
                             &format!("unexpected const parent path {:?}", parent_node,),
                         );
-                        tcx.types.err
+                        tcx.types.err()
                     }
                 }
 
@@ -299,7 +299,7 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
                         DUMMY_SP,
                         &format!("unexpected const parent in type_of_def_id(): {:?}", x),
                     );
-                    tcx.types.err
+                    tcx.types.err()
                 }
             }
         }
@@ -602,7 +602,7 @@ fn find_opaque_ty_constraints(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
         None => {
             let span = tcx.def_span(def_id);
             tcx.sess.span_err(span, "could not find defining uses");
-            tcx.types.err
+            tcx.types.err()
         }
     }
 }
@@ -635,7 +635,7 @@ fn infer_placeholder_type(
         }
         None => {
             let mut diag = bad_placeholder_type(tcx, vec![span]);
-            if ty != tcx.types.err {
+            if ty != tcx.types.err() {
                 diag.span_suggestion(
                     span,
                     "replace `_` with the correct type",

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -380,7 +380,7 @@ pub fn hir_trait_to_predicates<'tcx>(
         hir_trait,
         DUMMY_SP,
         hir::Constness::NotConst,
-        tcx.types.err,
+        tcx.types.err(),
         &mut bounds,
         true,
     );

--- a/src/librustc_typeck/variance/constraints.rs
+++ b/src/librustc_typeck/variance/constraints.rs
@@ -316,7 +316,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
 
                 if let Some(poly_trait_ref) = data.principal() {
                     let poly_trait_ref =
-                        poly_trait_ref.with_self_ty(self.tcx(), self.tcx().types.err);
+                        poly_trait_ref.with_self_ty(self.tcx(), self.tcx().types.err());
                     self.add_constraints_from_trait_ref(
                         current,
                         *poly_trait_ref.skip_binder(),


### PR DESCRIPTION
r? @eddyb 

Not sure how good of an idea this is... but it occurred to me that we can do more to enforce the invariant that `TyKind::Error` should only happen if errors are going to be emitted. We could also use the function to due a delay bug for good measure.