### PR TITLE
Add Ayu theme to rustdoc

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -20,6 +20,7 @@ use crate::core::new_handler;
 use crate::externalfiles::ExternalHtml;
 use crate::html;
 use crate::html::markdown::IdMap;
+use crate::html::render::StylePath;
 use crate::html::static_files;
 use crate::opts;
 use crate::passes::{self, Condition, DefaultPassOption};
@@ -207,7 +208,7 @@ pub struct RenderOptions {
     pub sort_modules_alphabetically: bool,
     /// List of themes to extend the docs with. Original argument name is included to assist in
     /// displaying errors if it fails a theme check.
-    pub themes: Vec<PathBuf>,
+    pub themes: Vec<StylePath>,
     /// If present, CSS file that contains rules to add to the default CSS.
     pub extension_css: Option<PathBuf>,
     /// A map of crate names to the URL to use instead of querying the crate's `html_root_url`.
@@ -410,7 +411,7 @@ impl Options {
                     ))
                     .emit();
                 }
-                themes.push(theme_file);
+                themes.push(StylePath { path: theme_file, disabled: true });
             }
         }
 

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -187,8 +187,8 @@ crate struct SharedContext {
     /// This flag indicates whether listings of modules (in the side bar and documentation itself)
     /// should be ordered alphabetically or in order of appearance (in the source code).
     pub sort_modules_alphabetically: bool,
-    /// Additional themes to be added to the generated docs.
-    pub themes: Vec<PathBuf>,
+    /// Additional CSS files to be added to the generated docs.
+    pub style_files: Vec<StylePath>,
     /// Suffix to be added on resource files (if suffix is "-v2" then "light.css" becomes
     /// "light-v2.css").
     pub resource_suffix: String,
@@ -417,6 +417,14 @@ impl Serialize for TypeWithKind {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct StylePath {
+    /// The path to the theme
+    pub path: PathBuf,
+    /// What the `disabled` attribute should be set to in the HTML tag
+    pub disabled: bool,
+}
+
 thread_local!(static CACHE_KEY: RefCell<Arc<Cache>> = Default::default());
 thread_local!(pub static CURRENT_DEPTH: Cell<usize> = Cell::new(0));
 
@@ -460,7 +468,7 @@ pub fn run(
         id_map,
         playground_url,
         sort_modules_alphabetically,
-        themes,
+        themes: style_files,
         extension_css,
         extern_html_root_urls,
         resource_suffix,
@@ -530,7 +538,7 @@ pub fn run(
         layout,
         created_dirs: Default::default(),
         sort_modules_alphabetically,
-        themes,
+        style_files,
         resource_suffix,
         static_root_path,
         fs: DocFS::new(&errors),
@@ -538,6 +546,18 @@ pub fn run(
         codes: ErrorCodes::from(UnstableFeatures::from_environment().is_nightly_build()),
         playground,
     };
+
+    // Add the default themes to the `Vec` of stylepaths
+    //
+    // Note that these must be added before `sources::render` is called
+    // so that the resulting source pages are styled
+    //
+    // `light.css` is not disabled because it is the stylesheet that stays loaded
+    // by the browser as the theme stylesheet. The theme system (hackily) works by
+    // changing the href to this stylesheet. All other themes are disabled to
+    // prevent rule conflicts
+    scx.style_files.push(StylePath { path: PathBuf::from("light.css"), disabled: false });
+    scx.style_files.push(StylePath { path: PathBuf::from("dark.css"), disabled: true });
 
     let dst = output;
     scx.ensure_dir(&dst)?;
@@ -615,11 +635,34 @@ fn write_shared(
     // then we'll run over the "official" styles.
     let mut themes: FxHashSet<String> = FxHashSet::default();
 
-    for entry in &cx.shared.themes {
-        let content = try_err!(fs::read(&entry), &entry);
-        let theme = try_none!(try_none!(entry.file_stem(), &entry).to_str(), &entry);
-        let extension = try_none!(try_none!(entry.extension(), &entry).to_str(), &entry);
-        cx.shared.fs.write(cx.path(&format!("{}.{}", theme, extension)), content.as_slice())?;
+    for entry in &cx.shared.style_files {
+        let theme = try_none!(try_none!(entry.path.file_stem(), &entry.path).to_str(), &entry.path);
+        let extension =
+            try_none!(try_none!(entry.path.extension(), &entry.path).to_str(), &entry.path);
+
+        // Handle the official themes
+        match theme {
+            "light" => write_minify(
+                &cx.shared.fs,
+                cx.path("light.css"),
+                static_files::themes::LIGHT,
+                options.enable_minification,
+            )?,
+            "dark" => write_minify(
+                &cx.shared.fs,
+                cx.path("dark.css"),
+                static_files::themes::DARK,
+                options.enable_minification,
+            )?,
+            _ => {
+                // Handle added third-party themes
+                let content = try_err!(fs::read(&entry.path), &entry.path);
+                cx.shared
+                    .fs
+                    .write(cx.path(&format!("{}.{}", theme, extension)), content.as_slice())?;
+            }
+        };
+
         themes.insert(theme.to_owned());
     }
 
@@ -633,20 +676,6 @@ fn write_shared(
     write(cx.path("brush.svg"), static_files::BRUSH_SVG)?;
     write(cx.path("wheel.svg"), static_files::WHEEL_SVG)?;
     write(cx.path("down-arrow.svg"), static_files::DOWN_ARROW_SVG)?;
-    write_minify(
-        &cx.shared.fs,
-        cx.path("light.css"),
-        static_files::themes::LIGHT,
-        options.enable_minification,
-    )?;
-    themes.insert("light".to_owned());
-    write_minify(
-        &cx.shared.fs,
-        cx.path("dark.css"),
-        static_files::themes::DARK,
-        options.enable_minification,
-    )?;
-    themes.insert("dark".to_owned());
 
     let mut themes: Vec<&String> = themes.iter().collect();
     themes.sort();
@@ -957,7 +986,7 @@ themePicker.onblur = handleThemeButtonsBlur;
                     })
                     .collect::<String>()
             );
-            let v = layout::render(&cx.shared.layout, &page, "", content, &cx.shared.themes);
+            let v = layout::render(&cx.shared.layout, &page, "", content, &cx.shared.style_files);
             cx.shared.fs.write(&dst, v.as_bytes())?;
         }
     }
@@ -1375,7 +1404,7 @@ impl Context {
             &page,
             sidebar,
             |buf: &mut Buffer| all.print(buf),
-            &self.shared.themes,
+            &self.shared.style_files,
         );
         self.shared.fs.write(&final_file, v.as_bytes())?;
 
@@ -1384,9 +1413,9 @@ impl Context {
         page.description = "Settings of Rustdoc";
         page.root_path = "./";
 
-        let mut themes = self.shared.themes.clone();
+        let mut style_files = self.shared.style_files.clone();
         let sidebar = "<p class='location'>Settings</p><div class='sidebar-elems'></div>";
-        themes.push(PathBuf::from("settings.css"));
+        style_files.push(StylePath { path: PathBuf::from("settings.css"), disabled: false });
         let v = layout::render(
             &self.shared.layout,
             &page,
@@ -1395,7 +1424,7 @@ impl Context {
                 self.shared.static_root_path.as_deref().unwrap_or("./"),
                 &self.shared.resource_suffix,
             ),
-            &themes,
+            &style_files,
         );
         self.shared.fs.write(&settings_file, v.as_bytes())?;
 
@@ -1457,7 +1486,7 @@ impl Context {
                 &page,
                 |buf: &mut _| print_sidebar(self, it, buf),
                 |buf: &mut _| print_item(self, it, buf),
-                &self.shared.themes,
+                &self.shared.style_files,
             )
         } else {
             let mut url = self.root_path();

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -558,6 +558,7 @@ pub fn run(
     // prevent rule conflicts
     scx.style_files.push(StylePath { path: PathBuf::from("light.css"), disabled: false });
     scx.style_files.push(StylePath { path: PathBuf::from("dark.css"), disabled: true });
+    scx.style_files.push(StylePath { path: PathBuf::from("ayu.css"), disabled: true });
 
     let dst = output;
     scx.ensure_dir(&dst)?;
@@ -652,6 +653,12 @@ fn write_shared(
                 &cx.shared.fs,
                 cx.path("dark.css"),
                 static_files::themes::DARK,
+                options.enable_minification,
+            )?,
+            "ayu" => write_minify(
+                &cx.shared.fs,
+                cx.path("ayu.css"),
+                static_files::themes::AYU,
                 options.enable_minification,
             )?,
             _ => {

--- a/src/librustdoc/html/sources.rs
+++ b/src/librustdoc/html/sources.rs
@@ -123,7 +123,7 @@ impl<'a> SourceCollector<'a> {
             &page,
             "",
             |buf: &mut _| print_src(buf, &contents),
-            &self.scx.themes,
+            &self.scx.style_files,
         );
         self.scx.fs.write(&cur, v.as_bytes())?;
         self.scx.local_sources.insert(p, href);

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -1,0 +1,561 @@
+/*
+Based off of the Ayu theme
+Original by Dempfi (https://github.com/dempfi/ayu)
+*/
+
+/* General structure and fonts */
+
+body {
+	background-color: #0f1419;
+	color: #c5c5c5;
+}
+
+h1, h2, h3:not(.impl):not(.method):not(.type):not(.tymethod), h4:not(.method):not(.type):not(.tymethod) {
+	color: white;
+}
+h1.fqn {
+	border-bottom-color: #5c6773;
+}
+h1.fqn  a {
+	color: #fff;
+}
+h2, h3:not(.impl):not(.method):not(.type):not(.tymethod) {
+	border-bottom-color: #5c6773;
+}
+h4:not(.method):not(.type):not(.tymethod):not(.associatedconstant) {
+	border: none;
+}
+
+.in-band {
+	background-color: #0f1419;
+}
+
+.invisible {
+	background: rgba(0, 0, 0, 0);
+}
+
+code {
+	color: #ffb454;
+}
+h3 > code, h4 > code, h5 > code {
+	color: #e6e1cf;
+}
+pre > code {
+    color: #e6e1cf; 
+}
+span code {
+    color: #e6e1cf;
+}
+.docblock a > code {
+    color: #39AFD7 !important;
+}
+.docblock code, .docblock-short code {
+	background-color: #191f26;
+}
+pre {
+	color: #e6e1cf;
+	background-color: #191f26;
+}
+
+.sidebar {
+	background-color: #14191f;
+}
+
+/* Improve the scrollbar display on firefox */
+* {
+	scrollbar-color: #5c6773 transparent;
+}
+
+.sidebar {
+	scrollbar-color: #5c6773 transparent;
+}
+
+/* Improve the scrollbar display on webkit-based browsers */
+::-webkit-scrollbar-track {
+	background-color: transparent;
+}
+::-webkit-scrollbar-thumb {
+	background-color: #5c6773;
+}
+.sidebar::-webkit-scrollbar-track {
+	background-color: transparent;
+}
+.sidebar::-webkit-scrollbar-thumb {
+	background-color: #5c6773;
+}
+
+.sidebar .current {
+	background-color: transparent;
+	color: #ffb44c;
+}
+
+.source .sidebar {
+	background-color: #0f1419;
+}
+
+.sidebar .location {
+	border-color: #000;
+	background-color: #0f1419;
+	color: #fff;
+}
+
+.sidebar-elems .location {
+    color: #ff7733;
+}
+
+.sidebar-elems .location a {
+    color: #fff;
+}
+
+.sidebar .version {
+	border-bottom-color: #DDD;
+}
+
+.sidebar-title {
+	border-top-color: #5c6773;
+	border-bottom-color: #5c6773;
+}
+
+.block a:hover {
+	background: transparent;
+	color: #ffb44c;
+}
+
+.line-numbers span { color: #5c6773ab; }
+.line-numbers .line-highlighted {
+    background-color: rgba(255, 236, 164, 0.06) !important;
+    padding-right: 4px;
+    border-right: 1px solid #ffb44c;
+}
+
+.docblock h1, .docblock h2, .docblock h3, .docblock h4, .docblock h5 {
+	border-bottom-color: #5c6773;
+}
+
+.docblock table, .docblock table td, .docblock table th {
+	border-color: #5c6773;
+}
+
+.content .method .where,
+.content .fn .where,
+.content .where.fmt-newline {
+	color: #c5c5c5;
+}
+
+.content .highlighted {
+	color: #000 !important;
+	background-color: #c6afb3;
+}
+.content .highlighted a, .content .highlighted span { color: #000 !important; }
+.content .highlighted {
+	background-color: #c6afb3;
+}
+.search-results a {
+	color: #0096cf;
+}
+.search-results a span.desc {
+	color: #c5c5c5;
+}
+
+.content .stability::before { color: #ccc; }
+
+.content span.foreigntype, .content a.foreigntype { color: #ef57ff; }
+.content span.union, .content a.union { color: #98a01c; }
+.content span.constant, .content a.constant,
+.content span.static, .content a.static { color: #6380a0; }
+.content span.primitive, .content a.primitive { color: #32889b; }
+.content span.traitalias, .content a.traitalias { color: #57d399; }
+.content span.keyword, .content a.keyword { color: #de5249; }
+
+.content span.externcrate, .content span.mod, .content a.mod {
+    color: #acccf9;
+}
+.content span.struct, .content a.struct {
+    color: #ffa0a5;
+}
+.content span.enum, .content a.enum {
+    color: #99e0c9;
+}
+.content span.trait, .content a.trait {
+    color: #39AFD7;
+}
+.content span.type, .content a.type {
+    color: #cfbcf5;
+}
+.content span.fn, .content a.fn, .content span.method,
+.content a.method, .content span.tymethod,
+.content a.tymethod, .content .fnname {
+    color: #fdd687;
+}
+.content span.attr, .content a.attr, .content span.derive,
+.content a.derive, .content span.macro, .content a.macro {
+    color: #a37acc;
+}
+
+pre.rust .comment, pre.rust .doccomment { 
+	color: #788797;
+	font-style: italic;
+}
+
+nav:not(.sidebar) {
+	border-bottom-color: #e0e0e0;
+}
+nav.main .current {
+	border-top-color: #5c6773;
+	border-bottom-color: #5c6773;
+}
+nav.main .separator {
+	border: 1px solid #5c6773;
+}
+a {
+	color: #c5c5c5;
+}
+
+.docblock:not(.type-decl) a:not(.srclink):not(.test-arrow),
+.docblock-short a:not(.srclink):not(.test-arrow), .stability a {
+	color: #39AFD7;
+}
+
+.stab.internal a {
+	color: #304FFE;
+}
+
+.collapse-toggle {
+	color: #999;
+}
+
+#crate-search {
+	color: #c5c5c5;
+	background-color: #141920;
+	border-radius: 4px;
+	box-shadow: none;
+	border-color: #5c6773;
+}
+
+.search-input {
+    color: #ffffff;
+    background-color: #141920;
+    box-shadow: none;
+    transition: box-shadow 150ms ease-in-out;
+    border-radius: 4px;
+    margin-left: 8px;
+}
+
+#crate-search+.search-input:focus {
+    box-shadow: 0px 6px 20px 0px black;
+}
+
+.search-focus:disabled {
+	color: #929292;
+}
+
+.module-item .stab {
+	color: #000;
+}
+
+.stab.unstable,
+.stab.internal,
+.stab.deprecated,
+.stab.portability {
+    color: #c5c5c5;
+	background: #314559 !important;
+	border-style: none !important;
+	border-radius: 4px;
+	padding: 3px 6px 3px 6px;
+}
+
+.stab.portability > code {
+	color: #e6e1cf;
+	background-color: transparent;
+}
+
+#help > div {
+    background: #14191f;
+    box-shadow: 0px 6px 20px 0px black;
+    border: none;
+    border-radius: 4px;
+}
+
+.since {
+	color: grey;
+}
+
+tr.result span.primitive::after, tr.result span.keyword::after {
+	color: #788797;
+}
+
+.line-numbers :target { background-color: transparent; }
+
+/* Code highlighting */
+pre.rust .number, pre.rust .string { color: #b8cc52; }
+pre.rust .kw, pre.rust .kw-2, pre.rust .prelude-ty,
+pre.rust .bool-val, pre.rust .prelude-val,
+pre.rust .op, pre.rust .lifetime { color: #ff7733; }
+pre.rust .macro, pre.rust .macro-nonterminal { color: #a37acc; }
+pre.rust .question-mark {
+	color: #ff9011;
+}
+pre.rust .self {
+    color: #36a3d9;
+    font-style: italic;
+}
+pre.rust .attribute {
+    color: #e6e1cf;
+}
+pre.rust .attribute .ident, pre.rust .attribute .op {
+    color: #e6e1cf;
+}
+
+.example-wrap > pre.line-number {
+	color: #5c67736e;
+	border: none;
+}
+
+a.test-arrow {
+    font-size: 100%;
+    color: #788797;
+    border-radius: 4px;
+    background-color: rgba(255, 255, 255, 0);
+}
+
+a.test-arrow:hover {
+    background-color: rgba(242, 151, 24, 0.05);
+    color: #ffb44c;
+}
+
+.toggle-label {
+	color: #999;
+}
+
+:target > code, :target > .in-band {
+	background: rgba(255, 236, 164, 0.06);
+	border-right: 3px solid #ffb44c;
+}
+
+pre.compile_fail {
+	border-left: 2px solid rgba(255,0,0,.4);
+}
+
+pre.compile_fail:hover, .information:hover + pre.compile_fail {
+	border-left: 2px solid #f00;
+}
+
+pre.should_panic {
+	border-left: 2px solid rgba(255,0,0,.4);
+}
+
+pre.should_panic:hover, .information:hover + pre.should_panic {
+	border-left: 2px solid #f00;
+}
+
+pre.ignore {
+	border-left: 2px solid rgba(255,142,0,.6);
+}
+
+pre.ignore:hover, .information:hover + pre.ignore {
+	border-left: 2px solid #ff9200;
+}
+
+.tooltip.compile_fail {
+	color: rgba(255,0,0,.5);
+}
+
+.information > .compile_fail:hover {
+	color: #f00;
+}
+
+.tooltip.should_panic {
+	color: rgba(255,0,0,.5);
+}
+
+.information > .should_panic:hover {
+	color: #f00;
+}
+
+.tooltip.ignore {
+	color: rgba(255,142,0,.6);
+}
+
+.information > .ignore:hover {
+	color: #ff9200;
+}
+
+.search-failed a {
+	color: #39AFD7;
+}
+
+.tooltip .tooltiptext {
+    background-color: #314559;
+    color: #c5c5c5;
+    border: 1px solid #5c6773;
+}
+
+.tooltip .tooltiptext::after {
+	border-color: transparent #314559 transparent transparent;
+}
+
+#titles > div.selected {
+    background-color: #141920 !important;
+	border-bottom: 1px solid #ffb44c !important;
+	border-top: none;
+}
+
+#titles > div:not(.selected) {
+	background-color: transparent !important;
+	border: none;
+}
+
+#titles > div:hover {
+    border-bottom: 1px solid rgba(242, 151, 24, 0.3);
+}
+
+#titles > div > div.count {
+	color: #888;
+}
+
+/* rules that this theme does not need to set, here to satisfy the rule checker */
+/* note that a lot of these are partially set in some way (meaning they are set
+individually rather than as a group) */
+/* TODO: these rules should be at the bottom of the file but currently must be
+above the `@media (max-width: 700px)` rules due to a bug in the css checker */
+/* see https://github.com/rust-lang/rust/pull/71237#issuecomment-618170143 */
+.content .highlighted.mod, .content .highlighted.externcrate {}
+.search-input:focus {}
+.content span.attr,.content a.attr,.block a.current.attr,.content span.derive,.content a.derive,.block a.current.derive,.content span.macro,.content a.macro,.block a.current.macro {}
+.content .highlighted.trait {}
+.content span.struct,.content a.struct,.block a.current.struct {}
+#titles>div:hover,#titles>div.selected {}
+.content .highlighted.traitalias {}
+.content span.type,.content a.type,.block a.current.type {}
+.content span.union,.content a.union,.block a.current.union {}
+.content .highlighted.foreigntype {}
+pre.rust .lifetime {}
+.content .highlighted.primitive {}
+.content .highlighted.constant,.content .highlighted.static {}
+.stab.unstable {}
+.content .highlighted.fn,.content .highlighted.method,.content .highlighted.tymethod {}
+h2,h3:not(.impl):not(.method):not(.type):not(.tymethod),h4:not(.method):not(.type):not(.tymethod) {}
+.content span.enum,.content a.enum,.block a.current.enum {}
+.content span.constant,.content a.constant,.block a.current.constant,.content span.static,.content a.static,.block a.current.static {}
+.content span.keyword,.content a.keyword,.block a.current.keyword {}
+pre.rust .comment {}
+.content .highlighted.enum {}
+.content .highlighted.struct {}
+.content .highlighted.keyword {}
+.content span.traitalias,.content a.traitalias,.block a.current.traitalias {}
+.content span.fn,.content a.fn,.block a.current.fn,.content span.method,.content a.method,.block a.current.method,.content span.tymethod,.content a.tymethod,.block a.current.tymethod,.content .fnname {}
+pre.rust .kw {}
+pre.rust .self,pre.rust .bool-val,pre.rust .prelude-val,pre.rust .attribute,pre.rust .attribute .ident {}
+.content span.foreigntype,.content a.foreigntype,.block a.current.foreigntype {}
+pre.rust .doccomment {}
+.stab.deprecated {}
+.content .highlighted.attr,.content .highlighted.derive,.content .highlighted.macro {}
+.stab.portability {}
+.content .highlighted.union {}
+.content span.primitive,.content a.primitive,.block a.current.primitive {}
+.content span.externcrate,.content span.mod,.content a.mod,.block a.current.mod {}
+.content .highlighted.type {}
+pre.rust .kw-2,pre.rust .prelude-ty {}
+.content span.trait,.content a.trait,.block a.current.trait {}
+.stab.internal {}
+
+@media (max-width: 700px) {
+	.sidebar-menu {
+		background-color: #14191f;
+		border-bottom-color: #5c6773;
+		border-right-color: #5c6773;
+	}
+
+	.sidebar-elems {
+		background-color: #14191f;
+		border-right-color: #5c6773;
+	}
+
+	#sidebar-filler {
+		background-color: #14191f;
+		border-bottom-color: #5c6773;
+	}
+}
+
+kbd {
+	color: #c5c5c5;
+	background-color: #314559;
+	border-color: #5c6773;
+	border-bottom-color: #5c6773;
+	box-shadow-color: #c6cbd1;
+}
+
+#theme-picker, #settings-menu {
+	border-color: #5c6773;
+    background-color: #0f1419;
+}
+
+#theme-picker > img, #settings-menu > img {
+    filter: invert(100);
+}
+
+#theme-picker:hover, #theme-picker:focus,
+#settings-menu:hover, #settings-menu:focus {
+	border-color: #e0e0e0;
+}
+
+#theme-choices {
+	border-color: #5c6773;
+	background-color: #0f1419;
+}
+
+#theme-choices > button:not(:first-child) {
+	border-top-color: #c5c5c5;
+}
+
+#theme-choices > button:hover, #theme-choices > button:focus {
+	background-color: rgba(70, 70, 70, 0.33);
+}
+
+@media (max-width: 700px) {
+	#theme-picker {
+		background: #0f1419;
+	}
+}
+
+#all-types {
+	background-color: #14191f;
+}
+#all-types:hover {
+	background-color: rgba(70, 70, 70, 0.33);
+}
+
+.search-results td span.alias {
+	color: #c5c5c5;
+}
+.search-results td span.grey {
+	color: #999;
+}
+
+#sidebar-toggle {
+	background-color: #14191f;
+}
+#sidebar-toggle:hover {
+	background-color: rgba(70, 70, 70, 0.33);
+}
+#source-sidebar {
+	background-color: #14191f;
+}
+#source-sidebar > .title {
+	color: #fff;
+	border-bottom-color: #5c6773;
+}
+div.files > a:hover, div.name:hover {
+	background-color: #14191f;
+	color: #ffb44c;
+}
+div.files > .selected {
+	background-color: #14191f;
+	color: #ffb44c;
+}
+.setting-line > .title {
+	border-bottom-color: #5c6773;
+}
+input:checked + .slider {
+	background-color: #ffb454 !important;
+}

