### PR TITLE
non-exhastive diagnostic: add note re. scrutinee type

### DIFF
--- a/src/librustc_mir_build/hair/pattern/check_match.rs
+++ b/src/librustc_mir_build/hair/pattern/check_match.rs
@@ -241,6 +241,7 @@ impl<'tcx> MatchVisitor<'_, 'tcx> {
             }
 
             adt_defined_here(cx, &mut err, pattern_ty, &witnesses);
+            err.note(&format!("the matched value is of type `{}`", pattern_ty));
             err.emit();
         });
     }
@@ -480,6 +481,7 @@ fn check_exhaustive<'p, 'tcx>(
         "ensure that all possible cases are being handled, \
          possibly by adding wildcards or more match arms",
     );
+    err.note(&format!("the matched value is of type `{}`", scrut_ty));
     err.emit();
 }
 

--- a/src/test/ui/consts/const-match-check.eval1.stderr
+++ b/src/test/ui/consts/const-match-check.eval1.stderr
@@ -6,6 +6,7 @@ LL |     A = { let 0 = 0; 0 },
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
 help: you might want to use `if let` to ignore the variant that isn't matched
    |
 LL |     A = { if let 0 = 0 { /* */ } 0 },

--- a/src/test/ui/consts/const-match-check.eval2.stderr
+++ b/src/test/ui/consts/const-match-check.eval2.stderr
@@ -6,6 +6,7 @@ LL |     let x: [i32; { let 0 = 0; 0 }] = [];
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
 help: you might want to use `if let` to ignore the variant that isn't matched
    |
 LL |     let x: [i32; { if let 0 = 0 { /* */ } 0 }] = [];

--- a/src/test/ui/consts/const-match-check.matchck.stderr
+++ b/src/test/ui/consts/const-match-check.matchck.stderr
@@ -6,6 +6,7 @@ LL | const X: i32 = { let 0 = 0; 0 };
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
 help: you might want to use `if let` to ignore the variant that isn't matched
    |
 LL | const X: i32 = { if let 0 = 0 { /* */ } 0 };
@@ -19,6 +20,7 @@ LL | static Y: i32 = { let 0 = 0; 0 };
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
 help: you might want to use `if let` to ignore the variant that isn't matched
    |
 LL | static Y: i32 = { if let 0 = 0 { /* */ } 0 };
@@ -32,6 +34,7 @@ LL |     const X: i32 = { let 0 = 0; 0 };
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
 help: you might want to use `if let` to ignore the variant that isn't matched
    |
 LL |     const X: i32 = { if let 0 = 0 { /* */ } 0 };
@@ -45,6 +48,7 @@ LL |     const X: i32 = { let 0 = 0; 0 };
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
 help: you might want to use `if let` to ignore the variant that isn't matched
    |
 LL |     const X: i32 = { if let 0 = 0 { /* */ } 0 };

--- a/src/test/ui/consts/const-pattern-irrefutable.stderr
+++ b/src/test/ui/consts/const-pattern-irrefutable.stderr
@@ -9,6 +9,8 @@ LL |     let a = 4;
    |         |
    |         interpreted as a constant pattern, not a new variable
    |         help: introduce a variable instead: `a_var`
+   |
+   = note: the matched value is of type `u8`
 
 error[E0005]: refutable pattern in local binding: `0u8..=1u8` and `3u8..=std::u8::MAX` not covered
   --> $DIR/const-pattern-irrefutable.rs:13:9
@@ -21,6 +23,8 @@ LL |     let c = 4;
    |         |
    |         interpreted as a constant pattern, not a new variable
    |         help: introduce a variable instead: `c_var`
+   |
+   = note: the matched value is of type `u8`
 
 error[E0005]: refutable pattern in local binding: `0u8..=1u8` and `3u8..=std::u8::MAX` not covered
   --> $DIR/const-pattern-irrefutable.rs:14:9
@@ -33,6 +37,8 @@ LL |     let d = 4;
    |         |
    |         interpreted as a constant pattern, not a new variable
    |         help: introduce a variable instead: `d_var`
+   |
+   = note: the matched value is of type `u8`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/const_let_refutable.stderr
+++ b/src/test/ui/consts/const_let_refutable.stderr
@@ -3,6 +3,8 @@ error[E0005]: refutable pattern in function argument: `&[]`, `&[_]` and `&[_, _,
    |
 LL | const fn slice(&[a, b]: &[i32]) -> i32 {
    |                ^^^^^^^ patterns `&[]`, `&[_]` and `&[_, _, _, ..]` not covered
+   |
+   = note: the matched value is of type `&[i32]`
 
 error[E0723]: loops and conditional expressions are not stable in const fn
   --> $DIR/const_let_refutable.rs:3:17

--- a/src/test/ui/consts/match_ice.stderr
+++ b/src/test/ui/consts/match_ice.stderr
@@ -14,6 +14,7 @@ LL |     match K {
    |           ^ pattern `&T` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&T`
 
 error: to use a constant of type `S` in a pattern, `S` must be annotated with `#[derive(PartialEq, Eq)]`
   --> $DIR/match_ice.rs:11:9

--- a/src/test/ui/empty/empty-never-array.stderr
+++ b/src/test/ui/empty/empty-never-array.stderr
@@ -14,6 +14,7 @@ LL |       let Helper::U(u) = Helper::T(t, []);
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `Helper<T, U>`
 help: you might want to use `if let` to ignore the variant that isn't matched
    |
 LL |     if let Helper::U(u) = Helper::T(t, []) { /* */ }

