### PR TITLE
specialize some collection and iterator operations to run in-place

### DIFF
--- a/library/alloc/benches/vec.rs
+++ b/library/alloc/benches/vec.rs
@@ -244,7 +244,7 @@ fn bench_extend_recycle(b: &mut Bencher) {
         let tmp = std::mem::replace(&mut data, Vec::new());
         let mut to_extend = black_box(Vec::new());
         to_extend.extend(tmp.into_iter());
-        std::mem::replace(&mut data, black_box(to_extend));
+        data = black_box(to_extend);
     });
 
     black_box(data);
@@ -502,16 +502,13 @@ fn bench_in_place_recycle(b: &mut test::Bencher) {
 
     b.iter(|| {
         let tmp = std::mem::replace(&mut data, Vec::new());
-        std::mem::replace(
-            &mut data,
-            black_box(
-                tmp.into_iter()
-                    .enumerate()
-                    .map(|(idx, e)| idx.wrapping_add(e))
-                    .fuse()
-                    .peekable()
-                    .collect::<Vec<usize>>(),
-            ),
+        data = black_box(
+            tmp.into_iter()
+                .enumerate()
+                .map(|(idx, e)| idx.wrapping_add(e))
+                .fuse()
+                .peekable()
+                .collect::<Vec<usize>>(),
         );
     });
 }
@@ -532,7 +529,7 @@ fn bench_in_place_zip_recycle(b: &mut test::Bencher) {
             .map(|(i, (d, s))| d.wrapping_add(i as u8) ^ s)
             .collect::<Vec<_>>();
         assert_eq!(mangled.len(), 1000);
-        std::mem::replace(&mut data, black_box(mangled));
+        data = black_box(mangled);
     });
 }
 

--- a/library/alloc/benches/vec.rs
+++ b/library/alloc/benches/vec.rs
@@ -643,9 +643,7 @@ fn bench_rev_1(b: &mut test::Bencher) {
 #[bench]
 fn bench_rev_2(b: &mut test::Bencher) {
     let data = black_box([0; LEN]);
-    b.iter(|| {
-        example_plain_slow(&data);
-    });
+    b.iter(|| example_plain_slow(&data));
 }
 
 #[bench]

--- a/library/alloc/benches/vec.rs
+++ b/library/alloc/benches/vec.rs
@@ -504,10 +504,10 @@ fn bench_in_place_recycle(b: &mut test::Bencher) {
 
 #[bench]
 fn bench_in_place_zip_recycle(b: &mut test::Bencher) {
-    let mut data = vec![0u8; 256];
+    let mut data = vec![0u8; 1000];
     let mut rng = rand::thread_rng();
-    let mut subst = (0..=255u8).collect::<Vec<_>>();
-    subst.shuffle(&mut rng);
+    let mut subst = vec![0u8; 1000];
+    rng.fill_bytes(&mut subst[..]);
 
     b.iter(|| {
         let tmp = std::mem::replace(&mut data, Vec::new());
@@ -517,7 +517,7 @@ fn bench_in_place_zip_recycle(b: &mut test::Bencher) {
             .enumerate()
             .map(|(i, (d, s))| d.wrapping_add(i as u8) ^ s)
             .collect::<Vec<_>>();
-        assert_eq!(mangled.len(), 256);
+        assert_eq!(mangled.len(), 1000);
         std::mem::replace(&mut data, black_box(mangled));
     });
 }
@@ -526,8 +526,8 @@ fn bench_in_place_zip_recycle(b: &mut test::Bencher) {
 fn bench_in_place_zip_iter_mut(b: &mut test::Bencher) {
     let mut data = vec![0u8; 256];
     let mut rng = rand::thread_rng();
-    let mut subst = (0..=255u8).collect::<Vec<_>>();
-    subst.shuffle(&mut rng);
+    let mut subst = vec![0u8; 1000];
+    rng.fill_bytes(&mut subst[..]);
 
     b.iter(|| {
         data.iter_mut().enumerate().for_each(|(i, d)| {

--- a/library/alloc/benches/vec.rs
+++ b/library/alloc/benches/vec.rs
@@ -482,6 +482,26 @@ bench_in_place![
 ];
 
 #[bench]
+fn bench_in_place_recycle(b: &mut test::Bencher) {
+    let mut data = vec![0; 1000];
+
+    b.iter(|| {
+        let tmp = std::mem::replace(&mut data, Vec::new());
+        std::mem::replace(
+            &mut data,
+            black_box(
+                tmp.into_iter()
+                    .enumerate()
+                    .map(|(idx, e)| idx.wrapping_add(e))
+                    .fuse()
+                    .peekable()
+                    .collect::<Vec<usize>>(),
+            ),
+        );
+    });
+}
+
+#[bench]
 fn bench_chain_collect(b: &mut test::Bencher) {
     let data = black_box([0; LEN]);
     b.iter(|| data.iter().cloned().chain([1].iter().cloned()).collect::<Vec<_>>());

--- a/library/alloc/benches/vec.rs
+++ b/library/alloc/benches/vec.rs
@@ -237,6 +237,20 @@ fn do_bench_extend_from_slice(b: &mut Bencher, dst_len: usize, src_len: usize) {
 }
 
 #[bench]
+fn bench_extend_recycle(b: &mut Bencher) {
+    let mut data = vec![0; 1000];
+
+    b.iter(|| {
+        let tmp = std::mem::replace(&mut data, Vec::new());
+        let mut to_extend = black_box(Vec::new());
+        to_extend.extend(tmp.into_iter());
+        std::mem::replace(&mut data, black_box(to_extend));
+    });
+
+    black_box(data);
+}
+
+#[bench]
 fn bench_extend_from_slice_0000_0000(b: &mut Bencher) {
     do_bench_extend_from_slice(b, 0, 0)
 }

--- a/library/alloc/benches/vec.rs
+++ b/library/alloc/benches/vec.rs
@@ -440,10 +440,11 @@ macro_rules! bench_in_place {
             #[bench]
             fn $fname(b: &mut Bencher) {
                 b.iter(|| {
-                    let src: Vec<$type> = vec![$init; $count];
-                    black_box(src.into_iter()
+                    let src: Vec<$type> = black_box(vec![$init; $count]);
+                    let mut sink = src.into_iter()
                         .enumerate()
-                        .map(|(idx, e)| { (idx as $type) ^ e }).collect::<Vec<$type>>())
+                        .map(|(idx, e)| { (idx as $type) ^ e }).collect::<Vec<$type>>();
+                    black_box(sink.as_mut_ptr())
                 });
             }
         )+

--- a/library/alloc/benches/vec.rs
+++ b/library/alloc/benches/vec.rs
@@ -1,5 +1,5 @@
 use std::iter::{repeat, FromIterator};
-use test::Bencher;
+use test::{black_box, Bencher};
 
 #[bench]
 fn bench_new(b: &mut Bencher) {
@@ -431,3 +431,42 @@ fn bench_clone_from_10_0100_0010(b: &mut Bencher) {
 fn bench_clone_from_10_1000_0100(b: &mut Bencher) {
     do_bench_clone_from(b, 10, 1000, 100)
 }
+
+macro_rules! bench_in_place {
+    (
+        $($fname:ident, $type:ty , $count:expr, $init: expr);*
+    ) => {
+        $(
+            #[bench]
+            fn $fname(b: &mut Bencher) {
+                b.iter(|| {
+                    let src: Vec<$type> = vec![$init; $count];
+                    black_box(src.into_iter()
+                        .enumerate()
+                        .map(|(idx, e)| { (idx as $type) ^ e }).collect::<Vec<$type>>())
+                });
+            }
+        )+
+    };
+}
+
+bench_in_place![
+    bench_in_place_xxu8_i0_0010,     u8,     10, 0;
+    bench_in_place_xxu8_i0_0100,     u8,    100, 0;
+    bench_in_place_xxu8_i0_1000,     u8,   1000, 0;
+    bench_in_place_xxu8_i1_0010,     u8,     10, 1;
+    bench_in_place_xxu8_i1_0100,     u8,    100, 1;
+    bench_in_place_xxu8_i1_1000,     u8,   1000, 1;
+    bench_in_place_xu32_i0_0010,    u32,     10, 0;
+    bench_in_place_xu32_i0_0100,    u32,    100, 0;
+    bench_in_place_xu32_i0_1000,    u32,   1000, 0;
+    bench_in_place_xu32_i1_0010,    u32,     10, 1;
+    bench_in_place_xu32_i1_0100,    u32,    100, 1;
+    bench_in_place_xu32_i1_1000,    u32,   1000, 1;
+    bench_in_place_u128_i0_0010,   u128,     10, 0;
+    bench_in_place_u128_i0_0100,   u128,    100, 0;
+    bench_in_place_u128_i0_1000,   u128,   1000, 0;
+    bench_in_place_u128_i1_0010,   u128,     10, 1;
+    bench_in_place_u128_i1_0100,   u128,    100, 1;
+    bench_in_place_u128_i1_1000,   u128,   1000, 1
+];

--- a/library/alloc/benches/vec.rs
+++ b/library/alloc/benches/vec.rs
@@ -7,6 +7,7 @@ fn bench_new(b: &mut Bencher) {
         let v: Vec<u32> = Vec::new();
         assert_eq!(v.len(), 0);
         assert_eq!(v.capacity(), 0);
+        v
     })
 }
 
@@ -17,6 +18,7 @@ fn do_bench_with_capacity(b: &mut Bencher, src_len: usize) {
         let v: Vec<u32> = Vec::with_capacity(src_len);
         assert_eq!(v.len(), 0);
         assert_eq!(v.capacity(), src_len);
+        v
     })
 }
 
@@ -47,6 +49,7 @@ fn do_bench_from_fn(b: &mut Bencher, src_len: usize) {
         let dst = (0..src_len).collect::<Vec<_>>();
         assert_eq!(dst.len(), src_len);
         assert!(dst.iter().enumerate().all(|(i, x)| i == *x));
+        dst
     })
 }
 
@@ -77,6 +80,7 @@ fn do_bench_from_elem(b: &mut Bencher, src_len: usize) {
         let dst: Vec<usize> = repeat(5).take(src_len).collect();
         assert_eq!(dst.len(), src_len);
         assert!(dst.iter().all(|x| *x == 5));
+        dst
     })
 }
 
@@ -109,6 +113,7 @@ fn do_bench_from_slice(b: &mut Bencher, src_len: usize) {
         let dst = src.clone()[..].to_vec();
         assert_eq!(dst.len(), src_len);
         assert!(dst.iter().enumerate().all(|(i, x)| i == *x));
+        dst
     });
 }
 
@@ -141,6 +146,7 @@ fn do_bench_from_iter(b: &mut Bencher, src_len: usize) {
         let dst: Vec<_> = FromIterator::from_iter(src.clone());
         assert_eq!(dst.len(), src_len);
         assert!(dst.iter().enumerate().all(|(i, x)| i == *x));
+        dst
     });
 }
 
