### PR TITLE
simplify `vec!` macro

### DIFF
--- a/src/liballoc/macros.rs
+++ b/src/liballoc/macros.rs
@@ -42,10 +42,9 @@ macro_rules! vec {
     ($elem:expr; $n:expr) => (
         $crate::vec::from_elem($elem, $n)
     );
-    ($($x:expr),*) => (
+    ($($x:expr),* $(,)?) => (
         <[_]>::into_vec(box [$($x),*])
     );
-    ($($x:expr,)*) => ($crate::vec![$($x),*])
 }
 
 // HACK(japaric): with cfg(test) the inherent `[T]::into_vec` method, which is

--- a/src/liballoc/macros.rs
+++ b/src/liballoc/macros.rs
@@ -42,8 +42,8 @@ macro_rules! vec {
     ($elem:expr; $n:expr) => (
         $crate::vec::from_elem($elem, $n)
     );
-    ($($x:expr),* $(,)?) => (
-        <[_]>::into_vec(box [$($x),*])
+    ($($x:expr),+ $(,)?) => (
+        <[_]>::into_vec(box [$($x),+])
     );
 }
 


### PR DESCRIPTION
Simplify `vec!` macro by replacing 2 following branches:
- `($($x:expr),*) => (...)`
- `($($x:expr,)*) => (...)`
with one:
- `($($x:expr),* $(,)?) => (...)`

This is a minor change, however, this will make the documentation cleaner 