### PR TITLE
perf: Remove inline attribute from `into_vec()`

### DIFF
--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -140,7 +140,6 @@ mod hack {
     use crate::string::ToString;
     use crate::vec::Vec;
 
-    #[inline]
     pub fn into_vec<T>(b: Box<[T]>) -> Vec<T> {
         unsafe {
             let len = b.len();


### PR DESCRIPTION
It was introduced in #70565 and is likely related to this perf results: https://perf.rust-lang.org/compare.html?start=1edcfc83c6a08ddc5e63fc652b149baea0236e7c&end=d249d756374737eb014079901ac132f1e1ed905e&stat=instructions:u
Let's check if it's related to that.
r? @wesleywiser could you kick off perf check? I don't think I can do it.