### PR TITLE
Replace last mention of IRC with Discord

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -91,7 +91,8 @@
 //! pull-requests for your suggested changes.
 //!
 //! Contributions are appreciated! If you see a part of the docs that can be
-//! improved, submit a PR, or chat with us first on irc.mozilla.org #rust-docs.
+//! improved, submit a PR, or chat with us first on [Discord][rust-discord]
+//! #docs.
 //!
 //! # A Tour of The Rust Standard Library
 //!
@@ -194,6 +195,7 @@
 //! [multithreading]: thread/index.html
 //! [other]: #what-is-in-the-standard-library-documentation
 //! [primitive types]: ../book/ch03-02-data-types.html
+//! [rust-discord]: https://discord.gg/rust-lang
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![doc(


### PR DESCRIPTION
Mozilla's IRC service was shut down in March 2020. The official instant messaging variant has been Discord for a while, and most of the links were already replaced by #61524.

This was the last line that came up with `irc.mozilla.org` or any combination of "irc.*#[a-z]+" in a `git grep`:

    git grep -i -E "irc.*#[a-z]+"

As there is only one other link directly to Rust's discord, I used the same Markdown link `[rust-discord]` as in `bootstrap/README.md` to stay consistent. This might come in handy if the chat platform changes at a later point again.