### PR TITLE
Moving more build-pass tests to check-pass

### DIFF
--- a/src/test/incremental/warnings-reemitted.rs
+++ b/src/test/incremental/warnings-reemitted.rs
@@ -1,6 +1,6 @@
 // revisions: cfail1 cfail2 cfail3
 // compile-flags: -Coverflow-checks=on
-// build-pass (FIXME(62277): could be check-pass?)
+// build-pass
 
 #![warn(arithmetic_overflow)]
 

--- a/src/test/ui/anon-params/anon-params-deprecated.fixed
+++ b/src/test/ui/anon-params/anon-params-deprecated.fixed
@@ -1,7 +1,7 @@
 #![warn(anonymous_parameters)]
 // Test for the anonymous_parameters deprecation lint (RFC 1685)
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // edition:2015
 // run-rustfix
 

--- a/src/test/ui/anon-params/anon-params-deprecated.rs
+++ b/src/test/ui/anon-params/anon-params-deprecated.rs
@@ -1,7 +1,7 @@
 #![warn(anonymous_parameters)]
 // Test for the anonymous_parameters deprecation lint (RFC 1685)
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // edition:2015
 // run-rustfix
 

--- a/src/test/ui/async-await/issues/issue-55324.rs
+++ b/src/test/ui/async-await/issues/issue-55324.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // edition:2018
 
 use std::future::Future;

--- a/src/test/ui/async-await/issues/issue-58885.rs
+++ b/src/test/ui/async-await/issues/issue-58885.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // edition:2018
 
 struct Xyz {

--- a/src/test/ui/async-await/issues/issue-59001.rs
+++ b/src/test/ui/async-await/issues/issue-59001.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // edition:2018
 
 use std::future::Future;

--- a/src/test/ui/async-await/issues/issue-60655-latebound-regions.rs
+++ b/src/test/ui/async-await/issues/issue-60655-latebound-regions.rs
@@ -1,6 +1,6 @@
 // Test that opaque `impl Trait` types are allowed to contain late-bound regions.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // edition:2018
 
 #![feature(type_alias_impl_trait)]

--- a/src/test/ui/attributes/item-attributes.rs
+++ b/src/test/ui/attributes/item-attributes.rs
@@ -2,7 +2,7 @@
 // for completeness since .rs files linked from .rc files support this
 // notation to specify their module's attributes
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rustc_attrs)]
 

--- a/src/test/ui/bastion-of-the-turbofish.rs
+++ b/src/test/ui/bastion-of-the-turbofish.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 // Bastion of the Turbofish
 // ------------------------

--- a/src/test/ui/codemap_tests/unicode_3.rs
+++ b/src/test/ui/codemap_tests/unicode_3.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 fn main() {
     let s = "ZͨA͑ͦ͒͋ͤ͑̚L̄͑͋Ĝͨͥ̿͒̽̈́Oͥ͛ͭ!̏"; while true { break; } //~ WARNING while_true

--- a/src/test/ui/const-generics/cannot-infer-type-for-const-param.rs
+++ b/src/test/ui/const-generics/cannot-infer-type-for-const-param.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![feature(const_generics)]
 //~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
 

--- a/src/test/ui/const-generics/issues/issue-60818-struct-constructors.rs
+++ b/src/test/ui/const-generics/issues/issue-60818-struct-constructors.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(const_generics)]
 //~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash

--- a/src/test/ui/deprecation/atomic_initializers.fixed
+++ b/src/test/ui/deprecation/atomic_initializers.fixed
@@ -1,5 +1,5 @@
 // run-rustfix
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #[allow(deprecated, unused_imports)]
 use std::sync::atomic::{AtomicIsize, ATOMIC_ISIZE_INIT};

--- a/src/test/ui/deprecation/atomic_initializers.rs
+++ b/src/test/ui/deprecation/atomic_initializers.rs
@@ -1,5 +1,5 @@
 // run-rustfix
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #[allow(deprecated, unused_imports)]
 use std::sync::atomic::{AtomicIsize, ATOMIC_ISIZE_INIT};

--- a/src/test/ui/derive-uninhabited-enum-38885.rs
+++ b/src/test/ui/derive-uninhabited-enum-38885.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // compile-flags: -Wunused
 
 // ensure there are no special warnings about uninhabited types

--- a/src/test/ui/editions/edition-extern-crate-allowed.rs
+++ b/src/test/ui/editions/edition-extern-crate-allowed.rs
@@ -1,6 +1,6 @@
 // aux-build:edition-extern-crate-allowed.rs
 // edition:2015
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![warn(rust_2018_idioms)]
 

--- a/src/test/ui/editions/edition-feature-redundant.rs
+++ b/src/test/ui/editions/edition-feature-redundant.rs
@@ -1,5 +1,5 @@
 // edition:2018
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rust_2018_preview)]
 //~^ WARN the feature `rust_2018_preview` is included in the Rust 2018 edition

--- a/src/test/ui/emit-artifact-notifications.rs
+++ b/src/test/ui/emit-artifact-notifications.rs
@@ -1,5 +1,5 @@
 // compile-flags:--emit=metadata --error-format=json --json artifacts
-// build-pass (FIXME(62277): could be check-pass?)
+// build-pass
 // ignore-pass
 // ^-- needed because `--pass check` does not emit the output needed.
 

--- a/src/test/ui/error-codes/E0705.rs
+++ b/src/test/ui/error-codes/E0705.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 // This is a stub feature that doesn't control anything, so to make tidy happy,
 // gate-test-test_2018_feature

