### PR TITLE
Seeking from Current(0) return current stream position.

### DIFF
--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -360,7 +360,7 @@ impl<R: Seek> Seek for BufReader<R> {
         let result: u64;
         if let SeekFrom::Current(n) = pos {
             if n == 0 {
-                return Ok(self.pos as u64)
+                return Ok(self.pos as u64);
             }
 
             let remainder = (self.cap - self.pos) as i64;

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -360,7 +360,7 @@ impl<R: Seek> Seek for BufReader<R> {
         let result: u64;
         if let SeekFrom::Current(n) = pos {
             if n == 0 {
-                return Ok(self.pos)
+                return Ok(self.pos as u64)
             }
 
             let remainder = (self.cap - self.pos) as i64;

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -359,6 +359,10 @@ impl<R: Seek> Seek for BufReader<R> {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
         let result: u64;
         if let SeekFrom::Current(n) = pos {
+            if n == 0 {
+                return Ok(self.pos)
+            }
+
             let remainder = (self.cap - self.pos) as i64;
             // it should be safe to assume that remainder fits within an i64 as the alternative
             // means we managed to allocate 8 exbibytes and that's absurd.

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -56,6 +56,7 @@ pub struct BufReader<R> {
     buf: Box<[u8]>,
     pos: usize,
     cap: usize,
+    inner_pos: u64,
 }
 
 impl<R: Read> BufReader<R> {
@@ -360,7 +361,7 @@ impl<R: Seek> Seek for BufReader<R> {
         let result: u64;
         if let SeekFrom::Current(n) = pos {
             if n == 0 {
-                return Ok(self.pos as u64);
+                return Ok(self.inner_pos);
             }
 
             let remainder = (self.cap - self.pos) as i64;
@@ -382,6 +383,7 @@ impl<R: Seek> Seek for BufReader<R> {
             result = self.inner.seek(pos)?;
         }
         self.discard_buffer();
+        self.inner_pos = result;
         Ok(result)
     }
 }


### PR DESCRIPTION
The stream_position convenience function is implemented with
seek(SeekFrom::Current(0)) and when used with a BufReader this causes
the internal buffer to be dumped every time the stream position is
queried, which negates many of the benefits when using BufReader with
high latency data streams.

See comments in this thread: https://github.com/rust-lang/rust/issues/31100