### PR TITLE
ty/print: pretty-print constant aggregates (arrays, tuples and ADTs).

### DIFF
--- a/src/librustc_middle/query/mod.rs
+++ b/src/librustc_middle/query/mod.rs
@@ -574,7 +574,7 @@ rustc_queries! {
             desc { "extract field of const" }
         }
 
-        /// Destructure a constant ADT or array into its variant indent and its
+        /// Destructure a constant ADT or array into its variant index and its
         /// field values.
         query destructure_const(
             key: ty::ParamEnvAnd<'tcx, &'tcx ty::Const<'tcx>>

--- a/src/test/mir-opt/const_prop/discriminant/32bit/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/discriminant/32bit/rustc.main.ConstProp.diff
@@ -16,7 +16,7 @@
           StorageLive(_2);                 // bb0[1]: scope 0 at $DIR/discriminant.rs:6:13: 6:64
           StorageLive(_3);                 // bb0[2]: scope 0 at $DIR/discriminant.rs:6:34: 6:44
 -         _3 = std::option::Option::<bool>::Some(const true); // bb0[3]: scope 0 at $DIR/discriminant.rs:6:34: 6:44
-+         _3 = const {transmute(0x01): std::option::Option<bool>}; // bb0[3]: scope 0 at $DIR/discriminant.rs:6:34: 6:44
++         _3 = const std::option::Option::<bool>::Some(true); // bb0[3]: scope 0 at $DIR/discriminant.rs:6:34: 6:44
                                            // ty::Const
 -                                          // + ty: bool
 +                                          // + ty: std::option::Option<bool>

--- a/src/test/mir-opt/const_prop/discriminant/32bit/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/discriminant/32bit/rustc.main.ConstProp.diff
@@ -15,7 +15,7 @@
           StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/discriminant.rs:6:9: 6:10
           StorageLive(_2);                 // bb0[1]: scope 0 at $DIR/discriminant.rs:6:13: 6:64
           StorageLive(_3);                 // bb0[2]: scope 0 at $DIR/discriminant.rs:6:34: 6:44
--         _3 = std::option::Option::<bool>::Some(const true,); // bb0[3]: scope 0 at $DIR/discriminant.rs:6:34: 6:44
+-         _3 = std::option::Option::<bool>::Some(const true); // bb0[3]: scope 0 at $DIR/discriminant.rs:6:34: 6:44
 +         _3 = const {transmute(0x01): std::option::Option<bool>}; // bb0[3]: scope 0 at $DIR/discriminant.rs:6:34: 6:44
                                            // ty::Const
 -                                          // + ty: bool

--- a/src/test/mir-opt/const_prop/discriminant/64bit/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/discriminant/64bit/rustc.main.ConstProp.diff
@@ -16,7 +16,7 @@
           StorageLive(_2);                 // bb0[1]: scope 0 at $DIR/discriminant.rs:6:13: 6:64
           StorageLive(_3);                 // bb0[2]: scope 0 at $DIR/discriminant.rs:6:34: 6:44
 -         _3 = std::option::Option::<bool>::Some(const true); // bb0[3]: scope 0 at $DIR/discriminant.rs:6:34: 6:44
-+         _3 = const {transmute(0x01): std::option::Option<bool>}; // bb0[3]: scope 0 at $DIR/discriminant.rs:6:34: 6:44
++         _3 = const std::option::Option::<bool>::Some(true); // bb0[3]: scope 0 at $DIR/discriminant.rs:6:34: 6:44
                                            // ty::Const
 -                                          // + ty: bool
 +                                          // + ty: std::option::Option<bool>

--- a/src/test/mir-opt/const_prop/discriminant/64bit/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/discriminant/64bit/rustc.main.ConstProp.diff
@@ -15,7 +15,7 @@
           StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/discriminant.rs:6:9: 6:10
           StorageLive(_2);                 // bb0[1]: scope 0 at $DIR/discriminant.rs:6:13: 6:64
           StorageLive(_3);                 // bb0[2]: scope 0 at $DIR/discriminant.rs:6:34: 6:44
--         _3 = std::option::Option::<bool>::Some(const true,); // bb0[3]: scope 0 at $DIR/discriminant.rs:6:34: 6:44
+-         _3 = std::option::Option::<bool>::Some(const true); // bb0[3]: scope 0 at $DIR/discriminant.rs:6:34: 6:44
 +         _3 = const {transmute(0x01): std::option::Option<bool>}; // bb0[3]: scope 0 at $DIR/discriminant.rs:6:34: 6:44
                                            // ty::Const
 -                                          // + ty: bool

--- a/src/test/mir-opt/deaggregator_test_enum_2/rustc.test1.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test_enum_2/rustc.test1.Deaggregator.diff
@@ -18,7 +18,7 @@
       bb1: {
           StorageLive(_5);                 // bb1[0]: scope 0 at $DIR/deaggregator_test_enum_2.rs:13:16: 13:17
           _5 = _2;                         // bb1[1]: scope 0 at $DIR/deaggregator_test_enum_2.rs:13:16: 13:17
--         _0 = Foo::B(move _5,);           // bb1[2]: scope 0 at $DIR/deaggregator_test_enum_2.rs:13:9: 13:18
+-         _0 = Foo::B(move _5);            // bb1[2]: scope 0 at $DIR/deaggregator_test_enum_2.rs:13:9: 13:18
 -         StorageDead(_5);                 // bb1[3]: scope 0 at $DIR/deaggregator_test_enum_2.rs:13:17: 13:18
 -         goto -> bb3;                     // bb1[4]: scope 0 at $DIR/deaggregator_test_enum_2.rs:10:5: 14:6
 +         ((_0 as B).0: i32) = move _5;    // bb1[2]: scope 0 at $DIR/deaggregator_test_enum_2.rs:13:9: 13:18
@@ -30,7 +30,7 @@
       bb2: {
           StorageLive(_4);                 // bb2[0]: scope 0 at $DIR/deaggregator_test_enum_2.rs:11:16: 11:17
           _4 = _2;                         // bb2[1]: scope 0 at $DIR/deaggregator_test_enum_2.rs:11:16: 11:17
--         _0 = Foo::A(move _4,);           // bb2[2]: scope 0 at $DIR/deaggregator_test_enum_2.rs:11:9: 11:18
+-         _0 = Foo::A(move _4);            // bb2[2]: scope 0 at $DIR/deaggregator_test_enum_2.rs:11:9: 11:18
 -         StorageDead(_4);                 // bb2[3]: scope 0 at $DIR/deaggregator_test_enum_2.rs:11:17: 11:18
 -         goto -> bb3;                     // bb2[4]: scope 0 at $DIR/deaggregator_test_enum_2.rs:10:5: 14:6
 +         ((_0 as A).0: i32) = move _4;    // bb2[2]: scope 0 at $DIR/deaggregator_test_enum_2.rs:11:9: 11:18

--- a/src/test/mir-opt/deaggregator_test_multiple/rustc.test.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test_multiple/rustc.test.Deaggregator.diff
@@ -13,12 +13,12 @@
           StorageLive(_2);                 // bb0[0]: scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
           StorageLive(_3);                 // bb0[1]: scope 0 at $DIR/deaggregator_test_multiple.rs:10:13: 10:14
           _3 = _1;                         // bb0[2]: scope 0 at $DIR/deaggregator_test_multiple.rs:10:13: 10:14
--         _2 = Foo::A(move _3,);           // bb0[3]: scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
+-         _2 = Foo::A(move _3);            // bb0[3]: scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
 -         StorageDead(_3);                 // bb0[4]: scope 0 at $DIR/deaggregator_test_multiple.rs:10:14: 10:15
 -         StorageLive(_4);                 // bb0[5]: scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
 -         StorageLive(_5);                 // bb0[6]: scope 0 at $DIR/deaggregator_test_multiple.rs:10:24: 10:25
 -         _5 = _1;                         // bb0[7]: scope 0 at $DIR/deaggregator_test_multiple.rs:10:24: 10:25
--         _4 = Foo::A(move _5,);           // bb0[8]: scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
+-         _4 = Foo::A(move _5);            // bb0[8]: scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
 -         StorageDead(_5);                 // bb0[9]: scope 0 at $DIR/deaggregator_test_multiple.rs:10:25: 10:26
 -         _0 = [move _2, move _4];         // bb0[10]: scope 0 at $DIR/deaggregator_test_multiple.rs:10:5: 10:27
 -         StorageDead(_4);                 // bb0[11]: scope 0 at $DIR/deaggregator_test_multiple.rs:10:26: 10:27

--- a/src/test/mir-opt/generator-storage-dead-unwind/rustc.main-{{closure}}.StateTransform.before.mir
+++ b/src/test/mir-opt/generator-storage-dead-unwind/rustc.main-{{closure}}.StateTransform.before.mir
@@ -21,7 +21,7 @@ yields ()
 
     bb0: {
         StorageLive(_3);                 // bb0[0]: scope 0 at $DIR/generator-storage-dead-unwind.rs:23:13: 23:14
-        _3 = Foo(const 5i32,);           // bb0[1]: scope 0 at $DIR/generator-storage-dead-unwind.rs:23:17: 23:23
+        _3 = Foo(const 5i32);            // bb0[1]: scope 0 at $DIR/generator-storage-dead-unwind.rs:23:17: 23:23
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000005))
@@ -29,7 +29,7 @@ yields ()
                                          // + span: $DIR/generator-storage-dead-unwind.rs:23:21: 23:22
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000005)) }
         StorageLive(_4);                 // bb0[2]: scope 1 at $DIR/generator-storage-dead-unwind.rs:24:13: 24:14
