### PR TITLE
[HACK] metadata/rmeta: skip sorting impls by `DefPathHash`es.

### DIFF
--- a/src/librustc_metadata/rmeta/encoder.rs
+++ b/src/librustc_metadata/rmeta/encoder.rs
@@ -1450,16 +1450,9 @@ impl EncodeContext<'tcx> {
 
         let all_impls: Vec<_> = all_impls
             .into_iter()
-            .map(|(trait_def_id, mut impls)| {
-                // Bring everything into deterministic order for hashing
-                impls.sort_by_cached_key(|&index| {
-                    tcx.hir().definitions().def_path_hash(LocalDefId { local_def_index: index })
-                });
-
-                TraitImpls {
-                    trait_id: (trait_def_id.krate.as_u32(), trait_def_id.index),
-                    impls: self.lazy(&impls),
-                }
+            .map(|(trait_def_id, impls)| TraitImpls {
+                trait_id: (trait_def_id.krate.as_u32(), trait_def_id.index),
+                impls: self.lazy(&impls),
             })
             .collect();
 


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/69060#issuecomment-604914176 for some background.

I'm mostly opening this to do some experimentation (which will require multiple perf runs using the same base, so I'll probably start try builds in parallel using a second PR).

I'd prefer the solution described in https://github.com/rust-lang/rust/issues/69060#issuecomment-604928032, as it should result in better accuracy as well, but that's more work than this quick hack, at least for testing purposes.

cc @nikomatsakis @michaelwoerister @Mark-Simulacrum 