### PR TITLE
Suggest `-> impl Trait` and `-> Box<dyn Trait>` on fn that doesn't return

### DIFF
--- a/src/librustc_error_codes/error_codes/E0746.md
+++ b/src/librustc_error_codes/error_codes/E0746.md
@@ -2,8 +2,7 @@ Return types cannot be `dyn Trait`s as they must be `Sized`.
 
 Erroneous code example:
 
-```compile_fail,E0277
-# // FIXME: after E0746 is in beta, change the above
+```compile_fail,E0746
 trait T {
     fn bar(&self);
 }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1305,7 +1305,6 @@ fn check_fn<'a, 'tcx>(
     let hir = tcx.hir();
 
     let declared_ret_ty = fn_sig.output();
-    fcx.require_type_is_sized(declared_ret_ty, decl.output.span(), traits::SizedReturnType);
     let revealed_ret_ty =
         fcx.instantiate_opaque_types_from_value(fn_id, &declared_ret_ty, decl.output.span());
     debug!("check_fn: declared_ret_ty: {}, revealed_ret_ty: {}", declared_ret_ty, revealed_ret_ty);
@@ -1374,7 +1373,25 @@ fn check_fn<'a, 'tcx>(
 
     inherited.tables.borrow_mut().liberated_fn_sigs_mut().insert(fn_id, fn_sig);
 
-    fcx.check_return_expr(&body.value);
+    if let ty::Dynamic(..) = declared_ret_ty.kind {
+        // FIXME: We need to verify that the return type is `Sized` after the return expression has
+        // been evaluated so that we have types available for all the nodes being returned, but that
+        // requires the coerced evaluated type to be stored. Moving `check_return_expr` before this
+        // causes unsized errors caused by the `declared_ret_ty` to point at the return expression,
+        // while keeping the current ordering we will ignore the tail expression's type because we
+        // don't know it yet. We can't do `check_expr_kind` while keeping `check_return_expr`
+        // because we will trigger "unreachable expression" lints unconditionally.
+        // Because of all of this, we perform a crude check to know whether the simplest `!Sized`
+        // case that a newcomer might make, returning a bare trait, and in that case we populate
+        // the tail expression's type so that the suggestion will be correct, but ignore all other
+        // possible cases.
+        fcx.check_expr(&body.value);
+        fcx.require_type_is_sized(declared_ret_ty, decl.output.span(), traits::SizedReturnType);
+        tcx.sess.delay_span_bug(decl.output.span(), "`!Sized` return type");
+    } else {
+        fcx.require_type_is_sized(declared_ret_ty, decl.output.span(), traits::SizedReturnType);
+        fcx.check_return_expr(&body.value);
+    }
 
     // We insert the deferred_generator_interiors entry after visiting the body.
     // This ensures that all nested generators appear before the entry of this generator.

--- a/src/test/ui/error-codes/E0746.stderr
+++ b/src/test/ui/error-codes/E0746.stderr
@@ -5,7 +5,7 @@ LL | fn foo() -> dyn Trait { Struct }
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
    = note: for information on `impl Trait`, see <https://doc.rust-lang.org/book/ch10-02-traits.html#returning-types-that-implement-traits>
-help: return `impl Trait` instead, as all return paths are of type `Struct`, which implements `Trait`
+help: use `impl Trait` as the return type, as all return paths are of type `Struct`, which implements `Trait`
    |
 LL | fn foo() -> impl Trait { Struct }
    |             ^^^^^^^^^^
@@ -17,7 +17,7 @@ LL | fn bar() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
    = note: for information on `impl Trait`, see <https://doc.rust-lang.org/book/ch10-02-traits.html#returning-types-that-implement-traits>
-help: return `impl Trait` instead, as all return paths are of type `{integer}`, which implements `Trait`
+help: use `impl Trait` as the return type, as all return paths are of type `{integer}`, which implements `Trait`
    |
 LL | fn bar() -> impl Trait {
    |             ^^^^^^^^^^

--- a/src/test/ui/impl-trait/dyn-trait-return-should-be-impl-trait.rs
+++ b/src/test/ui/impl-trait/dyn-trait-return-should-be-impl-trait.rs
@@ -26,7 +26,7 @@ fn bax() -> dyn Trait { //~ ERROR E0746
     if true {
         Struct
     } else {
-        42
+        42 //~ ERROR `if` and `else` have incompatible types
     }
 }
 fn bam() -> Box<dyn Trait> {

--- a/src/test/ui/impl-trait/dyn-trait-return-should-be-impl-trait.rs
+++ b/src/test/ui/impl-trait/dyn-trait-return-should-be-impl-trait.rs
@@ -14,7 +14,7 @@ fn bap() -> Trait { Struct }
 //~^ ERROR E0746
 fn ban() -> dyn Trait { Struct }
 //~^ ERROR E0746
-fn bak() -> dyn Trait { unimplemented!() } //~ ERROR E0277
+fn bak() -> dyn Trait { unimplemented!() } //~ ERROR E0746
 // Suggest using `Box<dyn Trait>`
 fn bal() -> dyn Trait { //~ ERROR E0746
     if true {

--- a/src/test/ui/impl-trait/dyn-trait-return-should-be-impl-trait.stderr
+++ b/src/test/ui/impl-trait/dyn-trait-return-should-be-impl-trait.stderr
@@ -49,7 +49,7 @@ LL | fn bap() -> Trait { Struct }
    |             ^^^^^ doesn't have a size known at compile-time
    |
    = note: for information on `impl Trait`, see <https://doc.rust-lang.org/book/ch10-02-traits.html#returning-types-that-implement-traits>
-help: return `impl Trait` instead, as all return paths are of type `Struct`, which implements `Trait`
+help: use `impl Trait` as the return type, as all return paths are of type `Struct`, which implements `Trait`
    |
 LL | fn bap() -> impl Trait { Struct }
    |             ^^^^^^^^^^
@@ -61,20 +61,32 @@ LL | fn ban() -> dyn Trait { Struct }
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
    = note: for information on `impl Trait`, see <https://doc.rust-lang.org/book/ch10-02-traits.html#returning-types-that-implement-traits>
-help: return `impl Trait` instead, as all return paths are of type `Struct`, which implements `Trait`
+help: use `impl Trait` as the return type, as all return paths are of type `Struct`, which implements `Trait`
    |
 LL | fn ban() -> impl Trait { Struct }
    |             ^^^^^^^^^^
 
-error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+error[E0746]: return type cannot have an unboxed trait object
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:17:13
    |
 LL | fn bak() -> dyn Trait { unimplemented!() }
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `(dyn Trait + 'static)`
-   = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: the return type of a function must have a statically known size
+   = note: currently nothing is being returned, depending on the final implementation you could change the return type in different ways
+   = note: for information on `impl Trait`, see <https://doc.rust-lang.org/book/ch10-02-traits.html#returning-types-that-implement-traits>
+   = note: for information on trait objects, see <https://doc.rust-lang.org/book/ch17-02-trait-objects.html#using-trait-objects-that-allow-for-values-of-different-types>
+help: you could use some type `T` that is `T: Sized` as the return type if all return paths will have the same type
+   |
+LL | fn bak() -> T { unimplemented!() }
+   |             ^
+help: you could use `impl Trait` as the return type if all return paths will have the same type but you want to expose only the trait in the signature
+   |
+LL | fn bak() -> impl Trait { unimplemented!() }
+   |             ^^^^^^^^^^
+help: you could use a boxed trait object if all return paths `impl` trait `Trait`
+   |
+LL | fn bak() -> Box<dyn Trait> { unimplemented!() }
+   |             ^^^^^^^^^^^^^^
 
 error[E0746]: return type cannot have an unboxed trait object
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:19:13
@@ -249,7 +261,7 @@ LL | fn bat() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
    = note: for information on `impl Trait`, see <https://doc.rust-lang.org/book/ch10-02-traits.html#returning-types-that-implement-traits>
-help: return `impl Trait` instead, as all return paths are of type `{integer}`, which implements `Trait`
+help: use `impl Trait` as the return type, as all return paths are of type `{integer}`, which implements `Trait`
    |
 LL | fn bat() -> impl Trait {
    |             ^^^^^^^^^^
@@ -261,7 +273,7 @@ LL | fn bay() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
    = note: for information on `impl Trait`, see <https://doc.rust-lang.org/book/ch10-02-traits.html#returning-types-that-implement-traits>
-help: return `impl Trait` instead, as all return paths are of type `{integer}`, which implements `Trait`
+help: use `impl Trait` as the return type, as all return paths are of type `{integer}`, which implements `Trait`
    |
 LL | fn bay() -> impl Trait {
    |             ^^^^^^^^^^

--- a/src/test/ui/impl-trait/dyn-trait-return-should-be-impl-trait.stderr
+++ b/src/test/ui/impl-trait/dyn-trait-return-should-be-impl-trait.stderr
@@ -72,18 +72,15 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn bak() -> dyn Trait { unimplemented!() }
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = note: currently nothing is being returned, depending on the final implementation you could change the return type in different ways
-   = note: for information on `impl Trait`, see <https://doc.rust-lang.org/book/ch10-02-traits.html#returning-types-that-implement-traits>
-   = note: for information on trait objects, see <https://doc.rust-lang.org/book/ch17-02-trait-objects.html#using-trait-objects-that-allow-for-values-of-different-types>
-help: you could use some type `T` that is `T: Sized` as the return type if all return paths will have the same type
+help: use some type `T` that is `T: Sized` as the return type if all return paths have the same type
    |
 LL | fn bak() -> T { unimplemented!() }
    |             ^
-help: you could use `impl Trait` as the return type if all return paths will have the same type but you want to expose only the trait in the signature
+help: use `impl Trait` as the return type if all return paths have the same type but you want to expose only the trait in the signature
    |
 LL | fn bak() -> impl Trait { unimplemented!() }
    |             ^^^^^^^^^^
-help: you could use a boxed trait object if all return paths `impl` trait `Trait`
+help: use a boxed trait object if all return paths implement trait `Trait`
    |
 LL | fn bak() -> Box<dyn Trait> { unimplemented!() }
    |             ^^^^^^^^^^^^^^
@@ -106,6 +103,18 @@ LL |         return Box::new(Struct);
 LL |     }
 LL |     Box::new(42)
    |
+
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:29:9
+   |
+LL | /     if true {
+LL | |         Struct
+   | |         ------ expected because of this
+LL | |     } else {
+LL | |         42
+   | |         ^^ expected struct `Struct`, found integer
+LL | |     }
+   | |_____- `if` and `else` have incompatible types
 
 error[E0746]: return type cannot have an unboxed trait object
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:25:13
@@ -278,7 +287,7 @@ help: use `impl Trait` as the return type, as all return paths are of type `{int
 LL | fn bay() -> impl Trait {
    |             ^^^^^^^^^^
 
-error: aborting due to 19 previous errors
+error: aborting due to 20 previous errors
 
 Some errors have detailed explanations: E0277, E0308, E0746.
 For more information about an error, try `rustc --explain E0277`.

--- a/src/test/ui/issues/issue-18107.rs
+++ b/src/test/ui/issues/issue-18107.rs
@@ -2,7 +2,7 @@ pub trait AbstractRenderer {}
 
 fn _create_render(_: &()) ->
     dyn AbstractRenderer
-//~^ ERROR the size for values of type
+//~^ ERROR return type cannot have an unboxed trait object
 {
     match 0 {
         _ => unimplemented!()

--- a/src/test/ui/issues/issue-18107.stderr
+++ b/src/test/ui/issues/issue-18107.stderr
@@ -4,18 +4,15 @@ error[E0746]: return type cannot have an unboxed trait object
 LL |     dyn AbstractRenderer
    |     ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = note: currently nothing is being returned, depending on the final implementation you could change the return type in different ways
-   = note: for information on `impl Trait`, see <https://doc.rust-lang.org/book/ch10-02-traits.html#returning-types-that-implement-traits>
-   = note: for information on trait objects, see <https://doc.rust-lang.org/book/ch17-02-trait-objects.html#using-trait-objects-that-allow-for-values-of-different-types>
-help: you could use some type `T` that is `T: Sized` as the return type if all return paths will have the same type
+help: use some type `T` that is `T: Sized` as the return type if all return paths have the same type
    |
 LL |     T
    |
-help: you could use `impl AbstractRenderer` as the return type if all return paths will have the same type but you want to expose only the trait in the signature
+help: use `impl AbstractRenderer` as the return type if all return paths have the same type but you want to expose only the trait in the signature
    |
 LL |     impl AbstractRenderer
    |
-help: you could use a boxed trait object if all return paths `impl` trait `AbstractRenderer`
+help: use a boxed trait object if all return paths implement trait `AbstractRenderer`
    |
 LL |     Box<dyn AbstractRenderer>
    |

--- a/src/test/ui/issues/issue-18107.stderr
+++ b/src/test/ui/issues/issue-18107.stderr
@@ -1,13 +1,25 @@
-error[E0277]: the size for values of type `(dyn AbstractRenderer + 'static)` cannot be known at compilation time
+error[E0746]: return type cannot have an unboxed trait object
   --> $DIR/issue-18107.rs:4:5
    |
 LL |     dyn AbstractRenderer
    |     ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `(dyn AbstractRenderer + 'static)`
-   = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: the return type of a function must have a statically known size
+   = note: currently nothing is being returned, depending on the final implementation you could change the return type in different ways
+   = note: for information on `impl Trait`, see <https://doc.rust-lang.org/book/ch10-02-traits.html#returning-types-that-implement-traits>
+   = note: for information on trait objects, see <https://doc.rust-lang.org/book/ch17-02-trait-objects.html#using-trait-objects-that-allow-for-values-of-different-types>
+help: you could use some type `T` that is `T: Sized` as the return type if all return paths will have the same type
+   |
+LL |     T
+   |
+help: you could use `impl AbstractRenderer` as the return type if all return paths will have the same type but you want to expose only the trait in the signature
+   |
+LL |     impl AbstractRenderer
+   |
+help: you could use a boxed trait object if all return paths `impl` trait `AbstractRenderer`
+   |
+LL |     Box<dyn AbstractRenderer>
+   |
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0746`.


### PR DESCRIPTION
During development, a function could have a return type set that is a
bare trait object by accident. We already suggest using either a boxed
trait object or `impl Trait` if the return paths will allow it. We now
do so too when there are *no* return paths or they all resolve to `!`.
We still don't handle cases where the trait object is *not* the entirety
of the return type gracefully.

Closes #38376.