### PR TITLE
suggest `;` on expr `mac!()` which is good as stmt `mac!()`

### DIFF
--- a/src/test/ui/macros/issue-34421-mac-expr-bad-stmt-good-add-semi.rs
+++ b/src/test/ui/macros/issue-34421-mac-expr-bad-stmt-good-add-semi.rs
@@ -1,0 +1,15 @@
+macro_rules! make_item {
+    ($a:ident) => {
+        struct $a;
+    }; //~^ ERROR expected expression
+       //~| ERROR expected expression
+}
+
+fn a() {
+    make_item!(A)
+}
+fn b() {
+    make_item!(B)
+}
+
+fn main() {}

--- a/src/test/ui/macros/issue-34421-mac-expr-bad-stmt-good-add-semi.stderr
+++ b/src/test/ui/macros/issue-34421-mac-expr-bad-stmt-good-add-semi.stderr
@@ -1,0 +1,34 @@
+error: expected expression, found keyword `struct`
+  --> $DIR/issue-34421-mac-expr-bad-stmt-good-add-semi.rs:3:9
+   |
+LL |         struct $a;
+   |         ^^^^^^ expected expression
+...
+LL |     make_item!(A)
+   |     ------------- in this macro invocation
+   |
+   = note: the macro call doesn't expand to an expression, but it can expand to a statement
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+help: add `;` to interpret the expansion as a statement
+   |
+LL |     make_item!(A);
+   |                  ^
+
+error: expected expression, found keyword `struct`
+  --> $DIR/issue-34421-mac-expr-bad-stmt-good-add-semi.rs:3:9
+   |
+LL |         struct $a;
+   |         ^^^^^^ expected expression
+...
+LL |     make_item!(B)
+   |     ------------- in this macro invocation
+   |
+   = note: the macro call doesn't expand to an expression, but it can expand to a statement
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+help: add `;` to interpret the expansion as a statement
+   |
+LL |     make_item!(B);
+   |                  ^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/macros/macro-in-expression-context-2.stderr
+++ b/src/test/ui/macros/macro-in-expression-context-2.stderr
@@ -6,6 +6,12 @@ LL | macro_rules! empty { () => () }
 ...
 LL |         _ => { empty!() }
    |                ^^^^^^^^ expected expression
+   |
+   = note: the macro call doesn't expand to an expression, but it can expand to a statement
+help: add `;` to interpret the expansion as a statement
+   |
+LL |         _ => { empty!(); }
+   |                        ^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/34421 by implementing @jseyfried's suggestion in https://github.com/rust-lang/rust/issues/34421#issuecomment-301578683.

r? @petrochenkov 