### PR TITLE
Remove unnecessary TypeFlags::NOMINAL_FLAGS

### DIFF
--- a/src/librustc_middle/ty/flags.rs
+++ b/src/librustc_middle/ty/flags.rs
@@ -28,7 +28,7 @@ impl FlagComputation {
     }
 
     fn add_flags(&mut self, flags: TypeFlags) {
-        self.flags = self.flags | (flags & TypeFlags::NOMINAL_FLAGS);
+        self.flags = self.flags | flags;
     }
 
     /// indicates that `self` refers to something at binding level `binder`

--- a/src/librustc_middle/ty/mod.rs
+++ b/src/librustc_middle/ty/mod.rs
@@ -598,29 +598,6 @@ bitflags! {
         /// Does this value have parameters/placeholders/inference variables which could be
         /// replaced later, in a way that would change the results of `impl` specialization?
         const STILL_FURTHER_SPECIALIZABLE = 1 << 18;
-
-        /// Flags representing the nominal content of a type,
-        /// computed by FlagsComputation. If you add a new nominal
-        /// flag, it should be added here too.
-        const NOMINAL_FLAGS               = TypeFlags::HAS_TY_PARAM.bits
-                                          | TypeFlags::HAS_RE_PARAM.bits
-                                          | TypeFlags::HAS_CT_PARAM.bits
-                                          | TypeFlags::HAS_TY_INFER.bits
-                                          | TypeFlags::HAS_RE_INFER.bits
-                                          | TypeFlags::HAS_CT_INFER.bits
-                                          | TypeFlags::HAS_TY_PLACEHOLDER.bits
-                                          | TypeFlags::HAS_RE_PLACEHOLDER.bits
-                                          | TypeFlags::HAS_CT_PLACEHOLDER.bits
-                                          | TypeFlags::HAS_FREE_LOCAL_REGIONS.bits
-                                          | TypeFlags::HAS_TY_PROJECTION.bits
-                                          | TypeFlags::HAS_TY_OPAQUE.bits
-                                          | TypeFlags::HAS_CT_PROJECTION.bits
-                                          | TypeFlags::KEEP_IN_LOCAL_TCX.bits
-                                          | TypeFlags::HAS_TY_ERR.bits
-                                          | TypeFlags::HAS_FREE_REGIONS.bits
-                                          | TypeFlags::HAS_RE_LATE_BOUND.bits
-                                          | TypeFlags::HAS_RE_ERASED.bits
-                                          | TypeFlags::STILL_FURTHER_SPECIALIZABLE.bits;
     }
 }
 


### PR DESCRIPTION
This was a relic from when we had "nominal flags" and "cached
properties." The latter no longer exists, so nominal flags are no
longer necessary. In fact, every flag is considered a nominal flag. I
went ahead and removed all references to NOMINAL_FLAGS.

Fixes rust-lang#70836