### PR TITLE
Keep codegen units unmerged when building compiler builtins

### DIFF
--- a/src/librustc_mir/monomorphize/partitioning.rs
+++ b/src/librustc_mir/monomorphize/partitioning.rs
@@ -455,10 +455,17 @@ fn default_visibility(tcx: TyCtxt<'_>, id: DefId, is_generic: bool) -> Visibilit
 fn merge_codegen_units<'tcx>(
     tcx: TyCtxt<'tcx>,
     initial_partitioning: &mut PreInliningPartitioning<'tcx>,
-    target_cgu_count: usize,
+    mut target_cgu_count: usize,
 ) {
     assert!(target_cgu_count >= 1);
     let codegen_units = &mut initial_partitioning.codegen_units;
+
+    if tcx.is_compiler_builtins(LOCAL_CRATE) {
+        // Compiler builtins require some degree of control over how mono items
+        // are partitioned into compilation units. Provide it by keeping the
+        // original partitioning when compiling the compiler builtins crate.
+        target_cgu_count = codegen_units.len();
+    }
 
     // Note that at this point in time the `codegen_units` here may not be in a
     // deterministic order (but we know they're deterministically the same set).

--- a/src/test/codegen-units/partitioning/compiler-builtins.rs
+++ b/src/test/codegen-units/partitioning/compiler-builtins.rs
@@ -1,0 +1,40 @@
+// Verifies that during compiler_builtins compilation the codegen units are kept
+// unmerged. Even when only a single codegen unit is requested with -Ccodegen-units=1.
+//
+// compile-flags: -Zprint-mono-items=eager -Ccodegen-units=1
+
+#![compiler_builtins]
+#![crate_type="lib"]
+#![feature(compiler_builtins)]
+
+mod atomics {
+    //~ MONO_ITEM fn compiler_builtins::atomics[0]::sync_1[0] @@ compiler_builtins-cgu.0[External]
+    #[no_mangle]
+    pub extern "C" fn sync_1() {}
+
+    //~ MONO_ITEM fn compiler_builtins::atomics[0]::sync_2[0] @@ compiler_builtins-cgu.0[External]
+    #[no_mangle]
+    pub extern "C" fn sync_2() {}
+
+    //~ MONO_ITEM fn compiler_builtins::atomics[0]::sync_3[0] @@ compiler_builtins-cgu.0[External]
+    #[no_mangle]
+    pub extern "C" fn sync_3() {}
+}
+
+mod x {
+    //~ MONO_ITEM fn compiler_builtins::x[0]::x[0] @@ compiler_builtins-cgu.1[External]
+    #[no_mangle]
+    pub extern "C" fn x() {}
+}
+
+mod y {
+    //~ MONO_ITEM fn compiler_builtins::y[0]::y[0] @@ compiler_builtins-cgu.2[External]
+    #[no_mangle]
+    pub extern "C" fn y() {}
+}
+
+mod z {
+    //~ MONO_ITEM fn compiler_builtins::z[0]::z[0] @@ compiler_builtins-cgu.3[External]
+    #[no_mangle]
+    pub extern "C" fn z() {}
+}


### PR DESCRIPTION
Make it possible to control how mono items are partitioned into code generation
units, when compiling the compiler builtins, by retaining the original partitioning.

Helps with #48625, #61063, #67960, #70489.

r? @alexcrichton 