### PR TITLE
std: Fix over-aligned allocations on wasm32-wasi

### DIFF
--- a/src/libstd/sys/wasi/alloc.rs
+++ b/src/libstd/sys/wasi/alloc.rs
@@ -10,7 +10,7 @@ unsafe impl GlobalAlloc for System {
         if layout.align() <= MIN_ALIGN && layout.align() <= layout.size() {
             libc::malloc(layout.size()) as *mut u8
         } else {
-            libc::aligned_alloc(layout.size(), layout.align()) as *mut u8
+            libc::aligned_alloc(layout.align(), layout.size()) as *mut u8
         }
     }
 


### PR DESCRIPTION
The wasm32-wasi target delegates its malloc implementation to the
functions in wasi-libc, but the invocation of `aligned_alloc` was
incorrect by passing the number of bytes requested first rather than the
alignment. This commit swaps the order of these two arguments to ensure
that we allocate over-aligned memory correctly.