### PR TITLE
Add `Rust` to the code snippet

### DIFF
--- a/.github/ISSUE_TEMPLATE/ice.md
+++ b/.github/ISSUE_TEMPLATE/ice.md
@@ -14,7 +14,7 @@ http://blog.pnkfx.org/blog/2019/11/18/rust-bug-minimization-patterns/
 
 ### Code
 
-```
+```Rust
 <code>
 ```
 


### PR DESCRIPTION
Adds `Rust` to the snippet where the code causing the ICE should be placed, so github can render it as Rust code rather than plain code.