### PR TITLE
allow wasm32 compilation of librustc_data_structures/profiling.rs

### DIFF
--- a/src/librustc_data_structures/profiling.rs
+++ b/src/librustc_data_structures/profiling.rs
@@ -99,11 +99,11 @@ use parking_lot::RwLock;
 
 /// MmapSerializatioSink is faster on macOS and Linux
 /// but FileSerializationSink is faster on Windows
-#[cfg(all(not(windows),not(target_arch="wasm32")))]
+#[cfg(all(not(windows), not(target_arch = "wasm32")))]
 type SerializationSink = measureme::MmapSerializationSink;
-#[cfg(all(windows,not(target_arch="wasm32")))]
+#[cfg(all(windows, not(target_arch = "wasm32")))]
 type SerializationSink = measureme::FileSerializationSink;
-#[cfg(target_arch="wasm32")]
+#[cfg(target_arch = "wasm32")]
 type SerializationSink = measureme::ByteVecSink;
 
 type Profiler = measureme::Profiler<SerializationSink>;
@@ -604,7 +604,7 @@ pub fn duration_to_secs_str(dur: std::time::Duration) -> String {
 }
 
 // Memory reporting
-#[cfg(all(unix,not(target_arch="wasm32")))]
+#[cfg(all(unix, not(target_arch = "wasm32")))]
 fn get_resident() -> Option<usize> {
     let field = 1;
     let contents = fs::read("/proc/self/statm").ok()?;
@@ -614,7 +614,7 @@ fn get_resident() -> Option<usize> {
     Some(npages * 4096)
 }
 
-#[cfg(all(windows,not(target_arch="wasm32")))]
+#[cfg(all(windows, not(target_arch = "wasm32")))]
 fn get_resident() -> Option<usize> {
     use std::mem::{self, MaybeUninit};
     use winapi::shared::minwindef::DWORD;
@@ -633,7 +633,7 @@ fn get_resident() -> Option<usize> {
     }
 }
 
-#[cfg(target_arch="wasm32")]
+#[cfg(target_arch = "wasm32")]
 fn get_resident() -> Option<usize> {
     None
 }

--- a/src/librustc_data_structures/profiling.rs
+++ b/src/librustc_data_structures/profiling.rs
@@ -99,10 +99,12 @@ use parking_lot::RwLock;
 
 /// MmapSerializatioSink is faster on macOS and Linux
 /// but FileSerializationSink is faster on Windows
-#[cfg(not(windows))]
+#[cfg(all(not(windows),not(target_arch="wasm32")))]
 type SerializationSink = measureme::MmapSerializationSink;
-#[cfg(windows)]
+#[cfg(all(windows,not(target_arch="wasm32")))]
 type SerializationSink = measureme::FileSerializationSink;
+#[cfg(target_arch="wasm32")]
+type SerializationSink = measureme::ByteVecSink;
 
 type Profiler = measureme::Profiler<SerializationSink>;
 
@@ -602,7 +604,7 @@ pub fn duration_to_secs_str(dur: std::time::Duration) -> String {
 }
 
 // Memory reporting
-#[cfg(unix)]
+#[cfg(all(unix,not(target_arch="wasm32")))]
 fn get_resident() -> Option<usize> {
     let field = 1;
     let contents = fs::read("/proc/self/statm").ok()?;
@@ -612,7 +614,7 @@ fn get_resident() -> Option<usize> {
     Some(npages * 4096)
 }
 
-#[cfg(windows)]
+#[cfg(all(windows,not(target_arch="wasm32")))]
 fn get_resident() -> Option<usize> {
     use std::mem::{self, MaybeUninit};
     use winapi::shared::minwindef::DWORD;
@@ -629,4 +631,9 @@ fn get_resident() -> Option<usize> {
             Some(pmc.WorkingSetSize as usize)
         }
     }
+}
+
+#[cfg(target_arch="wasm32")]
+fn get_resident() -> Option<usize> {
+    None
 }

--- a/src/librustc_data_structures/profiling.rs
+++ b/src/librustc_data_structures/profiling.rs
@@ -98,24 +98,14 @@ use measureme::{EventId, EventIdBuilder, SerializableString, StringId};
 use parking_lot::RwLock;
 
 cfg_if! {
-    if #[cfg(target_arch = "wasm32")] {
-        cfg_if! {
-            if #[cfg(target_os = "wasi")] {
-                type SerializationSink = measureme::FileSerializationSink;
-            } else {
-                type SerializationSink = measureme::ByteVecSink;
-            }
-        }
+    if #[cfg(any(windows, target_os = "wasi"))] {
+        /// FileSerializationSink is faster on Windows
+        type SerializationSink = measureme::FileSerializationSink;
+    } else if #[cfg(target_arch = "wasm32")] {
+        type SerializationSink = measureme::ByteVecSink;
     } else {
-        cfg_if! {
-            if #[cfg(windows)] {
-                /// FileSerializationSink is faster on Windows
-                type SerializationSink = measureme::FileSerializationSink;
-            } else {
-                /// MmapSerializatioSink is faster on macOS and Linux
-                type SerializationSink = measureme::MmapSerializationSink;
-            }
-        }
+        /// MmapSerializatioSink is faster on macOS and Linux
+        type SerializationSink = measureme::MmapSerializationSink;
     }
 }
 

