### PR TITLE
Only use read_unaligned in transmute_copy if necessary

### DIFF
--- a/src/libcore/mem/mod.rs
+++ b/src/libcore/mem/mod.rs
@@ -923,7 +923,12 @@ pub fn drop<T>(_x: T) {}
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn transmute_copy<T, U>(src: &T) -> U {
-    ptr::read_unaligned(src as *const T as *const U)
+    // If U has a higher alignment requirement, src may not be suitably aligned.
+    if align_of::<U>() > align_of::<T>() {
+        ptr::read_unaligned(src as *const T as *const U)
+    } else {
+        ptr::read(src as *const T as *const U)
+    }
 }
 
 /// Opaque type representing the discriminant of an enum.


### PR DESCRIPTION
I've noticed that this causes LLVM to generate poor code on targets that don't support unaligned memory accesses.