### PR TITLE
Point at the return type on `.into()` failure caused by `?`

### DIFF
--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -84,6 +84,8 @@ pub trait InferCtxtExt<'tcx> {
         trait_ref: &ty::Binder<ty::TraitRef<'tcx>>,
     );
 
+    fn return_type_span(&self, obligation: &PredicateObligation<'tcx>) -> Option<Span>;
+
     fn suggest_impl_trait(
         &self,
         err: &mut DiagnosticBuilder<'tcx>,
@@ -758,6 +760,17 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 }
             }
         }
+    }
+
+    fn return_type_span(&self, obligation: &PredicateObligation<'tcx>) -> Option<Span> {
+        let hir = self.tcx.hir();
+        let parent_node = hir.get_parent_node(obligation.cause.body_id);
+        let sig = match hir.find(parent_node) {
+            Some(hir::Node::Item(hir::Item { kind: hir::ItemKind::Fn(sig, ..), .. })) => sig,
+            _ => return None,
+        };
+
+        if let hir::FnRetTy::Return(ret_ty) = sig.decl.output { Some(ret_ty.span) } else { None }
     }
 
     /// If all conditions are met to identify a returned `dyn Trait`, suggest using `impl Trait` if

--- a/src/test/ui/issues/issue-32709.stderr
+++ b/src/test/ui/issues/issue-32709.stderr
@@ -1,6 +1,8 @@
 error[E0277]: `?` couldn't convert the error to `()`
   --> $DIR/issue-32709.rs:4:11
    |
+LL | fn a() -> Result<i32, ()> {
+   |           --------------- expected `()` because of this
 LL |     Err(5)?;
    |           ^ the trait `std::convert::From<{integer}>` is not implemented for `()`
    |

--- a/src/test/ui/option-to-result.stderr
+++ b/src/test/ui/option-to-result.stderr
@@ -1,6 +1,9 @@
 error[E0277]: `?` couldn't convert the error to `()`
   --> $DIR/option-to-result.rs:5:6
    |
+LL | fn test_result() -> Result<(),()> {
+   |                     ------------- expected `()` because of this
+LL |     let a:Option<()> = Some(());
 LL |     a?;
    |      ^ the trait `std::convert::From<std::option::NoneError>` is not implemented for `()`
    |
@@ -14,6 +17,9 @@ LL |     a.ok_or_else(|| /* error value */)?;
 error[E0277]: `?` couldn't convert the error to `std::option::NoneError`
   --> $DIR/option-to-result.rs:11:6
    |
+LL | fn test_option() -> Option<i32>{
+   |                     ----------- expected `std::option::NoneError` because of this
+LL |     let a:Result<i32, i32> = Ok(5);
 LL |     a?;
    |      ^ the trait `std::convert::From<i32>` is not implemented for `std::option::NoneError`
    |

--- a/src/test/ui/try-on-option.stderr
+++ b/src/test/ui/try-on-option.stderr
@@ -1,6 +1,9 @@
 error[E0277]: `?` couldn't convert the error to `()`
   --> $DIR/try-on-option.rs:7:6
    |
+LL | fn foo() -> Result<u32, ()> {
+   |             --------------- expected `()` because of this
+LL |     let x: Option<u32> = None;
 LL |     x?;
    |      ^ the trait `std::convert::From<std::option::NoneError>` is not implemented for `()`
    |


### PR DESCRIPTION
Fix #35946.