### PR TITLE
Use assoc int consts3

### DIFF
--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -2,7 +2,6 @@ use crate::cmp;
 use crate::fmt;
 use crate::intrinsics;
 use crate::ops::{Add, AddAssign, Try};
-use crate::usize;
 
 use super::{from_fn, LoopState};
 use super::{DoubleEndedIterator, ExactSizeIterator, FusedIterator, Iterator, TrustedLen};

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -1,7 +1,6 @@
 use crate::convert::TryFrom;
 use crate::mem;
 use crate::ops::{self, Add, Sub, Try};
-use crate::usize;
 
 use super::{FusedIterator, TrustedLen};
 

--- a/src/libcore/iter/sources.rs
+++ b/src/libcore/iter/sources.rs
@@ -1,6 +1,5 @@
 use crate::fmt;
 use crate::marker;
-use crate::usize;
 
 use super::{FusedIterator, TrustedLen};
 

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -265,7 +265,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn is_infinite(self) -> bool {
-        self.abs_private() == INFINITY
+        self.abs_private() == Self::INFINITY
     }
 
     /// Returns `true` if this number is neither infinite nor `NaN`.
@@ -287,7 +287,7 @@ impl f32 {
     pub fn is_finite(self) -> bool {
         // There's no need to handle NaN separately: if self is NaN,
         // the comparison is not true, exactly as desired.
-        self.abs_private() < INFINITY
+        self.abs_private() < Self::INFINITY
     }
 
     /// Returns `true` if the number is neither zero, infinite,

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -264,7 +264,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn is_infinite(self) -> bool {
-        self.abs_private() == INFINITY
+        self.abs_private() == Self::INFINITY
     }
 
     /// Returns `true` if this number is neither infinite nor `NaN`.
@@ -286,7 +286,7 @@ impl f64 {
     pub fn is_finite(self) -> bool {
         // There's no need to handle NaN separately: if self is NaN,
         // the comparison is not true, exactly as desired.
-        self.abs_private() < INFINITY
+        self.abs_private() < Self::INFINITY
     }
 
     /// Returns `true` if the number is neither zero, infinite,

--- a/src/libcore/num/flt2dec/decoder.rs
+++ b/src/libcore/num/flt2dec/decoder.rs
@@ -2,7 +2,6 @@
 
 use crate::num::dec2flt::rawfp::RawFloat;
 use crate::num::FpCategory;
-use crate::{f32, f64};
 
 /// Decoded unsigned finite value, such that:
 ///

--- a/src/libcore/num/flt2dec/mod.rs
+++ b/src/libcore/num/flt2dec/mod.rs
@@ -123,7 +123,6 @@ functions.
 )]
 
 pub use self::decoder::{decode, DecodableFloat, Decoded, FullDecoded};
-use crate::i16;
 
 pub mod decoder;
 pub mod estimator;