-        _4 = Bar(const 6i32,);           // bb0[3]: scope 1 at $DIR/generator-storage-dead-unwind.rs:24:17: 24:23
+        _4 = Bar(const 6i32);            // bb0[3]: scope 1 at $DIR/generator-storage-dead-unwind.rs:24:17: 24:23
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000006))

--- a/src/test/mir-opt/generator-tiny/rustc.main-{{closure}}.generator_resume.0.mir
+++ b/src/test/mir-opt/generator-tiny/rustc.main-{{closure}}.generator_resume.0.mir
@@ -34,7 +34,7 @@ fn main::{{closure}}#0(_1: std::pin::Pin<&mut [generator@$DIR/generator-tiny.rs:
         StorageLive(_6);                 // bb2[0]: scope 1 at $DIR/generator-tiny.rs:21:13: 21:18
         StorageLive(_7);                 // bb2[1]: scope 1 at $DIR/generator-tiny.rs:21:13: 21:18
         _7 = ();                         // bb2[2]: scope 1 at $DIR/generator-tiny.rs:21:13: 21:18
-        _0 = std::ops::GeneratorState::<(), ()>::Yielded(move _7,); // bb2[3]: scope 1 at $DIR/generator-tiny.rs:21:13: 21:18
+        _0 = std::ops::GeneratorState::<(), ()>::Yielded(move _7); // bb2[3]: scope 1 at $DIR/generator-tiny.rs:21:13: 21:18
         discriminant((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:18:16: 24:6 {u8, HasDrop, ()}]))) = 3; // bb2[4]: scope 1 at $DIR/generator-tiny.rs:21:13: 21:18
         return;                          // bb2[5]: scope 1 at $DIR/generator-tiny.rs:21:13: 21:18
     }

