### PR TITLE
Do not use "nil" to refer to `()`

### DIFF
--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -320,7 +320,7 @@ mod prim_char {}
 
 #[doc(primitive = "unit")]
 //
-/// The `()` type, sometimes called "unit" or "nil".
+/// The `()` type, also called "unit".
 ///
 /// The `()` type has exactly one value `()`, and is used when there
 /// is no other meaningful value that could be returned. `()` is most


### PR DESCRIPTION
"nil" is not used in the [book](https://doc.rust-lang.org/book) or in the [standard library docs](https://doc.rust-lang.org/std) anywhere else. Because "nil" is often used in programming languages to refer to "None" or "null" I think it could be a little confusing for newcomers to see this type referred to as "nil".