### PR TITLE
Use lib crate type for SGX in `fn build_auxiliary`

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1750,6 +1750,7 @@ impl<'test> TestCx<'test> {
             || self.config.target.contains("wasm32")
             || self.config.target.contains("nvptx")
             || self.is_vxworks_pure_static()
+            || self.config.target.contains("sgx")
         {
             // We primarily compile all auxiliary libraries as dynamic libraries
             // to avoid code size bloat and large binaries as much as possible


### PR DESCRIPTION
since SGX does not support `dylib`

cc @Goirad 