### PR TITLE
add err_machine_stop macro

### DIFF
--- a/src/librustc/mir/interpret/mod.rs
+++ b/src/librustc/mir/interpret/mod.rs
@@ -46,6 +46,13 @@ macro_rules! err_exhaust {
     };
 }
 
+#[macro_export]
+macro_rules! err_machine_stop {
+    ($($tt:tt)*) => {
+        $crate::mir::interpret::InterpError::MachineStop(Box::new($($tt)*))
+    };
+}
+
 // In the `throw_*` macros, avoid `return` to make them work with `try {}`.
 #[macro_export]
 macro_rules! throw_unsup {
@@ -79,9 +86,7 @@ macro_rules! throw_exhaust {
 
 #[macro_export]
 macro_rules! throw_machine_stop {
-    ($($tt:tt)*) => {
-        Err::<!, _>($crate::mir::interpret::InterpError::MachineStop(Box::new($($tt)*)))?
-    };
+    ($($tt:tt)*) => { Err::<!, _>(err_machine_stop!($($tt)*))? };
 }
 
 mod allocation;

--- a/src/librustc_mir/const_eval/error.rs
+++ b/src/librustc_mir/const_eval/error.rs
@@ -5,7 +5,7 @@ use rustc::mir::AssertKind;
 use rustc_span::Symbol;
 
 use super::InterpCx;
-use crate::interpret::{ConstEvalErr, InterpError, InterpErrorInfo, Machine};
+use crate::interpret::{ConstEvalErr, InterpErrorInfo, Machine};
 
 /// The CTFE machine has some custom error kinds.
 #[derive(Clone, Debug)]
@@ -21,7 +21,7 @@ pub enum ConstEvalErrKind {
 // handle these.
 impl<'tcx> Into<InterpErrorInfo<'tcx>> for ConstEvalErrKind {
     fn into(self) -> InterpErrorInfo<'tcx> {
-        InterpError::MachineStop(Box::new(self.to_string())).into()
+        err_machine_stop!(self.to_string()).into()
     }
 }
 


### PR DESCRIPTION
We have that for all other error kinds, but here I somehow forgot it.

r? @oli-obk 