### PR TITLE
Implement `Clone` for `liballoc::collections::linked_list::Cursor`.

### DIFF
--- a/src/liballoc/collections/linked_list.rs
+++ b/src/liballoc/collections/linked_list.rs
@@ -1198,6 +1198,14 @@ pub struct Cursor<'a, T: 'a> {
 }
 
 #[unstable(feature = "linked_list_cursors", issue = "58533")]
+impl<T> Clone for Cursor<'_, T> {
+    fn clone(&self) -> Self {
+        let Cursor { index, current, list } = *self;
+        Cursor { index, current, list }
+    }
+}
+
+#[unstable(feature = "linked_list_cursors", issue = "58533")]
 impl<T: fmt::Debug> fmt::Debug for Cursor<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Cursor").field(&self.list).field(&self.index()).finish()


### PR DESCRIPTION
This implements `Clone` for linked list `Cursor`. Implementing `Copy` is also possible here, but i'm not sure whether i should also do it.

r? @Amanieu 