@@ -175,6 +181,7 @@ fn do_bench_extend(b: &mut Bencher, dst_len: usize, src_len: usize) {
         dst.extend(src.clone());
         assert_eq!(dst.len(), dst_len + src_len);
         assert!(dst.iter().enumerate().all(|(i, x)| i == *x));
+        dst
     });
 }
 
@@ -224,6 +231,7 @@ fn do_bench_extend_from_slice(b: &mut Bencher, dst_len: usize, src_len: usize) {
         dst.extend_from_slice(&src);
         assert_eq!(dst.len(), dst_len + src_len);
         assert!(dst.iter().enumerate().all(|(i, x)| i == *x));
+        dst
     });
 }
 
@@ -271,6 +279,7 @@ fn do_bench_clone(b: &mut Bencher, src_len: usize) {
         let dst = src.clone();
         assert_eq!(dst.len(), src_len);
         assert!(dst.iter().enumerate().all(|(i, x)| i == *x));
+        dst
     });
 }
 
@@ -305,10 +314,10 @@ fn do_bench_clone_from(b: &mut Bencher, times: usize, dst_len: usize, src_len: u
 
         for _ in 0..times {
             dst.clone_from(&src);
-
             assert_eq!(dst.len(), src_len);
             assert!(dst.iter().enumerate().all(|(i, x)| dst_len + i == *x));
         }
+        dst
     });
 }
 

--- a/library/alloc/benches/vec.rs
+++ b/library/alloc/benches/vec.rs
@@ -513,7 +513,14 @@ impl Drop for Droppable {
 #[bench]
 fn bench_in_place_collect_droppable(b: &mut test::Bencher) {
     let v: Vec<Droppable> = std::iter::repeat_with(|| Droppable(0)).take(1000).collect();
-    b.iter(|| v.clone().into_iter().skip(100).collect::<Vec<_>>())
+    b.iter(|| {
+        v.clone()
+            .into_iter()
+            .skip(100)
+            .enumerate()
+            .map(|(i, e)| Droppable(i ^ e.0))
+            .collect::<Vec<_>>()
+    })
 }
 
 #[bench]

--- a/library/alloc/benches/vec.rs
+++ b/library/alloc/benches/vec.rs
@@ -501,6 +501,21 @@ fn bench_in_place_recycle(b: &mut test::Bencher) {
     });
 }
 
