### PR TITLE
 Quick and dirty fix of the unused_braces lint

### DIFF
--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -16,7 +16,7 @@ use rustc_middle::ty::{self, Ty};
 use rustc_session::lint::builtin::UNUSED_ATTRIBUTES;
 use rustc_span::symbol::Symbol;
 use rustc_span::symbol::{kw, sym};
-use rustc_span::{BytePos, Span};
+use rustc_span::{BytePos, Span, DUMMY_SP};
 
 use log::debug;
 
@@ -415,6 +415,12 @@ trait UnusedDelimLint {
         msg: &str,
         keep_space: (bool, bool),
     ) {
+        // FIXME(flip1995): Quick and dirty fix for #70814. This should be fixed in rustdoc
+        // properly.
+        if span == DUMMY_SP {
+            return;
+        }
+
         cx.struct_span_lint(self.lint(), span, |lint| {
             let span_msg = format!("unnecessary {} around {}", Self::DELIM_STR, msg);
             let mut err = lint.build(&span_msg);

--- a/src/test/rustdoc-ui/unused-braces-lint.rs
+++ b/src/test/rustdoc-ui/unused-braces-lint.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+// This tests the bug in #70814, where the unused_braces lint triggered on the following code
+// without providing a span.
+
+#![deny(unused_braces)]
+
+fn main() {
+    {
+        {
+            use std;
+        }
+    }
+}


### PR DESCRIPTION
cc @lcnr 

Adresses #70814 

This at least prevents lint output, if no span is available. Even though this also prevents the `unused_parens` lint from emitting, when the `DUMMY_SP` is used there, but I think that should be ok, since error messages without a span are quite useless anyway.

Clippy CI is currently blocked on this bug. If this quick and dirty fix should be rejected, I could try to work around this in Clippy.

r? @shepmaster 