### PR TITLE
Remove attribute `#[structural_match]` and any references to it

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -132,7 +132,6 @@
 #![feature(f16c_target_feature)]
 #![feature(hexagon_target_feature)]
 #![feature(const_transmute)]
-#![feature(structural_match)]
 #![feature(abi_unadjusted)]
 #![feature(adx_target_feature)]
 #![feature(maybe_uninit_slice)]

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -660,7 +660,6 @@ macro_rules! impls {
 ///
 /// [drop check]: ../../nomicon/dropck.html
 #[lang = "phantom_data"]
-#[structural_match]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct PhantomData<T: ?Sized>;
 

--- a/src/librustc/ty/relate.rs
+++ b/src/librustc/ty/relate.rs
@@ -518,7 +518,7 @@ pub fn super_relate_consts<R: TypeRelation<'tcx>>(
 
     // Currently, the values that can be unified are primitive types,
     // and those that derive both `PartialEq` and `Eq`, corresponding
-    // to `structural_match` types.
+    // to structural-match types.
     let new_const_val = match (eagerly_eval(a), eagerly_eval(b)) {
         (ty::ConstKind::Infer(_), _) | (_, ty::ConstKind::Infer(_)) => {
             // The caller should handle these cases!

--- a/src/librustc_error_codes/error_codes/E0741.md
+++ b/src/librustc_error_codes/error_codes/E0741.md
@@ -1,4 +1,4 @@
-Only `structural_match` types (that is, types that derive `PartialEq` and `Eq`)
+Only structural-match types (that is, types that derive `PartialEq` and `Eq`)
 may be used as the types of const generic parameters.
 
 ```compile_fail,E0741

--- a/src/librustc_feature/active.rs
+++ b/src/librustc_feature/active.rs
@@ -173,6 +173,8 @@ declare_features! (
     // no-tracking-issue-end
 
     /// Allows using `#[structural_match]` which indicates that a type is structurally matchable.
+    /// FIXME: Subsumed by trait `StructuralPartialEq`, cannot move to removed until a library
+    /// feature with the same name exists.
     (active, structural_match, "1.8.0", Some(31434), None),
 
     /// Allows using the `may_dangle` attribute (RFC 1327).

--- a/src/librustc_feature/builtin_attrs.rs
+++ b/src/librustc_feature/builtin_attrs.rs
@@ -377,11 +377,6 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     gated!(fundamental, Whitelisted, template!(Word), experimental!(fundamental)),
     gated!(
-        // RFC #1445.
-        structural_match, Whitelisted, template!(Word),
-        "the semantics of constant patterns is not yet settled",
-    ),
-    gated!(
         may_dangle, Normal, template!(Word), dropck_eyepatch,
         "`may_dangle` has unstable semantics and may be removed in the future",
     ),

--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -446,7 +446,7 @@ declare_lint! {
     pub INDIRECT_STRUCTURAL_MATCH,
     // defaulting to allow until rust-lang/rust#62614 is fixed.
     Allow,
-    "pattern with const indirectly referencing non-`#[structural_match]` type",
+    "pattern with const indirectly referencing non-structural-match type",
     @future_incompatible = FutureIncompatibleInfo {
         reference: "issue #62411 <https://github.com/rust-lang/rust/issues/62411>",
         edition: None,

--- a/src/librustc_trait_selection/traits/structural_match.rs
+++ b/src/librustc_trait_selection/traits/structural_match.rs
@@ -14,9 +14,9 @@ pub enum NonStructuralMatchTy<'tcx> {
 }
 
 /// This method traverses the structure of `ty`, trying to find an
-/// instance of an ADT (i.e. struct or enum) that was declared without
-/// the `#[structural_match]` attribute, or a generic type parameter
-/// (which cannot be determined to be `structural_match`).
+/// instance of an ADT (i.e. struct or enum) that doesn't implement
+/// the structural-match traits, or a generic type parameter
+/// (which cannot be determined to be structural-match).
 ///
 /// The "structure of a type" includes all components that would be
 /// considered when doing a pattern match on a constant of that
@@ -30,8 +30,8 @@ pub enum NonStructuralMatchTy<'tcx> {
 ///    instantiated generic like `PhantomData<T>`.
 ///
 /// The reason we do this search is Rust currently require all ADTs
-/// reachable from a constant's type to be annotated with
-/// `#[structural_match]`, an attribute which essentially says that
+/// reachable from a constant's type to implement the
+/// structural-match traits, which essentially say that
 /// the implementation of `PartialEq::eq` behaves *equivalently* to a
 /// comparison against the unfolded structure.
 ///

--- a/src/test/ui/const-generics/const-param-type-depends-on-type-param.rs
+++ b/src/test/ui/const-generics/const-param-type-depends-on-type-param.rs
@@ -2,7 +2,7 @@
 //~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
 
 // Currently, const parameters cannot depend on type parameters, because there is no way to
-// enforce the `structural_match` property on an arbitrary type parameter. This restriction
+// enforce the structural-match property on an arbitrary type parameter. This restriction
 // may be relaxed in the future. See https://github.com/rust-lang/rfcs/pull/2000 for more
 // details.
 

--- a/src/test/ui/rfc1445/cant-hide-behind-direct-struct-embedded.rs
+++ b/src/test/ui/rfc1445/cant-hide-behind-direct-struct-embedded.rs
@@ -1,6 +1,6 @@
 // This is part of a set of tests exploring the different ways a
-// `#[structural_match]` ADT might try to hold a
-// non-`#[structural_match]` in hidden manner that lets matches
+// structural-match ADT might try to hold a
+// non-structural-match in hidden manner that lets matches
 // through that we had intended to reject.
 //
 // See discussion on rust-lang/rust#62307 and rust-lang/rust#62339

--- a/src/test/ui/rfc1445/cant-hide-behind-direct-struct-param.rs
+++ b/src/test/ui/rfc1445/cant-hide-behind-direct-struct-param.rs
@@ -1,6 +1,6 @@
 // This is part of a set of tests exploring the different ways a
-// `#[structural_match]` ADT might try to hold a
-// non-`#[structural_match]` in hidden manner that lets matches
+// structural-match ADT might try to hold a
+// non-structural-match in hidden manner that lets matches
 // through that we had intended to reject.
 //
 // See discussion on rust-lang/rust#62307 and rust-lang/rust#62339

--- a/src/test/ui/rfc1445/cant-hide-behind-doubly-indirect-embedded.rs
+++ b/src/test/ui/rfc1445/cant-hide-behind-doubly-indirect-embedded.rs
@@ -1,6 +1,6 @@
 // This is part of a set of tests exploring the different ways a
-// `#[structural_match]` ADT might try to hold a
-// non-`#[structural_match]` in hidden manner that lets matches
+// structural-match ADT might try to hold a
+// non-structural-match in hidden manner that lets matches
 // through that we had intended to reject.
 //
 // See discussion on rust-lang/rust#62307 and rust-lang/rust#62339

--- a/src/test/ui/rfc1445/cant-hide-behind-doubly-indirect-param.rs
+++ b/src/test/ui/rfc1445/cant-hide-behind-doubly-indirect-param.rs
@@ -1,6 +1,6 @@
 // This is part of a set of tests exploring the different ways a
-// `#[structural_match]` ADT might try to hold a
-// non-`#[structural_match]` in hidden manner that lets matches
+// structural-match ADT might try to hold a
+// non-structural-match in hidden manner that lets matches
 // through that we had intended to reject.
 //
 // See discussion on rust-lang/rust#62307 and rust-lang/rust#62339

--- a/src/test/ui/rfc1445/cant-hide-behind-indirect-struct-embedded.rs
+++ b/src/test/ui/rfc1445/cant-hide-behind-indirect-struct-embedded.rs
@@ -1,6 +1,6 @@
 // This is part of a set of tests exploring the different ways a
-// `#[structural_match]` ADT might try to hold a
-// non-`#[structural_match]` in hidden manner that lets matches
+// structural-match ADT might try to hold a
+// non-structural-match in hidden manner that lets matches
 // through that we had intended to reject.
 //
 // See discussion on rust-lang/rust#62307 and rust-lang/rust#62339

--- a/src/test/ui/rfc1445/cant-hide-behind-indirect-struct-param.rs
+++ b/src/test/ui/rfc1445/cant-hide-behind-indirect-struct-param.rs
@@ -1,6 +1,6 @@
 // This is part of a set of tests exploring the different ways a
-// `#[structural_match]` ADT might try to hold a
-// non-`#[structural_match]` in hidden manner that lets matches
+// structural-match ADT might try to hold a
+// non-structural-match in hidden manner that lets matches
 // through that we had intended to reject.
 //
 // See discussion on rust-lang/rust#62307 and rust-lang/rust#62339

--- a/src/test/ui/rfc1445/feature-gate.rs
+++ b/src/test/ui/rfc1445/feature-gate.rs
@@ -1,4 +1,4 @@
-// Test that structural match is only permitted with a feature gate,
+// Test that use of structural-match traits is only permitted with a feature gate,
 // and that if a feature gate is supplied, it permits the type to be
 // used in a match.
 

--- a/src/test/ui/rfc1445/fn-ptr-is-structurally-matchable.rs
+++ b/src/test/ui/rfc1445/fn-ptr-is-structurally-matchable.rs
@@ -36,7 +36,7 @@ fn main() {
     // a singleton type of the fn itself that the type inference would
     // otherwise assign.
 
-    // Check that fn() is #[structural_match]
+    // Check that fn() is structural-match
     const CFN1: Wrap<fn()> = Wrap(trivial);
     let input: Wrap<fn()> = Wrap(trivial);
     match Wrap(input) {
@@ -44,7 +44,7 @@ fn main() {
         Wrap(_) => {}
     };
 
-    // Check that fn(T) is #[structural_match] when T is too.
+    // Check that fn(T) is structural-match when T is too.
     const CFN2: Wrap<fn(SM)> = Wrap(sm_to);
     let input: Wrap<fn(SM)> = Wrap(sm_to);
     match Wrap(input) {
@@ -52,7 +52,7 @@ fn main() {
         Wrap(_) => {}
     };
 
-    // Check that fn() -> T is #[structural_match] when T is too.
+    // Check that fn() -> T is structural-match when T is too.
     const CFN3: Wrap<fn() -> SM> = Wrap(to_sm);
     let input: Wrap<fn() -> SM> = Wrap(to_sm);
     match Wrap(input) {
@@ -60,7 +60,7 @@ fn main() {
         Wrap(_) => {}
     };
 
-    // Check that fn(T) is #[structural_match] even if T is not.
+    // Check that fn(T) is structural-match even if T is not.
     const CFN4: Wrap<fn(NotSM)> = Wrap(not_sm_to);
     let input: Wrap<fn(NotSM)> = Wrap(not_sm_to);
     match Wrap(input) {
@@ -68,7 +68,7 @@ fn main() {
         Wrap(_) => {}
     };
 
-    // Check that fn() -> T is #[structural_match] even if T is not.
+    // Check that fn() -> T is structural-match even if T is not.
     const CFN5: Wrap<fn() -> NotSM> = Wrap(to_not_sm);
     let input: Wrap<fn() -> NotSM> = Wrap(to_not_sm);
     match Wrap(input) {
@@ -76,7 +76,7 @@ fn main() {
         Wrap(_) => {}
     };
 
-    // Check that fn(&T) is #[structural_match] when T is too.
+    // Check that fn(&T) is structural-match when T is too.
     const CFN6: Wrap<fn(&SM)> = Wrap(r_sm_to);
     let input: Wrap<fn(&SM)> = Wrap(r_sm_to);
     match Wrap(input) {
@@ -84,7 +84,7 @@ fn main() {
         Wrap(_) => {}
     };
 
-    // Check that fn() -> &T is #[structural_match] when T is too.
+    // Check that fn() -> &T is structural-match when T is too.
     const CFN7: Wrap<fn(&()) -> &SM> = Wrap(r_to_r_sm);
     let input: Wrap<fn(&()) -> &SM> = Wrap(r_to_r_sm);
     match Wrap(input) {
@@ -92,7 +92,7 @@ fn main() {
         Wrap(_) => {}
     };
 
-    // Check that fn(T) is #[structural_match] even if T is not.
+    // Check that fn(T) is structural-match even if T is not.
     const CFN8: Wrap<fn(&NotSM)> = Wrap(r_not_sm_to);
     let input: Wrap<fn(&NotSM)> = Wrap(r_not_sm_to);
     match Wrap(input) {
@@ -100,7 +100,7 @@ fn main() {
         Wrap(_) => {}
     };
 
-    // Check that fn() -> T is #[structural_match] even if T is not.
+    // Check that fn() -> T is structural-match even if T is not.
     const CFN9: Wrap<fn(&()) -> &NotSM> = Wrap(r_to_r_not_sm);
     let input: Wrap<fn(&()) -> &NotSM> = Wrap(r_to_r_not_sm);
     match Wrap(input) {
@@ -108,7 +108,7 @@ fn main() {
         Wrap(_) => {}
     };
 
-    // Check that a type which has fn ptrs is `#[structural_match]`.
+    // Check that a type which has fn ptrs is structural-match.
     #[derive(PartialEq, Eq)]
     struct Foo {
         alpha: fn(NotSM),

--- a/src/test/ui/rfc1445/issue-61188-match-slice-forbidden-without-eq.rs
+++ b/src/test/ui/rfc1445/issue-61188-match-slice-forbidden-without-eq.rs
@@ -1,7 +1,7 @@
 // Issue 61188 pointed out a case where we hit an ICE during code gen:
 // the compiler assumed that `PartialEq` was always implemented on any
 // use of a `const` item in a pattern context, but the pre-existing
-// checking for the presence of `#[structural_match]` was too shallow
+// structural-match checking was too shallow
 // (see rust-lang/rust#62307), and so we hit cases where we were
 // trying to dispatch to `PartialEq` on types that did not implement
 // that trait.

--- a/src/test/ui/rfc1445/issue-62307-match-ref-ref-forbidden-without-eq.rs
+++ b/src/test/ui/rfc1445/issue-62307-match-ref-ref-forbidden-without-eq.rs
@@ -8,8 +8,8 @@
 // resolve the question of what semantics is used for such matching.
 // (See RFC 1445 for more details and discussion.)
 
-// Issue 62307 pointed out a case where the checking for
-// `#[structural_match]` was too shallow.
+// Issue 62307 pointed out a case where the structural-match checking
+// was too shallow.
 #![warn(indirect_structural_match)]
 // run-pass
 

--- a/src/test/ui/rfc1445/match-nonempty-array-forbidden-without-eq.rs
+++ b/src/test/ui/rfc1445/match-nonempty-array-forbidden-without-eq.rs
@@ -1,5 +1,5 @@
-// Issue 62307 pointed out a case where the checking for
-// `#[structural_match]` was too shallow.
+// Issue 62307 pointed out a case where the structural-match checking
+// was too shallow.
 //
 // Here we check similar behavior for non-empty arrays of types that
 // do not derive `Eq`.

--- a/src/test/ui/rfc1445/phantom-data-is-structurally-matchable.rs
+++ b/src/test/ui/rfc1445/phantom-data-is-structurally-matchable.rs
@@ -14,25 +14,25 @@ fn main() {
     #[derive(PartialEq, Eq)]
     struct SM;
 
-    // Check that SM is #[structural_match]:
+    // Check that SM is structural-match:
     const CSM: SM = SM;
     match SM {
         CSM => count += 1,
     };
 
-    // Check that PhantomData<T> is #[structural_match] even if T is not.
+    // Check that PhantomData<T> is structural-match even if T is not.
     const CPD1: PhantomData<NotSM> = PhantomData;
     match PhantomData {
         CPD1 => count += 1,
     };
 
-    // Check that PhantomData<T> is #[structural_match] when T is.
+    // Check that PhantomData<T> is structural-match when T is.
     const CPD2: PhantomData<SM> = PhantomData;
     match PhantomData {
         CPD2 => count += 1,
     };
 
-    // Check that a type which has a PhantomData is `#[structural_match]`.
+    // Check that a type which has a PhantomData is structural-match.
     #[derive(PartialEq, Eq, Default)]
     struct Foo {
         alpha: PhantomData<NotSM>,


### PR DESCRIPTION
A small remaining part of https://github.com/rust-lang/rust/issues/63438.