### PR TITLE
Request "-Z unstable-options" for unstable options

### DIFF
--- a/src/libtest/cli.rs
+++ b/src/libtest/cli.rs
@@ -213,7 +213,7 @@ macro_rules! unstable_optflag {
         let opt = $matches.opt_present($option_name);
         if !$allow_unstable && opt {
             return Err(format!(
-                "The \"{}\" flag is only accepted on the nightly compiler",
+                "The \"{}\" flag is only accepted on the nightly compiler with -Z unstable-options",
                 $option_name
             ));
         }


### PR DESCRIPTION
Explicitly requests the "-Z unstable-options" flag if someone attempts to use
a cargo option gated by it. This enhances discoverability, particularly in the
instance where the user is on the nightly compiler but isn't using the flag.

This relates to, but does not end with or resolve, issue #65770.