### PR TITLE
docs: make the description of Result::map_or more clear

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -521,14 +521,16 @@ impl<T, E> Result<T, E> {
         }
     }
 
-    /// Applies a function to the contained value (if any),
-    /// or returns the provided default (if not).
+    /// Applies a function to the contained value (if [`Ok`]),
+    /// or returns the provided default (if [`Err`]).
     ///
     /// Arguments passed to `map_or` are eagerly evaluated; if you are passing
     /// the result of a function call, it is recommended to use [`map_or_else`],
     /// which is lazily evaluated.
     ///
     /// [`map_or_else`]: #method.map_or_else
+    /// [`Ok`]: enum.Result.html#variant.Ok
+    /// [`Err`]: enum.Result.html#variant.Err
     ///
     /// # Examples
     ///


### PR DESCRIPTION
The documentation of [`Result::map_or`](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_or) is very unclear and confusing, probably because it was copied straight from [`Option::map_or`](https://doc.rust-lang.org/std/option/enum.Option.html#method.map_or) and someone forgot to adapt it for Result.