--- a/src/test/ui/explain.rs
+++ b/src/test/ui/explain.rs
@@ -1,2 +1,2 @@
 // compile-flags: --explain E0591
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass

--- a/src/test/ui/fn_must_use.rs
+++ b/src/test/ui/fn_must_use.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![warn(unused_must_use)]
 

--- a/src/test/ui/if/if-let.rs
+++ b/src/test/ui/if/if-let.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 fn macros() {
     macro_rules! foo{

--- a/src/test/ui/loops/loops-reject-duplicate-labels-2.rs
+++ b/src/test/ui/loops/loops-reject-duplicate-labels-2.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 // ignore-tidy-linelength
 

--- a/src/test/ui/loops/loops-reject-duplicate-labels.rs
+++ b/src/test/ui/loops/loops-reject-duplicate-labels.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 // ignore-tidy-linelength
 

--- a/src/test/ui/loops/loops-reject-labels-shadowing-lifetimes.rs
+++ b/src/test/ui/loops/loops-reject-labels-shadowing-lifetimes.rs
@@ -1,7 +1,7 @@
 // Issue #21633: reject duplicate loop labels in function bodies.
 // This is testing interaction between lifetime-params and labels.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![allow(dead_code, unused_variables)]
 

--- a/src/test/ui/loops/loops-reject-lifetime-shadowing-label.rs
+++ b/src/test/ui/loops/loops-reject-lifetime-shadowing-label.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![allow(dead_code, unused_variables)]
 

--- a/src/test/ui/macros/must-use-in-macro-55516.rs
+++ b/src/test/ui/macros/must-use-in-macro-55516.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // compile-flags: -Wunused
 
 // make sure write!() can't hide its unused Result

--- a/src/test/ui/parser/underscore-suffix-for-string.rs
+++ b/src/test/ui/parser/underscore-suffix-for-string.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 fn main() {
     let _ = "Foo"_;

--- a/src/test/ui/proc-macro/attributes-included.rs
+++ b/src/test/ui/proc-macro/attributes-included.rs
@@ -1,5 +1,5 @@
 // aux-build:attributes-included.rs
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![warn(unused)]
 

--- a/src/test/ui/rust-2018/macro-use-warned-against.rs
+++ b/src/test/ui/rust-2018/macro-use-warned-against.rs
@@ -1,6 +1,6 @@
 // aux-build:macro-use-warned-against.rs
 // aux-build:macro-use-warned-against2.rs
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![warn(macro_use_extern_crate, unused)]
 

--- a/src/test/ui/rust-2018/remove-extern-crate.fixed
+++ b/src/test/ui/rust-2018/remove-extern-crate.fixed
@@ -1,6 +1,6 @@
 // run-rustfix
 // edition:2018
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // aux-build:remove-extern-crate.rs
 // compile-flags:--extern remove_extern_crate
 

--- a/src/test/ui/rust-2018/remove-extern-crate.rs
+++ b/src/test/ui/rust-2018/remove-extern-crate.rs
@@ -1,6 +1,6 @@
 // run-rustfix
 // edition:2018
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // aux-build:remove-extern-crate.rs
 // compile-flags:--extern remove_extern_crate
 

--- a/src/test/ui/rust-2018/suggestions-not-always-applicable.fixed
+++ b/src/test/ui/rust-2018/suggestions-not-always-applicable.fixed
@@ -2,7 +2,7 @@
 // edition:2015
 // run-rustfix
 // rustfix-only-machine-applicable
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rust_2018_preview)]
 #![warn(rust_2018_compatibility)]

--- a/src/test/ui/rust-2018/suggestions-not-always-applicable.rs
+++ b/src/test/ui/rust-2018/suggestions-not-always-applicable.rs
@@ -2,7 +2,7 @@
 // edition:2015
 // run-rustfix
 // rustfix-only-machine-applicable
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rust_2018_preview)]
 #![warn(rust_2018_compatibility)]

--- a/src/test/ui/rust-2018/try-ident.fixed
+++ b/src/test/ui/rust-2018/try-ident.fixed
@@ -1,5 +1,5 @@
 // run-rustfix
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![warn(rust_2018_compatibility)]
 

--- a/src/test/ui/rust-2018/try-ident.rs
+++ b/src/test/ui/rust-2018/try-ident.rs
@@ -1,5 +1,5 @@
 // run-rustfix
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![warn(rust_2018_compatibility)]
 

--- a/src/test/ui/span/macro-span-replacement.rs
+++ b/src/test/ui/span/macro-span-replacement.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![warn(unused)]
 

--- a/src/test/ui/span/multispan-import-lint.rs
+++ b/src/test/ui/span/multispan-import-lint.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![warn(unused)]
 

--- a/src/test/ui/test-attrs/test-should-panic-attr.rs
+++ b/src/test/ui/test-attrs/test-should-panic-attr.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // compile-flags: --test
 
 #[test]

--- a/src/test/ui/underscore-imports/basic.rs
+++ b/src/test/ui/underscore-imports/basic.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // aux-build:underscore-imports.rs
 
 #![warn(unused_imports, unused_extern_crates)]


### PR DESCRIPTION
One or two tests became build-pass without the FIXME because they really
needed build-pass (were failing without it).

Helps with #62277

---
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rust-lang/rust/71340)
<!-- Reviewable:end -->
