### PR TITLE
forbid `dyn Trait` in patterns

### DIFF
--- a/src/librustc_mir_build/hair/pattern/const_to_pat.rs
+++ b/src/librustc_mir_build/hair/pattern/const_to_pat.rs
@@ -116,6 +116,9 @@ impl<'a, 'tcx> ConstToPat<'a, 'tcx> {
                     traits::NonStructuralMatchTy::Param => {
                         bug!("use of constant whose type is a parameter inside a pattern")
                     }
+                    traits::NonStructuralMatchTy::Dynamic => {
+                        bug!("use of a trait object inside a pattern")
+                    }
                 };
                 let path = self.tcx().def_path_str(adt_def.did);
 

--- a/src/librustc_mir_build/hair/pattern/const_to_pat.rs
+++ b/src/librustc_mir_build/hair/pattern/const_to_pat.rs
@@ -111,23 +111,21 @@ impl<'a, 'tcx> ConstToPat<'a, 'tcx> {
             }
 
             if let Some(non_sm_ty) = structural {
-                let adt_def = match non_sm_ty {
-                    traits::NonStructuralMatchTy::Adt(adt_def) => adt_def,
+                let msg = match non_sm_ty {
+                    traits::NonStructuralMatchTy::Adt(adt_def) => {
+                        let path = self.tcx().def_path_str(adt_def.did);
+                        format!(
+                            "to use a constant of type `{}` in a pattern, \
+                             `{}` must be annotated with `#[derive(PartialEq, Eq)]`",
+                            path, path,
+                        )
+                    }
+                    traits::NonStructuralMatchTy::Dynamic => {
+                        format!("trait objects cannot be used in patterns")
+                    }
                     traits::NonStructuralMatchTy::Param => {
                         bug!("use of constant whose type is a parameter inside a pattern")
                     }
-                    traits::NonStructuralMatchTy::Dynamic => {
-                        bug!("use of a trait object inside a pattern")
-                    }
-                };
-                let path = self.tcx().def_path_str(adt_def.did);
-
-                let make_msg = || -> String {
-                    format!(
-                        "to use a constant of type `{}` in a pattern, \
-                         `{}` must be annotated with `#[derive(PartialEq, Eq)]`",
-                        path, path,
-                    )
                 };
 
                 // double-check there even *is* a semantic `PartialEq` to dispatch to.
@@ -158,13 +156,13 @@ impl<'a, 'tcx> ConstToPat<'a, 'tcx> {
 
                 if !ty_is_partial_eq {
                     // span_fatal avoids ICE from resolution of non-existent method (rare case).
-                    self.tcx().sess.span_fatal(self.span, &make_msg());
+                    self.tcx().sess.span_fatal(self.span, &msg);
                 } else if mir_structural_match_violation {
                     self.tcx().struct_span_lint_hir(
                         lint::builtin::INDIRECT_STRUCTURAL_MATCH,
                         self.id,
                         self.span,
-                        |lint| lint.build(&make_msg()).emit(),
+                        |lint| lint.build(&msg).emit(),
                     );
                 } else {
                     debug!(

--- a/src/librustc_trait_selection/traits/structural_match.rs
+++ b/src/librustc_trait_selection/traits/structural_match.rs
@@ -11,6 +11,7 @@ use rustc_span::Span;
 pub enum NonStructuralMatchTy<'tcx> {
     Adt(&'tcx AdtDef),
     Param,
+    Dynamic,
 }
 
 /// This method traverses the structure of `ty`, trying to find an
@@ -135,6 +136,10 @@ impl<'a, 'tcx> TypeVisitor<'tcx> for Search<'a, 'tcx> {
             ty::Adt(adt_def, substs) => (adt_def, substs),
             ty::Param(_) => {
                 self.found = Some(NonStructuralMatchTy::Param);
+                return true; // Stop visiting.
+            }
+            ty::Dynamic(..) => {
+                self.found = Some(NonStructuralMatchTy::Dynamic);
                 return true; // Stop visiting.
             }
             ty::RawPtr(..) => {

--- a/src/test/ui/const-generics/issues/issue-63322-forbid-dyn.rs
+++ b/src/test/ui/const-generics/issues/issue-63322-forbid-dyn.rs
@@ -1,0 +1,15 @@
+#![feature(const_generics)]
+//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+
+trait A {}
+struct B;
+impl A for B {}
+
+fn test<const T: &'static dyn A>() {
+    //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]` to be used
+    unimplemented!()
+}
+
+fn main() {
+    test::<{ &B }>();
+}

--- a/src/test/ui/const-generics/issues/issue-63322-forbid-dyn.stderr
+++ b/src/test/ui/const-generics/issues/issue-63322-forbid-dyn.stderr
@@ -1,0 +1,17 @@
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/issue-63322-forbid-dyn.rs:1:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0741]: `&'static (dyn A + 'static)` must be annotated with `#[derive(PartialEq, Eq)]` to be used as the type of a const parameter
+  --> $DIR/issue-63322-forbid-dyn.rs:8:18
+   |
+LL | fn test<const T: &'static dyn A>() {
+   |                  ^^^^^^^^^^^^^^ `&'static (dyn A + 'static)` doesn't derive both `PartialEq` and `Eq`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0741`.

--- a/src/test/ui/const-generics/issues/issue-63322-forbid-dyn.stderr
+++ b/src/test/ui/const-generics/issues/issue-63322-forbid-dyn.stderr
@@ -12,6 +12,6 @@ error[E0741]: `&'static (dyn A + 'static)` must be annotated with `#[derive(Part
 LL | fn test<const T: &'static dyn A>() {
    |                  ^^^^^^^^^^^^^^ `&'static (dyn A + 'static)` doesn't derive both `PartialEq` and `Eq`
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0741`.

--- a/src/test/ui/match/issue-70972-dyn-trait.rs
+++ b/src/test/ui/match/issue-70972-dyn-trait.rs
@@ -1,0 +1,10 @@
+const F: &'static dyn Send = &7u32;
+
+fn main() {
+    let a: &dyn Send = &7u32;
+    match a {
+        F => panic!(),
+        //~^ ERROR trait objects cannot be used in patterns
+        _ => {}
+    }
+}

--- a/src/test/ui/match/issue-70972-dyn-trait.stderr
+++ b/src/test/ui/match/issue-70972-dyn-trait.stderr
@@ -1,0 +1,8 @@
+error: trait objects cannot be used in patterns
+  --> $DIR/issue-70972-dyn-trait.rs:6:9
+   |
+LL |         F => panic!(),
+   |         ^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Do not allow `&dyn Trait` as a generic const parameters.
This also changes dyn trait in pattern from ICE to error.

closes #63322
closes #70972

r? @eddyb 