--- a/src/libcore/num/int_macros.rs
+++ b/src/libcore/num/int_macros.rs
@@ -14,14 +14,14 @@ macro_rules! int_module {
             concat!("The smallest value that can be represented by this integer type.
 Use [`", stringify!($T), "::MIN", "`](../../std/primitive.", stringify!($T), ".html#associatedconstant.MIN) instead."),
             #[$attr]
-            pub const MIN: $T = $T::min_value();
+            pub const MIN: $T = $T::MIN;
         }
 
         doc_comment! {
             concat!("The largest value that can be represented by this integer type.
 Use [`", stringify!($T), "::MAX", "`](../../std/primitive.", stringify!($T), ".html#associatedconstant.MAX) instead."),
             #[$attr]
-            pub const MAX: $T = $T::max_value();
+            pub const MAX: $T = $T::MAX;
         }
     )
 }

--- a/src/libcore/slice/memchr.rs
+++ b/src/libcore/slice/memchr.rs
@@ -34,7 +34,7 @@ fn repeat_byte(b: u8) -> usize {
 #[cfg(not(target_pointer_width = "16"))]
 #[inline]
 fn repeat_byte(b: u8) -> usize {
-    (b as usize) * (crate::usize::MAX / 255)
+    (b as usize) * (usize::MAX / 255)
 }
 
 /// Returns the first index matching the byte `x` in `text`.

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -28,7 +28,6 @@ use crate::cmp;
 use crate::cmp::Ordering::{self, Equal, Greater, Less};
 use crate::fmt;
 use crate::intrinsics::{assume, exact_div, is_aligned_and_not_null, unchecked_sub};
-use crate::isize;
 use crate::iter::*;
 use crate::marker::{self, Copy, Send, Sized, Sync};
 use crate::mem;

--- a/src/libcore/str/pattern.rs
+++ b/src/libcore/str/pattern.rs
@@ -12,7 +12,6 @@
 use crate::cmp;
 use crate::fmt;
 use crate::slice::memchr;
-use crate::usize;
 
 // Pattern
 

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -12,9 +12,9 @@
 //! assert_eq!(Duration::new(5, 0), Duration::from_secs(5));
 //! ```
 
+use crate::fmt;
 use crate::iter::Sum;
 use crate::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
-use crate::{fmt, u64};
 
 const NANOS_PER_SEC: u32 = 1_000_000_000;
 const NANOS_PER_MILLI: u32 = 1_000_000;

--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -171,7 +171,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn signum(self) -> f32 {
-        if self.is_nan() { NAN } else { 1.0_f32.copysign(self) }
+        if self.is_nan() { Self::NAN } else { 1.0_f32.copysign(self) }
     }
 
     /// Returns a number composed of the magnitude of `self` and the sign of
@@ -832,8 +832,8 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn asinh(self) -> f32 {
-        if self == NEG_INFINITY {
-            NEG_INFINITY
+        if self == Self::NEG_INFINITY {
+            Self::NEG_INFINITY
         } else {
             (self + ((self * self) + 1.0).sqrt()).ln().copysign(self)
         }
@@ -855,7 +855,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn acosh(self) -> f32 {
-        if self < 1.0 { crate::f32::NAN } else { (self + ((self * self) - 1.0).sqrt()).ln() }
+        if self < 1.0 { Self::NAN } else { (self + ((self * self) - 1.0).sqrt()).ln() }
     }
 
     /// Inverse hyperbolic tangent function.

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -171,7 +171,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn signum(self) -> f64 {
-        if self.is_nan() { NAN } else { 1.0_f64.copysign(self) }
+        if self.is_nan() { Self::NAN } else { 1.0_f64.copysign(self) }
     }
 
     /// Returns a number composed of the magnitude of `self` and the sign of
@@ -834,8 +834,8 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn asinh(self) -> f64 {
-        if self == NEG_INFINITY {
-            NEG_INFINITY
+        if self == Self::NEG_INFINITY {
+            Self::NEG_INFINITY
         } else {
             (self + ((self * self) + 1.0).sqrt()).ln().copysign(self)
         }
@@ -857,7 +857,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn acosh(self) -> f64 {
-        if self < 1.0 { NAN } else { (self + ((self * self) - 1.0).sqrt()).ln() }
+        if self < 1.0 { Self::NAN } else { (self + ((self * self) - 1.0).sqrt()).ln() }
     }
 
     /// Inverse hyperbolic tangent function.
@@ -926,16 +926,16 @@ impl f64 {
                 if self > 0.0 {
                     log_fn(self)
                 } else if self == 0.0 {
-                    NEG_INFINITY // log(0) = -Inf
+                    Self::NEG_INFINITY // log(0) = -Inf
                 } else {
-                    NAN // log(-n) = NaN
+                    Self::NAN // log(-n) = NaN
                 }
             } else if self.is_nan() {
                 self // log(NaN) = NaN
             } else if self > 0.0 {
                 self // log(Inf) = Inf
             } else {
-                NAN // log(-Inf) = NaN
+                Self::NAN // log(-Inf) = NaN
             }
         }
     }

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -1062,7 +1062,7 @@ impl ThreadId {
 
             // If we somehow use up all our bits, panic so that we're not
             // covering up subtle bugs of IDs being reused.
-            if COUNTER == crate::u64::MAX {
+            if COUNTER == u64::MAX {
                 panic!("failed to generate unique thread ID: bitspace exhausted");
             }
 

--- a/src/test/rustdoc/show-const-contents.rs
+++ b/src/test/rustdoc/show-const-contents.rs
@@ -51,7 +51,7 @@ pub const MY_TYPE_WITH_STR: MyTypeWithStr = MyTypeWithStr("show this");
 // @has show_const_contents/constant.PI.html '; // 3.14159274f32'
 pub use std::f32::consts::PI;
 
-// @has show_const_contents/constant.MAX.html '= i32::max_value(); // 2_147_483_647i32'
+// @has show_const_contents/constant.MAX.html '= i32::MAX; // 2_147_483_647i32'
 pub use std::i32::MAX;
 
 macro_rules! int_module {


### PR DESCRIPTION
Define module level int consts with associated constants instead of `min_value()` and `max_value()`. So the code become consistent with what the docs recommend etc. Seems natural.

Also remove the last usages of the int module constants from this repo (except src/test/ directory which I have still not really done anything in). Some places were missed in the previous PRs because the code uses `crate::<IntTy>` to reach the constants.

This is a continuation of #70857

r? @dtolnay 