### PR TITLE
Remove inherited `#[stable(..)]` annotations

### DIFF
--- a/src/liballoc/borrow.rs
+++ b/src/liballoc/borrow.rs
@@ -173,12 +173,10 @@ where
     B: ToOwned,
 {
     /// Borrowed data.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    Borrowed(#[stable(feature = "rust1", since = "1.0.0")] &'a B),
+    Borrowed(&'a B),
 
     /// Owned data.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    Owned(#[stable(feature = "rust1", since = "1.0.0")] <B as ToOwned>::Owned),
+    Owned(<B as ToOwned>::Owned),
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/liballoc/collections/btree/map.rs
+++ b/src/liballoc/collections/btree/map.rs
@@ -474,12 +474,10 @@ impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for RangeMut<'_, K, V> {
 #[stable(feature = "rust1", since = "1.0.0")]
 pub enum Entry<'a, K: 'a, V: 'a> {
     /// A vacant entry.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    Vacant(#[stable(feature = "rust1", since = "1.0.0")] VacantEntry<'a, K, V>),
+    Vacant(VacantEntry<'a, K, V>),
 
     /// An occupied entry.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    Occupied(#[stable(feature = "rust1", since = "1.0.0")] OccupiedEntry<'a, K, V>),
+    Occupied(OccupiedEntry<'a, K, V>),
 }
 
 #[stable(feature = "debug_btree_map", since = "1.12.0")]

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -465,7 +465,7 @@ impl Ordering {
 /// ```
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Default, Hash)]
 #[stable(feature = "reverse_cmp_key", since = "1.19.0")]
-pub struct Reverse<T>(#[stable(feature = "reverse_cmp_key", since = "1.19.0")] pub T);
+pub struct Reverse<T>(pub T);
 
 #[stable(feature = "reverse_cmp_key", since = "1.19.0")]
 impl<T: PartialOrd> PartialOrd for Reverse<T> {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -179,7 +179,7 @@ NonZeroI8 NonZeroI16 NonZeroI32 NonZeroI64 NonZeroI128 NonZeroIsize }
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default, Hash)]
 #[repr(transparent)]
-pub struct Wrapping<T>(#[stable(feature = "rust1", since = "1.0.0")] pub T);
+pub struct Wrapping<T>(pub T);
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: fmt::Debug> fmt::Debug for Wrapping<T> {

--- a/src/libcore/ops/range.rs
+++ b/src/libcore/ops/range.rs
@@ -633,11 +633,9 @@ impl<Idx: PartialOrd<Idx>> RangeToInclusive<Idx> {
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub enum Bound<T> {
     /// An inclusive bound.
-    #[stable(feature = "collections_bound", since = "1.17.0")]
-    Included(#[stable(feature = "collections_bound", since = "1.17.0")] T),
+    Included(T),
     /// An exclusive bound.
-    #[stable(feature = "collections_bound", since = "1.17.0")]
-    Excluded(#[stable(feature = "collections_bound", since = "1.17.0")] T),
+    Excluded(T),
     /// An infinite endpoint. Indicates that there is no bound in this direction.
     #[stable(feature = "collections_bound", since = "1.17.0")]
     Unbounded,

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -155,11 +155,9 @@ use crate::{
 #[stable(feature = "rust1", since = "1.0.0")]
 pub enum Option<T> {
     /// No value
-    #[stable(feature = "rust1", since = "1.0.0")]
     None,
     /// Some value `T`
-    #[stable(feature = "rust1", since = "1.0.0")]
-    Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+    Some(T),
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -246,12 +246,10 @@ use crate::{convert, fmt};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub enum Result<T, E> {
     /// Contains the success value
-    #[stable(feature = "rust1", since = "1.0.0")]
-    Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
+    Ok(T),
 
     /// Contains the error value
-    #[stable(feature = "rust1", since = "1.0.0")]
-    Err(#[stable(feature = "rust1", since = "1.0.0")] E),
+    Err(E),
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/libcore/task/poll.rs
+++ b/src/libcore/task/poll.rs
@@ -10,15 +10,13 @@ use crate::result::Result;
 #[stable(feature = "futures_api", since = "1.36.0")]
 pub enum Poll<T> {
     /// Represents that a value is immediately ready.
-    #[stable(feature = "futures_api", since = "1.36.0")]
-    Ready(#[stable(feature = "futures_api", since = "1.36.0")] T),
+    Ready(T),
 
     /// Represents that a value is not ready yet.
     ///
     /// When a function returns `Pending`, the function *must* also
     /// ensure that the current task is scheduled to be awoken when
     /// progress can be made.
-    #[stable(feature = "futures_api", since = "1.36.0")]
     Pending,
 }
 

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -453,17 +453,13 @@ impl Eq for SourceFile {}
 #[derive(Clone)]
 pub enum TokenTree {
     /// A token stream surrounded by bracket delimiters.
-    #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
-    Group(#[stable(feature = "proc_macro_lib2", since = "1.29.0")] Group),
+    Group(Group),
     /// An identifier.
-    #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
-    Ident(#[stable(feature = "proc_macro_lib2", since = "1.29.0")] Ident),
+    Ident(Ident),
     /// A single punctuation character (`+`, `,`, `$`, etc.).
-    #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
-    Punct(#[stable(feature = "proc_macro_lib2", since = "1.29.0")] Punct),
+    Punct(Punct),
     /// A literal character (`'a'`), string (`"hello"`), number (`2.3`), etc.
-    #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
-    Literal(#[stable(feature = "proc_macro_lib2", since = "1.29.0")] Literal),
+    Literal(Literal),
 }
 
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1592,12 +1592,10 @@ impl<K, V, S> Debug for RawEntryBuilder<'_, K, V, S> {
 #[stable(feature = "rust1", since = "1.0.0")]
 pub enum Entry<'a, K: 'a, V: 'a> {
     /// An occupied entry.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    Occupied(#[stable(feature = "rust1", since = "1.0.0")] OccupiedEntry<'a, K, V>),
+    Occupied(OccupiedEntry<'a, K, V>),
 
     /// A vacant entry.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    Vacant(#[stable(feature = "rust1", since = "1.0.0")] VacantEntry<'a, K, V>),
+    Vacant(VacantEntry<'a, K, V>),
 }
 
 #[stable(feature = "debug_hash_map", since = "1.12.0")]

--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -260,14 +260,12 @@ fn _var_os(key: &OsStr) -> Option<OsString> {
 pub enum VarError {
     /// The specified environment variable was not present in the current
     /// process's environment.
-    #[stable(feature = "env", since = "1.0.0")]
     NotPresent,
 
     /// The specified environment variable was found, but it did not contain
     /// valid unicode data. The found data is returned as a payload of this
     /// variant.
-    #[stable(feature = "env", since = "1.0.0")]
-    NotUnicode(#[stable(feature = "env", since = "1.0.0")] OsString),
+    NotUnicode(OsString),
 }
 
 #[stable(feature = "env", since = "1.0.0")]

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1678,24 +1678,21 @@ pub trait Seek {
 #[stable(feature = "rust1", since = "1.0.0")]
 pub enum SeekFrom {
     /// Sets the offset to the provided number of bytes.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    Start(#[stable(feature = "rust1", since = "1.0.0")] u64),
+    Start(u64),
 
     /// Sets the offset to the size of this object plus the specified number of
     /// bytes.
     ///
     /// It is possible to seek beyond the end of an object, but it's an error to
     /// seek before byte 0.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    End(#[stable(feature = "rust1", since = "1.0.0")] i64),
+    End(i64),
 
     /// Sets the offset to the current position plus the specified number of
     /// bytes.
     ///
     /// It is possible to seek beyond the end of an object, but it's an error to
     /// seek before byte 0.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    Current(#[stable(feature = "rust1", since = "1.0.0")] i64),
+    Current(i64),
 }
 
 fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>) -> Result<usize> {

--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -40,11 +40,9 @@ use crate::vec;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub enum SocketAddr {
     /// An IPv4 socket address.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    V4(#[stable(feature = "rust1", since = "1.0.0")] SocketAddrV4),
+    V4(SocketAddrV4),
     /// An IPv6 socket address.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    V6(#[stable(feature = "rust1", since = "1.0.0")] SocketAddrV6),
+    V6(SocketAddrV6),
 }
 
 /// An IPv4 socket address.

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -42,11 +42,9 @@ use crate::sys_common::{AsInner, FromInner};
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, PartialOrd, Ord)]
 pub enum IpAddr {
     /// An IPv4 address.
-    #[stable(feature = "ip_addr", since = "1.7.0")]
-    V4(#[stable(feature = "ip_addr", since = "1.7.0")] Ipv4Addr),
+    V4(Ipv4Addr),
     /// An IPv6 address.
-    #[stable(feature = "ip_addr", since = "1.7.0")]
-    V6(#[stable(feature = "ip_addr", since = "1.7.0")] Ipv6Addr),
+    V6(Ipv6Addr),
 }
 
 /// An IPv4 address.

--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -187,7 +187,7 @@ pub auto trait RefUnwindSafe {}
 /// // ...
 /// ```
 #[stable(feature = "catch_unwind", since = "1.9.0")]
-pub struct AssertUnwindSafe<T>(#[stable(feature = "catch_unwind", since = "1.9.0")] pub T);
+pub struct AssertUnwindSafe<T>(pub T);
 
 // Implementations of the `UnwindSafe` trait:
 //

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -143,47 +143,35 @@ pub enum Prefix<'a> {
     ///
     /// Verbatim prefixes consist of `\\?\` immediately followed by the given
     /// component.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    Verbatim(#[stable(feature = "rust1", since = "1.0.0")] &'a OsStr),
+    Verbatim(&'a OsStr),
 
     /// Verbatim prefix using Windows' _**U**niform **N**aming **C**onvention_,
     /// e.g., `\\?\UNC\server\share`.
     ///
     /// Verbatim UNC prefixes consist of `\\?\UNC\` immediately followed by the
     /// server's hostname and a share name.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    VerbatimUNC(
-        #[stable(feature = "rust1", since = "1.0.0")] &'a OsStr,
-        #[stable(feature = "rust1", since = "1.0.0")] &'a OsStr,
-    ),
+    VerbatimUNC(&'a OsStr, &'a OsStr),
 
     /// Verbatim disk prefix, e.g., `\\?\C:\`.
     ///
     /// Verbatim disk prefixes consist of `\\?\` immediately followed by the
     /// drive letter and `:\`.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    VerbatimDisk(#[stable(feature = "rust1", since = "1.0.0")] u8),
+    VerbatimDisk(u8),
 
     /// Device namespace prefix, e.g., `\\.\COM42`.
     ///
     /// Device namespace prefixes consist of `\\.\` immediately followed by the
     /// device name.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    DeviceNS(#[stable(feature = "rust1", since = "1.0.0")] &'a OsStr),
+    DeviceNS(&'a OsStr),
 
     /// Prefix using Windows' _**U**niform **N**aming **C**onvention_, e.g.
     /// `\\server\share`.
     ///
     /// UNC prefixes consist of the server's hostname and a share name.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    UNC(
-        #[stable(feature = "rust1", since = "1.0.0")] &'a OsStr,
-        #[stable(feature = "rust1", since = "1.0.0")] &'a OsStr,
-    ),
+    UNC(&'a OsStr, &'a OsStr),
 
     /// Prefix `C:` for the given disk drive.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    Disk(#[stable(feature = "rust1", since = "1.0.0")] u8),
+    Disk(u8),
 }
 
 impl<'a> Prefix<'a> {
@@ -492,29 +480,24 @@ pub enum Component<'a> {
     /// Does not occur on Unix.
     ///
     /// [`Prefix`]: enum.Prefix.html
-    #[stable(feature = "rust1", since = "1.0.0")]
-    Prefix(#[stable(feature = "rust1", since = "1.0.0")] PrefixComponent<'a>),
+    Prefix(PrefixComponent<'a>),
 
     /// The root directory component, appears after any prefix and before anything else.
     ///
     /// It represents a separator that designates that a path starts from root.
-    #[stable(feature = "rust1", since = "1.0.0")]
     RootDir,
 
     /// A reference to the current directory, i.e., `.`.
-    #[stable(feature = "rust1", since = "1.0.0")]
     CurDir,
 
     /// A reference to the parent directory, i.e., `..`.
-    #[stable(feature = "rust1", since = "1.0.0")]
     ParentDir,
 
     /// A normal component, e.g., `a` and `b` in `a/b`.
     ///
     /// This variant is the most common one, it represents references to files
     /// or directories.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    Normal(#[stable(feature = "rust1", since = "1.0.0")] &'a OsStr),
+    Normal(&'a OsStr),
 }
 
 impl<'a> Component<'a> {

--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -553,7 +553,7 @@ unsafe impl<T: Send> Send for SyncSender<T> {}
 /// [`SyncSender::send`]: struct.SyncSender.html#method.send
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(PartialEq, Eq, Clone, Copy)]
-pub struct SendError<T>(#[stable(feature = "rust1", since = "1.0.0")] pub T);
+pub struct SendError<T>(pub T);
 
 /// An error returned from the [`recv`] function on a [`Receiver`].
 ///
@@ -626,15 +626,13 @@ pub enum TrySendError<T> {
     ///
     /// [`sync_channel`]: fn.sync_channel.html
     /// [`Receiver`]: struct.Receiver.html
-    #[stable(feature = "rust1", since = "1.0.0")]
-    Full(#[stable(feature = "rust1", since = "1.0.0")] T),
+    Full(T),
 
     /// This [`sync_channel`]'s receiving half has disconnected, so the data could not be
     /// sent. The data is returned back to the callee in this case.
     ///
     /// [`sync_channel`]: fn.sync_channel.html
-    #[stable(feature = "rust1", since = "1.0.0")]
-    Disconnected(#[stable(feature = "rust1", since = "1.0.0")] T),
+    Disconnected(T),
 }
 
 enum Flavor<T> {

--- a/src/libstd/sys_common/poison.rs
+++ b/src/libstd/sys_common/poison.rs
@@ -99,11 +99,9 @@ pub struct PoisonError<T> {
 pub enum TryLockError<T> {
     /// The lock could not be acquired because another thread failed while holding
     /// the lock.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    Poisoned(#[stable(feature = "rust1", since = "1.0.0")] PoisonError<T>),
+    Poisoned(PoisonError<T>),
     /// The lock could not be acquired at this time because the operation would
     /// otherwise block.
-    #[stable(feature = "rust1", since = "1.0.0")]
     WouldBlock,
 }
 


### PR DESCRIPTION
Fix #65515. Blocked on #71481 landing on the beta compiler used to build master.