### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/src/bootstrap/bin/rustdoc.rs
+++ b/src/bootstrap/bin/rustdoc.rs
@@ -52,12 +52,7 @@ fn main() {
     // Bootstrap's Cargo-command builder sets this variable to the current Rust version; let's pick
     // it up so we can make rustdoc print this into the docs
     if let Some(version) = env::var_os("RUSTDOC_CRATE_VERSION") {
-        // This "unstable-options" can be removed when `--crate-version` is stabilized
-        if !has_unstable {
-            cmd.arg("-Z").arg("unstable-options");
-        }
         cmd.arg("--crate-version").arg(version);
-        has_unstable = true;
     }
 
     // Needed to be able to run all rustdoc tests.

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -313,6 +313,9 @@ impl Step for Standalone {
             }
 
             let mut cmd = builder.rustdoc_cmd(compiler);
+            // Needed for --index-page flag
+            cmd.arg("-Z").arg("unstable-options");
+
             cmd.arg("--html-after-content")
                 .arg(&footer)
                 .arg("--html-before-content")
@@ -395,7 +398,7 @@ impl Step for Std {
 
             // Keep a whitelist so we do not build internal stdlib crates, these will be
             // build by the rustc step later if enabled.
-            cargo.arg("-Z").arg("unstable-options").arg("-p").arg(package);
+            cargo.arg("-p").arg(package);
             // Create all crate output directories first to make sure rustdoc uses
             // relative links.
             // FIXME: Cargo should probably do this itself.
@@ -406,6 +409,8 @@ impl Step for Std {
                 .arg("rust.css")
                 .arg("--markdown-no-toc")
                 .arg("--generate-redirect-pages")
+                .arg("-Z")
+                .arg("unstable-options")
                 .arg("--resource-suffix")
                 .arg(crate::channel::CFG_RELEASE_NUM)
                 .arg("--index-page")

--- a/src/doc/rustc/src/json.md
+++ b/src/doc/rustc/src/json.md
@@ -168,7 +168,7 @@ Diagnostics have the following format:
             "rendered": null
         },
         {
-            "message": "consider prefixing with an underscore",
+            "message": "if this is intentional, prefix it with an underscore",
             "code": null,
             "level": "help",
             "spans": [
@@ -201,7 +201,7 @@ Diagnostics have the following format:
     /* Optional string of the rendered version of the diagnostic as displayed
        by rustc. Note that this may be influenced by the `--json` flag.
     */
-    "rendered": "warning: unused variable: `x`\n --> lib.rs:2:9\n  |\n2 |     let x = 123;\n  |         ^ help: consider prefixing with an underscore: `_x`\n  |\n  = note: `#[warn(unused_variables)]` on by default\n\n"
+    "rendered": "warning: unused variable: `x`\n --> lib.rs:2:9\n  |\n2 |     let x = 123;\n  |         ^ help: if this is intentional, prefix it with an underscore: `_x`\n  |\n  = note: `#[warn(unused_variables)]` on by default\n\n"
 }
 ```
 

--- a/src/doc/rustdoc/src/command-line-arguments.md
+++ b/src/doc/rustdoc/src/command-line-arguments.md
@@ -390,3 +390,15 @@ the same CSS rules as the official `light` theme.
 `--check-theme` is a separate mode in `rustdoc`. When `rustdoc` sees the
 `--check-theme` flag, it discards all other flags and only performs the CSS rule
 comparison operation.
+
+### `--crate-version`: control the crate version
+
+Using this flag looks like this:
+
+```bash
+$ rustdoc src/lib.rs --crate-version 1.3.37
+```
+
+When `rustdoc` receives this flag, it will print an extra "Version (version)" into the sidebar of
+the crate root's docs. You can use this flag to differentiate between different versions of your
+library's documentation.

--- a/src/doc/rustdoc/src/unstable-features.md
+++ b/src/doc/rustdoc/src/unstable-features.md
@@ -269,18 +269,6 @@ Markdown file, the URL given to `--markdown-playground-url` will take precedence
 `--playground-url` and `#![doc(html_playground_url = "url")]` are present when rendering crate docs,
 the attribute will take precedence.
 
-### `--crate-version`: control the crate version
-
-Using this flag looks like this:
-
-```bash
-$ rustdoc src/lib.rs -Z unstable-options --crate-version 1.3.37
-```
-
-When `rustdoc` receives this flag, it will print an extra "Version (version)" into the sidebar of
-the crate root's docs. You can use this flag to differentiate between different versions of your
-library's documentation.
-
 ### `--sort-modules-by-appearance`: control how items on module pages are sorted
 
 Using this flag looks like this:

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -161,6 +161,7 @@ pub mod str;
 pub mod string;
 #[cfg(target_has_atomic = "ptr")]
 pub mod sync;
+pub mod task;
 #[cfg(test)]
 mod tests;
 pub mod vec;

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -161,6 +161,7 @@ pub mod str;
 pub mod string;
 #[cfg(target_has_atomic = "ptr")]
 pub mod sync;
+#[cfg(target_has_atomic = "ptr")]
 pub mod task;
 #[cfg(test)]
 mod tests;

--- a/src/liballoc/task.rs
+++ b/src/liballoc/task.rs
@@ -1,0 +1,91 @@
+#![unstable(feature = "wake_trait", issue = "0")]
+//! Types and Traits for working with asynchronous tasks.
+use core::mem;
+use core::task::{Waker, RawWaker, RawWakerVTable};
+
+use crate::sync::Arc;
+
+/// The implementation of waking a task on an executor.
+/// 
+/// This trait can be used to create a [`Waker`]. An executor can define an
+/// implementation of this trait, and use that to construct a Waker to pass
+/// to the tasks that are executed on that executor.
+///
+/// This trait is a memory-safe and ergonomic alternative to constructing a
+/// [`RawWaker`]. It supports the common executor design in which the data
+/// used to wake up a task is stored in an [`Arc`]. Some executors (especially
+/// those for embedded systems) cannot use this API, which is way [`RawWaker`]
+/// exists as an alternative for those systems.
+#[unstable(feature = "wake_trait", issue = "0")]
+pub trait Wake {
+    /// Wake this task.
+    #[unstable(feature = "wake_trait", issue = "0")]
+    fn wake(self: Arc<Self>);
+
+    /// Wake this task without consuming the waker.
+    ///
+    /// If an executor supports a cheaper way to wake without consuming the
+    /// waker, it should override this method. By default, it clones the
+    /// [`Arc`] and calls `wake` on the clone.
+    #[unstable(feature = "wake_trait", issue = "0")]
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.clone().wake();
+    }
+}
+
+#[unstable(feature = "wake_trait", issue = "0")]
+impl<W: Wake + Send + Sync + 'static> From<Arc<W>> for Waker {
+    fn from(waker: Arc<W>) -> Waker {
+        unsafe {
+            Waker::from_raw(raw_waker(waker))
+        }
+    }
+}
+
+#[unstable(feature = "wake_trait", issue = "0")]
+impl<W: Wake + Send + Sync + 'static> From<Arc<W>> for RawWaker {
+    fn from(waker: Arc<W>) -> RawWaker {
+        raw_waker(waker)
+    }
+}
+
+// NB: This private function for constructing a RawWaker is used, rather than
+// inlining this into the `From<Arc<W>> for RawWaker` impl, to ensure that
+// the safety of `From<Arc<W>> for Waker` does not depend on the correct
+// trait dispatch - instead both impls call this function directly and
+// explicitly.
+#[inline(always)]
+fn raw_waker<W: Wake + Send + Sync + 'static>(waker: Arc<W>) -> RawWaker {
+
+    // Increment the reference count of the arc to clone it.
+    unsafe fn clone_waker<W: Wake + Send + Sync + 'static>(waker: *const ()) -> RawWaker {
+        let waker: Arc<W> = Arc::from_raw(waker as *const W);
+        mem::forget(waker.clone());
+        raw_waker(waker)
+    }
+
+    // Wake by value, moving the Arc into the Wake::wake function
+    unsafe fn wake<W: Wake + Send + Sync + 'static>(waker: *const ()) {
+        let waker: Arc<W> = Arc::from_raw(waker as *const W);
+        Wake::wake(waker);
+    }
+
+    // Wake by reference, forgetting the Arc to avoid decrementing the reference count
+    unsafe fn wake_by_ref<W: Wake + Send + Sync + 'static>(waker: *const ()) {
+        let waker: Arc<W> = Arc::from_raw(waker as *const W);
+        Wake::wake_by_ref(&waker);
+        mem::forget(waker);
+    }
+
+    // Decrement the reference count of the Arc on drop
+    unsafe fn drop_waker<W: Wake + Send + Sync + 'static>(waker: *const ()) {
+        mem::drop(Arc::from_raw(waker as *const W));
+    }
+
+    RawWaker::new(Arc::into_raw(waker) as *const (), &RawWakerVTable::new(
+        clone_waker::<W>,
+        wake::<W>,
+        wake_by_ref::<W>,
+        drop_waker::<W>,
+    ))
+}

