### PR TITLE
Refactor `codegen`

### DIFF
--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -732,7 +732,9 @@ pub(crate) unsafe fn codegen(
             })?;
         }
 
-        if config.emit_asm || (config.emit_obj && config.no_integrated_as) {
+        let config_emit_normal_obj = config.emit_obj && !config.obj_is_bitcode;
+
+        if config.emit_asm || (config_emit_normal_obj && config.no_integrated_as) {
             let _timer = cgcx
                 .prof
                 .generic_activity_with_arg("LLVM_module_codegen_emit_asm", &module.name[..]);
@@ -747,7 +749,7 @@ pub(crate) unsafe fn codegen(
             })?;
         }
 
-        if config.emit_obj && !config.obj_is_bitcode && !config.no_integrated_as {
+        if config_emit_normal_obj && !config.no_integrated_as {
             let _timer = cgcx
                 .prof
                 .generic_activity_with_arg("LLVM_module_codegen_emit_obj", &module.name[..]);
@@ -761,7 +763,7 @@ pub(crate) unsafe fn codegen(
                     llvm::FileType::ObjectFile,
                 )
             })?;
-        } else if config.emit_obj && config.no_integrated_as {
+        } else if config_emit_normal_obj && config.no_integrated_as {
             let _timer = cgcx
                 .prof
                 .generic_activity_with_arg("LLVM_module_codegen_asm_to_obj", &module.name[..]);

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -18,7 +18,7 @@ use rustc::bug;
 use rustc::session::config::{self, Lto, OutputType, Passes, Sanitizer, SwitchWithOptPath};
 use rustc::session::Session;
 use rustc::ty::TyCtxt;
-use rustc_codegen_ssa::back::write::{run_assembler, CodegenContext, ModuleConfig};
+use rustc_codegen_ssa::back::write::{run_assembler, CodegenContext, EmbedBitcode, ModuleConfig};
 use rustc_codegen_ssa::traits::*;
 use rustc_codegen_ssa::{CompiledModule, ModuleCodegen, RLIB_BYTECODE_EXTENSION};
 use rustc_data_structures::small_c_str::SmallCStr;
@@ -662,7 +662,7 @@ pub(crate) unsafe fn codegen(
                 }
             }
 
-            if config.embed_bitcode {
+            if config.embed_bitcode == EmbedBitcode::Full {
                 let _timer = cgcx.prof.generic_activity_with_arg(
                     "LLVM_module_codegen_embed_bitcode",
                     &module.name[..],
@@ -682,7 +682,7 @@ pub(crate) unsafe fn codegen(
                     diag_handler.err(&msg);
                 }
             }
-        } else if config.embed_bitcode_marker {
+        } else if config.embed_bitcode == EmbedBitcode::Marker {
             embed_bitcode(cgcx, llcx, llmod, None);
         }
 

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -773,17 +773,19 @@ pub(crate) unsafe fn codegen(
             }
         }
 
