### PR TITLE
Dogfood or_patterns in rustdoc

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -377,9 +377,11 @@ impl Clean<Lifetime> for hir::Lifetime {
     fn clean(&self, cx: &DocContext<'_>) -> Lifetime {
         let def = cx.tcx.named_region(self.hir_id);
         match def {
-            Some(rl::Region::EarlyBound(_, node_id, _))
-            | Some(rl::Region::LateBound(_, node_id, _))
-            | Some(rl::Region::Free(_, node_id)) => {
+            Some(
+                rl::Region::EarlyBound(_, node_id, _)
+                | rl::Region::LateBound(_, node_id, _)
+                | rl::Region::Free(_, node_id),
+            ) => {
                 if let Some(lt) = cx.lt_substs.borrow().get(&node_id).cloned() {
                     return lt;
                 }

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -586,7 +586,7 @@ pub fn resolve_type(cx: &DocContext<'_>, path: Path, id: hir::HirId) -> Type {
         Res::Def(DefKind::TyParam, _) if path.segments.len() == 1 => {
             return Generic(format!("{:#}", path.print()));
         }
-        Res::SelfTy(..) | Res::Def(DefKind::TyParam, _) | Res::Def(DefKind::AssocTy, _) => true,
+        Res::SelfTy(..) | Res::Def(DefKind::TyParam | DefKind::AssocTy, _) => true,
         _ => false,
     };
     let did = register_res(&*cx, path.res);

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -235,9 +235,7 @@ impl<'a> Classifier<'a> {
             // If this '&' or '*' token is followed by a non-whitespace token, assume that it's the
             // reference or dereference operator or a reference or pointer type, instead of the
             // bit-and or multiplication operator.
-            token::BinOp(token::And) | token::BinOp(token::Star)
-                if self.peek()? != &token::Whitespace =>
-            {
+            token::BinOp(token::And | token::Star) if self.peek()? != &token::Whitespace => {
                 Class::RefKeyWord
             }
 
@@ -275,9 +273,7 @@ impl<'a> Classifier<'a> {
             | token::ModSep
             | token::LArrow
             | token::OpenDelim(_)
-            | token::CloseDelim(token::Brace)
-            | token::CloseDelim(token::Paren)
-            | token::CloseDelim(token::NoDelim) => Class::None,
+            | token::CloseDelim(token::Brace | token::Paren | token::NoDelim) => Class::None,
 
             token::Question => Class::QuestionMark,
 

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -850,7 +850,7 @@ pub fn plain_summary_line(md: &str) -> String {
                 Event::Start(Tag::Heading(_)) => (None, 1),
                 Event::Code(code) => (Some(format!("`{}`", code)), 0),
                 Event::Text(ref s) if self.is_in > 0 => (Some(s.as_ref().to_owned()), 0),
-                Event::End(Tag::Paragraph) | Event::End(Tag::Heading(_)) => (None, -1),
+                Event::End(Tag::Paragraph | Tag::Heading(_)) => (None, -1),
                 _ => (None, 0),
             };
             if is_in > 0 || (is_in < 0 && self.is_in > 0) {
@@ -909,7 +909,7 @@ pub fn markdown_links(md: &str) -> Vec<(String, Option<Range<usize>>)> {
                 debug!("found link: {}", dest);
                 links.push(match dest {
                     CowStr::Borrowed(s) => (s.to_owned(), locate(s)),
-                    s @ CowStr::Boxed(..) | s @ CowStr::Inlined(..) => (s.into_string(), None),
+                    s @ (CowStr::Boxed(..) | CowStr::Inlined(..)) => (s.into_string(), None),
                 });
             }
         }

--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -294,10 +294,13 @@ impl DocFolder for Cache {
                             // for where the type was defined. On the other
                             // hand, `paths` always has the right
                             // information if present.
-                            Some(&(ref fqp, ItemType::Trait))
-                            | Some(&(ref fqp, ItemType::Struct))
-                            | Some(&(ref fqp, ItemType::Union))
-                            | Some(&(ref fqp, ItemType::Enum)) => Some(&fqp[..fqp.len() - 1]),
+                            Some(&(
+                                ref fqp,
+                                ItemType::Trait
+                                | ItemType::Struct
+                                | ItemType::Union
+                                | ItemType::Enum,
+                            )) => Some(&fqp[..fqp.len() - 1]),
                             Some(..) => Some(&*self.stack),
                             None => None,
                         };

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -7,6 +7,7 @@
 #![feature(box_syntax)]
 #![feature(in_band_lifetimes)]
 #![feature(nll)]
+#![feature(or_patterns)]
 #![feature(test)]
 #![feature(vec_remove_item)]
 #![feature(ptr_offset_from)]

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -149,7 +149,7 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
                 // In case this is a trait item, skip the
                 // early return and try looking for the trait.
                 let value = match res {
-                    Res::Def(DefKind::AssocFn, _) | Res::Def(DefKind::AssocConst, _) => true,
+                    Res::Def(DefKind::AssocFn | DefKind::AssocConst, _) => true,
                     Res::Def(DefKind::AssocTy, _) => false,
                     Res::Def(DefKind::Variant, _) => {
                         return handle_variant(cx, res, extra_fragment);
@@ -226,10 +226,10 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
             }
             let ty_res = ty_res.map_id(|_| panic!("unexpected node_id"));
             match ty_res {
-                Res::Def(DefKind::Struct, did)
-                | Res::Def(DefKind::Union, did)
-                | Res::Def(DefKind::Enum, did)
-                | Res::Def(DefKind::TyAlias, did) => {
+                Res::Def(
+                    DefKind::Struct | DefKind::Union | DefKind::Enum | DefKind::TyAlias,
+                    did,
+                ) => {
                     let item = cx
                         .tcx
                         .inherent_impls(did)
@@ -814,7 +814,7 @@ fn ambiguity_error(
 
                     for (res, ns) in candidates {
                         let (action, mut suggestion) = match res {
-                            Res::Def(DefKind::AssocFn, _) | Res::Def(DefKind::Fn, _) => {
+                            Res::Def(DefKind::AssocFn | DefKind::Fn, _) => {
                                 ("add parentheses", format!("{}()", path_str))
                             }
                             Res::Def(DefKind::Macro(..), _) => {

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -309,14 +309,15 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             let attrs = clean::inline::load_attrs(self.cx, res_did);
             let self_is_hidden = attrs.lists(sym::doc).has_word(sym::hidden);
             match res {
-                Res::Def(DefKind::Trait, did)
-                | Res::Def(DefKind::Struct, did)
-                | Res::Def(DefKind::Union, did)
-                | Res::Def(DefKind::Enum, did)
-                | Res::Def(DefKind::ForeignTy, did)
-                | Res::Def(DefKind::TyAlias, did)
-                    if !self_is_hidden =>
-                {
+                Res::Def(
+                    DefKind::Trait
+                    | DefKind::Struct
+                    | DefKind::Union
+                    | DefKind::Enum
+                    | DefKind::ForeignTy
+                    | DefKind::TyAlias,
+                    did,
+                ) if !self_is_hidden => {
                     self.cx.renderinfo.get_mut().access_levels.map.insert(did, AccessLevel::Public);
                 }
                 Res::Def(DefKind::Mod, did) => {


### PR DESCRIPTION
We can start using `or_patterns` in `rustdoc` as a step toward stabilization.

cc #54883 @Centril 