### PR TITLE
windows-specific extensions for accessing Windows profileapi

### DIFF
--- a/src/libstd/sys/windows/ext/mod.rs
+++ b/src/libstd/sys/windows/ext/mod.rs
@@ -16,6 +16,7 @@ pub mod io;
 pub mod process;
 pub mod raw;
 pub mod thread;
+pub mod time;
 
 /// A prelude for conveniently writing platform-specific code.
 ///

--- a/src/libstd/sys/windows/ext/time.rs
+++ b/src/libstd/sys/windows/ext/time.rs
@@ -1,0 +1,21 @@
+//! Windows-specific extensions to access Windows profileapi.
+
+#![stable(feature = "windows_profileapi", since = "1.43.0")]
+
+use crate::sys::cvt;
+use crate::sys::c;
+
+/// Stores the current value of the performance counter to the memory pointed by the argument pointer,
+/// Counter value is a high resolution (<1us) time stamp that can be used for time-interval measurements.
+#[stable(feature = "windows_profileapi", since = "1.43.0")]
+pub fn QueryPerformanceCounter(qpc_value: &mut i64) -> crate::io::Result<i32> {
+    cvt( unsafe { c::QueryPerformanceCounter(qpc_value) } )
+}
+
+/// Stores the frequency of the performance counter to the memory pointed by the argument pointer.
+/// The frequency of the performance counter is fixed at system boot and is consistent across all processors.
+/// Therefore, the frequency need only be queried upon application initialization, and the result can be cached.
+#[stable(feature = "windows_profileapi", since = "1.43.0")]
+pub fn QueryPerformanceFrequency(frequency: &mut i64) -> crate::io::Result<i32> {
+    cvt( unsafe { c::QueryPerformanceFrequency(frequency) } )
+}

--- a/src/libstd/sys/windows/ext/time.rs
+++ b/src/libstd/sys/windows/ext/time.rs
@@ -2,8 +2,8 @@
 
 #![stable(feature = "windows_profileapi", since = "1.43.0")]
 
-use crate::sys::cvt;
 use crate::sys::c;
+use crate::sys::cvt;
 
 /// Stores the current value of the performance counter to the memory pointed by the argument pointer,
 /// Counter value is a high resolution (<1us) time stamp that can be used for time-interval measurements.

--- a/src/libstd/sys/windows/ext/time.rs
+++ b/src/libstd/sys/windows/ext/time.rs
@@ -9,7 +9,7 @@ use crate::sys::c;
 /// Counter value is a high resolution (<1us) time stamp that can be used for time-interval measurements.
 #[stable(feature = "windows_profileapi", since = "1.43.0")]
 pub fn QueryPerformanceCounter(qpc_value: &mut i64) -> crate::io::Result<i32> {
-    cvt( unsafe { c::QueryPerformanceCounter(qpc_value) } )
+    cvt(unsafe { c::QueryPerformanceCounter(qpc_value) })
 }
 
 /// Stores the frequency of the performance counter to the memory pointed by the argument pointer.
@@ -17,5 +17,5 @@ pub fn QueryPerformanceCounter(qpc_value: &mut i64) -> crate::io::Result<i32> {
 /// Therefore, the frequency need only be queried upon application initialization, and the result can be cached.
 #[stable(feature = "windows_profileapi", since = "1.43.0")]
 pub fn QueryPerformanceFrequency(frequency: &mut i64) -> crate::io::Result<i32> {
-    cvt( unsafe { c::QueryPerformanceFrequency(frequency) } )
+    cvt(unsafe { c::QueryPerformanceFrequency(frequency) })
 }


### PR DESCRIPTION
Added new module `time` to `std::os::windows`, for accessing **Windows profileapi** as below.
* `QueryPerformanceCounter`
* `QueryPerformanceFrequency`

Need for these extensions arised while working on rust-lang/miri#997, which requires implementing
3 Windows shims
* `GetSystemTimeAsFileTime`
* `QueryPerformanceCounter`
* `QueryPerformanceFrequency`

(The latter two shims are not yet mentioned in the issue, but they are currently needed to pass the latest version of test case : `MIRI/tests/run-pass/time.rs`))

Implementing the first shim didn't need new extensions to `std::os::windows`,
but implementing the other two shims needs direct access to Windows API.
(I couldn't find any public API from `libstd` to be used in `MIRI` for implementing the shims)

I also tried using [`winapi` library](https://docs.rs/winapi/0.3.8/winapi/um/profileapi/fn.QueryPerformanceFrequency.html) in MIRI, but I got an error saying that "MIRI doesn't support foreign functions".

p.s. -
It's my first time pushing code to `libstd`, so some annotations might have to be fixed..