### PR TITLE
Deprecate the asm! macro in favor of llvm_asm!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,7 +1736,7 @@ checksum = "5b31c9b90731276fdd24d896f31bb10aecf2e5151733364ae81123186643d939"
 dependencies = [
  "jsonrpc-core",
  "log",
- "parking_lot 0.10.0",
+ "parking_lot 0.10.2",
  "serde",
 ]
 
@@ -1855,9 +1855,9 @@ checksum = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 
 [[package]]
 name = "lock_api"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
+checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
 dependencies = [
  "scopeguard",
 ]
@@ -2395,12 +2395,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
+checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.7.0",
+ "parking_lot_core 0.7.1",
 ]
 
 [[package]]
@@ -2420,9 +2420,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
+checksum = "0e136c1904604defe99ce5fd71a28d473fa60a12255d511aa78a9ddf11237aeb"
 dependencies = [
  "cfg-if",
  "cloudabi",
@@ -3240,7 +3240,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "log",
  "measureme",
- "parking_lot 0.10.0",
+ "parking_lot 0.10.2",
  "rustc-ap-graphviz",
  "rustc-ap-rustc_index",
  "rustc-ap-serialize",
@@ -3686,7 +3686,7 @@ dependencies = [
  "libc",
  "log",
  "measureme",
- "parking_lot 0.10.0",
+ "parking_lot 0.10.2",
  "rustc-hash",
  "rustc-rayon",
  "rustc-rayon-core",
@@ -3984,7 +3984,7 @@ dependencies = [
  "jobserver",
  "log",
  "measureme",
- "parking_lot 0.10.0",
+ "parking_lot 0.10.2",
  "polonius-engine",
  "rustc-rayon",
  "rustc-rayon-core",
@@ -4133,7 +4133,7 @@ name = "rustc_query_system"
 version = "0.0.0"
 dependencies = [
  "log",
- "parking_lot 0.9.0",
+ "parking_lot 0.10.2",
  "rustc-rayon-core",
  "rustc_data_structures",
  "rustc_errors",

--- a/src/libcore/macros/mod.rs
+++ b/src/libcore/macros/mod.rs
@@ -1316,9 +1316,13 @@ pub(crate) mod builtin {
         issue = "70173",
         reason = "inline assembly is not stable enough for use and is subject to change"
     )]
-    #[rustc_deprecated(
-        since = "1.44.0",
-        reason = "the syntax of asm! will change soon, use llvm_asm! to avoid breakage"
+    #[cfg_attr(
+        not(bootstrap),
+        rustc_deprecated(
+            since = "1.44.0",
+            reason = "the syntax of asm! will change soon, use llvm_asm! to avoid breakage",
+            suggestion = "llvm_asm",
+        )
     )]
     #[rustc_builtin_macro]
     #[macro_export]

--- a/src/libcore/macros/mod.rs
+++ b/src/libcore/macros/mod.rs
@@ -1316,6 +1316,10 @@ pub(crate) mod builtin {
         issue = "70173",
         reason = "inline assembly is not stable enough for use and is subject to change"
     )]
