### PR TITLE
Remove the last remnant of unsigned Neg

### DIFF
--- a/src/libcore/ops/arith.rs
+++ b/src/libcore/ops/arith.rs
@@ -617,35 +617,22 @@ pub trait Neg {
     fn neg(self) -> Self::Output;
 }
 
-macro_rules! neg_impl_core {
-    ($id:ident => $body:expr, $($t:ty)*) => ($(
+macro_rules! neg_impl {
+    ($($t:ty)*) => ($(
         #[stable(feature = "rust1", since = "1.0.0")]
         impl Neg for $t {
             type Output = $t;
 
             #[inline]
             #[rustc_inherit_overflow_checks]
-            fn neg(self) -> $t { let $id = self; $body }
+            fn neg(self) -> $t { -self }
         }
 
         forward_ref_unop! { impl Neg, neg for $t }
     )*)
 }
 
-macro_rules! neg_impl_numeric {
-    ($($t:ty)*) => { neg_impl_core!{ x => -x, $($t)*} }
-}
-
-#[allow(unused_macros)]
-macro_rules! neg_impl_unsigned {
-    ($($t:ty)*) => {
-        neg_impl_core!{ x => {
-            !x.wrapping_add(1)
-        }, $($t)*} }
-}
-
-// neg_impl_unsigned! { usize u8 u16 u32 u64 }
-neg_impl_numeric! { isize i8 i16 i32 i64 i128 f32 f64 }
+neg_impl! { isize i8 i16 i32 i64 i128 f32 f64 }
 
 /// The addition assignment operator `+=`.
 ///


### PR DESCRIPTION
It's been gone since #23945, before Rust 1.0. The former wrapping
semantics have also been available as inherent methods for a long time
now. There's no reason to keep this unused macro around.