### PR TITLE
Remove some usage of `DUMMY_HIR_ID`

### DIFF
--- a/src/librustc_infer/infer/error_reporting/mod.rs
+++ b/src/librustc_infer/infer/error_reporting/mod.rs
@@ -93,7 +93,8 @@ pub(super) fn note_and_explain_region(
             let unknown_scope =
                 || format!("{}unknown scope: {:?}{}.  Please report a bug.", prefix, scope, suffix);
             let span = scope.span(tcx, region_scope_tree);
-            let tag = match tcx.hir().find(scope.hir_id(region_scope_tree)) {
+            let hir_id = scope.hir_id(region_scope_tree);
+            let tag = match hir_id.and_then(|hir_id| tcx.hir().find(hir_id)) {
                 Some(Node::Block(_)) => "block",
                 Some(Node::Expr(expr)) => match expr.kind {
                     hir::ExprKind::Call(..) => "call",

--- a/src/librustc_middle/middle/region.rs
+++ b/src/librustc_middle/middle/region.rs
@@ -159,21 +159,20 @@ impl Scope {
         self.id
     }
 
-    pub fn hir_id(&self, scope_tree: &ScopeTree) -> hir::HirId {
-        match scope_tree.root_body {
-            Some(hir_id) => hir::HirId { owner: hir_id.owner, local_id: self.item_local_id() },
-            None => hir::DUMMY_HIR_ID,
-        }
+    pub fn hir_id(&self, scope_tree: &ScopeTree) -> Option<hir::HirId> {
+        scope_tree
+            .root_body
+            .map(|hir_id| hir::HirId { owner: hir_id.owner, local_id: self.item_local_id() })
     }
 
     /// Returns the span of this `Scope`. Note that in general the
     /// returned span may not correspond to the span of any `NodeId` in
     /// the AST.
     pub fn span(&self, tcx: TyCtxt<'_>, scope_tree: &ScopeTree) -> Span {
-        let hir_id = self.hir_id(scope_tree);
-        if hir_id == hir::DUMMY_HIR_ID {
-            return DUMMY_SP;
-        }
+        let hir_id = match self.hir_id(scope_tree) {
+            Some(hir_id) => hir_id,
+            None => return DUMMY_SP,
+        };
         let span = tcx.hir().span(hir_id);
         if let ScopeData::Remainder(first_statement_index) = self.data {
             if let Node::Block(ref blk) = tcx.hir().get(hir_id) {

--- a/src/librustc_passes/check_attr.rs
+++ b/src/librustc_passes/check_attr.rs
@@ -14,7 +14,6 @@ use rustc_errors::struct_span_err;
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::{self, NestedVisitorMap, Visitor};
-use rustc_hir::DUMMY_HIR_ID;
 use rustc_hir::{self, HirId, Item, ItemKind, TraitItem};
 use rustc_hir::{MethodKind, Target};
 use rustc_session::lint::builtin::{CONFLICTING_REPR_HINTS, UNUSED_ATTRIBUTES};
@@ -360,7 +359,7 @@ impl CheckAttrVisitor<'tcx> {
         if let hir::StmtKind::Local(ref l) = stmt.kind {
             for attr in l.attrs.iter() {
                 if attr.check_name(sym::inline) {
-                    self.check_inline(DUMMY_HIR_ID, attr, &stmt.span, Target::Statement);
+                    self.check_inline(l.hir_id, attr, &stmt.span, Target::Statement);
                 }
                 if attr.check_name(sym::repr) {
                     self.emit_repr_error(
@@ -381,7 +380,7 @@ impl CheckAttrVisitor<'tcx> {
         };
         for attr in expr.attrs.iter() {
             if attr.check_name(sym::inline) {
-                self.check_inline(DUMMY_HIR_ID, attr, &expr.span, target);
+                self.check_inline(expr.hir_id, attr, &expr.span, target);
             }
             if attr.check_name(sym::repr) {
                 self.emit_repr_error(

--- a/src/librustc_trait_selection/traits/auto_trait.rs
+++ b/src/librustc_trait_selection/traits/auto_trait.rs
@@ -187,13 +187,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
             // to store all of the necessary region/lifetime bounds in the InferContext, as well as
             // an additional sanity check.
             let mut fulfill = FulfillmentContext::new();
-            fulfill.register_bound(
-                &infcx,
-                full_env,
-                ty,
-                trait_did,
-                ObligationCause::misc(DUMMY_SP, hir::DUMMY_HIR_ID),
-            );
+            fulfill.register_bound(&infcx, full_env, ty, trait_did, ObligationCause::dummy());
             fulfill.select_all_or_error(&infcx).unwrap_or_else(|e| {
                 panic!("Unable to fulfill trait {:?} for '{:?}': {:?}", trait_did, ty, e)
             });
@@ -292,7 +286,7 @@ impl AutoTraitFinder<'tcx> {
             user_env.caller_bounds.iter().cloned().collect();
 
         let mut new_env = param_env;
-        let dummy_cause = ObligationCause::misc(DUMMY_SP, hir::DUMMY_HIR_ID);
+        let dummy_cause = ObligationCause::dummy();
 
         while let Some(pred) = predicates.pop_front() {
             infcx.clear_caches();
@@ -615,7 +609,7 @@ impl AutoTraitFinder<'tcx> {
         select: &mut SelectionContext<'_, 'tcx>,
         only_projections: bool,
     ) -> bool {
-        let dummy_cause = ObligationCause::misc(DUMMY_SP, hir::DUMMY_HIR_ID);
+        let dummy_cause = ObligationCause::dummy();
 
         for (obligation, mut predicate) in nested.map(|o| (o.clone(), o.predicate)) {
             let is_new_pred = fresh_preds.insert(self.clean_pred(select.infcx(), predicate));

--- a/src/librustc_trait_selection/traits/mod.rs
+++ b/src/librustc_trait_selection/traits/mod.rs
@@ -31,7 +31,7 @@ use rustc_middle::middle::region;
 use rustc_middle::ty::fold::TypeFoldable;
 use rustc_middle::ty::subst::{InternalSubsts, SubstsRef};
 use rustc_middle::ty::{self, GenericParamDefKind, ToPredicate, Ty, TyCtxt, WithConstness};
-use rustc_span::{Span, DUMMY_SP};
+use rustc_span::Span;
 
 use std::fmt::Debug;
 
@@ -136,7 +136,7 @@ pub fn type_known_to_meet_bound_modulo_regions<'a, 'tcx>(
     let trait_ref = ty::TraitRef { def_id, substs: infcx.tcx.mk_substs_trait(ty, &[]) };
     let obligation = Obligation {
         param_env,
-        cause: ObligationCause::misc(span, hir::DUMMY_HIR_ID),
+        cause: ObligationCause::misc(span, hir::CRATE_HIR_ID),
         recursion_depth: 0,
         predicate: trait_ref.without_const().to_predicate(),
     };
@@ -163,7 +163,7 @@ pub fn type_known_to_meet_bound_modulo_regions<'a, 'tcx>(
         // We can use a dummy node-id here because we won't pay any mind
         // to region obligations that arise (there shouldn't really be any
         // anyhow).
-        let cause = ObligationCause::misc(span, hir::DUMMY_HIR_ID);
+        let cause = ObligationCause::misc(span, hir::CRATE_HIR_ID);
 
         fulfill_cx.register_bound(infcx, param_env, ty, def_id, cause);
 

--- a/src/librustc_traits/normalize_projection_ty.rs
+++ b/src/librustc_traits/normalize_projection_ty.rs
@@ -1,10 +1,8 @@
-use rustc_hir as hir;
 use rustc_infer::infer::canonical::{Canonical, QueryResponse};
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_infer::traits::TraitEngineExt as _;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{ParamEnvAnd, TyCtxt};
-use rustc_span::DUMMY_SP;
 use rustc_trait_selection::infer::InferCtxtBuilderExt;
 use rustc_trait_selection::traits::query::{
     normalize::NormalizationResult, CanonicalProjectionGoal, NoSolution,
@@ -27,7 +25,7 @@ fn normalize_projection_ty<'tcx>(
         &goal,
         |infcx, fulfill_cx, ParamEnvAnd { param_env, value: goal }| {
             let selcx = &mut SelectionContext::new(infcx);
-            let cause = ObligationCause::misc(DUMMY_SP, hir::DUMMY_HIR_ID);
+            let cause = ObligationCause::dummy();
             let mut obligations = vec![];
             let answer = traits::normalize_projection_type(
                 selcx,


### PR DESCRIPTION
Use `ObligationClause::dummy()` when appropriate or replace `hir::DUMMY_HIR_ID`by `hir::CRATE_HIR_ID`, as used in `ObligationClause::dummy()`.