### PR TITLE
rename Scalar::{ptr_null -> null_ptr} and add "machine_" prefix like elsewhere

### DIFF
--- a/src/librustc/mir/interpret/pointer.rs
+++ b/src/librustc/mir/interpret/pointer.rs
@@ -46,13 +46,13 @@ pub trait PointerArithmetic: layout::HasDataLayout {
     }
 
     #[inline]
-    fn usize_max(&self) -> u64 {
+    fn machine_usize_max(&self) -> u64 {
         let max_usize_plus_1 = 1u128 << self.pointer_size().bits();
         u64::try_from(max_usize_plus_1 - 1).unwrap()
     }
 
     #[inline]
-    fn isize_max(&self) -> i64 {
+    fn machine_isize_max(&self) -> i64 {
         let max_isize_plus_1 = 1u128 << (self.pointer_size().bits() - 1);
         i64::try_from(max_isize_plus_1 - 1).unwrap()
     }

--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -192,7 +192,7 @@ impl<'tcx, Tag> Scalar<Tag> {
     }
 
     #[inline]
-    pub fn ptr_null(cx: &impl HasDataLayout) -> Self {
+    pub fn null_ptr(cx: &impl HasDataLayout) -> Self {
         Scalar::Raw { data: 0, size: cx.data_layout().pointer_size.bytes() as u8 }
     }
 

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -139,7 +139,7 @@ impl<Tag> MemPlace<Tag> {
     /// Produces a Place that will error if attempted to be read from or written to
     #[inline(always)]
     fn null(cx: &impl HasDataLayout) -> Self {
-        Self::from_scalar_ptr(Scalar::ptr_null(cx), Align::from_bytes(1).unwrap())
+        Self::from_scalar_ptr(Scalar::null_ptr(cx), Align::from_bytes(1).unwrap())
     }
 
     #[inline(always)]


### PR DESCRIPTION
"NULL pointer" is just much more common terminology than "pointer-null".
Also I forgot two methods when renaming all the `Scalar` things to `(to|from)_machine_(u|i)size`.