### PR TITLE
 librustc_middle: change query functions to accept impl Into<$K> type

### DIFF
--- a/src/librustc_codegen_ssa/mir/constant.rs
+++ b/src/librustc_codegen_ssa/mir/constant.rs
@@ -83,7 +83,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 let values: Vec<_> = (0..fields)
                     .map(|field| {
                         let field = bx.tcx().const_field(
-                            ty::ParamEnv::reveal_all().and((&c, mir::Field::new(field as usize))),
+                            ty::ParamEnv::reveal_all().and((c, mir::Field::new(field as usize))),
                         );
                         if let Some(prim) = field.try_to_scalar() {
                             let layout = bx.layout_of(field_ty);

--- a/src/librustc_infer/infer/error_reporting/mod.rs
+++ b/src/librustc_infer/infer/error_reporting/mod.rs
@@ -1773,7 +1773,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             (Some(ref table), GenericKind::Param(ref param)) => {
                 let table_owner = table.borrow().hir_owner;
                 table_owner.and_then(|table_owner| {
-                    let generics = self.tcx.generics_of(table_owner.to_def_id());
+                    let generics = self.tcx.generics_of(table_owner);
                     // Account for the case where `param` corresponds to `Self`,
                     // which doesn't have the expected type argument.
                     if !(generics.has_self && param.index == 0) {

--- a/src/librustc_middle/mir/mono.rs
+++ b/src/librustc_middle/mir/mono.rs
@@ -168,7 +168,7 @@ impl<'tcx> MonoItem<'tcx> {
             MonoItem::GlobalAsm(..) => return true,
         };
 
-        tcx.substitute_normalize_and_test_predicates((def_id, &substs))
+        tcx.substitute_normalize_and_test_predicates((def_id, substs))
     }
 
     pub fn to_string(&self, tcx: TyCtxt<'tcx>, debug: bool) -> String {

--- a/src/librustc_middle/ty/query/plumbing.rs
+++ b/src/librustc_middle/ty/query/plumbing.rs
@@ -380,8 +380,8 @@ macro_rules! define_queries_inner {
         impl TyCtxtEnsure<$tcx> {
             $($(#[$attr])*
             #[inline(always)]
-            pub fn $name(self, key: $K) {
-                ensure_query::<queries::$name<'_>, _>(self.tcx, key)
+            pub fn $name(self, key: impl Into<$K>) {
+                ensure_query::<queries::$name<'_>, _>(self.tcx, key.into())
             })*
         }
 
@@ -421,7 +421,7 @@ macro_rules! define_queries_inner {
 
             $($(#[$attr])*
             #[inline(always)]
-            pub fn $name(self, key: $K) -> $V {
+            pub fn $name(self, key: impl Into<$K>) -> $V {
                 self.at(DUMMY_SP).$name(key)
             })*
 
@@ -458,8 +458,8 @@ macro_rules! define_queries_inner {
         impl TyCtxtAt<$tcx> {
             $($(#[$attr])*
             #[inline(always)]
-            pub fn $name(self, key: $K) -> $V {
-                get_query::<queries::$name<'_>, _>(self.tcx, self.span, key)
+            pub fn $name(self, key: impl Into<$K>) -> $V {
+                get_query::<queries::$name<'_>, _>(self.tcx, self.span, key.into())
             })*
         }
 

--- a/src/librustc_middle/ty/sty.rs
+++ b/src/librustc_middle/ty/sty.rs
@@ -2242,7 +2242,7 @@ impl<'tcx> Const<'tcx> {
 
         let expr = &tcx.hir().body(body_id).value;
 
-        let ty = tcx.type_of(def_id.to_def_id());
+        let ty = tcx.type_of(def_id);
 
         let lit_input = match expr.kind {
             hir::ExprKind::Lit(ref lit) => Some(LitToConstInput { lit: &lit.node, ty, neg: false }),

--- a/src/librustc_middle/ty/trait_def.rs
+++ b/src/librustc_middle/ty/trait_def.rs
@@ -193,7 +193,7 @@ pub(super) fn trait_impls_of_provider(tcx: TyCtxt<'_>, trait_id: DefId) -> &Trai
     let mut impls = TraitImpls::default();
 
     {
-        let mut add_impl = |impl_def_id| {
+        let mut add_impl = |impl_def_id: DefId| {
             let impl_self_ty = tcx.type_of(impl_def_id);
             if impl_def_id.is_local() && impl_self_ty.references_error() {
                 return;

--- a/src/librustc_span/def_id.rs
+++ b/src/librustc_span/def_id.rs
@@ -195,6 +195,12 @@ impl fmt::Debug for DefId {
     }
 }
 
+impl From<LocalDefId> for DefId {
+    fn from(local_def_id: LocalDefId) -> DefId {
+        local_def_id.to_def_id()
+    }
+}
+
 rustc_data_structures::define_id_collections!(DefIdMap, DefIdSet, DefId);
 
 /// A LocalDefId is equivalent to a DefId with `krate == LOCAL_CRATE`. Since

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -1618,7 +1618,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     fn point_at_param_definition(&self, err: &mut DiagnosticBuilder<'_>, param: ty::ParamTy) {
-        let generics = self.tcx.generics_of(self.body_id.owner.to_def_id());
+        let generics = self.tcx.generics_of(self.body_id.owner);
         let generic_param = generics.type_param(&param, self.tcx);
         if let ty::GenericParamDefKind::Type { synthetic: Some(..), .. } = generic_param.kind {
             return;

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -1023,7 +1023,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             if let (Some(ref param), Some(ref table)) = (param_type, self.in_progress_tables) {
                 let table_owner = table.borrow().hir_owner;
                 if let Some(table_owner) = table_owner {
-                    let generics = self.tcx.generics_of(table_owner.to_def_id());
+                    let generics = self.tcx.generics_of(table_owner);
                     let type_param = generics.type_param(param, self.tcx);
                     let hir = &self.tcx.hir();
                     if let Some(id) = hir.as_local_hir_id(type_param.def_id) {


### PR DESCRIPTION
This should help to increase the usage of LocalDefId instead of DefId.