### PR TITLE
Hint use of `use crate::` on invalid mod

### DIFF
--- a/src/librustc_expand/module.rs
+++ b/src/librustc_expand/module.rs
@@ -280,9 +280,13 @@ pub fn default_submod_path<'a>(
                 mod_name,
             );
             err.help(&format!(
-                "to create the module `{}`, create file \"{}\"",
+                "to create the module `{}` here, create file \"{}\"",
                 mod_name,
                 default_path.display(),
+            ));
+            err.help(&format!(
+                "if there is `mod {}` elsewhere in the crate already, import it with `use crate::` instead",
+                mod_name,
             ));
             Err(err)
         }

--- a/src/test/ui/error-codes/E0583.stderr
+++ b/src/test/ui/error-codes/E0583.stderr
@@ -4,7 +4,8 @@ error[E0583]: file not found for module `module_that_doesnt_exist`
 LL | mod module_that_doesnt_exist;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: to create the module `module_that_doesnt_exist`, create file "$DIR/module_that_doesnt_exist.rs"
+   = help: to create the module `module_that_doesnt_exist` here, create file "$DIR/module_that_doesnt_exist.rs"
+   = help: if there is `mod module_that_doesnt_exist` elsewhere in the crate already, import it with `use crate::` instead
 
 error: aborting due to previous error
 

--- a/src/test/ui/invalid-module-declaration/invalid-module-declaration.stderr
+++ b/src/test/ui/invalid-module-declaration/invalid-module-declaration.stderr
@@ -4,7 +4,8 @@ error[E0583]: file not found for module `baz`
 LL | pub mod baz;
    | ^^^^^^^^^^^^
    |
-   = help: to create the module `baz`, create file "$DIR/auxiliary/foo/bar/baz.rs"
+   = help: to create the module `baz` here, create file "$DIR/auxiliary/foo/bar/baz.rs"
+   = help: if there is `mod baz` elsewhere in the crate already, import it with `use crate::` instead
 
 error: aborting due to previous error
 

--- a/src/test/ui/missing_non_modrs_mod/missing_non_modrs_mod.stderr
+++ b/src/test/ui/missing_non_modrs_mod/missing_non_modrs_mod.stderr
@@ -4,7 +4,8 @@ error[E0583]: file not found for module `missing`
 LL | mod missing;
    | ^^^^^^^^^^^^
    |
-   = help: to create the module `missing`, create file "$DIR/foo/missing.rs"
+   = help: to create the module `missing` here, create file "$DIR/foo/missing.rs"
+   = help: if there is `mod missing` elsewhere in the crate already, import it with `use crate::` instead
 
 error: aborting due to previous error
 

--- a/src/test/ui/missing_non_modrs_mod/missing_non_modrs_mod_inline.stderr
+++ b/src/test/ui/missing_non_modrs_mod/missing_non_modrs_mod_inline.stderr
@@ -4,7 +4,8 @@ error[E0583]: file not found for module `missing`
 LL |     mod missing;
    |     ^^^^^^^^^^^^
    |
-   = help: to create the module `missing`, create file "$DIR/foo_inline/inline/missing.rs"
+   = help: to create the module `missing` here, create file "$DIR/foo_inline/inline/missing.rs"
+   = help: if there is `mod missing` elsewhere in the crate already, import it with `use crate::` instead
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/mod_file_not_exist.rs
+++ b/src/test/ui/parser/mod_file_not_exist.rs
@@ -1,7 +1,8 @@
 // ignore-windows
 
 mod not_a_real_file; //~ ERROR file not found for module `not_a_real_file`
-//~^ HELP to create the module `not_a_real_file`, create file
+//~^ HELP to create the module `not_a_real_file` here, create file
+//~| HELP if there is `mod not_a_real_file` elsewhere in the crate already
 
 fn main() {
     assert_eq!(mod_file_aux::bar(), 10);

--- a/src/test/ui/parser/mod_file_not_exist.stderr
+++ b/src/test/ui/parser/mod_file_not_exist.stderr
@@ -4,10 +4,11 @@ error[E0583]: file not found for module `not_a_real_file`
 LL | mod not_a_real_file;
    | ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: to create the module `not_a_real_file`, create file "$DIR/not_a_real_file.rs"
+   = help: to create the module `not_a_real_file` here, create file "$DIR/not_a_real_file.rs"
+   = help: if there is `mod not_a_real_file` elsewhere in the crate already, import it with `use crate::` instead
 
 error[E0433]: failed to resolve: use of undeclared type or module `mod_file_aux`
-  --> $DIR/mod_file_not_exist.rs:7:16
+  --> $DIR/mod_file_not_exist.rs:8:16
    |
 LL |     assert_eq!(mod_file_aux::bar(), 10);
    |                ^^^^^^^^^^^^ use of undeclared type or module `mod_file_aux`

--- a/src/test/ui/parser/mod_file_not_exist_windows.rs
+++ b/src/test/ui/parser/mod_file_not_exist_windows.rs
@@ -1,7 +1,8 @@
 // only-windows
 
 mod not_a_real_file; //~ ERROR file not found for module `not_a_real_file`
-//~^ HELP to create the module `not_a_real_file`, create file
+//~^ HELP to create the module `not_a_real_file` here, create file
+//~^ HELP if there is `mod not_a_real_file` elsewhere in the crate already
 
 fn main() {
     assert_eq!(mod_file_aux::bar(), 10);

--- a/src/test/ui/parser/mod_file_not_exist_windows.stderr
+++ b/src/test/ui/parser/mod_file_not_exist_windows.stderr
@@ -4,7 +4,8 @@ error[E0583]: file not found for module `not_a_real_file`
 LL | mod not_a_real_file;
    | ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: to create the module `not_a_real_file`, create file "$DIR/not_a_real_file.rs"
+   = help: to create the module `not_a_real_file` here, create file "$DIR/not_a_real_file.rs"
+   = help: if there is `mod not_a_real_file` elsewhere in the crate already, import it with `use crate::` instead
 
 error[E0433]: failed to resolve: use of undeclared type or module `mod_file_aux`
   --> $DIR/mod_file_not_exist_windows.rs:7:16


### PR DESCRIPTION
Next step in #69492

It's not feasible to know at this stage of parsing what other modules exists, so the help string is speculative unfortunately. 

The goal is to help users who assumed `mod foo;` works the same way as `#include "foo"` or `require("foo")`, and should have used `use crate::foo` instead.