+    #[rustc_deprecated(
+        since = "1.44.0",
+        reason = "the syntax of asm! will change soon, use llvm_asm! to avoid breakage"
+    )]
     #[rustc_builtin_macro]
     #[macro_export]
     macro_rules! asm {

--- a/src/libcore/prelude/v1.rs
+++ b/src/libcore/prelude/v1.rs
@@ -54,6 +54,7 @@ pub use crate::fmt::macros::Debug;
 pub use crate::hash::macros::Hash;
 
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[allow(deprecated)]
 #[doc(no_inline)]
 pub use crate::{
     asm, assert, cfg, column, compile_error, concat, concat_idents, env, file, format_args,

--- a/src/librustc_query_system/Cargo.toml
+++ b/src/librustc_query_system/Cargo.toml
@@ -18,5 +18,5 @@ rustc_index = { path = "../librustc_index" }
 rustc_macros = { path = "../librustc_macros" }
 rustc_serialize = { path = "../libserialize", package = "serialize" }
 rustc_span = { path = "../librustc_span" }
-parking_lot = "0.9"
+parking_lot = "0.10"
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -523,6 +523,7 @@ pub use core::{
 
 // Re-export built-in macros defined through libcore.
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[allow(deprecated)]
 pub use core::{
     asm, assert, cfg, column, compile_error, concat, concat_idents, env, file, format_args,
     format_args_nl, global_asm, include, include_bytes, include_str, line, llvm_asm, log_syntax,

--- a/src/libstd/prelude/v1.rs
+++ b/src/libstd/prelude/v1.rs
@@ -36,6 +36,7 @@ pub use crate::result::Result::{self, Err, Ok};
 
 // Re-exported built-in macros
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[allow(deprecated)]
 #[doc(no_inline)]
 pub use core::prelude::v1::{
     asm, assert, cfg, column, compile_error, concat, concat_idents, env, file, format_args,

--- a/src/test/ui/feature-gates/feature-gate-asm.rs
+++ b/src/test/ui/feature-gates/feature-gate-asm.rs
@@ -3,6 +3,7 @@
 fn main() {
     unsafe {
         asm!(""); //~ ERROR inline assembly is not stable enough
+        //~^ WARN use of deprecated item 'asm'
         llvm_asm!(""); //~ ERROR inline assembly is not stable enough
     }
 }

--- a/src/test/ui/feature-gates/feature-gate-asm.stderr
+++ b/src/test/ui/feature-gates/feature-gate-asm.stderr
@@ -8,7 +8,7 @@ LL |         asm!("");
    = help: add `#![feature(asm)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'llvm_asm': inline assembly is not stable enough for use and is subject to change
-  --> $DIR/feature-gate-asm.rs:6:9
+  --> $DIR/feature-gate-asm.rs:7:9
    |
 LL |         llvm_asm!("");
    |         ^^^^^^^^
@@ -16,6 +16,14 @@ LL |         llvm_asm!("");
    = note: see issue #70173 <https://github.com/rust-lang/rust/issues/70173> for more information
    = help: add `#![feature(llvm_asm)]` to the crate attributes to enable
 
-error: aborting due to 2 previous errors
+warning: use of deprecated item 'asm': the syntax of asm! will change soon, use llvm_asm! to avoid breakage
+  --> $DIR/feature-gate-asm.rs:5:9
+   |
+LL |         asm!("");
+   |         ^^^ help: replace the use of the deprecated item: `llvm_asm`
+   |
+   = note: `#[warn(deprecated)]` on by default
+
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gates/feature-gate-asm2.rs
+++ b/src/test/ui/feature-gates/feature-gate-asm2.rs
@@ -3,6 +3,7 @@
 fn main() {
     unsafe {
         println!("{:?}", asm!("")); //~ ERROR inline assembly is not stable
+        //~^ WARN use of deprecated item 'asm'
         println!("{:?}", llvm_asm!("")); //~ ERROR inline assembly is not stable
     }
 }

--- a/src/test/ui/feature-gates/feature-gate-asm2.stderr
+++ b/src/test/ui/feature-gates/feature-gate-asm2.stderr
@@ -8,7 +8,7 @@ LL |         println!("{:?}", asm!(""));
    = help: add `#![feature(asm)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'llvm_asm': inline assembly is not stable enough for use and is subject to change
-  --> $DIR/feature-gate-asm2.rs:6:26
+  --> $DIR/feature-gate-asm2.rs:7:26
    |
 LL |         println!("{:?}", llvm_asm!(""));
    |                          ^^^^^^^^
@@ -16,6 +16,14 @@ LL |         println!("{:?}", llvm_asm!(""));
    = note: see issue #70173 <https://github.com/rust-lang/rust/issues/70173> for more information
    = help: add `#![feature(llvm_asm)]` to the crate attributes to enable
 
-error: aborting due to 2 previous errors
+warning: use of deprecated item 'asm': the syntax of asm! will change soon, use llvm_asm! to avoid breakage
+  --> $DIR/feature-gate-asm2.rs:5:26
+   |
+LL |         println!("{:?}", asm!(""));
+   |                          ^^^ help: replace the use of the deprecated item: `llvm_asm`
+   |
+   = note: `#[warn(deprecated)]` on by default
+
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Since we will be changing the syntax of `asm!` soon, deprecate it and encourage people to use `llvm_asm!` instead (which preserves the old syntax). This will avoid breakage when `asm!` is changed.

RFC: https://github.com/rust-lang/rfcs/pull/2843