### PR TITLE
Enforce a whitelist on the constant primitive types allowed in patterns.

### DIFF
--- a/src/test/ui/const-generics/fn-const-param-infer.stderr
+++ b/src/test/ui/const-generics/fn-const-param-infer.stderr
@@ -6,44 +6,12 @@ LL | #![feature(const_generics, const_compare_raw_pointers)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0308]: mismatched types
-  --> $DIR/fn-const-param-infer.rs:16:31
+error[E0741]: the types of const generic parameters must derive `PartialEq` and `Eq`
+  --> $DIR/fn-const-param-infer.rs:4:25
    |
-LL |     let _: Checked<not_one> = Checked::<not_two>;
-   |            ----------------   ^^^^^^^^^^^^^^^^^^ expected `{not_one as fn(usize) -> bool}`, found `{not_two as fn(usize) -> bool}`
-   |            |
-   |            expected due to this
-   |
-   = note: expected struct `Checked<{not_one as fn(usize) -> bool}>`
-              found struct `Checked<{not_two as fn(usize) -> bool}>`
+LL | struct Checked<const F: fn(usize) -> bool>;
+   |                         ^^^^^^^^^^^^^^^^^ `fn(usize) -> bool` doesn't derive both `PartialEq` and `Eq`
 
-error[E0308]: mismatched types
-  --> $DIR/fn-const-param-infer.rs:20:24
-   |
-LL |     let _ = Checked::<{generic_arg::<u32>}>;
-   |                        ^^^^^^^^^^^^^^^^^^ expected `usize`, found `u32`
-   |
-   = note: expected fn pointer `fn(usize) -> _`
-                 found fn item `fn(u32) -> _ {generic_arg::<u32>}`
+error: aborting due to previous error
 
-error[E0282]: type annotations needed
-  --> $DIR/fn-const-param-infer.rs:22:23
-   |
-LL |     let _ = Checked::<generic>;
-   |                       ^^^^^^^ cannot infer type for type parameter `T` declared on the function `generic`
-
-error[E0308]: mismatched types
-  --> $DIR/fn-const-param-infer.rs:25:40
-   |
-LL |     let _: Checked<{generic::<u32>}> = Checked::<{generic::<u16>}>;
-   |            -------------------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `{generic::<u32> as fn(usize) -> bool}`, found `{generic::<u16> as fn(usize) -> bool}`
-   |            |
-   |            expected due to this
-   |
-   = note: expected struct `Checked<{generic::<u32> as fn(usize) -> bool}>`
-              found struct `Checked<{generic::<u16> as fn(usize) -> bool}>`
-
-error: aborting due to 4 previous errors
-
-Some errors have detailed explanations: E0282, E0308.
-For more information about an error, try `rustc --explain E0282`.
+For more information about this error, try `rustc --explain E0741`.

--- a/src/test/ui/const-generics/raw-ptr-const-param.stderr
+++ b/src/test/ui/const-generics/raw-ptr-const-param.stderr
@@ -6,17 +6,12 @@ LL | #![feature(const_generics, const_compare_raw_pointers)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0308]: mismatched types
-  --> $DIR/raw-ptr-const-param.rs:7:40
+error[E0741]: the types of const generic parameters must derive `PartialEq` and `Eq`
+  --> $DIR/raw-ptr-const-param.rs:4:23
    |
-LL |     let _: Const<{ 15 as *const _ }> = Const::<{ 10 as *const _ }>;
-   |            -------------------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `{0xf as *const u32}`, found `{0xa as *const u32}`
-   |            |
-   |            expected due to this
-   |
-   = note: expected struct `Const<{0xf as *const u32}>`
-              found struct `Const<{0xa as *const u32}>`
+LL | struct Const<const P: *const u32>;
+   |                       ^^^^^^^^^^ `*const u32` doesn't derive both `PartialEq` and `Eq`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0741`.

