### PR TITLE
Fix span of while (let) expressions after lowering

### DIFF
--- a/src/librustc_ast_lowering/expr.rs
+++ b/src/librustc_ast_lowering/expr.rs
@@ -397,12 +397,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let then_arm = self.arm(then_pat, self.arena.alloc(then_expr));
 
         // `match <scrutinee> { ... }`
-        let match_expr = self.expr_match(
-            scrutinee.span,
-            scrutinee,
-            arena_vec![self; then_arm, else_arm],
-            desugar,
-        );
+        let match_expr =
+            self.expr_match(span, scrutinee, arena_vec![self; then_arm, else_arm], desugar);
 
         // `[opt_ident]: loop { ... }`
         hir::ExprKind::Loop(self.block_expr(self.arena.alloc(match_expr)), opt_label, source)

--- a/src/test/mir-opt/while-storage/rustc.while_loop.PreCodegen.after.mir
+++ b/src/test/mir-opt/while-storage/rustc.while_loop.PreCodegen.after.mir
@@ -57,7 +57,7 @@ fn while_loop(_1: bool) -> () {
 
     bb5: {
         StorageDead(_4);                 // bb5[0]: scope 0 at $DIR/while-storage.rs:14:5: 14:6
-        StorageDead(_2);                 // bb5[1]: scope 0 at $DIR/while-storage.rs:10:21: 10:22
+        StorageDead(_2);                 // bb5[1]: scope 0 at $DIR/while-storage.rs:14:5: 14:6
         goto -> bb0;                     // bb5[2]: scope 0 at $DIR/while-storage.rs:10:5: 14:6
     }
 
@@ -74,7 +74,7 @@ fn while_loop(_1: bool) -> () {
     }
 
     bb7: {
-        StorageDead(_2);                 // bb7[0]: scope 0 at $DIR/while-storage.rs:10:21: 10:22
+        StorageDead(_2);                 // bb7[0]: scope 0 at $DIR/while-storage.rs:14:5: 14:6
         return;                          // bb7[1]: scope 0 at $DIR/while-storage.rs:15:2: 15:2
     }
 }

--- a/src/test/ui/block-result/block-must-not-have-result-while.stderr
+++ b/src/test/ui/block-result/block-must-not-have-result-while.stderr
@@ -9,8 +9,14 @@ LL |     while true {
 error[E0308]: mismatched types
   --> $DIR/block-must-not-have-result-while.rs:3:9
    |
-LL |         true
-   |         ^^^^ expected `()`, found `bool`
+LL | /     while true {
+LL | |         true
+   | |         ^^^^ expected `()`, found `bool`
+LL | |
+LL | |     }
+   | |     -- help: consider using a semicolon here
+   | |_____|
+   |       expected this to be `()`
 
 error: aborting due to previous error; 1 warning emitted
 


### PR DESCRIPTION
Credit goes to @alex-700 who found this while trying to fix a suggestion in Clippy.

While `if`, `try`, `for` and `await` expressions get the span of the original expression when desugared, `while` loops got the span of the scrutinee, which lead to weird code, when building the suggestion, that randomly worked: https://github.com/rust-lang/rust-clippy/pull/5511/files#diff-df4e9d2bf840a5f2e3b580bef73da3bcR106-R108

I'm wondering, if `DesugaringKind` should get a variant `WhileLoop` and instead of using the span of the `ast::ExprKind::While` expr directly, a new span with `self.mark_span_with_reason` should be used, like it is done with `for` loops.

There was some fallout, but I think that is acceptable. If not, I need some help to find out where this can be fixed.