### PR TITLE
Inherit `#[stable(..)]` annotations in enum variants and fields from its item

### DIFF
--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -774,8 +774,11 @@ impl SyntaxExtension {
             sess.parse_sess
                 .span_diagnostic
                 .struct_span_err(sp, "macros cannot have const stability attributes")
-                .span_label(sp, "invalid stability attribute")
-                .span_label(span, "in this macro")
+                .span_label(sp, "invalid const stability attribute")
+                .span_label(
+                    sess.source_map().guess_head_span(span),
+                    "const stability attribute affects this macro",
+                )
                 .emit();
         }
 

--- a/compiler/rustc_passes/src/lib_features.rs
+++ b/compiler/rustc_passes/src/lib_features.rs
@@ -109,7 +109,7 @@ impl LibFeatureCollector<'tcx> {
     }
 
     fn span_feature_error(&self, span: Span, msg: &str) {
-        struct_span_err!(self.tcx.sess, span, E0711, "{}", &msg,).emit();
+        struct_span_err!(self.tcx.sess, span, E0711, "{}", &msg).emit();
     }
 }
 

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -70,6 +70,17 @@ impl InheritConstStability {
     }
 }
 
+enum InheritStability {
+    Yes,
+    No,
+}
+
+impl InheritStability {
+    fn yes(&self) -> bool {
+        matches!(self, InheritStability::Yes)
+    }
+}
+
 // A private tree-walker for producing an Index.
 struct Annotator<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
@@ -91,6 +102,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         kind: AnnotationKind,
         inherit_deprecation: InheritDeprecation,
         inherit_const_stability: InheritConstStability,
+        inherit_from_parent: InheritStability,
         visit_children: F,
     ) where
         F: FnOnce(&mut Self),
