### PR TITLE
get rid of ConstPropUnsupported; use ZST marker structs instead

### DIFF
--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -164,7 +164,7 @@ impl dyn Any {
         // Get `TypeId` of the type this function is instantiated with.
         let t = TypeId::of::<T>();
 
-        // Get `TypeId` of the type in the trait object.
+        // Get `TypeId` of the type in the trait object (`self`).
         let concrete = self.type_id();
 
         // Compare both `TypeId`s on equality.

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -577,7 +577,7 @@ impl InterpError<'_> {
     /// waste of resources.
     pub fn allocates(&self) -> bool {
         match self {
-            // Zero-sized boxes to not allocate.
+            // Zero-sized boxes do not allocate.
             InterpError::MachineStop(b) => mem::size_of_val(&**b) > 0,
             InterpError::Unsupported(UnsupportedOpInfo::Unsupported(_))
             | InterpError::UndefinedBehavior(UndefinedBehaviorInfo::ValidationFailure(_))

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -578,7 +578,7 @@ impl InterpError<'_> {
     pub fn allocates(&self) -> bool {
         match self {
             // Zero-sized boxes do not allocate.
-            InterpError::MachineStop(b) => mem::size_of_val(&**b) > 0,
+            InterpError::MachineStop(b) => mem::size_of_val::<dyn MachineStopType>(&**b) > 0,
             InterpError::Unsupported(UnsupportedOpInfo::Unsupported(_))
             | InterpError::UndefinedBehavior(UndefinedBehaviorInfo::ValidationFailure(_))
             | InterpError::UndefinedBehavior(UndefinedBehaviorInfo::Ub(_))

--- a/src/librustc/mir/interpret/mod.rs
+++ b/src/librustc/mir/interpret/mod.rs
@@ -92,8 +92,8 @@ mod value;
 
 pub use self::error::{
     struct_error, ConstEvalErr, ConstEvalRawResult, ConstEvalResult, ErrorHandled, FrameInfo,
-    InterpError, InterpErrorInfo, InterpResult, InvalidProgramInfo, ResourceExhaustionInfo,
-    UndefinedBehaviorInfo, UnsupportedOpInfo,
+    InterpError, InterpErrorInfo, InterpResult, InvalidProgramInfo, MachineStopType,
+    ResourceExhaustionInfo, UndefinedBehaviorInfo, UnsupportedOpInfo,
 };
 
 pub use self::value::{get_slice_bytes, ConstValue, RawConst, Scalar, ScalarMaybeUndef};


### PR DESCRIPTION
This gets rid of yet another machine-specific error variant.

r? @oli-obk 