### PR TITLE
add back Scalar::null_ptr

### DIFF
--- a/src/librustc_middle/mir/interpret/value.rs
+++ b/src/librustc_middle/mir/interpret/value.rs
@@ -189,6 +189,11 @@ impl<'tcx, Tag> Scalar<Tag> {
     }
 
     #[inline]
+    pub fn null_ptr(cx: &impl HasDataLayout) -> Self {
+        Scalar::Raw { data: 0, size: cx.data_layout().pointer_size.bytes() as u8 }
+    }
+
+    #[inline]
     pub fn zst() -> Self {
         Scalar::Raw { data: 0, size: 0 }
     }


### PR DESCRIPTION
We were a bit overeager with removing this in https://github.com/rust-lang/rust/pull/71005, Miri uses this function quite a bit.

The important part is that the `Place::null` methods are gone. :)
r? @jonas-schievink @oli-obk 

Fixes https://github.com/rust-lang/rust/issues/71474