### PR TITLE
rustdoc: Don't try to load source files from external crates

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1937,6 +1937,7 @@ impl Clean<Span> for rustc_span::Span {
         let hi = sm.lookup_char_pos(self.hi());
         Span {
             filename,
+            cnum: lo.file.cnum,
             loline: lo.line,
             locol: lo.col.to_usize(),
             hiline: hi.line,

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -14,7 +14,7 @@ use rustc_ast::util::comments::strip_doc_comment_decoration;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_hir as hir;
 use rustc_hir::def::Res;
-use rustc_hir::def_id::{CrateNum, DefId};
+use rustc_hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use rustc_hir::lang_items;
 use rustc_hir::Mutability;
 use rustc_index::vec::IndexVec;
@@ -1357,6 +1357,7 @@ pub enum VariantKind {
 #[derive(Clone, Debug)]
 pub struct Span {
     pub filename: FileName,
+    pub cnum: CrateNum,
     pub loline: usize,
     pub locol: usize,
     pub hiline: usize,
@@ -1368,6 +1369,7 @@ impl Span {
     pub fn empty() -> Span {
         Span {
             filename: FileName::Anon(0),
+            cnum: LOCAL_CRATE,
             loline: 0,
             locol: 0,
             hiline: 0,

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -47,7 +47,7 @@ use rustc_data_structures::flock;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_feature::UnstableFeatures;
 use rustc_hir as hir;
-use rustc_hir::def_id::DefId;
+use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_hir::Mutability;
 use rustc_middle::middle::privacy::AccessLevels;
 use rustc_middle::middle::stability;
@@ -1623,14 +1623,14 @@ impl Context {
             _ => return None,
         };
 
-        let (krate, path) = if item.def_id.is_local() {
+        let (krate, path) = if item.source.cnum == LOCAL_CRATE {
             if let Some(path) = self.shared.local_sources.get(file) {
                 (&self.shared.layout.krate, path)
             } else {
                 return None;
             }
         } else {
-            let (krate, src_root) = match *self.cache.extern_locations.get(&item.def_id.krate)? {
+            let (krate, src_root) = match *self.cache.extern_locations.get(&item.source.cnum)? {
                 (ref name, ref src, Local) => (name, src),
                 (ref name, ref src, Remote(ref s)) => {
                     root = s.to_string();

--- a/src/librustdoc/html/sources.rs
+++ b/src/librustdoc/html/sources.rs
@@ -5,6 +5,7 @@ use crate::html::format::Buffer;
 use crate::html::highlight;
 use crate::html::layout;
 use crate::html::render::{Error, SharedContext, BASIC_KEYWORDS};
+use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_span::source_map::FileName;
 use std::ffi::OsStr;
 use std::fs;
@@ -37,8 +38,8 @@ impl<'a> DocFolder for SourceCollector<'a> {
         if self.scx.include_sources
             // skip all synthetic "files"
             && item.source.filename.is_real()
-            // skip non-local items
-            && item.def_id.is_local()
+            // skip non-local files
+            && item.source.cnum == LOCAL_CRATE
         {
             // If it turns out that we couldn't read this file, then we probably
             // can't read any of the files (generating html output from json or

--- a/src/test/rustdoc/auxiliary/external-macro-src.rs
+++ b/src/test/rustdoc/auxiliary/external-macro-src.rs
@@ -1,0 +1,15 @@
+// compile-flags:--remap-path-prefix={{src-base}}=/does-not-exist
+
+#![doc(html_root_url = "https://example.com/")]
+
+#[macro_export]
+macro_rules! make_foo {
+    () => {
+        pub struct Foo;
+        impl Foo {
+            pub fn new() -> Foo {
+                Foo
+            }
+        }
+    }
+}

--- a/src/test/rustdoc/external-macro-src.rs
+++ b/src/test/rustdoc/external-macro-src.rs
@@ -1,0 +1,15 @@
+// aux-build:external-macro-src.rs
+// ignore-tidy-linelength
+
+#![crate_name = "foo"]
+
+#[macro_use]
+extern crate external_macro_src;
+
+// @has foo/index.html '//a[@href="../src/foo/external-macro-src.rs.html#4-15"]' '[src]'
+
+// @has foo/struct.Foo.html
+// @has - '//a[@href="https://example.com/src/external_macro_src/external-macro-src.rs.html#8"]' '[src]'
+// @has - '//a[@href="https://example.com/src/external_macro_src/external-macro-src.rs.html#9-13"]' '[src]'
+// @has - '//a[@href="https://example.com/src/external_macro_src/external-macro-src.rs.html#10-12"]' '[src]'
+make_foo!();

--- a/src/test/rustdoc/issue-26606.rs
+++ b/src/test/rustdoc/issue-26606.rs
@@ -7,5 +7,5 @@
 extern crate issue_26606_macro;
 
 // @has issue_26606/constant.FOO.html
-// @has - '//a/@href' '../src/issue_26606/auxiliary/issue-26606-macro.rs.html#3'
+// @has - '//a/@href' '../src/issue_26606_macro/issue-26606-macro.rs.html#3'
 make_item!(FOO);

--- a/src/test/rustdoc/thread-local-src.rs
+++ b/src/test/rustdoc/thread-local-src.rs
@@ -1,0 +1,6 @@
+#![crate_name = "foo"]
+
+// @has foo/index.html '//a[@href="../src/foo/thread-local-src.rs.html#1-6"]' '[src]'
+
+// @has foo/constant.FOO.html '//a/@href' 'https://doc.rust-lang.org/nightly/src/std/'
+thread_local!(pub static FOO: bool = false);


### PR DESCRIPTION
Local items defined in external macros shouldn't generate rendered source files and should link to the external crate's docs instead.

Part of #70757

r? @GuillaumeGomez
cc @eddyb