### PR TITLE
Make `iter::Fuse` truly zero cost

### DIFF
--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -2259,17 +2259,11 @@ where
 #[derive(Clone, Debug)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct Fuse<I>
-where
-    I: Iterator,
-{
+pub struct Fuse<I> {
     iter: I,
     done: <I as fuse_flag::FlagType>::Flag,
 }
-impl<I> Fuse<I>
-where
-    I: Iterator,
-{
+impl<I> Fuse<I> {
     pub(super) fn new(iter: I) -> Fuse<I> {
         Fuse { iter, done: <_>::default() }
     }
@@ -2307,11 +2301,11 @@ mod fuse_flag {
         }
     }
 
-    pub trait FlagType: Iterator {
+    pub trait FlagType {
         type Flag: Flag;
     }
 
-    impl<I: Iterator> FlagType for I {
+    impl<I> FlagType for I {
         default type Flag = bool;
     }
 

--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -2272,6 +2272,48 @@ impl<I> Fuse<I> {
 #[stable(feature = "fused", since = "1.26.0")]
 impl<I> FusedIterator for Fuse<I> where I: Iterator {}
 
+mod fuse_flag {
+    pub trait Flag: Default {
+        fn is_set(&self) -> bool;
+        fn set(&mut self);
+    }
+
+    impl Flag for bool {
+        fn is_set(&self) -> bool {
+            *self
+        }
+
+        fn set(&mut self) {
+            *self = true
+        }
+    }
+
+    #[derive(Default)]
+    struct False;
+
+    impl Flag for False {
+        fn is_set(&self) -> bool {
+            false
+        }
+
+        fn set(&mut self) {
+            /* intenionally does nothing */
+        }
+    }
+
+    pub trait FlagType: Iterator {
+        type Flag: Flag;
+    }
+
+    impl<I: Iterator> FlagType for I {
+        default type Flag = bool;
+    }
+
+    impl<I: super::FusedIterator> FlagType for I {
+        type Flag = False;
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<I> Iterator for Fuse<I>
 where


### PR DESCRIPTION
As documentation for [`std::iter::FusedIterator`](https://doc.rust-lang.org/stable/std/iter/trait.FusedIterator.html) says:

> Note: In general, you should not use FusedIterator in generic bounds if you need a fused iterator. Instead, you should just call Iterator::fuse on the iterator. If the iterator is already fused, the additional Fuse wrapper will be a no-op with no performance penalty.

However, the "no performance penalty" part seems a bit questionable: `Fuse` always keeps `done` flag no matter if wrapped iterator is fused or not. For a fused iterator it makes no sense to actually keep this flag, yet `Fuse` blindly attaches it to everything.

This PR resolves the issue: the new implementation guarantess that `Fuse` on fused iterator just forwards methods to wrapped iterator and carries no additional data. This may bring benefit for code that operates on generic iterator and immediately calls `.fuse()` on it.

Possible reasons _not_ to merge this PR (in no particular order):

1. By always keeping a flag we can report correct `size_hint` for exhausted iterator even if internal one has improper `size_hint` implementation. However, now this opportunity is not used, and `Fuse::<I: FusedIterator>::size_hint` just [forwards method to wrapped iterator](https://github.com/rust-lang/rust/blob/2dcf54f564c6d8bbf48960fb9aaec88a0e2e062a/src/libcore/iter/adapters/mod.rs#L2426).
2. This PR adds one more use of specialization which is still incomplete.
3. This PR changes `Debug` output of `Fuse`. However, it can be easily mitigated with custom `Debug` impl.
4. This change can break crates that relies on iterator-contained types to have some specific concrete sizes.
5. Actual performance win is likely to be negligible.
6. This change relies on trick, and it is unclear if this trick will work with possible future methods of `Iterator`.

r? @SimonSapin 