### PR TITLE
Minor fix and addition to doc comments

### DIFF
--- a/src/librustc_middle/mir/mod.rs
+++ b/src/librustc_middle/mir/mod.rs
@@ -2611,14 +2611,14 @@ impl<'a, 'b> graph::GraphSuccessors<'b> for Body<'a> {
     type Iter = iter::Cloned<Successors<'b>>;
 }
 
+/// `Location` represents the position of the start of the statement; or, if
+/// `statement_index` equals the number of statements, then the start of the
+/// terminator.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, HashStable)]
 pub struct Location {
     /// The block that the location is within.
     pub block: BasicBlock,
 
-    /// The location is the position of the start of the statement; or, if
-    /// `statement_index` equals the number of statements, then the start of the
-    /// terminator.
     pub statement_index: usize,
 }
 

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -254,6 +254,7 @@ pub fn write_mir_pretty<'tcx>(
     Ok(())
 }
 
+/// Write out a human-readable textual representation for the given function.
 pub fn write_mir_fn<'tcx, F>(
     tcx: TyCtxt<'tcx>,
     src: MirSource<'tcx>,


### PR DESCRIPTION
1. Fixed doc comment of struct 'rustc_middle::mir::Location'
Currently, the general explanation of the struct appears at the field
explanation section. I moved and changed the doc comments slightly, so
that the general explanation would appear in the proper location in
docs.
2. Added doc comment explaining 'rustc_mir::util::pretty::write_mir_fn'
Unlike other counterparts, brief explanation for this function was missing,
so I added one.

Thank you for reviewing this PR :)