### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/librustc_error_codes/error_codes/E0515.md
+++ b/src/librustc_error_codes/error_codes/E0515.md
@@ -1,7 +1,4 @@
-Cannot return value that references local variable
-
-Local variables, function parameters and temporaries are all dropped before the
-end of the function body. So a reference to them cannot be returned.
+A reference to a local variable was returned.
 
 Erroneous code example:
 
@@ -19,6 +16,9 @@ fn get_dangling_iterator<'a>() -> Iter<'a, i32> {
     v.iter()
 }
 ```
+
+Local variables, function parameters and temporaries are all dropped before the
+end of the function body. So a reference to them cannot be returned.
 
 Consider returning an owned value instead:
 

--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -437,6 +437,29 @@ impl GenericParam<'hir> {
     }
 }
 
+pub trait NextTypeParamName {
+    fn next_type_param_name(&self) -> &'static str;
+}
+
+impl NextTypeParamName for &[GenericParam<'_>] {
+    fn next_type_param_name(&self) -> &'static str {
+        // This is the whitelist of possible parameter names that we might suggest.
+        let possible_names = ["T", "U", "V", "X", "Y", "Z", "A", "B", "C", "D", "E", "F", "G"];
+        let used_names = self
+            .iter()
+            .filter_map(|p| match p.name {
+                ParamName::Plain(ident) => Some(ident.name),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        possible_names
+            .iter()
+            .find(|n| !used_names.contains(&Symbol::intern(n)))
+            .unwrap_or(&"ParamName")
+    }
+}
+
 #[derive(Default)]
 pub struct GenericParamCount {
     pub lifetimes: usize,

--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -438,13 +438,15 @@ impl GenericParam<'hir> {
 }
 
 pub trait NextTypeParamName {
-    fn next_type_param_name(&self) -> &'static str;
+    fn next_type_param_name(&self, name: Option<&str>) -> String;
 }
 
 impl NextTypeParamName for &[GenericParam<'_>] {
-    fn next_type_param_name(&self) -> &'static str {
+    fn next_type_param_name(&self, name: Option<&str>) -> String {
         // This is the whitelist of possible parameter names that we might suggest.
-        let possible_names = ["T", "U", "V", "X", "Y", "Z", "A", "B", "C", "D", "E", "F", "G"];
+        let name = name.and_then(|n| n.chars().next()).map(|c| c.to_string().to_uppercase());
+        let name = name.as_ref().map(|s| s.as_str());
+        let possible_names = [name.unwrap_or("T"), "T", "U", "V", "X", "Y", "Z", "A", "B", "C"];
         let used_names = self
             .iter()
             .filter_map(|p| match p.name {
@@ -457,6 +459,7 @@ impl NextTypeParamName for &[GenericParam<'_>] {
             .iter()
             .find(|n| !used_names.contains(&Symbol::intern(n)))
             .unwrap_or(&"ParamName")
+            .to_string()
     }
 }
 

--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -437,32 +437,6 @@ impl GenericParam<'hir> {
     }
 }
 
-pub trait NextTypeParamName {
-    fn next_type_param_name(&self, name: Option<&str>) -> String;
-}
-
-impl NextTypeParamName for &[GenericParam<'_>] {
-    fn next_type_param_name(&self, name: Option<&str>) -> String {
-        // This is the whitelist of possible parameter names that we might suggest.
-        let name = name.and_then(|n| n.chars().next()).map(|c| c.to_string().to_uppercase());
-        let name = name.as_ref().map(|s| s.as_str());
-        let possible_names = [name.unwrap_or("T"), "T", "U", "V", "X", "Y", "Z", "A", "B", "C"];
-        let used_names = self
-            .iter()
-            .filter_map(|p| match p.name {
-                ParamName::Plain(ident) => Some(ident.name),
-                _ => None,
-            })
-            .collect::<Vec<_>>();
-
-        possible_names
-            .iter()
-            .find(|n| !used_names.contains(&Symbol::intern(n)))
-            .unwrap_or(&"ParamName")
-            .to_string()
-    }
-}
-
 #[derive(Default)]
 pub struct GenericParamCount {
     pub lifetimes: usize,

--- a/src/librustc_infer/traits/mod.rs
+++ b/src/librustc_infer/traits/mod.rs
@@ -1,6 +1,6 @@
-//! Trait Resolution. See the [rustc guide] for more information on how this works.
+//! Trait Resolution. See the [rustc-dev-guide] for more information on how this works.
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/traits/resolution.html
+//! [rustc-dev-guide]: https://rustc-dev-guide.rust-lang.org/traits/resolution.html
 
 mod engine;
 pub mod error_reporting;

--- a/src/librustc_mir/borrow_check/renumber.rs
+++ b/src/librustc_mir/borrow_check/renumber.rs
@@ -64,7 +64,11 @@ impl<'a, 'tcx> MutVisitor<'tcx> for NLLVisitor<'a, 'tcx> {
         debug!("visit_ty: ty={:?}", ty);
     }
 
-    fn process_projection_elem(&mut self, elem: &PlaceElem<'tcx>) -> Option<PlaceElem<'tcx>> {
+    fn process_projection_elem(
+        &mut self,
+        elem: &PlaceElem<'tcx>,
+        _: Location,
+    ) -> Option<PlaceElem<'tcx>> {
         if let PlaceElem::Field(field, ty) = elem {
             let new_ty = self.renumber_regions(ty);
 

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -89,13 +89,6 @@ impl<'tcx> MutVisitor<'tcx> for RenameLocalVisitor<'tcx> {
             *local = self.to;
         }
     }
-
-    fn process_projection_elem(&mut self, elem: &PlaceElem<'tcx>) -> Option<PlaceElem<'tcx>> {
-        match elem {
-            PlaceElem::Index(local) if *local == self.from => Some(PlaceElem::Index(self.to)),
-            _ => None,
-        }
-    }
 }
 
 struct DerefArgVisitor<'tcx> {

--- a/src/librustc_mir/transform/inline.rs
+++ b/src/librustc_mir/transform/inline.rs
@@ -706,18 +706,6 @@ impl<'a, 'tcx> MutVisitor<'tcx> for Integrator<'a, 'tcx> {
         self.super_place(place, context, location)
     }
 
-    fn process_projection_elem(&mut self, elem: &PlaceElem<'tcx>) -> Option<PlaceElem<'tcx>> {
-        if let PlaceElem::Index(local) = elem {
-            let new_local = self.make_integrate_local(*local);
-
-            if new_local != *local {
-                return Some(PlaceElem::Index(new_local));
-            }
-        }
-
-        None
-    }
-
     fn visit_basic_block_data(&mut self, block: BasicBlock, data: &mut BasicBlockData<'tcx>) {
         self.in_cleanup_block = data.is_cleanup;
         self.super_basic_block_data(block, data);

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -1036,15 +1036,6 @@ impl<'a, 'tcx> MutVisitor<'tcx> for Promoter<'a, 'tcx> {
             *local = self.promote_temp(*local);
         }
     }
-
-    fn process_projection_elem(&mut self, elem: &PlaceElem<'tcx>) -> Option<PlaceElem<'tcx>> {
-        match elem {
-            PlaceElem::Index(local) if self.is_temp_kind(*local) => {
-                Some(PlaceElem::Index(self.promote_temp(*local)))
-            }
-            _ => None,
-        }
-    }
 }
 
 pub fn promote_candidates<'tcx>(

--- a/src/librustc_mir/transform/simplify.rs
+++ b/src/librustc_mir/transform/simplify.rs
@@ -417,11 +417,4 @@ impl<'tcx> MutVisitor<'tcx> for LocalUpdater<'tcx> {
     fn visit_local(&mut self, l: &mut Local, _: PlaceContext, _: Location) {
         *l = self.map[*l].unwrap();
     }
-
-    fn process_projection_elem(&mut self, elem: &PlaceElem<'tcx>) -> Option<PlaceElem<'tcx>> {
-        match elem {
-            PlaceElem::Index(local) => Some(PlaceElem::Index(self.map[*local].unwrap())),
-            _ => None,
-        }
-    }
 }

--- a/src/librustc_mir/util/def_use.rs
+++ b/src/librustc_mir/util/def_use.rs
@@ -2,9 +2,7 @@
 
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir::visit::{MutVisitor, PlaceContext, Visitor};
-use rustc_middle::mir::{
-    Body, BodyAndCache, Local, Location, PlaceElem, ReadOnlyBodyAndCache, VarDebugInfo,
-};
+use rustc_middle::mir::{Body, BodyAndCache, Local, Location, ReadOnlyBodyAndCache, VarDebugInfo};
 use rustc_middle::ty::TyCtxt;
 use std::mem;
 
@@ -155,15 +153,6 @@ impl MutVisitor<'tcx> for MutateUseVisitor<'tcx> {
     fn visit_local(&mut self, local: &mut Local, _context: PlaceContext, _location: Location) {
         if *local == self.query {
             *local = self.new_local;
-        }
-    }
-
-    fn process_projection_elem(&mut self, elem: &PlaceElem<'tcx>) -> Option<PlaceElem<'tcx>> {
-        match elem {
-            PlaceElem::Index(local) if *local == self.query => {
-                Some(PlaceElem::Index(self.new_local))
-            }
-            _ => None,
         }
     }
 }

--- a/src/librustc_trait_selection/lib.rs
+++ b/src/librustc_trait_selection/lib.rs
@@ -2,9 +2,9 @@
 //!
 //! - **Traits.** Trait resolution is implemented in the `traits` module.
 //!
-//! For more information about how rustc works, see the [rustc guide].
+//! For more information about how rustc works, see the [rustc-dev-guide].
 //!
-//! [rustc guide]: https://rust-lang.github.io/rustc-guide/
+//! [rustc-dev-guide]: https://rustc-dev-guide.rust-lang.org/
 //!
 //! # Note
 //!

--- a/src/librustc_trait_selection/lib.rs
+++ b/src/librustc_trait_selection/lib.rs
@@ -16,6 +16,7 @@
 #![feature(in_band_lifetimes)]
 #![feature(crate_visibility_modifier)]
 #![feature(or_patterns)]
+#![feature(str_strip)]
 #![recursion_limit = "512"] // For rustdoc
 
 #[macro_use]

--- a/src/librustc_trait_selection/lib.rs
+++ b/src/librustc_trait_selection/lib.rs
@@ -17,6 +17,7 @@
 #![feature(crate_visibility_modifier)]
 #![feature(or_patterns)]
 #![feature(str_strip)]
+#![feature(option_zip)]
 #![recursion_limit = "512"] // For rustdoc
 
 #[macro_use]

--- a/src/librustc_trait_selection/traits/error_reporting/mod.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/mod.rs
@@ -388,7 +388,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             // which is somewhat confusing.
                             self.suggest_restricting_param_bound(
                                 &mut err,
-                                &trait_ref,
+                                trait_ref,
                                 obligation.cause.body_id,
                             );
                         } else {

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -211,14 +211,14 @@ fn suggest_restriction(
             }
         }
 
-        let type_param_name = generics.params.next_type_param_name();
+        let type_param_name = generics.params.next_type_param_name(Some(&name));
         // The type param `T: Trait` we will suggest to introduce.
         let type_param = format!("{}: {}", type_param_name, name);
 
         // FIXME: modify the `trait_ref` instead of string shenanigans.
         // Turn `<impl Trait as Foo>::Bar: Qux` into `<T as Foo>::Bar: Qux`.
         let pred = trait_ref.without_const().to_predicate().to_string();
-        let pred = pred.replace(&impl_name, type_param_name);
+        let pred = pred.replace(&impl_name, &type_param_name);
         let mut sugg = vec![
             match generics
                 .params

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -203,8 +203,7 @@ fn suggest_restriction(
             {
                 if segment.ident.as_str() == impl_name.as_str() {
                     // `fn foo(t: impl Trait)`
-                    //            ^^^^^^^^^^ get this to suggest
-                    //                       `T` instead
+                    //            ^^^^^^^^^^ get this to suggest `T` instead
 
                     // There might be more than one `impl Trait`.
                     ty_spans.push(input.span);
@@ -237,7 +236,10 @@ fn suggest_restriction(
                 None => (generics.span, format!("<{}>", type_param)),
                 // `fn foo<A>(t: impl Trait)`
                 //        ^^^ suggest `<A, T: Trait>` here
-                Some(param) => (param.span.shrink_to_hi(), format!(", {}", type_param)),
+                Some(param) => (
+                    param.bounds_span().unwrap_or(param.span).shrink_to_hi(),
+                    format!(", {}", type_param),
+                ),
             },
             // `fn foo(t: impl Trait)`
             //                       ^ suggest `where <T as Trait>::A: Bound`
@@ -247,8 +249,7 @@ fn suggest_restriction(
 
         // Suggest `fn foo<T: Trait>(t: T) where <T as Trait>::A: Bound`.
         err.multipart_suggestion(
-            "introduce a type parameter with a trait bound instead of using \
-                    `impl Trait`",
+            "introduce a type parameter with a trait bound instead of using `impl Trait`",
             sugg,
             Applicability::MaybeIncorrect,
         );

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -163,23 +163,123 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         };
 
         let suggest_restriction =
-            |generics: &hir::Generics<'_>, msg, err: &mut DiagnosticBuilder<'_>| {
+            |generics: &hir::Generics<'_>,
+             msg,
+             err: &mut DiagnosticBuilder<'_>,
+             fn_sig: Option<&hir::FnSig<'_>>| {
+                // Type parameter needs more bounds. The trivial case is `T` `where T: Bound`, but
+                // it can also be an `impl Trait` param that needs to be decomposed to a type
+                // param for cleaner code.
                 let span = generics.where_clause.span_for_predicates_or_empty_place();
                 if !span.from_expansion() && span.desugaring_kind().is_none() {
-                    err.span_suggestion(
-                        generics.where_clause.span_for_predicates_or_empty_place().shrink_to_hi(),
-                        &format!("consider further restricting {}", msg),
-                        format!(
-                            "{} {} ",
-                            if !generics.where_clause.predicates.is_empty() {
-                                ","
-                            } else {
-                                " where"
+                    // Given `fn foo(t: impl Trait)` where `Trait` requires assoc type `A`...
+                    if let Some((name, fn_sig)) = fn_sig.and_then(|sig| {
+                        projection.and_then(|p| {
+                            // Shenanigans to get the `Trait` from the `impl Trait`.
+                            match p.self_ty().kind {
+                                ty::Param(param) if param.name.as_str().starts_with("impl ") => {
+                                    let n = param.name.as_str();
+                                    // `fn foo(t: impl Trait)`
+                                    //                 ^^^^^ get this string
+                                    n.split_whitespace()
+                                        .skip(1)
+                                        .next()
+                                        .map(|n| (n.to_string(), sig))
+                                }
+                                _ => None,
+                            }
+                        })
+                    }) {
+                        // FIXME: Cleanup.
+                        let mut ty_spans = vec![];
+                        let impl_name = format!("impl {}", name);
+                        for i in fn_sig.decl.inputs {
+                            if let hir::TyKind::Path(hir::QPath::Resolved(None, path)) = i.kind {
+                                match path.segments {
+                                    [segment] if segment.ident.to_string() == impl_name => {
+                                        // `fn foo(t: impl Trait)`
+                                        //            ^^^^^^^^^^ get this to suggest
+                                        //                       `T` instead
+
+                                        // There might be more than one `impl Trait`.
+                                        ty_spans.push(i.span);
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+
+                        let type_param = format!("{}: {}", "T", name);
+                        // FIXME: modify the `trait_ref` instead of string shenanigans.
+                        // Turn `<impl Trait as Foo>::Bar: Qux` into `<T as Foo>::Bar: Qux`.
+                        let pred = trait_ref.without_const().to_predicate().to_string();
+                        let pred = pred.replace(&impl_name, "T");
+                        let mut sugg = vec![
+                            match generics
+                                .params
+                                .iter()
+                                .filter(|p| match p.kind {
+                                    hir::GenericParamKind::Type {
+                                        synthetic: Some(hir::SyntheticTyParamKind::ImplTrait),
+                                        ..
+                                    } => false,
+                                    _ => true,
+                                })
+                                .last()
+                            {
+                                // `fn foo(t: impl Trait)`
+                                //        ^ suggest `<T: Trait>` here
+                                None => (generics.span, format!("<{}>", type_param)),
+                                Some(param) => {
+                                    (param.span.shrink_to_hi(), format!(", {}", type_param))
+                                }
                             },
-                            trait_ref.without_const().to_predicate(),
-                        ),
-                        Applicability::MachineApplicable,
-                    );
+                            (
+                                // `fn foo(t: impl Trait)`
+                                //                       ^ suggest `where <T as Trait>::A: Bound`
+                                generics
+                                    .where_clause
+                                    .span_for_predicates_or_empty_place()
+                                    .shrink_to_hi(),
+                                format!(
+                                    "{} {} ",
+                                    if !generics.where_clause.predicates.is_empty() {
+                                        ","
+                                    } else {
+                                        " where"
+                                    },
+                                    pred,
+                                ),
+                            ),
+                        ];
+                        sugg.extend(ty_spans.into_iter().map(|s| (s, "T".to_string())));
+                        // Suggest `fn foo<T: Trait>(t: T) where <T as Trait>::A: Bound`.
+                        err.multipart_suggestion(
+                            "introduce a type parameter with a trait bound instead of using \
+                             `impl Trait`",
+                            sugg,
+                            Applicability::MaybeIncorrect,
+                        );
+                    } else {
+                        // Trivial case: `T` needs an extra bound.
+                        err.span_suggestion(
+                            generics
+                                .where_clause
+                                .span_for_predicates_or_empty_place()
+                                .shrink_to_hi(),
+                            &format!("consider further restricting {}", msg),
+                            format!(
+                                "{} {} ",
+                                if !generics.where_clause.predicates.is_empty() {
+                                    ","
+                                } else {
+                                    " where"
+                                },
+                                trait_ref.without_const().to_predicate(),
+                            ),
+                            Applicability::MachineApplicable,
+                        );
+                    }
                 }
             };
 
@@ -187,6 +287,10 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         //        don't suggest `T: Sized + ?Sized`.
         let mut hir_id = body_id;
         while let Some(node) = self.tcx.hir().find(hir_id) {
+            debug!(
+                "suggest_restricting_param_bound {:?} {:?} {:?} {:?}",
+                trait_ref, self_ty.kind, projection, node
+            );
             match node {
                 hir::Node::TraitItem(hir::TraitItem {
                     generics,
@@ -194,27 +298,33 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     ..
                 }) if param_ty && self_ty == self.tcx.types.self_param => {
                     // Restricting `Self` for a single method.
-                    suggest_restriction(&generics, "`Self`", err);
+                    suggest_restriction(&generics, "`Self`", err, None);
                     return;
                 }
 
                 hir::Node::TraitItem(hir::TraitItem {
                     generics,
-                    kind: hir::TraitItemKind::Fn(..),
+                    kind: hir::TraitItemKind::Fn(fn_sig, ..),
                     ..
                 })
                 | hir::Node::ImplItem(hir::ImplItem {
                     generics,
-                    kind: hir::ImplItemKind::Fn(..),
+                    kind: hir::ImplItemKind::Fn(fn_sig, ..),
                     ..
                 })
-                | hir::Node::Item(
-                    hir::Item { kind: hir::ItemKind::Fn(_, generics, _), .. }
-                    | hir::Item { kind: hir::ItemKind::Trait(_, _, generics, _, _), .. }
+                | hir::Node::Item(hir::Item {
+                    kind: hir::ItemKind::Fn(fn_sig, generics, _), ..
+                }) if projection.is_some() => {
+                    // Missing associated type bound.
+                    suggest_restriction(&generics, "the associated type", err, Some(fn_sig));
+                    return;
+                }
+                hir::Node::Item(
+                    hir::Item { kind: hir::ItemKind::Trait(_, _, generics, _, _), .. }
                     | hir::Item { kind: hir::ItemKind::Impl { generics, .. }, .. },
                 ) if projection.is_some() => {
                     // Missing associated type bound.
-                    suggest_restriction(&generics, "the associated type", err);
+                    suggest_restriction(&generics, "the associated type", err, None);
                     return;
                 }
 

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -29,7 +29,7 @@ use rustc_hir::def::{CtorKind, DefKind, Res};
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_hir::intravisit::{self, NestedVisitorMap, Visitor};
 use rustc_hir::weak_lang_items;
-use rustc_hir::{GenericParamKind, NextTypeParamName, Node, Unsafety};
+use rustc_hir::{GenericParamKind, Node, Unsafety};
 use rustc_middle::hir::map::blocks::FnLikeNode;
 use rustc_middle::hir::map::Map;
 use rustc_middle::middle::codegen_fn_attrs::{CodegenFnAttrFlags, CodegenFnAttrs};
@@ -45,6 +45,7 @@ use rustc_session::parse::feature_err;
 use rustc_span::symbol::{kw, sym, Symbol};
 use rustc_span::{Span, DUMMY_SP};
 use rustc_target::spec::abi;
+use rustc_trait_selection::traits::error_reporting::suggestions::NextTypeParamName;
 
 mod type_of;
 

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -29,7 +29,7 @@ use rustc_hir::def::{CtorKind, DefKind, Res};
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_hir::intravisit::{self, NestedVisitorMap, Visitor};
 use rustc_hir::weak_lang_items;
-use rustc_hir::{GenericParamKind, Node, Unsafety};
+use rustc_hir::{GenericParamKind, NextTypeParamName, Node, Unsafety};
 use rustc_middle::hir::map::blocks::FnLikeNode;
 use rustc_middle::hir::map::Map;
 use rustc_middle::middle::codegen_fn_attrs::{CodegenFnAttrFlags, CodegenFnAttrs};
@@ -135,20 +135,7 @@ crate fn placeholder_type_error(
     if placeholder_types.is_empty() {
         return;
     }
-    // This is the whitelist of possible parameter names that we might suggest.
-    let possible_names = ["T", "K", "L", "A", "B", "C"];
-    let used_names = generics
-        .iter()
-        .filter_map(|p| match p.name {
-            hir::ParamName::Plain(ident) => Some(ident.name),
-            _ => None,
-        })
-        .collect::<Vec<_>>();
-
-    let type_name = possible_names
-        .iter()
-        .find(|n| !used_names.contains(&Symbol::intern(n)))
-        .unwrap_or(&"ParamName");
+    let type_name = generics.next_type_param_name();
 
     let mut sugg: Vec<_> =
         placeholder_types.iter().map(|sp| (*sp, (*type_name).to_string())).collect();

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -135,7 +135,7 @@ crate fn placeholder_type_error(
     if placeholder_types.is_empty() {
         return;
     }
-    let type_name = generics.next_type_param_name();
+    let type_name = generics.next_type_param_name(None);
 
     let mut sugg: Vec<_> =
         placeholder_types.iter().map(|sp| (*sp, (*type_name).to_string())).collect();

--- a/src/test/run-make-fulldeps/windows-binary-no-external-deps/Makefile
+++ b/src/test/run-make-fulldeps/windows-binary-no-external-deps/Makefile
@@ -1,0 +1,9 @@
+-include ../tools.mk
+
+# only-windows
+
+PATH=$(SYSTEMROOT)/system32
+
+all:
+	$(RUSTC) hello.rs
+	$(TMPDIR)/hello.exe

--- a/src/test/run-make-fulldeps/windows-binary-no-external-deps/hello.rs
+++ b/src/test/run-make-fulldeps/windows-binary-no-external-deps/hello.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello World!");
+}

--- a/src/test/ui/suggestions/impl-trait-with-missing-bounds.rs
+++ b/src/test/ui/suggestions/impl-trait-with-missing-bounds.rs
@@ -24,7 +24,7 @@ fn baz(t: impl std::fmt::Debug, constraints: impl Iterator) {
     }
 }
 
-fn bat<K, T: std::fmt::Debug>(t: T, constraints: impl Iterator, _: K) {
+fn bat<I, T: std::fmt::Debug>(t: T, constraints: impl Iterator, _: I) {
     for constraint in constraints {
         qux(t);
         qux(constraint);

--- a/src/test/ui/suggestions/impl-trait-with-missing-bounds.rs
+++ b/src/test/ui/suggestions/impl-trait-with-missing-bounds.rs
@@ -1,0 +1,29 @@
+// The double space in `impl  Iterator` is load bearing! We want to make sure we don't regress by
+// accident if the internal string representation changes.
+#[rustfmt::skip]
+fn foo(constraints: impl  Iterator) {
+    for constraint in constraints {
+        qux(constraint);
+//~^ ERROR `<impl Iterator as std::iter::Iterator>::Item` doesn't implement `std::fmt::Debug`
+    }
+}
+
+fn bar<T>(t: T, constraints: impl Iterator) where T: std::fmt::Debug {
+    for constraint in constraints {
+        qux(t);
+        qux(constraint);
+//~^ ERROR `<impl Iterator as std::iter::Iterator>::Item` doesn't implement `std::fmt::Debug`
+    }
+}
+
+fn baz(t: impl std::fmt::Debug, constraints: impl Iterator) {
+    for constraint in constraints {
+        qux(t);
+        qux(constraint);
+//~^ ERROR `<impl Iterator as std::iter::Iterator>::Item` doesn't implement `std::fmt::Debug`
+    }
+}
+
+fn qux(_: impl std::fmt::Debug) {}
+
+fn main() {}

--- a/src/test/ui/suggestions/impl-trait-with-missing-bounds.rs
+++ b/src/test/ui/suggestions/impl-trait-with-missing-bounds.rs
@@ -24,11 +24,18 @@ fn baz(t: impl std::fmt::Debug, constraints: impl Iterator) {
     }
 }
 
-fn bat<T: std::fmt::Debug>(t: T, constraints: impl Iterator) {
+fn bat<K, T: std::fmt::Debug>(t: T, constraints: impl Iterator, _: K) {
     for constraint in constraints {
         qux(t);
         qux(constraint);
 //~^ ERROR `<impl Iterator as std::iter::Iterator>::Item` doesn't implement `std::fmt::Debug`
+    }
+}
+
+fn bak(constraints: impl  Iterator + std::fmt::Debug) {
+    for constraint in constraints {
+        qux(constraint);
+//~^ ERROR `<impl Iterator + std::fmt::Debug as std::iter::Iterator>::Item` doesn't implement
     }
 }
 

--- a/src/test/ui/suggestions/impl-trait-with-missing-bounds.rs
+++ b/src/test/ui/suggestions/impl-trait-with-missing-bounds.rs
@@ -24,6 +24,14 @@ fn baz(t: impl std::fmt::Debug, constraints: impl Iterator) {
     }
 }
 
+fn bat<T: std::fmt::Debug>(t: T, constraints: impl Iterator) {
+    for constraint in constraints {
+        qux(t);
+        qux(constraint);
+//~^ ERROR `<impl Iterator as std::iter::Iterator>::Item` doesn't implement `std::fmt::Debug`
+    }
+}
+
 fn qux(_: impl std::fmt::Debug) {}
 
 fn main() {}

--- a/src/test/ui/suggestions/impl-trait-with-missing-bounds.stderr
+++ b/src/test/ui/suggestions/impl-trait-with-missing-bounds.stderr
@@ -10,7 +10,7 @@ LL | fn qux(_: impl std::fmt::Debug) {}
    = help: the trait `std::fmt::Debug` is not implemented for `<impl Iterator as std::iter::Iterator>::Item`
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
    |
-LL | fn foo<T: Iterator>(constraints: T) where <T as std::iter::Iterator>::Item: std::fmt::Debug  {
+LL | fn foo<I: Iterator>(constraints: I) where <I as std::iter::Iterator>::Item: std::fmt::Debug  {
    |       ^^^^^^^^^^^^^              ^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `<impl Iterator as std::iter::Iterator>::Item` doesn't implement `std::fmt::Debug`
@@ -25,7 +25,7 @@ LL | fn qux(_: impl std::fmt::Debug) {}
    = help: the trait `std::fmt::Debug` is not implemented for `<impl Iterator as std::iter::Iterator>::Item`
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
    |
-LL | fn bar<T, U: Iterator>(t: T, constraints: U) where T: std::fmt::Debug, <U as std::iter::Iterator>::Item: std::fmt::Debug  {
+LL | fn bar<T, I: Iterator>(t: T, constraints: I) where T: std::fmt::Debug, <I as std::iter::Iterator>::Item: std::fmt::Debug  {
    |         ^^^^^^^^^^^^^                     ^                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `<impl Iterator as std::iter::Iterator>::Item` doesn't implement `std::fmt::Debug`
@@ -40,7 +40,7 @@ LL | fn qux(_: impl std::fmt::Debug) {}
    = help: the trait `std::fmt::Debug` is not implemented for `<impl Iterator as std::iter::Iterator>::Item`
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
    |
-LL | fn baz<T: Iterator>(t: impl std::fmt::Debug, constraints: T) where <T as std::iter::Iterator>::Item: std::fmt::Debug  {
+LL | fn baz<I: Iterator>(t: impl std::fmt::Debug, constraints: I) where <I as std::iter::Iterator>::Item: std::fmt::Debug  {
    |       ^^^^^^^^^^^^^                                       ^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `<impl Iterator as std::iter::Iterator>::Item` doesn't implement `std::fmt::Debug`
@@ -55,7 +55,7 @@ LL | fn qux(_: impl std::fmt::Debug) {}
    = help: the trait `std::fmt::Debug` is not implemented for `<impl Iterator as std::iter::Iterator>::Item`
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
    |
-LL | fn bat<K, T: std::fmt::Debug, U: Iterator>(t: T, constraints: U, _: K) where <U as std::iter::Iterator>::Item: std::fmt::Debug  {
+LL | fn bat<I, T: std::fmt::Debug, U: Iterator>(t: T, constraints: U, _: I) where <U as std::iter::Iterator>::Item: std::fmt::Debug  {
    |                             ^^^^^^^^^^^^^                     ^        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `<impl Iterator + std::fmt::Debug as std::iter::Iterator>::Item` doesn't implement `std::fmt::Debug`
@@ -70,7 +70,7 @@ LL | fn qux(_: impl std::fmt::Debug) {}
    = help: the trait `std::fmt::Debug` is not implemented for `<impl Iterator + std::fmt::Debug as std::iter::Iterator>::Item`
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
    |
-LL | fn bak<T: Iterator + std::fmt::Debug>(constraints: T) where <T as std::iter::Iterator>::Item: std::fmt::Debug  {
+LL | fn bak<I: Iterator + std::fmt::Debug>(constraints: I) where <I as std::iter::Iterator>::Item: std::fmt::Debug  {
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^              ^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 5 previous errors

--- a/src/test/ui/suggestions/impl-trait-with-missing-bounds.stderr
+++ b/src/test/ui/suggestions/impl-trait-with-missing-bounds.stderr
@@ -5,7 +5,7 @@ LL |         qux(constraint);
    |             ^^^^^^^^^^ `<impl Iterator as std::iter::Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
 ...
 LL | fn qux(_: impl std::fmt::Debug) {}
