### PR TITLE
fix target & runtool args order

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -263,7 +263,12 @@ fn run_test(
     if no_run && !compile_fail {
         compiler.arg("--emit=metadata");
     }
-    compiler.arg("--target").arg(target.to_string());
+    compiler.arg("--target").arg(match target {
+        TargetTriple::TargetTriple(s) => s,
+        TargetTriple::TargetPath(path) => {
+            path.to_str().expect("target path must be valid unicode").to_string()
+        }
+    });
 
     compiler.arg("-");
     compiler.stdin(Stdio::piped());
@@ -312,8 +317,8 @@ fn run_test(
 
     if let Some(tool) = runtool {
         cmd = Command::new(tool);
-        cmd.arg(output_file);
         cmd.args(runtool_args);
+        cmd.arg(output_file);
     } else {
         cmd = Command::new(output_file);
     }


### PR DESCRIPTION
- `TargetTripple::to_string` converts "path triples" to `<target>-<hash>`, but in this case we need the path. Afaict there is no method to get the real triple other than manually matching
- the order of the runtools arguments is inconsistent with the way tests usually pass arguments ie using `runner` key in `.cargo/config`