### PR TITLE
Remove `ReClosureBound`

### DIFF
--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -92,9 +92,6 @@ impl<'a> HashStable<StableHashingContext<'a>> for ty::RegionKind {
             ty::ReFree(ref free_region) => {
                 free_region.hash_stable(hcx, hasher);
             }
-            ty::ReClosureBound(vid) => {
-                vid.hash_stable(hcx, hasher);
-            }
             ty::ReVar(..) | ty::RePlaceholder(..) => {
                 bug!("StableHasher: unexpected region {:?}", *self)
             }

--- a/src/librustc/ty/print/pretty.rs
+++ b/src/librustc/ty/print/pretty.rs
@@ -1547,7 +1547,7 @@ impl<F: fmt::Write> PrettyPrinter<'tcx> for FmtPrinter<'_, 'tcx, F> {
 
             ty::ReVar(_) | ty::ReScope(_) | ty::ReErased => false,
 
-            ty::ReStatic | ty::ReEmpty(_) | ty::ReClosureBound(_) => true,
+            ty::ReStatic | ty::ReEmpty(_) => true,
         }
     }
 
@@ -1657,12 +1657,6 @@ impl<F: fmt::Write> FmtPrinter<'_, '_, F> {
             }
             ty::ReEmpty(ui) => {
                 p!(write("'<empty:{:?}>", ui));
-                return Ok(self);
-            }
-
-            // The user should never encounter these in unsubstituted form.
-            ty::ReClosureBound(vid) => {
-                p!(write("{:?}", vid));
                 return Ok(self);
             }
         }

--- a/src/librustc/ty/structural_impls.rs
+++ b/src/librustc/ty/structural_impls.rs
@@ -81,8 +81,6 @@ impl fmt::Debug for ty::RegionKind {
         match *self {
             ty::ReEarlyBound(ref data) => write!(f, "ReEarlyBound({}, {})", data.index, data.name),
 
-            ty::ReClosureBound(ref vid) => write!(f, "ReClosureBound({:?})", vid),
-
             ty::ReLateBound(binder_id, ref bound_region) => {
                 write!(f, "ReLateBound({:?}, {:?})", binder_id, bound_region)
             }

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1442,12 +1442,6 @@ pub enum RegionKind {
 
     /// Erased region, used by trait selection, in MIR and during codegen.
     ReErased,
-
-    /// These are regions bound in the "defining type" for a
-    /// closure. They are used ONLY as part of the
-    /// `ClosureRegionRequirements` that are produced by MIR borrowck.
-    /// See `ClosureRegionRequirements` for more details.
-    ReClosureBound(RegionVid),
 }
 
 impl<'tcx> rustc_serialize::UseSpecializedDecodable for Region<'tcx> {}
@@ -1689,7 +1683,6 @@ impl RegionKind {
             RegionKind::RePlaceholder(placeholder) => placeholder.name.is_named(),
             RegionKind::ReEmpty(_) => false,
             RegionKind::ReErased => false,
-            RegionKind::ReClosureBound(..) => false,
         }
     }
 
@@ -1768,9 +1761,6 @@ impl RegionKind {
                 flags = flags | TypeFlags::HAS_FREE_LOCAL_REGIONS;
             }
             ty::ReEmpty(_) | ty::ReStatic => {
-                flags = flags | TypeFlags::HAS_FREE_REGIONS;
-            }
-            ty::ReClosureBound(..) => {
                 flags = flags | TypeFlags::HAS_FREE_REGIONS;
             }
             ty::ReLateBound(..) => {

--- a/src/librustc_infer/infer/canonical/canonicalizer.rs
+++ b/src/librustc_infer/infer/canonical/canonicalizer.rs
@@ -336,10 +336,6 @@ impl<'cx, 'tcx> TypeFolder<'tcx> for Canonicalizer<'cx, 'tcx> {
             | ty::ReEmpty(_)
             | ty::RePlaceholder(..)
             | ty::ReErased => self.canonicalize_region_mode.canonicalize_free_region(self, r),
-
-            ty::ReClosureBound(..) => {
-                bug!("closure bound region encountered during canonicalization");
-            }
         }
     }
 

