### PR TITLE
[PERF] `BasicBlockData` always has a `Terminator`

### DIFF
--- a/src/librustc_codegen_ssa/mir/mod.rs
+++ b/src/librustc_codegen_ssa/mir/mod.rs
@@ -277,7 +277,7 @@ fn create_funclets<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
 
             let funclet;
             let ret_llbb;
-            match mir[bb].terminator.as_ref().map(|t| &t.kind) {
+            match mir[bb].terminator().kind {
                 // This is a basic block that we're aborting the program for,
                 // notably in an `extern` function. These basic blocks are inserted
                 // so that we assert that `extern` functions do indeed not panic,
@@ -298,7 +298,7 @@ fn create_funclets<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
                 //      } catch (...) {
                 //          bar();
                 //      }
-                Some(&mir::TerminatorKind::Abort) => {
+                mir::TerminatorKind::Abort => {
                     let mut cs_bx = bx.build_sibling_block(&format!("cs_funclet{:?}", bb));
                     let mut cp_bx = bx.build_sibling_block(&format!("cp_funclet{:?}", bb));
                     ret_llbb = cs_bx.llbb();

--- a/src/librustc_middle/mir/cache.rs
+++ b/src/librustc_middle/mir/cache.rs
@@ -48,10 +48,8 @@ impl Cache {
         if self.predecessors.is_none() {
             let mut result = IndexVec::from_elem(smallvec![], body.basic_blocks());
             for (bb, data) in body.basic_blocks().iter_enumerated() {
-                if let Some(ref term) = data.terminator {
-                    for &tgt in term.successors() {
-                        result[tgt].push(bb);
-                    }
+                for &tgt in data.terminator().successors() {
+                    result[tgt].push(bb);
                 }
             }
 

--- a/src/librustc_middle/mir/traversal.rs
+++ b/src/librustc_middle/mir/traversal.rs
@@ -55,9 +55,7 @@ impl<'a, 'tcx> Iterator for Preorder<'a, 'tcx> {
 
             let data = &self.body[idx];
 
-            if let Some(ref term) = data.terminator {
-                self.worklist.extend(term.successors());
-            }
+            self.worklist.extend(data.terminator().successors());
 
             return Some((idx, data));
         }
@@ -116,11 +114,9 @@ impl<'a, 'tcx> Postorder<'a, 'tcx> {
 
         let data = &po.body[root];
 
-        if let Some(ref term) = data.terminator {
-            po.visited.insert(root);
-            po.visit_stack.push((root, term.successors()));
-            po.traverse_successor();
-        }
+        po.visited.insert(root);
+        po.visit_stack.push((root, data.terminator().successors()));
+        po.traverse_successor();
 
         po
     }
@@ -185,9 +181,7 @@ impl<'a, 'tcx> Postorder<'a, 'tcx> {
             };
 
             if self.visited.insert(bb) {
-                if let Some(term) = &self.body[bb].terminator {
-                    self.visit_stack.push((bb, term.successors()));
-                }
+                self.visit_stack.push((bb, self.body[bb].terminator().successors()));
             }
         }
     }

--- a/src/librustc_middle/mir/visit.rs
+++ b/src/librustc_middle/mir/visit.rs
@@ -316,17 +316,13 @@ macro_rules! make_mir_visitor {
                     is_cleanup: _
                 } = data;
 
-                let mut index = 0;
+                let mut location = Location { block: block, statement_index: 0 };
                 for statement in statements {
-                    let location = Location { block: block, statement_index: index };
                     self.visit_statement(statement, location);
-                    index += 1;
+                    location.statement_index += 1;
                 }
 
-                if let Some(terminator) = terminator {
-                    let location = Location { block: block, statement_index: index };
-                    self.visit_terminator(terminator, location);
-                }
+                self.visit_terminator(terminator, location);
             }
 
             fn super_source_scope_data(&mut self, scope_data: & $($mutability)? SourceScopeData) {
@@ -824,9 +820,7 @@ macro_rules! make_mir_visitor {
             ) {
                 let basic_block = & $($mutability)? body[location.block];
                 if basic_block.statements.len() == location.statement_index {
-                    if let Some(ref $($mutability)? terminator) = basic_block.terminator {
-                        self.visit_terminator(terminator, location)
-                    }
+                    self.visit_terminator(& $($mutability)? basic_block.terminator, location)
                 } else {
                     let statement = & $($mutability)?
                         basic_block.statements[location.statement_index];

--- a/src/librustc_mir/borrow_check/diagnostics/mod.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/mod.rs
@@ -7,7 +7,7 @@ use rustc_hir::def_id::DefId;
 use rustc_hir::GeneratorKind;
 use rustc_middle::mir::{
     AggregateKind, Constant, Field, Local, LocalInfo, LocalKind, Location, Operand, Place,
-    PlaceRef, ProjectionElem, Rvalue, Statement, StatementKind, Terminator, TerminatorKind,
+    PlaceRef, ProjectionElem, Rvalue, Statement, StatementKind, TerminatorKind,
 };
 use rustc_middle::ty::print::Print;
 use rustc_middle::ty::{self, DefIdTree, Ty, TyCtxt};
@@ -443,10 +443,8 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     );
                     if !is_terminator {
                         continue;
-                    } else if let Some(Terminator {
-                        kind: TerminatorKind::Call { ref func, from_hir_call: false, .. },
-                        ..
-                    }) = bbd.terminator
+                    } else if let TerminatorKind::Call { ref func, from_hir_call: false, .. } =
+                        bbd.terminator().kind
                     {
                         if let Some(source) =
                             BorrowedContentSource::from_call(func.ty(*self.body, tcx), tcx)

--- a/src/librustc_mir/dataflow/framework/tests.rs
+++ b/src/librustc_mir/dataflow/framework/tests.rs
@@ -32,7 +32,7 @@ fn mock_body() -> mir::Body<'static> {
 
         blocks.push(mir::BasicBlockData {
             statements: std::iter::repeat(&nop).cloned().take(n).collect(),
-            terminator: Some(mir::Terminator { source_info, kind }),
+            terminator: mir::Terminator { source_info, kind },
             is_cleanup: false,
         })
     };

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -197,7 +197,7 @@ fn build_drop_shim<'tcx>(
     let block = |blocks: &mut IndexVec<_, _>, kind| {
         blocks.push(BasicBlockData {
             statements: vec![],
-            terminator: Some(Terminator { source_info, kind }),
+            terminator: Terminator { source_info, kind },
             is_cleanup: false,
         })
     };
@@ -397,7 +397,7 @@ impl CloneShimBuilder<'tcx> {
         let source_info = self.source_info();
         self.blocks.push(BasicBlockData {
             statements,
-            terminator: Some(Terminator { source_info, kind }),
+            terminator: Terminator { source_info, kind },
             is_cleanup,
         })
     }
@@ -775,7 +775,7 @@ fn build_call_shim<'tcx>(
     let block = |blocks: &mut IndexVec<_, _>, statements, kind, is_cleanup| {
         blocks.push(BasicBlockData {
             statements,
-            terminator: Some(Terminator { source_info, kind }),
+            terminator: Terminator { source_info, kind },
             is_cleanup,
         })
     };
@@ -888,7 +888,7 @@ pub fn build_adt_ctor(tcx: TyCtxt<'_>, ctor_id: DefId) -> &BodyAndCache<'_> {
 
     let start_block = BasicBlockData {
         statements,
-        terminator: Some(Terminator { source_info, kind: TerminatorKind::Return }),
+        terminator: Terminator { source_info, kind: TerminatorKind::Return },
         is_cleanup: false,
     };
 

--- a/src/librustc_mir/transform/add_moves_for_packed_drops.rs
+++ b/src/librustc_mir/transform/add_moves_for_packed_drops.rs
@@ -103,7 +103,7 @@ fn add_move_for_packed_drop<'tcx>(
 
     let storage_dead_block = patch.new_block(BasicBlockData {
         statements: vec![Statement { source_info, kind: StatementKind::StorageDead(temp) }],
-        terminator: Some(Terminator { source_info, kind: TerminatorKind::Goto { target } }),
+        terminator: Terminator { source_info, kind: TerminatorKind::Goto { target } },
         is_cleanup,
     });
 

--- a/src/librustc_mir/transform/elaborate_drops.rs
+++ b/src/librustc_mir/transform/elaborate_drops.rs
@@ -414,16 +414,13 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
         let unwind = unwind.unwrap_or_else(|| self.patch.resume_block());
         let unwind = self.patch.new_block(BasicBlockData {
             statements: vec![assign.clone()],
-            terminator: Some(Terminator {
-                kind: TerminatorKind::Goto { target: unwind },
-                ..*terminator
-            }),
+            terminator: Terminator { kind: TerminatorKind::Goto { target: unwind }, ..*terminator },
             is_cleanup: true,
         });
 
         let target = self.patch.new_block(BasicBlockData {
             statements: vec![assign],
-            terminator: Some(Terminator { kind: TerminatorKind::Goto { target }, ..*terminator }),
+            terminator: Terminator { kind: TerminatorKind::Goto { target }, ..*terminator },
             is_cleanup: false,
         });
 

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -805,7 +805,7 @@ fn insert_switch<'tcx>(
         0,
         BasicBlockData {
             statements: vec![assign],
-            terminator: Some(Terminator { source_info, kind: switch }),
+            terminator: Terminator { source_info, kind: switch },
             is_cleanup: false,
         },
     );
@@ -949,7 +949,7 @@ fn insert_term_block<'tcx>(
     let source_info = source_info(body);
     body.basic_blocks_mut().push(BasicBlockData {
         statements: Vec::new(),
-        terminator: Some(Terminator { source_info, kind }),
+        terminator: Terminator { source_info, kind },
         is_cleanup: false,
     });
     term_block
@@ -976,7 +976,7 @@ fn insert_panic_block<'tcx>(
     let source_info = source_info(body);
     body.basic_blocks_mut().push(BasicBlockData {
         statements: Vec::new(),
-        terminator: Some(Terminator { source_info, kind: term }),
+        terminator: Terminator { source_info, kind: term },
         is_cleanup: false,
     });
 
@@ -1054,7 +1054,7 @@ fn create_generator_resume_function<'tcx>(
         let source_info = source_info(body);
         body.basic_blocks_mut().push(BasicBlockData {
             statements: vec![transform.set_discr(VariantIdx::new(POISONED), source_info)],
-            terminator: Some(Terminator { source_info, kind: TerminatorKind::Resume }),
+            terminator: Terminator { source_info, kind: TerminatorKind::Resume },
             is_cleanup: true,
         });
 
@@ -1135,7 +1135,7 @@ fn insert_clean_drop(body: &mut BodyAndCache<'_>) -> BasicBlock {
     let source_info = source_info(body);
     body.basic_blocks_mut().push(BasicBlockData {
         statements: Vec::new(),
-        terminator: Some(Terminator { source_info, kind: term }),
+        terminator: Terminator { source_info, kind: term },
         is_cleanup: false,
     });
 
@@ -1208,10 +1208,7 @@ fn create_cases<'tcx>(
                 // Then jump to the real target
                 body.basic_blocks_mut().push(BasicBlockData {
                     statements,
-                    terminator: Some(Terminator {
-                        source_info,
-                        kind: TerminatorKind::Goto { target },
-                    }),
+                    terminator: Terminator { source_info, kind: TerminatorKind::Goto { target } },
                     is_cleanup: false,
                 });
 

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -767,10 +767,10 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
         let span = self.promoted.span;
         self.promoted.basic_blocks_mut().push(BasicBlockData {
             statements: vec![],
-            terminator: Some(Terminator {
+            terminator: Terminator {
                 source_info: SourceInfo { span, scope: OUTERMOST_SOURCE_SCOPE },
                 kind: TerminatorKind::Return,
-            }),
+            },
             is_cleanup: false,
         })
     }

--- a/src/librustc_mir/util/elaborate_drops.rs
+++ b/src/librustc_mir/util/elaborate_drops.rs
@@ -370,10 +370,10 @@ where
         if adt.variants.is_empty() {
             return self.elaborator.patch().new_block(BasicBlockData {
                 statements: vec![],
-                terminator: Some(Terminator {
+                terminator: Terminator {
                     source_info: self.source_info,
                     kind: TerminatorKind::Unreachable,
-                }),
+                },
                 is_cleanup: self.unwind.is_cleanup(),
             });
         }
@@ -527,7 +527,7 @@ where
         let discr_rv = Rvalue::Discriminant(self.place);
         let switch_block = BasicBlockData {
             statements: vec![self.assign(discr, discr_rv)],
-            terminator: Some(Terminator {
+            terminator: Terminator {
                 source_info: self.source_info,
                 kind: TerminatorKind::SwitchInt {
                     discr: Operand::Move(discr),
@@ -535,7 +535,7 @@ where
                     values: From::from(values.to_owned()),
                     targets: blocks,
                 },
-            }),
+            },
             is_cleanup: unwind.is_cleanup(),
         };
         let switch_block = self.elaborator.patch().new_block(switch_block);
@@ -564,7 +564,7 @@ where
                     self.place,
                 ),
             )],
-            terminator: Some(Terminator {
+            terminator: Terminator {
                 kind: TerminatorKind::Call {
                     func: Operand::function_handle(
                         tcx,
@@ -578,7 +578,7 @@ where
                     from_hir_call: true,
                 },
                 source_info: self.source_info,
-            }),
+            },
             is_cleanup: unwind.is_cleanup(),
         };
         self.elaborator.patch().new_block(result)
@@ -630,11 +630,11 @@ where
         let drop_block = BasicBlockData {
             statements: vec![self.assign(ptr, ptr_next), self.assign(Place::from(cur), cur_next)],
             is_cleanup: unwind.is_cleanup(),
-            terminator: Some(Terminator {
+            terminator: Terminator {
                 source_info: self.source_info,
                 // this gets overwritten by drop elaboration.
                 kind: TerminatorKind::Unreachable,
-            }),
+            },
         };
         let drop_block = self.elaborator.patch().new_block(drop_block);
 
@@ -644,10 +644,10 @@ where
                 Rvalue::BinaryOp(BinOp::Eq, copy(Place::from(cur)), copy(length_or_end)),
             )],
             is_cleanup: unwind.is_cleanup(),
