### PR TITLE
data_structures: Bump crossbeam_utils to 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3633,7 +3633,7 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "cfg-if",
- "crossbeam-utils 0.6.5",
+ "crossbeam-utils 0.7.0",
  "ena",
  "graphviz",
  "indexmap",

--- a/src/librustc_data_structures/Cargo.toml
+++ b/src/librustc_data_structures/Cargo.toml
@@ -18,7 +18,7 @@ lazy_static = "1"
 rustc_serialize = { path = "../libserialize", package = "serialize" }
 graphviz = { path = "../libgraphviz" }
 cfg-if = "0.1.2"
-crossbeam-utils = { version = "0.6.5", features = ["nightly"] }
+crossbeam-utils = { version = "0.7", features = ["nightly"] }
 stable_deref_trait = "1.0.0"
 rayon = { version = "0.3.0", package = "rustc-rayon" }
 rayon-core = { version = "0.3.0", package = "rustc-rayon-core" }


### PR DESCRIPTION
This pulls in the build fix for nightly build: https://github.com/crossbeam-rs/crossbeam/commit/5b5d727fcd2616b1f5314db03f4e6b96791a303d

Related: https://github.com/rust-lang/rls/issues/1571

r? @mati865 