### PR TITLE
Forbid pineapple on pizza

### DIFF
--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -48,6 +48,7 @@ mod late;
 mod levels;
 mod non_ascii_idents;
 mod nonstandard_style;
+mod nonstandard_taste;
 mod passes;
 mod redundant_semicolon;
 mod types;
@@ -69,6 +70,7 @@ use builtin::*;
 use internal::*;
 use non_ascii_idents::*;
 use nonstandard_style::*;
+use nonstandard_taste::*;
 use redundant_semicolon::*;
 use types::*;
 use unused::*;
@@ -183,6 +185,7 @@ macro_rules! late_lint_mod_passes {
                 UnreachablePub: UnreachablePub,
                 ExplicitOutlivesRequirements: ExplicitOutlivesRequirements,
                 InvalidValue: InvalidValue,
+                PineappleOnPizza: PineappleOnPizza,
             ]
         );
     };
@@ -246,6 +249,8 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
         store.register_lints(&BuiltinCombinedModuleLateLintPass::get_lints());
         store.register_lints(&BuiltinCombinedLateLintPass::get_lints());
     }
+
+    add_lint_group!("nonstandard_taste", PINEAPPLE_ON_PIZZA);
 
     add_lint_group!(
         "nonstandard_style",

--- a/src/librustc_lint/nonstandard_taste.rs
+++ b/src/librustc_lint/nonstandard_taste.rs
@@ -1,0 +1,52 @@
+use crate::{LateContext, LateLintPass, LintContext};
+use rustc_hir as hir;
+
+declare_lint! {
+    pub PINEAPPLE_ON_PIZZA,
+    Forbid,
+   "pineapple doesn't go on pizza"
+}
+
+declare_lint_pass!(PineappleOnPizza => [PINEAPPLE_ON_PIZZA]);
+
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for PineappleOnPizza {
+    fn check_ty(&mut self, cx: &LateContext<'_, '_>, ty: &hir::Ty<'_>) {
+        if let hir::TyKind::Path(hir::QPath::Resolved(_, path)) = &ty.kind {
+            for pizza_segment in path.segments {
+                if let Some(args) = pizza_segment.args {
+                    if pizza_segment.ident.name.as_str().to_lowercase() != "pizza" {
+                        continue;
+                    }
+                    for arg in args.args {
+                        if let hir::GenericArg::Type(hir::Ty {
+                            kind: hir::TyKind::Path(hir::QPath::Resolved(_, path)),
+                            ..
+                        }) = arg
+                        {
+                            for pineapple_segment in path.segments {
+                                if pineapple_segment.ident.name.as_str().to_lowercase()
+                                    == "pineapple"
+                                {
+                                    cx.struct_span_lint(
+                                        PINEAPPLE_ON_PIZZA,
+                                        pineapple_segment.ident.span,
+                                        |lint| {
+                                            let mut err =
+                                                lint.build("pineapple doesn't go on pizza");
+                                            err.span_label(
+                                                pizza_segment.ident.span,
+                                                "this is the pizza you ruined",
+                                            );
+                                            err.note("you're a monster"); // Yep Esteban, you are.
+                                            err.emit();
+                                        },
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/ui/lint/pineapple-on-pizza.rs
+++ b/src/test/ui/lint/pineapple-on-pizza.rs
@@ -1,0 +1,6 @@
+struct Pizza<T>(T);
+struct Pineapple;
+
+fn main() {
+    let _: Pizza<Pineapple>; //~ERROR pineapple doesn't go on pizza
+}

--- a/src/test/ui/lint/pineapple-on-pizza.stderr
+++ b/src/test/ui/lint/pineapple-on-pizza.stderr
@@ -1,0 +1,13 @@
+error: pineapple doesn't go on pizza
+  --> $DIR/pineapple-on-pizza.rs:5:18
+   |
+LL |     let _: Pizza<Pineapple>;
+   |            ----- ^^^^^^^^^
+   |            |
+   |            this is the pizza you ruined
+   |
+   = note: `#[forbid(pineapple_on_pizza)]` on by default
+   = note: you're a monster
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This PR adds a new forbid-by-default lint to the Rust compiler, preventing users from writing wildly untasteful types such as `Pizza<Pineapple>`.

![error](https://user-images.githubusercontent.com/2299951/78065002-ea354300-7392-11ea-875c-8eee5b2d7254.png)

r? @estebank
cc @steveklabnik, what do you think is the best way to document this feature?

<sub>This was inspired by @sgrif's awesome [RustConf 2017 talk](https://youtu.be/wxPehGkoNOw?t=526). Check it out!</sub>