### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3537,6 +3537,7 @@ dependencies = [
 name = "rustc_ast_passes"
 version = "0.0.0"
 dependencies = [
+ "itertools 0.8.0",
  "log",
  "rustc_ast",
  "rustc_ast_pretty",

--- a/src/etc/rust-gdb
+++ b/src/etc/rust-gdb
@@ -2,8 +2,16 @@
 # Exit if anything fails
 set -e
 
+# Prefer rustc in the same directory as this script
+DIR="$(dirname "$0")"
+if [ -x "$DIR/rustc" ]; then
+  RUSTC="$DIR/rustc"
+else
+  RUSTC="rustc"
+fi
+
 # Find out where the pretty printer Python module is
-RUSTC_SYSROOT=`rustc --print=sysroot`
+RUSTC_SYSROOT="$("$RUSTC" --print=sysroot)"
 GDB_PYTHON_MODULE_DIRECTORY="$RUSTC_SYSROOT/lib/rustlib/etc"
 
 # Run GDB with the additional arguments that load the pretty printers

--- a/src/etc/rust-gdbgui
+++ b/src/etc/rust-gdbgui
@@ -31,8 +31,16 @@ icon to start your program running.
     exit 0
 fi
 
+# Prefer rustc in the same directory as this script
+DIR="$(dirname "$0")"
+if [ -x "$DIR/rustc" ]; then
+  RUSTC="$DIR/rustc"
+else
+  RUSTC="rustc"
+fi
+
 # Find out where the pretty printer Python module is
-RUSTC_SYSROOT=`rustc --print=sysroot`
+RUSTC_SYSROOT="$("$RUSTC" --print=sysroot)"
 GDB_PYTHON_MODULE_DIRECTORY="$RUSTC_SYSROOT/lib/rustlib/etc"
 
 # Set the environment variable `RUST_GDB` to overwrite the call to a

--- a/src/libpanic_unwind/lib.rs
+++ b/src/libpanic_unwind/lib.rs
@@ -47,9 +47,6 @@ cfg_if::cfg_if! {
     } else if #[cfg(target_os = "hermit")] {
         #[path = "hermit.rs"]
         mod real_imp;
-    } else if #[cfg(all(target_env = "msvc", target_arch = "aarch64"))] {
-        #[path = "dummy.rs"]
-        mod real_imp;
     } else if #[cfg(target_env = "msvc")] {
         #[path = "seh.rs"]
         mod real_imp;

--- a/src/libpanic_unwind/seh.rs
+++ b/src/libpanic_unwind/seh.rs
@@ -117,7 +117,7 @@ mod imp {
     }
 }
 
