### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -971,7 +971,7 @@ impl<T> Vec<T> {
         }
 
         let len = self.len();
-        if !(index < len) {
+        if index >= len {
             assert_failed(index, len);
         }
         unsafe {
@@ -1010,7 +1010,7 @@ impl<T> Vec<T> {
         }
 
         let len = self.len();
-        if !(index <= len) {
+        if index > len {
             assert_failed(index, len);
         }
 
@@ -1058,7 +1058,7 @@ impl<T> Vec<T> {
         }
 
         let len = self.len();
-        if !(index < len) {
+        if index >= len {
             assert_failed(index, len);
         }
         unsafe {
@@ -1331,10 +1331,10 @@ impl<T> Vec<T> {
             panic!("end drain index (is {}) should be <= len (is {})", end, len);
         }
 
-        if !(start <= end) {
+        if start > end {
             start_assert_failed(start, end);
         }
-        if !(end <= len) {
+        if end > len {
             end_assert_failed(end, len);
         }
 
@@ -1432,7 +1432,7 @@ impl<T> Vec<T> {
             panic!("`at` split index (is {}) should be <= len (is {})", at, len);
         }
 
-        if !(at <= self.len()) {
+        if at > self.len() {
             assert_failed(at, self.len());
         }
 

--- a/src/librustc_builtin_macros/deriving/debug.rs
+++ b/src/librustc_builtin_macros/deriving/debug.rs
@@ -63,7 +63,7 @@ fn show_substructure(cx: &mut ExtCtxt<'_>, span: Span, substr: &Substructure<'_>
     let span = cx.with_def_site_ctxt(span);
     let name = cx.expr_lit(span, ast::LitKind::Str(ident.name, ast::StrStyle::Cooked));
     let builder = cx.ident_of("debug_trait_builder", span);
-    let builder_expr = cx.expr_ident(span, builder.clone());
+    let builder_expr = cx.expr_ident(span, builder);
 
     let fmt = substr.nonself_args[0].clone();
 

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -2005,7 +2005,7 @@ fn emit_to_destination(
     let _buffer_lock = lock::acquire_global_lock("rustc_errors");
     for (pos, line) in rendered_buffer.iter().enumerate() {
         for part in line {
-            dst.apply_style(lvl.clone(), part.style)?;
+            dst.apply_style(*lvl, part.style)?;
             write!(dst, "{}", part.text)?;
             dst.reset()?;
         }

--- a/src/librustc_infer/infer/error_reporting/mod.rs
+++ b/src/librustc_infer/infer/error_reporting/mod.rs
@@ -871,7 +871,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 return Some(());
             }
             if let &ty::Adt(def, _) = &ta.kind {
-                let path_ = self.tcx.def_path_str(def.did.clone());
+                let path_ = self.tcx.def_path_str(def.did);
                 if path_ == other_path {
                     self.highlight_outer(&mut t1_out, &mut t2_out, path, sub, i, &other_ty);
                     return Some(());
@@ -1091,8 +1091,8 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let sub_no_defaults_1 = self.strip_generic_default_params(def1.did, sub1);
                 let sub_no_defaults_2 = self.strip_generic_default_params(def2.did, sub2);
                 let mut values = (DiagnosticStyledString::new(), DiagnosticStyledString::new());
-                let path1 = self.tcx.def_path_str(def1.did.clone());
-                let path2 = self.tcx.def_path_str(def2.did.clone());
+                let path1 = self.tcx.def_path_str(def1.did);
+                let path2 = self.tcx.def_path_str(def2.did);
                 if def1.did == def2.did {
                     // Easy case. Replace same types with `_` to shorten the output and highlight
                     // the differing ones.

--- a/src/librustc_infer/infer/outlives/obligations.rs
+++ b/src/librustc_infer/infer/outlives/obligations.rs
@@ -452,7 +452,7 @@ where
         // even though a satisfactory solution exists.
         let generic = GenericKind::Projection(projection_ty);
         let verify_bound = self.verify_bound.generic_bound(generic);
-        self.delegate.push_verify(origin, generic.clone(), region, verify_bound);
+        self.delegate.push_verify(origin, generic, region, verify_bound);
     }
 }
 

--- a/src/librustc_infer/infer/outlives/verify.rs
+++ b/src/librustc_infer/infer/outlives/verify.rs
@@ -297,7 +297,6 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
         self.collect_outlives_from_predicate_list(
             move |ty| ty == identity_proj,
             traits::elaborate_predicates(tcx, trait_predicates)
-                .into_iter()
                 .map(|o| o.predicate)
                 .collect::<Vec<_>>(),
         )

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -1056,7 +1056,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                                  place: {:?}",
                                 place_span.0
                             );
-                            this.reservation_error_reported.insert(place_span.0.clone());
+                            this.reservation_error_reported.insert(place_span.0);
                         }
                         Activation(_, activating) => {
                             debug!(

--- a/src/librustc_mir/borrow_check/region_infer/mod.rs
+++ b/src/librustc_mir/borrow_check/region_infer/mod.rs
@@ -495,7 +495,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         // to store those. Otherwise, we'll pass in `None` to the
         // functions below, which will trigger them to report errors
         // eagerly.
-        let mut outlives_requirements = infcx.tcx.is_closure(mir_def_id).then(|| vec![]);
+        let mut outlives_requirements = infcx.tcx.is_closure(mir_def_id).then(Vec::new);
 
         self.check_type_tests(infcx, body, outlives_requirements.as_mut(), &mut errors_buffer);
 

--- a/src/librustc_mir/dataflow/move_paths/builder.rs
+++ b/src/librustc_mir/dataflow/move_paths/builder.rs
@@ -286,7 +286,7 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
                     // Box starts out uninitialized - need to create a separate
                     // move-path for the interior so it will be separate from
                     // the exterior.
-                    self.create_move_path(self.builder.tcx.mk_place_deref(place.clone()));
+                    self.create_move_path(self.builder.tcx.mk_place_deref(*place));
                     self.gather_init(place.as_ref(), InitKind::Shallow);
                 } else {
                     self.gather_init(place.as_ref(), InitKind::Deep);
@@ -458,9 +458,8 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
             for offset in from..to {
                 let elem =
                     ProjectionElem::ConstantIndex { offset, min_length: len, from_end: false };
-                let path = self.add_move_path(base_path, &elem, |tcx| {
-                    tcx.mk_place_elem(base_place.clone(), elem)
-                });
+                let path =
+                    self.add_move_path(base_path, &elem, |tcx| tcx.mk_place_elem(base_place, elem));
                 self.record_move(place, path);
             }
         } else {

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -549,7 +549,7 @@ where
                 let n = base.len(self)?;
                 if n < u64::from(min_length) {
                     // This can only be reached in ConstProp and non-rustc-MIR.
-                    throw_ub!(BoundsCheckFailed { len: min_length.into(), index: n.into() });
+                    throw_ub!(BoundsCheckFailed { len: min_length.into(), index: n });
                 }
 
                 let index = if from_end {

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -335,7 +335,7 @@ fn collect_items_rec<'tcx>(
     recursion_depths: &mut DefIdMap<usize>,
     inlining_map: MTRef<'_, MTLock<InliningMap<'tcx>>>,
 ) {
-    if !visited.lock_mut().insert(starting_point.clone()) {
+    if !visited.lock_mut().insert(starting_point) {
         // We've been here already, no need to search again.
         return;
     }

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -538,7 +538,7 @@ impl CloneShimBuilder<'tcx> {
         // BB #2
         // `dest[i] = Clone::clone(src[beg])`;
         // Goto #3 if ok, #5 if unwinding happens.
-        let dest_field = self.tcx.mk_place_index(dest.clone(), beg);
+        let dest_field = self.tcx.mk_place_index(dest, beg);
         let src_field = self.tcx.mk_place_index(src, beg);
         self.make_clone_call(dest_field, src_field, ty, BasicBlock::new(3), BasicBlock::new(5));
 
@@ -620,9 +620,9 @@ impl CloneShimBuilder<'tcx> {
         let mut previous_field = None;
         for (i, ity) in tys.enumerate() {
             let field = Field::new(i);
-            let src_field = self.tcx.mk_place_field(src.clone(), field, ity);
+            let src_field = self.tcx.mk_place_field(src, field, ity);
 
-            let dest_field = self.tcx.mk_place_field(dest.clone(), field, ity);
+            let dest_field = self.tcx.mk_place_field(dest, field, ity);
 
             // #(2i + 1) is the cleanup block for the previous clone operation
             let cleanup_block = self.block_index_offset(1);
@@ -633,7 +633,7 @@ impl CloneShimBuilder<'tcx> {
             // BB #(2i)
             // `dest.i = Clone::clone(&src.i);`
             // Goto #(2i + 2) if ok, #(2i + 1) if unwinding happens.
-            self.make_clone_call(dest_field.clone(), src_field, ity, next_block, cleanup_block);
+            self.make_clone_call(dest_field, src_field, ity, next_block, cleanup_block);
 
             // BB #(2i + 1) (cleanup)
             if let Some((previous_field, previous_cleanup)) = previous_field.take() {

--- a/src/librustc_mir/transform/check_consts/ops.rs
+++ b/src/librustc_mir/transform/check_consts/ops.rs
@@ -90,16 +90,6 @@ impl NonConstOp for FnCallNonConst {
     }
 }
 
-/// A function call where the callee is not a function definition or function pointer, e.g. a
-/// closure.
-///
-/// This can be subdivided in the future to produce a better error message.
-#[derive(Debug)]
-pub struct FnCallOther;
-impl NonConstOp for FnCallOther {
-    const IS_SUPPORTED_IN_MIRI: bool = false;
-}
-
 /// A call to a `#[unstable]` const fn or `#[rustc_const_unstable]` function.
 ///
 /// Contains the name of the feature that would allow the use of this function.

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -511,7 +511,7 @@ impl Visitor<'tcx> for Validator<'_, 'mir, 'tcx> {
                         return;
                     }
                     _ => {
-                        span_bug!(terminator.source_info.span, "invalid callee of type {:?}", fn_ty,)
+                        span_bug!(terminator.source_info.span, "invalid callee of type {:?}", fn_ty)
                     }
                 };
 

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -495,11 +495,11 @@ impl Visitor<'tcx> for Validator<'_, 'mir, 'tcx> {
         }
     }
 
-    fn visit_terminator_kind(&mut self, kind: &TerminatorKind<'tcx>, location: Location) {
-        trace!("visit_terminator_kind: kind={:?} location={:?}", kind, location);
-        self.super_terminator_kind(kind, location);
+    fn visit_terminator(&mut self, terminator: &Terminator<'tcx>, location: Location) {
+        trace!("visit_terminator: terminator={:?} location={:?}", terminator, location);
+        self.super_terminator(terminator, location);
 
-        match kind {
+        match &terminator.kind {
             TerminatorKind::Call { func, .. } => {
                 let fn_ty = func.ty(*self.body, self.tcx);
 
@@ -511,8 +511,7 @@ impl Visitor<'tcx> for Validator<'_, 'mir, 'tcx> {
                         return;
                     }
                     _ => {
-                        self.check_op(ops::FnCallOther);
-                        return;
+                        span_bug!(terminator.source_info.span, "invalid callee of type {:?}", fn_ty,)
                     }
                 };
 

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -578,11 +578,6 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
             return None;
         }
 
-        // FIXME we need to revisit this for #67176
-        if rvalue.needs_subst() {
-            return None;
-        }
-
         // Perform any special handling for specific Rvalue types.
         // Generally, checks here fall into one of two categories:
         //   1. Additional checking to provide useful lints to the user
@@ -621,6 +616,11 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
             }
 
             _ => {}
+        }
+
+        // FIXME we need to revisit this for #67176
+        if rvalue.needs_subst() {
+            return None;
         }
 
         self.use_ecx(|this| {

--- a/src/librustc_mir/transform/inline.rs
+++ b/src/librustc_mir/transform/inline.rs
@@ -582,7 +582,7 @@ impl Inliner<'tcx> {
             let tuple_tmp_args = tuple_tys.iter().enumerate().map(|(i, ty)| {
                 // This is e.g., `tuple_tmp.0` in our example above.
                 let tuple_field =
-                    Operand::Move(tcx.mk_place_field(tuple.clone(), Field::new(i), ty.expect_ty()));
+                    Operand::Move(tcx.mk_place_field(tuple, Field::new(i), ty.expect_ty()));
 
                 // Spill to a local to make e.g., `tmp0`.
                 self.create_temp_if_necessary(tuple_field, callsite, caller_body)

--- a/src/librustc_mir/util/aggregate.rs
+++ b/src/librustc_mir/util/aggregate.rs
@@ -56,7 +56,7 @@ pub fn expand_aggregate<'tcx>(
                 let offset = i as u32;
                 assert_eq!(offset as usize, i);
                 tcx.mk_place_elem(
-                    lhs.clone(),
+                    lhs,
                     ProjectionElem::ConstantIndex {
                         offset,
                         // FIXME(eddyb) `min_length` doesn't appear to be used.
@@ -66,7 +66,7 @@ pub fn expand_aggregate<'tcx>(
                 )
             } else {
                 let field = Field::new(active_field_index.unwrap_or(i));
-                tcx.mk_place_field(lhs.clone(), field, ty)
+                tcx.mk_place_field(lhs, field, ty)
             };
             Statement { source_info, kind: StatementKind::Assign(box (lhs_field, Rvalue::Use(op))) }
         })

--- a/src/librustc_mir_build/build/block.rs
+++ b/src/librustc_mir_build/build/block.rs
@@ -2,8 +2,8 @@ use crate::build::matches::ArmHasGuard;
 use crate::build::ForGuard::OutsideGuard;
 use crate::build::{BlockAnd, BlockAndExtension, BlockFrame, Builder};
 use crate::hair::*;
-use rustc_middle::mir::*;
 use rustc_hir as hir;
+use rustc_middle::mir::*;
 use rustc_span::Span;
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {
@@ -29,7 +29,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     // This is a `break`-able block
                     let exit_block = this.cfg.start_new_block();
                     let block_exit =
-                        this.in_breakable_scope(None, exit_block, destination.clone(), |this| {
+                        this.in_breakable_scope(None, exit_block, destination, |this| {
                             this.ast_block_stmts(destination, block, span, stmts, expr, safety_mode)
                         });
                     this.cfg.goto(unpack!(block_exit), source_info, exit_block);

--- a/src/librustc_mir_build/build/matches/mod.rs
+++ b/src/librustc_mir_build/build/matches/mod.rs
@@ -1903,9 +1903,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 self.schedule_drop_for_binding(binding.var_id, binding.span, OutsideGuard);
             }
             let rvalue = match binding.binding_mode {
-                BindingMode::ByValue => {
-                    Rvalue::Use(self.consume_by_copy_or_move(binding.source.clone()))
-                }
+                BindingMode::ByValue => Rvalue::Use(self.consume_by_copy_or_move(binding.source)),
                 BindingMode::ByRef(borrow_kind) => {
                     Rvalue::Ref(re_erased, borrow_kind, binding.source)
                 }

--- a/src/librustc_mir_build/build/matches/util.rs
+++ b/src/librustc_mir_build/build/matches/util.rs
@@ -15,11 +15,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         subpatterns
             .iter()
             .map(|fieldpat| {
-                let place = self.hir.tcx().mk_place_field(
-                    place.clone(),
-                    fieldpat.field,
-                    fieldpat.pattern.ty,
-                );
+                let place =
+                    self.hir.tcx().mk_place_field(place, fieldpat.field, fieldpat.pattern.ty);
                 MatchPair::new(place, &fieldpat.pattern)
             })
             .collect()
@@ -44,14 +41,14 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         match_pairs.extend(prefix.iter().enumerate().map(|(idx, subpattern)| {
             let elem =
                 ProjectionElem::ConstantIndex { offset: idx as u32, min_length, from_end: false };
-            let place = tcx.mk_place_elem(place.clone(), elem);
+            let place = tcx.mk_place_elem(*place, elem);
             MatchPair::new(place, subpattern)
         }));
 
         if let Some(subslice_pat) = opt_slice {
             let suffix_len = suffix.len() as u32;
             let subslice = tcx.mk_place_elem(
-                place.clone(),
+                *place,
                 ProjectionElem::Subslice {
                     from: prefix.len() as u32,
                     to: if exact_size { min_length - suffix_len } else { suffix_len },
@@ -68,7 +65,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 min_length,
                 from_end: !exact_size,
             };
-            let place = tcx.mk_place_elem(place.clone(), elem);
+            let place = tcx.mk_place_elem(*place, elem);
             MatchPair::new(place, subpattern)
         }));
     }

--- a/src/librustc_passes/stability.rs
+++ b/src/librustc_passes/stability.rs
@@ -610,7 +610,7 @@ pub fn check_unused_or_stable_features(tcx: TyCtxt<'_>) {
             // Warn if the user enables a lib feature multiple times.
             duplicate_feature_err(tcx.sess, *span, *feature);
         }
-        remaining_lib_features.insert(feature, span.clone());
+        remaining_lib_features.insert(feature, *span);
     }
     // `stdbuild` has special handling for `libc`, so we need to
     // recognise the feature when building std.

--- a/src/librustc_query_system/dep_graph/query.rs
+++ b/src/librustc_query_system/dep_graph/query.rs
@@ -15,7 +15,7 @@ impl<K: DepKind> DepGraphQuery<K> {
         let mut graph = Graph::with_capacity(nodes.len(), edges.len());
         let mut indices = FxHashMap::default();
         for node in nodes {
-            indices.insert(node.clone(), graph.add_node(node.clone()));
+            indices.insert(*node, graph.add_node(*node));
         }
 
         for &(ref source, ref target) in edges {

--- a/src/librustc_resolve/late/lifetimes.rs
+++ b/src/librustc_resolve/late/lifetimes.rs
@@ -643,13 +643,13 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
                                 if param_name.name == kw::UnderscoreLifetime {
                                     // Pick the elided lifetime "definition" if one exists
                                     // and use it to make an elision scope.
-                                    self.lifetime_uses.insert(def_id.clone(), LifetimeUseSet::Many);
+                                    self.lifetime_uses.insert(def_id, LifetimeUseSet::Many);
                                     elision = Some(reg);
                                 } else {
                                     lifetimes.insert(name, reg);
                                 }
                             } else {
-                                self.lifetime_uses.insert(def_id.clone(), LifetimeUseSet::Many);
+                                self.lifetime_uses.insert(def_id, LifetimeUseSet::Many);
                                 lifetimes.insert(name, reg);
                             }
                         }

--- a/src/librustc_trait_selection/traits/error_reporting/mod.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/mod.rs
@@ -1388,7 +1388,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
                     (self.tcx.sess.source_map().span_to_snippet(span), &obligation.cause.code)
                 {
                     let generics = self.tcx.generics_of(*def_id);
-                    if generics.params.iter().filter(|p| p.name.as_str() != "Self").next().is_some()
+                    if generics.params.iter().any(|p| p.name.as_str() != "Self")
                         && !snippet.ends_with('>')
                     {
                         // FIXME: To avoid spurious suggestions in functions where type arguments
@@ -1817,7 +1817,7 @@ pub fn suggest_constraining_type_param(
         // Account for `fn foo<T>(t: T) where T: Foo,` so we don't suggest two trailing commas.
         let mut trailing_comma = false;
         if let Ok(snippet) = tcx.sess.source_map().span_to_snippet(where_clause_span) {
-            trailing_comma = snippet.ends_with(",");
+            trailing_comma = snippet.ends_with(',');
         }
         let where_clause_span = if trailing_comma {
             let hi = where_clause_span.hi();

--- a/src/librustc_trait_selection/traits/error_reporting/mod.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/mod.rs
@@ -126,7 +126,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 .borrow_mut()
                 .entry(span)
                 .or_default()
-                .push(error.obligation.predicate.clone());
+                .push(error.obligation.predicate);
         }
 
         // We do this in 2 passes because we want to display errors in order, though

--- a/src/librustc_trait_selection/traits/error_reporting/mod.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/mod.rs
@@ -321,7 +321,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             err.span_suggestion_verbose(
                                 span.shrink_to_lo(),
                                 "consider converting the `Option<T>` into a `Result<T, _>` using `Option::ok_or` or `Option::ok_or_else`",
-                                ".ok_or_else(|_| /* error value */)".to_string(),
+                                ".ok_or_else(|| /* error value */)".to_string(),
                                 Applicability::HasPlaceholders,
                             );
                         } else if is_try && is_from && should_convert_result_to_option {
@@ -329,7 +329,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                                 span.shrink_to_lo(),
                                 "consider converting the `Result<T, _>` into an `Option<T>` using `Result::ok`",
                                 ".ok()".to_string(),
-                                Applicability::HasPlaceholders,
+                                Applicability::MachineApplicable,
                             );
                         }
 

--- a/src/librustc_trait_selection/traits/fulfill.rs
+++ b/src/librustc_trait_selection/traits/fulfill.rs
@@ -314,7 +314,7 @@ impl<'a, 'b, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'tcx> {
 
         match obligation.predicate {
             ty::Predicate::Trait(ref data, _) => {
-                let trait_obligation = obligation.with(data.clone());
+                let trait_obligation = obligation.with(*data);
 
                 if data.is_global() {
                     // no type variables present, can use evaluation for better caching.
@@ -420,7 +420,7 @@ impl<'a, 'b, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'tcx> {
             }
 
             ty::Predicate::Projection(ref data) => {
-                let project_obligation = obligation.with(data.clone());
+                let project_obligation = obligation.with(*data);
                 match project::poly_project_and_unify_type(self.selcx, &project_obligation) {
                     Ok(None) => {
                         let tcx = self.selcx.tcx();

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -373,7 +373,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                 );
             };
 
-            self.tables.user_provided_types_mut().insert(hir_id, c_ty.clone());
+            self.tables.user_provided_types_mut().insert(hir_id, *c_ty);
 
             if let ty::UserType::TypeOf(_, user_substs) = c_ty.value {
                 if self.rustc_dump_user_substs {
@@ -411,7 +411,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                 );
             };
 
-            self.tables.user_provided_sigs.insert(def_id, c_sig.clone());
+            self.tables.user_provided_sigs.insert(def_id, *c_sig);
         }
     }
 
@@ -562,7 +562,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
         for (&local_id, fn_sig) in fcx_tables.liberated_fn_sigs().iter() {
             let hir_id = hir::HirId { owner: common_hir_owner, local_id };
             let fn_sig = self.resolve(fn_sig, &hir_id);
-            self.tables.liberated_fn_sigs_mut().insert(hir_id, fn_sig.clone());
+            self.tables.liberated_fn_sigs_mut().insert(hir_id, fn_sig);
         }
     }
 

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -509,7 +509,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                         continue;
                     }
 
-                    let mut for_generics = self.extract_for_generics(tcx, orig_p.clone());
+                    let mut for_generics = self.extract_for_generics(tcx, orig_p);
 
                     assert!(bounds.len() == 1);
                     let mut b = bounds.pop().expect("bounds were empty");

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -47,7 +47,7 @@ pub fn try_inline(
     }
     let mut ret = Vec::new();
 
-    let attrs_clone = attrs.clone();
+    let attrs_clone = attrs;
 
     let inner = match res {
         Res::Def(DefKind::Trait, did) => {
@@ -292,7 +292,7 @@ pub fn build_impls(cx: &DocContext<'_>, did: DefId, attrs: Option<Attrs<'_>>) ->
     let mut impls = Vec::new();
 
     for &did in tcx.inherent_impls(did).iter() {
-        build_impl(cx, did, attrs.clone(), &mut impls);
+        build_impl(cx, did, attrs, &mut impls);
     }
 
     impls

--- a/src/librustdoc/docfs.rs
+++ b/src/librustdoc/docfs.rs
@@ -16,12 +16,12 @@ use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::Arc;
 
 macro_rules! try_err {
-    ($e:expr, $file:expr) => {{
+    ($e:expr, $file:expr) => {
         match $e {
             Ok(e) => e,
             Err(e) => return Err(E::new(e, $file)),
         }
-    }};
+    };
 }
 
 pub trait PathError {

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -683,7 +683,7 @@ impl Tester for Collector {
         let name = self.generate_name(line, &filename);
         let cratename = self.cratename.to_string();
         let opts = self.opts.clone();
-        let edition = config.edition.unwrap_or(self.options.edition.clone());
+        let edition = config.edition.unwrap_or(self.options.edition);
         let options = self.options.clone();
         let runtool = self.options.runtool.clone();
         let runtool_args = self.options.runtool_args.clone();

--- a/src/test/ui/asm/issue-54067.rs
+++ b/src/test/ui/asm/issue-54067.rs
@@ -1,0 +1,12 @@
+// check-pass
+// ignore-emscripten no llvm_asm! support
+
+#![feature(llvm_asm)]
+
+pub fn boot(addr: Option<u32>) {
+    unsafe {
+        llvm_asm!("mov sp, $0"::"r" (addr));
+    }
+}
+
+fn main() {}

--- a/src/test/ui/async-await/issues/auxiliary/issue_67893.rs
+++ b/src/test/ui/async-await/issues/auxiliary/issue_67893.rs
@@ -1,0 +1,10 @@
+// edition:2018
+
+use std::sync::{Arc, Mutex};
+
+pub async fn f(_: ()) {}
+
+pub async fn run() {
+    let x: Arc<Mutex<()>> = unimplemented!();
+    f(*x.lock().unwrap()).await;
+}

--- a/src/test/ui/async-await/issues/issue-67893.rs
+++ b/src/test/ui/async-await/issues/issue-67893.rs
@@ -1,0 +1,11 @@
+// aux-build: issue_67893.rs
+// edition:2018
+
+extern crate issue_67893;
+
+fn g(_: impl Send) {}
+
+fn main() {
+    g(issue_67893::run())
+    //~^ ERROR: `std::sync::MutexGuard<'_, ()>` cannot be sent between threads safely
+}

--- a/src/test/ui/async-await/issues/issue-67893.stderr
+++ b/src/test/ui/async-await/issues/issue-67893.stderr
@@ -1,0 +1,24 @@
+error[E0277]: `std::sync::MutexGuard<'_, ()>` cannot be sent between threads safely
+  --> $DIR/issue-67893.rs:9:5
+   |
+LL | fn g(_: impl Send) {}
+   |              ---- required by this bound in `g`
+...
+LL |     g(issue_67893::run())
+   |     ^ `std::sync::MutexGuard<'_, ()>` cannot be sent between threads safely
+   | 
+  ::: $DIR/auxiliary/issue_67893.rs:7:20
+   |
+LL | pub async fn run() {
+   |                    - within this `impl std::future::Future`
+   |
+   = help: within `impl std::future::Future`, the trait `std::marker::Send` is not implemented for `std::sync::MutexGuard<'_, ()>`
+   = note: required because it appears within the type `for<'r, 's, 't0, 't1, 't2, 't3> {std::future::ResumeTy, std::sync::Arc<std::sync::Mutex<()>>, &'r std::sync::Mutex<()>, std::result::Result<std::sync::MutexGuard<'s, ()>, std::sync::PoisonError<std::sync::MutexGuard<'t0, ()>>>, &'t1 std::sync::MutexGuard<'t2, ()>, std::sync::MutexGuard<'t3, ()>, (), impl std::future::Future}`
+   = note: required because it appears within the type `[static generator@DefId(15:11 ~ issue_67893[8787]::run[0]::{{closure}}[0]) for<'r, 's, 't0, 't1, 't2, 't3> {std::future::ResumeTy, std::sync::Arc<std::sync::Mutex<()>>, &'r std::sync::Mutex<()>, std::result::Result<std::sync::MutexGuard<'s, ()>, std::sync::PoisonError<std::sync::MutexGuard<'t0, ()>>>, &'t1 std::sync::MutexGuard<'t2, ()>, std::sync::MutexGuard<'t3, ()>, (), impl std::future::Future}]`
+   = note: required because it appears within the type `std::future::from_generator::GenFuture<[static generator@DefId(15:11 ~ issue_67893[8787]::run[0]::{{closure}}[0]) for<'r, 's, 't0, 't1, 't2, 't3> {std::future::ResumeTy, std::sync::Arc<std::sync::Mutex<()>>, &'r std::sync::Mutex<()>, std::result::Result<std::sync::MutexGuard<'s, ()>, std::sync::PoisonError<std::sync::MutexGuard<'t0, ()>>>, &'t1 std::sync::MutexGuard<'t2, ()>, std::sync::MutexGuard<'t3, ()>, (), impl std::future::Future}]>`
+   = note: required because it appears within the type `impl std::future::Future`
+   = note: required because it appears within the type `impl std::future::Future`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/intrinsics/issue-28575.rs
+++ b/src/test/ui/intrinsics/issue-28575.rs
@@ -1,0 +1,9 @@
+#![feature(intrinsics)]
+
+extern "C" {
+    pub static FOO: extern "rust-intrinsic" fn();
+}
+
+fn main() {
+    FOO() //~ ERROR: use of extern static is unsafe
+}

--- a/src/test/ui/intrinsics/issue-28575.stderr
+++ b/src/test/ui/intrinsics/issue-28575.stderr
@@ -1,0 +1,11 @@
+error[E0133]: use of extern static is unsafe and requires unsafe function or block
+  --> $DIR/issue-28575.rs:8:5
+   |
+LL |     FOO()
+   |     ^^^ use of extern static
+   |
+   = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/lint/lint-exceeding-bitshifts.noopt.stderr
+++ b/src/test/ui/lint/lint-exceeding-bitshifts.noopt.stderr
@@ -1,146 +1,150 @@
-error: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:22:13
+warning: this arithmetic operation will overflow
+  --> $DIR/lint-exceeding-bitshifts.rs:18:20
    |
-LL |     let _ = x << 42;
-   |             ^^^^^^^ attempt to shift left with overflow
+LL |     const N: i32 = T::N << 42;
+   |                    ^^^^^^^^^^ attempt to shift left with overflow
    |
 note: the lint level is defined here
   --> $DIR/lint-exceeding-bitshifts.rs:9:9
    |
-LL | #![deny(arithmetic_overflow, const_err)]
+LL | #![warn(arithmetic_overflow, const_err)]
    |         ^^^^^^^^^^^^^^^^^^^
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
+  --> $DIR/lint-exceeding-bitshifts.rs:22:13
+   |
+LL |     let _ = x << 42;
+   |             ^^^^^^^ attempt to shift left with overflow
+
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:27:15
    |
 LL |       let n = 1u8 << 8;
    |               ^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:29:15
    |
 LL |       let n = 1u16 << 16;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:31:15
    |
 LL |       let n = 1u32 << 32;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:33:15
    |
 LL |       let n = 1u64 << 64;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:35:15
    |
 LL |       let n = 1i8 << 8;
    |               ^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:37:15
    |
 LL |       let n = 1i16 << 16;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:39:15
    |
 LL |       let n = 1i32 << 32;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:41:15
    |
 LL |       let n = 1i64 << 64;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:44:15
    |
 LL |       let n = 1u8 >> 8;
    |               ^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:46:15
    |
 LL |       let n = 1u16 >> 16;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:48:15
    |
 LL |       let n = 1u32 >> 32;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:50:15
    |
 LL |       let n = 1u64 >> 64;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:52:15
    |
 LL |       let n = 1i8 >> 8;
    |               ^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:54:15
    |
 LL |       let n = 1i16 >> 16;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:56:15
    |
 LL |       let n = 1i32 >> 32;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:58:15
    |
 LL |       let n = 1i64 >> 64;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:62:15
    |
 LL |       let n = n << 8;
    |               ^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:64:15
    |
 LL |       let n = 1u8 << -8;
    |               ^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:69:15
    |
 LL |       let n = 1u8 << (4+4);
    |               ^^^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:71:15
    |
 LL |       let n = 1i64 >> [64][0];
    |               ^^^^^^^^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:77:15
    |
 LL |       let n = 1_isize << BITS;
    |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:78:15
    |
 LL |       let n = 1_usize << BITS;
    |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
-
-error: aborting due to 23 previous errors
 

--- a/src/test/ui/lint/lint-exceeding-bitshifts.noopt.stderr
+++ b/src/test/ui/lint/lint-exceeding-bitshifts.noopt.stderr
@@ -148,3 +148,5 @@ warning: this arithmetic operation will overflow
 LL |       let n = 1_usize << BITS;
    |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
 
+warning: 24 warnings emitted
+

--- a/src/test/ui/lint/lint-exceeding-bitshifts.opt.stderr
+++ b/src/test/ui/lint/lint-exceeding-bitshifts.opt.stderr
@@ -1,146 +1,150 @@
-error: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:22:13
+warning: this arithmetic operation will overflow
+  --> $DIR/lint-exceeding-bitshifts.rs:18:20
    |
-LL |     let _ = x << 42;
-   |             ^^^^^^^ attempt to shift left with overflow
+LL |     const N: i32 = T::N << 42;
+   |                    ^^^^^^^^^^ attempt to shift left with overflow
    |
 note: the lint level is defined here
   --> $DIR/lint-exceeding-bitshifts.rs:9:9
    |
-LL | #![deny(arithmetic_overflow, const_err)]
+LL | #![warn(arithmetic_overflow, const_err)]
    |         ^^^^^^^^^^^^^^^^^^^
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
+  --> $DIR/lint-exceeding-bitshifts.rs:22:13
+   |
+LL |     let _ = x << 42;
+   |             ^^^^^^^ attempt to shift left with overflow
+
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:27:15
    |
 LL |       let n = 1u8 << 8;
    |               ^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:29:15
    |
 LL |       let n = 1u16 << 16;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:31:15
    |
 LL |       let n = 1u32 << 32;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:33:15
    |
 LL |       let n = 1u64 << 64;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:35:15
    |
 LL |       let n = 1i8 << 8;
    |               ^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:37:15
    |
 LL |       let n = 1i16 << 16;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:39:15
    |
 LL |       let n = 1i32 << 32;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:41:15
    |
 LL |       let n = 1i64 << 64;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:44:15
    |
 LL |       let n = 1u8 >> 8;
    |               ^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:46:15
    |
 LL |       let n = 1u16 >> 16;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:48:15
    |
 LL |       let n = 1u32 >> 32;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:50:15
    |
 LL |       let n = 1u64 >> 64;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:52:15
    |
 LL |       let n = 1i8 >> 8;
    |               ^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:54:15
    |
 LL |       let n = 1i16 >> 16;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:56:15
    |
 LL |       let n = 1i32 >> 32;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:58:15
    |
 LL |       let n = 1i64 >> 64;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:62:15
    |
 LL |       let n = n << 8;
    |               ^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:64:15
    |
 LL |       let n = 1u8 << -8;
    |               ^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:69:15
    |
 LL |       let n = 1u8 << (4+4);
    |               ^^^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:71:15
    |
 LL |       let n = 1i64 >> [64][0];
    |               ^^^^^^^^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:77:15
    |
 LL |       let n = 1_isize << BITS;
    |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:78:15
    |
 LL |       let n = 1_usize << BITS;
    |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
-
-error: aborting due to 23 previous errors
 

--- a/src/test/ui/lint/lint-exceeding-bitshifts.opt.stderr
+++ b/src/test/ui/lint/lint-exceeding-bitshifts.opt.stderr
@@ -148,3 +148,5 @@ warning: this arithmetic operation will overflow
 LL |       let n = 1_usize << BITS;
    |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
 
+warning: 24 warnings emitted
+

--- a/src/test/ui/lint/lint-exceeding-bitshifts.opt_with_overflow_checks.stderr
+++ b/src/test/ui/lint/lint-exceeding-bitshifts.opt_with_overflow_checks.stderr
@@ -1,146 +1,150 @@
-error: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:22:13
+warning: this arithmetic operation will overflow
+  --> $DIR/lint-exceeding-bitshifts.rs:18:20
    |
-LL |     let _ = x << 42;
-   |             ^^^^^^^ attempt to shift left with overflow
+LL |     const N: i32 = T::N << 42;
+   |                    ^^^^^^^^^^ attempt to shift left with overflow
    |
 note: the lint level is defined here
   --> $DIR/lint-exceeding-bitshifts.rs:9:9
    |
-LL | #![deny(arithmetic_overflow, const_err)]
+LL | #![warn(arithmetic_overflow, const_err)]
    |         ^^^^^^^^^^^^^^^^^^^
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
+  --> $DIR/lint-exceeding-bitshifts.rs:22:13
+   |
+LL |     let _ = x << 42;
+   |             ^^^^^^^ attempt to shift left with overflow
+
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:27:15
    |
 LL |       let n = 1u8 << 8;
    |               ^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:29:15
    |
 LL |       let n = 1u16 << 16;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:31:15
    |
 LL |       let n = 1u32 << 32;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:33:15
    |
 LL |       let n = 1u64 << 64;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:35:15
    |
 LL |       let n = 1i8 << 8;
    |               ^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:37:15
    |
 LL |       let n = 1i16 << 16;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:39:15
    |
 LL |       let n = 1i32 << 32;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:41:15
    |
 LL |       let n = 1i64 << 64;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:44:15
    |
 LL |       let n = 1u8 >> 8;
    |               ^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:46:15
    |
 LL |       let n = 1u16 >> 16;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:48:15
    |
 LL |       let n = 1u32 >> 32;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:50:15
    |
 LL |       let n = 1u64 >> 64;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:52:15
    |
 LL |       let n = 1i8 >> 8;
    |               ^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:54:15
    |
 LL |       let n = 1i16 >> 16;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:56:15
    |
 LL |       let n = 1i32 >> 32;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:58:15
    |
 LL |       let n = 1i64 >> 64;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:62:15
    |
 LL |       let n = n << 8;
    |               ^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:64:15
    |
 LL |       let n = 1u8 << -8;
    |               ^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:69:15
    |
 LL |       let n = 1u8 << (4+4);
    |               ^^^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:71:15
    |
 LL |       let n = 1i64 >> [64][0];
    |               ^^^^^^^^^^^^^^^ attempt to shift right with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:77:15
    |
 LL |       let n = 1_isize << BITS;
    |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
 
-error: this arithmetic operation will overflow
+warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:78:15
    |
 LL |       let n = 1_usize << BITS;
    |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
-
-error: aborting due to 23 previous errors
 

--- a/src/test/ui/lint/lint-exceeding-bitshifts.opt_with_overflow_checks.stderr
+++ b/src/test/ui/lint/lint-exceeding-bitshifts.opt_with_overflow_checks.stderr
@@ -148,3 +148,5 @@ warning: this arithmetic operation will overflow
 LL |       let n = 1_usize << BITS;
    |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
 
+warning: 24 warnings emitted
+

--- a/src/test/ui/lint/lint-exceeding-bitshifts.rs
+++ b/src/test/ui/lint/lint-exceeding-bitshifts.rs
@@ -3,10 +3,10 @@
 //[opt]compile-flags: -O
 //[opt_with_overflow_checks]compile-flags: -C overflow-checks=on -O
 
-// build-fail
+// build-pass
 
 #![crate_type="lib"]
-#![deny(arithmetic_overflow, const_err)]
+#![warn(arithmetic_overflow, const_err)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
 
@@ -15,65 +15,65 @@ pub trait Foo {
 }
 
 impl<T: Foo> Foo for Vec<T> {
-    const N: i32 = T::N << 42; // FIXME this should warn
+    const N: i32 = T::N << 42; //~ WARN: arithmetic operation will overflow
 }
 
 pub fn foo(x: i32) {
-    let _ = x << 42; //~ ERROR: arithmetic operation will overflow
+    let _ = x << 42; //~ WARN: arithmetic operation will overflow
 }
 
 pub fn main() {
       let n = 1u8 << 7;
-      let n = 1u8 << 8;   //~ ERROR: arithmetic operation will overflow
+      let n = 1u8 << 8;   //~ WARN: arithmetic operation will overflow
       let n = 1u16 << 15;
-      let n = 1u16 << 16; //~ ERROR: arithmetic operation will overflow
+      let n = 1u16 << 16; //~ WARN: arithmetic operation will overflow
       let n = 1u32 << 31;
-      let n = 1u32 << 32; //~ ERROR: arithmetic operation will overflow
+      let n = 1u32 << 32; //~ WARN: arithmetic operation will overflow
       let n = 1u64 << 63;
-      let n = 1u64 << 64; //~ ERROR: arithmetic operation will overflow
+      let n = 1u64 << 64; //~ WARN: arithmetic operation will overflow
       let n = 1i8 << 7;
-      let n = 1i8 << 8;   //~ ERROR: arithmetic operation will overflow
+      let n = 1i8 << 8;   //~ WARN: arithmetic operation will overflow
       let n = 1i16 << 15;
-      let n = 1i16 << 16; //~ ERROR: arithmetic operation will overflow
+      let n = 1i16 << 16; //~ WARN: arithmetic operation will overflow
       let n = 1i32 << 31;
-      let n = 1i32 << 32; //~ ERROR: arithmetic operation will overflow
+      let n = 1i32 << 32; //~ WARN: arithmetic operation will overflow
       let n = 1i64 << 63;
-      let n = 1i64 << 64; //~ ERROR: arithmetic operation will overflow
+      let n = 1i64 << 64; //~ WARN: arithmetic operation will overflow
 
       let n = 1u8 >> 7;
-      let n = 1u8 >> 8;   //~ ERROR: arithmetic operation will overflow
+      let n = 1u8 >> 8;   //~ WARN: arithmetic operation will overflow
       let n = 1u16 >> 15;
-      let n = 1u16 >> 16; //~ ERROR: arithmetic operation will overflow
+      let n = 1u16 >> 16; //~ WARN: arithmetic operation will overflow
       let n = 1u32 >> 31;
-      let n = 1u32 >> 32; //~ ERROR: arithmetic operation will overflow
+      let n = 1u32 >> 32; //~ WARN: arithmetic operation will overflow
       let n = 1u64 >> 63;
-      let n = 1u64 >> 64; //~ ERROR: arithmetic operation will overflow
+      let n = 1u64 >> 64; //~ WARN: arithmetic operation will overflow
       let n = 1i8 >> 7;
-      let n = 1i8 >> 8;   //~ ERROR: arithmetic operation will overflow
+      let n = 1i8 >> 8;   //~ WARN: arithmetic operation will overflow
       let n = 1i16 >> 15;
-      let n = 1i16 >> 16; //~ ERROR: arithmetic operation will overflow
+      let n = 1i16 >> 16; //~ WARN: arithmetic operation will overflow
       let n = 1i32 >> 31;
-      let n = 1i32 >> 32; //~ ERROR: arithmetic operation will overflow
+      let n = 1i32 >> 32; //~ WARN: arithmetic operation will overflow
       let n = 1i64 >> 63;
-      let n = 1i64 >> 64; //~ ERROR: arithmetic operation will overflow
+      let n = 1i64 >> 64; //~ WARN: arithmetic operation will overflow
 
       let n = 1u8;
       let n = n << 7;
-      let n = n << 8; //~ ERROR: arithmetic operation will overflow
+      let n = n << 8; //~ WARN: arithmetic operation will overflow
 
-      let n = 1u8 << -8; //~ ERROR: arithmetic operation will overflow
+      let n = 1u8 << -8; //~ WARN: arithmetic operation will overflow
 
       let n = 1i8<<(1isize+-1);
 
       let n = 1u8 << (4+3);
-      let n = 1u8 << (4+4); //~ ERROR: arithmetic operation will overflow
+      let n = 1u8 << (4+4); //~ WARN: arithmetic operation will overflow
       let n = 1i64 >> [63][0];
-      let n = 1i64 >> [64][0]; //~ ERROR: arithmetic operation will overflow
+      let n = 1i64 >> [64][0]; //~ WARN: arithmetic operation will overflow
 
       #[cfg(target_pointer_width = "32")]
       const BITS: usize = 32;
       #[cfg(target_pointer_width = "64")]
       const BITS: usize = 64;
-      let n = 1_isize << BITS; //~ ERROR: arithmetic operation will overflow
-      let n = 1_usize << BITS; //~ ERROR: arithmetic operation will overflow
+      let n = 1_isize << BITS; //~ WARN: arithmetic operation will overflow
+      let n = 1_usize << BITS; //~ WARN: arithmetic operation will overflow
 }

--- a/src/test/ui/option-to-result.rs
+++ b/src/test/ui/option-to-result.rs
@@ -1,0 +1,13 @@
+fn main(){ }
+
+fn test_result() -> Result<(),()> {
+    let a:Option<()> = Some(());
+    a?;//~ ERROR `?` couldn't convert the error
+    Ok(())
+}
+
+fn test_option() -> Option<i32>{
+    let a:Result<i32, i32> = Ok(5);
+    a?;//~ ERROR `?` couldn't convert the error
+    Some(5)
+}

--- a/src/test/ui/option-to-result.stderr
+++ b/src/test/ui/option-to-result.stderr
@@ -8,8 +8,8 @@ LL |     a?;
    = note: required by `std::convert::From::from`
 help: consider converting the `Option<T>` into a `Result<T, _>` using `Option::ok_or` or `Option::ok_or_else`
    |
-LL |     a.ok_or_else(|_| /* error value */)?;
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     a.ok_or_else(|| /* error value */)?;
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `?` couldn't convert the error to `std::option::NoneError`
   --> $DIR/option-to-result.rs:11:6

--- a/src/test/ui/option-to-result.stderr
+++ b/src/test/ui/option-to-result.stderr
@@ -1,0 +1,29 @@
+error[E0277]: `?` couldn't convert the error to `()`
+  --> $DIR/option-to-result.rs:5:6
+   |
+LL |     a?;
+   |      ^ the trait `std::convert::From<std::option::NoneError>` is not implemented for `()`
+   |
+   = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
+   = note: required by `std::convert::From::from`
+help: consider converting the `Option<T>` into a `Result<T, _>` using `Option::ok_or` or `Option::ok_or_else`
+   |
+LL |     a.ok_or_else(|_| /* error value */)?;
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: `?` couldn't convert the error to `std::option::NoneError`
+  --> $DIR/option-to-result.rs:11:6
+   |
+LL |     a?;
+   |      ^ the trait `std::convert::From<i32>` is not implemented for `std::option::NoneError`
+   |
+   = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
+   = note: required by `std::convert::From::from`
+help: consider converting the `Result<T, _>` into an `Option<T>` using `Result::ok`
+   |
+LL |     a.ok()?;
+   |      ^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/static/auxiliary/issue_24843.rs
+++ b/src/test/ui/static/auxiliary/issue_24843.rs
@@ -1,0 +1,1 @@
+pub static TEST_STR: &'static str = "Hello world";

--- a/src/test/ui/static/issue-24843.rs
+++ b/src/test/ui/static/issue-24843.rs
@@ -1,0 +1,8 @@
+// aux-build: issue_24843.rs
+// check-pass
+
+extern crate issue_24843;
+
+static _TEST_STR_2: &'static str = &issue_24843::TEST_STR;
+
+fn main() {}

--- a/src/test/ui/try-on-option.stderr
+++ b/src/test/ui/try-on-option.stderr
@@ -6,6 +6,10 @@ LL |     x?;
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = note: required by `std::convert::From::from`
+help: consider converting the `Option<T>` into a `Result<T, _>` using `Option::ok_or` or `Option::ok_or_else`
+   |
+LL |     x.ok_or_else(|_| /* error value */)?;
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `std::ops::Try`)
   --> $DIR/try-on-option.rs:13:5

--- a/src/test/ui/try-on-option.stderr
+++ b/src/test/ui/try-on-option.stderr
@@ -8,8 +8,8 @@ LL |     x?;
    = note: required by `std::convert::From::from`
 help: consider converting the `Option<T>` into a `Result<T, _>` using `Option::ok_or` or `Option::ok_or_else`
    |
-LL |     x.ok_or_else(|_| /* error value */)?;
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     x.ok_or_else(|| /* error value */)?;
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `std::ops::Try`)
   --> $DIR/try-on-option.rs:13:5


### PR DESCRIPTION
Successful merges:

 - #70566 (Don't bail out before linting in generic contexts.)
 - #71141 (Provide better compiler output when using `?` on `Option` in fn returning `Result` and vice-versa)
 - #71149 (remove an impossible branch from check_consts)
 - #71179 (fix more clippy warnings)
 - #71182 (Add some regression tests)

Failed merges:


r? @ghost