### PR TITLE
Implement destructuring assignment

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1220,6 +1220,16 @@ pub enum RangeLimits {
 }
 
 #[derive(Clone, Encodable, Decodable, Debug)]
+pub enum StructRest {
+    /// `..x`.
+    Base(P<Expr>),
+    /// `..`.
+    Rest(Span),
+    /// No trailing `..` or expression.
+    None,
+}
+
+#[derive(Clone, Encodable, Decodable, Debug)]
 pub enum ExprKind {
     /// A `box x` expression.
     Box(P<Expr>),
@@ -1343,9 +1353,8 @@ pub enum ExprKind {
 
     /// A struct literal expression.
     ///
-    /// E.g., `Foo {x: 1, y: 2}`, or `Foo {x: 1, .. base}`,
-    /// where `base` is the `Option<Expr>`.
-    Struct(Path, Vec<Field>, Option<P<Expr>>),
+    /// E.g., `Foo {x: 1, y: 2}`, or `Foo {x: 1, .. rest}`.
+    Struct(Path, Vec<Field>, StructRest),
 
     /// An array literal constructed from one repeated element.
     ///

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1061,7 +1061,7 @@ pub struct Expr {
 
 // `Expr` is used a lot. Make sure it doesn't unintentionally get bigger.
 #[cfg(target_arch = "x86_64")]
-rustc_data_structures::static_assert_size!(Expr, 112);
+rustc_data_structures::static_assert_size!(Expr, 120);
 
 impl Expr {
     /// Returns `true` if this expression would be valid somewhere that expects a value;

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1192,6 +1192,7 @@ impl Expr {
             ExprKind::Field(..) => ExprPrecedence::Field,
             ExprKind::Index(..) => ExprPrecedence::Index,
             ExprKind::Range(..) => ExprPrecedence::Range,
+            ExprKind::Underscore => ExprPrecedence::Path,
             ExprKind::Path(..) => ExprPrecedence::Path,
             ExprKind::AddrOf(..) => ExprPrecedence::AddrOf,
             ExprKind::Break(..) => ExprPrecedence::Break,
@@ -1314,6 +1315,8 @@ pub enum ExprKind {
     Index(P<Expr>, P<Expr>),
     /// A range (e.g., `1..2`, `1..`, `..2`, `1..=2`, `..=2`).
     Range(Option<P<Expr>>, Option<P<Expr>>, RangeLimits),
+    /// An underscore.
+    Underscore,
 
     /// Variable reference, possibly containing `::` and/or type
     /// parameters (e.g., `foo::bar::<baz>`).

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1313,9 +1313,9 @@ pub enum ExprKind {
     Field(P<Expr>, Ident),
     /// An indexing operation (e.g., `foo[2]`).
     Index(P<Expr>, P<Expr>),
-    /// A range (e.g., `1..2`, `1..`, `..2`, `1..=2`, `..=2`).
+    /// A range (e.g., `1..2`, `1..`, `..2`, `1..=2`, `..=2`; and `..` in destructuring assingment).
     Range(Option<P<Expr>>, Option<P<Expr>>, RangeLimits),
-    /// An underscore.
+    /// An underscore, used in destructuring assignment to ignore a value.
     Underscore,
 
     /// Variable reference, possibly containing `::` and/or type

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -1218,6 +1218,7 @@ pub fn noop_visit_expr<T: MutVisitor>(
             visit_opt(e1, |e1| vis.visit_expr(e1));
             visit_opt(e2, |e2| vis.visit_expr(e2));
         }
+        ExprKind::Underscore => {}
         ExprKind::Path(qself, path) => {
             vis.visit_qself(qself);
             vis.visit_path(path);

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -1275,7 +1275,9 @@ pub fn noop_visit_expr<T: MutVisitor>(
         ExprKind::Struct(path, fields, expr) => {
             vis.visit_path(path);
             fields.flat_map_in_place(|field| vis.flat_map_field(field));
-            visit_opt(expr, |expr| vis.visit_expr(expr));
+            if let StructRest::Base(expr) = expr {
+                vis.visit_expr(expr);
+            }
         }
         ExprKind::Paren(expr) => {
             vis.visit_expr(expr);

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -807,6 +807,7 @@ pub fn walk_expr<'a, V: Visitor<'a>>(visitor: &mut V, expression: &'a Expr) {
             walk_list!(visitor, visit_expr, start);
             walk_list!(visitor, visit_expr, end);
         }
+        ExprKind::Underscore => {}
         ExprKind::Path(ref maybe_qself, ref path) => {
             if let Some(ref qself) = *maybe_qself {
                 visitor.visit_ty(&qself.ty);

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -724,7 +724,9 @@ pub fn walk_expr<'a, V: Visitor<'a>>(visitor: &mut V, expression: &'a Expr) {
         ExprKind::Struct(ref path, ref fields, ref optional_base) => {
             visitor.visit_path(path, expression.id);
             walk_list!(visitor, visit_field, fields);
-            walk_list!(visitor, visit_expr, optional_base);
+            if let StructRest::Base(expr) = optional_base {
+                visitor.visit_expr(expr);
+            }
         }
         ExprKind::Tup(ref subexpressions) => {
             walk_list!(visitor, visit_expr, subexpressions);

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -900,7 +900,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         eq_sign_span: Span,
         assignments: &mut Vec<hir::Stmt<'hir>>,
     ) -> &'hir hir::Pat<'hir> {
-        // TODO: Handle `_`, requires changes to the parser
+        // FIXME: Handle `_`, requires changes to the parser
         match &lhs.kind {
             // slices:
             ExprKind::Array(elements) => {
@@ -932,8 +932,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 }
             }
             // structs:
-            // TODO: support `..` here, requires changes to the parser
-            ExprKind::Struct(path, fields, rest) => {
+            // FIXME: support `..` here, requires changes to the parser
+            ExprKind::Struct(path, fields, _rest) => {
                 let field_pats = self.arena.alloc_from_iter(fields.iter().map(|f| {
                     let pat = self.destructure_assign(&f.expr, eq_sign_span, assignments);
                     hir::FieldPat {

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -871,8 +871,10 @@ impl<'hir> LoweringContext<'_, 'hir> {
     ) -> hir::ExprKind<'hir> {
         // Return early in case of an ordinary assignment.
         match lhs.kind {
-            ExprKind::Array(..) | ExprKind::Call(..) | ExprKind::Struct(..) | ExprKind::Tup(..) => {
-            }
+            ExprKind::Array(..)
+            | ExprKind::Call(..)
+            | ExprKind::Struct(_, _, None)
+            | ExprKind::Tup(..) => {}
             _ => {
                 return hir::ExprKind::Assign(
                     self.lower_expr(lhs),
@@ -959,7 +961,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             }
             // structs:
             // FIXME: support `..` here, requires changes to the parser
-            ExprKind::Struct(path, fields, _rest) => {
+            ExprKind::Struct(path, fields, None) => {
                 let field_pats = self.arena.alloc_from_iter(fields.iter().map(|f| {
                     let pat = self.destructure_assign(&f.expr, eq_sign_span, assignments);
                     hir::FieldPat {

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -871,7 +871,10 @@ impl<'hir> LoweringContext<'_, 'hir> {
     ) -> hir::ExprKind<'hir> {
         // Return early in case of an ordinary assignment.
         let is_ordinary = match &lhs.kind {
-            ExprKind::Array(..) | ExprKind::Struct(_, _, None) | ExprKind::Tup(..) => false,
+            ExprKind::Array(..)
+            | ExprKind::Struct(_, _, None)
+            | ExprKind::Tup(..)
+            | ExprKind::Underscore => false,
             ExprKind::Call(callee, ..) => {
                 // Check for tuple struct constructor.
                 if let ExprKind::Path(qself, path) = &callee.kind {
@@ -931,8 +934,10 @@ impl<'hir> LoweringContext<'_, 'hir> {
         eq_sign_span: Span,
         assignments: &mut Vec<hir::Stmt<'hir>>,
     ) -> &'hir hir::Pat<'hir> {
-        // FIXME: Handle `_`, requires changes to the parser
         match &lhs.kind {
+            ExprKind::Underscore => {
+                return self.pat(lhs.span, hir::PatKind::Wild);
+            }
             // slices:
             ExprKind::Array(elements) => {
                 let (pats, rest) =

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -896,6 +896,14 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     true
                 }
             }
+            // `(..)`.
+            ExprKind::Paren(e) => {
+                if let ExprKind::Range(None, None, RangeLimits::HalfOpen) = e.kind {
+                    false
+                } else {
+                    true
+                }
+            }
             _ => true,
         };
         if is_ordinary {
@@ -1031,6 +1039,13 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     self.destructure_sequence(elements, "tuple", eq_sign_span, assignments);
                 let tuple_pat = hir::PatKind::Tuple(pats, rest.map(|r| r.0));
                 return self.pat(lhs.span, tuple_pat);
+            }
+            // `(..)`. We special-case this for consistency with declarations.
+            ExprKind::Paren(e) => {
+                if let ExprKind::Range(None, None, RangeLimits::HalfOpen) = e.kind {
+                    let tuple_pat = hir::PatKind::Tuple(&[], Some(0));
+                    return self.pat(lhs.span, tuple_pat);
+                }
             }
             _ => {}
         }

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -2531,6 +2531,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 hir_id,
                 kind: hir::PatKind::Binding(bm, hir_id, ident.with_span_pos(span), None),
                 span,
+                default_binding_modes: true,
             }),
             hir_id,
         )
@@ -2541,7 +2542,21 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     }
 
     fn pat(&mut self, span: Span, kind: hir::PatKind<'hir>) -> &'hir hir::Pat<'hir> {
-        self.arena.alloc(hir::Pat { hir_id: self.next_id(), kind, span })
+        self.arena.alloc(hir::Pat {
+            hir_id: self.next_id(),
+            kind,
+            span,
+            default_binding_modes: true,
+        })
+    }
+
+    fn pat_without_dbm(&mut self, span: Span, kind: hir::PatKind<'hir>) -> &'hir hir::Pat<'hir> {
+        self.arena.alloc(hir::Pat {
+            hir_id: self.next_id(),
+            kind,
+            span,
+            default_binding_modes: false,
+        })
     }
 
     fn ty_path(

--- a/compiler/rustc_ast_lowering/src/pat.rs
+++ b/compiler/rustc_ast_lowering/src/pat.rs
@@ -277,7 +277,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     }
 
     /// Emit a friendly error for extra `..` patterns in a tuple/tuple struct/slice pattern.
-    fn ban_extra_rest_pat(&self, sp: Span, prev_sp: Span, ctx: &str) {
+    crate fn ban_extra_rest_pat(&self, sp: Span, prev_sp: Span, ctx: &str) {
         self.diagnostic()
             .struct_span_err(sp, &format!("`..` can only be used once per {} pattern", ctx))
             .span_label(sp, &format!("can only be used once per {} pattern", ctx))

--- a/compiler/rustc_ast_lowering/src/pat.rs
+++ b/compiler/rustc_ast_lowering/src/pat.rs
@@ -273,7 +273,12 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
 
     /// Construct a `Pat` with the `HirId` of `p.id` lowered.
     fn pat_with_node_id_of(&mut self, p: &Pat, kind: hir::PatKind<'hir>) -> &'hir hir::Pat<'hir> {
-        self.arena.alloc(hir::Pat { hir_id: self.lower_node_id(p.id), kind, span: p.span })
+        self.arena.alloc(hir::Pat {
+            hir_id: self.lower_node_id(p.id),
+            kind,
+            span: p.span,
+            default_binding_modes: true,
+        })
     }
 
     /// Emit a friendly error for extra `..` patterns in a tuple/tuple struct/slice pattern.

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -630,6 +630,7 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session) {
     gate_all!(const_trait_impl, "const trait impls are experimental");
     gate_all!(half_open_range_patterns, "half-open range patterns are unstable");
     gate_all!(inline_const, "inline-const is experimental");
+    gate_all!(destructuring_assignment, "destructuring assignments are unstable");
 
     // All uses of `gate_all!` below this point were added in #65742,
     // and subsequently disabled (with the non-early gating readded).

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -630,7 +630,7 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session) {
     gate_all!(const_trait_impl, "const trait impls are experimental");
     gate_all!(half_open_range_patterns, "half-open range patterns are unstable");
     gate_all!(inline_const, "inline-const is experimental");
-    if parse_sess.span_diagnostic.err_count() == 0 {
+    if sess.parse_sess.span_diagnostic.err_count() == 0 {
         // Errors for `destructuring_assignment` can get quite noisy, especially where `_` is
         // involved, so we only emit errors where there are no other parsing errors.
         gate_all!(destructuring_assignment, "destructuring assignments are unstable");

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -630,7 +630,11 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session) {
     gate_all!(const_trait_impl, "const trait impls are experimental");
     gate_all!(half_open_range_patterns, "half-open range patterns are unstable");
     gate_all!(inline_const, "inline-const is experimental");
-    gate_all!(destructuring_assignment, "destructuring assignments are unstable");
+    if parse_sess.span_diagnostic.err_count() == 0 {
+        // Errors for `destructuring_assignment` can get quite noisy, especially where `_` is
+        // involved, so we only emit errors where there are no other parsing errors.
+        gate_all!(destructuring_assignment, "destructuring assignments are unstable");
+    }
 
     // All uses of `gate_all!` below this point were added in #65742,
     // and subsequently disabled (with the non-early gating readded).

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1751,19 +1751,19 @@ impl<'a> State<'a> {
             |f| f.span,
         );
         match rest {
-            StructRest::Base(_) | StructRest::Rest(_) => {
+            ast::StructRest::Base(_) | ast::StructRest::Rest(_) => {
                 self.ibox(INDENT_UNIT);
                 if !fields.is_empty() {
                     self.s.word(",");
                     self.s.space();
                 }
                 self.s.word("..");
-                if let StructRest::Base(ref expr) = *rest {
+                if let ast::StructRest::Base(ref expr) = *rest {
                     self.print_expr(expr);
                 }
                 self.end();
             }
-            StructRest::None if !fields.is_empty() => self.s.word(","),
+            ast::StructRest::None if !fields.is_empty() => self.s.word(","),
             _ => {}
         }
         self.s.word("}");

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -2069,6 +2069,7 @@ impl<'a> State<'a> {
                     self.print_expr_maybe_paren(e, fake_prec);
                 }
             }
+            ast::ExprKind::Underscore => self.s.word("_"),
             ast::ExprKind::Path(None, ref path) => self.print_path(path, true, 0),
             ast::ExprKind::Path(Some(ref qself), ref path) => self.print_qpath(path, qself, true),
             ast::ExprKind::Break(opt_label, ref opt_expr) => {

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1729,7 +1729,7 @@ impl<'a> State<'a> {
         &mut self,
         path: &ast::Path,
         fields: &[ast::Field],
-        wth: &Option<P<ast::Expr>>,
+        rest: &ast::StructRest,
         attrs: &[ast::Attribute],
     ) {
         self.print_path(path, true, 0);
@@ -1750,22 +1750,21 @@ impl<'a> State<'a> {
             },
             |f| f.span,
         );
-        match *wth {
-            Some(ref expr) => {
+        match rest {
+            StructRest::Base(_) | StructRest::Rest(_) => {
                 self.ibox(INDENT_UNIT);
                 if !fields.is_empty() {
                     self.s.word(",");
                     self.s.space();
                 }
                 self.s.word("..");
-                self.print_expr(expr);
+                if let StructRest::Base(ref expr) = *rest {
+                    self.print_expr(expr);
+                }
                 self.end();
             }
-            _ => {
-                if !fields.is_empty() {
-                    self.s.word(",")
-                }
-            }
+            StructRest::None if !fields.is_empty() => self.s.word(","),
+            _ => {}
         }
         self.s.word("}");
     }
@@ -1891,8 +1890,8 @@ impl<'a> State<'a> {
             ast::ExprKind::Repeat(ref element, ref count) => {
                 self.print_expr_repeat(element, count, attrs);
             }
-            ast::ExprKind::Struct(ref path, ref fields, ref wth) => {
-                self.print_expr_struct(path, &fields[..], wth, attrs);
+            ast::ExprKind::Struct(ref path, ref fields, ref rest) => {
+                self.print_expr_struct(path, &fields[..], rest, attrs);
             }
             ast::ExprKind::Tup(ref exprs) => {
                 self.print_expr_tup(&exprs[..], attrs);

--- a/compiler/rustc_expand/src/build.rs
+++ b/compiler/rustc_expand/src/build.rs
@@ -298,7 +298,7 @@ impl<'a> ExtCtxt<'a> {
         path: ast::Path,
         fields: Vec<ast::Field>,
     ) -> P<ast::Expr> {
-        self.expr(span, ast::ExprKind::Struct(path, fields, None))
+        self.expr(span, ast::ExprKind::Struct(path, fields, ast::StructRest::None))
     }
     pub fn expr_struct_ident(
         &self,

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -611,6 +611,8 @@ declare_features! (
     (active, unsized_fn_params, "1.49.0", Some(48055), None),
 
     /// Allows the use of destructuring assignments.
+    /// The current issue reference refers to the rust-lang/rfcs issue. This will be changed to a
+    /// valid rust-lang/rust issue when the accompanying RFC is accepted.
     (active, destructuring_assignment, "1.49.0", Some(372), None),
 
     // -------------------------------------------------------------------------

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -611,7 +611,7 @@ declare_features! (
     (active, unsized_fn_params, "1.49.0", Some(48055), None),
 
     /// Allows the use of destructuring assignments.
-    (active, destructuring_assignment, "1.49.0", None, None),
+    (active, destructuring_assignment, "1.49.0", Some(372), None),
 
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -611,9 +611,7 @@ declare_features! (
     (active, unsized_fn_params, "1.49.0", Some(48055), None),
 
     /// Allows the use of destructuring assignments.
-    /// The current issue reference refers to the rust-lang/rfcs issue. This will be changed to a
-    /// valid rust-lang/rust issue when the accompanying RFC is accepted.
-    (active, destructuring_assignment, "1.49.0", Some(372), None),
+    (active, destructuring_assignment, "1.49.0", Some(71126), None),
 
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -610,6 +610,9 @@ declare_features! (
     /// Allows unsized fn parameters.
     (active, unsized_fn_params, "1.49.0", Some(48055), None),
 
+    /// Allows the use of destructuring assignments.
+    (active, destructuring_assignment, "1.49.0", None, None),
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -732,6 +732,9 @@ pub struct Pat<'hir> {
     pub hir_id: HirId,
     pub kind: PatKind<'hir>,
     pub span: Span,
+    // Whether to use default binding modes.
+    // At present, this is false only for destructuring assignment.
+    pub default_binding_modes: bool,
 }
 
 impl Pat<'_> {

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1680,8 +1680,8 @@ pub enum LocalSource {
     AsyncFn,
     /// A desugared `<expr>.await`.
     AwaitDesugar,
-    /// A desugared expr = expr where the LHS is a tuple, struct or array.
-    /// The span is for the `=` sign.
+    /// A desugared `expr = expr`, where the LHS is a tuple, struct or array.
+    /// The span is that of the `=` sign.
     AssignDesugar(Span),
 }
 

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1680,6 +1680,9 @@ pub enum LocalSource {
     AsyncFn,
     /// A desugared `<expr>.await`.
     AwaitDesugar,
+    /// A desugared expr = expr where the LHS is a tuple, struct or array.
+    /// The span is for the `=` sign.
+    AssignDesugar(Span),
 }
 
 /// Hints at the original code for a `match _ { .. }`.

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -69,6 +69,7 @@ impl<'tcx> Visitor<'tcx> for MatchVisitor<'_, 'tcx> {
             hir::LocalSource::ForLoopDesugar => ("`for` loop binding", None),
             hir::LocalSource::AsyncFn => ("async fn binding", None),
             hir::LocalSource::AwaitDesugar => ("`await` future binding", None),
+            hir::LocalSource::AssignDesugar(_) => ("destructuring assignment binding", None),
         };
         self.check_irrefutable(&loc.pat, msg, sp);
         self.check_patterns(&loc.pat);

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2108,7 +2108,7 @@ impl<'a> Parser<'a> {
                 // AST lowering will then report an error if it's not on the LHS of an assignment.
                 if self.token == token::CloseDelim(token::Brace) {
                     base = Some(self.mk_expr(
-                        self.prev_token.span,
+                        self.prev_token.span.shrink_to_hi(),
                         ExprKind::Underscore,
                         AttrVec::new(),
                     ));

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1117,6 +1117,7 @@ impl<'a> Parser<'a> {
                 self.parse_lit_expr(attrs)
             }
         } else if self.eat_keyword(kw::Underscore) {
+            self.sess.gated_spans.gate(sym::destructuring_assignment, self.prev_token.span);
             Ok(self.mk_expr(self.prev_token.span, ExprKind::Underscore, attrs))
         } else {
             self.parse_lit_expr(attrs)
@@ -2106,6 +2107,7 @@ impl<'a> Parser<'a> {
                 let exp_span = self.prev_token.span;
                 // We permit `.. }` on the left-hand side of a destructuring assignment.
                 if self.token == token::CloseDelim(token::Brace) {
+                    self.sess.gated_spans.gate(sym::destructuring_assignment, self.prev_token.span);
                     base = StructRest::Rest(self.prev_token.span.shrink_to_hi());
                     break;
                 }

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1116,6 +1116,8 @@ impl<'a> Parser<'a> {
             } else {
                 self.parse_lit_expr(attrs)
             }
+        } else if self.eat_keyword(kw::Underscore) {
+            Ok(self.mk_expr(self.prev_token.span, ExprKind::Underscore, attrs))
         } else {
             self.parse_lit_expr(attrs)
         }

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2108,11 +2108,11 @@ impl<'a> Parser<'a> {
                 // We permit `.. }` on the left-hand side of a destructuring assignment.
                 if self.token == token::CloseDelim(token::Brace) {
                     self.sess.gated_spans.gate(sym::destructuring_assignment, self.prev_token.span);
-                    base = StructRest::Rest(self.prev_token.span.shrink_to_hi());
+                    base = ast::StructRest::Rest(self.prev_token.span.shrink_to_hi());
                     break;
                 }
                 match self.parse_expr() {
-                    Ok(e) => base = StructRest::Base(e),
+                    Ok(e) => base = ast::StructRest::Base(e),
                     Err(mut e) if recover => {
                         e.emit();
                         self.recover_stmt();

--- a/compiler/rustc_save_analysis/src/dump_visitor.rs
+++ b/compiler/rustc_save_analysis/src/dump_visitor.rs
@@ -816,7 +816,7 @@ impl<'tcx> DumpVisitor<'tcx> {
         path: &'tcx hir::QPath<'tcx>,
         fields: &'tcx [hir::Field<'tcx>],
         variant: &'tcx ty::VariantDef,
-        base: Option<&'tcx hir::Expr<'tcx>>,
+        rest: &'tcx StructRest,
     ) {
         if let Some(struct_lit_data) = self.save_ctxt.get_expr_data(ex) {
             if let hir::QPath::Resolved(_, path) = path {
@@ -836,7 +836,9 @@ impl<'tcx> DumpVisitor<'tcx> {
             }
         }
 
-        walk_list!(self, visit_expr, base);
+        if let StructRest::Base(base) = rest {
+            self.visit_expr(base);
+        }
     }
 
     fn process_method_call(
@@ -1399,7 +1401,7 @@ impl<'tcx> Visitor<'tcx> for DumpVisitor<'tcx> {
         debug!("visit_expr {:?}", ex.kind);
         self.process_macro_use(ex.span);
         match ex.kind {
-            hir::ExprKind::Struct(ref path, ref fields, ref base) => {
+            hir::ExprKind::Struct(ref path, ref fields, ref rest) => {
                 let hir_expr = self.save_ctxt.tcx.hir().expect_expr(ex.hir_id);
                 let adt = match self.save_ctxt.typeck_results().expr_ty_opt(&hir_expr) {
                     Some(ty) if ty.ty_adt_def().is_some() => ty.ty_adt_def().unwrap(),
@@ -1409,7 +1411,7 @@ impl<'tcx> Visitor<'tcx> for DumpVisitor<'tcx> {
                     }
                 };
                 let res = self.save_ctxt.get_path_res(hir_expr.hir_id);
-                self.process_struct_lit(ex, path, fields, adt.variant_of_res(res), *base)
+                self.process_struct_lit(ex, path, fields, adt.variant_of_res(res), rest)
             }
             hir::ExprKind::MethodCall(ref seg, _, args, _) => {
                 self.process_method_call(ex, seg, args)

--- a/compiler/rustc_save_analysis/src/dump_visitor.rs
+++ b/compiler/rustc_save_analysis/src/dump_visitor.rs
@@ -816,7 +816,7 @@ impl<'tcx> DumpVisitor<'tcx> {
         path: &'tcx hir::QPath<'tcx>,
         fields: &'tcx [hir::Field<'tcx>],
         variant: &'tcx ty::VariantDef,
-        rest: &'tcx StructRest,
+        rest: Option<&'tcx hir::Expr<'tcx>>,
     ) {
         if let Some(struct_lit_data) = self.save_ctxt.get_expr_data(ex) {
             if let hir::QPath::Resolved(_, path) = path {
@@ -836,8 +836,8 @@ impl<'tcx> DumpVisitor<'tcx> {
             }
         }
 
-        if let StructRest::Base(base) = rest {
-            self.visit_expr(base);
+        if let Some(base) = rest {
+            self.visit_expr(&base);
         }
     }
 
@@ -1411,7 +1411,7 @@ impl<'tcx> Visitor<'tcx> for DumpVisitor<'tcx> {
                     }
                 };
                 let res = self.save_ctxt.get_path_res(hir_expr.hir_id);
-                self.process_struct_lit(ex, path, fields, adt.variant_of_res(res), rest)
+                self.process_struct_lit(ex, path, fields, adt.variant_of_res(res), *rest)
             }
             hir::ExprKind::MethodCall(ref seg, _, args, _) => {
                 self.process_method_call(ex, seg, args)

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -434,6 +434,7 @@ symbols! {
         deref_mut,
         deref_target,
         derive,
+        destructuring_assignment,
         diagnostic,
         direct,
         discriminant_kind,

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -39,6 +39,7 @@ use rustc_middle::ty::adjustment::{Adjust, Adjustment, AllowTwoPhase};
 use rustc_middle::ty::Ty;
 use rustc_middle::ty::TypeFoldable;
 use rustc_middle::ty::{AdtKind, Visibility};
+use rustc_session::parse::feature_err;
 use rustc_span::hygiene::DesugaringKind;
 use rustc_span::source_map::Span;
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
@@ -737,19 +738,37 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         err_code: &'static str,
         expr_span: &Span,
     ) {
-        if !lhs.is_syntactic_place_expr() {
-            // FIXME: Make this use SessionDiagnostic once error codes can be dynamically set.
-            let mut err = self.tcx.sess.struct_span_err_with_code(
-                *expr_span,
-                "invalid left-hand side of assignment",
-                DiagnosticId::Error(err_code.into()),
-            );
-            err.span_label(lhs.span, "cannot assign to this expression");
-            if self.is_destructuring_place_expr(lhs) {
-                err.note("destructuring assignments are not currently supported");
-                err.note("for more information, see https://github.com/rust-lang/rfcs/issues/372");
+        if lhs.is_syntactic_place_expr() {
+            return;
+        }
+
+        let da = self.is_destructuring_place_expr(lhs);
+        match (da, self.tcx.features().destructuring_assignment) {
+            // Valid destructuring assignment.
+            (true, true) => {}
+
+            // Destructuring assignment, but the feature is not enabled.
+            (true, false) => {
+                feature_err(
+                    &self.tcx.sess.parse_sess,
+                    sym::destructuring_assignment,
+                    *expr_span,
+                    "destructuring assignments are unstable",
+                )
+                .emit();
             }
-            err.emit();
+
+            // Invalid assignment.
+            (false, _) => {
+                // FIXME: Make this use SessionDiagnostic once error codes can be dynamically set.
+                let mut err = self.tcx.sess.struct_span_err_with_code(
+                    *expr_span,
+                    "invalid left-hand side of assignment",
+                    DiagnosticId::Error(err_code.into()),
+                );
+                err.span_label(lhs.span, "cannot assign to this expression");
+                err.emit();
+            }
         }
     }
 

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -270,6 +270,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ///
     /// When the pattern is a path pattern, `opt_path_res` must be `Some(res)`.
     fn calc_adjust_mode(&self, pat: &'tcx Pat<'tcx>, opt_path_res: Option<Res>) -> AdjustMode {
+        // When we perform destructuring assignment, we disable default match bindings, which are
+        // unintuitive in this context.
+        if !pat.default_binding_modes {
+            return AdjustMode::Reset;
+        }
         match &pat.kind {
             // Type checking these product-like types successfully always require
             // that the expected type be of those types and not reference types.

--- a/compiler/rustc_typeck/src/check/regionck.rs
+++ b/compiler/rustc_typeck/src/check/regionck.rs
@@ -577,7 +577,7 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
     fn link_pattern(&self, discr_cmt: PlaceWithHirId<'tcx>, root_pat: &hir::Pat<'_>) {
         debug!("link_pattern(discr_cmt={:?}, root_pat={:?})", discr_cmt, root_pat);
         ignore_err!(self.with_mc(|mc| {
-            mc.cat_pattern(discr_cmt, root_pat, |sub_cmt, hir::Pat { kind, span, hir_id }| {
+            mc.cat_pattern(discr_cmt, root_pat, |sub_cmt, hir::Pat { kind, span, hir_id, .. }| {
                 // `ref x` pattern
                 if let PatKind::Binding(..) = kind {
                     if let Some(ty::BindByReference(mutbl)) =

--- a/src/test/ui-fulldeps/pprust-expr-roundtrip.rs
+++ b/src/test/ui-fulldeps/pprust-expr-roundtrip.rs
@@ -155,7 +155,7 @@ fn iter_exprs(depth: usize, f: &mut dyn FnMut(P<Expr>)) {
             },
             17 => {
                 let path = Path::from_ident(Ident::from_str("S"));
-                g(ExprKind::Struct(path, vec![], Some(make_x())));
+                g(ExprKind::Struct(path, vec![], StructRest::Base(make_x())));
             },
             18 => {
                 iter_exprs(depth - 1, &mut |e| g(ExprKind::Try(e)));

--- a/src/test/ui/bad/bad-expr-lhs.rs
+++ b/src/test/ui/bad/bad-expr-lhs.rs
@@ -1,7 +1,9 @@
 fn main() {
     1 = 2; //~ ERROR invalid left-hand side of assignment
     1 += 2; //~ ERROR invalid left-hand side of assignment
-    (1, 2) = (3, 4); //~ ERROR invalid left-hand side of assignment
+    (1, 2) = (3, 4); //~ ERROR destructuring assignments are unstable
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR invalid left-hand side of assignment
 
     let (a, b) = (1, 2);
     (a, b) = (3, 4); //~ ERROR destructuring assignments are unstable

--- a/src/test/ui/bad/bad-expr-lhs.rs
+++ b/src/test/ui/bad/bad-expr-lhs.rs
@@ -4,7 +4,7 @@ fn main() {
     (1, 2) = (3, 4); //~ ERROR invalid left-hand side of assignment
 
     let (a, b) = (1, 2);
-    (a, b) = (3, 4); //~ ERROR invalid left-hand side of assignment
+    (a, b) = (3, 4); //~ ERROR destructuring assignments are unstable
 
     None = Some(3); //~ ERROR invalid left-hand side of assignment
 }

--- a/src/test/ui/bad/bad-expr-lhs.stderr
+++ b/src/test/ui/bad/bad-expr-lhs.stderr
@@ -14,31 +14,53 @@ LL |     1 += 2;
    |     |
    |     cannot assign to this expression
 
-error[E0070]: invalid left-hand side of assignment
+error[E0658]: destructuring assignments are unstable
   --> $DIR/bad-expr-lhs.rs:4:12
    |
 LL |     (1, 2) = (3, 4);
    |     ------ ^
    |     |
    |     cannot assign to this expression
-
-error[E0658]: destructuring assignments are unstable
-  --> $DIR/bad-expr-lhs.rs:7:12
    |
-LL |     (a, b) = (3, 4);
-   |            ^
-   |
+   = note: see issue #372 <https://github.com/rust-lang/rust/issues/372> for more information
    = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error[E0070]: invalid left-hand side of assignment
-  --> $DIR/bad-expr-lhs.rs:9:10
+  --> $DIR/bad-expr-lhs.rs:4:12
+   |
+LL |     (1, 2) = (3, 4);
+   |      -     ^
+   |      |
+   |      cannot assign to this expression
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/bad-expr-lhs.rs:4:12
+   |
+LL |     (1, 2) = (3, 4);
+   |         -  ^
+   |         |
+   |         cannot assign to this expression
+
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/bad-expr-lhs.rs:9:12
+   |
+LL |     (a, b) = (3, 4);
+   |     ------ ^
+   |     |
+   |     cannot assign to this expression
+   |
+   = note: see issue #372 <https://github.com/rust-lang/rust/issues/372> for more information
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/bad-expr-lhs.rs:11:10
    |
 LL |     None = Some(3);
    |     ---- ^
    |     |
    |     cannot assign to this expression
 
-error: aborting due to 5 previous errors
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0067, E0070, E0658.
 For more information about an error, try `rustc --explain E0067`.

--- a/src/test/ui/bad/bad-expr-lhs.stderr
+++ b/src/test/ui/bad/bad-expr-lhs.stderr
@@ -22,16 +22,13 @@ LL |     (1, 2) = (3, 4);
    |     |
    |     cannot assign to this expression
 
-error[E0070]: invalid left-hand side of assignment
+error[E0658]: destructuring assignments are unstable
   --> $DIR/bad-expr-lhs.rs:7:12
    |
 LL |     (a, b) = (3, 4);
-   |     ------ ^
-   |     |
-   |     cannot assign to this expression
+   |            ^
    |
-   = note: destructuring assignments are not currently supported
-   = note: for more information, see https://github.com/rust-lang/rfcs/issues/372
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error[E0070]: invalid left-hand side of assignment
   --> $DIR/bad-expr-lhs.rs:9:10
@@ -43,5 +40,5 @@ LL |     None = Some(3);
 
 error: aborting due to 5 previous errors
 
-Some errors have detailed explanations: E0067, E0070.
+Some errors have detailed explanations: E0067, E0070, E0658.
 For more information about an error, try `rustc --explain E0067`.

--- a/src/test/ui/bad/bad-expr-lhs.stderr
+++ b/src/test/ui/bad/bad-expr-lhs.stderr
@@ -22,7 +22,7 @@ LL |     (1, 2) = (3, 4);
    |     |
    |     cannot assign to this expression
    |
-   = note: see issue #372 <https://github.com/rust-lang/rust/issues/372> for more information
+   = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
    = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error[E0070]: invalid left-hand side of assignment
@@ -49,7 +49,7 @@ LL |     (a, b) = (3, 4);
    |     |
    |     cannot assign to this expression
    |
-   = note: see issue #372 <https://github.com/rust-lang/rust/issues/372> for more information
+   = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
    = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error[E0070]: invalid left-hand side of assignment

--- a/src/test/ui/cross/cross-file-errors/main.rs
+++ b/src/test/ui/cross/cross-file-errors/main.rs
@@ -4,4 +4,5 @@ mod underscore;
 fn main() {
     underscore!();
     //~^ ERROR expected expression, found reserved identifier `_`
+    //~^^ ERROR destructuring assignments are unstable
 }

--- a/src/test/ui/cross/cross-file-errors/main.stderr
+++ b/src/test/ui/cross/cross-file-errors/main.stderr
@@ -1,3 +1,18 @@
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/underscore.rs:8:9
+   |
+LL |         _
+   |         ^
+   | 
+  ::: $DIR/main.rs:5:5
+   |
+LL |     underscore!();
+   |     -------------- in this macro invocation
+   |
+   = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: expected expression, found reserved identifier `_`
   --> $DIR/underscore.rs:8:9
    |
@@ -11,5 +26,6 @@ LL |     underscore!();
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/destructuring-assignment/default-match-bindings-forbidden.rs
+++ b/src/test/ui/destructuring-assignment/default-match-bindings-forbidden.rs
@@ -1,0 +1,7 @@
+#![feature(destructuring_assignment)]
+
+fn main() {
+    let mut x = &0;
+    let mut y = &0;
+    (x, y) = &(1, 2); //~ ERROR mismatched types
+}

--- a/src/test/ui/destructuring-assignment/default-match-bindings-forbidden.stderr
+++ b/src/test/ui/destructuring-assignment/default-match-bindings-forbidden.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/default-match-bindings-forbidden.rs:6:5
+   |
+LL |     (x, y) = &(1, 2);
+   |     ^^^^^^   ------- this expression has type `&({integer}, {integer})`
+   |     |
+   |     expected reference, found tuple
+   |
+   = note: expected type `&({integer}, {integer})`
+             found tuple `(_, _)`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/destructuring-assignment/nested_destructure.rs
+++ b/src/test/ui/destructuring-assignment/nested_destructure.rs
@@ -1,0 +1,17 @@
+// run-pass
+
+#![feature(destructuring_assignment)]
+
+struct Struct<S, T> {
+    a: S,
+    b: T,
+}
+
+struct TupleStruct<S, T>(S, T);
+
+fn main() {
+    let (a, b, c, d);
+    Struct { a: TupleStruct((a, b), c), b: [d] } =
+        Struct { a: TupleStruct((0, 1), 2), b: [3] };
+    assert_eq!((a, b, c, d), (0, 1, 2, 3));
+}

--- a/src/test/ui/destructuring-assignment/nested_destructure.rs
+++ b/src/test/ui/destructuring-assignment/nested_destructure.rs
@@ -14,4 +14,7 @@ fn main() {
     Struct { a: TupleStruct((a, b), c), b: [d] } =
         Struct { a: TupleStruct((0, 1), 2), b: [3] };
     assert_eq!((a, b, c, d), (0, 1, 2, 3));
+
+    // unnested underscore: just discard
+    _ = 1;
 }

--- a/src/test/ui/destructuring-assignment/note-unsupported.rs
+++ b/src/test/ui/destructuring-assignment/note-unsupported.rs
@@ -3,23 +3,23 @@ struct S { x: u8, y: u8 }
 fn main() {
     let (a, b) = (1, 2);
 
-    (a, b) = (3, 4); //~ ERROR invalid left-hand side of assignment
-    (a, b) += (3, 4); //~ ERROR invalid left-hand side of assignment
+    (a, b) = (3, 4); //~ ERROR destructuring assignments are unstable
+    (a, b) += (3, 4); //~ ERROR destructuring assignments are unstable
     //~^ ERROR binary assignment operation `+=` cannot be applied
 
-    [a, b] = [3, 4]; //~ ERROR invalid left-hand side of assignment
-    [a, b] += [3, 4]; //~ ERROR invalid left-hand side of assignment
+    [a, b] = [3, 4]; //~ ERROR destructuring assignments are unstable
+    [a, b] += [3, 4]; //~ ERROR destructuring assignments are unstable
     //~^ ERROR binary assignment operation `+=` cannot be applied
 
     let s = S { x: 3, y: 4 };
 
-    S { x: a, y: b } = s; //~ ERROR invalid left-hand side of assignment
-    S { x: a, y: b } += s; //~ ERROR invalid left-hand side of assignment
+    S { x: a, y: b } = s; //~ ERROR destructuring assignments are unstable
+    S { x: a, y: b } += s; //~ ERROR destructuring assignments are unstable
     //~^ ERROR binary assignment operation `+=` cannot be applied
 
-    S { x: a, ..s } = S { x: 3, y: 4 }; //~ ERROR invalid left-hand side of assignment
+    S { x: a, ..s } = S { x: 3, y: 4 }; //~ ERROR destructuring assignments are unstable
 
     let c = 3;
 
-    ((a, b), c) = ((3, 4), 5); //~ ERROR invalid left-hand side of assignment
+    ((a, b), c) = ((3, 4), 5); //~ ERROR destructuring assignments are unstable
 }

--- a/src/test/ui/destructuring-assignment/note-unsupported.rs
+++ b/src/test/ui/destructuring-assignment/note-unsupported.rs
@@ -17,7 +17,8 @@ fn main() {
     S { x: a, y: b } += s; //~ ERROR invalid left-hand side of assignment
     //~| ERROR binary assignment operation `+=` cannot be applied
 
-    S { x: a, ..s } = S { x: 3, y: 4 }; //~ ERROR base expression not allowed
+    S { x: a, ..s } = S { x: 3, y: 4 };
+    //~^ ERROR functional record updates are not allowed in destructuring assignments
     //~| ERROR destructuring assignments are unstable
 
     let c = 3;

--- a/src/test/ui/destructuring-assignment/note-unsupported.rs
+++ b/src/test/ui/destructuring-assignment/note-unsupported.rs
@@ -4,20 +4,20 @@ fn main() {
     let (a, b) = (1, 2);
 
     (a, b) = (3, 4); //~ ERROR destructuring assignments are unstable
-    (a, b) += (3, 4); //~ ERROR destructuring assignments are unstable
-    //~^ ERROR binary assignment operation `+=` cannot be applied
+    (a, b) += (3, 4); //~ ERROR invalid left-hand side of assignment
+    //~| ERROR binary assignment operation `+=` cannot be applied
 
     [a, b] = [3, 4]; //~ ERROR destructuring assignments are unstable
-    [a, b] += [3, 4]; //~ ERROR destructuring assignments are unstable
-    //~^ ERROR binary assignment operation `+=` cannot be applied
+    [a, b] += [3, 4]; //~ ERROR invalid left-hand side of assignment
+    //~| ERROR binary assignment operation `+=` cannot be applied
 
     let s = S { x: 3, y: 4 };
 
     S { x: a, y: b } = s; //~ ERROR destructuring assignments are unstable
-    S { x: a, y: b } += s; //~ ERROR destructuring assignments are unstable
-    //~^ ERROR binary assignment operation `+=` cannot be applied
+    S { x: a, y: b } += s; //~ ERROR invalid left-hand side of assignment
+    //~| ERROR binary assignment operation `+=` cannot be applied
 
-    S { x: a, ..s } = S { x: 3, y: 4 }; //~ ERROR destructuring assignments are unstable
+    S { x: a, ..s } = S { x: 3, y: 4 }; //~ ERROR invalid left-hand side of assignment
 
     let c = 3;
 

--- a/src/test/ui/destructuring-assignment/note-unsupported.rs
+++ b/src/test/ui/destructuring-assignment/note-unsupported.rs
@@ -17,7 +17,8 @@ fn main() {
     S { x: a, y: b } += s; //~ ERROR invalid left-hand side of assignment
     //~| ERROR binary assignment operation `+=` cannot be applied
 
-    S { x: a, ..s } = S { x: 3, y: 4 }; //~ ERROR invalid left-hand side of assignment
+    S { x: a, ..s } = S { x: 3, y: 4 }; //~ ERROR base expression not allowed
+    //~| ERROR destructuring assignments are unstable
 
     let c = 3;
 

--- a/src/test/ui/destructuring-assignment/note-unsupported.stderr
+++ b/src/test/ui/destructuring-assignment/note-unsupported.stderr
@@ -1,3 +1,9 @@
+error: base expression not allowed here
+  --> $DIR/note-unsupported.rs:20:17
+   |
+LL |     S { x: a, ..s } = S { x: 3, y: 4 };
+   |                 ^ help: consider removing this
+
 error[E0658]: destructuring assignments are unstable
   --> $DIR/note-unsupported.rs:6:12
    |
@@ -81,16 +87,19 @@ LL |     S { x: a, y: b } += s;
    |     |
    |     cannot assign to this expression
 
-error[E0070]: invalid left-hand side of assignment
+error[E0658]: destructuring assignments are unstable
   --> $DIR/note-unsupported.rs:20:21
    |
 LL |     S { x: a, ..s } = S { x: 3, y: 4 };
    |     --------------- ^
    |     |
    |     cannot assign to this expression
+   |
+   = note: see issue #372 <https://github.com/rust-lang/rust/issues/372> for more information
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error[E0658]: destructuring assignments are unstable
-  --> $DIR/note-unsupported.rs:24:17
+  --> $DIR/note-unsupported.rs:25:17
    |
 LL |     ((a, b), c) = ((3, 4), 5);
    |     ----------- ^
@@ -100,7 +109,7 @@ LL |     ((a, b), c) = ((3, 4), 5);
    = note: see issue #372 <https://github.com/rust-lang/rust/issues/372> for more information
    = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
-error: aborting due to 11 previous errors
+error: aborting due to 12 previous errors
 
-Some errors have detailed explanations: E0067, E0070, E0368, E0658.
+Some errors have detailed explanations: E0067, E0368, E0658.
 For more information about an error, try `rustc --explain E0067`.

--- a/src/test/ui/destructuring-assignment/note-unsupported.stderr
+++ b/src/test/ui/destructuring-assignment/note-unsupported.stderr
@@ -1,8 +1,8 @@
-error: base expression not allowed here
+error: functional record updates are not allowed in destructuring assignments
   --> $DIR/note-unsupported.rs:20:17
    |
 LL |     S { x: a, ..s } = S { x: 3, y: 4 };
-   |                 ^ help: consider removing this
+   |                 ^ help: consider removing the trailing pattern
 
 error[E0658]: destructuring assignments are unstable
   --> $DIR/note-unsupported.rs:6:12
@@ -99,7 +99,7 @@ LL |     S { x: a, ..s } = S { x: 3, y: 4 };
    = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error[E0658]: destructuring assignments are unstable
-  --> $DIR/note-unsupported.rs:25:17
+  --> $DIR/note-unsupported.rs:26:17
    |
 LL |     ((a, b), c) = ((3, 4), 5);
    |     ----------- ^

--- a/src/test/ui/destructuring-assignment/note-unsupported.stderr
+++ b/src/test/ui/destructuring-assignment/note-unsupported.stderr
@@ -1,9 +1,12 @@
 error[E0658]: destructuring assignments are unstable
-  --> $DIR/destructuring-assignment.rs:6:12
+  --> $DIR/note-unsupported.rs:6:12
    |
 LL |     (a, b) = (3, 4);
-   |            ^
+   |     ------ ^
+   |     |
+   |     cannot assign to this expression
    |
+   = note: see issue #372 <https://github.com/rust-lang/rust/issues/372> for more information
    = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error[E0368]: binary assignment operation `+=` cannot be applied to type `({integer}, {integer})`
@@ -14,20 +17,23 @@ LL |     (a, b) += (3, 4);
    |     |
    |     cannot use `+=` on type `({integer}, {integer})`
 
-error[E0658]: destructuring assignments are unstable
-  --> $DIR/destructuring-assignment.rs:7:12
+error[E0067]: invalid left-hand side of assignment
+  --> $DIR/note-unsupported.rs:7:12
    |
 LL |     (a, b) += (3, 4);
-   |            ^^
-   |
-   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
+   |     ------ ^^
+   |     |
+   |     cannot assign to this expression
 
 error[E0658]: destructuring assignments are unstable
-  --> $DIR/destructuring-assignment.rs:10:12
+  --> $DIR/note-unsupported.rs:10:12
    |
 LL |     [a, b] = [3, 4];
-   |            ^
+   |     ------ ^
+   |     |
+   |     cannot assign to this expression
    |
+   = note: see issue #372 <https://github.com/rust-lang/rust/issues/372> for more information
    = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error[E0368]: binary assignment operation `+=` cannot be applied to type `[{integer}; 2]`
@@ -38,20 +44,23 @@ LL |     [a, b] += [3, 4];
    |     |
    |     cannot use `+=` on type `[{integer}; 2]`
 
-error[E0658]: destructuring assignments are unstable
-  --> $DIR/destructuring-assignment.rs:11:12
+error[E0067]: invalid left-hand side of assignment
+  --> $DIR/note-unsupported.rs:11:12
    |
 LL |     [a, b] += [3, 4];
-   |            ^^
-   |
-   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
+   |     ------ ^^
+   |     |
+   |     cannot assign to this expression
 
 error[E0658]: destructuring assignments are unstable
-  --> $DIR/destructuring-assignment.rs:16:22
+  --> $DIR/note-unsupported.rs:16:22
    |
 LL |     S { x: a, y: b } = s;
-   |                      ^
+   |     ---------------- ^
+   |     |
+   |     cannot assign to this expression
    |
+   = note: see issue #372 <https://github.com/rust-lang/rust/issues/372> for more information
    = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error[E0368]: binary assignment operation `+=` cannot be applied to type `S`
@@ -64,31 +73,34 @@ LL |     S { x: a, y: b } += s;
    |
    = note: an implementation of `std::ops::AddAssign` might be missing for `S`
 
-error[E0658]: destructuring assignments are unstable
-  --> $DIR/destructuring-assignment.rs:17:22
+error[E0067]: invalid left-hand side of assignment
+  --> $DIR/note-unsupported.rs:17:22
    |
 LL |     S { x: a, y: b } += s;
-   |                      ^^
-   |
-   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
+   |     ---------------- ^^
+   |     |
+   |     cannot assign to this expression
 
-error[E0658]: destructuring assignments are unstable
-  --> $DIR/destructuring-assignment.rs:20:21
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/note-unsupported.rs:20:21
    |
 LL |     S { x: a, ..s } = S { x: 3, y: 4 };
-   |                     ^
-   |
-   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
+   |     --------------- ^
+   |     |
+   |     cannot assign to this expression
 
 error[E0658]: destructuring assignments are unstable
-  --> $DIR/destructuring-assignment.rs:24:17
+  --> $DIR/note-unsupported.rs:24:17
    |
 LL |     ((a, b), c) = ((3, 4), 5);
-   |                 ^
+   |     ----------- ^
+   |     |
+   |     cannot assign to this expression
    |
+   = note: see issue #372 <https://github.com/rust-lang/rust/issues/372> for more information
    = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error: aborting due to 11 previous errors
 
-Some errors have detailed explanations: E0368, E0658.
-For more information about an error, try `rustc --explain E0368`.
+Some errors have detailed explanations: E0067, E0070, E0368, E0658.
+For more information about an error, try `rustc --explain E0067`.

--- a/src/test/ui/destructuring-assignment/note-unsupported.stderr
+++ b/src/test/ui/destructuring-assignment/note-unsupported.stderr
@@ -12,7 +12,7 @@ LL |     (a, b) = (3, 4);
    |     |
    |     cannot assign to this expression
    |
-   = note: see issue #372 <https://github.com/rust-lang/rust/issues/372> for more information
+   = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
    = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error[E0368]: binary assignment operation `+=` cannot be applied to type `({integer}, {integer})`
@@ -39,7 +39,7 @@ LL |     [a, b] = [3, 4];
    |     |
    |     cannot assign to this expression
    |
-   = note: see issue #372 <https://github.com/rust-lang/rust/issues/372> for more information
+   = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
    = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error[E0368]: binary assignment operation `+=` cannot be applied to type `[{integer}; 2]`
@@ -66,7 +66,7 @@ LL |     S { x: a, y: b } = s;
    |     |
    |     cannot assign to this expression
    |
-   = note: see issue #372 <https://github.com/rust-lang/rust/issues/372> for more information
+   = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
    = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error[E0368]: binary assignment operation `+=` cannot be applied to type `S`
@@ -95,7 +95,7 @@ LL |     S { x: a, ..s } = S { x: 3, y: 4 };
    |     |
    |     cannot assign to this expression
    |
-   = note: see issue #372 <https://github.com/rust-lang/rust/issues/372> for more information
+   = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
    = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error[E0658]: destructuring assignments are unstable
@@ -106,7 +106,7 @@ LL |     ((a, b), c) = ((3, 4), 5);
    |     |
    |     cannot assign to this expression
    |
-   = note: see issue #372 <https://github.com/rust-lang/rust/issues/372> for more information
+   = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
    = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error: aborting due to 12 previous errors

--- a/src/test/ui/destructuring-assignment/note-unsupported.stderr
+++ b/src/test/ui/destructuring-assignment/note-unsupported.stderr
@@ -1,13 +1,10 @@
-error[E0070]: invalid left-hand side of assignment
-  --> $DIR/note-unsupported.rs:6:12
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/destructuring-assignment.rs:6:12
    |
 LL |     (a, b) = (3, 4);
-   |     ------ ^
-   |     |
-   |     cannot assign to this expression
+   |            ^
    |
-   = note: destructuring assignments are not currently supported
-   = note: for more information, see https://github.com/rust-lang/rfcs/issues/372
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error[E0368]: binary assignment operation `+=` cannot be applied to type `({integer}, {integer})`
   --> $DIR/note-unsupported.rs:7:5
@@ -17,27 +14,21 @@ LL |     (a, b) += (3, 4);
    |     |
    |     cannot use `+=` on type `({integer}, {integer})`
 
-error[E0067]: invalid left-hand side of assignment
-  --> $DIR/note-unsupported.rs:7:12
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/destructuring-assignment.rs:7:12
    |
 LL |     (a, b) += (3, 4);
-   |     ------ ^^
-   |     |
-   |     cannot assign to this expression
+   |            ^^
    |
-   = note: destructuring assignments are not currently supported
-   = note: for more information, see https://github.com/rust-lang/rfcs/issues/372
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
-error[E0070]: invalid left-hand side of assignment
-  --> $DIR/note-unsupported.rs:10:12
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/destructuring-assignment.rs:10:12
    |
 LL |     [a, b] = [3, 4];
-   |     ------ ^
-   |     |
-   |     cannot assign to this expression
+   |            ^
    |
-   = note: destructuring assignments are not currently supported
-   = note: for more information, see https://github.com/rust-lang/rfcs/issues/372
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error[E0368]: binary assignment operation `+=` cannot be applied to type `[{integer}; 2]`
   --> $DIR/note-unsupported.rs:11:5
@@ -47,27 +38,21 @@ LL |     [a, b] += [3, 4];
    |     |
    |     cannot use `+=` on type `[{integer}; 2]`
 
-error[E0067]: invalid left-hand side of assignment
-  --> $DIR/note-unsupported.rs:11:12
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/destructuring-assignment.rs:11:12
    |
 LL |     [a, b] += [3, 4];
-   |     ------ ^^
-   |     |
-   |     cannot assign to this expression
+   |            ^^
    |
-   = note: destructuring assignments are not currently supported
-   = note: for more information, see https://github.com/rust-lang/rfcs/issues/372
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
-error[E0070]: invalid left-hand side of assignment
-  --> $DIR/note-unsupported.rs:16:22
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/destructuring-assignment.rs:16:22
    |
 LL |     S { x: a, y: b } = s;
-   |     ---------------- ^
-   |     |
-   |     cannot assign to this expression
+   |                      ^
    |
-   = note: destructuring assignments are not currently supported
-   = note: for more information, see https://github.com/rust-lang/rfcs/issues/372
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error[E0368]: binary assignment operation `+=` cannot be applied to type `S`
   --> $DIR/note-unsupported.rs:17:5
@@ -79,40 +64,31 @@ LL |     S { x: a, y: b } += s;
    |
    = note: an implementation of `std::ops::AddAssign` might be missing for `S`
 
-error[E0067]: invalid left-hand side of assignment
-  --> $DIR/note-unsupported.rs:17:22
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/destructuring-assignment.rs:17:22
    |
 LL |     S { x: a, y: b } += s;
-   |     ---------------- ^^
-   |     |
-   |     cannot assign to this expression
+   |                      ^^
    |
-   = note: destructuring assignments are not currently supported
-   = note: for more information, see https://github.com/rust-lang/rfcs/issues/372
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
-error[E0070]: invalid left-hand side of assignment
-  --> $DIR/note-unsupported.rs:20:21
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/destructuring-assignment.rs:20:21
    |
 LL |     S { x: a, ..s } = S { x: 3, y: 4 };
-   |     --------------- ^
-   |     |
-   |     cannot assign to this expression
+   |                     ^
    |
-   = note: destructuring assignments are not currently supported
-   = note: for more information, see https://github.com/rust-lang/rfcs/issues/372
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
-error[E0070]: invalid left-hand side of assignment
-  --> $DIR/note-unsupported.rs:24:17
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/destructuring-assignment.rs:24:17
    |
 LL |     ((a, b), c) = ((3, 4), 5);
-   |     ----------- ^
-   |     |
-   |     cannot assign to this expression
+   |                 ^
    |
-   = note: destructuring assignments are not currently supported
-   = note: for more information, see https://github.com/rust-lang/rfcs/issues/372
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error: aborting due to 11 previous errors
 
-Some errors have detailed explanations: E0067, E0070, E0368.
-For more information about an error, try `rustc --explain E0067`.
+Some errors have detailed explanations: E0368, E0658.
+For more information about an error, try `rustc --explain E0368`.

--- a/src/test/ui/destructuring-assignment/slice_destructure.rs
+++ b/src/test/ui/destructuring-assignment/slice_destructure.rs
@@ -6,10 +6,12 @@ fn main() {
   let (mut a, mut b);
   [a, b] = [0, 1];
   assert_eq!((a, b), (0, 1));
-  let c;
+  let mut c;
   [a, .., b, c] = [1, 2, 3, 4, 5];
   assert_eq!((a, b, c), (1, 4, 5));
   [_, a, _] = [1, 2, 3];
   assert_eq!((a, b), (2, 4));
   [..] = [1, 2, 3];
+  [c, ..] = [5, 6, 6];
+  assert_eq!(c, 5);
 }

--- a/src/test/ui/destructuring-assignment/slice_destructure.rs
+++ b/src/test/ui/destructuring-assignment/slice_destructure.rs
@@ -8,4 +8,6 @@ fn main() {
   assert_eq!((a,b), (0,1));
   [a, .., b] = [1,2];
   assert_eq!((a,b), (1,2));
+  [_, a] = [1,2];
+  assert_eq!((a,b), (2,2));
 }

--- a/src/test/ui/destructuring-assignment/slice_destructure.rs
+++ b/src/test/ui/destructuring-assignment/slice_destructure.rs
@@ -1,0 +1,11 @@
+// run-pass
+
+#![feature(destructuring_assignment)]
+
+fn main() {
+  let (mut a, mut b);
+  [a, b] = [0, 1];
+  assert_eq!((a,b), (0,1));
+  [a, .., b] = [1,2];
+  assert_eq!((a,b), (1,2));
+}

--- a/src/test/ui/destructuring-assignment/slice_destructure.rs
+++ b/src/test/ui/destructuring-assignment/slice_destructure.rs
@@ -5,9 +5,11 @@
 fn main() {
   let (mut a, mut b);
   [a, b] = [0, 1];
-  assert_eq!((a,b), (0,1));
-  [a, .., b] = [1,2];
-  assert_eq!((a,b), (1,2));
-  [_, a] = [1,2];
-  assert_eq!((a,b), (2,2));
+  assert_eq!((a, b), (0, 1));
+  let c;
+  [a, .., b, c] = [1, 2, 3, 4, 5];
+  assert_eq!((a, b, c), (1, 4, 5));
+  [_, a, _] = [1, 2, 3];
+  assert_eq!((a, b), (2, 4));
+  [..] = [1, 2, 3];
 }

--- a/src/test/ui/destructuring-assignment/slice_destructure_fail.rs
+++ b/src/test/ui/destructuring-assignment/slice_destructure_fail.rs
@@ -4,4 +4,5 @@ fn main() {
   let (mut a, mut b);
   [a, .., b, ..] = [0, 1]; //~ ERROR `..` can only be used once per slice pattern
   [a, a, b] = [1,2]; //~ ERROR pattern requires 3 elements but array has 2
+  [_] = [1,2]; //~ ERROR pattern requires 1 element but array has 2
 }

--- a/src/test/ui/destructuring-assignment/slice_destructure_fail.rs
+++ b/src/test/ui/destructuring-assignment/slice_destructure_fail.rs
@@ -1,0 +1,7 @@
+#![feature(destructuring_assignment)]
+
+fn main() {
+  let (mut a, mut b);
+  [a, .., b, ..] = [0, 1]; //~ ERROR `..` can only be used once per slice pattern
+  [a, a, b] = [1,2]; //~ ERROR pattern requires 3 elements but array has 2
+}

--- a/src/test/ui/destructuring-assignment/slice_destructure_fail.rs
+++ b/src/test/ui/destructuring-assignment/slice_destructure_fail.rs
@@ -3,6 +3,6 @@
 fn main() {
   let (mut a, mut b);
   [a, .., b, ..] = [0, 1]; //~ ERROR `..` can only be used once per slice pattern
-  [a, a, b] = [1,2]; //~ ERROR pattern requires 3 elements but array has 2
-  [_] = [1,2]; //~ ERROR pattern requires 1 element but array has 2
+  [a, a, b] = [1, 2]; //~ ERROR pattern requires 3 elements but array has 2
+  [_] = [1, 2]; //~ ERROR pattern requires 1 element but array has 2
 }

--- a/src/test/ui/destructuring-assignment/slice_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/slice_destructure_fail.stderr
@@ -9,13 +9,13 @@ LL |   [a, .., b, ..] = [0, 1];
 error[E0527]: pattern requires 3 elements but array has 2
   --> $DIR/slice_destructure_fail.rs:6:3
    |
-LL |   [a, a, b] = [1,2];
+LL |   [a, a, b] = [1, 2];
    |   ^^^^^^^^^ expected 2 elements
 
 error[E0527]: pattern requires 1 element but array has 2
   --> $DIR/slice_destructure_fail.rs:7:3
    |
-LL |   [_] = [1,2];
+LL |   [_] = [1, 2];
    |   ^^^ expected 2 elements
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/destructuring-assignment/slice_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/slice_destructure_fail.stderr
@@ -1,0 +1,17 @@
+error: `..` can only be used once per slice pattern
+  --> $DIR/slice_destructure_fail.rs:5:14
+   |
+LL |   [a, .., b, ..] = [0, 1];
+   |       --     ^^ can only be used once per slice pattern
+   |       |
+   |       previously used here
+
+error[E0527]: pattern requires 3 elements but array has 2
+  --> $DIR/slice_destructure_fail.rs:6:3
+   |
+LL |   [a, a, b] = [1,2];
+   |   ^^^^^^^^^ expected 2 elements
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0527`.

--- a/src/test/ui/destructuring-assignment/slice_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/slice_destructure_fail.stderr
@@ -12,6 +12,12 @@ error[E0527]: pattern requires 3 elements but array has 2
 LL |   [a, a, b] = [1,2];
    |   ^^^^^^^^^ expected 2 elements
 
-error: aborting due to 2 previous errors
+error[E0527]: pattern requires 1 element but array has 2
+  --> $DIR/slice_destructure_fail.rs:7:3
+   |
+LL |   [_] = [1,2];
+   |   ^^^ expected 2 elements
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0527`.

--- a/src/test/ui/destructuring-assignment/struct_destructure.rs
+++ b/src/test/ui/destructuring-assignment/struct_destructure.rs
@@ -1,0 +1,13 @@
+// run-pass
+
+#![feature(destructuring_assignment)]
+struct Struct<S, T> {
+    a: S,
+    b: T,
+}
+
+fn main() {
+    let (a, b);
+    Struct { a, b } = Struct { a: 0, b: 1 };
+    assert_eq!((a, b), (0, 1));
+}

--- a/src/test/ui/destructuring-assignment/struct_destructure.rs
+++ b/src/test/ui/destructuring-assignment/struct_destructure.rs
@@ -10,10 +10,12 @@ fn main() {
     let (mut a, mut b);
     Struct { a, b } = Struct { a: 0, b: 1 };
     assert_eq!((a, b), (0, 1));
-    Struct { a: b, b: a }  = Struct { a: 1, b: 2};
-    assert_eq!((a,b), (2,1));
+    Struct { a: b, b: a }  = Struct { a: 1, b: 2 };
+    assert_eq!((a,b), (2, 1));
     Struct { a: _, b } = Struct { a: 1, b: 2 };
-    assert_eq!((a,b), (2,2));
-    Struct { a, .. } = Struct { a: 1, b: 3};
-    assert_eq!((a,b), (1,2));
+    assert_eq!((a, b), (2, 2));
+    Struct { a, .. } = Struct { a: 1, b: 3 };
+    assert_eq!((a, b), (1, 2));
+    Struct { .. } = Struct { a: 1, b: 4 };
+    assert_eq!((a, b), (1, 2));
 }

--- a/src/test/ui/destructuring-assignment/struct_destructure.rs
+++ b/src/test/ui/destructuring-assignment/struct_destructure.rs
@@ -14,4 +14,6 @@ fn main() {
     assert_eq!((a,b), (2,1));
     Struct { a: _, b } = Struct { a: 1, b: 2 };
     assert_eq!((a,b), (2,2));
+    Struct { a, .. } = Struct { a: 1, b: 3};
+    assert_eq!((a,b), (1,2));
 }

--- a/src/test/ui/destructuring-assignment/struct_destructure.rs
+++ b/src/test/ui/destructuring-assignment/struct_destructure.rs
@@ -7,7 +7,11 @@ struct Struct<S, T> {
 }
 
 fn main() {
-    let (a, b);
+    let (mut a, mut b);
     Struct { a, b } = Struct { a: 0, b: 1 };
     assert_eq!((a, b), (0, 1));
+    Struct { a: b, b: a }  = Struct { a: 1, b: 2};
+    assert_eq!((a,b), (2,1));
+    Struct { a: _, b } = Struct { a: 1, b: 2 };
+    assert_eq!((a,b), (2,2));
 }

--- a/src/test/ui/destructuring-assignment/struct_destructure_fail.rs
+++ b/src/test/ui/destructuring-assignment/struct_destructure_fail.rs
@@ -11,6 +11,7 @@ fn main() {
     Struct { a, b, c } = Struct { a: 0, b: 1 }; //~ ERROR does not have a field named `c`
     Struct { a, _ } = Struct { a: 1, b: 2 }; //~ ERROR pattern does not mention field `b`
     //~| ERROR expected identifier, found reserved identifier `_`
-    Struct { a, ..d } = Struct { a: 1, b: 2 }; //~ ERROR base expression not allowed here
+    Struct { a, ..d } = Struct { a: 1, b: 2 };
+    //~^ ERROR functional record updates are not allowed in destructuring assignments
     Struct { a, .. }; //~ ERROR base expression required after `..`
 }

--- a/src/test/ui/destructuring-assignment/struct_destructure_fail.rs
+++ b/src/test/ui/destructuring-assignment/struct_destructure_fail.rs
@@ -1,0 +1,11 @@
+#![feature(destructuring_assignment)]
+struct Struct<S, T> {
+    a: S,
+    b: T,
+}
+
+fn main() {
+    let (mut a, b);
+    let mut c;
+    Struct { a, b, c } = Struct { a: 0, b: 1 }; //~ ERROR does not have a field named `c`
+}

--- a/src/test/ui/destructuring-assignment/struct_destructure_fail.rs
+++ b/src/test/ui/destructuring-assignment/struct_destructure_fail.rs
@@ -8,4 +8,6 @@ fn main() {
     let (mut a, b);
     let mut c;
     Struct { a, b, c } = Struct { a: 0, b: 1 }; //~ ERROR does not have a field named `c`
+    Struct { a, _ } = Struct { a: 1, b: 2 }; //~ ERROR pattern does not mention field `b`
+    //~| ERROR expected identifier, found reserved identifier `_`
 }

--- a/src/test/ui/destructuring-assignment/struct_destructure_fail.rs
+++ b/src/test/ui/destructuring-assignment/struct_destructure_fail.rs
@@ -7,7 +7,9 @@ struct Struct<S, T> {
 fn main() {
     let (mut a, b);
     let mut c;
+    let d = Struct { a: 0, b: 1 };
     Struct { a, b, c } = Struct { a: 0, b: 1 }; //~ ERROR does not have a field named `c`
     Struct { a, _ } = Struct { a: 1, b: 2 }; //~ ERROR pattern does not mention field `b`
     //~| ERROR expected identifier, found reserved identifier `_`
+    Struct { a, ..d } = Struct { a: 1, b: 2 }; //~ ERROR base expression not allowed here
 }

--- a/src/test/ui/destructuring-assignment/struct_destructure_fail.rs
+++ b/src/test/ui/destructuring-assignment/struct_destructure_fail.rs
@@ -12,4 +12,5 @@ fn main() {
     Struct { a, _ } = Struct { a: 1, b: 2 }; //~ ERROR pattern does not mention field `b`
     //~| ERROR expected identifier, found reserved identifier `_`
     Struct { a, ..d } = Struct { a: 1, b: 2 }; //~ ERROR base expression not allowed here
+    Struct { a, .. }; //~ ERROR base expression required after `..`
 }

--- a/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
@@ -16,7 +16,7 @@ error: base expression required after `..`
   --> $DIR/struct_destructure_fail.rs:16:19
    |
 LL |     Struct { a, .. };
-   |                   ^ add the base expression here
+   |                   ^ add a base expression here
 
 error[E0026]: struct `Struct` does not have a field named `c`
   --> $DIR/struct_destructure_fail.rs:11:20

--- a/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
@@ -10,7 +10,7 @@ error: functional record updates are not allowed in destructuring assignments
   --> $DIR/struct_destructure_fail.rs:14:19
    |
 LL |     Struct { a, ..d } = Struct { a: 1, b: 2 };
-   |                   ^ help: consider removing the trailing expression
+   |                   ^ help: consider removing the trailing pattern
 
 error: base expression required after `..`
   --> $DIR/struct_destructure_fail.rs:16:19

--- a/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
@@ -1,0 +1,9 @@
+error[E0026]: struct `Struct` does not have a field named `c`
+  --> $DIR/struct_destructure_fail.rs:10:20
+   |
+LL |     Struct { a, b, c } = Struct { a: 0, b: 1 };
+   |                    ^ struct `Struct` does not have this field
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0026`.

--- a/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
@@ -12,6 +12,12 @@ error: base expression not allowed here
 LL |     Struct { a, ..d } = Struct { a: 1, b: 2 };
    |                   ^ help: consider removing this
 
+error: base expression required after `..`
+  --> $DIR/struct_destructure_fail.rs:15:19
+   |
+LL |     Struct { a, .. };
+   |                   ^ add the base expression here
+
 error[E0026]: struct `Struct` does not have a field named `c`
   --> $DIR/struct_destructure_fail.rs:11:20
    |
@@ -24,7 +30,7 @@ error[E0027]: pattern does not mention field `b`
 LL |     Struct { a, _ } = Struct { a: 1, b: 2 };
    |     ^^^^^^^^^^^^^^^ missing field `b`
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0026, E0027.
 For more information about an error, try `rustc --explain E0026`.

--- a/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
@@ -1,24 +1,30 @@
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/struct_destructure_fail.rs:11:17
+  --> $DIR/struct_destructure_fail.rs:12:17
    |
 LL |     Struct { a, _ } = Struct { a: 1, b: 2 };
    |     ------      ^ expected identifier, found reserved identifier
    |     |
    |     while parsing this struct
 
+error: base expression not allowed here
+  --> $DIR/struct_destructure_fail.rs:14:19
+   |
+LL |     Struct { a, ..d } = Struct { a: 1, b: 2 };
+   |                   ^ help: consider removing this
+
 error[E0026]: struct `Struct` does not have a field named `c`
-  --> $DIR/struct_destructure_fail.rs:10:20
+  --> $DIR/struct_destructure_fail.rs:11:20
    |
 LL |     Struct { a, b, c } = Struct { a: 0, b: 1 };
    |                    ^ struct `Struct` does not have this field
 
 error[E0027]: pattern does not mention field `b`
-  --> $DIR/struct_destructure_fail.rs:11:5
+  --> $DIR/struct_destructure_fail.rs:12:5
    |
 LL |     Struct { a, _ } = Struct { a: 1, b: 2 };
    |     ^^^^^^^^^^^^^^^ missing field `b`
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0026, E0027.
 For more information about an error, try `rustc --explain E0026`.

--- a/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
@@ -1,9 +1,24 @@
+error: expected identifier, found reserved identifier `_`
+  --> $DIR/struct_destructure_fail.rs:11:17
+   |
+LL |     Struct { a, _ } = Struct { a: 1, b: 2 };
+   |     ------      ^ expected identifier, found reserved identifier
+   |     |
+   |     while parsing this struct
+
 error[E0026]: struct `Struct` does not have a field named `c`
   --> $DIR/struct_destructure_fail.rs:10:20
    |
 LL |     Struct { a, b, c } = Struct { a: 0, b: 1 };
    |                    ^ struct `Struct` does not have this field
 
-error: aborting due to previous error
+error[E0027]: pattern does not mention field `b`
+  --> $DIR/struct_destructure_fail.rs:11:5
+   |
+LL |     Struct { a, _ } = Struct { a: 1, b: 2 };
+   |     ^^^^^^^^^^^^^^^ missing field `b`
 
-For more information about this error, try `rustc --explain E0026`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0026, E0027.
+For more information about an error, try `rustc --explain E0026`.

--- a/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
@@ -6,14 +6,14 @@ LL |     Struct { a, _ } = Struct { a: 1, b: 2 };
    |     |
    |     while parsing this struct
 
-error: base expression not allowed here
+error: functional record updates are not allowed in destructuring assignments
   --> $DIR/struct_destructure_fail.rs:14:19
    |
 LL |     Struct { a, ..d } = Struct { a: 1, b: 2 };
-   |                   ^ help: consider removing this
+   |                   ^ help: consider removing the trailing expression
 
 error: base expression required after `..`
-  --> $DIR/struct_destructure_fail.rs:15:19
+  --> $DIR/struct_destructure_fail.rs:16:19
    |
 LL |     Struct { a, .. };
    |                   ^ add the base expression here

--- a/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
@@ -29,6 +29,15 @@ error[E0027]: pattern does not mention field `b`
    |
 LL |     Struct { a, _ } = Struct { a: 1, b: 2 };
    |     ^^^^^^^^^^^^^^^ missing field `b`
+   |
+help: include the missing field in the pattern
+   |
+LL |     Struct { a, b, _ } = Struct { a: 1, b: 2 };
+   |               ^^^
+help: if you don't care about this missing field, you can explicitely ignore it
+   |
+LL |     Struct { a, .., _ } = Struct { a: 1, b: 2 };
+   |               ^^^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/destructuring-assignment/tuple_destructure.rs
+++ b/src/test/ui/destructuring-assignment/tuple_destructure.rs
@@ -14,4 +14,6 @@ fn main() {
     assert_eq!((a, b), (2, 2));
     (..) = (3, 4);
     assert_eq!((a, b), (2, 2));
+    (b, ..) = (5, 6, 7);
+    assert_eq!(b, 5);
 }

--- a/src/test/ui/destructuring-assignment/tuple_destructure.rs
+++ b/src/test/ui/destructuring-assignment/tuple_destructure.rs
@@ -8,4 +8,6 @@ fn main() {
     assert_eq!((a,b), (0,1));
     (a, .., b) = (1,2);
     assert_eq!((a,b), (1,2));
+    (_, a) = (1,2);
+    assert_eq!((a,b), (2,2));
 }

--- a/src/test/ui/destructuring-assignment/tuple_destructure.rs
+++ b/src/test/ui/destructuring-assignment/tuple_destructure.rs
@@ -1,0 +1,11 @@
+// run-pass
+
+#![feature(destructuring_assignment)]
+
+fn main() {
+    let (mut a, mut b);
+    (a, b) = (0, 1);
+    assert_eq!((a,b), (0,1));
+    (a, .., b) = (1,2);
+    assert_eq!((a,b), (1,2));
+}

--- a/src/test/ui/destructuring-assignment/tuple_destructure.rs
+++ b/src/test/ui/destructuring-assignment/tuple_destructure.rs
@@ -5,9 +5,14 @@
 fn main() {
     let (mut a, mut b);
     (a, b) = (0, 1);
-    assert_eq!((a,b), (0,1));
-    (a, .., b) = (1,2);
-    assert_eq!((a,b), (1,2));
-    (_, a) = (1,2);
-    assert_eq!((a,b), (2,2));
+    assert_eq!((a, b), (0, 1));
+    (b, a) = (a, b);
+    assert_eq!((a, b), (1, 0));
+    (a, .., b) = (1, 2);
+    assert_eq!((a, b), (1, 2));
+    (_, a) = (1, 2);
+    assert_eq!((a, b), (2, 2));
+    // The following currently does not work, but should.
+    // (..) = (3, 4);
+    // assert_eq!((a, b), (2, 2));
 }

--- a/src/test/ui/destructuring-assignment/tuple_destructure.rs
+++ b/src/test/ui/destructuring-assignment/tuple_destructure.rs
@@ -12,7 +12,6 @@ fn main() {
     assert_eq!((a, b), (1, 2));
     (_, a) = (1, 2);
     assert_eq!((a, b), (2, 2));
-    // The following currently does not work, but should.
-    // (..) = (3, 4);
-    // assert_eq!((a, b), (2, 2));
+    (..) = (3, 4);
+    assert_eq!((a, b), (2, 2));
 }

--- a/src/test/ui/destructuring-assignment/tuple_destructure_fail.rs
+++ b/src/test/ui/destructuring-assignment/tuple_destructure_fail.rs
@@ -4,4 +4,5 @@ fn main() {
     let (mut a, mut b);
     (a, .., b, ..) = (0, 1); //~ ERROR `..` can only be used once per tuple pattern
     (a, a, b) = (1,2); //~ ERROR mismatched types
+    (_,) = (1,2); //~ ERROR mismatched types
 }

--- a/src/test/ui/destructuring-assignment/tuple_destructure_fail.rs
+++ b/src/test/ui/destructuring-assignment/tuple_destructure_fail.rs
@@ -3,6 +3,6 @@
 fn main() {
     let (mut a, mut b);
     (a, .., b, ..) = (0, 1); //~ ERROR `..` can only be used once per tuple pattern
-    (a, a, b) = (1,2); //~ ERROR mismatched types
-    (_,) = (1,2); //~ ERROR mismatched types
+    (a, a, b) = (1, 2); //~ ERROR mismatched types
+    (_,) = (1, 2); //~ ERROR mismatched types
 }

--- a/src/test/ui/destructuring-assignment/tuple_destructure_fail.rs
+++ b/src/test/ui/destructuring-assignment/tuple_destructure_fail.rs
@@ -1,0 +1,7 @@
+#![feature(destructuring_assignment)]
+
+fn main() {
+    let (mut a, mut b);
+    (a, .., b, ..) = (0, 1); //~ ERROR `..` can only be used once per tuple pattern
+    (a, a, b) = (1,2); //~ ERROR mismatched types
+}

--- a/src/test/ui/destructuring-assignment/tuple_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/tuple_destructure_fail.stderr
@@ -1,0 +1,22 @@
+error: `..` can only be used once per tuple pattern
+  --> $DIR/tuple_destructure_fail.rs:5:16
+   |
+LL |     (a, .., b, ..) = (0, 1);
+   |         --     ^^ can only be used once per tuple pattern
+   |         |
+   |         previously used here
+
+error[E0308]: mismatched types
+  --> $DIR/tuple_destructure_fail.rs:6:5
+   |
+LL |     (a, a, b) = (1,2);
+   |     ^^^^^^^^^   ----- this expression has type `({integer}, {integer})`
+   |     |
+   |     expected a tuple with 2 elements, found one with 3 elements
+   |
+   = note: expected tuple `({integer}, {integer})`
+              found tuple `(_, _, _)`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/destructuring-assignment/tuple_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/tuple_destructure_fail.stderr
@@ -9,8 +9,8 @@ LL |     (a, .., b, ..) = (0, 1);
 error[E0308]: mismatched types
   --> $DIR/tuple_destructure_fail.rs:6:5
    |
-LL |     (a, a, b) = (1,2);
-   |     ^^^^^^^^^   ----- this expression has type `({integer}, {integer})`
+LL |     (a, a, b) = (1, 2);
+   |     ^^^^^^^^^   ------ this expression has type `({integer}, {integer})`
    |     |
    |     expected a tuple with 2 elements, found one with 3 elements
    |
@@ -20,8 +20,8 @@ LL |     (a, a, b) = (1,2);
 error[E0308]: mismatched types
   --> $DIR/tuple_destructure_fail.rs:7:5
    |
-LL |     (_,) = (1,2);
-   |     ^^^^   ----- this expression has type `({integer}, {integer})`
+LL |     (_,) = (1, 2);
+   |     ^^^^   ------ this expression has type `({integer}, {integer})`
    |     |
    |     expected a tuple with 2 elements, found one with 1 element
    |

--- a/src/test/ui/destructuring-assignment/tuple_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/tuple_destructure_fail.stderr
@@ -17,6 +17,17 @@ LL |     (a, a, b) = (1,2);
    = note: expected tuple `({integer}, {integer})`
               found tuple `(_, _, _)`
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/tuple_destructure_fail.rs:7:5
+   |
+LL |     (_,) = (1,2);
+   |     ^^^^   ----- this expression has type `({integer}, {integer})`
+   |     |
+   |     expected a tuple with 2 elements, found one with 1 element
+   |
+   = note: expected tuple `({integer}, {integer})`
+              found tuple `(_,)`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/destructuring-assignment/tuple_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/tuple_destructure_fail.stderr
@@ -14,8 +14,8 @@ LL |     (a, a, b) = (1, 2);
    |     |
    |     expected a tuple with 2 elements, found one with 3 elements
    |
-   = note: expected tuple `({integer}, {integer})`
-              found tuple `(_, _, _)`
+   = note: expected type `({integer}, {integer})`
+             found tuple `(_, _, _)`
 
 error[E0308]: mismatched types
   --> $DIR/tuple_destructure_fail.rs:7:5
@@ -25,8 +25,8 @@ LL |     (_,) = (1, 2);
    |     |
    |     expected a tuple with 2 elements, found one with 1 element
    |
-   = note: expected tuple `({integer}, {integer})`
-              found tuple `(_,)`
+   = note: expected type `({integer}, {integer})`
+             found tuple `(_,)`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/destructuring-assignment/tuple_struct_destructure.rs
+++ b/src/test/ui/destructuring-assignment/tuple_struct_destructure.rs
@@ -7,9 +7,11 @@ struct TupleStruct<S, T>(S, T);
 fn main() {
     let (mut a, mut b);
     TupleStruct(a, b) = TupleStruct(0, 1);
-    assert_eq!((a,b), (0,1));
-    TupleStruct(a, .., b) = TupleStruct(1,2);
-    assert_eq!((a,b), (1,2));
-    TupleStruct(_, a) = TupleStruct(2,2);
-    assert_eq!((a,b), (2,2));
+    assert_eq!((a, b), (0, 1));
+    TupleStruct(a, .., b) = TupleStruct(1, 2);
+    assert_eq!((a, b), (1, 2));
+    TupleStruct(_, a) = TupleStruct(2, 2);
+    assert_eq!((a, b), (2, 2));
+    TupleStruct(..) = TupleStruct(3, 4);
+    assert_eq!((a, b), (2, 2));
 }

--- a/src/test/ui/destructuring-assignment/tuple_struct_destructure.rs
+++ b/src/test/ui/destructuring-assignment/tuple_struct_destructure.rs
@@ -1,0 +1,13 @@
+// run-pass
+
+#![feature(destructuring_assignment)]
+
+struct TupleStruct<S, T>(S, T);
+
+fn main() {
+    let (mut a, mut b);
+    TupleStruct(a, b) = TupleStruct(0, 1);
+    assert_eq!((a,b), (0,1));
+    TupleStruct(a, .., b) = TupleStruct(1,2);
+    assert_eq!((a,b), (1,2));
+}

--- a/src/test/ui/destructuring-assignment/tuple_struct_destructure.rs
+++ b/src/test/ui/destructuring-assignment/tuple_struct_destructure.rs
@@ -10,4 +10,6 @@ fn main() {
     assert_eq!((a,b), (0,1));
     TupleStruct(a, .., b) = TupleStruct(1,2);
     assert_eq!((a,b), (1,2));
+    TupleStruct(_, a) = TupleStruct(2,2);
+    assert_eq!((a,b), (2,2));
 }

--- a/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.rs
+++ b/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.rs
@@ -9,7 +9,9 @@ fn main() {
     TupleStruct(a, a, b) = TupleStruct(1,2);
     //~^ ERROR this pattern has 3 fields, but the corresponding tuple struct has 2 fields
     // Check if `test` is recognized as not a tuple struct but a function call:
-    test() = TupleStruct(0,0) //~ ERROR invalid left-hand side of assignment
+    test() = TupleStruct(0,0); //~ ERROR invalid left-hand side of assignment
+    TupleStruct(_) = TupleStruct(1,2);
+    //~^ ERROR this pattern has 1 field, but the corresponding tuple struct has 2 fields
 }
 
 fn test() -> TupleStruct<isize, isize> {

--- a/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.rs
+++ b/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.rs
@@ -6,11 +6,11 @@ fn main() {
     let (mut a, mut b);
     TupleStruct(a, .., b, ..) = TupleStruct(0, 1);
     //~^ ERROR `..` can only be used once per tuple struct pattern
-    TupleStruct(a, a, b) = TupleStruct(1,2);
+    TupleStruct(a, a, b) = TupleStruct(1, 2);
     //~^ ERROR this pattern has 3 fields, but the corresponding tuple struct has 2 fields
     // Check if `test` is recognized as not a tuple struct but a function call:
-    test() = TupleStruct(0,0); //~ ERROR invalid left-hand side of assignment
-    TupleStruct(_) = TupleStruct(1,2);
+    test() = TupleStruct(0, 0); //~ ERROR invalid left-hand side of assignment
+    TupleStruct(_) = TupleStruct(1, 2);
     //~^ ERROR this pattern has 1 field, but the corresponding tuple struct has 2 fields
 }
 

--- a/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.rs
+++ b/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.rs
@@ -1,0 +1,17 @@
+#![feature(destructuring_assignment)]
+
+struct TupleStruct<S, T>(S, T);
+
+fn main() {
+    let (mut a, mut b);
+    TupleStruct(a, .., b, ..) = TupleStruct(0, 1);
+    //~^ ERROR `..` can only be used once per tuple struct pattern
+    TupleStruct(a, a, b) = TupleStruct(1,2);
+    //~^ ERROR this pattern has 3 fields, but the corresponding tuple struct has 2 fields
+    // Check if `test` is recognized as not a tuple struct but a function call:
+    test() = TupleStruct(0,0) //~ ERROR invalid left-hand side of assignment
+}
+
+fn test() -> TupleStruct<isize, isize> {
+    TupleStruct(0, 0)
+}

--- a/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.stderr
@@ -18,12 +18,21 @@ LL |     TupleStruct(a, a, b) = TupleStruct(1,2);
 error[E0070]: invalid left-hand side of assignment
   --> $DIR/tuple_struct_destructure_fail.rs:12:12
    |
-LL |     test() = TupleStruct(0,0)
+LL |     test() = TupleStruct(0,0);
    |     ------ ^
    |     |
    |     cannot assign to this expression
 
-error: aborting due to 3 previous errors
+error[E0023]: this pattern has 1 field, but the corresponding tuple struct has 2 fields
+  --> $DIR/tuple_struct_destructure_fail.rs:13:5
+   |
+LL | struct TupleStruct<S, T>(S, T);
+   | ------------------------------- tuple struct defined here
+...
+LL |     TupleStruct(_) = TupleStruct(1,2);
+   |     ^^^^^^^^^^^^^^ expected 2 fields, found 1
+
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0023, E0070.
 For more information about an error, try `rustc --explain E0023`.

--- a/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.stderr
@@ -1,0 +1,29 @@
+error: `..` can only be used once per tuple struct pattern
+  --> $DIR/tuple_struct_destructure_fail.rs:7:27
+   |
+LL |     TupleStruct(a, .., b, ..) = TupleStruct(0, 1);
+   |                    --     ^^ can only be used once per tuple struct pattern
+   |                    |
+   |                    previously used here
+
+error[E0023]: this pattern has 3 fields, but the corresponding tuple struct has 2 fields
+  --> $DIR/tuple_struct_destructure_fail.rs:9:5
+   |
+LL | struct TupleStruct<S, T>(S, T);
+   | ------------------------------- tuple struct defined here
+...
+LL |     TupleStruct(a, a, b) = TupleStruct(1,2);
+   |     ^^^^^^^^^^^^^^^^^^^^ expected 2 fields, found 3
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/tuple_struct_destructure_fail.rs:12:12
+   |
+LL |     test() = TupleStruct(0,0)
+   |     ------ ^
+   |     |
+   |     cannot assign to this expression
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0023, E0070.
+For more information about an error, try `rustc --explain E0023`.

--- a/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.stderr
@@ -12,13 +12,13 @@ error[E0023]: this pattern has 3 fields, but the corresponding tuple struct has 
 LL | struct TupleStruct<S, T>(S, T);
    | ------------------------------- tuple struct defined here
 ...
-LL |     TupleStruct(a, a, b) = TupleStruct(1,2);
+LL |     TupleStruct(a, a, b) = TupleStruct(1, 2);
    |     ^^^^^^^^^^^^^^^^^^^^ expected 2 fields, found 3
 
 error[E0070]: invalid left-hand side of assignment
   --> $DIR/tuple_struct_destructure_fail.rs:12:12
    |
-LL |     test() = TupleStruct(0,0);
+LL |     test() = TupleStruct(0, 0);
    |     ------ ^
    |     |
    |     cannot assign to this expression
@@ -29,7 +29,7 @@ error[E0023]: this pattern has 1 field, but the corresponding tuple struct has 2
 LL | struct TupleStruct<S, T>(S, T);
    | ------------------------------- tuple struct defined here
 ...
-LL |     TupleStruct(_) = TupleStruct(1,2);
+LL |     TupleStruct(_) = TupleStruct(1, 2);
    |     ^^^^^^^^^^^^^^ expected 2 fields, found 1
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/destructuring-assignment/underscore-range-expr-gating.rs
+++ b/src/test/ui/destructuring-assignment/underscore-range-expr-gating.rs
@@ -1,0 +1,10 @@
+fn main() {}
+
+struct S { x : u32 }
+
+#[cfg(FALSE)]
+fn foo() {
+    _; //~ ERROR destructuring assignments are unstable
+
+    S { x: 5, .. }; //~ ERROR destructuring assignments are unstable
+}

--- a/src/test/ui/destructuring-assignment/underscore-range-expr-gating.stderr
+++ b/src/test/ui/destructuring-assignment/underscore-range-expr-gating.stderr
@@ -1,0 +1,21 @@
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/underscore-range-expr-gating.rs:7:5
+   |
+LL |     _;
+   |     ^
+   |
+   = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
+
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/underscore-range-expr-gating.rs:9:15
+   |
+LL |     S { x: 5, .. };
+   |               ^^
+   |
+   = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/destructuring-assignment/warn-unused-duplication.rs
+++ b/src/test/ui/destructuring-assignment/warn-unused-duplication.rs
@@ -1,0 +1,13 @@
+// run-pass
+
+#![feature(destructuring_assignment)]
+
+#![warn(unused_assignments)]
+
+fn main() {
+    let mut a;
+    // Assignment occurs left-to-right.
+    // However, we emit warnings when this happens, so it is clear that this is happening.
+    (a, a) = (0, 1); //~ WARN value assigned to `a` is never read
+    assert_eq!(a, 1);
+}

--- a/src/test/ui/destructuring-assignment/warn-unused-duplication.rs
+++ b/src/test/ui/destructuring-assignment/warn-unused-duplication.rs
@@ -10,4 +10,14 @@ fn main() {
     // However, we emit warnings when this happens, so it is clear that this is happening.
     (a, a) = (0, 1); //~ WARN value assigned to `a` is never read
     assert_eq!(a, 1);
+
+    // We can't always tell when a variable is being assigned to twice, which is why we don't try
+    // to emit an error, which would be fallible.
+    let mut x = 1;
+    (*foo(&mut x), *foo(&mut x)) = (5, 6);
+    assert_eq!(x, 6);
+}
+
+fn foo<'a>(x: &'a mut u32) -> &'a mut u32 {
+    x
 }

--- a/src/test/ui/destructuring-assignment/warn-unused-duplication.stderr
+++ b/src/test/ui/destructuring-assignment/warn-unused-duplication.stderr
@@ -11,3 +11,5 @@ LL | #![warn(unused_assignments)]
    |         ^^^^^^^^^^^^^^^^^^
    = help: maybe it is overwritten before being read?
 
+warning: 1 warning emitted
+

--- a/src/test/ui/destructuring-assignment/warn-unused-duplication.stderr
+++ b/src/test/ui/destructuring-assignment/warn-unused-duplication.stderr
@@ -1,0 +1,13 @@
+warning: value assigned to `a` is never read
+  --> $DIR/warn-unused-duplication.rs:11:6
+   |
+LL |     (a, a) = (0, 1);
+   |      ^
+   |
+note: the lint level is defined here
+  --> $DIR/warn-unused-duplication.rs:5:9
+   |
+LL | #![warn(unused_assignments)]
+   |         ^^^^^^^^^^^^^^^^^^
+   = help: maybe it is overwritten before being read?
+

--- a/src/test/ui/feature-gates/feature-gate-destructuring_assignment.rs
+++ b/src/test/ui/feature-gates/feature-gate-destructuring_assignment.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let (a, b) = (0, 1);
+    (a, b) = (2, 3); //~ ERROR destructuring assignments are unstable
+}

--- a/src/test/ui/feature-gates/feature-gate-destructuring_assignment.stderr
+++ b/src/test/ui/feature-gates/feature-gate-destructuring_assignment.stderr
@@ -6,7 +6,7 @@ LL |     (a, b) = (2, 3);
    |     |
    |     cannot assign to this expression
    |
-   = note: see issue #372 <https://github.com/rust-lang/rust/issues/372> for more information
+   = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
    = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-destructuring_assignment.stderr
+++ b/src/test/ui/feature-gates/feature-gate-destructuring_assignment.stderr
@@ -1,0 +1,11 @@
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/feature-gate-destructuring_assignment.rs:3:12
+   |
+LL |     (a, b) = (2, 3);
+   |            ^
+   |
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gates/feature-gate-destructuring_assignment.stderr
+++ b/src/test/ui/feature-gates/feature-gate-destructuring_assignment.stderr
@@ -2,8 +2,11 @@ error[E0658]: destructuring assignments are unstable
   --> $DIR/feature-gate-destructuring_assignment.rs:3:12
    |
 LL |     (a, b) = (2, 3);
-   |            ^
+   |     ------ ^
+   |     |
+   |     cannot assign to this expression
    |
+   = note: see issue #372 <https://github.com/rust-lang/rust/issues/372> for more information
    = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-34334.rs
+++ b/src/test/ui/issues/issue-34334.rs
@@ -1,6 +1,12 @@
 fn main () {
     let sr: Vec<(u32, _, _) = vec![];
     //~^ ERROR expected one of `,` or `>`, found `=`
+    //~| ERROR expected value, found struct `Vec`
+    //~| ERROR expected value, found builtin type `u32`
+    //~| ERROR mismatched types
+    //~| ERROR invalid left-hand side of assignment
+    //~| ERROR expected expression, found reserved identifier `_`
+    //~| ERROR expected expression, found reserved identifier `_`
     let sr2: Vec<(u32, _, _)> = sr.iter().map(|(faction, th_sender, th_receiver)| {}).collect();
     //~^ ERROR a value of type `Vec<(u32, _, _)>` cannot be built
 }

--- a/src/test/ui/issues/issue-34334.rs
+++ b/src/test/ui/issues/issue-34334.rs
@@ -1,12 +1,6 @@
 fn main () {
     let sr: Vec<(u32, _, _) = vec![];
     //~^ ERROR expected one of `,` or `>`, found `=`
-    //~| ERROR expected value, found struct `Vec`
-    //~| ERROR expected value, found builtin type `u32`
-    //~| ERROR mismatched types
-    //~| ERROR invalid left-hand side of assignment
-    //~| ERROR expected expression, found reserved identifier `_`
-    //~| ERROR expected expression, found reserved identifier `_`
     let sr2: Vec<(u32, _, _)> = sr.iter().map(|(faction, th_sender, th_receiver)| {}).collect();
     //~^ ERROR a value of type `Vec<(u32, _, _)>` cannot be built
 }

--- a/src/test/ui/issues/issue-34334.stderr
+++ b/src/test/ui/issues/issue-34334.stderr
@@ -6,14 +6,56 @@ LL |     let sr: Vec<(u32, _, _) = vec![];
    |         |
    |         while parsing the type for `sr`
 
-error[E0277]: a value of type `Vec<(u32, _, _)>` cannot be built from an iterator over elements of type `()`
-  --> $DIR/issue-34334.rs:4:87
+error[E0423]: expected value, found struct `Vec`
+  --> $DIR/issue-34334.rs:2:13
+   |
+LL |     let sr: Vec<(u32, _, _) = vec![];
+   |             ^^^ did you mean `Vec { /* fields */ }`?
+
+error[E0423]: expected value, found builtin type `u32`
+  --> $DIR/issue-34334.rs:2:18
+   |
+LL |     let sr: Vec<(u32, _, _) = vec![];
+   |                  ^^^ not a value
+
+error: expected expression, found reserved identifier `_`
+  --> $DIR/issue-34334.rs:2:23
+   |
+LL |     let sr: Vec<(u32, _, _) = vec![];
+   |                       ^ expected expression
+
+error: expected expression, found reserved identifier `_`
+  --> $DIR/issue-34334.rs:2:26
+   |
+LL |     let sr: Vec<(u32, _, _) = vec![];
+   |                          ^ expected expression
+
+error[E0308]: mismatched types
+  --> $DIR/issue-34334.rs:2:31
+   |
+LL |     let sr: Vec<(u32, _, _) = vec![];
+   |                               ^^^^^^ expected `bool`, found struct `std::vec::Vec`
+   |
+   = note: expected type `bool`
+            found struct `std::vec::Vec<_>`
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/issue-34334.rs:2:29
+   |
+LL |     let sr: Vec<(u32, _, _) = vec![];
+   |             --------------- ^
+   |             |
+   |             cannot assign to this expression
+
+error[E0599]: no method named `iter` found for unit type `()` in the current scope
+  --> $DIR/issue-34334.rs:10:36
    |
 LL |     let sr2: Vec<(u32, _, _)> = sr.iter().map(|(faction, th_sender, th_receiver)| {}).collect();
    |                                                                                       ^^^^^^^ value of type `Vec<(u32, _, _)>` cannot be built from `std::iter::Iterator<Item=()>`
    |
    = help: the trait `FromIterator<()>` is not implemented for `Vec<(u32, _, _)>`
 
-error: aborting due to 2 previous errors
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/issues/issue-34334.stderr
+++ b/src/test/ui/issues/issue-34334.stderr
@@ -6,56 +6,14 @@ LL |     let sr: Vec<(u32, _, _) = vec![];
    |         |
    |         while parsing the type for `sr`
 
-error[E0423]: expected value, found struct `Vec`
-  --> $DIR/issue-34334.rs:2:13
-   |
-LL |     let sr: Vec<(u32, _, _) = vec![];
-   |             ^^^ did you mean `Vec { /* fields */ }`?
-
-error[E0423]: expected value, found builtin type `u32`
-  --> $DIR/issue-34334.rs:2:18
-   |
-LL |     let sr: Vec<(u32, _, _) = vec![];
-   |                  ^^^ not a value
-
-error: expected expression, found reserved identifier `_`
-  --> $DIR/issue-34334.rs:2:23
-   |
-LL |     let sr: Vec<(u32, _, _) = vec![];
-   |                       ^ expected expression
-
-error: expected expression, found reserved identifier `_`
-  --> $DIR/issue-34334.rs:2:26
-   |
-LL |     let sr: Vec<(u32, _, _) = vec![];
-   |                          ^ expected expression
-
-error[E0308]: mismatched types
-  --> $DIR/issue-34334.rs:2:31
-   |
-LL |     let sr: Vec<(u32, _, _) = vec![];
-   |                               ^^^^^^ expected `bool`, found struct `std::vec::Vec`
-   |
-   = note: expected type `bool`
-            found struct `std::vec::Vec<_>`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0070]: invalid left-hand side of assignment
-  --> $DIR/issue-34334.rs:2:29
-   |
-LL |     let sr: Vec<(u32, _, _) = vec![];
-   |             --------------- ^
-   |             |
-   |             cannot assign to this expression
-
-error[E0599]: no method named `iter` found for unit type `()` in the current scope
-  --> $DIR/issue-34334.rs:10:36
+error[E0277]: a value of type `Vec<(u32, _, _)>` cannot be built from an iterator over elements of type `()`
+  --> $DIR/issue-34334.rs:4:87
    |
 LL |     let sr2: Vec<(u32, _, _)> = sr.iter().map(|(faction, th_sender, th_receiver)| {}).collect();
    |                                                                                       ^^^^^^^ value of type `Vec<(u32, _, _)>` cannot be built from `std::iter::Iterator<Item=()>`
    |
    = help: the trait `FromIterator<()>` is not implemented for `Vec<(u32, _, _)>`
 
-error: aborting due to 8 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/suggestions/fn-or-tuple-struct-with-underscore-args.rs
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-with-underscore-args.rs
@@ -10,10 +10,16 @@ fn main() {
     let _: usize = foo(_, _);
     //~^ ERROR expected expression
     //~| ERROR expected expression
+    //~| ERROR destructuring assignments are unstable
+    //~| ERROR destructuring assignments are unstable
     let _: S = S(_, _);
     //~^ ERROR expected expression
     //~| ERROR expected expression
+    //~| ERROR destructuring assignments are unstable
+    //~| ERROR destructuring assignments are unstable
     let _: usize = T::baz(_, _);
     //~^ ERROR expected expression
     //~| ERROR expected expression
+    //~| ERROR destructuring assignments are unstable
+    //~| ERROR destructuring assignments are unstable
 }

--- a/src/test/ui/suggestions/fn-or-tuple-struct-with-underscore-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-with-underscore-args.stderr
@@ -1,3 +1,57 @@
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:10:24
+   |
+LL |     let _: usize = foo(_, _);
+   |                        ^
+   |
+   = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
+
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:10:27
+   |
+LL |     let _: usize = foo(_, _);
+   |                           ^
+   |
+   = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
+
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:15:18
+   |
+LL |     let _: S = S(_, _);
+   |                  ^
+   |
+   = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
+
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:15:21
+   |
+LL |     let _: S = S(_, _);
+   |                     ^
+   |
+   = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
+
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:20:27
+   |
+LL |     let _: usize = T::baz(_, _);
+   |                           ^
+   |
+   = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
+
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:20:30
+   |
+LL |     let _: usize = T::baz(_, _);
+   |                              ^
+   |
+   = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
+
 error: expected expression, found reserved identifier `_`
   --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:10:24
    |
@@ -11,28 +65,29 @@ LL |     let _: usize = foo(_, _);
    |                           ^ expected expression
 
 error: expected expression, found reserved identifier `_`
-  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:13:18
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:15:18
    |
 LL |     let _: S = S(_, _);
    |                  ^ expected expression
 
 error: expected expression, found reserved identifier `_`
-  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:13:21
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:15:21
    |
 LL |     let _: S = S(_, _);
    |                     ^ expected expression
 
 error: expected expression, found reserved identifier `_`
-  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:16:27
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:20:27
    |
 LL |     let _: usize = T::baz(_, _);
    |                           ^ expected expression
 
 error: expected expression, found reserved identifier `_`
-  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:16:30
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:20:30
    |
 LL |     let _: usize = T::baz(_, _);
    |                              ^ expected expression
 
-error: aborting due to 6 previous errors
+error: aborting due to 12 previous errors
 
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/suggestions/if-let-typo.rs
+++ b/src/test/ui/suggestions/if-let-typo.rs
@@ -2,7 +2,12 @@ fn main() {
     let foo = Some(0);
     let bar = None;
     if Some(x) = foo {} //~ ERROR cannot find value `x` in this scope
+    //~^ ERROR mismatched types
+    //~^^ ERROR destructuring assignments are unstable
     if Some(foo) = bar {} //~ ERROR mismatched types
+    //~^ ERROR destructuring assignments are unstable
     if 3 = foo {} //~ ERROR mismatched types
     if Some(3) = foo {} //~ ERROR mismatched types
+    //~^ ERROR destructuring assignments are unstable
+    //~^^ ERROR invalid left-hand side of assignment
 }

--- a/src/test/ui/suggestions/if-let-typo.stderr
+++ b/src/test/ui/suggestions/if-let-typo.stderr
@@ -9,23 +9,51 @@ help: you might have meant to use pattern matching
 LL |     if let Some(x) = foo {}
    |        ^^^
 
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/if-let-typo.rs:4:16
+   |
+LL |     if Some(x) = foo {}
+   |        ------- ^
+   |        |
+   |        cannot assign to this expression
+   |
+   = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
+
 error[E0308]: mismatched types
-  --> $DIR/if-let-typo.rs:5:8
+  --> $DIR/if-let-typo.rs:4:8
+   |
+LL |     if Some(x) = foo {}
+   |        ^^^^^^^^^^^^^ expected `bool`, found `()`
+
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/if-let-typo.rs:7:18
+   |
+LL |     if Some(foo) = bar {}
+   |        --------- ^
+   |        |
+   |        cannot assign to this expression
+   |
+   = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
+
+error[E0308]: mismatched types
+  --> $DIR/if-let-typo.rs:7:8
    |
 LL |     if Some(foo) = bar {}
    |        ^^^^^^^^^^^^^^^ expected `bool`, found `()`
-   |
-help: you might have meant to use pattern matching
-   |
-LL |     if let Some(foo) = bar {}
-   |        ^^^
-help: you might have meant to compare for equality
-   |
-LL |     if Some(foo) == bar {}
-   |                  ^^
 
 error[E0308]: mismatched types
-  --> $DIR/if-let-typo.rs:6:8
+  --> $DIR/if-let-typo.rs:9:12
+   |
+LL |     if 3 = foo {}
+   |            ^^^ expected integer, found enum `Option`
+   |
+   = note: expected type `{integer}`
+              found enum `Option<{integer}>`
+
+error[E0308]: mismatched types
+  --> $DIR/if-let-typo.rs:9:8
    |
 LL |     if 3 = foo {}
    |        ^^^^^^^ expected `bool`, found `()`
@@ -35,22 +63,32 @@ help: you might have meant to use pattern matching
 LL |     if let 3 = foo {}
    |        ^^^
 
+error[E0658]: destructuring assignments are unstable
+  --> $DIR/if-let-typo.rs:11:16
+   |
+LL |     if Some(3) = foo {}
+   |        ------- ^
+   |        |
+   |        cannot assign to this expression
+   |
+   = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
+   = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/if-let-typo.rs:11:16
+   |
+LL |     if Some(3) = foo {}
+   |             -  ^
+   |             |
+   |             cannot assign to this expression
+
 error[E0308]: mismatched types
-  --> $DIR/if-let-typo.rs:7:8
+  --> $DIR/if-let-typo.rs:11:8
    |
 LL |     if Some(3) = foo {}
    |        ^^^^^^^^^^^^^ expected `bool`, found `()`
-   |
-help: you might have meant to use pattern matching
-   |
-LL |     if let Some(3) = foo {}
-   |        ^^^
-help: you might have meant to compare for equality
-   |
-LL |     if Some(3) == foo {}
-   |                ^^
 
-error: aborting due to 4 previous errors
+error: aborting due to 10 previous errors
 
-Some errors have detailed explanations: E0308, E0425.
-For more information about an error, try `rustc --explain E0308`.
+Some errors have detailed explanations: E0070, E0308, E0425, E0658.
+For more information about an error, try `rustc --explain E0070`.

--- a/src/test/ui/suggestions/if-let-typo.stderr
+++ b/src/test/ui/suggestions/if-let-typo.stderr
@@ -44,15 +44,6 @@ LL |     if Some(foo) = bar {}
    |        ^^^^^^^^^^^^^^^ expected `bool`, found `()`
 
 error[E0308]: mismatched types
-  --> $DIR/if-let-typo.rs:9:12
-   |
-LL |     if 3 = foo {}
-   |            ^^^ expected integer, found enum `Option`
-   |
-   = note: expected type `{integer}`
-              found enum `Option<{integer}>`
-
-error[E0308]: mismatched types
   --> $DIR/if-let-typo.rs:9:8
    |
 LL |     if 3 = foo {}
@@ -64,7 +55,7 @@ LL |     if let 3 = foo {}
    |        ^^^
 
 error[E0658]: destructuring assignments are unstable
-  --> $DIR/if-let-typo.rs:11:16
+  --> $DIR/if-let-typo.rs:10:16
    |
 LL |     if Some(3) = foo {}
    |        ------- ^
@@ -75,7 +66,7 @@ LL |     if Some(3) = foo {}
    = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
 
 error[E0070]: invalid left-hand side of assignment
-  --> $DIR/if-let-typo.rs:11:16
+  --> $DIR/if-let-typo.rs:10:16
    |
 LL |     if Some(3) = foo {}
    |             -  ^
@@ -83,12 +74,12 @@ LL |     if Some(3) = foo {}
    |             cannot assign to this expression
 
 error[E0308]: mismatched types
-  --> $DIR/if-let-typo.rs:11:8
+  --> $DIR/if-let-typo.rs:10:8
    |
 LL |     if Some(3) = foo {}
    |        ^^^^^^^^^^^^^ expected `bool`, found `()`
 
-error: aborting due to 10 previous errors
+error: aborting due to 9 previous errors
 
 Some errors have detailed explanations: E0070, E0308, E0425, E0658.
 For more information about an error, try `rustc --explain E0070`.

--- a/src/tools/clippy/clippy_lints/src/utils/ast_utils.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/ast_utils.rs
@@ -107,6 +107,15 @@ pub fn eq_expr_opt(l: &Option<P<Expr>>, r: &Option<P<Expr>>) -> bool {
     both(l, r, |l, r| eq_expr(l, r))
 }
 
+pub fn eq_struct_rest(l: &StructRest, r: &StructRest) -> bool {
+    match (l, r) {
+        (StructRest::Base(lb), StructRest::Base(rb)) => eq_expr(lb, rb),
+        (StructRest::Rest(_), StructRest::Rest(_)) => true,
+        (StructRest::None, StructRest::None) => true,
+        _ => false,
+    }
+}
+
 pub fn eq_expr(l: &Expr, r: &Expr) -> bool {
     use ExprKind::*;
     if !over(&l.attrs, &r.attrs, |l, r| eq_attr(l, r)) {
@@ -150,7 +159,7 @@ pub fn eq_expr(l: &Expr, r: &Expr) -> bool {
         (Path(lq, lp), Path(rq, rp)) => both(lq, rq, |l, r| eq_qself(l, r)) && eq_path(lp, rp),
         (MacCall(l), MacCall(r)) => eq_mac_call(l, r),
         (Struct(lp, lfs, lb), Struct(rp, rfs, rb)) => {
-            eq_path(lp, rp) && eq_expr_opt(lb, rb) && unordered_over(lfs, rfs, |l, r| eq_field(l, r))
+            eq_path(lp, rp) && eq_struct_rest(lb, rb) && unordered_over(lfs, rfs, |l, r| eq_field(l, r))
         },
         _ => false,
     }

--- a/src/tools/clippy/clippy_lints/src/utils/sugg.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/sugg.rs
@@ -170,6 +170,7 @@ impl<'a> Sugg<'a> {
             | ast::ExprKind::MacCall(..)
             | ast::ExprKind::MethodCall(..)
             | ast::ExprKind::Paren(..)
+            | ast::ExprKind::Underscore
             | ast::ExprKind::Path(..)
             | ast::ExprKind::Repeat(..)
             | ast::ExprKind::Ret(..)


### PR DESCRIPTION
Implement destructuring assignment, as suggested in https://github.com/rust-lang/rfcs/issues/372. The accompanying RFC is https://github.com/rust-lang/rfcs/pull/2909.

**Note**: This PR has been split up into #78748, #78836, #79016, which have been merged.

Quick summary: This allows destructuring the LHS of an assignment if it's a (possibly nested) tuple, tuple struct, or slice.
It is implemented via a desugaring (AST -> HIR lowering) as follows:
```rust
(a,b) = (1,2)
```
... becomes ...
```rust
{
  let (lhs0,lhs1) = (1,2);
  a = lhs0;
  b = lhs1;
}
```

Parser changes:
* In order to support `_` in the LHS, it allows parsing `_` as an expression (a change to the parser). It is still disallowed in all other places.
* Struct expressions are not required to have a base expression, i.e. `Struct { a: 1, .. }` becomes legal (in order to act like a struct pattern).

Tracking issue: #71126.