### PR TITLE
Fix typo in Default trait docs: Provides -> Provide

### DIFF
--- a/src/libcore/default.rs
+++ b/src/libcore/default.rs
@@ -54,7 +54,7 @@
 ///
 /// ## How can I implement `Default`?
 ///
-/// Provides an implementation for the `default()` method that returns the value of
+/// Provide an implementation for the `default()` method that returns the value of
 /// your type that should be the default:
 ///
 /// ```


### PR DESCRIPTION
An earlier commit (99ed06e) accidentally changed this paragraph from the original, imperative `Provide` to the present tense `Provides`. The latter is indeed the standard for Rustdoc comments relating to a function or method, but this snippet is introducing the `Default` trait in general terms and not talking about any particular function. I believe this change was likely made in error and should be reverted.