### PR TITLE
Minor fixes to doc comments of 'VecDeque'

### DIFF
--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -488,7 +488,7 @@ impl<T> VecDeque<T> {
         VecDeque { tail: 0, head: 0, buf: RawVec::with_capacity(cap) }
     }
 
-    /// Retrieves an element in the `VecDeque` by index.
+    /// Provides a reference to the element at the given index.
     ///
     /// Element at index 0 is the front of the queue.
     ///
@@ -513,7 +513,7 @@ impl<T> VecDeque<T> {
         }
     }
 
-    /// Retrieves an element in the `VecDeque` mutably by index.
+    /// Provides a mutable reference to the element at the given index.
     ///
     /// Element at index 0 is the front of the queue.
     ///
@@ -651,7 +651,7 @@ impl<T> VecDeque<T> {
         }
     }
 
-    /// Tries to reserves the minimum capacity for exactly `additional` more elements to
+    /// Tries to reserve the minimum capacity for exactly `additional` more elements to
     /// be inserted in the given `VecDeque<T>`. After calling `reserve_exact`,
     /// capacity will be greater than or equal to `self.len() + additional`.
     /// Does nothing if the capacity is already sufficient.
@@ -662,7 +662,7 @@ impl<T> VecDeque<T> {
     ///
     /// # Errors
     ///
-    /// If the capacity overflows, or the allocator reports a failure, then an error
+    /// If the capacity overflows `usize`, or the allocator reports a failure, then an error
     /// is returned.
     ///
     /// # Examples
@@ -678,7 +678,7 @@ impl<T> VecDeque<T> {
     ///     // Pre-reserve the memory, exiting if we can't
     ///     output.try_reserve_exact(data.len())?;
     ///
-    ///     // Now we know this can't OOM in the middle of our complex work
+    ///     // Now we know this can't OOM(Out-Of-Memory) in the middle of our complex work
     ///     output.extend(data.iter().map(|&val| {
     ///         val * 2 + 5 // very complicated
     ///     }));
@@ -700,7 +700,7 @@ impl<T> VecDeque<T> {
     ///
     /// # Errors
     ///
-    /// If the capacity overflows, or the allocator reports a failure, then an error
+    /// If the capacity overflows `usize`, or the allocator reports a failure, then an error
     /// is returned.
     ///
     /// # Examples


### PR DESCRIPTION
1. Changed descriptions of `fn get` & `fn get_mut`.
  Since both of these functions are returning references, and not the owned value, I thought the doc comments could be fixed to be consistent with doc comments of `fn front` & `fn front_mut`.

2. Other changes are minor fixes or additions for clarification.

Thank you for taking a look :)