### PR TITLE
Make mir::Constant Copy

### DIFF
--- a/src/librustc_middle/mir/mod.rs
+++ b/src/librustc_middle/mir/mod.rs
@@ -2339,7 +2339,7 @@ impl<'tcx> Debug for Rvalue<'tcx> {
 /// this does not necessarily mean that they are "==" in Rust -- in
 /// particular one must be wary of `NaN`!
 
-#[derive(Clone, PartialEq, RustcEncodable, RustcDecodable, HashStable)]
+#[derive(Clone, Copy, PartialEq, RustcEncodable, RustcDecodable, HashStable)]
 pub struct Constant<'tcx> {
     pub span: Span,
 


### PR DESCRIPTION
Meanwhile working on #70820, we said that `mir::Constant` should be `Copy`, make that here but I don't have any particular change related to this right now.

r? @eddyb 