### PR TITLE
Specialize io::copy for BufRead sources

### DIFF
--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -5,7 +5,7 @@ use crate::io::{self, BufRead, Initializer, IoSlice, IoSliceMut, Read, Write};
 
 mod copy_specialization {
     use crate::mem::MaybeUninit;
-    use crate::io::{self, Read, BufRead, Write, ErrorKind};
+    use crate::io::{self, BufRead, ErrorKind, Read, Write};
 
     pub trait Copyable {
         fn copy_to<W: ?Sized + Write>(&mut self, writer: &mut W) -> io::Result<u64>;

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -4,8 +4,8 @@ use crate::fmt;
 use crate::io::{self, BufRead, Initializer, IoSlice, IoSliceMut, Read, Write};
 
 mod copy_specialization {
-    use crate::mem::MaybeUninit;
     use crate::io::{self, BufRead, ErrorKind, Read, Write};
+    use crate::mem::MaybeUninit;
 
     pub trait Copyable {
         fn copy_to<W: ?Sized + Write>(&mut self, writer: &mut W) -> io::Result<u64>;

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -6,11 +6,11 @@ use crate::io::{self, BufRead, Initializer, IoSlice, IoSliceMut, Read, Write};
 mod copy_specialization {
     use crate::mem::MaybeUninit;
     use crate::io::{self, Read, BufRead, Write, ErrorKind};
-    
+
     pub trait Copyable {
         fn copy_to<W: ?Sized + Write>(&mut self, writer: &mut W) -> io::Result<u64>;
     }
-    
+
     impl<T: Read + ?Sized> Copyable for T {
         default fn copy_to<W: ?Sized + Write>(&mut self, writer: &mut W) -> io::Result<u64> {
             let mut buf = MaybeUninit::<[u8; io::DEFAULT_BUF_SIZE]>::uninit();
@@ -49,7 +49,7 @@ mod copy_specialization {
                     }?;
                     (writer.write_all(buf), buf.len())
                 };
-                
+
                 // make sure to consume the data before dealing with write errors
                 // to maintain the same semantics as the default impl
                 //


### PR DESCRIPTION
Allocating an additional buffer and then copying through it is completely unnecessary if the source we're copying from is `BufRead` (i.e. already maintains a buffer internally). Using specialization, we can detect this and handle it accordingly.

Note that this also makes it possible to specify a custom buffer size for copy operations by wrapping the source in a `BufReader::with_capacity`. This might fix #49921.

Here's why this is better:

```
io::copy 1GB: 64.019007ms
specialized copy 1GB: 63.741937ms
specialized copy 1GB with bigger buffer: 27.649244ms
io::copy 1GB BufRead: 124.040431ms
specialized copy 1GB BufRead: 688ns
```

I know this benchmark is unfair, but that's basically the point.

```rust
fn main() {
    // don't want to use std::io::sink() here because we don't want anything to get optimized out
    let mut null = File::create("/dev/null").unwrap();
    
    let now = Instant::now();
    io::copy(&mut io::repeat(42).take(1024 * 1024 * 1024), &mut null).unwrap();
    println!("io::copy 1GB: {:?}", now.elapsed());

    let now = Instant::now();
    copy(&mut io::repeat(42).take(1024 * 1024 * 1024), &mut null).unwrap();
    println!("specialized copy 1GB: {:?}", now.elapsed());
    
    let now = Instant::now();
    copy(&mut BufReader::with_capacity(64 * 1024, io::repeat(42).take(1024 * 1024 * 1024)), &mut null).unwrap();
    println!("specialized copy 1GB with bigger buffer: {:?}", now.elapsed());
    
    let testdata = vec![42u8; 1024 * 1024 * 1024];

    let now = Instant::now();
    io::copy(&mut testdata.as_slice(), &mut null).unwrap();
    println!("io::copy 1GB BufRead: {:?}", now.elapsed());

    let now = Instant::now();
    copy(&mut testdata.as_slice(), &mut null).unwrap();
    println!("specialized copy 1GB BufRead: {:?}", now.elapsed());
}
```