### PR TITLE
Update compiler_builtins to 0.1.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.25"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "438ac08ddc5efe81452f984a9e33ba425b00b31d1f48e6acd9e2210aa28cc52e"
+checksum = "38f18416546abfbf8d801c555a0e99524453e7214f9cc9107ad49de3d5948ccc"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",


### PR DESCRIPTION
* aarch64: Exclude FP intrinsics on +nofp or +nosimd
* Place intrinsics in individual object files

https://github.com/rust-lang/compiler-builtins/compare/0.1.25...0.1.27