--- a/src/librustc_infer/infer/combine.rs
+++ b/src/librustc_infer/infer/combine.rs
@@ -581,10 +581,6 @@ impl TypeRelation<'tcx> for Generalizer<'_, 'tcx> {
                 return Ok(r);
             }
 
-            ty::ReClosureBound(..) => {
-                span_bug!(self.span, "encountered unexpected ReClosureBound: {:?}", r,);
-            }
-
             ty::RePlaceholder(..)
             | ty::ReVar(..)
             | ty::ReEmpty(_)

--- a/src/librustc_infer/infer/error_reporting/mod.rs
+++ b/src/librustc_infer/infer/error_reporting/mod.rs
@@ -152,11 +152,6 @@ pub(super) fn note_and_explain_region(
         ty::ReVar(_) | ty::ReLateBound(..) | ty::ReErased => {
             (format!("lifetime {:?}", region), None)
         }
-
-        // We shouldn't encounter an error message with ReClosureBound.
-        ty::ReClosureBound(..) => {
-            bug!("encountered unexpected ReClosureBound: {:?}", region,);
-        }
     };
 
     emit_msg_span(err, prefix, description, span, suffix);

--- a/src/librustc_infer/infer/freshen.rs
+++ b/src/librustc_infer/infer/freshen.rs
@@ -135,10 +135,6 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TypeFreshener<'a, 'tcx> {
                 // replace all free regions with 'erased
                 self.tcx().lifetimes.re_erased
             }
-
-            ty::ReClosureBound(..) => {
-                bug!("encountered unexpected region: {:?}", r,);
-            }
         }
     }
 

--- a/src/librustc_infer/infer/lexical_region_resolve/mod.rs
+++ b/src/librustc_infer/infer/lexical_region_resolve/mod.rs
@@ -464,12 +464,7 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
     /// term "concrete regions").
     fn lub_concrete_regions(&self, a: Region<'tcx>, b: Region<'tcx>) -> Region<'tcx> {
         let r = match (a, b) {
-            (&ty::ReClosureBound(..), _)
-            | (_, &ty::ReClosureBound(..))
-            | (&ReLateBound(..), _)
-            | (_, &ReLateBound(..))
-            | (&ReErased, _)
-            | (_, &ReErased) => {
+            (&ReLateBound(..), _) | (_, &ReLateBound(..)) | (&ReErased, _) | (_, &ReErased) => {
                 bug!("cannot relate region: LUB({:?}, {:?})", a, b);
             }
 

--- a/src/librustc_infer/infer/region_constraints/mod.rs
+++ b/src/librustc_infer/infer/region_constraints/mod.rs
@@ -798,7 +798,7 @@ impl<'tcx> RegionConstraintCollector<'tcx> {
             | ty::ReEarlyBound(..) => ty::UniverseIndex::ROOT,
             ty::ReEmpty(ui) => ui,
             ty::RePlaceholder(placeholder) => placeholder.universe,
-            ty::ReClosureBound(vid) | ty::ReVar(vid) => self.var_universe(vid),
+            ty::ReVar(vid) => self.var_universe(vid),
             ty::ReLateBound(..) => bug!("universe(): encountered bound region {:?}", region),
         }
     }

--- a/src/librustc_mir/borrow_check/diagnostics/region_name.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/region_name.rs
@@ -292,8 +292,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
             | ty::ReVar(..)
             | ty::RePlaceholder(..)
             | ty::ReEmpty(_)
-            | ty::ReErased
-            | ty::ReClosureBound(..) => None,
+            | ty::ReErased => None,
         }
     }
 