-   |    ---         --------------- required by this bound in `qux`
+   |                --------------- required by this bound in `qux`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `<impl Iterator as std::iter::Iterator>::Item`
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
@@ -20,7 +20,7 @@ LL |         qux(constraint);
    |             ^^^^^^^^^^ `<impl Iterator as std::iter::Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
 ...
 LL | fn qux(_: impl std::fmt::Debug) {}
-   |    ---         --------------- required by this bound in `qux`
+   |                --------------- required by this bound in `qux`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `<impl Iterator as std::iter::Iterator>::Item`
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
@@ -35,7 +35,7 @@ LL |         qux(constraint);
    |             ^^^^^^^^^^ `<impl Iterator as std::iter::Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
 ...
 LL | fn qux(_: impl std::fmt::Debug) {}
-   |    ---         --------------- required by this bound in `qux`
+   |                --------------- required by this bound in `qux`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `<impl Iterator as std::iter::Iterator>::Item`
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
@@ -50,7 +50,7 @@ LL |         qux(constraint);
    |             ^^^^^^^^^^ `<impl Iterator as std::iter::Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
 ...
 LL | fn qux(_: impl std::fmt::Debug) {}
-   |    ---         --------------- required by this bound in `qux`
+   |                --------------- required by this bound in `qux`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `<impl Iterator as std::iter::Iterator>::Item`
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
@@ -65,7 +65,7 @@ LL |         qux(constraint);
    |             ^^^^^^^^^^ `<impl Iterator + std::fmt::Debug as std::iter::Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
 ...
 LL | fn qux(_: impl std::fmt::Debug) {}