--- a/src/liballoc/task.rs
+++ b/src/liballoc/task.rs
@@ -1,4 +1,4 @@
-#![unstable(feature = "wake_trait", issue = "0")]
+#![unstable(feature = "wake_trait", issue = "69912")]
 //! Types and Traits for working with asynchronous tasks.
 use core::mem::{self, ManuallyDrop};
 use core::task::{RawWaker, RawWakerVTable, Waker};

--- a/src/liballoc/task.rs
+++ b/src/liballoc/task.rs
@@ -16,10 +16,10 @@ use crate::sync::Arc;
 /// used to wake up a task is stored in an [`Arc`]. Some executors (especially
 /// those for embedded systems) cannot use this API, which is why [`RawWaker`]
 /// exists as an alternative for those systems.
-#[unstable(feature = "wake_trait", issue = "0")]
+#[unstable(feature = "wake_trait", issue = "69912")]
 pub trait Wake {
     /// Wake this task.
-    #[unstable(feature = "wake_trait", issue = "0")]
+    #[unstable(feature = "wake_trait", issue = "69912")]
     fn wake(self: Arc<Self>);
 
     /// Wake this task without consuming the waker.
@@ -27,13 +27,13 @@ pub trait Wake {
     /// If an executor supports a cheaper way to wake without consuming the
     /// waker, it should override this method. By default, it clones the
     /// [`Arc`] and calls `wake` on the clone.
-    #[unstable(feature = "wake_trait", issue = "0")]
+    #[unstable(feature = "wake_trait", issue = "69912")]
     fn wake_by_ref(self: &Arc<Self>) {
         self.clone().wake();
     }
 }
 
-#[unstable(feature = "wake_trait", issue = "0")]
+#[unstable(feature = "wake_trait", issue = "69912")]
 impl<W: Wake + Send + Sync + 'static> From<Arc<W>> for Waker {
     fn from(waker: Arc<W>) -> Waker {
         // SAFETY: This is safe because raw_waker safely constructs
@@ -42,7 +42,7 @@ impl<W: Wake + Send + Sync + 'static> From<Arc<W>> for Waker {
     }
 }
 
-#[unstable(feature = "wake_trait", issue = "0")]
+#[unstable(feature = "wake_trait", issue = "69912")]
 impl<W: Wake + Send + Sync + 'static> From<Arc<W>> for RawWaker {
     fn from(waker: Arc<W>) -> RawWaker {
         raw_waker(waker)

--- a/src/liballoc/task.rs
+++ b/src/liballoc/task.rs
@@ -59,20 +59,20 @@ fn raw_waker<W: Wake + Send + Sync + 'static>(waker: Arc<W>) -> RawWaker {
     // Increment the reference count of the arc to clone it.
     unsafe fn clone_waker<W: Wake + Send + Sync + 'static>(waker: *const ()) -> RawWaker {
         let waker: Arc<W> = Arc::from_raw(waker as *const W);
-        mem::forget(waker.clone());
+        mem::forget(Arc::clone(&waker));
         raw_waker(waker)
     }
 
     // Wake by value, moving the Arc into the Wake::wake function
     unsafe fn wake<W: Wake + Send + Sync + 'static>(waker: *const ()) {
         let waker: Arc<W> = Arc::from_raw(waker as *const W);
-        Wake::wake(waker);
+        <W as Wake>::wake(waker);
     }
 
     // Wake by reference, wrap the waker in ManuallyDrop to avoid dropping it
     unsafe fn wake_by_ref<W: Wake + Send + Sync + 'static>(waker: *const ()) {
         let waker: ManuallyDrop<Arc<W>> = ManuallyDrop::new(Arc::from_raw(waker as *const W));
-        Wake::wake_by_ref(&waker);
+        <W as Wake>::wake_by_ref(&waker);
     }
 
     // Decrement the reference count of the Arc on drop

--- a/src/liballoc/task.rs
+++ b/src/liballoc/task.rs
@@ -83,5 +83,5 @@ fn raw_waker<W: Wake + Send + Sync + 'static>(waker: Arc<W>) -> RawWaker {
     RawWaker::new(
         Arc::into_raw(waker) as *const (),
         &RawWakerVTable::new(clone_waker::<W>, wake::<W>, wake_by_ref::<W>, drop_waker::<W>),
-    ))
+    )
 }

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -282,10 +282,10 @@ impl<'a> ArgumentV1<'a> {
         // SAFETY: `mem::transmute(x)` is safe because
         //     1. `&'b T` keeps the lifetime it originated with `'b`
         //              (so as to not have an unbounded lifetime)
-        //     2. `&'b T` and `&'b Void` have the same memory layout
+        //     2. `&'b T` and `&'b Opaque` have the same memory layout
         //              (when `T` is `Sized`, as it is here)
         // `mem::transmute(f)` is safe since `fn(&T, &mut Formatter<'_>) -> Result`
-        // and `fn(&Void, &mut Formatter<'_>) -> Result` have the same ABI
+        // and `fn(&Opaque, &mut Formatter<'_>) -> Result` have the same ABI
         // (as long as `T` is `Sized`)
         unsafe { ArgumentV1 { formatter: mem::transmute(f), value: mem::transmute(x) } }
     }

--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -489,19 +489,8 @@ impl<'tcx> DepNodeParams<'tcx> for HirId {
 /// some independent path or string that persists between runs without
 /// the need to be mapped or unmapped. (This ensures we can serialize
 /// them even in the absence of a tcx.)
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    RustcEncodable,
-    RustcDecodable,
-    HashStable
-)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, RustcEncodable, RustcDecodable)]
+#[derive(HashStable)]
 pub struct WorkProductId {
     hash: Fingerprint,
 }

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -40,18 +40,8 @@ impl CrateSource {
     }
 }
 
-#[derive(
-    RustcEncodable,
-    RustcDecodable,
-    Copy,
-    Clone,
-    Ord,
-    PartialOrd,
-    Eq,
-    PartialEq,
-    Debug,
-    HashStable
-)]
+#[derive(RustcEncodable, RustcDecodable, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Debug)]
+#[derive(HashStable)]
 pub enum DepKind {
     /// A dependency that is only used for its macros.
     MacrosOnly,

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -80,18 +80,8 @@ use std::fmt;
 // placate the same deriving in `ty::FreeRegion`, but we may want to
 // actually attach a more meaningful ordering to scopes than the one
 // generated via deriving here.
-#[derive(
-    Clone,
-    PartialEq,
-    PartialOrd,
-    Eq,
-    Ord,
-    Hash,
-    Copy,
-    RustcEncodable,
-    RustcDecodable,
-    HashStable
-)]
+#[derive(Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy, RustcEncodable, RustcDecodable)]
+#[derive(HashStable)]
 pub struct Scope {
     pub id: hir::ItemLocalId,
     pub data: ScopeData,
@@ -114,19 +104,8 @@ impl fmt::Debug for Scope {
     }
 }
 
-#[derive(
-    Clone,
-    PartialEq,
-    PartialOrd,
-    Eq,
-    Ord,
-    Hash,
-    Debug,
-    Copy,
-    RustcEncodable,
-    RustcDecodable,
-    HashStable
-)]
+#[derive(Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Debug, Copy, RustcEncodable, RustcDecodable)]
+#[derive(HashStable)]
 pub enum ScopeData {
     Node,
 

--- a/src/librustc/mir/interpret/allocation.rs
+++ b/src/librustc/mir/interpret/allocation.rs
@@ -15,18 +15,8 @@ use std::ops::{Deref, DerefMut, Range};
 
 // NOTE: When adding new fields, make sure to adjust the `Snapshot` impl in
 // `src/librustc_mir/interpret/snapshot.rs`.
-#[derive(
-    Clone,
-    Debug,
-    Eq,
-    PartialEq,
-    PartialOrd,
-    Ord,
-    Hash,
-    RustcEncodable,
-    RustcDecodable,
-    HashStable
-)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, RustcEncodable, RustcDecodable)]
+#[derive(HashStable)]
 pub struct Allocation<Tag = (), Extra = ()> {
     /// The actual bytes of the allocation.
     /// Note that the bytes of a pointer represent the offset of the pointer.
@@ -759,18 +749,8 @@ type Block = u64;
 
 /// A bitmask where each bit refers to the byte with the same index. If the bit is `true`, the byte
 /// is defined. If it is `false` the byte is undefined.
-#[derive(
-    Clone,
-    Debug,
-    Eq,
-    PartialEq,
-    PartialOrd,
-    Ord,
-    Hash,
-    RustcEncodable,
-    RustcDecodable,
-    HashStable
-)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, RustcEncodable, RustcDecodable)]
+#[derive(HashStable)]
 pub struct UndefMask {
     blocks: Vec<Block>,
     len: Size,

--- a/src/librustc/mir/interpret/mod.rs
+++ b/src/librustc/mir/interpret/mod.rs
@@ -46,6 +46,13 @@ macro_rules! err_exhaust {
     };
 }
 
