### PR TITLE
Allow constants to refer statics in const eval

### DIFF
--- a/src/librustc_mir/borrow_check/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/type_check/mod.rs
@@ -366,20 +366,6 @@ impl<'a, 'b, 'tcx> Visitor<'tcx> for TypeVerifier<'a, 'b, 'tcx> {
                         );
                     }
                 }
-            } else if let Some(static_def_id) = constant.check_static_ptr(tcx) {
-                let unnormalized_ty = tcx.type_of(static_def_id);
-                let locations = location.to_locations();
-                let normalized_ty = self.cx.normalize(unnormalized_ty, locations);
-                let literal_ty = constant.literal.ty.builtin_deref(true).unwrap().ty;
-
-                if let Err(terr) = self.cx.eq_types(
-                    normalized_ty,
-                    literal_ty,
-                    locations,
-                    ConstraintCategory::Boring,
-                ) {
-                    span_mirbug!(self, constant, "bad static type {:?} ({:?})", constant, terr);
-                }
             }
 
             if let ty::FnDef(def_id, substs) = constant.literal.ty.kind {

--- a/src/librustc_mir/const_eval/mod.rs
+++ b/src/librustc_mir/const_eval/mod.rs
@@ -42,7 +42,7 @@ pub(crate) fn const_field<'tcx>(
     let field = ecx.operand_field(down, field.index()).unwrap();
     // and finally move back to the const world, always normalizing because
     // this is not called for statics.
-    op_to_const(&ecx, field)
+    try_op_to_const(&ecx, field).unwrap()
 }
 
 pub(crate) fn const_caller_location(
@@ -81,7 +81,7 @@ pub(crate) fn destructure_const<'tcx>(
     let down = ecx.operand_downcast(op, variant).unwrap();
     let fields_iter = (0..field_count).map(|i| {
         let field_op = ecx.operand_field(down, i).unwrap();
-        let val = op_to_const(&ecx, field_op);
+        let val = try_op_to_const(&ecx, field_op).unwrap();
         ty::Const::from_value(tcx, val, field_op.layout.ty)
     });
     let fields = tcx.arena.alloc_from_iter(fields_iter);

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -7,7 +7,6 @@ use std::hash::Hash;
 
 use rustc_middle::mir;
 use rustc_middle::ty::{self, Ty};
-use rustc_span::def_id::DefId;
 
 use super::{
     AllocId, Allocation, AllocationExtra, Frame, ImmTy, InterpCx, InterpResult, Memory, MemoryKind,
@@ -207,13 +206,11 @@ pub trait Machine<'mir, 'tcx>: Sized {
     }
 
     /// Called before a global allocation is accessed.
-    /// `def_id` is `Some` if this is the "lazy" allocation of a static.
     #[inline]
     fn before_access_global(
         _memory_extra: &Self::MemoryExtra,
         _alloc_id: AllocId,
         _allocation: &Allocation,
-        _static_def_id: Option<DefId>,
         _is_write: bool,
     ) -> InterpResult<'tcx> {
         Ok(())

--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -411,11 +411,11 @@ impl<'rt, 'mir, 'tcx, M: Machine<'mir, 'tcx>> ValidityVisitor<'rt, 'mir, 'tcx, M
                     if !did.is_local() || self.ecx.tcx.is_foreign_item(did) {
                         return Ok(());
                     }
+                    // FIXME: Statics referenced from consts are skipped.
+                    // This avoids spurious "const accesses static" errors
+                    // unrelated to validity, but is similarly unsound.
                     if !self.may_ref_to_static && self.ecx.tcx.is_static(did) {
-                        throw_validation_failure!(
-                            format_args!("a {} pointing to a static variable", kind),
-                            self.path
-                        );
+                        return Ok(());
                     }
                 }
             }

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -23,7 +23,7 @@ use rustc_middle::ty::layout::{HasTyCtxt, LayoutError, TyAndLayout};
 use rustc_middle::ty::subst::{InternalSubsts, Subst};
 use rustc_middle::ty::{self, ConstKind, Instance, ParamEnv, Ty, TyCtxt, TypeFoldable};
 use rustc_session::lint;
