### PR TITLE
Miri engine: stronger type-based sanity check for assignments

### DIFF
--- a/src/librustc_mir/interpret/mod.rs
+++ b/src/librustc_mir/interpret/mod.rs
@@ -18,19 +18,13 @@ mod visitor;
 pub use rustc_middle::mir::interpret::*; // have all the `interpret` symbols in one place: here
 
 pub use self::eval_context::{Frame, InterpCx, LocalState, LocalValue, StackPopCleanup};
-
-pub use self::place::{MPlaceTy, MemPlace, MemPlaceMeta, Place, PlaceTy};
-
-pub use self::memory::{AllocCheck, FnVal, Memory, MemoryKind};
-
+pub use self::intern::{intern_const_alloc_recursive, InternKind};
 pub use self::machine::{AllocMap, Machine, MayLeak, StackPopJump};
-
-pub use self::operand::{ImmTy, Immediate, OpTy, Operand, ScalarMaybeUndef};
-
+pub use self::memory::{AllocCheck, FnVal, Memory, MemoryKind};
+pub use self::operand::{ImmTy, Immediate, OpTy, Operand};
+pub use self::place::{MPlaceTy, MemPlace, MemPlaceMeta, Place, PlaceTy};
+pub use self::validity::RefTracking;
 pub use self::visitor::{MutValueVisitor, ValueVisitor};
 
-pub use self::validity::RefTracking;
-
-pub use self::intern::{intern_const_alloc_recursive, InternKind};
-
 crate use self::intrinsics::eval_nullary_intrinsic;
+use eval_context::{from_known_layout, mir_assign_valid_types};

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -868,7 +868,7 @@ where
         // We do NOT compare the types for equality, because well-typed code can
         // actually "transmute" `&mut T` to `&T` in an assignment without a cast.
         assert!(
-            mir_assign_valid_types(src.layout.ty, dest.layout.ty),
+            mir_assign_valid_types(src.layout, dest.layout),
             "type mismatch when copying!\nsrc: {:?},\ndest: {:?}",
             src.layout.ty,
             dest.layout.ty,
@@ -922,7 +922,7 @@ where
         src: OpTy<'tcx, M::PointerTag>,
         dest: PlaceTy<'tcx, M::PointerTag>,
     ) -> InterpResult<'tcx> {
-        if mir_assign_valid_types(src.layout.ty, dest.layout.ty) {
+        if mir_assign_valid_types(src.layout, dest.layout) {
             // Fast path: Just use normal `copy_op`
             return self.copy_op(src, dest);
         }


### PR DESCRIPTION
r? @oli-obk @eddyb
Fixes https://github.com/rust-lang/rust/issues/70405

That issue says
> be sure to also add appropriate mutability checks to the patterns (mutable for the source, immutable for the dest)

I decided not to do that because I see no good reason to do it. The engine does not care either way, the assignment will happen correctly.