### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,7 +203,7 @@ They are just regular files and directories. This is in contrast to `submodule` 
 There are two synchronization directions: `subtree push` and `subtree pull`.
 
 ```
-git subtree push -P src/tools/clippy git@github.com:your-github-name/rust-clippy rustup
+git subtree push -P src/tools/clippy git@github.com:your-github-name/rust-clippy sync-from-rust
 ```
 
 takes all the changes that
@@ -211,8 +211,8 @@ happened to the copy in this repo and creates commits on the remote repo that ma
 changes. Every local commit that touched the subtree causes a commit on the remote repo, but is
 modified to move the files from the specified directory to the tool repo root.
 
-Make sure to not pick the `master` branch, so you can open a normal PR to the tool to merge that
-subrepo push.
+Make sure to not pick the `master` branch on the tool repo, so you can open a normal PR to the tool
+to merge that subrepo push.
 
 ```
 git subtree pull -P src/tools/clippy https://github.com/rust-lang/rust-clippy master
@@ -224,20 +224,21 @@ the specified directory in the rust repository.
 
 It is recommended that you always do a push first and get that merged to the tool master branch.
 Then, when you do a pull, the merge works without conflicts.
-While definitely possible to resolve conflicts during a pull, you may have to redo the conflict
+While it's definitely possible to resolve conflicts during a pull, you may have to redo the conflict
 resolution if your PR doesn't get merged fast enough and there are new conflicts. Do not try to
 rebase the result of a `git subtree pull`, rebasing merge commits is a bad idea in general.
 
 You always need to specify the `-P` prefix to the subtree directory and the corresponding remote
 repository. If you specify the wrong directory or repository
 you'll get very fun merges that try to push the wrong directory to the wrong remote repository.
-Luckily you can just abort this without any consequences and try again. It is usually fairly obvious
+Luckily you can just abort this without any consequences by throwing away either the pulled commits
+in rustc or the pushed branch on the remote and try again. It is usually fairly obvious
 that this is happening because you suddenly get thousands of commits that want to be synchronized.
 
 #### Creating a new subtree dependency
 
 If you want to create a new subtree dependency from an existing repository, call (from this
-repository's root directory!!)
+repository's root directory!)
 
 ```
 git subtree add -P src/tools/clippy https://github.com/rust-lang/rust-clippy.git master
@@ -247,7 +248,7 @@ This will create a new commit, which you may not rebase under any circumstances!
 and redo the operation if you need to rebase.
 
 Now you're done, the `src/tools/clippy` directory behaves as if clippy were part of the rustc
-monorepo, so no one but you (or others that synchronize subtrees) needs actually use `git subtree`.
+monorepo, so no one but you (or others that synchronize subtrees) actually needs to use `git subtree`.
 
 
 ### External Dependencies (submodules)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,7 +188,7 @@ with one another are rolled up.
 Speaking of tests, Rust has a comprehensive test suite. More information about
 it can be found [here][rctd].
 
-### External Dependencies (subrepo)
+### External Dependencies (subtree)
 
 As a developer to this repository, you don't have to treat the following external projects
 differently from other crates that are directly in this repo:
@@ -198,39 +198,39 @@ differently from other crates that are directly in this repo:
 They are just regular files and directories. This is in contrast to `submodule` dependencies
 (see below for those).
 
-If you want to synchronize or otherwise work with subrepos, install the `git subrepo` command via
-instructions found at https://github.com/ingydotnet/git-subrepo
+If you want to synchronize or otherwise work with subtrees, install the `git subtree` command via
+instructions found at https://github.com/ingydotnet/git-subtree
 
-#### Synchronizing a subrepo
+#### Synchronizing a subtree
 
-There are two synchronization directions: `subrepo push` and `subrepo pull`. Both operations create
-a synchronization commit in the rustc repo.
-This commit is very important in order to make future synchronizations work.
-Do not rebase this commit under any circumstances.
-Prefer to merge in case of conflicts or redo the operation if you really need to rebase.
+There are two synchronization directions: `subtree push` and `subtree pull`.
 
-A `git subrepo push src/tools/clippy`
+A `git subtree push -P src/tools/clippy`
 takes all the changes that
 happened to the copy in this repo and creates commits on the remote repo that match the local
-changes (so every local commit that touched the subrepo causes a commit on the remote repo).
+changes (so every local commit that touched the subtree causes a commit on the remote repo).
 