-   |    ---         --------------- required by this bound in `qux`
+   |                --------------- required by this bound in `qux`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `<impl Iterator + std::fmt::Debug as std::iter::Iterator>::Item`
 help: introduce a type parameter with a trait bound instead of using `impl Trait`

--- a/src/test/ui/suggestions/impl-trait-with-missing-bounds.stderr
+++ b/src/test/ui/suggestions/impl-trait-with-missing-bounds.stderr
@@ -1,0 +1,48 @@
+error[E0277]: `<impl Iterator as std::iter::Iterator>::Item` doesn't implement `std::fmt::Debug`
+  --> $DIR/impl-trait-with-missing-bounds.rs:6:13
+   |
+LL |         qux(constraint);
+   |             ^^^^^^^^^^ `<impl Iterator as std::iter::Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
+...
+LL | fn qux(_: impl std::fmt::Debug) {}
+   |    ---         --------------- required by this bound in `qux`
+   |
+   = help: the trait `std::fmt::Debug` is not implemented for `<impl Iterator as std::iter::Iterator>::Item`
+help: introduce a type parameter with a trait bound instead of using `impl Trait`
+   |
+LL | fn foo<T: Iterator>(constraints: T) where <T as std::iter::Iterator>::Item: std::fmt::Debug  {
+   |       ^^^^^^^^^^^^^              ^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: `<impl Iterator as std::iter::Iterator>::Item` doesn't implement `std::fmt::Debug`
+  --> $DIR/impl-trait-with-missing-bounds.rs:14:13
+   |
+LL |         qux(constraint);
+   |             ^^^^^^^^^^ `<impl Iterator as std::iter::Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
+...
+LL | fn qux(_: impl std::fmt::Debug) {}
+   |    ---         --------------- required by this bound in `qux`
+   |
+   = help: the trait `std::fmt::Debug` is not implemented for `<impl Iterator as std::iter::Iterator>::Item`
+help: introduce a type parameter with a trait bound instead of using `impl Trait`
+   |
+LL | fn bar<T, T: Iterator>(t: T, constraints: T) where T: std::fmt::Debug, <T as std::iter::Iterator>::Item: std::fmt::Debug  {
+   |         ^^^^^^^^^^^^^                     ^                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: `<impl Iterator as std::iter::Iterator>::Item` doesn't implement `std::fmt::Debug`
+  --> $DIR/impl-trait-with-missing-bounds.rs:22:13
+   |
+LL |         qux(constraint);
+   |             ^^^^^^^^^^ `<impl Iterator as std::iter::Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
+...
+LL | fn qux(_: impl std::fmt::Debug) {}
+   |    ---         --------------- required by this bound in `qux`
+   |
+   = help: the trait `std::fmt::Debug` is not implemented for `<impl Iterator as std::iter::Iterator>::Item`
+help: introduce a type parameter with a trait bound instead of using `impl Trait`
+   |
+LL | fn baz<T: Iterator>(t: impl std::fmt::Debug, constraints: T) where <T as std::iter::Iterator>::Item: std::fmt::Debug  {
+   |       ^^^^^^^^^^^^^                                       ^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/suggestions/impl-trait-with-missing-bounds.stderr
+++ b/src/test/ui/suggestions/impl-trait-with-missing-bounds.stderr
@@ -43,6 +43,21 @@ help: introduce a type parameter with a trait bound instead of using `impl Trait
 LL | fn baz<T: Iterator>(t: impl std::fmt::Debug, constraints: T) where <T as std::iter::Iterator>::Item: std::fmt::Debug  {
    |       ^^^^^^^^^^^^^                                       ^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error[E0277]: `<impl Iterator as std::iter::Iterator>::Item` doesn't implement `std::fmt::Debug`
+  --> $DIR/impl-trait-with-missing-bounds.rs:30:13
+   |
+LL |         qux(constraint);
+   |             ^^^^^^^^^^ `<impl Iterator as std::iter::Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
+...
+LL | fn qux(_: impl std::fmt::Debug) {}
+   |    ---         --------------- required by this bound in `qux`
+   |
+   = help: the trait `std::fmt::Debug` is not implemented for `<impl Iterator as std::iter::Iterator>::Item`
+help: introduce a type parameter with a trait bound instead of using `impl Trait`
+   |
+LL | fn bat<T: std::fmt::Debug, T: Iterator>(t: T, constraints: T) where <T as std::iter::Iterator>::Item: std::fmt::Debug  {
+   |                          ^^^^^^^^^^^^^                     ^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/suggestions/impl-trait-with-missing-bounds.stderr
+++ b/src/test/ui/suggestions/impl-trait-with-missing-bounds.stderr
@@ -25,7 +25,7 @@ LL | fn qux(_: impl std::fmt::Debug) {}
    = help: the trait `std::fmt::Debug` is not implemented for `<impl Iterator as std::iter::Iterator>::Item`
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
    |
-LL | fn bar<T, T: Iterator>(t: T, constraints: T) where T: std::fmt::Debug, <T as std::iter::Iterator>::Item: std::fmt::Debug  {
+LL | fn bar<T, U: Iterator>(t: T, constraints: U) where T: std::fmt::Debug, <U as std::iter::Iterator>::Item: std::fmt::Debug  {
    |         ^^^^^^^^^^^^^                     ^                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `<impl Iterator as std::iter::Iterator>::Item` doesn't implement `std::fmt::Debug`
@@ -55,9 +55,24 @@ LL | fn qux(_: impl std::fmt::Debug) {}
    = help: the trait `std::fmt::Debug` is not implemented for `<impl Iterator as std::iter::Iterator>::Item`
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
    |
-LL | fn bat<T: std::fmt::Debug, T: Iterator>(t: T, constraints: T) where <T as std::iter::Iterator>::Item: std::fmt::Debug  {
-   |                          ^^^^^^^^^^^^^                     ^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn bat<K, T: std::fmt::Debug, U: Iterator>(t: T, constraints: U, _: K) where <U as std::iter::Iterator>::Item: std::fmt::Debug  {
+   |                             ^^^^^^^^^^^^^                     ^        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+error[E0277]: `<impl Iterator + std::fmt::Debug as std::iter::Iterator>::Item` doesn't implement `std::fmt::Debug`
+  --> $DIR/impl-trait-with-missing-bounds.rs:37:13
+   |
+LL |         qux(constraint);
+   |             ^^^^^^^^^^ `<impl Iterator + std::fmt::Debug as std::iter::Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
+...
+LL | fn qux(_: impl std::fmt::Debug) {}
+   |    ---         --------------- required by this bound in `qux`
+   |
+   = help: the trait `std::fmt::Debug` is not implemented for `<impl Iterator + std::fmt::Debug as std::iter::Iterator>::Item`
+help: introduce a type parameter with a trait bound instead of using `impl Trait`
+   |
+LL | fn bak<T: Iterator + std::fmt::Debug>(constraints: T) where <T as std::iter::Iterator>::Item: std::fmt::Debug  {
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^              ^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/src/test/ui/typeck/typeck_type_placeholder_item.stderr
@@ -106,7 +106,7 @@ LL | fn test6_b<T>(_: _, _: T) { }
    |
 help: use type parameters instead
    |
-LL | fn test6_b<T, K>(_: K, _: T) { }
+LL | fn test6_b<T, U>(_: U, _: T) { }
    |             ^^^     ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
@@ -117,7 +117,7 @@ LL | fn test6_c<T, K, L, A, B>(_: _, _: (T, K, L, A, B)) { }
    |
 help: use type parameters instead
    |
-LL | fn test6_c<T, K, L, A, B, C>(_: C, _: (T, K, L, A, B)) { }
+LL | fn test6_c<T, K, L, A, B, U>(_: U, _: (T, K, L, A, B)) { }
    |                         ^^^     ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
@@ -377,7 +377,7 @@ LL | struct BadStruct2<_, T>(_, T);
    |
 help: use type parameters instead
    |
-LL | struct BadStruct2<K, T>(K, T);
+LL | struct BadStruct2<U, T>(U, T);
    |                   ^     ^
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures


### PR DESCRIPTION
Successful merges:

 - #69707 (Handle `impl Trait` where `Trait` has an assoc type with missing bounds)
 - #71013 (Pass the `PlaceElem::Index` local to `visit_local`)
 - #71023 ([windows] Add testscase for self-contained executables)
 - #71034 (Clean up E0515 explanation)
 - #71041 (Update links of `rustc guide`)

Failed merges:


r? @ghost