### PR TITLE
parse: recover on `const fn()` / `async fn()`

### DIFF
--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -1494,7 +1494,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Is the current token the start of an `FnHeader` / not a valid parse?
-    fn check_fn_front_matter(&mut self) -> bool {
+    pub(super) fn check_fn_front_matter(&mut self) -> bool {
         // We use an over-approximation here.
         // `const const`, `fn const` won't parse, but we're not stepping over other syntax either.
         const QUALS: [Symbol; 4] = [kw::Const, kw::Async, kw::Unsafe, kw::Extern];
@@ -1521,7 +1521,7 @@ impl<'a> Parser<'a> {
     /// FnQual = "const"? "async"? "unsafe"? Extern? ;
     /// FnFrontMatter = FnQual? "fn" ;
     /// ```
-    fn parse_fn_front_matter(&mut self) -> PResult<'a, FnHeader> {
+    pub(super) fn parse_fn_front_matter(&mut self) -> PResult<'a, FnHeader> {
         let constness = self.parse_constness();
         let asyncness = self.parse_asyncness();
         let unsafety = self.parse_unsafety();

--- a/src/test/ui/keyword/extern/keyword-extern-as-identifier-type.rs
+++ b/src/test/ui/keyword/extern/keyword-extern-as-identifier-type.rs
@@ -1,3 +1,3 @@
-type A = extern::foo::bar; //~ ERROR expected `fn`, found `::`
+type A = extern::foo::bar; //~ ERROR expected type, found keyword `extern`
 
 fn main() {}

--- a/src/test/ui/keyword/extern/keyword-extern-as-identifier-type.stderr
+++ b/src/test/ui/keyword/extern/keyword-extern-as-identifier-type.stderr
@@ -1,8 +1,8 @@
-error: expected `fn`, found `::`
-  --> $DIR/keyword-extern-as-identifier-type.rs:1:16
+error: expected type, found keyword `extern`
+  --> $DIR/keyword-extern-as-identifier-type.rs:1:10
    |
 LL | type A = extern::foo::bar;
-   |                ^^ expected `fn`
+   |          ^^^^^^ expected type
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issue-63116.stderr
+++ b/src/test/ui/parser/issue-63116.stderr
@@ -12,7 +12,7 @@ error: expected one of `!`, `(`, `)`, `+`, `,`, `::`, or `<`, found `;`
 LL | impl W <s(f;Y(;]
    |            ^ expected one of 7 possible tokens
 
-error: expected one of `!`, `&&`, `&`, `(`, `)`, `*`, `+`, `,`, `->`, `...`, `::`, `<`, `>`, `?`, `[`, `_`, `dyn`, `extern`, `fn`, `for`, `impl`, `unsafe`, lifetime, or path, found `;`
+error: expected one of `!`, `&&`, `&`, `(`, `)`, `*`, `+`, `,`, `->`, `...`, `::`, `<`, `>`, `?`, `[`, `_`, `async`, `const`, `dyn`, `extern`, `fn`, `for`, `impl`, `unsafe`, lifetime, or path, found `;`
   --> $DIR/issue-63116.rs:3:15
    |
 LL | impl W <s(f;Y(;]

--- a/src/test/ui/parser/recover-const-async-fn-ptr.rs
+++ b/src/test/ui/parser/recover-const-async-fn-ptr.rs
@@ -1,0 +1,25 @@
+// edition:2018
+
+type T0 = const fn(); //~ ERROR an `fn` pointer type cannot be `const`
+type T1 = const extern "C" fn(); //~ ERROR an `fn` pointer type cannot be `const`
+type T2 = const unsafe extern fn(); //~ ERROR an `fn` pointer type cannot be `const`
+type T3 = async fn(); //~ ERROR an `fn` pointer type cannot be `async`
+type T4 = async extern fn(); //~ ERROR an `fn` pointer type cannot be `async`
+type T5 = async unsafe extern "C" fn(); //~ ERROR an `fn` pointer type cannot be `async`
+type T6 = const async unsafe extern "C" fn();
+//~^ ERROR an `fn` pointer type cannot be `const`
+//~| ERROR an `fn` pointer type cannot be `async`
+
+type FT0 = for<'a> const fn(); //~ ERROR an `fn` pointer type cannot be `const`
+type FT1 = for<'a> const extern "C" fn(); //~ ERROR an `fn` pointer type cannot be `const`
+type FT2 = for<'a> const unsafe extern fn(); //~ ERROR an `fn` pointer type cannot be `const`
+type FT3 = for<'a> async fn(); //~ ERROR an `fn` pointer type cannot be `async`
+type FT4 = for<'a> async extern fn(); //~ ERROR an `fn` pointer type cannot be `async`
+type FT5 = for<'a> async unsafe extern "C" fn(); //~ ERROR an `fn` pointer type cannot be `async`
+type FT6 = for<'a> const async unsafe extern "C" fn();
+//~^ ERROR an `fn` pointer type cannot be `const`
+//~| ERROR an `fn` pointer type cannot be `async`
+
+fn main() {
+    let _recovery_witness: () = 0; //~ ERROR mismatched types
+}

--- a/src/test/ui/parser/recover-const-async-fn-ptr.stderr
+++ b/src/test/ui/parser/recover-const-async-fn-ptr.stderr
@@ -1,0 +1,155 @@
+error: an `fn` pointer type cannot be `const`
+  --> $DIR/recover-const-async-fn-ptr.rs:3:11
+   |
+LL | type T0 = const fn();
+   |           -----^^^^^
+   |           |
+   |           `const` because of this
+   |           help: remove the `const` qualifier
+
+error: an `fn` pointer type cannot be `const`
+  --> $DIR/recover-const-async-fn-ptr.rs:4:11
+   |
+LL | type T1 = const extern "C" fn();
+   |           -----^^^^^^^^^^^^^^^^
+   |           |
+   |           `const` because of this
+   |           help: remove the `const` qualifier
+
+error: an `fn` pointer type cannot be `const`
+  --> $DIR/recover-const-async-fn-ptr.rs:5:11
+   |
+LL | type T2 = const unsafe extern fn();
+   |           -----^^^^^^^^^^^^^^^^^^^
+   |           |
+   |           `const` because of this
+   |           help: remove the `const` qualifier
+
+error: an `fn` pointer type cannot be `async`
+  --> $DIR/recover-const-async-fn-ptr.rs:6:11
+   |
+LL | type T3 = async fn();
+   |           -----^^^^^
+   |           |
+   |           `async` because of this
+   |           help: remove the `async` qualifier
+
+error: an `fn` pointer type cannot be `async`
+  --> $DIR/recover-const-async-fn-ptr.rs:7:11
+   |
+LL | type T4 = async extern fn();
+   |           -----^^^^^^^^^^^^
+   |           |
+   |           `async` because of this
+   |           help: remove the `async` qualifier
+
+error: an `fn` pointer type cannot be `async`
+  --> $DIR/recover-const-async-fn-ptr.rs:8:11
+   |
+LL | type T5 = async unsafe extern "C" fn();
+   |           -----^^^^^^^^^^^^^^^^^^^^^^^
+   |           |
+   |           `async` because of this
+   |           help: remove the `async` qualifier
+
+error: an `fn` pointer type cannot be `const`
+  --> $DIR/recover-const-async-fn-ptr.rs:9:11
+   |
+LL | type T6 = const async unsafe extern "C" fn();
+   |           -----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |           |
+   |           `const` because of this
+   |           help: remove the `const` qualifier
+
+error: an `fn` pointer type cannot be `async`
+  --> $DIR/recover-const-async-fn-ptr.rs:9:11
+   |
+LL | type T6 = const async unsafe extern "C" fn();
+   |           ^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 `async` because of this
+   |                 help: remove the `async` qualifier
+
+error: an `fn` pointer type cannot be `const`
+  --> $DIR/recover-const-async-fn-ptr.rs:13:12
+   |
+LL | type FT0 = for<'a> const fn();
+   |            ^^^^^^^^-----^^^^^
+   |                    |
+   |                    `const` because of this
+   |                    help: remove the `const` qualifier
+
+error: an `fn` pointer type cannot be `const`
+  --> $DIR/recover-const-async-fn-ptr.rs:14:12
+   |
+LL | type FT1 = for<'a> const extern "C" fn();
+   |            ^^^^^^^^-----^^^^^^^^^^^^^^^^
+   |                    |
+   |                    `const` because of this
+   |                    help: remove the `const` qualifier
+
+error: an `fn` pointer type cannot be `const`
+  --> $DIR/recover-const-async-fn-ptr.rs:15:12
+   |
+LL | type FT2 = for<'a> const unsafe extern fn();
+   |            ^^^^^^^^-----^^^^^^^^^^^^^^^^^^^
+   |                    |
+   |                    `const` because of this
+   |                    help: remove the `const` qualifier
+
+error: an `fn` pointer type cannot be `async`
+  --> $DIR/recover-const-async-fn-ptr.rs:16:12
+   |
+LL | type FT3 = for<'a> async fn();
+   |            ^^^^^^^^-----^^^^^
+   |                    |
+   |                    `async` because of this
+   |                    help: remove the `async` qualifier
+
+error: an `fn` pointer type cannot be `async`
+  --> $DIR/recover-const-async-fn-ptr.rs:17:12
+   |
+LL | type FT4 = for<'a> async extern fn();
+   |            ^^^^^^^^-----^^^^^^^^^^^^
+   |                    |
+   |                    `async` because of this
+   |                    help: remove the `async` qualifier
+
+error: an `fn` pointer type cannot be `async`
+  --> $DIR/recover-const-async-fn-ptr.rs:18:12
+   |
+LL | type FT5 = for<'a> async unsafe extern "C" fn();
+   |            ^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
+   |                    |
+   |                    `async` because of this
+   |                    help: remove the `async` qualifier
+
+error: an `fn` pointer type cannot be `const`
+  --> $DIR/recover-const-async-fn-ptr.rs:19:12
+   |
+LL | type FT6 = for<'a> const async unsafe extern "C" fn();
+   |            ^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                    |
+   |                    `const` because of this
+   |                    help: remove the `const` qualifier
+
+error: an `fn` pointer type cannot be `async`
+  --> $DIR/recover-const-async-fn-ptr.rs:19:12
+   |
+LL | type FT6 = for<'a> const async unsafe extern "C" fn();
+   |            ^^^^^^^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
+   |                          |
+   |                          `async` because of this
+   |                          help: remove the `async` qualifier
+
+error[E0308]: mismatched types
+  --> $DIR/recover-const-async-fn-ptr.rs:24:33
+   |
+LL |     let _recovery_witness: () = 0;
+   |                            --   ^ expected `()`, found integer
+   |                            |
+   |                            expected due to this
+
+error: aborting due to 17 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Recover on `const fn()` and `async fn()` function pointers, suggesting to remove the qualifier.
For example:
```
error: an `fn` pointer type cannot be `async`
  --> $DIR/recover-const-async-fn-ptr.rs:6:11
   |
LL | type T3 = async fn();
   |           -----^^^^^
   |           |
   |           `async` because of this
   |           help: remove the `async` qualifier
```

r? @estebank 