### PR TITLE
ci: move /var/lib/docker to /mnt on GHA

### DIFF
--- a/src/ci/scripts/symlink-build-dir.sh
+++ b/src/ci/scripts/symlink-build-dir.sh
@@ -24,4 +24,10 @@ elif isLinux && isGitHubActions; then
     mv "${current_dir}" /mnt/more-space/workspace
     ln -s /mnt/more-space/workspace "${current_dir}"
     cd "${current_dir}"
+
+    # Move the Docker data directory to /mnt
+    sudo systemctl stop docker.service
+    sudo mv /var/lib/docker /mnt/docker
+    sudo ln -s /mnt/docker /var/lib/docker
+    sudo systemctl start docker.service
 fi


### PR DESCRIPTION
There are some builders that are running out of disk space while building the Docker images, such as arm-android. This moves and symlinks `/var/lib/docker` to the `/mnt` partition on Linux GHA.

Example of a build failing because of this: https://github.com/rust-lang-ci/rust/runs/564628621

