### PR TITLE
parse_and_disallow_postfix_after_cast: account for `ExprKind::Err`.

### DIFF
--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -638,6 +638,7 @@ impl<'a> Parser<'a> {
                     ExprKind::MethodCall(_, _) => "a method call",
                     ExprKind::Call(_, _) => "a function call",
                     ExprKind::Await(_) => "`.await`",
+                    ExprKind::Err => return Ok(with_postfix),
                     _ => unreachable!("parse_dot_or_call_expr_with_ shouldn't produce this"),
                 }
             );

--- a/src/test/ui/parser/issue-70552-ascription-in-parens-after-call.rs
+++ b/src/test/ui/parser/issue-70552-ascription-in-parens-after-call.rs
@@ -1,0 +1,3 @@
+fn main() {
+    expr as fun()(:); //~ ERROR expected expression
+}

--- a/src/test/ui/parser/issue-70552-ascription-in-parens-after-call.stderr
+++ b/src/test/ui/parser/issue-70552-ascription-in-parens-after-call.stderr
@@ -1,0 +1,8 @@
+error: expected expression, found `:`
+  --> $DIR/issue-70552-ascription-in-parens-after-call.rs:2:19
+   |
+LL |     expr as fun()(:);
+   |                   ^ expected expression
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/70552.

r? @estebank 
cc @daboross 