### PR TITLE
Confusing suggestion on incorrect closing `}`

### DIFF
--- a/src/librustc_parse/lexer/tokentrees.rs
+++ b/src/librustc_parse/lexer/tokentrees.rs
@@ -246,7 +246,7 @@ impl<'a> TokenTreesReader<'a> {
                             if (parent.0.to(parent.1)).contains(span) {
                                 err.span_label(
                                     span,
-                                    "this block is empty, you might have not meant to close it",
+                                    "block is empty, you might have not meant to close it",
                                 );
                             }
                             else {

--- a/src/librustc_parse/lexer/tokentrees.rs
+++ b/src/librustc_parse/lexer/tokentrees.rs
@@ -172,7 +172,6 @@ impl<'a> TokenTreesReader<'a> {
                         let mut unclosed_delimiter = None;
                         let mut candidate = None;
 
-
                         if self.last_unclosed_found_span != Some(self.token.span) {
                             // do not complain about the same unclosed delimiter multiple times
                             self.last_unclosed_found_span = Some(self.token.span);

--- a/src/librustc_parse/lexer/tokentrees.rs
+++ b/src/librustc_parse/lexer/tokentrees.rs
@@ -77,6 +77,7 @@ impl<'a> TokenTreesReader<'a> {
 
     fn parse_token_tree(&mut self) -> PResult<'a, TreeAndJoint> {
         let sm = self.string_reader.sess.source_map();
+
         match self.token.kind {
             token::Eof => {
                 let msg = "this file contains an unclosed delimiter";
@@ -216,7 +217,7 @@ impl<'a> TokenTreesReader<'a> {
 
                 Ok(TokenTree::Delimited(delim_span, delim, tts).into())
             }
-            token::CloseDelim(delim) => {
+            token::CloseDelim(_delim) => {
                 // An unexpected closing delimiter (i.e., there is no
                 // matching opening delimiter).
                 let token_str = token_to_string(&self.token);
@@ -224,13 +225,8 @@ impl<'a> TokenTreesReader<'a> {
                 let mut err =
                     self.string_reader.sess.span_diagnostic.struct_span_err(self.token.span, &msg);
 
-                if let Some(span) = self.last_delim_empty_block_spans.remove(&delim) {
-                    err.span_label(
-                        span,
-                        "this block is empty, you might have not meant to close it",
-                    );
-                }
                 err.span_label(self.token.span, "unexpected closing delimiter");
+
                 Err(err)
             }
             _ => {

--- a/src/test/ui/parser/issue-70583-block-is-empty-1.rs
+++ b/src/test/ui/parser/issue-70583-block-is-empty-1.rs
@@ -16,5 +16,5 @@ fn struct_generic(x: Vec<i32>) {
     for v in x {
         println!("{}", v);
     }
-    } 
+    }
 } //~ ERROR unexpected closing delimiter: `}`

--- a/src/test/ui/parser/issue-70583-block-is-empty-1.rs
+++ b/src/test/ui/parser/issue-70583-block-is-empty-1.rs
@@ -1,0 +1,20 @@
+pub enum ErrorHandled {
+    Reported,
+    TooGeneric,
+}
+
+impl ErrorHandled {
+    pub fn assert_reported(self) {
+        match self {
+            ErrorHandled::Reported => {}
+            ErrorHandled::TooGeneric => panic!(),
+        }
+    }
+}
+
+fn struct_generic(x: Vec<i32>) {
+    for v in x {
+        println!("{}", v);
+    }
+    } 
+} //~ ERROR unexpected closing delimiter: `}`

--- a/src/test/ui/parser/issue-70583-block-is-empty-1.stderr
+++ b/src/test/ui/parser/issue-70583-block-is-empty-1.stderr
@@ -1,6 +1,9 @@
 error: unexpected closing delimiter: `}`
   --> $DIR/issue-70583-block-is-empty-1.rs:20:1
    |
+LL |             ErrorHandled::Reported => {}
+   |                                       -- this block is empty, you might have not meant to close it
+...
 LL | }
    | ^ unexpected closing delimiter
 

--- a/src/test/ui/parser/issue-70583-block-is-empty-1.stderr
+++ b/src/test/ui/parser/issue-70583-block-is-empty-1.stderr
@@ -1,9 +1,11 @@
 error: unexpected closing delimiter: `}`
   --> $DIR/issue-70583-block-is-empty-1.rs:20:1
    |
-LL |             ErrorHandled::Reported => {}
-   |                                       -- this block is empty, you might have not meant to close it
+LL | fn struct_generic(x: Vec<i32>) {
+   |                                - this opening brace...
 ...
+LL |     }
+   |     - ...matches this closing brace
 LL | }
    | ^ unexpected closing delimiter
 

--- a/src/test/ui/parser/issue-70583-block-is-empty-1.stderr
+++ b/src/test/ui/parser/issue-70583-block-is-empty-1.stderr
@@ -1,0 +1,8 @@
+error: unexpected closing delimiter: `}`
+  --> $DIR/issue-70583-block-is-empty-1.rs:20:1
+   |
+LL | }
+   | ^ unexpected closing delimiter
+
+error: aborting due to previous error
+

--- a/src/test/ui/parser/issue-70583-block-is-empty-2.rs
+++ b/src/test/ui/parser/issue-70583-block-is-empty-2.rs
@@ -6,8 +6,8 @@ pub enum ErrorHandled {
 impl ErrorHandled {
     pub fn assert_reported(self) {
         match self {
-            ErrorHandled::Reported => {}} 
-                                     //^~ ERROR this block is empty, you might have not mean to close it
+            ErrorHandled::Reported => {}}
+                                     //^~ ERROR this block is empty, you might have not meant to close it
             ErrorHandled::TooGeneric => panic!(),
         }
     }

--- a/src/test/ui/parser/issue-70583-block-is-empty-2.rs
+++ b/src/test/ui/parser/issue-70583-block-is-empty-2.rs
@@ -1,0 +1,14 @@
+pub enum ErrorHandled {
+    Reported,
+    TooGeneric,
+}
+
+impl ErrorHandled {
+    pub fn assert_reported(self) {
+        match self {
+            ErrorHandled::Reported => {}} 
+                                     //^~ ERROR this block is empty, you might have not mean to close it
+            ErrorHandled::TooGeneric => panic!(),
+        }
+    }
+} //~ ERROR unexpected closing delimiter: `}`

--- a/src/test/ui/parser/issue-70583-block-is-empty-2.rs
+++ b/src/test/ui/parser/issue-70583-block-is-empty-2.rs
@@ -7,7 +7,7 @@ impl ErrorHandled {
     pub fn assert_reported(self) {
         match self {
             ErrorHandled::Reported => {}}
-                                     //^~ ERROR this block is empty, you might have not meant to close it
+                                     //^~ ERROR block is empty, you might have not meant to close it
             ErrorHandled::TooGeneric => panic!(),
         }
     }

--- a/src/test/ui/parser/issue-70583-block-is-empty-2.stderr
+++ b/src/test/ui/parser/issue-70583-block-is-empty-2.stderr
@@ -1,7 +1,7 @@
 error: unexpected closing delimiter: `}`
   --> $DIR/issue-70583-block-is-empty-2.rs:14:1
    |
-LL |             ErrorHandled::Reported => {}} 
+LL |             ErrorHandled::Reported => {}}
    |                                       -- this block is empty, you might have not meant to close it
 ...
 LL | }

