### PR TITLE
Don't fuse Chain in its second iterator

### DIFF
--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -42,6 +42,7 @@
 #![feature(unwrap_infallible)]
 #![feature(leading_trailing_ones)]
 #![feature(const_forget)]
+#![feature(option_unwrap_none)]
 
 extern crate test;
 


### PR DESCRIPTION
Only the "first" iterator is actually set `None` when exhausted,
depending on whether you iterate forward or backward. This restores
behavior similar to the former `ChainState`, where it would transition
from `Both` to `Front`/`Back` and only continue from that side.

However, if you mix directions, then this may still set both sides to
`None`, totally fusing the iterator.

Fixes #71375
r? @scottmcm