### PR TITLE
Fix some aliasing issues in Vec

### DIFF
--- a/src/liballoc/tests/vec.rs
+++ b/src/liballoc/tests/vec.rs
@@ -1352,6 +1352,13 @@ fn test_try_reserve_exact() {
 
 #[test]
 fn test_stable_pointers() {
+    /// Pull an element from the iterator, then drop it.
+    /// Useful to cover both the `next` and `drop` paths of an iterator.
+    fn next_then_drop<I: Iterator>(mut i: I) {
+        i.next().unwrap();
+        drop(i);
+    }
+
     // Test that, if we reserved enough space, adding and removing elements does not
     // invalidate references into the vector (such as `v0`).  This test also
     // runs in Miri, which would detect such problems.
@@ -1402,16 +1409,16 @@ fn test_stable_pointers() {
 
     // Partial draining
     v.resize_with(10, || 42);
-    drop(v.drain(5..));
+    next_then_drop(v.drain(5..));
     assert_eq!(*v0, 13);
 
     // Splicing
     v.resize_with(10, || 42);
-    drop(v.splice(5.., vec![1, 2, 3, 4, 5])); // empty tail after range
+    next_then_drop(v.splice(5.., vec![1, 2, 3, 4, 5])); // empty tail after range
     assert_eq!(*v0, 13);
-    drop(v.splice(5..8, vec![1])); // replacement is smaller than original range
+    next_then_drop(v.splice(5..8, vec![1])); // replacement is smaller than original range
     assert_eq!(*v0, 13);
-    drop(v.splice(5..6, vec![1; 10].into_iter().filter(|_| true))); // lower bound not exact
+    next_then_drop(v.splice(5..6, vec![1; 10].into_iter().filter(|_| true))); // lower bound not exact
     assert_eq!(*v0, 13);
 }
 

--- a/src/liballoc/tests/vec.rs
+++ b/src/liballoc/tests/vec.rs
@@ -1371,7 +1371,12 @@ fn test_stable_pointers() {
     v.pop().unwrap();
     assert_eq!(*v0, 13);
 
+    // Appending
+    v.append(&mut vec![27, 19]);
+    assert_eq!(*v0, 13);
+
     // Extending
+    v.extend_from_slice(&[1, 2]);
     v.extend(&[1, 2]); // `slice::Iter` (with `T: Copy`) specialization
     v.extend(vec![2, 3]); // `vec::IntoIter` specialization
     v.extend(std::iter::once(3)); // `TrustedLen` specialization
@@ -1382,6 +1387,31 @@ fn test_stable_pointers() {
 
     // Truncation
     v.truncate(2);
+    assert_eq!(*v0, 13);
+
+    // Resizing
+    v.resize_with(v.len() + 10, || 42);
+    assert_eq!(*v0, 13);
+    v.resize_with(2, || panic!());
+    assert_eq!(*v0, 13);
+
+    // No-op reservation
+    v.reserve(32);
+    v.reserve_exact(32);
+    assert_eq!(*v0, 13);
+
+    // Partial draining
+    v.resize_with(10, || 42);
+    drop(v.drain(5..));
+    assert_eq!(*v0, 13);
+
+    // Splicing
+    v.resize_with(10, || 42);
+    drop(v.splice(5.., vec![1, 2, 3, 4, 5])); // empty tail after range
+    assert_eq!(*v0, 13);
+    drop(v.splice(5..8, vec![1])); // replacement is smaller than original range
+    assert_eq!(*v0, 13);
+    drop(v.splice(5..6, vec![1; 10].into_iter().filter(|_| true))); // lower bound not exact
     assert_eq!(*v0, 13);
 }
 

--- a/src/liballoc/tests/vec.rs
+++ b/src/liballoc/tests/vec.rs
@@ -1366,7 +1366,8 @@ fn test_stable_pointers() {
     v.push(13);
 
     // Laundering the lifetime -- we take care that `v` does not reallocate, so that's okay.
-    let v0 = unsafe { &*(&v[0] as *const _) };
+    let v0 = &mut v[0];
+    let v0 = unsafe { &mut *(v0 as *mut _) };
     // Now do a bunch of things and occasionally use `v0` again to assert it is still valid.
 
     // Pushing/inserting and popping/removing
@@ -1420,6 +1421,10 @@ fn test_stable_pointers() {
     assert_eq!(*v0, 13);
     next_then_drop(v.splice(5..6, vec![1; 10].into_iter().filter(|_| true))); // lower bound not exact
     assert_eq!(*v0, 13);
+
+    // Smoke test that would fire even outside Miri if an actual relocation happened.
+    *v0 -= 13;
+    assert_eq!(v[0], 0);
 }
 
 // https://github.com/rust-lang/rust/pull/49496 introduced specialization based on:

--- a/src/liballoc/tests/vec.rs
+++ b/src/liballoc/tests/vec.rs
@@ -1378,6 +1378,11 @@ fn test_stable_pointers() {
     v.remove(1);
     v.pop().unwrap();
     assert_eq!(*v0, 13);
+    v.push(1);
+    v.swap_remove(1);
+    assert_eq!(v.len(), 2);
+    v.swap_remove(1); // swap_remove the last element
+    assert_eq!(*v0, 13);
 
     // Appending
     v.append(&mut vec![27, 19]);

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -963,14 +963,15 @@ impl<T> Vec<T> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn swap_remove(&mut self, index: usize) -> T {
-        assert!(index < self.len);
+        let len = self.len();
+        assert!(index < len);
         unsafe {
             // We replace self[index] with the last element. Note that if the
             // bounds check above succeeds there must be a last element (which
             // can be self[index] itself).
-            let last = ptr::read(self.as_ptr().add(self.len - 1));
+            let last = ptr::read(self.as_ptr().add(len - 1));
             let hole: *mut T = self.as_mut_ptr().add(index);
-            self.len -= 1;
+            self.set_len(len - 1);
             ptr::replace(hole, last)
         }
     }

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1200,7 +1200,7 @@ impl<T> Vec<T> {
         } else {
             unsafe {
                 self.len -= 1;
-                Some(ptr::read(self.get_unchecked(self.len())))
+                Some(ptr::read(self.as_ptr().add(self.len())))
             }
         }
     }
@@ -2020,9 +2020,7 @@ where
                 let (lower, _) = iterator.size_hint();
                 let mut vector = Vec::with_capacity(lower.saturating_add(1));
                 unsafe {
-                    // `vector` is new, cannot have aliases, so us getting exclusive references
-                    // here is okay.
-                    ptr::write(vector.get_unchecked_mut(0), element);
+                    ptr::write(vector.as_mut_ptr(), element);
                     vector.set_len(1);
                 }
                 vector

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2122,8 +2122,9 @@ where
         self.reserve(slice.len());
         unsafe {
             let len = self.len();
+            let dst_slice = slice::from_raw_parts_mut(self.as_mut_ptr().add(len), slice.len());
+            dst_slice.copy_from_slice(slice);
             self.set_len(len + slice.len());
-            self.get_unchecked_mut(len..).copy_from_slice(slice);
         }
     }
 }

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -963,12 +963,13 @@ impl<T> Vec<T> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn swap_remove(&mut self, index: usize) -> T {
+        assert!(index < self.len);
         unsafe {
             // We replace self[index] with the last element. Note that if the
-            // bounds check on hole succeeds there must be a last element (which
+            // bounds check above succeeds there must be a last element (which
             // can be self[index] itself).
-            let hole: *mut T = &mut self[index];
-            let last = ptr::read(self.get_unchecked(self.len - 1));
+            let last = ptr::read(self.as_ptr().add(self.len - 1));
+            let hole: *mut T = self.as_mut_ptr().add(index);
             self.len -= 1;
             ptr::replace(hole, last)
         }

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -739,7 +739,8 @@ impl<T> Vec<T> {
             if len > self.len {
                 return;
             }
-            let s = self.get_unchecked_mut(len..) as *mut _;
+            let remaining_len = self.len - len;
+            let s = slice::from_raw_parts_mut(self.as_mut_ptr().add(len), remaining_len);
             self.len = len;
             ptr::drop_in_place(s);
         }

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2019,6 +2019,8 @@ where
                 let (lower, _) = iterator.size_hint();
                 let mut vector = Vec::with_capacity(lower.saturating_add(1));
                 unsafe {
+                    // `vector` is new, cannot have aliases, so us getting exclusive references
+                    // here is okay.
                     ptr::write(vector.get_unchecked_mut(0), element);
                     vector.set_len(1);
                 }
@@ -2145,7 +2147,7 @@ impl<T> Vec<T> {
                 self.reserve(lower.saturating_add(1));
             }
             unsafe {
-                ptr::write(self.get_unchecked_mut(len), element);
+                ptr::write(self.as_mut_ptr().add(len), element);
                 // NB can't overflow since we would have had to alloc the address space
                 self.set_len(len + 1);
             }


### PR DESCRIPTION
`Vec::extend` and `Vec::truncate` invalidated references into the vector even without reallocation, because they (implicitly) created a mutable reference covering the *entire* initialized part of the vector.

Fixes https://github.com/rust-lang/rust/issues/70301
I verified the fix by adding some new tests here that I ran in Miri.