### PR TITLE
On `FnDef` type annotation suggestion, use fn-pointer output

### DIFF
--- a/src/librustc_infer/infer/error_reporting/need_type_info.rs
+++ b/src/librustc_infer/infer/error_reporting/need_type_info.rs
@@ -248,7 +248,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             };
             printer.name_resolver = Some(Box::new(&getter));
             let _ = if let ty::FnDef(..) = ty.kind {
-                // We don't want the regular output for `fn`s because it inscludes its path in
+                // We don't want the regular output for `fn`s because it includes its path in
                 // invalid pseduo-syntax, we want the `fn`-pointer output instead.
                 ty.fn_sig(self.tcx).print(printer)
             } else {

--- a/src/librustc_infer/infer/error_reporting/need_type_info.rs
+++ b/src/librustc_infer/infer/error_reporting/need_type_info.rs
@@ -247,7 +247,13 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 None
             };
             printer.name_resolver = Some(Box::new(&getter));
-            let _ = ty.print(printer);
+            let _ = if let ty::FnDef(..) = ty.kind {
+                // We don't want the regular output for `fn`s because it inscludes its path in
+                // invalid pseduo-syntax, we want the `fn`-pointer output instead.
+                ty.fn_sig(self.tcx).print(printer)
+            } else {
+                ty.print(printer)
+            };
             s
         };
 

--- a/src/test/ui/suggestions/fn-needing-specified-return-type-param.rs
+++ b/src/test/ui/suggestions/fn-needing-specified-return-type-param.rs
@@ -1,0 +1,5 @@
+fn f<A>() -> A { unimplemented!() }
+fn foo() {
+    let _ = f; //~ ERROR type annotations needed for `fn() -> A`
+}
+fn main() {}

--- a/src/test/ui/suggestions/fn-needing-specified-return-type-param.stderr
+++ b/src/test/ui/suggestions/fn-needing-specified-return-type-param.stderr
@@ -1,0 +1,11 @@
+error[E0282]: type annotations needed for `fn() -> A`
+  --> $DIR/fn-needing-specified-return-type-param.rs:3:13
+   |
+LL |     let _ = f;
+   |         -   ^ cannot infer type for type parameter `A` declared on the function `f`
+   |         |
+   |         consider giving this pattern the explicit type `fn() -> A`, where the type parameter `A` is specified
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
Address the last point in #71209.