### PR TITLE
Lint must_use on mem::replace

### DIFF
--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -709,6 +709,7 @@ unsafe impl<T: ?Sized> Freeze for &mut T {}
 /// So this, for example, can only be done on types implementing `Unpin`:
 ///
 /// ```rust
+/// # #![allow(unused_must_use)]
 /// use std::mem;
 /// use std::pin::Pin;
 ///

--- a/src/libcore/mem/mod.rs
+++ b/src/libcore/mem/mod.rs
@@ -808,6 +808,7 @@ pub fn take<T: Default>(dest: &mut T) -> T {
 /// [`Clone`]: ../../std/clone/trait.Clone.html
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
+#[must_use = "if you don't need the old value, you can just assign the new value directly"]
 pub fn replace<T>(dest: &mut T, mut src: T) -> T {
     swap(dest, &mut src);
     src

--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -547,8 +547,7 @@ impl<'a> Parser<'a> {
                 // Rewind to before attempting to parse the type with generics, to recover
                 // from situations like `x as usize < y` in which we first tried to parse
                 // `usize < y` as a type with generic arguments.
-                let parser_snapshot_after_type = self.clone();
-                mem::replace(self, parser_snapshot_before_type);
+                let parser_snapshot_after_type = mem::replace(self, parser_snapshot_before_type);
 
                 match self.parse_path(PathStyle::Expr) {
                     Ok(path) => {
@@ -560,7 +559,7 @@ impl<'a> Parser<'a> {
                                 // example because `parse_ty_no_plus` returns `Err` on keywords,
                                 // but `parse_path` returns `Ok` on them due to error recovery.
                                 // Return original error and parser state.
-                                mem::replace(self, parser_snapshot_after_type);
+                                *self = parser_snapshot_after_type;
                                 return Err(type_err);
                             }
                         };
@@ -601,7 +600,7 @@ impl<'a> Parser<'a> {
                     Err(mut path_err) => {
                         // Couldn't parse as a path, return original error and parser state.
                         path_err.cancel();
-                        mem::replace(self, parser_snapshot_after_type);
+                        *self = parser_snapshot_after_type;
                         return Err(type_err);
                     }
                 }

--- a/src/librustc_parse/parser/generics.rs
+++ b/src/librustc_parse/parser/generics.rs
@@ -105,7 +105,7 @@ impl<'a> Parser<'a> {
                     }
                     Err(mut err) => {
                         err.cancel();
-                        std::mem::replace(self, snapshot);
+                        *self = snapshot;
                         break;
                     }
                 }

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -1650,7 +1650,7 @@ impl<'a> Parser<'a> {
                 // Recover from attempting to parse the argument as a type without pattern.
                 Err(mut err) => {
                     err.cancel();
-                    mem::replace(self, parser_snapshot_before_ty);
+                    *self = parser_snapshot_before_ty;
                     self.recover_arg_parse()?
                 }
             }

--- a/src/librustc_parse/parser/stmt.rs
+++ b/src/librustc_parse/parser/stmt.rs
@@ -163,8 +163,8 @@ impl<'a> Parser<'a> {
                 Ok(ty) => (None, Some(ty)),
                 Err(mut err) => {
                     // Rewind to before attempting to parse the type and continue parsing.
-                    let parser_snapshot_after_type = self.clone();
-                    mem::replace(self, parser_snapshot_before_type);
+                    let parser_snapshot_after_type =
+                        mem::replace(self, parser_snapshot_before_type);
                     if let Ok(snip) = self.span_to_snippet(pat.span) {
                         err.span_label(pat.span, format!("while parsing the type for `{}`", snip));
                     }
@@ -201,7 +201,7 @@ impl<'a> Parser<'a> {
                 // Couldn't parse the type nor the initializer, only raise the type error and
                 // return to the parser state before parsing the type as the initializer.
                 // let x: <parse_error>;
-                mem::replace(self, snapshot);
+                *self = snapshot;
                 return Err(ty_err);
             }
             (Err(err), None) => {

--- a/src/librustc_resolve/late/lifetimes.rs
+++ b/src/librustc_resolve/late/lifetimes.rs
@@ -26,7 +26,7 @@ use rustc_span::symbol::{kw, sym};
 use rustc_span::Span;
 use std::borrow::Cow;
 use std::cell::Cell;
-use std::mem::{replace, take};
+use std::mem::take;
 
 use log::debug;
 
@@ -371,7 +371,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
         self.with(Scope::Body { id: body.id(), s: self.scope }, |_, this| {
             this.visit_body(body);
         });
-        replace(&mut self.labels_in_fn, saved);
+        self.labels_in_fn = saved;
     }
 
     fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {

--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -301,7 +301,7 @@ mod lazy {
             // value (an aliasing violation). To avoid setting the "I'm running a
             // destructor" flag we just use `mem::replace` which should sequence the
             // operations a little differently and make this safe to call.
-            mem::replace(&mut *ptr, Some(value));
+            let _ = mem::replace(&mut *ptr, Some(value));
 
             // After storing `Some` we want to get a reference to the contents of
             // what we just stored. While we could use `unwrap` here and it should

--- a/src/test/ui/imports/import-in-block.rs
+++ b/src/test/ui/imports/import-in-block.rs
@@ -4,7 +4,7 @@
 pub fn main() {
     use std::mem::replace;
     let mut x = 5;
-    replace(&mut x, 6);
+    let _ = replace(&mut x, 6);
     {
         use std::mem::*;
         let mut y = 6;

--- a/src/test/ui/issues/issue-23611-enum-swap-in-drop.rs
+++ b/src/test/ui/issues/issue-23611-enum-swap-in-drop.rs
@@ -154,7 +154,7 @@ impl<'a> Drop for E<'a> {
         };
 
         if do_drop {
-            mem::replace(self, E::A(GaspA(f_a, 0xA3A0, log, D::new("drop", 6, log)), true));
+            let _ = mem::replace(self, E::A(GaspA(f_a, 0xA3A0, log, D::new("drop", 6, log)), true));
         }
     }
 }

--- a/src/test/ui/issues/issue-23611-enum-swap-in-drop.rs
+++ b/src/test/ui/issues/issue-23611-enum-swap-in-drop.rs
@@ -153,8 +153,9 @@ impl<'a> Drop for E<'a> {
             }
         };
 
+        #[allow(unused_must_use)]
         if do_drop {
-            let _ = mem::replace(self, E::A(GaspA(f_a, 0xA3A0, log, D::new("drop", 6, log)), true));
+            mem::replace(self, E::A(GaspA(f_a, 0xA3A0, log, D::new("drop", 6, log)), true));
         }
     }
 }


### PR DESCRIPTION
This adds a hint on `mem::replace`, "if you don't need the old value,
you can just assign the new value directly". This is in similar spirit
to the `must_use` on `ManuallyDrop::take`.