### PR TITLE
Remove unused single_step flag

### DIFF
--- a/src/librustc_expand/expand.rs
+++ b/src/librustc_expand/expand.rs
@@ -507,9 +507,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                 expanded_fragments.push(Vec::new());
             }
             expanded_fragments[depth - 1].push((expn_id, expanded_fragment));
-            if !self.cx.ecfg.single_step {
-                invocations.extend(new_invocations.into_iter().rev());
-            }
+            invocations.extend(new_invocations.into_iter().rev());
         }
 
         self.cx.current_expansion = orig_expansion_data;
@@ -1819,7 +1817,6 @@ pub struct ExpansionConfig<'feat> {
     pub recursion_limit: usize,
     pub trace_mac: bool,
     pub should_test: bool, // If false, strip `#[test]` nodes
-    pub single_step: bool,
     pub keep_macs: bool,
 }
 
@@ -1831,7 +1828,6 @@ impl<'feat> ExpansionConfig<'feat> {
             recursion_limit: 1024,
             trace_mac: false,
             should_test: false,
-            single_step: false,
             keep_macs: false,
         }
     }


### PR DESCRIPTION
This appears to have never been used ever since its introduction in 61c7569d4 --
the plugin discussed on the PR introducing that commit, 34811, never
materialized.

It's also simple to re-add in the current scheme, but given that macro expansion
is already quite complicated, additional useless state seems good to remove
while we're not using it.