### PR TITLE
[format_args!] Warn on whitespace before the `}` in a format specifier

### DIFF
--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -319,7 +319,7 @@ impl<'a> Parser<'a> {
                 Some(pos)
             } else {
                 let pos = self.to_span_index(pos);
-                let description = format!("expected `'}}'`, found `{:?}`", maybe);
+                let description = format!("expected `}}`, found `{:?}`", maybe);
                 let label = "expected `}`".to_owned();
                 let note =
                     Some("if you intended to print `{`, you can escape it using `{{`".to_owned());

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -321,12 +321,11 @@ impl<'a> Parser<'a> {
                 let pos = self.to_span_index(pos);
                 let description = format!("expected `'}}'`, found `{:?}`", maybe);
                 let label = "expected `}`".to_owned();
-                let note = Some(
-                        "if you intended to print `{`, you can escape it using `{{`".to_owned(),
-                );
-                let secondary_label =
-                    self.last_opening_brace
-                        .map(|sp| ("because of this opening brace".to_owned(), sp));
+                let note =
+                    Some("if you intended to print `{`, you can escape it using `{{`".to_owned());
+                let secondary_label = self
+                    .last_opening_brace
+                    .map(|sp| ("because of this opening brace".to_owned(), sp));
                 self.errors.push(ParseError {
                     description,
                     note,

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -357,17 +357,6 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Consumes all whitespace characters until the first non-whitespace character
-    fn ws(&mut self) {
-        while let Some(&(_, c)) = self.cur.peek() {
-            if c.is_whitespace() {
-                self.cur.next();
-            } else {
-                break;
-            }
-        }
-    }
-
     /// Parses all of a string which is to be considered a "raw literal" in a
     /// format string. This is everything outside of the braces.
     fn string(&mut self, start: usize) -> &'a str {

--- a/src/test/ui/issues/issue-51848.stderr
+++ b/src/test/ui/issues/issue-51848.stderr
@@ -1,8 +1,8 @@
-error: invalid format string: expected `'}'` but string was terminated
+error: invalid format string: expected `}` but string was terminated
   --> $DIR/issue-51848.rs:6:20
    |
 LL |         println!("{");
-   |                   -^ expected `'}'` in format string
+   |                   -^ expected `}` in format string
    |                   |
    |                   because of this opening brace
 ...


### PR DESCRIPTION
Fixes #71088.