### PR TITLE
Update the minimum external LLVM to 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,13 @@ jobs:
       matrix:
         name:
           - mingw-check
-          - x86_64-gnu-llvm-7
+          - x86_64-gnu-llvm-8
           - x86_64-gnu-tools
         include:
           - name: mingw-check
             os: ubuntu-latest-xl
             env: {}
-          - name: x86_64-gnu-llvm-7
+          - name: x86_64-gnu-llvm-8
             os: ubuntu-latest-xl
             env: {}
           - name: x86_64-gnu-tools
@@ -352,7 +352,7 @@ jobs:
           - x86_64-gnu-debug
           - x86_64-gnu-distcheck
           - x86_64-gnu-full-bootstrap
-          - x86_64-gnu-llvm-7
+          - x86_64-gnu-llvm-8
           - x86_64-gnu-nopt
           - x86_64-gnu-tools
           - x86_64-mingw-1
@@ -469,7 +469,7 @@ jobs:
           - name: x86_64-gnu-full-bootstrap
             os: ubuntu-latest-xl
             env: {}
-          - name: x86_64-gnu-llvm-7
+          - name: x86_64-gnu-llvm-8
             env:
               RUST_BACKTRACE: 1
             os: ubuntu-latest-xl

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -289,11 +289,11 @@ fn check_llvm_version(builder: &Builder<'_>, llvm_config: &Path) {
     let version = output(cmd.arg("--version"));
     let mut parts = version.split('.').take(2).filter_map(|s| s.parse::<u32>().ok());
     if let (Some(major), Some(_minor)) = (parts.next(), parts.next()) {
-        if major >= 7 {
+        if major >= 8 {
             return;
         }
     }
-    panic!("\n\nbad LLVM version: {}, need >=7.0\n\n", version)
+    panic!("\n\nbad LLVM version: {}, need >=8.0\n\n", version)
 }
 
 fn configure_cmake(

--- a/src/ci/azure-pipelines/auto.yml
+++ b/src/ci/azure-pipelines/auto.yml
@@ -29,7 +29,7 @@ jobs:
   - template: steps/run.yml
   strategy:
     matrix:
-      x86_64-gnu-llvm-7:
+      x86_64-gnu-llvm-8:
         RUST_BACKTRACE: 1
       dist-x86_64-linux: {}
       dist-x86_64-linux-alt:

--- a/src/ci/azure-pipelines/pr.yml
+++ b/src/ci/azure-pipelines/pr.yml
@@ -29,7 +29,7 @@ jobs:
     - template: steps/run.yml
   strategy:
     matrix:
-      x86_64-gnu-llvm-7: {}
+      x86_64-gnu-llvm-8: {}
       mingw-check: {}
       x86_64-gnu-tools:
         CI_ONLY_WHEN_SUBMODULES_CHANGED: 1

--- a/src/ci/docker/x86_64-gnu-llvm-8/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-llvm-8/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   cmake \
   sudo \
   gdb \
-  llvm-7-tools \
+  llvm-8-tools \
   libedit-dev \
   libssl-dev \
   pkg-config \
@@ -26,7 +26,7 @@ RUN sh /scripts/sccache.sh
 # using llvm-link-shared due to libffi issues -- see #34486
 ENV RUST_CONFIGURE_ARGS \
       --build=x86_64-unknown-linux-gnu \
-      --llvm-root=/usr/lib/llvm-7 \
+      --llvm-root=/usr/lib/llvm-8 \
       --enable-llvm-link-shared \
       --set rust.thin-lto-import-instr-limit=10
 

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -259,13 +259,13 @@ jobs:
       matrix:
         name:
           - mingw-check
-          - x86_64-gnu-llvm-7
+          - x86_64-gnu-llvm-8
           - x86_64-gnu-tools
         include:
           - name: mingw-check
             <<: *job-linux-xl
 
-          - name: x86_64-gnu-llvm-7
+          - name: x86_64-gnu-llvm-8
             <<: *job-linux-xl
 
           - name: x86_64-gnu-tools
@@ -349,7 +349,7 @@ jobs:
           - x86_64-gnu-debug
           - x86_64-gnu-distcheck
           - x86_64-gnu-full-bootstrap
-          - x86_64-gnu-llvm-7
+          - x86_64-gnu-llvm-8
           - x86_64-gnu-nopt
           - x86_64-gnu-tools
           - x86_64-mingw-1
@@ -471,7 +471,7 @@ jobs:
           - name: x86_64-gnu-full-bootstrap
             <<: *job-linux-xl
 
-          - name: x86_64-gnu-llvm-7
+          - name: x86_64-gnu-llvm-8
             env:
               RUST_BACKTRACE: 1
             <<: *job-linux-xl

--- a/src/librustc_codegen_llvm/attributes.rs
+++ b/src/librustc_codegen_llvm/attributes.rs
@@ -82,21 +82,12 @@ fn naked(val: &'ll Value, is_naked: bool) {
 
 pub fn set_frame_pointer_elimination(cx: &CodegenCx<'ll, '_>, llfn: &'ll Value) {
     if cx.sess().must_not_eliminate_frame_pointers() {
-        if llvm_util::get_major_version() >= 8 {
-            llvm::AddFunctionAttrStringValue(
-                llfn,
-                llvm::AttributePlace::Function,
-                const_cstr!("frame-pointer"),
-                const_cstr!("all"),
-            );
-        } else {
-            llvm::AddFunctionAttrStringValue(
-                llfn,
-                llvm::AttributePlace::Function,
-                const_cstr!("no-frame-pointer-elim"),
-                const_cstr!("true"),
-            );
-        }
+        llvm::AddFunctionAttrStringValue(
+            llfn,
+            llvm::AttributePlace::Function,
+            const_cstr!("frame-pointer"),
+            const_cstr!("all"),
+        );
     }
 }
 

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -16,7 +16,6 @@ use crate::llvm::debuginfo::{
     DIArray, DICompositeType, DIDescriptor, DIFile, DIFlags, DILexicalBlock, DIScope, DIType,
     DebugEmissionKind,
 };
-use crate::llvm_util;
 use crate::value::Value;
 
 use log::debug;
@@ -1289,22 +1288,11 @@ fn prepare_union_metadata(
 // Enums
 //=-----------------------------------------------------------------------------
 
-/// DWARF variant support is only available starting in LLVM 8.
-/// Although the earlier enum debug info output did not work properly
-/// in all situations, it is better for the time being to continue to
-/// sometimes emit the old style rather than emit something completely
-/// useless when rust is compiled against LLVM 6 or older. LLVM 7
-/// contains an early version of the DWARF variant support, and will
-/// crash when handling the new debug info format. This function
-/// decides which representation will be emitted.
+/// DWARF variant support is only available starting in LLVM 8, but
+/// on MSVC we have to use the fallback mode, because LLVM doesn't
+/// lower variant parts to PDB.
 fn use_enum_fallback(cx: &CodegenCx<'_, '_>) -> bool {
-    // On MSVC we have to use the fallback mode, because LLVM doesn't
-    // lower variant parts to PDB.
     cx.sess().target.target.options.is_like_msvc
-        // LLVM version 7 did not release with an important bug fix;
-        // but the required patch is in the LLVM 8.  Rust LLVM reports
-        // 8 as well.
-        || llvm_util::get_major_version() < 8
 }
 
 // FIXME(eddyb) maybe precompute this? Right now it's computed once

--- a/src/librustc_codegen_llvm/llvm_util.rs
+++ b/src/librustc_codegen_llvm/llvm_util.rs
@@ -83,17 +83,15 @@ unsafe fn configure_llvm(sess: &Session) {
         if !sess.opts.debugging_opts.no_generate_arange_section {
             add("-generate-arange-section", false);
         }
-        if get_major_version() >= 8 {
-            match sess
-                .opts
-                .debugging_opts
-                .merge_functions
-                .unwrap_or(sess.target.target.options.merge_functions)
-            {
-                MergeFunctions::Disabled | MergeFunctions::Trampolines => {}
-                MergeFunctions::Aliases => {
-                    add("-mergefunc-use-aliases", false);
-                }
+        match sess
+            .opts
+            .debugging_opts
+            .merge_functions
+            .unwrap_or(sess.target.target.options.merge_functions)
+        {
+            MergeFunctions::Disabled | MergeFunctions::Trampolines => {}
+            MergeFunctions::Aliases => {
+                add("-mergefunc-use-aliases", false);
             }
         }
 

--- a/src/test/codegen/enum-debug-clike.rs
+++ b/src/test/codegen/enum-debug-clike.rs
@@ -1,18 +1,13 @@
-// This test depends on a patch that was committed to upstream LLVM
-// before 7.0, then backported to the Rust LLVM fork.  It tests that
-// debug info for "c-like" enums is properly emitted.
+// This tests that debug info for "c-like" enums is properly emitted.
+// This is ignored for the fallback mode on MSVC due to problems with PDB.
 
 // ignore-tidy-linelength
-// ignore-windows
-// min-system-llvm-version 8.0
+// ignore-msvc
 
 // compile-flags: -g -C no-prepopulate-passes
 
-// DIFlagFixedEnum was deprecated in 8.0, renamed to DIFlagEnumClass.
-// We match either for compatibility.
-
 // CHECK-LABEL: @main
-// CHECK: {{.*}}DICompositeType{{.*}}tag: DW_TAG_enumeration_type,{{.*}}name: "E",{{.*}}flags: {{(DIFlagEnumClass|DIFlagFixedEnum)}},{{.*}}
+// CHECK: {{.*}}DICompositeType{{.*}}tag: DW_TAG_enumeration_type,{{.*}}name: "E",{{.*}}flags: DIFlagEnumClass,{{.*}}
 // CHECK: {{.*}}DIEnumerator{{.*}}name: "A",{{.*}}value: {{[0-9].*}}
 // CHECK: {{.*}}DIEnumerator{{.*}}name: "B",{{.*}}value: {{[0-9].*}}
 // CHECK: {{.*}}DIEnumerator{{.*}}name: "C",{{.*}}value: {{[0-9].*}}

--- a/src/test/codegen/enum-debug-niche-2.rs
+++ b/src/test/codegen/enum-debug-niche-2.rs
@@ -1,10 +1,8 @@
-// This test depends on a patch that was committed to upstream LLVM
-// before 7.0, then backported to the Rust LLVM fork.  It tests that
-// optimized enum debug info accurately reflects the enum layout.
+// This tests that optimized enum debug info accurately reflects the enum layout.
+// This is ignored for the fallback mode on MSVC due to problems with PDB.
 
 // ignore-tidy-linelength
-// ignore-windows
-// min-system-llvm-version 8.0
+// ignore-msvc
 
 // compile-flags: -g -C no-prepopulate-passes
 

--- a/src/test/codegen/enum-debug-niche.rs
+++ b/src/test/codegen/enum-debug-niche.rs
@@ -1,9 +1,7 @@
-// This test depends on a patch that was committed to upstream LLVM
-// before 7.0, then backported to the Rust LLVM fork.  It tests that
-// optimized enum debug info accurately reflects the enum layout.
+// This tests that optimized enum debug info accurately reflects the enum layout.
+// This is ignored for the fallback mode on MSVC due to problems with PDB.
 
-// ignore-windows
-// min-system-llvm-version 8.0
+// ignore-msvc
 
 // compile-flags: -g -C no-prepopulate-passes
 

--- a/src/test/codegen/enum-debug-tagged.rs
+++ b/src/test/codegen/enum-debug-tagged.rs
@@ -1,9 +1,7 @@
-// This test depends on a patch that was committed to upstream LLVM
-// before 7.0, then backported to the Rust LLVM fork.  It tests that
-// debug info for tagged (ordinary) enums is properly emitted.
+// This tests that debug info for tagged (ordinary) enums is properly emitted.
+// This is ignored for the fallback mode on MSVC due to problems with PDB.
 
-// ignore-windows
-// min-system-llvm-version 8.0
+// ignore-msvc
 
 // compile-flags: -g -C no-prepopulate-passes
 

--- a/src/test/codegen/force-frame-pointers.rs
+++ b/src/test/codegen/force-frame-pointers.rs
@@ -1,4 +1,3 @@
-// min-llvm-version 8.0
 // compile-flags: -C no-prepopulate-passes -C force-frame-pointers=y
 
 #![crate_type="lib"]

--- a/src/test/codegen/instrument-mcount.rs
+++ b/src/test/codegen/instrument-mcount.rs
@@ -1,4 +1,3 @@
-// min-llvm-version 8.0
 // ignore-tidy-linelength
 // compile-flags: -Z instrument-mcount
 

--- a/src/test/debuginfo/borrowed-enum.rs
+++ b/src/test/debuginfo/borrowed-enum.rs
@@ -1,7 +1,6 @@
 // ignore-tidy-linelength
 
-// Require LLVM with DW_TAG_variant_part and a gdb or lldb that can read it.
-// min-system-llvm-version: 8.0
+// Require a gdb or lldb that can read DW_TAG_variant_part.
 // min-gdb-version: 8.2
 // rust-lldb
 

--- a/src/test/debuginfo/enum-thinlto.rs
+++ b/src/test/debuginfo/enum-thinlto.rs
@@ -1,5 +1,4 @@
-// Require LLVM with DW_TAG_variant_part and a gdb that can read it.
-// min-system-llvm-version: 8.0
+// Require a gdb that can read DW_TAG_variant_part.
 // min-gdb-version: 8.2
 
 // compile-flags:-g -Z thinlto

--- a/src/test/debuginfo/generator-objects.rs
+++ b/src/test/debuginfo/generator-objects.rs
@@ -1,7 +1,6 @@
 // ignore-tidy-linelength
 
-// Require LLVM with DW_TAG_variant_part and a gdb that can read it.
-// min-system-llvm-version: 8.0
+// Require a gdb that can read DW_TAG_variant_part.
 // min-gdb-version: 8.2
 
 // compile-flags:-g

--- a/src/test/debuginfo/generic-enum-with-different-disr-sizes.rs
+++ b/src/test/debuginfo/generic-enum-with-different-disr-sizes.rs
@@ -1,8 +1,7 @@
 // ignore-lldb: FIXME(#27089)
 // min-lldb-version: 310
 
-// Require LLVM with DW_TAG_variant_part and a gdb that can read it.
-// min-system-llvm-version: 8.0
+// Require a gdb that can read DW_TAG_variant_part.
 // min-gdb-version: 8.2
 
 // compile-flags:-g

--- a/src/test/debuginfo/generic-struct-style-enum.rs
+++ b/src/test/debuginfo/generic-struct-style-enum.rs
@@ -1,8 +1,7 @@
 // ignore-tidy-linelength
 // min-lldb-version: 310
 
-// Require LLVM with DW_TAG_variant_part and a gdb that can read it.
-// min-system-llvm-version: 8.0
+// Require a gdb that can read DW_TAG_variant_part.
 // min-gdb-version: 8.2
 
 // compile-flags:-g

--- a/src/test/debuginfo/generic-tuple-style-enum.rs
+++ b/src/test/debuginfo/generic-tuple-style-enum.rs
@@ -1,8 +1,6 @@
 // ignore-tidy-linelength
 
-// Require LLVM with DW_TAG_variant_part and a gdb and lldb that can
-// read it.
-// min-system-llvm-version: 8.0
+// Require a gdb or lldb that can read DW_TAG_variant_part.
 // min-gdb-version: 8.2
 // rust-lldb
 

--- a/src/test/debuginfo/issue-57822.rs
+++ b/src/test/debuginfo/issue-57822.rs
@@ -1,8 +1,7 @@
 // This test makes sure that the LLDB pretty printer does not throw an exception
 // for nested closures and generators.
 
-// Require LLVM with DW_TAG_variant_part and a gdb that can read it.
-// min-system-llvm-version: 8.0
+// Require a gdb that can read DW_TAG_variant_part.
 // min-gdb-version: 8.2
 // ignore-tidy-linelength
 

--- a/src/test/debuginfo/recursive-struct.rs
+++ b/src/test/debuginfo/recursive-struct.rs
@@ -1,7 +1,6 @@
 // ignore-lldb
 
-// Require LLVM with DW_TAG_variant_part and a gdb that can read it.
-// min-system-llvm-version: 8.0
+// Require a gdb that can read DW_TAG_variant_part.
 // min-gdb-version: 8.2
 
 // compile-flags:-g

--- a/src/test/debuginfo/struct-style-enum.rs
+++ b/src/test/debuginfo/struct-style-enum.rs
@@ -1,8 +1,6 @@
 // ignore-tidy-linelength
 
-// Require LLVM with DW_TAG_variant_part and a gdb and lldb that can
-// read it.
-// min-system-llvm-version: 8.0
+// Require a gdb or lldb that can read DW_TAG_variant_part.
 // min-gdb-version: 8.2
 // rust-lldb
 

--- a/src/test/debuginfo/tuple-style-enum.rs
+++ b/src/test/debuginfo/tuple-style-enum.rs
@@ -1,8 +1,6 @@
 // ignore-tidy-linelength
 
-// Require LLVM with DW_TAG_variant_part and a gdb and lldb that can
-// read it.
-// min-system-llvm-version: 8.0
+// Require a gdb or lldb that can read DW_TAG_variant_part.
 // min-gdb-version: 8.2
 // rust-lldb
 

--- a/src/test/debuginfo/unique-enum.rs
+++ b/src/test/debuginfo/unique-enum.rs
@@ -1,6 +1,4 @@
-// Require LLVM with DW_TAG_variant_part and a gdb and lldb that can
-// read it.
-// min-system-llvm-version: 8.0
+// Require a gdb or lldb that can read DW_TAG_variant_part.
 // min-gdb-version: 8.2
 // rust-lldb
 

--- a/src/test/ui/simd/simd-intrinsic-generic-arithmetic-saturating.rs
+++ b/src/test/ui/simd/simd-intrinsic-generic-arithmetic-saturating.rs
@@ -1,6 +1,5 @@
 // run-pass
 // ignore-emscripten
-// min-llvm-version 8.0
 
 #![allow(non_camel_case_types)]
 #![feature(repr_simd, platform_intrinsics)]


### PR DESCRIPTION
LLVM 8 was released on March 20, 2019, over a year ago.