### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4013,7 +4013,6 @@ dependencies = [
  "log",
  "rustc_ast",
  "rustc_ast_pretty",
- "rustc_attr",
  "rustc_data_structures",
  "rustc_errors",
  "rustc_feature",

--- a/src/librustc_codegen_llvm/attributes.rs
+++ b/src/librustc_codegen_llvm/attributes.rs
@@ -21,7 +21,7 @@ use crate::attributes;
 use crate::llvm::AttributePlace::Function;
 use crate::llvm::{self, Attribute};
 use crate::llvm_util;
-pub use rustc_attr::{self as attr, InlineAttr, OptimizeAttr};
+pub use rustc_attr::{InlineAttr, OptimizeAttr};
 
 use crate::context::CodegenCx;
 use crate::value::Value;

--- a/src/librustc_parse/Cargo.toml
+++ b/src/librustc_parse/Cargo.toml
@@ -13,7 +13,6 @@ doctest = false
 bitflags = "1.0"
 log = "0.4"
 rustc_ast_pretty = { path = "../librustc_ast_pretty" }
-rustc_attr = { path = "../librustc_attr" }
 rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_feature = { path = "../librustc_feature" }
 rustc_lexer = { path = "../librustc_lexer" }


### PR DESCRIPTION
Successful merges:

 - #70140 (Add Result<Result<T, E>, E>::flatten -> Result<T, E>)
 - #70526 (reduce `rustc_attr` usage in places)
 - #70527 (Update LLVM submodule)

Failed merges:


r? @ghost