### PR TITLE
smoke-test for async fn with mir-opt-level=0

### DIFF
--- a/src/test/ui/async-await/async-await.rs
+++ b/src/test/ui/async-await/async-await.rs
@@ -1,5 +1,8 @@
 // run-pass
 
+// revisions: default nomiropt
+//[nomiropt]compile-flags: -Z mir-opt-level=0
+
 #![allow(unused)]
 
 // edition:2018

--- a/src/test/ui/async-await/async-closure.rs
+++ b/src/test/ui/async-await/async-closure.rs
@@ -1,5 +1,8 @@
 // run-pass
 
+// revisions: default nomiropt
+//[nomiropt]compile-flags: -Z mir-opt-level=0
+
 // edition:2018
 // aux-build:arc_wake.rs
 

--- a/src/test/ui/async-await/drop-order/drop-order-for-async-fn-parameters.rs
+++ b/src/test/ui/async-await/drop-order/drop-order-for-async-fn-parameters.rs
@@ -2,6 +2,9 @@
 // edition:2018
 // run-pass
 
+// revisions: default nomiropt
+//[nomiropt]compile-flags: -Z mir-opt-level=0
+
 #![allow(unused_variables)]
 
 // Test that the drop order for parameters in a fn and async fn matches up. Also test that

--- a/src/test/ui/async-await/drop-order/drop-order-for-temporary-in-tail-return-expr.rs
+++ b/src/test/ui/async-await/drop-order/drop-order-for-temporary-in-tail-return-expr.rs
@@ -2,6 +2,9 @@
 // edition:2018
 // run-pass
 
+// revisions: default nomiropt
+//[nomiropt]compile-flags: -Z mir-opt-level=0
+
 #![allow(unused_variables)]
 
 // Test the drop order for parameters relative to local variables and

--- a/src/test/ui/async-await/drop-order/drop-order-when-cancelled.rs
+++ b/src/test/ui/async-await/drop-order/drop-order-when-cancelled.rs
@@ -2,6 +2,9 @@
 // edition:2018
 // run-pass
 
+// revisions: default nomiropt
+//[nomiropt]compile-flags: -Z mir-opt-level=0
+
 // Test that the drop order for parameters in a fn and async fn matches up. Also test that
 // parameters (used or unused) are not dropped until the async fn is cancelled.
 // This file is mostly copy-pasted from drop-order-for-async-fn-parameters.rs

--- a/src/test/ui/generator/conditional-drop.rs
+++ b/src/test/ui/generator/conditional-drop.rs
@@ -1,5 +1,8 @@
 // run-pass
 
+// revisions: default nomiropt
+//[nomiropt]compile-flags: -Z mir-opt-level=0
+
 #![feature(generators, generator_trait)]
 
 use std::ops::Generator;

--- a/src/test/ui/generator/control-flow.rs
+++ b/src/test/ui/generator/control-flow.rs
@@ -1,5 +1,8 @@
 // run-pass
 
+// revisions: default nomiropt
+//[nomiropt]compile-flags: -Z mir-opt-level=0
+
 #![feature(generators, generator_trait)]
 
 use std::marker::Unpin;

--- a/src/test/ui/generator/drop-env.rs
+++ b/src/test/ui/generator/drop-env.rs
@@ -1,5 +1,8 @@
 // run-pass
 
+// revisions: default nomiropt
+//[nomiropt]compile-flags: -Z mir-opt-level=0
+
 #![feature(generators, generator_trait)]
 
 use std::ops::Generator;

--- a/src/test/ui/generator/smoke-resume-args.rs
+++ b/src/test/ui/generator/smoke-resume-args.rs
@@ -1,5 +1,8 @@
 // run-pass
 
+// revisions: default nomiropt
+//[nomiropt]compile-flags: -Z mir-opt-level=0
+
 #![feature(generators, generator_trait)]
 
 use std::fmt::Debug;

--- a/src/test/ui/generator/smoke.rs
+++ b/src/test/ui/generator/smoke.rs
@@ -1,5 +1,8 @@
 // run-pass
 
+// revisions: default nomiropt
+//[nomiropt]compile-flags: -Z mir-opt-level=0
+
 // ignore-emscripten no threads support
 // compile-flags: --test
 


### PR DESCRIPTION
MIR opt levels heavily influence which MIR transformations run, and we barely test non-default opt levels. I am particularly worried about `async fn` lowering and how it might (not) work when the set of preceding MIR passes changes -- see https://github.com/rust-lang/rust/pull/70073.

This adds some basic smoke testing, where at least a few `async fn` `run-pass` test are ensured to also work with mir-opt-level=0.