### PR TITLE
miri-unleash tests: ensure they fire even with 'allow(const_err)'

### DIFF
--- a/src/test/ui/consts/miri_unleashed/abi-mismatch.rs
+++ b/src/test/ui/consts/miri_unleashed/abi-mismatch.rs
@@ -2,15 +2,20 @@
 // compile-flags: -Z unleash-the-miri-inside-of-you
 
 #![feature(const_extern_fn)]
+#![allow(const_err)]
 
 const extern "C" fn c_fn() {}
 
 const fn call_rust_fn(my_fn: extern "Rust" fn()) {
-    my_fn(); //~ ERROR any use of this value will cause an error
+    my_fn();
     //~^ WARN skipping const checks
+    //~| ERROR could not evaluate static initializer
+    //~| NOTE calling a function with ABI C using caller ABI Rust
+    //~| NOTE inside `call_rust_fn`
 }
 
-const VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
+static VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
 //~^ WARN skipping const checks
+//~| NOTE inside `VAL`
 
 fn main() {}

--- a/src/test/ui/consts/miri_unleashed/abi-mismatch.stderr
+++ b/src/test/ui/consts/miri_unleashed/abi-mismatch.stderr
@@ -1,29 +1,27 @@
 warning: skipping const checks
-  --> $DIR/abi-mismatch.rs:9:5
+  --> $DIR/abi-mismatch.rs:10:5
    |
 LL |     my_fn();
    |     ^^^^^^^
 
 warning: skipping const checks
-  --> $DIR/abi-mismatch.rs:13:39
+  --> $DIR/abi-mismatch.rs:17:40
    |
-LL | const VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | static VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: any use of this value will cause an error
-  --> $DIR/abi-mismatch.rs:9:5
+error[E0080]: could not evaluate static initializer
+  --> $DIR/abi-mismatch.rs:10:5
    |
 LL |     my_fn();
    |     ^^^^^^^
    |     |
    |     calling a function with ABI C using caller ABI Rust
-   |     inside `call_rust_fn` at $DIR/abi-mismatch.rs:9:5
-   |     inside `VAL` at $DIR/abi-mismatch.rs:13:17
+   |     inside `call_rust_fn` at $DIR/abi-mismatch.rs:10:5
 ...
-LL | const VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
-   | --------------------------------------------------------------------------------------
-   |
-   = note: `#[deny(const_err)]` on by default
+LL | static VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
+   |                  --------------------------------------------------------------------- inside `VAL` at $DIR/abi-mismatch.rs:17:18
 
 error: aborting due to previous error; 2 warnings emitted
 
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/box.rs
+++ b/src/test/ui/consts/miri_unleashed/box.rs
@@ -1,6 +1,6 @@
 // compile-flags: -Zunleash-the-miri-inside-of-you
 #![feature(const_mut_refs, box_syntax)]
-#![deny(const_err)]
+#![allow(const_err)]
 
 use std::mem::ManuallyDrop;
 

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static.rs
@@ -1,39 +1,37 @@
+// build-fail
 // compile-flags: -Zunleash-the-miri-inside-of-you
-#![warn(const_err)]
+#![allow(const_err)]
 
 #![feature(const_raw_ptr_deref)]
 
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
-const REF_INTERIOR_MUT: &usize = { //~ ERROR undefined behavior to use this value
-    static FOO: AtomicUsize = AtomicUsize::new(0);
-    unsafe { &*(&FOO as *const _ as *const usize) }
-    //~^ WARN skipping const checks
-};
+// These tests only cause an error when *using* the const.
 
 const MUTATE_INTERIOR_MUT: usize = {
     static FOO: AtomicUsize = AtomicUsize::new(0);
-    FOO.fetch_add(1, Ordering::Relaxed) //~ WARN any use of this value will cause an error
+    FOO.fetch_add(1, Ordering::Relaxed)
     //~^ WARN skipping const checks
     //~| WARN skipping const checks
 };
 
 const READ_INTERIOR_MUT: usize = {
     static FOO: AtomicUsize = AtomicUsize::new(0);
-    unsafe { *(&FOO as *const _ as *const usize) } //~ WARN any use of this value will cause an err
+    unsafe { *(&FOO as *const _ as *const usize) }
     //~^ WARN skipping const checks
 };
 
 static mut MUTABLE: u32 = 0;
