### PR TITLE
Stabilize UNICODE_VERSION (feature unicode_version)

### DIFF
--- a/src/libcore/char/mod.rs
+++ b/src/libcore/char/mod.rs
@@ -34,9 +34,7 @@ pub use self::convert::ParseCharError;
 pub use self::convert::{from_digit, from_u32};
 #[stable(feature = "decode_utf16", since = "1.9.0")]
 pub use self::decode::{decode_utf16, DecodeUtf16, DecodeUtf16Error};
-
-// unstable re-exports
-#[unstable(feature = "unicode_version", issue = "49726")]
+#[stable(feature = "unicode_version", since = "1.45.0")]
 pub use crate::unicode::UNICODE_VERSION;
 
 use crate::fmt::{self, Write};

--- a/src/libcore/unicode/mod.rs
+++ b/src/libcore/unicode/mod.rs
@@ -7,9 +7,14 @@ mod unicode_data;
 /// The version of [Unicode](http://www.unicode.org/) that the Unicode parts of
 /// `char` and `str` methods are based on.
 ///
+/// New versions of Unicode are released regularly and subsequently all methods
+/// in the standard library depending on Unicode are updated. Therefore the
+/// behavior of some `char` and `str` methods and the value of this constant
+/// changes over time. This is *not* considered to be a breaking change.
+///
 /// The version numbering scheme is explained in
 /// [Unicode 11.0 or later, Section 3.1 Versions of the Unicode Standard](https://www.unicode.org/versions/Unicode11.0.0/ch03.pdf#page=4).
-#[unstable(feature = "unicode_version", issue = "49726")]
+#[stable(feature = "unicode_version", since = "1.45.0")]
 pub const UNICODE_VERSION: (u8, u8, u8) = unicode_data::UNICODE_VERSION;
 
 // For use in liballoc, not re-exported in libstd.

--- a/src/test/ui/char_unicode.rs
+++ b/src/test/ui/char_unicode.rs
@@ -1,8 +1,6 @@
 // run-pass
 
-#![feature(unicode_version)]
-
-/// Tests access to the internal Unicode Version type and value.
+/// Tests access to the Unicode version constant.
 pub fn main() {
     check(std::char::UNICODE_VERSION);
 }


### PR DESCRIPTION
Tracking issue: #49726 

r? @sfackler 

#71020 changed the definition of `UNICODE_VERSION` just yesterday from a struct to a tuple. Maybe you want to wait some more before stabilizing this constant, on the other hand this is a very small and simple addition.

CC @behnam @SimonSapin @Serentty