### PR TITLE
Corrects a typo in rustdoc documentation.

### DIFF
--- a/src/doc/rustdoc/src/documentation-tests.md
+++ b/src/doc/rustdoc/src/documentation-tests.md
@@ -352,9 +352,9 @@ are added.
 /// ```
 ```
 
-`edition2018` tells `rustdoc` that the code sample should be compiled the 2018
-edition of Rust. Similarly, you can specify `edition2015` to compile the code
-with the 2015 edition.
+`edition2018` tells `rustdoc` that the code sample should be compiled using
+the 2018 edition of Rust. Similarly, you can specify `edition2015` to compile
+the code with the 2015 edition.
 
 ## Syntax reference
 


### PR DESCRIPTION
Fixes rust-lang#70856

Sorry, I am just learning git and I think I may have accidentally done some wacky stuff that closed my last PR. Here it is again.