### PR TITLE
Fix invalid suggestion on `&mut` iterators yielding `&` references

### DIFF
--- a/src/test/ui/borrowck/issue-69789-iterator-mut-suggestion.rs
+++ b/src/test/ui/borrowck/issue-69789-iterator-mut-suggestion.rs
@@ -1,0 +1,11 @@
+// Regression test for #69789: rustc generated an invalid suggestion
+// when `&` reference from `&mut` iterator is mutated.
+
+fn main() {
+    for item in &mut std::iter::empty::<&'static ()>() {
+        //~^ NOTE this iterator yields `&` references
+        *item = ();
+        //~^ ERROR cannot assign
+        //~| NOTE  cannot be written
+    }
+}

--- a/src/test/ui/borrowck/issue-69789-iterator-mut-suggestion.stderr
+++ b/src/test/ui/borrowck/issue-69789-iterator-mut-suggestion.stderr
@@ -1,0 +1,12 @@
+error[E0594]: cannot assign to `*item` which is behind a `&` reference
+  --> $DIR/issue-69789-iterator-mut-suggestion.rs:7:9
+   |
+LL |     for item in &mut std::iter::empty::<&'static ()>() {
+   |                 -------------------------------------- this iterator yields `&` references
+LL |
+LL |         *item = ();
+   |         ^^^^^^^^^^ `item` is a `&` reference, so the data it refers to cannot be written
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0594`.


### PR DESCRIPTION
Fixes #69789.

rustc suggested an invalid code when `&` reference from `&mut` iterator is mutated. The compiler knew we're mutating a value behind `&` reference, but as the assignment RHS is from desugaring, it could only see the iterator expression from source and inserted `mut` there.

r? @estebank