### PR TITLE
remove param_def_id_to_index field of Generics

### DIFF
--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1020,10 +1020,6 @@ pub struct Generics {
     pub parent_count: usize,
     pub params: Vec<GenericParamDef>,
 
-    /// Reverse map to the `index` field of each `GenericParamDef`.
-    #[stable_hasher(ignore)]
-    pub param_def_id_to_index: FxHashMap<DefId, u32>,
-
     pub has_self: bool,
     pub has_late_bound_regions: Option<Span>,
 }
@@ -1031,6 +1027,17 @@ pub struct Generics {
 impl<'tcx> Generics {
     pub fn count(&self) -> usize {
         self.parent_count + self.params.len()
+    }
+
+    /// Returns the index of the param with the given `DefId`,
+    /// panics in case no param is found.
+    #[inline]
+    pub fn param_def_id_to_index(&self, def_id: DefId) -> u32 {
+        self.params
+            .iter()
+            .find(|param| param.def_id == def_id)
+            .map(|param| param.index)
+            .expect("invalid def_id")
     }
 
     pub fn own_counts(&self) -> GenericParamCount {

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -2323,7 +2323,7 @@ impl<'tcx> Const<'tcx> {
                 let item_id = tcx.hir().get_parent_node(hir_id);
                 let item_def_id = tcx.hir().local_def_id(item_id);
                 let generics = tcx.generics_of(item_def_id);
-                let index = generics.param_def_id_to_index[&tcx.hir().local_def_id(hir_id)];
+                let index = generics.param_def_id_to_index(tcx.hir().local_def_id(hir_id));
                 let name = tcx.hir().name(hir_id);
                 ty::ConstKind::Param(ty::ParamConst::new(index, name))
             }

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1538,7 +1538,7 @@ impl ExplicitOutlivesRequirements {
         inferred_outlives: &'tcx [(ty::Predicate<'tcx>, Span)],
         ty_generics: &'tcx ty::Generics,
     ) -> Vec<ty::Region<'tcx>> {
-        let index = ty_generics.param_def_id_to_index[&tcx.hir().local_def_id(param.hir_id)];
+        let index = ty_generics.param_def_id_to_index(tcx.hir().local_def_id(param.hir_id));
 
         match param.kind {
             hir::GenericParamKind::Lifetime { .. } => {
@@ -1711,7 +1711,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ExplicitOutlivesRequirements {
                         match predicate.bounded_ty.kind {
                             hir::TyKind::Path(hir::QPath::Resolved(None, ref path)) => {
                                 if let Res::Def(DefKind::TyParam, def_id) = path.res {
-                                    let index = ty_generics.param_def_id_to_index[&def_id];
+                                    let index = ty_generics.param_def_id_to_index(def_id);
                                     (
                                         Self::lifetimes_outliving_type(inferred_outlives, index),
                                         &predicate.bounds,

--- a/src/librustc_mir_build/hair/cx/expr.rs
+++ b/src/librustc_mir_build/hair/cx/expr.rs
@@ -693,7 +693,7 @@ fn convert_path_expr<'a, 'tcx>(
             let item_def_id = cx.tcx.hir().local_def_id(item_id);
             let generics = cx.tcx.generics_of(item_def_id);
             let local_def_id = cx.tcx.hir().local_def_id(hir_id);
-            let index = generics.param_def_id_to_index[&local_def_id];
+            let index = generics.param_def_id_to_index(local_def_id);
             let name = cx.tcx.hir().name(hir_id);
             let val = ty::ConstKind::Param(ty::ParamConst::new(index, name));
             ExprKind::Literal {

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -2662,7 +2662,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 let item_id = tcx.hir().get_parent_node(hir_id);
                 let item_def_id = tcx.hir().local_def_id(item_id);
                 let generics = tcx.generics_of(item_def_id);
-                let index = generics.param_def_id_to_index[&def_id];
+                let index = generics.param_def_id_to_index(def_id);
                 tcx.mk_ty_param(index, tcx.hir().name(hir_id))
             }
             Res::SelfTy(Some(_), None) => {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2714,7 +2714,7 @@ impl<'a, 'tcx> AstConv<'tcx> for FnCtxt<'a, 'tcx> {
         let item_id = tcx.hir().ty_param_owner(hir_id);
         let item_def_id = tcx.hir().local_def_id(item_id);
         let generics = tcx.generics_of(item_def_id);
-        let index = generics.param_def_id_to_index[&def_id];
+        let index = generics.param_def_id_to_index(def_id);
         ty::GenericPredicates {
             parent: None,
             predicates: tcx.arena.alloc_from_iter(self.param_env.caller_bounds.iter().filter_map(

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -503,7 +503,7 @@ fn type_param_predicates(
     let param_owner = tcx.hir().ty_param_owner(param_id);
     let param_owner_def_id = tcx.hir().local_def_id(param_owner);
     let generics = tcx.generics_of(param_owner_def_id);
-    let index = generics.param_def_id_to_index[&def_id];
+    let index = generics.param_def_id_to_index(def_id);
     let ty = tcx.mk_ty_param(index, tcx.hir().ty_param_name(param_id));
 
     // Don't look for bounds where the type parameter isn't in scope.
@@ -1394,13 +1394,10 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> &ty::Generics {
         }));
     }
 
-    let param_def_id_to_index = params.iter().map(|param| (param.def_id, param.index)).collect();
-
     tcx.arena.alloc(ty::Generics {
         parent: parent_def_id,
         parent_count,
         params,
-        param_def_id_to_index,
         has_self: has_self || parent_has_self,
         has_late_bound_regions: has_late_bound_regions(tcx, node),
     })


### PR DESCRIPTION
Considering that most generics have a very low amount of params, it might be more efficient to iterate each param instead of using a hashmap.

I was unable to find a PR testing the perf of this, so here we are.