### PR TITLE
Polonius: update to 0.12.1, fix more move errors false positives, update test expectations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2522,9 +2522,9 @@ checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
 name = "polonius-engine"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d8ef65e3f89ecaec9ca7cb0e0911b4617352d4494018bcf934992f03f2024c"
+checksum = "ef2558a4b464e185b36ee08a2937ebb62ea5464c38856cfb1465c97cb38db52d"
 dependencies = [
  "datafrog",
  "log",

--- a/src/librustc_mir/borrow_check/type_check/liveness/polonius.rs
+++ b/src/librustc_mir/borrow_check/type_check/liveness/polonius.rs
@@ -43,7 +43,7 @@ impl UseFactsExtractor<'_> {
 
     fn insert_path_access(&mut self, path: MovePathIndex, location: Location) {
         debug!("UseFactsExtractor::insert_path_access({:?}, {:?})", path, location);
-        self.path_accessed_at_base.push((path, self.location_table.start_index(location)));
+        self.path_accessed_at_base.push((path, self.location_to_index(location)));
     }
 
     fn place_to_mpi(&self, place: &Place<'_>) -> Option<MovePathIndex> {

--- a/src/test/ui/closures/closure-expected-type/expect-region-supply-region.polonius.stderr
+++ b/src/test/ui/closures/closure-expected-type/expect-region-supply-region.polonius.stderr
@@ -2,7 +2,7 @@ error[E0521]: borrowed data escapes outside of closure
   --> $DIR/expect-region-supply-region.rs:18:9
    |
 LL |     let mut f: Option<&u32> = None;
-   |         ----- `f` is declared here, outside of the closure body
+   |         ----- `f` declared here, outside of the closure body
 LL |     closure_expecting_bound(|x| {
    |                              - `x` is a reference that is only valid in the closure body
 LL |         f = Some(x);
@@ -12,7 +12,7 @@ error[E0521]: borrowed data escapes outside of closure
   --> $DIR/expect-region-supply-region.rs:28:9
    |
 LL |     let mut f: Option<&u32> = None;
-   |         ----- `f` is declared here, outside of the closure body
+   |         ----- `f` declared here, outside of the closure body
 LL |     closure_expecting_bound(|x: &u32| {
    |                              - `x` is a reference that is only valid in the closure body
 LL |         f = Some(x);
@@ -33,7 +33,7 @@ error[E0521]: borrowed data escapes outside of closure
   --> $DIR/expect-region-supply-region.rs:42:9
    |
 LL |     let mut f: Option<&u32> = None;
-   |         ----- `f` is declared here, outside of the closure body
+   |         ----- `f` declared here, outside of the closure body
 ...
 LL |     closure_expecting_bound(|x: &'x u32| {
    |                              - `x` is a reference that is only valid in the closure body

--- a/src/test/ui/hrtb/hrtb-perfect-forwarding.polonius.stderr
+++ b/src/test/ui/hrtb/hrtb-perfect-forwarding.polonius.stderr
@@ -39,6 +39,7 @@ LL | |     // Not OK -- The forwarding impl for `Foo` requires that `Bar` also
 ...  |
 LL | |     foo_hrtb_bar_not(&mut t);
    | |     ------------------------ recursive call site
+LL | |
 LL | | }
    | |_^ cannot return without recursing
    |
@@ -51,7 +52,7 @@ LL |     foo_hrtb_bar_not(&mut t);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: function cannot return without recursing
-  --> $DIR/hrtb-perfect-forwarding.rs:49:1
+  --> $DIR/hrtb-perfect-forwarding.rs:50:1
    |
 LL | / fn foo_hrtb_bar_hrtb<T>(mut t: T)
 LL | |     where T : for<'a> Foo<&'a isize> + for<'b> Bar<&'b isize>

--- a/src/test/ui/impl-trait/multiple-lifetimes/error-handling.polonius.stderr
+++ b/src/test/ui/impl-trait/multiple-lifetimes/error-handling.polonius.stderr
@@ -1,10 +1,13 @@
 error: lifetime may not live long enough
-  --> $DIR/error-handling.rs:13:56
+  --> $DIR/error-handling.rs:23:16
    |
 LL | fn foo<'a, 'b, 'c>(x: &'static i32, mut y: &'a i32) -> E<'b, 'c> {
-   |        --  -- lifetime `'b` defined here               ^^^^^^^^^ opaque type requires that `'a` must outlive `'b`
+   |        --  -- lifetime `'b` defined here
    |        |
    |        lifetime `'a` defined here
+...
+LL |         let _: &'b i32 = *u.0;
+   |                ^^^^^^^ type annotation requires that `'a` must outlive `'b`
    |
    = help: consider adding the following bound: `'a: 'b`
 

--- a/src/test/ui/nll/outlives-suggestion-simple.polonius.stderr
+++ b/src/test/ui/nll/outlives-suggestion-simple.polonius.stderr
@@ -72,6 +72,8 @@ LL |     (x, x)
    |
    = help: consider adding the following bound: `'a: 'c`
 
+help: add bound `'a: 'b + 'c`
+
 error: lifetime may not live long enough
   --> $DIR/outlives-suggestion-simple.rs:31:9
    |
@@ -106,16 +108,16 @@ LL |         self.x
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error[E0521]: borrowed data escapes outside of function
+error[E0521]: borrowed data escapes outside of associated function
   --> $DIR/outlives-suggestion-simple.rs:73:9
    |
 LL |     fn get_bar(&self) -> Bar2 {
    |                -----
    |                |
-   |                `self` is declared here, outside of the function body
-   |                `self` is a reference that is only valid in the function body
+   |                `self` declared here, outside of the associated function body
+   |                `self` is a reference that is only valid in the associated function body
 LL |         Bar2::new(&self)
-   |         ^^^^^^^^^^^^^^^^ `self` escapes the function body here
+   |         ^^^^^^^^^^^^^^^^ `self` escapes the associated function body here
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/nll/user-annotations/closure-substs.polonius.stderr
+++ b/src/test/ui/nll/user-annotations/closure-substs.polonius.stderr
@@ -50,7 +50,7 @@ error[E0521]: borrowed data escapes outside of closure
   --> $DIR/closure-substs.rs:29:9
    |
 LL |     |x: &i32, b: fn(&'static i32)| {
-   |      -        - `b` is declared here, outside of the closure body
+   |      -        - `b` declared here, outside of the closure body
    |      |
    |      `x` is a reference that is only valid in the closure body
 LL |         b(x);


### PR DESCRIPTION
This PR:
- updates `polonius-engine` to version 0.12.1 to fix some move errors false positives
- fixes a fact generation mistake creating the other move errors false positives
- updates the test expectations for the polonius compare-mode so that all (minus the 2 OOMs) ui tests pass again (matching the [analysis doc](https://hackmd.io/CjYB0fs4Q9CweyeTdKWyEg?view) starting at case 34)

In my opinion, this is safe to rollup.

r? @nikomatsakis 