### PR TITLE
Exhaustively match on `{Statement,Terminator}Kind` during const checking

### DIFF
--- a/src/librustc_mir/transform/check_consts/ops.rs
+++ b/src/librustc_mir/transform/check_consts/ops.rs
@@ -148,6 +148,10 @@ impl NonConstOp for IfOrMatch {
 }
 
 #[derive(Debug)]
+pub struct InlineAsm;
+impl NonConstOp for InlineAsm {}
+
+#[derive(Debug)]
 pub struct LiveDrop;
 impl NonConstOp for LiveDrop {
     fn emit_error(&self, item: &Item<'_, '_>, span: Span) {

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -485,9 +485,11 @@ impl Visitor<'tcx> for Validator<'_, 'mir, 'tcx> {
                 | FakeReadCause::ForGuardBinding,
                 _,
             ) => {
+                self.super_statement(statement, location);
                 self.check_op(ops::IfOrMatch);
             }
             StatementKind::LlvmInlineAsm { .. } => {
+                self.super_statement(statement, location);
                 self.check_op(ops::InlineAsm);
             }
 

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -478,15 +478,20 @@ impl Visitor<'tcx> for Validator<'_, 'mir, 'tcx> {
             StatementKind::Assign(..) | StatementKind::SetDiscriminant { .. } => {
                 self.super_statement(statement, location);
             }
-            StatementKind::FakeRead(FakeReadCause::ForMatchedPlace, _) => {
+
+            StatementKind::FakeRead(
+                FakeReadCause::ForMatchedPlace
+                | FakeReadCause::ForMatchGuard
+                | FakeReadCause::ForGuardBinding,
+                _,
+            ) => {
                 self.check_op(ops::IfOrMatch);
             }
             StatementKind::LlvmInlineAsm { .. } => {
                 self.check_op(ops::InlineAsm);
             }
 
-            // FIXME(eddyb) should these really do nothing?
-            StatementKind::FakeRead(..)
+            StatementKind::FakeRead(FakeReadCause::ForLet | FakeReadCause::ForIndex, _)
             | StatementKind::StorageLive(_)
             | StatementKind::StorageDead(_)
             | StatementKind::Retag { .. }

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -580,6 +580,8 @@ impl Visitor<'tcx> for Validator<'_, 'mir, 'tcx> {
                 }
             }
 
+            // FIXME: Some of these are only caught by `min_const_fn`, but should error here
+            // instead.
             TerminatorKind::Abort
             | TerminatorKind::Assert { .. }
             | TerminatorKind::FalseEdges { .. }

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -580,7 +580,17 @@ impl Visitor<'tcx> for Validator<'_, 'mir, 'tcx> {
                 }
             }
 
-            _ => {}
+            TerminatorKind::Abort
+            | TerminatorKind::Assert { .. }
+            | TerminatorKind::FalseEdges { .. }
+            | TerminatorKind::FalseUnwind { .. }
+            | TerminatorKind::GeneratorDrop
+            | TerminatorKind::Goto { .. }
+            | TerminatorKind::Resume
+            | TerminatorKind::Return
+            | TerminatorKind::SwitchInt { .. }
+            | TerminatorKind::Unreachable
+            | TerminatorKind::Yield { .. } => {}
         }
     }
 }

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -481,11 +481,14 @@ impl Visitor<'tcx> for Validator<'_, 'mir, 'tcx> {
             StatementKind::FakeRead(FakeReadCause::ForMatchedPlace, _) => {
                 self.check_op(ops::IfOrMatch);
             }
+            StatementKind::LlvmInlineAsm { .. } => {
+                self.check_op(ops::InlineAsm);
+            }
+
             // FIXME(eddyb) should these really do nothing?
             StatementKind::FakeRead(..)
             | StatementKind::StorageLive(_)
             | StatementKind::StorageDead(_)
-            | StatementKind::LlvmInlineAsm { .. }
             | StatementKind::Retag { .. }
             | StatementKind::AscribeUserType(..)
             | StatementKind::Nop => {}

--- a/src/test/ui/consts/inline_asm.rs
+++ b/src/test/ui/consts/inline_asm.rs
@@ -1,0 +1,6 @@
+#![feature(llvm_asm)]
+
+const _: () = unsafe { llvm_asm!("nop") };
+//~^ ERROR contains unimplemented expression type
+
+fn main() {}

--- a/src/test/ui/consts/inline_asm.stderr
+++ b/src/test/ui/consts/inline_asm.stderr
@@ -1,0 +1,9 @@
+error[E0019]: constant contains unimplemented expression type
+  --> $DIR/inline_asm.rs:3:1
+   |
+LL | const _: () = unsafe { llvm_asm!("nop") };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0019`.

--- a/src/test/ui/consts/inline_asm.stderr
+++ b/src/test/ui/consts/inline_asm.stderr
@@ -1,8 +1,10 @@
 error[E0019]: constant contains unimplemented expression type
-  --> $DIR/inline_asm.rs:3:1
+  --> $DIR/inline_asm.rs:3:24
    |
 LL | const _: () = unsafe { llvm_asm!("nop") };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                        ^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/miri_unleashed/inline_asm.rs
+++ b/src/test/ui/consts/miri_unleashed/inline_asm.rs
@@ -6,9 +6,11 @@
 fn main() {}
 
 // Make sure we catch executing inline assembly.
-static TEST_BAD: () = { //~ WARN: skipping const checks
+static TEST_BAD: () = {
     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
     //~^ ERROR could not evaluate static initializer
     //~| NOTE in this expansion of llvm_asm!
     //~| NOTE inline assembly is not supported
+    //~| WARN skipping const checks
+    //~| NOTE in this expansion of llvm_asm!
 };

--- a/src/test/ui/consts/miri_unleashed/inline_asm.rs
+++ b/src/test/ui/consts/miri_unleashed/inline_asm.rs
@@ -6,7 +6,7 @@
 fn main() {}
 
 // Make sure we catch executing inline assembly.
-static TEST_BAD: () = {
+static TEST_BAD: () = { //~ WARN: skipping const checks
     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
     //~^ ERROR could not evaluate static initializer
     //~| NOTE in this expansion of llvm_asm!

--- a/src/test/ui/consts/miri_unleashed/inline_asm.stderr
+++ b/src/test/ui/consts/miri_unleashed/inline_asm.stderr
@@ -1,13 +1,10 @@
 warning: skipping const checks
-  --> $DIR/inline_asm.rs:9:1
+  --> $DIR/inline_asm.rs:10:14
    |
-LL | / static TEST_BAD: () = {
-LL | |     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
-LL | |
-LL | |
-LL | |
-LL | | };
-   | |__^
+LL |     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: could not evaluate static initializer
   --> $DIR/inline_asm.rs:10:14

--- a/src/test/ui/consts/miri_unleashed/inline_asm.stderr
+++ b/src/test/ui/consts/miri_unleashed/inline_asm.stderr
@@ -1,3 +1,14 @@
+warning: skipping const checks
+  --> $DIR/inline_asm.rs:9:1
+   |
+LL | / static TEST_BAD: () = {
+LL | |     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
+LL | |
+LL | |
+LL | |
+LL | | };
+   | |__^
+
 error[E0080]: could not evaluate static initializer
   --> $DIR/inline_asm.rs:10:14
    |
@@ -6,6 +17,6 @@ LL |     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
This adds a pre-monomorphization error for inline assembly in a const context as well.

r? @oli-obk 