### PR TITLE
Add conversion from Arc<Fn> to Waker

### DIFF
--- a/src/liballoc/task.rs
+++ b/src/liballoc/task.rs
@@ -51,6 +51,26 @@ impl<W: Wake + Send + Sync + 'static> From<Arc<W>> for RawWaker {
     }
 }
 
+/// Convert a closure into a waker.
+///
+/// # Examples
+///
+/// ```
+/// use std::sync::Arc;
+/// use std::task::Waker;
+///
+/// let waker = Waker::from(Arc::new(|| {
+///     // wake called
+/// }));
+/// waker.wake();
+/// ```
+#[unstable(feature = "wake_from_fn", issue = "none")]
+impl<F: Fn() + Send + Sync + 'static> Wake for F {
+    fn wake(self: Arc<Self>) {
+        (self)()
+    }
+}
+
 // NB: This private function for constructing a RawWaker is used, rather than
 // inlining this into the `From<Arc<W>> for RawWaker` impl, to ensure that
 // the safety of `From<Arc<W>> for Waker` does not depend on the correct


### PR DESCRIPTION
This is an addition to work done in https://github.com/rust-lang/rust/pull/68700. This patch adds a conversion from `Arc<Fn>` to `Waker` making it significantly easier to construct wakers for instrumentation purposes.

The conversion of a closure into a waker has seen prior adoption in the ecosystem in the form of the [`wakeful`](https://docs.rs/wakeful/0.1.1/wakeful/fn.waker_fn.html) crate by @sagebind. And was later adopted by @stjepang in [`async-task`](https://docs.rs/async-task/1.3.1/async_task/fn.waker_fn.html) as well.

## Usage

```rust
let waker = Waker::from(Arc::new(|| {
    println!("wake called");
}));
waker.wake();
```

## Alternatives

Originally there was talk about adding a `task::waker_fn` instead. But @withoutboats pointed out there had always been an intention to add a safe `Wake` trait, and conversions from closures could instead utilize that. Now that `Wake` is available on nightly, it seemed like a good idea to implement this conversion as well.

While drafting this patch I also tried to make a non-arc conversion work, but unfortunately failed because of orphan rules (`Waker` and `Fn` are defined in `core`, `Arc` is defined in `alloc`):

```rust
// This would use From<Fn() + Send + Sync + 'static> for Waker,
// which is currently not allowed.
let waker = Waker::from(|| {
    println!("wake called");
});
waker.wake();
```

I'm not sure if there is a way around that given that tests wouldn't compile if this was a problem. But if that's not desirable for any reason, we should probably review this conversion is forward-compatible with a future conversion from `From<Fn() + Sync + Send + 'static> for Waker`.

## Stability

I think this conversion should be separate from the core trait introduced in https://github.com/rust-lang/rust/pull/68700. Any issues that might arise from this should not hold up the stabilization of the core trait; so I propose we track this (and any future conversions) separately.

## References

- [`wakeful::waker_fn`](https://docs.rs/wakeful/0.1.1/wakeful/fn.waker_fn.html)
- [`async-task::waker_fn`](https://docs.rs/async-task/1.3.1/async_task/fn.waker_fn.html)
- [Tracking Issue for the `Wake` trait](https://github.com/rust-lang/rust/issues/69912)