--- a/src/test/ui/consts/match_ice.stderr
+++ b/src/test/ui/consts/match_ice.stderr
@@ -4,17 +4,11 @@ error: to use a constant of type `S` in a pattern, `S` must be annotated with `#
 LL |         C => {}
    |         ^
 
-error[E0004]: non-exhaustive patterns: `&T` not covered
-  --> $DIR/match_ice.rs:16:11
+error: constants of type `T` cannot be used in a pattern
+  --> $DIR/match_ice.rs:17:9
    |
-LL | struct T;
-   | --------- `T` defined here
-...
-LL |     match K {
-   |           ^ pattern `&T` not covered
-   |
-   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
-   = note: the matched value is of type `&T`
+LL |         K => {}
+   |         ^
 
 error: to use a constant of type `S` in a pattern, `S` must be annotated with `#[derive(PartialEq, Eq)]`
   --> $DIR/match_ice.rs:11:9
@@ -22,6 +16,11 @@ error: to use a constant of type `S` in a pattern, `S` must be annotated with `#
 LL |         C => {}
    |         ^
 
-error: aborting due to 3 previous errors
+error: constants of type `T` cannot be used in a pattern
+  --> $DIR/match_ice.rs:17:9
+   |
+LL |         K => {}
+   |         ^
 
-For more information about this error, try `rustc --explain E0004`.
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/feature-gates/feature-gate-const_generics-ptr.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_generics-ptr.stderr
@@ -25,6 +25,12 @@ LL | struct ConstFn<const F: fn()>;
    = note: see issue #53020 <https://github.com/rust-lang/rust/issues/53020> for more information
    = help: add `#![feature(const_compare_raw_pointers)]` to the crate attributes to enable
 
+error[E0741]: the types of const generic parameters must derive `PartialEq` and `Eq`
+  --> $DIR/feature-gate-const_generics-ptr.rs:1:25
+   |
+LL | struct ConstFn<const F: fn()>;
+   |                         ^^^^ `fn()` doesn't derive both `PartialEq` and `Eq`
+
 error[E0658]: using raw pointers as const generic parameters is unstable
   --> $DIR/feature-gate-const_generics-ptr.rs:5:26
    |
@@ -34,6 +40,13 @@ LL | struct ConstPtr<const P: *const u32>;
    = note: see issue #53020 <https://github.com/rust-lang/rust/issues/53020> for more information
    = help: add `#![feature(const_compare_raw_pointers)]` to the crate attributes to enable
 
-error: aborting due to 4 previous errors
+error[E0741]: the types of const generic parameters must derive `PartialEq` and `Eq`
+  --> $DIR/feature-gate-const_generics-ptr.rs:5:26
+   |
+LL | struct ConstPtr<const P: *const u32>;
+   |                          ^^^^^^^^^^ `*const u32` doesn't derive both `PartialEq` and `Eq`
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0658, E0741.
+For more information about an error, try `rustc --explain E0658`.

--- a/src/test/ui/rfc1445/issue-61188-match-slice-forbidden-without-eq.stderr
+++ b/src/test/ui/rfc1445/issue-61188-match-slice-forbidden-without-eq.stderr
@@ -1,8 +1,14 @@
-error: to use a constant of type `B` in a pattern, `B` must be annotated with `#[derive(PartialEq, Eq)]`
+error: constants of type `B` cannot be used in a pattern
   --> $DIR/issue-61188-match-slice-forbidden-without-eq.rs:15:9
    |
 LL |         A => (),
    |         ^
 
-error: aborting due to previous error
+error: constants of type `B` cannot be used in a pattern
+  --> $DIR/issue-61188-match-slice-forbidden-without-eq.rs:15:9
+   |
+LL |         A => (),
+   |         ^
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
The primary effect of this is that it bans function and raw pointers from being used in constants that show up in patterns (see #70861).

This PR is for Crater only, and I suspect the fallout might be bad enough that we can't ever do this.

If we can't change the rules for *patterns*, we need to come up with *separate* rules for `const` generics, that take into account the "structurally matchable" property *for user-defined ADTs*, but otherwise has a strict whitelist of *primitive types*. And I suppose we don't need to do a value-based analysis for `const` generics, we can be stricter on purpose.

cc @pnkfelix  @varkor @yodaldevoid 