### PR TITLE
Only run dataflow for const qualification if type-based check would fail

### DIFF
--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -28,7 +28,7 @@ use crate::dataflow::{self, Analysis};
 // We are using `MaybeMutBorrowedLocals` as a proxy for whether an item may have been mutated
 // through a pointer prior to the given point. This is okay even though `MaybeMutBorrowedLocals`
 // kills locals upon `StorageDead` because a local will never be used after a `StorageDead`.
-pub type IndirectlyMutableResults<'mir, 'tcx> =
+type IndirectlyMutableResults<'mir, 'tcx> =
     dataflow::ResultsCursor<'mir, 'tcx, MaybeMutBorrowedLocals<'mir, 'tcx>>;
 
 struct QualifCursor<'a, 'mir, 'tcx, Q: Qualif> {

--- a/src/test/ui/issues/issue-17252.stderr
+++ b/src/test/ui/issues/issue-17252.stderr
@@ -1,11 +1,22 @@
-error[E0391]: cycle detected when const checking `FOO`
-  --> $DIR/issue-17252.rs:1:20
+error[E0391]: cycle detected when normalizing `FOO`
+   |
+note: ...which requires const-evaluating + checking `FOO`...
+  --> $DIR/issue-17252.rs:1:1
    |
 LL | const FOO: usize = FOO;
-   |                    ^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating + checking `FOO`...
+  --> $DIR/issue-17252.rs:1:1
    |
-   = note: ...which again requires const checking `FOO`, completing the cycle
-note: cycle used when const checking `main::{{constant}}#0`
+LL | const FOO: usize = FOO;
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating `FOO`...
+  --> $DIR/issue-17252.rs:1:1
+   |
+LL | const FOO: usize = FOO;
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which again requires normalizing `FOO`, completing the cycle
+note: cycle used when const-evaluating `main::{{constant}}#0`
   --> $DIR/issue-17252.rs:4:18
    |
 LL |     let _x: [u8; FOO]; // caused stack overflow prior to fix

--- a/src/test/ui/issues/issue-23302-1.stderr
+++ b/src/test/ui/issues/issue-23302-1.stderr
@@ -1,15 +1,26 @@
-error[E0391]: cycle detected when const checking `X::A::{{constant}}#0`
+error[E0391]: cycle detected when const-evaluating + checking `X::A::{{constant}}#0`
   --> $DIR/issue-23302-1.rs:4:9
    |
 LL |     A = X::A as isize,
    |         ^^^^^^^^^^^^^
    |
-   = note: ...which again requires const checking `X::A::{{constant}}#0`, completing the cycle
-note: cycle used when processing `X::A::{{constant}}#0`
+note: ...which requires const-evaluating + checking `X::A::{{constant}}#0`...
   --> $DIR/issue-23302-1.rs:4:9
    |
 LL |     A = X::A as isize,
    |         ^^^^^^^^^^^^^
