### PR TITLE
Define UB in float-to-int casts to saturate

### DIFF
--- a/src/librustc_codegen_ssa/mir/rvalue.rs
+++ b/src/librustc_codegen_ssa/mir/rvalue.rs
@@ -768,7 +768,7 @@ fn cast_float_to_int<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
 ) -> Bx::Value {
     let fptosui_result = if signed { bx.fptosi(x, int_ty) } else { bx.fptoui(x, int_ty) };
 
-    if !bx.cx().sess().opts.debugging_opts.saturating_float_casts {
+    if let Some(false) = bx.cx().sess().opts.debugging_opts.saturating_float_casts {
         return fptosui_result;
     }
 

--- a/src/librustc_interface/tests.rs
+++ b/src/librustc_interface/tests.rs
@@ -558,7 +558,7 @@ fn test_debugging_options_tracking_hash() {
     tracked!(sanitizer, Some(Sanitizer::Address));
     tracked!(sanitizer_memory_track_origins, 2);
     tracked!(sanitizer_recover, vec![Sanitizer::Address]);
-    tracked!(saturating_float_casts, true);
+    tracked!(saturating_float_casts, Some(true));
     tracked!(share_generics, Some(true));
     tracked!(show_span, Some(String::from("abc")));
     tracked!(src_hash_algorithm, Some(SourceFileHashAlgorithm::Sha1));

--- a/src/librustc_session/options.rs
+++ b/src/librustc_session/options.rs
@@ -936,9 +936,9 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
         "enable origins tracking in MemorySanitizer"),
     sanitizer_recover: Vec<Sanitizer> = (vec![], parse_sanitizer_list, [TRACKED],
         "enable recovery for selected sanitizers"),
-    saturating_float_casts: bool = (false, parse_bool, [TRACKED],
+    saturating_float_casts: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "make float->int casts UB-free: numbers outside the integer type's range are clipped to \
-        the max/min integer respectively, and NaN is mapped to 0 (default: no)"),
+        the max/min integer respectively, and NaN is mapped to 0 (default: yes)"),
     save_analysis: bool = (false, parse_bool, [UNTRACKED],
         "write syntax and type analysis (in JSON format) information, in \
         addition to normal output (default: no)"),

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -909,13 +909,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             cast_suggestion,
                             Applicability::MaybeIncorrect, // lossy conversion
                         );
-                        err.warn(
-                            "if the rounded value cannot be represented by the target \
-                                integer type, including `Inf` and `NaN`, casting will cause \
-                                undefined behavior \
-                                (see issue #10184 <https://github.com/rust-lang/rust/issues/10184> \
-                                for more information)",
-                        );
                     }
                     true
                 }

--- a/src/test/codegen/unchecked-float-casts.rs
+++ b/src/test/codegen/unchecked-float-casts.rs
@@ -1,7 +1,7 @@
-// compile-flags: -C no-prepopulate-passes
+// This file tests that we don't generate any code for saturation when using the
+// unchecked intrinsics.
 
-// This file tests that we don't generate any code for saturation if
-// -Z saturating-float-casts is not enabled.
+// compile-flags: -C opt-level=3
 
 #![crate_type = "lib"]
 
@@ -12,7 +12,7 @@ pub fn f32_to_u32(x: f32) -> u32 {
     // CHECK-NOT: fcmp
     // CHECK-NOT: icmp
     // CHECK-NOT: select
-    x as u32
+    unsafe { x.to_int_unchecked() }
 }
 
 // CHECK-LABEL: @f32_to_i32
@@ -22,7 +22,7 @@ pub fn f32_to_i32(x: f32) -> i32 {
     // CHECK-NOT: fcmp
     // CHECK-NOT: icmp
     // CHECK-NOT: select
-    x as i32
+    unsafe { x.to_int_unchecked() }
 }
 
 #[no_mangle]
@@ -31,5 +31,5 @@ pub fn f64_to_u16(x: f64) -> u16 {
     // CHECK-NOT: fcmp
     // CHECK-NOT: icmp
     // CHECK-NOT: select
-    x as u16
+    unsafe { x.to_int_unchecked() }
 }

