### PR TITLE
typeck: always expose explicit enum discriminant `AnonConst`s' parent in `generics_of`.

### DIFF
--- a/src/librustc_middle/ty/mod.rs
+++ b/src/librustc_middle/ty/mod.rs
@@ -2388,21 +2388,14 @@ impl<'tcx> AdtDef {
                     None
                 }
             }
-            Err(ErrorHandled::Reported(ErrorReported) | ErrorHandled::Linted) => {
-                if !expr_did.is_local() {
-                    span_bug!(
-                        tcx.def_span(expr_did),
-                        "variant discriminant evaluation succeeded \
-                         in its crate but failed locally"
-                    );
-                }
-                None
-            }
-            Err(ErrorHandled::TooGeneric) => {
-                tcx.sess.delay_span_bug(
-                    tcx.def_span(expr_did),
-                    "enum discriminant depends on generic arguments",
-                );
+            Err(err) => {
+                let msg = match err {
+                    ErrorHandled::Reported(ErrorReported) | ErrorHandled::Linted => {
+                        "enum discriminant evaluation failed"
+                    }
+                    ErrorHandled::TooGeneric => "enum discriminant depends on generics",
+                };
+                tcx.sess.delay_span_bug(tcx.def_span(expr_did), msg);
                 None
             }
         }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1178,9 +1178,11 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::Generics {
                 let parent_node = tcx.hir().get(tcx.hir().get_parent_node(hir_id));
                 match parent_node {
                     // HACK(eddyb) this provides the correct generics for repeat
-                    // expressions' count (i.e. `N` in `[x; N]`), as they shouldn't
-                    // be able to cause query cycle errors.
+                    // expressions' count (i.e. `N` in `[x; N]`), and explicit
+                    // `enum` discriminants (i.e. `D` in `enum Foo { Bar = D }`),
+                    // as they shouldn't be able to cause query cycle errors.
                     Node::Expr(&Expr { kind: ExprKind::Repeat(_, ref constant), .. })
+                    | Node::Variant(Variant { disr_expr: Some(ref constant), .. })
                         if constant.hir_id == hir_id =>
                     {
                         Some(parent_def_id.to_def_id())

--- a/src/test/ui/enum-discriminant/issue-70453-generics-in-discr-ice-2.rs
+++ b/src/test/ui/enum-discriminant/issue-70453-generics-in-discr-ice-2.rs
@@ -1,0 +1,16 @@
+#![feature(arbitrary_enum_discriminant, core_intrinsics)]
+
+extern crate core;
+use core::intrinsics::discriminant_value;
+
+#[repr(usize)]
+enum MyWeirdOption<T> {
+    None = 0,
+    Some(T) = std::mem::size_of::<T>(),
+    //~^ ERROR constant expression depends on a generic parameter
+}
+
+fn main() {
+    assert_eq!(discriminant_value(&MyWeirdOption::<u8>::None), 0);
+    assert_eq!(discriminant_value(&MyWeirdOption::Some(0u8)), 1);
+}

--- a/src/test/ui/enum-discriminant/issue-70453-generics-in-discr-ice-2.stderr
+++ b/src/test/ui/enum-discriminant/issue-70453-generics-in-discr-ice-2.stderr
@@ -1,0 +1,10 @@
+error: constant expression depends on a generic parameter
+  --> $DIR/issue-70453-generics-in-discr-ice-2.rs:9:15
+   |
+LL |     Some(T) = std::mem::size_of::<T>(),
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error: aborting due to previous error
+

--- a/src/test/ui/enum-discriminant/issue-70453-generics-in-discr-ice.rs
+++ b/src/test/ui/enum-discriminant/issue-70453-generics-in-discr-ice.rs
@@ -1,0 +1,17 @@
+#![feature(core_intrinsics)]
+
+extern crate core;
+use core::intrinsics::discriminant_value;
+
+#[repr(usize)]
+enum MyWeirdOption<T> {
+//~^ ERROR parameter `T` is never used
+    None = 0,
+    Some = std::mem::size_of::<T>(),
+    //~^ ERROR constant expression depends on a generic parameter
+}
+
+fn main() {
+    assert_eq!(discriminant_value(&MyWeirdOption::<u8>::None), 0);
+    assert_eq!(discriminant_value(&MyWeirdOption::<u8>::Some), 1);
+}

--- a/src/test/ui/enum-discriminant/issue-70453-generics-in-discr-ice.stderr
+++ b/src/test/ui/enum-discriminant/issue-70453-generics-in-discr-ice.stderr
@@ -1,0 +1,19 @@
+error: constant expression depends on a generic parameter
+  --> $DIR/issue-70453-generics-in-discr-ice.rs:10:12
+   |
+LL |     Some = std::mem::size_of::<T>(),
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error[E0392]: parameter `T` is never used
+  --> $DIR/issue-70453-generics-in-discr-ice.rs:7:20
+   |
+LL | enum MyWeirdOption<T> {
+   |                    ^ unused parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `std::marker::PhantomData`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0392`.

--- a/src/test/ui/enum-discriminant/issue-70453-polymorphic-ctfe.rs
+++ b/src/test/ui/enum-discriminant/issue-70453-polymorphic-ctfe.rs
@@ -1,0 +1,17 @@
+// run-pass
+
+#![feature(arbitrary_enum_discriminant, core_intrinsics)]
+
+extern crate core;
+use core::intrinsics::discriminant_value;
+
+#[repr(usize)]
+enum MyWeirdOption<T> {
+    None = 0,
+    Some(T) = core::mem::size_of::<*mut T>(),
+}
+
+fn main() {
+    assert_eq!(discriminant_value(&MyWeirdOption::<()>::None), 0);
+    assert_eq!(discriminant_value(&MyWeirdOption::Some(())), core::mem::size_of::<usize>() as u64);
+}


### PR DESCRIPTION
This is similar to #70452 but for explicit `enum` discriminant constant expressions.
However, unlike #70452, this PR should have no effect on stable code, as while it alleviates #43408 errors, there is no way to actually compile an `enum` with generic parameters *and* explicit discriminants, without `#![feature(arbitrary_enum_discriminant)]`, as explicit discriminant expression don't count as uses of parameters (if they did, they would count as invariant uses).

<hr/>

There's also 2 other commits here, both related to #70453:
* "ty: use `delay_span_bug` in `ty::AdtDef::eval_explicit_discr`." - hides the ICEs demonstrated on #70453, when there are other errors (which the next commit adds)
* "typeck/wfcheck: require that explicit enum discriminants const-evaluate succesfully." - closes #70453 by picking alternative "2", i.e. erroring when a discriminant doesn't fully const-evaluate from the perspective of the `enum` definition

In the future, it might be possible to allow `enum` discriminants to actually depend on parameters, but that will likely require #68436 + some way to restrict the values so no two variants can end up with overlapping discriminants.

As this PR would close #70453, it shouldn't be merged until a decision is reached there.

r? @nikomatsakis