### PR TITLE
bootstrap: work around "unused attribute" errors in incremental stdlib rebuilds.

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1099,6 +1099,13 @@ impl<'a> Builder<'a> {
 
             if self.config.deny_warnings {
                 rustflags.arg("-Dwarnings");
+
+                // FIXME(#58633) hide "unused attribute" errors in incremental
+                // builds of the standard library, as the underlying checks are
+                // not yet properly integrated with incremental recompilation.
+                if mode == Mode::Std && compiler.stage == 0 && self.config.incremental {
+                    rustflags.arg("-Aunused-attributes");
+                }
             }
         }
 


### PR DESCRIPTION
This should alleviate #58633 separately from a proper fix.

r? @Mark-Simulacrum 