### PR TITLE
[WIP] rustc_target: Remove `crt_static_respected` and `crt_static_allows_dylibs`

### DIFF
--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -501,7 +501,7 @@ fn link_natively<'a, B: ArchiveBuilder<'a>>(
         cmd.args(args);
     }
     if let Some(args) = sess.target.target.options.pre_link_args_crt.get(&flavor) {
-        if sess.crt_static(Some(crate_type)) {
+        if sess.crt_static_feature(Some(crate_type)) {
             cmd.args(args);
         }
     }
@@ -527,7 +527,7 @@ fn link_natively<'a, B: ArchiveBuilder<'a>>(
         cmd.arg(get_file_path(sess, obj));
     }
 
-    if crate_type == config::CrateType::Executable && sess.crt_static(Some(crate_type)) {
+    if crate_type == config::CrateType::Executable && sess.crt_static_feature(Some(crate_type)) {
         for obj in &sess.target.target.options.pre_link_objects_exe_crt {
             cmd.arg(get_file_path(sess, obj));
         }
@@ -571,7 +571,7 @@ fn link_natively<'a, B: ArchiveBuilder<'a>>(
     for obj in &sess.target.target.options.post_link_objects {
         cmd.arg(get_file_path(sess, obj));
     }
-    if sess.crt_static(Some(crate_type)) {
+    if sess.crt_static_feature(Some(crate_type)) {
         for obj in &sess.target.target.options.post_link_objects_crt {
             cmd.arg(get_file_path(sess, obj));
         }
@@ -1313,7 +1313,9 @@ fn link_args<'a, B: ArchiveBuilder<'a>>(
             let more_args = &sess.opts.cg.link_arg;
             let mut args = args.iter().chain(more_args.iter()).chain(used_link_args.iter());
 
-            if is_pic(sess) && !sess.crt_static(Some(crate_type)) && !args.any(|x| *x == "-static")
+            if is_pic(sess)
+                && !sess.crt_static_feature(Some(crate_type))
+                && !args.any(|x| *x == "-static")
             {
                 position_independent_executable = true;
             }
@@ -1406,7 +1408,7 @@ fn link_args<'a, B: ArchiveBuilder<'a>>(
     if crate_type != config::CrateType::Executable {
         cmd.build_dylib(out_filename);
     }
-    if crate_type == config::CrateType::Executable && sess.crt_static(Some(crate_type)) {
+    if crate_type == config::CrateType::Executable && sess.crt_static_feature(Some(crate_type)) {
         cmd.build_static_executable();
     }
 

--- a/src/librustc_metadata/dependency_format.rs
+++ b/src/librustc_metadata/dependency_format.rs
@@ -98,7 +98,7 @@ fn calculate_type(tcx: TyCtxt<'_>, ty: config::CrateType) -> DependencyList {
         // If the global prefer_dynamic switch is turned off, or the final
         // executable will be statically linked, prefer static crate linkage.
         config::CrateType::Executable
-            if !sess.opts.cg.prefer_dynamic || sess.crt_static(Some(ty)) =>
+            if !sess.opts.cg.prefer_dynamic || sess.crt_static_feature(Some(ty)) =>
         {
             Linkage::Static
         }
@@ -129,11 +129,7 @@ fn calculate_type(tcx: TyCtxt<'_>, ty: config::CrateType) -> DependencyList {
 
         // Staticlibs and static executables must have all static dependencies.
         // If any are not found, generate some nice pretty errors.
-        if ty == config::CrateType::Staticlib
-            || (ty == config::CrateType::Executable
-                && sess.crt_static(Some(ty))
-                && !sess.target.target.options.crt_static_allows_dylibs)
-        {
+        if ty == config::CrateType::Staticlib {
             for &cnum in tcx.crates().iter() {
                 if tcx.dep_kind(cnum).macros_only() {
                     continue;

--- a/src/librustc_session/output.rs
+++ b/src/librustc_session/output.rs
@@ -198,11 +198,6 @@ pub fn invalid_output_for_target(sess: &Session, crate_type: config::CrateType) 
             if !sess.target.target.options.dynamic_linking {
                 return true;
             }
-            if sess.crt_static(Some(crate_type))
-                && !sess.target.target.options.crt_static_allows_dylibs
-            {
-                return true;
-            }
         }
         _ => {}
     }

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -544,16 +544,6 @@ impl Session {
             .unwrap_or(self.opts.debug_assertions)
     }
 
-    /// Check whether this compile session and crate type use static crt.
-    pub fn crt_static(&self, crate_type: Option<config::CrateType>) -> bool {
-        // If the target does not opt in to crt-static support, use its default.
-        if self.target.target.options.crt_static_respected {
-            self.crt_static_feature(crate_type)
-        } else {
-            self.target.target.options.crt_static_default
-        }
-    }
-
     /// Check whether this compile session and crate type use `crt-static` feature.
     pub fn crt_static_feature(&self, crate_type: Option<config::CrateType>) -> bool {
         let requested_features = self.opts.cg.target_feature.split(',');

--- a/src/librustc_target/spec/linux_musl_base.rs
+++ b/src/librustc_target/spec/linux_musl_base.rs
@@ -27,8 +27,6 @@ pub fn opts() -> TargetOptions {
 
     // These targets statically link libc by default
     base.crt_static_default = true;
-    // These targets allow the user to choose between static and dynamic linking.
-    base.crt_static_respected = true;
 
     base
 }

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -728,12 +728,8 @@ pub struct TargetOptions {
     /// ABIs are considered to be supported on all platforms and cannot be blacklisted.
     pub abi_blacklist: Vec<Abi>,
 
-    /// Whether or not linking dylibs to a static CRT is allowed.
-    pub crt_static_allows_dylibs: bool,
     /// Whether or not the CRT is statically linked by default.
     pub crt_static_default: bool,
-    /// Whether or not crt-static is respected by the compiler (or is a no-op).
-    pub crt_static_respected: bool,
 
     /// Whether or not stack probes (__rust_probestack) are enabled
     pub stack_probes: bool,
@@ -872,9 +868,7 @@ impl Default for TargetOptions {
             atomic_cas: true,
             panic_strategy: PanicStrategy::Unwind,
             abi_blacklist: vec![],
-            crt_static_allows_dylibs: false,
             crt_static_default: false,
-            crt_static_respected: false,
             stack_probes: false,
             min_global_align: None,
             default_codegen_units: None,
@@ -1185,9 +1179,7 @@ impl Target {
         key!(min_atomic_width, Option<u64>);
         key!(atomic_cas, bool);
         key!(panic_strategy, PanicStrategy)?;
-        key!(crt_static_allows_dylibs, bool);
         key!(crt_static_default, bool);
-        key!(crt_static_respected, bool);
         key!(stack_probes, bool);
         key!(min_global_align, Option<u64>);
         key!(default_codegen_units, Option<u64>);
@@ -1412,9 +1404,7 @@ impl ToJson for Target {
         target_option_val!(max_atomic_width);
         target_option_val!(atomic_cas);
         target_option_val!(panic_strategy);
-        target_option_val!(crt_static_allows_dylibs);
         target_option_val!(crt_static_default);
-        target_option_val!(crt_static_respected);
         target_option_val!(stack_probes);
         target_option_val!(min_global_align);
         target_option_val!(default_codegen_units);

--- a/src/librustc_target/spec/redox_base.rs
+++ b/src/librustc_target/spec/redox_base.rs
@@ -30,7 +30,6 @@ pub fn opts() -> TargetOptions {
         relro_level: RelroLevel::Full,
         has_elf_tls: true,
         crt_static_default: true,
-        crt_static_respected: true,
         ..Default::default()
     }
 }

--- a/src/librustc_target/spec/vxworks_base.rs
+++ b/src/librustc_target/spec/vxworks_base.rs
@@ -32,8 +32,6 @@ pub fn opts() -> TargetOptions {
         has_elf_tls: true,
         pre_link_args_crt: args_crt,
         crt_static_default: true,
-        crt_static_respected: true,
-        crt_static_allows_dylibs: true,
         // VxWorks needs to implement this to support profiling
         target_mcount: "_mcount".to_string(),
         ..Default::default()

--- a/src/librustc_target/spec/wasm32_wasi.rs
+++ b/src/librustc_target/spec/wasm32_wasi.rs
@@ -95,11 +95,6 @@ pub fn target() -> Result<Target, String> {
     // need an external compiler but it's still interoperable with an external
     // compiler if configured correctly.
     options.crt_static_default = true;
-    options.crt_static_respected = true;
-
-    // Allow `+crt-static` to create a "cdylib" output which is just a wasm file
-    // without a main function.
-    options.crt_static_allows_dylibs = true;
 
     // WASI's `sys::args::init` function ignores its arguments; instead,
     // `args::args()` makes the WASI API calls itself.

--- a/src/librustc_target/spec/windows_msvc_base.rs
+++ b/src/librustc_target/spec/windows_msvc_base.rs
@@ -25,8 +25,6 @@ pub fn opts() -> TargetOptions {
         link_env: vec![("VSLANG".to_string(), "1033".to_string())],
         lld_flavor: LldFlavor::Link,
         pre_link_args: args,
-        crt_static_allows_dylibs: true,
-        crt_static_respected: true,
         abi_return_struct_as_int: true,
         emit_debug_gdb_scripts: false,
         requires_uwtable: true,

--- a/src/librustc_target/spec/windows_uwp_msvc_base.rs
+++ b/src/librustc_target/spec/windows_uwp_msvc_base.rs
@@ -26,8 +26,6 @@ pub fn opts() -> TargetOptions {
         is_like_windows: true,
         is_like_msvc: true,
         pre_link_args: args,
-        crt_static_allows_dylibs: true,
-        crt_static_respected: true,
         abi_return_struct_as_int: true,
         emit_debug_gdb_scripts: false,
         requires_uwtable: true,


### PR DESCRIPTION
Always respect `+crt-static` option if user passed it.
If the user wants to link to e.g. bionic or glibc statically, `rustc` should at least not stay in the way.

Linking to libc statically may require linking some startup files as well or passing extra linker options.
For some targets like `*-musl` `rustc` supports doing it implicitly.
For other targets it's responsibility of the user passing `+crt-static` to link them using `-C (pre-)link-args` and similar flags.

cc https://github.com/rust-lang/libc/issues/1711 https://github.com/rust-lang/rust/pull/40113 https://github.com/rust-lang/rust/pull/70095