--- a/src/test/ui/error-codes/E0004-2.stderr
+++ b/src/test/ui/error-codes/E0004-2.stderr
@@ -13,6 +13,7 @@ LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
    |     ---- not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `std::option::Option<i32>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0004.stderr
+++ b/src/test/ui/error-codes/E0004.stderr
@@ -12,6 +12,7 @@ LL |       match x {
    |             ^ pattern `HastaLaVistaBaby` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `Terminator`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0005.stderr
+++ b/src/test/ui/error-codes/E0005.stderr
@@ -11,6 +11,7 @@ LL |     None,
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `std::option::Option<i32>`
 help: you might want to use `if let` to ignore the variant that isn't matched
    |
 LL |     if let Some(y) = x { /* */ }

--- a/src/test/ui/error-codes/E0297.stderr
+++ b/src/test/ui/error-codes/E0297.stderr
@@ -8,6 +8,8 @@ LL |     for Some(x) in xs {}
    |
 LL |     None,
    |     ---- not covered
+   |
+   = note: the matched value is of type `std::option::Option<i32>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-exhaustive-patterns.stderr
+++ b/src/test/ui/feature-gates/feature-gate-exhaustive-patterns.stderr
@@ -11,6 +11,7 @@ LL |     Err(#[stable(feature = "rust1", since = "1.0.0")] E),
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `std::result::Result<u32, !>`
 help: you might want to use `if let` to ignore the variant that isn't matched
    |
 LL |     if let Ok(_x) = foo() { /* */ }

--- a/src/test/ui/feature-gates/feature-gate-precise_pointer_size_matching.stderr
+++ b/src/test/ui/feature-gates/feature-gate-precise_pointer_size_matching.stderr
@@ -5,6 +5,7 @@ LL |     match 0usize {
    |           ^^^^^^ pattern `_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `usize`
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/feature-gate-precise_pointer_size_matching.rs:10:11
@@ -13,6 +14,7 @@ LL |     match 0isize {
    |           ^^^^^^ pattern `_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `isize`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/for/for-loop-refutable-pattern-error-message.stderr
+++ b/src/test/ui/for/for-loop-refutable-pattern-error-message.stderr
@@ -3,6 +3,8 @@ error[E0005]: refutable pattern in `for` loop binding: `&std::i32::MIN..=0i32` a
    |
 LL |     for &1 in [1].iter() {}
    |         ^^ patterns `&std::i32::MIN..=0i32` and `&2i32..=std::i32::MAX` not covered
+   |
+   = note: the matched value is of type `&i32`
 
 error: aborting due to previous error
 

--- a/src/test/ui/half-open-range-patterns/half-open-range-pats-exhaustive-fail.stderr
+++ b/src/test/ui/half-open-range-patterns/half-open-range-pats-exhaustive-fail.stderr
@@ -5,6 +5,7 @@ LL |     m!(0f32, core::f32::NEG_INFINITY..);
    |        ^^^^ pattern `_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `f32`
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:17:8
@@ -13,6 +14,7 @@ LL |     m!(0f32, ..core::f32::INFINITY);
    |        ^^^^ pattern `_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `f32`
 
 error[E0004]: non-exhaustive patterns: `'\u{10ffff}'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:26:8
@@ -21,6 +23,7 @@ LL |     m!('a', ..core::char::MAX);
    |        ^^^ pattern `'\u{10ffff}'` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `char`
 
 error[E0004]: non-exhaustive patterns: `'\u{10fffe}'..='\u{10ffff}'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:27:8
@@ -29,6 +32,7 @@ LL |     m!('a', ..ALMOST_MAX);
    |        ^^^ pattern `'\u{10fffe}'..='\u{10ffff}'` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `char`
 
 error[E0004]: non-exhaustive patterns: `'\u{0}'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:28:8
@@ -37,6 +41,7 @@ LL |     m!('a', ALMOST_MIN..);
    |        ^^^ pattern `'\u{0}'` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `char`
 
 error[E0004]: non-exhaustive patterns: `'\u{10ffff}'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:29:8
@@ -45,6 +50,7 @@ LL |     m!('a', ..=ALMOST_MAX);
    |        ^^^ pattern `'\u{10ffff}'` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `char`
 
 error[E0004]: non-exhaustive patterns: `'b'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:30:8
@@ -53,6 +59,7 @@ LL |     m!('a', ..=VAL | VAL_2..);
    |        ^^^ pattern `'b'` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `char`
 
 error[E0004]: non-exhaustive patterns: `'b'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:31:8
@@ -61,6 +68,7 @@ LL |     m!('a', ..VAL_1 | VAL_2..);
    |        ^^^ pattern `'b'` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `char`
 
 error[E0004]: non-exhaustive patterns: `std::u8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:41:12
@@ -69,6 +77,7 @@ LL |         m!(0, ..core::u8::MAX);
    |            ^ pattern `std::u8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `254u8..=std::u8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:42:12
@@ -77,6 +86,7 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `254u8..=std::u8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `0u8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:43:12
@@ -85,6 +95,7 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `0u8` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `std::u8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:44:12
@@ -93,6 +104,7 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `std::u8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `43u8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:45:12
@@ -101,6 +113,7 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43u8` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `43u8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:46:12
@@ -109,6 +122,7 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43u8` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `std::u16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:54:12
@@ -117,6 +131,7 @@ LL |         m!(0, ..core::u16::MAX);
    |            ^ pattern `std::u16::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u16`
 
 error[E0004]: non-exhaustive patterns: `65534u16..=std::u16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:55:12
@@ -125,6 +140,7 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `65534u16..=std::u16::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u16`
 
 error[E0004]: non-exhaustive patterns: `0u16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:56:12
@@ -133,6 +149,7 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `0u16` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u16`
 
 error[E0004]: non-exhaustive patterns: `std::u16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:57:12
@@ -141,6 +158,7 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `std::u16::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u16`
 
 error[E0004]: non-exhaustive patterns: `43u16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:58:12
@@ -149,6 +167,7 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43u16` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u16`
 
 error[E0004]: non-exhaustive patterns: `43u16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:59:12
@@ -157,6 +176,7 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43u16` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u16`
 
 error[E0004]: non-exhaustive patterns: `std::u32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:67:12
@@ -165,6 +185,7 @@ LL |         m!(0, ..core::u32::MAX);
    |            ^ pattern `std::u32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u32`
 
 error[E0004]: non-exhaustive patterns: `4294967294u32..=std::u32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:68:12
@@ -173,6 +194,7 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `4294967294u32..=std::u32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u32`
 
 error[E0004]: non-exhaustive patterns: `0u32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:69:12
@@ -181,6 +203,7 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `0u32` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u32`
 
 error[E0004]: non-exhaustive patterns: `std::u32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:70:12
@@ -189,6 +212,7 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `std::u32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u32`
 
 error[E0004]: non-exhaustive patterns: `43u32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:71:12
@@ -197,6 +221,7 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43u32` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u32`
 
 error[E0004]: non-exhaustive patterns: `43u32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:72:12
@@ -205,6 +230,7 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43u32` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u32`
 
 error[E0004]: non-exhaustive patterns: `std::u64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:80:12
@@ -213,6 +239,7 @@ LL |         m!(0, ..core::u64::MAX);
    |            ^ pattern `std::u64::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u64`
 
 error[E0004]: non-exhaustive patterns: `18446744073709551614u64..=std::u64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:81:12
@@ -221,6 +248,7 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `18446744073709551614u64..=std::u64::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u64`
 
 error[E0004]: non-exhaustive patterns: `0u64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:82:12
@@ -229,6 +257,7 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `0u64` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u64`
 
 error[E0004]: non-exhaustive patterns: `std::u64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:83:12
@@ -237,6 +266,7 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `std::u64::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u64`
 
 error[E0004]: non-exhaustive patterns: `43u64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:84:12
@@ -245,6 +275,7 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43u64` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u64`
 
 error[E0004]: non-exhaustive patterns: `43u64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:85:12
@@ -253,6 +284,7 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43u64` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u64`
 
 error[E0004]: non-exhaustive patterns: `std::u128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:93:12
@@ -261,6 +293,7 @@ LL |         m!(0, ..core::u128::MAX);
    |            ^ pattern `std::u128::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u128`
 
 error[E0004]: non-exhaustive patterns: `340282366920938463463374607431768211454u128..=std::u128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:94:12
@@ -269,6 +302,7 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `340282366920938463463374607431768211454u128..=std::u128::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u128`
 
 error[E0004]: non-exhaustive patterns: `0u128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:95:12
@@ -277,6 +311,7 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `0u128` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u128`
 
 error[E0004]: non-exhaustive patterns: `std::u128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:96:12
@@ -285,6 +320,7 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `std::u128::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u128`
 
 error[E0004]: non-exhaustive patterns: `43u128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:97:12
@@ -293,6 +329,7 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43u128` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u128`
 
 error[E0004]: non-exhaustive patterns: `43u128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:98:12
@@ -301,6 +338,7 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43u128` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u128`
 
 error[E0004]: non-exhaustive patterns: `std::i8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:109:12
@@ -309,6 +347,7 @@ LL |         m!(0, ..core::i8::MAX);
    |            ^ pattern `std::i8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i8`
 
 error[E0004]: non-exhaustive patterns: `126i8..=std::i8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:110:12
@@ -317,6 +356,7 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `126i8..=std::i8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i8`
 
 error[E0004]: non-exhaustive patterns: `std::i8::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:111:12
@@ -325,6 +365,7 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `std::i8::MIN` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i8`
 
 error[E0004]: non-exhaustive patterns: `std::i8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:112:12
@@ -333,6 +374,7 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `std::i8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i8`
 
 error[E0004]: non-exhaustive patterns: `43i8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:113:12
@@ -341,6 +383,7 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43i8` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i8`
 
 error[E0004]: non-exhaustive patterns: `43i8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:114:12
@@ -349,6 +392,7 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43i8` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i8`
 
 error[E0004]: non-exhaustive patterns: `std::i16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:122:12
@@ -357,6 +401,7 @@ LL |         m!(0, ..core::i16::MAX);
    |            ^ pattern `std::i16::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i16`
 
 error[E0004]: non-exhaustive patterns: `32766i16..=std::i16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:123:12
@@ -365,6 +410,7 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `32766i16..=std::i16::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i16`
 
 error[E0004]: non-exhaustive patterns: `std::i16::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:124:12
@@ -373,6 +419,7 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `std::i16::MIN` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i16`
 
 error[E0004]: non-exhaustive patterns: `std::i16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:125:12
@@ -381,6 +428,7 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `std::i16::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i16`
 
 error[E0004]: non-exhaustive patterns: `43i16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:126:12
@@ -389,6 +437,7 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43i16` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i16`
 
 error[E0004]: non-exhaustive patterns: `43i16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:127:12
@@ -397,6 +446,7 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43i16` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i16`
 
 error[E0004]: non-exhaustive patterns: `std::i32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:135:12
@@ -405,6 +455,7 @@ LL |         m!(0, ..core::i32::MAX);
    |            ^ pattern `std::i32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i32`
 
 error[E0004]: non-exhaustive patterns: `2147483646i32..=std::i32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:136:12
@@ -413,6 +464,7 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `2147483646i32..=std::i32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i32`
 
 error[E0004]: non-exhaustive patterns: `std::i32::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:137:12
@@ -421,6 +473,7 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `std::i32::MIN` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i32`
 
 error[E0004]: non-exhaustive patterns: `std::i32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:138:12
@@ -429,6 +482,7 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `std::i32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i32`
 
 error[E0004]: non-exhaustive patterns: `43i32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:139:12
@@ -437,6 +491,7 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43i32` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i32`
 
 error[E0004]: non-exhaustive patterns: `43i32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:140:12
@@ -445,6 +500,7 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43i32` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i32`
 
 error[E0004]: non-exhaustive patterns: `std::i64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:148:12
@@ -453,6 +509,7 @@ LL |         m!(0, ..core::i64::MAX);
    |            ^ pattern `std::i64::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i64`
 
 error[E0004]: non-exhaustive patterns: `9223372036854775806i64..=std::i64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:149:12
@@ -461,6 +518,7 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `9223372036854775806i64..=std::i64::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i64`
 
 error[E0004]: non-exhaustive patterns: `std::i64::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:150:12
@@ -469,6 +527,7 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `std::i64::MIN` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i64`
 
 error[E0004]: non-exhaustive patterns: `std::i64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:151:12
@@ -477,6 +536,7 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `std::i64::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i64`
 
 error[E0004]: non-exhaustive patterns: `43i64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:152:12
@@ -485,6 +545,7 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43i64` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i64`
 
 error[E0004]: non-exhaustive patterns: `43i64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:153:12
@@ -493,6 +554,7 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43i64` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i64`
 
 error[E0004]: non-exhaustive patterns: `std::i128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:161:12
@@ -501,6 +563,7 @@ LL |         m!(0, ..core::i128::MAX);
    |            ^ pattern `std::i128::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i128`
 
 error[E0004]: non-exhaustive patterns: `170141183460469231731687303715884105726i128..=std::i128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:162:12
@@ -509,6 +572,7 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `170141183460469231731687303715884105726i128..=std::i128::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i128`
 
 error[E0004]: non-exhaustive patterns: `std::i128::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:163:12
@@ -517,6 +581,7 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `std::i128::MIN` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i128`
 
 error[E0004]: non-exhaustive patterns: `std::i128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:164:12
@@ -525,6 +590,7 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `std::i128::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i128`
 
 error[E0004]: non-exhaustive patterns: `43i128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:165:12
@@ -533,6 +599,7 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43i128` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i128`
 
 error[E0004]: non-exhaustive patterns: `43i128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:166:12
@@ -541,6 +608,7 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43i128` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i128`
 
 error: aborting due to 68 previous errors
 

--- a/src/test/ui/issues/issue-15129.stderr
+++ b/src/test/ui/issues/issue-15129.stderr
@@ -5,6 +5,7 @@ LL |     match (T::T1(()), V::V2(true)) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `(T1(()), V2(_))` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `(T, V)`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-15381.stderr
+++ b/src/test/ui/issues/issue-15381.stderr
@@ -3,6 +3,8 @@ error[E0005]: refutable pattern in `for` loop binding: `&[]`, `&[_]`, `&[_, _]` 
    |
 LL |     for &[x,y,z] in values.chunks(3).filter(|&xs| xs.len() == 3) {
    |         ^^^^^^^^ patterns `&[]`, `&[_]`, `&[_, _]` and 1 more not covered
+   |
+   = note: the matched value is of type `&[u8]`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-2111.stderr
+++ b/src/test/ui/issues/issue-2111.stderr
@@ -5,6 +5,7 @@ LL |   match (a,b) {
    |         ^^^^^ pattern `(None, None)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `(std::option::Option<usize>, std::option::Option<usize>)`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-30240.stderr
+++ b/src/test/ui/issues/issue-30240.stderr
@@ -5,6 +5,7 @@ LL |     match "world" {
    |           ^^^^^^^ pattern `&_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&str`
 
 error[E0004]: non-exhaustive patterns: `&_` not covered
   --> $DIR/issue-30240.rs:6:11
@@ -13,6 +14,7 @@ LL |     match "world" {
    |           ^^^^^^^ pattern `&_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&str`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-3096-1.stderr
+++ b/src/test/ui/issues/issue-3096-1.stderr
@@ -5,6 +5,7 @@ LL |     match () { }
    |           ^^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `()`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-3096-2.stderr
+++ b/src/test/ui/issues/issue-3096-2.stderr
@@ -5,6 +5,7 @@ LL |     match x { }
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `*const Bottom`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-31561.stderr
+++ b/src/test/ui/issues/issue-31561.stderr
@@ -15,6 +15,7 @@ LL |       let Thing::Foo(y) = Thing::Foo(1);
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `Thing`
 help: you might want to use `if let` to ignore the variant that isn't matched
    |
 LL |     if let Thing::Foo(y) = Thing::Foo(1) { /* */ }

--- a/src/test/ui/issues/issue-3601.stderr
+++ b/src/test/ui/issues/issue-3601.stderr
@@ -5,6 +5,7 @@ LL |         box NodeKind::Element(ed) => match ed.kind {
    |                                            ^^^^^^^ pattern `Box(_)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `std::boxed::Box<ElementKind>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-39362.stderr
+++ b/src/test/ui/issues/issue-39362.stderr
@@ -10,6 +10,7 @@ LL |       match f {
    |             ^ patterns `Bar { bar: C, .. }`, `Bar { bar: D, .. }`, `Bar { bar: E, .. }` and 1 more not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `Foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-4321.stderr
+++ b/src/test/ui/issues/issue-4321.stderr
@@ -5,6 +5,7 @@ LL |     println!("foo {:}", match tup {
    |                               ^^^ pattern `(true, false)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `(bool, bool)`
 
 error: aborting due to previous error
 

--- a/src/test/ui/match/issue-50900.stderr
+++ b/src/test/ui/match/issue-50900.stderr
@@ -8,6 +8,7 @@ LL |     match Tag::ExifIFDPointer {
    |           ^^^^^^^^^^^^^^^^^^^ pattern `Tag(Exif, _)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `Tag`
 
 error: aborting due to previous error
 

--- a/src/test/ui/missing/missing-items/issue-40221.stderr
+++ b/src/test/ui/missing/missing-items/issue-40221.stderr
@@ -11,6 +11,7 @@ LL |       match proto {
    |             ^^^^^ pattern `C(QA)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `P`
 
 error: aborting due to previous error
 

--- a/src/test/ui/or-patterns/exhaustiveness-non-exhaustive.stderr
+++ b/src/test/ui/or-patterns/exhaustiveness-non-exhaustive.stderr
@@ -5,6 +5,7 @@ LL |     match (0u8, 0u8) {
    |           ^^^^^^^^^^ pattern `(2u8..=std::u8::MAX, _)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `(u8, u8)`
 
 error[E0004]: non-exhaustive patterns: `((4u8..=std::u8::MAX))` not covered
   --> $DIR/exhaustiveness-non-exhaustive.rs:10:11
@@ -13,6 +14,7 @@ LL |     match ((0u8,),) {
    |           ^^^^^^^^^ pattern `((4u8..=std::u8::MAX))` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `((u8,),)`
 
 error[E0004]: non-exhaustive patterns: `(Some(2u8..=std::u8::MAX))` not covered
   --> $DIR/exhaustiveness-non-exhaustive.rs:14:11
@@ -21,6 +23,7 @@ LL |     match (Some(0u8),) {
    |           ^^^^^^^^^^^^ pattern `(Some(2u8..=std::u8::MAX))` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `(std::option::Option<u8>,)`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/or-patterns/issue-69875-should-have-been-expanded-earlier-non-exhaustive.stderr
+++ b/src/test/ui/or-patterns/issue-69875-should-have-been-expanded-earlier-non-exhaustive.stderr
@@ -6,6 +6,7 @@ LL |     let 0 | (1 | 2) = 0;
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
 help: you might want to use `if let` to ignore the variant that isn't matched
    |
 LL |     if let 0 | (1 | 2) = 0 { /* */ }
@@ -18,6 +19,7 @@ LL |     match 0 {
    |           ^ patterns `std::i32::MIN..=-1i32` and `3i32..=std::i32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i32`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/pattern/usefulness/always-inhabited-union-ref.stderr
+++ b/src/test/ui/pattern/usefulness/always-inhabited-union-ref.stderr
@@ -5,6 +5,7 @@ LL |     match uninhab_ref() {
    |           ^^^^^^^^^^^^^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&!`
 
 error[E0004]: non-exhaustive patterns: type `Foo` is non-empty
   --> $DIR/always-inhabited-union-ref.rs:27:11
@@ -18,6 +19,7 @@ LL |       match uninhab_union() {
    |             ^^^^^^^^^^^^^^^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `Foo`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/pattern/usefulness/exhaustive_integer_patterns.stderr
+++ b/src/test/ui/pattern/usefulness/exhaustive_integer_patterns.stderr
@@ -17,6 +17,7 @@ LL |     match x {
    |           ^ pattern `128u8..=std::u8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `11u8..=19u8`, `31u8..=34u8`, `36u8..=69u8` and 1 more not covered
   --> $DIR/exhaustive_integer_patterns.rs:33:11
@@ -25,6 +26,7 @@ LL |     match x {
    |           ^ patterns `11u8..=19u8`, `31u8..=34u8`, `36u8..=69u8` and 1 more not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u8`
 
 error: unreachable pattern
   --> $DIR/exhaustive_integer_patterns.rs:44:9
@@ -39,6 +41,7 @@ LL |     match x {
    |           ^ patterns `std::i8::MIN..=-8i8`, `-6i8`, `121i8..=124i8` and 1 more not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i8`
 
 error[E0004]: non-exhaustive patterns: `std::i8::MIN` not covered
   --> $DIR/exhaustive_integer_patterns.rs:83:11
@@ -47,6 +50,7 @@ LL |     match 0i8 {
    |           ^^^ pattern `std::i8::MIN` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i8`
 
 error[E0004]: non-exhaustive patterns: `0i16` not covered
   --> $DIR/exhaustive_integer_patterns.rs:91:11
@@ -55,6 +59,7 @@ LL |     match 0i16 {
    |           ^^^^ pattern `0i16` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i16`
 
 error[E0004]: non-exhaustive patterns: `128u8..=std::u8::MAX` not covered
   --> $DIR/exhaustive_integer_patterns.rs:109:11
@@ -63,6 +68,7 @@ LL |     match 0u8 {
    |           ^^^ pattern `128u8..=std::u8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `(0u8, Some(_))` and `(2u8..=std::u8::MAX, Some(_))` not covered
   --> $DIR/exhaustive_integer_patterns.rs:121:11
@@ -71,6 +77,7 @@ LL |     match (0u8, Some(())) {
    |           ^^^^^^^^^^^^^^^ patterns `(0u8, Some(_))` and `(2u8..=std::u8::MAX, Some(_))` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `(u8, std::option::Option<()>)`
 
 error[E0004]: non-exhaustive patterns: `(126u8..=127u8, false)` not covered
   --> $DIR/exhaustive_integer_patterns.rs:126:11
@@ -79,6 +86,7 @@ LL |     match (0u8, true) {
    |           ^^^^^^^^^^^ pattern `(126u8..=127u8, false)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `(u8, bool)`
 
 error: multiple patterns covering the same range
   --> $DIR/exhaustive_integer_patterns.rs:141:9
@@ -101,6 +109,7 @@ LL |     match 0u128 {
    |           ^^^^^ pattern `std::u128::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u128`
 
 error[E0004]: non-exhaustive patterns: `5u128..=std::u128::MAX` not covered
   --> $DIR/exhaustive_integer_patterns.rs:150:11
@@ -109,6 +118,7 @@ LL |     match 0u128 {
    |           ^^^^^ pattern `5u128..=std::u128::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u128`
 
 error[E0004]: non-exhaustive patterns: `0u128..=3u128` not covered
   --> $DIR/exhaustive_integer_patterns.rs:154:11
@@ -117,6 +127,7 @@ LL |     match 0u128 {
    |           ^^^^^ pattern `0u128..=3u128` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u128`
 
 error: unreachable pattern
   --> $DIR/exhaustive_integer_patterns.rs:162:9

--- a/src/test/ui/pattern/usefulness/issue-35609.stderr
+++ b/src/test/ui/pattern/usefulness/issue-35609.stderr
@@ -5,6 +5,7 @@ LL |     match (A, ()) {
    |           ^^^^^^^ patterns `(B, _)`, `(C, _)`, `(D, _)` and 2 more not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `(Enum, ())`
 
 error[E0004]: non-exhaustive patterns: `(_, B)`, `(_, C)`, `(_, D)` and 2 more not covered
   --> $DIR/issue-35609.rs:14:11
@@ -13,6 +14,7 @@ LL |     match (A, A) {
    |           ^^^^^^ patterns `(_, B)`, `(_, C)`, `(_, D)` and 2 more not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `(Enum, Enum)`
 
 error[E0004]: non-exhaustive patterns: `((B, _), _)`, `((C, _), _)`, `((D, _), _)` and 2 more not covered
   --> $DIR/issue-35609.rs:18:11
@@ -21,6 +23,7 @@ LL |     match ((A, ()), ()) {
    |           ^^^^^^^^^^^^^ patterns `((B, _), _)`, `((C, _), _)`, `((D, _), _)` and 2 more not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `((Enum, ()), ())`
 
 error[E0004]: non-exhaustive patterns: `((B, _), _)`, `((C, _), _)`, `((D, _), _)` and 2 more not covered
   --> $DIR/issue-35609.rs:22:11
@@ -29,6 +32,7 @@ LL |     match ((A, ()), A) {
    |           ^^^^^^^^^^^^ patterns `((B, _), _)`, `((C, _), _)`, `((D, _), _)` and 2 more not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `((Enum, ()), Enum)`
 
 error[E0004]: non-exhaustive patterns: `((B, _), _)`, `((C, _), _)`, `((D, _), _)` and 2 more not covered
   --> $DIR/issue-35609.rs:26:11
@@ -37,6 +41,7 @@ LL |     match ((A, ()), ()) {
    |           ^^^^^^^^^^^^^ patterns `((B, _), _)`, `((C, _), _)`, `((D, _), _)` and 2 more not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `((Enum, ()), ())`
 
 error[E0004]: non-exhaustive patterns: `S(B, _)`, `S(C, _)`, `S(D, _)` and 2 more not covered
   --> $DIR/issue-35609.rs:31:11
@@ -48,6 +53,7 @@ LL |     match S(A, ()) {
    |           ^^^^^^^^ patterns `S(B, _)`, `S(C, _)`, `S(D, _)` and 2 more not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `S`
 
 error[E0004]: non-exhaustive patterns: `Sd { x: B, .. }`, `Sd { x: C, .. }`, `Sd { x: D, .. }` and 2 more not covered
   --> $DIR/issue-35609.rs:35:11
@@ -59,6 +65,7 @@ LL |     match (Sd { x: A, y: () }) {
    |           ^^^^^^^^^^^^^^^^^^^^ patterns `Sd { x: B, .. }`, `Sd { x: C, .. }`, `Sd { x: D, .. }` and 2 more not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `Sd`
 
 error[E0004]: non-exhaustive patterns: `Some(B)`, `Some(C)`, `Some(D)` and 2 more not covered
   --> $DIR/issue-35609.rs:39:11
@@ -67,6 +74,7 @@ LL |     match Some(A) {
    |           ^^^^^^^ patterns `Some(B)`, `Some(C)`, `Some(D)` and 2 more not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `std::option::Option<Enum>`
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/pattern/usefulness/match-arm-statics-2.stderr
+++ b/src/test/ui/pattern/usefulness/match-arm-statics-2.stderr
@@ -5,6 +5,7 @@ LL |     match (true, false) {
    |           ^^^^^^^^^^^^^ pattern `(true, false)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `(bool, bool)`
 
 error[E0004]: non-exhaustive patterns: `Some(Some(West))` not covered
   --> $DIR/match-arm-statics-2.rs:34:11
@@ -21,6 +22,7 @@ LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
    |     not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `std::option::Option<std::option::Option<Direction>>`
 
 error[E0004]: non-exhaustive patterns: `Foo { bar: Some(North), baz: NewBool(true) }` not covered
   --> $DIR/match-arm-statics-2.rs:53:11
@@ -35,6 +37,7 @@ LL |       match (Foo { bar: Some(North), baz: NewBool(true) }) {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `Foo { bar: Some(North), baz: NewBool(true) }` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `Foo`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/pattern/usefulness/match-byte-array-patterns-2.stderr
+++ b/src/test/ui/pattern/usefulness/match-byte-array-patterns-2.stderr
@@ -5,6 +5,7 @@ LL |     match buf {
    |           ^^^ patterns `&[0u8..=64u8, _, _, _]` and `&[66u8..=std::u8::MAX, _, _, _]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[u8; 4]`
 
 error[E0004]: non-exhaustive patterns: `&[]`, `&[_]`, `&[_, _]` and 2 more not covered
   --> $DIR/match-byte-array-patterns-2.rs:10:11
@@ -13,6 +14,7 @@ LL |     match buf {
    |           ^^^ patterns `&[]`, `&[_]`, `&[_, _]` and 2 more not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[u8]`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/pattern/usefulness/match-empty-exhaustive_patterns.stderr
+++ b/src/test/ui/pattern/usefulness/match-empty-exhaustive_patterns.stderr
@@ -35,6 +35,7 @@ LL |     match_empty!(0u8);
    |                  ^^^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyStruct` is non-empty
   --> $DIR/match-empty-exhaustive_patterns.rs:66:18
@@ -46,6 +47,7 @@ LL |     match_empty!(NonEmptyStruct(true));
    |                  ^^^^^^^^^^^^^^^^^^^^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyStruct`
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion1` is non-empty
   --> $DIR/match-empty-exhaustive_patterns.rs:68:18
@@ -59,6 +61,7 @@ LL |       match_empty!((NonEmptyUnion1 { foo: () }));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyUnion1`
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion2` is non-empty
   --> $DIR/match-empty-exhaustive_patterns.rs:70:18
@@ -73,6 +76,7 @@ LL |       match_empty!((NonEmptyUnion2 { foo: () }));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyUnion2`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` not covered
   --> $DIR/match-empty-exhaustive_patterns.rs:72:18
@@ -89,6 +93,7 @@ LL |       match_empty!(NonEmptyEnum1::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `Foo(_)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyEnum1`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` and `Bar` not covered
   --> $DIR/match-empty-exhaustive_patterns.rs:74:18
@@ -109,6 +114,7 @@ LL |       match_empty!(NonEmptyEnum2::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `Foo(_)` and `Bar` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyEnum2`
 
 error[E0004]: non-exhaustive patterns: `V1`, `V2`, `V3` and 2 more not covered
   --> $DIR/match-empty-exhaustive_patterns.rs:76:18
@@ -122,6 +128,7 @@ LL |       match_empty!(NonEmptyEnum5::V1);
    |                    ^^^^^^^^^^^^^^^^^ patterns `V1`, `V2`, `V3` and 2 more not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyEnum5`
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/match-empty-exhaustive_patterns.rs:79:18
@@ -130,6 +137,7 @@ LL |     match_false!(0u8);
    |                  ^^^ pattern `_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct(_)` not covered
   --> $DIR/match-empty-exhaustive_patterns.rs:81:18
@@ -141,6 +149,7 @@ LL |     match_false!(NonEmptyStruct(true));
    |                  ^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyStruct(_)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyStruct`
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion1 { .. }` not covered
   --> $DIR/match-empty-exhaustive_patterns.rs:83:18
@@ -154,6 +163,7 @@ LL |       match_false!((NonEmptyUnion1 { foo: () }));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyUnion1 { .. }` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyUnion1`
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion2 { .. }` not covered
   --> $DIR/match-empty-exhaustive_patterns.rs:85:18
@@ -168,6 +178,7 @@ LL |       match_false!((NonEmptyUnion2 { foo: () }));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyUnion2 { .. }` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyUnion2`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` not covered
   --> $DIR/match-empty-exhaustive_patterns.rs:87:18
@@ -184,6 +195,7 @@ LL |       match_false!(NonEmptyEnum1::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `Foo(_)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyEnum1`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` and `Bar` not covered
   --> $DIR/match-empty-exhaustive_patterns.rs:89:18
@@ -204,6 +216,7 @@ LL |       match_false!(NonEmptyEnum2::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `Foo(_)` and `Bar` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyEnum2`
 
 error[E0004]: non-exhaustive patterns: `V1`, `V2`, `V3` and 2 more not covered
   --> $DIR/match-empty-exhaustive_patterns.rs:91:18
@@ -217,6 +230,7 @@ LL |       match_false!(NonEmptyEnum5::V1);
    |                    ^^^^^^^^^^^^^^^^^ patterns `V1`, `V2`, `V3` and 2 more not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyEnum5`
 
 error: aborting due to 18 previous errors
 

--- a/src/test/ui/pattern/usefulness/match-empty.stderr
+++ b/src/test/ui/pattern/usefulness/match-empty.stderr
@@ -8,6 +8,7 @@ LL |     match_false!(x); // Not detected as unreachable nor exhaustive.
    |                  ^ pattern `_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `Foo`
 
 error[E0004]: non-exhaustive patterns: type `u8` is non-empty
   --> $DIR/match-empty.rs:63:18
@@ -16,6 +17,7 @@ LL |     match_empty!(0u8);
    |                  ^^^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyStruct` is non-empty
   --> $DIR/match-empty.rs:65:18
@@ -27,6 +29,7 @@ LL |     match_empty!(NonEmptyStruct(true));
    |                  ^^^^^^^^^^^^^^^^^^^^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyStruct`
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion1` is non-empty
   --> $DIR/match-empty.rs:67:18
@@ -40,6 +43,7 @@ LL |       match_empty!((NonEmptyUnion1 { foo: () }));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyUnion1`
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion2` is non-empty
   --> $DIR/match-empty.rs:69:18
@@ -54,6 +58,7 @@ LL |       match_empty!((NonEmptyUnion2 { foo: () }));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyUnion2`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` not covered
   --> $DIR/match-empty.rs:71:18
@@ -70,6 +75,7 @@ LL |       match_empty!(NonEmptyEnum1::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `Foo(_)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyEnum1`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` and `Bar` not covered
   --> $DIR/match-empty.rs:73:18
@@ -90,6 +96,7 @@ LL |       match_empty!(NonEmptyEnum2::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `Foo(_)` and `Bar` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyEnum2`
 
 error[E0004]: non-exhaustive patterns: `V1`, `V2`, `V3` and 2 more not covered
   --> $DIR/match-empty.rs:75:18
@@ -103,6 +110,7 @@ LL |       match_empty!(NonEmptyEnum5::V1);
    |                    ^^^^^^^^^^^^^^^^^ patterns `V1`, `V2`, `V3` and 2 more not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyEnum5`
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/match-empty.rs:78:18
@@ -111,6 +119,7 @@ LL |     match_false!(0u8);
    |                  ^^^ pattern `_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct(_)` not covered
   --> $DIR/match-empty.rs:80:18
@@ -122,6 +131,7 @@ LL |     match_false!(NonEmptyStruct(true));
    |                  ^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyStruct(_)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyStruct`
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion1 { .. }` not covered
   --> $DIR/match-empty.rs:82:18
@@ -135,6 +145,7 @@ LL |       match_false!((NonEmptyUnion1 { foo: () }));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyUnion1 { .. }` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyUnion1`
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion2 { .. }` not covered
   --> $DIR/match-empty.rs:84:18
@@ -149,6 +160,7 @@ LL |       match_false!((NonEmptyUnion2 { foo: () }));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyUnion2 { .. }` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyUnion2`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` not covered
   --> $DIR/match-empty.rs:86:18
@@ -165,6 +177,7 @@ LL |       match_false!(NonEmptyEnum1::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `Foo(_)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyEnum1`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` and `Bar` not covered
   --> $DIR/match-empty.rs:88:18
@@ -185,6 +198,7 @@ LL |       match_false!(NonEmptyEnum2::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `Foo(_)` and `Bar` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyEnum2`
 
 error[E0004]: non-exhaustive patterns: `V1`, `V2`, `V3` and 2 more not covered
   --> $DIR/match-empty.rs:90:18
@@ -198,6 +212,7 @@ LL |       match_false!(NonEmptyEnum5::V1);
    |                    ^^^^^^^^^^^^^^^^^ patterns `V1`, `V2`, `V3` and 2 more not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonEmptyEnum5`
 
 error: aborting due to 15 previous errors
 

--- a/src/test/ui/pattern/usefulness/match-non-exhaustive.stderr
+++ b/src/test/ui/pattern/usefulness/match-non-exhaustive.stderr
@@ -5,6 +5,7 @@ LL |     match 0 { 1 => () }
    |           ^ patterns `std::i32::MIN..=0i32` and `2i32..=std::i32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i32`
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/match-non-exhaustive.rs:3:11
@@ -13,6 +14,7 @@ LL |     match 0 { 0 if false => () }
    |           ^ pattern `_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `i32`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/pattern/usefulness/match-privately-empty.stderr
+++ b/src/test/ui/pattern/usefulness/match-privately-empty.stderr
@@ -10,6 +10,7 @@ LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
    |     ---- not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `std::option::Option<private::Private>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/pattern/usefulness/match-slice-patterns.stderr
+++ b/src/test/ui/pattern/usefulness/match-slice-patterns.stderr
@@ -5,6 +5,7 @@ LL |     match list {
    |           ^^^^ pattern `&[_, Some(_), .., None, _]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[std::option::Option<()>]`
 
 error: aborting due to previous error
 

--- a/src/test/ui/pattern/usefulness/non-exhaustive-defined-here.stderr
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-defined-here.stderr
@@ -20,6 +20,7 @@ LL |       match e1 {
    |             ^^ patterns `B` and `C` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `E`
 
 error[E0005]: refutable pattern in local binding: `B` and `C` not covered
   --> $DIR/non-exhaustive-defined-here.rs:36:9
@@ -44,6 +45,7 @@ LL |       let E::A = e;
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `E`
 help: you might want to use `if let` to ignore the variant that isn't matched
    |
 LL |     if let E::A = e { /* */ }
@@ -71,6 +73,7 @@ LL |       match e {
    |             ^ patterns `&B` and `&C` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&E`
 
 error[E0005]: refutable pattern in local binding: `&B` and `&C` not covered
   --> $DIR/non-exhaustive-defined-here.rs:44:9
@@ -95,6 +98,7 @@ LL |       let E::A = e;
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `&E`
 help: you might want to use `if let` to ignore the variant that isn't matched
    |
 LL |     if let E::A = e { /* */ }
@@ -122,6 +126,7 @@ LL |       match e {
    |             ^ patterns `&&mut &B` and `&&mut &C` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&&mut &E`
 
 error[E0005]: refutable pattern in local binding: `&&mut &B` and `&&mut &C` not covered
   --> $DIR/non-exhaustive-defined-here.rs:52:9
@@ -146,6 +151,7 @@ LL |       let E::A = e;
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `&&mut &E`
 help: you might want to use `if let` to ignore the variant that isn't matched
    |
 LL |     if let E::A = e { /* */ }
@@ -168,6 +174,7 @@ LL |       match e {
    |             ^ pattern `None` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `Opt`
 
 error[E0005]: refutable pattern in local binding: `None` not covered
   --> $DIR/non-exhaustive-defined-here.rs:69:9
@@ -187,6 +194,7 @@ LL |       let Opt::Some(ref _x) = e;
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `Opt`
 help: you might want to use `if let` to ignore the variant that isn't matched
    |
 LL |     if let Opt::Some(ref _x) = e { /* */ }

--- a/src/test/ui/pattern/usefulness/non-exhaustive-float-range-match.stderr
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-float-range-match.stderr
@@ -5,6 +5,7 @@ LL |     match 0.0 {
    |           ^^^ pattern `_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `f64`
 
 error: aborting due to previous error
 

--- a/src/test/ui/pattern/usefulness/non-exhaustive-match-nested.stderr
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-match-nested.stderr
@@ -5,6 +5,7 @@ LL |     match (l1, l2) {
    |           ^^^^^^^^ pattern `(Some(&[]), Err(_))` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `(std::option::Option<&[T]>, std::result::Result<&[T], ()>)`
 
 error[E0004]: non-exhaustive patterns: `A(C)` not covered
   --> $DIR/non-exhaustive-match-nested.rs:15:11
@@ -19,6 +20,7 @@ LL |     match x {
    |           ^ pattern `A(C)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `T`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/pattern/usefulness/non-exhaustive-match.stderr
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-match.stderr
@@ -11,6 +11,7 @@ LL |     match x { T::B => { } }
    |           ^ pattern `A` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `T`
 
 error[E0004]: non-exhaustive patterns: `false` not covered
   --> $DIR/non-exhaustive-match.rs:13:11
@@ -19,6 +20,7 @@ LL |     match true {
    |           ^^^^ pattern `false` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `bool`
 
 error[E0004]: non-exhaustive patterns: `Some(_)` not covered
   --> $DIR/non-exhaustive-match.rs:16:11
@@ -32,6 +34,7 @@ LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
    |     ---- not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `std::option::Option<i32>`
 
 error[E0004]: non-exhaustive patterns: `(_, _, std::i32::MIN..=3i32)` and `(_, _, 5i32..=std::i32::MAX)` not covered
   --> $DIR/non-exhaustive-match.rs:19:11
@@ -40,6 +43,7 @@ LL |     match (2, 3, 4) {
    |           ^^^^^^^^^ patterns `(_, _, std::i32::MIN..=3i32)` and `(_, _, 5i32..=std::i32::MAX)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `(i32, i32, i32)`
 
 error[E0004]: non-exhaustive patterns: `(A, A)` not covered
   --> $DIR/non-exhaustive-match.rs:23:11
@@ -48,6 +52,7 @@ LL |     match (T::A, T::A) {
    |           ^^^^^^^^^^^^ pattern `(A, A)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `(T, T)`
 
 error[E0004]: non-exhaustive patterns: `B` not covered
   --> $DIR/non-exhaustive-match.rs:27:11
@@ -62,6 +67,7 @@ LL |     match T::A {
    |           ^^^^ pattern `B` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `T`
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
   --> $DIR/non-exhaustive-match.rs:38:11
@@ -70,6 +76,7 @@ LL |     match *vec {
    |           ^^^^ pattern `[]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `[std::option::Option<isize>]`
 
 error[E0004]: non-exhaustive patterns: `[_, _, _, _, ..]` not covered
   --> $DIR/non-exhaustive-match.rs:51:11
@@ -78,6 +85,7 @@ LL |     match *vec {
    |           ^^^^ pattern `[_, _, _, _, ..]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `[f32]`
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/pattern/usefulness/non-exhaustive-pattern-witness.stderr
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-pattern-witness.stderr
@@ -11,6 +11,7 @@ LL |       match (Foo { first: true, second: None }) {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `Foo { first: false, second: Some([_, _, _, _]) }` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `Foo`
 
 error[E0004]: non-exhaustive patterns: `Red` not covered
   --> $DIR/non-exhaustive-pattern-witness.rs:23:11
@@ -27,6 +28,7 @@ LL |       match Color::Red {
    |             ^^^^^^^^^^ pattern `Red` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `Color`
 
 error[E0004]: non-exhaustive patterns: `East`, `South` and `West` not covered
   --> $DIR/non-exhaustive-pattern-witness.rs:35:11
@@ -44,6 +46,7 @@ LL |       match Direction::North {
    |             ^^^^^^^^^^^^^^^^ patterns `East`, `South` and `West` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `Direction`
 
 error[E0004]: non-exhaustive patterns: `Second`, `Third`, `Fourth` and 8 more not covered
   --> $DIR/non-exhaustive-pattern-witness.rs:46:11
@@ -57,6 +60,7 @@ LL |       match ExcessiveEnum::First {
    |             ^^^^^^^^^^^^^^^^^^^^ patterns `Second`, `Third`, `Fourth` and 8 more not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `ExcessiveEnum`
 
 error[E0004]: non-exhaustive patterns: `CustomRGBA { a: true, .. }` not covered
   --> $DIR/non-exhaustive-pattern-witness.rs:54:11
@@ -73,6 +77,7 @@ LL |       match Color::Red {
    |             ^^^^^^^^^^ pattern `CustomRGBA { a: true, .. }` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `Color`
 
 error[E0004]: non-exhaustive patterns: `[Second(true), Second(false)]` not covered
   --> $DIR/non-exhaustive-pattern-witness.rs:70:11
@@ -81,6 +86,7 @@ LL |     match *x {
    |           ^^ pattern `[Second(true), Second(false)]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `[Enum]`
 
 error[E0004]: non-exhaustive patterns: `((), false)` not covered
   --> $DIR/non-exhaustive-pattern-witness.rs:83:11
@@ -89,6 +95,7 @@ LL |     match ((), false) {
    |           ^^^^^^^^^^^ pattern `((), false)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `((), bool)`
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/pattern/usefulness/refutable-pattern-errors.stderr
+++ b/src/test/ui/pattern/usefulness/refutable-pattern-errors.stderr
@@ -3,6 +3,8 @@ error[E0005]: refutable pattern in function argument: `(_, _)` not covered
    |
 LL | fn func((1, (Some(1), 2..=3)): (isize, (Option<isize>, isize))) { }
    |         ^^^^^^^^^^^^^^^^^^^^^ pattern `(_, _)` not covered
+   |
+   = note: the matched value is of type `(isize, (std::option::Option<isize>, isize))`
 
 error[E0005]: refutable pattern in local binding: `(std::i32::MIN..=0i32, _)` and `(2i32..=std::i32::MAX, _)` not covered
   --> $DIR/refutable-pattern-errors.rs:7:9
@@ -12,6 +14,7 @@ LL |     let (1, (Some(1), 2..=3)) = (1, (None, 2));
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `(i32, (std::option::Option<i32>, i32))`
 help: you might want to use `if let` to ignore the variant that isn't matched
    |
 LL |     if let (1, (Some(1), 2..=3)) = (1, (None, 2)) { /* */ }

--- a/src/test/ui/pattern/usefulness/refutable-pattern-in-fn-arg.stderr
+++ b/src/test/ui/pattern/usefulness/refutable-pattern-in-fn-arg.stderr
@@ -3,6 +3,8 @@ error[E0005]: refutable pattern in function argument: `_` not covered
    |
 LL |     let f = |3: isize| println!("hello");
    |              ^ pattern `_` not covered
+   |
+   = note: the matched value is of type `isize`
 
 error: aborting due to previous error
 

--- a/src/test/ui/pattern/usefulness/slice-patterns-exhaustiveness.stderr
+++ b/src/test/ui/pattern/usefulness/slice-patterns-exhaustiveness.stderr
@@ -5,6 +5,7 @@ LL |     match s2 {
    |           ^^ pattern `&[false, _]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[bool; 2]`
 
 error[E0004]: non-exhaustive patterns: `&[false, ..]` not covered
   --> $DIR/slice-patterns-exhaustiveness.rs:12:11
@@ -13,6 +14,7 @@ LL |     match s3 {
    |           ^^ pattern `&[false, ..]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[bool; 3]`
 
 error[E0004]: non-exhaustive patterns: `&[false, ..]` not covered
   --> $DIR/slice-patterns-exhaustiveness.rs:16:11
@@ -21,6 +23,7 @@ LL |     match s10 {
    |           ^^^ pattern `&[false, ..]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[bool; 10]`
 
 error[E0004]: non-exhaustive patterns: `&[false, true]` not covered
   --> $DIR/slice-patterns-exhaustiveness.rs:25:11
@@ -29,6 +32,7 @@ LL |     match s2 {
    |           ^^ pattern `&[false, true]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[bool; 2]`
 
 error[E0004]: non-exhaustive patterns: `&[false, .., true]` not covered
   --> $DIR/slice-patterns-exhaustiveness.rs:30:11
@@ -37,6 +41,7 @@ LL |     match s3 {
    |           ^^ pattern `&[false, .., true]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[bool; 3]`
 
 error[E0004]: non-exhaustive patterns: `&[false, .., true]` not covered
   --> $DIR/slice-patterns-exhaustiveness.rs:35:11
@@ -45,6 +50,7 @@ LL |     match s {
    |           ^ pattern `&[false, .., true]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[bool]`
 
 error[E0004]: non-exhaustive patterns: `&[_, ..]` not covered
   --> $DIR/slice-patterns-exhaustiveness.rs:42:11
@@ -53,6 +59,7 @@ LL |     match s {
    |           ^ pattern `&[_, ..]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[bool]`
 
 error[E0004]: non-exhaustive patterns: `&[_, _, ..]` not covered
   --> $DIR/slice-patterns-exhaustiveness.rs:46:11
@@ -61,6 +68,7 @@ LL |     match s {
    |           ^ pattern `&[_, _, ..]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[bool]`
 
 error[E0004]: non-exhaustive patterns: `&[false, ..]` not covered
   --> $DIR/slice-patterns-exhaustiveness.rs:51:11
@@ -69,6 +77,7 @@ LL |     match s {
    |           ^ pattern `&[false, ..]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[bool]`
 
 error[E0004]: non-exhaustive patterns: `&[false, _, ..]` not covered
   --> $DIR/slice-patterns-exhaustiveness.rs:56:11
@@ -77,6 +86,7 @@ LL |     match s {
    |           ^ pattern `&[false, _, ..]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[bool]`
 
 error[E0004]: non-exhaustive patterns: `&[_, .., false]` not covered
   --> $DIR/slice-patterns-exhaustiveness.rs:62:11
@@ -85,6 +95,7 @@ LL |     match s {
    |           ^ pattern `&[_, .., false]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[bool]`
 
 error[E0004]: non-exhaustive patterns: `&[_, _, .., true]` not covered
   --> $DIR/slice-patterns-exhaustiveness.rs:69:11
@@ -93,6 +104,7 @@ LL |     match s {
    |           ^ pattern `&[_, _, .., true]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[bool]`
 
 error[E0004]: non-exhaustive patterns: `&[true, _, .., _]` not covered
   --> $DIR/slice-patterns-exhaustiveness.rs:76:11
@@ -101,6 +113,7 @@ LL |     match s {
    |           ^ pattern `&[true, _, .., _]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[bool]`
 
 error[E0004]: non-exhaustive patterns: `&[..]` not covered
   --> $DIR/slice-patterns-exhaustiveness.rs:85:11
@@ -109,6 +122,7 @@ LL |     match s {
    |           ^ pattern `&[..]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[bool]`
 
 error[E0004]: non-exhaustive patterns: `&[true]` not covered
   --> $DIR/slice-patterns-exhaustiveness.rs:89:11
@@ -117,6 +131,7 @@ LL |     match s {
    |           ^ pattern `&[true]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[bool]`
 
 error[E0004]: non-exhaustive patterns: `&[false]` not covered
   --> $DIR/slice-patterns-exhaustiveness.rs:97:11
@@ -125,6 +140,7 @@ LL |     match s1 {
    |           ^^ pattern `&[false]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[bool; 1]`
 
 error: aborting due to 16 previous errors
 

--- a/src/test/ui/pattern/usefulness/struct-like-enum-nonexhaustive.stderr
+++ b/src/test/ui/pattern/usefulness/struct-like-enum-nonexhaustive.stderr
@@ -12,6 +12,7 @@ LL |       match x {
    |             ^ pattern `B { x: Some(_) }` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `A`
 
 error: aborting due to previous error
 

--- a/src/test/ui/pattern/usefulness/tuple-struct-nonexhaustive.stderr
+++ b/src/test/ui/pattern/usefulness/tuple-struct-nonexhaustive.stderr
@@ -8,6 +8,7 @@ LL |     match x {
    |           ^ pattern `Foo(_, _)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `Foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/precise_pointer_size_matching.stderr
+++ b/src/test/ui/precise_pointer_size_matching.stderr
@@ -5,6 +5,7 @@ LL |     match 0isize {
    |           ^^^^^^ patterns `std::isize::MIN..=-6isize` and `21isize..=std::isize::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `isize`
 
 error[E0004]: non-exhaustive patterns: `0usize` and `21usize..=std::usize::MAX` not covered
   --> $DIR/precise_pointer_size_matching.rs:29:11
@@ -13,6 +14,7 @@ LL |     match 0usize {
    |           ^^^^^^ patterns `0usize` and `21usize..=std::usize::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `usize`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/recursion/recursive-types-are-not-uninhabited.stderr
+++ b/src/test/ui/recursion/recursive-types-are-not-uninhabited.stderr
@@ -11,6 +11,7 @@ LL |     Err(#[stable(feature = "rust1", since = "1.0.0")] E),
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `std::result::Result<u32, &R>`
 help: you might want to use `if let` to ignore the variant that isn't matched
    |
 LL |     if let Ok(x) = res { /* */ }

--- a/src/test/ui/rfc-2005-default-binding-mode/slice.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/slice.stderr
@@ -5,6 +5,7 @@ LL |     match sl {
    |           ^^ pattern `&[]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[u8]`
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2008-non-exhaustive/enum.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/enum.stderr
@@ -5,6 +5,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `enums::EmptyNonExhaustiveEnum`
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/enum.rs:16:11
@@ -13,6 +14,7 @@ LL |     match enum_unit {
    |           ^^^^^^^^^ pattern `_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `enums::NonExhaustiveEnum`
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/enum.rs:23:11
@@ -21,6 +23,7 @@ LL |     match enum_unit {};
    |           ^^^^^^^^^ pattern `_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `enums::NonExhaustiveEnum`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
@@ -18,6 +18,7 @@ LL |       match NonExhaustiveEnum::Unit {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^ patterns `Unit`, `Tuple(_)` and `Struct { .. }` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NonExhaustiveEnum`
 
 error[E0004]: non-exhaustive patterns: `Unit`, `Tuple(_)` and `Struct { .. }` not covered
   --> $DIR/enum_same_crate_empty_match.rs:35:11
@@ -39,6 +40,7 @@ LL |       match NormalEnum::Unit {}
    |             ^^^^^^^^^^^^^^^^ patterns `Unit`, `Tuple(_)` and `Struct { .. }` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `NormalEnum`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match.stderr
@@ -5,6 +5,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `uninhabited::IndirectUninhabitedEnum`
 
 error[E0004]: non-exhaustive patterns: type `uninhabited::IndirectUninhabitedStruct` is non-empty
   --> $DIR/indirect_match.rs:23:11
@@ -13,6 +14,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `uninhabited::IndirectUninhabitedStruct`
 
 error[E0004]: non-exhaustive patterns: type `uninhabited::IndirectUninhabitedTupleStruct` is non-empty
   --> $DIR/indirect_match.rs:27:11
@@ -21,6 +23,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `uninhabited::IndirectUninhabitedTupleStruct`
 
 error[E0004]: non-exhaustive patterns: type `uninhabited::IndirectUninhabitedVariants` is non-empty
   --> $DIR/indirect_match.rs:33:11
@@ -29,6 +32,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `uninhabited::IndirectUninhabitedVariants`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match_same_crate.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match_same_crate.stderr
@@ -8,6 +8,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `IndirectUninhabitedEnum`
 
 error[E0004]: non-exhaustive patterns: type `IndirectUninhabitedStruct` is non-empty
   --> $DIR/indirect_match_same_crate.rs:38:11
@@ -19,6 +20,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `IndirectUninhabitedStruct`
 
 error[E0004]: non-exhaustive patterns: type `IndirectUninhabitedTupleStruct` is non-empty
   --> $DIR/indirect_match_same_crate.rs:42:11
@@ -30,6 +32,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `IndirectUninhabitedTupleStruct`
 
 error[E0004]: non-exhaustive patterns: type `IndirectUninhabitedVariants` is non-empty
   --> $DIR/indirect_match_same_crate.rs:48:11
@@ -41,6 +44,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `IndirectUninhabitedVariants`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match_with_exhaustive_patterns.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/indirect_match_with_exhaustive_patterns.stderr
@@ -5,6 +5,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `uninhabited::IndirectUninhabitedEnum`
 
 error[E0004]: non-exhaustive patterns: type `uninhabited::IndirectUninhabitedStruct` is non-empty
   --> $DIR/indirect_match_with_exhaustive_patterns.rs:27:11
@@ -13,6 +14,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `uninhabited::IndirectUninhabitedStruct`
 
 error[E0004]: non-exhaustive patterns: type `uninhabited::IndirectUninhabitedTupleStruct` is non-empty
   --> $DIR/indirect_match_with_exhaustive_patterns.rs:31:11
@@ -21,6 +23,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `uninhabited::IndirectUninhabitedTupleStruct`
 
 error[E0004]: non-exhaustive patterns: type `uninhabited::IndirectUninhabitedVariants` is non-empty
   --> $DIR/indirect_match_with_exhaustive_patterns.rs:37:11
@@ -29,6 +32,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `uninhabited::IndirectUninhabitedVariants`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match.stderr
@@ -5,6 +5,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `uninhabited::UninhabitedEnum`
 
 error[E0004]: non-exhaustive patterns: type `uninhabited::UninhabitedStruct` is non-empty
   --> $DIR/match.rs:23:11
@@ -13,6 +14,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `uninhabited::UninhabitedStruct`
 
 error[E0004]: non-exhaustive patterns: type `uninhabited::UninhabitedTupleStruct` is non-empty
   --> $DIR/match.rs:27:11
@@ -21,6 +23,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `uninhabited::UninhabitedTupleStruct`
 
 error[E0004]: non-exhaustive patterns: `Tuple(_)` and `Struct { .. }` not covered
   --> $DIR/match.rs:31:11
@@ -36,6 +39,7 @@ LL |     #[non_exhaustive] Struct { x: ! }
    |                       ------ not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `uninhabited::UninhabitedVariants`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_same_crate.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_same_crate.stderr
@@ -10,6 +10,7 @@ LL |       match x {}
    |             ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `UninhabitedStruct`
 
 error[E0004]: non-exhaustive patterns: type `UninhabitedTupleStruct` is non-empty
   --> $DIR/match_same_crate.rs:34:11
@@ -21,6 +22,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `UninhabitedTupleStruct`
 
 error[E0004]: non-exhaustive patterns: `Tuple(_)` and `Struct { .. }` not covered
   --> $DIR/match_same_crate.rs:38:11
@@ -37,6 +39,7 @@ LL |       match x {}
    |             ^ patterns `Tuple(_)` and `Struct { .. }` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `UninhabitedVariants`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns.stderr
@@ -5,6 +5,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `uninhabited::UninhabitedEnum`
 
 error[E0004]: non-exhaustive patterns: type `uninhabited::UninhabitedStruct` is non-empty
   --> $DIR/match_with_exhaustive_patterns.rs:26:11
@@ -13,6 +14,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `uninhabited::UninhabitedStruct`
 
 error[E0004]: non-exhaustive patterns: type `uninhabited::UninhabitedTupleStruct` is non-empty
   --> $DIR/match_with_exhaustive_patterns.rs:30:11
@@ -21,6 +23,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `uninhabited::UninhabitedTupleStruct`
 
 error[E0004]: non-exhaustive patterns: `Tuple(_)` and `Struct { .. }` not covered
   --> $DIR/match_with_exhaustive_patterns.rs:34:11
@@ -36,6 +39,7 @@ LL |     #[non_exhaustive] Struct { x: ! }
    |                       ------ not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `uninhabited::UninhabitedVariants`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/suggestions/const-pat-non-exaustive-let-new-var.stderr
+++ b/src/test/ui/suggestions/const-pat-non-exaustive-let-new-var.stderr
@@ -9,6 +9,8 @@ LL |     let A = 3;
 ...
 LL |     const A: i32 = 2;
    |     ----------------- constant defined here
+   |
+   = note: the matched value is of type `i32`
 
 error: aborting due to previous error
 

--- a/src/test/ui/uninhabited/uninhabited-irrefutable.stderr
+++ b/src/test/ui/uninhabited/uninhabited-irrefutable.stderr
@@ -15,6 +15,7 @@ LL |       let Foo::D(_y) = x;
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `Foo`
 help: you might want to use `if let` to ignore the variant that isn't matched
    |
 LL |     if let Foo::D(_y) = x { /* */ }

--- a/src/test/ui/uninhabited/uninhabited-matches-feature-gated.stderr
+++ b/src/test/ui/uninhabited/uninhabited-matches-feature-gated.stderr
@@ -10,6 +10,7 @@ LL |     Err(#[stable(feature = "rust1", since = "1.0.0")] E),
    |     --- not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `std::result::Result<u32, &Void>`
 
 error[E0004]: non-exhaustive patterns: type `&Void` is non-empty
   --> $DIR/uninhabited-matches-feature-gated.rs:20:19
@@ -21,6 +22,7 @@ LL |     let _ = match x {};
    |                   ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&Void`
 
 error[E0004]: non-exhaustive patterns: type `(Void,)` is non-empty
   --> $DIR/uninhabited-matches-feature-gated.rs:23:19
@@ -29,6 +31,7 @@ LL |     let _ = match x {};
    |                   ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `(Void,)`
 
 error[E0004]: non-exhaustive patterns: type `[Void; 1]` is non-empty
   --> $DIR/uninhabited-matches-feature-gated.rs:26:19
@@ -37,6 +40,7 @@ LL |     let _ = match x {};
    |                   ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `[Void; 1]`
 
 error[E0004]: non-exhaustive patterns: `&[_, ..]` not covered
   --> $DIR/uninhabited-matches-feature-gated.rs:29:19
@@ -45,6 +49,7 @@ LL |     let _ = match x {
    |                   ^ pattern `&[_, ..]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[Void]`
 
 error[E0004]: non-exhaustive patterns: `Err(_)` not covered
   --> $DIR/uninhabited-matches-feature-gated.rs:37:19
@@ -58,6 +63,7 @@ LL |     Err(#[stable(feature = "rust1", since = "1.0.0")] E),
    |     --- not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `std::result::Result<u32, Void>`
 
 error[E0005]: refutable pattern in local binding: `Err(_)` not covered
   --> $DIR/uninhabited-matches-feature-gated.rs:42:9
@@ -72,6 +78,7 @@ LL |     Err(#[stable(feature = "rust1", since = "1.0.0")] E),
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `std::result::Result<u32, Void>`
 help: you might want to use `if let` to ignore the variant that isn't matched
    |
 LL |     if let Ok(x) = x { /* */ }


### PR DESCRIPTION
This fixes https://github.com/rust-lang/rust/issues/67259 by adding a note:
```
    = note: the matched value is of type &[i32] 
```
to non-exhaustive pattern matching errors.

r? @varkor @estebank 