### PR TITLE
Don't use the HirId to NodeId map in MIR

### DIFF
--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -641,13 +641,17 @@ pub fn check_unsafety(tcx: TyCtxt<'_>, def_id: DefId) {
         }
     }
 
-    let mut unsafe_blocks: Vec<_> = unsafe_blocks.iter().collect();
-    unsafe_blocks.sort_by_cached_key(|(hir_id, _)| tcx.hir().hir_id_to_node_id(*hir_id));
-    let used_unsafe: FxHashSet<_> =
-        unsafe_blocks.iter().flat_map(|&&(id, used)| used.then_some(id)).collect();
-    for &(block_id, is_used) in unsafe_blocks {
-        if !is_used {
-            report_unused_unsafe(tcx, &used_unsafe, block_id);
+    let (mut unsafe_used, mut unsafe_unused): (FxHashSet<_>, Vec<_>) = Default::default();
+    for &(block_id, is_used) in unsafe_blocks.iter() {
+        if is_used {
+            unsafe_used.insert(block_id);
+        } else {
+            unsafe_unused.push(block_id);
         }
+    }
+    unsafe_unused.sort_by_cached_key(|hir_id| tcx.hir().hir_id_to_node_id(*hir_id));
+
+    for &block_id in &unsafe_unused {
+        report_unused_unsafe(tcx, &unsafe_used, block_id);
     }
 }

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -649,6 +649,8 @@ pub fn check_unsafety(tcx: TyCtxt<'_>, def_id: DefId) {
             unsafe_unused.push(block_id);
         }
     }
+    // The unused unsafe blocks might not be in source order; sort them so that the unused unsafe
+    // error messages are properly aligned and the issue-45107 and lint-unused-unsafe tests pass.
     unsafe_unused.sort_by_cached_key(|hir_id| tcx.hir().span(*hir_id));
 
     for &block_id in &unsafe_unused {

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -649,7 +649,7 @@ pub fn check_unsafety(tcx: TyCtxt<'_>, def_id: DefId) {
             unsafe_unused.push(block_id);
         }
     }
-    unsafe_unused.sort_by_cached_key(|hir_id| tcx.hir().hir_id_to_node_id(*hir_id));
+    unsafe_unused.sort_by_cached_key(|hir_id| tcx.hir().span(*hir_id));
 
     for &block_id in &unsafe_unused {
         report_unused_unsafe(tcx, &unsafe_used, block_id);


### PR DESCRIPTION
Another step towards not having to build a `HirId` to `NodeId` map other than for doc and RLS purposes.

We are currently sorting `unsafe` blocks by `NodeId` in `check_unsafety`; change it to sorting by `Span` instead; this passes the tests, but better ideas are welcome.

In addition, simplify the split between the used and unused `unsafe` blocks for readability and less sorting.

cc https://github.com/rust-lang/rust/issues/50928