### PR TITLE
GHA: enable running multiple try builds at the same time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
         with:
           github_token: "${{ secrets.github_token }}"
-        if: success() && !env.SKIP_JOB
+        if: "success() && !env.SKIP_JOB && github.ref != 'refs/heads/try'"
       - name: add extra environment variables
         run: src/ci/scripts/setup-environment.sh
         env:
@@ -196,7 +196,7 @@ jobs:
         uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
         with:
           github_token: "${{ secrets.github_token }}"
-        if: success() && !env.SKIP_JOB
+        if: "success() && !env.SKIP_JOB && github.ref != 'refs/heads/try'"
       - name: add extra environment variables
         run: src/ci/scripts/setup-environment.sh
         env:
@@ -626,7 +626,7 @@ jobs:
         uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
         with:
           github_token: "${{ secrets.github_token }}"
-        if: success() && !env.SKIP_JOB
+        if: "success() && !env.SKIP_JOB && github.ref != 'refs/heads/try'"
       - name: add extra environment variables
         run: src/ci/scripts/setup-environment.sh
         env:

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -103,6 +103,7 @@ x--expand-yaml-anchors--remove:
         uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
         with:
           github_token: "${{ secrets.github_token }}"
+        if: success() && !env.SKIP_JOB && github.ref != 'refs/heads/try'
         <<: *step
 
       - name: add extra environment variables


### PR DESCRIPTION
While for auto, try and PR builds we only want the latest commit to be tested, that's not true for try builds: each commit pushed to the branch is a different PR being tested, and we want multiple PRs to be tested in parallel if there is enough demand.

Fixes #70569