-const READ_MUT: u32 = unsafe { MUTABLE }; //~ WARN any use of this value will cause an error
+const READ_MUT: u32 = unsafe { MUTABLE };
 //~^ WARN skipping const checks
 //~| WARN skipping const checks
 
-// ok some day perhaps
-const READ_IMMUT: &usize = { //~ ERROR it is undefined behavior to use this value
-    static FOO: usize = 0;
-    &FOO
-    //~^ WARN skipping const checks
-};
-fn main() {}
+fn main() {
+    MUTATE_INTERIOR_MUT;
+    //~^ ERROR: erroneous constant used
+    READ_INTERIOR_MUT;
+    //~^ ERROR: erroneous constant used
+    READ_MUT;
+    //~^ ERROR: erroneous constant used
+}

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
@@ -1,106 +1,51 @@
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:11:18
-   |
-LL |     unsafe { &*(&FOO as *const _ as *const usize) }
-   |                  ^^^
-
-warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:17:5
+  --> $DIR/const_refers_to_static.rs:14:5
    |
 LL |     FOO.fetch_add(1, Ordering::Relaxed)
    |     ^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:17:5
+  --> $DIR/const_refers_to_static.rs:14:5
    |
 LL |     FOO.fetch_add(1, Ordering::Relaxed)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:24:17
+  --> $DIR/const_refers_to_static.rs:21:17
    |
 LL |     unsafe { *(&FOO as *const _ as *const usize) }
    |                 ^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:29:32
+  --> $DIR/const_refers_to_static.rs:26:32
    |
 LL | const READ_MUT: u32 = unsafe { MUTABLE };
    |                                ^^^^^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:29:32
+  --> $DIR/const_refers_to_static.rs:26:32
    |
 LL | const READ_MUT: u32 = unsafe { MUTABLE };
    |                                ^^^^^^^
 
-warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:36:6
+error[E0080]: erroneous constant used
+  --> $DIR/const_refers_to_static.rs:31:5
    |
-LL |     &FOO
-   |      ^^^
+LL |     MUTATE_INTERIOR_MUT;
+   |     ^^^^^^^^^^^^^^^^^^^ referenced constant has errors
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static.rs:9:1
+error[E0080]: erroneous constant used
+  --> $DIR/const_refers_to_static.rs:33:5
    |
-LL | / const REF_INTERIOR_MUT: &usize = {
-LL | |     static FOO: AtomicUsize = AtomicUsize::new(0);
-LL | |     unsafe { &*(&FOO as *const _ as *const usize) }
-LL | |
-LL | | };
-   | |__^ type validation failed: encountered a reference pointing to a static variable
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+LL |     READ_INTERIOR_MUT;
+   |     ^^^^^^^^^^^^^^^^^ referenced constant has errors
 
-warning: any use of this value will cause an error
-  --> $DIR/const_refers_to_static.rs:17:5
+error[E0080]: erroneous constant used
+  --> $DIR/const_refers_to_static.rs:35:5
    |
-LL | / const MUTATE_INTERIOR_MUT: usize = {
-LL | |     static FOO: AtomicUsize = AtomicUsize::new(0);
-LL | |     FOO.fetch_add(1, Ordering::Relaxed)
-   | |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ calling non-const function `std::sync::atomic::AtomicUsize::fetch_add`
-LL | |
-LL | |
-LL | | };
-   | |__-
-   |
-note: the lint level is defined here
-  --> $DIR/const_refers_to_static.rs:2:9
-   |
-LL | #![warn(const_err)]
-   |         ^^^^^^^^^
+LL |     READ_MUT;
+   |     ^^^^^^^^ referenced constant has errors
 
