### PR TITLE
Improve scrollbar display in rustdoc

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -182,6 +182,18 @@ nav.sub {
 	top: 0;
 	bottom: 0;
 	overflow: auto;
+	/* Improve the sidebar display on firefox */
+	scrollbar-width: thin;
+}
+
+/* Improve the sidebar display on webkit-based browsers */
+.sidebar::-webkit-scrollbar {
+	width: 8px;
+}
+
+/* Improve the sidebar display on webkit-based browsers */
+.sidebar::-webkit-scrollbar-track {
+	-webkit-box-shadow: inset 0;
 }
 
 .sidebar .block > ul > li {

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -182,17 +182,24 @@ nav.sub {
 	top: 0;
 	bottom: 0;
 	overflow: auto;
-	/* Improve the sidebar display on firefox */
+}
+
+/* Improve the scrollbar display on firefox */
+* {
+	scrollbar-width: initial;
+}
+.sidebar {
 	scrollbar-width: thin;
 }
 
-/* Improve the sidebar display on webkit-based browsers */
+/* Improve the scrollbar display on webkit-based browsers */
+::-webkit-scrollbar {
+	width: 12px;
+}
 .sidebar::-webkit-scrollbar {
 	width: 8px;
 }
-
-/* Improve the sidebar display on webkit-based browsers */
-.sidebar::-webkit-scrollbar-track {
+::-webkit-scrollbar-track {
 	-webkit-box-shadow: inset 0;
 }
 

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -30,6 +30,18 @@ pre {
 
 .sidebar {
 	background-color: #505050;
+	/* Improve the sidebar display on firefox */
+	scrollbar-color: rgba(32,34,37,.6) transparent;
+}
+
+/* Improve the sidebar display on webkit-based browsers */
+.sidebar::-webkit-scrollbar-track {
+	background-color: #717171;
+}
+
+/* Improve the sidebar display on webkit-based browsers */
+.sidebar::-webkit-scrollbar-thumb {
+	background-color: rgba(32, 34, 37, .6);
 }
 
 .sidebar .current {

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -30,16 +30,26 @@ pre {
 
 .sidebar {
 	background-color: #505050;
-	/* Improve the sidebar display on firefox */
+}
+
+/* Improve the scrollbar display on firefox */
+* {
+	scrollbar-color: rgb(64, 65, 67) #717171;
+}
+.sidebar {
 	scrollbar-color: rgba(32,34,37,.6) transparent;
 }
 
-/* Improve the sidebar display on webkit-based browsers */
+/* Improve the scrollbar display on webkit-based browsers */
+::-webkit-scrollbar-track {
+	background-color: #717171;
+}
+::-webkit-scrollbar-thumb {
+	background-color: rgba(32, 34, 37, .6);
+}
 .sidebar::-webkit-scrollbar-track {
 	background-color: #717171;
 }
-
-/* Improve the sidebar display on webkit-based browsers */
 .sidebar::-webkit-scrollbar-thumb {
 	background-color: rgba(32, 34, 37, .6);
 }

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -32,16 +32,27 @@ pre {
 
 .sidebar {
 	background-color: #F1F1F1;
-	/* Improve the sidebar display on firefox */
+}
+
+/* Improve the scrollbar display on firefox */
+* {
+	scrollbar-color: rgba(36, 37, 39, 0.6) #e6e6e6;
+}
+
+.sidebar {
 	scrollbar-color: rgba(36, 37, 39, 0.6) #d9d9d9;
 }
 
-/* Improve the sidebar display on webkit-based browsers */
+/* Improve the scrollbar display on webkit-based browsers */
+::-webkit-scrollbar-track {
+	background-color: #ecebeb;
+}
+::-webkit-scrollbar-thumb {
+	background-color: rgba(36, 37, 39, 0.6);
+}
 .sidebar::-webkit-scrollbar-track {
 	background-color: #dcdcdc;
 }
-
-/* Improve the sidebar display on webkit-based browsers */
 .sidebar::-webkit-scrollbar-thumb {
 	background-color: rgba(36, 37, 39, 0.6);
 }

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -32,6 +32,18 @@ pre {
 
 .sidebar {
 	background-color: #F1F1F1;
+	/* Improve the sidebar display on firefox */
+	scrollbar-color: rgba(36, 37, 39, 0.6) #d9d9d9;
+}
+
+/* Improve the sidebar display on webkit-based browsers */
+.sidebar::-webkit-scrollbar-track {
+	background-color: #dcdcdc;
+}
+
+/* Improve the sidebar display on webkit-based browsers */
+.sidebar::-webkit-scrollbar-thumb {
+	background-color: rgba(36, 37, 39, 0.6);
 }
 
 .sidebar .current {


### PR DESCRIPTION
The scrollbar of the left sidebar in rustdoc looks very bad on firefox (on dark theme). This PR improves it:

<div style="display:inline-block;">
<div style="width:50%;display:inline-block;float:left;">
<image src="https://user-images.githubusercontent.com/3050060/78148412-202b0380-7435-11ea-8ff3-79f02ea8f9ed.png">
</div>
<div style="width:50%;display:inline-block;float:left;">
<image src="https://user-images.githubusercontent.com/3050060/78148437-28833e80-7435-11ea-946b-a6fc9320b705.png">
</div>
</div>

With light theme:

![old-firefox-light](https://user-images.githubusercontent.com/3050060/78148718-7bf58c80-7435-11ea-93d3-2a2cafd5c6ae.png)
![firefox-light](https://user-images.githubusercontent.com/3050060/78148736-7f891380-7435-11ea-8b10-a8898f73b4c9.png)

And on chrome:

![chrome-light](https://user-images.githubusercontent.com/3050060/78148903-ac3d2b00-7435-11ea-9a10-6c0376a675c3.png)
![chrome-dark](https://user-images.githubusercontent.com/3050060/78148907-ae9f8500-7435-11ea-9b89-0397b977753c.png)

Small extra question: should I extend it to all scrollbars? I think it'd be better but just in case...

r? @kinnison 