### PR TITLE
Prefer sysroot from rustc in same directory as rust-gdb

### DIFF
--- a/src/etc/rust-gdb
+++ b/src/etc/rust-gdb
@@ -2,8 +2,16 @@
 # Exit if anything fails
 set -e
 
+# Prefer rustc in the same directory as this script
+DIR="$(dirname "$0")"
+if [ -x "$DIR/rustc" ]; then
+  RUSTC="$DIR/rustc"
+else
+  RUSTC="rustc"
+fi
+
 # Find out where the pretty printer Python module is
-RUSTC_SYSROOT=`rustc --print=sysroot`
+RUSTC_SYSROOT="$("$RUSTC" --print=sysroot)"
 GDB_PYTHON_MODULE_DIRECTORY="$RUSTC_SYSROOT/lib/rustlib/etc"
 
 # Run GDB with the additional arguments that load the pretty printers

--- a/src/etc/rust-gdbgui
+++ b/src/etc/rust-gdbgui
@@ -31,8 +31,16 @@ icon to start your program running.
     exit 0
 fi
 
+# Prefer rustc in the same directory as this script
+DIR="$(dirname "$0")"
+if [ -x "$DIR/rustc" ]; then
+  RUSTC="$DIR/rustc"
+else
+  RUSTC="rustc"
+fi
+
 # Find out where the pretty printer Python module is
-RUSTC_SYSROOT=`rustc --print=sysroot`
+RUSTC_SYSROOT="$("$RUSTC" --print=sysroot)"
 GDB_PYTHON_MODULE_DIRECTORY="$RUSTC_SYSROOT/lib/rustlib/etc"
 
 # Set the environment variable `RUST_GDB` to overwrite the call to a


### PR DESCRIPTION
If there isn't a rustc in the same directory, then fall back to searching
the path.