### PR TITLE
Dogfood or_patterns in the standard library

### DIFF
--- a/src/liballoc/collections/btree/map.rs
+++ b/src/liballoc/collections/btree/map.rs
@@ -2058,12 +2058,7 @@ where
         (Excluded(s), Excluded(e)) if s == e => {
             panic!("range start and end are equal and excluded in BTreeMap")
         }
-        (Included(s), Included(e))
-        | (Included(s), Excluded(e))
-        | (Excluded(s), Included(e))
-        | (Excluded(s), Excluded(e))
-            if s > e =>
-        {
+        (Included(s) | Excluded(s), Included(e) | Excluded(e)) if s > e => {
             panic!("range start is greater than range end in BTreeMap")
         }
         _ => {}

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -103,6 +103,7 @@
 #![feature(new_uninit)]
 #![feature(nll)]
 #![feature(optin_builtin_traits)]
+#![feature(or_patterns)]
 #![feature(pattern)]
 #![feature(ptr_internals)]
 #![feature(ptr_offset_from)]

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -858,7 +858,7 @@ pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn le(&self, other: &Rhs) -> bool {
-        matches!(self.partial_cmp(other), Some(Less) | Some(Equal))
+        matches!(self.partial_cmp(other), Some(Less | Equal))
     }
 
     /// This method tests greater than (for `self` and `other`) and is used by the `>` operator.
@@ -895,7 +895,7 @@ pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn ge(&self, other: &Rhs) -> bool {
-        matches!(self.partial_cmp(other), Some(Greater) | Some(Equal))
+        matches!(self.partial_cmp(other), Some(Greater | Equal))
     }
 }
 

--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -3109,7 +3109,7 @@ pub trait Iterator {
         Self::Item: PartialOrd<I::Item>,
         Self: Sized,
     {
-        matches!(self.partial_cmp(other), Some(Ordering::Less) | Some(Ordering::Equal))
+        matches!(self.partial_cmp(other), Some(Ordering::Less | Ordering::Equal))
     }
 
     /// Determines if the elements of this `Iterator` are lexicographically
@@ -3149,7 +3149,7 @@ pub trait Iterator {
         Self::Item: PartialOrd<I::Item>,
         Self: Sized,
     {
-        matches!(self.partial_cmp(other), Some(Ordering::Greater) | Some(Ordering::Equal))
+        matches!(self.partial_cmp(other), Some(Ordering::Greater | Ordering::Equal))
     }
 
     /// Checks if the elements of this iterator are sorted.

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -105,6 +105,7 @@
 #![feature(exhaustive_patterns)]
 #![feature(no_core)]
 #![feature(optin_builtin_traits)]
+#![feature(or_patterns)]
 #![feature(prelude_import)]
 #![feature(repr_simd, platform_intrinsics)]
 #![feature(rustc_attrs)]

--- a/src/libcore/num/dec2flt/parse.rs
+++ b/src/libcore/num/dec2flt/parse.rs
@@ -54,7 +54,7 @@ pub fn parse_decimal(s: &str) -> ParseResult<'_> {
 
     match s.first() {
         None => Valid(Decimal::new(integral, b"", 0)),
-        Some(&b'e') | Some(&b'E') => {
+        Some(&b'e' | &b'E') => {
             if integral.is_empty() {
                 return Invalid; // No digits before 'e'
             }
@@ -70,7 +70,7 @@ pub fn parse_decimal(s: &str) -> ParseResult<'_> {
 
             match s.first() {
                 None => Valid(Decimal::new(integral, fractional, 0)),
-                Some(&b'e') | Some(&b'E') => parse_exp(integral, fractional, &s[1..]),
+                Some(&b'e' | &b'E') => parse_exp(integral, fractional, &s[1..]),
                 _ => Invalid, // Trailing junk after fractional part
             }
         }

--- a/src/libcore/num/flt2dec/mod.rs
+++ b/src/libcore/num/flt2dec/mod.rs
@@ -422,14 +422,14 @@ fn determine_sign(sign: Sign, decoded: &FullDecoded, negative: bool) -> &'static
                 "+"
             }
         }
-        (_, Sign::Minus) | (_, Sign::MinusRaw) => {
+        (_, Sign::Minus | Sign::MinusRaw) => {
             if negative {
                 "-"
             } else {
                 ""
             }
         }
-        (_, Sign::MinusPlus) | (_, Sign::MinusPlusRaw) => {
+        (_, Sign::MinusPlus | Sign::MinusPlusRaw) => {
             if negative {
                 "-"
             } else {

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -285,6 +285,7 @@
 #![feature(never_type)]
 #![feature(nll)]
 #![feature(optin_builtin_traits)]
+#![feature(or_patterns)]
 #![feature(panic_info_message)]
 #![feature(panic_internals)]
 #![feature(panic_unwind)]

--- a/src/libstd/sync/mpsc/oneshot.rs
+++ b/src/libstd/sync/mpsc/oneshot.rs
@@ -260,7 +260,7 @@ impl<T> Packet<T> {
         let state = match self.state.load(Ordering::SeqCst) {
             // Each of these states means that no further activity will happen
             // with regard to abortion selection
-            s @ EMPTY | s @ DATA | s @ DISCONNECTED => s,
+            s @ (EMPTY | DATA | DISCONNECTED) => s,
 
             // If we've got a blocked thread, then use an atomic to gain ownership
             // of it (may fail)

--- a/src/libstd/sync/mpsc/stream.rs
+++ b/src/libstd/sync/mpsc/stream.rs
@@ -205,7 +205,7 @@ impl<T> Packet<T> {
             // Messages which actually popped from the queue shouldn't count as
             // a steal, so offset the decrement here (we already have our
             // "steal" factored into the channel count above).
-            data @ Ok(..) | data @ Err(Upgraded(..)) => unsafe {
+            data @ (Ok(..) | Err(Upgraded(..))) => unsafe {
                 *self.queue.consumer_addition().steals.get() -= 1;
                 data
             },


### PR DESCRIPTION
We can start using `or_patterns` in the standard library as a step toward stabilization.

cc #54883 @Centril 