### PR TITLE
Explain why we shouldn't add inline attr to into_vec

### DIFF
--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -140,6 +140,9 @@ mod hack {
     use crate::string::ToString;
     use crate::vec::Vec;
 
+    // We shouldn't add inline attribute to this since this is used in
+    // `vec!` macro mostly and causes perf regression. See #71204 for
+    // discussion and perf results.
     pub fn into_vec<T>(b: Box<[T]>) -> Vec<T> {
         unsafe {
             let len = b.len();


### PR DESCRIPTION
Follow-up of #71204
r? @RalfJung 