### PR TITLE
Do not suggest adding type param when `use` is already suggested

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2480,8 +2480,7 @@ impl<'a> Resolver<'a> {
             let (span, found_use) = UsePlacementFinder::check(krate, node_id);
             if !candidates.is_empty() {
                 diagnostics::show_candidates(&mut err, span, &candidates, better, found_use);
-            }
-            if let Some((span, msg, sugg, appl)) = suggestion {
+            } else if let Some((span, msg, sugg, appl)) = suggestion {
                 err.span_suggestion(span, msg, sugg, appl);
             }
             err.emit();

--- a/src/test/ui/privacy/privacy-ns1.stderr
+++ b/src/test/ui/privacy/privacy-ns1.stderr
@@ -63,10 +63,6 @@ LL | use foo2::Bar;
    |
 LL | use foo3::Bar;
    |
-help: you might be missing a type parameter
-   |
-LL | fn test_glob3<Bar>() {
-   |              ^^^^^
 
 error[E0107]: wrong number of const arguments: expected 0, found 1
   --> $DIR/privacy-ns1.rs:35:17

--- a/src/test/ui/suggestions/no-extern-crate-in-type.stderr
+++ b/src/test/ui/suggestions/no-extern-crate-in-type.stderr
@@ -8,10 +8,6 @@ help: possible candidate is found in another module, you can import it into scop
    |
 LL | use foo::Foo;
    |
-help: you might be missing a type parameter
-   |
-LL | type Output<Foo> = Option<Foo>;
-   |            ^^^^^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fix #70365, cc #70572.