### PR TITLE
compiletest: don't use `std::io::stdout()`, as it bypasses `set_print`.

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -180,29 +180,25 @@ pub fn make_diff(expected: &str, actual: &str, context_size: usize) -> Vec<Misma
 }
 
 fn print_diff(expected: &str, actual: &str, context_size: usize) {
-    write_diff(expected, actual, context_size, std::io::stdout());
-}
-
-fn write_diff(expected: &str, actual: &str, context_size: usize, mut dest: impl io::Write) {
     let diff_results = make_diff(expected, actual, context_size);
     for result in diff_results {
         let mut line_number = result.line_number;
         for line in result.lines {
             match line {
                 DiffLine::Expected(e) => {
-                    writeln!(dest, "-\t{}", e).unwrap();
+                    println!("-\t{}", e);
                     line_number += 1;
                 }
                 DiffLine::Context(c) => {
-                    writeln!(dest, "{}\t{}", line_number, c).unwrap();
+                    println!("{}\t{}", line_number, c);
                     line_number += 1;
                 }
                 DiffLine::Resulting(r) => {
-                    writeln!(dest, "+\t{}", r).unwrap();
+                    println!("+\t{}", r);
                 }
             }
         }
-        writeln!(dest).unwrap();
+        println!();
     }
 }
 


### PR DESCRIPTION
This PR undoes a change made during #69916, which became unnecessary during review but was left in by accident, and which isn't correct due to `libtest` using `std::io::set_print`, which overwrites the `println!` behavior but *not* `writeln!(std::io::stdout(), ...)`.

The effect of using `writeln!(std::io::stdout(), ...)` was that the diff output would show *while* running the tests, instead of at the end, when failing tests are listed.

r? @Mark-Simulacrum cc @oli-obk 