--- a/src/test/mir-opt/inline/inline-into-box-place/32bit/rustc.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline-into-box-place/32bit/rustc.main.Inline.diff
@@ -19,7 +19,7 @@
           _2 = Box(std::vec::Vec<u32>);    // bb0[2]: scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
 -         (*_2) = const std::vec::Vec::<u32>::new() -> [return: bb2, unwind: bb4]; // bb0[3]: scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         _4 = &mut (*_2);                 // bb0[3]: scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-+         ((*_4).0: alloc::raw_vec::RawVec<u32>) = const ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), undef_mask: UndefMask { blocks: [255], len: Size { raw: 8 } }, size: Size { raw: 8 }, align: Align { pow2: 2 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }: alloc::raw_vec::RawVec::<u32>; // bb0[4]: scope 2 at $SRC_DIR/liballoc/vec.rs:LL:COL
++         ((*_4).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: std::ptr::Unique::<u32> { pointer: {0x4 as *const u32}, _marker: std::marker::PhantomData::<u32> }, cap: 0usize, alloc: std::alloc::Global }; // bb0[4]: scope 2 at $SRC_DIR/liballoc/vec.rs:LL:COL
                                            // ty::Const
 -                                          // + ty: fn() -> std::vec::Vec<u32> {std::vec::Vec::<u32>::new}
 -                                          // + val: Value(Scalar(<ZST>))

