### PR TITLE
avoid creating unnecessary reference in Windows Env iterator

### DIFF
--- a/src/libstd/sys/windows/os.rs
+++ b/src/libstd/sys/windows/os.rs
@@ -94,7 +94,7 @@ impl Iterator for Env {
                 if *self.cur == 0 {
                     return None;
                 }
-                let p = &*self.cur as *const u16;
+                let p = self.cur as *const u16;
                 let mut len = 0;
                 while *p.offset(len) != 0 {
                     len += 1;


### PR DESCRIPTION
Discovered in https://github.com/rust-lang/miri/pull/1225: the Windows `Env` iterator violates Stacked Borrows by creating an `&u16`, turning it into a raw pointer, and then accessing memory outside the range of that type.

There is no need to create a reference here in the first place, so the fix is trivial.
Cc @JOE1994 
Cc https://github.com/rust-lang/unsafe-code-guidelines/issues/134