### PR TITLE
Let compiletest recognize gdb 10.x

### DIFF
--- a/src/tools/compiletest/src/tests.rs
+++ b/src/tools/compiletest/src/tests.rs
@@ -7,9 +7,9 @@ fn test_extract_gdb_version() {
     )*}}}
 
     test! {
-        7000001: "GNU gdb (GDB) CentOS (7.0.1-45.el5.centos)",
+        7000001: "GNU gdb (GDB) CentOS 7.0.1-45.el5.centos",
 
-        7002000: "GNU gdb (GDB) Red Hat Enterprise Linux (7.2-90.el6)",
+        7002000: "GNU gdb (GDB) Red Hat Enterprise Linux 7.2-90.el6",
 
         7004000: "GNU gdb (Ubuntu/Linaro 7.4-2012.04-0ubuntu2.1) 7.4-2012.04",
         7004001: "GNU gdb (GDB) 7.4.1-debian",


### PR DESCRIPTION
git gdb has moved to version 10.  My build prints this as its
--version:

    GNU gdb (GDB) 10.0.50.20200420-git

Unfortunately this conflicts with this comment in compiletest:

    // We limit major to 1 digit, otherwise, on openSUSE, we parse the openSUSE version

This patch changes the version parsing to follow the GNU coding
standard, which accounts for both the openSUSE case as well as
handling gdb 10.

My debuginfo test run now says:

NOTE: compiletest thinks it is using GDB with native rust support
NOTE: compiletest thinks it is using GDB version 10000050

... where previously it failed to find that gdb 10 had rust support.