### PR TITLE
Small `BitSet` optimization

### DIFF
--- a/src/librustc_index/lib.rs
+++ b/src/librustc_index/lib.rs
@@ -5,6 +5,7 @@
 #![feature(unboxed_closures)]
 #![feature(test)]
 #![feature(fn_traits)]
+#![feature(vec_into_raw_parts)]
 
 pub mod bit_set;
 pub mod vec;


### PR DESCRIPTION
While compiling the standard library, I observed that ~97% of `BitSet`s have a domain size smaller than 64 (one `usize` worth of bits), and approximately 99% have a domain size smaller than 192 (three `usize`s worth of bits). Since a `BitSet` is currently four pointers big, we could be storing the vast majority of them on the stack without using extra space. More importantly, those percentages mean that the branch predictor will be correct most of the time when getting a pointer to the underlying storage.

There's a few configurations that would achieve this goal. This particular one tries to maximize the amount of inline storage available by not storing the number of words, instead recomputing it from the domain size whenever it is needed (ideally just `add` + `shr`). This gives us an extra `usize` worth of space, but may not be optimal. Regardless, benchmarking this PR should give us a good idea of whether this class of optimizations is worthwhile.