### PR TITLE
Remove the Ord bound that was plaguing drain_filter

### DIFF
--- a/src/liballoc/collections/btree/map.rs
+++ b/src/liballoc/collections/btree/map.rs
@@ -1699,28 +1699,22 @@ impl<K, V> Clone for Values<'_, K, V> {
 #[unstable(feature = "btree_drain_filter", issue = "70530")]
 pub struct DrainFilter<'a, K, V, F>
 where
-    K: 'a + Ord, // This Ord bound should be removed before stabilization.
+    K: 'a,
     V: 'a,
     F: 'a + FnMut(&K, &mut V) -> bool,
 {
     pred: F,
     inner: DrainFilterInner<'a, K, V>,
 }
-pub(super) struct DrainFilterInner<'a, K, V>
-where
-    K: 'a + Ord,
-    V: 'a,
-{
+pub(super) struct DrainFilterInner<'a, K: 'a, V: 'a> {
     length: &'a mut usize,
     cur_leaf_edge: Option<Handle<NodeRef<marker::Mut<'a>, K, V, marker::Leaf>, marker::Edge>>,
 }
 
 #[unstable(feature = "btree_drain_filter", issue = "70530")]
-impl<'a, K, V, F> Drop for DrainFilter<'a, K, V, F>
+impl<K, V, F> Drop for DrainFilter<'_, K, V, F>
 where
-    K: 'a + Ord,
-    V: 'a,
-    F: 'a + FnMut(&K, &mut V) -> bool,
+    F: FnMut(&K, &mut V) -> bool,
 {
     fn drop(&mut self) {
         self.for_each(drop);
@@ -1728,11 +1722,11 @@ where
 }
 
 #[unstable(feature = "btree_drain_filter", issue = "70530")]
-impl<'a, K, V, F> fmt::Debug for DrainFilter<'a, K, V, F>
+impl<K, V, F> fmt::Debug for DrainFilter<'_, K, V, F>
 where
-    K: 'a + fmt::Debug + Ord,
-    V: 'a + fmt::Debug,
-    F: 'a + FnMut(&K, &mut V) -> bool,
+    K: fmt::Debug,
+    V: fmt::Debug,
+    F: FnMut(&K, &mut V) -> bool,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("DrainFilter").field(&self.inner.peek()).finish()
@@ -1740,11 +1734,9 @@ where
 }
 
 #[unstable(feature = "btree_drain_filter", issue = "70530")]
-impl<'a, K, V, F> Iterator for DrainFilter<'a, K, V, F>
+impl<K, V, F> Iterator for DrainFilter<'_, K, V, F>
 where
-    K: 'a + Ord,
-    V: 'a,
-    F: 'a + FnMut(&K, &mut V) -> bool,
+    F: FnMut(&K, &mut V) -> bool,
 {
     type Item = (K, V);
 
@@ -1757,11 +1749,7 @@ where
     }
 }
 
-impl<'a, K, V> DrainFilterInner<'a, K, V>
-where
-    K: 'a + Ord,
-    V: 'a,
-{
+impl<'a, K: 'a, V: 'a> DrainFilterInner<'a, K, V> {
     /// Allow Debug implementations to predict the next element.
     pub(super) fn peek(&self) -> Option<(&K, &V)> {
         let edge = self.cur_leaf_edge.as_ref()?;
@@ -1800,12 +1788,7 @@ where
 }
 
 #[unstable(feature = "btree_drain_filter", issue = "70530")]
-impl<K, V, F> FusedIterator for DrainFilter<'_, K, V, F>
-where
-    K: Ord,
-    F: FnMut(&K, &mut V) -> bool,
-{
-}
+impl<K, V, F> FusedIterator for DrainFilter<'_, K, V, F> where F: FnMut(&K, &mut V) -> bool {}
 
 #[stable(feature = "btree_range", since = "1.17.0")]
 impl<'a, K, V> Iterator for Range<'a, K, V> {

--- a/src/liballoc/collections/btree/set.rs
+++ b/src/liballoc/collections/btree/set.rs
@@ -1094,7 +1094,7 @@ impl<'a, T> IntoIterator for &'a BTreeSet<T> {
 #[unstable(feature = "btree_drain_filter", issue = "70530")]
 pub struct DrainFilter<'a, T, F>
 where
-    T: 'a + Ord,
+    T: 'a,
     F: 'a + FnMut(&T) -> bool,
 {
     pred: F,
@@ -1102,10 +1102,9 @@ where
 }
 
 #[unstable(feature = "btree_drain_filter", issue = "70530")]
-impl<'a, T, F> Drop for DrainFilter<'a, T, F>
+impl<T, F> Drop for DrainFilter<'_, T, F>
 where
-    T: 'a + Ord,
-    F: 'a + FnMut(&T) -> bool,
+    F: FnMut(&T) -> bool,
 {
     fn drop(&mut self) {
         self.for_each(drop);
@@ -1113,10 +1112,10 @@ where
 }
 
 #[unstable(feature = "btree_drain_filter", issue = "70530")]
-impl<'a, T, F> fmt::Debug for DrainFilter<'a, T, F>
+impl<T, F> fmt::Debug for DrainFilter<'_, T, F>
 where
-    T: 'a + Ord + fmt::Debug,
-    F: 'a + FnMut(&T) -> bool,
+    T: fmt::Debug,
+    F: FnMut(&T) -> bool,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("DrainFilter").field(&self.inner.peek().map(|(k, _)| k)).finish()
@@ -1124,10 +1123,9 @@ where
 }
 
 #[unstable(feature = "btree_drain_filter", issue = "70530")]
-impl<'a, 'f, T, F> Iterator for DrainFilter<'a, T, F>
+impl<'a, T, F> Iterator for DrainFilter<'_, T, F>
 where
-    T: 'a + Ord,
-    F: 'a + 'f + FnMut(&T) -> bool,
+    F: 'a + FnMut(&T) -> bool,
 {
     type Item = T;
 
@@ -1143,12 +1141,7 @@ where
 }
 
 #[unstable(feature = "btree_drain_filter", issue = "70530")]
-impl<'a, T, F> FusedIterator for DrainFilter<'a, T, F>
-where
-    T: 'a + Ord,
-    F: 'a + FnMut(&T) -> bool,
-{
-}
+impl<T, F> FusedIterator for DrainFilter<'_, T, F> where F: FnMut(&T) -> bool {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Ord> Extend<T> for BTreeSet<T> {


### PR DESCRIPTION
Now that  #70795 made it superfluous. Also removes superfluous lifetime specifiers (at least I think they are).