--- a/src/test/mir-opt/inline/inline-into-box-place/64bit/rustc.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline-into-box-place/64bit/rustc.main.Inline.diff
@@ -19,7 +19,7 @@
           _2 = Box(std::vec::Vec<u32>);    // bb0[2]: scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
 -         (*_2) = const std::vec::Vec::<u32>::new() -> [return: bb2, unwind: bb4]; // bb0[3]: scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         _4 = &mut (*_2);                 // bb0[3]: scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-+         ((*_4).0: alloc::raw_vec::RawVec<u32>) = const ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), undef_mask: UndefMask { blocks: [65535], len: Size { raw: 16 } }, size: Size { raw: 16 }, align: Align { pow2: 3 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }: alloc::raw_vec::RawVec::<u32>; // bb0[4]: scope 2 at $SRC_DIR/liballoc/vec.rs:LL:COL
++         ((*_4).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: std::ptr::Unique::<u32> { pointer: {0x4 as *const u32}, _marker: std::marker::PhantomData::<u32> }, cap: 0usize, alloc: std::alloc::Global }; // bb0[4]: scope 2 at $SRC_DIR/liballoc/vec.rs:LL:COL
                                            // ty::Const
 -                                          // + ty: fn() -> std::vec::Vec<u32> {std::vec::Vec::<u32>::new}
 -                                          // + val: Value(Scalar(<ZST>))

--- a/src/test/mir-opt/issue-41888/rustc.main.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue-41888/rustc.main.ElaborateDrops.after.mir
@@ -80,7 +80,7 @@ fn main() -> () {
         StorageLive(_3);                 // bb5[0]: scope 1 at $DIR/issue-41888.rs:9:13: 9:20
         StorageLive(_4);                 // bb5[1]: scope 1 at $DIR/issue-41888.rs:9:18: 9:19
         _4 = K;                          // bb5[2]: scope 1 at $DIR/issue-41888.rs:9:18: 9:19
-        _3 = E::F(move _4,);             // bb5[3]: scope 1 at $DIR/issue-41888.rs:9:13: 9:20
+        _3 = E::F(move _4);              // bb5[3]: scope 1 at $DIR/issue-41888.rs:9:13: 9:20
         StorageDead(_4);                 // bb5[4]: scope 1 at $DIR/issue-41888.rs:9:19: 9:20
         goto -> bb14;                    // bb5[5]: scope 1 at $DIR/issue-41888.rs:9:9: 9:10
     }