--- a/src/librustc_data_structures/profiling.rs
+++ b/src/librustc_data_structures/profiling.rs
@@ -607,41 +607,39 @@ pub fn duration_to_secs_str(dur: std::time::Duration) -> String {
 }
 
 // Memory reporting
-cfg_if! {
-    if #[cfg(target_arch = "wasm32")] {
-        fn get_resident() -> Option<usize> {
-            None
-        }
-    } else {
-        cfg_if! {
-            if #[cfg(windows)] {
-                fn get_resident() -> Option<usize> {
-                    use std::mem::{self, MaybeUninit};
-                    use winapi::shared::minwindef::DWORD;
-                    use winapi::um::processthreadsapi::GetCurrentProcess;
-                    use winapi::um::psapi::{GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS};
+    cfg_if! {
+        if #[cfg(windows)] {
+            fn get_resident() -> Option<usize> {
+                use std::mem::{self, MaybeUninit};
+                use winapi::shared::minwindef::DWORD;
+                use winapi::um::processthreadsapi::GetCurrentProcess;
+                use winapi::um::psapi::{GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS};
 
-                    let mut pmc = MaybeUninit::<PROCESS_MEMORY_COUNTERS>::uninit();
-                    match unsafe {
-                        GetProcessMemoryInfo(GetCurrentProcess(), pmc.as_mut_ptr(), mem::size_of_val(&pmc) as DWORD)
-                    } {
-                        0 => None,
-                        _ => {
-                            let pmc = unsafe { pmc.assume_init() };
-                            Some(pmc.WorkingSetSize as usize)
-                        }
+                let mut pmc = MaybeUninit::<PROCESS_MEMORY_COUNTERS>::uninit();
+                match unsafe {
+                    GetProcessMemoryInfo(GetCurrentProcess(), pmc.as_mut_ptr(), mem::size_of_val(&pmc) as DWORD)
+                } {
+                    0 => None,
+                    _ => {
+                        let pmc = unsafe { pmc.assume_init() };
+                        Some(pmc.WorkingSetSize as usize)
                     }
                 }
-            } else {
-                fn get_resident() -> Option<usize> {
-                    let field = 1;
-                    let contents = fs::read("/proc/self/statm").ok()?;
-                    let contents = String::from_utf8(contents).ok()?;
-                    let s = contents.split_whitespace().nth(field)?;
-                    let npages = s.parse::<usize>().ok()?;
-                    Some(npages * 4096)
-                }
             }
+        } else if #[cfg(unix)] {
+            fn get_resident() -> Option<usize> {
+                let field = 1;
+                let contents = fs::read("/proc/self/statm").ok()?;
+                let contents = String::from_utf8(contents).ok()?;
+                let s = contents.split_whitespace().nth(field)?;
+                let npages = s.parse::<usize>().ok()?;
+                Some(npages * 4096)
+            }
+        } else {
+            fn get_resident() -> Option<usize> {
+                None
+            }
+        }
         }
     }
 }


### PR DESCRIPTION
I'm trying to use rustfmt from a wasm app. I ran into this compilation problem https://github.com/rust-lang/rustfmt/issues/4132 and after investigating, it looked like just adjusting a few cfg's. I based it on how measureme added support in https://github.com/rust-lang/measureme/pull/43.

My testing on my macbook was just that librustc_data_structures builds now with both:
- cargo build
- cargo build --target wasm32-unknown-unknown