### PR TITLE
proc_macro::is_available()

### DIFF
--- a/src/libproc_macro/bridge/client.rs
+++ b/src/libproc_macro/bridge/client.rs
@@ -290,6 +290,13 @@ impl BridgeState<'_> {
 }
 
 impl Bridge<'_> {
+    pub(crate) fn is_available() -> bool {
+        BridgeState::with(|state| match state {
+            BridgeState::Connected(_) | BridgeState::InUse => true,
+            BridgeState::NotConnected => false,
+        })
+    }
+
     fn enter<R>(self, f: impl FnOnce() -> R) -> R {
         // Hide the default panic output within `proc_macro` expansions.
         // NB. the server can't do this because it may use a different libstd.

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -58,7 +58,7 @@ use std::{error, fmt, iter, mem};
 /// non-panicking way to detect whether the infrastructure required to use the
 /// API of proc_macro is presently available. Returns true if invoked from
 /// inside of a procedural macro, false if invoked from any other binary.
-#[unstable(feature = "proc_macro_is_available", issue = "none")] // FIXME
+#[unstable(feature = "proc_macro_is_available", issue = "71436")]
 pub fn is_available() -> bool {
     bridge::Bridge::is_available()
 }

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -45,6 +45,24 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::{error, fmt, iter, mem};
 
+/// Determines whether proc_macro has been made accessible to the currently
+/// running program.
+///
+/// The proc_macro crate is only intended for use inside the implementation of
+/// procedural macros. All the functions in this crate panic if invoked from
+/// outside of a procedural macro, such as from a build script or unit test or
+/// ordinary Rust binary.
+///
+/// With consideration for Rust libraries that are designed to support both
+/// macro and non-macro use cases, `proc_macro::is_available()` provides a
+/// non-panicking way to detect whether the infrastructure required to use the
+/// API of proc_macro is presently available. Returns true if invoked from
+/// inside of a procedural macro, false if invoked from any other binary.
+#[unstable(feature = "proc_macro_is_available", issue = "none")] // FIXME
+pub fn is_available() -> bool {
+    bridge::Bridge::is_available()
+}
+
 /// The main type provided by this crate, representing an abstract stream of
 /// tokens, or, more specifically, a sequence of token trees.
 /// The type provide interfaces for iterating over those token trees and, conversely,

--- a/src/test/ui/proc-macro/auxiliary/is-available.rs
+++ b/src/test/ui/proc-macro/auxiliary/is-available.rs
@@ -1,0 +1,14 @@
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+#![feature(proc_macro_is_available)]
+
+extern crate proc_macro;
+
+use proc_macro::{Literal, TokenStream, TokenTree};
+
+#[proc_macro]
+pub fn from_inside_proc_macro(_input: TokenStream) -> TokenStream {
+    proc_macro::is_available().to_string().parse().unwrap()
+}

--- a/src/test/ui/proc-macro/is-available.rs
+++ b/src/test/ui/proc-macro/is-available.rs
@@ -1,0 +1,17 @@
+// run-pass
+
+#![feature(proc_macro_hygiene, proc_macro_is_available)]
+
+extern crate proc_macro;
+
+// aux-build:is-available.rs
+extern crate is_available;
+
+fn main() {
+    let a = proc_macro::is_available();
+    let b = is_available::from_inside_proc_macro!();
+    let c = proc_macro::is_available();
+    assert!(!a);
+    assert!(b);
+    assert!(!c);
+}


### PR DESCRIPTION
This PR adds `proc_macro::is_available() -> bool` to determine whether proc_macro has been made accessible to the currently running program.

The proc_macro crate is only intended for use inside the implementation of procedural macros. All the functions in the crate panic if invoked from outside of a procedural macro, such as from a build script or unit test or ordinary Rust binary.

Unfortunately those panics made it impossible for libraries that are designed to support both macro and non-macro use cases (e.g. Syn) to be used from binaries that are compiled with panic=abort. In panic=unwind mode we're able to attempt a proc macro call inside catch_unwind and use libproc_macro's result if it succeeds, otherwise fall back to a non-macro alternative implementation. But in panic=abort there was no way to determine which implementation needs to be used.

r? @eddyb 
attn: @petrochenkov @adetaylor
ref: https://github.com/dtolnay/cxx/issues/130