### PR TITLE
AtomicPtr without losing pointer provenance

### DIFF
--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -121,6 +121,7 @@ use self::Ordering::*;
 use crate::cell::UnsafeCell;
 use crate::fmt;
 use crate::intrinsics;
+use crate::mem;
 
 use crate::hint::spin_loop;
 
@@ -970,7 +971,7 @@ impl<T> AtomicPtr<T> {
     pub fn store(&self, ptr: *mut T, order: Ordering) {
         // SAFETY: data races are prevented by atomic intrinsics.
         unsafe {
-            atomic_store(self.p.get() as *mut usize, ptr as usize, order);
+            atomic_store(self.p.get() as *mut usize, mem::transmute(ptr), order);
         }
     }
 
@@ -1003,7 +1004,7 @@ impl<T> AtomicPtr<T> {
     #[cfg(target_has_atomic = "ptr")]
     pub fn swap(&self, ptr: *mut T, order: Ordering) -> *mut T {
         // SAFETY: data races are prevented by atomic intrinsics.
-        unsafe { atomic_swap(self.p.get() as *mut usize, ptr as usize, order) as *mut T }
+        unsafe { atomic_swap(self.p.get() as *mut usize, mem::transmute(ptr), order) as *mut T }
     }
 
     /// Stores a value into the pointer if the current value is the same as the `current` value.
@@ -1091,8 +1092,8 @@ impl<T> AtomicPtr<T> {
         unsafe {
             let res = atomic_compare_exchange(
                 self.p.get() as *mut usize,
-                current as usize,
-                new as usize,
+                mem::transmute(current),
+                mem::transmute(new),
                 success,
                 failure,
             );
@@ -1155,8 +1156,8 @@ impl<T> AtomicPtr<T> {
         unsafe {
             let res = atomic_compare_exchange_weak(
                 self.p.get() as *mut usize,
-                current as usize,
-                new as usize,
+                mem::transmute(current),
+                mem::transmute(new),
                 success,
                 failure,
             );

--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -970,6 +970,9 @@ impl<T> AtomicPtr<T> {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn store(&self, ptr: *mut T, order: Ordering) {
         // SAFETY: data races are prevented by atomic intrinsics.
+        // We transmute to an integer instead of casting to avoid losing pointer
+        // provenance -- in particular this helps Miri not lose track of the pointer
+        // when checking for memory leaks.
         unsafe {
             atomic_store(self.p.get() as *mut usize, mem::transmute(ptr), order);
         }

--- a/src/libstd/sys/windows/mutex.rs
+++ b/src/libstd/sys/windows/mutex.rs
@@ -21,10 +21,10 @@
 
 use crate::cell::UnsafeCell;
 use crate::mem::{self, MaybeUninit};
-use crate::sync::atomic::{AtomicUsize, AtomicPtr, Ordering};
+use crate::ptr;
+use crate::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 use crate::sys::c;
 use crate::sys::compat;
-use crate::ptr;
 
 pub struct Mutex {
     lock: AtomicUsize,


### PR DESCRIPTION
This came up while debugging why Miri kept reporting memory leaks on Windows. The leaked memory came from libstd static `sys:common::mutex::Mutex`. When such a mutex gets initialized, allocation happens (on Windows XP, which is also the code path that Miri uses), and then the pointer to that allocation is *cast to an integer* and stored in static memory. When doing leak checking, Miri cannot tell that there is a pointer here, it just sees an integer, and thus the memory that the integer "points to" is considered leaked.

The easiest fix would be to *transmute* the pointer to an integer instead of casting it. That avoids dropping the provenance which Miri uses to later do leak checking.

However, since this could happen with anyone handling pointers atomically, I wanted to use `AtomicPtr` instead -- which, as it turns out, internally also performed ptr-to-int casts, so I replaced those by transmutes.

Ideally we'd call `atomic_store` and friends at pointer type, but that leads to a codegen error:
```
error[E0511]: invalid monomorphization of `atomic_load` intrinsic: expected basic integer type, found `*mut ()`
    --> /home/r/src/rust/rustc.2/src/libcore/sync/atomic.rs:2277:19
     |
2277 |         SeqCst => intrinsics::atomic_load(dst),
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
If that codegen check can be relaxed to also accept pointers, we could avoid transmutes and casts entirely, but that goes beyond my LLVM knowledge.

(In principle whether or not provenance is dropped should also make a difference for optimizations in LLVM, but currently LLVM is buggy in that area and [does not make this distinction](https://bugs.llvm.org/show_bug.cgi?id=34548).)