-            terminator: Some(Terminator {
+            terminator: Terminator {
                 source_info: self.source_info,
                 kind: TerminatorKind::if_(tcx, move_(can_go), succ, drop_block),
-            }),
+            },
         };
         let loop_block = self.elaborator.patch().new_block(loop_block);
 
@@ -712,7 +712,7 @@ where
                 self.assign(len, Rvalue::Len(self.place)),
             ],
             is_cleanup: self.unwind.is_cleanup(),
-            terminator: Some(Terminator {
+            terminator: Terminator {
                 source_info: self.source_info,
                 kind: TerminatorKind::SwitchInt {
                     discr: move_(elem_size),
@@ -723,7 +723,7 @@ where
                         self.drop_loop_pair(ety, true, len.clone()),
                     ],
                 },
-            }),
+            },
         };
         self.elaborator.patch().new_block(base_block)
     }
@@ -773,10 +773,10 @@ where
         let drop_block = self.elaborator.patch().new_block(BasicBlockData {
             statements: drop_block_stmts,
             is_cleanup: unwind.is_cleanup(),
-            terminator: Some(Terminator {
+            terminator: Terminator {
                 source_info: self.source_info,
                 kind: TerminatorKind::Goto { target: loop_block },
-            }),
+            },
         });
 
         // FIXME(#34708): handle partially-dropped array/slice elements.
