### PR TITLE
Fix link in task::Wake docs

### DIFF
--- a/src/liballoc/task.rs
+++ b/src/liballoc/task.rs
@@ -12,10 +12,12 @@ use crate::sync::Arc;
 /// to the tasks that are executed on that executor.
 ///
 /// This trait is a memory-safe and ergonomic alternative to constructing a
-/// [`RawWaker`]. It supports the common executor design in which the data
-/// used to wake up a task is stored in an [`Arc`]. Some executors (especially
+/// [`RawWaker`]. It supports the common executor design in which the data used
+/// to wake up a task is stored in an [`Arc`][arc]. Some executors (especially
 /// those for embedded systems) cannot use this API, which is why [`RawWaker`]
 /// exists as an alternative for those systems.
+///
+/// [arc]: ../../std/sync/struct.Arc.html
 #[unstable(feature = "wake_trait", issue = "69912")]
 pub trait Wake {
     /// Wake this task.


### PR DESCRIPTION
`task::Wake` was introduced in https://github.com/rust-lang/rust/pull/68700. While I was browsing the docs I noticed a link to `sync::Arc` wasn't resolving correctly. This patch fixes that. Thanks!

## Before

![Screenshot_2020-04-03 std task Wake - Rust](https://user-images.githubusercontent.com/2467194/78346384-466cb280-759f-11ea-97c8-aede186c674e.png)

## Proposed

![Screenshot_2020-04-03 alloc task Wake - Rust](https://user-images.githubusercontent.com/2467194/78349819-79657500-75a4-11ea-9282-16691ae2a5d4.png)
