### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/src/librustc_codegen_llvm/type_of.rs
+++ b/src/librustc_codegen_llvm/type_of.rs
@@ -81,7 +81,7 @@ fn uncached_llvm_type<'a, 'tcx>(
     };
 
     match layout.fields {
-        FieldsShape::Union(_) => {
+        FieldsShape::Primitive | FieldsShape::Union(_) => {
             let fill = cx.type_padding_filler(layout.size, layout.align.abi);
             let packed = false;
             match name {
@@ -368,7 +368,7 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyAndLayout<'tcx> {
             _ => {}
         }
         match self.fields {
-            FieldsShape::Union(_) => {
+            FieldsShape::Primitive | FieldsShape::Union(_) => {
                 bug!("TyAndLayout::llvm_field_index({:?}): not applicable", self)
             }
 

--- a/src/librustc_data_structures/stable_hasher.rs
+++ b/src/librustc_data_structures/stable_hasher.rs
@@ -210,6 +210,12 @@ impl<CTX> HashStable<CTX> for ::std::num::NonZeroU32 {
     }
 }
 
+impl<CTX> HashStable<CTX> for ::std::num::NonZeroUsize {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+        self.get().hash_stable(ctx, hasher)
+    }
+}
+
 impl<CTX> HashStable<CTX> for f32 {
     fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         let val: u32 = unsafe { ::std::mem::transmute(*self) };

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -312,6 +312,9 @@ struct HandlerInner {
     /// The stashed diagnostics count towards the total error count.
     /// When `.abort_if_errors()` is called, these are also emitted.
     stashed_diagnostics: FxIndexMap<(Span, StashKey), Diagnostic>,
+
+    /// The warning count, used for a recap upon finishing
+    deduplicated_warn_count: usize,
 }
 
 /// A key denoting where from a diagnostic was stashed.
@@ -414,6 +417,7 @@ impl Handler {
                 flags,
                 err_count: 0,
                 deduplicated_err_count: 0,
+                deduplicated_warn_count: 0,
                 emitter,
                 delayed_span_bugs: Vec::new(),
                 taught_diagnostics: Default::default(),
@@ -439,6 +443,7 @@ impl Handler {
         let mut inner = self.inner.borrow_mut();
         inner.err_count = 0;
         inner.deduplicated_err_count = 0;
+        inner.deduplicated_warn_count = 0;
 
         // actually free the underlying memory (which `clear` would not do)
         inner.delayed_span_bugs = Default::default();
@@ -745,6 +750,8 @@ impl HandlerInner {
             self.emitter.emit_diagnostic(diagnostic);
             if diagnostic.is_error() {
                 self.deduplicated_err_count += 1;
+            } else if diagnostic.level == Warning {
+                self.deduplicated_warn_count += 1;
             }
         }
         if diagnostic.is_error() {
@@ -763,8 +770,13 @@ impl HandlerInner {
     fn print_error_count(&mut self, registry: &Registry) {
         self.emit_stashed_diagnostics();
 
-        let s = match self.deduplicated_err_count {
-            0 => return,
+        let warnings = match self.deduplicated_warn_count {
+            0 => String::new(),
+            1 => "1 warning emitted".to_string(),
+            count => format!("{} warnings emitted", count),
+        };
+        let errors = match self.deduplicated_err_count {
+            0 => String::new(),
             1 => "aborting due to previous error".to_string(),
             count => format!("aborting due to {} previous errors", count),
         };
@@ -772,7 +784,16 @@ impl HandlerInner {
             return;
         }
 
-        let _ = self.fatal(&s);
+        match (errors.len(), warnings.len()) {
+            (0, 0) => return,
+            (0, _) => self.emit_diagnostic(&Diagnostic::new(Level::Warning, &warnings)),
+            (_, 0) => {
+                let _ = self.fatal(&errors);
+            }
+            (_, _) => {
+                let _ = self.fatal(&format!("{}; {}", &errors, &warnings));
+            }
+        }
 
         let can_show_explain = self.emitter.should_show_explain();
         let are_there_diagnostics = !self.emitted_diagnostic_codes.is_empty();

--- a/src/librustc_infer/infer/error_reporting/mod.rs
+++ b/src/librustc_infer/infer/error_reporting/mod.rs
@@ -59,7 +59,7 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::{pluralize, struct_span_err};
 use rustc_errors::{Applicability, DiagnosticBuilder, DiagnosticStyledString};
 use rustc_hir as hir;
-use rustc_hir::def_id::{DefId, LocalDefId};
+use rustc_hir::def_id::DefId;
 use rustc_hir::Node;
 use rustc_middle::middle::region;
 use rustc_middle::ty::error::TypeError;
@@ -1589,16 +1589,12 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         // it's a actual definition. According to the comments (e.g. in
         // librustc_typeck/check/compare_method.rs:compare_predicate_entailment) the latter
         // is relied upon by some other code. This might (or might not) need cleanup.
-        let body_owner_def_id = self
-            .tcx
-            .hir()
-            .opt_local_def_id(cause.body_id)
-            .map(LocalDefId::to_def_id)
-            .unwrap_or_else(|| {
+        let body_owner_def_id =
+            self.tcx.hir().opt_local_def_id(cause.body_id).unwrap_or_else(|| {
                 self.tcx.hir().body_owner_def_id(hir::BodyId { hir_id: cause.body_id })
             });
         self.check_and_note_conflicting_crates(diag, terr);
-        self.tcx.note_and_explain_type_err(diag, terr, span, body_owner_def_id);
+        self.tcx.note_and_explain_type_err(diag, terr, span, body_owner_def_id.to_def_id());
 
         // It reads better to have the error origin as the final
         // thing.

--- a/src/librustc_infer/infer/error_reporting/mod.rs
+++ b/src/librustc_infer/infer/error_reporting/mod.rs
@@ -59,7 +59,7 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::{pluralize, struct_span_err};
 use rustc_errors::{Applicability, DiagnosticBuilder, DiagnosticStyledString};
 use rustc_hir as hir;
-use rustc_hir::def_id::DefId;
+use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::Node;
 use rustc_middle::middle::region;
 use rustc_middle::ty::error::TypeError;
@@ -1589,8 +1589,12 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         // it's a actual definition. According to the comments (e.g. in
         // librustc_typeck/check/compare_method.rs:compare_predicate_entailment) the latter
         // is relied upon by some other code. This might (or might not) need cleanup.
-        let body_owner_def_id =
-            self.tcx.hir().opt_local_def_id(cause.body_id).unwrap_or_else(|| {
+        let body_owner_def_id = self
+            .tcx
+            .hir()
+            .opt_local_def_id(cause.body_id)
+            .map(LocalDefId::to_def_id)
+            .unwrap_or_else(|| {
                 self.tcx.hir().body_owner_def_id(hir::BodyId { hir_id: cause.body_id })
             });
         self.check_and_note_conflicting_crates(diag, terr);

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -812,7 +812,7 @@ fn analysis(tcx: TyCtxt<'_>, cnum: CrateNum) -> Result<()> {
             {
                 sess.time("match_checking", || {
                     tcx.par_body_owners(|def_id| {
-                        tcx.ensure().check_match(def_id);
+                        tcx.ensure().check_match(def_id.to_def_id());
                     });
                 });
             },
@@ -834,7 +834,7 @@ fn analysis(tcx: TyCtxt<'_>, cnum: CrateNum) -> Result<()> {
     });
 
     sess.time("MIR_borrow_checking", || {
-        tcx.par_body_owners(|def_id| tcx.ensure().mir_borrowck(def_id));
+        tcx.par_body_owners(|def_id| tcx.ensure().mir_borrowck(def_id.to_def_id()));
     });
 
     sess.time("dumping_chalk_like_clauses", || {
@@ -843,7 +843,7 @@ fn analysis(tcx: TyCtxt<'_>, cnum: CrateNum) -> Result<()> {
 
     sess.time("MIR_effect_checking", || {
         for def_id in tcx.body_owners() {
-            mir::transform::check_unsafety::check_unsafety(tcx, def_id)
+            mir::transform::check_unsafety::check_unsafety(tcx, def_id.to_def_id())
         }
     });
 

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1166,7 +1166,7 @@ declare_lint_pass!(
 );
 
 fn check_const(cx: &LateContext<'_, '_>, body_id: hir::BodyId) {
-    let def_id = cx.tcx.hir().body_owner_def_id(body_id);
+    let def_id = cx.tcx.hir().body_owner_def_id(body_id).to_def_id();
     // trigger the query once for all constants since that will already report the errors
     // FIXME: Use ensure here
     let _ = cx.tcx.const_eval_poly(def_id);

--- a/src/librustc_middle/hir/map/mod.rs
+++ b/src/librustc_middle/hir/map/mod.rs
@@ -160,14 +160,16 @@ impl<'hir> Map<'hir> {
     // FIXME(eddyb) this function can and should return `LocalDefId`.
     #[inline]
     pub fn local_def_id_from_node_id(&self, node: NodeId) -> DefId {
-        self.opt_local_def_id_from_node_id(node).unwrap_or_else(|| {
-            let hir_id = self.node_id_to_hir_id(node);
-            bug!(
-                "local_def_id_from_node_id: no entry for `{}`, which has a map of `{:?}`",
-                node,
-                self.find_entry(hir_id)
-            )
-        })
+        self.opt_local_def_id_from_node_id(node)
+            .unwrap_or_else(|| {
+                let hir_id = self.node_id_to_hir_id(node);
+                bug!(
+                    "local_def_id_from_node_id: no entry for `{}`, which has a map of `{:?}`",
+                    node,
+                    self.find_entry(hir_id)
+                )
+            })
+            .to_def_id()
     }
 
     // FIXME(eddyb) this function can and should return `LocalDefId`.
@@ -185,12 +187,12 @@ impl<'hir> Map<'hir> {
     #[inline]
     pub fn opt_local_def_id(&self, hir_id: HirId) -> Option<DefId> {
         let node_id = self.hir_id_to_node_id(hir_id);
-        self.opt_local_def_id_from_node_id(node_id)
+        Some(self.opt_local_def_id_from_node_id(node_id)?.to_def_id())
     }
 
     #[inline]
-    pub fn opt_local_def_id_from_node_id(&self, node: NodeId) -> Option<DefId> {
-        Some(self.tcx.definitions.opt_local_def_id(node)?.to_def_id())
+    pub fn opt_local_def_id_from_node_id(&self, node: NodeId) -> Option<LocalDefId> {
+        self.tcx.definitions.opt_local_def_id(node)
     }
 
     #[inline]

--- a/src/librustc_middle/hir/map/mod.rs
+++ b/src/librustc_middle/hir/map/mod.rs
@@ -370,9 +370,8 @@ impl<'hir> Map<'hir> {
         parent
     }
 
-    // FIXME(eddyb) this function can and should return `LocalDefId`.
-    pub fn body_owner_def_id(&self, id: BodyId) -> DefId {
-        self.local_def_id(self.body_owner(id))
+    pub fn body_owner_def_id(&self, id: BodyId) -> LocalDefId {
+        self.local_def_id(self.body_owner(id)).expect_local()
     }
 
     /// Given a `HirId`, returns the `BodyId` associated with it,

--- a/src/librustc_middle/hir/map/mod.rs
+++ b/src/librustc_middle/hir/map/mod.rs
@@ -720,9 +720,8 @@ impl<'hir> Map<'hir> {
         scope
     }
 
-    // FIXME(eddyb) this function can and should return `LocalDefId`.
-    pub fn get_parent_did(&self, id: HirId) -> DefId {
-        self.local_def_id(self.get_parent_item(id))
+    pub fn get_parent_did(&self, id: HirId) -> LocalDefId {
+        self.local_def_id(self.get_parent_item(id)).expect_local()
     }
 
     pub fn get_foreign_abi(&self, hir_id: HirId) -> Abi {

--- a/src/librustc_middle/hir/map/mod.rs
+++ b/src/librustc_middle/hir/map/mod.rs
@@ -150,7 +150,7 @@ impl<'hir> Map<'hir> {
     }
 
     pub fn def_path_from_hir_id(&self, id: HirId) -> Option<DefPath> {
-        self.opt_local_def_id(id).map(|def_id| self.def_path(def_id.expect_local()))
+        self.opt_local_def_id(id).map(|def_id| self.def_path(def_id))
     }
 
     pub fn def_path(&self, def_id: LocalDefId) -> DefPath {
@@ -175,19 +175,21 @@ impl<'hir> Map<'hir> {
     // FIXME(eddyb) this function can and should return `LocalDefId`.
     #[inline]
     pub fn local_def_id(&self, hir_id: HirId) -> DefId {
-        self.opt_local_def_id(hir_id).unwrap_or_else(|| {
-            bug!(
-                "local_def_id: no entry for `{:?}`, which has a map of `{:?}`",
-                hir_id,
-                self.find_entry(hir_id)
-            )
-        })
+        self.opt_local_def_id(hir_id)
+            .unwrap_or_else(|| {
+                bug!(
+                    "local_def_id: no entry for `{:?}`, which has a map of `{:?}`",
+                    hir_id,
+                    self.find_entry(hir_id)
+                )
+            })
+            .to_def_id()
     }
 
     #[inline]
-    pub fn opt_local_def_id(&self, hir_id: HirId) -> Option<DefId> {
+    pub fn opt_local_def_id(&self, hir_id: HirId) -> Option<LocalDefId> {
         let node_id = self.hir_id_to_node_id(hir_id);
-        Some(self.opt_local_def_id_from_node_id(node_id)?.to_def_id())
+        self.opt_local_def_id_from_node_id(node_id)
     }
 
     #[inline]

--- a/src/librustc_middle/hir/map/mod.rs
+++ b/src/librustc_middle/hir/map/mod.rs
@@ -157,19 +157,16 @@ impl<'hir> Map<'hir> {
         self.tcx.definitions.def_path(def_id)
     }
 
-    // FIXME(eddyb) this function can and should return `LocalDefId`.
     #[inline]
-    pub fn local_def_id_from_node_id(&self, node: NodeId) -> DefId {
-        self.opt_local_def_id_from_node_id(node)
-            .unwrap_or_else(|| {
-                let hir_id = self.node_id_to_hir_id(node);
-                bug!(
-                    "local_def_id_from_node_id: no entry for `{}`, which has a map of `{:?}`",
-                    node,
-                    self.find_entry(hir_id)
-                )
-            })
-            .to_def_id()
+    pub fn local_def_id_from_node_id(&self, node: NodeId) -> LocalDefId {
+        self.opt_local_def_id_from_node_id(node).unwrap_or_else(|| {
+            let hir_id = self.node_id_to_hir_id(node);
+            bug!(
+                "local_def_id_from_node_id: no entry for `{}`, which has a map of `{:?}`",
+                node,
+                self.find_entry(hir_id)
+            )
+        })
     }
 
     // FIXME(eddyb) this function can and should return `LocalDefId`.

--- a/src/librustc_middle/ty/mod.rs
+++ b/src/librustc_middle/ty/mod.rs
@@ -2678,13 +2678,13 @@ pub enum ImplOverlapKind {
 
 impl<'tcx> TyCtxt<'tcx> {
     pub fn body_tables(self, body: hir::BodyId) -> &'tcx TypeckTables<'tcx> {
-        self.typeck_tables_of(self.hir().body_owner_def_id(body))
+        self.typeck_tables_of(self.hir().body_owner_def_id(body).to_def_id())
     }
 
     /// Returns an iterator of the `DefId`s for all body-owners in this
     /// crate. If you would prefer to iterate over the bodies
     /// themselves, you can do `self.hir().krate().body_ids.iter()`.
-    pub fn body_owners(self) -> impl Iterator<Item = DefId> + Captures<'tcx> + 'tcx {
+    pub fn body_owners(self) -> impl Iterator<Item = LocalDefId> + Captures<'tcx> + 'tcx {
         self.hir()
             .krate()
             .body_ids
@@ -2692,7 +2692,7 @@ impl<'tcx> TyCtxt<'tcx> {
             .map(move |&body_id| self.hir().body_owner_def_id(body_id))
     }
 
-    pub fn par_body_owners<F: Fn(DefId) + sync::Sync + sync::Send>(self, f: F) {
+    pub fn par_body_owners<F: Fn(LocalDefId) + sync::Sync + sync::Send>(self, f: F) {
         par_iter(&self.hir().krate().body_ids)
             .for_each(|&body_id| f(self.hir().body_owner_def_id(body_id)));
     }

--- a/src/librustc_mir/const_eval/fn_queries.rs
+++ b/src/librustc_mir/const_eval/fn_queries.rs
@@ -84,11 +84,7 @@ pub fn is_min_const_fn(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
 
 pub fn is_parent_const_impl_raw(tcx: TyCtxt<'_>, hir_id: hir::HirId) -> bool {
     let parent_id = tcx.hir().get_parent_did(hir_id);
-    if !parent_id.is_top_level_module() {
-        is_const_impl_raw(tcx, parent_id.expect_local())
-    } else {
-        false
-    }
+    if !parent_id.is_top_level_module() { is_const_impl_raw(tcx, parent_id) } else { false }
 }
 
 /// Checks whether the function has a `const` modifier or, in case it is an intrinsic, whether

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -254,6 +254,14 @@ pub trait Machine<'mir, 'tcx>: Sized {
         kind: Option<MemoryKind<Self::MemoryKind>>,
     ) -> (Cow<'b, Allocation<Self::PointerTag, Self::AllocExtra>>, Self::PointerTag);
 
+    /// Called to notify the machine before a deallocation occurs.
+    fn before_deallocation(
+        _memory_extra: &mut Self::MemoryExtra,
+        _id: AllocId,
+    ) -> InterpResult<'tcx> {
+        Ok(())
+    }
+
     /// Return the "base" tag for the given *global* allocation: the one that is used for direct
     /// accesses to this static/const/fn allocation. If `id` is not a global allocation,
     /// this will return an unusable tag (i.e., accesses will be UB)!

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -254,6 +254,8 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
             );
         }
 
+        M::before_deallocation(&mut self.extra, ptr.alloc_id)?;
+
         let (alloc_kind, mut alloc) = match self.alloc_map.remove(&ptr.alloc_id) {
             Some(alloc) => alloc,
             None => {

--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -6,6 +6,7 @@
 
 use std::convert::TryFrom;
 use std::fmt::Write;
+use std::num::NonZeroUsize;
 use std::ops::RangeInclusive;
 
 use rustc_data_structures::fx::FxHashSet;
@@ -642,10 +643,11 @@ impl<'rt, 'mir, 'tcx, M: Machine<'mir, 'tcx>> ValueVisitor<'mir, 'tcx, M>
     }
 
     #[inline(always)]
-    fn visit_union(&mut self, op: OpTy<'tcx, M::PointerTag>, fields: usize) -> InterpResult<'tcx> {
-        // Empty unions are not accepted by rustc. But uninhabited enums
-        // claim to be unions, so allow them, too.
-        assert!(op.layout.abi.is_uninhabited() || fields > 0);
+    fn visit_union(
+        &mut self,
+        _op: OpTy<'tcx, M::PointerTag>,
+        _fields: NonZeroUsize,
+    ) -> InterpResult<'tcx> {
         Ok(())
     }
 

--- a/src/librustc_mir/interpret/visitor.rs
+++ b/src/librustc_mir/interpret/visitor.rs
@@ -6,6 +6,8 @@ use rustc_middle::ty;
 use rustc_middle::ty::layout::TyAndLayout;
 use rustc_target::abi::{FieldsShape, VariantIdx, Variants};
 
+use std::num::NonZeroUsize;
+
 use super::{InterpCx, MPlaceTy, Machine, OpTy};
 
 // A thing that we can project into, and that has a layout.
@@ -130,7 +132,7 @@ macro_rules! make_value_visitor {
             }
             /// Visits the given value as a union. No automatic recursion can happen here.
             #[inline(always)]
-            fn visit_union(&mut self, _v: Self::V, _fields: usize) -> InterpResult<'tcx>
+            fn visit_union(&mut self, _v: Self::V, _fields: NonZeroUsize) -> InterpResult<'tcx>
             {
                 Ok(())
             }
@@ -208,6 +210,7 @@ macro_rules! make_value_visitor {
 
                 // Visit the fields of this value.
                 match v.layout().fields {
+                    FieldsShape::Primitive => {},
                     FieldsShape::Union(fields) => {
                         self.visit_union(v, fields)?;
                     },

--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -1,7 +1,7 @@
 use crate::{shim, util};
 use rustc_ast::ast;
 use rustc_hir as hir;
-use rustc_hir::def_id::{CrateNum, DefId, DefIdSet, LOCAL_CRATE};
+use rustc_hir::def_id::{CrateNum, DefId, DefIdSet, LocalDefId, LOCAL_CRATE};
 use rustc_hir::intravisit::{self, NestedVisitorMap, Visitor};
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir::{BodyAndCache, ConstQualifs, MirPhase, Promoted};
@@ -62,7 +62,7 @@ fn mir_keys(tcx: TyCtxt<'_>, krate: CrateNum) -> &DefIdSet {
     let mut set = DefIdSet::default();
 
     // All body-owners have MIR associated with them.
-    set.extend(tcx.body_owners());
+    set.extend(tcx.body_owners().map(LocalDefId::to_def_id));
 
     // Additionally, tuple struct/variant constructors have MIR, but
     // they don't have a BodyId, so we need to build them separately.

--- a/src/librustc_passes/intrinsicck.rs
+++ b/src/librustc_passes/intrinsicck.rs
@@ -131,8 +131,8 @@ impl Visitor<'tcx> for ItemVisitor<'tcx> {
     fn visit_nested_body(&mut self, body_id: hir::BodyId) {
         let owner_def_id = self.tcx.hir().body_owner_def_id(body_id);
         let body = self.tcx.hir().body(body_id);
-        let param_env = self.tcx.param_env(owner_def_id);
-        let tables = self.tcx.typeck_tables_of(owner_def_id);
+        let param_env = self.tcx.param_env(owner_def_id.to_def_id());
+        let tables = self.tcx.typeck_tables_of(owner_def_id.to_def_id());
         ExprVisitor { tcx: self.tcx, param_env, tables }.visit_body(body);
         self.visit_body(body);
     }

--- a/src/librustc_passes/reachable.rs
+++ b/src/librustc_passes/reachable.rs
@@ -10,7 +10,7 @@ use rustc_data_structures::sync::Lrc;
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::LOCAL_CRATE;
-use rustc_hir::def_id::{CrateNum, DefId};
+use rustc_hir::def_id::{CrateNum, DefId, LocalDefId};
 use rustc_hir::intravisit::{self, NestedVisitorMap, Visitor};
 use rustc_hir::itemlikevisit::ItemLikeVisitor;
 use rustc_hir::{HirIdSet, Node};
@@ -42,7 +42,7 @@ fn item_might_be_inlined(tcx: TyCtxt<'tcx>, item: &hir::Item<'_>, attrs: Codegen
 fn method_might_be_inlined(
     tcx: TyCtxt<'_>,
     impl_item: &hir::ImplItem<'_>,
-    impl_src: DefId,
+    impl_src: LocalDefId,
 ) -> bool {
     let codegen_fn_attrs = tcx.codegen_fn_attrs(impl_item.hir_id.owner.to_def_id());
     let generics = tcx.generics_of(tcx.hir().local_def_id(impl_item.hir_id));
@@ -54,7 +54,7 @@ fn method_might_be_inlined(
             return true;
         }
     }
-    if let Some(impl_hir_id) = tcx.hir().as_local_hir_id(impl_src) {
+    if let Some(impl_hir_id) = tcx.hir().as_local_hir_id(impl_src.to_def_id()) {
         match tcx.hir().find(impl_hir_id) {
             Some(Node::Item(item)) => item_might_be_inlined(tcx, &item, codegen_fn_attrs),
             Some(..) | None => span_bug!(impl_item.span, "impl did is not an item"),
@@ -171,7 +171,7 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
                         if generics.requires_monomorphization(self.tcx) || attrs.requests_inline() {
                             true
                         } else {
-                            let impl_did = self.tcx.hir().get_parent_did(hir_id);
+                            let impl_did = self.tcx.hir().get_parent_did(hir_id).to_def_id();
                             // Check the impl. If the generics on the self
                             // type of the impl require inlining, this method
                             // does too.

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -248,7 +248,7 @@ fn def_id_visibility<'tcx>(
                     }
                 }
                 Node::TraitItem(..) | Node::Variant(..) => {
-                    return def_id_visibility(tcx, tcx.hir().get_parent_did(hir_id));
+                    return def_id_visibility(tcx, tcx.hir().get_parent_did(hir_id).to_def_id());
                 }
                 Node::ImplItem(impl_item) => {
                     match tcx.hir().get(tcx.hir().get_parent_item(hir_id)) {
@@ -270,7 +270,7 @@ fn def_id_visibility<'tcx>(
                             let (mut ctor_vis, mut span, mut descr) =
                                 def_id_visibility(tcx, parent_did);
 
-                            let adt_def = tcx.adt_def(tcx.hir().get_parent_did(hir_id));
+                            let adt_def = tcx.adt_def(tcx.hir().get_parent_did(hir_id).to_def_id());
                             let ctor_did = tcx.hir().local_def_id(vdata.ctor_hir_id().unwrap());
                             let variant = adt_def.variant_with_ctor_id(ctor_did);
 
@@ -309,7 +309,8 @@ fn def_id_visibility<'tcx>(
                             // If the structure is marked as non_exhaustive then lower the
                             // visibility to within the crate.
                             if ctor_vis == ty::Visibility::Public {
-                                let adt_def = tcx.adt_def(tcx.hir().get_parent_did(hir_id));
+                                let adt_def =
+                                    tcx.adt_def(tcx.hir().get_parent_did(hir_id).to_def_id());
                                 if adt_def.non_enum_variant().is_field_list_non_exhaustive() {
                                     ctor_vis =
                                         ty::Visibility::Restricted(DefId::local(CRATE_DEF_INDEX));

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -107,7 +107,7 @@ impl<'l, 'tcx> DumpVisitor<'l, 'tcx> {
     where
         F: FnOnce(&mut Self),
     {
-        let item_def_id = self.tcx.hir().local_def_id_from_node_id(item_id);
+        let item_def_id = self.tcx.hir().local_def_id_from_node_id(item_id).to_def_id();
 
         let tables = if self.tcx.has_typeck_tables(item_def_id) {
             self.tcx.typeck_tables_of(item_def_id)
@@ -423,8 +423,10 @@ impl<'l, 'tcx> DumpVisitor<'l, 'tcx> {
         vis: ast::Visibility,
         attrs: &'l [Attribute],
     ) {
-        let qualname =
-            format!("::{}", self.tcx.def_path_str(self.tcx.hir().local_def_id_from_node_id(id)));
+        let qualname = format!(
+            "::{}",
+            self.tcx.def_path_str(self.tcx.hir().local_def_id_from_node_id(id).to_def_id())
+        );
 
         if !self.span.filter_generated(ident.span) {
             let sig = sig::assoc_const_signature(id, ident.name, typ, expr, &self.save_ctxt);
@@ -470,7 +472,7 @@ impl<'l, 'tcx> DumpVisitor<'l, 'tcx> {
         let name = item.ident.to_string();
         let qualname = format!(
             "::{}",
-            self.tcx.def_path_str(self.tcx.hir().local_def_id_from_node_id(item.id))
+            self.tcx.def_path_str(self.tcx.hir().local_def_id_from_node_id(item.id).to_def_id())
         );
 
         let kind = match item.kind {
@@ -670,7 +672,7 @@ impl<'l, 'tcx> DumpVisitor<'l, 'tcx> {
             }
             v.process_generic_params(generics, "", item.id);
             for impl_item in impl_items {
-                v.process_impl_item(impl_item, map.local_def_id_from_node_id(item.id));
+                v.process_impl_item(impl_item, map.local_def_id_from_node_id(item.id).to_def_id());
             }
         });
     }
@@ -685,7 +687,7 @@ impl<'l, 'tcx> DumpVisitor<'l, 'tcx> {
         let name = item.ident.to_string();
         let qualname = format!(
             "::{}",
-            self.tcx.def_path_str(self.tcx.hir().local_def_id_from_node_id(item.id))
+            self.tcx.def_path_str(self.tcx.hir().local_def_id_from_node_id(item.id).to_def_id())
         );
         let mut val = name.clone();
         if !generics.params.is_empty() {
@@ -751,7 +753,7 @@ impl<'l, 'tcx> DumpVisitor<'l, 'tcx> {
         self.process_generic_params(generics, &qualname, item.id);
         for method in methods {
             let map = &self.tcx.hir();
-            self.process_trait_item(method, map.local_def_id_from_node_id(item.id))
+            self.process_trait_item(method, map.local_def_id_from_node_id(item.id).to_def_id())
         }
     }
 
@@ -1030,7 +1032,9 @@ impl<'l, 'tcx> DumpVisitor<'l, 'tcx> {
                 let name = trait_item.ident.name.to_string();
                 let qualname = format!(
                     "::{}",
-                    self.tcx.def_path_str(self.tcx.hir().local_def_id_from_node_id(trait_item.id))
+                    self.tcx.def_path_str(
+                        self.tcx.hir().local_def_id_from_node_id(trait_item.id).to_def_id()
+                    )
                 );
 
                 if !self.span.filter_generated(trait_item.ident.span) {
@@ -1173,7 +1177,7 @@ impl<'l, 'tcx> DumpVisitor<'l, 'tcx> {
 
                 // Make a comma-separated list of names of imported modules.
                 let def_id = self.tcx.hir().local_def_id_from_node_id(id);
-                let names = self.tcx.names_imported_by_glob_use(def_id);
+                let names = self.tcx.names_imported_by_glob_use(def_id.to_def_id());
                 let names: Vec<_> = names.iter().map(|n| n.to_string()).collect();
 
                 // Otherwise it's a span with wrong macro expansion info, which
@@ -1227,8 +1231,10 @@ impl<'l, 'tcx> Visitor<'l> for DumpVisitor<'l, 'tcx> {
         // only get called for the root module of a crate.
         assert_eq!(id, ast::CRATE_NODE_ID);
 
-        let qualname =
-            format!("::{}", self.tcx.def_path_str(self.tcx.hir().local_def_id_from_node_id(id)));
+        let qualname = format!(
+            "::{}",
+            self.tcx.def_path_str(self.tcx.hir().local_def_id_from_node_id(id).to_def_id())
+        );
 
         let sm = self.tcx.sess.source_map();
         let filename = sm.span_to_filename(span);
@@ -1311,7 +1317,9 @@ impl<'l, 'tcx> Visitor<'l> for DumpVisitor<'l, 'tcx> {
             TyAlias(_, ref ty_params, _, ref ty) => {
                 let qualname = format!(
                     "::{}",
-                    self.tcx.def_path_str(self.tcx.hir().local_def_id_from_node_id(item.id))
+                    self.tcx.def_path_str(
+                        self.tcx.hir().local_def_id_from_node_id(item.id).to_def_id()
+                    )
                 );
                 let value = match ty {
                     Some(ty) => ty_to_string(&ty),

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -1134,7 +1134,7 @@ impl<'l, 'tcx> DumpVisitor<'l, 'tcx> {
             .tcx
             .hir()
             .opt_local_def_id_from_node_id(id)
-            .and_then(|id| self.save_ctxt.tcx.parent(id))
+            .and_then(|id| self.save_ctxt.tcx.parent(id.to_def_id()))
             .map(id_from_def_id);
 
         match use_tree.kind {
@@ -1273,7 +1273,7 @@ impl<'l, 'tcx> Visitor<'l> for DumpVisitor<'l, 'tcx> {
                         .tcx
                         .hir()
                         .opt_local_def_id_from_node_id(item.id)
-                        .and_then(|id| self.save_ctxt.tcx.parent(id))
+                        .and_then(|id| self.save_ctxt.tcx.parent(id.to_def_id()))
                         .map(id_from_def_id);
                     self.dumper.import(
                         &Access { public: false, reachable: false },

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -130,7 +130,7 @@ impl<'l, 'tcx> SaveContext<'l, 'tcx> {
     pub fn get_extern_item_data(&self, item: &ast::ForeignItem) -> Option<Data> {
         let qualname = format!(
             "::{}",
-            self.tcx.def_path_str(self.tcx.hir().local_def_id_from_node_id(item.id))
+            self.tcx.def_path_str(self.tcx.hir().local_def_id_from_node_id(item.id).to_def_id())
         );
         match item.kind {
             ast::ForeignItemKind::Fn(_, ref sig, ref generics, _) => {
@@ -183,7 +183,9 @@ impl<'l, 'tcx> SaveContext<'l, 'tcx> {
             ast::ItemKind::Fn(_, ref sig, .., ref generics, _) => {
                 let qualname = format!(
                     "::{}",
-                    self.tcx.def_path_str(self.tcx.hir().local_def_id_from_node_id(item.id))
+                    self.tcx.def_path_str(
+                        self.tcx.hir().local_def_id_from_node_id(item.id).to_def_id()
+                    )
                 );
                 filter!(self.span_utils, item.ident.span);
                 Some(Data::DefData(Def {
@@ -204,7 +206,9 @@ impl<'l, 'tcx> SaveContext<'l, 'tcx> {
             ast::ItemKind::Static(ref typ, ..) => {
                 let qualname = format!(
                     "::{}",
-                    self.tcx.def_path_str(self.tcx.hir().local_def_id_from_node_id(item.id))
+                    self.tcx.def_path_str(
+                        self.tcx.hir().local_def_id_from_node_id(item.id).to_def_id()
+                    )
                 );
 
                 filter!(self.span_utils, item.ident.span);
@@ -230,7 +234,9 @@ impl<'l, 'tcx> SaveContext<'l, 'tcx> {
             ast::ItemKind::Const(_, ref typ, _) => {
                 let qualname = format!(
                     "::{}",
-                    self.tcx.def_path_str(self.tcx.hir().local_def_id_from_node_id(item.id))
+                    self.tcx.def_path_str(
+                        self.tcx.hir().local_def_id_from_node_id(item.id).to_def_id()
+                    )
                 );
                 filter!(self.span_utils, item.ident.span);
 
@@ -255,7 +261,9 @@ impl<'l, 'tcx> SaveContext<'l, 'tcx> {
             ast::ItemKind::Mod(ref m) => {
                 let qualname = format!(
                     "::{}",
-                    self.tcx.def_path_str(self.tcx.hir().local_def_id_from_node_id(item.id))
+                    self.tcx.def_path_str(
+                        self.tcx.hir().local_def_id_from_node_id(item.id).to_def_id()
+                    )
                 );
 
                 let sm = self.tcx.sess.source_map();
@@ -282,7 +290,9 @@ impl<'l, 'tcx> SaveContext<'l, 'tcx> {
                 let name = item.ident.to_string();
                 let qualname = format!(
                     "::{}",
-                    self.tcx.def_path_str(self.tcx.hir().local_def_id_from_node_id(item.id))
+                    self.tcx.def_path_str(
+                        self.tcx.hir().local_def_id_from_node_id(item.id).to_def_id()
+                    )
                 );
                 filter!(self.span_utils, item.ident.span);
                 let variants_str =
@@ -363,11 +373,11 @@ impl<'l, 'tcx> SaveContext<'l, 'tcx> {
             let name = ident.to_string();
             let qualname = format!(
                 "::{}::{}",
-                self.tcx.def_path_str(self.tcx.hir().local_def_id_from_node_id(scope)),
+                self.tcx.def_path_str(self.tcx.hir().local_def_id_from_node_id(scope).to_def_id()),
                 ident
             );
             filter!(self.span_utils, ident.span);
-            let def_id = self.tcx.hir().local_def_id_from_node_id(field.id);
+            let def_id = self.tcx.hir().local_def_id_from_node_id(field.id).to_def_id();
             let typ = self.tcx.type_of(def_id).to_string();
 
             let id = id_from_node_id(field.id, self);
@@ -399,7 +409,7 @@ impl<'l, 'tcx> SaveContext<'l, 'tcx> {
         // which the method is declared in, followed by the method's name.
         let (qualname, parent_scope, decl_id, docs, attributes) = match self
             .tcx
-            .impl_of_method(self.tcx.hir().local_def_id_from_node_id(id))
+            .impl_of_method(self.tcx.hir().local_def_id_from_node_id(id).to_def_id())
         {
             Some(impl_id) => match self.tcx.hir().get_if_local(impl_id) {
                 Some(Node::Item(item)) => match item.kind {
@@ -448,7 +458,10 @@ impl<'l, 'tcx> SaveContext<'l, 'tcx> {
                     );
                 }
             },
-            None => match self.tcx.trait_of_item(self.tcx.hir().local_def_id_from_node_id(id)) {
+            None => match self
+                .tcx
+                .trait_of_item(self.tcx.hir().local_def_id_from_node_id(id).to_def_id())
+            {
                 Some(def_id) => {
                     let mut docs = String::new();
                     let mut attrs = vec![];

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -1073,7 +1073,7 @@ fn id_from_def_id(id: DefId) -> rls_data::Id {
 
 fn id_from_node_id(id: NodeId, scx: &SaveContext<'_, '_>) -> rls_data::Id {
     let def_id = scx.tcx.hir().opt_local_def_id_from_node_id(id);
-    def_id.map(id_from_def_id).unwrap_or_else(|| {
+    def_id.map(|id| id_from_def_id(id.to_def_id())).unwrap_or_else(|| {
         // Create a *fake* `DefId` out of a `NodeId` by subtracting the `NodeId`
         // out of the maximum u32 value. This will work unless you have *billions*
         // of definitions in a single crate (very unlikely to actually happen).

--- a/src/librustc_span/def_id.rs
+++ b/src/librustc_span/def_id.rs
@@ -224,6 +224,11 @@ impl LocalDefId {
     pub fn to_def_id(self) -> DefId {
         DefId { krate: LOCAL_CRATE, index: self.local_def_index }
     }
+
+    #[inline]
+    pub fn is_top_level_module(self) -> bool {
+        self.local_def_index == CRATE_DEF_INDEX
+    }
 }
 
 impl fmt::Debug for LocalDefId {

--- a/src/librustc_target/abi/call/mod.rs
+++ b/src/librustc_target/abi/call/mod.rs
@@ -308,13 +308,16 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
             }
 
             Abi::ScalarPair(..) | Abi::Aggregate { .. } => {
-                // Helper for computing `homogenous_aggregate`, allowing a custom
+                // Helper for computing `homogeneous_aggregate`, allowing a custom
                 // starting offset (used below for handling variants).
                 let from_fields_at =
                     |layout: Self,
                      start: Size|
                      -> Result<(HomogeneousAggregate, Size), Heterogeneous> {
                         let is_union = match layout.fields {
+                            FieldsShape::Primitive => {
+                                unreachable!("aggregates can't have `FieldsShape::Primitive`")
+                            }
                             FieldsShape::Array { count, .. } => {
                                 assert_eq!(start, Size::ZERO);
 

--- a/src/librustc_target/abi/call/riscv.rs
+++ b/src/librustc_target/abi/call/riscv.rs
@@ -87,6 +87,9 @@ where
         },
         Abi::Vector { .. } | Abi::Uninhabited => return Err(CannotUseFpConv),
         Abi::ScalarPair(..) | Abi::Aggregate { .. } => match arg_layout.fields {
+            FieldsShape::Primitive => {
+                unreachable!("aggregates can't have `FieldsShape::Primitive`")
+            }
             FieldsShape::Union(_) => {
                 if !arg_layout.is_zst() {
                     return Err(CannotUseFpConv);

--- a/src/librustc_trait_selection/traits/error_reporting/mod.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/mod.rs
@@ -14,7 +14,7 @@ use crate::infer::{self, InferCtxt, TyCtxtInferExt};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::{pluralize, struct_span_err, Applicability, DiagnosticBuilder};
 use rustc_hir as hir;
-use rustc_hir::def_id::{DefId, LOCAL_CRATE};
+use rustc_hir::def_id::{DefId, LocalDefId, LOCAL_CRATE};
 use rustc_hir::{Node, QPath, TyKind, WhereBoundPredicate, WherePredicate};
 use rustc_middle::mir::interpret::ErrorHandled;
 use rustc_middle::ty::error::ExpectedFound;
@@ -354,6 +354,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             let enclosing_scope_span = tcx.def_span(
                                 tcx.hir()
                                     .opt_local_def_id(obligation.cause.body_id)
+                                    .map(LocalDefId::to_def_id)
                                     .unwrap_or_else(|| {
                                         tcx.hir().body_owner_def_id(hir::BodyId {
                                             hir_id: obligation.cause.body_id,

--- a/src/librustc_trait_selection/traits/error_reporting/mod.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/mod.rs
@@ -14,7 +14,7 @@ use crate::infer::{self, InferCtxt, TyCtxtInferExt};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::{pluralize, struct_span_err, Applicability, DiagnosticBuilder};
 use rustc_hir as hir;
-use rustc_hir::def_id::{DefId, LocalDefId, LOCAL_CRATE};
+use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_hir::{Node, QPath, TyKind, WhereBoundPredicate, WherePredicate};
 use rustc_middle::mir::interpret::ErrorHandled;
 use rustc_middle::ty::error::ExpectedFound;
@@ -354,12 +354,12 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             let enclosing_scope_span = tcx.def_span(
                                 tcx.hir()
                                     .opt_local_def_id(obligation.cause.body_id)
-                                    .map(LocalDefId::to_def_id)
                                     .unwrap_or_else(|| {
                                         tcx.hir().body_owner_def_id(hir::BodyId {
                                             hir_id: obligation.cause.body_id,
                                         })
-                                    }),
+                                    })
+                                    .to_def_id(),
                             );
 
                             err.span_label(enclosing_scope_span, s.as_str());

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -2371,7 +2371,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 
             let parent_def_id = def_id
                 .and_then(|def_id| tcx.hir().as_local_hir_id(def_id))
-                .map(|hir_id| tcx.hir().get_parent_did(hir_id));
+                .map(|hir_id| tcx.hir().get_parent_did(hir_id).to_def_id());
 
             debug!("qpath_to_ty: parent_def_id={:?}", parent_def_id);
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -751,7 +751,7 @@ fn check_mod_item_types(tcx: TyCtxt<'_>, module_def_id: DefId) {
 fn typeck_item_bodies(tcx: TyCtxt<'_>, crate_num: CrateNum) {
     debug_assert!(crate_num == LOCAL_CRATE);
     tcx.par_body_owners(|body_owner_def_id| {
-        tcx.ensure().typeck_tables_of(body_owner_def_id);
+        tcx.ensure().typeck_tables_of(body_owner_def_id.to_def_id());
     });
 }
 

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -109,7 +109,7 @@ macro_rules! ignore_err {
 
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub fn regionck_expr(&self, body: &'tcx hir::Body<'tcx>) {
-        let subject = self.tcx.hir().body_owner_def_id(body.id());
+        let subject = self.tcx.hir().body_owner_def_id(body.id()).to_def_id();
         let id = body.value.hir_id;
         let mut rcx =
             RegionCtxt::new(self, RepeatingScope(id), id, Subject(subject), self.param_env);
@@ -154,7 +154,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// constraints to add.
     pub fn regionck_fn(&self, fn_id: hir::HirId, body: &'tcx hir::Body<'tcx>) {
         debug!("regionck_fn(id={})", fn_id);
-        let subject = self.tcx.hir().body_owner_def_id(body.id());
+        let subject = self.tcx.hir().body_owner_def_id(body.id()).to_def_id();
         let hir_id = body.value.hir_id;
         let mut rcx =
             RegionCtxt::new(self, RepeatingScope(hir_id), hir_id, Subject(subject), self.param_env);
@@ -290,7 +290,7 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
 
         let body_id = body.id();
         self.body_id = body_id.hir_id;
-        self.body_owner = self.tcx.hir().body_owner_def_id(body_id);
+        self.body_owner = self.tcx.hir().body_owner_def_id(body_id).to_def_id();
 
         let call_site =
             region::Scope { id: body.value.hir_id.local_id, data: region::ScopeData::CallSite };

--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -146,7 +146,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         }
 
-        let body_owner_def_id = self.tcx.hir().body_owner_def_id(body.id());
+        let body_owner_def_id = self.tcx.hir().body_owner_def_id(body.id()).to_def_id();
         assert_eq!(body_owner_def_id, closure_def_id);
         let mut delegate = InferBorrowKind {
             fcx: self,

--- a/src/librustc_typeck/check_unused.rs
+++ b/src/librustc_typeck/check_unused.rs
@@ -12,7 +12,7 @@ pub fn check_crate(tcx: TyCtxt<'_>) {
     let mut used_trait_imports = DefIdSet::default();
     for &body_id in tcx.hir().krate().bodies.keys() {
         let item_def_id = tcx.hir().body_owner_def_id(body_id);
-        let imports = tcx.used_trait_imports(item_def_id);
+        let imports = tcx.used_trait_imports(item_def_id.to_def_id());
         debug!("GatherVisitor: item_def_id={:?} with imports {:#?}", item_def_id, imports);
         used_trait_imports.extend(imports.iter());
     }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1513,7 +1513,7 @@ fn fn_sig(tcx: TyCtxt<'_>, def_id: DefId) -> ty::PolyFnSig<'_> {
         }
 
         Ctor(data) | Variant(hir::Variant { data, .. }) if data.ctor_hir_id().is_some() => {
-            let ty = tcx.type_of(tcx.hir().get_parent_did(hir_id));
+            let ty = tcx.type_of(tcx.hir().get_parent_did(hir_id).to_def_id());
             let inputs =
                 data.fields().iter().map(|f| tcx.type_of(tcx.hir().local_def_id(f.hir_id)));
             ty::Binder::bind(tcx.mk_fn_sig(

--- a/src/librustc_typeck/collect/type_of.rs
+++ b/src/librustc_typeck/collect/type_of.rs
@@ -59,14 +59,14 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
                 }
             }
             ImplItemKind::OpaqueTy(_) => {
-                if tcx.impl_trait_ref(tcx.hir().get_parent_did(hir_id)).is_none() {
+                if tcx.impl_trait_ref(tcx.hir().get_parent_did(hir_id).to_def_id()).is_none() {
                     report_assoc_ty_on_inherent_impl(tcx, item.span);
                 }
 
                 find_opaque_ty_constraints(tcx, def_id)
             }
             ImplItemKind::TyAlias(ref ty) => {
-                if tcx.impl_trait_ref(tcx.hir().get_parent_did(hir_id)).is_none() {
+                if tcx.impl_trait_ref(tcx.hir().get_parent_did(hir_id).to_def_id()).is_none() {
                     report_assoc_ty_on_inherent_impl(tcx, item.span);
                 }
 
@@ -177,7 +177,7 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
 
         Node::Ctor(&ref def) | Node::Variant(Variant { data: ref def, .. }) => match *def {
             VariantData::Unit(..) | VariantData::Struct(..) => {
-                tcx.type_of(tcx.hir().get_parent_did(hir_id))
+                tcx.type_of(tcx.hir().get_parent_did(hir_id).to_def_id())
             }
             VariantData::Tuple(..) => {
                 let substs = InternalSubsts::identity_for_item(tcx, def_id);
@@ -207,9 +207,11 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
                     tcx.types.usize
                 }
 
-                Node::Variant(Variant { disr_expr: Some(ref e), .. }) if e.hir_id == hir_id => {
-                    tcx.adt_def(tcx.hir().get_parent_did(hir_id)).repr.discr_type().to_ty(tcx)
-                }
+                Node::Variant(Variant { disr_expr: Some(ref e), .. }) if e.hir_id == hir_id => tcx
+                    .adt_def(tcx.hir().get_parent_did(hir_id).to_def_id())
+                    .repr
+                    .discr_type()
+                    .to_ty(tcx),
 
                 Node::Ty(&Ty { kind: TyKind::Path(_), .. })
                 | Node::Expr(&Expr { kind: ExprKind::Struct(..), .. })

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -451,7 +451,11 @@ fn build_module(cx: &DocContext<'_>, did: DefId, visited: &mut FxHashSet<DefId>)
                         name: None,
                         attrs: clean::Attributes::default(),
                         source: clean::Span::empty(),
-                        def_id: cx.tcx.hir().local_def_id_from_node_id(ast::CRATE_NODE_ID),
+                        def_id: cx
+                            .tcx
+                            .hir()
+                            .local_def_id_from_node_id(ast::CRATE_NODE_ID)
+                            .to_def_id(),
                         visibility: clean::Public,
                         stability: None,
                         deprecation: None,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1554,7 +1554,7 @@ impl<'tcx> Clean<Type> for Ty<'tcx> {
                 BareFunction(box BareFunctionDecl {
                     unsafety: sig.unsafety(),
                     generic_params: Vec::new(),
-                    decl: (local_def_id, sig).clean(cx),
+                    decl: (local_def_id.to_def_id(), sig).clean(cx),
                     abi: sig.abi(),
                 })
             }
@@ -2264,7 +2264,7 @@ impl Clean<Vec<Item>> for doctree::Import<'_> {
             name: None,
             attrs: self.attrs.clean(cx),
             source: self.whence.clean(cx),
-            def_id: cx.tcx.hir().local_def_id_from_node_id(ast::CRATE_NODE_ID),
+            def_id: cx.tcx.hir().local_def_id_from_node_id(ast::CRATE_NODE_ID).to_def_id(),
             visibility: self.vis.clean(cx),
             stability: None,
             deprecation: None,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -419,7 +419,10 @@ impl Clean<Lifetime> for hir::GenericParam<'_> {
 impl Clean<Constant> for hir::ConstArg {
     fn clean(&self, cx: &DocContext<'_>) -> Constant {
         Constant {
-            type_: cx.tcx.type_of(cx.tcx.hir().body_owner_def_id(self.value.body)).clean(cx),
+            type_: cx
+                .tcx
+                .type_of(cx.tcx.hir().body_owner_def_id(self.value.body).to_def_id())
+                .clean(cx),
             expr: print_const_expr(cx, self.value.body),
             value: None,
             is_literal: is_literal_expr(cx, self.value.body.hir_id),

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -152,12 +152,15 @@ impl<'tcx> DocContext<'tcx> {
         self.tcx
             .hir()
             .opt_local_def_id(id)
-            .and_then(|def_id| self.tcx.lookup_stability(def_id))
+            .and_then(|def_id| self.tcx.lookup_stability(def_id.to_def_id()))
             .cloned()
     }
 
     pub fn deprecation(&self, id: HirId) -> Option<attr::Deprecation> {
-        self.tcx.hir().opt_local_def_id(id).and_then(|def_id| self.tcx.lookup_deprecation(def_id))
+        self.tcx
+            .hir()
+            .opt_local_def_id(id)
+            .and_then(|def_id| self.tcx.lookup_deprecation(def_id.to_def_id()))
     }
 }
 

--- a/src/test/rustdoc-ui/deprecated-attrs.stderr
+++ b/src/test/rustdoc-ui/deprecated-attrs.stderr
@@ -7,3 +7,5 @@ warning: the `#![doc(passes = "...")]` attribute is considered deprecated
    |
    = warning: see issue #44136 <https://github.com/rust-lang/rust/issues/44136> for more information
 
+warning: 2 warnings emitted
+

--- a/src/test/rustdoc-ui/intra-links-warning-crlf.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning-crlf.stderr
@@ -31,3 +31,5 @@ LL |  * It also has an [error].
    |
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
 
+warning: 4 warnings emitted
+

--- a/src/test/rustdoc-ui/intra-links-warning.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning.stderr
@@ -177,3 +177,5 @@ LL | f!("Foo\nbar [BarF] bar\nbaz");
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
+warning: 19 warnings emitted
+

--- a/src/test/rustdoc-ui/invalid-syntax.stderr
+++ b/src/test/rustdoc-ui/invalid-syntax.stderr
@@ -147,3 +147,5 @@ help: mark blocks that do not contain Rust code as text
 LL | /// ```text
    |     ^^^^^^^
 
+warning: 12 warnings emitted
+

--- a/src/test/ui-fulldeps/feature-gate-plugin.stderr
+++ b/src/test/ui-fulldeps/feature-gate-plugin.stderr
@@ -15,6 +15,6 @@ LL | #![plugin(empty_plugin)]
    |
    = note: `#[warn(deprecated)]` on by default
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui-fulldeps/gated-plugin.stderr
+++ b/src/test/ui-fulldeps/gated-plugin.stderr
@@ -15,6 +15,6 @@ LL | #![plugin(empty_plugin)]
    |
    = note: `#[warn(deprecated)]` on by default
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui-fulldeps/issue-15778-fail.stderr
+++ b/src/test/ui-fulldeps/issue-15778-fail.stderr
@@ -18,5 +18,5 @@ LL | | pub fn main() { }
    |
    = note: requested on the command line with `-D crate-not-okay`
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui-fulldeps/issue-15778-pass.stderr
+++ b/src/test/ui-fulldeps/issue-15778-pass.stderr
@@ -6,3 +6,5 @@ LL | #![plugin(lint_for_crate_rpass)]
    |
    = note: `#[warn(deprecated)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui-fulldeps/issue-40001.stderr
+++ b/src/test/ui-fulldeps/issue-40001.stderr
@@ -6,3 +6,5 @@ LL | #![plugin(issue_40001_plugin)]
    |
    = note: `#[warn(deprecated)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui-fulldeps/lint-group-plugin-deny-cmdline.stderr
+++ b/src/test/ui-fulldeps/lint-group-plugin-deny-cmdline.stderr
@@ -22,5 +22,5 @@ LL | fn pleaselintme() { }
    |
    = note: `-D please-lint` implied by `-D lint-me`
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/src/test/ui-fulldeps/lint-group-plugin.stderr
+++ b/src/test/ui-fulldeps/lint-group-plugin.stderr
@@ -22,3 +22,5 @@ LL | fn pleaselintme() { }
    |
    = note: `#[warn(please_lint)]` on by default
 
+warning: 3 warnings emitted
+

--- a/src/test/ui-fulldeps/lint-plugin-cmdline-allow.stderr
+++ b/src/test/ui-fulldeps/lint-plugin-cmdline-allow.stderr
@@ -6,3 +6,5 @@ LL | #![plugin(lint_plugin_test)]
    |
    = note: `#[warn(deprecated)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui-fulldeps/lint-plugin-cmdline-load.stderr
+++ b/src/test/ui-fulldeps/lint-plugin-cmdline-load.stderr
@@ -14,3 +14,5 @@ LL | fn lintme() { }
    |
    = note: `#[warn(test_lint)]` on by default
 
+warning: 2 warnings emitted
+

--- a/src/test/ui-fulldeps/lint-plugin-deny-attr.stderr
+++ b/src/test/ui-fulldeps/lint-plugin-deny-attr.stderr
@@ -18,5 +18,5 @@ note: the lint level is defined here
 LL | #![deny(test_lint)]
    |         ^^^^^^^^^
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui-fulldeps/lint-plugin-deny-cmdline.stderr
+++ b/src/test/ui-fulldeps/lint-plugin-deny-cmdline.stderr
@@ -14,5 +14,5 @@ LL | fn lintme() { }
    |
    = note: requested on the command line with `-D test-lint`
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui-fulldeps/lint-plugin-forbid-attrs.stderr
+++ b/src/test/ui-fulldeps/lint-plugin-forbid-attrs.stderr
@@ -45,6 +45,6 @@ LL | #![forbid(test_lint)]
 LL | #[allow(test_lint)]
    |         ^^^^^^^^^ overruled by previous forbid
 
-error: aborting due to 4 previous errors
+error: aborting due to 4 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0453`.

--- a/src/test/ui-fulldeps/lint-plugin-forbid-cmdline.stderr
+++ b/src/test/ui-fulldeps/lint-plugin-forbid-cmdline.stderr
@@ -38,6 +38,6 @@ LL | #[allow(test_lint)]
    |
    = note: `forbid` lint level was set on command line
 
-error: aborting due to 4 previous errors
+error: aborting due to 4 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0453`.

--- a/src/test/ui-fulldeps/lint-plugin.stderr
+++ b/src/test/ui-fulldeps/lint-plugin.stderr
@@ -14,3 +14,5 @@ LL | fn lintme() { }
    |
    = note: `#[warn(test_lint)]` on by default
 
+warning: 2 warnings emitted
+

--- a/src/test/ui-fulldeps/lint-tool-cmdline-allow.stderr
+++ b/src/test/ui-fulldeps/lint-tool-cmdline-allow.stderr
@@ -30,3 +30,5 @@ warning: lint name `test_lint` is deprecated and does not have an effect anymore
    |
    = note: requested on the command line with `-A test_lint`
 
+warning: 6 warnings emitted
+

--- a/src/test/ui-fulldeps/lint-tool-test.stderr
+++ b/src/test/ui-fulldeps/lint-tool-test.stderr
@@ -96,5 +96,5 @@ warning: lint name `test_group` is deprecated and may not have an effect in the 
 LL | #[allow(test_group)]
    |         ^^^^^^^^^^ help: change it to: `clippy::test_group`
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 11 warnings emitted
 

--- a/src/test/ui-fulldeps/lto-syntax-extension.stderr
+++ b/src/test/ui-fulldeps/lto-syntax-extension.stderr
@@ -6,3 +6,5 @@ LL | #![plugin(lto_syntax_extension_plugin)]
    |
    = note: `#[warn(deprecated)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui-fulldeps/macro-crate-rlib.stderr
+++ b/src/test/ui-fulldeps/macro-crate-rlib.stderr
@@ -12,5 +12,5 @@ LL | #![plugin(rlib_crate_test)]
    |
    = note: `#[warn(deprecated)]` on by default
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui-fulldeps/outlive-expansion-phase.stderr
+++ b/src/test/ui-fulldeps/outlive-expansion-phase.stderr
@@ -6,3 +6,5 @@ LL | #![plugin(outlive_expansion_phase)]
    |
    = note: `#[warn(deprecated)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui-fulldeps/plugin-args.stderr
+++ b/src/test/ui-fulldeps/plugin-args.stderr
@@ -12,5 +12,5 @@ LL | #![plugin(empty_plugin(args))]
    |
    = note: `#[warn(deprecated)]` on by default
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/anon-params/anon-params-deprecated.stderr
+++ b/src/test/ui/anon-params/anon-params-deprecated.stderr
@@ -30,3 +30,5 @@ LL |     fn bar_with_default_impl(String, String) {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue #41686 <https://github.com/rust-lang/rust/issues/41686>
 
+warning: 3 warnings emitted
+

--- a/src/test/ui/array-slice-vec/match_arr_unknown_len.stderr
+++ b/src/test/ui/array-slice-vec/match_arr_unknown_len.stderr
@@ -15,6 +15,6 @@ LL |         [1, 2] => true,
    = note: expected array `[u32; 2]`
               found array `[u32; _]`
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/asm/asm-misplaced-option.stderr
+++ b/src/test/ui/asm/asm-misplaced-option.stderr
@@ -10,3 +10,5 @@ warning: expected a clobber, found an option
 LL |         llvm_asm!("add $2, $1; mov $1, $0" : "=r"(x) : "r"(x), "r"(8_usize) : "cc", "volatile");
    |                                                                                     ^^^^^^^^^^
 
+warning: 2 warnings emitted
+

--- a/src/test/ui/associated-type-bounds/duplicate.stderr
+++ b/src/test/ui/associated-type-bounds/duplicate.stderr
@@ -726,6 +726,6 @@ error: could not find defining uses
 LL | type TADyn3 = dyn Iterator<Item: 'static, Item: 'static>;
    |                                           ^^^^^^^^^^^^^
 
-error: aborting due to 96 previous errors
+error: aborting due to 96 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0719`.

--- a/src/test/ui/associated-type-bounds/dyn-lcsit.stderr
+++ b/src/test/ui/associated-type-bounds/dyn-lcsit.stderr
@@ -6,3 +6,5 @@ LL | #![feature(impl_trait_in_bindings)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/associated-type-bounds/lcsit.stderr
+++ b/src/test/ui/associated-type-bounds/lcsit.stderr
@@ -6,3 +6,5 @@ LL | #![feature(impl_trait_in_bindings)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/associated-type-bounds/type-alias.stderr
+++ b/src/test/ui/associated-type-bounds/type-alias.stderr
@@ -131,3 +131,5 @@ help: the bound will not be checked when the type alias is used, and should be r
 LL | type _TaInline6<T> = T;
    |                 --
 
+warning: 12 warnings emitted
+

--- a/src/test/ui/async-await/issues/issue-54752-async-block.stderr
+++ b/src/test/ui/async-await/issues/issue-54752-async-block.stderr
@@ -6,3 +6,5 @@ LL | fn main() { let _a = (async  { }); }
    |
    = note: `#[warn(unused_parens)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/bad/bad-lint-cap3.stderr
+++ b/src/test/ui/bad/bad-lint-cap3.stderr
@@ -11,3 +11,5 @@ LL | #![deny(warnings)]
    |         ^^^^^^^^
    = note: `#[warn(unused_imports)]` implied by `#[warn(warnings)]`
 
+warning: 1 warning emitted
+

--- a/src/test/ui/binding/const-param.stderr
+++ b/src/test/ui/binding/const-param.stderr
@@ -12,6 +12,6 @@ error[E0158]: const parameters cannot be referenced in patterns
 LL |         N => {}
    |         ^
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0158`.

--- a/src/test/ui/block-expr-precedence.stderr
+++ b/src/test/ui/block-expr-precedence.stderr
@@ -6,3 +6,5 @@ LL |   if (true) { 12; };;; -num;
    |
    = note: `#[warn(redundant_semicolons)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/block-result/block-must-not-have-result-while.stderr
+++ b/src/test/ui/block-result/block-must-not-have-result-while.stderr
@@ -12,6 +12,6 @@ error[E0308]: mismatched types
 LL |         true
    |         ^^^^ expected `()`, found `bool`
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/borrowck/mut-borrow-in-loop.stderr
+++ b/src/test/ui/borrowck/mut-borrow-in-loop.stderr
@@ -42,6 +42,6 @@ LL |             (self.func)(arg)
    |             |           mutable borrow starts here in previous iteration of loop
    |             argument requires that `*arg` is borrowed for `'a`
 
-error: aborting due to 3 previous errors
+error: aborting due to 3 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0499`.

--- a/src/test/ui/borrowck/two-phase-reservation-sharing-interference-2.migrate2015.stderr
+++ b/src/test/ui/borrowck/two-phase-reservation-sharing-interference-2.migrate2015.stderr
@@ -35,6 +35,6 @@ LL |     v.push(shared.len());
    = warning: this borrowing pattern was not meant to be accepted, and may become a hard error in the future
    = note: for more information, see issue #59159 <https://github.com/rust-lang/rust/issues/59159>
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0502`.

--- a/src/test/ui/borrowck/two-phase-reservation-sharing-interference-2.migrate2018.stderr
+++ b/src/test/ui/borrowck/two-phase-reservation-sharing-interference-2.migrate2018.stderr
@@ -35,6 +35,6 @@ LL |     v.push(shared.len());
    = warning: this borrowing pattern was not meant to be accepted, and may become a hard error in the future
    = note: for more information, see issue #59159 <https://github.com/rust-lang/rust/issues/59159>
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0502`.

--- a/src/test/ui/borrowck/two-phase-reservation-sharing-interference-future-compat-lint.stderr
+++ b/src/test/ui/borrowck/two-phase-reservation-sharing-interference-future-compat-lint.stderr
@@ -36,5 +36,5 @@ LL |     #![deny(mutable_borrow_reservation_conflict)]
    = warning: this borrowing pattern was not meant to be accepted, and may become a hard error in the future
    = note: for more information, see issue #59159 <https://github.com/rust-lang/rust/issues/59159>
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/codemap_tests/unicode_3.stderr
+++ b/src/test/ui/codemap_tests/unicode_3.stderr
@@ -6,3 +6,5 @@ LL |     let s = "ZͨA͑ͦ͒͋ͤ͑̚L̄͑͋Ĝͨͥ̿͒̽̈́Oͥ͛ͭ!̏"; while tru
    |
    = note: `#[warn(while_true)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/coherence/coherence-subtyping.old.stderr
+++ b/src/test/ui/coherence/coherence-subtyping.old.stderr
@@ -12,3 +12,5 @@ LL | impl TheTrait for for<'a> fn(&'a u8, &'a u8) -> &'a u8 {
    = note: for more information, see issue #56105 <https://github.com/rust-lang/rust/issues/56105>
    = note: this behavior recently changed as a result of a bug fix; see rust-lang/rust#56105 for details
 
+warning: 1 warning emitted
+

--- a/src/test/ui/coherence/coherence-subtyping.re.stderr
+++ b/src/test/ui/coherence/coherence-subtyping.re.stderr
@@ -12,3 +12,5 @@ LL | impl TheTrait for for<'a> fn(&'a u8, &'a u8) -> &'a u8 {
    = note: for more information, see issue #56105 <https://github.com/rust-lang/rust/issues/56105>
    = note: this behavior recently changed as a result of a bug fix; see rust-lang/rust#56105 for details
 
+warning: 1 warning emitted
+

--- a/src/test/ui/conditional-compilation/cfg-attr-multi-true.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-multi-true.stderr
@@ -36,3 +36,5 @@ note: the lint level is defined here
 LL | #![warn(unused_must_use)]
    |         ^^^^^^^^^^^^^^^
 
+warning: 5 warnings emitted
+

--- a/src/test/ui/const-generics/apit-with-const-param.stderr
+++ b/src/test/ui/const-generics/apit-with-const-param.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/argument_order.stderr
+++ b/src/test/ui/const-generics/argument_order.stderr
@@ -12,5 +12,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/const-generics/array-size-in-generic-struct-param.stderr
+++ b/src/test/ui/const-generics/array-size-in-generic-struct-param.stderr
@@ -22,5 +22,5 @@ LL |     arr: [u8; CFG.arr_size],
    |
    = note: this may fail depending on what value the parameter takes
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/src/test/ui/const-generics/array-wrapper-struct-ctor.stderr
+++ b/src/test/ui/const-generics/array-wrapper-struct-ctor.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/broken-mir-1.stderr
+++ b/src/test/ui/const-generics/broken-mir-1.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/broken-mir-2.stderr
+++ b/src/test/ui/const-generics/broken-mir-2.stderr
@@ -17,6 +17,6 @@ LL | struct S<T: Debug, const N: usize>([T; N]);
    = note: required for the cast to the object type `dyn std::fmt::Debug`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/const-generics/cannot-infer-const-args.stderr
+++ b/src/test/ui/const-generics/cannot-infer-const-args.stderr
@@ -12,6 +12,6 @@ error[E0282]: type annotations needed
 LL |     foo();
    |     ^^^ cannot infer type for fn item `fn() -> usize {foo::<{_: usize}>}`
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/const-generics/cannot-infer-type-for-const-param.stderr
+++ b/src/test/ui/const-generics/cannot-infer-type-for-const-param.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/concrete-const-as-fn-arg.stderr
+++ b/src/test/ui/const-generics/concrete-const-as-fn-arg.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/concrete-const-impl-method.stderr
+++ b/src/test/ui/const-generics/concrete-const-impl-method.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/condition-in-trait-const-arg.stderr
+++ b/src/test/ui/const-generics/condition-in-trait-const-arg.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/const-arg-in-fn.stderr
+++ b/src/test/ui/const-generics/const-arg-in-fn.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/const-arg-type-arg-misordered.stderr
+++ b/src/test/ui/const-generics/const-arg-type-arg-misordered.stderr
@@ -14,6 +14,6 @@ LL | fn foo<const N: usize>() -> Array<N, ()> {
    |
    = note: type arguments must be provided before constant arguments
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0747`.

--- a/src/test/ui/const-generics/const-expression-parameter.stderr
+++ b/src/test/ui/const-generics/const-expression-parameter.stderr
@@ -12,5 +12,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/const-generics/const-fn-with-const-param.stderr
+++ b/src/test/ui/const-generics/const-fn-with-const-param.stderr
@@ -19,5 +19,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/const-generics/const-generic-array-wrapper.stderr
+++ b/src/test/ui/const-generics/const-generic-array-wrapper.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/const-generic-type_name.stderr
+++ b/src/test/ui/const-generics/const-generic-type_name.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/const-param-elided-lifetime.stderr
+++ b/src/test/ui/const-generics/const-param-elided-lifetime.stderr
@@ -36,6 +36,6 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error: aborting due to 5 previous errors
+error: aborting due to 5 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0637`.

--- a/src/test/ui/const-generics/const-param-from-outer-fn.stderr
+++ b/src/test/ui/const-generics/const-param-from-outer-fn.stderr
@@ -16,6 +16,6 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0401`.

--- a/src/test/ui/const-generics/const-param-in-trait.stderr
+++ b/src/test/ui/const-generics/const-param-in-trait.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
+++ b/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
@@ -12,6 +12,6 @@ error[E0741]: the types of const generic parameters must derive `PartialEq` and 
 LL | pub struct Dependent<T, const X: T>([(); X]);
    |                                  ^ `T` doesn't derive both `PartialEq` and `Eq`
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0741`.

--- a/src/test/ui/const-generics/const-parameter-uppercase-lint.stderr
+++ b/src/test/ui/const-generics/const-parameter-uppercase-lint.stderr
@@ -18,5 +18,5 @@ note: the lint level is defined here
 LL | #![deny(non_upper_case_globals)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/const-generics/const-types.stderr
+++ b/src/test/ui/const-generics/const-types.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/derive-debug-array-wrapper.stderr
+++ b/src/test/ui/const-generics/derive-debug-array-wrapper.stderr
@@ -17,6 +17,6 @@ LL |     a: [u32; N],
    = note: required for the cast to the object type `dyn std::fmt::Debug`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/const-generics/fn-const-param-call.stderr
+++ b/src/test/ui/const-generics/fn-const-param-call.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics, const_compare_raw_pointers)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/fn-const-param-infer.stderr
+++ b/src/test/ui/const-generics/fn-const-param-infer.stderr
@@ -43,7 +43,7 @@ LL |     let _: Checked<{generic::<u32>}> = Checked::<{generic::<u16>}>;
    = note: expected struct `Checked<{generic::<u32> as fn(usize) -> bool}>`
               found struct `Checked<{generic::<u16> as fn(usize) -> bool}>`
 
-error: aborting due to 4 previous errors
+error: aborting due to 4 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0282, E0308.
 For more information about an error, try `rustc --explain E0282`.

--- a/src/test/ui/const-generics/fn-taking-const-generic-array.stderr
+++ b/src/test/ui/const-generics/fn-taking-const-generic-array.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/forbid-non-structural_match-types.stderr
+++ b/src/test/ui/const-generics/forbid-non-structural_match-types.stderr
@@ -12,6 +12,6 @@ error[E0741]: the types of const generic parameters must derive `PartialEq` and 
 LL | struct D<const X: C>;
    |                   ^ `C` doesn't derive both `PartialEq` and `Eq`
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0741`.

--- a/src/test/ui/const-generics/foreign-item-const-parameter.stderr
+++ b/src/test/ui/const-generics/foreign-item-const-parameter.stderr
@@ -22,6 +22,6 @@ LL |     fn bar<T, const X: usize>(_: T);
    |
    = help: replace the type or const parameters with concrete types or consts
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0044`.

--- a/src/test/ui/const-generics/impl-const-generic-struct.stderr
+++ b/src/test/ui/const-generics/impl-const-generic-struct.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/incorrect-number-of-const-args.stderr
+++ b/src/test/ui/const-generics/incorrect-number-of-const-args.stderr
@@ -18,6 +18,6 @@ error[E0107]: wrong number of const arguments: expected 2, found 3
 LL |     foo::<0, 0, 0>();
    |                 ^ unexpected const argument
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0107`.

--- a/src/test/ui/const-generics/infer_arg_from_pat.stderr
+++ b/src/test/ui/const-generics/infer_arg_from_pat.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/infer_arr_len_from_pat.stderr
+++ b/src/test/ui/const-generics/infer_arr_len_from_pat.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/integer-literal-generic-arg-in-where-clause.stderr
+++ b/src/test/ui/const-generics/integer-literal-generic-arg-in-where-clause.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/issue-61522-array-len-succ.stderr
+++ b/src/test/ui/const-generics/issue-61522-array-len-succ.stderr
@@ -22,5 +22,5 @@ LL |     fn inner(&self) -> &[u8; COUNT + 1] {
    |
    = note: this may fail depending on what value the parameter takes
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/src/test/ui/const-generics/issue-66596-impl-trait-for-str-const-arg.stderr
+++ b/src/test/ui/const-generics/issue-66596-impl-trait-for-str-const-arg.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/issues/issue-60818-struct-constructors.stderr
+++ b/src/test/ui/const-generics/issues/issue-60818-struct-constructors.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/issues/issue-61336-1.stderr
+++ b/src/test/ui/const-generics/issues/issue-61336-1.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/issues/issue-61336-2.stderr
+++ b/src/test/ui/const-generics/issues/issue-61336-2.stderr
@@ -18,6 +18,6 @@ help: consider restricting type parameter `T`
 LL | fn g<T: std::marker::Copy, const N: usize>(x: T) -> [T; N] {
    |       ^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/const-generics/issues/issue-61336.stderr
+++ b/src/test/ui/const-generics/issues/issue-61336.stderr
@@ -18,6 +18,6 @@ help: consider restricting type parameter `T`
 LL | fn g<T: std::marker::Copy, const N: usize>(x: T) -> [T; N] {
    |       ^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/const-generics/issues/issue-61422.stderr
+++ b/src/test/ui/const-generics/issues/issue-61422.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/issues/issue-61432.stderr
+++ b/src/test/ui/const-generics/issues/issue-61432.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/issues/issue-61747.stderr
+++ b/src/test/ui/const-generics/issues/issue-61747.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/issues/issue-62187-encountered-polymorphic-const.stderr
+++ b/src/test/ui/const-generics/issues/issue-62187-encountered-polymorphic-const.stderr
@@ -14,3 +14,5 @@ LL |     let foo = <[u8; 2]>::BIT_LEN;
    |
    = note: `#[warn(unused_variables)]` on by default
 
+warning: 2 warnings emitted
+

--- a/src/test/ui/const-generics/issues/issue-62456.stderr
+++ b/src/test/ui/const-generics/issues/issue-62456.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/issues/issue-62579-no-match.stderr
+++ b/src/test/ui/const-generics/issues/issue-62579-no-match.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/issues/issue-64519.stderr
+++ b/src/test/ui/const-generics/issues/issue-64519.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/issues/issue-66906.stderr
+++ b/src/test/ui/const-generics/issues/issue-66906.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/issues/issue-70125-1.stderr
+++ b/src/test/ui/const-generics/issues/issue-70125-1.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/issues/issue-70125-2.stderr
+++ b/src/test/ui/const-generics/issues/issue-70125-2.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/issues/issue-70167.stderr
+++ b/src/test/ui/const-generics/issues/issue-70167.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/issues/issue70273-assoc-fn.stderr
+++ b/src/test/ui/const-generics/issues/issue70273-assoc-fn.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/mut-ref-const-param-array.stderr
+++ b/src/test/ui/const-generics/mut-ref-const-param-array.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/raw-ptr-const-param-deref.stderr
+++ b/src/test/ui/const-generics/raw-ptr-const-param-deref.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics, const_compare_raw_pointers)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/raw-ptr-const-param.stderr
+++ b/src/test/ui/const-generics/raw-ptr-const-param.stderr
@@ -17,6 +17,6 @@ LL |     let _: Const<{ 15 as *const _ }> = Const::<{ 10 as *const _ }>;
    = note: expected struct `Const<{0xf as *const u32}>`
               found struct `Const<{0xa as *const u32}>`
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/const-generics/slice-const-param-mismatch.stderr
+++ b/src/test/ui/const-generics/slice-const-param-mismatch.stderr
@@ -39,6 +39,6 @@ LL |     let _: ConstBytes<b"AAA"> = ConstBytes::<b"BBB">;
    = note: expected struct `ConstBytes<b"AAA">`
               found struct `ConstBytes<b"BBB">`
 
-error: aborting due to 3 previous errors
+error: aborting due to 3 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/const-generics/slice-const-param.stderr
+++ b/src/test/ui/const-generics/slice-const-param.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/struct-with-invalid-const-param.stderr
+++ b/src/test/ui/const-generics/struct-with-invalid-const-param.stderr
@@ -15,6 +15,6 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0573`.

--- a/src/test/ui/const-generics/transparent-maybeunit-array-wrapper.stderr
+++ b/src/test/ui/const-generics/transparent-maybeunit-array-wrapper.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/type_of_anon_const.stderr
+++ b/src/test/ui/const-generics/type_of_anon_const.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/types-mismatch-const-args.stderr
+++ b/src/test/ui/const-generics/types-mismatch-const-args.stderr
@@ -28,6 +28,6 @@ LL |     let _: A<'a, u16, {2u32}, {3u32}> = A::<'b, u32, {2u32}, {3u32}> { data
    = note: expected struct `A<'a, u16, _, _>`
               found struct `A<'b, u32, _, _>`
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/const-generics/uninferred-consts-during-codegen-1.stderr
+++ b/src/test/ui/const-generics/uninferred-consts-during-codegen-1.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/uninferred-consts-during-codegen-2.stderr
+++ b/src/test/ui/const-generics/uninferred-consts-during-codegen-2.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/unused-const-param.stderr
+++ b/src/test/ui/const-generics/unused-const-param.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/const-generics/unused_braces.stderr
+++ b/src/test/ui/const-generics/unused_braces.stderr
@@ -18,3 +18,5 @@ note: the lint level is defined here
 LL | #![warn(unused_braces)]
    |         ^^^^^^^^^^^^^
 
+warning: 2 warnings emitted
+

--- a/src/test/ui/consts/array-literal-index-oob.stderr
+++ b/src/test/ui/consts/array-literal-index-oob.stderr
@@ -30,3 +30,5 @@ warning: erroneous constant used
 LL |     &{ [1, 2, 3][4] };
    |     ^^^^^^^^^^^^^^^^^ referenced constant has errors
 
+warning: 3 warnings emitted
+

--- a/src/test/ui/consts/assoc_const_generic_impl.stderr
+++ b/src/test/ui/consts/assoc_const_generic_impl.stderr
@@ -18,5 +18,5 @@ error: erroneous constant encountered
 LL |         let () = Self::I_AM_ZERO_SIZED;
    |                  ^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/consts/const-err.stderr
+++ b/src/test/ui/consts/const-err.stderr
@@ -24,6 +24,6 @@ error[E0080]: erroneous constant used
 LL |     black_box((FOO, FOO));
    |                     ^^^ referenced constant has errors
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/conditional_array_execution.stderr
+++ b/src/test/ui/consts/const-eval/conditional_array_execution.stderr
@@ -24,6 +24,6 @@ warning: erroneous constant used
 LL |     println!("{}", FOO);
    |                    ^^^ referenced constant has errors
 
-error: aborting due to previous error
+error: aborting due to previous error; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/const_fn_ptr.stderr
+++ b/src/test/ui/consts/const-eval/const_fn_ptr.stderr
@@ -16,3 +16,5 @@ warning: skipping const checks
 LL |     x(y)
    |     ^^^^
 
+warning: 3 warnings emitted
+

--- a/src/test/ui/consts/const-eval/const_fn_ptr_fail.stderr
+++ b/src/test/ui/consts/const-eval/const_fn_ptr_fail.stderr
@@ -4,3 +4,5 @@ warning: skipping const checks
 LL |     X(x) // FIXME: this should error someday
    |     ^^^^
 
+warning: 1 warning emitted
+

--- a/src/test/ui/consts/const-eval/const_fn_ptr_fail2.stderr
+++ b/src/test/ui/consts/const-eval/const_fn_ptr_fail2.stderr
@@ -24,6 +24,6 @@ LL |     assert_eq!(Z, 4);
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/index-out-of-bounds-never-type.stderr
+++ b/src/test/ui/consts/const-eval/index-out-of-bounds-never-type.stderr
@@ -18,5 +18,5 @@ error: erroneous constant encountered
 LL |     let _ = PrintName::<T>::VOID;
    |             ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/consts/const-eval/issue-43197.stderr
+++ b/src/test/ui/consts/const-eval/issue-43197.stderr
@@ -44,6 +44,6 @@ warning: erroneous constant used
 LL |     println!("{} {}", X, Y);
    |                          ^ referenced constant has errors
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 4 warnings emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/panic-assoc-never-type.stderr
+++ b/src/test/ui/consts/const-eval/panic-assoc-never-type.stderr
@@ -19,6 +19,6 @@ error[E0080]: erroneous constant used
 LL |     let _ = PrintName::VOID;
    |             ^^^^^^^^^^^^^^^ referenced constant has errors
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/panic-never-type.stderr
+++ b/src/test/ui/consts/const-eval/panic-never-type.stderr
@@ -19,6 +19,6 @@ error[E0080]: erroneous constant used
 LL |     let _ = VOID;
    |             ^^^^ referenced constant has errors
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/promoted_errors.noopt.stderr
+++ b/src/test/ui/consts/const-eval/promoted_errors.noopt.stderr
@@ -76,3 +76,5 @@ warning: this operation will panic at runtime
 LL |     let _x = 1 / (false as u32);
    |              ^^^^^^^^^^^^^^^^^^ attempt to divide by zero
 
+warning: 10 warnings emitted
+

--- a/src/test/ui/consts/const-eval/promoted_errors.opt.stderr
+++ b/src/test/ui/consts/const-eval/promoted_errors.opt.stderr
@@ -70,3 +70,5 @@ warning: this operation will panic at runtime
 LL |     let _x = 1 / (false as u32);
    |              ^^^^^^^^^^^^^^^^^^ attempt to divide by zero
 
+warning: 9 warnings emitted
+

--- a/src/test/ui/consts/const-eval/promoted_errors.opt_with_overflow_checks.stderr
+++ b/src/test/ui/consts/const-eval/promoted_errors.opt_with_overflow_checks.stderr
@@ -76,3 +76,5 @@ warning: this operation will panic at runtime
 LL |     let _x = 1 / (false as u32);
    |              ^^^^^^^^^^^^^^^^^^ attempt to divide by zero
 
+warning: 10 warnings emitted
+

--- a/src/test/ui/consts/const-eval/pub_const_err.stderr
+++ b/src/test/ui/consts/const-eval/pub_const_err.stderr
@@ -12,3 +12,5 @@ note: the lint level is defined here
 LL | #![warn(const_err)]
    |         ^^^^^^^^^
 
+warning: 1 warning emitted
+

--- a/src/test/ui/consts/const-eval/pub_const_err_bin.stderr
+++ b/src/test/ui/consts/const-eval/pub_const_err_bin.stderr
@@ -12,3 +12,5 @@ note: the lint level is defined here
 LL | #![warn(const_err)]
    |         ^^^^^^^^^
 
+warning: 1 warning emitted
+

--- a/src/test/ui/consts/const-eval/validate_uninhabited_zsts.stderr
+++ b/src/test/ui/consts/const-eval/validate_uninhabited_zsts.stderr
@@ -48,6 +48,6 @@ LL | const BAR: [Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
    |
    = note: enums with no variants have no valid value
 
-error: aborting due to previous error
+error: aborting due to previous error; 3 warnings emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-points-to-static.stderr
+++ b/src/test/ui/consts/const-points-to-static.stderr
@@ -12,6 +12,6 @@ LL | const TEST: &u8 = &MY_STATIC;
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-prop-read-static-in-const.stderr
+++ b/src/test/ui/consts/const-prop-read-static-in-const.stderr
@@ -14,5 +14,5 @@ LL | const TEST: u8 = MY_STATIC;
    |
    = note: `#[deny(const_err)]` on by default
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/consts/miri_unleashed/abi-mismatch.stderr
+++ b/src/test/ui/consts/miri_unleashed/abi-mismatch.stderr
@@ -25,5 +25,5 @@ LL | const VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C
    |
    = note: `#[deny(const_err)]` on by default
 
-error: aborting due to previous error
+error: aborting due to previous error; 2 warnings emitted
 

--- a/src/test/ui/consts/miri_unleashed/assoc_const.stderr
+++ b/src/test/ui/consts/miri_unleashed/assoc_const.stderr
@@ -10,6 +10,6 @@ error[E0080]: erroneous constant used
 LL |     let y = <String as Bar<Vec<u32>, String>>::F;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
@@ -101,6 +101,6 @@ LL | | };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 10 warnings emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/drop.stderr
+++ b/src/test/ui/consts/miri_unleashed/drop.stderr
@@ -22,6 +22,6 @@ LL | | }
 LL |   };
    |   - inside `TEST_BAD` at $DIR/drop.rs:19:1
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/mutable_const.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_const.stderr
@@ -22,5 +22,5 @@ note: the lint level is defined here
 LL | #![deny(const_err)]
    |         ^^^^^^^^^
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/consts/miri_unleashed/mutable_const2.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_const2.stderr
@@ -4,13 +4,15 @@ warning: skipping const checks
 LL | const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
    |                                      ^^^^^^^^^^^^^^^^^^^^
 
+warning: 1 warning emitted
+
 error: internal compiler error: mutable allocation in constant
   --> $DIR/mutable_const2.rs:15:1
    |
 LL | const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-thread 'rustc' panicked at 'no errors encountered even though `delay_span_bug` issued', src/librustc_errors/lib.rs:360:17
+thread 'rustc' panicked at 'no errors encountered even though `delay_span_bug` issued', src/librustc_errors/lib.rs:363:17
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 error: internal compiler error: unexpected panic

--- a/src/test/ui/consts/miri_unleashed/mutable_references.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_references.stderr
@@ -10,6 +10,6 @@ error[E0594]: cannot assign to `*OH_YES`, as `OH_YES` is an immutable static ite
 LL |     *OH_YES = 99;
    |     ^^^^^^^^^^^^ cannot assign
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0594`.

--- a/src/test/ui/consts/miri_unleashed/mutable_references_ice.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_references_ice.stderr
@@ -19,3 +19,5 @@ note: rustc VERSION running on TARGET
 
 note: compiler flags: FLAGS
 
+warning: 1 warning emitted
+

--- a/src/test/ui/consts/miri_unleashed/mutating_global.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutating_global.stderr
@@ -25,5 +25,5 @@ LL | | };
    |
    = note: `#[deny(const_err)]` on by default
 
-error: aborting due to previous error
+error: aborting due to previous error; 2 warnings emitted
 

--- a/src/test/ui/consts/miri_unleashed/non_const_fn.stderr
+++ b/src/test/ui/consts/miri_unleashed/non_const_fn.stderr
@@ -30,6 +30,6 @@ warning: erroneous constant used
 LL |     println!("{:?}", C);
    |                      ^ referenced constant has errors
 
-error: aborting due to previous error
+error: aborting due to previous error; 3 warnings emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/packed_pattern.stderr
+++ b/src/test/ui/consts/packed_pattern.stderr
@@ -6,3 +6,5 @@ LL |         FOO => unreachable!(),
    |
    = note: `#[warn(unreachable_patterns)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/consts/packed_pattern2.stderr
+++ b/src/test/ui/consts/packed_pattern2.stderr
@@ -6,3 +6,5 @@ LL |         FOO => unreachable!(),
    |
    = note: `#[warn(unreachable_patterns)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/deduplicate-diagnostics-2.deduplicate.stderr
+++ b/src/test/ui/deduplicate-diagnostics-2.deduplicate.stderr
@@ -26,3 +26,5 @@ LL |         1.0 => {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
+warning: 3 warnings emitted
+

--- a/src/test/ui/deduplicate-diagnostics-2.duplicate.stderr
+++ b/src/test/ui/deduplicate-diagnostics-2.duplicate.stderr
@@ -35,3 +35,5 @@ LL |         2.0 => {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
+warning: 4 warnings emitted
+

--- a/src/test/ui/deprecation/atomic_initializers.stderr
+++ b/src/test/ui/deprecation/atomic_initializers.stderr
@@ -6,3 +6,5 @@ LL | static FOO: AtomicIsize = ATOMIC_ISIZE_INIT;
    |
    = note: `#[warn(deprecated)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/deprecation/deprecated-macro_escape-inner.stderr
+++ b/src/test/ui/deprecation/deprecated-macro_escape-inner.stderr
@@ -6,3 +6,5 @@ LL |     #![macro_escape]
    |
    = help: try an outer attribute: `#[macro_use]`
 
+warning: 1 warning emitted
+

--- a/src/test/ui/deprecation/deprecated-macro_escape.stderr
+++ b/src/test/ui/deprecation/deprecated-macro_escape.stderr
@@ -4,3 +4,5 @@ warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
 LL | #[macro_escape]
    | ^^^^^^^^^^^^^^^
 
+warning: 1 warning emitted
+

--- a/src/test/ui/deprecation/deprecation-in-future.stderr
+++ b/src/test/ui/deprecation/deprecation-in-future.stderr
@@ -6,3 +6,5 @@ LL |     deprecated_future(); // ok; deprecated_in_future only applies to rustc_
    |
    = note: `#[warn(deprecated)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/derive-uninhabited-enum-38885.stderr
+++ b/src/test/ui/derive-uninhabited-enum-38885.stderr
@@ -6,3 +6,5 @@ LL |     Void(Void),
    |
    = note: `-W dead-code` implied by `-W unused`
 
+warning: 1 warning emitted
+

--- a/src/test/ui/did_you_mean/issue-31424.stderr
+++ b/src/test/ui/did_you_mean/issue-31424.stderr
@@ -28,6 +28,6 @@ LL |         (&mut self).bar();
    |         cannot borrow as mutable
    |         try removing `&mut` here
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/editions/edition-extern-crate-allowed.stderr
+++ b/src/test/ui/editions/edition-extern-crate-allowed.stderr
@@ -11,3 +11,5 @@ LL | #![warn(rust_2018_idioms)]
    |         ^^^^^^^^^^^^^^^^
    = note: `#[warn(unused_extern_crates)]` implied by `#[warn(rust_2018_idioms)]`
 
+warning: 1 warning emitted
+

--- a/src/test/ui/editions/edition-feature-redundant.stderr
+++ b/src/test/ui/editions/edition-feature-redundant.stderr
@@ -4,3 +4,6 @@ warning[E0705]: the feature `rust_2018_preview` is included in the Rust 2018 edi
 LL | #![feature(rust_2018_preview)]
    |            ^^^^^^^^^^^^^^^^^
 
+warning: 1 warning emitted
+
+For more information about this error, try `rustc --explain E0705`.

--- a/src/test/ui/enum/enum-size-variance.stderr
+++ b/src/test/ui/enum/enum-size-variance.stderr
@@ -10,3 +10,5 @@ note: the lint level is defined here
 LL | #![warn(variant_size_differences)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
+warning: 1 warning emitted
+

--- a/src/test/ui/error-codes/E0705.stderr
+++ b/src/test/ui/error-codes/E0705.stderr
@@ -4,3 +4,6 @@ warning[E0705]: the feature `test_2018_feature` is included in the Rust 2018 edi
 LL | #![feature(test_2018_feature)]
    |            ^^^^^^^^^^^^^^^^^
 
+warning: 1 warning emitted
+
+For more information about this error, try `rustc --explain E0705`.

--- a/src/test/ui/error-codes/E0730.stderr
+++ b/src/test/ui/error-codes/E0730.stderr
@@ -12,6 +12,6 @@ error[E0730]: cannot pattern-match on an array without a fixed length
 LL |         [1, 2, ..] => true,
    |         ^^^^^^^^^^
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0730`.

--- a/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.stderr
@@ -1234,3 +1234,5 @@ warning: unused attribute
 LL | #![proc_macro_derive()]
    | ^^^^^^^^^^^^^^^^^^^^^^^
 
+warning: 203 warnings emitted
+

--- a/src/test/ui/feature-gate/issue-43106-gating-of-macro_escape.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-macro_escape.stderr
@@ -6,3 +6,5 @@ LL | #![macro_escape]
    |
    = help: try an outer attribute: `#[macro_use]`
 
+warning: 1 warning emitted
+

--- a/src/test/ui/feature-gates/feature-gate-plugin_registrar.stderr
+++ b/src/test/ui/feature-gates/feature-gate-plugin_registrar.stderr
@@ -24,6 +24,6 @@ LL | #[plugin_registrar]
    |
    = note: `#[warn(deprecated)]` on by default
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/fn_must_use.stderr
+++ b/src/test/ui/fn_must_use.stderr
@@ -55,3 +55,5 @@ warning: unused comparison that must be used
 LL |     m == n;
    |     ^^^^^^
 
+warning: 8 warnings emitted
+

--- a/src/test/ui/generic-associated-types/gat-incomplete-warning.stderr
+++ b/src/test/ui/generic-associated-types/gat-incomplete-warning.stderr
@@ -6,3 +6,5 @@ LL | #![feature(generic_associated_types)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/hygiene/generic_params.stderr
+++ b/src/test/ui/hygiene/generic_params.stderr
@@ -6,3 +6,5 @@ LL | #![feature(decl_macro, rustc_attrs, const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/hygiene/hygienic-labels-in-let.stderr
+++ b/src/test/ui/hygiene/hygienic-labels-in-let.stderr
@@ -330,3 +330,5 @@ LL |             run_once!(continue 'x);
    |
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
+warning: 28 warnings emitted
+

--- a/src/test/ui/hygiene/hygienic-labels.stderr
+++ b/src/test/ui/hygiene/hygienic-labels.stderr
@@ -330,3 +330,5 @@ LL |         run_once!(continue 'x);
    |
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
+warning: 28 warnings emitted
+

--- a/src/test/ui/hygiene/issue-61574-const-parameters.stderr
+++ b/src/test/ui/hygiene/issue-61574-const-parameters.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/if-attrs/let-chains-attr.stderr
+++ b/src/test/ui/if-attrs/let-chains-attr.stderr
@@ -6,3 +6,5 @@ LL | #![feature(let_chains)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/if-ret.stderr
+++ b/src/test/ui/if-ret.stderr
@@ -8,3 +8,5 @@ LL | fn foo() { if (return) { } }
    |
    = note: `#[warn(unreachable_code)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/if/if-let.stderr
+++ b/src/test/ui/if/if-let.stderr
@@ -63,3 +63,5 @@ LL | |         println!("irrefutable pattern");
 LL | |     }
    | |_____^
 
+warning: 6 warnings emitted
+

--- a/src/test/ui/impl-trait-in-bindings.stderr
+++ b/src/test/ui/impl-trait-in-bindings.stderr
@@ -6,3 +6,5 @@ LL | #![feature(impl_trait_in_bindings)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/impl-trait/bindings-opaque.stderr
+++ b/src/test/ui/impl-trait/bindings-opaque.stderr
@@ -24,6 +24,6 @@ error[E0599]: no method named `count_ones` found for opaque type `impl std::mark
 LL |     let _ = foo.count_ones();
    |                 ^^^^^^^^^^ method not found in `impl std::marker::Copy`
 
-error: aborting due to 3 previous errors
+error: aborting due to 3 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0599`.

--- a/src/test/ui/impl-trait/bindings.stderr
+++ b/src/test/ui/impl-trait/bindings.stderr
@@ -30,6 +30,6 @@ LL | #![feature(impl_trait_in_bindings)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error: aborting due to 4 previous errors
+error: aborting due to 4 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0435`.

--- a/src/test/ui/impl-trait/bound-normalization-fail.stderr
+++ b/src/test/ui/impl-trait/bound-normalization-fail.stderr
@@ -36,6 +36,6 @@ LL |     fn foo2_fail<'a, T: Trait<'a>>() -> impl FooLike<Output=T::Assoc> {
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
    = note: the return type of a function must have a statically known size
 
-error: aborting due to 3 previous errors
+error: aborting due to 3 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0271`.

--- a/src/test/ui/impl-trait/bound-normalization-pass.stderr
+++ b/src/test/ui/impl-trait/bound-normalization-pass.stderr
@@ -6,3 +6,5 @@ LL | #![feature(impl_trait_in_bindings)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/impl-trait/equal-hidden-lifetimes.stderr
+++ b/src/test/ui/impl-trait/equal-hidden-lifetimes.stderr
@@ -6,3 +6,5 @@ LL | fn equal_regions_static<'a: 'static>(x: &'a i32) -> impl Sized {
    |
    = help: you can use the `'static` lifetime directly, in place of `'a`
 
+warning: 1 warning emitted
+

--- a/src/test/ui/imports/reexports.stderr
+++ b/src/test/ui/imports/reexports.stderr
@@ -56,7 +56,7 @@ note: the lint level is defined here
 LL | #![warn(unused_imports)]
    |         ^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 3 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0364, E0603.
 For more information about an error, try `rustc --explain E0364`.

--- a/src/test/ui/inference/cannot-infer-async-enabled-impl-trait-bindings.stderr
+++ b/src/test/ui/inference/cannot-infer-async-enabled-impl-trait-bindings.stderr
@@ -14,6 +14,6 @@ LL |     let fut = async {
 LL |         make_unit()?;
    |         ^^^^^^^^^^^^ cannot infer type
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/inference/inference-variable-behind-raw-pointer.stderr
+++ b/src/test/ui/inference/inference-variable-behind-raw-pointer.stderr
@@ -8,3 +8,5 @@ LL |     if data.is_null() {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue #46906 <https://github.com/rust-lang/rust/issues/46906>
 
+warning: 1 warning emitted
+

--- a/src/test/ui/inference/inference_unstable.stderr
+++ b/src/test/ui/inference/inference_unstable.stderr
@@ -10,3 +10,5 @@ LL |     assert_eq!('x'.ipu_flatten(), 1);
    = help: call with fully qualified syntax `inference_unstable_itertools::IpuItertools::ipu_flatten(...)` to keep using the current method
    = help: add `#![feature(ipu_flatten)]` to the crate attributes to enable `inference_unstable_iterator::IpuIterator::ipu_flatten`
 
+warning: 1 warning emitted
+

--- a/src/test/ui/invalid/invalid-plugin-attr.stderr
+++ b/src/test/ui/invalid/invalid-plugin-attr.stderr
@@ -24,5 +24,5 @@ error: crate-level attribute should be an inner attribute: add an exclamation ma
 LL | #[plugin(bla)]
    | ^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/src/test/ui/issues/issue-14221.stderr
+++ b/src/test/ui/issues/issue-14221.stderr
@@ -27,6 +27,6 @@ note: the lint level is defined here
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: aborting due to previous error; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0170`.

--- a/src/test/ui/issues/issue-19100.stderr
+++ b/src/test/ui/issues/issue-19100.stderr
@@ -12,3 +12,6 @@ warning[E0170]: pattern binding `Baz` is named the same as one of the variants o
 LL | Baz if false
    | ^^^ help: to match on the variant, qualify the path: `Foo::Baz`
 
+warning: 2 warnings emitted
+
+For more information about this error, try `rustc --explain E0170`.

--- a/src/test/ui/issues/issue-27042.stderr
+++ b/src/test/ui/issues/issue-27042.stderr
@@ -43,6 +43,6 @@ LL | /         'd:
 LL | |         while let Some(_) = None { break };
    | |__________________________________________^ expected `i32`, found `()`
 
-error: aborting due to 4 previous errors
+error: aborting due to 4 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/issues/issue-30079.stderr
+++ b/src/test/ui/issues/issue-30079.stderr
@@ -26,6 +26,6 @@ LL |     impl ::SemiPrivTrait for () {
 LL |         type Assoc = Priv;
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0446`.

--- a/src/test/ui/issues/issue-30302.stderr
+++ b/src/test/ui/issues/issue-30302.stderr
@@ -21,6 +21,6 @@ note: the lint level is defined here
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0170`.

--- a/src/test/ui/issues/issue-33140-traitobject-crate.stderr
+++ b/src/test/ui/issues/issue-33140-traitobject-crate.stderr
@@ -38,3 +38,5 @@ LL | unsafe impl Trait for dyn (::std::marker::Sync) + Send + Sync { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #56484 <https://github.com/rust-lang/rust/issues/56484>
 
+warning: 3 warnings emitted
+

--- a/src/test/ui/issues/issue-37515.stderr
+++ b/src/test/ui/issues/issue-37515.stderr
@@ -11,3 +11,5 @@ LL | #![warn(unused)]
    |         ^^^^^^
    = note: `#[warn(dead_code)]` implied by `#[warn(unused)]`
 
+warning: 1 warning emitted
+

--- a/src/test/ui/issues/issue-37534.stderr
+++ b/src/test/ui/issues/issue-37534.stderr
@@ -23,7 +23,7 @@ LL | struct Foo<T: ?Hash> { }
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `std::marker::PhantomData`
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0392, E0404.
 For more information about an error, try `rustc --explain E0392`.

--- a/src/test/ui/issues/issue-49934.stderr
+++ b/src/test/ui/issues/issue-49934.stderr
@@ -36,3 +36,5 @@ warning: unused attribute
 LL |         #[derive(Debug)]
    |         ^^^^^^^^^^^^^^^^
 
+warning: 5 warnings emitted
+

--- a/src/test/ui/issues/issue-50993.stderr
+++ b/src/test/ui/issues/issue-50993.stderr
@@ -1,2 +1,4 @@
 warning: dropping unsupported crate type `dylib` for target `thumbv7em-none-eabihf`
 
+warning: 1 warning emitted
+

--- a/src/test/ui/issues/issue-55511.stderr
+++ b/src/test/ui/issues/issue-55511.stderr
@@ -24,6 +24,6 @@ LL |         <() as Foo<'static>>::C => { }
 LL | }
    | - `a` dropped here while still borrowed
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/issues/issue-59508-1.stderr
+++ b/src/test/ui/issues/issue-59508-1.stderr
@@ -12,5 +12,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/issues/issue-70041.stderr
+++ b/src/test/ui/issues/issue-70041.stderr
@@ -17,3 +17,5 @@ LL | use regex;
    |
    = note: `#[warn(unused_imports)]` on by default
 
+warning: 2 warnings emitted
+

--- a/src/test/ui/issues/issue-8727.stderr
+++ b/src/test/ui/issues/issue-8727.stderr
@@ -17,5 +17,5 @@ LL | |     generic::<Option<T>>();
 LL | | }
    | |_^
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/iterators/into-iter-on-arrays-lint.stderr
+++ b/src/test/ui/iterators/into-iter-on-arrays-lint.stderr
@@ -107,3 +107,5 @@ LL |     Box::new(Box::new([0u8; 33])).into_iter();
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>
 
+warning: 12 warnings emitted
+

--- a/src/test/ui/layout/debug.stderr
+++ b/src/test/ui/layout/debug.stderr
@@ -316,9 +316,7 @@ LL | type Test = Result<i32, i32>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: layout_of(i32) = Layout {
-    fields: Union(
-        0,
-    ),
+    fields: Primitive,
     variants: Single {
         index: 0,
     },

--- a/src/test/ui/lint/command-line-lint-group-warn.stderr
+++ b/src/test/ui/lint/command-line-lint-group-warn.stderr
@@ -6,3 +6,5 @@ LL |     let _InappropriateCamelCasing = true;
    |
    = note: `-W non-snake-case` implied by `-W bad-style`
 
+warning: 1 warning emitted
+

--- a/src/test/ui/lint/inclusive-range-pattern-syntax.stderr
+++ b/src/test/ui/lint/inclusive-range-pattern-syntax.stderr
@@ -16,3 +16,5 @@ warning: `...` range patterns are deprecated
 LL |         &1...2 => {}
    |         ^^^^^^ help: use `..=` for an inclusive range: `&(1..=2)`
 
+warning: 2 warnings emitted
+

--- a/src/test/ui/lint/inline-trait-and-foreign-items.stderr
+++ b/src/test/ui/lint/inline-trait-and-foreign-items.stderr
@@ -67,6 +67,6 @@ error: could not find defining uses
 LL |     type U = impl Trait;
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 6 previous errors
+error: aborting due to 6 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0518`.

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
@@ -122,3 +122,5 @@ LL |     let (mut var, unused_var) = (1, 2);
    |          |
    |          help: remove this `mut`
 
+warning: 16 warnings emitted
+

--- a/src/test/ui/lint/lint-change-warnings.stderr
+++ b/src/test/ui/lint/lint-change-warnings.stderr
@@ -32,5 +32,5 @@ LL | #[forbid(warnings)]
    |          ^^^^^^^^
    = note: `#[forbid(while_true)]` implied by `#[forbid(warnings)]`
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/src/test/ui/lint/lint-group-nonstandard-style.stderr
+++ b/src/test/ui/lint/lint-group-nonstandard-style.stderr
@@ -63,5 +63,5 @@ LL |         #![warn(nonstandard_style)]
    |                 ^^^^^^^^^^^^^^^^^
    = note: `#[warn(non_snake_case)]` implied by `#[warn(nonstandard_style)]`
 
-error: aborting due to 3 previous errors
+error: aborting due to 3 previous errors; 2 warnings emitted
 

--- a/src/test/ui/lint/lint-output-format-2.stderr
+++ b/src/test/ui/lint/lint-output-format-2.stderr
@@ -12,3 +12,5 @@ warning: use of deprecated item 'lint_output_format::foo': text
 LL |     let _x = foo();
    |              ^^^
 
+warning: 2 warnings emitted
+

--- a/src/test/ui/lint/lint-pre-expansion-extern-module.stderr
+++ b/src/test/ui/lint/lint-pre-expansion-extern-module.stderr
@@ -8,3 +8,5 @@ LL | pub fn try() {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
+warning: 1 warning emitted
+

--- a/src/test/ui/lint/lint-removed-cmdline.stderr
+++ b/src/test/ui/lint/lint-removed-cmdline.stderr
@@ -27,5 +27,5 @@ LL | #[deny(warnings)]
    |        ^^^^^^^^
    = note: `#[deny(unused_variables)]` implied by `#[deny(warnings)]`
 
-error: aborting due to previous error
+error: aborting due to previous error; 4 warnings emitted
 

--- a/src/test/ui/lint/lint-removed.stderr
+++ b/src/test/ui/lint/lint-removed.stderr
@@ -18,5 +18,5 @@ note: the lint level is defined here
 LL | #[deny(unused_variables)]
    |        ^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/lint/lint-renamed-cmdline.stderr
+++ b/src/test/ui/lint/lint-renamed-cmdline.stderr
@@ -27,5 +27,5 @@ LL | #[deny(unused)]
    |        ^^^^^^
    = note: `#[deny(unused_variables)]` implied by `#[deny(unused)]`
 
-error: aborting due to previous error
+error: aborting due to previous error; 4 warnings emitted
 

--- a/src/test/ui/lint/lint-renamed.stderr
+++ b/src/test/ui/lint/lint-renamed.stderr
@@ -19,5 +19,5 @@ LL | #[deny(unused)]
    |        ^^^^^^
    = note: `#[deny(unused_variables)]` implied by `#[deny(unused)]`
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/lint/lint-stability-deprecated.stderr
+++ b/src/test/ui/lint/lint-stability-deprecated.stderr
@@ -652,3 +652,5 @@ warning: use of deprecated item 'lint_stability::TraitWithAssociatedTypes::TypeD
 LL |             TypeDeprecated = u16,
    |             ^^^^^^^^^^^^^^^^^^^^
 
+warning: 108 warnings emitted
+

--- a/src/test/ui/lint/lint-type-limits2.stderr
+++ b/src/test/ui/lint/lint-type-limits2.stderr
@@ -19,5 +19,5 @@ LL | #![warn(overflowing_literals)]
    |         ^^^^^^^^^^^^^^^^^^^^
    = note: the literal `128` does not fit into the type `i8` whose range is `-128..=127`
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/lint/lint-type-limits3.stderr
+++ b/src/test/ui/lint/lint-type-limits3.stderr
@@ -19,5 +19,5 @@ LL | #![warn(overflowing_literals)]
    |         ^^^^^^^^^^^^^^^^^^^^
    = note: the literal `200` does not fit into the type `i8` whose range is `-128..=127`
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/lint/lint-unexported-no-mangle.stderr
+++ b/src/test/ui/lint/lint-unexported-no-mangle.stderr
@@ -48,5 +48,5 @@ LL | pub const PUB_FOO: u64 = 1;
    | |
    | help: try a static value: `pub static`
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 8 warnings emitted
 

--- a/src/test/ui/lint/lint-unnecessary-parens.stderr
+++ b/src/test/ui/lint/lint-unnecessary-parens.stderr
@@ -114,5 +114,5 @@ error: unnecessary parentheses around assigned value
 LL |     _a += (1);
    |           ^^^ help: remove these parentheses
 
-error: aborting due to 17 previous errors
+error: aborting due to 17 previous errors; 1 warning emitted
 

--- a/src/test/ui/lint/lint-unused-mut-variables.stderr
+++ b/src/test/ui/lint/lint-unused-mut-variables.stderr
@@ -218,5 +218,5 @@ note: the lint level is defined here
 LL | #[deny(unused_mut)]
    |        ^^^^^^^^^^
 
-error: aborting due to previous error
+error: aborting due to previous error; 25 warnings emitted
 

--- a/src/test/ui/lint/lint-uppercase-variables.stderr
+++ b/src/test/ui/lint/lint-uppercase-variables.stderr
@@ -85,6 +85,6 @@ error: variable `Foo` should have a snake case name
 LL |     fn in_param(Foo: foo::Foo) {}
    |                 ^^^ help: convert the identifier to snake case (notice the capitalization): `foo`
 
-error: aborting due to 6 previous errors
+error: aborting due to 6 previous errors; 6 warnings emitted
 
 For more information about this error, try `rustc --explain E0170`.

--- a/src/test/ui/lint/lints-in-foreign-macros.stderr
+++ b/src/test/ui/lint/lints-in-foreign-macros.stderr
@@ -56,3 +56,5 @@ warning: missing documentation for a function
 LL | baz2!(pub fn undocumented2() {});
    |       ^^^^^^^^^^^^^^^^^^^^^^
 
+warning: 6 warnings emitted
+

--- a/src/test/ui/lint/must-use-ops.stderr
+++ b/src/test/ui/lint/must-use-ops.stderr
@@ -130,3 +130,5 @@ warning: unused unary operation that must be used
 LL |     *val_pointer;
    |     ^^^^^^^^^^^^
 
+warning: 21 warnings emitted
+

--- a/src/test/ui/lint/not_found.stderr
+++ b/src/test/ui/lint/not_found.stderr
@@ -18,3 +18,5 @@ warning: unknown lint: `Warnings`
 LL | #[deny(Warnings)]
    |        ^^^^^^^^ help: did you mean (notice the capitalization): `warnings`
 
+warning: 3 warnings emitted
+

--- a/src/test/ui/lint/reasons-erroneous.stderr
+++ b/src/test/ui/lint/reasons-erroneous.stderr
@@ -186,6 +186,6 @@ error[E0452]: malformed lint attribute input
 LL | #![warn(keyword_idents, reason = "root in rubble", macro_use_extern_crate)]
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^ reason in lint attribute must come last
 
-error: aborting due to 30 previous errors
+error: aborting due to 30 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0452`.

--- a/src/test/ui/lint/reasons.stderr
+++ b/src/test/ui/lint/reasons.stderr
@@ -26,3 +26,5 @@ LL |     nonstandard_style,
    |     ^^^^^^^^^^^^^^^^^
    = note: `#[warn(non_snake_case)]` implied by `#[warn(nonstandard_style)]`
 
+warning: 2 warnings emitted
+

--- a/src/test/ui/lint/suggestions.stderr
+++ b/src/test/ui/lint/suggestions.stderr
@@ -105,5 +105,5 @@ LL |     #[no_mangle] pub(crate) fn crossfield<T>() {}
    |     |
    |     help: remove this attribute
 
-error: aborting due to 3 previous errors
+error: aborting due to 3 previous errors; 8 warnings emitted
 

--- a/src/test/ui/lint/type-overflow.stderr
+++ b/src/test/ui/lint/type-overflow.stderr
@@ -61,3 +61,5 @@ LL |     let fail = -0b1111_1111i8;
    |
    = note: the literal `0b1111_1111i8` (decimal `255`) does not fit into the type `i8` and will become `-1i8`
 
+warning: 7 warnings emitted
+

--- a/src/test/ui/lint/unreachable_pub-pub_crate.stderr
+++ b/src/test/ui/lint/unreachable_pub-pub_crate.stderr
@@ -144,3 +144,5 @@ LL |         pub fn catalyze() -> bool;
    |
    = help: or consider exporting it for use by other crates
 
+warning: 14 warnings emitted
+

--- a/src/test/ui/lint/unreachable_pub.stderr
+++ b/src/test/ui/lint/unreachable_pub.stderr
@@ -144,3 +144,5 @@ LL |         pub fn catalyze() -> bool;
    |
    = help: or consider exporting it for use by other crates
 
+warning: 14 warnings emitted
+

--- a/src/test/ui/lint/unused_braces.stderr
+++ b/src/test/ui/lint/unused_braces.stderr
@@ -40,3 +40,5 @@ warning: unnecessary braces around function argument
 LL |     consume({ 7 });
    |             ^^^^^ help: remove these braces
 
+warning: 5 warnings emitted
+

--- a/src/test/ui/lint/unused_braces_borrow.stderr
+++ b/src/test/ui/lint/unused_braces_borrow.stderr
@@ -10,3 +10,5 @@ note: the lint level is defined here
 LL | #![warn(unused_braces)]
    |         ^^^^^^^^^^^^^
 
+warning: 1 warning emitted
+

--- a/src/test/ui/lint/unused_import_warning_issue_45268.stderr
+++ b/src/test/ui/lint/unused_import_warning_issue_45268.stderr
@@ -10,3 +10,5 @@ note: the lint level is defined here
 LL | #![warn(unused_imports)] // Warning explanation here, it's OK
    |         ^^^^^^^^^^^^^^
 
+warning: 1 warning emitted
+

--- a/src/test/ui/lint/unused_labels.stderr
+++ b/src/test/ui/lint/unused_labels.stderr
@@ -61,3 +61,5 @@ LL |
 LL |         'many_used_shadowed: for _ in 0..10 {
    |         ^^^^^^^^^^^^^^^^^^^ lifetime 'many_used_shadowed already in scope
 
+warning: 9 warnings emitted
+

--- a/src/test/ui/lint/use-redundant.stderr
+++ b/src/test/ui/lint/use-redundant.stderr
@@ -25,3 +25,5 @@ LL | use crate::foo::Bar;
 LL |     use crate::foo::Bar;
    |         ^^^^^^^^^^^^^^^
 
+warning: 3 warnings emitted
+

--- a/src/test/ui/liveness/liveness-move-in-while.stderr
+++ b/src/test/ui/liveness/liveness-move-in-while.stderr
@@ -29,6 +29,6 @@ LL |         println!("{}", y);
 LL |         while true { while true { while true { x = y; x.clone(); } } }
    |                                                    - value moved here, in previous iteration of loop
 
-error: aborting due to previous error
+error: aborting due to previous error; 3 warnings emitted
 
 For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/liveness/liveness-unused.stderr
+++ b/src/test/ui/liveness/liveness-unused.stderr
@@ -112,5 +112,5 @@ LL |         x = 0;
    |
    = help: maybe it is overwritten before being read?
 
-error: aborting due to 13 previous errors
+error: aborting due to 13 previous errors; 1 warning emitted
 

--- a/src/test/ui/loops/loop-break-value.stderr
+++ b/src/test/ui/loops/loop-break-value.stderr
@@ -151,7 +151,7 @@ LL |         break;
    |         expected integer, found `()`
    |         help: give it a value of the expected type: `break value`
 
-error: aborting due to 16 previous errors
+error: aborting due to 16 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0308, E0571.
 For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/loops/loops-reject-duplicate-labels-2.stderr
+++ b/src/test/ui/loops/loops-reject-duplicate-labels-2.stderr
@@ -62,3 +62,5 @@ LL |     { 'lt: loop { break; } }
 LL |     { 'lt: while let Some(_) = None::<i32> { break; } }
    |       ^^^ lifetime 'lt already in scope
 
+warning: 8 warnings emitted
+

--- a/src/test/ui/loops/loops-reject-duplicate-labels.stderr
+++ b/src/test/ui/loops/loops-reject-duplicate-labels.stderr
@@ -62,3 +62,5 @@ LL |     'lt: loop { break; }
 LL |     'lt: while let Some(_) = None::<i32> { break; }
    |     ^^^ lifetime 'lt already in scope
 
+warning: 8 warnings emitted
+

--- a/src/test/ui/loops/loops-reject-labels-shadowing-lifetimes.stderr
+++ b/src/test/ui/loops/loops-reject-labels-shadowing-lifetimes.stderr
@@ -100,3 +100,5 @@ LL |         fn meth_bad<'bad>(&self) {
 LL |             'bad: loop { break 'bad; }
    |             ^^^^ lifetime 'bad already in scope
 
+warning: 12 warnings emitted
+

--- a/src/test/ui/loops/loops-reject-lifetime-shadowing-label.stderr
+++ b/src/test/ui/loops/loops-reject-lifetime-shadowing-label.stderr
@@ -6,3 +6,5 @@ LL |     'a: loop {
 LL |         let b = Box::new(|x: &i8| *x) as Box<dyn for <'a> Fn(&'a i8) -> i8>;
    |                                                       ^^ lifetime 'a already in scope
 
+warning: 1 warning emitted
+

--- a/src/test/ui/lto-duplicate-symbols.stderr
+++ b/src/test/ui/lto-duplicate-symbols.stderr
@@ -2,5 +2,5 @@ warning: Linking globals named 'foo': symbol multiply defined!
 
 error: failed to load bc of "lto_duplicate_symbols2.3a1fbbbh-cgu.0": 
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/macros/macro-deprecation.stderr
+++ b/src/test/ui/macros/macro-deprecation.stderr
@@ -12,3 +12,5 @@ warning: use of deprecated item 'deprecated_macro': deprecation note
 LL |     deprecated_macro!();
    |     ^^^^^^^^^^^^^^^^
 
+warning: 2 warnings emitted
+

--- a/src/test/ui/macros/macro-lifetime-used-with-labels.stderr
+++ b/src/test/ui/macros/macro-lifetime-used-with-labels.stderr
@@ -11,3 +11,5 @@ LL |         br2!('b);
    |
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
+warning: 1 warning emitted
+

--- a/src/test/ui/macros/macro-stability.stderr
+++ b/src/test/ui/macros/macro-stability.stderr
@@ -36,6 +36,6 @@ warning: use of deprecated item 'local_deprecated': local deprecation reason
 LL |     local_deprecated!();
    |     ^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 3 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/macros/macro-use-all-and-none.stderr
+++ b/src/test/ui/macros/macro-use-all-and-none.stderr
@@ -10,3 +10,5 @@ note: the lint level is defined here
 LL | #![warn(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
+warning: 1 warning emitted
+

--- a/src/test/ui/macros/must-use-in-macro-55516.stderr
+++ b/src/test/ui/macros/must-use-in-macro-55516.stderr
@@ -8,3 +8,5 @@ LL |     write!(&mut example, "{}", 42);
    = note: this `Result` may be an `Err` variant, which should be handled
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
+warning: 1 warning emitted
+

--- a/src/test/ui/malformed/malformed-plugin-1.stderr
+++ b/src/test/ui/malformed/malformed-plugin-1.stderr
@@ -12,5 +12,5 @@ LL | #![plugin]
    |
    = note: `#[warn(deprecated)]` on by default
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/malformed/malformed-plugin-2.stderr
+++ b/src/test/ui/malformed/malformed-plugin-2.stderr
@@ -12,5 +12,5 @@ LL | #![plugin="bleh"]
    |
    = note: `#[warn(deprecated)]` on by default
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/malformed/malformed-plugin-3.stderr
+++ b/src/test/ui/malformed/malformed-plugin-3.stderr
@@ -12,5 +12,5 @@ LL | #![plugin(foo="bleh")]
    |
    = note: `#[warn(deprecated)]` on by default
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/maybe-bounds-where.stderr
+++ b/src/test/ui/maybe-bounds-where.stderr
@@ -40,6 +40,6 @@ warning: default bound relaxed for a type parameter, but this does nothing becau
 LL | struct S5<T>(*const T) where T: ?Trait<'static> + ?Sized;
    |           ^
 
-error: aborting due to 6 previous errors
+error: aborting due to 6 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0203`.

--- a/src/test/ui/multiple-plugin-registrars.stderr
+++ b/src/test/ui/multiple-plugin-registrars.stderr
@@ -25,5 +25,5 @@ note: one is here
 LL | pub fn two() {}
    | ^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: aborting due to previous error; 2 warnings emitted
 

--- a/src/test/ui/never_type/never-assign-dead-code.stderr
+++ b/src/test/ui/never_type/never-assign-dead-code.stderr
@@ -34,3 +34,5 @@ LL | #![warn(unused)]
    |         ^^^^^^
    = note: `#[warn(unused_variables)]` implied by `#[warn(unused)]`
 
+warning: 3 warnings emitted
+

--- a/src/test/ui/nll/issue-51191.stderr
+++ b/src/test/ui/nll/issue-51191.stderr
@@ -48,6 +48,6 @@ LL |         (&mut self).bar();
    |         cannot borrow as mutable
    |         try removing `&mut` here
 
-error: aborting due to 5 previous errors
+error: aborting due to 5 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/non-ice-error-on-worker-io-fail.stderr
+++ b/src/test/ui/non-ice-error-on-worker-io-fail.stderr
@@ -2,5 +2,5 @@ warning: ignoring --out-dir flag due to -o flag
 
 error: io error modifying /dev/
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/parser/impl-item-type-no-body-semantic-fail.stderr
+++ b/src/test/ui/parser/impl-item-type-no-body-semantic-fail.stderr
@@ -74,6 +74,6 @@ error[E0202]: associated types are not yet supported in inherent impls (see #899
 LL |     type W where Self: Eq;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 10 previous errors
+error: aborting due to 10 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0202`.

--- a/src/test/ui/parser/issue-68890-2.stderr
+++ b/src/test/ui/parser/issue-68890-2.stderr
@@ -18,6 +18,6 @@ error[E0224]: at least one trait is required for an object type
 LL | type X<'a> = (?'a) +;
    |              ^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0224`.

--- a/src/test/ui/parser/macro/trait-object-macro-matcher.stderr
+++ b/src/test/ui/parser/macro/trait-object-macro-matcher.stderr
@@ -18,6 +18,6 @@ error[E0224]: at least one trait is required for an object type
 LL |     m!('static);
    |        ^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0224`.

--- a/src/test/ui/parser/trait-object-trait-parens.stderr
+++ b/src/test/ui/parser/trait-object-trait-parens.stderr
@@ -69,6 +69,6 @@ LL |     let _: Box<(for<'a> Trait<'a>) + (Obj) + (?Sized)>;
    |                 first non-auto trait
    |                 trait alias used in trait object type (first use)
 
-error: aborting due to 6 previous errors
+error: aborting due to 6 previous errors; 3 warnings emitted
 
 For more information about this error, try `rustc --explain E0225`.

--- a/src/test/ui/parser/underscore-suffix-for-string.stderr
+++ b/src/test/ui/parser/underscore-suffix-for-string.stderr
@@ -7,3 +7,5 @@ LL |     let _ = "Foo"_;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: see issue #42326 <https://github.com/rust-lang/rust/issues/42326> for more information
 
+warning: 1 warning emitted
+

--- a/src/test/ui/path-lookahead.stderr
+++ b/src/test/ui/path-lookahead.stderr
@@ -10,3 +10,5 @@ note: the lint level is defined here
 LL | #![warn(unused_parens)]
    |         ^^^^^^^^^^^^^
 
+warning: 1 warning emitted
+

--- a/src/test/ui/pattern/issue-67776-match-same-name-enum-variant-refs.stderr
+++ b/src/test/ui/pattern/issue-67776-match-same-name-enum-variant-refs.stderr
@@ -36,3 +36,6 @@ warning[E0170]: pattern binding `Baz` is named the same as one of the variants o
 LL |         Baz => {},
    |         ^^^ help: to match on the variant, qualify the path: `Foo::Baz`
 
+warning: 6 warnings emitted
+
+For more information about this error, try `rustc --explain E0170`.

--- a/src/test/ui/pattern/usefulness/issue-43253.stderr
+++ b/src/test/ui/pattern/usefulness/issue-43253.stderr
@@ -48,3 +48,5 @@ warning: unreachable pattern
 LL |         6 => {},
    |         ^
 
+warning: 6 warnings emitted
+

--- a/src/test/ui/pattern/usefulness/match-range-fail-dominate.stderr
+++ b/src/test/ui/pattern/usefulness/match-range-fail-dominate.stderr
@@ -89,5 +89,5 @@ LL |       0.02f64 => {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
-error: aborting due to 5 previous errors
+error: aborting due to 5 previous errors; 6 warnings emitted
 

--- a/src/test/ui/privacy/private-in-public-assoc-ty.stderr
+++ b/src/test/ui/privacy/private-in-public-assoc-ty.stderr
@@ -89,7 +89,7 @@ LL |     trait PrivTr {}
 LL |         type Exist = impl PrivTr;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
 
-error: aborting due to 5 previous errors
+error: aborting due to 5 previous errors; 3 warnings emitted
 
 Some errors have detailed explanations: E0445, E0446.
 For more information about an error, try `rustc --explain E0445`.

--- a/src/test/ui/privacy/private-in-public-non-principal.stderr
+++ b/src/test/ui/privacy/private-in-public-non-principal.stderr
@@ -20,5 +20,5 @@ note: the lint level is defined here
 LL | #[deny(missing_docs)]
    |        ^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/privacy/private-in-public-warn.stderr
+++ b/src/test/ui/privacy/private-in-public-warn.stderr
@@ -356,6 +356,6 @@ help: the clause will not be checked when the type alias is used, and should be 
 LL |     pub type Alias<T>  = T;
    |                      --
 
-error: aborting due to 36 previous errors
+error: aborting due to 36 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0446`.

--- a/src/test/ui/proc-macro/attributes-included.stderr
+++ b/src/test/ui/proc-macro/attributes-included.stderr
@@ -11,3 +11,5 @@ LL | #![warn(unused)]
    |         ^^^^^^
    = note: `#[warn(unused_variables)]` implied by `#[warn(unused)]`
 
+warning: 1 warning emitted
+

--- a/src/test/ui/proc-macro/attributes-on-definitions.stderr
+++ b/src/test/ui/proc-macro/attributes-on-definitions.stderr
@@ -6,3 +6,5 @@ LL | attributes_on_definitions::with_attrs!();
    |
    = note: `#[warn(deprecated)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/proc-macro/generate-mod.stderr
+++ b/src/test/ui/proc-macro/generate-mod.stderr
@@ -75,6 +75,6 @@ LL |     #[derive(generate_mod::CheckDerive)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #50504 <https://github.com/rust-lang/rust/issues/50504>
 
-error: aborting due to 4 previous errors
+error: aborting due to 4 previous errors; 4 warnings emitted
 
 For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/proc-macro/no-macro-use-attr.stderr
+++ b/src/test/ui/proc-macro/no-macro-use-attr.stderr
@@ -16,5 +16,5 @@ error: fatal error triggered by #[rustc_error]
 LL | fn main() {}
    | ^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/range/range-inclusive-pattern-precedence.stderr
+++ b/src/test/ui/range/range-inclusive-pattern-precedence.stderr
@@ -28,5 +28,5 @@ warning: `...` range patterns are deprecated
 LL |         box 0...9 => {}
    |              ^^^ help: use `..=` for an inclusive range
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 2 warnings emitted
 

--- a/src/test/ui/reachable/unreachable-try-pattern.stderr
+++ b/src/test/ui/reachable/unreachable-try-pattern.stderr
@@ -31,3 +31,5 @@ warning: unreachable pattern
 LL |     let y = (match x { Ok(n) => Ok(n), Err(e) => Err(e) })?;
    |                                        ^^^^^^
 
+warning: 3 warnings emitted
+

--- a/src/test/ui/regions/region-bound-on-closure-outlives-call.stderr
+++ b/src/test/ui/regions/region-bound-on-closure-outlives-call.stderr
@@ -19,6 +19,6 @@ LL |     (|x| f(x))(call_rec(f))
    |      |   borrow occurs due to use in closure
    |      borrow of `f` occurs here
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0505`.

--- a/src/test/ui/removing-extern-crate.stderr
+++ b/src/test/ui/removing-extern-crate.stderr
@@ -29,3 +29,5 @@ warning: unused extern crate
 LL |     extern crate core;
    |     ^^^^^^^^^^^^^^^^^^ help: remove it
 
+warning: 4 warnings emitted
+

--- a/src/test/ui/resolve/issue-65035-static-with-parent-generics.stderr
+++ b/src/test/ui/resolve/issue-65035-static-with-parent-generics.stderr
@@ -57,7 +57,7 @@ LL |     static a: [u8; N] = [0; N];
    = note: expected array `[u8; _]`
               found array `[u8; _]`
 
-error: aborting due to 6 previous errors
+error: aborting due to 6 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0308, E0401.
 For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/rfc-2091-track-caller/caller-location-fnptr-rt-ctfe-equiv.stderr
+++ b/src/test/ui/rfc-2091-track-caller/caller-location-fnptr-rt-ctfe-equiv.stderr
@@ -4,3 +4,5 @@ warning: skipping const checks
 LL |     ptr()
    |     ^^^^^
 
+warning: 1 warning emitted
+

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -980,7 +980,7 @@ LL |         let 0 = 0?;
    = help: the trait `std::ops::Try` is not implemented for `{integer}`
    = note: required by `std::ops::Try::into_result`
 
-error: aborting due to 106 previous errors
+error: aborting due to 106 previous errors; 2 warnings emitted
 
 Some errors have detailed explanations: E0277, E0308, E0600, E0614, E0658.
 For more information about an error, try `rustc --explain E0277`.

--- a/src/test/ui/rfc-2497-if-let-chains/protect-precedences.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/protect-precedences.stderr
@@ -8,3 +8,5 @@ LL |         if let _ = return true && false {};
    |
    = note: `#[warn(unreachable_code)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-and-name.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-and-name.stderr
@@ -12,5 +12,5 @@ error: cannot use `#[link_name]` with `#[link_ordinal]`
 LL |     #[link_ordinal(42)]
    |     ^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-invalid-format.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-invalid-format.stderr
@@ -14,5 +14,5 @@ LL |     #[link_ordinal("JustMonika")]
    |
    = note: an unsuffixed integer value, e.g., `1`, is expected
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-large.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-large.stderr
@@ -14,5 +14,5 @@ LL |     #[link_ordinal(18446744073709551616)]
    |
    = note: the value may not exceed `usize::MAX`
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/rfc1445/cant-hide-behind-doubly-indirect-embedded.stderr
+++ b/src/test/ui/rfc1445/cant-hide-behind-doubly-indirect-embedded.stderr
@@ -12,3 +12,5 @@ LL | #![warn(indirect_structural_match)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
 
+warning: 1 warning emitted
+

--- a/src/test/ui/rfc1445/cant-hide-behind-doubly-indirect-param.stderr
+++ b/src/test/ui/rfc1445/cant-hide-behind-doubly-indirect-param.stderr
@@ -12,3 +12,5 @@ LL | #![warn(indirect_structural_match)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
 
+warning: 1 warning emitted
+

--- a/src/test/ui/rfc1445/cant-hide-behind-indirect-struct-embedded.stderr
+++ b/src/test/ui/rfc1445/cant-hide-behind-indirect-struct-embedded.stderr
@@ -12,3 +12,5 @@ LL | #![warn(indirect_structural_match)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
 
+warning: 1 warning emitted
+

--- a/src/test/ui/rfc1445/cant-hide-behind-indirect-struct-param.stderr
+++ b/src/test/ui/rfc1445/cant-hide-behind-indirect-struct-param.stderr
@@ -12,3 +12,5 @@ LL | #![warn(indirect_structural_match)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
 
+warning: 1 warning emitted
+

--- a/src/test/ui/rfc1445/issue-62307-match-ref-ref-forbidden-without-eq.stderr
+++ b/src/test/ui/rfc1445/issue-62307-match-ref-ref-forbidden-without-eq.stderr
@@ -21,3 +21,5 @@ LL |         RR_B1 => { println!("CLAIM RR1: {:?} matches {:?}", RR_B1, RR_B1); 
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
 
+warning: 2 warnings emitted
+

--- a/src/test/ui/rfc1445/match-forbidden-without-eq.stderr
+++ b/src/test/ui/rfc1445/match-forbidden-without-eq.stderr
@@ -29,5 +29,5 @@ LL |         f32::INFINITY => { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 2 warnings emitted
 

--- a/src/test/ui/rust-2018/macro-use-warned-against.stderr
+++ b/src/test/ui/rust-2018/macro-use-warned-against.stderr
@@ -23,3 +23,5 @@ LL | #![warn(macro_use_extern_crate, unused)]
    |                                 ^^^^^^
    = note: `#[warn(unused_imports)]` implied by `#[warn(unused)]`
 
+warning: 2 warnings emitted
+

--- a/src/test/ui/rust-2018/remove-extern-crate.stderr
+++ b/src/test/ui/rust-2018/remove-extern-crate.stderr
@@ -17,3 +17,5 @@ warning: `extern crate` is not idiomatic in the new edition
 LL |     extern crate core;
    |     ^^^^^^^^^^^^^^^^^^ help: convert it to a `use`
 
+warning: 2 warnings emitted
+

--- a/src/test/ui/rust-2018/suggestions-not-always-applicable.stderr
+++ b/src/test/ui/rust-2018/suggestions-not-always-applicable.stderr
@@ -24,3 +24,5 @@ LL |     #[foo]
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
    = note: this warning originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
+warning: 2 warnings emitted
+

--- a/src/test/ui/rust-2018/try-ident.stderr
+++ b/src/test/ui/rust-2018/try-ident.stderr
@@ -22,3 +22,5 @@ LL | fn try() {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
+warning: 2 warnings emitted
+

--- a/src/test/ui/rust-2018/try-macro.stderr
+++ b/src/test/ui/rust-2018/try-macro.stderr
@@ -13,3 +13,5 @@ LL | #![warn(rust_2018_compatibility)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
+warning: 1 warning emitted
+

--- a/src/test/ui/sanitize/inline-always.stderr
+++ b/src/test/ui/sanitize/inline-always.stderr
@@ -11,3 +11,5 @@ note: inlining requested here
 LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^
 
+warning: 1 warning emitted
+

--- a/src/test/ui/span/issue-24690.stderr
+++ b/src/test/ui/span/issue-24690.stderr
@@ -25,3 +25,5 @@ warning: variable `theOtherTwo` should have a snake case name
 LL |     let theOtherTwo = 2;
    |         ^^^^^^^^^^^ help: convert the identifier to snake case: `the_other_two`
 
+warning: 3 warnings emitted
+

--- a/src/test/ui/span/macro-span-replacement.stderr
+++ b/src/test/ui/span/macro-span-replacement.stderr
@@ -15,3 +15,5 @@ LL | #![warn(unused)]
    = note: `#[warn(dead_code)]` implied by `#[warn(unused)]`
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
+warning: 1 warning emitted
+

--- a/src/test/ui/span/multispan-import-lint.stderr
+++ b/src/test/ui/span/multispan-import-lint.stderr
@@ -11,3 +11,5 @@ LL | #![warn(unused)]
    |         ^^^^^^
    = note: `#[warn(unused_imports)]` implied by `#[warn(unused)]`
 
+warning: 1 warning emitted
+

--- a/src/test/ui/span/unused-warning-point-at-identifier.stderr
+++ b/src/test/ui/span/unused-warning-point-at-identifier.stderr
@@ -29,3 +29,5 @@ warning: function is never used: `func_complete_span`
 LL | func_complete_span()
    | ^^^^^^^^^^^^^^^^^^
 
+warning: 4 warnings emitted
+

--- a/src/test/ui/static/static-lifetime-bound.stderr
+++ b/src/test/ui/static/static-lifetime-bound.stderr
@@ -17,6 +17,6 @@ LL |     f(&x);
 LL | }
    | - `x` dropped here while still borrowed
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0597`.

--- a/src/test/ui/test-attrs/test-on-macro.stderr
+++ b/src/test/ui/test-attrs/test-on-macro.stderr
@@ -4,3 +4,5 @@ warning: `#[test]` attribute should not be used on macros. Use `#[cfg(test)]` in
 LL | foo!();
    | ^^^^^^^
 
+warning: 1 warning emitted
+

--- a/src/test/ui/test-attrs/test-should-panic-attr.stderr
+++ b/src/test/ui/test-attrs/test-should-panic-attr.stderr
@@ -30,3 +30,5 @@ LL | #[should_panic(expected = "foo", bar)]
    |
    = note: errors in this attribute were erroneously allowed and will become a hard error in a future release.
 
+warning: 4 warnings emitted
+

--- a/src/test/ui/traits/trait-bounds-not-on-bare-trait.stderr
+++ b/src/test/ui/traits/trait-bounds-not-on-bare-trait.stderr
@@ -17,6 +17,6 @@ LL | fn foo(_x: Foo + Send) {
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-copy.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-copy.stderr
@@ -24,3 +24,5 @@ warning: Trait bound for<'b> &'b mut i32: std::marker::Copy does not depend on a
 LL | fn copy_mut<'a>(t: &&'a mut i32) -> &'a mut i32 where for<'b> &'b mut i32: Copy {
    |                                                                            ^^^^
 
+warning: 4 warnings emitted
+

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-projection.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-projection.stderr
@@ -42,3 +42,5 @@ warning: Trait bound B: A does not depend on any type or lifetime parameters
 LL |     B: A<X = u8> + A
    |                    ^
 
+warning: 7 warnings emitted
+

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-sized.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-sized.stderr
@@ -18,3 +18,5 @@ warning: Trait bound str: std::marker::Sized does not depend on any type or life
 LL | fn return_str() -> str where str: Sized {
    |                                   ^^^^^
 
+warning: 3 warnings emitted
+

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-well-formed.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-well-formed.stderr
@@ -12,3 +12,5 @@ warning: Trait bound str: std::marker::Copy does not depend on any type or lifet
 LL | pub fn foo() where Vec<str>: Debug, str: Copy {
    |                                          ^^^^
 
+warning: 2 warnings emitted
+

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent.stderr
@@ -90,3 +90,5 @@ warning: Trait bound i32: std::iter::Iterator does not depend on any type or lif
 LL | fn use_for() where i32: Iterator {
    |                         ^^^^^^^^
 
+warning: 14 warnings emitted
+

--- a/src/test/ui/try-block/try-block-unreachable-code-lint.stderr
+++ b/src/test/ui/try-block/try-block-unreachable-code-lint.stderr
@@ -36,3 +36,5 @@ LL |
 LL |           42
    |           ^^ unreachable expression
 
+warning: 3 warnings emitted
+

--- a/src/test/ui/type-alias-impl-trait/assoc-type-const.stderr
+++ b/src/test/ui/type-alias-impl-trait/assoc-type-const.stderr
@@ -6,3 +6,5 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-const.stderr
+++ b/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-const.stderr
@@ -6,3 +6,5 @@ LL | #![feature(impl_trait_in_bindings)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
+warning: 1 warning emitted
+

--- a/src/test/ui/type/issue-67690-type-alias-bound-diagnostic-crash.stderr
+++ b/src/test/ui/type/issue-67690-type-alias-bound-diagnostic-crash.stderr
@@ -10,3 +10,5 @@ help: the bound will not be checked when the type alias is used, and should be r
 LL | pub type T<P> = P;
    |            --
 
+warning: 1 warning emitted
+

--- a/src/test/ui/type/type-alias-bounds.stderr
+++ b/src/test/ui/type/type-alias-bounds.stderr
@@ -108,3 +108,5 @@ help: the bound will not be checked when the type alias is used, and should be r
 LL | type T6<U> = ::std::vec::Vec<U>;
    |         --
 
+warning: 9 warnings emitted
+

--- a/src/test/ui/underscore-imports/basic.stderr
+++ b/src/test/ui/underscore-imports/basic.stderr
@@ -16,3 +16,5 @@ warning: unused import: `S as _`
 LL |     use S as _;
    |         ^^^^^^
 
+warning: 2 warnings emitted
+

--- a/src/test/ui/utf8_idents.stderr
+++ b/src/test/ui/utf8_idents.stderr
@@ -42,6 +42,6 @@ LL |     γ
    |
    = note: `#[warn(non_camel_case_types)]` on by default
 
-error: aborting due to 4 previous errors
+error: aborting due to 4 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/while-let.stderr
+++ b/src/test/ui/while-let.stderr
@@ -34,3 +34,5 @@ LL | |         break;
 LL | |     }
    | |_____^
 
+warning: 3 warnings emitted
+


### PR DESCRIPTION
Successful merges:

 - #69926 (rustc: Add a warning count upon completion)
 - #70629 (rustc_target::abi: add Primitive variant to FieldsShape.)
 - #70962 (added machine hooks to track deallocations)
 - #70986 (rustc_middle: return `LocalDefId` where possible in hir::map module)

Failed merges:

 - #55617 (Prevent compiler stack overflow for deeply recursive code)

r? @ghost