### PR TITLE
Replace big JS dict with JSON parsing

### DIFF
--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -631,7 +631,7 @@ fn build_index(krate: &clean::Crate, cache: &mut Cache) -> String {
 
     // Collect the index into a string
     format!(
-        r#"searchIndex["{}"] = {};"#,
+        r#""{}":{}"#,
         krate.name,
         serde_json::to_string(&CrateData {
             doc: crate_doc,
@@ -639,6 +639,11 @@ fn build_index(krate: &clean::Crate, cache: &mut Cache) -> String {
             paths: crate_paths,
         })
         .expect("failed serde conversion")
+        // All these `replace` calls are because we have to go through JS string for JSON content.
+        .replace(r"\", r"\\")
+        .replace("'", r"\'")
+        // We need to escape double quotes for the JSON.
+        .replace("\\\"", "\\\\\"")
     )
 }
 


### PR DESCRIPTION
Part of #56545.

@ollie27 suggested that using JSON instead of a JS dict might be faster, so I decided to test it. And the results far exceeded whatever expectations I had...

I used https://github.com/adamgreig/stm32ral for my tests. If you want to build it locally:

```bash
$ cargo doc --features doc --open
```

But I strongly recommend to do it with this PR. Some numbers:

 * Loading a page with the JSON search-index: less than 1 second
 * Loading a page with the JS search-index: crashed after 30 seconds

I think the results are clear enough...

r? @ollie27 

cc @rust-lang/rustdoc 