--- a/src/librustc_trait_selection/opaque_types.rs
+++ b/src/librustc_trait_selection/opaque_types.rs
@@ -823,11 +823,7 @@ impl TypeFolder<'tcx> for ReverseMapper<'tcx> {
             // The regions that we expect from borrow checking.
             ty::ReEarlyBound(_) | ty::ReFree(_) | ty::ReEmpty(ty::UniverseIndex::ROOT) => {}
 
-            ty::ReEmpty(_)
-            | ty::RePlaceholder(_)
-            | ty::ReVar(_)
-            | ty::ReScope(_)
-            | ty::ReClosureBound(_) => {
+            ty::ReEmpty(_) | ty::RePlaceholder(_) | ty::ReVar(_) | ty::ReScope(_) => {
                 // All of the regions in the type should either have been
                 // erased by writeback, or mapped back to named regions by
                 // borrow checking.

--- a/src/librustc_typeck/outlives/utils.rs
+++ b/src/librustc_typeck/outlives/utils.rs
@@ -170,7 +170,6 @@ fn is_free_region(tcx: TyCtxt<'_>, region: Region<'_>) -> bool {
 
         // These regions don't appear in types from type declarations:
         RegionKind::ReErased
-        | RegionKind::ReClosureBound(..)
         | RegionKind::ReScope(..)
         | RegionKind::ReVar(..)
         | RegionKind::RePlaceholder(..)

--- a/src/librustc_typeck/variance/constraints.rs
+++ b/src/librustc_typeck/variance/constraints.rs
@@ -449,7 +449,6 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
             }
 
             ty::ReFree(..)
-            | ty::ReClosureBound(..)
             | ty::ReScope(..)
             | ty::ReVar(..)
             | ty::RePlaceholder(..)

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -450,7 +450,6 @@ impl Clean<Option<Lifetime>> for ty::RegionKind {
             | ty::ReVar(..)
             | ty::RePlaceholder(..)
             | ty::ReEmpty(_)
-            | ty::ReClosureBound(_)
             | ty::ReErased => {
                 debug!("cannot clean region {:?}", self);
                 None

--- a/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
@@ -108,7 +108,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
            ]
    = note: number of external vids: 4
-   = note: where <T as Anything<ReClosureBound('_#2r)>>::AssocType: '_#3r
+   = note: where <T as Anything<ReEarlyBound(1, 'b)>>::AssocType: '_#3r
 
 note: no external requirements
   --> $DIR/projection-one-region-closure.rs:62:1

--- a/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
@@ -90,7 +90,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
            ]
    = note: number of external vids: 4
-   = note: where <T as Anything<ReClosureBound('_#2r)>>::AssocType: '_#3r
+   = note: where <T as Anything<ReEarlyBound(1, 'b)>>::AssocType: '_#3r
 
 note: no external requirements
   --> $DIR/projection-one-region-trait-bound-closure.rs:52:1

--- a/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
@@ -10,7 +10,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
            ]
    = note: late-bound region is '_#4r
    = note: number of external vids: 5
-   = note: where <T as Anything<ReClosureBound('_#1r), ReClosureBound('_#2r)>>::AssocType: '_#3r
+   = note: where <T as Anything<ReEarlyBound(0, 'b), ReEarlyBound(1, 'c)>>::AssocType: '_#3r
 
 note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:34:1
@@ -26,13 +26,13 @@ LL | | }
    |
    = note: defining type: no_relationships_late::<'_#1r, '_#2r, T>
 
-error[E0309]: the associated type `<T as Anything<'_#5r, '_#6r>>::AssocType` may not live long enough
+error[E0309]: the associated type `<T as Anything<ReEarlyBound(0, 'b), ReEarlyBound(1, 'c)>>::AssocType` may not live long enough
   --> $DIR/projection-two-region-trait-bound-closure.rs:38:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: consider adding an explicit lifetime bound `<T as Anything<'_#5r, '_#6r>>::AssocType: 'a`...
+   = help: consider adding an explicit lifetime bound `<T as Anything<ReEarlyBound(0, 'b), ReEarlyBound(1, 'c)>>::AssocType: 'a`...
 
 note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:48:29
@@ -45,7 +45,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
                extern "rust-call" fn((std::cell::Cell<&'_#4r ()>, T)),
            ]
    = note: number of external vids: 5
-   = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#3r)>>::AssocType: '_#4r
+   = note: where <T as Anything<ReEarlyBound(1, 'b), ReEarlyBound(2, 'c)>>::AssocType: '_#4r
 
 note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:43:1
@@ -61,13 +61,13 @@ LL | | }
    |
    = note: defining type: no_relationships_early::<'_#1r, '_#2r, '_#3r, T>
 
-error[E0309]: the associated type `<T as Anything<'_#6r, '_#7r>>::AssocType` may not live long enough
+error[E0309]: the associated type `<T as Anything<ReEarlyBound(1, 'b), ReEarlyBound(2, 'c)>>::AssocType` may not live long enough
   --> $DIR/projection-two-region-trait-bound-closure.rs:48:29
    |
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: consider adding an explicit lifetime bound `<T as Anything<'_#6r, '_#7r>>::AssocType: 'a`...
+   = help: consider adding an explicit lifetime bound `<T as Anything<ReEarlyBound(1, 'b), ReEarlyBound(2, 'c)>>::AssocType: 'a`...
 
 note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:61:29
@@ -80,7 +80,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
                extern "rust-call" fn((std::cell::Cell<&'_#4r ()>, T)),
            ]
    = note: number of external vids: 5
-   = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#3r)>>::AssocType: '_#4r
+   = note: where <T as Anything<ReEarlyBound(1, 'b), ReEarlyBound(2, 'c)>>::AssocType: '_#4r
 
 note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:53:1
@@ -107,7 +107,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
                extern "rust-call" fn((std::cell::Cell<&'_#4r ()>, T)),
            ]
    = note: number of external vids: 5
-   = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#3r)>>::AssocType: '_#4r
+   = note: where <T as Anything<ReEarlyBound(1, 'b), ReEarlyBound(2, 'c)>>::AssocType: '_#4r
 
 note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:65:1
@@ -134,7 +134,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
                extern "rust-call" fn((std::cell::Cell<&'_#4r ()>, T)),
            ]
    = note: number of external vids: 5
-   = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#3r)>>::AssocType: '_#4r
+   = note: where <T as Anything<ReEarlyBound(1, 'b), ReEarlyBound(2, 'c)>>::AssocType: '_#4r
 
 note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:74:1
@@ -162,7 +162,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
            ]
    = note: late-bound region is '_#3r
    = note: number of external vids: 4
-   = note: where <T as Anything<ReClosureBound('_#1r), ReClosureBound('_#1r)>>::AssocType: '_#2r
+   = note: where <T as Anything<ReEarlyBound(0, 'b), ReEarlyBound(0, 'b)>>::AssocType: '_#2r
 
 note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:83:1
@@ -202,7 +202,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
                extern "rust-call" fn((std::cell::Cell<&'_#3r ()>, T)),
            ]
    = note: number of external vids: 4
-   = note: where <T as Anything<ReClosureBound('_#2r), ReClosureBound('_#2r)>>::AssocType: '_#3r
+   = note: where <T as Anything<ReEarlyBound(1, 'b), ReEarlyBound(1, 'b)>>::AssocType: '_#3r
 
 note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:92:1
@@ -229,7 +229,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
                extern "rust-call" fn((std::cell::Cell<&'_#2r ()>, T)),
            ]
    = note: number of external vids: 3
-   = note: where <T as Anything<ReClosureBound('_#1r), ReClosureBound('_#1r)>>::AssocType: '_#2r
+   = note: where <T as Anything<ReEarlyBound(0, 'a), ReEarlyBound(0, 'a)>>::AssocType: '_#2r
 
 note: no external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:101:1


### PR DESCRIPTION
We now substitute external names for regions in the query response.

r? @nikomatsakis 