@@ -131,12 +143,13 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         }
 
         if self.tcx.features().staged_api {
-            if let Some(..) = attrs.iter().find(|a| self.tcx.sess.check_name(a, sym::deprecated)) {
-                self.tcx.sess.span_err(
-                    item_sp,
-                    "`#[deprecated]` cannot be used in staged API; \
-                                                use `#[rustc_deprecated]` instead",
-                );
+            if let Some(a) = attrs.iter().find(|a| self.tcx.sess.check_name(a, sym::deprecated)) {
+                self.tcx
+                    .sess
+                    .struct_span_err(a.span, "`#[deprecated]` cannot be used in staged API")
+                    .span_label(a.span, "use `#[rustc_deprecated]` instead")
+                    .span_label(item_sp, "")
+                    .emit();
             }
         } else {
             self.recurse_with_stability_attrs(
@@ -185,7 +198,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
             if kind == AnnotationKind::Prohibited
                 || (kind == AnnotationKind::Container && stab.level.is_stable() && is_deprecated)
             {
-                self.tcx.sess.span_err(item_sp, "This stability annotation is useless");
+                self.tcx.sess.span_err(item_sp, "this stability annotation is useless");
             }
 
             debug!("annotate: found {:?}", stab);
@@ -202,7 +215,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
                 {
                     match stab_v.parse::<u64>() {
                         Err(_) => {
-                            self.tcx.sess.span_err(item_sp, "Invalid stability version found");
+                            self.tcx.sess.span_err(item_sp, "invalid stability version found");
                             break;
                         }
                         Ok(stab_vp) => match dep_v.parse::<u64>() {
@@ -210,7 +223,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
                                 Ordering::Less => {
                                     self.tcx.sess.span_err(
                                         item_sp,
-                                        "An API can't be stabilized after it is deprecated",
+                                        "an API can't be stabilized after it is deprecated",
                                     );
                                     break;
                                 }
@@ -221,7 +234,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
                                 if dep_v != "TBD" {
                                     self.tcx
                                         .sess
-                                        .span_err(item_sp, "Invalid deprecation version found");
+                                        .span_err(item_sp, "invalid deprecation version found");
                                 }
                                 break;
                             }
@@ -237,7 +250,9 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         if stab.is_none() {
             debug!("annotate: stab not found, parent = {:?}", self.parent_stab);
             if let Some(stab) = self.parent_stab {
-                if inherit_deprecation.yes() && stab.level.is_unstable() {
+                if inherit_deprecation.yes() && stab.level.is_unstable()
+                    || inherit_from_parent.yes()
+                {
                     self.index.stab_map.insert(hir_id, stab);
                 }
             }
@@ -368,6 +383,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
                         AnnotationKind::Required,
                         InheritDeprecation::Yes,
                         InheritConstStability::No,
+                        InheritStability::Yes,
                         |_| {},
                     )
                 }
@@ -382,6 +398,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             kind,
             InheritDeprecation::Yes,
             const_stab_inherit,
+            InheritStability::No,
             |v| intravisit::walk_item(v, i),
         );
         self.in_trait_impl = orig_in_trait_impl;
@@ -395,6 +412,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             AnnotationKind::Required,
             InheritDeprecation::Yes,
             InheritConstStability::No,
+            InheritStability::No,
             |v| {
                 intravisit::walk_trait_item(v, ti);
             },
@@ -411,6 +429,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             kind,
             InheritDeprecation::Yes,
             InheritConstStability::No,
+            InheritStability::No,
             |v| {
                 intravisit::walk_impl_item(v, ii);
             },
@@ -425,6 +444,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             AnnotationKind::Required,
             InheritDeprecation::Yes,
             InheritConstStability::No,
+            InheritStability::Yes,
             |v| {
                 if let Some(ctor_hir_id) = var.data.ctor_hir_id() {
                     v.annotate(
@@ -434,6 +454,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
                         AnnotationKind::Required,
                         InheritDeprecation::Yes,
                         InheritConstStability::No,
+                        InheritStability::No,
                         |_| {},
                     );
                 }
@@ -451,6 +472,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             AnnotationKind::Required,
             InheritDeprecation::Yes,
             InheritConstStability::No,
+            InheritStability::Yes,
             |v| {
                 intravisit::walk_struct_field(v, s);
             },
@@ -465,6 +487,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             AnnotationKind::Required,
             InheritDeprecation::Yes,
             InheritConstStability::No,
+            InheritStability::No,
             |v| {
                 intravisit::walk_foreign_item(v, i);
             },
@@ -479,6 +502,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             AnnotationKind::Required,
             InheritDeprecation::Yes,
             InheritConstStability::No,
+            InheritStability::No,
             |_| {},
         );
     }
@@ -499,6 +523,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             kind,
             InheritDeprecation::No,
             InheritConstStability::No,
+            InheritStability::No,
             |v| {
                 intravisit::walk_generic_param(v, p);
             },
@@ -669,6 +694,7 @@ fn new_index(tcx: TyCtxt<'tcx>) -> Index<'tcx> {
             AnnotationKind::Required,
             InheritDeprecation::Yes,
             InheritConstStability::No,
+            InheritStability::No,
             |v| intravisit::walk_crate(v, krate),
         );
     }

--- a/src/test/ui/attributes/const-stability-on-macro.rs
+++ b/src/test/ui/attributes/const-stability-on-macro.rs
@@ -1,0 +1,13 @@
+#[rustc_const_stable(feature = "foo", since = "0")]
+//~^ ERROR macros cannot have const stability attributes
+macro_rules! foo {
+    () => {};
+}
+
+#[rustc_const_unstable(feature = "bar", issue="none")]
+//~^ ERROR macros cannot have const stability attributes
+macro_rules! bar {
+    () => {};
+}
+
+fn main() {}

--- a/src/test/ui/attributes/const-stability-on-macro.stderr
+++ b/src/test/ui/attributes/const-stability-on-macro.stderr
@@ -1,0 +1,20 @@
+error: macros cannot have const stability attributes
+  --> $DIR/const-stability-on-macro.rs:1:1
+   |
+LL | #[rustc_const_stable(feature = "foo", since = "0")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid const stability attribute
+LL |
+LL | macro_rules! foo {
+   | ---------------- const stability attribute affects this macro
+
+error: macros cannot have const stability attributes
+  --> $DIR/const-stability-on-macro.rs:7:1
+   |
+LL | #[rustc_const_unstable(feature = "bar", issue="none")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid const stability attribute
+LL |
+LL | macro_rules! bar {
+   | ---------------- const stability attribute affects this macro
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/deprecation/deprecation-in-staged-api.rs
+++ b/src/test/ui/deprecation/deprecation-in-staged-api.rs
@@ -1,8 +1,4 @@
-// #[deprecated] cannot be used in staged API
-
 #![feature(staged_api)]
-
 #![stable(feature = "stable_test_feature", since = "1.0.0")]
-
-#[deprecated]
-fn main() { } //~ ERROR `#[deprecated]` cannot be used in staged API
+#[deprecated] //~ ERROR `#[deprecated]` cannot be used in staged API
+fn main() {}

--- a/src/test/ui/deprecation/deprecation-in-staged-api.stderr
+++ b/src/test/ui/deprecation/deprecation-in-staged-api.stderr
@@ -1,8 +1,10 @@
-error: `#[deprecated]` cannot be used in staged API; use `#[rustc_deprecated]` instead
-  --> $DIR/deprecation-in-staged-api.rs:8:1
+error: `#[deprecated]` cannot be used in staged API
+  --> $DIR/deprecation-in-staged-api.rs:3:1
    |
-LL | fn main() { }
-   | ^^^^^^^^^^^^^
+LL | #[deprecated]
+   | ^^^^^^^^^^^^^ use `#[rustc_deprecated]` instead
+LL | fn main() {}
+   | ------------
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/auxiliary/lint_stability_fields.rs
+++ b/src/test/ui/lint/auxiliary/lint_stability_fields.rs
@@ -3,20 +3,35 @@
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Stable {
-    #[stable(feature = "rust1", since = "1.0.0")]
-    pub inherit: u8, // it's a lie (stable doesn't inherit)
+    pub inherit: u8,
     #[unstable(feature = "unstable_test_feature", issue = "none")]
     pub override1: u8,
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     #[unstable(feature = "unstable_test_feature", issue = "none")]
     pub override2: u8,
+    #[stable(feature = "rust2", since = "2.0.0")]
+    pub override3: u8,
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct Stable2(#[stable(feature = "rust1", since = "1.0.0")] pub u8,
+pub struct Stable2(#[stable(feature = "rust2", since = "2.0.0")] pub u8,
                    #[unstable(feature = "unstable_test_feature", issue = "none")] pub u8,
                    #[unstable(feature = "unstable_test_feature", issue = "none")]
-                   #[rustc_deprecated(since = "1.0.0", reason = "text")] pub u8);
+                   #[rustc_deprecated(since = "1.0.0", reason = "text")] pub u8,
+                   pub u8);
+
+#[stable(feature = "rust1", since = "1.0.0")]
+pub enum Stable3 {
+    Inherit(u8),
+    InheritOverride(#[stable(feature = "rust2", since = "2.0.0")] u8),
+    #[stable(feature = "rust2", since = "2.0.0")]
+    Override1,
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
+    Override2,
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
+    Override3,
+}
 
 #[unstable(feature = "unstable_test_feature", issue = "none")]
 pub struct Unstable {

--- a/src/test/ui/lint/lint-stability-fields-deprecated.rs
+++ b/src/test/ui/lint/lint-stability-fields-deprecated.rs
@@ -17,33 +17,38 @@ mod cross_crate {
             override1: 2,
             override2: 3,
             //~^ ERROR use of deprecated field
+            override3: 4,
         };
 
         let _ = x.inherit;
         let _ = x.override1;
         let _ = x.override2;
         //~^ ERROR use of deprecated field
+        let _ = x.override3;
 
         let Stable {
             inherit: _,
             override1: _,
-            override2: _
+            override2: _,
             //~^ ERROR use of deprecated field
+            override3: _,
         } = x;
         // all fine
         let Stable { .. } = x;
 
-        let x = Stable2(1, 2, 3);
+        let x = Stable2(1, 2, 3, 4);
 
         let _ = x.0;
         let _ = x.1;
         let _ = x.2;
         //~^ ERROR use of deprecated field
+        let _ = x.3;
 
         let Stable2(_,
                    _,
+                   _,
+                   //~^ ERROR use of deprecated field
                    _)
-            //~^ ERROR use of deprecated field
             = x;
         // all fine
         let Stable2(..) = x;

--- a/src/test/ui/lint/lint-stability-fields-deprecated.stderr
+++ b/src/test/ui/lint/lint-stability-fields-deprecated.stderr
@@ -1,5 +1,5 @@
 error: use of deprecated struct `cross_crate::lint_stability_fields::Deprecated`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:94:17
+  --> $DIR/lint-stability-fields-deprecated.rs:99:17
    |
 LL |         let x = Deprecated {
    |                 ^^^^^^^^^^
@@ -11,67 +11,67 @@ LL | #![deny(deprecated)]
    |         ^^^^^^^^^^
 
 error: use of deprecated struct `cross_crate::lint_stability_fields::Deprecated`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:111:13
+  --> $DIR/lint-stability-fields-deprecated.rs:116:13
    |
 LL |         let Deprecated {
    |             ^^^^^^^^^^
 
 error: use of deprecated struct `cross_crate::lint_stability_fields::Deprecated`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:121:13
+  --> $DIR/lint-stability-fields-deprecated.rs:126:13
    |
 LL |         let Deprecated
    |             ^^^^^^^^^^
 
 error: use of deprecated struct `cross_crate::lint_stability_fields::Deprecated2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:126:17
+  --> $DIR/lint-stability-fields-deprecated.rs:131:17
    |
 LL |         let x = Deprecated2(1, 2, 3);
    |                 ^^^^^^^^^^^
 
 error: use of deprecated struct `cross_crate::lint_stability_fields::Deprecated2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:136:13
+  --> $DIR/lint-stability-fields-deprecated.rs:141:13
    |
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
 
 error: use of deprecated struct `cross_crate::lint_stability_fields::Deprecated2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:145:13
+  --> $DIR/lint-stability-fields-deprecated.rs:150:13
    |
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
 
 error: use of deprecated struct `this_crate::Deprecated`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:281:17
+  --> $DIR/lint-stability-fields-deprecated.rs:286:17
    |
 LL |         let x = Deprecated {
    |                 ^^^^^^^^^^
 
 error: use of deprecated struct `this_crate::Deprecated`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:298:13
+  --> $DIR/lint-stability-fields-deprecated.rs:303:13
    |
 LL |         let Deprecated {
    |             ^^^^^^^^^^
 
 error: use of deprecated struct `this_crate::Deprecated`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:308:13
+  --> $DIR/lint-stability-fields-deprecated.rs:313:13
    |
 LL |         let Deprecated
    |             ^^^^^^^^^^
 
 error: use of deprecated tuple struct `this_crate::Deprecated2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:313:17
+  --> $DIR/lint-stability-fields-deprecated.rs:318:17
    |
 LL |         let x = Deprecated2(1, 2, 3);
    |                 ^^^^^^^^^^^
 
 error: use of deprecated tuple struct `this_crate::Deprecated2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:323:13
+  --> $DIR/lint-stability-fields-deprecated.rs:328:13
    |
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
 
 error: use of deprecated tuple struct `this_crate::Deprecated2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:332:13
+  --> $DIR/lint-stability-fields-deprecated.rs:337:13
    |
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
@@ -83,295 +83,295 @@ LL |             override2: 3,
    |             ^^^^^^^^^^^^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Stable::override2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:24:17
+  --> $DIR/lint-stability-fields-deprecated.rs:25:17
    |
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Stable::override2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:30:13
+  --> $DIR/lint-stability-fields-deprecated.rs:32:13
    |
-LL |             override2: _
+LL |             override2: _,
    |             ^^^^^^^^^^^^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Stable2::2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:40:17
+  --> $DIR/lint-stability-fields-deprecated.rs:43:17
    |
 LL |         let _ = x.2;
    |                 ^^^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Stable2::2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:45:20
+  --> $DIR/lint-stability-fields-deprecated.rs:49:20
    |
-LL |                    _)
+LL |                    _,
    |                    ^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Unstable::override2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:55:13
+  --> $DIR/lint-stability-fields-deprecated.rs:60:13
    |
 LL |             override2: 3,
    |             ^^^^^^^^^^^^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Unstable::override2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:61:17
+  --> $DIR/lint-stability-fields-deprecated.rs:66:17
    |
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Unstable::override2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:67:13
+  --> $DIR/lint-stability-fields-deprecated.rs:72:13
    |
 LL |             override2: _
    |             ^^^^^^^^^^^^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Unstable2::2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:80:17
+  --> $DIR/lint-stability-fields-deprecated.rs:85:17
    |
 LL |         let _ = x.2;
    |                 ^^^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Unstable2::2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:86:14
+  --> $DIR/lint-stability-fields-deprecated.rs:91:14
    |
 LL |              _)
    |              ^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated::inherit`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:96:13
+  --> $DIR/lint-stability-fields-deprecated.rs:101:13
    |
 LL |             inherit: 1,
    |             ^^^^^^^^^^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated::override1`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:98:13
+  --> $DIR/lint-stability-fields-deprecated.rs:103:13
    |
 LL |             override1: 2,
    |             ^^^^^^^^^^^^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated::override2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:100:13
+  --> $DIR/lint-stability-fields-deprecated.rs:105:13
    |
 LL |             override2: 3,
    |             ^^^^^^^^^^^^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated::inherit`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:104:17
+  --> $DIR/lint-stability-fields-deprecated.rs:109:17
    |
 LL |         let _ = x.inherit;
    |                 ^^^^^^^^^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated::override1`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:106:17
+  --> $DIR/lint-stability-fields-deprecated.rs:111:17
    |
 LL |         let _ = x.override1;
    |                 ^^^^^^^^^^^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated::override2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:108:17
+  --> $DIR/lint-stability-fields-deprecated.rs:113:17
    |
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated::inherit`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:113:13
+  --> $DIR/lint-stability-fields-deprecated.rs:118:13
    |
 LL |             inherit: _,
    |             ^^^^^^^^^^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated::override1`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:115:13
+  --> $DIR/lint-stability-fields-deprecated.rs:120:13
    |
 LL |             override1: _,
    |             ^^^^^^^^^^^^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated::override2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:117:13
+  --> $DIR/lint-stability-fields-deprecated.rs:122:13
    |
 LL |             override2: _
    |             ^^^^^^^^^^^^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated2::0`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:129:17
+  --> $DIR/lint-stability-fields-deprecated.rs:134:17
    |
 LL |         let _ = x.0;
    |                 ^^^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated2::1`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:131:17
+  --> $DIR/lint-stability-fields-deprecated.rs:136:17
    |
 LL |         let _ = x.1;
    |                 ^^^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated2::2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:133:17
+  --> $DIR/lint-stability-fields-deprecated.rs:138:17
    |
 LL |         let _ = x.2;
    |                 ^^^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated2::0`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:138:14
+  --> $DIR/lint-stability-fields-deprecated.rs:143:14
    |
 LL |             (_,
    |              ^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated2::1`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:140:14
+  --> $DIR/lint-stability-fields-deprecated.rs:145:14
    |
 LL |              _,
    |              ^
 
 error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated2::2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:142:14
+  --> $DIR/lint-stability-fields-deprecated.rs:147:14
    |
 LL |              _)
    |              ^
 
 error: use of deprecated field `this_crate::Stable::override2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:205:13
+  --> $DIR/lint-stability-fields-deprecated.rs:210:13
    |
 LL |             override2: 3,
    |             ^^^^^^^^^^^^
 
 error: use of deprecated field `this_crate::Stable::override2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:211:17
+  --> $DIR/lint-stability-fields-deprecated.rs:216:17
    |
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
 
 error: use of deprecated field `this_crate::Stable::override2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:217:13
+  --> $DIR/lint-stability-fields-deprecated.rs:222:13
    |
 LL |             override2: _
    |             ^^^^^^^^^^^^
 
 error: use of deprecated field `this_crate::Stable2::2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:227:17
+  --> $DIR/lint-stability-fields-deprecated.rs:232:17
    |
 LL |         let _ = x.2;
    |                 ^^^
 
 error: use of deprecated field `this_crate::Stable2::2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:232:20
+  --> $DIR/lint-stability-fields-deprecated.rs:237:20
    |
 LL |                    _)
    |                    ^
 
 error: use of deprecated field `this_crate::Unstable::override2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:242:13
+  --> $DIR/lint-stability-fields-deprecated.rs:247:13
    |
 LL |             override2: 3,
    |             ^^^^^^^^^^^^
 
 error: use of deprecated field `this_crate::Unstable::override2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:248:17
+  --> $DIR/lint-stability-fields-deprecated.rs:253:17
    |
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
 
 error: use of deprecated field `this_crate::Unstable::override2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:254:13
+  --> $DIR/lint-stability-fields-deprecated.rs:259:13
    |
 LL |             override2: _
    |             ^^^^^^^^^^^^
 
 error: use of deprecated field `this_crate::Unstable2::2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:267:17
+  --> $DIR/lint-stability-fields-deprecated.rs:272:17
    |
 LL |         let _ = x.2;
    |                 ^^^
 
 error: use of deprecated field `this_crate::Unstable2::2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:273:14
+  --> $DIR/lint-stability-fields-deprecated.rs:278:14
    |
 LL |              _)
    |              ^
 
 error: use of deprecated field `this_crate::Deprecated::inherit`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:283:13
+  --> $DIR/lint-stability-fields-deprecated.rs:288:13
    |
 LL |             inherit: 1,
    |             ^^^^^^^^^^
 
 error: use of deprecated field `this_crate::Deprecated::override1`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:285:13
+  --> $DIR/lint-stability-fields-deprecated.rs:290:13
    |
 LL |             override1: 2,
    |             ^^^^^^^^^^^^
 
 error: use of deprecated field `this_crate::Deprecated::override2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:287:13
+  --> $DIR/lint-stability-fields-deprecated.rs:292:13
    |
 LL |             override2: 3,
    |             ^^^^^^^^^^^^
 
 error: use of deprecated field `this_crate::Deprecated::inherit`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:291:17
+  --> $DIR/lint-stability-fields-deprecated.rs:296:17
    |
 LL |         let _ = x.inherit;
    |                 ^^^^^^^^^
 
 error: use of deprecated field `this_crate::Deprecated::override1`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:293:17
+  --> $DIR/lint-stability-fields-deprecated.rs:298:17
    |
 LL |         let _ = x.override1;
    |                 ^^^^^^^^^^^
 
 error: use of deprecated field `this_crate::Deprecated::override2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:295:17
+  --> $DIR/lint-stability-fields-deprecated.rs:300:17
    |
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
 
 error: use of deprecated field `this_crate::Deprecated::inherit`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:300:13
+  --> $DIR/lint-stability-fields-deprecated.rs:305:13
    |
 LL |             inherit: _,
    |             ^^^^^^^^^^
 
 error: use of deprecated field `this_crate::Deprecated::override1`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:302:13
+  --> $DIR/lint-stability-fields-deprecated.rs:307:13
    |
 LL |             override1: _,
    |             ^^^^^^^^^^^^
 
 error: use of deprecated field `this_crate::Deprecated::override2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:304:13
+  --> $DIR/lint-stability-fields-deprecated.rs:309:13
    |
 LL |             override2: _
    |             ^^^^^^^^^^^^
 
 error: use of deprecated field `this_crate::Deprecated2::0`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:316:17
+  --> $DIR/lint-stability-fields-deprecated.rs:321:17
    |
 LL |         let _ = x.0;
    |                 ^^^
 
 error: use of deprecated field `this_crate::Deprecated2::1`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:318:17
+  --> $DIR/lint-stability-fields-deprecated.rs:323:17
    |
 LL |         let _ = x.1;
    |                 ^^^
 
 error: use of deprecated field `this_crate::Deprecated2::2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:320:17
+  --> $DIR/lint-stability-fields-deprecated.rs:325:17
    |
 LL |         let _ = x.2;
    |                 ^^^
 
 error: use of deprecated field `this_crate::Deprecated2::0`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:325:14
+  --> $DIR/lint-stability-fields-deprecated.rs:330:14
    |
 LL |             (_,
    |              ^
 
 error: use of deprecated field `this_crate::Deprecated2::1`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:327:14
+  --> $DIR/lint-stability-fields-deprecated.rs:332:14
    |
 LL |              _,
    |              ^
 
 error: use of deprecated field `this_crate::Deprecated2::2`: text
-  --> $DIR/lint-stability-fields-deprecated.rs:329:14
+  --> $DIR/lint-stability-fields-deprecated.rs:334:14
    |
 LL |              _)
    |              ^

--- a/src/test/ui/lint/lint-stability-fields.rs
+++ b/src/test/ui/lint/lint-stability-fields.rs
@@ -20,29 +20,34 @@ mod cross_crate {
             inherit: 1,
             override1: 2, //~ ERROR use of unstable
             override2: 3, //~ ERROR use of unstable
+            override3: 4,
         };
 
         let _ = x.inherit;
         let _ = x.override1; //~ ERROR use of unstable
         let _ = x.override2; //~ ERROR use of unstable
+        let _ = x.override3;
 
         let Stable {
             inherit: _,
             override1: _, //~ ERROR use of unstable
-            override2: _ //~ ERROR use of unstable
+            override2: _, //~ ERROR use of unstable
+            override3: _
         } = x;
         // all fine
         let Stable { .. } = x;
 
-        let x = Stable2(1, 2, 3);
+        let x = Stable2(1, 2, 3, 4);
 
         let _ = x.0;
         let _ = x.1; //~ ERROR use of unstable
         let _ = x.2; //~ ERROR use of unstable
+        let _ = x.3;
 
         let Stable2(_,
                    _, //~ ERROR use of unstable
-                   _) //~ ERROR use of unstable
+                   _, //~ ERROR use of unstable
+                   _)
             = x;
         // all fine
         let Stable2(..) = x;
@@ -133,11 +138,13 @@ mod this_crate {
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
         #[unstable(feature = "unstable_test_feature", issue = "none")]
         override2: u8,
+        #[stable(feature = "rust2", since = "2.0.0")]
+        override3: u8,
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
     struct Stable2(u8,
-                   #[stable(feature = "rust1", since = "1.0.0")] u8,
+                   #[stable(feature = "rust2", since = "2.0.0")] u8,
                    #[unstable(feature = "unstable_test_feature", issue = "none")]
                    #[rustc_deprecated(since = "1.0.0", reason = "text")] u8);
 
@@ -178,16 +185,19 @@ mod this_crate {
             inherit: 1,
             override1: 2,
             override2: 3,
+            override3: 4,
         };
 
         let _ = x.inherit;
         let _ = x.override1;
         let _ = x.override2;
+        let _ = x.override3;
 
         let Stable {
             inherit: _,
             override1: _,
-            override2: _
+            override2: _,
+            override3: _
         } = x;
         // all fine
         let Stable { .. } = x;

--- a/src/test/ui/lint/lint-stability-fields.stderr
+++ b/src/test/ui/lint/lint-stability-fields.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:51:17
+  --> $DIR/lint-stability-fields.rs:56:17
    |
 LL |         let x = Unstable {
    |                 ^^^^^^^^
@@ -7,7 +7,7 @@ LL |         let x = Unstable {
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:61:13
+  --> $DIR/lint-stability-fields.rs:66:13
    |
 LL |         let Unstable {
    |             ^^^^^^^^
@@ -15,7 +15,7 @@ LL |         let Unstable {
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:67:13
+  --> $DIR/lint-stability-fields.rs:72:13
    |
 LL |         let Unstable
    |             ^^^^^^^^
@@ -23,7 +23,7 @@ LL |         let Unstable
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:72:17
+  --> $DIR/lint-stability-fields.rs:77:17
    |
 LL |         let x = reexport::Unstable2(1, 2, 3);
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -31,18 +31,10 @@ LL |         let x = reexport::Unstable2(1, 2, 3);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:74:17
+  --> $DIR/lint-stability-fields.rs:79:17
    |
 LL |         let x = Unstable2(1, 2, 3);
    |                 ^^^^^^^^^
-   |
-   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
-
-error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:80:13
-   |
-LL |         let Unstable2
-   |             ^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
@@ -55,7 +47,15 @@ LL |         let Unstable2
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:90:17
+  --> $DIR/lint-stability-fields.rs:90:13
+   |
+LL |         let Unstable2
+   |             ^^^^^^^^^
+   |
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+
+error[E0658]: use of unstable library feature 'unstable_test_feature'
+  --> $DIR/lint-stability-fields.rs:95:17
    |
 LL |         let x = Deprecated {
    |                 ^^^^^^^^^^
@@ -63,7 +63,7 @@ LL |         let x = Deprecated {
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:100:13
+  --> $DIR/lint-stability-fields.rs:105:13
    |
 LL |         let Deprecated {
    |             ^^^^^^^^^^
@@ -71,7 +71,7 @@ LL |         let Deprecated {
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:106:13
+  --> $DIR/lint-stability-fields.rs:111:13
    |
 LL |         let Deprecated
    |             ^^^^^^^^^^
@@ -79,7 +79,7 @@ LL |         let Deprecated
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:110:17
+  --> $DIR/lint-stability-fields.rs:115:17
    |
 LL |         let x = Deprecated2(1, 2, 3);
    |                 ^^^^^^^^^^^
@@ -87,7 +87,7 @@ LL |         let x = Deprecated2(1, 2, 3);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:116:13
+  --> $DIR/lint-stability-fields.rs:121:13
    |
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
@@ -95,7 +95,7 @@ LL |         let Deprecated2
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:121:13
+  --> $DIR/lint-stability-fields.rs:126:13
    |
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
@@ -119,7 +119,7 @@ LL |             override2: 3,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:26:17
+  --> $DIR/lint-stability-fields.rs:27:17
    |
 LL |         let _ = x.override1;
    |                 ^^^^^^^^^^^
@@ -127,7 +127,7 @@ LL |         let _ = x.override1;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:27:17
+  --> $DIR/lint-stability-fields.rs:28:17
    |
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
@@ -135,7 +135,7 @@ LL |         let _ = x.override2;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:31:13
+  --> $DIR/lint-stability-fields.rs:33:13
    |
 LL |             override1: _,
    |             ^^^^^^^^^^^^
@@ -143,15 +143,15 @@ LL |             override1: _,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:32:13
+  --> $DIR/lint-stability-fields.rs:34:13
    |
-LL |             override2: _
+LL |             override2: _,
    |             ^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:40:17
+  --> $DIR/lint-stability-fields.rs:43:17
    |
 LL |         let _ = x.1;
    |                 ^^^
@@ -159,7 +159,7 @@ LL |         let _ = x.1;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:41:17
+  --> $DIR/lint-stability-fields.rs:44:17
    |
 LL |         let _ = x.2;
    |                 ^^^
@@ -167,7 +167,7 @@ LL |         let _ = x.2;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:44:20
+  --> $DIR/lint-stability-fields.rs:48:20
    |
 LL |                    _,
    |                    ^
@@ -175,15 +175,15 @@ LL |                    _,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:45:20
+  --> $DIR/lint-stability-fields.rs:49:20
    |
-LL |                    _)
+LL |                    _,
    |                    ^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:52:13
+  --> $DIR/lint-stability-fields.rs:57:13
    |
 LL |             inherit: 1,
    |             ^^^^^^^^^^
@@ -191,7 +191,7 @@ LL |             inherit: 1,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:54:13
+  --> $DIR/lint-stability-fields.rs:59:13
    |
 LL |             override2: 3,
    |             ^^^^^^^^^^^^
@@ -199,7 +199,7 @@ LL |             override2: 3,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:57:17
+  --> $DIR/lint-stability-fields.rs:62:17
    |
 LL |         let _ = x.inherit;
    |                 ^^^^^^^^^
@@ -207,7 +207,7 @@ LL |         let _ = x.inherit;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:59:17
+  --> $DIR/lint-stability-fields.rs:64:17
    |
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
@@ -215,7 +215,7 @@ LL |         let _ = x.override2;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:62:13
+  --> $DIR/lint-stability-fields.rs:67:13
    |
 LL |             inherit: _,
    |             ^^^^^^^^^^
@@ -223,7 +223,7 @@ LL |             inherit: _,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:64:13
+  --> $DIR/lint-stability-fields.rs:69:13
    |
 LL |             override2: _
    |             ^^^^^^^^^^^^
@@ -231,7 +231,7 @@ LL |             override2: _
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:76:17
+  --> $DIR/lint-stability-fields.rs:81:17
    |
 LL |         let _ = x.0;
    |                 ^^^
@@ -239,7 +239,7 @@ LL |         let _ = x.0;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:78:17
+  --> $DIR/lint-stability-fields.rs:83:17
    |
 LL |         let _ = x.2;
    |                 ^^^
@@ -247,7 +247,7 @@ LL |         let _ = x.2;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:81:14
+  --> $DIR/lint-stability-fields.rs:86:14
    |
 LL |             (_,
    |              ^
@@ -255,7 +255,7 @@ LL |             (_,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:83:14
+  --> $DIR/lint-stability-fields.rs:88:14
    |
 LL |              _)
    |              ^
@@ -263,7 +263,7 @@ LL |              _)
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:91:13
+  --> $DIR/lint-stability-fields.rs:96:13
    |
 LL |             inherit: 1,
    |             ^^^^^^^^^^
@@ -271,7 +271,7 @@ LL |             inherit: 1,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:93:13
+  --> $DIR/lint-stability-fields.rs:98:13
    |
 LL |             override2: 3,
    |             ^^^^^^^^^^^^
@@ -279,7 +279,7 @@ LL |             override2: 3,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:96:17
+  --> $DIR/lint-stability-fields.rs:101:17
    |
 LL |         let _ = x.inherit;
    |                 ^^^^^^^^^
@@ -287,7 +287,7 @@ LL |         let _ = x.inherit;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:98:17
+  --> $DIR/lint-stability-fields.rs:103:17
    |
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
@@ -295,7 +295,7 @@ LL |         let _ = x.override2;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:101:13
+  --> $DIR/lint-stability-fields.rs:106:13
    |
 LL |             inherit: _,
    |             ^^^^^^^^^^
@@ -303,7 +303,7 @@ LL |             inherit: _,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:103:13
+  --> $DIR/lint-stability-fields.rs:108:13
    |
 LL |             override2: _
    |             ^^^^^^^^^^^^
@@ -311,7 +311,7 @@ LL |             override2: _
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:112:17
+  --> $DIR/lint-stability-fields.rs:117:17
    |
 LL |         let _ = x.0;
    |                 ^^^
@@ -319,7 +319,7 @@ LL |         let _ = x.0;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:114:17
+  --> $DIR/lint-stability-fields.rs:119:17
    |
 LL |         let _ = x.2;
    |                 ^^^
@@ -327,7 +327,7 @@ LL |         let _ = x.2;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:117:14
+  --> $DIR/lint-stability-fields.rs:122:14
    |
 LL |             (_,
    |              ^
@@ -335,7 +335,7 @@ LL |             (_,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
-  --> $DIR/lint-stability-fields.rs:119:14
+  --> $DIR/lint-stability-fields.rs:124:14
    |
 LL |              _)
    |              ^

--- a/src/test/ui/stability-attribute/stability-attribute-issue-43027.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-issue-43027.rs
@@ -1,10 +1,15 @@
+// check-pass
 #![feature(staged_api)]
 #![stable(feature = "test", since = "0")]
 
 #[stable(feature = "test", since = "0")]
-pub struct Reverse<T>(pub T); //~ ERROR field has missing stability attribute
+pub struct A<T>(pub T);
+
+#[stable(feature = "test", since = "0")]
+pub struct B<T>(#[stable(feature = "test", since = "0")] pub T);
 
 fn main() {
     // Make sure the field is used to fill the stability cache
-    Reverse(0).0;
+    A(0).0;
+    B(0).0;
 }

--- a/src/test/ui/stability-attribute/stability-attribute-issue-43027.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-issue-43027.stderr
@@ -1,8 +1,0 @@
-error: field has missing stability attribute
-  --> $DIR/stability-attribute-issue-43027.rs:5:23
-   |
-LL | pub struct Reverse<T>(pub T);
-   |                       ^^^^^
-
-error: aborting due to previous error
-

--- a/src/test/ui/stability-attribute/stability-attribute-sanity.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity.rs
@@ -62,12 +62,11 @@ fn multiple3() { }
 #[rustc_deprecated(since = "b", reason = "text")] //~ ERROR multiple deprecated attributes
 #[rustc_const_unstable(feature = "c", issue = "none")]
 #[rustc_const_unstable(feature = "d", issue = "none")] //~ ERROR multiple stability levels
-pub const fn multiple4() { }
-//~^ ERROR Invalid stability version found
+pub const fn multiple4() { } //~ ERROR invalid stability version found
 
 #[stable(feature = "a", since = "1.0.0")]
 #[rustc_deprecated(since = "invalid", reason = "text")]
-fn invalid_deprecation_version() {} //~ ERROR Invalid deprecation version found
+fn invalid_deprecation_version() {} //~ ERROR invalid deprecation version found
 
 #[rustc_deprecated(since = "a", reason = "text")]
 fn deprecated_without_unstable_or_stable() { }

--- a/src/test/ui/stability-attribute/stability-attribute-sanity.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity.rs
@@ -57,16 +57,16 @@ fn multiple2() { }
 #[stable(feature = "a", since = "b")] //~ ERROR multiple stability levels [E0544]
 fn multiple3() { }
 
-#[stable(feature = "a", since = "b")]
+#[stable(feature = "a", since = "b")] //~ ERROR invalid stability version found
 #[rustc_deprecated(since = "b", reason = "text")]
 #[rustc_deprecated(since = "b", reason = "text")] //~ ERROR multiple deprecated attributes
 #[rustc_const_unstable(feature = "c", issue = "none")]
 #[rustc_const_unstable(feature = "d", issue = "none")] //~ ERROR multiple stability levels
-pub const fn multiple4() { } //~ ERROR invalid stability version found
+pub const fn multiple4() { }
 
-#[stable(feature = "a", since = "1.0.0")]
+#[stable(feature = "a", since = "1.0.0")] //~ ERROR invalid deprecation version found
 #[rustc_deprecated(since = "invalid", reason = "text")]
-fn invalid_deprecation_version() {} //~ ERROR invalid deprecation version found
+fn invalid_deprecation_version() {}
 
 #[rustc_deprecated(since = "a", reason = "text")]
 fn deprecated_without_unstable_or_stable() { }

--- a/src/test/ui/stability-attribute/stability-attribute-sanity.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity.stderr
@@ -96,20 +96,20 @@ error[E0544]: multiple stability levels
 LL | #[rustc_const_unstable(feature = "d", issue = "none")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Invalid stability version found
+error: invalid stability version found
   --> $DIR/stability-attribute-sanity.rs:65:1
    |
 LL | pub const fn multiple4() { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Invalid deprecation version found
-  --> $DIR/stability-attribute-sanity.rs:70:1
+error: invalid deprecation version found
+  --> $DIR/stability-attribute-sanity.rs:69:1
    |
 LL | fn invalid_deprecation_version() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0549]: rustc_deprecated attribute must be paired with either stable or unstable attribute
-  --> $DIR/stability-attribute-sanity.rs:72:1
+  --> $DIR/stability-attribute-sanity.rs:71:1
    |
 LL | #[rustc_deprecated(since = "a", reason = "text")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/stability-attribute/stability-attribute-sanity.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity.stderr
@@ -97,16 +97,22 @@ LL | #[rustc_const_unstable(feature = "d", issue = "none")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: invalid stability version found
-  --> $DIR/stability-attribute-sanity.rs:65:1
+  --> $DIR/stability-attribute-sanity.rs:60:1
    |
+LL | #[stable(feature = "a", since = "b")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid stability version
+...
 LL | pub const fn multiple4() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ---------------------------- the stability attribute annotates this item
 
 error: invalid deprecation version found
-  --> $DIR/stability-attribute-sanity.rs:69:1
+  --> $DIR/stability-attribute-sanity.rs:67:1
    |
+LL | #[stable(feature = "a", since = "1.0.0")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid deprecation version
+LL | #[rustc_deprecated(since = "invalid", reason = "text")]
 LL | fn invalid_deprecation_version() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ----------------------------------- the stability attribute annotates this item
 
 error[E0549]: rustc_deprecated attribute must be paired with either stable or unstable attribute
   --> $DIR/stability-attribute-sanity.rs:71:1


### PR DESCRIPTION
Lint changes for #65515. The stdlib will have to be updated once this lands in beta and that version is promoted in master.