### PR TITLE
add AnonConst as potential parent_item

### DIFF
--- a/src/librustc_middle/hir/map/mod.rs
+++ b/src/librustc_middle/hir/map/mod.rs
@@ -641,7 +641,8 @@ impl<'hir> Map<'hir> {
     pub fn get_parent_item(&self, hir_id: HirId) -> HirId {
         for (hir_id, node) in self.parent_iter(hir_id) {
             match node {
-                Node::Crate(_)
+                Node::AnonConst(_)
+                | Node::Crate(_)
                 | Node::Item(_)
                 | Node::ForeignItem(_)
                 | Node::TraitItem(_)

--- a/src/test/ui/consts/enum-discr-type-err.stderr
+++ b/src/test/ui/consts/enum-discr-type-err.stderr
@@ -11,10 +11,6 @@ LL | | }
    | |_- in this macro invocation
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
-help: you can convert an `i32` to `isize` and panic if the converted value wouldn't fit
-   |
-LL |             $( $v = $s::V.try_into().unwrap(), )*
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/enum-discr-type-err.rs:18:21
@@ -29,10 +25,6 @@ LL | | }
    | |_- in this macro invocation
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
-help: you can convert an `i32` to `isize` and panic if the converted value wouldn't fit
-   |
-LL |             $( $v = $s::V.try_into().unwrap(), )*
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/discrim/discrim-ill-typed.stderr
+++ b/src/test/ui/discrim/discrim-ill-typed.stderr
@@ -3,88 +3,48 @@ error[E0308]: mismatched types
    |
 LL |         OhNo = 0_u8,
    |                ^^^^ expected `i8`, found `u8`
-   |
-help: change the type of the numeric literal from `u8` to `i8`
-   |
-LL |         OhNo = 0_i8,
-   |                ^^^^
 
 error[E0308]: mismatched types
   --> $DIR/discrim-ill-typed.rs:30:16
    |
 LL |         OhNo = 0_i8,
    |                ^^^^ expected `u8`, found `i8`
-   |
-help: change the type of the numeric literal from `i8` to `u8`
-   |
-LL |         OhNo = 0_u8,
-   |                ^^^^
 
 error[E0308]: mismatched types
   --> $DIR/discrim-ill-typed.rs:43:16
    |
 LL |         OhNo = 0_u16,
    |                ^^^^^ expected `i16`, found `u16`
-   |
-help: change the type of the numeric literal from `u16` to `i16`
-   |
-LL |         OhNo = 0_i16,
-   |                ^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/discrim-ill-typed.rs:56:16
    |
 LL |         OhNo = 0_i16,
    |                ^^^^^ expected `u16`, found `i16`
-   |
-help: change the type of the numeric literal from `i16` to `u16`
-   |
-LL |         OhNo = 0_u16,
-   |                ^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/discrim-ill-typed.rs:69:16
    |
 LL |         OhNo = 0_u32,
    |                ^^^^^ expected `i32`, found `u32`
-   |
-help: change the type of the numeric literal from `u32` to `i32`
-   |
-LL |         OhNo = 0_i32,
-   |                ^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/discrim-ill-typed.rs:82:16
    |
 LL |         OhNo = 0_i32,
    |                ^^^^^ expected `u32`, found `i32`
-   |
-help: change the type of the numeric literal from `i32` to `u32`
-   |
-LL |         OhNo = 0_u32,
-   |                ^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/discrim-ill-typed.rs:95:16
    |
 LL |         OhNo = 0_u64,
    |                ^^^^^ expected `i64`, found `u64`
-   |
-help: change the type of the numeric literal from `u64` to `i64`
-   |
-LL |         OhNo = 0_i64,
-   |                ^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/discrim-ill-typed.rs:108:16
    |
 LL |         OhNo = 0_i64,
    |                ^^^^^ expected `u64`, found `i64`
-   |
-help: change the type of the numeric literal from `i64` to `u64`
-   |
-LL |         OhNo = 0_u64,
-   |                ^^^^^
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/issues/issue-31910.stderr
+++ b/src/test/ui/issues/issue-31910.stderr
@@ -3,11 +3,6 @@ error[E0308]: mismatched types
    |
 LL |     X = Trait::Number,
    |         ^^^^^^^^^^^^^ expected `isize`, found `i32`
-   |
-help: you can convert an `i32` to `isize` and panic if the converted value wouldn't fit
-   |
-LL |     X = Trait::Number.try_into().unwrap(),
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-8761.stderr
+++ b/src/test/ui/issues/issue-8761.stderr
@@ -3,22 +3,12 @@ error[E0308]: mismatched types
    |
 LL |     A = 1i64,
    |         ^^^^ expected `isize`, found `i64`
-   |
-help: change the type of the numeric literal from `i64` to `isize`
-   |
-LL |     A = 1isize,
-   |         ^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/issue-8761.rs:5:9
    |
 LL |     B = 2u8
    |         ^^^ expected `isize`, found `u8`
-   |
-help: change the type of the numeric literal from `u8` to `isize`
-   |
-LL |     B = 2isize
-   |         ^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/repeat_count.stderr
+++ b/src/test/ui/repeat_count.stderr
@@ -39,22 +39,12 @@ error[E0308]: mismatched types
    |
 LL |     let f = [0; -4_isize];
    |                 ^^^^^^^^ expected `usize`, found `isize`
-   |
-help: you can convert an `isize` to `usize` and panic if the converted value wouldn't fit
-   |
-LL |     let f = [0; (-4_isize).try_into().unwrap()];
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/repeat_count.rs:22:23
    |
 LL |     let f = [0_usize; -1_isize];
    |                       ^^^^^^^^ expected `usize`, found `isize`
-   |
-help: you can convert an `isize` to `usize` and panic if the converted value wouldn't fit
-   |
-LL |     let f = [0_usize; (-1_isize).try_into().unwrap()];
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 8 previous errors
 


### PR DESCRIPTION
This prevents some help messages in const contexts, due to

https://github.com/rust-lang/rust/blob/413a12909f3b149af17d75268ed4a136afb82c36/src/librustc_typeck/check/demand.rs#L597-L601
considering that the check in `is_const_context` was previously unreachable,
this is actually a bugfix :laughing: 
https://github.com/rust-lang/rust/blob/413a12909f3b149af17d75268ed4a136afb82c36/src/librustc_middle/hir/map/mod.rs#L563

r? @eddyb cc @estebank 