--- a/src/test/ui/parser/issue-70583-block-is-empty-2.stderr
+++ b/src/test/ui/parser/issue-70583-block-is-empty-2.stderr
@@ -2,7 +2,7 @@ error: unexpected closing delimiter: `}`
   --> $DIR/issue-70583-block-is-empty-2.rs:14:1
    |
 LL |             ErrorHandled::Reported => {}}
-   |                                       -- this block is empty, you might have not meant to close it
+   |                                       -- block is empty, you might have not meant to close it
 ...
 LL | }
    | ^ unexpected closing delimiter

--- a/src/test/ui/parser/issue-70583-block-is-empty-2.stderr
+++ b/src/test/ui/parser/issue-70583-block-is-empty-2.stderr
@@ -1,0 +1,11 @@
+error: unexpected closing delimiter: `}`
+  --> $DIR/issue-70583-block-is-empty-2.rs:14:1
+   |
+LL |             ErrorHandled::Reported => {}} 
+   |                                       -- this block is empty, you might have not meant to close it
+...
+LL | }
+   | ^ unexpected closing delimiter
+
+error: aborting due to previous error
+

--- a/src/test/ui/parser/macro-mismatched-delim-paren-brace.stderr
+++ b/src/test/ui/parser/macro-mismatched-delim-paren-brace.stderr
@@ -1,6 +1,11 @@
 error: unexpected closing delimiter: `}`
   --> $DIR/macro-mismatched-delim-paren-brace.rs:5:1
    |
+LL | fn main() {
+   |           - this opening brace...
+...
+LL |     }
+   |     - ...matches this closing brace
 LL | }
    | ^ unexpected closing delimiter
 

--- a/src/test/ui/parser/mismatched-delim-brace-empty-block.stderr
+++ b/src/test/ui/parser/mismatched-delim-brace-empty-block.stderr
@@ -1,6 +1,12 @@
 error: unexpected closing delimiter: `}`
   --> $DIR/mismatched-delim-brace-empty-block.rs:5:1
    |
+LL | fn main() {
+   |           - this opening brace...
+LL | 
+LL | }
+   | - ...matches this closing brace
+LL |     let _ = ();
 LL | }
    | ^ unexpected closing delimiter
 


### PR DESCRIPTION
Compiler returns 
``` 
error: unexpected closing delimiter: `}`
  --> main.rs:20:1
   |
9  |             ErrorHandled::Reported => {}
   |                                       -- this block is empty, you might have not meant to close it temp
...
20 | }
   | ^ unexpected closing delimiter

error: aborting due to previous error
```