-#[cfg(any(target_arch = "x86_64", target_arch = "arm"))]
+#[cfg(not(target_arch = "x86"))]
 #[macro_use]
 mod imp {
     pub type ptr_t = u32;

--- a/src/librustc_ast/ast.rs
+++ b/src/librustc_ast/ast.rs
@@ -300,8 +300,8 @@ pub enum GenericBound {
 impl GenericBound {
     pub fn span(&self) -> Span {
         match self {
-            &GenericBound::Trait(ref t, ..) => t.span,
-            &GenericBound::Outlives(ref l) => l.ident.span,
+            GenericBound::Trait(ref t, ..) => t.span,
+            GenericBound::Outlives(ref l) => l.ident.span,
         }
     }
 }

--- a/src/librustc_ast_passes/Cargo.toml
+++ b/src/librustc_ast_passes/Cargo.toml
@@ -9,6 +9,7 @@ name = "rustc_ast_passes"
 path = "lib.rs"
 
 [dependencies]
+itertools = "0.8"
 log = "0.4"
 rustc_ast_pretty = { path = "../librustc_ast_pretty" }
 rustc_attr = { path = "../librustc_attr" }

--- a/src/librustc_ast_passes/ast_validation.rs
+++ b/src/librustc_ast_passes/ast_validation.rs
@@ -697,14 +697,7 @@ impl<'a> AstValidator<'a> {
                 arg_spans.clone(),
                 "generic arguments must come before the first constraint",
             )
-            .span_labels(
-                constraint_spans,
-                &format!(
-                    "the constraint{} {} provided here",
-                    pluralize!(constraint_len),
-                    if constraint_len == 1 { "is" } else { "are" }
-                ),
-            )
+            .span_labels(constraint_spans, "constraint")
             .span_labels(arg_spans, "generic argument")
             .span_suggestion_verbose(
                 data.span,

--- a/src/librustc_ast_passes/ast_validation.rs
+++ b/src/librustc_ast_passes/ast_validation.rs
@@ -688,8 +688,13 @@ impl<'a> AstValidator<'a> {
                 arg_spans.clone(),
                 "generic arguments must come before the first constraint",
             )
-            .span_labels(constraint_spans, "constraint")
-            .span_labels(arg_spans, "generic argument")
+            .span_label(constraint_spans[0], &format!("constraint{}", pluralize!(constraint_len)))
+            .span_label(
+                *arg_spans.iter().last().unwrap(),
+                &format!("generic argument{}", pluralize!(args_len)),
+            )
+            .span_labels(constraint_spans, "")
+            .span_labels(arg_spans, "")
             .span_suggestion_verbose(
                 data.span,
                 &format!(

--- a/src/librustc_ast_pretty/pprust.rs
+++ b/src/librustc_ast_pretty/pprust.rs
@@ -870,7 +870,7 @@ impl<'a> State<'a> {
         }
     }
 
-    fn print_assoc_constraint(&mut self, constraint: &ast::AssocTyConstraint) {
+    pub fn print_assoc_constraint(&mut self, constraint: &ast::AssocTyConstraint) {
         self.print_ident(constraint.ident);
         self.s.space();
         match &constraint.kind {
@@ -884,7 +884,7 @@ impl<'a> State<'a> {
         }
     }
 
-    crate fn print_generic_arg(&mut self, generic_arg: &GenericArg) {
+    pub fn print_generic_arg(&mut self, generic_arg: &GenericArg) {
         match generic_arg {
             GenericArg::Lifetime(lt) => self.print_lifetime(*lt),
             GenericArg::Type(ty) => self.print_type(ty),

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -315,6 +315,20 @@ impl<'a> DiagnosticBuilder<'a> {
         self
     }
 
+    pub fn span_suggestion_verbose(
+        &mut self,
+        sp: Span,
+        msg: &str,
+        suggestion: String,
+        applicability: Applicability,
+    ) -> &mut Self {
+        if !self.0.allow_suggestions {
+            return self;
+        }
+        self.0.diagnostic.span_suggestion_verbose(sp, msg, suggestion, applicability);
+        self
+    }
+
     pub fn span_suggestion_hidden(
         &mut self,
         sp: Span,

--- a/src/librustc_mir/borrow_check/diagnostics/explain_borrow.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/explain_borrow.rs
@@ -208,45 +208,34 @@ impl BorrowExplanation {
                     );
                 };
 
-                self.add_lifetime_bound_suggestion_to_diagnostic(
-                    tcx,
-                    err,
-                    &category,
-                    span,
-                    region_name,
-                );
+                self.add_lifetime_bound_suggestion_to_diagnostic(err, &category, span, region_name);
             }
             _ => {}
         }
     }
-    pub(in crate::borrow_check) fn add_lifetime_bound_suggestion_to_diagnostic<'tcx>(
+    pub(in crate::borrow_check) fn add_lifetime_bound_suggestion_to_diagnostic(
         &self,
-        tcx: TyCtxt<'tcx>,
         err: &mut DiagnosticBuilder<'_>,
         category: &ConstraintCategory,
         span: Span,
         region_name: &RegionName,
     ) {
         if let ConstraintCategory::OpaqueType = category {
-            if let Ok(snippet) = tcx.sess.source_map().span_to_snippet(span) {
-                let suggestable_name = if region_name.was_named() {
-                    region_name.to_string()
-                } else {
-                    "'_".to_string()
-                };
+            let suggestable_name =
+                if region_name.was_named() { region_name.to_string() } else { "'_".to_string() };
 
-                err.span_suggestion(
-                    span,
-                    &format!(
-                        "you can add a bound to the {}to make it last less than \
-                             `'static` and match `{}`",
-                        category.description(),
-                        region_name,
-                    ),
-                    format!("{} + {}", snippet, suggestable_name),
-                    Applicability::Unspecified,
-                );
-            }
+            let msg = format!(
+                "you can add a bound to the {}to make it last less than `'static` and match `{}`",
+                category.description(),
+                region_name,
+            );
+
+            err.span_suggestion_verbose(
+                span.shrink_to_hi(),
+                &msg,
+                format!(" + {}", suggestable_name),
+                Applicability::Unspecified,
+            );
         }
     }
 }

--- a/src/librustc_resolve/def_collector.rs
+++ b/src/librustc_resolve/def_collector.rs
@@ -2,6 +2,7 @@ use log::debug;
 use rustc_ast::ast::*;
 use rustc_ast::token::{self, Token};
 use rustc_ast::visit::{self, FnKind};
+use rustc_ast::walk_list;
 use rustc_expand::expand::AstFragment;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::definitions::*;
@@ -117,10 +118,8 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
                 // we must mirror everything that `visit::walk_fn` below does.
                 self.visit_fn_header(&sig.header);
                 visit::walk_fn_decl(self, &sig.decl);
-                if let Some(body) = body {
-                    let closure_def = self.create_def(closure_id, DefPathData::ClosureExpr, span);
-                    self.with_parent(closure_def, |this| this.visit_block(body));
-                }
+                let closure_def = self.create_def(closure_id, DefPathData::ClosureExpr, span);
+                self.with_parent(closure_def, |this| walk_list!(this, visit_block, body));
                 return;
             }
         }

--- a/src/librustc_target/spec/aarch64_pc_windows_msvc.rs
+++ b/src/librustc_target/spec/aarch64_pc_windows_msvc.rs
@@ -1,13 +1,10 @@
-use crate::spec::{LinkerFlavor, PanicStrategy, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::windows_msvc_base::opts();
     base.max_atomic_width = Some(64);
     base.has_elf_tls = true;
     base.features = "+neon,+fp-armv8".to_string();
-
-    // FIXME: this shouldn't be panic=abort, it should be panic=unwind
-    base.panic_strategy = PanicStrategy::Abort;
 
     Ok(Target {
         llvm_target: "aarch64-pc-windows-msvc".to_string(),

--- a/src/librustc_target/spec/aarch64_uwp_windows_msvc.rs
+++ b/src/librustc_target/spec/aarch64_uwp_windows_msvc.rs
@@ -1,12 +1,9 @@
-use crate::spec::{LinkerFlavor, PanicStrategy, Target, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::windows_uwp_msvc_base::opts();
     base.max_atomic_width = Some(64);
     base.has_elf_tls = true;
-
-    // FIXME: this shouldn't be panic=abort, it should be panic=unwind
-    base.panic_strategy = PanicStrategy::Abort;
 
     Ok(Target {
         llvm_target: "aarch64-pc-windows-msvc".to_string(),

--- a/src/test/ui/impl-trait/does-not-live-long-enough.stderr
+++ b/src/test/ui/impl-trait/does-not-live-long-enough.stderr
@@ -14,7 +14,7 @@ LL |     }
 help: you can add a bound to the opaque type to make it last less than `'static` and match `'a`
    |
 LL |     fn started_with<'a>(&'a self, prefix: &'a str) -> impl Iterator<Item=&'a str> + 'a {
-   |                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                                                                   ^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issue-32214.stderr
+++ b/src/test/ui/parser/issue-32214.stderr
@@ -5,6 +5,11 @@ LL | pub fn test<W, I: Trait<Item=(), W> >() {}
    |                         -------  ^ generic argument
    |                         |
    |                         the constraint is provided here
+   |
+help: move the constraints after the generic arguments
+   |
+LL | pub fn test<W, I: Trait<W, Item=()> >() {}
+   |                        --^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issue-32214.stderr
+++ b/src/test/ui/parser/issue-32214.stderr
@@ -6,10 +6,10 @@ LL | pub fn test<W, I: Trait<Item=(), W> >() {}
    |                         |
    |                         the constraint is provided here
    |
-help: move the constraints after the generic arguments
+help: move the constraint after the generic argument
    |
-LL | pub fn test<W, I: Trait<W, Item=()> >() {}
-   |                        --^^^^^^^
+LL | pub fn test<W, I: Trait<W, Item = ()> >() {}
+   |                        ^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issue-32214.stderr
+++ b/src/test/ui/parser/issue-32214.stderr
@@ -4,7 +4,7 @@ error: generic arguments must come before the first constraint
 LL | pub fn test<W, I: Trait<Item=(), W> >() {}
    |                         -------  ^ generic argument
    |                         |
-   |                         the constraint is provided here
+   |                         constraint
    |
 help: move the constraint after the generic argument
    |

--- a/src/test/ui/parser/issue-32214.stderr
+++ b/src/test/ui/parser/issue-32214.stderr
@@ -4,7 +4,7 @@ error: generic arguments must come before the first constraint
 LL | pub fn test<W, I: Trait<Item=(), W> >() {}
    |                         -------  ^ generic argument
    |                         |
-   |                         the first constraint is provided here
+   |                         the constraint is provided here
 
 error: aborting due to previous error
 

--- a/src/test/ui/resolve/issue-70736-async-fn-no-body-def-collector.rs
+++ b/src/test/ui/resolve/issue-70736-async-fn-no-body-def-collector.rs
@@ -1,0 +1,20 @@
+// edition:2018
+
+async fn free(); //~ ERROR without a body
+
+struct A;
+impl A {
+    async fn inherent(); //~ ERROR without body
+}
+
+trait B {
+    async fn associated();
+    //~^ ERROR cannot be declared `async`
+}
+impl B for A {
+    async fn associated(); //~ ERROR without body
+    //~^ ERROR cannot be declared `async`
+    //~| ERROR incompatible type for trait
+}
+
+fn main() {}

--- a/src/test/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
+++ b/src/test/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
@@ -1,0 +1,65 @@
+error: free function without a body
+  --> $DIR/issue-70736-async-fn-no-body-def-collector.rs:3:1
+   |
+LL | async fn free();
+   | ^^^^^^^^^^^^^^^-
+   |                |
+   |                help: provide a definition for the function: `{ <body> }`
+
+error: associated function in `impl` without body
+  --> $DIR/issue-70736-async-fn-no-body-def-collector.rs:7:5
+   |
+LL |     async fn inherent();
+   |     ^^^^^^^^^^^^^^^^^^^-
+   |                        |
+   |                        help: provide a definition for the function: `{ <body> }`
+
+error[E0706]: functions in traits cannot be declared `async`
+  --> $DIR/issue-70736-async-fn-no-body-def-collector.rs:11:5
+   |
+LL |     async fn associated();
+   |     -----^^^^^^^^^^^^^^^^^
+   |     |
+   |     `async` because of this
+   |
+   = note: `async` trait functions are not currently supported
+   = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
+
+error: associated function in `impl` without body
+  --> $DIR/issue-70736-async-fn-no-body-def-collector.rs:15:5
+   |
+LL |     async fn associated();
+   |     ^^^^^^^^^^^^^^^^^^^^^-
+   |                          |
+   |                          help: provide a definition for the function: `{ <body> }`
+
+error[E0706]: functions in traits cannot be declared `async`
+  --> $DIR/issue-70736-async-fn-no-body-def-collector.rs:15:5
+   |
+LL |     async fn associated();
+   |     -----^^^^^^^^^^^^^^^^^
+   |     |
+   |     `async` because of this
+   |
+   = note: `async` trait functions are not currently supported
+   = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
+
+error[E0053]: method `associated` has an incompatible type for trait
+  --> $DIR/issue-70736-async-fn-no-body-def-collector.rs:15:26
+   |
+LL |     async fn associated();
+   |                          - type in trait
+...
+LL |     async fn associated();
+   |                          ^
+   |                          |
+   |                          the `Output` of this `async fn`'s found opaque type
+   |                          expected `()`, found opaque type
+   |
+   = note: expected fn pointer `fn()`
+              found fn pointer `fn() -> impl std::future::Future`
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0053, E0706.
+For more information about an error, try `rustc --explain E0053`.

--- a/src/test/ui/suggestions/suggest-move-types.stderr
+++ b/src/test/ui/suggestions/suggest-move-types.stderr
@@ -5,6 +5,11 @@ LL | struct A<T, M: One<A=(), T>> {
    |                    ----  ^ generic argument
    |                    |
    |                    the constraint is provided here
+   |
+help: move the constraints after the generic arguments
+   |
+LL | struct A<T, M: One<T, A=()>> {
+   |                   --^^^^
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:33:43
@@ -14,6 +19,11 @@ LL | struct Al<'a, T, M: OneWithLifetime<A=(), T, 'a>> {
    |                                     |     |
    |                                     |     generic argument
    |                                     the constraint is provided here
+   |
+help: move the constraints after the generic arguments
+   |
+LL | struct Al<'a, T, M: OneWithLifetime<T, 'a, A=()>> {
+   |                                    --    ^^^^
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:40:46
@@ -26,6 +36,11 @@ LL | struct B<T, U, V, M: Three<A=(), B=(), C=(), T, U, V>> {
    |                            |     |     the constraints are provided here
    |                            |     the constraints are provided here
    |                            the constraints are provided here
+   |
+help: move the constraints after the generic arguments
+   |
+LL | struct B<T, U, V, M: Three<T, U, V, A=(), B=(), C=()>> {
+   |                           --      ^^^^^^^^^^^^^^^^
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:48:71
@@ -41,6 +56,11 @@ LL | struct Bl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<A=(), B=(), C=(), T, U,
    |                                                     |     |     the constraints are provided here
    |                                                     |     the constraints are provided here
    |                                                     the constraints are provided here
+   |
+help: move the constraints after the generic arguments
+   |
+LL | struct Bl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, U, V, 'a, 'b, 'c, A=(), B=(), C=()>> {
+   |                                                    --                  ^^^^^^^^^^^^^^^^
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:57:28
@@ -53,6 +73,11 @@ LL | struct C<T, U, V, M: Three<T, A=(), B=(), C=(), U, V>> {
    |                            |  |     the constraints are provided here
    |                            |  the constraints are provided here
    |                            generic argument
+   |
+help: move the constraints after the generic arguments
+   |
+LL | struct C<T, U, V, M: Three<A=(), B=(), C=(), U, V, A=(), B=(), C=()>> {
+   |                           --                     ^^^^^^^^^^^^^^^^
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:65:53
@@ -68,6 +93,11 @@ LL | struct Cl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), C=()
    |                                                     |  |   the constraints are provided here
    |                                                     |  generic argument
    |                                                     generic argument
+   |
+help: move the constraints after the generic arguments
+   |
+LL | struct Cl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<A=(), B=(), C=(), U, 'b, V, 'c, A=(), B=(), C=()>> {
+   |                                                    --                             ^^^^^^^^^^^^^^^^
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:74:28
@@ -80,6 +110,11 @@ LL | struct D<T, U, V, M: Three<T, A=(), B=(), U, C=(), V>> {
    |                            |  |     the constraints are provided here
    |                            |  the constraints are provided here
    |                            generic argument
+   |
+help: move the constraints after the generic arguments
+   |
+LL | struct D<T, U, V, M: Three<A=(), B=(), U, C=(), V, A=(), B=(), U, C=()>> {
+   |                           --                     ^^^^^^^^^^^^^^^^^^^
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:82:53
@@ -95,6 +130,11 @@ LL | struct Dl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), U, '
    |                                                     |  |   the constraints are provided here
    |                                                     |  generic argument
    |                                                     generic argument
+   |
+help: move the constraints after the generic arguments
+   |
+LL | struct Dl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<A=(), B=(), U, 'b, C=(), V, 'c, A=(), B=(), U, 'b, C=()>> {
+   |                                                    --                             ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0747]: type provided when a lifetime was expected
   --> $DIR/suggest-move-types.rs:33:43

--- a/src/test/ui/suggestions/suggest-move-types.stderr
+++ b/src/test/ui/suggestions/suggest-move-types.stderr
@@ -4,7 +4,7 @@ error: generic arguments must come before the first constraint
 LL | struct A<T, M: One<A=(), T>> {
    |                    ----  ^ generic argument
    |                    |
-   |                    the constraint is provided here
+   |                    constraint
    |
 help: move the constraint after the generic argument
    |
@@ -18,7 +18,7 @@ LL | struct Al<'a, T, M: OneWithLifetime<A=(), T, 'a>> {
    |                                     ----  ^  ^^ generic argument
    |                                     |     |
    |                                     |     generic argument
-   |                                     the constraint is provided here
+   |                                     constraint
    |
 help: move the constraint after the generic arguments
    |
@@ -33,9 +33,9 @@ LL | struct B<T, U, V, M: Three<A=(), B=(), C=(), T, U, V>> {
    |                            |     |     |     |  |
    |                            |     |     |     |  generic argument
    |                            |     |     |     generic argument
-   |                            |     |     the constraints are provided here
-   |                            |     the constraints are provided here
-   |                            the constraints are provided here
+   |                            |     |     constraint
+   |                            |     constraint
+   |                            constraint
    |
 help: move the constraints after the generic arguments
    |
@@ -53,9 +53,9 @@ LL | struct Bl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<A=(), B=(), C=(), T, U,
    |                                                     |     |     |     |  |  generic argument
    |                                                     |     |     |     |  generic argument
    |                                                     |     |     |     generic argument
-   |                                                     |     |     the constraints are provided here
-   |                                                     |     the constraints are provided here
-   |                                                     the constraints are provided here
+   |                                                     |     |     constraint
+   |                                                     |     constraint
+   |                                                     constraint
    |
 help: move the constraints after the generic arguments
    |
@@ -69,9 +69,9 @@ LL | struct C<T, U, V, M: Three<T, A=(), B=(), C=(), U, V>> {
    |                            ^  ----  ----  ----  ^  ^ generic argument
    |                            |  |     |     |     |
    |                            |  |     |     |     generic argument
-   |                            |  |     |     the constraints are provided here
-   |                            |  |     the constraints are provided here
-   |                            |  the constraints are provided here
+   |                            |  |     |     constraint
+   |                            |  |     constraint
+   |                            |  constraint
    |                            generic argument
    |
 help: move the constraints after the generic arguments
@@ -88,9 +88,9 @@ LL | struct Cl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), C=()
    |                                                     |  |   |     |     |     |  |   generic argument
    |                                                     |  |   |     |     |     |  generic argument
    |                                                     |  |   |     |     |     generic argument
-   |                                                     |  |   |     |     the constraints are provided here
-   |                                                     |  |   |     the constraints are provided here
-   |                                                     |  |   the constraints are provided here
+   |                                                     |  |   |     |     constraint
+   |                                                     |  |   |     constraint
+   |                                                     |  |   constraint
    |                                                     |  generic argument
    |                                                     generic argument
    |
@@ -105,10 +105,10 @@ error: generic arguments must come before the first constraint
 LL | struct D<T, U, V, M: Three<T, A=(), B=(), U, C=(), V>> {
    |                            ^  ----  ----  ^  ----  ^ generic argument
    |                            |  |     |     |  |
-   |                            |  |     |     |  the constraints are provided here
+   |                            |  |     |     |  constraint
    |                            |  |     |     generic argument
-   |                            |  |     the constraints are provided here
-   |                            |  the constraints are provided here
+   |                            |  |     constraint
+   |                            |  constraint
    |                            generic argument
    |
 help: move the constraints after the generic arguments
@@ -123,11 +123,11 @@ LL | struct Dl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), U, '
    |                                                     ^  ^^  ----  ----  ^  ^^  ----  ^  ^^ generic argument
    |                                                     |  |   |     |     |  |   |     |
    |                                                     |  |   |     |     |  |   |     generic argument
-   |                                                     |  |   |     |     |  |   the constraints are provided here
+   |                                                     |  |   |     |     |  |   constraint
    |                                                     |  |   |     |     |  generic argument
    |                                                     |  |   |     |     generic argument
-   |                                                     |  |   |     the constraints are provided here
-   |                                                     |  |   the constraints are provided here
+   |                                                     |  |   |     constraint
+   |                                                     |  |   constraint
    |                                                     |  generic argument
    |                                                     generic argument
    |

--- a/src/test/ui/suggestions/suggest-move-types.stderr
+++ b/src/test/ui/suggestions/suggest-move-types.stderr
@@ -15,9 +15,8 @@ error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:33:43
    |
 LL | struct Al<'a, T, M: OneWithLifetime<A=(), T, 'a>> {
-   |                                     ----  ^  ^^ generic argument
-   |                                     |     |
-   |                                     |     generic argument
+   |                                     ----  ^  ^^ generic arguments
+   |                                     |
    |                                     constraint
    |
 help: move the constraint after the generic arguments
@@ -29,13 +28,9 @@ error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:40:46
    |
 LL | struct B<T, U, V, M: Three<A=(), B=(), C=(), T, U, V>> {
-   |                            ----  ----  ----  ^  ^  ^ generic argument
-   |                            |     |     |     |  |
-   |                            |     |     |     |  generic argument
-   |                            |     |     |     generic argument
-   |                            |     |     constraint
-   |                            |     constraint
-   |                            constraint
+   |                            ----  ----  ----  ^  ^  ^ generic arguments
+   |                            |
+   |                            constraints
    |
 help: move the constraints after the generic arguments
    |
@@ -46,16 +41,9 @@ error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:48:71
    |
 LL | struct Bl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<A=(), B=(), C=(), T, U, V, 'a, 'b, 'c>> {
-   |                                                     ----  ----  ----  ^  ^  ^  ^^  ^^  ^^ generic argument
-   |                                                     |     |     |     |  |  |  |   |
-   |                                                     |     |     |     |  |  |  |   generic argument
-   |                                                     |     |     |     |  |  |  generic argument
-   |                                                     |     |     |     |  |  generic argument
-   |                                                     |     |     |     |  generic argument
-   |                                                     |     |     |     generic argument
-   |                                                     |     |     constraint
-   |                                                     |     constraint
-   |                                                     constraint
+   |                                                     ----  ----  ----  ^  ^  ^  ^^  ^^  ^^ generic arguments
+   |                                                     |
+   |                                                     constraints
    |
 help: move the constraints after the generic arguments
    |
@@ -66,13 +54,9 @@ error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:57:28
    |
 LL | struct C<T, U, V, M: Three<T, A=(), B=(), C=(), U, V>> {
-   |                            ^  ----  ----  ----  ^  ^ generic argument
-   |                            |  |     |     |     |
-   |                            |  |     |     |     generic argument
-   |                            |  |     |     constraint
-   |                            |  |     constraint
-   |                            |  constraint
-   |                            generic argument
+   |                            ^  ----  ----  ----  ^  ^ generic arguments
+   |                               |
+   |                               constraints
    |
 help: move the constraints after the generic arguments
    |
@@ -83,16 +67,9 @@ error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:65:53
    |
 LL | struct Cl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), C=(), U, 'b, V, 'c>> {
-   |                                                     ^  ^^  ----  ----  ----  ^  ^^  ^  ^^ generic argument
-   |                                                     |  |   |     |     |     |  |   |
-   |                                                     |  |   |     |     |     |  |   generic argument
-   |                                                     |  |   |     |     |     |  generic argument
-   |                                                     |  |   |     |     |     generic argument
-   |                                                     |  |   |     |     constraint
-   |                                                     |  |   |     constraint
-   |                                                     |  |   constraint
-   |                                                     |  generic argument
-   |                                                     generic argument
+   |                                                     ^  ^^  ----  ----  ----  ^  ^^  ^  ^^ generic arguments
+   |                                                            |
+   |                                                            constraints
    |
 help: move the constraints after the generic arguments
    |
@@ -103,13 +80,9 @@ error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:74:28
    |
 LL | struct D<T, U, V, M: Three<T, A=(), B=(), U, C=(), V>> {
-   |                            ^  ----  ----  ^  ----  ^ generic argument
-   |                            |  |     |     |  |
-   |                            |  |     |     |  constraint
-   |                            |  |     |     generic argument
-   |                            |  |     constraint
-   |                            |  constraint
-   |                            generic argument
+   |                            ^  ----  ----  ^  ----  ^ generic arguments
+   |                               |
+   |                               constraints
    |
 help: move the constraints after the generic arguments
    |
@@ -120,16 +93,9 @@ error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:82:53
    |
 LL | struct Dl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), U, 'b, C=(), V, 'c>> {
-   |                                                     ^  ^^  ----  ----  ^  ^^  ----  ^  ^^ generic argument
-   |                                                     |  |   |     |     |  |   |     |
-   |                                                     |  |   |     |     |  |   |     generic argument
-   |                                                     |  |   |     |     |  |   constraint
-   |                                                     |  |   |     |     |  generic argument
-   |                                                     |  |   |     |     generic argument
-   |                                                     |  |   |     constraint
-   |                                                     |  |   constraint
-   |                                                     |  generic argument
-   |                                                     generic argument
+   |                                                     ^  ^^  ----  ----  ^  ^^  ----  ^  ^^ generic arguments
+   |                                                            |
+   |                                                            constraints
    |
 help: move the constraints after the generic arguments
    |

--- a/src/test/ui/suggestions/suggest-move-types.stderr
+++ b/src/test/ui/suggestions/suggest-move-types.stderr
@@ -6,10 +6,10 @@ LL | struct A<T, M: One<A=(), T>> {
    |                    |
    |                    the constraint is provided here
    |
-help: move the constraints after the generic arguments
+help: move the constraint after the generic argument
    |
-LL | struct A<T, M: One<T, A=()>> {
-   |                   --^^^^
+LL | struct A<T, M: One<T, A = ()>> {
+   |                   ^^^^^^^^^^^
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:33:43
@@ -20,10 +20,10 @@ LL | struct Al<'a, T, M: OneWithLifetime<A=(), T, 'a>> {
    |                                     |     generic argument
    |                                     the constraint is provided here
    |
-help: move the constraints after the generic arguments
+help: move the constraint after the generic arguments
    |
-LL | struct Al<'a, T, M: OneWithLifetime<T, 'a, A=()>> {
-   |                                    --    ^^^^
+LL | struct Al<'a, T, M: OneWithLifetime<'a, T, A = ()>> {
+   |                                    ^^^^^^^^^^^^^^^
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:40:46
@@ -39,8 +39,8 @@ LL | struct B<T, U, V, M: Three<A=(), B=(), C=(), T, U, V>> {
    |
 help: move the constraints after the generic arguments
    |
-LL | struct B<T, U, V, M: Three<T, U, V, A=(), B=(), C=()>> {
-   |                           --      ^^^^^^^^^^^^^^^^
+LL | struct B<T, U, V, M: Three<T, U, V, A = (), B = (), C = ()>> {
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:48:71
@@ -59,8 +59,8 @@ LL | struct Bl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<A=(), B=(), C=(), T, U,
    |
 help: move the constraints after the generic arguments
    |
-LL | struct Bl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, U, V, 'a, 'b, 'c, A=(), B=(), C=()>> {
-   |                                                    --                  ^^^^^^^^^^^^^^^^
+LL | struct Bl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<'a, 'b, 'c, T, U, V, A = (), B = (), C = ()>> {
+   |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:57:28
@@ -76,8 +76,8 @@ LL | struct C<T, U, V, M: Three<T, A=(), B=(), C=(), U, V>> {
    |
 help: move the constraints after the generic arguments
    |
-LL | struct C<T, U, V, M: Three<A=(), B=(), C=(), U, V, A=(), B=(), C=()>> {
-   |                           --                     ^^^^^^^^^^^^^^^^
+LL | struct C<T, U, V, M: Three<T, U, V, A = (), B = (), C = ()>> {
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:65:53
@@ -96,8 +96,8 @@ LL | struct Cl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), C=()
    |
 help: move the constraints after the generic arguments
    |
-LL | struct Cl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<A=(), B=(), C=(), U, 'b, V, 'c, A=(), B=(), C=()>> {
-   |                                                    --                             ^^^^^^^^^^^^^^^^
+LL | struct Cl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<'a, 'b, 'c, T, U, V, A = (), B = (), C = ()>> {
+   |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:74:28
@@ -113,8 +113,8 @@ LL | struct D<T, U, V, M: Three<T, A=(), B=(), U, C=(), V>> {
    |
 help: move the constraints after the generic arguments
    |
-LL | struct D<T, U, V, M: Three<A=(), B=(), U, C=(), V, A=(), B=(), U, C=()>> {
-   |                           --                     ^^^^^^^^^^^^^^^^^^^
+LL | struct D<T, U, V, M: Three<T, U, V, A = (), B = (), C = ()>> {
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:82:53
@@ -133,8 +133,8 @@ LL | struct Dl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), U, '
    |
 help: move the constraints after the generic arguments
    |
-LL | struct Dl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<A=(), B=(), U, 'b, C=(), V, 'c, A=(), B=(), U, 'b, C=()>> {
-   |                                                    --                             ^^^^^^^^^^^^^^^^^^^^^^^
+LL | struct Dl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<'a, 'b, 'c, T, U, V, A = (), B = (), C = ()>> {
+   |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0747]: type provided when a lifetime was expected
   --> $DIR/suggest-move-types.rs:33:43

--- a/src/test/ui/suggestions/suggest-move-types.stderr
+++ b/src/test/ui/suggestions/suggest-move-types.stderr
@@ -4,7 +4,7 @@ error: generic arguments must come before the first constraint
 LL | struct A<T, M: One<A=(), T>> {
    |                    ----  ^ generic argument
    |                    |
-   |                    the first constraint is provided here
+   |                    the constraint is provided here
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:33:43
@@ -13,70 +13,88 @@ LL | struct Al<'a, T, M: OneWithLifetime<A=(), T, 'a>> {
    |                                     ----  ^  ^^ generic argument
    |                                     |     |
    |                                     |     generic argument
-   |                                     the first constraint is provided here
+   |                                     the constraint is provided here
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:40:46
    |
 LL | struct B<T, U, V, M: Three<A=(), B=(), C=(), T, U, V>> {
-   |                            ----              ^  ^  ^ generic argument
-   |                            |                 |  |
-   |                            |                 |  generic argument
-   |                            |                 generic argument
-   |                            the first constraint is provided here
+   |                            ----  ----  ----  ^  ^  ^ generic argument
+   |                            |     |     |     |  |
+   |                            |     |     |     |  generic argument
+   |                            |     |     |     generic argument
+   |                            |     |     the constraints are provided here
+   |                            |     the constraints are provided here
+   |                            the constraints are provided here
 
 error: generic arguments must come before the first constraint
   --> $DIR/suggest-move-types.rs:48:71
    |
 LL | struct Bl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<A=(), B=(), C=(), T, U, V, 'a, 'b, 'c>> {
-   |                                                     ----              ^  ^  ^  ^^  ^^  ^^ generic argument
-   |                                                     |                 |  |  |  |   |
-   |                                                     |                 |  |  |  |   generic argument
-   |                                                     |                 |  |  |  generic argument
-   |                                                     |                 |  |  generic argument
-   |                                                     |                 |  generic argument
-   |                                                     |                 generic argument
-   |                                                     the first constraint is provided here
+   |                                                     ----  ----  ----  ^  ^  ^  ^^  ^^  ^^ generic argument
+   |                                                     |     |     |     |  |  |  |   |
+   |                                                     |     |     |     |  |  |  |   generic argument
+   |                                                     |     |     |     |  |  |  generic argument
+   |                                                     |     |     |     |  |  generic argument
+   |                                                     |     |     |     |  generic argument
+   |                                                     |     |     |     generic argument
+   |                                                     |     |     the constraints are provided here
+   |                                                     |     the constraints are provided here
+   |                                                     the constraints are provided here
 
 error: generic arguments must come before the first constraint
-  --> $DIR/suggest-move-types.rs:57:49
+  --> $DIR/suggest-move-types.rs:57:28
    |
 LL | struct C<T, U, V, M: Three<T, A=(), B=(), C=(), U, V>> {
-   |                               ----              ^  ^ generic argument
-   |                               |                 |
-   |                               |                 generic argument
-   |                               the first constraint is provided here
+   |                            ^  ----  ----  ----  ^  ^ generic argument
+   |                            |  |     |     |     |
+   |                            |  |     |     |     generic argument
+   |                            |  |     |     the constraints are provided here
+   |                            |  |     the constraints are provided here
+   |                            |  the constraints are provided here
+   |                            generic argument
 
 error: generic arguments must come before the first constraint
-  --> $DIR/suggest-move-types.rs:65:78
+  --> $DIR/suggest-move-types.rs:65:53
    |
 LL | struct Cl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), C=(), U, 'b, V, 'c>> {
-   |                                                            ----              ^  ^^  ^  ^^ generic argument
-   |                                                            |                 |  |   |
-   |                                                            |                 |  |   generic argument
-   |                                                            |                 |  generic argument
-   |                                                            |                 generic argument
-   |                                                            the first constraint is provided here
+   |                                                     ^  ^^  ----  ----  ----  ^  ^^  ^  ^^ generic argument
+   |                                                     |  |   |     |     |     |  |   |
+   |                                                     |  |   |     |     |     |  |   generic argument
+   |                                                     |  |   |     |     |     |  generic argument
+   |                                                     |  |   |     |     |     generic argument
+   |                                                     |  |   |     |     the constraints are provided here
+   |                                                     |  |   |     the constraints are provided here
+   |                                                     |  |   the constraints are provided here
+   |                                                     |  generic argument
+   |                                                     generic argument
 
 error: generic arguments must come before the first constraint
-  --> $DIR/suggest-move-types.rs:74:43
+  --> $DIR/suggest-move-types.rs:74:28
    |
 LL | struct D<T, U, V, M: Three<T, A=(), B=(), U, C=(), V>> {
-   |                               ----        ^        ^ generic argument
-   |                               |           |
-   |                               |           generic argument
-   |                               the first constraint is provided here
+   |                            ^  ----  ----  ^  ----  ^ generic argument
+   |                            |  |     |     |  |
+   |                            |  |     |     |  the constraints are provided here
+   |                            |  |     |     generic argument
+   |                            |  |     the constraints are provided here
+   |                            |  the constraints are provided here
+   |                            generic argument
 
 error: generic arguments must come before the first constraint
-  --> $DIR/suggest-move-types.rs:82:72
+  --> $DIR/suggest-move-types.rs:82:53
    |
 LL | struct Dl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), U, 'b, C=(), V, 'c>> {
-   |                                                            ----        ^  ^^        ^  ^^ generic argument
-   |                                                            |           |  |         |
-   |                                                            |           |  |         generic argument
-   |                                                            |           |  generic argument
-   |                                                            |           generic argument
-   |                                                            the first constraint is provided here
+   |                                                     ^  ^^  ----  ----  ^  ^^  ----  ^  ^^ generic argument
+   |                                                     |  |   |     |     |  |   |     |
+   |                                                     |  |   |     |     |  |   |     generic argument
+   |                                                     |  |   |     |     |  |   the constraints are provided here
+   |                                                     |  |   |     |     |  generic argument
+   |                                                     |  |   |     |     generic argument
+   |                                                     |  |   |     the constraints are provided here
+   |                                                     |  |   the constraints are provided here
+   |                                                     |  generic argument
+   |                                                     generic argument
 
 error[E0747]: type provided when a lifetime was expected
   --> $DIR/suggest-move-types.rs:33:43


### PR DESCRIPTION
Successful merges:

 - #70519 (Tweak output of type params and constraints in the wrong order)
 - #70704 (Make panic unwind the default for aarch64-*-windows-msvc targets)
 - #70713 (Prefer sysroot from rustc in same directory as rust-gdb)
 - #70739 (def_collector, visit_fn: account for no body)
 - #70827 (Use smaller span for suggestion restricting lifetime)

Failed merges:


r? @ghost