### PR TITLE
add test for 62220

### DIFF
--- a/src/test/ui/const-generics/issues/issue-62220.rs
+++ b/src/test/ui/const-generics/issues/issue-62220.rs
@@ -1,0 +1,22 @@
+// build-pass
+#![allow(incomplete_features)]
+
+#![feature(const_generics)]
+pub struct Vector<T, const N: usize>([T; N]);
+
+pub type TruncatedVector<T, const N: usize> = Vector<T, { N - 1 }>;
+
+impl<T, const N: usize> Vector<T, { N }> {
+    /// Drop the last component and return the vector with one fewer dimension.
+    pub fn trunc(self) -> (TruncatedVector<T, { N }>, T) {
+        unimplemented!()
+    }
+}
+
+fn vec4<T>(a: T, b: T, c: T, d: T) -> Vector<T, 4> {
+    Vector([a, b, c, d])
+}
+
+fn main() {
+    let (_xyz, _w): (TruncatedVector<u32, 4>, u32) = vec4(0u32, 1, 2, 3).trunc();
+}


### PR DESCRIPTION
Closes #62220 

Adds a test for https://github.com/rust-lang/rust/issues/62220.

Im not sure whether `check-pass` is sufficient here. I didn't put `run-pass` in, as I'm afraid that'll fail due to the `unimplemented!()` return in the code.