### PR TITLE
cargotest: remove webrender

### DIFF
--- a/src/tools/cargotest/main.rs
+++ b/src/tools/cargotest/main.rs
@@ -58,13 +58,6 @@ const TEST_REPOS: &'static [Test] = &[
         // This takes much less time to build than all of Servo and supports stable Rust.
         packages: &["selectors"],
     },
-    Test {
-        name: "webrender",
-        repo: "https://github.com/servo/webrender",
-        sha: "a3d6e6894c5a601fa547c6273eb963ca1321c2bb",
-        lock: None,
-        packages: &[],
-    },
 ];
 
 fn main() {


### PR DESCRIPTION
The current webrender commit occasionally fails without a reason, and the latest webrender commit is missing a dependency on our Windows builders. It's not worth installing an extra dependency for cargotest, and the spurious failure makes keeping this test not worth it.

r? @Mark-Simulacrum 