### PR TITLE
use ManuallyDrop instead of forget inside collections

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -469,8 +469,8 @@ impl<T: ?Sized> Box<T> {
     #[inline]
     #[doc(hidden)]
     pub fn into_unique(b: Box<T>) -> Unique<T> {
+        let b = mem::ManuallyDrop::new(b);
         let mut unique = b.0;
-        mem::forget(b);
         // Box is kind-of a library type, but recognized as a "unique pointer" by
         // Stacked Borrows.  This function here corresponds to "reborrowing to
         // a raw pointer", but there is no actual reborrow here -- so


### PR DESCRIPTION
This PR changes some usage of `mem::forget` into `mem::ManuallyDrop` in some `Vec`, `VecDeque`, `BTreeMap` and `Box` methods.

Before the commit, the generated IR for some of the methods was longer, and even after optimization, some unwinding artifacts were still present.