-use rustc_span::{def_id::DefId, Span};
+use rustc_span::Span;
 use rustc_target::abi::{HasDataLayout, LayoutOf, Size, TargetDataLayout};
 use rustc_trait_selection::traits;
 
@@ -274,7 +274,6 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for ConstPropMachine {
         _memory_extra: &(),
         _alloc_id: AllocId,
         allocation: &Allocation<Self::PointerTag, Self::AllocExtra>,
-        _static_def_id: Option<DefId>,
         is_write: bool,
     ) -> InterpResult<'tcx> {
         if is_write {

--- a/src/librustc_mir_build/build/expr/as_constant.rs
+++ b/src/librustc_mir_build/build/expr/as_constant.rs
@@ -21,7 +21,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let Expr { ty, temp_lifetime: _, span, kind } = expr;
         match kind {
             ExprKind::Scope { region_scope: _, lint_level: _, value } => this.as_constant(value),
-            ExprKind::Literal { literal, user_ty } => {
+            ExprKind::Literal { literal, user_ty } |
+            ExprKind::StaticRef { literal, user_ty, .. } => {
                 let user_ty = user_ty.map(|user_ty| {
                     this.canonical_user_type_annotations.push(CanonicalUserTypeAnnotation {
                         span,
@@ -32,7 +33,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 assert_eq!(literal.ty, ty);
                 Constant { span, user_ty, literal }
             }
-            ExprKind::StaticRef { literal, .. } => Constant { span, user_ty: None, literal },
             _ => span_bug!(span, "expression is not a valid constant {:?}", kind),
         }
     }

--- a/src/librustc_mir_build/hair/mod.rs
+++ b/src/librustc_mir_build/hair/mod.rs
@@ -275,6 +275,7 @@ crate enum ExprKind<'tcx> {
     /// info for diagnostics.
     StaticRef {
         literal: &'tcx Const<'tcx>,
+        user_ty: Option<Canonical<'tcx, UserType<'tcx>>>,
         def_id: DefId,
     },
     LlvmInlineAsm {

--- a/src/test/mir-opt/const-promotion-extern-static/rustc.BAR-promoted[0].ConstProp.after.mir
+++ b/src/test/mir-opt/const-promotion-extern-static/rustc.BAR-promoted[0].ConstProp.after.mir
@@ -13,6 +13,7 @@ promoted[0] in BAR: &[&i32; 1] = {
                                          // + val: Value(Scalar(alloc0+0))
                                          // mir::Constant
                                          // + span: $DIR/const-promotion-extern-static.rs:9:33: 9:34
+                                         // + user_ty: UserType(0)
                                          // + literal: Const { ty: &i32, val: Value(Scalar(alloc0+0)) }
         _2 = _3;                         // bb0[1]: scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
         _1 = [move _2];                  // bb0[2]: scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35

--- a/src/test/mir-opt/const-promotion-extern-static/rustc.BAR.PromoteTemps.diff
+++ b/src/test/mir-opt/const-promotion-extern-static/rustc.BAR.PromoteTemps.diff
@@ -1,6 +1,9 @@
 - // MIR for `BAR` before PromoteTemps
 + // MIR for `BAR` after PromoteTemps
   
+  | User Type Annotations
+  | 0: Canonical { max_universe: U0, variables: [CanonicalVarInfo { kind: Region(U0) }], value: Ty(&i32) } at $DIR/const-promotion-extern-static.rs:9:33: 9:34
+  |
   static mut BAR: *const &i32 = {
       let mut _0: *const &i32;             // return place in scope 0 at $DIR/const-promotion-extern-static.rs:9:17: 9:28
       let mut _1: &[&i32];                 // in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
@@ -25,6 +28,7 @@
 +                                          // + val: Unevaluated(DefId(0:6 ~ const_promotion_extern_static[317d]::BAR[0]), [], Some(promoted[0]))
                                            // mir::Constant
 -                                          // + span: $DIR/const-promotion-extern-static.rs:9:33: 9:34
+-                                          // + user_ty: UserType(0)
 -                                          // + literal: Const { ty: &i32, val: Value(Scalar(alloc0+0)) }
 -         _4 = &(*_5);                     // bb0[6]: scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
 -         _3 = [move _4];                  // bb0[7]: scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35

--- a/src/test/mir-opt/const-promotion-extern-static/rustc.FOO-promoted[0].ConstProp.after.mir
+++ b/src/test/mir-opt/const-promotion-extern-static/rustc.FOO-promoted[0].ConstProp.after.mir
@@ -15,6 +15,7 @@ promoted[0] in FOO: &[&i32; 1] = {
                                          // + val: Value(Scalar(alloc2+0))
                                          // mir::Constant
                                          // + span: $DIR/const-promotion-extern-static.rs:13:42: 13:43
+                                         // + user_ty: UserType(0)
                                          // + literal: Const { ty: &i32, val: Value(Scalar(alloc2+0)) }
         _2 = _3;                         // bb0[1]: scope 0 at $DIR/const-promotion-extern-static.rs:13:41: 13:43
         _1 = [move _2];                  // bb0[2]: scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46

--- a/src/test/mir-opt/const-promotion-extern-static/rustc.FOO.PromoteTemps.diff
+++ b/src/test/mir-opt/const-promotion-extern-static/rustc.FOO.PromoteTemps.diff
@@ -1,6 +1,9 @@
 - // MIR for `FOO` before PromoteTemps
 + // MIR for `FOO` after PromoteTemps
   
+  | User Type Annotations
+  | 0: Canonical { max_universe: U0, variables: [CanonicalVarInfo { kind: Region(U0) }], value: Ty(&i32) } at $DIR/const-promotion-extern-static.rs:13:42: 13:43
+  |
   static mut FOO: *const &i32 = {
       let mut _0: *const &i32;             // return place in scope 0 at $DIR/const-promotion-extern-static.rs:13:17: 13:28
       let mut _1: &[&i32];                 // in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
@@ -27,6 +30,7 @@
 +                                          // + val: Unevaluated(DefId(0:7 ~ const_promotion_extern_static[317d]::FOO[0]), [], Some(promoted[0]))
                                            // mir::Constant
 -                                          // + span: $DIR/const-promotion-extern-static.rs:13:42: 13:43
+-                                          // + user_ty: UserType(0)
 -                                          // + literal: Const { ty: &i32, val: Value(Scalar(alloc2+0)) }
 -         _4 = &(*_5);                     // bb0[6]: scope 1 at $DIR/const-promotion-extern-static.rs:13:41: 13:43
 -         _3 = [move _4];                  // bb0[7]: scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46

--- a/src/test/mir-opt/const_allocation/32bit/rustc.main.ConstProp.after.mir
+++ b/src/test/mir-opt/const_allocation/32bit/rustc.main.ConstProp.after.mir
@@ -14,6 +14,7 @@ fn main() -> () {
                                          // + val: Value(Scalar(alloc0+0))
                                          // mir::Constant
                                          // + span: $DIR/const_allocation.rs:8:5: 8:8
+                                         // + user_ty: UserType(0)
                                          // + literal: Const { ty: &&[(std::option::Option<i32>, &[&str])], val: Value(Scalar(alloc0+0)) }
         _1 = (*_2);                      // bb0[3]: scope 0 at $DIR/const_allocation.rs:8:5: 8:8
         StorageDead(_2);                 // bb0[4]: scope 0 at $DIR/const_allocation.rs:8:8: 8:9

--- a/src/test/mir-opt/const_allocation/64bit/rustc.main.ConstProp.after.mir
+++ b/src/test/mir-opt/const_allocation/64bit/rustc.main.ConstProp.after.mir
@@ -14,6 +14,7 @@ fn main() -> () {
                                          // + val: Value(Scalar(alloc0+0))
                                          // mir::Constant
                                          // + span: $DIR/const_allocation.rs:8:5: 8:8
+                                         // + user_ty: UserType(0)
                                          // + literal: Const { ty: &&[(std::option::Option<i32>, &[&str])], val: Value(Scalar(alloc0+0)) }
         _1 = (*_2);                      // bb0[3]: scope 0 at $DIR/const_allocation.rs:8:5: 8:8
         StorageDead(_2);                 // bb0[4]: scope 0 at $DIR/const_allocation.rs:8:8: 8:9

--- a/src/test/mir-opt/const_allocation2/64bit/rustc.main.ConstProp.after.mir
+++ b/src/test/mir-opt/const_allocation2/64bit/rustc.main.ConstProp.after.mir
@@ -14,6 +14,7 @@ fn main() -> () {
                                          // + val: Value(Scalar(alloc0+0))
                                          // mir::Constant
                                          // + span: $DIR/const_allocation2.rs:5:5: 5:8
+                                         // + user_ty: UserType(0)
                                          // + literal: Const { ty: &&[(std::option::Option<i32>, &[&u8])], val: Value(Scalar(alloc0+0)) }
         _1 = (*_2);                      // bb0[3]: scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
         StorageDead(_2);                 // bb0[4]: scope 0 at $DIR/const_allocation2.rs:5:8: 5:9

--- a/src/test/mir-opt/const_allocation3/64bit/rustc.main.ConstProp.after.mir
+++ b/src/test/mir-opt/const_allocation3/64bit/rustc.main.ConstProp.after.mir
@@ -14,6 +14,7 @@ fn main() -> () {
                                          // + val: Value(Scalar(alloc0+0))
                                          // mir::Constant
                                          // + span: $DIR/const_allocation3.rs:5:5: 5:8
+                                         // + user_ty: UserType(0)
                                          // + literal: Const { ty: &&Packed, val: Value(Scalar(alloc0+0)) }
         _1 = (*_2);                      // bb0[3]: scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
         StorageDead(_2);                 // bb0[4]: scope 0 at $DIR/const_allocation3.rs:5:8: 5:9

--- a/src/test/mir-opt/const_prop/read_immutable_static/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/read_immutable_static/rustc.main.ConstProp.diff
@@ -22,6 +22,7 @@
                                            // + val: Value(Scalar(alloc0+0))
                                            // mir::Constant
                                            // + span: $DIR/read_immutable_static.rs:7:13: 7:16
+                                           // + user_ty: UserType(0)
                                            // + literal: Const { ty: &u8, val: Value(Scalar(alloc0+0)) }
 -         _2 = (*_3);                      // bb0[4]: scope 0 at $DIR/read_immutable_static.rs:7:13: 7:16
 +         _2 = const 2u8;                  // bb0[4]: scope 0 at $DIR/read_immutable_static.rs:7:13: 7:16
@@ -39,6 +40,7 @@
                                            // + val: Value(Scalar(alloc0+0))
                                            // mir::Constant
                                            // + span: $DIR/read_immutable_static.rs:7:19: 7:22
+                                           // + user_ty: UserType(1)
                                            // + literal: Const { ty: &u8, val: Value(Scalar(alloc0+0)) }
 -         _4 = (*_5);                      // bb0[8]: scope 0 at $DIR/read_immutable_static.rs:7:19: 7:22
 -         _1 = Add(move _2, move _4);      // bb0[9]: scope 0 at $DIR/read_immutable_static.rs:7:13: 7:22

--- a/src/test/ui/consts/const-points-to-static.rs
+++ b/src/test/ui/consts/const-points-to-static.rs
@@ -1,10 +1,10 @@
+// check-pass
 // compile-flags: -Zunleash-the-miri-inside-of-you
 
 #![allow(dead_code)]
 
 const TEST: &u8 = &MY_STATIC;
 //~^ skipping const checks
-//~| it is undefined behavior to use this value
 
 static MY_STATIC: u8 = 4;
 

--- a/src/test/ui/consts/const-points-to-static.stderr
+++ b/src/test/ui/consts/const-points-to-static.stderr
@@ -1,17 +1,8 @@
 warning: skipping const checks
-  --> $DIR/const-points-to-static.rs:5:20
+  --> $DIR/const-points-to-static.rs:6:20
    |
 LL | const TEST: &u8 = &MY_STATIC;
    |                    ^^^^^^^^^
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const-points-to-static.rs:5:1
-   |
-LL | const TEST: &u8 = &MY_STATIC;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a reference pointing to a static variable
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+warning: 1 warning emitted
 
-error: aborting due to previous error; 1 warning emitted
-
-For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-prop-read-static-in-const.rs
+++ b/src/test/ui/consts/const-prop-read-static-in-const.rs
@@ -1,8 +1,9 @@
+// check-pass
 // compile-flags: -Zunleash-the-miri-inside-of-you
 
 #![allow(dead_code)]
 
-const TEST: u8 = MY_STATIC; //~ ERROR any use of this value will cause an error
+const TEST: u8 = MY_STATIC;
 //~^ skipping const checks
 
 static MY_STATIC: u8 = 4;

--- a/src/test/ui/consts/const-prop-read-static-in-const.stderr
+++ b/src/test/ui/consts/const-prop-read-static-in-const.stderr
@@ -1,18 +1,8 @@
 warning: skipping const checks
-  --> $DIR/const-prop-read-static-in-const.rs:5:18
+  --> $DIR/const-prop-read-static-in-const.rs:6:18
    |
 LL | const TEST: u8 = MY_STATIC;
    |                  ^^^^^^^^^
 
-error: any use of this value will cause an error
-  --> $DIR/const-prop-read-static-in-const.rs:5:18
-   |
-LL | const TEST: u8 = MY_STATIC;
-   | -----------------^^^^^^^^^-
-   |                  |
-   |                  constant accesses static
-   |
-   = note: `#[deny(const_err)]` on by default
-
-error: aborting due to previous error; 1 warning emitted
+warning: 1 warning emitted
 

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
@@ -1,59 +1,73 @@
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:11:18
+  --> $DIR/const_refers_to_static.rs:14:6
+   |
+LL |     &FOO
+   |      ^^^
+
+warning: skipping const checks
+  --> $DIR/const_refers_to_static.rs:22:18
    |
 LL |     unsafe { &*(&FOO as *const _ as *const usize) }
    |                  ^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:17:5
+  --> $DIR/const_refers_to_static.rs:27:38
+   |
+LL | const REF_EXTERN: &usize = unsafe { &EXTERN };
+   |                                      ^^^^^^
+
+warning: skipping const checks
+  --> $DIR/const_refers_to_static.rs:37:5
    |
 LL |     FOO.fetch_add(1, Ordering::Relaxed)
    |     ^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:17:5
+  --> $DIR/const_refers_to_static.rs:37:5
    |
 LL |     FOO.fetch_add(1, Ordering::Relaxed)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:24:17
+  --> $DIR/const_refers_to_static.rs:44:17
    |
 LL |     unsafe { *(&FOO as *const _ as *const usize) }
    |                 ^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:29:32
+  --> $DIR/const_refers_to_static.rs:49:32
    |
 LL | const READ_MUT: u32 = unsafe { MUTABLE };
    |                                ^^^^^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:29:32
+  --> $DIR/const_refers_to_static.rs:49:32
    |
 LL | const READ_MUT: u32 = unsafe { MUTABLE };
    |                                ^^^^^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:36:6
+  --> $DIR/const_refers_to_static.rs:53:37
    |
-LL |     &FOO
-   |      ^^^
-
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static.rs:9:1
-   |
-LL | / const REF_INTERIOR_MUT: &usize = {
-LL | |     static FOO: AtomicUsize = AtomicUsize::new(0);
-LL | |     unsafe { &*(&FOO as *const _ as *const usize) }
-LL | |
-LL | | };
-   | |__^ type validation failed: encountered a reference pointing to a static variable
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+LL | const READ_EXTERN: usize = unsafe { EXTERN };
+   |                                     ^^^^^^
 
 warning: any use of this value will cause an error
-  --> $DIR/const_refers_to_static.rs:17:5
+  --> $DIR/const_refers_to_static.rs:32:35
+   |
+LL | const DEREF_INTERIOR_MUT: usize = *REF_INTERIOR_MUT;
+   | ----------------------------------^^^^^^^^^^^^^^^^^-
+   |                                   |
+   |                                   constant accesses static
+   |
+note: the lint level is defined here
+  --> $DIR/const_refers_to_static.rs:3:9
+   |
+LL | #![warn(const_err)]
+   |         ^^^^^^^^^
+
+warning: any use of this value will cause an error
+  --> $DIR/const_refers_to_static.rs:37:5
    |
 LL | / const MUTATE_INTERIOR_MUT: usize = {
 LL | |     static FOO: AtomicUsize = AtomicUsize::new(0);
@@ -63,15 +77,9 @@ LL | |
 LL | |
 LL | | };
    | |__-
-   |
-note: the lint level is defined here
-  --> $DIR/const_refers_to_static.rs:2:9
-   |
-LL | #![warn(const_err)]
-   |         ^^^^^^^^^
 
 warning: any use of this value will cause an error
-  --> $DIR/const_refers_to_static.rs:24:14
+  --> $DIR/const_refers_to_static.rs:44:14
    |
 LL | / const READ_INTERIOR_MUT: usize = {
 LL | |     static FOO: AtomicUsize = AtomicUsize::new(0);
@@ -82,25 +90,20 @@ LL | | };
    | |__-
 
 warning: any use of this value will cause an error
-  --> $DIR/const_refers_to_static.rs:29:32
+  --> $DIR/const_refers_to_static.rs:49:32
    |
 LL | const READ_MUT: u32 = unsafe { MUTABLE };
    | -------------------------------^^^^^^^---
    |                                |
    |                                constant accesses static
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static.rs:34:1
+warning: any use of this value will cause an error
+  --> $DIR/const_refers_to_static.rs:53:37
    |
-LL | / const READ_IMMUT: &usize = {
-LL | |     static FOO: usize = 0;
-LL | |     &FOO
-LL | |
-LL | | };
-   | |__^ type validation failed: encountered a reference pointing to a static variable
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+LL | const READ_EXTERN: usize = unsafe { EXTERN };
+   | ------------------------------------^^^^^^---
+   |                                     |
+   |                                     cannot read from foreign (extern) static DefId(0:11 ~ const_refers_to_static[317d]::[0]::EXTERN[0])
 
-error: aborting due to 2 previous errors; 10 warnings emitted
+warning: 14 warnings emitted
 
-For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/use-static-via-const.rs
+++ b/src/test/ui/consts/miri_unleashed/use-static-via-const.rs
@@ -1,0 +1,29 @@
+// run-pass
+// compile-flags: -Zunleash-the-miri-inside-of-you
+
+static DATA: [u8; 3] = *b"abc";
+
+const REF: &'static [u8] = &DATA;
+//~^ WARN skipping const checks
+
+const PTR: *const u8 = DATA.as_ptr();
+//~^ WARN skipping const checks
+
+fn parse_slice(r: &[u8]) -> bool {
+    match r {
+        REF => true,
+        _ => false,
+    }
+}
+
+fn parse_id(p: *const u8) -> bool {
+    match p {
+        p if p == PTR => true,
+        _ => false,
+    }
+}
+
+fn main() {
+    assert!(parse_slice(&DATA));
+    assert!(parse_id(DATA.as_ptr()));
+}

--- a/src/test/ui/consts/miri_unleashed/use-static-via-const.stderr
+++ b/src/test/ui/consts/miri_unleashed/use-static-via-const.stderr
@@ -1,0 +1,14 @@
+warning: skipping const checks
+  --> $DIR/use-static-via-const.rs:6:29
+   |
+LL | const REF: &'static [u8] = &DATA;
+   |                             ^^^^
+
+warning: skipping const checks
+  --> $DIR/use-static-via-const.rs:9:24
+   |
+LL | const PTR: *const u8 = DATA.as_ptr();
+   |                        ^^^^
+
+warning: 2 warnings emitted
+

--- a/src/test/ui/issues/issue-52060.rs
+++ b/src/test/ui/issues/issue-52060.rs
@@ -3,6 +3,5 @@
 static A: &'static [u32] = &[1];
 static B: [u32; 1] = [0; A.len()];
 //~^ ERROR [E0013]
-//~| ERROR evaluation of constant value failed
 
 fn main() {}

--- a/src/test/ui/issues/issue-52060.stderr
+++ b/src/test/ui/issues/issue-52060.stderr
@@ -6,13 +6,6 @@ LL | static B: [u32; 1] = [0; A.len()];
    |
    = help: consider extracting the value of the `static` to a `const`, and referring to that
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-52060.rs:4:26
-   |
-LL | static B: [u32; 1] = [0; A.len()];
-   |                          ^ constant accesses static
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0013, E0080.
-For more information about an error, try `rustc --explain E0013`.
+For more information about this error, try `rustc --explain E0013`.


### PR DESCRIPTION
This is the dynamic portion of what we discussed in rust-lang/const-eval#11.
Changes to the static check are left to a separate PR.

r? @oli-obk