### PR TITLE
Miri: remove an outdated FIXME

### DIFF
--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -75,7 +75,6 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
 
             Drop { location, target, unwind } => {
-                // FIXME(CTFE): forbid drop in const eval
                 let place = self.eval_place(location)?;
                 let ty = place.layout.ty;
                 trace!("TerminatorKind::drop: {:?}, type {}", location, ty);


### PR DESCRIPTION
We even [have a test ](https://github.com/rust-lang/rust/blob/49dc2f9f091748beb1a8a9d5b3eb3bbe7362c3bd/src/test/ui/consts/miri_unleashed/drop.rs) making sure that we detect dropping with a non-const implementation.

r? @oli-obk 