-A `git subrepo pull src/tools/clippy` takes all changes since the last `subrepo pull` from the clippy
+A `git subtree pull -P src/tools/clippy` takes all changes since the last `subtree pull` from the clippy
 repo and creates a single commit in the rustc repo with all the changes.
 
-#### Creating a new subrepo dependency
+You always need to specifiy the `-P` prefix to the subtree directory. If you specify the wrong directory
+you'll get very fun merges that try to push the wrong directory to the remote repository. Luckily you
+can just abort this without any consequences.
 
-If you want to create a new subrepo dependency from an existing repository, call (from this
+#### Creating a new subtree dependency
+
+If you want to create a new subtree dependency from an existing repository, call (from this
 repository's root directory!!)
 
 ```
-git subrepo clone https://github.com/rust-lang/rust-clippy.git src/tools/clippy
+git subtree add -P src/tools/clippy https://github.com/rust-lang/rust-clippy.git master
 ```
 
 This will create a new commit, which you may not rebase under any circumstances! Delete the commit
 and redo the operation if you need to rebase.
 
 Now you're done, the `src/tools/clippy` directory behaves as if clippy were part of the rustc
-monorepo, so no one but you (or others that synchronize subrepos) needs to have `git subrepo`
+monorepo, so no one but you (or others that synchronize subtrees) needs to have `git subtree`
 installed.
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,23 +196,31 @@ differently from other crates that are directly in this repo:
 * none so far, see https://github.com/rust-lang/rust/issues/70651 for more info
 
 They are just regular files and directories. This is in contrast to `submodule` dependencies
-(see below for those).
+(see below for those). Only tool authors will actually use any operations here.
 
 #### Synchronizing a subtree
 
 There are two synchronization directions: `subtree push` and `subtree pull`.
 
-A `git subtree push -P src/tools/clippy`
+`git subtree push -P src/tools/clippy https://github.com/rust-lang/rust-clippy.git`
+
 takes all the changes that
 happened to the copy in this repo and creates commits on the remote repo that match the local
 changes (so every local commit that touched the subtree causes a commit on the remote repo).
 
-A `git subtree pull -P src/tools/clippy` takes all changes since the last `subtree pull` from the clippy
-repo and creates a single commit in the rustc repo with all the changes.
+`git subtree pull -P src/tools/clippy https://github.com/rust-lang/rust-clippy.git`
+takes all changes since the last `subtree pull` from the clippy
+repo and adds these commits to the rustc repo + a merge commit with the existing changes.
+It is recommended that you always do a push before a pull, so that the merge works without conflicts.
+While definitely possible to resolve conflicts during a pull, you may have to redo the conflict
+resolution if your PR doesn't get merged fast enough and there are new conflicts. Do not try to
+rebase the result of a `git subtree pull`, rebasing merge commits is a bad idea in general.
 
-You always need to specifiy the `-P` prefix to the subtree directory. If you specify the wrong directory
-you'll get very fun merges that try to push the wrong directory to the remote repository. Luckily you
-can just abort this without any consequences.
+You always need to specify the `-P` prefix to the subtree directory and the corresponding remote
+repository. If you specify the wrong directory or repository
+you'll get very fun merges that try to push the wrong directory to the wrong remote repository.
+Luckily you can just abort this without any consequences and try again. It is usually fairly obvious
+that this is happening because you suddenly get thousands of commits that want to be synchronized.
 
 #### Creating a new subtree dependency
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,21 +203,27 @@ They are just regular files and directories. This is in contrast to `submodule` 
 There are two synchronization directions: `subtree push` and `subtree pull`.
 
 ```
-git subtree push -P src/tools/clippy https://github.com/rust-lang/rust-clippy.git
+git subtree push -P src/tools/clippy git@github.com:your-github-name/rust-clippy rustup
 ```
 
 takes all the changes that
 happened to the copy in this repo and creates commits on the remote repo that match the local
-changes (so every local commit that touched the subtree causes a commit on the remote repo).
+changes. Every local commit that touched the subtree causes a commit on the remote repo, but is
+modified to move the files from the specified directory to the tool repo root.
+
+Make sure to not pick the `master` branch, so you can open a normal PR to the tool to merge that
+subrepo push.
 
 ```
-git subtree pull -P src/tools/clippy https://github.com/rust-lang/rust-clippy.git
+git subtree pull -P src/tools/clippy https://github.com/rust-lang/rust-clippy master
 ```
 
+takes all changes since the last `subtree pull` from the tool repo
+repo and adds these commits to the rustc repo + a merge commit that moves the tool changes into
+the specified directory in the rust repository.
 
-takes all changes since the last `subtree pull` from the clippy
-repo and adds these commits to the rustc repo + a merge commit with the existing changes.
-It is recommended that you always do a push before a pull, so that the merge works without conflicts.
+It is recommended that you always do a push first and get that merged to the tool master branch.
+Then, when you do a pull, the merge works without conflicts.
 While definitely possible to resolve conflicts during a pull, you may have to redo the conflict
 resolution if your PR doesn't get merged fast enough and there are new conflicts. Do not try to
 rebase the result of a `git subtree pull`, rebasing merge commits is a bad idea in general.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,7 +188,53 @@ with one another are rolled up.
 Speaking of tests, Rust has a comprehensive test suite. More information about
 it can be found [here][rctd].
 
-### External Dependencies
+### External Dependencies (subrepo)
+
+As a developer to this repository, you don't have to treat the following external projects
+differently from other crates that are directly in this repo:
+
+* none so far, see https://github.com/rust-lang/rust/issues/70651 for more info
+
+They are just regular files and directories. This is in contrast to `submodule` dependencies
+(see below for those).
+
+If you want to synchronize or otherwise work with subrepos, install the `git subrepo` command via
+instructions found at https://github.com/ingydotnet/git-subrepo
+
+#### Synchronizing a subrepo
+
+There are two synchronization directions: `subrepo push` and `subrepo pull`. Both operations create
+a synchronization commit in the rustc repo.
+This commit is very important in order to make future synchronizations work.
+Do not rebase this commit under any circumstances.
+Prefer to merge in case of conflicts or redo the operation if you really need to rebase.
+
+A `git subrepo push src/tools/clippy`
+takes all the changes that
+happened to the copy in this repo and creates commits on the remote repo that match the local
+changes (so every local commit that touched the subrepo causes a commit on the remote repo).
+
+A `git subrepo pull src/tools/clippy` takes all changes since the last `subrepo pull` from the clippy
+repo and creates a single commit in the rustc repo with all the changes.
+
+#### Creating a new subrepo dependency
+
+If you want to create a new subrepo dependency from an existing repository, call (from this
+repository's root directory!!)
+
+```
+git subrepo clone https://github.com/rust-lang/rust-clippy.git src/tools/clippy
+```
+
+This will create a new commit, which you may not rebase under any circumstances! Delete the commit
+and redo the operation if you need to rebase.
+
+Now you're done, the `src/tools/clippy` directory behaves as if clippy were part of the rustc
+monorepo, so no one but you (or others that synchronize subrepos) needs to have `git subrepo`
+installed.
+
+
+### External Dependencies (submodules)
 
 Currently building Rust will also build the following external projects:
 
@@ -221,7 +267,6 @@ before the PR is merged.
 
 Rust's build system builds a number of tools that make use of the
 internals of the compiler. This includes
-[Clippy](https://github.com/rust-lang/rust-clippy),
 [RLS](https://github.com/rust-lang/rls) and
 [rustfmt](https://github.com/rust-lang/rustfmt). If these tools
 break because of your changes, you may run into a sort of "chicken and egg"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,13 +202,19 @@ They are just regular files and directories. This is in contrast to `submodule` 
 
 There are two synchronization directions: `subtree push` and `subtree pull`.
 
-`git subtree push -P src/tools/clippy https://github.com/rust-lang/rust-clippy.git`
+```
+git subtree push -P src/tools/clippy https://github.com/rust-lang/rust-clippy.git
+```
 
 takes all the changes that
 happened to the copy in this repo and creates commits on the remote repo that match the local
 changes (so every local commit that touched the subtree causes a commit on the remote repo).
 
-`git subtree pull -P src/tools/clippy https://github.com/rust-lang/rust-clippy.git`
+```
+git subtree pull -P src/tools/clippy https://github.com/rust-lang/rust-clippy.git
+```
+
+
 takes all changes since the last `subtree pull` from the clippy
 repo and adds these commits to the rustc repo + a merge commit with the existing changes.
 It is recommended that you always do a push before a pull, so that the merge works without conflicts.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,9 +198,6 @@ differently from other crates that are directly in this repo:
 They are just regular files and directories. This is in contrast to `submodule` dependencies
 (see below for those).
 
-If you want to synchronize or otherwise work with subtrees, install the `git subtree` command via
-instructions found at https://github.com/ingydotnet/git-subtree
-
 #### Synchronizing a subtree
 
 There are two synchronization directions: `subtree push` and `subtree pull`.
@@ -230,8 +227,7 @@ This will create a new commit, which you may not rebase under any circumstances!
 and redo the operation if you need to rebase.
 
 Now you're done, the `src/tools/clippy` directory behaves as if clippy were part of the rustc
-monorepo, so no one but you (or others that synchronize subtrees) needs to have `git subtree`
-installed.
+monorepo, so no one but you (or others that synchronize subtrees) needs actually use `git subtree`.
 
 
 ### External Dependencies (submodules)

--- a/src/librustc_infer/infer/error_reporting/mod.rs
+++ b/src/librustc_infer/infer/error_reporting/mod.rs
@@ -191,7 +191,7 @@ fn msg_span_from_early_bound_and_free_regions(
     let sm = tcx.sess.source_map();
 
     let scope = region.free_region_binding_scope(tcx);
-    let node = tcx.hir().as_local_hir_id(scope).unwrap_or(hir::DUMMY_HIR_ID);
+    let node = tcx.hir().as_local_hir_id(scope).unwrap();
     let tag = match tcx.hir().find(node) {
         Some(Node::Block(_)) | Some(Node::Expr(_)) => "body",
         Some(Node::Item(it)) => item_scope_tag(&it),

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1354,7 +1354,7 @@ declare_lint! {
 }
 
 pub struct UnnameableTestItems {
-    boundary: hir::HirId, // HirId of the item under which things are not nameable
+    boundary: Option<hir::HirId>, // HirId of the item under which things are not nameable
     items_nameable: bool,
 }
 
@@ -1362,7 +1362,7 @@ impl_lint_pass!(UnnameableTestItems => [UNNAMEABLE_TEST_ITEMS]);
 
 impl UnnameableTestItems {
     pub fn new() -> Self {
-        Self { boundary: hir::DUMMY_HIR_ID, items_nameable: true }
+        Self { boundary: None, items_nameable: true }
     }
 }
 
@@ -1372,7 +1372,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnnameableTestItems {
             if let hir::ItemKind::Mod(..) = it.kind {
             } else {
                 self.items_nameable = false;
-                self.boundary = it.hir_id;
+                self.boundary = Some(it.hir_id);
             }
             return;
         }
@@ -1385,7 +1385,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnnameableTestItems {
     }
 
     fn check_item_post(&mut self, _cx: &LateContext<'_, '_>, it: &hir::Item<'_>) {
-        if !self.items_nameable && self.boundary == it.hir_id {
+        if !self.items_nameable && self.boundary == Some(it.hir_id) {
             self.items_nameable = true;
         }
     }

--- a/src/librustc_traits/implied_outlives_bounds.rs
+++ b/src/librustc_traits/implied_outlives_bounds.rs
@@ -62,7 +62,7 @@ fn compute_implied_outlives_bounds<'tcx>(
         // unresolved inference variables here anyway, but there might be
         // during typeck under some circumstances.)
         let obligations =
-            wf::obligations(infcx, param_env, hir::DUMMY_HIR_ID, ty, DUMMY_SP).unwrap_or(vec![]);
+            wf::obligations(infcx, param_env, hir::CRATE_HIR_ID, ty, DUMMY_SP).unwrap_or(vec![]);
 
         // N.B., all of these predicates *ought* to be easily proven
         // true. In fact, their correctness is (mostly) implied by

--- a/src/librustc_ty/ty.rs
+++ b/src/librustc_ty/ty.rs
@@ -265,7 +265,7 @@ fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
     let unnormalized_env =
         ty::ParamEnv::new(tcx.intern_predicates(&predicates), traits::Reveal::UserFacing, None);
 
-    let body_id = tcx.hir().as_local_hir_id(def_id).map_or(hir::DUMMY_HIR_ID, |id| {
+    let body_id = tcx.hir().as_local_hir_id(def_id).map_or(hir::CRATE_HIR_ID, |id| {
         tcx.hir().maybe_body_owned_by(id).map_or(id, |body| body.hir_id)
     });
     let cause = traits::ObligationCause::misc(tcx.def_span(def_id), body_id);

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -217,14 +217,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         span: Span,
         expected: Ty<'tcx>,
         checked_ty: Ty<'tcx>,
+        hir_id: hir::HirId,
     ) -> Vec<AssocItem> {
-        let mut methods = self.probe_for_return_type(
-            span,
-            probe::Mode::MethodCall,
-            expected,
-            checked_ty,
-            hir::DUMMY_HIR_ID,
-        );
+        let mut methods =
+            self.probe_for_return_type(span, probe::Mode::MethodCall, expected, checked_ty, hir_id);
         methods.retain(|m| {
             self.has_no_input_arg(m)
                 && self

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -1513,7 +1513,6 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             );
             pcx.allow_similar_names = true;
             pcx.assemble_inherent_candidates();
-            pcx.assemble_extension_candidates_for_traits_in_scope(hir::DUMMY_HIR_ID)?;
 
             let method_names = pcx.candidate_method_names();
             pcx.allow_similar_names = false;
@@ -1523,10 +1522,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                     pcx.reset();
                     pcx.method_name = Some(method_name);
                     pcx.assemble_inherent_candidates();
-                    pcx.assemble_extension_candidates_for_traits_in_scope(hir::DUMMY_HIR_ID)
-                        .map_or(None, |_| {
-                            pcx.pick_core().and_then(|pick| pick.ok()).map(|pick| pick.item)
-                        })
+                    pcx.pick_core().and_then(|pick| pick.ok()).map(|pick| pick.item)
                 })
                 .collect();
 

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -452,7 +452,7 @@ fn method_autoderef_steps<'tcx>(
     tcx.infer_ctxt().enter_with_canonical(DUMMY_SP, &goal, |ref infcx, goal, inference_vars| {
         let ParamEnvAnd { param_env, value: self_ty } = goal;
 
-        let mut autoderef = Autoderef::new(infcx, param_env, hir::DUMMY_HIR_ID, DUMMY_SP, self_ty)
+        let mut autoderef = Autoderef::new(infcx, param_env, hir::CRATE_HIR_ID, DUMMY_SP, self_ty)
             .include_raw_pointers()
             .silence_errors();
         let mut reached_raw_pointer = false;

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -5000,7 +5000,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         } else if !self.check_for_cast(err, expr, found, expected) {
             let is_struct_pat_shorthand_field =
                 self.is_hir_id_from_struct_pattern_shorthand_field(expr.hir_id, expr.span);
-            let methods = self.get_conversion_methods(expr.span, expected, found);
+            let methods = self.get_conversion_methods(expr.span, expected, found, expr.hir_id);
             if let Ok(expr_text) = self.sess().source_map().span_to_snippet(expr.span) {
                 let mut suggestions = iter::repeat(&expr_text)
                     .zip(methods.iter())

--- a/src/test/ui/const-generics/const-fn-with-const-param.rs
+++ b/src/test/ui/const-generics/const-fn-with-const-param.rs
@@ -1,11 +1,11 @@
+// run-pass
 #![feature(const_generics)]
 //~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
 
 const fn const_u32_identity<const X: u32>() -> u32 {
-    //~^ ERROR const parameters are not permitted in const functions
     X
 }
 
 fn main() {
-    println!("{:?}", const_u32_identity::<18>());
+    assert_eq!(const_u32_identity::<18>(), 18);
 }

--- a/src/test/ui/const-generics/const-fn-with-const-param.stderr
+++ b/src/test/ui/const-generics/const-fn-with-const-param.stderr
@@ -1,23 +1,10 @@
-error: const parameters are not permitted in const functions
-  --> $DIR/const-fn-with-const-param.rs:4:1
-   |
-LL |   const fn const_u32_identity<const X: u32>() -> u32 {
-   |   ^----
-   |   |
-   |  _`const` because of this
-   | |
-LL | |
-LL | |     X
-LL | | }
-   | |_^
-
 warning: the feature `const_generics` is incomplete and may cause the compiler to crash
-  --> $DIR/const-fn-with-const-param.rs:1:12
+  --> $DIR/const-fn-with-const-param.rs:2:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error: aborting due to previous error; 1 warning emitted
+warning: 1 warning emitted
 

--- a/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-sized.rs
+++ b/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-sized.rs
@@ -1,0 +1,17 @@
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+
+type A = impl Sized;
+fn f1() -> A { 0 }
+
+type B = impl ?Sized;
+fn f2() -> &'static B { &[0] }
+
+type C = impl ?Sized + 'static;
+fn f3() -> &'static C { &[0] }
+
+type D = impl ?Sized;
+fn f4() -> &'static D { &1 }
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #70654 (Explain how to work with subtree)
 - #71092 (Remove some usage of `DUMMY_HIR_ID`)
 - #71103 (Add test case for type aliasing `impl Sized`)
 - #71109 (allow const generics in const fn)

Failed merges:


r? @ghost