### PR TITLE
Provide better compiler output when using `?` on `Option` in fn returning `Result` and vice-versa

### DIFF
--- a/src/librustc_trait_selection/traits/error_reporting/mod.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/mod.rs
@@ -321,7 +321,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             err.span_suggestion_verbose(
                                 span.shrink_to_lo(),
                                 "consider converting the `Option<T>` into a `Result<T, _>` using `Option::ok_or` or `Option::ok_or_else`",
-                                ".ok_or_else(|_| /* error value */)".to_string(),
+                                ".ok_or_else(|| /* error value */)".to_string(),
                                 Applicability::HasPlaceholders,
                             );
                         } else if is_try && is_from && should_convert_result_to_option {
@@ -329,7 +329,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                                 span.shrink_to_lo(),
                                 "consider converting the `Result<T, _>` into an `Option<T>` using `Result::ok`",
                                 ".ok()".to_string(),
-                                Applicability::HasPlaceholders,
+                                Applicability::MachineApplicable,
                             );
                         }
 

--- a/src/test/ui/option-to-result.rs
+++ b/src/test/ui/option-to-result.rs
@@ -1,0 +1,13 @@
+fn main(){ }
+
+fn test_result() -> Result<(),()> {
+    let a:Option<()> = Some(());
+    a?;//~ ERROR `?` couldn't convert the error
+    Ok(())
+}
+
+fn test_option() -> Option<i32>{
+    let a:Result<i32, i32> = Ok(5);
+    a?;//~ ERROR `?` couldn't convert the error
+    Some(5)
+}

--- a/src/test/ui/option-to-result.stderr
+++ b/src/test/ui/option-to-result.stderr
@@ -8,8 +8,8 @@ LL |     a?;
    = note: required by `std::convert::From::from`
 help: consider converting the `Option<T>` into a `Result<T, _>` using `Option::ok_or` or `Option::ok_or_else`
    |
-LL |     a.ok_or_else(|_| /* error value */)?;
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     a.ok_or_else(|| /* error value */)?;
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `?` couldn't convert the error to `std::option::NoneError`
   --> $DIR/option-to-result.rs:11:6

--- a/src/test/ui/option-to-result.stderr
+++ b/src/test/ui/option-to-result.stderr
@@ -1,0 +1,29 @@
+error[E0277]: `?` couldn't convert the error to `()`
+  --> $DIR/option-to-result.rs:5:6
+   |
+LL |     a?;
+   |      ^ the trait `std::convert::From<std::option::NoneError>` is not implemented for `()`
+   |
+   = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
+   = note: required by `std::convert::From::from`
+help: consider converting the `Option<T>` into a `Result<T, _>` using `Option::ok_or` or `Option::ok_or_else`
+   |
+LL |     a.ok_or_else(|_| /* error value */)?;
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: `?` couldn't convert the error to `std::option::NoneError`
+  --> $DIR/option-to-result.rs:11:6
+   |
+LL |     a?;
+   |      ^ the trait `std::convert::From<i32>` is not implemented for `std::option::NoneError`
+   |
+   = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
+   = note: required by `std::convert::From::from`
+help: consider converting the `Result<T, _>` into an `Option<T>` using `Result::ok`
+   |
+LL |     a.ok()?;
+   |      ^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/try-on-option.stderr
+++ b/src/test/ui/try-on-option.stderr
@@ -6,6 +6,10 @@ LL |     x?;
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = note: required by `std::convert::From::from`
+help: consider converting the `Option<T>` into a `Result<T, _>` using `Option::ok_or` or `Option::ok_or_else`
+   |
+LL |     x.ok_or_else(|_| /* error value */)?;
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `std::ops::Try`)
   --> $DIR/try-on-option.rs:13:5

--- a/src/test/ui/try-on-option.stderr
+++ b/src/test/ui/try-on-option.stderr
@@ -8,8 +8,8 @@ LL |     x?;
    = note: required by `std::convert::From::from`
 help: consider converting the `Option<T>` into a `Result<T, _>` using `Option::ok_or` or `Option::ok_or_else`
    |
-LL |     x.ok_or_else(|_| /* error value */)?;
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     x.ok_or_else(|| /* error value */)?;
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `std::ops::Try`)
   --> $DIR/try-on-option.rs:13:5


### PR DESCRIPTION
Fixes #71089 