### PR TITLE
Create output dir in rustdoc markdown render

### DIFF
--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -1,4 +1,4 @@
-use std::fs::File;
+use std::fs::{create_dir_all, File};
 use std::io::prelude::*;
 use std::path::PathBuf;
 
@@ -40,6 +40,11 @@ pub fn render(
     diag: &rustc_errors::Handler,
     edition: Edition,
 ) -> i32 {
+    if let Err(e) = create_dir_all(&options.output) {
+        diag.struct_err(&format!("{}: {}", options.output.display(), e)).emit();
+        return 4;
+    }
+
     let mut output = options.output;
     output.push(input.file_name().unwrap());
     output.set_extension("html");


### PR DESCRIPTION
`rustdoc` command on a standalone markdown document fails because the output directory (which default to `doc/`) is not created, even when specified with the `--output` argument.

This PR adds the creation of the output directory before the file creation to avoid an unexpected error which is unclear.

I am not sure about the returned error code. I did not find a table explaining them. So I simply put the same error code that is returned when `File::create` fails because they are both related to file-system errors. 

Resolve #70431 