### PR TITLE
Normalize MIR locals' types for generator layout computation.

### DIFF
--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -720,15 +720,18 @@ fn compute_layout<'tcx>(
         _ => bug!(),
     };
 
+    let param_env = tcx.param_env(source.def_id());
+
     for (local, decl) in body.local_decls.iter_enumerated() {
         // Ignore locals which are internal or not live
         if !live_locals.contains(local) || decl.internal {
             continue;
         }
+        let decl_ty = tcx.normalize_erasing_regions(param_env, decl.ty);
 
         // Sanity check that typeck knows about the type of locals which are
         // live across a suspension point
-        if !allowed.contains(&decl.ty) && !allowed_upvars.contains(&decl.ty) {
+        if !allowed.contains(&decl_ty) && !allowed_upvars.contains(&decl_ty) {
             span_bug!(
                 body.span,
                 "Broken MIR: generator contains type {} in MIR, \

--- a/src/test/ui/repeat_count_const_in_async_fn.rs
+++ b/src/test/ui/repeat_count_const_in_async_fn.rs
@@ -1,0 +1,10 @@
+// check-pass
+// edition:2018
+// compile-flags: --crate-type=lib
+
+pub async fn test() {
+    const C: usize = 4;
+    foo(&mut [0u8; C]).await;
+}
+
+async fn foo(_: &mut [u8]) {}


### PR DESCRIPTION
fixes #70905 