+#[macro_export]
+macro_rules! err_machine_stop {
+    ($($tt:tt)*) => {
+        $crate::mir::interpret::InterpError::MachineStop(Box::new($($tt)*))
+    };
+}
+
 // In the `throw_*` macros, avoid `return` to make them work with `try {}`.
 #[macro_export]
 macro_rules! throw_unsup {
@@ -79,9 +86,7 @@ macro_rules! throw_exhaust {
 
 #[macro_export]
 macro_rules! throw_machine_stop {
-    ($($tt:tt)*) => {
-        Err::<!, _>($crate::mir::interpret::InterpError::MachineStop(Box::new($($tt)*)))?
-    };
+    ($($tt:tt)*) => { Err::<!, _>(err_machine_stop!($($tt)*))? };
 }
 
 mod allocation;

--- a/src/librustc/mir/interpret/pointer.rs
+++ b/src/librustc/mir/interpret/pointer.rs
@@ -111,18 +111,8 @@ impl<T: layout::HasDataLayout> PointerArithmetic for T {}
 ///
 /// `Pointer` is also generic over the `Tag` associated with each pointer,
 /// which is used to do provenance tracking during execution.
-#[derive(
-    Copy,
-    Clone,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    RustcEncodable,
-    RustcDecodable,
-    Hash,
-    HashStable
-)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, RustcEncodable, RustcDecodable, Hash)]
+#[derive(HashStable)]
 pub struct Pointer<Tag = (), Id = AllocId> {
     pub alloc_id: Id,
     pub offset: Size,

--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -23,19 +23,8 @@ pub struct RawConst<'tcx> {
 
 /// Represents a constant value in Rust. `Scalar` and `Slice` are optimizations for
 /// array length computations, enum discriminants and the pattern matching logic.
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    Eq,
-    PartialEq,
-    PartialOrd,
-    Ord,
-    RustcEncodable,
-    RustcDecodable,
-    Hash,
-    HashStable
-)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, RustcEncodable, RustcDecodable, Hash)]
+#[derive(HashStable)]
 pub enum ConstValue<'tcx> {
     /// Used only for types with `layout::abi::Scalar` ABI and ZSTs.
     ///
@@ -98,18 +87,8 @@ impl<'tcx> ConstValue<'tcx> {
 /// `memory::Allocation`. It is in many ways like a small chunk of a `Allocation`, up to 8 bytes in
 /// size. Like a range of bytes in an `Allocation`, a `Scalar` can either represent the raw bytes
 /// of a simple value or a pointer into another `Allocation`
-#[derive(
-    Clone,
-    Copy,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    RustcEncodable,
-    RustcDecodable,
-    Hash,
-    HashStable
-)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, RustcEncodable, RustcDecodable, Hash)]
+#[derive(HashStable)]
 pub enum Scalar<Tag = (), Id = AllocId> {
     /// The raw bytes of a simple value.
     Raw {

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -69,18 +69,8 @@ impl<'tcx> HasLocalDecls<'tcx> for Body<'tcx> {
 /// The various "big phases" that MIR goes through.
 ///
 /// Warning: ordering of variants is significant.
-#[derive(
-    Copy,
-    Clone,
-    RustcEncodable,
-    RustcDecodable,
-    HashStable,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord
-)]
+#[derive(Copy, Clone, RustcEncodable, RustcDecodable, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(HashStable)]
 pub enum MirPhase {
     Build = 0,
     Const = 1,
@@ -439,18 +429,8 @@ pub struct SourceInfo {
 ///////////////////////////////////////////////////////////////////////////
 // Borrow kinds
 
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    RustcEncodable,
-    RustcDecodable,
-    HashStable
-)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, RustcEncodable, RustcDecodable)]
+#[derive(HashStable)]
 pub enum BorrowKind {
     /// Data must be immutable and is aliasable.
     Shared,

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2642,19 +2642,8 @@ impl<'tcx> FieldDef {
 ///
 /// You can get the environment type of a closure using
 /// `tcx.closure_env_ty()`.
-#[derive(
-    Clone,
-    Copy,
-    PartialOrd,
-    Ord,
-    PartialEq,
-    Eq,
-    Hash,
-    Debug,
-    RustcEncodable,
-    RustcDecodable,
-    HashStable
-)]
+#[derive(Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash, Debug, RustcEncodable, RustcDecodable)]
+#[derive(HashStable)]
 pub enum ClosureKind {
     // Warning: Ordering is significant here! The ordering is chosen
     // because the trait Fn is a subtrait of FnMut and so in turn, and

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -31,38 +31,15 @@ use std::cmp::Ordering;
 use std::marker::PhantomData;
 use std::ops::Range;
 
-#[derive(
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Debug,
-    RustcEncodable,
-    RustcDecodable,
-    HashStable,
-    TypeFoldable,
-    Lift
-)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, RustcEncodable, RustcDecodable)]
+#[derive(HashStable, TypeFoldable, Lift)]
 pub struct TypeAndMut<'tcx> {
     pub ty: Ty<'tcx>,
     pub mutbl: hir::Mutability,
 }
 
-#[derive(
-    Clone,
-    PartialEq,
-    PartialOrd,
-    Eq,
-    Ord,
-    Hash,
-    RustcEncodable,
-    RustcDecodable,
-    Copy,
-    HashStable
-)]
+#[derive(Clone, PartialEq, PartialOrd, Eq, Ord, Hash, RustcEncodable, RustcDecodable, Copy)]
+#[derive(HashStable)]
 /// A "free" region `fr` can be interpreted as "some region
 /// at least as big as the scope `fr.scope`".
 pub struct FreeRegion {
@@ -70,18 +47,8 @@ pub struct FreeRegion {
     pub bound_region: BoundRegion,
 }
 
-#[derive(
-    Clone,
-    PartialEq,
-    PartialOrd,
-    Eq,
-    Ord,
-    Hash,
-    RustcEncodable,
-    RustcDecodable,
-    Copy,
-    HashStable
-)]
+#[derive(Clone, PartialEq, PartialOrd, Eq, Ord, Hash, RustcEncodable, RustcDecodable, Copy)]
+#[derive(HashStable)]
 pub enum BoundRegion {
     /// An anonymous region parameter for a given fn (&T)
     BrAnon(u32),
@@ -119,18 +86,8 @@ impl BoundRegion {
 
 /// N.B., if you change this, you'll probably want to change the corresponding
 /// AST structure in `librustc_ast/ast.rs` as well.
-#[derive(
-    Clone,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    RustcEncodable,
-    RustcDecodable,
-    HashStable,
-    Debug
-)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, RustcEncodable, RustcDecodable, Debug)]
+#[derive(HashStable)]
 #[rustc_diagnostic_item = "TyKind"]
 pub enum TyKind<'tcx> {
     /// The primitive boolean type. Written as `bool`.
@@ -1147,18 +1104,8 @@ impl<'tcx> PolyFnSig<'tcx> {
 
 pub type CanonicalPolyFnSig<'tcx> = Canonical<'tcx, Binder<FnSig<'tcx>>>;
 
-#[derive(
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    RustcEncodable,
-    RustcDecodable,
-    HashStable
-)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, RustcEncodable, RustcDecodable)]
+#[derive(HashStable)]
 pub struct ParamTy {
     pub index: u32,
     pub name: Symbol,
@@ -1182,18 +1129,8 @@ impl<'tcx> ParamTy {
     }
 }
 
-#[derive(
-    Copy,
-    Clone,
-    Hash,
-    RustcEncodable,
-    RustcDecodable,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    HashStable
-)]
+#[derive(Copy, Clone, Hash, RustcEncodable, RustcDecodable, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(HashStable)]
 pub struct ParamConst {
     pub index: u32,
     pub name: Symbol,
@@ -1465,18 +1402,8 @@ impl Atom for RegionVid {
     }
 }
 