--- a/src/test/ui/numbers-arithmetic/saturating-float-casts.rs
+++ b/src/test/ui/numbers-arithmetic/saturating-float-casts.rs
@@ -1,14 +1,19 @@
 // run-pass
 // Tests saturating float->int casts. See u128-as-f32.rs for the opposite direction.
+//
+// Some of these tests come from a similar file in miri,
+// tests/run-pass/float.rs. They're just duplicated currently but we may want
+// to merge this in the future.
 
 #![feature(test, stmt_expr_attributes)]
+#![feature(track_caller)]
 #![deny(overflowing_literals)]
 extern crate test;
 
 use std::{f32, f64};
-use std::{u8, i8, u16, i16, u32, i32, u64, i64};
-#[cfg(not(target_os="emscripten"))]
-use std::{u128, i128};
+#[cfg(not(target_os = "emscripten"))]
+use std::{i128, u128};
+use std::{i16, i32, i64, i8, u16, u32, u64, u8};
 use test::black_box;
 
 macro_rules! test {
@@ -84,11 +89,459 @@ macro_rules! fptoui_tests {
     })
 }
 
+use std::fmt::Debug;
+
+// Helper function to avoid promotion so that this tests "run-time" casts, not CTFE.
+#[track_caller]
+#[inline(never)]
+fn assert_eq<T: PartialEq + Debug>(x: T, y: T) {
+    assert_eq!(x, y);
+}
+
+trait FloatToInt<Int>: Copy {
+    fn cast(self) -> Int;
+    unsafe fn cast_unchecked(self) -> Int;
+}
+
+impl FloatToInt<i8> for f32 {
+    fn cast(self) -> i8 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> i8 {
+        self.to_int_unchecked()
+    }
+}
+impl FloatToInt<i32> for f32 {
+    fn cast(self) -> i32 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> i32 {
+        self.to_int_unchecked()
+    }
+}
+impl FloatToInt<u32> for f32 {
+    fn cast(self) -> u32 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> u32 {
+        self.to_int_unchecked()
+    }
+}
+impl FloatToInt<i64> for f32 {
+    fn cast(self) -> i64 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> i64 {
+        self.to_int_unchecked()
+    }
+}
+impl FloatToInt<u64> for f32 {
+    fn cast(self) -> u64 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> u64 {
+        self.to_int_unchecked()
+    }
+}
+
+impl FloatToInt<i8> for f64 {
+    fn cast(self) -> i8 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> i8 {
+        self.to_int_unchecked()
+    }
+}
+impl FloatToInt<i32> for f64 {
+    fn cast(self) -> i32 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> i32 {
+        self.to_int_unchecked()
+    }
+}
+impl FloatToInt<u32> for f64 {
+    fn cast(self) -> u32 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> u32 {
+        self.to_int_unchecked()
+    }
+}
+impl FloatToInt<i64> for f64 {
+    fn cast(self) -> i64 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> i64 {
+        self.to_int_unchecked()
+    }
+}
+impl FloatToInt<u64> for f64 {
+    fn cast(self) -> u64 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> u64 {
+        self.to_int_unchecked()
+    }
+}
+// FIXME emscripten does not support i128
+#[cfg(not(target_os = "emscripten"))]
+impl FloatToInt<i128> for f64 {
+    fn cast(self) -> i128 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> i128 {
+        self.to_int_unchecked()
+    }
+}
+// FIXME emscripten does not support i128
+#[cfg(not(target_os = "emscripten"))]
+impl FloatToInt<u128> for f64 {
+    fn cast(self) -> u128 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> u128 {
+        self.to_int_unchecked()
+    }
+}
+
+/// Test this cast both via `as` and via `to_int_unchecked` (i.e., it must not saturate).
+#[track_caller]
+#[inline(never)]
+fn test_both_cast<F, I>(x: F, y: I)
+where
+    F: FloatToInt<I>,
+    I: PartialEq + Debug,
+{
+    assert_eq!(x.cast(), y);
+    assert_eq!(unsafe { x.cast_unchecked() }, y);
+}
+
+fn basic() {
+    // basic arithmetic
+    assert_eq(6.0_f32 * 6.0_f32, 36.0_f32);
+    assert_eq(6.0_f64 * 6.0_f64, 36.0_f64);
+    assert_eq(-{ 5.0_f32 }, -5.0_f32);
+    assert_eq(-{ 5.0_f64 }, -5.0_f64);
+    // infinities, NaN
+    assert!((5.0_f32 / 0.0).is_infinite());
+    assert_ne!({ 5.0_f32 / 0.0 }, { -5.0_f32 / 0.0 });
+    assert!((5.0_f64 / 0.0).is_infinite());
+    assert_ne!({ 5.0_f64 / 0.0 }, { 5.0_f64 / -0.0 });
+    assert!((-5.0_f32).sqrt().is_nan());
+    assert!((-5.0_f64).sqrt().is_nan());
+    assert_ne!(f32::NAN, f32::NAN);
+    assert_ne!(f64::NAN, f64::NAN);
+    // negative zero
+    let posz = 0.0f32;
+    let negz = -0.0f32;
+    assert_eq(posz, negz);
+    assert_ne!(posz.to_bits(), negz.to_bits());
+    let posz = 0.0f64;
+    let negz = -0.0f64;
+    assert_eq(posz, negz);
+    assert_ne!(posz.to_bits(), negz.to_bits());
+    // byte-level transmute
+    let x: u64 = unsafe { std::mem::transmute(42.0_f64) };
+    let y: f64 = unsafe { std::mem::transmute(x) };
+    assert_eq(y, 42.0_f64);
+    let x: u32 = unsafe { std::mem::transmute(42.0_f32) };
+    let y: f32 = unsafe { std::mem::transmute(x) };
+    assert_eq(y, 42.0_f32);
+}
+
+fn casts() {
+    // f32 -> i8
+    test_both_cast::<f32, i8>(127.99, 127);
+    test_both_cast::<f32, i8>(-128.99, -128);
+
+    // f32 -> i32
+    test_both_cast::<f32, i32>(0.0, 0);
+    test_both_cast::<f32, i32>(-0.0, 0);
+    test_both_cast::<f32, i32>(/*0x1p-149*/ f32::from_bits(0x00000001), 0);
+    test_both_cast::<f32, i32>(/*-0x1p-149*/ f32::from_bits(0x80000001), 0);
+    test_both_cast::<f32, i32>(/*0x1.19999ap+0*/ f32::from_bits(0x3f8ccccd), 1);
+    test_both_cast::<f32, i32>(/*-0x1.19999ap+0*/ f32::from_bits(0xbf8ccccd), -1);
+    test_both_cast::<f32, i32>(1.9, 1);
+    test_both_cast::<f32, i32>(-1.9, -1);
+    test_both_cast::<f32, i32>(5.0, 5);
+    test_both_cast::<f32, i32>(-5.0, -5);
+    test_both_cast::<f32, i32>(2147483520.0, 2147483520);
+    test_both_cast::<f32, i32>(-2147483648.0, -2147483648);
+    // unrepresentable casts
+    assert_eq::<i32>(2147483648.0f32 as i32, i32::MAX);
+    assert_eq::<i32>(-2147483904.0f32 as i32, i32::MIN);
+    assert_eq::<i32>(f32::MAX as i32, i32::MAX);
+    assert_eq::<i32>(f32::MIN as i32, i32::MIN);
+    assert_eq::<i32>(f32::INFINITY as i32, i32::MAX);
+    assert_eq::<i32>(f32::NEG_INFINITY as i32, i32::MIN);
+    assert_eq::<i32>(f32::NAN as i32, 0);
+    assert_eq::<i32>((-f32::NAN) as i32, 0);
+
+    // f32 -> u32
+    test_both_cast::<f32, u32>(0.0, 0);
+    test_both_cast::<f32, u32>(-0.0, 0);
+    test_both_cast::<f32, u32>(-0.9999999, 0);
+    test_both_cast::<f32, u32>(/*0x1p-149*/ f32::from_bits(0x1), 0);
+    test_both_cast::<f32, u32>(/*-0x1p-149*/ f32::from_bits(0x80000001), 0);
+    test_both_cast::<f32, u32>(/*0x1.19999ap+0*/ f32::from_bits(0x3f8ccccd), 1);
+    test_both_cast::<f32, u32>(1.9, 1);
+    test_both_cast::<f32, u32>(5.0, 5);
+    test_both_cast::<f32, u32>(2147483648.0, 0x8000_0000);
+    test_both_cast::<f32, u32>(4294967040.0, 0u32.wrapping_sub(256));
+    test_both_cast::<f32, u32>(/*-0x1.ccccccp-1*/ f32::from_bits(0xbf666666), 0);
+    test_both_cast::<f32, u32>(/*-0x1.fffffep-1*/ f32::from_bits(0xbf7fffff), 0);
+    test_both_cast::<f32, u32>((u32::MAX - 128) as f32, u32::MAX - 255); // rounding loss
+
+    // unrepresentable casts:
+
+    // rounds up and then becomes unrepresentable
+    assert_eq::<u32>((u32::MAX - 127) as f32 as u32, u32::MAX);
+
+    assert_eq::<u32>(4294967296.0f32 as u32, u32::MAX);
+    assert_eq::<u32>(-5.0f32 as u32, 0);
+    assert_eq::<u32>(f32::MAX as u32, u32::MAX);
+    assert_eq::<u32>(f32::MIN as u32, 0);
+    assert_eq::<u32>(f32::INFINITY as u32, u32::MAX);
+    assert_eq::<u32>(f32::NEG_INFINITY as u32, 0);
+    assert_eq::<u32>(f32::NAN as u32, 0);
+    assert_eq::<u32>((-f32::NAN) as u32, 0);
+
+    // f32 -> i64
+    test_both_cast::<f32, i64>(4294967296.0, 4294967296);
+    test_both_cast::<f32, i64>(-4294967296.0, -4294967296);
+    test_both_cast::<f32, i64>(9223371487098961920.0, 9223371487098961920);
+    test_both_cast::<f32, i64>(-9223372036854775808.0, -9223372036854775808);
+
+    // f64 -> i8
+    test_both_cast::<f64, i8>(127.99, 127);
+    test_both_cast::<f64, i8>(-128.99, -128);
+
+    // f64 -> i32
+    test_both_cast::<f64, i32>(0.0, 0);
+    test_both_cast::<f64, i32>(-0.0, 0);
+    test_both_cast::<f64, i32>(/*0x1.199999999999ap+0*/ f64::from_bits(0x3ff199999999999a), 1);
+    test_both_cast::<f64, i32>(
+        /*-0x1.199999999999ap+0*/ f64::from_bits(0xbff199999999999a),
+        -1,
+    );
+    test_both_cast::<f64, i32>(1.9, 1);
+    test_both_cast::<f64, i32>(-1.9, -1);
+    test_both_cast::<f64, i32>(1e8, 100_000_000);
+    test_both_cast::<f64, i32>(2147483647.0, 2147483647);
+    test_both_cast::<f64, i32>(-2147483648.0, -2147483648);
+    // unrepresentable casts
+    assert_eq::<i32>(2147483648.0f64 as i32, i32::MAX);
+    assert_eq::<i32>(-2147483649.0f64 as i32, i32::MIN);
+
+    // f64 -> i64
+    test_both_cast::<f64, i64>(0.0, 0);
+    test_both_cast::<f64, i64>(-0.0, 0);
+    test_both_cast::<f64, i64>(/*0x0.0000000000001p-1022*/ f64::from_bits(0x1), 0);
+    test_both_cast::<f64, i64>(
+        /*-0x0.0000000000001p-1022*/ f64::from_bits(0x8000000000000001),
+        0,
+    );
+    test_both_cast::<f64, i64>(/*0x1.199999999999ap+0*/ f64::from_bits(0x3ff199999999999a), 1);
+    test_both_cast::<f64, i64>(
+        /*-0x1.199999999999ap+0*/ f64::from_bits(0xbff199999999999a),
+        -1,
+    );
+    test_both_cast::<f64, i64>(5.0, 5);
+    test_both_cast::<f64, i64>(5.9, 5);
+    test_both_cast::<f64, i64>(-5.0, -5);
+    test_both_cast::<f64, i64>(-5.9, -5);
+    test_both_cast::<f64, i64>(4294967296.0, 4294967296);
+    test_both_cast::<f64, i64>(-4294967296.0, -4294967296);
+    test_both_cast::<f64, i64>(9223372036854774784.0, 9223372036854774784);
+    test_both_cast::<f64, i64>(-9223372036854775808.0, -9223372036854775808);
+    // unrepresentable casts
+    assert_eq::<i64>(9223372036854775808.0f64 as i64, i64::MAX);
+    assert_eq::<i64>(-9223372036854777856.0f64 as i64, i64::MIN);
+    assert_eq::<i64>(f64::MAX as i64, i64::MAX);
+    assert_eq::<i64>(f64::MIN as i64, i64::MIN);
+    assert_eq::<i64>(f64::INFINITY as i64, i64::MAX);
+    assert_eq::<i64>(f64::NEG_INFINITY as i64, i64::MIN);
+    assert_eq::<i64>(f64::NAN as i64, 0);
+    assert_eq::<i64>((-f64::NAN) as i64, 0);
+
+    // f64 -> u64
+    test_both_cast::<f64, u64>(0.0, 0);
+    test_both_cast::<f64, u64>(-0.0, 0);
+    test_both_cast::<f64, u64>(-0.99999999999, 0);
+    test_both_cast::<f64, u64>(5.0, 5);
+    test_both_cast::<f64, u64>(1e16, 10000000000000000);
+    test_both_cast::<f64, u64>((u64::MAX - 1024) as f64, u64::MAX - 2047); // rounding loss
+    test_both_cast::<f64, u64>(9223372036854775808.0, 9223372036854775808);
+    // unrepresentable casts
+    assert_eq::<u64>(-5.0f64 as u64, 0);
+    // rounds up and then becomes unrepresentable
+    assert_eq::<u64>((u64::MAX - 1023) as f64 as u64, u64::MAX);
+    assert_eq::<u64>(18446744073709551616.0f64 as u64, u64::MAX);
+    assert_eq::<u64>(f64::MAX as u64, u64::MAX);
+    assert_eq::<u64>(f64::MIN as u64, 0);
+    assert_eq::<u64>(f64::INFINITY as u64, u64::MAX);
+    assert_eq::<u64>(f64::NEG_INFINITY as u64, 0);
+    assert_eq::<u64>(f64::NAN as u64, 0);
+    assert_eq::<u64>((-f64::NAN) as u64, 0);
+
+    // FIXME emscripten does not support i128
+    #[cfg(not(target_os = "emscripten"))]
+    {
+        // f64 -> i128
+        assert_eq::<i128>(f64::MAX as i128, i128::MAX);
+        assert_eq::<i128>(f64::MIN as i128, i128::MIN);
+
+        // f64 -> u128
+        assert_eq::<u128>(f64::MAX as u128, u128::MAX);
+        assert_eq::<u128>(f64::MIN as u128, 0);
+    }
+
+    // int -> f32
+    assert_eq::<f32>(127i8 as f32, 127.0);
+    assert_eq::<f32>(2147483647i32 as f32, 2147483648.0);
+    assert_eq::<f32>((-2147483648i32) as f32, -2147483648.0);
+    assert_eq::<f32>(1234567890i32 as f32, /*0x1.26580cp+30*/ f32::from_bits(0x4e932c06));
+    assert_eq::<f32>(16777217i32 as f32, 16777216.0);
+    assert_eq::<f32>((-16777217i32) as f32, -16777216.0);
+    assert_eq::<f32>(16777219i32 as f32, 16777220.0);
+    assert_eq::<f32>((-16777219i32) as f32, -16777220.0);
+    assert_eq::<f32>(
+        0x7fffff4000000001i64 as f32,
+        /*0x1.fffffep+62*/ f32::from_bits(0x5effffff),
+    );
+    assert_eq::<f32>(
+        0x8000004000000001u64 as i64 as f32,
+        /*-0x1.fffffep+62*/ f32::from_bits(0xdeffffff),
+    );
+    assert_eq::<f32>(
+        0x0020000020000001i64 as f32,
+        /*0x1.000002p+53*/ f32::from_bits(0x5a000001),
+    );
+    assert_eq::<f32>(
+        0xffdfffffdfffffffu64 as i64 as f32,
+        /*-0x1.000002p+53*/ f32::from_bits(0xda000001),
+    );
+    // FIXME emscripten does not support i128
+    #[cfg(not(target_os = "emscripten"))]
+    {
+        assert_eq::<f32>(i128::MIN as f32, -170141183460469231731687303715884105728.0f32);
+        assert_eq::<f32>(u128::MAX as f32, f32::INFINITY); // saturation
+    }
+
+    // int -> f64
+    assert_eq::<f64>(127i8 as f64, 127.0);
+    assert_eq::<f64>(i16::MIN as f64, -32768.0f64);
+    assert_eq::<f64>(2147483647i32 as f64, 2147483647.0);
+    assert_eq::<f64>(-2147483648i32 as f64, -2147483648.0);
+    assert_eq::<f64>(987654321i32 as f64, 987654321.0);
+    assert_eq::<f64>(9223372036854775807i64 as f64, 9223372036854775807.0);
+    assert_eq::<f64>(-9223372036854775808i64 as f64, -9223372036854775808.0);
+    assert_eq::<f64>(4669201609102990i64 as f64, 4669201609102990.0); // Feigenbaum (?)
+    assert_eq::<f64>(9007199254740993i64 as f64, 9007199254740992.0);
+    assert_eq::<f64>(-9007199254740993i64 as f64, -9007199254740992.0);
+    assert_eq::<f64>(9007199254740995i64 as f64, 9007199254740996.0);
+    assert_eq::<f64>(-9007199254740995i64 as f64, -9007199254740996.0);
+    // FIXME emscripten does not support i128
+    #[cfg(not(target_os = "emscripten"))]
+    {
+        // even that fits...
+        assert_eq::<f64>(u128::MAX as f64, 340282366920938463463374607431768211455.0f64);
+    }
+
+    // f32 -> f64
+    assert_eq::<u64>((0.0f32 as f64).to_bits(), 0.0f64.to_bits());
+    assert_eq::<u64>(((-0.0f32) as f64).to_bits(), (-0.0f64).to_bits());
+    assert_eq::<f64>(5.0f32 as f64, 5.0f64);
+    assert_eq::<f64>(
+        /*0x1p-149*/ f32::from_bits(0x1) as f64,
+        /*0x1p-149*/ f64::from_bits(0x36a0000000000000),
+    );
+    assert_eq::<f64>(
+        /*-0x1p-149*/ f32::from_bits(0x80000001) as f64,
+        /*-0x1p-149*/ f64::from_bits(0xb6a0000000000000),
+    );
+    assert_eq::<f64>(
+        /*0x1.fffffep+127*/ f32::from_bits(0x7f7fffff) as f64,
+        /*0x1.fffffep+127*/ f64::from_bits(0x47efffffe0000000),
+    );
+    assert_eq::<f64>(
+        /*-0x1.fffffep+127*/ (-f32::from_bits(0x7f7fffff)) as f64,
+        /*-0x1.fffffep+127*/ -f64::from_bits(0x47efffffe0000000),
+    );
+    assert_eq::<f64>(
+        /*0x1p-119*/ f32::from_bits(0x4000000) as f64,
+        /*0x1p-119*/ f64::from_bits(0x3880000000000000),
+    );
+    assert_eq::<f64>(
+        /*0x1.8f867ep+125*/ f32::from_bits(0x7e47c33f) as f64,
+        6.6382536710104395e+37,
+    );
+    assert_eq::<f64>(f32::INFINITY as f64, f64::INFINITY);
+    assert_eq::<f64>(f32::NEG_INFINITY as f64, f64::NEG_INFINITY);
+
+    // f64 -> f32
+    assert_eq::<u32>((0.0f64 as f32).to_bits(), 0.0f32.to_bits());
+    assert_eq::<u32>(((-0.0f64) as f32).to_bits(), (-0.0f32).to_bits());
+    assert_eq::<f32>(5.0f64 as f32, 5.0f32);
+    assert_eq::<f32>(/*0x0.0000000000001p-1022*/ f64::from_bits(0x1) as f32, 0.0);
+    assert_eq::<f32>(/*-0x0.0000000000001p-1022*/ (-f64::from_bits(0x1)) as f32, -0.0);
+    assert_eq::<f32>(
+        /*0x1.fffffe0000000p-127*/ f64::from_bits(0x380fffffe0000000) as f32,
+        /*0x1p-149*/ f32::from_bits(0x800000),
+    );
+    assert_eq::<f32>(
+        /*0x1.4eae4f7024c7p+108*/ f64::from_bits(0x46b4eae4f7024c70) as f32,
+        /*0x1.4eae5p+108*/ f32::from_bits(0x75a75728),
+    );
+    assert_eq::<f32>(f64::MAX as f32, f32::INFINITY);
+    assert_eq::<f32>(f64::MIN as f32, f32::NEG_INFINITY);
+    assert_eq::<f32>(f64::INFINITY as f32, f32::INFINITY);
+    assert_eq::<f32>(f64::NEG_INFINITY as f32, f32::NEG_INFINITY);
+}
+
+fn ops() {
+    // f32 min/max
+    assert_eq((1.0 as f32).max(-1.0), 1.0);
+    assert_eq((1.0 as f32).min(-1.0), -1.0);
+    assert_eq(f32::NAN.min(9.0), 9.0);
+    assert_eq(f32::NAN.max(-9.0), -9.0);
+    assert_eq((9.0 as f32).min(f32::NAN), 9.0);
+    assert_eq((-9.0 as f32).max(f32::NAN), -9.0);
+
+    // f64 min/max
+    assert_eq((1.0 as f64).max(-1.0), 1.0);
+    assert_eq((1.0 as f64).min(-1.0), -1.0);
+    assert_eq(f64::NAN.min(9.0), 9.0);
+    assert_eq(f64::NAN.max(-9.0), -9.0);
+    assert_eq((9.0 as f64).min(f64::NAN), 9.0);
+    assert_eq((-9.0 as f64).max(f64::NAN), -9.0);
+
+    // f32 copysign
+    assert_eq(3.5_f32.copysign(0.42), 3.5_f32);
+    assert_eq(3.5_f32.copysign(-0.42), -3.5_f32);
+    assert_eq((-3.5_f32).copysign(0.42), 3.5_f32);
+    assert_eq((-3.5_f32).copysign(-0.42), -3.5_f32);
+    assert!(f32::NAN.copysign(1.0).is_nan());
+
+    // f64 copysign
+    assert_eq(3.5_f64.copysign(0.42), 3.5_f64);
+    assert_eq(3.5_f64.copysign(-0.42), -3.5_f64);
+    assert_eq((-3.5_f64).copysign(0.42), 3.5_f64);
+    assert_eq((-3.5_f64).copysign(-0.42), -3.5_f64);
+    assert!(f64::NAN.copysign(1.0).is_nan());
+}
+
 pub fn main() {
+    basic();
+    casts();
+    ops();
+
     common_fptoi_tests!(f* -> i8 i16 i32 i64 u8 u16 u32 u64);
     fptoui_tests!(f* -> u8 u16 u32 u64);
     // FIXME emscripten does not support i128
-    #[cfg(not(target_os="emscripten"))] {
+    #[cfg(not(target_os = "emscripten"))]
+    {
         common_fptoi_tests!(f* -> i128 u128);
         fptoui_tests!(f* -> u128);
     }
@@ -123,7 +576,7 @@ pub fn main() {
     test!(4294967296., f* -> u32, 4294967295);
 
     // # u128
-    #[cfg(not(target_os="emscripten"))]
+    #[cfg(not(target_os = "emscripten"))]
     {
         // float->int:
         test_c!(f32::MAX, f32 -> u128, 0xffffff00000000000000000000000000);

--- a/src/test/ui/numbers-arithmetic/saturating-float-casts.rs
+++ b/src/test/ui/numbers-arithmetic/saturating-float-casts.rs
@@ -1,6 +1,5 @@
 // run-pass
 // Tests saturating float->int casts. See u128-as-f32.rs for the opposite direction.
-// compile-flags: -Z saturating-float-casts
 
 #![feature(test, stmt_expr_attributes)]
 #![deny(overflowing_literals)]


### PR DESCRIPTION
This closes #10184 by defining the behavior there to saturate infinities and values exceeding the integral range (on the lower or upper end). `NaN` is sent to zero.