--- a/src/test/mir-opt/issue-62289/rustc.test.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/issue-62289/rustc.test.ElaborateDrops.before.mir
@@ -115,7 +115,7 @@ fn test() -> std::option::Option<std::boxed::Box<u32>> {
 
     bb12: {
         StorageDead(_2);                 // bb12[0]: scope 0 at $DIR/issue-62289.rs:9:20: 9:21
-        _0 = std::option::Option::<std::boxed::Box<u32>>::Some(move _1,); // bb12[1]: scope 0 at $DIR/issue-62289.rs:9:5: 9:22
+        _0 = std::option::Option::<std::boxed::Box<u32>>::Some(move _1); // bb12[1]: scope 0 at $DIR/issue-62289.rs:9:5: 9:22
         drop(_1) -> bb13;                // bb12[2]: scope 0 at $DIR/issue-62289.rs:9:21: 9:22
     }
 

--- a/src/test/mir-opt/match_false_edges/rustc.full_tested_match.PromoteTemps.after.mir
+++ b/src/test/mir-opt/match_false_edges/rustc.full_tested_match.PromoteTemps.after.mir
@@ -26,7 +26,7 @@ fn full_tested_match() -> () {
     bb0: {
         StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/match_false_edges.rs:15:13: 19:6
         StorageLive(_2);                 // bb0[1]: scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
-        _2 = std::option::Option::<i32>::Some(const 42i32,); // bb0[2]: scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
+        _2 = std::option::Option::<i32>::Some(const 42i32); // bb0[2]: scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x0000002a))

--- a/src/test/mir-opt/match_false_edges/rustc.full_tested_match2.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges/rustc.full_tested_match2.PromoteTemps.before.mir
@@ -25,7 +25,7 @@ fn full_tested_match2() -> () {
     bb0: {
         StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/match_false_edges.rs:26:13: 30:6
         StorageLive(_2);                 // bb0[1]: scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
-        _2 = std::option::Option::<i32>::Some(const 42i32,); // bb0[2]: scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
+        _2 = std::option::Option::<i32>::Some(const 42i32); // bb0[2]: scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x0000002a))

--- a/src/test/mir-opt/match_false_edges/rustc.main.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges/rustc.main.PromoteTemps.before.mir
@@ -36,7 +36,7 @@ fn main() -> () {
     bb0: {
         StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
         StorageLive(_2);                 // bb0[1]: scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
-        _2 = std::option::Option::<i32>::Some(const 1i32,); // bb0[2]: scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
+        _2 = std::option::Option::<i32>::Some(const 1i32); // bb0[2]: scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000001))

--- a/src/test/mir-opt/packed-struct-drop-aligned/32bit/rustc.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/packed-struct-drop-aligned/32bit/rustc.main.SimplifyCfg-elaborate-drops.after.mir
@@ -16,27 +16,27 @@ fn main() -> () {
         StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:9: 6:14
         StorageLive(_2);                 // bb0[1]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
         StorageLive(_3);                 // bb0[2]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
-        _3 = Droppy(const 0usize,);      // bb0[3]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
+        _3 = Droppy(const 0usize);       // bb0[3]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x00000000))
                                          // mir::Constant
                                          // + span: $DIR/packed-struct-drop-aligned.rs:6:39: 6:40
                                          // + literal: Const { ty: usize, val: Value(Scalar(0x00000000)) }
-        _2 = Aligned(move _3,);          // bb0[4]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
+        _2 = Aligned(move _3);           // bb0[4]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
         StorageDead(_3);                 // bb0[5]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:41: 6:42
-        _1 = Packed(move _2,);           // bb0[6]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:17: 6:43
+        _1 = Packed(move _2);            // bb0[6]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:17: 6:43
         StorageDead(_2);                 // bb0[7]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:42: 6:43
         StorageLive(_4);                 // bb0[8]: scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
         StorageLive(_5);                 // bb0[9]: scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
-        _5 = Droppy(const 0usize,);      // bb0[10]: scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
+        _5 = Droppy(const 0usize);       // bb0[10]: scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x00000000))
                                          // mir::Constant
                                          // + span: $DIR/packed-struct-drop-aligned.rs:7:26: 7:27
                                          // + literal: Const { ty: usize, val: Value(Scalar(0x00000000)) }
-        _4 = Aligned(move _5,);          // bb0[11]: scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
+        _4 = Aligned(move _5);           // bb0[11]: scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
         StorageDead(_5);                 // bb0[12]: scope 1 at $DIR/packed-struct-drop-aligned.rs:7:28: 7:29
         StorageLive(_6);                 // bb0[13]: scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
         _6 = move (_1.0: Aligned);       // bb0[14]: scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8

--- a/src/test/mir-opt/packed-struct-drop-aligned/64bit/rustc.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/packed-struct-drop-aligned/64bit/rustc.main.SimplifyCfg-elaborate-drops.after.mir
@@ -16,27 +16,27 @@ fn main() -> () {
         StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:9: 6:14
         StorageLive(_2);                 // bb0[1]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
         StorageLive(_3);                 // bb0[2]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
-        _3 = Droppy(const 0usize,);      // bb0[3]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
+        _3 = Droppy(const 0usize);       // bb0[3]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x0000000000000000))
                                          // mir::Constant
                                          // + span: $DIR/packed-struct-drop-aligned.rs:6:39: 6:40
                                          // + literal: Const { ty: usize, val: Value(Scalar(0x0000000000000000)) }
-        _2 = Aligned(move _3,);          // bb0[4]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
+        _2 = Aligned(move _3);           // bb0[4]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
         StorageDead(_3);                 // bb0[5]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:41: 6:42
-        _1 = Packed(move _2,);           // bb0[6]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:17: 6:43
+        _1 = Packed(move _2);            // bb0[6]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:17: 6:43
         StorageDead(_2);                 // bb0[7]: scope 0 at $DIR/packed-struct-drop-aligned.rs:6:42: 6:43
         StorageLive(_4);                 // bb0[8]: scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
         StorageLive(_5);                 // bb0[9]: scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
-        _5 = Droppy(const 0usize,);      // bb0[10]: scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
+        _5 = Droppy(const 0usize);       // bb0[10]: scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x0000000000000000))
                                          // mir::Constant
                                          // + span: $DIR/packed-struct-drop-aligned.rs:7:26: 7:27
                                          // + literal: Const { ty: usize, val: Value(Scalar(0x0000000000000000)) }
-        _4 = Aligned(move _5,);          // bb0[11]: scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
+        _4 = Aligned(move _5);           // bb0[11]: scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
         StorageDead(_5);                 // bb0[12]: scope 1 at $DIR/packed-struct-drop-aligned.rs:7:28: 7:29
         StorageLive(_6);                 // bb0[13]: scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
         _6 = move (_1.0: Aligned);       // bb0[14]: scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8

--- a/src/test/mir-opt/retag/rustc.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag/rustc.main.SimplifyCfg-elaborate-drops.after.mir
@@ -67,7 +67,7 @@ fn main() -> () {
         StorageLive(_3);                 // bb0[3]: scope 1 at $DIR/retag.rs:32:13: 32:14
         StorageLive(_4);                 // bb0[4]: scope 1 at $DIR/retag.rs:32:17: 32:24
         StorageLive(_5);                 // bb0[5]: scope 1 at $DIR/retag.rs:32:17: 32:24
-        _5 = Test(const 0i32,);          // bb0[6]: scope 1 at $DIR/retag.rs:32:17: 32:24
+        _5 = Test(const 0i32);           // bb0[6]: scope 1 at $DIR/retag.rs:32:17: 32:24
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000000))
@@ -170,7 +170,7 @@ fn main() -> () {
         StorageLive(_19);                // bb5[4]: scope 7 at $DIR/retag.rs:47:5: 47:24
         StorageLive(_20);                // bb5[5]: scope 7 at $DIR/retag.rs:47:5: 47:12
         StorageLive(_21);                // bb5[6]: scope 7 at $DIR/retag.rs:47:5: 47:12
-        _21 = Test(const 0i32,);         // bb5[7]: scope 7 at $DIR/retag.rs:47:5: 47:12
+        _21 = Test(const 0i32);          // bb5[7]: scope 7 at $DIR/retag.rs:47:5: 47:12
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000000))

--- a/src/test/mir-opt/simplify-locals-removes-unused-consts/rustc.main.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify-locals-removes-unused-consts/rustc.main.SimplifyLocals.diff
@@ -24,7 +24,7 @@
 -         StorageLive(_2);                 // bb0[1]: scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:21: 13:23
 -         _2 = const ();                   // bb0[2]: scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:21: 13:23
 +         StorageLive(_1);                 // bb0[0]: scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
-+         _1 = const use_zst(const {transmute(()): ((), ())}) -> bb1; // bb0[1]: scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
++         _1 = const use_zst(const ((), ())) -> bb1; // bb0[1]: scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
                                            // ty::Const
 -                                          // + ty: ()
 -                                          // + val: Value(Scalar(<ZST>))
@@ -39,7 +39,7 @@
 -                                          // mir::Constant
 -                                          // + span: $DIR/simplify-locals-removes-unused-consts.rs:13:25: 13:27
 -                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
--         _1 = const {transmute(()): ((), ())}; // bb0[5]: scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:20: 13:28
+-         _1 = const ((), ());             // bb0[5]: scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:20: 13:28
 -                                          // ty::Const
 -                                          // + ty: ((), ())
 -                                          // + val: Value(Scalar(<ZST>))
@@ -68,7 +68,7 @@
 -                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
 -         StorageDead(_7);                 // bb0[14]: scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:20: 14:21
 -         StorageDead(_6);                 // bb0[15]: scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:20: 14:21
--         _4 = const use_zst(const {transmute(()): ((), ())}) -> bb1; // bb0[16]: scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
+-         _4 = const use_zst(const ((), ())) -> bb1; // bb0[16]: scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
 -                                          // ty::Const
                                            // + ty: fn(((), ())) {use_zst}
                                            // + val: Value(Scalar(<ZST>))
@@ -88,7 +88,7 @@
 -         StorageLive(_8);                 // bb1[1]: scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35
 -         StorageLive(_10);                // bb1[2]: scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:30
 -         StorageLive(_11);                // bb1[3]: scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:28
--         _11 = const {transmute(0x28): Temp}; // bb1[4]: scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:28
+-         _11 = const Temp { x: 40u8 };    // bb1[4]: scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:28
 +         StorageDead(_1);                 // bb1[0]: scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:22: 14:23
 +         StorageLive(_2);                 // bb1[1]: scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35
 +         _2 = const use_u8(const 42u8) -> bb2; // bb1[2]: scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35

--- a/src/test/mir-opt/storage_ranges/rustc.main.nll.0.mir
+++ b/src/test/mir-opt/storage_ranges/rustc.main.nll.0.mir
@@ -50,7 +50,7 @@ fn main() -> () {
         StorageLive(_4);                 // bb0[5]: scope 1 at $DIR/storage_ranges.rs:6:18: 6:25
         StorageLive(_5);                 // bb0[6]: scope 1 at $DIR/storage_ranges.rs:6:23: 6:24
         _5 = _1;                         // bb0[7]: scope 1 at $DIR/storage_ranges.rs:6:23: 6:24
-        _4 = std::option::Option::<i32>::Some(move _5,); // bb0[8]: scope 1 at $DIR/storage_ranges.rs:6:18: 6:25
+        _4 = std::option::Option::<i32>::Some(move _5); // bb0[8]: scope 1 at $DIR/storage_ranges.rs:6:18: 6:25
         StorageDead(_5);                 // bb0[9]: scope 1 at $DIR/storage_ranges.rs:6:24: 6:25
         _3 = &_4;                        // bb0[10]: scope 1 at $DIR/storage_ranges.rs:6:17: 6:25
         FakeRead(ForLet, _3);            // bb0[11]: scope 1 at $DIR/storage_ranges.rs:6:13: 6:14


### PR DESCRIPTION
Oddly enough, we don't have any UI tests showing this off in types, only `mir-opt` tests.
However, the pretty form should show up in the test output diff of #71018, if this PR is merged first.

<hr/>

Examples of before/after:
|`Option<bool>`|
|:-:|
|`{transmute(0x01): std::option::Option<bool>}`|
| :sparkles: ↓↓↓ :sparkles: |
|`std::option::Option::<bool>::Some(true)`|

| `RawVec<u32>` |
|:-:|
| `ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), undef_mask: UndefMask { blocks: [65535], len: Size { raw: 16 } }, size: Size { raw: 16 }, align: Align { pow2: 3 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }: alloc::raw_vec::RawVec::<u32>`|
| :sparkles: ↓↓↓ :sparkles: |
|`alloc::raw_vec::RawVec::<u32> { ptr: std::ptr::Unique::<u32> { pointer: {0x4 as *const u32}, _marker: std::marker::PhantomData::<u32> }, cap: 0usize, alloc: std::alloc::Global }`|

<hr/>

This PR is a prerequisite for #61486, *sort of*, in that we need to be able to pretty-print values in order to even consider how we might mangle them.
We still don't have pretty-printing for constants of reference types, @oli-obk has the necessary support logic in a PR but I didn't want to interfere with that.

<hr/>

Each commit should be reviewed separately, as I've fixed a couple deficiencies along the way.

r? @oli-obk cc @rust-lang/wg-mir-opt @varkor @yodaldevoid 