+note: ...which requires const-evaluating `X::A::{{constant}}#0`...
+  --> $DIR/issue-23302-1.rs:4:9
+   |
+LL |     A = X::A as isize,
+   |         ^^^^^^^^^^^^^
+   = note: ...which requires normalizing `X::A as isize`...
+   = note: ...which again requires const-evaluating + checking `X::A::{{constant}}#0`, completing the cycle
+note: cycle used when collecting item types in top-level module
+  --> $DIR/issue-23302-1.rs:3:1
+   |
+LL | enum X {
+   | ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-23302-2.stderr
+++ b/src/test/ui/issues/issue-23302-2.stderr
@@ -1,15 +1,26 @@
-error[E0391]: cycle detected when const checking `Y::A::{{constant}}#0`
+error[E0391]: cycle detected when const-evaluating + checking `Y::A::{{constant}}#0`
   --> $DIR/issue-23302-2.rs:4:9
    |
 LL |     A = Y::B as isize,
    |         ^^^^^^^^^^^^^
    |
-   = note: ...which again requires const checking `Y::A::{{constant}}#0`, completing the cycle
-note: cycle used when processing `Y::A::{{constant}}#0`
+note: ...which requires const-evaluating + checking `Y::A::{{constant}}#0`...
   --> $DIR/issue-23302-2.rs:4:9
    |
 LL |     A = Y::B as isize,
    |         ^^^^^^^^^^^^^
+note: ...which requires const-evaluating `Y::A::{{constant}}#0`...
+  --> $DIR/issue-23302-2.rs:4:9
+   |
+LL |     A = Y::B as isize,
+   |         ^^^^^^^^^^^^^
+   = note: ...which requires normalizing `Y::B as isize`...
+   = note: ...which again requires const-evaluating + checking `Y::A::{{constant}}#0`, completing the cycle
+note: cycle used when collecting item types in top-level module
+  --> $DIR/issue-23302-2.rs:3:1
+   |
+LL | enum Y {
+   | ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-23302-3.stderr
+++ b/src/test/ui/issues/issue-23302-3.stderr
@@ -1,20 +1,38 @@
-error[E0391]: cycle detected when const checking `A`
-  --> $DIR/issue-23302-3.rs:1:16
-   |
-LL | const A: i32 = B;
-   |                ^
-   |
-note: ...which requires const checking `B`...
-  --> $DIR/issue-23302-3.rs:3:16
-   |
-LL | const B: i32 = A;
-   |                ^
-   = note: ...which again requires const checking `A`, completing the cycle
-note: cycle used when processing `A`
+error[E0391]: cycle detected when const-evaluating + checking `A`
   --> $DIR/issue-23302-3.rs:1:1
    |
 LL | const A: i32 = B;
    | ^^^^^^^^^^^^^^^^^
+   |
+note: ...which requires const-evaluating + checking `A`...
+  --> $DIR/issue-23302-3.rs:1:1
+   |
+LL | const A: i32 = B;
+   | ^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating `A`...
+  --> $DIR/issue-23302-3.rs:1:1
+   |
+LL | const A: i32 = B;
+   | ^^^^^^^^^^^^^^^^^
+   = note: ...which requires normalizing `B`...
+note: ...which requires const-evaluating + checking `B`...
+  --> $DIR/issue-23302-3.rs:3:1
+   |
+LL | const B: i32 = A;
+   | ^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating + checking `B`...
+  --> $DIR/issue-23302-3.rs:3:1
+   |
+LL | const B: i32 = A;
+   | ^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating `B`...
+  --> $DIR/issue-23302-3.rs:3:1
+   |
+LL | const B: i32 = A;
+   | ^^^^^^^^^^^^^^^^^
+   = note: ...which requires normalizing `A`...
+   = note: ...which again requires const-evaluating + checking `A`, completing the cycle
+   = note: cycle used when running analysis passes on this crate
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-36163.stderr
+++ b/src/test/ui/issues/issue-36163.stderr
@@ -1,20 +1,48 @@
-error[E0391]: cycle detected when const checking `Foo::B::{{constant}}#0`
+error[E0391]: cycle detected when const-evaluating + checking `Foo::B::{{constant}}#0`
   --> $DIR/issue-36163.rs:4:9
    |
 LL |     B = A,
    |         ^
    |
-note: ...which requires const checking `A`...
-  --> $DIR/issue-36163.rs:1:18
+note: ...which requires const-evaluating + checking `Foo::B::{{constant}}#0`...
+  --> $DIR/issue-36163.rs:4:9
+   |
+LL |     B = A,
+   |         ^
+note: ...which requires const-evaluating `Foo::B::{{constant}}#0`...
+  --> $DIR/issue-36163.rs:4:9
+   |
+LL |     B = A,
+   |         ^
+   = note: ...which requires normalizing `A`...
+note: ...which requires const-evaluating + checking `A`...
+  --> $DIR/issue-36163.rs:1:1
    |
 LL | const A: isize = Foo::B as isize;
-   |                  ^^^^^^^^^^^^^^^
-   = note: ...which again requires const checking `Foo::B::{{constant}}#0`, completing the cycle
-note: cycle used when processing `Foo::B::{{constant}}#0`
-  --> $DIR/issue-36163.rs:4:9
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating + checking `A`...
+  --> $DIR/issue-36163.rs:1:1
    |
-LL |     B = A,
-   |         ^
+LL | const A: isize = Foo::B as isize;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating `A`...
+  --> $DIR/issue-36163.rs:1:1
+   |
+LL | const A: isize = Foo::B as isize;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires normalizing `A`...
+   = note: ...which again requires const-evaluating + checking `Foo::B::{{constant}}#0`, completing the cycle
+note: cycle used when collecting item types in top-level module
+  --> $DIR/issue-36163.rs:1:1
+   |
+LL | / const A: isize = Foo::B as isize;
+LL | |
+LL | | enum Foo {
+LL | |     B = A,
+LL | | }
+LL | |
+LL | | fn main() {}
+   | |____________^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This is the optimization discussed in https://github.com/rust-lang/rust/issues/49146#issuecomment-614012476. We wait for `Qualif::in_any_value_of_ty` to return `true` before running dataflow. For bodies that deal mostly with primitive types, this will avoid running dataflow at all during const qualification.

This also removes the `BitSet` used to cache `in_any_value_of_ty` for each local, which was only necessary for an old version of #64470 that also handled promotability.