### PR TITLE
rustc_target: late_link_args -> link_args

### DIFF
--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -577,16 +577,16 @@ pub struct TargetOptions {
     pub pre_link_objects_exe: Vec<String>, // ... when linking an executable, unconditionally
     pub pre_link_objects_exe_crt: Vec<String>, // ... when linking an executable with a bundled crt
     pub pre_link_objects_dll: Vec<String>, // ... when linking a dylib
-    /// Linker arguments that are unconditionally passed after any
-    /// user-defined but before post_link_objects. Standard platform
+    /// Linker arguments that are unconditionally passed immediately after any
+    /// user-defined linker arguments (`-C link-args` and friends). Standard platform
     /// libraries that should be always be linked to, usually go here.
-    pub late_link_args: LinkArgs,
-    /// Linker arguments used in addition to `late_link_args` if at least one
+    pub link_args: LinkArgs,
+    /// Linker arguments used in addition to `link_args` if at least one
     /// Rust dependency is dynamically linked.
-    pub late_link_args_dynamic: LinkArgs,
-    /// Linker arguments used in addition to `late_link_args` if aall Rust
+    pub link_args_dynamic: LinkArgs,
+    /// Linker arguments used in addition to `link_args` if aall Rust
     /// dependencies are statically linked.
-    pub late_link_args_static: LinkArgs,
+    pub link_args_static: LinkArgs,
     /// Objects to link after all others, always found within the
     /// sysroot folder.
     pub post_link_objects: Vec<String>, // ... unconditionally
@@ -857,9 +857,9 @@ impl Default for TargetOptions {
             pre_link_objects_dll: Vec::new(),
             post_link_objects: Vec::new(),
             post_link_objects_crt: Vec::new(),
-            late_link_args: LinkArgs::new(),
-            late_link_args_dynamic: LinkArgs::new(),
-            late_link_args_static: LinkArgs::new(),
+            link_args: LinkArgs::new(),
+            link_args_dynamic: LinkArgs::new(),
+            link_args_static: LinkArgs::new(),
             link_env: Vec::new(),
             link_env_remove: Vec::new(),
             archive_format: "gnu".to_string(),
@@ -1135,9 +1135,9 @@ impl Target {
         key!(pre_link_objects_exe, list);
         key!(pre_link_objects_exe_crt, list);
         key!(pre_link_objects_dll, list);
-        key!(late_link_args, link_args);
-        key!(late_link_args_dynamic, link_args);
-        key!(late_link_args_static, link_args);
+        key!(link_args, link_args);
+        key!(link_args_dynamic, link_args);
+        key!(link_args_static, link_args);
         key!(post_link_objects, list);
         key!(post_link_objects_crt, list);
         key!(post_link_args, link_args);
@@ -1362,9 +1362,9 @@ impl ToJson for Target {
         target_option_val!(pre_link_objects_exe);
         target_option_val!(pre_link_objects_exe_crt);
         target_option_val!(pre_link_objects_dll);
-        target_option_val!(link_args - late_link_args);
-        target_option_val!(link_args - late_link_args_dynamic);
-        target_option_val!(link_args - late_link_args_static);
+        target_option_val!(link_args - link_args);
+        target_option_val!(link_args - link_args_dynamic);
+        target_option_val!(link_args - link_args_static);
         target_option_val!(post_link_objects);
         target_option_val!(post_link_objects_crt);
         target_option_val!(link_args - post_link_args);

--- a/src/librustc_target/spec/windows_base.rs
+++ b/src/librustc_target/spec/windows_base.rs
@@ -16,10 +16,10 @@ pub fn opts() -> TargetOptions {
         ],
     );
 
-    let mut late_link_args = LinkArgs::new();
-    let mut late_link_args_dynamic = LinkArgs::new();
-    let mut late_link_args_static = LinkArgs::new();
-    late_link_args.insert(
+    let mut link_args = LinkArgs::new();
+    let mut link_args_dynamic = LinkArgs::new();
+    let mut link_args_static = LinkArgs::new();
+    link_args.insert(
         LinkerFlavor::Gcc,
         vec![
             "-lmingwex".to_string(),
@@ -38,7 +38,7 @@ pub fn opts() -> TargetOptions {
             "-lkernel32".to_string(),
         ],
     );
-    late_link_args_dynamic.insert(
+    link_args_dynamic.insert(
         LinkerFlavor::Gcc,
         vec![
             // If any of our crates are dynamically linked then we need to use
@@ -49,7 +49,7 @@ pub fn opts() -> TargetOptions {
             "-lkernel32".to_string(),
         ],
     );
-    late_link_args_static.insert(
+    link_args_static.insert(
         LinkerFlavor::Gcc,
         vec![
             // If all of our crates are statically linked then we can get away
@@ -90,9 +90,9 @@ pub fn opts() -> TargetOptions {
             "dllcrt2.o".to_string(), // mingw C runtime initialization for dlls
             "rsbegin.o".to_string(),
         ],
-        late_link_args,
-        late_link_args_dynamic,
-        late_link_args_static,
+        link_args,
+        link_args_dynamic,
+        link_args_static,
         post_link_objects: vec!["rsend.o".to_string()],
         abi_return_struct_as_int: true,
         emit_debug_gdb_scripts: false,

--- a/src/librustc_target/spec/windows_uwp_base.rs
+++ b/src/librustc_target/spec/windows_uwp_base.rs
@@ -14,8 +14,8 @@ pub fn opts() -> TargetOptions {
         ],
     );
 
-    let mut late_link_args = LinkArgs::new();
-    late_link_args.insert(
+    let mut link_args = LinkArgs::new();
+    link_args.insert(
         LinkerFlavor::Gcc,
         vec![
             //"-lwinstorecompat".to_string(),
@@ -52,7 +52,7 @@ pub fn opts() -> TargetOptions {
             "rsbegin.o".to_string(), // Rust compiler runtime initialization, see rsbegin.rs
         ],
         pre_link_objects_dll: vec!["rsbegin.o".to_string()],
-        late_link_args,
+        link_args,
         post_link_objects: vec!["rsend.o".to_string()],
         abi_return_struct_as_int: true,
         emit_debug_gdb_scripts: false,

--- a/src/libunwind/build.rs
+++ b/src/libunwind/build.rs
@@ -33,7 +33,7 @@ fn main() {
     } else if target.contains("dragonfly") {
         println!("cargo:rustc-link-lib=gcc_pic");
     } else if target.contains("pc-windows-gnu") {
-        // This is handled in the target spec with late_link_args_[static|dynamic]
+        // This is handled in the target spec with link_args_[static|dynamic]
 
         // cfg!(bootstrap) doesn't work in build scripts
         if env::var("RUSTC_STAGE").ok() == Some("0".to_string()) {


### PR DESCRIPTION
These options directly correspond to `-C link-args` and are passed together with them, except that they are defined by the target specification rather than by command line options.

(I'm trying to put linker options into groups to document what is passed after what and at which point `-C link-args` and `-Z pre-link-args` are inserted. cc https://github.com/rust-lang/rust/pull/70505)