### PR TITLE
disable LLD build for cross compiled hosts

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -733,7 +733,7 @@ impl Step for Assemble {
         // when not performing a full bootstrap).
         builder.ensure(Rustc { compiler: build_compiler, target: target_compiler.host });
 
-        let lld_install = if builder.config.lld_enabled {
+        let lld_install = if builder.lld_enabled(target_compiler.host) {
             Some(builder.ensure(native::Lld { target: target_compiler.host }))
         } else {
             None

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -519,7 +519,7 @@ impl Step for Rustc {
             maybe_install_llvm_dylib(builder, host, image);
 
             // Copy over lld if it's there
-            if builder.config.lld_enabled {
+            if builder.lld_enabled(compiler.host) {
                 let exe = exe("rust-lld", &compiler.host);
                 let src =
                     builder.sysroot_libdir(compiler, host).parent().unwrap().join("bin").join(&exe);

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -561,6 +561,12 @@ impl Build {
         self.out.join(&*target).join("lld")
     }
 
+    fn lld_enabled(&self, target: Interned<String>) -> bool {
+        // LLD does not currently cross compile correctly, so build it only for
+        // the native toolchain:
+        self.config.lld_enabled && self.config.build == target
+    }
+
     /// Output directory for all documentation for a target
     fn doc_out(&self, target: Interned<String>) -> PathBuf {
         self.out.join(&*target).join("doc")

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -440,7 +440,7 @@ impl Step for Lld {
         run.builder.ensure(Lld { target: run.target });
     }
 
-    /// Compile LLVM for `target`.
+    /// Compile LLD for `target`.
     fn run(self, builder: &Builder<'_>) -> PathBuf {
         if builder.config.dry_run {
             return PathBuf::from("lld-out-dir-test-gen");


### PR DESCRIPTION
At present, the LLD build requested by the --enable-lld configure option
appears to make direct use of the "llvm-config" binary built as part of
the LLVM build.  For cross built LLVM, the "llvm-config" binary produced
is intended to run on the target system, so it seems like this cannot
work as intended today.  Disable the LLD build for cross compiled hosts,
while continuing to allow --enable-lld to build a native LLD for use by
targets like Fuchsia that expect to use it for linking.