### PR TITLE
Inline some serialize impls

### DIFF
--- a/src/librustc_metadata/rmeta/encoder.rs
+++ b/src/librustc_metadata/rmeta/encoder.rs
@@ -59,15 +59,19 @@ struct EncodeContext<'tcx> {
 
 macro_rules! encoder_methods {
     ($($name:ident($ty:ty);)*) => {
-        $(fn $name(&mut self, value: $ty) -> Result<(), Self::Error> {
-            self.opaque.$name(value)
-        })*
+        $(
+            #[inline]
+            fn $name(&mut self, value: $ty) -> Result<(), Self::Error> {
+                self.opaque.$name(value)
+            }
+        )*
     }
 }
 
 impl<'tcx> Encoder for EncodeContext<'tcx> {
     type Error = <opaque::Encoder as Encoder>::Error;
 
+    #[inline]
     fn emit_unit(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }

--- a/src/librustc_middle/ty/query/on_disk_cache.rs
+++ b/src/librustc_middle/ty/query/on_disk_cache.rs
@@ -922,6 +922,7 @@ where
 {
     type Error = E::Error;
 
+    #[inline]
     fn emit_unit(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }

--- a/src/librustc_middle/ty/query/on_disk_cache.rs
+++ b/src/librustc_middle/ty/query/on_disk_cache.rs
@@ -909,10 +909,12 @@ where
 
 macro_rules! encoder_methods {
     ($($name:ident($ty:ty);)*) => {
-        #[inline]
-        $(fn $name(&mut self, value: $ty) -> Result<(), Self::Error> {
-            self.encoder.$name(value)
-        })*
+        $(
+            #[inline]
+            fn $name(&mut self, value: $ty) -> Result<(), Self::Error> {
+                self.encoder.$name(value)
+            }
+        )*
     }
 }
 


### PR DESCRIPTION
Some trivial methods in impls of the `Serialize::Encoder` trait are not marked `#[inline]` but are not generic and are (I believe) used cross-crate.

r? @eddyb 