### PR TITLE
link with "libssp" on *-sun-solaris systems

### DIFF
--- a/src/librustc_target/spec/solaris_base.rs
+++ b/src/librustc_target/spec/solaris_base.rs
@@ -1,7 +1,20 @@
-use crate::spec::TargetOptions;
+use crate::spec::{LinkArgs, LinkerFlavor, TargetOptions};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {
+    let mut late_link_args = LinkArgs::new();
+    late_link_args.insert(
+        LinkerFlavor::Gcc,
+        vec![
+            // LLVM will insert calls to the stack protector functions
+            // "__stack_chk_fail" and "__stack_chk_guard" into code in native
+            // object files.  Some platforms include these symbols directly in
+            // libc, but at least historically these have been provided in
+            // libssp.so on illumos and Solaris systems.
+            "-lssp".to_string(),
+        ],
+    );
+
     TargetOptions {
         dynamic_linking: true,
         executables: true,
@@ -9,6 +22,7 @@ pub fn opts() -> TargetOptions {
         target_family: Some("unix".to_string()),
         is_like_solaris: true,
         limit_rdylib_exports: false, // Linker doesn't support this
+        late_link_args,
 
         ..Default::default()
     }


### PR DESCRIPTION
LLVM will insert calls to the stack protector functions
"__stack_chk_fail" and "__stack_chk_guard" into code in native object
files.  Some platforms include these symbols directly in libc, but at
least historically these have been provided in libssp.so on illumos and
Solaris systems.  Include "-lssp" in the arguments to the linker when
building for those targets.