+#[derive(Clone)]
+struct Droppable(usize);
+
+impl Drop for Droppable {
+    fn drop(&mut self) {
+        black_box(self);
+    }
+}
+
+#[bench]
+fn bench_in_place_collect_droppable(b: &mut test::Bencher) {
+    let v: Vec<Droppable> = std::iter::repeat_with(|| Droppable(0)).take(1000).collect();
+    b.iter(|| v.clone().into_iter().skip(100).collect::<Vec<_>>())
+}
+
 #[bench]
 fn bench_chain_collect(b: &mut test::Bencher) {
     let data = black_box([0; LEN]);

--- a/library/alloc/src/collections/binary_heap.rs
+++ b/library/alloc/src/collections/binary_heap.rs
@@ -151,7 +151,7 @@ use core::ops::{Deref, DerefMut};
 use core::ptr;
 
 use crate::slice;
-use crate::vec::{self, Vec};
+use crate::vec::{self, Vec, AsIntoIter};
 
 use super::SpecExtend;
 
@@ -1175,16 +1175,22 @@ impl<T> FusedIterator for IntoIter<T> {}
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
 unsafe impl<T> SourceIter for IntoIter<T> {
-    type Source = impl Iterator<Item = T>;
+    type Source = IntoIter<T>;
 
     #[inline]
     fn as_inner(&mut self) -> &mut Self::Source {
-        &mut self.iter
+        self
     }
 }
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
 unsafe impl<I> InPlaceIterable for IntoIter<I> {}
+
+impl<I> AsIntoIter<I> for IntoIter<I> {
+    fn as_into_iter(&mut self) -> &mut vec::IntoIter<I> {
+        &mut self.iter
+    }
+}
 
 #[unstable(feature = "binary_heap_into_iter_sorted", issue = "59278")]
 #[derive(Clone, Debug)]

--- a/library/alloc/src/collections/binary_heap.rs
+++ b/library/alloc/src/collections/binary_heap.rs
@@ -1174,7 +1174,7 @@ impl<T> ExactSizeIterator for IntoIter<T> {
 impl<T> FusedIterator for IntoIter<T> {}
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
-impl<T> SourceIter for IntoIter<T> {
+unsafe impl<T> SourceIter for IntoIter<T> {
     type Source = crate::vec::IntoIter<T>;
 
     #[inline]

--- a/library/alloc/src/collections/binary_heap.rs
+++ b/library/alloc/src/collections/binary_heap.rs
@@ -1186,8 +1186,10 @@ unsafe impl<T> SourceIter for IntoIter<T> {
 #[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<I> InPlaceIterable for IntoIter<I> {}
 
-impl<I> AsIntoIter<I> for IntoIter<I> {
-    fn as_into_iter(&mut self) -> &mut vec::IntoIter<I> {
+impl<I> AsIntoIter for IntoIter<I> {
+    type Item = I;
+
+    fn as_into_iter(&mut self) -> &mut vec::IntoIter<Self::Item> {
         &mut self.iter
     }
 }

--- a/library/alloc/src/collections/binary_heap.rs
+++ b/library/alloc/src/collections/binary_heap.rs
@@ -1175,7 +1175,7 @@ impl<T> FusedIterator for IntoIter<T> {}
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
 unsafe impl<T> SourceIter for IntoIter<T> {
-    type Source = crate::vec::IntoIter<T>;
+    type Source = impl Iterator<Item = T>;
 
     #[inline]
     fn as_inner(&mut self) -> &mut Self::Source {

--- a/library/alloc/src/collections/binary_heap.rs
+++ b/library/alloc/src/collections/binary_heap.rs
@@ -1178,7 +1178,7 @@ unsafe impl<T> SourceIter for IntoIter<T> {
     type Source = IntoIter<T>;
 
     #[inline]
-    fn as_inner(&mut self) -> &mut Self::Source {
+    unsafe fn as_inner(&mut self) -> &mut Self::Source {
         self
     }
 }

--- a/library/alloc/src/collections/binary_heap.rs
+++ b/library/alloc/src/collections/binary_heap.rs
@@ -145,7 +145,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use core::fmt;
-use core::iter::{FromIterator, FusedIterator, TrustedLen};
+use core::iter::{FromIterator, FusedIterator, InPlaceIterable, SourceIter, TrustedLen};
 use core::mem::{self, size_of, swap, ManuallyDrop};
 use core::ops::{Deref, DerefMut};
 use core::ptr;
@@ -1172,6 +1172,19 @@ impl<T> ExactSizeIterator for IntoIter<T> {
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for IntoIter<T> {}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+impl<T> SourceIter for IntoIter<T> {
+    type Source = crate::vec::IntoIter<T>;
+
+    #[inline]
+    fn as_inner(&mut self) -> &mut Self::Source {
+        &mut self.iter
+    }
+}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<I> InPlaceIterable for IntoIter<I> {}
 
 #[unstable(feature = "binary_heap_into_iter_sorted", issue = "59278")]
 #[derive(Clone, Debug)]

--- a/library/alloc/src/collections/binary_heap.rs
+++ b/library/alloc/src/collections/binary_heap.rs
@@ -151,7 +151,7 @@ use core::ops::{Deref, DerefMut};
 use core::ptr;
 
 use crate::slice;
-use crate::vec::{self, Vec, AsIntoIter};
+use crate::vec::{self, AsIntoIter, Vec};
 
 use super::SpecExtend;
 
@@ -1173,7 +1173,7 @@ impl<T> ExactSizeIterator for IntoIter<T> {
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for IntoIter<T> {}
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<T> SourceIter for IntoIter<T> {
     type Source = IntoIter<T>;
 
@@ -1183,7 +1183,7 @@ unsafe impl<T> SourceIter for IntoIter<T> {
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<I> InPlaceIterable for IntoIter<I> {}
 
 impl<I> AsIntoIter<I> for IntoIter<I> {

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -107,7 +107,7 @@
 #![feature(map_first_last)]
 #![feature(map_into_keys_values)]
 #![feature(negative_impls)]
-#![cfg_attr(bootstrap, feature(never_type))]
+#![feature(never_type)]
 #![feature(new_uninit)]
 #![feature(nll)]
 #![feature(nonnull_slice_from_raw_parts)]

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -135,6 +135,7 @@
 #![feature(slice_partition_dedup)]
 #![feature(maybe_uninit_extra, maybe_uninit_slice)]
 #![feature(alloc_layout_extra)]
+#![feature(trusted_random_access)]
 #![feature(try_trait)]
 #![feature(type_alias_impl_trait)]
 #![feature(associated_type_bounds)]

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -107,7 +107,6 @@
 #![feature(map_first_last)]
 #![feature(map_into_keys_values)]
 #![feature(negative_impls)]
-#![feature(never_type)]
 #![feature(new_uninit)]
 #![feature(nll)]
 #![feature(nonnull_slice_from_raw_parts)]

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -99,6 +99,7 @@
 #![feature(fmt_internals)]
 #![feature(fn_traits)]
 #![feature(fundamental)]
+#![feature(inplace_iteration)]
 #![feature(internal_uninit_const)]
 #![feature(lang_items)]
 #![feature(layout_for_ptr)]

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -136,6 +136,7 @@
 #![feature(maybe_uninit_extra, maybe_uninit_slice)]
 #![feature(alloc_layout_extra)]
 #![feature(try_trait)]
+#![feature(type_alias_impl_trait)]
 #![feature(associated_type_bounds)]
 // Allow testing this library
 

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -107,6 +107,7 @@
 #![feature(map_first_last)]
 #![feature(map_into_keys_values)]
 #![feature(negative_impls)]
+#![cfg_attr(bootstrap, feature(never_type))]
 #![feature(new_uninit)]
 #![feature(nll)]
 #![feature(nonnull_slice_from_raw_parts)]

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -107,6 +107,7 @@
 #![feature(map_first_last)]
 #![feature(map_into_keys_values)]
 #![feature(negative_impls)]
+#![feature(never_type)]
 #![feature(new_uninit)]
 #![feature(nll)]
 #![feature(nonnull_slice_from_raw_parts)]

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2164,8 +2164,8 @@ where
     }
 }
 
-// A helper struct for in-place iteration that drops the destination slice of iteration.
-// The source slice is dropped by IntoIter
+// A helper struct for in-place iteration that drops the destination slice of iteration,
+// i.e. the head. The source slice (the tail) is dropped by IntoIter.
 struct InPlaceDrop<T> {
     inner: *mut T,
     dst: *mut T,

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2131,12 +2131,14 @@ where
     I: Iterator<Item = T> + InPlaceIterable + SourceIter<Source = IntoIter<T>>,
 {
     let mut insert_pos = 0;
+    let original_ptr = iterator.as_inner().buf.as_ptr();
 
     // FIXME: how to drop values written into source when iteration panics?
     //   tail already gets cleaned by IntoIter::drop
     while let Some(item) = iterator.next() {
         let source_iter = iterator.as_inner();
         let src_buf = source_iter.buf.as_ptr();
+        debug_assert_eq!(original_ptr, src_buf);
         let src_idx = source_iter.ptr;
         unsafe {
             let dst = src_buf.offset(insert_pos as isize);

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2086,11 +2086,8 @@ impl<T> Extend<T> for Vec<T> {
             <Self as SpecExtend<T, I::IntoIter>>::spec_extend(self, iter.into_iter())
         } else {
             // if self has no allocation then use the more powerful from_iter specializations
-            let other = SpecFrom::from_iter(iter.into_iter());
-            // replace self, don't run drop since self was empty
-            unsafe {
-                ptr::write(self, other);
-            }
+            // and overwrite self
+            *self = SpecFrom::from_iter(iter.into_iter());
         }
     }
 
@@ -2544,11 +2541,8 @@ impl<'a, T: 'a + Copy> Extend<&'a T> for Vec<T> {
             self.spec_extend(iter.into_iter())
         } else {
             // if self has no allocation then use the more powerful from_iter specializations
-            let other = SpecFrom::from_iter(iter.into_iter());
-            // replace self, don't run drop since self was empty
-            unsafe {
-                ptr::write(self, other);
-            }
+            // and overwrite self
+            *self = SpecFrom::from_iter(iter.into_iter());
         }
     }
 

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2941,7 +2941,7 @@ impl<T> FusedIterator for IntoIter<T> {}
 unsafe impl<T> TrustedLen for IntoIter<T> {}
 
 #[doc(hidden)]
-#[unstable(issue = "0", feature = "std_internals")]
+#[unstable(issue = "none", feature = "std_internals")]
 // T: Copy as approximation for !Drop since get_unchecked does not advance self.ptr
 // and thus we can't implement drop-handling
 unsafe impl<T> TrustedRandomAccess for IntoIter<T>
@@ -2987,10 +2987,10 @@ unsafe impl<#[may_dangle] T> Drop for IntoIter<T> {
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<T> InPlaceIterable for IntoIter<T> {}
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<T> SourceIter for IntoIter<T> {
     type Source = IntoIter<T>;
 

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2082,13 +2082,7 @@ impl<'a, T> IntoIterator for &'a mut Vec<T> {
 impl<T> Extend<T> for Vec<T> {
     #[inline]
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
-        if self.capacity() > 0 {
-            <Self as SpecExtend<T, I::IntoIter>>::spec_extend(self, iter.into_iter())
-        } else {
-            // if self has no allocation then use the more powerful from_iter specializations
-            // and overwrite self
-            *self = SpecFrom::from_iter(iter.into_iter());
-        }
+        <Self as SpecExtend<T, I::IntoIter>>::spec_extend(self, iter.into_iter())
     }
 
     #[inline]
@@ -2544,13 +2538,7 @@ impl<T> Vec<T> {
 #[stable(feature = "extend_ref", since = "1.2.0")]
 impl<'a, T: 'a + Copy> Extend<&'a T> for Vec<T> {
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
-        if self.capacity() > 0 {
-            self.spec_extend(iter.into_iter())
-        } else {
-            // if self has no allocation then use the more powerful from_iter specializations
-            // and overwrite self
-            *self = SpecFrom::from_iter(iter.into_iter());
-        }
+        self.spec_extend(iter.into_iter())
     }
 
     #[inline]

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2826,7 +2826,7 @@ unsafe impl<#[may_dangle] T> Drop for IntoIter<T> {
 unsafe impl<T> InPlaceIterable for IntoIter<T> {}
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
-impl<T> SourceIter for IntoIter<T> {
+unsafe impl<T> SourceIter for IntoIter<T> {
     type Source = IntoIter<T>;
 
     #[inline]

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2297,6 +2297,15 @@ where
     }
 }
 
+impl<T> SpecExtend<T, IntoIter<T>> for Vec<T> {
+    fn spec_extend(&mut self, mut iterator: IntoIter<T>) {
+        unsafe {
+            self.append_elements(iterator.as_slice() as _);
+        }
+        iterator.ptr = iterator.end;
+    }
+}
+
 impl<'a, T: 'a, I> SpecExtend<&'a T, I> for Vec<T>
 where
     I: Iterator<Item = &'a T>,

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2181,7 +2181,7 @@ impl<T> Drop for InPlaceDrop<T> {
     #[inline]
     fn drop(&mut self) {
         unsafe {
-            ptr::drop_in_place(slice::from_raw_parts_mut(self.inner, self.len()) as *mut _);
+            ptr::drop_in_place(slice::from_raw_parts_mut(self.inner, self.len()));
         }
     }
 }

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2227,6 +2227,12 @@ fn write_in_place_with_drop<T>(
 #[rustc_unsafe_specialization_marker]
 trait SourceIterMarker: SourceIter<Source: AsIntoIter> {}
 
+// The std-internal SourceIter/InPlaceIterable traits are only implemented by chains of
+// Adapter<Adapter<Adapter<IntoIter>>> (all owned by core/std). Additional bounds
+// on the adapter implementations (beyond `impl<I: Trait> Trait for Adapter<I>`) only depend on other
+// traits already marked as specialization traits (Copy, TrustedRandomAccess, FusedIterator).
+// I.e. the marker does not depend on lifetimes of user-supplied types. Modulo the Copy hole, which
+// several other specializations already depend on.
 impl<T> SourceIterMarker for T where T: SourceIter<Source: AsIntoIter> + InPlaceIterable {}
 
 impl<T, I> SpecFrom<T, I> for Vec<T>

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2240,9 +2240,14 @@ fn write_in_place_with_drop<T>(
     }
 }
 
+#[rustc_unsafe_specialization_marker]
+trait SourceIterMarker: SourceIter<Source: AsIntoIter> {}
+
+impl<T> SourceIterMarker for T where T: SourceIter<Source: AsIntoIter> {}
+
 impl<T, I> SpecFrom<T, I> for Vec<T>
 where
-    I: Iterator<Item = T> + InPlaceIterable + SourceIter<Source: AsIntoIter>,
+    I: Iterator<Item = T> + InPlaceIterable + SourceIterMarker,
 {
     default fn from_iter(mut iterator: I) -> Self {
         // Additional requirements which cannot expressed via trait bounds. We rely on const eval
@@ -3015,6 +3020,7 @@ unsafe impl<T> SourceIter for IntoIter<T> {
 }
 
 // internal helper trait for in-place iteration specialization.
+#[rustc_specialization_trait]
 pub(crate) trait AsIntoIter {
     type Item;
     fn as_into_iter(&mut self) -> &mut IntoIter<Self::Item>;

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2172,8 +2172,8 @@ struct InPlaceDrop<T> {
 }
 
 impl<T> InPlaceDrop<T> {
-    unsafe fn len(&self) -> usize {
-        self.dst.offset_from(self.inner) as usize
+    fn len(&self) -> usize {
+        unsafe { self.dst.offset_from(self.inner) as usize }
     }
 }
 

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -3042,7 +3042,7 @@ where
     old_len: usize,
     /// The filter test predicate.
     pred: F,
-    /// A flag that indicates a panic has occurred in the filter test prodicate.
+    /// A flag that indicates a panic has occurred in the filter test predicate.
     /// This is used as a hint in the drop implementation to prevent consumption
     /// of the remainder of the `DrainFilter`. Any unprocessed items will be
     /// backshifted in the `vec`, but no further items will be dropped or

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2299,6 +2299,20 @@ where
     }
 }
 
+impl<'a, T: 'a> SpecFrom<&'a T, slice::Iter<'a, T>> for Vec<T>
+where
+    T: Copy,
+{
+    // reuses the extend specialization for T: Copy
+    fn from_iter(iterator: slice::Iter<'a, T>) -> Self {
+        let mut vec = Vec::new();
+        // must delegate to spec_extend() since extend() itself delegates
+        // to spec_from for empty Vecs
+        vec.spec_extend(iterator);
+        vec
+    }
+}
+
 // Specialization trait used for Vec::extend
 trait SpecExtend<T, I> {
     fn spec_extend(&mut self, iter: I);

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2108,7 +2108,13 @@ trait SpecFrom<T, I> {
     fn from_iter(iter: I) -> Self;
 }
 
-impl<T, I> SpecFrom<T, I> for Vec<T>
+// Another specialization trait for Vec::from_iter
+// necessary to manually prioritize overlapping specializations
+trait SpecFromNested<T, I> {
+    fn from_iter(iter: I) -> Self;
+}
+
+impl<T, I> SpecFromNested<T, I> for Vec<T>
 where
     I: Iterator<Item = T>,
 {
@@ -2134,6 +2140,28 @@ where
         // to spec_from for empty Vecs
         <Vec<T> as SpecExtend<T, I>>::spec_extend(&mut vector, iterator);
         vector
+    }
+}
+
+impl<T, I> SpecFromNested<T, I> for Vec<T>
+where
+    I: TrustedLen<Item = T>,
+{
+    fn from_iter(iterator: I) -> Self {
+        let mut vector = Vec::new();
+        // must delegate to spec_extend() since extend() itself delegates
+        // to spec_from for empty Vecs
+        vector.spec_extend(iterator);
+        vector
+    }
+}
+
+impl<T, I> SpecFrom<T, I> for Vec<T>
+where
+    I: Iterator<Item = T>,
+{
+    default fn from_iter(iterator: I) -> Self {
+        SpecFromNested::from_iter(iterator)
     }
 }
 

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2080,7 +2080,16 @@ impl<'a, T> IntoIterator for &'a mut Vec<T> {
 impl<T> Extend<T> for Vec<T> {
     #[inline]
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
-        <Self as SpecExtend<T, I::IntoIter>>::spec_extend(self, iter.into_iter())
+        if self.capacity() > 0 {
+            <Self as SpecExtend<T, I::IntoIter>>::spec_extend(self, iter.into_iter())
+        } else {
+            // if self has no allocation then use the more powerful from_iter specializations
+            let other = SpecFrom::from_iter(iter.into_iter());
+            // replace self, don't run drop since self was empty
+            unsafe {
+                ptr::write(self, other);
+            }
+        }
     }
 
     #[inline]
@@ -2121,6 +2130,8 @@ where
                 vector
             }
         };
+        // must delegate to spec_extend() since extend() itself delegates
+        // to spec_from for empty Vecs
         <Vec<T> as SpecExtend<T, I>>::spec_extend(&mut vector, iterator);
         vector
     }
@@ -2230,7 +2241,9 @@ impl<T> SpecFrom<T, IntoIter<T>> for Vec<T> {
         }
 
         let mut vec = Vec::new();
-        vec.extend(iterator);
+        // must delegate to spec_extend() since extend() itself delegates
+        // to spec_from for empty Vecs
+        vec.spec_extend(iterator);
         vec
     }
 }
@@ -2475,7 +2488,16 @@ impl<T> Vec<T> {
 #[stable(feature = "extend_ref", since = "1.2.0")]
 impl<'a, T: 'a + Copy> Extend<&'a T> for Vec<T> {
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
-        self.spec_extend(iter.into_iter())
+        if self.capacity() > 0 {
+            self.spec_extend(iter.into_iter())
+        } else {
+            // if self has no allocation then use the more powerful from_iter specializations
+            let other = SpecFrom::from_iter(iter.into_iter());
+            // replace self, don't run drop since self was empty
+            unsafe {
+                ptr::write(self, other);
+            }
+        }
     }
 
     #[inline]

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2386,13 +2386,7 @@ where
 {
     fn spec_extend(&mut self, iterator: slice::Iter<'a, T>) {
         let slice = iterator.as_slice();
-        self.reserve(slice.len());
-        unsafe {
-            let len = self.len();
-            let dst_slice = slice::from_raw_parts_mut(self.as_mut_ptr().add(len), slice.len());
-            dst_slice.copy_from_slice(slice);
-            self.set_len(len + slice.len());
-        }
+        unsafe { self.append_elements(slice) };
     }
 }
 

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2156,7 +2156,7 @@ where
         debug_assert_eq!(original_ptr, src_buf);
         let src_idx = source_iter.ptr;
         unsafe {
-            let dst = src_buf.offset(front_buffer.count as isize);
+            let dst = src_buf.add(front_buffer.count);
             debug_assert!(
                 dst as *const _ < src_idx,
                 "InPlaceIterable implementation produced more\

--- a/library/alloc/tests/binary_heap.rs
+++ b/library/alloc/tests/binary_heap.rs
@@ -231,6 +231,18 @@ fn test_to_vec() {
 }
 
 #[test]
+fn test_in_place_iterator_specialization() {
+    let src: Vec<usize> = vec![1, 2, 3];
+    let src_ptr = src.as_ptr();
+    let heap: BinaryHeap<_> = src.into_iter().map(std::convert::identity).collect();
+    let heap_ptr = heap.iter().next().unwrap() as *const usize;
+    assert_eq!(src_ptr, heap_ptr);
+    let sink: Vec<_> = heap.into_iter().map(std::convert::identity).collect();
+    let sink_ptr = sink.as_ptr();
+    assert_eq!(heap_ptr, sink_ptr);
+}
+
+#[test]
 fn test_empty_pop() {
     let mut heap = BinaryHeap::<i32>::new();
     assert!(heap.pop().is_none());

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -14,6 +14,7 @@
 #![feature(slice_ptr_get)]
 #![feature(split_inclusive)]
 #![feature(binary_heap_retain)]
+#![feature(inplace_iteration)]
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -15,6 +15,7 @@
 #![feature(split_inclusive)]
 #![feature(binary_heap_retain)]
 #![feature(inplace_iteration)]
+#![feature(iter_map_while)]
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};

--- a/library/alloc/tests/slice.rs
+++ b/library/alloc/tests/slice.rs
@@ -1460,6 +1460,15 @@ fn test_to_vec() {
 }
 
 #[test]
+fn test_in_place_iterator_specialization() {
+    let src: Box<[usize]> = box [1, 2, 3];
+    let src_ptr = src.as_ptr();
+    let sink: Box<_> = src.into_vec().into_iter().map(std::convert::identity).collect();
+    let sink_ptr = sink.as_ptr();
+    assert_eq!(src_ptr, sink_ptr);
+}
+
+#[test]
 fn test_box_slice_clone() {
     let data = vec![vec![0, 1], vec![0], vec![1]];
     let data2 = data.clone().into_boxed_slice().clone().to_vec();

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -799,16 +799,6 @@ fn test_from_iter_partially_drained_in_place_specialization() {
 }
 
 #[test]
-fn test_extend_in_place_specialization() {
-    let src: Vec<usize> = vec![0usize; 1];
-    let srcptr = src.as_ptr();
-    let mut dst = Vec::new();
-    dst.extend(src.into_iter());
-    let dstptr = dst.as_ptr();
-    assert_eq!(srcptr, dstptr);
-}
-
-#[test]
 fn test_from_iter_specialization_with_iterator_adapters() {
     fn assert_in_place_trait<T: InPlaceIterable>(_: &T) {};
     let src: Vec<usize> = vec![0usize; 65535];

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -812,7 +812,14 @@ fn test_from_iter_specialization_with_iterator_adapters() {
     fn assert_in_place_trait<T: InPlaceIterable>(_: &T) {};
     let src: Vec<usize> = vec![0usize; 65535];
     let srcptr = src.as_ptr();
-    let iter = src.into_iter().enumerate().map(|i| i.0 + i.1).peekable().skip(1);
+    let iter = src
+        .into_iter()
+        .enumerate()
+        .map(|i| i.0 + i.1)
+        .zip(std::iter::repeat(1usize))
+        .map(|(a, b)| a + b)
+        .peekable()
+        .skip(1);
     assert_in_place_trait(&iter);
     let sink = iter.collect::<Vec<_>>();
     let sinkptr = sink.as_ptr();

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -820,11 +820,12 @@ fn test_from_iter_specialization_with_iterator_adapters() {
         .zip(std::iter::repeat(1usize))
         .map(|(a, b)| a + b)
         .peekable()
-        .skip(1);
+        .skip(1)
+        .map(|e| std::num::NonZeroUsize::new(e));
     assert_in_place_trait(&iter);
     let sink = iter.collect::<Vec<_>>();
     let sinkptr = sink.as_ptr();
-    assert_eq!(srcptr, sinkptr);
+    assert_eq!(srcptr, sinkptr as *const usize);
 }
 
 #[test]

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -819,6 +819,7 @@ fn test_from_iter_specialization_with_iterator_adapters() {
         .map(|i| i.0 + i.1)
         .zip(std::iter::repeat(1usize))
         .map(|(a, b)| a + b)
+        .map_while(Option::Some)
         .peekable()
         .skip(1)
         .map(|e| std::num::NonZeroUsize::new(e));

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -786,6 +786,28 @@ fn test_from_iter_specialization() {
 }
 
 #[test]
+fn test_from_iter_partially_drained_in_place_specialization() {
+    let src: Vec<usize> = vec![0usize; 10];
+    let srcptr = src.as_ptr();
+    let mut iter = src.into_iter();
+    iter.next();
+    iter.next();
+    let sink = iter.collect::<Vec<_>>();
+    let sinkptr = sink.as_ptr();
+    assert_eq!(srcptr, sinkptr);
+}
+
+#[test]
+fn test_extend_in_place_specialization() {
+    let src: Vec<usize> = vec![0usize; 1];
+    let srcptr = src.as_ptr();
+    let mut dst = Vec::new();
+    dst.extend(src.into_iter());
+    let dstptr = dst.as_ptr();
+    assert_eq!(srcptr, dstptr);
+}
+
+#[test]
 fn test_from_iter_specialization_with_iterator_adapters() {
     fn assert_in_place_trait<T: InPlaceIterable>(_: &T) {};
     let src: Vec<usize> = vec![0usize; 65535];

--- a/library/core/src/iter/adapters/fuse.rs
+++ b/library/core/src/iter/adapters/fuse.rs
@@ -1,10 +1,10 @@
+use super::InPlaceIterable;
 use crate::intrinsics;
 use crate::iter::adapters::zip::try_get_unchecked;
 use crate::iter::TrustedRandomAccess;
 use crate::iter::{DoubleEndedIterator, ExactSizeIterator, FusedIterator, Iterator};
-use crate::ops::Try;
 use crate::iter::adapters::SourceIter;
-use super::InPlaceIterable;
+use crate::ops::Try;
 
 /// An iterator that yields `None` forever after the underlying iterator
 /// yields `None` once.
@@ -522,8 +522,8 @@ where
 
 #[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<S: Iterator, I: FusedIterator> SourceIter for Fuse<I>
-    where
-        I: SourceIter<Source = S>,
+where
+    I: SourceIter<Source = S>,
 {
     type Source = S;
 

--- a/library/core/src/iter/adapters/fuse.rs
+++ b/library/core/src/iter/adapters/fuse.rs
@@ -529,9 +529,10 @@ unsafe impl<S: Iterator, I: FusedIterator> SourceIter for Fuse<I>
     type Source = S;
 
     #[inline]
-    fn as_inner(&mut self) -> &mut S {
+    unsafe fn as_inner(&mut self) -> &mut S {
         match self.iter {
-            Some(ref mut iter) => SourceIter::as_inner(iter),
+            // Safety: unsafe function forwarding to unsafe function with the same requirements
+            Some(ref mut iter) => unsafe { SourceIter::as_inner(iter) },
             // SAFETY: the specialized iterator never sets `None`
             None => unsafe { intrinsics::unreachable() },
         }

--- a/library/core/src/iter/adapters/fuse.rs
+++ b/library/core/src/iter/adapters/fuse.rs
@@ -520,8 +520,7 @@ where
     }
 }
 
-
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<S: Iterator, I: FusedIterator> SourceIter for Fuse<I>
     where
         I: SourceIter<Source = S>,
@@ -539,5 +538,5 @@ unsafe impl<S: Iterator, I: FusedIterator> SourceIter for Fuse<I>
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<I: InPlaceIterable> InPlaceIterable for Fuse<I> {}

--- a/library/core/src/iter/adapters/fuse.rs
+++ b/library/core/src/iter/adapters/fuse.rs
@@ -1,9 +1,9 @@
 use super::InPlaceIterable;
 use crate::intrinsics;
 use crate::iter::adapters::zip::try_get_unchecked;
+use crate::iter::adapters::SourceIter;
 use crate::iter::TrustedRandomAccess;
 use crate::iter::{DoubleEndedIterator, ExactSizeIterator, FusedIterator, Iterator};
-use crate::iter::adapters::SourceIter;
 use crate::ops::Try;
 
 /// An iterator that yields `None` forever after the underlying iterator

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -485,7 +485,6 @@ where
 unsafe impl<I> TrustedRandomAccess for Cloned<I>
 where
     I: TrustedRandomAccess,
-
 {
     #[inline]
     fn may_have_side_effect() -> bool {

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -69,10 +69,6 @@ pub unsafe trait SourceIter {
     /// rely on it not being modified.
     ///
     /// Adapters must not rely on exclusive ownership or immutability of the source.
-    /// For example a peeking adapter could either exploit [`TrustedRandomAccess`] to look ahead
-    /// or implement this trait, but it cannot do both because a caller could call `next()` or any
-    /// other mutating method on the source between iteration steps and thus invalidate the peeked
-    /// values.
     /// The lack of exclusive ownership also requires that adapters must uphold the source's
     /// public API even when they have crate- or module-internal access.
     ///
@@ -84,7 +80,6 @@ pub unsafe trait SourceIter {
     /// access to the underlying storage of an iterator while restricting any statefulness
     /// and side-effects of the pipeline stages from affecting or relying on that storage.
     ///
-    /// [`TrustedRandomAccess`]: trait.TrustedRandomAccess.html
     /// [`next()`]: trait.Iterator.html#method.next
     fn as_inner(&mut self) -> &mut Self::Source;
 }

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -85,7 +85,7 @@ pub unsafe trait SourceIter {
     /// and side-effects of the pipeline stages from affecting or relying on that storage.
     ///
     /// [`TrustedRandomAccess`]: trait.TrustedRandomAccess.html
-    /// [`next`]: trait.Iterator.html#method.next
+    /// [`next()`]: trait.Iterator.html#method.next
     fn as_inner(&mut self) -> &mut Self::Source;
 }
 

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -55,7 +55,7 @@ pub use self::zip::Zip;
 ///
 /// [`FromIterator`]: crate::iter::FromIterator
 /// [`as_inner`]: SourceIter::as_inner
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 pub unsafe trait SourceIter {
     /// A source stage in an iterator pipeline.
     type Source: Iterator;
@@ -1010,7 +1010,7 @@ where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<S: Iterator, B, I: Iterator, F> SourceIter for Map<I, F>
 where
     F: FnMut(I::Item) -> B,
@@ -1025,7 +1025,7 @@ where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<B, I: InPlaceIterable, F> InPlaceIterable for Map<I, F> where F: FnMut(I::Item) -> B {}
 
 /// An iterator that filters the elements of `iter` with `predicate`.
@@ -1159,10 +1159,11 @@ where
 #[stable(feature = "fused", since = "1.26.0")]
 impl<I: FusedIterator, P> FusedIterator for Filter<I, P> where P: FnMut(&I::Item) -> bool {}
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<S: Iterator, P, I: Iterator> SourceIter for Filter<I, P> where
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, P, I: Iterator> SourceIter for Filter<I, P>
+where
     P: FnMut(&I::Item) -> bool,
-    I: SourceIter<Source = S>
+    I: SourceIter<Source = S>,
 {
     type Source = S;
 
@@ -1173,9 +1174,8 @@ unsafe impl<S: Iterator, P, I: Iterator> SourceIter for Filter<I, P> where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<I: InPlaceIterable, P> InPlaceIterable for Filter<I, P>
-    where P: FnMut(&I::Item) -> bool {}
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<I: InPlaceIterable, P> InPlaceIterable for Filter<I, P> where P: FnMut(&I::Item) -> bool {}
 
 /// An iterator that uses `f` to both filter and map elements from `iter`.
 ///
@@ -1303,10 +1303,11 @@ where
 #[stable(feature = "fused", since = "1.26.0")]
 impl<B, I: FusedIterator, F> FusedIterator for FilterMap<I, F> where F: FnMut(I::Item) -> Option<B> {}
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<S: Iterator, B, I: Iterator, F> SourceIter for FilterMap<I, F> where
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, B, I: Iterator, F> SourceIter for FilterMap<I, F>
+where
     F: FnMut(I::Item) -> Option<B>,
-    I: SourceIter<Source = S>
+    I: SourceIter<Source = S>,
 {
     type Source = S;
 
@@ -1317,10 +1318,11 @@ unsafe impl<S: Iterator, B, I: Iterator, F> SourceIter for FilterMap<I, F> where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<B, I: InPlaceIterable, F> InPlaceIterable for FilterMap<I, F>
-    where F: FnMut(I::Item) -> Option<B> {}
-
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<B, I: InPlaceIterable, F> InPlaceIterable for FilterMap<I, F> where
+    F: FnMut(I::Item) -> Option<B>
+{
+}
 
 /// An iterator that yields the current count and the element during iteration.
 ///
@@ -1540,7 +1542,7 @@ impl<I> FusedIterator for Enumerate<I> where I: FusedIterator {}
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<I> TrustedLen for Enumerate<I> where I: TrustedLen {}
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<S: Iterator, I: Iterator> SourceIter for Enumerate<I>
 where
     I: SourceIter<Source = S>,
@@ -1554,7 +1556,7 @@ where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<I: InPlaceIterable> InPlaceIterable for Enumerate<I> {}
 
 /// An iterator with a `peek()` that returns an optional reference to the next
@@ -1838,7 +1840,7 @@ impl<I: Iterator> Peekable<I> {
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<I> TrustedLen for Peekable<I> where I: TrustedLen {}
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<S: Iterator, I: Iterator> SourceIter for Peekable<I>
 where
     I: SourceIter<Source = S>,
@@ -1852,7 +1854,7 @@ where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<I: InPlaceIterable> InPlaceIterable for Peekable<I> {}
 
 /// An iterator that rejects elements while `predicate` returns `true`.
@@ -1956,10 +1958,11 @@ where
 {
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<S: Iterator, P, I: Iterator> SourceIter for SkipWhile<I, P> where
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, P, I: Iterator> SourceIter for SkipWhile<I, P>
+where
     P: FnMut(&I::Item) -> bool,
-    I: SourceIter<Source = S>
+    I: SourceIter<Source = S>,
 {
     type Source = S;
 
@@ -1970,9 +1973,11 @@ unsafe impl<S: Iterator, P, I: Iterator> SourceIter for SkipWhile<I, P> where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<I: InPlaceIterable, F> InPlaceIterable for SkipWhile<I, F>
-    where F: FnMut(&I::Item) -> bool {}
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<I: InPlaceIterable, F> InPlaceIterable for SkipWhile<I, F> where
+    F: FnMut(&I::Item) -> bool
+{
+}
 
 /// An iterator that only accepts elements while `predicate` returns `true`.
 ///
@@ -2088,6 +2093,27 @@ where
 {
 }
 
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, P, I: Iterator> SourceIter for TakeWhile<I, P>
+    where
+        P: FnMut(&I::Item) -> bool,
+        I: SourceIter<Source = S>,
+{
+    type Source = S;
+
+    #[inline]
+    unsafe fn as_inner(&mut self) -> &mut S {
+        // Safety: unsafe function forwarding to unsafe function with the same requirements
+        unsafe { SourceIter::as_inner(&mut self.iter) }
+    }
+}
+
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<I: InPlaceIterable, F> InPlaceIterable for TakeWhile<I, F> where
+    F: FnMut(&I::Item) -> bool
+{
+}
+
 /// An iterator that only accepts elements while `predicate` returns `Some(_)`.
 ///
 /// This `struct` is created by the [`map_while`] method on [`Iterator`]. See its
@@ -2164,25 +2190,6 @@ where
         self.try_fold(init, ok(fold)).unwrap()
     }
 }
-
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<S: Iterator, P, I: Iterator> SourceIter for TakeWhile<I, P> where
-    P: FnMut(&I::Item) -> bool,
-    I: SourceIter<Source = S>
-{
-    type Source = S;
-
-    #[inline]
-    unsafe fn as_inner(&mut self) -> &mut S {
-        // Safety: unsafe function forwarding to unsafe function with the same requirements
-        unsafe { SourceIter::as_inner(&mut self.iter) }
-    }
-}
-
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<I: InPlaceIterable, F> InPlaceIterable for TakeWhile<I, F>
-    where F: FnMut(&I::Item) -> bool {}
-
 
 /// An iterator that skips over `n` elements of `iter`.
 ///
@@ -2367,7 +2374,7 @@ where
 #[stable(feature = "fused", since = "1.26.0")]
 impl<I> FusedIterator for Skip<I> where I: FusedIterator {}
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<S: Iterator, I: Iterator> SourceIter for Skip<I>
 where
     I: SourceIter<Source = S>,
@@ -2381,7 +2388,7 @@ where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<I: InPlaceIterable> InPlaceIterable for Skip<I> {}
 
 /// An iterator that only iterates over the first `n` iterations of `iter`.
@@ -2494,8 +2501,11 @@ where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<S: Iterator, I: Iterator> SourceIter for Take<I> where I: SourceIter<Source = S> {
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, I: Iterator> SourceIter for Take<I>
+where
+    I: SourceIter<Source = S>,
+{
     type Source = S;
 
     #[inline]
@@ -2505,7 +2515,7 @@ unsafe impl<S: Iterator, I: Iterator> SourceIter for Take<I> where I: SourceIter
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<I: InPlaceIterable> InPlaceIterable for Take<I> {}
 
 #[stable(feature = "double_ended_take_iterator", since = "1.38.0")]
@@ -2672,10 +2682,11 @@ where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<St, F, B, S: Iterator, I: Iterator> SourceIter for Scan<I, St, F>
-    where I: SourceIter<Source = S>,
-          F: FnMut(&mut St, I::Item) -> Option<B>,
+where
+    I: SourceIter<Source = S>,
+    F: FnMut(&mut St, I::Item) -> Option<B>,
 {
     type Source = S;
 
@@ -2686,10 +2697,11 @@ unsafe impl<St, F, B, S: Iterator, I: Iterator> SourceIter for Scan<I, St, F>
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<St, F, B, I: InPlaceIterable> InPlaceIterable for Scan<I, St, F>
-    where F: FnMut(&mut St, I::Item) -> Option<B>,
-{}
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<St, F, B, I: InPlaceIterable> InPlaceIterable for Scan<I, St, F> where
+    F: FnMut(&mut St, I::Item) -> Option<B>
+{
+}
 
 /// An iterator that calls a function with a reference to each element before
 /// yielding it.
@@ -2837,10 +2849,11 @@ where
 #[stable(feature = "fused", since = "1.26.0")]
 impl<I: FusedIterator, F> FusedIterator for Inspect<I, F> where F: FnMut(&I::Item) {}
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<S: Iterator, I: Iterator, F> SourceIter for Inspect<I, F> where
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, I: Iterator, F> SourceIter for Inspect<I, F>
+where
     F: FnMut(&I::Item),
-    I: SourceIter<Source = S>
+    I: SourceIter<Source = S>,
 {
     type Source = S;
 
@@ -2851,8 +2864,8 @@ unsafe impl<S: Iterator, I: Iterator, F> SourceIter for Inspect<I, F> where
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<I: InPlaceIterable, F> InPlaceIterable for Inspect<I, F> where F: FnMut(&I::Item)  {}
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<I: InPlaceIterable, F> InPlaceIterable for Inspect<I, F> where F: FnMut(&I::Item) {}
 
 /// An iterator adapter that produces output as long as the underlying
 /// iterator produces `Result::Ok` values.

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -1166,7 +1166,8 @@ unsafe impl<S: Iterator, P, I: Iterator> SourceIter for Filter<I, P> where
 }
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<I: InPlaceIterable, P> InPlaceIterable for Filter<I, P> where P: FnMut(&I::Item) -> bool {}
+unsafe impl<I: InPlaceIterable, P> InPlaceIterable for Filter<I, P>
+    where P: FnMut(&I::Item) -> bool {}
 
 /// An iterator that uses `f` to both filter and map elements from `iter`.
 ///
@@ -1308,7 +1309,8 @@ unsafe impl<S: Iterator, B, I: Iterator, F> SourceIter for FilterMap<I, F> where
 }
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<B, I: InPlaceIterable, F> InPlaceIterable for FilterMap<I, F> where F: FnMut(I::Item) -> Option<B> {}
+unsafe impl<B, I: InPlaceIterable, F> InPlaceIterable for FilterMap<I, F>
+    where F: FnMut(I::Item) -> Option<B> {}
 
 
 /// An iterator that yields the current count and the element during iteration.
@@ -1957,7 +1959,8 @@ unsafe impl<S: Iterator, P, I: Iterator> SourceIter for SkipWhile<I, P> where
 }
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<I: InPlaceIterable, F> InPlaceIterable for SkipWhile<I, F> where F: FnMut(&I::Item) -> bool {}
+unsafe impl<I: InPlaceIterable, F> InPlaceIterable for SkipWhile<I, F>
+    where F: FnMut(&I::Item) -> bool {}
 
 /// An iterator that only accepts elements while `predicate` returns `true`.
 ///
@@ -2164,7 +2167,8 @@ unsafe impl<S: Iterator, P, I: Iterator> SourceIter for TakeWhile<I, P> where
 }
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<I: InPlaceIterable, F> InPlaceIterable for TakeWhile<I, F> where F: FnMut(&I::Item) -> bool {}
+unsafe impl<I: InPlaceIterable, F> InPlaceIterable for TakeWhile<I, F>
+    where F: FnMut(&I::Item) -> bool {}
 
 
 /// An iterator that skips over `n` elements of `iter`.

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -1152,6 +1152,22 @@ where
 #[stable(feature = "fused", since = "1.26.0")]
 impl<I: FusedIterator, P> FusedIterator for Filter<I, P> where P: FnMut(&I::Item) -> bool {}
 
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, P, I: Iterator> SourceIter for Filter<I, P> where
+    P: FnMut(&I::Item) -> bool,
+    I: SourceIter<Source = S>
+{
+    type Source = S;
+
+    #[inline]
+    fn as_inner(&mut self) -> &mut S {
+        SourceIter::as_inner(&mut self.iter)
+    }
+}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<I: InPlaceIterable, P> InPlaceIterable for Filter<I, P> where P: FnMut(&I::Item) -> bool {}
+
 /// An iterator that uses `f` to both filter and map elements from `iter`.
 ///
 /// This `struct` is created by the [`filter_map`] method on [`Iterator`]. See its
@@ -1277,6 +1293,23 @@ where
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<B, I: FusedIterator, F> FusedIterator for FilterMap<I, F> where F: FnMut(I::Item) -> Option<B> {}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, B, I: Iterator, F> SourceIter for FilterMap<I, F> where
+    F: FnMut(I::Item) -> Option<B>,
+    I: SourceIter<Source = S>
+{
+    type Source = S;
+
+    #[inline]
+    fn as_inner(&mut self) -> &mut S {
+        SourceIter::as_inner(&mut self.iter)
+    }
+}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<B, I: InPlaceIterable, F> InPlaceIterable for FilterMap<I, F> where F: FnMut(I::Item) -> Option<B> {}
+
 
 /// An iterator that yields the current count and the element during iteration.
 ///
@@ -1910,6 +1943,22 @@ where
 {
 }
 
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, P, I: Iterator> SourceIter for SkipWhile<I, P> where
+    P: FnMut(&I::Item) -> bool,
+    I: SourceIter<Source = S>
+{
+    type Source = S;
+
+    #[inline]
+    fn as_inner(&mut self) -> &mut S {
+        SourceIter::as_inner(&mut self.iter)
+    }
+}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<I: InPlaceIterable, F> InPlaceIterable for SkipWhile<I, F> where F: FnMut(&I::Item) -> bool {}
+
 /// An iterator that only accepts elements while `predicate` returns `true`.
 ///
 /// This `struct` is created by the [`take_while`] method on [`Iterator`]. See its
@@ -2100,6 +2149,23 @@ where
         self.try_fold(init, ok(fold)).unwrap()
     }
 }
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, P, I: Iterator> SourceIter for TakeWhile<I, P> where
+    P: FnMut(&I::Item) -> bool,
+    I: SourceIter<Source = S>
+{
+    type Source = S;
+
+    #[inline]
+    fn as_inner(&mut self) -> &mut S {
+        SourceIter::as_inner(&mut self.iter)
+    }
+}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<I: InPlaceIterable, F> InPlaceIterable for TakeWhile<I, F> where F: FnMut(&I::Item) -> bool {}
+
 
 /// An iterator that skips over `n` elements of `iter`.
 ///
@@ -2410,6 +2476,19 @@ where
     }
 }
 
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, I: Iterator> SourceIter for Take<I> where I: SourceIter<Source = S> {
+    type Source = S;
+
+    #[inline]
+    fn as_inner(&mut self) -> &mut S {
+        SourceIter::as_inner(&mut self.iter)
+    }
+}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<I: InPlaceIterable> InPlaceIterable for Take<I> {}
+
 #[stable(feature = "double_ended_take_iterator", since = "1.38.0")]
 impl<I> DoubleEndedIterator for Take<I>
 where
@@ -2574,6 +2653,24 @@ where
     }
 }
 
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<St, F, B, S: Iterator, I: Iterator> SourceIter for Scan<I, St, F>
+    where I: SourceIter<Source = S>,
+          F: FnMut(&mut St, I::Item) -> Option<B>,
+{
+    type Source = S;
+
+    #[inline]
+    fn as_inner(&mut self) -> &mut S {
+        SourceIter::as_inner(&mut self.iter)
+    }
+}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<St, F, B, I: InPlaceIterable> InPlaceIterable for Scan<I, St, F>
+    where F: FnMut(&mut St, I::Item) -> Option<B>,
+{}
+
 /// An iterator that calls a function with a reference to each element before
 /// yielding it.
 ///
@@ -2719,6 +2816,22 @@ where
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<I: FusedIterator, F> FusedIterator for Inspect<I, F> where F: FnMut(&I::Item) {}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, I: Iterator, F> SourceIter for Inspect<I, F> where
+    F: FnMut(&I::Item),
+    I: SourceIter<Source = S>
+{
+    type Source = S;
+
+    #[inline]
+    fn as_inner(&mut self) -> &mut S {
+        SourceIter::as_inner(&mut self.iter)
+    }
+}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<I: InPlaceIterable, F> InPlaceIterable for Inspect<I, F> where F: FnMut(&I::Item)  {}
 
 /// An iterator adapter that produces output as long as the underlying
 /// iterator produces `Result::Ok` values.

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -18,7 +18,8 @@ pub use self::chain::Chain;
 pub use self::flatten::{FlatMap, Flatten};
 pub use self::fuse::Fuse;
 use self::zip::try_get_unchecked;
-pub(crate) use self::zip::TrustedRandomAccess;
+#[unstable(feature = "trusted_random_access", issue = "none")]
+pub use self::zip::TrustedRandomAccess;
 pub use self::zip::Zip;
 
 /// This trait provides transitive access to source-stages in an interator-adapter pipeline
@@ -480,6 +481,7 @@ where
 unsafe impl<I> TrustedRandomAccess for Cloned<I>
 where
     I: TrustedRandomAccess,
+
 {
     #[inline]
     fn may_have_side_effect() -> bool {

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -2191,6 +2191,27 @@ where
     }
 }
 
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<S: Iterator, B, I: Iterator, P> SourceIter for MapWhile<I, P>
+where
+    P: FnMut(I::Item) -> Option<B>,
+    I: SourceIter<Source = S>,
+{
+    type Source = S;
+
+    #[inline]
+    unsafe fn as_inner(&mut self) -> &mut S {
+        // Safety: unsafe function forwarding to unsafe function with the same requirements
+        unsafe { SourceIter::as_inner(&mut self.iter) }
+    }
+}
+
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<B, I: InPlaceIterable, P> InPlaceIterable for MapWhile<I, P> where
+    P: FnMut(I::Item) -> Option<B>
+{
+}
+
 /// An iterator that skips over `n` elements of `iter`.
 ///
 /// This `struct` is created by the [`skip`] method on [`Iterator`]. See its

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -2095,9 +2095,9 @@ where
 
 #[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<S: Iterator, P, I: Iterator> SourceIter for TakeWhile<I, P>
-    where
-        P: FnMut(&I::Item) -> bool,
-        I: SourceIter<Source = S>,
+where
+    P: FnMut(&I::Item) -> bool,
+    I: SourceIter<Source = S>,
 {
     type Source = S;
 

--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -1,7 +1,10 @@
 use crate::cmp;
 use crate::fmt::{self, Debug};
 
-use super::super::{DoubleEndedIterator, ExactSizeIterator, FusedIterator, Iterator, TrustedLen};
+use super::super::{
+    DoubleEndedIterator, ExactSizeIterator, FusedIterator, InPlaceIterable, Iterator, SourceIter,
+    TrustedLen,
+};
 
 /// An iterator that iterates two other iterators simultaneously.
 ///
@@ -326,6 +329,26 @@ where
     B: TrustedLen,
 {
 }
+
+// Arbitrarily selects the left side of the zip iteration as extractable "source"
+// it would require negative trait bounds to be able to try both
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<S, A, B> SourceIter for Zip<A, B>
+    where
+        A: SourceIter<Source = S>,
+        B: Iterator,
+        S: Iterator,
+{
+    type Source = S;
+
+    #[inline]
+    fn as_inner(&mut self) -> &mut S {
+        SourceIter::as_inner(&mut self.a)
+    }
+}
+
+#[unstable(issue = "0", feature = "inplace_iteration")]
+unsafe impl<A: InPlaceIterable, B: Iterator> InPlaceIterable for Zip<A, B> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A: Debug, B: Debug> Debug for Zip<A, B> {

--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -334,10 +334,10 @@ where
 // it would require negative trait bounds to be able to try both
 #[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<S, A, B> SourceIter for Zip<A, B>
-    where
-        A: SourceIter<Source = S>,
-        B: Iterator,
-        S: Iterator,
+where
+    A: SourceIter<Source = S>,
+    B: Iterator,
+    S: Iterator,
 {
     type Source = S;
 

--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -332,7 +332,7 @@ where
 
 // Arbitrarily selects the left side of the zip iteration as extractable "source"
 // it would require negative trait bounds to be able to try both
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<S, A, B> SourceIter for Zip<A, B>
     where
         A: SourceIter<Source = S>,
@@ -348,7 +348,7 @@ unsafe impl<S, A, B> SourceIter for Zip<A, B>
     }
 }
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 // Limited to Item: Copy since interaction between Zip's use of TrustedRandomAccess
 // and Drop implementation of the source is unclear.
 //

--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -342,13 +342,19 @@ unsafe impl<S, A, B> SourceIter for Zip<A, B>
     type Source = S;
 
     #[inline]
-    fn as_inner(&mut self) -> &mut S {
-        SourceIter::as_inner(&mut self.a)
+    unsafe fn as_inner(&mut self) -> &mut S {
+        // Safety: unsafe function forwarding to unsafe function with the same requirements
+        unsafe { SourceIter::as_inner(&mut self.a) }
     }
 }
 
 #[unstable(issue = "0", feature = "inplace_iteration")]
-unsafe impl<A: InPlaceIterable, B: Iterator> InPlaceIterable for Zip<A, B> {}
+// Limited to Item: Copy since interaction between Zip's use of TrustedRandomAccess
+// and Drop implementation of the source is unclear.
+//
+// An additional method returning the number of times the source has been logically advanced
+// (without calling next()) would be needed to properly drop the remainder of the source.
+unsafe impl<A: InPlaceIterable, B: Iterator> InPlaceIterable for Zip<A, B> where A::Item: Copy {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A: Debug, B: Debug> Debug for Zip<A, B> {

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -342,7 +342,7 @@ pub use self::traits::{DoubleEndedIterator, Extend, FromIterator, IntoIterator};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::traits::{ExactSizeIterator, Product, Sum};
 
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 pub use self::traits::InPlaceIterable;
 
 #[stable(feature = "iter_cloned", since = "1.1.0")]
@@ -351,9 +351,10 @@ pub use self::adapters::Cloned;
 pub use self::adapters::Copied;
 #[stable(feature = "iterator_flatten", since = "1.29.0")]
 pub use self::adapters::Flatten;
+
 #[unstable(feature = "iter_map_while", reason = "recently added", issue = "68537")]
 pub use self::adapters::MapWhile;
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 pub use self::adapters::SourceIter;
 #[stable(feature = "iterator_step_by", since = "1.28.0")]
 pub use self::adapters::StepBy;

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -357,6 +357,8 @@ pub use self::adapters::MapWhile;
 pub use self::adapters::SourceIter;
 #[stable(feature = "iterator_step_by", since = "1.28.0")]
 pub use self::adapters::StepBy;
+#[unstable(feature = "trusted_random_access", issue = "none")]
+pub use self::adapters::TrustedRandomAccess;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::adapters::{Chain, Cycle, Enumerate, Filter, FilterMap, Map, Rev, Zip};
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -364,7 +366,7 @@ pub use self::adapters::{FlatMap, Peekable, Scan, Skip, SkipWhile, Take, TakeWhi
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::adapters::{Fuse, Inspect};
 
-pub(crate) use self::adapters::{process_results, TrustedRandomAccess};
+pub(crate) use self::adapters::process_results;
 
 mod adapters;
 mod range;

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -342,6 +342,9 @@ pub use self::traits::{DoubleEndedIterator, Extend, FromIterator, IntoIterator};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::traits::{ExactSizeIterator, Product, Sum};
 
+#[unstable(issue = "0", feature = "inplace_iteration")]
+pub use self::traits::InPlaceIterable;
+
 #[stable(feature = "iter_cloned", since = "1.1.0")]
 pub use self::adapters::Cloned;
 #[stable(feature = "iter_copied", since = "1.36.0")]
@@ -350,6 +353,8 @@ pub use self::adapters::Copied;
 pub use self::adapters::Flatten;
 #[unstable(feature = "iter_map_while", reason = "recently added", issue = "68537")]
 pub use self::adapters::MapWhile;
+#[unstable(issue = "0", feature = "inplace_iteration")]
+pub use self::adapters::SourceIter;
 #[stable(feature = "iterator_step_by", since = "1.28.0")]
 pub use self::adapters::StepBy;
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/iter/traits/marker.rs
+++ b/library/core/src/iter/traits/marker.rs
@@ -52,5 +52,5 @@ unsafe impl<I: TrustedLen + ?Sized> TrustedLen for &mut I {}
 /// In other words this trait indicates that an iterator pipeline can be collected in place.
 ///
 /// [`SourceIter`]: ../../std/iter/trait.SourceIter.html
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 pub unsafe trait InPlaceIterable: Iterator {}

--- a/library/core/src/iter/traits/marker.rs
+++ b/library/core/src/iter/traits/marker.rs
@@ -53,5 +53,4 @@ unsafe impl<I: TrustedLen + ?Sized> TrustedLen for &mut I {}
 ///
 /// [`SourceIter`]: ../../std/iter/trait.SourceIter.html
 #[unstable(issue = "none", feature = "inplace_iteration")]
-#[rustc_specialization_trait]
 pub unsafe trait InPlaceIterable: Iterator {}

--- a/library/core/src/iter/traits/marker.rs
+++ b/library/core/src/iter/traits/marker.rs
@@ -53,4 +53,5 @@ unsafe impl<I: TrustedLen + ?Sized> TrustedLen for &mut I {}
 ///
 /// [`SourceIter`]: ../../std/iter/trait.SourceIter.html
 #[unstable(issue = "none", feature = "inplace_iteration")]
+#[rustc_specialization_trait]
 pub unsafe trait InPlaceIterable: Iterator {}

--- a/library/core/src/iter/traits/marker.rs
+++ b/library/core/src/iter/traits/marker.rs
@@ -42,3 +42,15 @@ pub unsafe trait TrustedLen: Iterator {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<I: TrustedLen + ?Sized> TrustedLen for &mut I {}
+
+/// An iterator that when yielding an item will have taken at least one element
+/// from its underlying [`SourceIter`].
+///
+/// Calling next() guarantees that at least one value of the iterator's underlying source
+/// has been moved out and the result of the iterator chain could be inserted in its place,
+/// assuming structural constraints of the source allow such an insertion.
+/// In other words this trait indicates that an iterator pipeline can be collected in place.
+///
+/// [`SourceIter`]: ../../std/iter/trait.SourceIter.html
+#[unstable(issue = "0", feature = "inplace_iteration")]
+pub unsafe trait InPlaceIterable: Iterator {}

--- a/library/core/src/iter/traits/mod.rs
+++ b/library/core/src/iter/traits/mod.rs
@@ -11,7 +11,7 @@ pub use self::double_ended::DoubleEndedIterator;
 pub use self::exact_size::ExactSizeIterator;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::iterator::Iterator;
-#[unstable(issue = "0", feature = "inplace_iteration")]
+#[unstable(issue = "none", feature = "inplace_iteration")]
 pub use self::marker::InPlaceIterable;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::marker::{FusedIterator, TrustedLen};

--- a/library/core/src/iter/traits/mod.rs
+++ b/library/core/src/iter/traits/mod.rs
@@ -11,5 +11,7 @@ pub use self::double_ended::DoubleEndedIterator;
 pub use self::exact_size::ExactSizeIterator;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::iterator::Iterator;
+#[unstable(issue = "0", feature = "inplace_iteration")]
+pub use self::marker::InPlaceIterable;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::marker::{FusedIterator, TrustedLen};

--- a/src/test/ui/iterators/issue-58952-filter-type-length.rs
+++ b/src/test/ui/iterators/issue-58952-filter-type-length.rs
@@ -3,6 +3,7 @@
 //! so check that we don't accidentially exceed the type length limit.
 // FIXME: Once the size of iterator adaptors is further reduced,
 // increase the complexity of this test.
+use std::collections::VecDeque;
 
 fn main() {
     let c = 2;
@@ -27,5 +28,5 @@ fn main() {
         .filter(|a| b.clone().any(|b| *b == *a))
         .filter(|a| b.clone().any(|b| *b == *a))
         .filter(|a| b.clone().any(|b| *b == *a))
-        .collect::<Vec<_>>();
+        .collect::<VecDeque<_>>();
 }


### PR DESCRIPTION
This is a rebase and update of #66383 which was closed due inactivity.

Recent rustc changes made the compile time regressions disappear, at least for webrender-wrench. Running a stage2 compile and the rustc-perf suite takes hours on the hardware I have at the moment, so I can't do much more than that.

![Screenshot_2020-04-05 rustc performance data](https://user-images.githubusercontent.com/1065730/78462657-5d60f100-76d4-11ea-8a0b-4f3962707c38.png)

In the best case of the `vec::bench_in_place_recycle` synthetic microbenchmark these optimizations can provide a 15x speedup over the regular implementation which allocates a new vec for every benchmark iteration. [Benchmark results](https://gist.github.com/the8472/6d999b2d08a2bedf3b93f12112f96e2f). In real code the speedups are tiny, but it also depends on the allocator used, a system allocator that uses a process-wide mutex will benefit more than one with thread-local pools.


## What was changed

* `SpecExtend` which covered `from_iter` and `extend` specializations was split into separate traits
* `extend` and `from_iter` now reuse the `append_elements` if passed iterators are from slices.
* A preexisting `vec.into_iter().collect::<Vec<_>>()` optimization that passed through the original vec has been generalized further to also cover cases where the original has been partially drained.
* A chain of *Vec<T> / BinaryHeap<T> / Box<[T]>* `IntoIter`s  through various iterator adapters collected into *Vec<U>* and *BinaryHeap<U>* will be performed in place as long as `T` and `U` have the same alignment and size and aren't ZSTs.
* To enable above specialization the unsafe, unstable `SourceIter` and `InPlaceIterable` traits have been added. The first allows reaching through the iterator pipeline to grab a pointer to the source memory. The latter is a marker that promises that the read pointer will advance as fast or faster than the write pointer and thus in-place operation is possible in the first place.
* `vec::IntoIter` implements `TrustedRandomAccess` for `T: Copy` to allow in-place collection when there is a `Zip` adapter in the iterator. TRA had to be made an unstable public trait to support this.


## In-place collectible adapters

* `Map`
* `MapWhile`
* `Filter`
* `FilterMap`
* `Fuse`
* `Skip`
* `SkipWhile`
* `Take`
* `TakeWhile`
* `Enumerate`
* `Zip` (left hand side only, `Copy` types only)
* `Peek`
* `Scan`
* `Inspect`

## Concerns

`vec.into_iter().filter(|_| false).collect()` will no longer return a vec with 0 capacity, instead it will return its original allocation. This avoids the cost of doing any allocation or deallocation but could lead to large allocations living longer than expected.
If that's not acceptable some resizing policy at the end of the attempted in-place collect would be necessary, which in the worst case could result in one more memcopy than the non-specialized case.


## Possible followup work

* split liballoc/vec.rs to remove `ignore-tidy-filelength`
* try to get trivial chains such as `vec.into_iter().skip(1).collect::<Vec<)>>()` to compile to a `memmove` (currently compiles to a pile of SIMD, see #69187 )
* improve up the traits so they can be reused by other crates, e.g. itertools. I think currently they're only good enough for internal use
* allow iterators sourced from a `HashSet` to be in-place collected into a `Vec`
