### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4957,8 +4957,6 @@ Version 1.10.0 (2016-07-07)
 Language
 --------
 
-* [Allow `concat_idents!` in type positions as well as in expression
-  positions](https://github.com/rust-lang/rust/pull/33735).
 * [`Copy` types are required to have a trivial implementation of `Clone`](https://github.com/rust-lang/rust/pull/33420).
   [RFC 1521](https://github.com/rust-lang/rfcs/blob/master/text/1521-copy-clone-semantics.md).
 * [Single-variant enums support the `#[repr(..)]` attribute](https://github.com/rust-lang/rust/pull/33355).

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4838,7 +4838,6 @@ Version 1.11.0 (2016-08-18)
 Language
 --------
 
-* [`cfg_attr` works on `path` attributes](https://github.com/rust-lang/rust/pull/34546)
 * [Support nested `cfg_attr` attributes](https://github.com/rust-lang/rust/pull/34216)
 * [Allow statement-generating braced macro invocations at the end of blocks](https://github.com/rust-lang/rust/pull/34436)
 * [Macros can be expanded inside of trait definitions](https://github.com/rust-lang/rust/pull/34213)

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -573,10 +573,11 @@ impl<T: ?Sized> Rc<T> {
     /// Constructs an `Rc` from a raw pointer.
     ///
     /// The raw pointer must have been previously returned by a call to a
-    /// [`Rc::into_raw`][into_raw].
+    /// [`Rc::into_raw`][into_raw] using the same `T`.
     ///
-    /// This function is unsafe because improper use may lead to memory problems. For example, a
-    /// double-free may occur if the function is called twice on the same raw pointer.
+    /// This function is unsafe because improper use may lead to memory unsafety,
+    /// even if `T` is never accessed. For example, a double-free may occur if the function is
+    /// called twice on the same raw pointer.
     ///
     /// [into_raw]: struct.Rc.html#method.into_raw
     ///

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -259,6 +259,10 @@ use crate::vec::Vec;
 #[cfg(test)]
 mod tests;
 
+// This is repr(C) to future-proof against possible field-reordering, which
+// would interfere with otherwise safe [into|from]_raw() of transmutable
+// inner types.
+#[repr(C)]
 struct RcBox<T: ?Sized> {
     strong: Cell<usize>,
     weak: Cell<usize>,

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -570,16 +570,24 @@ impl<T: ?Sized> Rc<T> {
         ptr
     }
 
-    /// Constructs an `Rc` from a raw pointer.
+    /// Constructs an `Rc<T>` from a raw pointer.
     ///
-    /// The raw pointer must have been previously returned by a call to a
-    /// [`Rc::into_raw`][into_raw] using the same `T`.
+    /// The raw pointer must have been previously returned by a call to
+    /// [`Rc<U>::into_raw`][into_raw] where `U` must have the same size
+    /// and alignment as `T`. This is trivially true if `U` is `T`.
+    /// Note that if `U` is not `T` but has the same size and alignment, this is
+    /// basically like transmuting references of different types. See
+    /// [`mem::transmute`][transmute] for more information on what
+    /// restrictions apply in this case.
+    ///
+    /// The user of `from_raw` has to make sure a specific value of `T` is only
+    /// dropped once.
     ///
     /// This function is unsafe because improper use may lead to memory unsafety,
-    /// even if `T` is never accessed. For example, a double-free may occur if the function is
-    /// called twice on the same raw pointer.
+    /// even if the returned `Rc<T>` is never accessed.
     ///
     /// [into_raw]: struct.Rc.html#method.into_raw
+    /// [transmute]: ../../std/mem/fn.transmute.html
     ///
     /// # Examples
     ///

--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -145,8 +145,7 @@ mod hack {
         unsafe {
             let len = b.len();
             let b = Box::into_raw(b);
-            let xs = Vec::from_raw_parts(b as *mut T, len, len);
-            xs
+            Vec::from_raw_parts(b as *mut T, len, len)
         }
     }
 

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -553,10 +553,11 @@ impl<T: ?Sized> Arc<T> {
     /// Constructs an `Arc` from a raw pointer.
     ///
     /// The raw pointer must have been previously returned by a call to a
-    /// [`Arc::into_raw`][into_raw].
+    /// [`Arc::into_raw`][into_raw], using the same `T`.
     ///
-    /// This function is unsafe because improper use may lead to memory problems. For example, a
-    /// double-free may occur if the function is called twice on the same raw pointer.
+    /// This function is unsafe because improper use may lead to memory unsafety,
+    /// even if `T` is never accessed. For example, a double-free may occur if the function is
+    /// called twice on the same raw pointer.
     ///
     /// [into_raw]: struct.Arc.html#method.into_raw
     ///

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -550,16 +550,24 @@ impl<T: ?Sized> Arc<T> {
         ptr
     }
 
-    /// Constructs an `Arc` from a raw pointer.
+    /// Constructs an `Arc<T>` from a raw pointer.
     ///
-    /// The raw pointer must have been previously returned by a call to a
-    /// [`Arc::into_raw`][into_raw], using the same `T`.
+    /// The raw pointer must have been previously returned by a call to
+    /// [`Arc<U>::into_raw`][into_raw] where `U` must have the same size and
+    /// alignment as `T`. This is trivially true if `U` is `T`.
+    /// Note that if `U` is not `T` but has the same size and alignment, this is
+    /// basically like transmuting references of different types. See
+    /// [`mem::transmute`][transmute] for more information on what
+    /// restrictions apply in this case.
+    ///
+    /// The user of `from_raw` has to make sure a specific value of `T` is only
+    /// dropped once.
     ///
     /// This function is unsafe because improper use may lead to memory unsafety,
-    /// even if `T` is never accessed. For example, a double-free may occur if the function is
-    /// called twice on the same raw pointer.
+    /// even if the returned `Arc<T>` is never accessed.
     ///
     /// [into_raw]: struct.Arc.html#method.into_raw
+    /// [transmute]: ../../std/mem/fn.transmute.html
     ///
     /// # Examples
     ///

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -270,6 +270,10 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for Weak<T> {
     }
 }
 
+// This is repr(C) to future-proof against possible field-reordering, which
+// would interfere with otherwise safe [into|from]_raw() of transmutable
+// inner types.
+#[repr(C)]
 struct ArcInner<T: ?Sized> {
     strong: atomic::AtomicUsize,
 

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -1038,9 +1038,7 @@ pub(super) fn index_hir<'tcx>(tcx: TyCtxt<'tcx>, cnum: CrateNum) -> &'tcx Indexe
         collector.finalize_and_compute_crate_hash(crate_disambiguator, &*tcx.cstore, cmdline_args)
     };
 
-    let map = tcx.arena.alloc(IndexedHir { crate_hash, map });
-
-    map
+    tcx.arena.alloc(IndexedHir { crate_hash, map })
 }
 
 /// Identical to the `PpAnn` implementation for `hir::Crate`,

--- a/src/librustc/ty/query/plumbing.rs
+++ b/src/librustc/ty/query/plumbing.rs
@@ -692,7 +692,7 @@ impl<'tcx> TyCtxt<'tcx> {
     /// side-effects -- e.g., in order to report errors for erroneous programs.
     ///
     /// Note: The optimization is only available during incr. comp.
-    pub(super) fn ensure_query<Q: QueryDescription<'tcx> + 'tcx>(self, key: Q::Key) -> () {
+    pub(super) fn ensure_query<Q: QueryDescription<'tcx> + 'tcx>(self, key: Q::Key) {
         if Q::EVAL_ALWAYS {
             let _ = self.get_query::<Q>(DUMMY_SP, key);
             return;

--- a/src/librustc_builtin_macros/deriving/generic/mod.rs
+++ b/src/librustc_builtin_macros/deriving/generic/mod.rs
@@ -1056,8 +1056,9 @@ impl<'a> MethodDef<'a> {
                     self_: field,
                     other: other_fields
                         .iter_mut()
-                        .map(|l| match l.next().unwrap() {
-                            (.., ex, _) => ex,
+                        .map(|l| {
+                            let (.., ex, _) = l.next().unwrap();
+                            ex
                         })
                         .collect(),
                     attrs,

--- a/src/librustc_codegen_ssa/back/rpath.rs
+++ b/src/librustc_codegen_ssa/back/rpath.rs
@@ -81,9 +81,7 @@ fn get_rpaths(config: &mut RPathConfig<'_>, libs: &[PathBuf]) -> Vec<String> {
     rpaths.extend_from_slice(&fallback_rpaths);
 
     // Remove duplicates
-    let rpaths = minimize_rpaths(&rpaths);
-
-    rpaths
+    minimize_rpaths(&rpaths)
 }
 
 fn get_rpaths_relative_to_output(config: &mut RPathConfig<'_>, libs: &[PathBuf]) -> Vec<String> {

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -288,7 +288,7 @@ fn generate_lto_work<B: ExtraBackendMethods>(
         B::run_thin_lto(cgcx, needs_thin_lto, import_only_modules).unwrap_or_else(|e| e.raise())
     };
 
-    let result = lto_modules
+    lto_modules
         .into_iter()
         .map(|module| {
             let cost = module.cost();
@@ -303,9 +303,7 @@ fn generate_lto_work<B: ExtraBackendMethods>(
                 0,
             )
         }))
-        .collect();
-
-    result
+        .collect()
 }
 
 pub struct CompiledModules {

--- a/src/librustc_data_structures/profiling.rs
+++ b/src/librustc_data_structures/profiling.rs
@@ -345,7 +345,7 @@ impl SelfProfilerRef {
     ) {
         drop(self.exec(event_filter, |profiler| {
             let event_id = StringId::new_virtual(query_invocation_id.0);
-            let thread_id = std::thread::current().id().as_u64() as u32;
+            let thread_id = std::thread::current().id().as_u64().get() as u32;
 
             profiler.profiler.record_instant_event(
                 event_kind(profiler),
@@ -522,7 +522,7 @@ impl<'a> TimingGuard<'a> {
         event_kind: StringId,
         event_id: EventId,
     ) -> TimingGuard<'a> {
-        let thread_id = std::thread::current().id().as_u64() as u32;
+        let thread_id = std::thread::current().id().as_u64().get() as u32;
         let raw_profiler = &profiler.profiler;
         let timing_guard =
             raw_profiler.start_recording_interval_event(event_kind, event_id, thread_id);

--- a/src/librustc_infer/infer/canonical/canonicalizer.rs
+++ b/src/librustc_infer/infer/canonical/canonicalizer.rs
@@ -555,7 +555,7 @@ impl<'cx, 'tcx> Canonicalizer<'cx, 'tcx> {
         // avoid allocations in those cases. We also don't use `indices` to
         // determine if a kind has been seen before until the limit of 8 has
         // been exceeded, to also avoid allocations for `indices`.
-        let var = if !var_values.spilled() {
+        if !var_values.spilled() {
             // `var_values` is stack-allocated. `indices` isn't used yet. Do a
             // direct linear search of `var_values`.
             if let Some(idx) = var_values.iter().position(|&k| k == kind) {
@@ -589,9 +589,7 @@ impl<'cx, 'tcx> Canonicalizer<'cx, 'tcx> {
                 assert_eq!(variables.len(), var_values.len());
                 BoundVar::new(variables.len() - 1)
             })
-        };
-
-        var
+        }
     }
 
     /// Shorthand helper that creates a canonical region variable for

--- a/src/librustc_infer/traits/project.rs
+++ b/src/librustc_infer/traits/project.rs
@@ -23,7 +23,7 @@ pub type NormalizedTy<'tcx> = Normalized<'tcx, Ty<'tcx>>;
 
 impl<'tcx, T> Normalized<'tcx, T> {
     pub fn with<U>(self, value: U) -> Normalized<'tcx, U> {
-        Normalized { value: value, obligations: self.obligations }
+        Normalized { value, obligations: self.obligations }
     }
 }
 

--- a/src/librustc_infer/traits/util.rs
+++ b/src/librustc_infer/traits/util.rs
@@ -47,7 +47,7 @@ struct PredicateSet<'tcx> {
 
 impl PredicateSet<'tcx> {
     fn new(tcx: TyCtxt<'tcx>) -> Self {
-        Self { tcx: tcx, set: Default::default() }
+        Self { tcx, set: Default::default() }
     }
 
     fn insert(&mut self, pred: &ty::Predicate<'tcx>) -> bool {

--- a/src/librustc_metadata/dynamic_lib.rs
+++ b/src/librustc_metadata/dynamic_lib.rs
@@ -94,14 +94,12 @@ mod dl {
             let result = f();
 
             let last_error = libc::dlerror() as *const _;
-            let ret = if ptr::null() == last_error {
+            if ptr::null() == last_error {
                 Ok(result)
             } else {
                 let s = CStr::from_ptr(last_error).to_bytes();
                 Err(str::from_utf8(s).unwrap().to_owned())
-            };
-
-            ret
+            }
         }
     }
 

--- a/src/librustc_mir/borrow_check/diagnostics/move_errors.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/move_errors.rs
@@ -490,17 +490,13 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                 {
                     if pat_snippet.starts_with('&') {
                         let pat_snippet = pat_snippet[1..].trim_start();
-                        let suggestion;
-                        let to_remove;
-                        if pat_snippet.starts_with("mut")
+                        let (suggestion, to_remove) = if pat_snippet.starts_with("mut")
                             && pat_snippet["mut".len()..].starts_with(rustc_lexer::is_whitespace)
                         {
-                            suggestion = pat_snippet["mut".len()..].trim_start();
-                            to_remove = "&mut";
+                            (pat_snippet["mut".len()..].trim_start(), "&mut")
                         } else {
-                            suggestion = pat_snippet;
-                            to_remove = "&";
-                        }
+                            (pat_snippet, "&")
+                        };
                         suggestions.push((pat_span, to_remove, suggestion.to_owned()));
                     }
                 }

--- a/src/librustc_mir/const_eval/machine.rs
+++ b/src/librustc_mir/const_eval/machine.rs
@@ -335,9 +335,7 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
     }
 
     #[inline(always)]
-    fn tag_static_base_pointer(_memory_extra: &MemoryExtra, _id: AllocId) -> Self::PointerTag {
-        ()
-    }
+    fn tag_static_base_pointer(_memory_extra: &MemoryExtra, _id: AllocId) -> Self::PointerTag {}
 
     fn box_alloc(
         _ecx: &mut InterpCx<'mir, 'tcx, Self>,

--- a/src/librustc_mir/dataflow/move_paths/builder.rs
+++ b/src/librustc_mir/dataflow/move_paths/builder.rs
@@ -184,14 +184,13 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
             ..
         } = self.builder;
         *rev_lookup.projections.entry((base, elem.lift())).or_insert_with(move || {
-            let path = MoveDataBuilder::new_move_path(
+            MoveDataBuilder::new_move_path(
                 move_paths,
                 path_map,
                 init_path_map,
                 Some(base),
                 mk_place(*tcx),
-            );
-            path
+            )
         })
     }
 

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -581,7 +581,8 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
     /// If `target` is `None`, that indicates the function cannot return, so we raise UB.
     pub fn return_to_block(&mut self, target: Option<mir::BasicBlock>) -> InterpResult<'tcx> {
         if let Some(target) = target {
-            Ok(self.go_to_block(target))
+            self.go_to_block(target);
+            Ok(())
         } else {
             throw_ub!(Unreachable)
         }

--- a/src/librustc_mir/interpret/intrinsics/type_name.rs
+++ b/src/librustc_mir/interpret/intrinsics/type_name.rs
@@ -192,7 +192,8 @@ impl PrettyPrinter<'tcx> for AbsolutePathPrinter<'tcx> {
 
 impl Write for AbsolutePathPrinter<'_> {
     fn write_str(&mut self, s: &str) -> std::fmt::Result {
-        Ok(self.path.push_str(s))
+        self.path.push_str(s);
+        Ok(())
     }
 }
 

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -370,7 +370,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                         self.stack.pop();
                         Err(err)
                     }
-                    Ok(v) => Ok(v),
+                    Ok(()) => Ok(()),
                 }
             }
             // cannot use the shim here, because that will only result in infinite recursion

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -232,9 +232,7 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for ConstPropMachine {
     }
 
     #[inline(always)]
-    fn tag_static_base_pointer(_memory_extra: &(), _id: AllocId) -> Self::PointerTag {
-        ()
-    }
+    fn tag_static_base_pointer(_memory_extra: &(), _id: AllocId) -> Self::PointerTag {}
 
     fn box_alloc(
         _ecx: &mut InterpCx<'mir, 'tcx, Self>,

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -400,7 +400,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
     where
         F: FnOnce(&mut Self) -> InterpResult<'tcx, T>,
     {
-        let r = match f(self) {
+        match f(self) {
             Ok(val) => Some(val),
             Err(error) => {
                 // Some errors shouldn't come up because creating them causes
@@ -414,8 +414,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
                 );
                 None
             }
-        };
-        r
+        }
     }
 
     fn eval_constant(&mut self, c: &Constant<'tcx>, source_info: SourceInfo) -> Option<OpTy<'tcx>> {

--- a/src/librustc_mir_build/build/expr/as_temp.rs
+++ b/src/librustc_mir_build/build/expr/as_temp.rs
@@ -73,10 +73,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             // they are never assigned.
             ExprKind::Break { .. } | ExprKind::Continue { .. } | ExprKind::Return { .. } => (),
             ExprKind::Block { body: hir::Block { expr: None, targeted_by_break: false, .. } }
-                if expr_ty.is_never() =>
-            {
-                ()
-            }
+                if expr_ty.is_never() => {}
             _ => {
                 this.cfg
                     .push(block, Statement { source_info, kind: StatementKind::StorageLive(temp) });

--- a/src/librustc_mir_build/build/mod.rs
+++ b/src/librustc_mir_build/build/mod.rs
@@ -637,11 +637,12 @@ where
     );
     assert_eq!(block, builder.return_block());
 
-    let mut spread_arg = None;
-    if abi == Abi::RustCall {
+    let spread_arg = if abi == Abi::RustCall {
         // RustCall pseudo-ABI untuples the last argument.
-        spread_arg = Some(Local::new(arguments.len()));
-    }
+        Some(Local::new(arguments.len()))
+    } else {
+        None
+    };
     debug!("fn_id {:?} has attrs {:?}", fn_def_id, tcx.get_attrs(fn_def_id));
 
     let mut body = builder.finish();

--- a/src/librustc_parse/lexer/mod.rs
+++ b/src/librustc_parse/lexer/mod.rs
@@ -179,14 +179,12 @@ impl<'a> StringReader<'a> {
             rustc_lexer::TokenKind::LineComment => {
                 let string = self.str_from(start);
                 // comments with only more "/"s are not doc comments
-                let tok = if comments::is_line_doc_comment(string) {
+                if comments::is_line_doc_comment(string) {
                     self.forbid_bare_cr(start, string, "bare CR not allowed in doc-comment");
                     token::DocComment(Symbol::intern(string))
                 } else {
                     token::Comment
-                };
-
-                tok
+                }
             }
             rustc_lexer::TokenKind::BlockComment { terminated } => {
                 let string = self.str_from(start);
@@ -204,14 +202,12 @@ impl<'a> StringReader<'a> {
                     self.fatal_span_(start, last_bpos, msg).raise();
                 }
 
-                let tok = if is_doc_comment {
+                if is_doc_comment {
                     self.forbid_bare_cr(start, string, "bare CR not allowed in block doc-comment");
                     token::DocComment(Symbol::intern(string))
                 } else {
                     token::Comment
-                };
-
-                tok
+                }
             }
             rustc_lexer::TokenKind::Whitespace => token::Whitespace,
             rustc_lexer::TokenKind::Ident | rustc_lexer::TokenKind::RawIdent => {

--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -925,8 +925,17 @@ impl<'a> Parser<'a> {
             self.parse_closure_expr(attrs)
         } else if self.eat_keyword(kw::If) {
             self.parse_if_expr(attrs)
-        } else if self.eat_keyword(kw::For) {
-            self.parse_for_expr(None, self.prev_token.span, attrs)
+        } else if self.check_keyword(kw::For) {
+            if self.choose_generics_over_qpath(1) {
+                // NOTE(Centril, eddyb): DO NOT REMOVE! Beyond providing parser recovery,
+                // this is an insurance policy in case we allow qpaths in (tuple-)struct patterns.
+                // When `for <Foo as Bar>::Proj in $expr $block` is wanted,
+                // you can disambiguate in favor of a pattern with `(...)`.
+                self.recover_quantified_closure_expr(attrs)
+            } else {
+                assert!(self.eat_keyword(kw::For));
+                self.parse_for_expr(None, self.prev_token.span, attrs)
+            }
         } else if self.eat_keyword(kw::While) {
             self.parse_while_expr(None, self.prev_token.span, attrs)
         } else if let Some(label) = self.eat_label() {
@@ -1414,6 +1423,26 @@ impl<'a> Parser<'a> {
         let (inner_attrs, blk) = self.parse_block_common(lo, blk_mode)?;
         attrs.extend(inner_attrs);
         Ok(self.mk_expr(blk.span, ExprKind::Block(blk, opt_label), attrs))
+    }
+
+    /// Recover on an explicitly quantified closure expression, e.g., `for<'a> |x: &'a u8| *x + 1`.
+    fn recover_quantified_closure_expr(&mut self, attrs: AttrVec) -> PResult<'a, P<Expr>> {
+        let lo = self.token.span;
+        let _ = self.parse_late_bound_lifetime_defs()?;
+        let span_for = lo.to(self.prev_token.span);
+        let closure = self.parse_closure_expr(attrs)?;
+
+        self.struct_span_err(span_for, "cannot introduce explicit parameters for a closure")
+            .span_label(closure.span, "the parameters are attached to this closure")
+            .span_suggestion(
+                span_for,
+                "remove the parameters",
+                String::new(),
+                Applicability::MachineApplicable,
+            )
+            .emit();
+
+        Ok(self.mk_expr_err(lo.to(closure.span)))
     }
 
     /// Parses a closure expression (e.g., `move |args| expr`).

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -458,7 +458,7 @@ impl<'a> Parser<'a> {
         self.expect_keyword(kw::Impl)?;
 
         // First, parse generic parameters if necessary.
-        let mut generics = if self.choose_generics_over_qpath() {
+        let mut generics = if self.choose_generics_over_qpath(0) {
             self.parse_generics()?
         } else {
             let mut generics = Generics::default();

--- a/src/librustc_parse/parser/stmt.rs
+++ b/src/librustc_parse/parser/stmt.rs
@@ -217,13 +217,7 @@ impl<'a> Parser<'a> {
 
     /// Parses the RHS of a local variable declaration (e.g., '= 14;').
     fn parse_initializer(&mut self, skip_eq: bool) -> PResult<'a, Option<P<Expr>>> {
-        if self.eat(&token::Eq) {
-            Ok(Some(self.parse_expr()?))
-        } else if skip_eq {
-            Ok(Some(self.parse_expr()?))
-        } else {
-            Ok(None)
-        }
+        if self.eat(&token::Eq) || skip_eq { Ok(Some(self.parse_expr()?)) } else { Ok(None) }
     }
 
     /// Parses a block. No inner attributes are allowed.

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -750,14 +750,16 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
                 // If this is a tuple or unit struct, define a name
                 // in the value namespace as well.
                 if let Some(ctor_node_id) = vdata.ctor_id() {
-                    let mut ctor_vis = vis;
                     // If the structure is marked as non_exhaustive then lower the visibility
                     // to within the crate.
-                    if vis == ty::Visibility::Public
+                    let mut ctor_vis = if vis == ty::Visibility::Public
                         && attr::contains_name(&item.attrs, sym::non_exhaustive)
                     {
-                        ctor_vis = ty::Visibility::Restricted(DefId::local(CRATE_DEF_INDEX));
-                    }
+                        ty::Visibility::Restricted(DefId::local(CRATE_DEF_INDEX))
+                    } else {
+                        vis
+                    };
+
                     for field in vdata.fields() {
                         // NOTE: The field may be an expansion placeholder, but expansion sets
                         // correct visibilities for unnamed field placeholders specifically, so the
@@ -1166,7 +1168,7 @@ macro_rules! method {
                 visit::$walk(self, node);
             }
         }
-    }
+    };
 }
 
 impl<'a, 'b> Visitor<'b> for BuildReducedGraphVisitor<'a, 'b> {

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -59,8 +59,7 @@ crate struct ImportSuggestion {
 /// `source_map` functions and this function to something more robust.
 fn reduce_impl_span_to_impl_keyword(sm: &SourceMap, impl_span: Span) -> Span {
     let impl_span = sm.span_until_char(impl_span, '<');
-    let impl_span = sm.span_until_whitespace(impl_span);
-    impl_span
+    sm.span_until_whitespace(impl_span)
 }
 
 impl<'a> Resolver<'a> {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1871,7 +1871,7 @@ impl<'a> Resolver<'a> {
                 // No adjustments
             }
         }
-        let result = self.resolve_ident_in_module_unadjusted_ext(
+        self.resolve_ident_in_module_unadjusted_ext(
             module,
             ident,
             ns,
@@ -1879,8 +1879,7 @@ impl<'a> Resolver<'a> {
             false,
             record_used,
             path_span,
-        );
-        result
+        )
     }
 
     fn resolve_crate_root(&mut self, ident: Ident) -> Module<'a> {

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -856,7 +856,7 @@ pub enum ExternalSource {
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum ExternalSourceKind {
     /// The external source has been loaded already.
-    Present(String),
+    Present(Lrc<String>),
     /// No attempt has been made to load the external source.
     AbsentOk,
     /// A failed attempt has been made to load the external source.
@@ -872,7 +872,7 @@ impl ExternalSource {
         }
     }
 
-    pub fn get_source(&self) -> Option<&str> {
+    pub fn get_source(&self) -> Option<&Lrc<String>> {
         match self {
             ExternalSource::Foreign { kind: ExternalSourceKind::Present(ref src), .. } => Some(src),
             _ => None,
@@ -1138,7 +1138,7 @@ impl SourceFile {
                     hasher.write(src.as_bytes());
 
                     if hasher.finish::<u128>() == self.src_hash {
-                        *src_kind = ExternalSourceKind::Present(src);
+                        *src_kind = ExternalSourceKind::Present(Lrc::new(src));
                         return true;
                     }
                 } else {

--- a/src/librustc_span/source_map.rs
+++ b/src/librustc_span/source_map.rs
@@ -370,11 +370,11 @@ impl SourceMap {
     pub fn doctest_offset_line(&self, file: &FileName, orig: usize) -> usize {
         match file {
             FileName::DocTest(_, offset) => {
-                return if *offset >= 0 {
-                    orig + *offset as usize
-                } else {
+                if *offset < 0 {
                     orig - (-(*offset)) as usize
-                };
+                } else {
+                    orig + *offset as usize
+                }
             }
             _ => orig,
         }

--- a/src/librustc_target/spec/apple_base.rs
+++ b/src/librustc_target/spec/apple_base.rs
@@ -57,7 +57,7 @@ pub fn macos_link_env_remove() -> Vec<String> {
     let mut env_remove = Vec::with_capacity(2);
     // Remove the `SDKROOT` environment variable if it's clearly set for the wrong platform, which
     // may occur when we're linking a custom build script while targeting iOS for example.
-    if let Some(sdkroot) = env::var("SDKROOT").ok() {
+    if let Ok(sdkroot) = env::var("SDKROOT") {
         if sdkroot.contains("iPhoneOS.platform") || sdkroot.contains("iPhoneSimulator.platform") {
             env_remove.push("SDKROOT".to_string())
         }

--- a/src/librustc_target/spec/apple_sdk_base.rs
+++ b/src/librustc_target/spec/apple_sdk_base.rs
@@ -43,7 +43,7 @@ pub fn get_sdk_root(sdk_name: &str) -> Result<String, String> {
     // to allow the SDK path to be set. (For clang, xcrun sets
     // SDKROOT; for rustc, the user or build system can set it, or we
     // can fall back to checking for xcrun on PATH.)
-    if let Some(sdkroot) = env::var("SDKROOT").ok() {
+    if let Ok(sdkroot) = env::var("SDKROOT") {
         let p = Path::new(&sdkroot);
         match sdk_name {
             // Ignore `SDKROOT` if it's clearly set for the wrong platform.

--- a/src/librustc_target/spec/apple_sdk_base.rs
+++ b/src/librustc_target/spec/apple_sdk_base.rs
@@ -49,34 +49,20 @@ pub fn get_sdk_root(sdk_name: &str) -> Result<String, String> {
             // Ignore `SDKROOT` if it's clearly set for the wrong platform.
             "appletvos"
                 if sdkroot.contains("TVSimulator.platform")
-                    || sdkroot.contains("MacOSX.platform") =>
-            {
-                ()
-            }
+                    || sdkroot.contains("MacOSX.platform") => {}
             "appletvsimulator"
-                if sdkroot.contains("TVOS.platform") || sdkroot.contains("MacOSX.platform") =>
-            {
-                ()
-            }
+                if sdkroot.contains("TVOS.platform") || sdkroot.contains("MacOSX.platform") => {}
             "iphoneos"
                 if sdkroot.contains("iPhoneSimulator.platform")
-                    || sdkroot.contains("MacOSX.platform") =>
-            {
-                ()
-            }
+                    || sdkroot.contains("MacOSX.platform") => {}
             "iphonesimulator"
-                if sdkroot.contains("iPhoneOS.platform") || sdkroot.contains("MacOSX.platform") =>
-            {
-                ()
+                if sdkroot.contains("iPhoneOS.platform") || sdkroot.contains("MacOSX.platform") => {
             }
             "macosx10.15"
                 if sdkroot.contains("iPhoneOS.platform")
-                    || sdkroot.contains("iPhoneSimulator.platform") =>
-            {
-                ()
-            }
+                    || sdkroot.contains("iPhoneSimulator.platform") => {}
             // Ignore `SDKROOT` if it's not a valid path.
-            _ if !p.is_absolute() || p == Path::new("/") || !p.exists() => (),
+            _ if !p.is_absolute() || p == Path::new("/") || !p.exists() => {}
             _ => return Ok(sdkroot),
         }
     }

--- a/src/librustc_trait_selection/traits/select.rs
+++ b/src/librustc_trait_selection/traits/select.rs
@@ -2792,7 +2792,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 trait_def_id, trait_obligations
             );
 
-            VtableTraitAliasData { alias_def_id, substs: substs, nested: trait_obligations }
+            VtableTraitAliasData { alias_def_id, substs, nested: trait_obligations }
         })
     }
 

--- a/src/librustc_traits/type_op.rs
+++ b/src/librustc_traits/type_op.rs
@@ -80,11 +80,11 @@ impl AscribeUserTypeCx<'me, 'tcx> {
     where
         T: ToTrace<'tcx>,
     {
-        Ok(self
-            .infcx
+        self.infcx
             .at(&ObligationCause::dummy(), self.param_env)
             .relate(a, variance, b)?
-            .into_value_registering_obligations(self.infcx, self.fulfill_cx))
+            .into_value_registering_obligations(self.infcx, self.fulfill_cx);
+        Ok(())
     }
 
     fn prove_predicate(&mut self, predicate: Predicate<'tcx>) {
@@ -165,10 +165,11 @@ fn type_op_eq<'tcx>(
 ) -> Result<&'tcx Canonical<'tcx, QueryResponse<'tcx, ()>>, NoSolution> {
     tcx.infer_ctxt().enter_canonical_trait_query(&canonicalized, |infcx, fulfill_cx, key| {
         let (param_env, Eq { a, b }) = key.into_parts();
-        Ok(infcx
+        infcx
             .at(&ObligationCause::dummy(), param_env)
             .eq(a, b)?
-            .into_value_registering_obligations(infcx, fulfill_cx))
+            .into_value_registering_obligations(infcx, fulfill_cx);
+        Ok(())
     })
 }
 
@@ -221,10 +222,11 @@ fn type_op_subtype<'tcx>(
 ) -> Result<&'tcx Canonical<'tcx, QueryResponse<'tcx, ()>>, NoSolution> {
     tcx.infer_ctxt().enter_canonical_trait_query(&canonicalized, |infcx, fulfill_cx, key| {
         let (param_env, Subtype { sub, sup }) = key.into_parts();
-        Ok(infcx
+        infcx
             .at(&ObligationCause::dummy(), param_env)
             .sup(sup, sub)?
-            .into_value_registering_obligations(infcx, fulfill_cx))
+            .into_value_registering_obligations(infcx, fulfill_cx);
+        Ok(())
     })
 }
 

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -1069,16 +1069,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         });
 
-        let elt_ts_iter = elts.iter().enumerate().map(|(i, e)| {
-            let t = match flds {
-                Some(ref fs) if i < fs.len() => {
-                    let ety = fs[i].expect_ty();
-                    self.check_expr_coercable_to_type(&e, ety);
-                    ety
-                }
-                _ => self.check_expr_with_expectation(&e, NoExpectation),
-            };
-            t
+        let elt_ts_iter = elts.iter().enumerate().map(|(i, e)| match flds {
+            Some(ref fs) if i < fs.len() => {
+                let ety = fs[i].expect_ty();
+                self.check_expr_coercable_to_type(&e, ety);
+                ety
+            }
+            _ => self.check_expr_with_expectation(&e, NoExpectation),
         });
         let tuple = self.tcx.mk_tup(elt_ts_iter);
         if tuple.references_error() {

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -368,11 +368,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let fn_sig = tcx.fn_sig(def_id);
         let fn_sig = self.replace_bound_vars_with_fresh_vars(span, infer::FnCall, &fn_sig).0;
         let fn_sig = fn_sig.subst(self.tcx, substs);
-        let fn_sig = match self.normalize_associated_types_in_as_infer_ok(span, &fn_sig) {
-            InferOk { value, obligations: o } => {
-                obligations.extend(o);
-                value
-            }
+
+        let InferOk { value, obligations: o } =
+            self.normalize_associated_types_in_as_infer_ok(span, &fn_sig);
+        let fn_sig = {
+            obligations.extend(o);
+            value
         };
 
         // Register obligations for the parameters. This will include the
@@ -384,12 +385,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // Note that as the method comes from a trait, it should not have
         // any late-bound regions appearing in its bounds.
         let bounds = self.tcx.predicates_of(def_id).instantiate(self.tcx, substs);
-        let bounds = match self.normalize_associated_types_in_as_infer_ok(span, &bounds) {
-            InferOk { value, obligations: o } => {
-                obligations.extend(o);
-                value
-            }
+
+        let InferOk { value, obligations: o } =
+            self.normalize_associated_types_in_as_infer_ok(span, &bounds);
+        let bounds = {
+            obligations.extend(o);
+            value
         };
+
         assert!(!bounds.has_escaping_bound_vars());
 
         let cause = traits::ObligationCause::misc(span, self.body_id);

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3654,14 +3654,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Otherwise, fall back to the immutable version.
         let (imm_tr, imm_op) = self.resolve_place_op(op, false);
-        let method = match (method, imm_tr) {
+        match (method, imm_tr) {
             (None, Some(trait_did)) => {
                 self.lookup_method_in_trait(span, imm_op, trait_did, base_ty, Some(arg_tys))
             }
             (method, _) => method,
-        };
-
-        method
+        }
     }
 
     fn check_method_argument_types(

--- a/src/librustc_typeck/coherence/builtin.rs
+++ b/src/librustc_typeck/coherence/builtin.rs
@@ -178,10 +178,7 @@ fn visit_implementation_of_dispatch_from_dyn(tcx: TyCtxt<'_>, impl_did: DefId) {
             use ty::TyKind::*;
             match (&source.kind, &target.kind) {
                 (&Ref(r_a, _, mutbl_a), Ref(r_b, _, mutbl_b))
-                    if infcx.at(&cause, param_env).eq(r_a, r_b).is_ok() && mutbl_a == *mutbl_b =>
-                {
-                    ()
-                }
+                    if infcx.at(&cause, param_env).eq(r_a, r_b).is_ok() && mutbl_a == *mutbl_b => {}
                 (&RawPtr(tm_a), &RawPtr(tm_b)) if tm_a.mutbl == tm_b.mutbl => (),
                 (&Adt(def_a, substs_a), &Adt(def_b, substs_b))
                     if def_a.is_struct() && def_b.is_struct() =>

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -507,7 +507,7 @@ pub fn print_const(cx: &DocContext<'_>, n: &'tcx ty::Const<'_>) -> String {
 }
 
 pub fn print_evaluated_const(cx: &DocContext<'_>, def_id: DefId) -> Option<String> {
-    let value = cx.tcx.const_eval_poly(def_id).ok().and_then(|val| {
+    cx.tcx.const_eval_poly(def_id).ok().and_then(|val| {
         let ty = cx.tcx.type_of(def_id);
         match (val, &ty.kind) {
             (_, &ty::Ref(..)) => None,
@@ -518,9 +518,7 @@ pub fn print_evaluated_const(cx: &DocContext<'_>, def_id: DefId) -> Option<Strin
             }
             _ => None,
         }
-    });
-
-    value
+    })
 }
 
 fn format_integer_with_underscore_sep(num: &str) -> String {

--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -666,13 +666,12 @@ fn get_index_search_type(item: &clean::Item) -> Option<IndexItemFunctionType> {
 }
 
 fn get_index_type(clean_type: &clean::Type) -> RenderType {
-    let t = RenderType {
+    RenderType {
         ty: clean_type.def_id(),
         idx: None,
         name: get_index_type_name(clean_type, true).map(|s| s.to_ascii_lowercase()),
         generics: get_generics(clean_type),
-    };
-    t
+    }
 }
 
 fn get_index_type_name(clean_type: &clean::Type, accept_generic: bool) -> Option<String> {

--- a/src/librustdoc/theme.rs
+++ b/src/librustdoc/theme.rs
@@ -234,9 +234,7 @@ pub fn load_css_paths(v: &[u8]) -> CssPath {
 }
 
 pub fn get_differences(against: &CssPath, other: &CssPath, v: &mut Vec<String>) {
-    if against.name != other.name {
-        return;
-    } else {
+    if against.name == other.name {
         for child in &against.children {
             let mut found = false;
             let mut found_working = false;

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -1082,8 +1082,8 @@ impl ThreadId {
     /// it is not guaranteed which values new threads will return, and this may
     /// change across Rust versions.
     #[unstable(feature = "thread_id_value", issue = "67939")]
-    pub fn as_u64(&self) -> u64 {
-        self.0.get()
+    pub fn as_u64(&self) -> NonZeroU64 {
+        self.0
     }
 }
 

--- a/src/test/ui/const-generics/issues/issue-66906.rs
+++ b/src/test/ui/const-generics/issues/issue-66906.rs
@@ -1,0 +1,12 @@
+// check-pass
+
+#![feature(const_generics)]
+//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+
+pub struct Tuple;
+
+pub trait Trait<const I: usize> {
+    type Input: From<<Self as Trait<I>>::Input>;
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-66906.stderr
+++ b/src/test/ui/const-generics/issues/issue-66906.stderr
@@ -1,0 +1,8 @@
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/issue-66906.rs:3:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+

--- a/src/test/ui/const-generics/issues/issue-70167.rs
+++ b/src/test/ui/const-generics/issues/issue-70167.rs
@@ -1,0 +1,10 @@
+// check-pass
+
+#![feature(const_generics)]
+//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+
+pub trait Trait<const N: usize>: From<<Self as Trait<N>>::Item> {
+  type Item;
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-70167.stderr
+++ b/src/test/ui/const-generics/issues/issue-70167.stderr
@@ -1,0 +1,8 @@
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/issue-70167.rs:3:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+

--- a/src/test/ui/parser/recover-quantified-closure.rs
+++ b/src/test/ui/parser/recover-quantified-closure.rs
@@ -1,0 +1,10 @@
+fn main() {
+    for<'a> |x: &'a u8| *x + 1;
+    //~^ ERROR cannot introduce explicit parameters for a closure
+}
+
+enum Foo { Bar }
+fn foo(x: impl Iterator<Item = Foo>) {
+    for <Foo>::Bar in x {}
+    //~^ ERROR expected one of `move`, `static`, `|`
+}

--- a/src/test/ui/parser/recover-quantified-closure.stderr
+++ b/src/test/ui/parser/recover-quantified-closure.stderr
@@ -1,0 +1,16 @@
+error: cannot introduce explicit parameters for a closure
+  --> $DIR/recover-quantified-closure.rs:2:5
+   |
+LL |     for<'a> |x: &'a u8| *x + 1;
+   |     ^^^^^^^ ------------------ the parameters are attached to this closure
+   |     |
+   |     help: remove the parameters
+
+error: expected one of `move`, `static`, `|`, or `||`, found `::`
+  --> $DIR/recover-quantified-closure.rs:8:14
+   |
+LL |     for <Foo>::Bar in x {}
+   |              ^^ expected one of `move`, `static`, `|`, or `||`
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/proc-macro/export-macro.stderr
+++ b/src/test/ui/proc-macro/export-macro.stderr
@@ -1,10 +1,8 @@
 error: cannot export macro_rules! macros from a `proc-macro` crate type currently
   --> $DIR/export-macro.rs:9:1
    |
-LL | / macro_rules! foo {
-LL | |     ($e:expr) => ($e)
-LL | | }
-   | |_^
+LL | macro_rules! foo {
+   | ^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/proc-macro/exports.stderr
+++ b/src/test/ui/proc-macro/exports.stderr
@@ -2,7 +2,7 @@ error: `proc-macro` crate types currently cannot export any items other than fun
   --> $DIR/exports.rs:7:1
    |
 LL | pub fn a() {}
-   | ^^^^^^^^^^^^^
+   | ^^^^^^^^^^
 
 error: `proc-macro` crate types currently cannot export any items other than functions tagged with `#[proc_macro]`, `#[proc_macro_derive]`, or `#[proc_macro_attribute]`
   --> $DIR/exports.rs:8:1
@@ -14,13 +14,13 @@ error: `proc-macro` crate types currently cannot export any items other than fun
   --> $DIR/exports.rs:9:1
    |
 LL | pub enum C {}
-   | ^^^^^^^^^^^^^
+   | ^^^^^^^^^^
 
 error: `proc-macro` crate types currently cannot export any items other than functions tagged with `#[proc_macro]`, `#[proc_macro_derive]`, or `#[proc_macro_attribute]`
   --> $DIR/exports.rs:10:1
    |
 LL | pub mod d {}
-   | ^^^^^^^^^^^^
+   | ^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/proc-macro/non-root.stderr
+++ b/src/test/ui/proc-macro/non-root.stderr
@@ -2,7 +2,7 @@ error: functions tagged with `#[proc_macro]` must currently reside in the root o
   --> $DIR/non-root.rs:11:5
    |
 LL |     pub fn foo(arg: TokenStream) -> TokenStream { arg }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/proc-macro/pub-at-crate-root.stderr
+++ b/src/test/ui/proc-macro/pub-at-crate-root.stderr
@@ -1,32 +1,20 @@
 error: `proc-macro` crate types currently cannot export any items other than functions tagged with `#[proc_macro]`, `#[proc_macro_derive]`, or `#[proc_macro_attribute]`
   --> $DIR/pub-at-crate-root.rs:8:1
    |
-LL | / pub mod a {
-LL | |     use proc_macro::TokenStream;
-LL | |
-LL | |     #[proc_macro_derive(B)]
-...  |
-LL | |     }
-LL | | }
-   | |_^
+LL | pub mod a {
+   | ^^^^^^^^^
 
 error: functions tagged with `#[proc_macro_derive]` must currently reside in the root of the crate
   --> $DIR/pub-at-crate-root.rs:12:5
    |
-LL | /     pub fn bar(a: TokenStream) -> TokenStream {
-LL | |
-LL | |         a
-LL | |     }
-   | |_____^
+LL |     pub fn bar(a: TokenStream) -> TokenStream {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: functions tagged with `#[proc_macro_derive]` must be `pub`
   --> $DIR/pub-at-crate-root.rs:19:1
    |
-LL | / fn bar(a: proc_macro::TokenStream) -> proc_macro::TokenStream {
-LL | |
-LL | |     a
-LL | | }
-   | |_^
+LL | fn bar(a: proc_macro::TokenStream) -> proc_macro::TokenStream {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #68099 (Amend Rc/Arc::from_raw() docs regarding unsafety)
 - #70172 (parse/lexer: support `StringReader::retokenize` called on external files.)
 - #70209 (parser: recover on `for<'a> |...| body` closures)
 - #70223 (fix type of const params in associated types.)
 - #70229 (more clippy fixes)
 - #70240 (Return NonZeroU64 from ThreadId::as_u64.)
 - #70250 (Remove wrong entry from RELEASES.md)
 - #70253 (Remove another wrong entry from RELEASES.md)
 - #70254 (couple more clippy fixes (let_and_return, if_same_then_else))
 - #70266 (proc_macro_harness: Use item header spans for errors)

Failed merges:


r? @ghost