### PR TITLE
miri-unleashed: test that we detect heap allocations

### DIFF
--- a/src/librustc_mir/transform/check_consts/mod.rs
+++ b/src/librustc_mir/transform/check_consts/mod.rs
@@ -13,7 +13,7 @@ use std::fmt;
 
 pub use self::qualifs::Qualif;
 
-pub mod ops;
+mod ops;
 pub mod qualifs;
 mod resolver;
 pub mod validation;

--- a/src/librustc_mir/transform/check_consts/ops.rs
+++ b/src/librustc_mir/transform/check_consts/ops.rs
@@ -113,8 +113,6 @@ impl NonConstOp for FnCallUnstable {
 #[derive(Debug)]
 pub struct HeapAllocation;
 impl NonConstOp for HeapAllocation {
-    const IS_SUPPORTED_IN_MIRI: bool = false;
-
     fn emit_error(&self, item: &Item<'_, '_>, span: Span) {
         let mut err = struct_span_err!(
             item.tcx.sess,

--- a/src/test/ui/consts/miri_unleashed/box.rs
+++ b/src/test/ui/consts/miri_unleashed/box.rs
@@ -1,0 +1,14 @@
+// compile-flags: -Zunleash-the-miri-inside-of-you
+#![feature(const_mut_refs, box_syntax)]
+#![deny(const_err)]
+
+use std::mem::ManuallyDrop;
+
+fn main() {}
+
+static TEST_BAD: &mut i32 = {
+    &mut *(box 0)
+    //~^ WARN skipping const check
+    //~| ERROR could not evaluate static initializer
+    //~| NOTE heap allocations
+};

--- a/src/test/ui/consts/miri_unleashed/box.stderr
+++ b/src/test/ui/consts/miri_unleashed/box.stderr
@@ -1,0 +1,15 @@
+warning: skipping const checks
+  --> $DIR/box.rs:10:11
+   |
+LL |     &mut *(box 0)
+   |           ^^^^^^^
+
+error[E0080]: could not evaluate static initializer
+  --> $DIR/box.rs:10:11
+   |
+LL |     &mut *(box 0)
+   |           ^^^^^^^ "heap allocations via `box` keyword" needs an rfc before being allowed inside constants
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
This removes the second-to-last use of `IS_SUPPORTED_IN_MIRI = false`.

r? @ecstatic-morse @oli-obk 