### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -488,7 +488,7 @@ impl<T> VecDeque<T> {
         VecDeque { tail: 0, head: 0, buf: RawVec::with_capacity(cap) }
     }
 
-    /// Retrieves an element in the `VecDeque` by index.
+    /// Provides a reference to the element at the given index.
     ///
     /// Element at index 0 is the front of the queue.
     ///
@@ -513,7 +513,7 @@ impl<T> VecDeque<T> {
         }
     }
 
-    /// Retrieves an element in the `VecDeque` mutably by index.
+    /// Provides a mutable reference to the element at the given index.
     ///
     /// Element at index 0 is the front of the queue.
     ///
@@ -651,7 +651,7 @@ impl<T> VecDeque<T> {
         }
     }
 
-    /// Tries to reserves the minimum capacity for exactly `additional` more elements to
+    /// Tries to reserve the minimum capacity for exactly `additional` more elements to
     /// be inserted in the given `VecDeque<T>`. After calling `reserve_exact`,
     /// capacity will be greater than or equal to `self.len() + additional`.
     /// Does nothing if the capacity is already sufficient.
@@ -662,7 +662,7 @@ impl<T> VecDeque<T> {
     ///
     /// # Errors
     ///
-    /// If the capacity overflows, or the allocator reports a failure, then an error
+    /// If the capacity overflows `usize`, or the allocator reports a failure, then an error
     /// is returned.
     ///
     /// # Examples
@@ -678,7 +678,7 @@ impl<T> VecDeque<T> {
     ///     // Pre-reserve the memory, exiting if we can't
     ///     output.try_reserve_exact(data.len())?;
     ///
-    ///     // Now we know this can't OOM in the middle of our complex work
+    ///     // Now we know this can't OOM(Out-Of-Memory) in the middle of our complex work
     ///     output.extend(data.iter().map(|&val| {
     ///         val * 2 + 5 // very complicated
     ///     }));
@@ -700,7 +700,7 @@ impl<T> VecDeque<T> {
     ///
     /// # Errors
     ///
-    /// If the capacity overflows, or the allocator reports a failure, then an error
+    /// If the capacity overflows `usize`, or the allocator reports a failure, then an error
     /// is returned.
     ///
     /// # Examples

--- a/src/librustc_error_codes/error_codes.rs
+++ b/src/librustc_error_codes/error_codes.rs
@@ -393,6 +393,7 @@ E0703: include_str!("./error_codes/E0703.md"),
 E0704: include_str!("./error_codes/E0704.md"),
 E0705: include_str!("./error_codes/E0705.md"),
 E0706: include_str!("./error_codes/E0706.md"),
+E0708: include_str!("./error_codes/E0708.md"),
 E0710: include_str!("./error_codes/E0710.md"),
 E0712: include_str!("./error_codes/E0712.md"),
 E0713: include_str!("./error_codes/E0713.md"),
@@ -605,8 +606,6 @@ E0751: include_str!("./error_codes/E0751.md"),
     E0696, // `continue` pointing to a labeled block
 //  E0702, // replaced with a generic attribute input check
 //  E0707, // multiple elided lifetimes used in arguments of `async fn`
-    E0708, // `async` non-`move` closures with parameters are not currently
-           // supported
 //  E0709, // multiple different lifetimes used in arguments of `async fn`
     E0711, // a feature has been declared with conflicting stability attributes
     E0717, // rustc_promotable without stability attribute

--- a/src/librustc_error_codes/error_codes/E0708.md
+++ b/src/librustc_error_codes/error_codes/E0708.md
@@ -1,0 +1,26 @@
+`async` non-`move` closures with parameters are currently not supported.
+
+Erroneous code example:
+
+```compile_fail,edition2018
+#![feature(async_closure)]
+
+fn main() {
+    let add_one = async |num: u8| { // error!
+        num + 1
+    };
+}
+```
+
+`async` with non-move is currently not supported with the current
+version, you can use successfully by using move:
+
+```edition2018
+#![feature(async_closure)]
+
+fn main() {
+    let add_one = async move |num: u8| { // ok!
+        num + 1
+    };
+}
+```

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -641,13 +641,17 @@ pub fn check_unsafety(tcx: TyCtxt<'_>, def_id: DefId) {
         }
     }
 
-    let mut unsafe_blocks: Vec<_> = unsafe_blocks.iter().collect();
-    unsafe_blocks.sort_by_cached_key(|(hir_id, _)| tcx.hir().hir_id_to_node_id(*hir_id));
-    let used_unsafe: FxHashSet<_> =
-        unsafe_blocks.iter().flat_map(|&&(id, used)| used.then_some(id)).collect();
-    for &(block_id, is_used) in unsafe_blocks {
-        if !is_used {
-            report_unused_unsafe(tcx, &used_unsafe, block_id);
+    let (mut unsafe_used, mut unsafe_unused): (FxHashSet<_>, Vec<_>) = Default::default();
+    for &(block_id, is_used) in unsafe_blocks.iter() {
+        if is_used {
+            unsafe_used.insert(block_id);
+        } else {
+            unsafe_unused.push(block_id);
         }
+    }
+    unsafe_unused.sort_by_cached_key(|hir_id| tcx.hir().hir_id_to_node_id(*hir_id));
+
+    for &block_id in &unsafe_unused {
+        report_unused_unsafe(tcx, &unsafe_used, block_id);
     }
 }

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -649,6 +649,8 @@ pub fn check_unsafety(tcx: TyCtxt<'_>, def_id: DefId) {
             unsafe_unused.push(block_id);
         }
     }
+    // The unused unsafe blocks might not be in source order; sort them so that the unused unsafe
+    // error messages are properly aligned and the issue-45107 and lint-unused-unsafe tests pass.
     unsafe_unused.sort_by_cached_key(|hir_id| tcx.hir().span(*hir_id));
 
     for &block_id in &unsafe_unused {

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -649,7 +649,7 @@ pub fn check_unsafety(tcx: TyCtxt<'_>, def_id: DefId) {
             unsafe_unused.push(block_id);
         }
     }
-    unsafe_unused.sort_by_cached_key(|hir_id| tcx.hir().hir_id_to_node_id(*hir_id));
+    unsafe_unused.sort_by_cached_key(|hir_id| tcx.hir().span(*hir_id));
 
     for &block_id in &unsafe_unused {
         report_unused_unsafe(tcx, &unsafe_used, block_id);

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -377,9 +377,11 @@ impl Clean<Lifetime> for hir::Lifetime {
     fn clean(&self, cx: &DocContext<'_>) -> Lifetime {
         let def = cx.tcx.named_region(self.hir_id);
         match def {
-            Some(rl::Region::EarlyBound(_, node_id, _))
-            | Some(rl::Region::LateBound(_, node_id, _))
-            | Some(rl::Region::Free(_, node_id)) => {
+            Some(
+                rl::Region::EarlyBound(_, node_id, _)
+                | rl::Region::LateBound(_, node_id, _)
+                | rl::Region::Free(_, node_id),
+            ) => {
                 if let Some(lt) = cx.lt_substs.borrow().get(&node_id).cloned() {
                     return lt;
                 }

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -586,7 +586,7 @@ pub fn resolve_type(cx: &DocContext<'_>, path: Path, id: hir::HirId) -> Type {
         Res::Def(DefKind::TyParam, _) if path.segments.len() == 1 => {
             return Generic(format!("{:#}", path.print()));
         }
-        Res::SelfTy(..) | Res::Def(DefKind::TyParam, _) | Res::Def(DefKind::AssocTy, _) => true,
+        Res::SelfTy(..) | Res::Def(DefKind::TyParam | DefKind::AssocTy, _) => true,
         _ => false,
     };
     let did = register_res(&*cx, path.res);

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -235,9 +235,7 @@ impl<'a> Classifier<'a> {
             // If this '&' or '*' token is followed by a non-whitespace token, assume that it's the
             // reference or dereference operator or a reference or pointer type, instead of the
             // bit-and or multiplication operator.
-            token::BinOp(token::And) | token::BinOp(token::Star)
-                if self.peek()? != &token::Whitespace =>
-            {
+            token::BinOp(token::And | token::Star) if self.peek()? != &token::Whitespace => {
                 Class::RefKeyWord
             }
 
@@ -275,9 +273,7 @@ impl<'a> Classifier<'a> {
             | token::ModSep
             | token::LArrow
             | token::OpenDelim(_)
-            | token::CloseDelim(token::Brace)
-            | token::CloseDelim(token::Paren)
-            | token::CloseDelim(token::NoDelim) => Class::None,
+            | token::CloseDelim(token::Brace | token::Paren | token::NoDelim) => Class::None,
 
             token::Question => Class::QuestionMark,
 

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -850,7 +850,7 @@ pub fn plain_summary_line(md: &str) -> String {
                 Event::Start(Tag::Heading(_)) => (None, 1),
                 Event::Code(code) => (Some(format!("`{}`", code)), 0),
                 Event::Text(ref s) if self.is_in > 0 => (Some(s.as_ref().to_owned()), 0),
-                Event::End(Tag::Paragraph) | Event::End(Tag::Heading(_)) => (None, -1),
+                Event::End(Tag::Paragraph | Tag::Heading(_)) => (None, -1),
                 _ => (None, 0),
             };
             if is_in > 0 || (is_in < 0 && self.is_in > 0) {
@@ -909,7 +909,7 @@ pub fn markdown_links(md: &str) -> Vec<(String, Option<Range<usize>>)> {
                 debug!("found link: {}", dest);
                 links.push(match dest {
                     CowStr::Borrowed(s) => (s.to_owned(), locate(s)),
-                    s @ CowStr::Boxed(..) | s @ CowStr::Inlined(..) => (s.into_string(), None),
+                    s @ (CowStr::Boxed(..) | CowStr::Inlined(..)) => (s.into_string(), None),
                 });
             }
         }

--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -294,10 +294,13 @@ impl DocFolder for Cache {
                             // for where the type was defined. On the other
                             // hand, `paths` always has the right
                             // information if present.
-                            Some(&(ref fqp, ItemType::Trait))
-                            | Some(&(ref fqp, ItemType::Struct))
-                            | Some(&(ref fqp, ItemType::Union))
-                            | Some(&(ref fqp, ItemType::Enum)) => Some(&fqp[..fqp.len() - 1]),
+                            Some(&(
+                                ref fqp,
+                                ItemType::Trait
+                                | ItemType::Struct
+                                | ItemType::Union
+                                | ItemType::Enum,
+                            )) => Some(&fqp[..fqp.len() - 1]),
                             Some(..) => Some(&*self.stack),
                             None => None,
                         };

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -7,6 +7,7 @@
 #![feature(box_syntax)]
 #![feature(in_band_lifetimes)]
 #![feature(nll)]
+#![feature(or_patterns)]
 #![feature(test)]
 #![feature(vec_remove_item)]
 #![feature(ptr_offset_from)]

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -149,7 +149,7 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
                 // In case this is a trait item, skip the
                 // early return and try looking for the trait.
                 let value = match res {
-                    Res::Def(DefKind::AssocFn, _) | Res::Def(DefKind::AssocConst, _) => true,
+                    Res::Def(DefKind::AssocFn | DefKind::AssocConst, _) => true,
                     Res::Def(DefKind::AssocTy, _) => false,
                     Res::Def(DefKind::Variant, _) => {
                         return handle_variant(cx, res, extra_fragment);
@@ -226,10 +226,10 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
             }
             let ty_res = ty_res.map_id(|_| panic!("unexpected node_id"));
             match ty_res {
-                Res::Def(DefKind::Struct, did)
-                | Res::Def(DefKind::Union, did)
-                | Res::Def(DefKind::Enum, did)
-                | Res::Def(DefKind::TyAlias, did) => {
+                Res::Def(
+                    DefKind::Struct | DefKind::Union | DefKind::Enum | DefKind::TyAlias,
+                    did,
+                ) => {
                     let item = cx
                         .tcx
                         .inherent_impls(did)
@@ -814,7 +814,7 @@ fn ambiguity_error(
 
                     for (res, ns) in candidates {
                         let (action, mut suggestion) = match res {
-                            Res::Def(DefKind::AssocFn, _) | Res::Def(DefKind::Fn, _) => {
+                            Res::Def(DefKind::AssocFn | DefKind::Fn, _) => {
                                 ("add parentheses", format!("{}()", path_str))
                             }
                             Res::Def(DefKind::Macro(..), _) => {

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -309,14 +309,15 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             let attrs = clean::inline::load_attrs(self.cx, res_did);
             let self_is_hidden = attrs.lists(sym::doc).has_word(sym::hidden);
             match res {
-                Res::Def(DefKind::Trait, did)
-                | Res::Def(DefKind::Struct, did)
-                | Res::Def(DefKind::Union, did)
-                | Res::Def(DefKind::Enum, did)
-                | Res::Def(DefKind::ForeignTy, did)
-                | Res::Def(DefKind::TyAlias, did)
-                    if !self_is_hidden =>
-                {
+                Res::Def(
+                    DefKind::Trait
+                    | DefKind::Struct
+                    | DefKind::Union
+                    | DefKind::Enum
+                    | DefKind::ForeignTy
+                    | DefKind::TyAlias,
+                    did,
+                ) if !self_is_hidden => {
                     self.cx.renderinfo.get_mut().access_levels.map.insert(did, AccessLevel::Public);
                 }
                 Res::Def(DefKind::Mod, did) => {

--- a/src/test/ui/async-await/no-params-non-move-async-closure.stderr
+++ b/src/test/ui/async-await/no-params-non-move-async-closure.stderr
@@ -8,3 +8,4 @@ LL |     let _ = async |x: u8| {};
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0708`.


### PR DESCRIPTION
Successful merges:

 - #70611 (Add long error explanation for E0708 #61137)
 - #71197 (Don't use the HirId to NodeId map in MIR)
 - #71211 (Update cargo)
 - #71219 (Minor fixes to doc comments of 'VecDeque')
 - #71221 (Dogfood or_patterns in rustdoc)

Failed merges:


r? @ghost