### PR TITLE
add 'fn write_u16s' to Memory

### DIFF
--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -24,6 +24,7 @@ Rust MIR: a lowered representation of Rust.
 #![feature(range_is_empty)]
 #![feature(stmt_expr_attributes)]
 #![feature(trait_alias)]
+#![feature(option_expect_none)]
 #![recursion_limit = "256"]
 
 #[macro_use]


### PR DESCRIPTION
Added new function `Memory::write_u16s`. Needed in `MIRI` for implementing helper function to write wide_str to memory (for Windows).