### PR TITLE
Ensure there are versions of test code for aarch64 windows

### DIFF
--- a/src/test/ui/intrinsics/intrinsic-alignment.rs
+++ b/src/test/ui/intrinsics/intrinsic-alignment.rs
@@ -56,16 +56,6 @@ mod m {
 #[cfg(target_os = "windows")]
 mod m {
     #[main]
-    #[cfg(target_arch = "x86")]
-    pub fn main() {
-        unsafe {
-            assert_eq!(::rusti::pref_align_of::<u64>(), 8);
-            assert_eq!(::rusti::min_align_of::<u64>(), 8);
-        }
-    }
-
-    #[main]
-    #[cfg(target_arch = "x86_64")]
     pub fn main() {
         unsafe {
             assert_eq!(::rusti::pref_align_of::<u64>(), 8);

--- a/src/test/ui/structs-enums/rec-align-u64.rs
+++ b/src/test/ui/structs-enums/rec-align-u64.rs
@@ -67,13 +67,6 @@ mod m {
 
 #[cfg(target_os = "windows")]
 mod m {
-    #[cfg(target_arch = "x86")]
-    pub mod m {
-        pub fn align() -> usize { 8 }
-        pub fn size() -> usize { 16 }
-    }
-
-    #[cfg(target_arch = "x86_64")]
     pub mod m {
         pub fn align() -> usize { 8 }
         pub fn size() -> usize { 16 }


### PR DESCRIPTION
Remove the `cfg` flags that were preventing some tests from running on `aarch64-pc-windows-msvc`.

All the existing `target_os = windows` targets had the same `align()` and `size()` values, so this change just removes the `target_arch` flags.

r? @alexcrichton 