### PR TITLE
Move arg/constraint partition check to validation & improve recovery

### DIFF
--- a/src/librustc_ast/ast.rs
+++ b/src/librustc_ast/ast.rs
@@ -214,11 +214,18 @@ impl GenericArg {
 pub struct AngleBracketedArgs {
     /// The overall span.
     pub span: Span,
-    /// The arguments for this path segment.
-    pub args: Vec<GenericArg>,
-    /// Constraints on associated types, if any.
-    /// E.g., `Foo<A = Bar, B: Baz>`.
-    pub constraints: Vec<AssocTyConstraint>,
+    /// The comma separated parts in the `<...>`.
+    pub args: Vec<AngleBracketedArg>,
+}
+
+/// Either an argument for a parameter e.g., `'a`, `Vec<u8>`, `0`,
+/// or a constraint on an associated item, e.g., `Item = String` or `Item: Bound`.
+#[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
+pub enum AngleBracketedArg {
+    /// Argument for a generic parameter.
+    Arg(GenericArg),
+    /// Constraint for an associated item.
+    Constraint(AssocTyConstraint),
 }
 
 impl Into<Option<P<GenericArgs>>> for AngleBracketedArgs {
@@ -248,11 +255,13 @@ pub struct ParenthesizedArgs {
 
 impl ParenthesizedArgs {
     pub fn as_angle_bracketed_args(&self) -> AngleBracketedArgs {
-        AngleBracketedArgs {
-            span: self.span,
-            args: self.inputs.iter().cloned().map(GenericArg::Type).collect(),
-            constraints: vec![],
-        }
+        let args = self
+            .inputs
+            .iter()
+            .cloned()
+            .map(|input| AngleBracketedArg::Arg(GenericArg::Type(input)))
+            .collect();
+        AngleBracketedArgs { span: self.span, args }
     }
 }
 

--- a/src/librustc_ast/mut_visit.rs
+++ b/src/librustc_ast/mut_visit.rs
@@ -546,9 +546,11 @@ pub fn noop_visit_angle_bracketed_parameter_data<T: MutVisitor>(
     data: &mut AngleBracketedArgs,
     vis: &mut T,
 ) {
-    let AngleBracketedArgs { args, constraints, span } = data;
-    visit_vec(args, |arg| vis.visit_generic_arg(arg));
-    visit_vec(constraints, |constraint| vis.visit_ty_constraint(constraint));
+    let AngleBracketedArgs { args, span } = data;
+    visit_vec(args, |arg| match arg {
+        AngleBracketedArg::Arg(arg) => vis.visit_generic_arg(arg),
+        AngleBracketedArg::Constraint(constraint) => vis.visit_ty_constraint(constraint),
+    });
     vis.visit_span(span);
 }
 

--- a/src/librustc_ast/visit.rs
+++ b/src/librustc_ast/visit.rs
@@ -464,8 +464,12 @@ where
 {
     match *generic_args {
         GenericArgs::AngleBracketed(ref data) => {
-            walk_list!(visitor, visit_generic_arg, &data.args);
-            walk_list!(visitor, visit_assoc_ty_constraint, &data.constraints);
+            for arg in &data.args {
+                match arg {
+                    AngleBracketedArg::Arg(a) => visitor.visit_generic_arg(a),
+                    AngleBracketedArg::Constraint(c) => visitor.visit_assoc_ty_constraint(c),
+                }
+            }
         }
         GenericArgs::Parenthesized(ref data) => {
             walk_list!(visitor, visit_ty, &data.inputs);

--- a/src/librustc_ast_lowering/lib.rs
+++ b/src/librustc_ast_lowering/lib.rs
@@ -34,6 +34,7 @@
 #![feature(crate_visibility_modifier)]
 #![feature(marker_trait_attr)]
 #![feature(specialization)]
+#![feature(or_patterns)]
 #![recursion_limit = "256"]
 
 use rustc_ast::ast;

--- a/src/librustc_ast_lowering/path.rs
+++ b/src/librustc_ast_lowering/path.rs
@@ -366,22 +366,27 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         param_mode: ParamMode,
         mut itctx: ImplTraitContext<'_, 'hir>,
     ) -> (GenericArgsCtor<'hir>, bool) {
-        let &AngleBracketedArgs { ref args, ref constraints, .. } = data;
-        let has_non_lt_args = args.iter().any(|arg| match arg {
-            ast::GenericArg::Lifetime(_) => false,
-            ast::GenericArg::Type(_) => true,
-            ast::GenericArg::Const(_) => true,
+        let has_non_lt_args = data.args.iter().any(|arg| match arg {
+            AngleBracketedArg::Arg(ast::GenericArg::Lifetime(_)) => false,
+            AngleBracketedArg::Arg(ast::GenericArg::Type(_) | ast::GenericArg::Const(_))
+            | AngleBracketedArg::Constraint(_) => true,
         });
-        (
-            GenericArgsCtor {
-                args: args.iter().map(|a| self.lower_generic_arg(a, itctx.reborrow())).collect(),
-                bindings: self.arena.alloc_from_iter(
-                    constraints.iter().map(|b| self.lower_assoc_ty_constraint(b, itctx.reborrow())),
-                ),
-                parenthesized: false,
-            },
-            !has_non_lt_args && param_mode == ParamMode::Optional,
-        )
+        let args = data
+            .args
+            .iter()
+            .filter_map(|arg| match arg {
+                AngleBracketedArg::Arg(arg) => Some(self.lower_generic_arg(arg, itctx.reborrow())),
+                AngleBracketedArg::Constraint(_) => None,
+            })
+            .collect();
+        let bindings = self.arena.alloc_from_iter(data.args.iter().filter_map(|arg| match arg {
+            AngleBracketedArg::Constraint(c) => {
+                Some(self.lower_assoc_ty_constraint(c, itctx.reborrow()))
+            }
+            AngleBracketedArg::Arg(_) => None,
+        }));
+        let ctor = GenericArgsCtor { args, bindings, parenthesized: false };
+        (ctor, !has_non_lt_args && param_mode == ParamMode::Optional)
     }
 
     fn lower_parenthesized_parameter_data(

--- a/src/librustc_ast_lowering/path.rs
+++ b/src/librustc_ast_lowering/path.rs
@@ -367,9 +367,9 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         mut itctx: ImplTraitContext<'_, 'hir>,
     ) -> (GenericArgsCtor<'hir>, bool) {
         let has_non_lt_args = data.args.iter().any(|arg| match arg {
-            AngleBracketedArg::Arg(ast::GenericArg::Lifetime(_)) => false,
-            AngleBracketedArg::Arg(ast::GenericArg::Type(_) | ast::GenericArg::Const(_))
-            | AngleBracketedArg::Constraint(_) => true,
+            AngleBracketedArg::Arg(ast::GenericArg::Lifetime(_))
+            | AngleBracketedArg::Constraint(_) => false,
+            AngleBracketedArg::Arg(ast::GenericArg::Type(_) | ast::GenericArg::Const(_)) => true,
         });
         let args = data
             .args

--- a/src/librustc_ast_passes/ast_validation.rs
+++ b/src/librustc_ast_passes/ast_validation.rs
@@ -660,12 +660,8 @@ impl<'a> AstValidator<'a> {
         // ...and then error:
         self.err_handler()
             .struct_span_err(
-                data.span,
-                "constraints in a path segment must come after generic arguments",
-            )
-            .span_labels(
                 misplaced_args,
-                "this generic argument must come before the first constraint",
+                "generic arguments must come before the first constraint",
             )
             .span_label(first.unwrap(), "the first constraint is provided here")
             .emit();

--- a/src/librustc_ast_passes/ast_validation.rs
+++ b/src/librustc_ast_passes/ast_validation.rs
@@ -660,10 +660,11 @@ impl<'a> AstValidator<'a> {
         // ...and then error:
         self.err_handler()
             .struct_span_err(
-                misplaced_args,
+                misplaced_args.clone(),
                 "generic arguments must come before the first constraint",
             )
             .span_label(first.unwrap(), "the first constraint is provided here")
+            .span_labels(misplaced_args, "generic argument")
             .emit();
     }
 }

--- a/src/librustc_ast_passes/ast_validation.rs
+++ b/src/librustc_ast_passes/ast_validation.rs
@@ -639,6 +639,37 @@ impl<'a> AstValidator<'a> {
             .emit();
         }
     }
+
+    /// Enforce generic args coming before constraints in `<...>` of a path segment.
+    fn check_generic_args_before_constraints(&self, data: &AngleBracketedArgs) {
+        // Early exit in case it's partitioned as it should be.
+        if data.args.iter().is_partitioned(|arg| matches!(arg, AngleBracketedArg::Arg(_))) {
+            return;
+        }
+        // Find all generic argument coming after the first constraint...
+        let mut misplaced_args = Vec::new();
+        let mut first = None;
+        for arg in &data.args {
+            match (arg, first) {
+                (AngleBracketedArg::Arg(a), Some(_)) => misplaced_args.push(a.span()),
+                (AngleBracketedArg::Constraint(c), None) => first = Some(c.span),
+                (AngleBracketedArg::Arg(_), None) | (AngleBracketedArg::Constraint(_), Some(_)) => {
+                }
+            }
+        }
+        // ...and then error:
+        self.err_handler()
+            .struct_span_err(
+                data.span,
+                "constraints in a path segment must come after generic arguments",
+            )
+            .span_labels(
+                misplaced_args,
+                "this generic argument must come before the first constraint",
+            )
+            .span_label(first.unwrap(), "the first constraint is provided here")
+            .emit();
+    }
 }
 
 /// Checks that generic parameters are in the correct order,
@@ -1008,17 +1039,20 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
     fn visit_generic_args(&mut self, _: Span, generic_args: &'a GenericArgs) {
         match *generic_args {
             GenericArgs::AngleBracketed(ref data) => {
-                walk_list!(self, visit_generic_arg, &data.args);
+                self.check_generic_args_before_constraints(data);
 
-                // Type bindings such as `Item = impl Debug` in `Iterator<Item = Debug>`
-                // are allowed to contain nested `impl Trait`.
-                self.with_impl_trait(None, |this| {
-                    walk_list!(
-                        this,
-                        visit_assoc_ty_constraint_from_generic_args,
-                        &data.constraints
-                    );
-                });
+                for arg in &data.args {
+                    match arg {
+                        AngleBracketedArg::Arg(arg) => self.visit_generic_arg(arg),
+                        // Type bindings such as `Item = impl Debug` in `Iterator<Item = Debug>`
+                        // are allowed to contain nested `impl Trait`.
+                        AngleBracketedArg::Constraint(constraint) => {
+                            self.with_impl_trait(None, |this| {
+                                this.visit_assoc_ty_constraint_from_generic_args(constraint);
+                            });
+                        }
+                    }
+                }
             }
             GenericArgs::Parenthesized(ref data) => {
                 walk_list!(self, visit_ty, &data.inputs);

--- a/src/librustc_ast_passes/lib.rs
+++ b/src/librustc_ast_passes/lib.rs
@@ -1,9 +1,11 @@
-#![feature(bindings_after_at)]
 //! The `rustc_ast_passes` crate contains passes which validate the AST in `syntax`
 //! parsed by `rustc_parse` and then lowered, after the passes in this crate,
 //! by `rustc_ast_lowering`.
 //!
 //! The crate also contains other misc AST visitors, e.g. `node_count` and `show_span`.
+
+#![feature(bindings_after_at)]
+#![feature(iter_is_partitioned)]
 
 pub mod ast_validation;
 pub mod feature_gate;

--- a/src/librustc_expand/build.rs
+++ b/src/librustc_expand/build.rs
@@ -36,7 +36,8 @@ impl<'a> ExtCtxt<'a> {
             idents.into_iter().map(|ident| ast::PathSegment::from_ident(ident.with_span_pos(span))),
         );
         let args = if !args.is_empty() {
-            ast::AngleBracketedArgs { args, constraints: Vec::new(), span }.into()
+            let args = args.into_iter().map(ast::AngleBracketedArg::Arg).collect();
+            ast::AngleBracketedArgs { args, span }.into()
         } else {
             None
         };

--- a/src/librustc_parse/parser/path.rs
+++ b/src/librustc_parse/parser/path.rs
@@ -4,6 +4,7 @@ use crate::maybe_whole;
 use rustc_ast::ast::{self, AngleBracketedArg, AngleBracketedArgs, GenericArg, ParenthesizedArgs};
 use rustc_ast::ast::{AnonConst, AssocTyConstraint, AssocTyConstraintKind, BlockCheckMode};
 use rustc_ast::ast::{Ident, Path, PathSegment, QSelf};
+use rustc_ast::ptr::P;
 use rustc_ast::token::{self, Token};
 use rustc_errors::{pluralize, Applicability, PResult};
 use rustc_span::source_map::{BytePos, Span};
@@ -405,7 +406,8 @@ impl<'a> Parser<'a> {
             let lo = self.token.span;
             let ident = self.parse_ident()?;
             let kind = if self.eat(&token::Eq) {
-                AssocTyConstraintKind::Equality { ty: self.parse_ty()? }
+                let ty = self.parse_assoc_equality_term(ident, self.prev_token.span)?;
+                AssocTyConstraintKind::Equality { ty }
             } else if self.eat(&token::Colon) {
                 let bounds = self.parse_generic_bounds(Some(self.prev_token.span))?;
                 AssocTyConstraintKind::Bound { bounds }
@@ -425,6 +427,46 @@ impl<'a> Parser<'a> {
         } else {
             Ok(self.parse_generic_arg()?.map(AngleBracketedArg::Arg))
         }
+    }
+
+    /// Parse the term to the right of an associated item equality constraint.
+    /// That is, parse `<term>` in `Item = <term>`.
+    /// Right now, this only admits types in `<term>`.
+    fn parse_assoc_equality_term(&mut self, ident: Ident, eq: Span) -> PResult<'a, P<ast::Ty>> {
+        let arg = self.parse_generic_arg()?;
+        let span = ident.span.to(self.prev_token.span);
+        match arg {
+            Some(GenericArg::Type(ty)) => return Ok(ty),
+            Some(GenericArg::Const(expr)) => {
+                self.struct_span_err(span, "cannot constrain an associated constant to a value")
+                    .span_label(ident.span, "the value constrains this associated constant")
+                    .span_label(expr.value.span, "the value is given in this expression")
+                    .emit();
+            }
+            Some(GenericArg::Lifetime(lt)) => {
+                self.struct_span_err(span, "associated lifetimes are not supported")
+                    .span_label(lt.ident.span, "the lifetime is given here")
+                    .help("if you meant to specify a trait object, write `dyn Trait + 'lifetime`")
+                    .emit();
+            }
+            None => {
+                self.struct_span_err(span, "missing type to the right of `=`")
+                    .span_suggestion(
+                        span,
+                        "to constrain the associated type, add a type after `=`",
+                        format!("{} = TheType", ident),
+                        Applicability::HasPlaceholders,
+                    )
+                    .span_suggestion(
+                        eq,
+                        &format!("remove the `=` if `{}` is a type", ident),
+                        String::new(),
+                        Applicability::MaybeIncorrect,
+                    )
+                    .emit();
+            }
+        }
+        Ok(self.mk_ty(span, ast::TyKind::Err))
     }
 
     /// Parse a generic argument in a path segment.

--- a/src/librustc_parse/parser/path.rs
+++ b/src/librustc_parse/parser/path.rs
@@ -399,8 +399,7 @@ impl<'a> Parser<'a> {
 
     /// Parses a single argument in the angle arguments `<...>` of a path segment.
     fn parse_angle_arg(&mut self) -> PResult<'a, Option<AngleBracketedArg>> {
-        let arg = if self.check_ident()
-            && self.look_ahead(1, |t| matches!(t.kind, token::Eq | token::Colon))
+        if self.check_ident() && self.look_ahead(1, |t| matches!(t.kind, token::Eq | token::Colon))
         {
             // Parse associated type constraint.
             let lo = self.token.span;
@@ -422,10 +421,18 @@ impl<'a> Parser<'a> {
             }
 
             let constraint = AssocTyConstraint { id: ast::DUMMY_NODE_ID, ident, kind, span };
-            AngleBracketedArg::Constraint(constraint)
-        } else if self.check_lifetime() && self.look_ahead(1, |t| !t.is_like_plus()) {
+            Ok(Some(AngleBracketedArg::Constraint(constraint)))
+        } else {
+            Ok(self.parse_generic_arg()?.map(AngleBracketedArg::Arg))
+        }
+    }
+
+    /// Parse a generic argument in a path segment.
+    /// This does not include constraints, e.g., `Item = u8`, which is handled in `parse_angle_arg`.
+    fn parse_generic_arg(&mut self) -> PResult<'a, Option<GenericArg>> {
+        let arg = if self.check_lifetime() && self.look_ahead(1, |t| !t.is_like_plus()) {
             // Parse lifetime argument.
-            AngleBracketedArg::Arg(GenericArg::Lifetime(self.expect_lifetime()))
+            GenericArg::Lifetime(self.expect_lifetime())
         } else if self.check_const_arg() {
             // Parse const argument.
             let expr = if let token::OpenDelim(token::Brace) = self.token.kind {
@@ -451,11 +458,10 @@ impl<'a> Parser<'a> {
             } else {
                 self.parse_literal_maybe_minus()?
             };
-            let value = AnonConst { id: ast::DUMMY_NODE_ID, value: expr };
-            AngleBracketedArg::Arg(GenericArg::Const(value))
+            GenericArg::Const(AnonConst { id: ast::DUMMY_NODE_ID, value: expr })
         } else if self.check_type() {
             // Parse type argument.
-            AngleBracketedArg::Arg(GenericArg::Type(self.parse_ty()?))
+            GenericArg::Type(self.parse_ty()?)
         } else {
             return Ok(None);
         };

--- a/src/librustc_parse/parser/path.rs
+++ b/src/librustc_parse/parser/path.rs
@@ -399,10 +399,7 @@ impl<'a> Parser<'a> {
 
     /// Parses a single argument in the angle arguments `<...>` of a path segment.
     fn parse_angle_arg(&mut self) -> PResult<'a, Option<AngleBracketedArg>> {
-        let arg = if self.check_lifetime() && self.look_ahead(1, |t| !t.is_like_plus()) {
-            // Parse lifetime argument.
-            AngleBracketedArg::Arg(GenericArg::Lifetime(self.expect_lifetime()))
-        } else if self.check_ident()
+        let arg = if self.check_ident()
             && self.look_ahead(1, |t| matches!(t.kind, token::Eq | token::Colon))
         {
             // Parse associated type constraint.
@@ -426,6 +423,9 @@ impl<'a> Parser<'a> {
 
             let constraint = AssocTyConstraint { id: ast::DUMMY_NODE_ID, ident, kind, span };
             AngleBracketedArg::Constraint(constraint)
+        } else if self.check_lifetime() && self.look_ahead(1, |t| !t.is_like_plus()) {
+            // Parse lifetime argument.
+            AngleBracketedArg::Arg(GenericArg::Lifetime(self.expect_lifetime()))
         } else if self.check_const_arg() {
             // Parse const argument.
             let expr = if let token::OpenDelim(token::Brace) = self.token.kind {

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -783,7 +783,7 @@ impl<'l, 'tcx> DumpVisitor<'l, 'tcx> {
                 match **generic_args {
                     ast::GenericArgs::AngleBracketed(ref data) => {
                         for arg in &data.args {
-                            if let ast::GenericArg::Type(ty) = arg {
+                            if let ast::AngleBracketedArg::Arg(ast::GenericArg::Type(ty)) = arg {
                                 self.visit_ty(ty);
                             }
                         }
@@ -849,7 +849,7 @@ impl<'l, 'tcx> DumpVisitor<'l, 'tcx> {
             if let ast::GenericArgs::AngleBracketed(ref data) = **generic_args {
                 for arg in &data.args {
                     match arg {
-                        ast::GenericArg::Type(ty) => self.visit_ty(ty),
+                        ast::AngleBracketedArg::Arg(ast::GenericArg::Type(ty)) => self.visit_ty(ty),
                         _ => {}
                     }
                 }

--- a/src/test/ui/parser/constraints-before-generic-args-syntactic-pass.rs
+++ b/src/test/ui/parser/constraints-before-generic-args-syntactic-pass.rs
@@ -1,0 +1,9 @@
+// check-pass
+
+#[cfg(FALSE)]
+fn syntax() {
+    foo::<T = u8, T: Ord, String>();
+    foo::<T = u8, 'a, T: Ord>();
+}
+
+fn main() {}

--- a/src/test/ui/parser/issue-32214.rs
+++ b/src/test/ui/parser/issue-32214.rs
@@ -1,6 +1,6 @@
 trait Trait<T> { type Item; }
 
 pub fn test<W, I: Trait<Item=(), W> >() {}
-//~^ ERROR constraints in a path segment must come after generic arguments
+//~^ ERROR generic arguments must come before the first constraint
 
 fn main() { }

--- a/src/test/ui/parser/issue-32214.rs
+++ b/src/test/ui/parser/issue-32214.rs
@@ -1,6 +1,6 @@
 trait Trait<T> { type Item; }
 
 pub fn test<W, I: Trait<Item=(), W> >() {}
-//~^ ERROR associated type bindings must be declared after generic parameters
+//~^ ERROR constraints in a path segment must come after generic arguments
 
 fn main() { }

--- a/src/test/ui/parser/issue-32214.stderr
+++ b/src/test/ui/parser/issue-32214.stderr
@@ -1,10 +1,9 @@
-error: constraints in a path segment must come after generic arguments
-  --> $DIR/issue-32214.rs:3:24
+error: generic arguments must come before the first constraint
+  --> $DIR/issue-32214.rs:3:34
    |
 LL | pub fn test<W, I: Trait<Item=(), W> >() {}
-   |                        ^-------^^-^
-   |                         |        |
-   |                         |        this generic argument must come before the first constraint
+   |                         -------  ^
+   |                         |
    |                         the first constraint is provided here
 
 error: aborting due to previous error

--- a/src/test/ui/parser/issue-32214.stderr
+++ b/src/test/ui/parser/issue-32214.stderr
@@ -2,7 +2,7 @@ error: generic arguments must come before the first constraint
   --> $DIR/issue-32214.rs:3:34
    |
 LL | pub fn test<W, I: Trait<Item=(), W> >() {}
-   |                         -------  ^
+   |                         -------  ^ generic argument
    |                         |
    |                         the first constraint is provided here
 

--- a/src/test/ui/parser/issue-32214.stderr
+++ b/src/test/ui/parser/issue-32214.stderr
@@ -1,10 +1,11 @@
-error: associated type bindings must be declared after generic parameters
-  --> $DIR/issue-32214.rs:3:25
+error: constraints in a path segment must come after generic arguments
+  --> $DIR/issue-32214.rs:3:24
    |
 LL | pub fn test<W, I: Trait<Item=(), W> >() {}
-   |                         -------^^^
-   |                         |
-   |                         this associated type binding should be moved after the generic parameters
+   |                        ^-------^^-^
+   |                         |        |
+   |                         |        this generic argument must come before the first constraint
+   |                         the first constraint is provided here
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/recover-assoc-const-constraint.rs
+++ b/src/test/ui/parser/recover-assoc-const-constraint.rs
@@ -1,0 +1,7 @@
+#[cfg(FALSE)]
+fn syntax() {
+    bar::<Item = 42>(); //~ ERROR cannot constrain an associated constant to a value
+    bar::<Item = { 42 }>(); //~ ERROR cannot constrain an associated constant to a value
+}
+
+fn main() {}

--- a/src/test/ui/parser/recover-assoc-const-constraint.stderr
+++ b/src/test/ui/parser/recover-assoc-const-constraint.stderr
@@ -1,0 +1,20 @@
+error: cannot constrain an associated constant to a value
+  --> $DIR/recover-assoc-const-constraint.rs:3:11
+   |
+LL |     bar::<Item = 42>();
+   |           ----^^^--
+   |           |      |
+   |           |      the value is given in this expression
+   |           the value constrains this associated constant
+
+error: cannot constrain an associated constant to a value
+  --> $DIR/recover-assoc-const-constraint.rs:4:11
+   |
+LL |     bar::<Item = { 42 }>();
+   |           ----^^^------
+   |           |      |
+   |           |      the value is given in this expression
+   |           the value constrains this associated constant
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/parser/recover-assoc-const-constraint.stderr
+++ b/src/test/ui/parser/recover-assoc-const-constraint.stderr
@@ -4,8 +4,8 @@ error: cannot constrain an associated constant to a value
 LL |     bar::<Item = 42>();
    |           ----^^^--
    |           |      |
-   |           |      the value is given in this expression
-   |           the value constrains this associated constant
+   |           |      ...cannot be constrained to this value
+   |           this associated constant...
 
 error: cannot constrain an associated constant to a value
   --> $DIR/recover-assoc-const-constraint.rs:4:11
@@ -13,8 +13,8 @@ error: cannot constrain an associated constant to a value
 LL |     bar::<Item = { 42 }>();
    |           ----^^^------
    |           |      |
-   |           |      the value is given in this expression
-   |           the value constrains this associated constant
+   |           |      ...cannot be constrained to this value
+   |           this associated constant...
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/recover-assoc-eq-missing-term.rs
+++ b/src/test/ui/parser/recover-assoc-eq-missing-term.rs
@@ -1,0 +1,6 @@
+#[cfg(FALSE)]
+fn syntax() {
+    bar::<Item = >(); //~ ERROR missing type to the right of `=`
+}
+
+fn main() {}

--- a/src/test/ui/parser/recover-assoc-eq-missing-term.rs
+++ b/src/test/ui/parser/recover-assoc-eq-missing-term.rs
@@ -1,6 +1,6 @@
 #[cfg(FALSE)]
 fn syntax() {
-    bar::<Item = >(); //~ ERROR missing type to the right of `=`
+    bar::<Item =   >(); //~ ERROR missing type to the right of `=`
 }
 
 fn main() {}

--- a/src/test/ui/parser/recover-assoc-eq-missing-term.stderr
+++ b/src/test/ui/parser/recover-assoc-eq-missing-term.stderr
@@ -1,0 +1,17 @@
+error: missing type to the right of `=`
+  --> $DIR/recover-assoc-eq-missing-term.rs:3:11
+   |
+LL |     bar::<Item = >();
+   |           ^^^^^^
+   |
+help: to constrain the associated type, add a type after `=`
+   |
+LL |     bar::<Item = TheType >();
+   |           ^^^^^^^^^^^^^^
+help: remove the `=` if `Item` is a type
+   |
+LL |     bar::<Item  >();
+   |               --
+
+error: aborting due to previous error
+

--- a/src/test/ui/parser/recover-assoc-eq-missing-term.stderr
+++ b/src/test/ui/parser/recover-assoc-eq-missing-term.stderr
@@ -1,16 +1,16 @@
 error: missing type to the right of `=`
-  --> $DIR/recover-assoc-eq-missing-term.rs:3:11
+  --> $DIR/recover-assoc-eq-missing-term.rs:3:17
    |
-LL |     bar::<Item = >();
-   |           ^^^^^^
+LL |     bar::<Item =   >();
+   |                 ^^^
    |
 help: to constrain the associated type, add a type after `=`
    |
-LL |     bar::<Item = TheType >();
-   |           ^^^^^^^^^^^^^^
+LL |     bar::<Item = TheType>();
+   |                  ^^^^^^^
 help: remove the `=` if `Item` is a type
    |
-LL |     bar::<Item  >();
+LL |     bar::<Item >();
    |               --
 
 error: aborting due to previous error

--- a/src/test/ui/parser/recover-assoc-lifetime-constraint.rs
+++ b/src/test/ui/parser/recover-assoc-lifetime-constraint.rs
@@ -1,0 +1,6 @@
+#[cfg(FALSE)]
+fn syntax() {
+    bar::<Item = 'a>(); //~ ERROR associated lifetimes are not supported
+}
+
+fn main() {}

--- a/src/test/ui/parser/recover-assoc-lifetime-constraint.stderr
+++ b/src/test/ui/parser/recover-assoc-lifetime-constraint.stderr
@@ -1,0 +1,12 @@
+error: associated lifetimes are not supported
+  --> $DIR/recover-assoc-lifetime-constraint.rs:3:11
+   |
+LL |     bar::<Item = 'a>();
+   |           ^^^^^^^--
+   |                  |
+   |                  the lifetime is given here
+   |
+   = help: if you meant to specify a trait object, write `dyn Trait + 'lifetime`
+
+error: aborting due to previous error
+

--- a/src/test/ui/suggestions/suggest-move-types.rs
+++ b/src/test/ui/suggestions/suggest-move-types.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 #![allow(warnings)]
 
 // This test verifies that the suggestion to move types before associated type bindings
@@ -25,20 +23,22 @@ trait ThreeWithLifetime<'a, 'b, 'c, T, U, V> {
   type C;
 }
 
-struct A<T, M: One<A=(), T>> { //~ ERROR associated type bindings must be declared after generic parameters
+struct A<T, M: One<A=(), T>> {
+//~^ ERROR constraints in a path segment must come after generic arguments
     m: M,
     t: T,
 }
 
 
 struct Al<'a, T, M: OneWithLifetime<A=(), T, 'a>> {
-//~^ ERROR associated type bindings must be declared after generic parameters
+//~^ ERROR constraints in a path segment must come after generic arguments
 //~^^ ERROR type provided when a lifetime was expected
     m: M,
     t: &'a T,
 }
 
-struct B<T, U, V, M: Three<A=(), B=(), C=(), T, U, V>> { //~ ERROR associated type bindings must be declared after generic parameters
+struct B<T, U, V, M: Three<A=(), B=(), C=(), T, U, V>> {
+//~^ ERROR constraints in a path segment must come after generic arguments
     m: M,
     t: T,
     u: U,
@@ -46,7 +46,7 @@ struct B<T, U, V, M: Three<A=(), B=(), C=(), T, U, V>> { //~ ERROR associated ty
 }
 
 struct Bl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<A=(), B=(), C=(), T, U, V, 'a, 'b, 'c>> {
-//~^ ERROR associated type bindings must be declared after generic parameters
+//~^ ERROR constraints in a path segment must come after generic arguments
 //~^^ ERROR type provided when a lifetime was expected
     m: M,
     t: &'a T,
@@ -54,7 +54,8 @@ struct Bl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<A=(), B=(), C=(), T, U, V, '
     v: &'c V,
 }
 
-struct C<T, U, V, M: Three<T, A=(), B=(), C=(), U, V>> { //~ ERROR associated type bindings must be declared after generic parameters
+struct C<T, U, V, M: Three<T, A=(), B=(), C=(), U, V>> {
+//~^ ERROR constraints in a path segment must come after generic arguments
     m: M,
     t: T,
     u: U,
@@ -62,7 +63,7 @@ struct C<T, U, V, M: Three<T, A=(), B=(), C=(), U, V>> { //~ ERROR associated ty
 }
 
 struct Cl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), C=(), U, 'b, V, 'c>> {
-//~^ ERROR associated type bindings must be declared after generic parameters
+//~^ ERROR constraints in a path segment must come after generic arguments
 //~^^ ERROR lifetime provided when a type was expected
     m: M,
     t: &'a T,
@@ -70,7 +71,8 @@ struct Cl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), C=(), U, 
     v: &'c V,
 }
 
-struct D<T, U, V, M: Three<T, A=(), B=(), U, C=(), V>> { //~ ERROR associated type bindings must be declared after generic parameters
+struct D<T, U, V, M: Three<T, A=(), B=(), U, C=(), V>> {
+//~^ ERROR constraints in a path segment must come after generic arguments
     m: M,
     t: T,
     u: U,
@@ -78,7 +80,7 @@ struct D<T, U, V, M: Three<T, A=(), B=(), U, C=(), V>> { //~ ERROR associated ty
 }
 
 struct Dl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), U, 'b, C=(), V, 'c>> {
-//~^ ERROR associated type bindings must be declared after generic parameters
+//~^ ERROR constraints in a path segment must come after generic arguments
 //~^^ ERROR lifetime provided when a type was expected
     m: M,
     t: &'a T,

--- a/src/test/ui/suggestions/suggest-move-types.rs
+++ b/src/test/ui/suggestions/suggest-move-types.rs
@@ -24,21 +24,21 @@ trait ThreeWithLifetime<'a, 'b, 'c, T, U, V> {
 }
 
 struct A<T, M: One<A=(), T>> {
-//~^ ERROR constraints in a path segment must come after generic arguments
+//~^ ERROR generic arguments must come before the first constraint
     m: M,
     t: T,
 }
 
 
 struct Al<'a, T, M: OneWithLifetime<A=(), T, 'a>> {
-//~^ ERROR constraints in a path segment must come after generic arguments
+//~^ ERROR generic arguments must come before the first constraint
 //~^^ ERROR type provided when a lifetime was expected
     m: M,
     t: &'a T,
 }
 
 struct B<T, U, V, M: Three<A=(), B=(), C=(), T, U, V>> {
-//~^ ERROR constraints in a path segment must come after generic arguments
+//~^ ERROR generic arguments must come before the first constraint
     m: M,
     t: T,
     u: U,
@@ -46,7 +46,7 @@ struct B<T, U, V, M: Three<A=(), B=(), C=(), T, U, V>> {
 }
 
 struct Bl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<A=(), B=(), C=(), T, U, V, 'a, 'b, 'c>> {
-//~^ ERROR constraints in a path segment must come after generic arguments
+//~^ ERROR generic arguments must come before the first constraint
 //~^^ ERROR type provided when a lifetime was expected
     m: M,
     t: &'a T,
@@ -55,7 +55,7 @@ struct Bl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<A=(), B=(), C=(), T, U, V, '
 }
 
 struct C<T, U, V, M: Three<T, A=(), B=(), C=(), U, V>> {
-//~^ ERROR constraints in a path segment must come after generic arguments
+//~^ ERROR generic arguments must come before the first constraint
     m: M,
     t: T,
     u: U,
@@ -63,7 +63,7 @@ struct C<T, U, V, M: Three<T, A=(), B=(), C=(), U, V>> {
 }
 
 struct Cl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), C=(), U, 'b, V, 'c>> {
-//~^ ERROR constraints in a path segment must come after generic arguments
+//~^ ERROR generic arguments must come before the first constraint
 //~^^ ERROR lifetime provided when a type was expected
     m: M,
     t: &'a T,
@@ -72,7 +72,7 @@ struct Cl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), C=(), U, 
 }
 
 struct D<T, U, V, M: Three<T, A=(), B=(), U, C=(), V>> {
-//~^ ERROR constraints in a path segment must come after generic arguments
+//~^ ERROR generic arguments must come before the first constraint
     m: M,
     t: T,
     u: U,
@@ -80,7 +80,7 @@ struct D<T, U, V, M: Three<T, A=(), B=(), U, C=(), V>> {
 }
 
 struct Dl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), U, 'b, C=(), V, 'c>> {
-//~^ ERROR constraints in a path segment must come after generic arguments
+//~^ ERROR generic arguments must come before the first constraint
 //~^^ ERROR lifetime provided when a type was expected
     m: M,
     t: &'a T,

--- a/src/test/ui/suggestions/suggest-move-types.stderr
+++ b/src/test/ui/suggestions/suggest-move-types.stderr
@@ -1,81 +1,93 @@
-error: associated type bindings must be declared after generic parameters
-  --> $DIR/suggest-move-types.rs:28:20
+error: constraints in a path segment must come after generic arguments
+  --> $DIR/suggest-move-types.rs:26:19
    |
 LL | struct A<T, M: One<A=(), T>> {
-   |                    ----^^^
-   |                    |
-   |                    this associated type binding should be moved after the generic parameters
+   |                   ^----^^-^
+   |                    |     |
+   |                    |     this generic argument must come before the first constraint
+   |                    the first constraint is provided here
 
-error: associated type bindings must be declared after generic parameters
-  --> $DIR/suggest-move-types.rs:34:37
+error: constraints in a path segment must come after generic arguments
+  --> $DIR/suggest-move-types.rs:33:36
    |
 LL | struct Al<'a, T, M: OneWithLifetime<A=(), T, 'a>> {
-   |                                     ----^^^^^^^
-   |                                     |
-   |                                     this associated type binding should be moved after the generic parameters
+   |                                    ^----^^-^^--^
+   |                                     |     |  |
+   |                                     |     |  this generic argument must come before the first constraint
+   |                                     |     this generic argument must come before the first constraint
+   |                                     the first constraint is provided here
 
-error: associated type bindings must be declared after generic parameters
-  --> $DIR/suggest-move-types.rs:41:28
+error: constraints in a path segment must come after generic arguments
+  --> $DIR/suggest-move-types.rs:40:27
    |
 LL | struct B<T, U, V, M: Three<A=(), B=(), C=(), T, U, V>> {
-   |                            ----^^----^^----^^^^^^^^^
-   |                            |     |     |
-   |                            |     |     this associated type binding should be moved after the generic parameters
-   |                            |     this associated type binding should be moved after the generic parameters
-   |                            this associated type binding should be moved after the generic parameters
+   |                           ^----^^^^^^^^^^^^^^-^^-^^-^
+   |                            |                 |  |  |
+   |                            |                 |  |  this generic argument must come before the first constraint
+   |                            |                 |  this generic argument must come before the first constraint
+   |                            |                 this generic argument must come before the first constraint
+   |                            the first constraint is provided here
 
-error: associated type bindings must be declared after generic parameters
-  --> $DIR/suggest-move-types.rs:48:53
+error: constraints in a path segment must come after generic arguments
+  --> $DIR/suggest-move-types.rs:48:52
    |
 LL | struct Bl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<A=(), B=(), C=(), T, U, V, 'a, 'b, 'c>> {
-   |                                                     ----^^----^^----^^^^^^^^^^^^^^^^^^^^^
-   |                                                     |     |     |
-   |                                                     |     |     this associated type binding should be moved after the generic parameters
-   |                                                     |     this associated type binding should be moved after the generic parameters
-   |                                                     this associated type binding should be moved after the generic parameters
+   |                                                    ^----^^^^^^^^^^^^^^-^^-^^-^^--^^--^^--^
+   |                                                     |                 |  |  |  |   |   |
+   |                                                     |                 |  |  |  |   |   this generic argument must come before the first constraint
+   |                                                     |                 |  |  |  |   this generic argument must come before the first constraint
+   |                                                     |                 |  |  |  this generic argument must come before the first constraint
+   |                                                     |                 |  |  this generic argument must come before the first constraint
+   |                                                     |                 |  this generic argument must come before the first constraint
+   |                                                     |                 this generic argument must come before the first constraint
+   |                                                     the first constraint is provided here
 
-error: associated type bindings must be declared after generic parameters
-  --> $DIR/suggest-move-types.rs:57:28
+error: constraints in a path segment must come after generic arguments
+  --> $DIR/suggest-move-types.rs:57:27
    |
 LL | struct C<T, U, V, M: Three<T, A=(), B=(), C=(), U, V>> {
-   |                            ^^^----^^----^^----^^^^^^
-   |                               |     |     |
-   |                               |     |     this associated type binding should be moved after the generic parameters
-   |                               |     this associated type binding should be moved after the generic parameters
-   |                               this associated type binding should be moved after the generic parameters
+   |                           ^^^^----^^^^^^^^^^^^^^-^^-^
+   |                               |                 |  |
+   |                               |                 |  this generic argument must come before the first constraint
+   |                               |                 this generic argument must come before the first constraint
+   |                               the first constraint is provided here
 
-error: associated type bindings must be declared after generic parameters
-  --> $DIR/suggest-move-types.rs:64:53
+error: constraints in a path segment must come after generic arguments
+  --> $DIR/suggest-move-types.rs:65:52
    |
 LL | struct Cl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), C=(), U, 'b, V, 'c>> {
-   |                                                     ^^^^^^^----^^----^^----^^^^^^^^^^^^^^
-   |                                                            |     |     |
-   |                                                            |     |     this associated type binding should be moved after the generic parameters
-   |                                                            |     this associated type binding should be moved after the generic parameters
-   |                                                            this associated type binding should be moved after the generic parameters
+   |                                                    ^^^^^^^^----^^^^^^^^^^^^^^-^^--^^-^^--^
+   |                                                            |                 |  |   |  |
+   |                                                            |                 |  |   |  this generic argument must come before the first constraint
+   |                                                            |                 |  |   this generic argument must come before the first constraint
+   |                                                            |                 |  this generic argument must come before the first constraint
+   |                                                            |                 this generic argument must come before the first constraint
+   |                                                            the first constraint is provided here
 
-error: associated type bindings must be declared after generic parameters
-  --> $DIR/suggest-move-types.rs:73:28
+error: constraints in a path segment must come after generic arguments
+  --> $DIR/suggest-move-types.rs:74:27
    |
 LL | struct D<T, U, V, M: Three<T, A=(), B=(), U, C=(), V>> {
-   |                            ^^^----^^----^^^^^----^^^
-   |                               |     |        |
-   |                               |     |        this associated type binding should be moved after the generic parameters
-   |                               |     this associated type binding should be moved after the generic parameters
-   |                               this associated type binding should be moved after the generic parameters
+   |                           ^^^^----^^^^^^^^-^^^^^^^^-^
+   |                               |           |        |
+   |                               |           |        this generic argument must come before the first constraint
+   |                               |           this generic argument must come before the first constraint
+   |                               the first constraint is provided here
 
-error: associated type bindings must be declared after generic parameters
-  --> $DIR/suggest-move-types.rs:80:53
+error: constraints in a path segment must come after generic arguments
+  --> $DIR/suggest-move-types.rs:82:52
    |
 LL | struct Dl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), U, 'b, C=(), V, 'c>> {
-   |                                                     ^^^^^^^----^^----^^^^^^^^^----^^^^^^^
-   |                                                            |     |            |
-   |                                                            |     |            this associated type binding should be moved after the generic parameters
-   |                                                            |     this associated type binding should be moved after the generic parameters
-   |                                                            this associated type binding should be moved after the generic parameters
+   |                                                    ^^^^^^^^----^^^^^^^^-^^--^^^^^^^^-^^--^
+   |                                                            |           |  |         |  |
+   |                                                            |           |  |         |  this generic argument must come before the first constraint
+   |                                                            |           |  |         this generic argument must come before the first constraint
+   |                                                            |           |  this generic argument must come before the first constraint
+   |                                                            |           this generic argument must come before the first constraint
+   |                                                            the first constraint is provided here
 
 error[E0747]: type provided when a lifetime was expected
-  --> $DIR/suggest-move-types.rs:34:43
+  --> $DIR/suggest-move-types.rs:33:43
    |
 LL | struct Al<'a, T, M: OneWithLifetime<A=(), T, 'a>> {
    |                                           ^
@@ -91,7 +103,7 @@ LL | struct Bl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<A=(), B=(), C=(), T, U,
    = note: lifetime arguments must be provided before type arguments
 
 error[E0747]: lifetime provided when a type was expected
-  --> $DIR/suggest-move-types.rs:64:56
+  --> $DIR/suggest-move-types.rs:65:56
    |
 LL | struct Cl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), C=(), U, 'b, V, 'c>> {
    |                                                        ^^
@@ -99,7 +111,7 @@ LL | struct Cl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), C=()
    = note: type arguments must be provided before lifetime arguments
 
 error[E0747]: lifetime provided when a type was expected
-  --> $DIR/suggest-move-types.rs:80:56
+  --> $DIR/suggest-move-types.rs:82:56
    |
 LL | struct Dl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), U, 'b, C=(), V, 'c>> {
    |                                                        ^^

--- a/src/test/ui/suggestions/suggest-move-types.stderr
+++ b/src/test/ui/suggestions/suggest-move-types.stderr
@@ -1,89 +1,65 @@
-error: constraints in a path segment must come after generic arguments
-  --> $DIR/suggest-move-types.rs:26:19
+error: generic arguments must come before the first constraint
+  --> $DIR/suggest-move-types.rs:26:26
    |
 LL | struct A<T, M: One<A=(), T>> {
-   |                   ^----^^-^
-   |                    |     |
-   |                    |     this generic argument must come before the first constraint
+   |                    ----  ^
+   |                    |
    |                    the first constraint is provided here
 
-error: constraints in a path segment must come after generic arguments
-  --> $DIR/suggest-move-types.rs:33:36
+error: generic arguments must come before the first constraint
+  --> $DIR/suggest-move-types.rs:33:43
    |
 LL | struct Al<'a, T, M: OneWithLifetime<A=(), T, 'a>> {
-   |                                    ^----^^-^^--^
-   |                                     |     |  |
-   |                                     |     |  this generic argument must come before the first constraint
-   |                                     |     this generic argument must come before the first constraint
+   |                                     ----  ^  ^^
+   |                                     |
    |                                     the first constraint is provided here
 
-error: constraints in a path segment must come after generic arguments
-  --> $DIR/suggest-move-types.rs:40:27
+error: generic arguments must come before the first constraint
+  --> $DIR/suggest-move-types.rs:40:46
    |
 LL | struct B<T, U, V, M: Three<A=(), B=(), C=(), T, U, V>> {
-   |                           ^----^^^^^^^^^^^^^^-^^-^^-^
-   |                            |                 |  |  |
-   |                            |                 |  |  this generic argument must come before the first constraint
-   |                            |                 |  this generic argument must come before the first constraint
-   |                            |                 this generic argument must come before the first constraint
+   |                            ----              ^  ^  ^
+   |                            |
    |                            the first constraint is provided here
 
-error: constraints in a path segment must come after generic arguments
-  --> $DIR/suggest-move-types.rs:48:52
+error: generic arguments must come before the first constraint
+  --> $DIR/suggest-move-types.rs:48:71
    |
 LL | struct Bl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<A=(), B=(), C=(), T, U, V, 'a, 'b, 'c>> {
-   |                                                    ^----^^^^^^^^^^^^^^-^^-^^-^^--^^--^^--^
-   |                                                     |                 |  |  |  |   |   |
-   |                                                     |                 |  |  |  |   |   this generic argument must come before the first constraint
-   |                                                     |                 |  |  |  |   this generic argument must come before the first constraint
-   |                                                     |                 |  |  |  this generic argument must come before the first constraint
-   |                                                     |                 |  |  this generic argument must come before the first constraint
-   |                                                     |                 |  this generic argument must come before the first constraint
-   |                                                     |                 this generic argument must come before the first constraint
+   |                                                     ----              ^  ^  ^  ^^  ^^  ^^
+   |                                                     |
    |                                                     the first constraint is provided here
 
-error: constraints in a path segment must come after generic arguments
-  --> $DIR/suggest-move-types.rs:57:27
+error: generic arguments must come before the first constraint
+  --> $DIR/suggest-move-types.rs:57:49
    |
 LL | struct C<T, U, V, M: Three<T, A=(), B=(), C=(), U, V>> {
-   |                           ^^^^----^^^^^^^^^^^^^^-^^-^
-   |                               |                 |  |
-   |                               |                 |  this generic argument must come before the first constraint
-   |                               |                 this generic argument must come before the first constraint
+   |                               ----              ^  ^
+   |                               |
    |                               the first constraint is provided here
 
-error: constraints in a path segment must come after generic arguments
-  --> $DIR/suggest-move-types.rs:65:52
+error: generic arguments must come before the first constraint
+  --> $DIR/suggest-move-types.rs:65:78
    |
 LL | struct Cl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), C=(), U, 'b, V, 'c>> {
-   |                                                    ^^^^^^^^----^^^^^^^^^^^^^^-^^--^^-^^--^
-   |                                                            |                 |  |   |  |
-   |                                                            |                 |  |   |  this generic argument must come before the first constraint
-   |                                                            |                 |  |   this generic argument must come before the first constraint
-   |                                                            |                 |  this generic argument must come before the first constraint
-   |                                                            |                 this generic argument must come before the first constraint
+   |                                                            ----              ^  ^^  ^  ^^
+   |                                                            |
    |                                                            the first constraint is provided here
 
-error: constraints in a path segment must come after generic arguments
-  --> $DIR/suggest-move-types.rs:74:27
+error: generic arguments must come before the first constraint
+  --> $DIR/suggest-move-types.rs:74:43
    |
 LL | struct D<T, U, V, M: Three<T, A=(), B=(), U, C=(), V>> {
-   |                           ^^^^----^^^^^^^^-^^^^^^^^-^
-   |                               |           |        |
-   |                               |           |        this generic argument must come before the first constraint
-   |                               |           this generic argument must come before the first constraint
+   |                               ----        ^        ^
+   |                               |
    |                               the first constraint is provided here
 
-error: constraints in a path segment must come after generic arguments
-  --> $DIR/suggest-move-types.rs:82:52
+error: generic arguments must come before the first constraint
+  --> $DIR/suggest-move-types.rs:82:72
    |
 LL | struct Dl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), U, 'b, C=(), V, 'c>> {
-   |                                                    ^^^^^^^^----^^^^^^^^-^^--^^^^^^^^-^^--^
-   |                                                            |           |  |         |  |
-   |                                                            |           |  |         |  this generic argument must come before the first constraint
-   |                                                            |           |  |         this generic argument must come before the first constraint
-   |                                                            |           |  this generic argument must come before the first constraint
-   |                                                            |           this generic argument must come before the first constraint
+   |                                                            ----        ^  ^^        ^  ^^
+   |                                                            |
    |                                                            the first constraint is provided here
 
 error[E0747]: type provided when a lifetime was expected

--- a/src/test/ui/suggestions/suggest-move-types.stderr
+++ b/src/test/ui/suggestions/suggest-move-types.stderr
@@ -2,7 +2,7 @@ error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:26:26
    |
 LL | struct A<T, M: One<A=(), T>> {
-   |                    ----  ^
+   |                    ----  ^ generic argument
    |                    |
    |                    the first constraint is provided here
 
@@ -10,56 +10,72 @@ error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:33:43
    |
 LL | struct Al<'a, T, M: OneWithLifetime<A=(), T, 'a>> {
-   |                                     ----  ^  ^^
-   |                                     |
+   |                                     ----  ^  ^^ generic argument
+   |                                     |     |
+   |                                     |     generic argument
    |                                     the first constraint is provided here
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:40:46
    |
 LL | struct B<T, U, V, M: Three<A=(), B=(), C=(), T, U, V>> {
-   |                            ----              ^  ^  ^
-   |                            |
+   |                            ----              ^  ^  ^ generic argument
+   |                            |                 |  |
+   |                            |                 |  generic argument
+   |                            |                 generic argument
    |                            the first constraint is provided here
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:48:71
    |
 LL | struct Bl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<A=(), B=(), C=(), T, U, V, 'a, 'b, 'c>> {
-   |                                                     ----              ^  ^  ^  ^^  ^^  ^^
-   |                                                     |
+   |                                                     ----              ^  ^  ^  ^^  ^^  ^^ generic argument
+   |                                                     |                 |  |  |  |   |
+   |                                                     |                 |  |  |  |   generic argument
+   |                                                     |                 |  |  |  generic argument
+   |                                                     |                 |  |  generic argument
+   |                                                     |                 |  generic argument
+   |                                                     |                 generic argument
    |                                                     the first constraint is provided here
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:57:49
    |
 LL | struct C<T, U, V, M: Three<T, A=(), B=(), C=(), U, V>> {
-   |                               ----              ^  ^
-   |                               |
+   |                               ----              ^  ^ generic argument
+   |                               |                 |
+   |                               |                 generic argument
    |                               the first constraint is provided here
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:65:78
    |
 LL | struct Cl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), C=(), U, 'b, V, 'c>> {
-   |                                                            ----              ^  ^^  ^  ^^
-   |                                                            |
+   |                                                            ----              ^  ^^  ^  ^^ generic argument
+   |                                                            |                 |  |   |
+   |                                                            |                 |  |   generic argument
+   |                                                            |                 |  generic argument
+   |                                                            |                 generic argument
    |                                                            the first constraint is provided here
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:74:43
    |
 LL | struct D<T, U, V, M: Three<T, A=(), B=(), U, C=(), V>> {
-   |                               ----        ^        ^
-   |                               |
+   |                               ----        ^        ^ generic argument
+   |                               |           |
+   |                               |           generic argument
    |                               the first constraint is provided here
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:82:72
    |
 LL | struct Dl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), U, 'b, C=(), V, 'c>> {
-   |                                                            ----        ^  ^^        ^  ^^
-   |                                                            |
+   |                                                            ----        ^  ^^        ^  ^^ generic argument
+   |                                                            |           |  |         |
+   |                                                            |           |  |         generic argument
+   |                                                            |           |  generic argument
+   |                                                            |           generic argument
    |                                                            the first constraint is provided here
 
 error[E0747]: type provided when a lifetime was expected


### PR DESCRIPTION
- In the first commit, we move the check rejecting e.g., `<'a, Item = u8, String>` from the parser into AST validation.
- We then use this to improve the code for parsing generic arguments.
- And we add recovery for e.g., `<Item = >` (missing), `<Item = 42>` (constant), and `<Item = 'a>` (lifetime).

This is also preparatory work for supporting https://github.com/rust-lang/rust/issues/70256.

r? @varkor 