### PR TITLE
Moving all rustdoc-ui tests to check-pass

### DIFF
--- a/src/test/rustdoc-ui/cfg-test.rs
+++ b/src/test/rustdoc-ui/cfg-test.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // compile-flags:--test --test-args --test-threads=1
 // normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
 

--- a/src/test/rustdoc-ui/coverage/basic.rs
+++ b/src/test/rustdoc-ui/coverage/basic.rs
@@ -1,5 +1,5 @@
 // compile-flags:-Z unstable-options --show-coverage
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(extern_types)]
 

--- a/src/test/rustdoc-ui/coverage/empty.rs
+++ b/src/test/rustdoc-ui/coverage/empty.rs
@@ -1,4 +1,4 @@
 // compile-flags:-Z unstable-options --show-coverage
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 // an empty crate still has one item to document: the crate root

--- a/src/test/rustdoc-ui/coverage/enums.rs
+++ b/src/test/rustdoc-ui/coverage/enums.rs
@@ -1,5 +1,5 @@
 // compile-flags:-Z unstable-options --show-coverage
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 //! (remember the crate root is still a module)
 

--- a/src/test/rustdoc-ui/coverage/exotic.rs
+++ b/src/test/rustdoc-ui/coverage/exotic.rs
@@ -1,5 +1,5 @@
 // compile-flags:-Z unstable-options --show-coverage
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(doc_keyword)]
 

--- a/src/test/rustdoc-ui/coverage/json.rs
+++ b/src/test/rustdoc-ui/coverage/json.rs
@@ -1,4 +1,4 @@
-// build-pass
+// check-pass
 // compile-flags:-Z unstable-options --output-format json --show-coverage
 
 pub mod foo {

--- a/src/test/rustdoc-ui/coverage/private.rs
+++ b/src/test/rustdoc-ui/coverage/private.rs
@@ -1,5 +1,5 @@
 // compile-flags:-Z unstable-options --show-coverage --document-private-items
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![allow(unused)]
 

--- a/src/test/rustdoc-ui/coverage/statics-consts.rs
+++ b/src/test/rustdoc-ui/coverage/statics-consts.rs
@@ -1,5 +1,5 @@
 // compile-flags:-Z unstable-options --show-coverage
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 //! gotta make sure we can count statics and consts correctly, too
 

--- a/src/test/rustdoc-ui/coverage/traits.rs
+++ b/src/test/rustdoc-ui/coverage/traits.rs
@@ -1,5 +1,5 @@
 // compile-flags:-Z unstable-options --show-coverage
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(trait_alias)]
 

--- a/src/test/rustdoc-ui/deprecated-attrs.rs
+++ b/src/test/rustdoc-ui/deprecated-attrs.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![doc(no_default_passes, passes = "collapse-docs unindent-comments")]
 

--- a/src/test/rustdoc-ui/doc-test-doctest-feature.rs
+++ b/src/test/rustdoc-ui/doc-test-doctest-feature.rs
@@ -1,4 +1,4 @@
-// build-pass
+// check-pass
 // compile-flags:--test
 // normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
 

--- a/src/test/rustdoc-ui/doc-test-rustdoc-feature.rs
+++ b/src/test/rustdoc-ui/doc-test-rustdoc-feature.rs
@@ -1,4 +1,4 @@
-// build-pass
+// check-pass
 // compile-flags:--test
 // normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
 

--- a/src/test/rustdoc-ui/intra-links-warning-crlf.rs
+++ b/src/test/rustdoc-ui/intra-links-warning-crlf.rs
@@ -1,5 +1,5 @@
 // ignore-tidy-cr
-// build-pass
+// check-pass
 
 // This file checks the spans of intra-link warnings in a file with CRLF line endings. The
 // .gitattributes file in this directory should enforce it.

--- a/src/test/rustdoc-ui/intra-links-warning.rs
+++ b/src/test/rustdoc-ui/intra-links-warning.rs
@@ -1,4 +1,4 @@
-// build-pass
+// check-pass
 
        //! Test with [Foo::baz], [Bar::foo], ...
 //~^ WARNING `[Foo::baz]` cannot be resolved

--- a/src/test/rustdoc-ui/invalid-syntax.rs
+++ b/src/test/rustdoc-ui/invalid-syntax.rs
@@ -1,4 +1,4 @@
-// build-pass
+// check-pass
 
 /// ```
 /// \__________pkt->size___________/          \_result->size_/ \__pkt->size__/

--- a/src/test/rustdoc-ui/issue-58473-2.rs
+++ b/src/test/rustdoc-ui/issue-58473-2.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![deny(private_doc_tests)]
 

--- a/src/test/rustdoc-ui/issue-58473.rs
+++ b/src/test/rustdoc-ui/issue-58473.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 pub trait Foo {
     /**

--- a/src/test/rustdoc-ui/test-no_std.rs
+++ b/src/test/rustdoc-ui/test-no_std.rs
@@ -1,6 +1,6 @@
 // compile-flags:--test
 // normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
-// build-pass
+// check-pass
 
 #![no_std]
 

--- a/src/test/rustdoc-ui/unused.rs
+++ b/src/test/rustdoc-ui/unused.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 // This test purpose is to check that unused_imports lint isn't fired
 // by rustdoc. Why would it? Because when rustdoc is running, it uses


### PR DESCRIPTION
These were all build-pass before and don't seem to need it.

Helps with #62277

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rust-lang/rust/71337)
<!-- Reviewable:end -->
