### PR TITLE
Enable "full tools" option on ARM dist builders

### DIFF
--- a/src/bootstrap/bin/llvm-config-wrapper.rs
+++ b/src/bootstrap/bin/llvm-config-wrapper.rs
@@ -10,7 +10,14 @@ fn main() {
     let mut cmd = Command::new(real_llvm_config);
     cmd.args(env::args().skip(1)).stderr(Stdio::piped());
     let output = cmd.output().expect("failed to spawn llvm-config");
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut stdout = String::from_utf8_lossy(&output.stdout);
+
+    if let Ok(to_replace) = env::var("LLVM_CONFIG_SHIM_REPLACE") {
+        if let Ok(replace_with) = env::var("LLVM_CONFIG_SHIM_REPLACE_WITH") {
+            stdout = stdout.replace(&to_replace, &replace_with).into();
+        }
+    }
+
     print!("{}", stdout.replace("\\", "/"));
     io::stdout().flush().unwrap();
     process::exit(output.status.code().unwrap_or(1));

--- a/src/ci/docker/dist-aarch64-linux/Dockerfile
+++ b/src/ci/docker/dist-aarch64-linux/Dockerfile
@@ -33,7 +33,7 @@ ENV CC_aarch64_unknown_linux_gnu=aarch64-unknown-linux-gnueabi-gcc \
 ENV HOSTS=aarch64-unknown-linux-gnu
 
 ENV RUST_CONFIGURE_ARGS \
-      --enable-extended \
+      --enable-full-tools \
       --enable-profiler \
       --disable-docs
 ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-arm-linux/Dockerfile
+++ b/src/ci/docker/dist-arm-linux/Dockerfile
@@ -27,5 +27,5 @@ ENV CC_arm_unknown_linux_gnueabi=arm-unknown-linux-gnueabi-gcc \
 
 ENV HOSTS=arm-unknown-linux-gnueabi
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
+ENV RUST_CONFIGURE_ARGS --enable-full-tools --disable-docs
 ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-armhf-linux/Dockerfile
+++ b/src/ci/docker/dist-armhf-linux/Dockerfile
@@ -27,5 +27,5 @@ ENV CC_arm_unknown_linux_gnueabihf=arm-unknown-linux-gnueabihf-gcc \
 
 ENV HOSTS=arm-unknown-linux-gnueabihf
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
+ENV RUST_CONFIGURE_ARGS --enable-full-tools --disable-docs
 ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/dist-armv7-linux/Dockerfile
+++ b/src/ci/docker/dist-armv7-linux/Dockerfile
@@ -27,5 +27,5 @@ ENV CC_armv7_unknown_linux_gnueabihf=armv7-unknown-linux-gnueabihf-gcc \
 
 ENV HOSTS=armv7-unknown-linux-gnueabihf
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
+ENV RUST_CONFIGURE_ARGS --enable-full-tools --disable-docs
 ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS


### PR DESCRIPTION
This commit switches the `--enable-extended` option on the arm-related
dist builders to `--enable-full-tools`. This alias in `config.py`
corresponds to enabling a few more options:

* `rust.lld = true` - this is the main purpose of this PR, to enable LLD
  on ARM-related platforms. This means it will effectively unlock
  compilation of wasm programs from an arm host.

* `rust.llvm-tools = true` - it turns out that this option is largely
  ignored in rustbuild today. This is only read in one location to set
  some flags for the `llvm-tools` package, but the `llvm-tools` package
  is already produced on all of these builders. It's predicted that this
  will have no effect on build times.

* `rust.codegen-backends = ['llvm']` - historically this also enabled
  the emscripten backend, but that has long since been removed.

This brings the ARM dist builders in line with the x86_64 dist builders
using this flag. The hope is that the extra time spent on CI building
LLD will acceptable because it's cached by `sccache`, LLD is a
relatively small C++ project, and the dist builders are all clocking
well under 3 hours (the slowest of all builders) around 2 hours.

There's likely some possible cleanup that can happen with these
configure options since it doesn't look like they've aged too too well,
but I'm hopeful that possible refactorings, if necessary, could be
deferred to future PRs.