### PR TITLE
remove build warnings

### DIFF
--- a/src/librustc_mir/borrow_check/diagnostics/region_name.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/region_name.rs
@@ -148,7 +148,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
     ///
     /// This function would create a label like this:
     ///
-    /// ```
+    /// ```text
     ///  | fn foo(x: &u32) { .. }
     ///           ------- fully elaborated type of `x` is `&'1 u32`
     /// ```
@@ -300,7 +300,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
     /// elaborated type, returning something like `'1`. Result looks
     /// like:
     ///
-    /// ```
+    /// ```text
     ///  | fn foo(x: &u32) { .. }
     ///           ------- fully elaborated type of `x` is `&'1 u32`
     /// ```
@@ -347,7 +347,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
     /// that has no type annotation.
     /// For example, we might produce an annotation like this:
     ///
-    /// ```
+    /// ```text
     ///  |     foo(|a, b| b)
     ///  |          -  -
     ///  |          |  |
@@ -396,7 +396,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
     /// that contains the anonymous reference we want to give a name
     /// to. For example, we might produce an annotation like this:
     ///
-    /// ```
+    /// ```text
     ///  | fn a<T>(items: &[T]) -> Box<dyn Iterator<Item = &T>> {
     ///  |                - let's call the lifetime of this reference `'1`
     /// ```
@@ -600,7 +600,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
     /// fully elaborated type, returning something like `'1`. Result
     /// looks like:
     ///
-    /// ```
+    /// ```text
     ///  | let x = Some(&22);
     ///        - fully elaborated type of `x` is `Option<&'1 u32>`
     /// ```

--- a/src/librustc_parse/parser/diagnostics.rs
+++ b/src/librustc_parse/parser/diagnostics.rs
@@ -579,11 +579,13 @@ impl<'a> Parser<'a> {
     /// Keep in mind that given that `outer_op.is_comparison()` holds and comparison ops are left
     /// associative we can infer that we have:
     ///
+    /// ```text
     ///           outer_op
     ///           /   \
     ///     inner_op   r2
     ///        /  \
     ///      l1    r1
+    /// ```
     pub(super) fn check_no_chained_comparison(
         &mut self,
         inner_op: &Expr,

--- a/src/librustc_parse/parser/generics.rs
+++ b/src/librustc_parse/parser/generics.rs
@@ -8,7 +8,7 @@ use rustc_span::symbol::{kw, sym};
 impl<'a> Parser<'a> {
     /// Parses bounds of a lifetime parameter `BOUND + BOUND + BOUND`, possibly with trailing `+`.
     ///
-    /// ```
+    /// ```text
     /// BOUND = LT_BOUND (e.g., `'a`)
     /// ```
     fn parse_lt_param_bounds(&mut self) -> GenericBounds {

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -743,7 +743,7 @@ impl<'a> Parser<'a> {
 
     /// Parses a `UseTree`.
     ///
-    /// ```
+    /// ```text
     /// USE_TREE = [`::`] `*` |
     ///            [`::`] `{` USE_TREE_LIST `}` |
     ///            PATH `::` `*` |
@@ -792,7 +792,7 @@ impl<'a> Parser<'a> {
 
     /// Parses a `UseTreeKind::Nested(list)`.
     ///
-    /// ```
+    /// ```text
     /// USE_TREE_LIST = Ø | (USE_TREE `,`)* USE_TREE [`,`]
     /// ```
     fn parse_use_tree_list(&mut self) -> PResult<'a, Vec<(UseTree, ast::NodeId)>> {

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -1031,7 +1031,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
 
     /// Suggest a missing `self::` if that resolves to an correct module.
     ///
-    /// ```
+    /// ```text
     ///    |
     /// LL | use foo::Bar;
     ///    |     ^^^ did you mean `self::foo`?
@@ -1083,7 +1083,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
 
     /// Suggests a missing `super::` if that resolves to an correct module.
     ///
-    /// ```
+    /// ```text
     ///    |
     /// LL | use foo::Bar;
     ///    |     ^^^ did you mean `super::foo`?
@@ -1103,7 +1103,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
 
     /// Suggests a missing external crate name if that resolves to an correct module.
     ///
-    /// ```
+    /// ```text
     ///    |
     /// LL | use foobar::Baz;
     ///    |     ^^^^^^ did you mean `baz::foobar`?

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -1045,7 +1045,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
     /// Adds an async-await specific note to the diagnostic when the future does not implement
     /// an auto trait because of a captured type.
     ///
-    /// ```ignore (diagnostic)
+    /// ```text
     /// note: future does not implement `Qux` as this value is used across an await
     ///   --> $DIR/issue-64130-3-other.rs:17:5
     ///    |
@@ -1060,7 +1060,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
     /// When the diagnostic does not implement `Send` or `Sync` specifically, then the diagnostic
     /// is "replaced" with a different message and a more specific error.
     ///
-    /// ```ignore (diagnostic)
+    /// ```text
     /// error: future cannot be sent between threads safely
     ///   --> $DIR/issue-64130-2-send.rs:21:5
     ///    |

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1250,7 +1250,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
     /// This helper takes a *converted* parameter type (`param_ty`)
     /// and an *unconverted* list of bounds:
     ///
-    /// ```
+    /// ```text
     /// fn foo<T: Debug>
     ///        ^  ^^^^^ `ast_bounds` parameter, in HIR form
     ///        |
@@ -2992,7 +2992,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 /// representations). These lists of bounds occur in many places in
 /// Rust's syntax:
 ///
-/// ```
+/// ```text
 /// trait Foo: Bar + Baz { }
 ///            ^^^^^^^^^ supertrait list bounding the `Self` type parameter
 ///


### PR DESCRIPTION
Code blocks that are not annotated are assumed to be Rust