### PR TITLE
allow const generics in const fn

### DIFF
--- a/src/test/ui/const-generics/const-fn-with-const-param.rs
+++ b/src/test/ui/const-generics/const-fn-with-const-param.rs
@@ -1,11 +1,11 @@
+// run-pass
 #![feature(const_generics)]
 //~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
 
 const fn const_u32_identity<const X: u32>() -> u32 {
-    //~^ ERROR const parameters are not permitted in const functions
     X
 }
 
 fn main() {
-    println!("{:?}", const_u32_identity::<18>());
+    assert_eq!(const_u32_identity::<18>(), 18);
 }

--- a/src/test/ui/const-generics/const-fn-with-const-param.stderr
+++ b/src/test/ui/const-generics/const-fn-with-const-param.stderr
@@ -1,23 +1,10 @@
-error: const parameters are not permitted in const functions
-  --> $DIR/const-fn-with-const-param.rs:4:1
-   |
-LL |   const fn const_u32_identity<const X: u32>() -> u32 {
-   |   ^----
-   |   |
-   |  _`const` because of this
-   | |
-LL | |
-LL | |     X
-LL | | }
-   | |_^
-
 warning: the feature `const_generics` is incomplete and may cause the compiler to crash
-  --> $DIR/const-fn-with-const-param.rs:1:12
+  --> $DIR/const-fn-with-const-param.rs:2:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error: aborting due to previous error; 1 warning emitted
+warning: 1 warning emitted
 


### PR DESCRIPTION
This was explicitly forbidden before. As we were unable to think of a reason
why this should still be the case, this check has been removed.

r? @eddyb 
cc @varkor @Centril 