-warning: any use of this value will cause an error
-  --> $DIR/const_refers_to_static.rs:24:14
-   |
-LL | / const READ_INTERIOR_MUT: usize = {
-LL | |     static FOO: AtomicUsize = AtomicUsize::new(0);
-LL | |     unsafe { *(&FOO as *const _ as *const usize) }
-   | |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant accesses static
-LL | |
-LL | | };
-   | |__-
-
-warning: any use of this value will cause an error
-  --> $DIR/const_refers_to_static.rs:29:32
-   |
-LL | const READ_MUT: u32 = unsafe { MUTABLE };
-   | -------------------------------^^^^^^^---
-   |                                |
-   |                                constant accesses static
-
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static.rs:34:1
-   |
-LL | / const READ_IMMUT: &usize = {
-LL | |     static FOO: usize = 0;
-LL | |     &FOO
-LL | |
-LL | | };
-   | |__^ type validation failed: encountered a reference pointing to a static variable
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-
-error: aborting due to 2 previous errors; 10 warnings emitted
+error: aborting due to 3 previous errors; 5 warnings emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static2.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static2.rs
@@ -1,0 +1,24 @@
+// compile-flags: -Zunleash-the-miri-inside-of-you
+#![allow(const_err)]
+
+#![feature(const_raw_ptr_deref)]
+
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+// These tests cause immediate error when *defining* the const.
+
+const REF_INTERIOR_MUT: &usize = { //~ ERROR undefined behavior to use this value
+    static FOO: AtomicUsize = AtomicUsize::new(0);
+    unsafe { &*(&FOO as *const _ as *const usize) }
+    //~^ WARN skipping const checks
+};
+
+// ok some day perhaps
+const READ_IMMUT: &usize = { //~ ERROR it is undefined behavior to use this value
+    static FOO: usize = 0;
+    &FOO
+    //~^ WARN skipping const checks
+};
+
+fn main() {}

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static2.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static2.stderr
@@ -1,0 +1,39 @@
+warning: skipping const checks
+  --> $DIR/const_refers_to_static2.rs:13:18
+   |
+LL |     unsafe { &*(&FOO as *const _ as *const usize) }
+   |                  ^^^
+
+warning: skipping const checks
+  --> $DIR/const_refers_to_static2.rs:20:6
+   |
+LL |     &FOO
+   |      ^^^
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/const_refers_to_static2.rs:11:1
+   |
+LL | / const REF_INTERIOR_MUT: &usize = {
+LL | |     static FOO: AtomicUsize = AtomicUsize::new(0);
+LL | |     unsafe { &*(&FOO as *const _ as *const usize) }
+LL | |
+LL | | };
+   | |__^ type validation failed: encountered a reference pointing to a static variable
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/const_refers_to_static2.rs:18:1
+   |
+LL | / const READ_IMMUT: &usize = {
+LL | |     static FOO: usize = 0;
+LL | |     &FOO
+LL | |
+LL | | };
+   | |__^ type validation failed: encountered a reference pointing to a static variable
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+
+error: aborting due to 2 previous errors; 2 warnings emitted
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/drop.rs
+++ b/src/test/ui/consts/miri_unleashed/drop.rs
@@ -1,6 +1,6 @@
 // compile-flags: -Zunleash-the-miri-inside-of-you
 // error-pattern: calling non-const function `<std::vec::Vec<i32> as std::ops::Drop>::drop`
-#![deny(const_err)]
+#![allow(const_err)]
 
 use std::mem::ManuallyDrop;
 

--- a/src/test/ui/consts/miri_unleashed/mutable_const.rs
+++ b/src/test/ui/consts/miri_unleashed/mutable_const.rs
@@ -1,8 +1,13 @@
 // compile-flags: -Zunleash-the-miri-inside-of-you
+// normalize-stderr-test "alloc[0-9]+" -> "allocN"
 
 #![feature(const_raw_ptr_deref)]
 #![feature(const_mut_refs)]
-#![deny(const_err)] // FIXME: ICEs with allow! See #71316.
+#![deny(const_err)] // The `allow` variant is tested by `mutable_const2`.
+//~^ NOTE lint level
+// Here we check that even though `MUTABLE_BEHIND_RAW` is created from a mutable
+// allocation, we intern that allocation as *immutable* and reject writes to it.
+// We avoid the `delay_span_bug` ICE by having compilation fail via the `deny` above.
 
 use std::cell::UnsafeCell;
 
@@ -10,10 +15,13 @@ use std::cell::UnsafeCell;
 const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
 //~^ WARN: skipping const checks
 
-const MUTATING_BEHIND_RAW: () = {
+const MUTATING_BEHIND_RAW: () = { //~ NOTE
     // Test that `MUTABLE_BEHIND_RAW` is actually immutable, by doing this at const time.
     unsafe {
         *MUTABLE_BEHIND_RAW = 99 //~ ERROR any use of this value will cause an error
+        //~^ NOTE: which is read-only
+        // FIXME would be good to match more of the error message here, but looks like we
+        // normalize *after* checking the annoations here.
     }
 };
 

--- a/src/test/ui/consts/miri_unleashed/mutable_const.rs
+++ b/src/test/ui/consts/miri_unleashed/mutable_const.rs
@@ -2,7 +2,7 @@
 
 #![feature(const_raw_ptr_deref)]
 #![feature(const_mut_refs)]
-#![deny(const_err)]
+#![deny(const_err)] // FIXME: ICEs with allow! See #71316.
 
 use std::cell::UnsafeCell;
 

--- a/src/test/ui/consts/miri_unleashed/mutable_const.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_const.stderr
@@ -19,7 +19,7 @@ LL | | };
 note: the lint level is defined here
   --> $DIR/mutable_const.rs:5:9
    |