-#[derive(
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    RustcEncodable,
-    RustcDecodable,
-    HashStable
-)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, RustcEncodable, RustcDecodable)]
+#[derive(HashStable)]
 pub enum InferTy {
     TyVar(TyVid),
     IntVar(IntVid),
@@ -1494,37 +1421,15 @@ rustc_index::newtype_index! {
     pub struct BoundVar { .. }
 }
 
-#[derive(
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Debug,
-    RustcEncodable,
-    RustcDecodable,
-    HashStable
-)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, RustcEncodable, RustcDecodable)]
+#[derive(HashStable)]
 pub struct BoundTy {
     pub var: BoundVar,
     pub kind: BoundTyKind,
 }
 
-#[derive(
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Debug,
-    RustcEncodable,
-    RustcDecodable,
-    HashStable
-)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, RustcEncodable, RustcDecodable)]
+#[derive(HashStable)]
 pub enum BoundTyKind {
     Anon,
     Param(Symbol),
@@ -2358,19 +2263,8 @@ impl<'tcx> TyS<'tcx> {
 }
 
 /// Typed constant value.
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    Hash,
-    RustcEncodable,
-    RustcDecodable,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    HashStable
-)]
+#[derive(Copy, Clone, Debug, Hash, RustcEncodable, RustcDecodable, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(HashStable)]
 pub struct Const<'tcx> {
     pub ty: Ty<'tcx>,
 
@@ -2499,19 +2393,8 @@ impl<'tcx> Const<'tcx> {
 impl<'tcx> rustc_serialize::UseSpecializedDecodable for &'tcx Const<'tcx> {}
 
 /// Represents a constant in Rust.
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    Eq,
-    PartialEq,
-    PartialOrd,
-    Ord,
-    RustcEncodable,
-    RustcDecodable,
-    Hash,
-    HashStable
-)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, RustcEncodable, RustcDecodable, Hash)]
+#[derive(HashStable)]
 pub enum ConstKind<'tcx> {
     /// A const generic parameter.
     Param(ParamConst),
@@ -2549,19 +2432,8 @@ impl<'tcx> ConstKind<'tcx> {
 }
 
 /// An inference variable for a const, for use in const generics.
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    Eq,
-    PartialEq,
-    PartialOrd,
-    Ord,
-    RustcEncodable,
-    RustcDecodable,
-    Hash,
-    HashStable
-)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, RustcEncodable, RustcDecodable, Hash)]
+#[derive(HashStable)]
 pub enum InferConst<'tcx> {
     /// Infer the value of the const.
     Var(ConstVid<'tcx>),

--- a/src/librustc_ast/ast.rs
+++ b/src/librustc_ast/ast.rs
@@ -684,19 +684,8 @@ pub enum PatKind {
     MacCall(MacCall),
 }
 
-#[derive(
-    Clone,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    RustcEncodable,
-    RustcDecodable,
-    Debug,
-    Copy,
-    HashStable_Generic
-)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, RustcEncodable, RustcDecodable, Debug, Copy)]
+#[derive(HashStable_Generic)]
 pub enum Mutability {
     Mut,
     Not,
@@ -1321,19 +1310,8 @@ pub enum CaptureBy {
 
 /// The movability of a generator / closure literal:
 /// whether a generator contains self-references, causing it to be `!Unpin`.
-#[derive(
-    Clone,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    RustcEncodable,
-    RustcDecodable,
-    Debug,
-    Copy,
-    HashStable_Generic
-)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, RustcEncodable, RustcDecodable, Debug, Copy)]
+#[derive(HashStable_Generic)]
 pub enum Movability {
     /// May contain self-references, `!Unpin`.
     Static,
@@ -1614,19 +1592,8 @@ pub struct FnSig {
     pub decl: P<FnDecl>,
 }
 
-#[derive(
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    HashStable_Generic,
-    RustcEncodable,
-    RustcDecodable,
-    Debug
-)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, RustcEncodable, RustcDecodable, Debug)]
+#[derive(HashStable_Generic)]
 pub enum FloatTy {
     F32,
     F64,
@@ -1655,19 +1622,8 @@ impl FloatTy {
     }
 }
 
-#[derive(
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    HashStable_Generic,
-    RustcEncodable,
-    RustcDecodable,
-    Debug
-)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, RustcEncodable, RustcDecodable, Debug)]
+#[derive(HashStable_Generic)]
 pub enum IntTy {
     Isize,
     I8,
@@ -1731,19 +1687,8 @@ impl IntTy {
     }
 }
 
-#[derive(
-    Clone,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    HashStable_Generic,
-    RustcEncodable,
-    RustcDecodable,
-    Copy,
-    Debug
-)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, RustcEncodable, RustcDecodable, Copy, Debug)]
+#[derive(HashStable_Generic)]
 pub enum UintTy {
     Usize,
     U8,

--- a/src/librustc_attr/builtin.rs
+++ b/src/librustc_attr/builtin.rs
@@ -120,17 +120,8 @@ pub fn find_unwind_attr(diagnostic: Option<&Handler>, attrs: &[Attribute]) -> Op
 }
 
 /// Represents the #[stable], #[unstable], #[rustc_deprecated] attributes.
-#[derive(
-    RustcEncodable,
-    RustcDecodable,
-    Copy,
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    Hash,
-    HashStable_Generic
-)]
+#[derive(RustcEncodable, RustcDecodable, Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(HashStable_Generic)]
 pub struct Stability {
     pub level: StabilityLevel,
     pub feature: Symbol,
@@ -138,17 +129,8 @@ pub struct Stability {
 }
 
 /// Represents the #[rustc_const_unstable] and #[rustc_const_stable] attributes.
-#[derive(
-    RustcEncodable,
-    RustcDecodable,
-    Copy,
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    Hash,
-    HashStable_Generic
-)]
+#[derive(RustcEncodable, RustcDecodable, Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(HashStable_Generic)]
 pub struct ConstStability {
     pub level: StabilityLevel,
     pub feature: Symbol,
@@ -159,18 +141,8 @@ pub struct ConstStability {
 }
 
 /// The available stability levels.
-#[derive(
-    RustcEncodable,
-    RustcDecodable,
-    PartialEq,
-    PartialOrd,
-    Copy,
-    Clone,
-    Debug,
-    Eq,
-    Hash,
-    HashStable_Generic
-)]
+#[derive(RustcEncodable, RustcDecodable, PartialEq, PartialOrd, Copy, Clone, Debug, Eq, Hash)]
+#[derive(HashStable_Generic)]
 pub enum StabilityLevel {
     // Reason for the current stability level and the relevant rust-lang issue
     Unstable { reason: Option<Symbol>, issue: Option<NonZeroU32>, is_soft: bool },
@@ -186,18 +158,8 @@ impl StabilityLevel {
     }
 }
 
