### PR TITLE
submodules: update clippy from af5940b7 to d236b30a

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ dependencies = [
  "cargo_metadata 0.9.1",
  "clippy-mini-macro-test",
  "clippy_lints",
- "compiletest_rs",
+ "compiletest_rs 0.5.0",
  "derive-new",
  "lazy_static 1.4.0",
  "regex",
@@ -607,6 +607,28 @@ dependencies = [
  "miow 0.3.3",
  "regex",
  "rustfix 0.4.6",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tempfile",
+ "tester",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "compiletest_rs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f737835bfbbe29ed1ff82d5137520338d7ed5bf1a1d4b9c1c7c58bb45b8fa29"
+dependencies = [
+ "diff",
+ "filetime",
+ "getopts",
+ "libc",
+ "log",
+ "miow 0.3.3",
+ "regex",
+ "rustfix 0.5.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2179,7 +2201,7 @@ dependencies = [
  "byteorder",
  "cargo_metadata 0.9.1",
  "colored",
- "compiletest_rs",
+ "compiletest_rs 0.4.0",
  "directories",
  "env_logger 0.7.1",
  "getrandom",


### PR DESCRIPTION
Changes:
````
rustup https://github.com/rust-lang/rust/pull/70643
Explain panic on `E0463` in integration tests
Temporarily disable rustfmt integration test
Cleanup: Use rustc's is_proc_macro_attr
Cleanup: Use our `sym!` macro more
Fixes #5405: redundant clone false positive with arrays
update lints
verbose_bit_mask: fix bit mask used in docs
Update documentation for new_ret_no_self
````

Fixes #71114