-LL | #![deny(const_err)]
+LL | #![deny(const_err)] // FIXME: ICEs with allow! See #71316.
    |         ^^^^^^^^^
 
 error: aborting due to previous error; 1 warning emitted

--- a/src/test/ui/consts/miri_unleashed/mutable_const.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_const.stderr
@@ -1,25 +1,26 @@
 warning: skipping const checks
-  --> $DIR/mutable_const.rs:10:38
+  --> $DIR/mutable_const.rs:15:38
    |
 LL | const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
    |                                      ^^^^^^^^^^^^^^^^^^^^
 
 error: any use of this value will cause an error
-  --> $DIR/mutable_const.rs:16:9
+  --> $DIR/mutable_const.rs:21:9
    |
 LL | / const MUTATING_BEHIND_RAW: () = {
 LL | |     // Test that `MUTABLE_BEHIND_RAW` is actually immutable, by doing this at const time.
 LL | |     unsafe {
 LL | |         *MUTABLE_BEHIND_RAW = 99
-   | |         ^^^^^^^^^^^^^^^^^^^^^^^^ writing to alloc2 which is read-only
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^ writing to allocN which is read-only
+...  |
 LL | |     }
 LL | | };
    | |__-
    |
 note: the lint level is defined here
-  --> $DIR/mutable_const.rs:5:9
+  --> $DIR/mutable_const.rs:6:9
    |
-LL | #![deny(const_err)] // FIXME: ICEs with allow! See #71316.
+LL | #![deny(const_err)] // The `allow` variant is tested by `mutable_const2`.
    |         ^^^^^^^^^
 
 error: aborting due to previous error; 1 warning emitted

--- a/src/test/ui/consts/miri_unleashed/mutable_const2.rs
+++ b/src/test/ui/consts/miri_unleashed/mutable_const2.rs
@@ -3,7 +3,7 @@
 // rustc-env:RUST_BACKTRACE=0
 // normalize-stderr-test "note: rustc 1.* running on .*" -> "note: rustc VERSION running on TARGET"
 // normalize-stderr-test "note: compiler flags: .*" -> "note: compiler flags: FLAGS"
-// normalize-stderr-test "interpret/intern.rs:[0-9]*:[0-9]*" -> "interpret/intern.rs:LL:CC"
+// normalize-stderr-test "interpret/intern.rs:[0-9]+:[0-9]+" -> "interpret/intern.rs:LL:CC"
 
 #![feature(const_raw_ptr_deref)]
 #![feature(const_mut_refs)]

--- a/src/test/ui/consts/miri_unleashed/mutable_const2.rs
+++ b/src/test/ui/consts/miri_unleashed/mutable_const2.rs
@@ -7,7 +7,7 @@
 
 #![feature(const_raw_ptr_deref)]
 #![feature(const_mut_refs)]
-#![deny(const_err)]
+#![allow(const_err)]
 
 use std::cell::UnsafeCell;
 

--- a/src/test/ui/consts/miri_unleashed/mutable_references_ice.rs
+++ b/src/test/ui/consts/miri_unleashed/mutable_references_ice.rs
@@ -3,7 +3,7 @@
 // rustc-env:RUST_BACKTRACE=0
 // normalize-stderr-test "note: rustc 1.* running on .*" -> "note: rustc VERSION running on TARGET"
 // normalize-stderr-test "note: compiler flags: .*" -> "note: compiler flags: FLAGS"
-// normalize-stderr-test "interpret/intern.rs:[0-9]*:[0-9]*" -> "interpret/intern.rs:LL:CC"
+// normalize-stderr-test "interpret/intern.rs:[0-9]+:[0-9]+" -> "interpret/intern.rs:LL:CC"
 
 #![allow(const_err)]
 

