### PR TITLE
Remove another wrong entry from RELEASES.md

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4838,7 +4838,6 @@ Version 1.11.0 (2016-08-18)
 Language
 --------
 
-* [`cfg_attr` works on `path` attributes](https://github.com/rust-lang/rust/pull/34546)
 * [Support nested `cfg_attr` attributes](https://github.com/rust-lang/rust/pull/34216)
 * [Allow statement-generating braced macro invocations at the end of blocks](https://github.com/rust-lang/rust/pull/34436)
 * [Macros can be expanded inside of trait definitions](https://github.com/rust-lang/rust/pull/34213)


### PR DESCRIPTION
The entry is under 1.11.0, but the feature is only available since 1.12.0 (for which an identical entry exists).

![Screenshot_2020-03-22 Support `cfg_attr` on `path` attributes by jseyfried · Pull Request #34546 · rust-lang rust](https://user-images.githubusercontent.com/951129/77238862-85c8f580-6bd4-11ea-8d31-77e2994a4b5a.png)