@@ -967,7 +967,7 @@ where
     fn new_block(&mut self, unwind: Unwind, k: TerminatorKind<'tcx>) -> BasicBlock {
         self.elaborator.patch().new_block(BasicBlockData {
             statements: vec![],
-            terminator: Some(Terminator { source_info: self.source_info, kind: k }),
+            terminator: Terminator { source_info: self.source_info, kind: k },
             is_cleanup: unwind.is_cleanup(),
         })
     }

--- a/src/librustc_mir/util/patch.rs
+++ b/src/librustc_mir/util/patch.rs
@@ -49,10 +49,10 @@ impl<'tcx> MirPatch<'tcx> {
         let resume_block = resume_block.unwrap_or_else(|| {
             result.new_block(BasicBlockData {
                 statements: vec![],
-                terminator: Some(Terminator {
+                terminator: Terminator {
                     source_info: SourceInfo { span: body.span, scope: OUTERMOST_SOURCE_SCOPE },
                     kind: TerminatorKind::Resume,
-                }),
+                },
                 is_cleanup: true,
             })
         });

--- a/src/librustc_mir_build/build/cfg.rs
+++ b/src/librustc_mir_build/build/cfg.rs
@@ -16,7 +16,7 @@ impl<'tcx> CFG<'tcx> {
     // it as #[inline(never)] to keep rustc's stack use in check.
     #[inline(never)]
     crate fn start_new_block(&mut self) -> BasicBlock {
-        self.basic_blocks.push(BasicBlockData::new(None))
+        self.basic_blocks.push(BasicBlockData::new(Terminator::tombstone()))
     }
 
     crate fn start_new_cleanup_block(&mut self) -> BasicBlock {
@@ -87,12 +87,12 @@ impl<'tcx> CFG<'tcx> {
     ) {
         debug!("terminating block {:?} <- {:?}", block, kind);
         debug_assert!(
-            self.block_data(block).terminator.is_none(),
+            self.block_data(block).terminator().is_tombstone(),
             "terminate: block {:?}={:?} already has a terminator set",
             block,
             self.block_data(block)
         );
-        self.block_data_mut(block).terminator = Some(Terminator { source_info, kind });
+        self.block_data_mut(block).set_terminator(Terminator { source_info, kind });
     }
 
     /// In the `origin` block, push a `goto -> target` terminator.


### PR DESCRIPTION
The `terminator` field of `BasicBlockData` is an `Option` that will always be `Some` once the MIR is built. Encode this in the type system and instead use a dummy value while building the MIR (`TerminatorKind::Goto { target: BasicBlock::MAX }`).

This also uses the `terminator{,_mut}()` getters when possible.

r? @ghost