### PR TITLE
Enable layout debugging for `impl Trait` type aliases

### DIFF
--- a/src/librustc_passes/layout_test.rs
+++ b/src/librustc_passes/layout_test.rs
@@ -27,7 +27,8 @@ impl ItemLikeVisitor<'tcx> for LayoutTest<'tcx> {
             ItemKind::TyAlias(..)
             | ItemKind::Enum(..)
             | ItemKind::Struct(..)
-            | ItemKind::Union(..) => {
+            | ItemKind::Union(..)
+            | ItemKind::OpaqueTy(..) => {
                 for attr in self.tcx.get_attrs(item_def_id).iter() {
                     if attr.check_name(sym::rustc_layout) {
                         self.dump_layout_of(item_def_id, item, attr);

--- a/src/librustc_passes/layout_test.rs
+++ b/src/librustc_passes/layout_test.rs
@@ -85,7 +85,7 @@ impl LayoutTest<'tcx> {
                         sym::debug => {
                             self.tcx.sess.span_err(
                                 item.span,
-                                &format!("layout debugging: {:#?}", *ty_layout),
+                                &format!("layout debugging for type {:?}: {:#?}", ty, *ty_layout),
                             );
                         }
 

--- a/src/test/ui/layout/debug.rs
+++ b/src/test/ui/layout/debug.rs
@@ -1,5 +1,5 @@
 // normalize-stderr-test "pref: Align \{\n *pow2: [1-3],\n *\}" -> "pref: $$PREF_ALIGN"
-#![feature(never_type, rustc_attrs)]
+#![feature(never_type, rustc_attrs, type_alias_impl_trait)]
 #![crate_type = "lib"]
 
 #[rustc_layout(debug)]
@@ -13,3 +13,10 @@ union U { f1: (i32, i32), f3: i32 } //~ ERROR: layout debugging
 
 #[rustc_layout(debug)]
 type Test = Result<i32, i32>; //~ ERROR: layout debugging
+
+#[rustc_layout(debug)]
+type T = impl std::fmt::Debug; //~ ERROR: layout debugging
+
+fn f() -> T {
+    0i32
+}

--- a/src/test/ui/layout/debug.stderr
+++ b/src/test/ui/layout/debug.stderr
@@ -1,4 +1,4 @@
-error: layout debugging: Layout {
+error: layout debugging for type E: Layout {
     fields: Arbitrary {
         offsets: [
             Size {
@@ -110,7 +110,7 @@ error: layout debugging: Layout {
 LL | enum E { Foo, Bar(!, i32, i32) }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: layout debugging: Layout {
+error: layout debugging for type S: Layout {
     fields: Arbitrary {
         offsets: [
             Size {
@@ -164,7 +164,7 @@ error: layout debugging: Layout {
 LL | struct S { f1: i32, f2: (), f3: i32 }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: layout debugging: Layout {
+error: layout debugging for type U: Layout {
     fields: Union(
         2,
     ),
@@ -190,7 +190,7 @@ error: layout debugging: Layout {
 LL | union U { f1: (i32, i32), f3: i32 }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: layout debugging: Layout {
+error: layout debugging for type std::result::Result<i32, i32>: Layout {
     fields: Arbitrary {
         offsets: [
             Size {
@@ -315,7 +315,7 @@ error: layout debugging: Layout {
 LL | type Test = Result<i32, i32>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: layout debugging: Layout {
+error: layout debugging for type i32: Layout {
     fields: Union(
         0,
     ),

--- a/src/test/ui/layout/debug.stderr
+++ b/src/test/ui/layout/debug.stderr
@@ -315,5 +315,37 @@ error: layout debugging: Layout {
 LL | type Test = Result<i32, i32>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: layout debugging: Layout {
+    fields: Union(
+        0,
+    ),
+    variants: Single {
+        index: 0,
+    },
+    abi: Scalar(
+        Scalar {
+            value: Int(
+                I32,
+                true,
+            ),
+            valid_range: 0..=4294967295,
+        },
+    ),
+    largest_niche: None,
+    align: AbiAndPrefAlign {
+        abi: Align {
+            pow2: 2,
+        },
+        pref: $PREF_ALIGN,
+    },
+    size: Size {
+        raw: 4,
+    },
+}
+  --> $DIR/debug.rs:18:1
+   |
+LL | type T = impl std::fmt::Debug;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
I also made it print the actual type name that the alias picks under the hood.