--- a/src/librustdoc/html/static_files.rs
+++ b/src/librustdoc/html/static_files.rs
@@ -64,6 +64,9 @@ pub mod themes {
 
     /// The "dark" theme.
     pub static DARK: &str = include_str!("static/themes/dark.css");
+
+    /// The "ayu" theme.
+    pub static AYU: &str = include_str!("static/themes/ayu.css");
 }
 
 /// Files related to the Fira Sans font.


### PR DESCRIPTION
This is a port of a theme I maintain (https://github.com/Cldfire/ayu-rs) to the native rustdoc theme system. [Ayu](https://github.com/dempfi/ayu) (dark) is a richly-colored dark theme that many people enjoy using across a wide variety of environments.

Corresponds to the Ayu theme in [mdBook](https://github.com/rust-lang/mdBook).

Some screenshots:

![image](https://user-images.githubusercontent.com/13814214/79547087-6c935780-8061-11ea-8a33-38e9472e9fec.png)

![image](https://user-images.githubusercontent.com/13814214/79547150-8339ae80-8061-11ea-97be-9e13a8b275d7.png)

![image](https://user-images.githubusercontent.com/13814214/79547221-98164200-8061-11ea-9649-9b11ccbb33e3.png)

![image](https://user-images.githubusercontent.com/13814214/79547310-b419e380-8061-11ea-9965-d4f90b2280ab.png)

![image](https://user-images.githubusercontent.com/13814214/79547443-e7f50900-8061-11ea-8872-06d74010691e.png)

Note that this pull request also makes some small code changes to allow for disabling theme stylesheets, preventing the rules from all the different themes from conflicting with one another. The only stylesheet that is not disabled is `light.css`; the theming system (quite hackily) switches themes by changing the href on this stylesheet and so permanently disabling all the others works perfectly fine.

