### PR TITLE
Clarify unused_doc_comments note on macro invocations

### DIFF
--- a/src/librustc_lint/context.rs
+++ b/src/librustc_lint/context.rs
@@ -566,7 +566,7 @@ pub trait LintContext: Sized {
                     stability::deprecation_suggestion(&mut db, suggestion, span)
                 }
                 BuiltinLintDiagnostics::UnusedDocComment(span) => {
-                    db.span_label(span, "rustdoc does not generate documentation for macros");
+                    db.span_label(span, "rustdoc does not generate documentation for macro invocations");
                     db.help("to document an item produced by a macro, \
                                   the macro must produce the documentation as part of its expansion");
                 }

--- a/src/test/ui/useless-comment.stderr
+++ b/src/test/ui/useless-comment.stderr
@@ -2,7 +2,7 @@ error: unused doc comment
   --> $DIR/useless-comment.rs:9:1
    |
 LL | /// foo
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ rustdoc does not generate documentation for macros
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ rustdoc does not generate documentation for macro invocations
    |
 note: the lint level is defined here
   --> $DIR/useless-comment.rs:3:9
@@ -15,7 +15,7 @@ error: unused doc comment
   --> $DIR/useless-comment.rs:32:5
    |
 LL |     /// bar
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ rustdoc does not generate documentation for macros
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ rustdoc does not generate documentation for macro invocations
    |
    = help: to document an item produced by a macro, the macro must produce the documentation as part of its expansion
 


### PR DESCRIPTION
The previous error message used to say:

<pre>
/// doc
^^^^^^^ rustdoc does not generate documentation for <b>macros</b>
</pre>

Obviously we do generate documentation for macros, such as https://docs.rs/bitflags/1.2.1/bitflags/macro.bitflags.html. It's only macro invocations that don't get their own docs. This PR updates the message to say "rustdoc does not generate documentation for <b>macro invocations</b>".

I observe that prior to #69084 this used to say "rustdoc does not generate documentation for **macro expansions**", as implemented originally in #57882. I don't have a preference between those but I made the commit before looking up the history.

r? @Manishearth 
attn: @yaahc @euclio 