### PR TITLE
expand vec![] to Vec::new()

### DIFF
--- a/src/liballoc/macros.rs
+++ b/src/liballoc/macros.rs
@@ -36,6 +36,9 @@
 #[stable(feature = "rust1", since = "1.0.0")]
 #[allow_internal_unstable(box_syntax)]
 macro_rules! vec {
+    () => (
+        $crate::vec::Vec::new()
+    );
     ($elem:expr; $n:expr) => (
         $crate::vec::from_elem($elem, $n)
     );
@@ -51,6 +54,9 @@ macro_rules! vec {
 // NB see the slice::hack module in slice.rs for more information
 #[cfg(test)]
 macro_rules! vec {
+    () => (
+        $crate::vec::Vec::new()
+    );
     ($elem:expr; $n:expr) => (
         $crate::vec::from_elem($elem, $n)
     );


### PR DESCRIPTION
The current expansion of `vec![]` calls `into_vec` on a boxed slice, which results in longer IR, and even after optimization, some unwinding artifacts are still present in the IR. This PR uses `Vec::new()` for `vec![]`.

This also allows `vec![]` to be used in const expressions.