-        if config.emit_obj && config.obj_is_bitcode {
-            debug!("copying bitcode {:?} to obj {:?}", bc_out, obj_out);
-            if let Err(e) = link_or_copy(&bc_out, &obj_out) {
-                diag_handler.err(&format!("failed to copy bitcode to object file: {}", e));
+        if config.obj_is_bitcode {
+            if config.emit_obj {
+                debug!("copying bitcode {:?} to obj {:?}", bc_out, obj_out);
+                if let Err(e) = link_or_copy(&bc_out, &obj_out) {
+                    diag_handler.err(&format!("failed to copy bitcode to object file: {}", e));
+                }
             }
-        }
 
-        if !config.emit_bc && config.obj_is_bitcode {
-            debug!("removing_bitcode {:?}", bc_out);
-            if let Err(e) = fs::remove_file(&bc_out) {
-                diag_handler.err(&format!("failed to remove bitcode: {}", e));
+            if !config.emit_bc {
+                debug!("removing_bitcode {:?}", bc_out);
+                if let Err(e) = fs::remove_file(&bc_out) {
+                    diag_handler.err(&format!("failed to remove bitcode: {}", e));
+                }
             }
         }
 

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -749,29 +749,31 @@ pub(crate) unsafe fn codegen(
             })?;
         }
 
-        if config_emit_normal_obj && !config.no_integrated_as {
-            let _timer = cgcx
-                .prof
-                .generic_activity_with_arg("LLVM_module_codegen_emit_obj", &module.name[..]);
-            with_codegen(tm, llmod, config.no_builtins, |cpm| {
-                write_output_file(
-                    diag_handler,
-                    tm,
-                    cpm,
-                    llmod,
-                    &obj_out,
-                    llvm::FileType::ObjectFile,
-                )
-            })?;
-        } else if config_emit_normal_obj && config.no_integrated_as {
-            let _timer = cgcx
-                .prof
-                .generic_activity_with_arg("LLVM_module_codegen_asm_to_obj", &module.name[..]);
-            let assembly = cgcx.output_filenames.temp_path(OutputType::Assembly, module_name);
-            run_assembler(cgcx, diag_handler, &assembly, &obj_out);
+        if config_emit_normal_obj {
+            if !config.no_integrated_as {
+                let _timer = cgcx
+                    .prof
+                    .generic_activity_with_arg("LLVM_module_codegen_emit_obj", &module.name[..]);
+                with_codegen(tm, llmod, config.no_builtins, |cpm| {
+                    write_output_file(
+                        diag_handler,
+                        tm,
+                        cpm,
+                        llmod,
+                        &obj_out,
+                        llvm::FileType::ObjectFile,
+                    )
+                })?;
+            } else {
+                let _timer = cgcx
+                    .prof
+                    .generic_activity_with_arg("LLVM_module_codegen_asm_to_obj", &module.name[..]);
+                let assembly = cgcx.output_filenames.temp_path(OutputType::Assembly, module_name);
+                run_assembler(cgcx, diag_handler, &assembly, &obj_out);
 
-            if !config.emit_asm && !cgcx.save_temps {
-                drop(fs::remove_file(&assembly));
+                if !config.emit_asm && !cgcx.save_temps {
+                    drop(fs::remove_file(&assembly));
+                }
             }
         }
 

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -74,7 +74,6 @@ pub struct ModuleConfig {
     pub emit_no_opt_bc: bool,
     pub emit_bc: bool,
     pub emit_bc_compressed: bool,
-    pub emit_lto_bc: bool,
     pub emit_ir: bool,
     pub emit_asm: bool,
     pub emit_obj: bool,
@@ -116,7 +115,6 @@ impl ModuleConfig {
             emit_pre_lto_bc: false,
             emit_bc: false,
             emit_bc_compressed: false,
-            emit_lto_bc: false,
             emit_ir: false,
             emit_asm: false,
             emit_obj: false,
@@ -381,7 +379,6 @@ pub fn start_async_codegen<B: ExtraBackendMethods>(
         modules_config.emit_no_opt_bc = true;
         modules_config.emit_pre_lto_bc = true;
         modules_config.emit_bc = true;
-        modules_config.emit_lto_bc = true;
         metadata_config.emit_bc = true;
         allocator_config.emit_bc = true;
     }

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -51,6 +51,14 @@ use std::thread;
 
 const PRE_LTO_BC_EXT: &str = "pre-lto.bc";
 
+/// The kind of bitcode to embed in object files.
+#[derive(PartialEq)]
+pub enum EmbedBitcode {
+    None,
+    Marker,
+    Full,
+}
+
 /// Module-specific configuration for `optimize_and_codegen`.
 pub struct ModuleConfig {
     /// Names of additional optimization passes to run.
@@ -93,8 +101,7 @@ pub struct ModuleConfig {
     // emscripten's ecc compiler, when used as the linker.
     pub obj_is_bitcode: bool,
     pub no_integrated_as: bool,
-    pub embed_bitcode: bool,
-    pub embed_bitcode_marker: bool,
+    pub embed_bitcode: EmbedBitcode,
 }
 
 impl ModuleConfig {
@@ -119,8 +126,7 @@ impl ModuleConfig {
             emit_asm: false,
             emit_obj: false,
             obj_is_bitcode: false,
-            embed_bitcode: false,
-            embed_bitcode_marker: false,
+            embed_bitcode: EmbedBitcode::None,
             no_integrated_as: false,
 
             verify_llvm_ir: false,
@@ -143,16 +149,15 @@ impl ModuleConfig {
         self.new_llvm_pass_manager = sess.opts.debugging_opts.new_llvm_pass_manager;
         self.obj_is_bitcode =
             sess.target.target.options.obj_is_bitcode || sess.opts.cg.linker_plugin_lto.enabled();
-        let embed_bitcode =
-            sess.target.target.options.embed_bitcode || sess.opts.debugging_opts.embed_bitcode;
-        if embed_bitcode {
-            match sess.opts.optimize {
-                config::OptLevel::No | config::OptLevel::Less => {
-                    self.embed_bitcode_marker = embed_bitcode;
+        self.embed_bitcode =
+            if sess.target.target.options.embed_bitcode || sess.opts.debugging_opts.embed_bitcode {
+                match sess.opts.optimize {
+                    config::OptLevel::No | config::OptLevel::Less => EmbedBitcode::Marker,
+                    _ => EmbedBitcode::Full,
                 }
-                _ => self.embed_bitcode = embed_bitcode,
-            }
-        }
+            } else {
+                EmbedBitcode::None
+            };
 
         // Copy what clang does by turning on loop vectorization at O2 and
         // slp vectorization at O3. Otherwise configure other optimization aspects
@@ -188,7 +193,10 @@ impl ModuleConfig {
     }
 
     pub fn bitcode_needed(&self) -> bool {
-        self.emit_bc || self.obj_is_bitcode || self.emit_bc_compressed || self.embed_bitcode
+        self.emit_bc
+            || self.obj_is_bitcode
+            || self.emit_bc_compressed
+            || self.embed_bitcode == EmbedBitcode::Full
     }
 }
 


### PR DESCRIPTION
`codegen` in `src/librustc_codegen_llvm/back/write.rs` is long and has complex control flow. These commits refactor it and make it easier to understand.