### PR TITLE
Make our pattern matching logic undestand `&[T]` constants

### DIFF
--- a/src/librustc_mir_build/hair/pattern/_match.rs
+++ b/src/librustc_mir_build/hair/pattern/_match.rs
@@ -297,8 +297,9 @@ impl<'tcx> LiteralExpander<'tcx> {
                     }
                 }
             }
-            // Unsize array to slice if pattern is array
-            // but match value or other patterns are slice.
+			// Unsize the array to a slice if we're matching on a slice,
+			// or other patterns are a slice (despite this pattern being
+			// an array).
             (ConstValue::Scalar(s), ty::Array(t, n), ty::Slice(u)) => {
                 assert_eq!(t, u);
                 let n = n.eval_usize(self.tcx, ty::ParamEnv::empty()).try_into().unwrap();

--- a/src/test/ui/pattern/const-pat-unreachable.rs
+++ b/src/test/ui/pattern/const-pat-unreachable.rs
@@ -1,0 +1,15 @@
+#![feature(const_transmute)]
+#![deny(unreachable_patterns)]
+
+const FOO: &[u8] = unsafe { std::mem::transmute::<usize, &[u8; 0]>(1) };
+const BAR: &[u8] = unsafe { std::mem::transmute::<usize, &[u8; 0]>(3) };
+
+fn main() {
+    let x: &[u8] = unimplemented!();
+    match x {
+        b"" => {}
+        FOO => {} //~ ERROR unreachable pattern
+        BAR => {} //~ ERROR unreachable pattern
+        _ => {}
+    }
+}

--- a/src/test/ui/pattern/const-pat-unreachable.stderr
+++ b/src/test/ui/pattern/const-pat-unreachable.stderr
@@ -1,0 +1,20 @@
+error: unreachable pattern
+  --> $DIR/const-pat-unreachable.rs:11:9
+   |
+LL |         FOO => {}
+   |         ^^^
+   |
+note: the lint level is defined here
+  --> $DIR/const-pat-unreachable.rs:2:9
+   |
+LL | #![deny(unreachable_patterns)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/const-pat-unreachable.rs:12:9
+   |
+LL |         BAR => {}
+   |         ^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/pattern/usefulness/slice-pattern-const-2.rs
+++ b/src/test/ui/pattern/usefulness/slice-pattern-const-2.rs
@@ -6,13 +6,13 @@ fn main() {
     match s {
         MAGIC_TEST => (),
         [0x00, 0x00, 0x00, 0x00] => (),
-        [4, 5, 6, 7] => (), // FIXME(oli-obk): this should warn, but currently does not
+        [4, 5, 6, 7] => (), //~ ERROR unreachable pattern
         _ => (),
     }
     match s {
         [0x00, 0x00, 0x00, 0x00] => (),
         MAGIC_TEST => (),
-        [4, 5, 6, 7] => (), // FIXME(oli-obk): this should warn, but currently does not
+        [4, 5, 6, 7] => (), //~ ERROR unreachable pattern
         _ => (),
     }
     match s {

--- a/src/test/ui/pattern/usefulness/slice-pattern-const-2.stderr
+++ b/src/test/ui/pattern/usefulness/slice-pattern-const-2.stderr
@@ -1,8 +1,8 @@
 error: unreachable pattern
-  --> $DIR/slice-pattern-const-2.rs:28:9
+  --> $DIR/slice-pattern-const-2.rs:9:9
    |
-LL |         FOO => (),
-   |         ^^^
+LL |         [4, 5, 6, 7] => (),
+   |         ^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/slice-pattern-const-2.rs:1:9
@@ -10,5 +10,17 @@ note: the lint level is defined here
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: unreachable pattern
+  --> $DIR/slice-pattern-const-2.rs:15:9
+   |
+LL |         [4, 5, 6, 7] => (),
+   |         ^^^^^^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/slice-pattern-const-2.rs:28:9
+   |
+LL |         FOO => (),
+   |         ^^^
+
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/pattern/usefulness/slice-patterns-exhaustiveness.rs
+++ b/src/test/ui/pattern/usefulness/slice-patterns-exhaustiveness.rs
@@ -87,7 +87,6 @@ fn main() {
         CONST => {}
     }
     match s {
-    //~^ ERROR `&[true]` not covered
         [] => {},
         [false] => {},
         CONST => {},

--- a/src/test/ui/pattern/usefulness/slice-patterns-exhaustiveness.stderr
+++ b/src/test/ui/pattern/usefulness/slice-patterns-exhaustiveness.stderr
@@ -124,17 +124,8 @@ LL |     match s {
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `&[bool]`
 
-error[E0004]: non-exhaustive patterns: `&[true]` not covered
-  --> $DIR/slice-patterns-exhaustiveness.rs:89:11
-   |
-LL |     match s {
-   |           ^ pattern `&[true]` not covered
-   |
-   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
-   = note: the matched value is of type `&[bool]`
-
 error[E0004]: non-exhaustive patterns: `&[false]` not covered
-  --> $DIR/slice-patterns-exhaustiveness.rs:97:11
+  --> $DIR/slice-patterns-exhaustiveness.rs:96:11
    |
 LL |     match s1 {
    |           ^^ pattern `&[false]` not covered
@@ -142,6 +133,6 @@ LL |     match s1 {
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `&[bool; 1]`
 
-error: aborting due to 16 previous errors
+error: aborting due to 15 previous errors
 
 For more information about this error, try `rustc --explain E0004`.


### PR DESCRIPTION
We should generalize this to other types, too, so treat this as a proof of concept.