### PR TITLE
remove an impossible branch from check_consts

### DIFF
--- a/src/librustc_mir/transform/check_consts/ops.rs
+++ b/src/librustc_mir/transform/check_consts/ops.rs
@@ -90,16 +90,6 @@ impl NonConstOp for FnCallNonConst {
     }
 }
 
-/// A function call where the callee is not a function definition or function pointer, e.g. a
-/// closure.
-///
-/// This can be subdivided in the future to produce a better error message.
-#[derive(Debug)]
-pub struct FnCallOther;
-impl NonConstOp for FnCallOther {
-    const IS_SUPPORTED_IN_MIRI: bool = false;
-}
-
 /// A call to a `#[unstable]` const fn or `#[rustc_const_unstable]` function.
 ///
 /// Contains the name of the feature that would allow the use of this function.

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -511,7 +511,7 @@ impl Visitor<'tcx> for Validator<'_, 'mir, 'tcx> {
                         return;
                     }
                     _ => {
-                        span_bug!(terminator.source_info.span, "invalid callee of type {:?}", fn_ty,)
+                        span_bug!(terminator.source_info.span, "invalid callee of type {:?}", fn_ty)
                     }
                 };
 

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -495,11 +495,11 @@ impl Visitor<'tcx> for Validator<'_, 'mir, 'tcx> {
         }
     }
 
-    fn visit_terminator_kind(&mut self, kind: &TerminatorKind<'tcx>, location: Location) {
-        trace!("visit_terminator_kind: kind={:?} location={:?}", kind, location);
-        self.super_terminator_kind(kind, location);
+    fn visit_terminator(&mut self, terminator: &Terminator<'tcx>, location: Location) {
+        trace!("visit_terminator: terminator={:?} location={:?}", terminator, location);
+        self.super_terminator(terminator, location);
 
-        match kind {
+        match &terminator.kind {
             TerminatorKind::Call { func, .. } => {
                 let fn_ty = func.ty(*self.body, self.tcx);
 
@@ -511,8 +511,7 @@ impl Visitor<'tcx> for Validator<'_, 'mir, 'tcx> {
                         return;
                     }
                     _ => {
-                        self.check_op(ops::FnCallOther);
-                        return;
+                        span_bug!(terminator.source_info.span, "invalid callee of type {:?}", fn_ty,)
                     }
                 };
 


### PR DESCRIPTION
All function calleess are either `FnPtr` or `FnDef`, so we can remove the alternative from check_consts and just make it ICE instead.