### PR TITLE
Mark a few libcore types as structurally equal if their contents are

### DIFF
--- a/src/libcore/array/mod.rs
+++ b/src/libcore/array/mod.rs
@@ -12,6 +12,7 @@ use crate::convert::{Infallible, TryFrom};
 use crate::fmt;
 use crate::hash::{self, Hash};
 use crate::marker::Unsize;
+use crate::marker::{StructuralEq, StructuralPartialEq};
 use crate::slice::{Iter, IterMut};
 
 mod iter;
@@ -228,6 +229,14 @@ where
     }
 }
 
+#[unstable(feature = "structural_match", issue = "31434")]
+impl<A, const N: usize> StructuralPartialEq for [A; N]
+where
+    A: StructuralPartialEq,
+    [A; N]: LengthAtMost32,
+{
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A, B, const N: usize> PartialEq<[B; N]> for [A; N]
 where
@@ -344,6 +353,14 @@ where
 // NOTE: some less important impls are omitted to reduce code bloat
 // __impl_slice_eq2! { [A; $N], &'b [B; $N] }
 // __impl_slice_eq2! { [A; $N], &'b mut [B; $N] }
+
+#[unstable(feature = "structural_match", issue = "31434")]
+impl<A, const N: usize> StructuralEq for [A; N]
+where
+    A: StructuralEq,
+    [A; N]: LengthAtMost32,
+{
+}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Eq, const N: usize> Eq for [T; N] where [T; N]: LengthAtMost32 {}

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -1043,6 +1043,7 @@ pub fn max_by_key<T, F: FnMut(&T) -> K, K: Ord>(v1: T, v2: T, mut f: F) -> T {
 mod impls {
     use crate::cmp::Ordering::{self, Equal, Greater, Less};
     use crate::hint::unreachable_unchecked;
+    use crate::marker::{StructuralEq, StructuralPartialEq};
 
     macro_rules! partial_eq_impl {
         ($($t:ty)*) => ($(
@@ -1209,6 +1210,9 @@ mod impls {
 
     // & pointers
 
+    #[unstable(feature = "structural_match", issue = "31434")]
+    impl<A: ?Sized> StructuralPartialEq for &A where A: StructuralPartialEq {}
+
     #[stable(feature = "rust1", since = "1.0.0")]
     impl<A: ?Sized, B: ?Sized> PartialEq<&B> for &A
     where
@@ -1259,10 +1263,17 @@ mod impls {
             Ord::cmp(*self, *other)
         }
     }
+
+    #[unstable(feature = "structural_match", issue = "31434")]
+    impl<A: ?Sized> StructuralEq for &A where A: StructuralEq {}
+
     #[stable(feature = "rust1", since = "1.0.0")]
     impl<A: ?Sized> Eq for &A where A: Eq {}
 
     // &mut pointers
+
+    #[unstable(feature = "structural_match", issue = "31434")]
+    impl<A: ?Sized> StructuralPartialEq for &mut A where A: StructuralPartialEq {}
 
     #[stable(feature = "rust1", since = "1.0.0")]
     impl<A: ?Sized, B: ?Sized> PartialEq<&mut B> for &mut A
@@ -1314,6 +1325,10 @@ mod impls {
             Ord::cmp(*self, *other)
         }
     }
+
+    #[unstable(feature = "structural_match", issue = "31434")]
+    impl<A: ?Sized> StructuralEq for &mut A where A: StructuralEq {}
+
     #[stable(feature = "rust1", since = "1.0.0")]
     impl<A: ?Sized> Eq for &mut A where A: Eq {}
 

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -30,6 +30,7 @@ use crate::intrinsics::{assume, exact_div, is_aligned_and_not_null, unchecked_su
 use crate::isize;
 use crate::iter::*;
 use crate::marker::{self, Copy, Send, Sized, Sync};
+use crate::marker::{StructuralEq, StructuralPartialEq};
 use crate::mem;
 use crate::ops::{self, FnMut, Range};
 use crate::option::Option;
@@ -5752,6 +5753,9 @@ extern "C" {
     fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32;
 }
 
+#[unstable(feature = "structural_match", issue = "31434")]
+impl<A> StructuralPartialEq for [A] where A: StructuralPartialEq {}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A, B> PartialEq<[B]> for [A]
 where
@@ -5765,6 +5769,9 @@ where
         SlicePartialEq::not_equal(self, other)
     }
 }
+
+#[unstable(feature = "structural_match", issue = "31434")]
+impl<A> StructuralEq for [A] where A: StructuralEq {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Eq> Eq for [T] {}

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -1720,6 +1720,7 @@ Section: Trait implementations
 
 mod traits {
     use crate::cmp::Ordering;
+    use crate::marker::{StructuralEq, StructuralPartialEq};
     use crate::ops;
     use crate::slice::{self, SliceIndex};
 
@@ -1738,6 +1739,9 @@ mod traits {
         }
     }
 
+    #[unstable(feature = "structural_match", issue = "31434")]
+    impl StructuralEq for str {}
+
     #[stable(feature = "rust1", since = "1.0.0")]
     impl PartialEq for str {
         #[inline]
@@ -1749,6 +1753,9 @@ mod traits {
             !(*self).eq(other)
         }
     }
+
+    #[unstable(feature = "structural_match", issue = "31434")]
+    impl StructuralPartialEq for str {}
 
     #[stable(feature = "rust1", since = "1.0.0")]
     impl Eq for str {}

--- a/src/libcore/tuple.rs
+++ b/src/libcore/tuple.rs
@@ -2,6 +2,7 @@
 
 use crate::cmp::Ordering::*;
 use crate::cmp::*;
+use crate::marker::{StructuralEq, StructuralPartialEq};
 
 // macro for implementing n-ary tuple functions and operations
 macro_rules! tuple_impls {
@@ -22,6 +23,14 @@ macro_rules! tuple_impls {
                     $(self.$idx != other.$idx)||+
                 }
             }
+
+            #[unstable(feature = "structural_match", issue = "31434")]
+            impl<$($T:StructuralPartialEq),+> StructuralPartialEq for ($($T,)+)
+                where last_type!($($T,)+): ?Sized {}
+
+            #[unstable(feature = "structural_match", issue = "31434")]
+            impl<$($T:StructuralEq),+> StructuralEq for ($($T,)+)
+                where last_type!($($T,)+): ?Sized {}
 
             #[stable(feature = "rust1", since = "1.0.0")]
             impl<$($T:Eq),+> Eq for ($($T,)+) where last_type!($($T,)+): ?Sized {}


### PR DESCRIPTION
* `str` was just missing a marker
* arrays of `StructuralEq` types are already treated as `StructuralEq` in the rustc pattern match logic
* tuples of `StructuralEq` types are also already treated as `StructuralEq`
* `[T]` types shouldn't behave differently from arrays in pattern matching, so I marked them as `StructuralEq` if their contents are.
* `&T` types where `T: StructuralEq` cannot have a custom `Eq` or `PartialEq` impl, they must be using the generic impl. Thus the user cannot have created any handwritten impls for `&UserType`, thus we can treat them as `StructuralEq`.

r? @petrochenkov 

cc @pnkfelix @nikomatsakis @ecstatic-morse 

cc #31434