### PR TITLE
`error_bad_item_kind`: add help text

### DIFF
--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -908,8 +908,10 @@ impl<'a> Parser<'a> {
 
     fn error_bad_item_kind<T>(&self, span: Span, kind: &ItemKind, ctx: &str) -> Option<T> {
         let span = self.sess.source_map().guess_head_span(span);
-        let msg = format!("{} is not supported in {}", kind.descr(), ctx);
-        self.struct_span_err(span, &msg).emit();
+        let descr = kind.descr();
+        self.struct_span_err(span, &format!("{} is not supported in {}", descr, ctx))
+            .help(&format!("consider moving the {} out to a nearby module scope", descr))
+            .emit();
         None
     }
 

--- a/src/test/ui/parser/default-on-wrong-item-kind.stderr
+++ b/src/test/ui/parser/default-on-wrong-item-kind.stderr
@@ -123,6 +123,8 @@ error: extern crate is not supported in `extern` blocks
    |
 LL |     default extern crate foo;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the extern crate out to a nearby module scope
 
 error: a `use` import cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:35:5
@@ -137,6 +139,8 @@ error: `use` import is not supported in `extern` blocks
    |
 LL |     default use foo;
    |     ^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the `use` import out to a nearby module scope
 
 error: a static item cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:37:5
@@ -169,6 +173,8 @@ error: module is not supported in `extern` blocks
    |
 LL |     default mod foo {}
    |     ^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the module out to a nearby module scope
 
 error: an extern block cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:43:5
@@ -183,6 +189,8 @@ error: extern block is not supported in `extern` blocks
    |
 LL |     default extern "C" {}
    |     ^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the extern block out to a nearby module scope
 
 error: an enum cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:46:5
@@ -197,6 +205,8 @@ error: enum is not supported in `extern` blocks
    |
 LL |     default enum foo {}
    |     ^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the enum out to a nearby module scope
 
 error: a struct cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:48:5
@@ -211,6 +221,8 @@ error: struct is not supported in `extern` blocks
    |
 LL |     default struct foo {}
    |     ^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the struct out to a nearby module scope
 
 error: a union cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:50:5
@@ -225,6 +237,8 @@ error: union is not supported in `extern` blocks
    |
 LL |     default union foo {}
    |     ^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the union out to a nearby module scope
 
 error: a trait cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:52:5
@@ -239,6 +253,8 @@ error: trait is not supported in `extern` blocks
    |
 LL |     default trait foo {}
    |     ^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the trait out to a nearby module scope
 
 error: a trait alias cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:54:5
@@ -253,12 +269,16 @@ error: trait alias is not supported in `extern` blocks
    |
 LL |     default trait foo = Ord;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the trait alias out to a nearby module scope
 
 error: implementation is not supported in `extern` blocks
   --> $DIR/default-on-wrong-item-kind.rs:56:5
    |
 LL |     default impl foo {}
    |     ^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the implementation out to a nearby module scope
 
 error: an item macro invocation cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:60:5
@@ -289,6 +309,8 @@ error: macro definition is not supported in `extern` blocks
    |
 LL |     default macro foo {}
    |     ^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the macro definition out to a nearby module scope
 
 error: a macro definition cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:64:5
@@ -303,6 +325,8 @@ error: macro definition is not supported in `extern` blocks
    |
 LL |     default macro_rules! foo {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the macro definition out to a nearby module scope
 
 error: an extern crate cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:70:5
@@ -317,6 +341,8 @@ error: extern crate is not supported in `trait`s or `impl`s
    |
 LL |     default extern crate foo;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the extern crate out to a nearby module scope
 
 error: a `use` import cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:72:5
@@ -331,6 +357,8 @@ error: `use` import is not supported in `trait`s or `impl`s
    |
 LL |     default use foo;
    |     ^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the `use` import out to a nearby module scope
 
 error: a static item cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:74:5
@@ -359,6 +387,8 @@ error: module is not supported in `trait`s or `impl`s
    |
 LL |     default mod foo {}
    |     ^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the module out to a nearby module scope
 
 error: an extern block cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:80:5
@@ -373,6 +403,8 @@ error: extern block is not supported in `trait`s or `impl`s
    |
 LL |     default extern "C" {}
    |     ^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the extern block out to a nearby module scope
 
 error: an enum cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:83:5
@@ -387,6 +419,8 @@ error: enum is not supported in `trait`s or `impl`s
    |
 LL |     default enum foo {}
    |     ^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the enum out to a nearby module scope
 
 error: a struct cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:85:5
@@ -401,6 +435,8 @@ error: struct is not supported in `trait`s or `impl`s
    |
 LL |     default struct foo {}
    |     ^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the struct out to a nearby module scope
 
 error: a union cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:87:5
@@ -415,6 +451,8 @@ error: union is not supported in `trait`s or `impl`s
    |
 LL |     default union foo {}
    |     ^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the union out to a nearby module scope
 
 error: a trait cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:89:5
@@ -429,6 +467,8 @@ error: trait is not supported in `trait`s or `impl`s
    |
 LL |     default trait foo {}
    |     ^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the trait out to a nearby module scope
 
 error: a trait alias cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:91:5
@@ -443,12 +483,16 @@ error: trait alias is not supported in `trait`s or `impl`s
    |
 LL |     default trait foo = Ord;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the trait alias out to a nearby module scope
 
 error: implementation is not supported in `trait`s or `impl`s
   --> $DIR/default-on-wrong-item-kind.rs:93:5
    |
 LL |     default impl foo {}
    |     ^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the implementation out to a nearby module scope
 
 error: an item macro invocation cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:97:5
@@ -479,6 +523,8 @@ error: macro definition is not supported in `trait`s or `impl`s
    |
 LL |     default macro foo {}
    |     ^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the macro definition out to a nearby module scope
 
 error: a macro definition cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:101:5
@@ -493,6 +539,8 @@ error: macro definition is not supported in `trait`s or `impl`s
    |
 LL |     default macro_rules! foo {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the macro definition out to a nearby module scope
 
 error: an extern crate cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:107:5
@@ -507,6 +555,8 @@ error: extern crate is not supported in `trait`s or `impl`s
    |
 LL |     default extern crate foo;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the extern crate out to a nearby module scope
 
 error: a `use` import cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:109:5
@@ -521,6 +571,8 @@ error: `use` import is not supported in `trait`s or `impl`s
    |
 LL |     default use foo;
    |     ^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the `use` import out to a nearby module scope
 
 error: a static item cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:111:5
@@ -549,6 +601,8 @@ error: module is not supported in `trait`s or `impl`s
    |
 LL |     default mod foo {}
    |     ^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the module out to a nearby module scope
 
 error: an extern block cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:117:5
@@ -563,6 +617,8 @@ error: extern block is not supported in `trait`s or `impl`s
    |
 LL |     default extern "C" {}
    |     ^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the extern block out to a nearby module scope
 
 error: an enum cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:120:5
@@ -577,6 +633,8 @@ error: enum is not supported in `trait`s or `impl`s
    |
 LL |     default enum foo {}
    |     ^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the enum out to a nearby module scope
 
 error: a struct cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:122:5
@@ -591,6 +649,8 @@ error: struct is not supported in `trait`s or `impl`s
    |
 LL |     default struct foo {}
    |     ^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the struct out to a nearby module scope
 
 error: a union cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:124:5
@@ -605,6 +665,8 @@ error: union is not supported in `trait`s or `impl`s
    |
 LL |     default union foo {}
    |     ^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the union out to a nearby module scope
 
 error: a trait cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:126:5
@@ -619,6 +681,8 @@ error: trait is not supported in `trait`s or `impl`s
    |
 LL |     default trait foo {}
    |     ^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the trait out to a nearby module scope
 
 error: a trait alias cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:128:5
@@ -633,12 +697,16 @@ error: trait alias is not supported in `trait`s or `impl`s
    |
 LL |     default trait foo = Ord;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the trait alias out to a nearby module scope
 
 error: implementation is not supported in `trait`s or `impl`s
   --> $DIR/default-on-wrong-item-kind.rs:130:5
    |
 LL |     default impl foo {}
    |     ^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the implementation out to a nearby module scope
 
 error: an item macro invocation cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:134:5
@@ -669,6 +737,8 @@ error: macro definition is not supported in `trait`s or `impl`s
    |
 LL |     default macro foo {}
    |     ^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the macro definition out to a nearby module scope
 
 error: a macro definition cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:138:5
@@ -683,6 +753,8 @@ error: macro definition is not supported in `trait`s or `impl`s
    |
 LL |     default macro_rules! foo {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the macro definition out to a nearby module scope
 
 error: aborting due to 95 previous errors
 

--- a/src/test/ui/parser/issue-48137-macros-cannot-interpolate-impl-items-bad-variants.stderr
+++ b/src/test/ui/parser/issue-48137-macros-cannot-interpolate-impl-items-bad-variants.stderr
@@ -3,6 +3,8 @@ error: struct is not supported in `trait`s or `impl`s
    |
 LL |     struct BadS;
    |     ^^^^^^^^^^^^
+   |
+   = help: consider moving the struct out to a nearby module scope
 
 error: enum is not supported in `trait`s or `impl`s
   --> $DIR/issue-48137-macros-cannot-interpolate-impl-items-bad-variants.rs:5:9
@@ -13,6 +15,7 @@ LL |         enum BadE {}
 LL |     expand_to_enum!();
    |     ------------------ in this macro invocation
    |
+   = help: consider moving the enum out to a nearby module scope
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: struct is not supported in `trait`s or `impl`s
@@ -20,6 +23,8 @@ error: struct is not supported in `trait`s or `impl`s
    |
 LL |     struct BadS;
    |     ^^^^^^^^^^^^
+   |
+   = help: consider moving the struct out to a nearby module scope
 
 error: enum is not supported in `trait`s or `impl`s
   --> $DIR/issue-48137-macros-cannot-interpolate-impl-items-bad-variants.rs:5:9
@@ -30,6 +35,7 @@ LL |         enum BadE {}
 LL |     expand_to_enum!();
    |     ------------------ in this macro invocation
    |
+   = help: consider moving the enum out to a nearby module scope
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: struct is not supported in `extern` blocks
@@ -37,6 +43,8 @@ error: struct is not supported in `extern` blocks
    |
 LL |     struct BadS;
    |     ^^^^^^^^^^^^
+   |
+   = help: consider moving the struct out to a nearby module scope
 
 error: enum is not supported in `extern` blocks
   --> $DIR/issue-48137-macros-cannot-interpolate-impl-items-bad-variants.rs:5:9
@@ -47,6 +55,7 @@ LL |         enum BadE {}
 LL |     expand_to_enum!();
    |     ------------------ in this macro invocation
    |
+   = help: consider moving the enum out to a nearby module scope
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 6 previous errors

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-impl-trait.stderr
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-impl-trait.stderr
@@ -12,12 +12,16 @@ error: trait is not supported in `trait`s or `impl`s
    |
 LL | trait T {
    | ^^^^^^^
+   |
+   = help: consider moving the trait out to a nearby module scope
 
 error: struct is not supported in `trait`s or `impl`s
   --> $DIR/missing-close-brace-in-impl-trait.rs:11:1
    |
 LL | pub(crate) struct Bar<T>();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the struct out to a nearby module scope
 
 error[E0405]: cannot find trait `T` in this scope
   --> $DIR/missing-close-brace-in-impl-trait.rs:3:6

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-trait.stderr
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-trait.stderr
@@ -12,12 +12,16 @@ error: struct is not supported in `trait`s or `impl`s
    |
 LL | pub(crate) struct Bar<T>();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the struct out to a nearby module scope
 
 error: implementation is not supported in `trait`s or `impl`s
   --> $DIR/missing-close-brace-in-trait.rs:7:1
    |
 LL | impl T for Bar<usize> {
    | ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the implementation out to a nearby module scope
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
For example, this adds:
```
    = help: consider moving the `use` import out to a nearby module scope 
```
r? @petrochenkov @estebank 

Fixes https://github.com/rust-lang/rust/issues/37205.