### PR TITLE
Enabling static-pie for musl

### DIFF
--- a/src/librustc_target/spec/x86_64_unknown_linux_musl.rs
+++ b/src/librustc_target/spec/x86_64_unknown_linux_musl.rs
@@ -6,6 +6,7 @@ pub fn target() -> TargetResult {
     base.max_atomic_width = Some(64);
     base.pre_link_args.get_mut(&LinkerFlavor::Gcc).unwrap().push("-m64".to_string());
     base.stack_probes = true;
+    base.static_position_independent_executables = true;
 
     Ok(Target {
         llvm_target: "x86_64-unknown-linux-musl".to_string(),

--- a/src/test/run-make/static-pie/Makefile
+++ b/src/test/run-make/static-pie/Makefile
@@ -1,0 +1,15 @@
+-include ../../run-make-fulldeps/tools.mk
+
+# only-x86_64-unknown-linux-musl
+
+# How to manually run this
+# $ ./x.py test --target x86_64-unknown-linux-musl src/test/run-make/static-pie
+
+all:
+	$(RUSTC) --target $(TARGET) -C target-feature=+crt-static test-aslr.rs
+	# Check that no dynamic interpreter is set
+	! readelf -l $(call RUN_BINFILE,test-aslr) | $(CGREP) INTERP
+	# Check that we have a dynamic executable
+	readelf -l $(call RUN_BINFILE,test-aslr) | $(CGREP) DYNAMIC
+	# Check for address space layout randomization
+	$(call RUN,test-aslr) --test-aslr

--- a/src/test/run-make/static-pie/test-aslr.rs
+++ b/src/test/run-make/static-pie/test-aslr.rs
@@ -1,0 +1,43 @@
+const NUM_RUNS: usize = 10;
+
+fn run_self(exe: &str) -> usize {
+    use std::process::Command;
+    let mut set = std::collections::HashSet::new();
+
+    let mut cmd = Command::new(exe);
+    cmd.arg("--report");
+    (0..NUM_RUNS).for_each(|_| {
+        set.insert(cmd.output().expect("failed to execute process").stdout);
+    });
+    set.len()
+}
+
+fn main() {
+    let mut args = std::env::args();
+    let arg0 = args.next().unwrap();
+    match args.next() {
+        Some(s) if s.eq("--report") => {
+            println!("main = {:#?}", &main as *const _);
+        }
+        Some(s) if s.eq("--test-no-aslr") => {
+            let cnt = run_self(&arg0);
+            if cnt != 1 {
+                eprintln!("FAIL: {} most likely ASLR", arg0);
+                std::process::exit(1);
+            }
+            println!("PASS: {} does no ASLR", arg0);
+        }
+        Some(s) if s.eq("--test-aslr") => {
+            let cnt = run_self(&arg0);
+            if cnt != NUM_RUNS {
+                eprintln!("FAIL: {} most likely no ASLR", arg0);
+                std::process::exit(1);
+            }
+            println!("PASS: {} does ASLR", arg0);
+        }
+        Some(_) | None => {
+            println!("Usage: {} --test-no-aslr | --test-aslr", arg0);
+            std::process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
and make it the default for the x86_64-unknown-linux-musl target

This is a quick implementation for https://github.com/rust-lang/rust/issues/70693

Opening it as a draft PR to gather some feedback, before I put more work in it.

```console
❯ cat hello.rs
fn main() {
    println!("main = {:#x}", &main as *const _ as usize);
}


❯  /tmp/rust-musl/bin/rustc  --target x86_64-unknown-linux-musl  ~/hello.rs

❯ ldd hello
	statically linked

❯ file hello
hello: ELF 64-bit LSB shared object, x86-64, version 1 (GNU/Linux), statically linked, BuildID[sha1]=fec5cdc170f503a712a63a6958691ce5ce433654, with debug_info, not stripped

❯ ./hello
main = 0x7f233ca30008

❯ ./hello
main = 0x7f9ddc529008

❯ ./hello
main = 0x7f1e5a224008

❯ ./hello
main = 0x7f4485c7c008

❯ /tmp/rust-musl/bin/rustc  --target x86_64-unknown-linux-musl  -Z print-link-args  ~/hello.rs
"cc" "-Wl,--as-needed" "-Wl,-z,noexecstack" "-Wl,--eh-frame-hdr" "-m64" "-nostdlib" "/tmp/rust-musl/lib/rustlib/x86_64-unknown-linux-musl/lib/rcrt1.o" "/tmp/rust-musl/lib/rustlib/x86_64-unknown-linux-musl/lib/crti.o" "-L" "/tmp/rust-musl/lib/rustlib/x86_64-unknown-linux-musl/lib" "hello.hello.7rcbfp3g-cgu.0.rcgu.o" "hello.hello.7rcbfp3g-cgu.1.rcgu.o" "hello.hello.7rcbfp3g-cgu.2.rcgu.o" "hello.hello.7rcbfp3g-cgu.3.rcgu.o" "hello.hello.7rcbfp3g-cgu.4.rcgu.o" "hello.hello.7rcbfp3g-cgu.5.rcgu.o" "-o" "hello" "hello.1nxjf9so94czdgcz.rcgu.o" "-Wl,--gc-sections" "-static-pie" "-Wl,-zrelro" "-Wl,-znow" "-nodefaultlibs" "-L" "/tmp/rust-musl/lib/rustlib/x86_64-unknown-linux-musl/lib" "-Wl,--start-group" "-Wl,-Bstatic" "/tmp/rust-musl/lib/rustlib/x86_64-unknown-linux-musl/lib/libstd-0f9cb7646f9e2c34.rlib" "/tmp/rust-musl/lib/rustlib/x86_64-unknown-linux-musl/lib/libpanic_unwind-ba857f2f2e4e7187.rlib" "/tmp/rust-musl/lib/rustlib/x86_64-unknown-linux-musl/lib/libhashbrown-58ba5e25bbdf9d29.rlib" "/tmp/rust-musl/lib/rustlib/x86_64-unknown-linux-musl/lib/librustc_std_workspace_alloc-886bfe43afa847dc.rlib" "/tmp/rust-musl/lib/rustlib/x86_64-unknown-linux-musl/lib/libbacktrace-fbfb8fe99f19a67b.rlib" "/tmp/rust-musl/lib/rustlib/x86_64-unknown-linux-musl/lib/libbacktrace_sys-85fa859e7d364cc9.rlib" "/tmp/rust-musl/lib/rustlib/x86_64-unknown-linux-musl/lib/librustc_demangle-07ab026cd3ec0d82.rlib" "/tmp/rust-musl/lib/rustlib/x86_64-unknown-linux-musl/lib/libunwind-a8ec5932d92ea864.rlib" "/tmp/rust-musl/lib/rustlib/x86_64-unknown-linux-musl/lib/libcfg_if-0ba4cc2f38a198d5.rlib" "/tmp/rust-musl/lib/rustlib/x86_64-unknown-linux-musl/lib/liblibc-c1bb2b3ce4f78b7c.rlib" "/tmp/rust-musl/lib/rustlib/x86_64-unknown-linux-musl/lib/liballoc-0ff673c1cf0d451a.rlib" "/tmp/rust-musl/lib/rustlib/x86_64-unknown-linux-musl/lib/librustc_std_workspace_core-c8ff2001db856926.rlib" "/tmp/rust-musl/lib/rustlib/x86_64-unknown-linux-musl/lib/libcore-2ae14177140eeca2.rlib" "-Wl,--end-group" "/tmp/rust-musl/lib/rustlib/x86_64-unknown-linux-musl/lib/libcompiler_builtins-4fd81b5ce1b08a9c.rlib" "-static" "-Wl,-Bdynamic" "/tmp/rust-musl/lib/rustlib/x86_64-unknown-linux-musl/lib/crtn.o"
```

Closes https://github.com/rust-lang/rust/issues/70693
Closes https://github.com/rust-lang/rust/issues/53968