### PR TITLE
Add needs_substs check to `check_binary_op`.

### DIFF
--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -521,6 +521,8 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
         None
     }
 
+    /// Check for overflow for a unary op. Like check_binary_op, safe to call even if the operand
+    /// needs substs. In that case, no work is done.
     fn check_unary_op(
         &mut self,
         op: UnOp,
@@ -548,6 +550,8 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
         Some(())
     }
 
+    /// Check a binary operand for overflow. Safe to call with values that need substs -- those
+    /// values just won't be checked.
     fn check_binary_op(
         &mut self,
         op: BinOp,

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -576,18 +576,20 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
                 }
             }
 
-            // The remaining operators are handled through `overflowing_binary_op`.
-            if self.use_ecx(|this| {
-                let l = this.ecx.read_immediate(this.ecx.eval_operand(left, None)?)?;
-                let (_res, overflow, _ty) = this.ecx.overflowing_binary_op(op, l, r)?;
-                Ok(overflow)
-            })? {
-                self.report_assert_as_lint(
-                    lint::builtin::ARITHMETIC_OVERFLOW,
-                    source_info,
-                    "this arithmetic operation will overflow",
-                    AssertKind::Overflow(op),
-                )?;
+            if !left.needs_subst() {
+                // The remaining operators are handled through `overflowing_binary_op`.
+                if self.use_ecx(|this| {
+                    let l = this.ecx.read_immediate(this.ecx.eval_operand(left, None)?)?;
+                    let (_res, overflow, _ty) = this.ecx.overflowing_binary_op(op, l, r)?;
+                    Ok(overflow)
+                })? {
+                    self.report_assert_as_lint(
+                        lint::builtin::ARITHMETIC_OVERFLOW,
+                        source_info,
+                        "this arithmetic operation will overflow",
+                        AssertKind::Overflow(op),
+                    )?;
+                }
             }
         }
 

--- a/src/test/ui/consts/const-eval/ice-generic-assoc-const.rs
+++ b/src/test/ui/consts/const-eval/ice-generic-assoc-const.rs
@@ -1,4 +1,5 @@
-// check-pass
+// build-pass
+#![crate_type = "lib"]
 
 pub trait Nullable {
     const NULL: Self;
@@ -12,7 +13,4 @@ impl<T> Nullable for *const T {
     fn is_null(&self) -> bool {
         *self == Self::NULL
     }
-}
-
-fn main() {
 }


### PR DESCRIPTION
Fixes #71353.

Fixes a regression introduced in  #70566 by adding a needs_substs check to `check_binary_op` for the rhs. We need this check now because `const_prop` no longer bail outs of generic contexts before `check_binary_op` is reached.

Also amends the `Nullable` test case to catch this issue in the future.

r? @RalfJung 