### PR TITLE
Add a convenience method on `TyCtxt` for checking for thread locals

### DIFF
--- a/src/librustc_codegen_llvm/consts.rs
+++ b/src/librustc_codegen_llvm/consts.rs
@@ -212,6 +212,7 @@ impl CodegenCx<'ll, 'tcx> {
         let g = if let Some(def_id) = def_id.as_local() {
             let id = self.tcx.hir().as_local_hir_id(def_id);
             let llty = self.layout_of(ty).llvm_type(self);
+            // FIXME: refactor this to work without accessing the HIR
             let (g, attrs) = match self.tcx.hir().get(id) {
                 Node::Item(&hir::Item { attrs, span, kind: hir::ItemKind::Static(..), .. }) => {
                     let sym_str = sym.as_str();

--- a/src/librustc_middle/mir/interpret/error.rs
+++ b/src/librustc_middle/mir/interpret/error.rs
@@ -438,7 +438,7 @@ impl fmt::Debug for UndefinedBehaviorInfo {
 /// Error information for when the program did something that might (or might not) be correct
 /// to do according to the Rust spec, but due to limitations in the interpreter, the
 /// operation could not be carried out. These limitations can differ between CTFE and the
-/// Miri engine, e.g., CTFE does not support casting pointers to "real" integers.
+/// Miri engine, e.g., CTFE does not support dereferencing pointers at integral addresses.
 ///
 /// Currently, we also use this as fall-back error kind for errors that have not been
 /// categorized yet.

--- a/src/librustc_middle/mir/interpret/error.rs
+++ b/src/librustc_middle/mir/interpret/error.rs
@@ -451,6 +451,8 @@ pub enum UnsupportedOpInfo {
     NoMirFor(DefId),
     /// Encountered a pointer where we needed raw bytes.
     ReadPointerAsBytes,
+
+    // The variants below are only reachable from CTFE/const prop, miri will never emit them.
     /// Encountered raw bytes where we needed a pointer.
     ReadBytesAsPointer,
 }

--- a/src/librustc_middle/mir/interpret/error.rs
+++ b/src/librustc_middle/mir/interpret/error.rs
@@ -439,9 +439,6 @@ impl fmt::Debug for UndefinedBehaviorInfo {
 /// to do according to the Rust spec, but due to limitations in the interpreter, the
 /// operation could not be carried out. These limitations can differ between CTFE and the
 /// Miri engine, e.g., CTFE does not support dereferencing pointers at integral addresses.
-///
-/// Currently, we also use this as fall-back error kind for errors that have not been
-/// categorized yet.
 pub enum UnsupportedOpInfo {
     /// Free-form case. Only for errors that are never caught!
     Unsupported(String),
@@ -451,8 +448,9 @@ pub enum UnsupportedOpInfo {
     NoMirFor(DefId),
     /// Encountered a pointer where we needed raw bytes.
     ReadPointerAsBytes,
-
+    //
     // The variants below are only reachable from CTFE/const prop, miri will never emit them.
+    //
     /// Encountered raw bytes where we needed a pointer.
     ReadBytesAsPointer,
 }

--- a/src/librustc_middle/ty/util.rs
+++ b/src/librustc_middle/ty/util.rs
@@ -1,6 +1,7 @@
 //! Miscellaneous type-system utilities that are too small to deserve their own modules.
 
 use crate::ich::NodeIdHashingMode;
+use crate::middle::codegen_fn_attrs::CodegenFnAttrFlags;
 use crate::mir::interpret::{sign_extend, truncate};
 use crate::ty::layout::IntegerExt;
 use crate::ty::query::TyCtxtAt;
@@ -526,6 +527,11 @@ impl<'tcx> TyCtxt<'tcx> {
     /// Returns `true` if the node pointed to by `def_id` is a `static` item.
     pub fn is_static(&self, def_id: DefId) -> bool {
         self.static_mutability(def_id).is_some()
+    }
+
+    /// Returns `true` if this is a `static` item with the `#[thread_local]` attribute.
+    pub fn is_thread_local_static(&self, def_id: DefId) -> bool {
+        self.codegen_fn_attrs(def_id).flags.contains(CodegenFnAttrFlags::THREAD_LOCAL)
     }
 
     /// Returns `true` if the node pointed to by `def_id` is a mutable `static` item.

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -8,7 +8,6 @@ use rustc_middle::mir::visit::{MutatingUseContext, NonMutatingUseContext, PlaceC
 use rustc_middle::mir::*;
 use rustc_middle::ty::cast::CastTy;
 use rustc_middle::ty::{self, Instance, InstanceDef, TyCtxt};
-use rustc_span::symbol::sym;
 use rustc_span::Span;
 use rustc_trait_selection::traits::error_reporting::InferCtxtExt;
 use rustc_trait_selection::traits::{self, TraitEngine};
@@ -224,7 +223,7 @@ impl Validator<'mir, 'tcx> {
 
         // Ensure that the end result is `Sync` in a non-thread local `static`.
         let should_check_for_sync =
-            const_kind == Some(ConstKind::Static) && !tcx.has_attr(def_id, sym::thread_local);
+            const_kind == Some(ConstKind::Static) && !tcx.is_thread_local_static(def_id);
 
         if should_check_for_sync {
             let hir_id = tcx.hir().as_local_hir_id(def_id.expect_local());
@@ -267,8 +266,7 @@ impl Validator<'mir, 'tcx> {
     }
 
     fn check_static(&mut self, def_id: DefId, span: Span) {
-        let is_thread_local = self.tcx.has_attr(def_id, sym::thread_local);
-        if is_thread_local {
+        if self.tcx.is_thread_local_static(def_id) {
             self.check_op_spanned(ops::ThreadLocalAccess, span)
         } else {
             self.check_op_spanned(ops::StaticAccess, span)

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -522,7 +522,7 @@ impl<'tcx> Validator<'_, 'tcx> {
                         return Err(Unpromotable);
                     }
 
-                    let is_thread_local = self.tcx.has_attr(def_id, sym::thread_local);
+                    let is_thread_local = self.tcx.is_thread_local_static(def_id);
                     if is_thread_local {
                         return Err(Unpromotable);
                     }

--- a/src/librustc_mir_build/build/expr/as_temp.rs
+++ b/src/librustc_mir_build/build/expr/as_temp.rs
@@ -3,10 +3,9 @@
 use crate::build::scope::DropKind;
 use crate::build::{BlockAnd, BlockAndExtension, Builder};
 use crate::hair::*;
+use rustc_hir as hir;
 use rustc_middle::middle::region;
 use rustc_middle::mir::*;
-use rustc_hir as hir;
-use rustc_span::symbol::sym;
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// Compile `expr` into a fresh temporary. This is used when building
@@ -60,7 +59,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 local_decl = local_decl.block_tail(tail_info);
             }
             if let ExprKind::StaticRef { def_id, .. } = expr.kind {
-                let is_thread_local = this.hir.tcx().has_attr(def_id, sym::thread_local);
+                let is_thread_local = this.hir.tcx().is_thread_local_static(def_id);
                 local_decl.internal = true;
                 local_decl.local_info = LocalInfo::StaticRef { def_id, is_thread_local };
             }

--- a/src/test/ui/linkage-attr/linkage3.rs
+++ b/src/test/ui/linkage-attr/linkage3.rs
@@ -1,6 +1,6 @@
 // FIXME https://github.com/rust-lang/rust/issues/59774
 
-// build-fail
+// check-fail
 // normalize-stderr-test "thread.*panicked.*Metadata module not compiled.*\n" -> ""
 // normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
 


### PR DESCRIPTION
This PR extracts the cleanup part of #71192 

r? @bjorn3 