### PR TITLE
rustc_target::abi: rename FieldPlacement to FieldsShape.

### DIFF
--- a/src/librustc_codegen_llvm/type_of.rs
+++ b/src/librustc_codegen_llvm/type_of.rs
@@ -79,7 +79,7 @@ fn uncached_llvm_type<'a, 'tcx>(
     };
 
     match layout.fields {
-        layout::FieldPlacement::Union(_) => {
+        layout::FieldsShape::Union(_) => {
             let fill = cx.type_padding_filler(layout.size, layout.align.abi);
             let packed = false;
             match name {
@@ -91,10 +91,10 @@ fn uncached_llvm_type<'a, 'tcx>(
                 }
             }
         }
-        layout::FieldPlacement::Array { count, .. } => {
+        layout::FieldsShape::Array { count, .. } => {
             cx.type_array(layout.field(cx, 0).llvm_type(cx), count)
         }
-        layout::FieldPlacement::Arbitrary { .. } => match name {
+        layout::FieldsShape::Arbitrary { .. } => match name {
             None => {
                 let (llfields, packed) = struct_llfields(cx, layout);
                 cx.type_struct(&llfields, packed)
@@ -371,13 +371,13 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyAndLayout<'tcx> {
             _ => {}
         }
         match self.fields {
-            layout::FieldPlacement::Union(_) => {
+            layout::FieldsShape::Union(_) => {
                 bug!("TyAndLayout::llvm_field_index({:?}): not applicable", self)
             }
 
-            layout::FieldPlacement::Array { .. } => index as u64,
+            layout::FieldsShape::Array { .. } => index as u64,
 
-            layout::FieldPlacement::Arbitrary { .. } => {
+            layout::FieldsShape::Arbitrary { .. } => {
                 1 + (self.fields.memory_index(index) as u64) * 2
             }
         }

--- a/src/librustc_codegen_ssa/mir/place.rs
+++ b/src/librustc_codegen_ssa/mir/place.rs
@@ -66,7 +66,7 @@ impl<'a, 'tcx, V: CodegenObject> PlaceRef<'tcx, V> {
     }
 
     pub fn len<Cx: ConstMethods<'tcx, Value = V>>(&self, cx: &Cx) -> V {
-        if let layout::FieldPlacement::Array { count, .. } = self.layout.fields {
+        if let layout::FieldsShape::Array { count, .. } = self.layout.fields {
             if self.layout.is_unsized() {
                 assert_eq!(count, 0);
                 self.llextra.unwrap()

--- a/src/librustc_middle/ty/layout.rs
+++ b/src/librustc_middle/ty/layout.rs
@@ -229,7 +229,7 @@ enum StructKind {
 // Invert a bijective mapping, i.e. `invert(map)[y] = x` if `map[x] = y`.
 // This is used to go between `memory_index` (source field order to memory order)
 // and `inverse_memory_index` (memory order to source field order).
-// See also `FieldPlacement::Arbitrary::memory_index` for more details.
+// See also `FieldsShape::Arbitrary::memory_index` for more details.
 // FIXME(eddyb) build a better abstraction for permutations, if possible.
 fn invert_mapping(map: &[u32]) -> Vec<u32> {
     let mut inverse = vec![0; map.len()];
@@ -256,7 +256,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
 
         Layout {
             variants: Variants::Single { index: VariantIdx::new(0) },
-            fields: FieldPlacement::Arbitrary {
+            fields: FieldsShape::Arbitrary {
                 offsets: vec![Size::ZERO, b_offset],
                 memory_index: vec![0, 1],
             },
@@ -442,7 +442,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                         };
                         let pair = self.scalar_pair(a.clone(), b.clone());
                         let pair_offsets = match pair.fields {
-                            FieldPlacement::Arbitrary { ref offsets, ref memory_index } => {
+                            FieldsShape::Arbitrary { ref offsets, ref memory_index } => {
                                 assert_eq!(memory_index, &[0, 1]);
                                 offsets
                             }
@@ -470,7 +470,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
 
         Ok(Layout {
             variants: Variants::Single { index: VariantIdx::new(0) },
-            fields: FieldPlacement::Arbitrary { offsets, memory_index },
+            fields: FieldsShape::Arbitrary { offsets, memory_index },
             abi,
             largest_niche,
             align,
@@ -519,7 +519,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
             // The never type.
             ty::Never => tcx.intern_layout(Layout {
                 variants: Variants::Single { index: VariantIdx::new(0) },
-                fields: FieldPlacement::Union(0),
+                fields: FieldsShape::Union(0),
                 abi: Abi::Uninhabited,
                 largest_niche: None,
                 align: dl.i8_align,
@@ -580,7 +580,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
 
                 tcx.intern_layout(Layout {
                     variants: Variants::Single { index: VariantIdx::new(0) },
-                    fields: FieldPlacement::Array { stride: element.size, count },
+                    fields: FieldsShape::Array { stride: element.size, count },
                     abi,
                     largest_niche,
                     align: element.align,
@@ -591,7 +591,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                 let element = self.layout_of(element)?;
                 tcx.intern_layout(Layout {
                     variants: Variants::Single { index: VariantIdx::new(0) },
-                    fields: FieldPlacement::Array { stride: element.size, count: 0 },
+                    fields: FieldsShape::Array { stride: element.size, count: 0 },
                     abi: Abi::Aggregate { sized: false },
                     largest_niche: None,
                     align: element.align,
@@ -600,7 +600,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
             }
             ty::Str => tcx.intern_layout(Layout {
                 variants: Variants::Single { index: VariantIdx::new(0) },
-                fields: FieldPlacement::Array { stride: Size::from_bytes(1), count: 0 },
+                fields: FieldsShape::Array { stride: Size::from_bytes(1), count: 0 },
                 abi: Abi::Aggregate { sized: false },
                 largest_niche: None,
                 align: dl.i8_align,
@@ -669,7 +669,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
 
                 tcx.intern_layout(Layout {
                     variants: Variants::Single { index: VariantIdx::new(0) },
-                    fields: FieldPlacement::Array { stride: element.size, count },
+                    fields: FieldsShape::Array { stride: element.size, count },
                     abi: Abi::Vector { element: scalar, count },
                     largest_niche: element.largest_niche.clone(),
                     size,
@@ -745,7 +745,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
 
                     return Ok(tcx.intern_layout(Layout {
                         variants: Variants::Single { index },
-                        fields: FieldPlacement::Union(variants[index].len()),
+                        fields: FieldsShape::Union(variants[index].len()),
                         abi,
                         largest_niche: None,
                         align,
@@ -979,7 +979,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                                     discr_index: 0,
                                     variants: st,
                                 },
-                                fields: FieldPlacement::Arbitrary {
+                                fields: FieldsShape::Arbitrary {
                                     offsets: vec![offset],
                                     memory_index: vec![0],
                                 },
@@ -1120,7 +1120,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                     let new_ity_size = ity.size();
                     for variant in &mut layout_variants {
                         match variant.fields {
-                            FieldPlacement::Arbitrary { ref mut offsets, .. } => {
+                            FieldsShape::Arbitrary { ref mut offsets, .. } => {
                                 for i in offsets {
                                     if *i <= old_ity_size {
                                         assert_eq!(*i, old_ity_size);
@@ -1150,7 +1150,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                     let mut common_prim = None;
                     for (field_layouts, layout_variant) in variants.iter().zip(&layout_variants) {
                         let offsets = match layout_variant.fields {
-                            FieldPlacement::Arbitrary { ref offsets, .. } => offsets,
+                            FieldsShape::Arbitrary { ref offsets, .. } => offsets,
                             _ => bug!(),
                         };
                         let mut fields =
@@ -1186,7 +1186,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                     if let Some((prim, offset)) = common_prim {
                         let pair = self.scalar_pair(tag.clone(), scalar_unit(prim));
                         let pair_offsets = match pair.fields {
-                            FieldPlacement::Arbitrary { ref offsets, ref memory_index } => {
+                            FieldsShape::Arbitrary { ref offsets, ref memory_index } => {
                                 assert_eq!(memory_index, &[0, 1]);
                                 offsets
                             }
@@ -1217,7 +1217,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                         discr_index: 0,
                         variants: layout_variants,
                     },
-                    fields: FieldPlacement::Arbitrary {
+                    fields: FieldsShape::Arbitrary {
                         offsets: vec![Size::ZERO],
                         memory_index: vec![0],
                     },
@@ -1434,7 +1434,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
         // GeneratorLayout.
         debug!("prefix = {:#?}", prefix);
         let (outer_fields, promoted_offsets, promoted_memory_index) = match prefix.fields {
-            FieldPlacement::Arbitrary { mut offsets, memory_index } => {
+            FieldsShape::Arbitrary { mut offsets, memory_index } => {
                 let mut inverse_memory_index = invert_mapping(&memory_index);
 
                 // "a" (`0..b_start`) and "b" (`b_start..`) correspond to
@@ -1457,7 +1457,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                 let memory_index_b = invert_mapping(&inverse_memory_index_b);
 
                 let outer_fields =
-                    FieldPlacement::Arbitrary { offsets: offsets_a, memory_index: memory_index_a };
+                    FieldsShape::Arbitrary { offsets: offsets_a, memory_index: memory_index_a };
                 (outer_fields, offsets_b, memory_index_b)
             }
             _ => bug!(),
@@ -1491,7 +1491,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                 variant.variants = Variants::Single { index };
 
                 let (offsets, memory_index) = match variant.fields {
-                    FieldPlacement::Arbitrary { offsets, memory_index } => (offsets, memory_index),
+                    FieldsShape::Arbitrary { offsets, memory_index } => (offsets, memory_index),
                     _ => bug!(),
                 };
 
@@ -1534,7 +1534,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                 combined_inverse_memory_index.retain(|&i| i != INVALID_FIELD_IDX);
                 let combined_memory_index = invert_mapping(&combined_inverse_memory_index);
 
-                variant.fields = FieldPlacement::Arbitrary {
+                variant.fields = FieldsShape::Arbitrary {
                     offsets: combined_offsets,
                     memory_index: combined_memory_index,
                 };
@@ -1989,7 +1989,7 @@ where
                 if index == variant_index &&
                 // Don't confuse variants of uninhabited enums with the enum itself.
                 // For more details see https://github.com/rust-lang/rust/issues/69763.
-                this.fields != FieldPlacement::Union(0) =>
+                this.fields != FieldsShape::Union(0) =>
             {
                 this.layout
             }
@@ -2007,7 +2007,7 @@ where
                 let tcx = cx.tcx();
                 tcx.intern_layout(Layout {
                     variants: Variants::Single { index: variant_index },
-                    fields: FieldPlacement::Union(fields),
+                    fields: FieldsShape::Union(fields),
                     abi: Abi::Uninhabited,
                     largest_niche: None,
                     align: tcx.data_layout.i8_align,
@@ -2053,7 +2053,7 @@ where
                 // Reuse the fat `*T` type as its own thin pointer data field.
                 // This provides information about, e.g., DST struct pointees
                 // (which may have no non-DST form), and will work as long
-                // as the `Abi` or `FieldPlacement` is checked by users.
+                // as the `Abi` or `FieldsShape` is checked by users.
                 if i == 0 {
                     let nil = tcx.mk_unit();
                     let ptr_ty = if this.ty.is_unsafe_ptr() {
@@ -2218,7 +2218,7 @@ where
 
                 if let Some(variant) = data_variant {
                     // We're not interested in any unions.
-                    if let FieldPlacement::Union(_) = variant.fields {
+                    if let FieldsShape::Union(_) = variant.fields {
                         data_variant = None;
                     }
                 }

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -219,7 +219,7 @@ impl<'tcx, Tag> MPlaceTy<'tcx, Tag> {
             // Go through the layout.  There are lots of types that support a length,
             // e.g., SIMD types.
             match self.layout.fields {
-                layout::FieldPlacement::Array { count, .. } => Ok(count),
+                layout::FieldsShape::Array { count, .. } => Ok(count),
                 _ => bug!("len not supported on sized type {:?}", self.layout.ty),
             }
         }
@@ -437,7 +437,7 @@ where
     ) -> InterpResult<'tcx, MPlaceTy<'tcx, M::PointerTag>> {
         // Not using the layout method because we want to compute on u64
         match base.layout.fields {
-            layout::FieldPlacement::Array { stride, .. } => {
+            layout::FieldsShape::Array { stride, .. } => {
                 let len = base.len(self)?;
                 if index >= len {
                     // This can only be reached in ConstProp and non-rustc-MIR.
@@ -463,7 +463,7 @@ where
     {
         let len = base.len(self)?; // also asserts that we have a type where this makes sense
         let stride = match base.layout.fields {
-            layout::FieldPlacement::Array { stride, .. } => stride,
+            layout::FieldsShape::Array { stride, .. } => stride,
             _ => bug!("mplace_array_fields: expected an array layout"),
         };
         let layout = base.layout.field(self, 0)?;
@@ -493,7 +493,7 @@ where
         // Not using layout method because that works with usize, and does not work with slices
         // (that have count 0 in their layout).
         let from_offset = match base.layout.fields {
-            layout::FieldPlacement::Array { stride, .. } => stride * from, // `Size` multiplication is checked
+            layout::FieldsShape::Array { stride, .. } => stride * from, // `Size` multiplication is checked
             _ => bug!("Unexpected layout of index access: {:#?}", base.layout),
         };
 

--- a/src/librustc_mir/interpret/visitor.rs
+++ b/src/librustc_mir/interpret/visitor.rs
@@ -207,10 +207,10 @@ macro_rules! make_value_visitor {
 
                 // Visit the fields of this value.
                 match v.layout().fields {
-                    layout::FieldPlacement::Union(fields) => {
+                    layout::FieldsShape::Union(fields) => {
                         self.visit_union(v, fields)?;
                     },
-                    layout::FieldPlacement::Arbitrary { ref offsets, .. } => {
+                    layout::FieldsShape::Arbitrary { ref offsets, .. } => {
                         // FIXME: We collect in a vec because otherwise there are lifetime
                         // errors: Projecting to a field needs access to `ecx`.
                         let fields: Vec<InterpResult<'tcx, Self::V>> =
@@ -220,7 +220,7 @@ macro_rules! make_value_visitor {
                             .collect();
                         self.visit_aggregate(v, fields.into_iter())?;
                     },
-                    layout::FieldPlacement::Array { .. } => {
+                    layout::FieldsShape::Array { .. } => {
                         // Let's get an mplace first.
                         let mplace = v.to_op(self.ecx())?.assert_mem_place(self.ecx());
                         // Now we can go over all the fields.

--- a/src/librustc_target/abi/call/mips64.rs
+++ b/src/librustc_target/abi/call/mips64.rs
@@ -49,7 +49,7 @@ where
         // use of float registers to structures (not unions) containing exactly one or two
         // float fields.
 
-        if let abi::FieldPlacement::Arbitrary { .. } = ret.layout.fields {
+        if let abi::FieldsShape::Arbitrary { .. } = ret.layout.fields {
             if ret.layout.fields.count() == 1 {
                 if let Some(reg) = float_reg(cx, ret, 0) {
                     ret.cast_to(reg);
@@ -88,15 +88,15 @@ where
     let mut prefix_index = 0;
 
     match arg.layout.fields {
-        abi::FieldPlacement::Array { .. } => {
+        abi::FieldsShape::Array { .. } => {
             // Arrays are passed indirectly
             arg.make_indirect();
             return;
         }
-        abi::FieldPlacement::Union(_) => {
+        abi::FieldsShape::Union(_) => {
             // Unions and are always treated as a series of 64-bit integer chunks
         }
-        abi::FieldPlacement::Arbitrary { .. } => {
+        abi::FieldsShape::Arbitrary { .. } => {
             // Structures are split up into a series of 64-bit integer chunks, but any aligned
             // doubles not part of another aggregate are passed as floats.
             let mut last_offset = Size::ZERO;

--- a/src/librustc_target/abi/call/mod.rs
+++ b/src/librustc_target/abi/call/mod.rs
@@ -1,4 +1,4 @@
-use crate::abi::{self, Abi, Align, FieldPlacement, Size};
+use crate::abi::{self, Abi, Align, FieldsShape, Size};
 use crate::abi::{HasDataLayout, LayoutOf, TyAndLayout, TyAndLayoutMethods};
 use crate::spec::{self, HasTargetSpec};
 
@@ -315,7 +315,7 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
                      start: Size|
                      -> Result<(HomogeneousAggregate, Size), Heterogeneous> {
                         let is_union = match layout.fields {
-                            FieldPlacement::Array { count, .. } => {
+                            FieldsShape::Array { count, .. } => {
                                 assert_eq!(start, Size::ZERO);
 
                                 let result = if count > 0 {
@@ -325,8 +325,8 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
                                 };
                                 return Ok((result, layout.size));
                             }
-                            FieldPlacement::Union(_) => true,
-                            FieldPlacement::Arbitrary { .. } => false,
+                            FieldsShape::Union(_) => true,
+                            FieldsShape::Arbitrary { .. } => false,
                         };
 
                         let mut result = HomogeneousAggregate::NoData;

--- a/src/librustc_target/abi/call/riscv.rs
+++ b/src/librustc_target/abi/call/riscv.rs
@@ -6,7 +6,7 @@
 
 use crate::abi::call::{ArgAbi, ArgAttribute, CastTarget, FnAbi, PassMode, Reg, RegKind, Uniform};
 use crate::abi::{
-    self, Abi, FieldPlacement, HasDataLayout, LayoutOf, Size, TyAndLayout, TyAndLayoutMethods,
+    self, Abi, FieldsShape, HasDataLayout, LayoutOf, Size, TyAndLayout, TyAndLayoutMethods,
 };
 use crate::spec::HasTargetSpec;
 
@@ -87,12 +87,12 @@ where
         },
         Abi::Vector { .. } | Abi::Uninhabited => return Err(CannotUseFpConv),
         Abi::ScalarPair(..) | Abi::Aggregate { .. } => match arg_layout.fields {
-            FieldPlacement::Union(_) => {
+            FieldsShape::Union(_) => {
                 if !arg_layout.is_zst() {
                     return Err(CannotUseFpConv);
                 }
             }
-            FieldPlacement::Array { count, .. } => {
+            FieldsShape::Array { count, .. } => {
                 for _ in 0..count {
                     let elem_layout = arg_layout.field(cx, 0);
                     should_use_fp_conv_helper(
@@ -105,7 +105,7 @@ where
                     )?;
                 }
             }
-            FieldPlacement::Arbitrary { .. } => {
+            FieldsShape::Arbitrary { .. } => {
                 match arg_layout.variants {
                     abi::Variants::Multiple { .. } => return Err(CannotUseFpConv),
                     abi::Variants::Single { .. } => (),


### PR DESCRIPTION
Originally suggested by @eddyb.