### PR TITLE
rustc_session: forbid lints override regardless of position

### DIFF
--- a/src/doc/rustc/src/lints/levels.md
+++ b/src/doc/rustc/src/lints/levels.md
@@ -170,7 +170,7 @@ The order of these command line arguments is taken into account. The following a
 $ rustc lib.rs --crate-type=lib -D unused-variables -A unused-variables
 ```
 
-You can make use of this behavior by overriding the level of one specific lint out of a group of lints. The following example denies all the lints in the `unused` group, but explicitly allows the `unused-variables` lint in that group:
+You can make use of this behavior by overriding the level of one specific lint out of a group of lints. The following example denies all the lints in the `unused` group, but explicitly allows the `unused-variables` lint in that group (forbid still trumps everything regardless of ordering):
 
 ```bash
 $ rustc lib.rs --crate-type=lib -D unused -A unused-variables

--- a/src/librustc_session/config.rs
+++ b/src/librustc_session/config.rs
@@ -1017,7 +1017,13 @@ pub fn get_cmd_lint_options(
     let mut describe_lints = false;
 
     for &level in &[lint::Allow, lint::Warn, lint::Deny, lint::Forbid] {
-        for (arg_pos, lint_name) in matches.opt_strs_pos(level.as_str()) {
+        for (passed_arg_pos, lint_name) in matches.opt_strs_pos(level.as_str()) {
+            let arg_pos = if let lint::Forbid = level {
+                // forbid is always specified last, so it can't be overridden
+                usize::max_value()
+            } else {
+                passed_arg_pos
+            };
             if lint_name == "help" {
                 describe_lints = true;
             } else {

--- a/src/test/ui-fulldeps/lint-group-forbid-always-trumps-cli.rs
+++ b/src/test/ui-fulldeps/lint-group-forbid-always-trumps-cli.rs
@@ -1,0 +1,7 @@
+// aux-build:lint-group-plugin-test.rs
+// compile-flags: -F unused -A unused
+
+fn main() {
+    let x = 1;
+    //~^ ERROR unused variable: `x`
+}

--- a/src/test/ui-fulldeps/lint-group-forbid-always-trumps-cli.stderr
+++ b/src/test/ui-fulldeps/lint-group-forbid-always-trumps-cli.stderr
@@ -1,0 +1,10 @@
+error: unused variable: `x`
+  --> $DIR/lint-group-forbid-always-trumps-cli.rs:5:9
+   |
+LL |     let x = 1;
+   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
+   |
+   = note: `-F unused-variables` implied by `-F unused`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Addresses the regression reported in #70819 for command line arguments, but does not address the source code flag regression.