--- a/src/test/ui/consts/miri_unleashed/mutating_global.rs
+++ b/src/test/ui/consts/miri_unleashed/mutating_global.rs
@@ -1,14 +1,15 @@
 // compile-flags: -Zunleash-the-miri-inside-of-you
+#![allow(const_err)]
 
 // Make sure we cannot mutate globals.
 
 static mut GLOBAL: i32 = 0;
 
-const MUTATING_GLOBAL: () = {
+static MUTATING_GLOBAL: () = {
     unsafe {
-        GLOBAL = 99 //~ ERROR any use of this value will cause an error
-        //~^ WARN skipping const checks
-        //~| WARN skipping const checks
+        GLOBAL = 99
+        //~^ ERROR could not evaluate static initializer
+        //~| NOTE modifying a static's initial value
     }
 };
 

--- a/src/test/ui/consts/miri_unleashed/mutating_global.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutating_global.stderr
@@ -1,29 +1,9 @@
-warning: skipping const checks
-  --> $DIR/mutating_global.rs:9:9
+error[E0080]: could not evaluate static initializer
+  --> $DIR/mutating_global.rs:10:9
    |
 LL |         GLOBAL = 99
-   |         ^^^^^^
+   |         ^^^^^^^^^^^ modifying a static's initial value from another static's initializer
 
-warning: skipping const checks
-  --> $DIR/mutating_global.rs:9:9
-   |
-LL |         GLOBAL = 99
-   |         ^^^^^^
+error: aborting due to previous error
 
-error: any use of this value will cause an error
-  --> $DIR/mutating_global.rs:9:9
-   |
-LL | / const MUTATING_GLOBAL: () = {
-LL | |     unsafe {
-LL | |         GLOBAL = 99
-   | |         ^^^^^^^^^^^ modifying a static's initial value from another static's initializer
-LL | |
-LL | |
-LL | |     }
-LL | | };
-   | |__-
-   |
-   = note: `#[deny(const_err)]` on by default
-
-error: aborting due to previous error; 2 warnings emitted
-
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/non_const_fn.rs
+++ b/src/test/ui/consts/miri_unleashed/non_const_fn.rs
@@ -1,17 +1,13 @@
-// build-fail
 // compile-flags: -Zunleash-the-miri-inside-of-you
 
-#![warn(const_err)]
+#![allow(const_err)]
 
 // A test demonstrating that we prevent calling non-const fn during CTFE.
 
 fn foo() {}
 
-const C: () = foo(); //~ WARN: skipping const checks
-//~^ WARN any use of this value will cause an error
+static C: () = foo(); //~ WARN: skipping const checks
+//~^ ERROR could not evaluate static initializer
+//~| NOTE calling non-const function `foo`
 
-fn main() {
-    println!("{:?}", C);
-    //~^ ERROR: evaluation of constant expression failed
-    //~| WARN: erroneous constant used [const_err]
-}
+fn main() {}

--- a/src/test/ui/consts/miri_unleashed/non_const_fn.stderr
+++ b/src/test/ui/consts/miri_unleashed/non_const_fn.stderr
@@ -1,35 +1,15 @@
 warning: skipping const checks
-  --> $DIR/non_const_fn.rs:10:15
+  --> $DIR/non_const_fn.rs:9:16
    |
-LL | const C: () = foo();
-   |               ^^^^^
+LL | static C: () = foo();
+   |                ^^^^^
 
-warning: any use of this value will cause an error
-  --> $DIR/non_const_fn.rs:10:15
+error[E0080]: could not evaluate static initializer
+  --> $DIR/non_const_fn.rs:9:16
    |
-LL | const C: () = foo();
-   | --------------^^^^^-
-   |               |
-   |               calling non-const function `foo`
-   |
-note: the lint level is defined here
-  --> $DIR/non_const_fn.rs:4:9
-   |
-LL | #![warn(const_err)]
-   |         ^^^^^^^^^
+LL | static C: () = foo();
+   |                ^^^^^ calling non-const function `foo`
 
-error[E0080]: evaluation of constant expression failed
-  --> $DIR/non_const_fn.rs:14:22
-   |
-LL |     println!("{:?}", C);
-   |                      ^ referenced constant has errors
-
-warning: erroneous constant used
-  --> $DIR/non_const_fn.rs:14:22
-   |
-LL |     println!("{:?}", C);
-   |                      ^ referenced constant has errors
-
-error: aborting due to previous error; 3 warnings emitted
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
This is easier with `static` than `const` so I switched some of them over.