### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -2104,7 +2104,7 @@ impl<T> VecDeque<T> {
     ///     assert_eq!(slice, &[3, 2, 1] as &[_]);
     /// }
     /// ```
-    #[unstable(feature = "deque_make_contiguous", issue = "none")]
+    #[unstable(feature = "deque_make_contiguous", issue = "70929")]
     pub fn make_contiguous(&mut self) -> &mut [T] {
         if self.is_contiguous() {
             let tail = self.tail;

--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -141,6 +141,7 @@ mod hack {
     use crate::string::ToString;
     use crate::vec::Vec;
 
+    #[inline]
     pub fn into_vec<T>(b: Box<[T]>) -> Vec<T> {
         unsafe {
             let len = b.len();

--- a/src/librustc_codegen_llvm/callee.rs
+++ b/src/librustc_codegen_llvm/callee.rs
@@ -29,7 +29,7 @@ pub fn get_fn(cx: &CodegenCx<'ll, 'tcx>, instance: Instance<'tcx>) -> &'ll Value
 
     assert!(!instance.substs.needs_infer());
     assert!(!instance.substs.has_escaping_bound_vars());
-    assert!(!instance.substs.has_param_types());
+    assert!(!instance.substs.has_param_types_or_consts());
 
     if let Some(&llfn) = cx.instances.borrow().get(&instance) {
         return llfn;

--- a/src/librustc_codegen_llvm/mono_item.rs
+++ b/src/librustc_codegen_llvm/mono_item.rs
@@ -47,7 +47,7 @@ impl PreDefineMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         visibility: Visibility,
         symbol_name: &str,
     ) {
-        assert!(!instance.substs.needs_infer() && !instance.substs.has_param_types());
+        assert!(!instance.substs.needs_infer() && !instance.substs.has_param_types_or_consts());
 
         let fn_abi = FnAbi::of_instance(self, instance, &[]);
         let lldecl = self.declare_fn(symbol_name, &fn_abi);

--- a/src/librustc_middle/ty/fold.rs
+++ b/src/librustc_middle/ty/fold.rs
@@ -84,7 +84,7 @@ pub trait TypeFoldable<'tcx>: fmt::Debug + Clone {
     fn references_error(&self) -> bool {
         self.has_type_flags(TypeFlags::HAS_TY_ERR)
     }
-    fn has_param_types(&self) -> bool {
+    fn has_param_types_or_consts(&self) -> bool {
         self.has_type_flags(TypeFlags::HAS_TY_PARAM | TypeFlags::HAS_CT_PARAM)
     }
     fn has_infer_types(&self) -> bool {

--- a/src/librustc_middle/ty/instance.rs
+++ b/src/librustc_middle/ty/instance.rs
@@ -91,7 +91,7 @@ impl<'tcx> Instance<'tcx> {
         // There shouldn't be any params - if there are, then
         // Instance.ty_env should have been used to provide the proper
         // ParamEnv
-        if self.substs.has_param_types() {
+        if self.substs.has_param_types_or_consts() {
             bug!("Instance.ty called for type {:?} with params in substs: {:?}", ty, self.substs);
         }
         tcx.subst_and_normalize_erasing_regions(self.substs, ty::ParamEnv::reveal_all(), &ty)

--- a/src/librustc_middle/ty/layout.rs
+++ b/src/librustc_middle/ty/layout.rs
@@ -1585,7 +1585,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
         // Ignore layouts that are done with non-empty environments or
         // non-monomorphic layouts, as the user only wants to see the stuff
         // resulting from the final codegen session.
-        if layout.ty.has_param_types() || !self.param_env.caller_bounds.is_empty() {
+        if layout.ty.has_param_types_or_consts() || !self.param_env.caller_bounds.is_empty() {
             return;
         }
 
@@ -1754,7 +1754,7 @@ impl<'tcx> SizeSkeleton<'tcx> {
                 let tail = tcx.struct_tail_erasing_lifetimes(pointee, param_env);
                 match tail.kind {
                     ty::Param(_) | ty::Projection(_) => {
-                        debug_assert!(tail.has_param_types());
+                        debug_assert!(tail.has_param_types_or_consts());
                         Ok(SizeSkeleton::Pointer { non_zero, tail: tcx.erase_regions(&tail) })
                     }
                     _ => bug!(

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -25,6 +25,7 @@ Rust MIR: a lowered representation of Rust.
 #![feature(stmt_expr_attributes)]
 #![feature(trait_alias)]
 #![feature(option_expect_none)]
+#![feature(or_patterns)]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/src/librustc_mir/util/borrowck_errors.rs
+++ b/src/librustc_mir/util/borrowck_errors.rs
@@ -431,6 +431,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
     crate fn cannot_capture_in_long_lived_closure(
         &self,
         closure_span: Span,
+        closure_kind: &str,
         borrowed_path: &str,
         capture_span: Span,
     ) -> DiagnosticBuilder<'cx> {
@@ -438,9 +439,10 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
             self,
             closure_span,
             E0373,
-            "closure may outlive the current function, \
+            "{} may outlive the current function, \
              but it borrows {}, \
              which is owned by the current function",
+            closure_kind,
             borrowed_path,
         );
         err.span_label(capture_span, format!("{} is borrowed here", borrowed_path))

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -1238,7 +1238,13 @@ impl<'a, 'tcx> Visitor<'tcx> for TypePrivacyVisitor<'a, 'tcx> {
         if !self.in_body {
             // Avoid calling `hir_trait_to_predicates` in bodies, it will ICE.
             // The traits' privacy in bodies is already checked as a part of trait object types.
-            let bounds = rustc_typeck::hir_trait_to_predicates(self.tcx, trait_ref);
+            let bounds = rustc_typeck::hir_trait_to_predicates(
+                self.tcx,
+                trait_ref,
+                // NOTE: This isn't really right, but the actual type doesn't matter here. It's
+                // just required by `ty::TraitRef`.
+                self.tcx.types.trait_object_dummy_self,
+            );
 
             for (trait_predicate, _, _) in bounds.trait_bounds {
                 if self.visit_trait(*trait_predicate.skip_binder()) {

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -1243,7 +1243,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypePrivacyVisitor<'a, 'tcx> {
                 trait_ref,
                 // NOTE: This isn't really right, but the actual type doesn't matter here. It's
                 // just required by `ty::TraitRef`.
-                self.tcx.types.trait_object_dummy_self,
+                self.tcx.types.never,
             );
 
             for (trait_predicate, _, _) in bounds.trait_bounds {

--- a/src/librustc_query_system/dep_graph/graph.rs
+++ b/src/librustc_query_system/dep_graph/graph.rs
@@ -1112,6 +1112,7 @@ impl DepNodeColorMap {
         DepNodeColorMap { values: (0..size).map(|_| AtomicU32::new(COMPRESSED_NONE)).collect() }
     }
 
+    #[inline]
     fn get(&self, index: SerializedDepNodeIndex) -> Option<DepNodeColor> {
         match self.values[index].load(Ordering::Acquire) {
             COMPRESSED_NONE => None,

--- a/src/librustc_query_system/query/plumbing.rs
+++ b/src/librustc_query_system/query/plumbing.rs
@@ -51,6 +51,7 @@ pub struct QueryState<CTX: QueryContext, C: QueryCache> {
 }
 
 impl<CTX: QueryContext, C: QueryCache> QueryState<CTX, C> {
+    #[inline]
     pub(super) fn get_lookup<'tcx>(
         &'tcx self,
         key: &C::Key,

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2480,8 +2480,7 @@ impl<'a> Resolver<'a> {
             let (span, found_use) = UsePlacementFinder::check(krate, node_id);
             if !candidates.is_empty() {
                 diagnostics::show_candidates(&mut err, span, &candidates, better, found_use);
-            }
-            if let Some((span, msg, sugg, appl)) = suggestion {
+            } else if let Some((span, msg, sugg, appl)) = suggestion {
                 err.span_suggestion(span, msg, sugg, appl);
             }
             err.emit();

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -706,13 +706,13 @@ fn check_where_clauses<'tcx, 'fcx>(
                         return default_ty.into();
                     }
                 }
-                // Mark unwanted params as error.
-                fcx.tcx.types.err.into()
+
+                fcx.tcx.mk_param_from_def(param)
             }
 
             GenericParamDefKind::Const => {
                 // FIXME(const_generics:defaults)
-                fcx.tcx.consts.err.into()
+                fcx.tcx.mk_param_from_def(param)
             }
         }
     });
@@ -750,7 +750,10 @@ fn check_where_clauses<'tcx, 'fcx>(
             let substituted_pred = pred.subst(fcx.tcx, substs);
             // Don't check non-defaulted params, dependent defaults (including lifetimes)
             // or preds with multiple params.
-            if substituted_pred.references_error() || param_count.params.len() > 1 || has_region {
+            if substituted_pred.has_param_types_or_consts()
+                || param_count.params.len() > 1
+                || has_region
+            {
                 None
             } else if predicates.predicates.iter().any(|&(p, _)| p == substituted_pred) {
                 // Avoid duplication of predicates that contain no parameters, for example.

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -367,6 +367,7 @@ pub fn hir_ty_to_ty<'tcx>(tcx: TyCtxt<'tcx>, hir_ty: &hir::Ty<'_>) -> Ty<'tcx> {
 pub fn hir_trait_to_predicates<'tcx>(
     tcx: TyCtxt<'tcx>,
     hir_trait: &hir::TraitRef<'_>,
+    self_ty: Ty<'tcx>,
 ) -> Bounds<'tcx> {
     // In case there are any projections, etc., find the "environment"
     // def-ID that will be used to determine the traits/predicates in
@@ -380,7 +381,7 @@ pub fn hir_trait_to_predicates<'tcx>(
         hir_trait,
         DUMMY_SP,
         hir::Constness::NotConst,
-        tcx.types.err,
+        self_ty,
         &mut bounds,
         true,
     );

--- a/src/librustc_typeck/variance/constraints.rs
+++ b/src/librustc_typeck/variance/constraints.rs
@@ -315,8 +315,8 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
                 self.add_constraints_from_region(current, r, contra);
 
                 if let Some(poly_trait_ref) = data.principal() {
-                    let poly_trait_ref =
-                        poly_trait_ref.with_self_ty(self.tcx(), self.tcx().types.err);
+                    let poly_trait_ref = poly_trait_ref
+                        .with_self_ty(self.tcx(), self.tcx().types.trait_object_dummy_self);
                     self.add_constraints_from_trait_ref(
                         current,
                         *poly_trait_ref.skip_binder(),

--- a/src/librustc_typeck/variance/constraints.rs
+++ b/src/librustc_typeck/variance/constraints.rs
@@ -315,11 +315,9 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
                 self.add_constraints_from_region(current, r, contra);
 
                 if let Some(poly_trait_ref) = data.principal() {
-                    let poly_trait_ref = poly_trait_ref
-                        .with_self_ty(self.tcx(), self.tcx().types.trait_object_dummy_self);
-                    self.add_constraints_from_trait_ref(
+                    self.add_constraints_from_invariant_substs(
                         current,
-                        *poly_trait_ref.skip_binder(),
+                        poly_trait_ref.skip_binder().substs,
                         variance,
                     );
                 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1937,6 +1937,7 @@ impl Clean<Span> for rustc_span::Span {
         let hi = sm.lookup_char_pos(self.hi());
         Span {
             filename,
+            cnum: lo.file.cnum,
             loline: lo.line,
             locol: lo.col.to_usize(),
             hiline: hi.line,

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -14,7 +14,7 @@ use rustc_ast::util::comments::strip_doc_comment_decoration;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_hir as hir;
 use rustc_hir::def::Res;
-use rustc_hir::def_id::{CrateNum, DefId};
+use rustc_hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use rustc_hir::lang_items;
 use rustc_hir::Mutability;
 use rustc_index::vec::IndexVec;
@@ -1357,6 +1357,7 @@ pub enum VariantKind {
 #[derive(Clone, Debug)]
 pub struct Span {
     pub filename: FileName,
+    pub cnum: CrateNum,
     pub loline: usize,
     pub locol: usize,
     pub hiline: usize,
@@ -1368,6 +1369,7 @@ impl Span {
     pub fn empty() -> Span {
         Span {
             filename: FileName::Anon(0),
+            cnum: LOCAL_CRATE,
             loline: 0,
             locol: 0,
             hiline: 0,

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -47,7 +47,7 @@ use rustc_data_structures::flock;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_feature::UnstableFeatures;
 use rustc_hir as hir;
-use rustc_hir::def_id::DefId;
+use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_hir::Mutability;
 use rustc_middle::middle::privacy::AccessLevels;
 use rustc_middle::middle::stability;
@@ -1623,14 +1623,14 @@ impl Context {
             _ => return None,
         };
 
-        let (krate, path) = if item.def_id.is_local() {
+        let (krate, path) = if item.source.cnum == LOCAL_CRATE {
             if let Some(path) = self.shared.local_sources.get(file) {
                 (&self.shared.layout.krate, path)
             } else {
                 return None;
             }
         } else {
-            let (krate, src_root) = match *self.cache.extern_locations.get(&item.def_id.krate)? {
+            let (krate, src_root) = match *self.cache.extern_locations.get(&item.source.cnum)? {
                 (ref name, ref src, Local) => (name, src),
                 (ref name, ref src, Remote(ref s)) => {
                     root = s.to_string();

--- a/src/librustdoc/html/sources.rs
+++ b/src/librustdoc/html/sources.rs
@@ -5,6 +5,7 @@ use crate::html::format::Buffer;
 use crate::html::highlight;
 use crate::html::layout;
 use crate::html::render::{Error, SharedContext, BASIC_KEYWORDS};
+use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_span::source_map::FileName;
 use std::ffi::OsStr;
 use std::fs;
@@ -37,8 +38,8 @@ impl<'a> DocFolder for SourceCollector<'a> {
         if self.scx.include_sources
             // skip all synthetic "files"
             && item.source.filename.is_real()
-            // skip non-local items
-            && item.def_id.is_local()
+            // skip non-local files
+            && item.source.cnum == LOCAL_CRATE
         {
             // If it turns out that we couldn't read this file, then we probably
             // can't read any of the files (generating html output from json or

--- a/src/libstd/os/mod.rs
+++ b/src/libstd/os/mod.rs
@@ -24,7 +24,7 @@ cfg_if::cfg_if! {
         // If we're not documenting libstd then we just expose the main modules
         // as we otherwise would.
 
-        #[cfg(any(target_os = "redox", unix, target_os = "vxworks"))]
+        #[cfg(any(target_os = "redox", unix, target_os = "vxworks", target_os = "hermit"))]
         #[stable(feature = "rust1", since = "1.0.0")]
         pub use crate::sys::ext as unix;
 

--- a/src/libstd/sys/hermit/ext/ffi.rs
+++ b/src/libstd/sys/hermit/ext/ffi.rs
@@ -1,0 +1,38 @@
+//! HermitCore-specific extension to the primitives in the `std::ffi` module
+//!
+//! # Examples
+//!
+//! ```
+//! use std::ffi::OsString;
+//! use std::os::hermit::ffi::OsStringExt;
+//!
+//! let bytes = b"foo".to_vec();
+//!
+//! // OsStringExt::from_vec
+//! let os_string = OsString::from_vec(bytes);
+//! assert_eq!(os_string.to_str(), Some("foo"));
+//!
+//! // OsStringExt::into_vec
+//! let bytes = os_string.into_vec();
+//! assert_eq!(bytes, b"foo");
+//! ```
+//!
+//! ```
+//! use std::ffi::OsStr;
+//! use std::os::hermit::ffi::OsStrExt;
+//!
+//! let bytes = b"foo";
+//!
+//! // OsStrExt::from_bytes
+//! let os_str = OsStr::from_bytes(bytes);
+//! assert_eq!(os_str.to_str(), Some("foo"));
+//!
+//! // OsStrExt::as_bytes
+//! let bytes = os_str.as_bytes();
+//! assert_eq!(bytes, b"foo");
+//! ```
+
+#![stable(feature = "rust1", since = "1.0.0")]
+
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use crate::sys_common::os_str_bytes::*;

--- a/src/libstd/sys/hermit/ext/mod.rs
+++ b/src/libstd/sys/hermit/ext/mod.rs
@@ -1,0 +1,14 @@
+#![stable(feature = "rust1", since = "1.0.0")]
+#![allow(missing_docs)]
+
+pub mod ffi;
+
+/// A prelude for conveniently writing platform-specific code.
+///
+/// Includes all extension traits, and some important type definitions.
+#[stable(feature = "rust1", since = "1.0.0")]
+pub mod prelude {
+    #[doc(no_inline)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use super::ffi::{OsStrExt, OsStringExt};
+}

--- a/src/libstd/sys/hermit/mod.rs
+++ b/src/libstd/sys/hermit/mod.rs
@@ -21,6 +21,7 @@ pub mod args;
 pub mod cmath;
 pub mod condvar;
 pub mod env;
+pub mod ext;
 pub mod fast_thread_local;
 pub mod fd;
 pub mod fs;

--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -253,6 +253,7 @@ impl<T: 'static> LocalKey<T> {
     /// This function will still `panic!()` if the key is uninitialized and the
     /// key's initializer panics.
     #[stable(feature = "thread_local_try_with", since = "1.26.0")]
+    #[inline]
     pub fn try_with<F, R>(&'static self, f: F) -> Result<R, AccessError>
     where
         F: FnOnce(&T) -> R,

--- a/src/test/rustdoc/auxiliary/external-macro-src.rs
+++ b/src/test/rustdoc/auxiliary/external-macro-src.rs
@@ -1,0 +1,15 @@
+// compile-flags:--remap-path-prefix={{src-base}}=/does-not-exist
+
+#![doc(html_root_url = "https://example.com/")]
+
+#[macro_export]
+macro_rules! make_foo {
+    () => {
+        pub struct Foo;
+        impl Foo {
+            pub fn new() -> Foo {
+                Foo
+            }
+        }
+    }
+}

--- a/src/test/rustdoc/external-macro-src.rs
+++ b/src/test/rustdoc/external-macro-src.rs
@@ -1,0 +1,15 @@
+// aux-build:external-macro-src.rs
+// ignore-tidy-linelength
+
+#![crate_name = "foo"]
+
+#[macro_use]
+extern crate external_macro_src;
+
+// @has foo/index.html '//a[@href="../src/foo/external-macro-src.rs.html#4-15"]' '[src]'
+
+// @has foo/struct.Foo.html
+// @has - '//a[@href="https://example.com/src/external_macro_src/external-macro-src.rs.html#8"]' '[src]'
+// @has - '//a[@href="https://example.com/src/external_macro_src/external-macro-src.rs.html#9-13"]' '[src]'
+// @has - '//a[@href="https://example.com/src/external_macro_src/external-macro-src.rs.html#10-12"]' '[src]'
+make_foo!();

--- a/src/test/rustdoc/issue-26606.rs
+++ b/src/test/rustdoc/issue-26606.rs
@@ -7,5 +7,5 @@
 extern crate issue_26606_macro;
 
 // @has issue_26606/constant.FOO.html
-// @has - '//a/@href' '../src/issue_26606/auxiliary/issue-26606-macro.rs.html#3'
+// @has - '//a/@href' '../src/issue_26606_macro/issue-26606-macro.rs.html#3'
 make_item!(FOO);

--- a/src/test/rustdoc/thread-local-src.rs
+++ b/src/test/rustdoc/thread-local-src.rs
@@ -1,0 +1,6 @@
+#![crate_name = "foo"]
+
+// @has foo/index.html '//a[@href="../src/foo/thread-local-src.rs.html#1-6"]' '[src]'
+
+// @has foo/constant.FOO.html '//a/@href' 'https://doc.rust-lang.org/nightly/src/std/'
+thread_local!(pub static FOO: bool = false);

--- a/src/test/ui/async-await/async-borrowck-escaping-block-error.fixed
+++ b/src/test/ui/async-await/async-borrowck-escaping-block-error.fixed
@@ -1,12 +1,18 @@
 // edition:2018
 // run-rustfix
 
-fn foo() -> Box<impl std::future::Future<Output = u32>> {
+fn test_boxed() -> Box<impl std::future::Future<Output = u32>> {
     let x = 0u32;
     Box::new(async move { x } )
     //~^ ERROR E0373
 }
 
+fn test_ref(x: &u32) -> impl std::future::Future<Output = u32> + '_ {
+    async move { *x }
+    //~^ ERROR E0373
+}
+
 fn main() {
-    let _foo = foo();
+    let _ = test_boxed();
+    let _ = test_ref(&0u32);
 }

--- a/src/test/ui/async-await/async-borrowck-escaping-block-error.rs
+++ b/src/test/ui/async-await/async-borrowck-escaping-block-error.rs
@@ -1,12 +1,18 @@
 // edition:2018
 // run-rustfix
 
-fn foo() -> Box<impl std::future::Future<Output = u32>> {
+fn test_boxed() -> Box<impl std::future::Future<Output = u32>> {
     let x = 0u32;
     Box::new(async { x } )
     //~^ ERROR E0373
 }
 
+fn test_ref(x: &u32) -> impl std::future::Future<Output = u32> + '_ {
+    async { *x }
+    //~^ ERROR E0373
+}
+
 fn main() {
-    let _foo = foo();
+    let _ = test_boxed();
+    let _ = test_ref(&0u32);
 }

--- a/src/test/ui/async-await/async-borrowck-escaping-block-error.stderr
+++ b/src/test/ui/async-await/async-borrowck-escaping-block-error.stderr
@@ -1,4 +1,4 @@
-error[E0373]: closure may outlive the current function, but it borrows `x`, which is owned by the current function
+error[E0373]: async block may outlive the current function, but it borrows `x`, which is owned by the current function
   --> $DIR/async-borrowck-escaping-block-error.rs:6:20
    |
 LL |     Box::new(async { x } )
@@ -7,16 +7,35 @@ LL |     Box::new(async { x } )
    |                    | `x` is borrowed here
    |                    may outlive borrowed value `x`
    |
-note: generator is returned here
-  --> $DIR/async-borrowck-escaping-block-error.rs:4:13
+note: async block is returned here
+  --> $DIR/async-borrowck-escaping-block-error.rs:4:20
    |
-LL | fn foo() -> Box<impl std::future::Future<Output = u32>> {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn test_boxed() -> Box<impl std::future::Future<Output = u32>> {
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: to force the async block to take ownership of `x` (and any other referenced variables), use the `move` keyword
    |
 LL |     Box::new(async move { x } )
    |                    ^^^^^^^^^^
 
-error: aborting due to previous error
+error[E0373]: async block may outlive the current function, but it borrows `x`, which is owned by the current function
+  --> $DIR/async-borrowck-escaping-block-error.rs:11:11
+   |
+LL |     async { *x }
+   |           ^^^-^^
+   |           |  |
+   |           |  `x` is borrowed here
+   |           may outlive borrowed value `x`
+   |
+note: async block is returned here
+  --> $DIR/async-borrowck-escaping-block-error.rs:11:5
+   |
+LL |     async { *x }
+   |     ^^^^^^^^^^^^
+help: to force the async block to take ownership of `x` (and any other referenced variables), use the `move` keyword
+   |
+LL |     async move { *x }
+   |           ^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0373`.

--- a/src/test/ui/async-await/async-borrowck-escaping-closure-error.rs
+++ b/src/test/ui/async-await/async-borrowck-escaping-closure-error.rs
@@ -1,5 +1,5 @@
 // edition:2018
-#![feature(async_closure,async_await)]
+#![feature(async_closure)]
 fn foo() -> Box<dyn std::future::Future<Output = u32>> {
     let x = 0u32;
     Box::new((async || x)())

--- a/src/test/ui/impl-trait/does-not-live-long-enough.rs
+++ b/src/test/ui/impl-trait/does-not-live-long-enough.rs
@@ -4,7 +4,7 @@ struct List {
 impl List {
     fn started_with<'a>(&'a self, prefix: &'a str) -> impl Iterator<Item=&'a str> {
         self.data.iter().filter(|s| s.starts_with(prefix)).map(|s| s.as_ref())
-        //~^ ERROR does not live long enough
+        //~^ ERROR E0373
     }
 }
 

--- a/src/test/ui/impl-trait/does-not-live-long-enough.stderr
+++ b/src/test/ui/impl-trait/does-not-live-long-enough.stderr
@@ -1,21 +1,21 @@
-error[E0597]: `prefix` does not live long enough
-  --> $DIR/does-not-live-long-enough.rs:6:51
+error[E0373]: closure may outlive the current function, but it borrows `prefix`, which is owned by the current function
+  --> $DIR/does-not-live-long-enough.rs:6:33
+   |
+LL |         self.data.iter().filter(|s| s.starts_with(prefix)).map(|s| s.as_ref())
+   |                                 ^^^               ------ `prefix` is borrowed here
+   |                                 |
+   |                                 may outlive borrowed value `prefix`
+   |
+note: closure is returned here
+  --> $DIR/does-not-live-long-enough.rs:5:55
    |
 LL |     fn started_with<'a>(&'a self, prefix: &'a str) -> impl Iterator<Item=&'a str> {
-   |                     -- lifetime `'a` defined here     --------------------------- opaque type requires that `prefix` is borrowed for `'a`
-LL |         self.data.iter().filter(|s| s.starts_with(prefix)).map(|s| s.as_ref())
-   |                                 ---               ^^^^^^ borrowed value does not live long enough
-   |                                 |
-   |                                 value captured here
-LL |
-LL |     }
-   |     - `prefix` dropped here while still borrowed
+   |                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: to force the closure to take ownership of `prefix` (and any other referenced variables), use the `move` keyword
    |
-help: you can add a bound to the opaque type to make it last less than `'static` and match `'a`
-   |
-LL |     fn started_with<'a>(&'a self, prefix: &'a str) -> impl Iterator<Item=&'a str> + 'a {
-   |                                                                                   ^^^^
+LL |         self.data.iter().filter(move |s| s.starts_with(prefix)).map(|s| s.as_ref())
+   |                                 ^^^^^^^^
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0373`.

--- a/src/test/ui/privacy/privacy-ns1.stderr
+++ b/src/test/ui/privacy/privacy-ns1.stderr
@@ -63,10 +63,6 @@ LL | use foo2::Bar;
    |
 LL | use foo3::Bar;
    |
-help: you might be missing a type parameter
-   |
-LL | fn test_glob3<Bar>() {
-   |              ^^^^^
 
 error[E0107]: wrong number of const arguments: expected 0, found 1
   --> $DIR/privacy-ns1.rs:35:17

--- a/src/test/ui/suggestions/no-extern-crate-in-type.stderr
+++ b/src/test/ui/suggestions/no-extern-crate-in-type.stderr
@@ -8,10 +8,6 @@ help: possible candidate is found in another module, you can import it into scop
    |
 LL | use foo::Foo;
    |
-help: you might be missing a type parameter
-   |
-LL | type Output<Foo> = Option<Foo>;
-   |            ^^^^^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #70134 (add basic support of OsStrExt for HermitCore)
 - #70565 (Add inline attributes for functions used in the query system)
 - #70828 (rustdoc: Don't try to load source files from external crates)
 - #70870 (Fix abuses of tykind::err)
 - #70906 (Suggest move for closures and async blocks in more cases.)
 - #70912 (Do not suggest adding type param when `use` is already suggested)
 - #70930 (add tracking issue to `VecDeque::make_contiguous`)

Failed merges:


r? @ghost