### PR TITLE
Make LLVM version suffix independent of rustc version on dev channel

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -84,8 +84,9 @@
 #link-shared = false
 
 # When building llvm, this configures what is being appended to the version.
-# If absent, we let the version as-is.
-#version-suffix = "-rust"
+# The default is "-rust-$version-$channel", except for dev channel where rustc
+# version number is omitted. To use LLVM version as is, provide an empty string.
+#version-suffix = "-rust-dev"
 
 # On MSVC you can compile LLVM with clang-cl, but the test suite doesn't pass
 # with clang-cl, so this is special in that it only compiles LLVM with clang-cl

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -235,10 +235,14 @@ impl Step for Llvm {
             if !suffix.is_empty() {
                 cfg.define("LLVM_VERSION_SUFFIX", suffix);
             }
+        } else if builder.config.channel == "dev" {
+            // Changes to a version suffix require a complete rebuild of the LLVM.
+            // To avoid rebuilds during a time of version bump, don't include rustc
+            // release number on the dev channel.
+            cfg.define("LLVM_VERSION_SUFFIX", "-rust-dev");
         } else {
-            let default_suffix =
-                format!("-rust-{}-{}", channel::CFG_RELEASE_NUM, builder.config.channel);
-            cfg.define("LLVM_VERSION_SUFFIX", default_suffix);
+            let suffix = format!("-rust-{}-{}", channel::CFG_RELEASE_NUM, builder.config.channel);
+            cfg.define("LLVM_VERSION_SUFFIX", suffix);
         }
 
         if let Some(ref linker) = builder.config.llvm_use_linker {


### PR DESCRIPTION
Remove rustc version from LLVM version suffix on dev channel,
avoiding the need for full rebuilds when switching between
branches with different LLVM submodule & rustc version.

Note: To avoid full rebuild, on subsequent LLVM submodule update, copy the
current value of `LLVM_VERSION_SUFFIX` from `build/*/llvm/build/CMakeCache.txt`,
to `version-suffix` in `config.toml`. 
