### PR TITLE
[breaking change] Disallow statics initializing themselves

### DIFF
--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -404,7 +404,9 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
                     // We may be reading from a static.
                     // In order to ensure that `static FOO: Type = FOO;` causes a cycle error
                     // instead of magically pulling *any* ZST value from the ether, we need to
-                    // trigger a read here.
+                    // actually access the referenced allocation. The caller is likely
+                    // to short-circuit on `None`, so we trigger the access here to
+                    // make sure it happens.
                     self.get_raw(ptr.alloc_id)?;
                     None
                 } else {

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -242,13 +242,11 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
         };
 
+        let alloc = self.memory.get_raw(ptr.alloc_id)?;
+
         match mplace.layout.abi {
             Abi::Scalar(..) => {
-                let scalar = self.memory.get_raw(ptr.alloc_id)?.read_scalar(
-                    self,
-                    ptr,
-                    mplace.layout.size,
-                )?;
+                let scalar = alloc.read_scalar(self, ptr, mplace.layout.size)?;
                 Ok(Some(ImmTy { imm: scalar.into(), layout: mplace.layout }))
             }
             Abi::ScalarPair(ref a, ref b) => {
@@ -261,8 +259,8 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let b_offset = a_size.align_to(b.align(self).abi);
                 assert!(b_offset.bytes() > 0); // we later use the offset to tell apart the fields
                 let b_ptr = ptr.offset(b_offset, self)?;
-                let a_val = self.memory.get_raw(ptr.alloc_id)?.read_scalar(self, a_ptr, a_size)?;
-                let b_val = self.memory.get_raw(ptr.alloc_id)?.read_scalar(self, b_ptr, b_size)?;
+                let a_val = alloc.read_scalar(self, a_ptr, a_size)?;
+                let b_val = alloc.read_scalar(self, b_ptr, b_size)?;
                 Ok(Some(ImmTy { imm: Immediate::ScalarPair(a_val, b_val), layout: mplace.layout }))
             }
             _ => Ok(None),

--- a/src/test/ui/consts/recursive-zst-static.rs
+++ b/src/test/ui/consts/recursive-zst-static.rs
@@ -1,6 +1,10 @@
-// build-pass
+// This test ensures that we do not allow ZST statics to initialize themselves without ever
+// actually creating a value of that type. This is important, as the ZST may have private fields
+// that users can reasonably expect to only get initialized by their own code. Thus unsafe code
+// can depend on this fact and will thus do unsound things when it is violated.
+// See https://github.com/rust-lang/rust/issues/71078 for more details.
 
-static FOO: () = FOO;
+static FOO: () = FOO; //~ cycle detected when const-evaluating `FOO`
 
 fn main() {
     FOO

--- a/src/test/ui/consts/recursive-zst-static.stderr
+++ b/src/test/ui/consts/recursive-zst-static.stderr
@@ -1,0 +1,21 @@
+error[E0391]: cycle detected when const-evaluating `FOO`
+  --> $DIR/recursive-zst-static.rs:7:18
+   |
+LL | static FOO: () = FOO;
+   |                  ^^^
+   |
+note: ...which requires const-evaluating `FOO`...
+  --> $DIR/recursive-zst-static.rs:7:1
+   |
+LL | static FOO: () = FOO;
+   | ^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which again requires const-evaluating `FOO`, completing the cycle
+note: cycle used when const-evaluating + checking `FOO`
+  --> $DIR/recursive-zst-static.rs:7:1
+   |
+LL | static FOO: () = FOO;
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0391`.


### PR DESCRIPTION
fixes #71078

Self-initialization is unsound because it breaks privacy assumptions that unsafe code can make. In

```rust
pub mod foo {
    #[derive(Debug, Copy, Clone)]
    pub struct Foo {
        x: (),
    }
}

pub static FOO: foo::Foo = FOO;
```

unsafe could could expect that ony functions inside the `foo` module were able to create a value of type `Foo`.