-#[derive(
-    RustcEncodable,
-    RustcDecodable,
-    PartialEq,
-    PartialOrd,
-    Copy,
-    Clone,
-    Debug,
-    Eq,
-    Hash,
-    HashStable_Generic
-)]
+#[derive(RustcEncodable, RustcDecodable, PartialEq, PartialOrd, Copy, Clone, Debug, Eq, Hash)]
+#[derive(HashStable_Generic)]
 pub struct RustcDeprecation {
     pub since: Symbol,
     pub reason: Symbol,

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -1574,7 +1574,7 @@ impl EmitterWriter {
                 .span_to_lines(parts[0].span)
                 .expect("span_to_lines failed when emitting suggestion");
 
-            assert!(!lines.lines.is_empty());
+            assert!(!lines.lines.is_empty() || parts[0].span.is_dummy());
 
             let line_start = sm.lookup_char_pos(parts[0].span.lo()).line;
             draw_col_separator_no_space(&mut buffer, 1, max_line_num_len + 1);

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -194,7 +194,7 @@ impl CodeSuggestion {
                 let bounding_span = Span::with_root_ctxt(lo, hi);
                 // The different spans might belong to different contexts, if so ignore suggestion.
                 let lines = sm.span_to_lines(bounding_span).ok()?;
-                assert!(!lines.lines.is_empty());
+                assert!(!lines.lines.is_empty() || bounding_span.is_dummy());
 
                 // We can't splice anything if the source is unavailable.
                 if !sm.ensure_source_file_source_present(lines.file.clone()) {
@@ -213,8 +213,8 @@ impl CodeSuggestion {
                 let sf = &lines.file;
                 let mut prev_hi = sm.lookup_char_pos(bounding_span.lo());
                 prev_hi.col = CharPos::from_usize(0);
-
-                let mut prev_line = sf.get_line(lines.lines[0].line_index);
+                let mut prev_line =
+                    lines.lines.get(0).and_then(|line0| sf.get_line(line0.line_index));
                 let mut buf = String::new();
 
                 for part in &substitution.parts {

--- a/src/librustc_mir/const_eval/error.rs
+++ b/src/librustc_mir/const_eval/error.rs
@@ -5,7 +5,7 @@ use rustc::mir::AssertKind;
 use rustc_span::Symbol;
 
 use super::InterpCx;
-use crate::interpret::{ConstEvalErr, InterpError, InterpErrorInfo, Machine};
+use crate::interpret::{ConstEvalErr, InterpErrorInfo, Machine};
 
 /// The CTFE machine has some custom error kinds.
 #[derive(Clone, Debug)]
@@ -21,7 +21,7 @@ pub enum ConstEvalErrKind {
 // handle these.
 impl<'tcx> Into<InterpErrorInfo<'tcx>> for ConstEvalErrKind {
     fn into(self) -> InterpErrorInfo<'tcx> {
-        InterpError::MachineStop(Box::new(self.to_string())).into()
+        err_machine_stop!(self.to_string()).into()
     }
 }
 

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -561,7 +561,7 @@ fn write_mir_sig(
 
     ty::print::with_forced_impl_filename_line(|| {
         // see notes on #41697 elsewhere
-        write!(w, " {}", tcx.def_path_str(src.def_id()))
+        write!(w, "{}", tcx.def_path_str(src.def_id()))
     })?;
 
     if src.promoted.is_none() && is_function {

--- a/src/librustc_passes/liveness.rs
+++ b/src/librustc_passes/liveness.rs
@@ -1565,7 +1565,7 @@ impl<'tcx> Liveness<'_, 'tcx> {
                             }
                         } else {
                             err.multipart_suggestion(
-                                "consider prefixing with an underscore",
+                                "if this is intentional, prefix it with an underscore",
                                 spans.iter().map(|span| (*span, format!("_{}", name))).collect(),
                                 Applicability::MachineApplicable,
                             );

--- a/src/librustc_span/def_id.rs
+++ b/src/librustc_span/def_id.rs
@@ -105,19 +105,8 @@ impl ::std::fmt::Debug for CrateNum {
     }
 }
 
-#[derive(
-    Copy,
-    Clone,
-    Hash,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Debug,
-    RustcEncodable,
-    RustcDecodable,
-    HashStable_Generic
-)]
+#[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Debug, RustcEncodable, RustcDecodable)]
+#[derive(HashStable_Generic)]
 pub struct DefPathHash(pub Fingerprint);
 
 impl Borrow<Fingerprint> for DefPathHash {

--- a/src/librustc_span/edition.rs
+++ b/src/librustc_span/edition.rs
@@ -5,18 +5,8 @@ use std::str::FromStr;
 use rustc_macros::HashStable_Generic;
 
 /// The edition of the compiler (RFC 2052)
-#[derive(
-    Clone,
-    Copy,
-    Hash,
-    PartialEq,
-    PartialOrd,
-    Debug,
-    RustcEncodable,
-    RustcDecodable,
-    Eq,
-    HashStable_Generic
-)]
+#[derive(Clone, Copy, Hash, PartialEq, PartialOrd, Debug, RustcEncodable, RustcDecodable, Eq)]
+#[derive(HashStable_Generic)]
 pub enum Edition {
     // editions must be kept in order, oldest to newest
     /// The 2015 edition

--- a/src/librustc_span/hygiene.rs
+++ b/src/librustc_span/hygiene.rs
@@ -59,18 +59,8 @@ pub struct ExpnId(u32);
 
 /// A property of a macro expansion that determines how identifiers
 /// produced by that expansion are resolved.
-#[derive(
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Hash,
-    Debug,
-    RustcEncodable,
-    RustcDecodable,
-    HashStable_Generic
-)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Hash, Debug, RustcEncodable, RustcDecodable)]
+#[derive(HashStable_Generic)]
 pub enum Transparency {
     /// Identifier produced by a transparent expansion is always resolved at call-site.
     /// Call-site spans in procedural macros, hygiene opt-out in `macro` should use this.
@@ -747,17 +737,8 @@ impl ExpnKind {
 }
 
 /// The kind of macro invocation or definition.
-#[derive(
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    RustcEncodable,
-    RustcDecodable,
-    Hash,
-    Debug,
-    HashStable_Generic
-)]
+#[derive(Clone, Copy, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+#[derive(HashStable_Generic)]
 pub enum MacroKind {
     /// A bang macro `foo!()`.
     Bang,

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -72,18 +72,8 @@ impl Globals {
 scoped_tls::scoped_thread_local!(pub static GLOBALS: Globals);
 
 /// Differentiates between real files and common virtual files.
-#[derive(
-    Debug,
-    Eq,
-    PartialEq,
-    Clone,
-    Ord,
-    PartialOrd,
-    Hash,
-    RustcDecodable,
-    RustcEncodable,
-    HashStable_Generic
-)]
+#[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash, RustcDecodable, RustcEncodable)]
+#[derive(HashStable_Generic)]
 pub enum FileName {
     Real(PathBuf),
     /// Call to `quote!`.

--- a/src/librustc_span/source_map.rs
+++ b/src/librustc_span/source_map.rs
@@ -535,6 +535,10 @@ impl SourceMap {
         let (lo, hi) = self.is_valid_span(sp)?;
         assert!(hi.line >= lo.line);
 
+        if sp.is_dummy() {
+            return Ok(FileLines { file: lo.file, lines: Vec::new() });
+        }
+
         let mut lines = Vec::with_capacity(hi.line - lo.line + 1);
 
         // The span starts partway through the first line,
@@ -545,6 +549,9 @@ impl SourceMap {
         // and to the end of the line. Be careful because the line
         // numbers in Loc are 1-based, so we subtract 1 to get 0-based
         // lines.
+        //
+        // FIXME: now that we handle DUMMY_SP up above, we should consider
+        // aseerting the line numbers here are all indeed 1-based.
         let hi_line = hi.line.saturating_sub(1);
         for line_index in lo.line.saturating_sub(1)..hi_line {
             let line_len = lo.file.get_line(line_index).map(|s| s.chars().count()).unwrap_or(0);

--- a/src/librustc_span/source_map.rs
+++ b/src/librustc_span/source_map.rs
@@ -551,7 +551,7 @@ impl SourceMap {
         // lines.
         //
         // FIXME: now that we handle DUMMY_SP up above, we should consider
-        // aseerting the line numbers here are all indeed 1-based.
+        // asserting that the line numbers here are all indeed 1-based.
         let hi_line = hi.line.saturating_sub(1);
         for line_index in lo.line.saturating_sub(1)..hi_line {
             let line_len = lo.file.get_line(line_index).map(|s| s.chars().count()).unwrap_or(0);

--- a/src/librustc_target/spec/abi.rs
+++ b/src/librustc_target/spec/abi.rs
@@ -5,19 +5,8 @@ use rustc_macros::HashStable_Generic;
 #[cfg(test)]
 mod tests;
 
-#[derive(
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    RustcEncodable,
-    RustcDecodable,
-    Clone,
-    Copy,
-    Debug,
-    HashStable_Generic
-)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, RustcEncodable, RustcDecodable, Clone, Copy, Debug)]
+#[derive(HashStable_Generic)]
 pub enum Abi {
     // N.B., this ordering MUST match the AbiDatas array below.
     // (This is ensured by the test indices_are_correct().)

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -266,7 +266,7 @@ fn opts() -> Vec<RustcOptGroup> {
         unstable("display-warnings", |o| {
             o.optflag("", "display-warnings", "to print code warnings when testing doc")
         }),
-        unstable("crate-version", |o| {
+        stable("crate-version", |o| {
             o.optopt("", "crate-version", "crate version to print into documentation", "VERSION")
         }),
         unstable("sort-modules-by-appearance", |o| {

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -470,7 +470,7 @@ pub mod task {
     pub use core::task::*;
 
     #[doc(inline)]
-    #[unstable(feature = "wake_trait", issue = "0")]
+    #[unstable(feature = "wake_trait", issue = "69912")]
     pub use alloc::task::*;
 }
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -463,9 +463,14 @@ pub mod time;
 #[stable(feature = "futures_api", since = "1.36.0")]
 pub mod task {
     //! Types and Traits for working with asynchronous tasks.
+
     #[doc(inline)]
     #[stable(feature = "futures_api", since = "1.36.0")]
     pub use core::task::*;
+
+    #[doc(inline)]
+    #[unstable(feature = "wake_trait", issue = "0")]
+    pub use alloc::task::*;
 }
 
 #[stable(feature = "futures_api", since = "1.36.0")]

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -310,6 +310,7 @@
 #![feature(untagged_unions)]
 #![feature(unwind_attributes)]
 #![feature(vec_into_raw_parts)]
+#![feature(wake_trait)]
 // NB: the above list is sorted to minimize merge conflicts.
 #![default_lib_allocator]
 

--- a/src/test/mir-opt/retag.rs
+++ b/src/test/mir-opt/retag.rs
@@ -114,7 +114,7 @@ fn main() {
 // }
 // END rustc.main-{{closure}}.EraseRegions.after.mir
 // START rustc.ptr-drop_in_place.Test.SimplifyCfg-make_shim.after.mir
-// fn  std::intrinsics::drop_in_place(_1: *mut Test) -> () {
+// fn std::intrinsics::drop_in_place(_1: *mut Test) -> () {
 //     ...
 //     bb0: {
 //         Retag([raw] _1);

--- a/src/test/rustdoc/crate-version.rs
+++ b/src/test/rustdoc/crate-version.rs
@@ -1,3 +1,3 @@
-// compile-flags: --crate-version=1.3.37 -Z unstable-options
+// compile-flags: --crate-version=1.3.37
 
 // @has 'crate_version/index.html' '//div[@class="block version"]/p' 'Version 1.3.37'

--- a/src/test/ui/const-generics/issues/issue-62187-encountered-polymorphic-const.stderr
+++ b/src/test/ui/const-generics/issues/issue-62187-encountered-polymorphic-const.stderr
@@ -10,7 +10,7 @@ warning: unused variable: `foo`
   --> $DIR/issue-62187-encountered-polymorphic-const.rs:15:9
    |
 LL |     let foo = <[u8; 2]>::BIT_LEN;
-   |         ^^^ help: consider prefixing with an underscore: `_foo`
+   |         ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
    = note: `#[warn(unused_variables)]` on by default
 

--- a/src/test/ui/issues/issue-17999.stderr
+++ b/src/test/ui/issues/issue-17999.stderr
@@ -2,7 +2,7 @@ error: unused variable: `x`
   --> $DIR/issue-17999.rs:5:13
    |
 LL |         let x = ();
-   |             ^ help: consider prefixing with an underscore: `_x`
+   |             ^ help: if this is intentional, prefix it with an underscore: `_x`
    |
 note: the lint level is defined here
   --> $DIR/issue-17999.rs:1:9
@@ -14,7 +14,7 @@ error: unused variable: `a`
   --> $DIR/issue-17999.rs:7:13
    |
 LL |             a => {}
-   |             ^ help: consider prefixing with an underscore: `_a`
+   |             ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-22599.stderr
+++ b/src/test/ui/issues/issue-22599.stderr
@@ -2,7 +2,7 @@ error: unused variable: `a`
   --> $DIR/issue-22599.rs:8:19
    |
 LL |     v = match 0 { a => 0 };
-   |                   ^ help: consider prefixing with an underscore: `_a`
+   |                   ^ help: if this is intentional, prefix it with an underscore: `_a`
    |
 note: the lint level is defined here
   --> $DIR/issue-22599.rs:1:9

--- a/src/test/ui/issues/issue-53275.rs
+++ b/src/test/ui/issues/issue-53275.rs
@@ -1,0 +1,8 @@
+// run-pass
+
+#![crate_type = "lib"]
+struct S(u8);
+
+pub fn ice() {
+    S([][0]);
+}

--- a/src/test/ui/issues/issue-53275.rs
+++ b/src/test/ui/issues/issue-53275.rs
@@ -1,6 +1,7 @@
-// run-pass
+// build-pass
 
 #![crate_type = "lib"]
+#![allow(unconditional_panic)]
 struct S(u8);
 
 pub fn ice() {

--- a/src/test/ui/issues/issue-56685.stderr
+++ b/src/test/ui/issues/issue-56685.stderr
@@ -9,7 +9,7 @@ note: the lint level is defined here
    |
 LL | #![deny(unused_variables)]
    |         ^^^^^^^^^^^^^^^^
-help: consider prefixing with an underscore
+help: if this is intentional, prefix it with an underscore
    |
 LL |         E::A(_x) | E::B(_x) => {}
    |              ^^         ^^
@@ -20,7 +20,7 @@ error: unused variable: `x`
 LL |         F::A(x, y) | F::B(x, y) => { y },
    |              ^            ^
    |
-help: consider prefixing with an underscore
+help: if this is intentional, prefix it with an underscore
    |
 LL |         F::A(_x, y) | F::B(_x, y) => { y },
    |              ^^            ^^
@@ -29,13 +29,13 @@ error: unused variable: `a`
   --> $DIR/issue-56685.rs:27:14
    |
 LL |         F::C(a, b) => { 3 }
-   |              ^ help: consider prefixing with an underscore: `_a`
+   |              ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
   --> $DIR/issue-56685.rs:27:17
    |
 LL |         F::C(a, b) => { 3 }
-   |                 ^ help: consider prefixing with an underscore: `_b`
+   |                 ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `x`
   --> $DIR/issue-56685.rs:32:25
@@ -43,7 +43,7 @@ error: unused variable: `x`
 LL |     let _ = if let F::A(x, y) | F::B(x, y) = F::A(1, 2) {
    |                         ^            ^
    |
-help: consider prefixing with an underscore
+help: if this is intentional, prefix it with an underscore
    |
 LL |     let _ = if let F::A(_x, y) | F::B(_x, y) = F::A(1, 2) {
    |                         ^^            ^^
@@ -54,7 +54,7 @@ error: unused variable: `x`
 LL |     while let F::A(x, y) | F::B(x, y) = F::A(1, 2) {
    |                    ^            ^
    |
-help: consider prefixing with an underscore
+help: if this is intentional, prefix it with an underscore
    |
 LL |     while let F::A(_x, y) | F::B(_x, y) = F::A(1, 2) {
    |                    ^^            ^^

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
@@ -2,7 +2,7 @@ warning: unused variable: `i_think_continually`
   --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:26:9
    |
 LL |     let i_think_continually = 2;
-   |         ^^^^^^^^^^^^^^^^^^^ help: consider prefixing with an underscore: `_i_think_continually`
+   |         ^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_i_think_continually`
    |
 note: the lint level is defined here
   --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:5:9
@@ -15,19 +15,19 @@ warning: unused variable: `mut_unused_var`
   --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:33:13
    |
 LL |     let mut mut_unused_var = 1;
-   |             ^^^^^^^^^^^^^^ help: consider prefixing with an underscore: `_mut_unused_var`
+   |             ^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_mut_unused_var`
 
 warning: unused variable: `var`
   --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:37:14
    |
 LL |     let (mut var, unused_var) = (1, 2);
-   |              ^^^ help: consider prefixing with an underscore: `_var`
+   |              ^^^ help: if this is intentional, prefix it with an underscore: `_var`
 
 warning: unused variable: `unused_var`
   --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:37:19
    |
 LL |     let (mut var, unused_var) = (1, 2);
-   |                   ^^^^^^^^^^ help: consider prefixing with an underscore: `_unused_var`
+   |                   ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_var`
 
 warning: unused variable: `corridors_of_light`
   --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:45:26

--- a/src/test/ui/lint/lint-match-arms.stderr
+++ b/src/test/ui/lint/lint-match-arms.stderr
@@ -2,7 +2,7 @@ error: unused variable: `y`
   --> $DIR/lint-match-arms.rs:5:9
    |
 LL |         y => (),
-   |         ^ help: consider prefixing with an underscore: `_y`
+   |         ^ help: if this is intentional, prefix it with an underscore: `_y`
    |
 note: the lint level is defined here
   --> $DIR/lint-match-arms.rs:3:16

--- a/src/test/ui/lint/lint-removed-allow.stderr
+++ b/src/test/ui/lint/lint-removed-allow.stderr
@@ -2,7 +2,7 @@ error: unused variable: `unused`
   --> $DIR/lint-removed-allow.rs:8:17
    |
 LL | fn main() { let unused = (); }
-   |                 ^^^^^^ help: consider prefixing with an underscore: `_unused`
+   |                 ^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused`
    |
 note: the lint level is defined here
   --> $DIR/lint-removed-allow.rs:7:8

--- a/src/test/ui/lint/lint-removed-cmdline.stderr
+++ b/src/test/ui/lint/lint-removed-cmdline.stderr
@@ -18,7 +18,7 @@ error: unused variable: `unused`
   --> $DIR/lint-removed-cmdline.rs:12:17
    |
 LL | fn main() { let unused = (); }
-   |                 ^^^^^^ help: consider prefixing with an underscore: `_unused`
+   |                 ^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused`
    |
 note: the lint level is defined here
   --> $DIR/lint-removed-cmdline.rs:11:8

--- a/src/test/ui/lint/lint-removed.stderr
+++ b/src/test/ui/lint/lint-removed.stderr
@@ -10,7 +10,7 @@ error: unused variable: `unused`
   --> $DIR/lint-removed.rs:8:17
    |
 LL | fn main() { let unused = (); }
-   |                 ^^^^^^ help: consider prefixing with an underscore: `_unused`
+   |                 ^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused`
    |
 note: the lint level is defined here
   --> $DIR/lint-removed.rs:7:8

--- a/src/test/ui/lint/lint-renamed-allow.stderr
+++ b/src/test/ui/lint/lint-renamed-allow.stderr
@@ -2,7 +2,7 @@ error: unused variable: `unused`
   --> $DIR/lint-renamed-allow.rs:8:17
    |
 LL | fn main() { let unused = (); }
-   |                 ^^^^^^ help: consider prefixing with an underscore: `_unused`
+   |                 ^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused`
    |
 note: the lint level is defined here
   --> $DIR/lint-renamed-allow.rs:7:8

--- a/src/test/ui/lint/lint-renamed-cmdline.stderr
+++ b/src/test/ui/lint/lint-renamed-cmdline.stderr
@@ -18,7 +18,7 @@ error: unused variable: `unused`
   --> $DIR/lint-renamed-cmdline.rs:8:17
    |
 LL | fn main() { let unused = (); }
-   |                 ^^^^^^ help: consider prefixing with an underscore: `_unused`
+   |                 ^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused`
    |
 note: the lint level is defined here
   --> $DIR/lint-renamed-cmdline.rs:7:8

--- a/src/test/ui/lint/lint-renamed.stderr
+++ b/src/test/ui/lint/lint-renamed.stderr
@@ -10,7 +10,7 @@ error: unused variable: `unused`
   --> $DIR/lint-renamed.rs:4:17
    |
 LL | fn main() { let unused = (); }
-   |                 ^^^^^^ help: consider prefixing with an underscore: `_unused`
+   |                 ^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused`
    |
 note: the lint level is defined here
   --> $DIR/lint-renamed.rs:3:8

--- a/src/test/ui/lint/lint-unused-variables.stderr
+++ b/src/test/ui/lint/lint-unused-variables.stderr
@@ -2,7 +2,7 @@ error: unused variable: `a`
   --> $DIR/lint-unused-variables.rs:8:5
    |
 LL |     a: i32,
-   |     ^ help: consider prefixing with an underscore: `_a`
+   |     ^ help: if this is intentional, prefix it with an underscore: `_a`
    |
 note: the lint level is defined here
   --> $DIR/lint-unused-variables.rs:5:9
@@ -14,61 +14,61 @@ error: unused variable: `b`
   --> $DIR/lint-unused-variables.rs:14:5
    |
 LL |     b: i32,
-   |     ^ help: consider prefixing with an underscore: `_b`
+   |     ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
   --> $DIR/lint-unused-variables.rs:68:9
    |
 LL |         a: i32,
-   |         ^ help: consider prefixing with an underscore: `_a`
+   |         ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
   --> $DIR/lint-unused-variables.rs:74:9
    |
 LL |         b: i32,
-   |         ^ help: consider prefixing with an underscore: `_b`
+   |         ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `b`
   --> $DIR/lint-unused-variables.rs:42:9
    |
 LL |         b: i32,
-   |         ^ help: consider prefixing with an underscore: `_b`
+   |         ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `b`
   --> $DIR/lint-unused-variables.rs:47:9
    |
 LL |         b: i32,
-   |         ^ help: consider prefixing with an underscore: `_b`
+   |         ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
   --> $DIR/lint-unused-variables.rs:22:9
    |
 LL |         a: i32,
-   |         ^ help: consider prefixing with an underscore: `_a`
+   |         ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
   --> $DIR/lint-unused-variables.rs:29:9
    |
 LL |         b: i32,
-   |         ^ help: consider prefixing with an underscore: `_b`
+   |         ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `b`
   --> $DIR/lint-unused-variables.rs:34:9
    |
 LL |         b: i32,
-   |         ^ help: consider prefixing with an underscore: `_b`
+   |         ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `b`
   --> $DIR/lint-unused-variables.rs:55:9
    |
 LL |         b: i32,
-   |         ^ help: consider prefixing with an underscore: `_b`
+   |         ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `b`
   --> $DIR/lint-unused-variables.rs:60:9
    |
 LL |         b: i32,
-   |         ^ help: consider prefixing with an underscore: `_b`
+   |         ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: aborting due to 11 previous errors
 

--- a/src/test/ui/lint/lint-uppercase-variables.stderr
+++ b/src/test/ui/lint/lint-uppercase-variables.stderr
@@ -22,7 +22,7 @@ warning: unused variable: `Foo`
   --> $DIR/lint-uppercase-variables.rs:22:9
    |
 LL |         Foo => {}
-   |         ^^^ help: consider prefixing with an underscore: `_Foo`
+   |         ^^^ help: if this is intentional, prefix it with an underscore: `_Foo`
    |
 note: the lint level is defined here
   --> $DIR/lint-uppercase-variables.rs:1:9
@@ -35,13 +35,13 @@ warning: unused variable: `Foo`
   --> $DIR/lint-uppercase-variables.rs:28:9
    |
 LL |     let Foo = foo::Foo::Foo;
-   |         ^^^ help: consider prefixing with an underscore: `_Foo`
+   |         ^^^ help: if this is intentional, prefix it with an underscore: `_Foo`
 
 warning: unused variable: `Foo`
   --> $DIR/lint-uppercase-variables.rs:33:17
    |
 LL |     fn in_param(Foo: foo::Foo) {}
-   |                 ^^^ help: consider prefixing with an underscore: `_Foo`
+   |                 ^^^ help: if this is intentional, prefix it with an underscore: `_Foo`
 
 error: structure field `X` should have a snake case name
   --> $DIR/lint-uppercase-variables.rs:10:5

--- a/src/test/ui/liveness/liveness-unused.stderr
+++ b/src/test/ui/liveness/liveness-unused.stderr
@@ -17,7 +17,7 @@ error: unused variable: `x`
   --> $DIR/liveness-unused.rs:8:7
    |
 LL | fn f1(x: isize) {
-   |       ^ help: consider prefixing with an underscore: `_x`
+   |       ^ help: if this is intentional, prefix it with an underscore: `_x`
    |
 note: the lint level is defined here
   --> $DIR/liveness-unused.rs:2:9
@@ -29,19 +29,19 @@ error: unused variable: `x`
   --> $DIR/liveness-unused.rs:12:8
    |
 LL | fn f1b(x: &mut isize) {
-   |        ^ help: consider prefixing with an underscore: `_x`
+   |        ^ help: if this is intentional, prefix it with an underscore: `_x`
 
 error: unused variable: `x`
   --> $DIR/liveness-unused.rs:20:9
    |
 LL |     let x: isize;
-   |         ^ help: consider prefixing with an underscore: `_x`
+   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
 
 error: unused variable: `x`
   --> $DIR/liveness-unused.rs:25:9
    |
 LL |     let x = 3;
-   |         ^ help: consider prefixing with an underscore: `_x`
+   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
 
 error: variable `x` is assigned to, but never used
   --> $DIR/liveness-unused.rs:30:13
@@ -76,25 +76,25 @@ error: unused variable: `i`
   --> $DIR/liveness-unused.rs:59:12
    |
 LL |       Some(i) => {
-   |            ^ help: consider prefixing with an underscore: `_i`
+   |            ^ help: if this is intentional, prefix it with an underscore: `_i`
 
 error: unused variable: `x`
   --> $DIR/liveness-unused.rs:79:9
    |
 LL |     for x in 1..10 { }
-   |         ^ help: consider prefixing with an underscore: `_x`
+   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
 
 error: unused variable: `x`
   --> $DIR/liveness-unused.rs:84:10
    |
 LL |     for (x, _) in [1, 2, 3].iter().enumerate() { }
-   |          ^ help: consider prefixing with an underscore: `_x`
+   |          ^ help: if this is intentional, prefix it with an underscore: `_x`
 
 error: unused variable: `x`
   --> $DIR/liveness-unused.rs:89:13
    |
 LL |     for (_, x) in [1, 2, 3].iter().enumerate() {
-   |             ^ help: consider prefixing with an underscore: `_x`
+   |             ^ help: if this is intentional, prefix it with an underscore: `_x`
 
 error: variable `x` is assigned to, but never used
   --> $DIR/liveness-unused.rs:112:9

--- a/src/test/ui/never_type/never-assign-dead-code.stderr
+++ b/src/test/ui/never_type/never-assign-dead-code.stderr
@@ -25,7 +25,7 @@ warning: unused variable: `x`
   --> $DIR/never-assign-dead-code.rs:9:9
    |
 LL |     let x: ! = panic!("aah");
-   |         ^ help: consider prefixing with an underscore: `_x`
+   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
    |
 note: the lint level is defined here
   --> $DIR/never-assign-dead-code.rs:6:9

--- a/src/test/ui/proc-macro/attributes-included.stderr
+++ b/src/test/ui/proc-macro/attributes-included.stderr
@@ -2,7 +2,7 @@ warning: unused variable: `a`
   --> $DIR/attributes-included.rs:17:9
    |
 LL |     let a: i32 = "foo";
-   |         ^ help: consider prefixing with an underscore: `_a`
+   |         ^ help: if this is intentional, prefix it with an underscore: `_a`
    |
 note: the lint level is defined here
   --> $DIR/attributes-included.rs:4:9

--- a/src/test/ui/rfc-2565-param-attrs/param-attrs-cfg.stderr
+++ b/src/test/ui/rfc-2565-param-attrs/param-attrs-cfg.stderr
@@ -2,7 +2,7 @@ error: unused variable: `a`
   --> $DIR/param-attrs-cfg.rs:24:23
    |
 LL |     #[cfg(something)] a: i32,
-   |                       ^ help: consider prefixing with an underscore: `_a`
+   |                       ^ help: if this is intentional, prefix it with an underscore: `_a`
    |
 note: the lint level is defined here
   --> $DIR/param-attrs-cfg.rs:5:9
@@ -14,109 +14,109 @@ error: unused variable: `b`
   --> $DIR/param-attrs-cfg.rs:30:23
    |
 LL |     #[cfg(something)] b: i32,
-   |                       ^ help: consider prefixing with an underscore: `_b`
+   |                       ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `c`
   --> $DIR/param-attrs-cfg.rs:32:40
    |
 LL |     #[cfg_attr(nothing, cfg(nothing))] c: i32,
-   |                                        ^ help: consider prefixing with an underscore: `_c`
+   |                                        ^ help: if this is intentional, prefix it with an underscore: `_c`
 
 error: unused variable: `a`
   --> $DIR/param-attrs-cfg.rs:107:27
    |
 LL |         #[cfg(something)] a: i32,
-   |                           ^ help: consider prefixing with an underscore: `_a`
+   |                           ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
   --> $DIR/param-attrs-cfg.rs:113:27
    |
 LL |         #[cfg(something)] b: i32,
-   |                           ^ help: consider prefixing with an underscore: `_b`
+   |                           ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `c`
   --> $DIR/param-attrs-cfg.rs:115:44
    |
 LL |         #[cfg_attr(nothing, cfg(nothing))] c: i32,
-   |                                            ^ help: consider prefixing with an underscore: `_c`
+   |                                            ^ help: if this is intentional, prefix it with an underscore: `_c`
 
 error: unused variable: `b`
   --> $DIR/param-attrs-cfg.rs:67:27
    |
 LL |         #[cfg(something)] b: i32,
-   |                           ^ help: consider prefixing with an underscore: `_b`
+   |                           ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `c`
   --> $DIR/param-attrs-cfg.rs:69:44
    |
 LL |         #[cfg_attr(nothing, cfg(nothing))] c: i32,
-   |                                            ^ help: consider prefixing with an underscore: `_c`
+   |                                            ^ help: if this is intentional, prefix it with an underscore: `_c`
 
 error: unused variable: `b`
   --> $DIR/param-attrs-cfg.rs:75:27
    |
 LL |         #[cfg(something)] b: i32,
-   |                           ^ help: consider prefixing with an underscore: `_b`
+   |                           ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `c`
   --> $DIR/param-attrs-cfg.rs:77:44
    |
 LL |         #[cfg_attr(nothing, cfg(nothing))] c: i32,
-   |                                            ^ help: consider prefixing with an underscore: `_c`
+   |                                            ^ help: if this is intentional, prefix it with an underscore: `_c`
 
 error: unused variable: `a`
   --> $DIR/param-attrs-cfg.rs:41:27
    |
 LL |         #[cfg(something)] a: i32,
-   |                           ^ help: consider prefixing with an underscore: `_a`
+   |                           ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
   --> $DIR/param-attrs-cfg.rs:48:27
    |
 LL |         #[cfg(something)] b: i32,
-   |                           ^ help: consider prefixing with an underscore: `_b`
+   |                           ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `c`
   --> $DIR/param-attrs-cfg.rs:50:44
    |
 LL |         #[cfg_attr(nothing, cfg(nothing))] c: i32,
-   |                                            ^ help: consider prefixing with an underscore: `_c`
+   |                                            ^ help: if this is intentional, prefix it with an underscore: `_c`
 
 error: unused variable: `b`
   --> $DIR/param-attrs-cfg.rs:56:27
    |
 LL |         #[cfg(something)] b: i32,
-   |                           ^ help: consider prefixing with an underscore: `_b`
+   |                           ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `c`
   --> $DIR/param-attrs-cfg.rs:58:44
    |
 LL |         #[cfg_attr(nothing, cfg(nothing))] c: i32,
-   |                                            ^ help: consider prefixing with an underscore: `_c`
+   |                                            ^ help: if this is intentional, prefix it with an underscore: `_c`
 
 error: unused variable: `b`
   --> $DIR/param-attrs-cfg.rs:86:27
    |
 LL |         #[cfg(something)] b: i32,
-   |                           ^ help: consider prefixing with an underscore: `_b`
+   |                           ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `c`
   --> $DIR/param-attrs-cfg.rs:88:44
    |
 LL |         #[cfg_attr(nothing, cfg(nothing))] c: i32,
-   |                                            ^ help: consider prefixing with an underscore: `_c`
+   |                                            ^ help: if this is intentional, prefix it with an underscore: `_c`
 
 error: unused variable: `b`
   --> $DIR/param-attrs-cfg.rs:94:27
    |
 LL |         #[cfg(something)] b: i32,
-   |                           ^ help: consider prefixing with an underscore: `_b`
+   |                           ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `c`
   --> $DIR/param-attrs-cfg.rs:96:44
    |
 LL |         #[cfg_attr(nothing, cfg(nothing))] c: i32,
-   |                                            ^ help: consider prefixing with an underscore: `_c`
+   |                                            ^ help: if this is intentional, prefix it with an underscore: `_c`
 
 error: aborting due to 19 previous errors
 

--- a/src/test/ui/span/issue-24690.stderr
+++ b/src/test/ui/span/issue-24690.stderr
@@ -2,7 +2,7 @@ warning: unused variable: `theOtherTwo`
   --> $DIR/issue-24690.rs:13:9
    |
 LL |     let theOtherTwo = 2;
-   |         ^^^^^^^^^^^ help: consider prefixing with an underscore: `_theOtherTwo`
+   |         ^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_theOtherTwo`
    |
 note: the lint level is defined here
   --> $DIR/issue-24690.rs:8:9

--- a/src/test/ui/suggestions/unused-closure-argument.stderr
+++ b/src/test/ui/suggestions/unused-closure-argument.stderr
@@ -14,7 +14,7 @@ error: unused variable: `x`
   --> $DIR/unused-closure-argument.rs:17:15
    |
 LL |         .map(|x| 4)
-   |               ^ help: consider prefixing with an underscore: `_x`
+   |               ^ help: if this is intentional, prefix it with an underscore: `_x`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #68700 (Add Wake trait for safe construction of Wakers.)
 - #69494 (Stabilize --crate-version option in rustdoc)
 - #70080 (rustc_mir: remove extra space when pretty-printing MIR.)
 - #70195 (Add test for issue #53275)
 - #70199 (Revised span-to-lines conversion to produce an empty vec on DUMMY_SP.)
 - #70299 (add err_machine_stop macro)
 - #70300 (Reword unused variable warning)
 - #70315 (Rename remaining occurences of Void to Opaque.)
 - #70318 (Split long derive lists into two derive attributes.)

Failed merges:


r? @ghost