### PR TITLE
submodules: update clippy from 1ff81c1b to 70b93aab

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,6 @@ dependencies = [
  "if_chain",
  "itertools 0.9.0",
  "lazy_static 1.4.0",
- "matches",
  "pulldown-cmark 0.7.0",
  "quine-mc_cluskey",
  "regex-syntax",


### PR DESCRIPTION
Changes:
````
remove redundant import
rustup https://github.com/rust-lang/rust/pull/68404
rustup https://github.com/rust-lang/rust/pull/69644
rustup https://github.com/rust-lang/rust/pull/70344
Move verbose_file_reads to restriction
move redundant_pub_crate to nursery
readme: explain how to run only a single lint on a codebase
Remove dependency on `matches` crate
Move useless_transmute to nursery
nursery group -> style
Update for PR feedback
Auto merge of #5314 - ehuss:remove-git2, r=flip1995
Lint for `pub(crate)` items that are not crate visible due to the visibility of the module that contains them
````

Fixes #70456